### PR TITLE
feat: add agent-requested context compression

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -57,7 +57,16 @@ def _ra():
 
 
 AGENT_RUNTIME_POST_HOOK_TOOL_NAMES = frozenset(
-    {"todo", "session_search", "memory", "clarify", "read_terminal", "delegate_task"}
+    {
+        "todo",
+        "session_search",
+        "memory",
+        "clarify",
+        "read_terminal",
+        "delegate_task",
+        "context_status",
+        "request_compression",
+    }
 )
 
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2627,13 +2627,14 @@ This compaction should PRIORITISE preserving all information related to the focu
     # Main compression entry point
     # ------------------------------------------------------------------
 
-    def compress(self, messages: List[Dict[str, Any]], current_tokens: int = None, focus_topic: str = None, force: bool = False) -> List[Dict[str, Any]]:
+    def compress(self, messages: List[Dict[str, Any]], current_tokens: int = None, focus_topic: str = None, force: bool = False, aggressive: bool = False) -> List[Dict[str, Any]]:
         """Compress conversation messages by summarizing middle turns.
 
         Algorithm:
           1. Prune old tool results (cheap pre-pass, no LLM call)
           2. Protect head messages (system prompt + first exchange)
           3. Find tail boundary by token budget (~20K tokens of recent context)
+             or by message count (protect_last_n) when aggressive=True
           4. Summarize middle turns with structured LLM prompt
           5. On re-compression, iteratively update the previous summary
 
@@ -2648,6 +2649,11 @@ This compaction should PRIORITISE preserving all information related to the focu
             force: If True, clear any active summary-failure cooldown before
                 running so a manual ``/compress`` can retry immediately after
                 an auto-compression abort.  Auto-compress callers pass False.
+            aggressive: If True, use message-count-based tail protection
+                (protect_last_n) instead of the default token-budget tail.
+                Designed for agent-requested compression during idle/poll
+                loops where the agent knows it can safely compress most
+                context away.
         """
         # Reset per-call summary failure state — callers inspect these fields
         # after compress() returns to decide whether to surface a warning.
@@ -2698,8 +2704,22 @@ This compaction should PRIORITISE preserving all information related to the focu
         compress_start = self._protect_head_size(messages)
         compress_start = self._align_boundary_forward(messages, compress_start)
 
-        # Use token-budget tail protection instead of fixed message count
-        compress_end = self._find_tail_cut_by_tokens(messages, compress_start)
+        # Use token-budget tail protection instead of fixed message count.
+        # Agent-requested compression can opt into a more aggressive, fixed
+        # message-count tail when the model knows it is entering an idle/poll
+        # loop and can safely summarize more of the transcript.
+        if aggressive:
+            tail_count = max(3, min(self.protect_last_n, _MAX_TAIL_MESSAGE_FLOOR))
+            compress_end = max(compress_start + 1, len(messages) - tail_count)
+            compress_end = self._align_boundary_backward(messages, compress_end)
+            if not self.quiet_mode:
+                logger.info(
+                    "Aggressive compression tail=%d messages (protect_last_n=%d)",
+                    tail_count,
+                    self.protect_last_n,
+                )
+        else:
+            compress_end = self._find_tail_cut_by_tokens(messages, compress_start)
 
         if compress_start >= compress_end:
             # No compressable window — the entire transcript fits within

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -400,6 +400,7 @@ def compress_context(
     task_id: str = "default",
     focus_topic: Optional[str] = None,
     force: bool = False,
+    aggressive: bool = False,
 ) -> Tuple[list, str]:
     """Compress conversation context and split the session in SQLite.
 
@@ -416,6 +417,9 @@ def compress_context(
             by the manual ``/compress`` slash command so users can retry
             immediately after an auto-compress abort.  Auto-compress
             callers use the default ``False``.
+        aggressive: If True, use message-count-based tail protection
+            (protect_last_n) instead of the default token-budget tail.
+            Intended for agent-requested compression during idle/poll loops.
 
     Returns:
         ``(compressed_messages, new_system_prompt)`` tuple.  When
@@ -580,15 +584,26 @@ def compress_context(
             pass
 
     try:
-        compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic, force=force)
+        compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic, force=force, aggressive=aggressive)
     except TypeError:
-        # Plugin context engine with strict signature that doesn't accept
-        # focus_topic / force — fall back to calling without them.
+        # Plugin context engine with a strict pre-aggressive signature: retry
+        # with the older focus_topic/force kwargs before falling all the way
+        # back to the minimal historical call shape.
         try:
-            compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens)
-        except BaseException:
-            _release_lock()
-            raise
+            compressed = agent.context_compressor.compress(
+                messages,
+                current_tokens=approx_tokens,
+                focus_topic=focus_topic,
+                force=force,
+            )
+        except TypeError:
+            # Plugin context engine with strict signature that doesn't accept
+            # focus_topic / force — fall back to calling without them.
+            try:
+                compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens)
+            except BaseException:
+                _release_lock()
+                raise
     except BaseException:
         # ANY exception during compress() must release the lock so the
         # session isn't permanently blocked from future compression.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4531,6 +4531,16 @@ def run_conversation(
 
                 agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
 
+                if getattr(agent, "_request_compression_applied", False):
+                    agent._request_compression_applied = False
+                    # request_compression mutates the live `messages` list and
+                    # may rotate the session id. Clear the original caller
+                    # history baseline so persistence/CLI state rebases on the
+                    # compacted transcript rather than treating dropped turns as
+                    # still-current history.
+                    conversation_history = None
+                    active_system_prompt = getattr(agent, "_cached_system_prompt", None) or active_system_prompt
+
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
                     _turn_exit_reason = "guardrail_halt"

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1183,6 +1183,42 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_duration = time.time() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('todo', function_args, tool_duration, result=function_result)}")
+        elif function_name == "context_status":
+            def _execute(next_args: dict) -> Any:
+                from tools.context_usage_tool import context_status_handler as _ctx_status
+                return _ctx_status(next_args, agent=agent)
+            function_result, function_args = _run_agent_tool_execution_middleware(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                execute=_execute,
+            )
+            tool_duration = time.time() - tool_start_time
+            if agent._should_emit_quiet_tool_messages():
+                agent._vprint(f"  {_get_cute_tool_message_impl('context_status', function_args, tool_duration, result=function_result)}")
+        elif function_name == "request_compression":
+            def _execute(next_args: dict) -> Any:
+                from tools.context_usage_tool import request_compression_handler as _req_compress
+                return _req_compress(
+                    next_args,
+                    agent=agent,
+                    messages=messages,
+                    task_id=effective_task_id,
+                    tool_call_id=getattr(tool_call, "id", "") or "",
+                )
+            function_result, function_args = _run_agent_tool_execution_middleware(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                execute=_execute,
+            )
+            tool_duration = time.time() - tool_start_time
+            if agent._should_emit_quiet_tool_messages():
+                agent._vprint(f"  {_get_cute_tool_message_impl('request_compression', function_args, tool_duration, result=function_result)}")
         elif function_name == "session_search":
             def _execute(next_args: dict) -> Any:
                 session_db = agent._get_session_db_for_recall()

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -434,6 +434,17 @@ compression:
   # head messages, matching the pre-feature behaviour.
   protect_first_n: 3
 
+  # Whether the agent can request compression itself via the
+  # request_compression tool (default: false).  When enabled, the model can
+  # compact the live tool-loop context before long idle/poll phases.  This is
+  # lossy, so keep it off unless you want the agent to manage its own context.
+  allow_agent_trigger: false
+
+  # Optional minimum context usage (0.0 - 1.0) below which agent-triggered
+  # compression requests are rejected unless the tool call passes force=true.
+  # Only relevant when allow_agent_trigger is true.
+  # agent_suggest_threshold: 0.50
+
   # To pin a specific model/provider for compression summaries, use the
   # auxiliary section below (auxiliary.compression.provider / model).
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1337,6 +1337,13 @@ DEFAULT_CONFIG = {
                                       # 0 for long-running rolling-compaction sessions
                                       # where you want nothing pinned except the
                                       # system prompt + rolling summary + recent tail.
+        "allow_agent_trigger": False, # When True, exposes request_compression so
+                                      # the agent can voluntarily compact the live
+                                      # tool-loop context. Off by default because it
+                                      # is a lossy, model-triggered runtime action.
+        "agent_suggest_threshold": None,  # Optional minimum context-usage ratio
+                                      # below which request_compression is rejected
+                                      # unless the tool call passes force=true.
         "abort_on_summary_failure": False,  # When True, auto-compression that fails
                                       # to generate a summary (aux LLM errored / returned
                                       # non-JSON / timed out) aborts entirely instead of

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -73,6 +73,7 @@ CONFIGURABLE_TOOLSETS = [
     ("todo",            "📋 Task Planning",             "todo"),
     ("memory",          "💾 Memory",                    "persistent memory across sessions"),
     ("context_engine",  "🧩 Context Engine",            "runtime tools from the active context engine"),
+    ("context_usage",   "🗜️ Context Usage",             "context_status, request_compression"),
     ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
@@ -115,7 +116,10 @@ def gui_toolset_label(label: str) -> str:
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+_DEFAULT_OFF_TOOLSETS = {
+    "moa", "homeassistant", "spotify", "discord", "discord_admin",
+    "video", "video_gen", "x_search", "context_usage",
+}
 
 
 def _xai_credentials_present() -> bool:

--- a/run_agent.py
+++ b/run_agent.py
@@ -5541,19 +5541,23 @@ class AIAgent:
         """
         return self.api_mode != "codex_responses"
 
-    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None, force: bool = False) -> tuple:
+    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None, force: bool = False, aggressive: bool = False) -> tuple:
         """Forwarder — see ``agent.conversation_compression.compress_context``.
 
         ``force=True`` is passed by the manual ``/compress`` slash command
         so users can bypass the summary-failure cooldown after an
         auto-compress abort.  Auto-compress callers use the default
         ``force=False``.
+
+        ``aggressive=True`` enables message-count-based tail protection
+        instead of token-budget tail protection for agent-requested
+        compression during idle/poll loops.
         """
         from agent.conversation_compression import compress_context
         return compress_context(
             self, messages, system_message,
             approx_tokens=approx_tokens, task_id=task_id, focus_topic=focus_topic,
-            force=force,
+            force=force, aggressive=aggressive,
         )
 
     def _set_tool_guardrail_halt(self, decision: ToolGuardrailDecision) -> None:

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -230,6 +230,26 @@ class TestToolsetConsistency:
         assert len(core) > 20, f"Suspiciously small shared core: {len(core)} tools"
 
 
+    def test_context_usage_is_opt_in_not_core(self):
+        assert set(resolve_toolset("context_usage")) == {
+            "context_status",
+            "request_compression",
+        }
+        for platform in [
+            "hermes-cli",
+            "hermes-telegram",
+            "hermes-discord",
+            "hermes-whatsapp",
+            "hermes-slack",
+            "hermes-signal",
+            "hermes-homeassistant",
+        ]:
+            tools = set(resolve_toolset(platform))
+            assert "context_status" not in tools
+            assert "request_compression" not in tools
+
+
+
 class TestPluginToolsets:
     def test_get_all_toolsets_includes_plugin_toolset(self, monkeypatch):
         reg = ToolRegistry()

--- a/tests/tools/test_context_usage_tool.py
+++ b/tests/tools/test_context_usage_tool.py
@@ -1,0 +1,294 @@
+import json
+from types import SimpleNamespace
+
+import tools.context_usage_tool as context_usage_tool
+
+
+class _Compressor(SimpleNamespace):
+    def can_compress(self):
+        return True
+
+
+def _agent(**overrides):
+    agent = SimpleNamespace(
+        session_prompt_tokens=120,
+        session_total_tokens=180,
+        session_id="old-session",
+        _cached_system_prompt="system prompt",
+        context_compressor=_Compressor(
+            context_length=1_000,
+            last_prompt_tokens=400,
+            last_real_prompt_tokens=350,
+            last_compression_rough_tokens=0,
+            awaiting_real_usage_after_compression=False,
+        ),
+        tools=None,
+    )
+    for key, value in overrides.items():
+        setattr(agent, key, value)
+    return agent
+
+
+def test_context_status_reports_post_compression_rough_estimate(monkeypatch):
+    monkeypatch.setattr(
+        context_usage_tool,
+        "_read_compression_config",
+        lambda _agent: {
+            "enabled": True,
+            "threshold": 0.5,
+            "allow_agent_trigger": True,
+            "agent_suggest_threshold": 0.75,
+        },
+    )
+    agent = _agent(
+        context_compressor=_Compressor(
+            context_length=1_000,
+            last_prompt_tokens=-1,
+            last_real_prompt_tokens=900,
+            last_compression_rough_tokens=123,
+            awaiting_real_usage_after_compression=True,
+        )
+    )
+
+    result = json.loads(context_usage_tool.context_status_handler({}, agent=agent))
+
+    assert result["tokens_used"] == 123
+    assert result["percent_used"] == 12.3
+    assert result["compression_threshold_pct"] == 50.0
+    assert result["allow_agent_trigger"] is True
+    assert result["agent_suggest_threshold"] == 0.75
+
+
+def test_request_compression_is_hidden_unless_config_allows(monkeypatch):
+    monkeypatch.setattr(
+        context_usage_tool,
+        "_read_compression_config",
+        lambda _agent: {"enabled": True, "allow_agent_trigger": False},
+    )
+
+    assert context_usage_tool._check_context_status_reqs() is True
+    assert context_usage_tool._check_request_compression_reqs() is False
+
+    result = json.loads(
+        context_usage_tool.request_compression_handler(
+            {"reason": "too long"},
+            agent=_agent(),
+            messages=[{"role": "user", "content": "hello"}],
+        )
+    )
+    assert result["compressed"] is False
+    assert "allow_agent_trigger" in result["error"]
+
+
+def test_request_compression_mutates_live_messages_and_marks_loop_rebase(monkeypatch):
+    monkeypatch.setattr(
+        context_usage_tool,
+        "_read_compression_config",
+        lambda _agent: {
+            "enabled": True,
+            "allow_agent_trigger": True,
+            "agent_suggest_threshold": 0.5,
+        },
+    )
+    estimates = iter([1_000, 250])
+    monkeypatch.setattr(
+        context_usage_tool,
+        "_estimate_request_tokens",
+        lambda *_args, **_kwargs: next(estimates),
+    )
+
+    live_messages = [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "two"},
+        {"role": "user", "content": "three"},
+    ]
+    compressed_messages = [{"role": "user", "content": "summary"}]
+
+    def _compress_context(messages, system_message, **kwargs):
+        assert messages is live_messages
+        assert system_message is None
+        assert kwargs["task_id"] == "task-1"
+        assert kwargs["force"] is True
+        assert kwargs["aggressive"] is True
+        assert kwargs["focus_topic"] == "Agent-requested: preparing for poll loop"
+        agent.session_id = "new-session"
+        return compressed_messages, "new system prompt"
+
+    agent = _agent()
+    agent._compress_context = _compress_context
+
+    result = json.loads(
+        context_usage_tool.request_compression_handler(
+            {"reason": "preparing for poll loop", "force": True},
+            agent=agent,
+            messages=live_messages,
+            task_id="task-1",
+        )
+    )
+
+    assert result["compressed"] is True
+    assert result["applied"] is True
+    assert result["tokens_saved"] == 750
+    assert result["messages_before"] == 3
+    assert result["messages_after"] == 1
+    assert result["old_session_id"] == "old-session"
+    assert result["new_session_id"] == "new-session"
+    assert live_messages == compressed_messages
+    assert agent._session_messages is live_messages
+    assert agent.conversation_history is live_messages
+    assert agent._cached_system_prompt == "new system prompt"
+    assert agent._request_compression_applied is True
+
+
+def test_request_compression_non_force_preserves_normal_compression_cooldown(monkeypatch):
+    monkeypatch.setattr(
+        context_usage_tool,
+        "_read_compression_config",
+        lambda _agent: {
+            "enabled": True,
+            "allow_agent_trigger": True,
+            "agent_suggest_threshold": None,
+        },
+    )
+    estimates = iter([1_000, 800])
+    monkeypatch.setattr(
+        context_usage_tool,
+        "_estimate_request_tokens",
+        lambda *_args, **_kwargs: next(estimates),
+    )
+
+    live_messages = [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "two"},
+    ]
+    compressed_messages = [{"role": "user", "content": "summary"}]
+
+    def _compress_context(messages, system_message, **kwargs):
+        assert messages is live_messages
+        assert system_message is None
+        assert kwargs["force"] is False
+        assert kwargs["aggressive"] is False
+        assert kwargs["focus_topic"] == "Agent-requested: routine cleanup"
+        return compressed_messages, "system prompt"
+
+    agent = _agent()
+    agent._compress_context = _compress_context
+
+    result = json.loads(
+        context_usage_tool.request_compression_handler(
+            {"reason": "routine cleanup"},
+            agent=agent,
+            messages=live_messages,
+            task_id="task-1",
+        )
+    )
+
+    assert result["compressed"] is True
+    assert result["messages_before"] == 2
+    assert result["messages_after"] == 1
+
+
+def test_request_compression_preserves_inflight_tool_call_group(monkeypatch):
+    monkeypatch.setattr(
+        context_usage_tool,
+        "_read_compression_config",
+        lambda _agent: {
+            "enabled": True,
+            "allow_agent_trigger": True,
+            "agent_suggest_threshold": None,
+        },
+    )
+    estimates = iter([2_000, 500])
+    monkeypatch.setattr(
+        context_usage_tool,
+        "_estimate_request_tokens",
+        lambda *_args, **_kwargs: next(estimates),
+    )
+
+    assistant_tool_call = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call-status",
+                "type": "function",
+                "function": {"name": "context_status", "arguments": "{}"},
+            },
+            {
+                "id": "call-compress",
+                "type": "function",
+                "function": {"name": "request_compression", "arguments": "{}"},
+            },
+        ],
+    }
+    prior_tool_result = {
+        "role": "tool",
+        "tool_call_id": "call-status",
+        "name": "context_status",
+        "content": "{}",
+    }
+    live_messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "please work"},
+        assistant_tool_call,
+        prior_tool_result,
+    ]
+    compressed_prefix = [
+        {"role": "system", "content": "system"},
+        {"role": "assistant", "content": "summary"},
+    ]
+
+    def _compress_context(messages, system_message, **kwargs):
+        assert messages == live_messages[:2]
+        assert all(not message.get("tool_calls") for message in messages)
+        assert system_message is None
+        assert kwargs["force"] is False
+        assert kwargs["aggressive"] is False
+        agent.session_id = "new-session"
+        return compressed_prefix, "new system prompt"
+
+    agent = _agent()
+    agent._compress_context = _compress_context
+
+    result = json.loads(
+        context_usage_tool.request_compression_handler(
+            {"reason": "before long wait"},
+            agent=agent,
+            messages=live_messages,
+            task_id="task-1",
+            tool_call_id="call-compress",
+        )
+    )
+
+    assert result["compressed"] is True
+    assert result["protected_inflight_tool_messages"] == 2
+    assert live_messages == compressed_prefix + [assistant_tool_call, prior_tool_result]
+    assert not any(
+        message.get("role") == "tool" and message.get("tool_call_id") == "call-compress"
+        for message in live_messages
+    )
+
+
+def test_request_compression_error_response_escapes_exception_text(monkeypatch):
+    monkeypatch.setattr(
+        context_usage_tool,
+        "_read_compression_config",
+        lambda _agent: {"enabled": True, "allow_agent_trigger": True},
+    )
+
+    def _compress_context(*_args, **_kwargs):
+        raise RuntimeError('bad "quote"\nand newline')
+
+    agent = _agent()
+    agent._compress_context = _compress_context
+
+    result = json.loads(
+        context_usage_tool.request_compression_handler(
+            {"reason": "test escaping"},
+            agent=agent,
+            messages=[{"role": "user", "content": "hello"}],
+        )
+    )
+
+    assert result["compressed"] is False
+    assert 'bad "quote"' in result["error"]

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -106,6 +106,13 @@ class TestClassification:
         for name in BRIDGE_TOOL_NAMES:
             assert not is_deferrable_tool_name(name)
 
+    def test_context_usage_tools_are_visible_when_opted_in(self):
+        import tools.context_usage_tool  # noqa: F401 - registers context_usage tools
+        from tools.tool_search import is_deferrable_tool_name
+
+        assert not is_deferrable_tool_name("context_status")
+        assert not is_deferrable_tool_name("request_compression")
+
     def test_unknown_tool_not_deferrable(self):
         """Defensive: a tool name we cannot resolve to a registry entry must
         not be claimed as deferrable. This protects against the OpenClaw

--- a/tools/context_usage_tool.py
+++ b/tools/context_usage_tool.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""
+Context Usage & Agent-Triggered Compression Tool Module
+
+Provides two tools the agent can call to monitor and manage context usage:
+
+1. ``context_status()`` — reports current context window usage (tokens used,
+   percent consumed, context length, compression threshold, etc.) without
+   side effects.
+
+2. ``request_compression(reason)`` — requests the runtime to trigger context
+   compression now, with a human-readable reason the agent provides.  Gated
+   by config (``compression.allow_agent_trigger``) and an optional minimum
+   usage threshold (``compression.agent_suggest_threshold``).
+
+Design:
+- Tools are lightweight read / request — no state of their own.
+- ``request_compression`` delegates to the agent's ``_compress_context()``
+  which already exists for ``/compress`` slash commands and auto-compression.
+- Safety: tool is opt-in via config, runtime may reject if already in
+  progress or cooldown is active.
+"""
+
+import json
+import logging
+from typing import Any, Dict
+
+
+logger = logging.getLogger(__name__)
+
+
+def _json_response(payload: Dict[str, Any]) -> str:
+    """Serialize a tool response without hand-building JSON strings."""
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _tool_call_id_from_entry(tool_call: Any) -> str:
+    """Extract a tool call ID from a persisted dict or SDK-ish object."""
+    if isinstance(tool_call, dict):
+        return str(tool_call.get("call_id") or tool_call.get("id") or "")
+    return str(getattr(tool_call, "call_id", "") or getattr(tool_call, "id", "") or "")
+
+
+def _latest_inflight_tool_tail_start(messages: list, current_tool_call_id: str) -> int | None:
+    """Return the index of the current assistant tool-call group, if any.
+
+    During tool execution, ``messages`` already contains the assistant message
+    with its tool_calls, while the current tool result has not been appended
+    yet.  Compressing that assistant message makes the compressor's tool-pair
+    sanitizer insert synthetic "missing result" stubs for the in-flight call.
+    To avoid corrupting the transcript, request_compression compacts only the
+    history *before* the current assistant tool-call group and re-attaches the
+    in-flight assistant/tool-result tail verbatim afterward.
+    """
+    if not current_tool_call_id:
+        return None
+    for idx in range(len(messages) - 1, -1, -1):
+        msg = messages[idx]
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        call_ids = {
+            _tool_call_id_from_entry(tc)
+            for tc in (msg.get("tool_calls") or [])
+        }
+        if current_tool_call_id in call_ids:
+            return idx
+    return None
+
+
+# --- Schema ---
+
+CONTEXT_STATUS_SCHEMA = {
+    "name": "context_status",
+    "description": (
+        "Read the current context window usage for this session. "
+        "Returns tokens used, percent of context consumed, the model's "
+        "maximum context length, the compression threshold, whether "
+        "compression is enabled, and whether the agent is allowed to "
+        "request compression.  No side effects."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    },
+}
+
+COMPRESS_SCHEMA = {
+    "name": "request_compression",
+    "description": (
+        "Request context compression to free up space in the current "
+        "conversation window.  Middle turns are summarized by a fast "
+        "auxiliary model while head and tail context are preserved.  "
+        "Gated by configuration — the runtime may reject the request "
+        "if compression is already in progress, too recent, or usage "
+        "is below the agent-suggest threshold.  Provide a reason so "
+        "the runtime can log why compression was requested.  "
+        "Pass force=true to bypass the agent_suggest_threshold gate "
+        "and use aggressive message-count-based tail protection for "
+        "maximum compression at any context percentage."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "reason": {
+                "type": "string",
+                "description": (
+                    "Why compression is needed.  Examples: "
+                    "\"approaching context limit in long PM workflow\", "
+                    "\"about to receive large tool result\""
+                ),
+            },
+            "force": {
+                "type": "boolean",
+                "description": (
+                    "When true, bypass the agent_suggest_threshold gate "
+                    "and use aggressive message-count-based tail "
+                    "protection (protect_last_n) instead of the default "
+                    "token-budget tail.  Use this when the agent knows "
+                    "it is entering an idle/poll loop and can safely "
+                    "compress most context away."
+                ),
+            },
+        },
+        "required": ["reason"],
+    },
+}
+
+
+# --- Handler used by tool_executor (receives agent reference via kwargs) ---
+
+def context_status_handler(args: Dict[str, Any], **kw: Any) -> str:
+    """
+    Handler for ``context_status`` tool.
+
+    Expects ``kw['agent']`` — the AIAgent instance whose context to inspect.
+    """
+    agent = kw.get("agent")
+    if agent is None:
+        return _json_response({
+            "error": "context_status requires agent reference",
+            "available": False,
+        })
+
+    prompt_tokens = getattr(agent, "session_prompt_tokens", 0)
+    total_tokens = getattr(agent, "session_total_tokens", 0)
+
+    # Read context length from the context compressor, falling back to the
+    # model metadata helper if the compressor is not yet initialised.
+    context_length = _resolve_context_length(agent)
+
+    # Current actual prompt tokens (from context compressor, NOT session cumul)
+    compressor = getattr(agent, "context_compressor", None)
+    last_prompt_tokens = 0
+    if compressor is not None:
+        lp = getattr(compressor, "last_prompt_tokens", None)
+        awaiting_after_compression = bool(
+            getattr(compressor, "awaiting_real_usage_after_compression", False)
+        )
+        if lp == -1 and awaiting_after_compression:
+            # Compression just ran; no provider-reported post-compression
+            # prompt count exists yet. Report the rough compressed estimate
+            # instead of falling back to the stale pre-compression real usage.
+            lct = getattr(compressor, "last_compression_rough_tokens", None)
+            if lct is not None and lct > 0:
+                last_prompt_tokens = int(lct)
+        elif lp is not None and lp >= 0:
+            last_prompt_tokens = lp
+        if not last_prompt_tokens:
+            lrp = getattr(compressor, "last_real_prompt_tokens", None)
+            if lrp is not None and lrp > 0:
+                last_prompt_tokens = lrp
+
+    # Read compression config from agent or reach into agent's config store.
+    compression_config = _read_compression_config(agent)
+    threshold = compression_config.get("threshold", 0.50)
+    enabled = compression_config.get("enabled", True)
+    agent_suggest = compression_config.get("agent_suggest_threshold", None)
+    allow_agent_trigger = compression_config.get("allow_agent_trigger", False)
+
+    percent_used = round(last_prompt_tokens / context_length * 100, 1) if context_length > 0 else 0.0
+    threshold_pct = round(threshold * 100, 1)
+    session_percent = round(prompt_tokens / context_length * 100, 1) if context_length > 0 else 0.0
+
+    return _json_response({
+        "tokens_used": last_prompt_tokens,
+        "session_prompt_tokens": prompt_tokens,
+        "total_tokens_this_session": total_tokens,
+        "context_length": context_length,
+        "percent_used": percent_used,
+        "session_percent": session_percent,
+        "compression_threshold_pct": threshold_pct,
+        "compression_enabled": enabled,
+        "allow_agent_trigger": allow_agent_trigger,
+        "agent_suggest_threshold": agent_suggest,
+        "tool": "context_status",
+    })
+
+
+def request_compression_handler(args: Dict[str, Any], **kw: Any) -> str:
+    """
+    Handler for ``request_compression`` tool.
+
+    Expects ``kw['agent']`` plus, for live tool-loop compression,
+    ``kw['messages']`` — the mutable message list currently being sent
+    through ``run_conversation``.  Falling back to agent-level snapshots is
+    best-effort only; the live list is what makes compression take effect in
+    the current turn.
+    """
+    agent = kw.get("agent")
+    if agent is None:
+        return _json_response({
+            "error": "request_compression requires agent reference",
+            "compressed": False,
+        })
+
+    reason = args.get("reason", "").strip()
+    if not reason:
+        return _json_response({"error": "reason is required", "compressed": False})
+
+    force = bool(args.get("force", False))
+
+    # Gate 1: check config allows agent-triggered compression
+    compression_config = _read_compression_config(agent)
+    if not compression_config.get("allow_agent_trigger", False):
+        return _json_response({
+            "error": (
+                "agent-triggered compression is disabled in config "
+                "(compression.allow_agent_trigger)"
+            ),
+            "compressed": False,
+        })
+
+    if not compression_config.get("enabled", True):
+        return _json_response({
+            "error": "compression is disabled in config",
+            "compressed": False,
+        })
+
+    # Gate 2: check agent_suggest_threshold (skip when force=True)
+    agent_suggest = compression_config.get("agent_suggest_threshold")
+    if agent_suggest is not None and not force:
+        context_length = _resolve_context_length(agent)
+        # Use current prompt tokens (from compressor), not session cumul
+        compressor = getattr(agent, "context_compressor", None)
+        current_tokens = 0
+        if compressor is not None:
+            lp = getattr(compressor, "last_prompt_tokens", None)
+            if lp is not None and lp >= 0:
+                current_tokens = lp
+            if not current_tokens:
+                lrp = getattr(compressor, "last_real_prompt_tokens", None)
+                if lrp is not None and lrp > 0:
+                    current_tokens = lrp
+        percent_used = current_tokens / context_length if context_length > 0 else 0.0
+        if percent_used < agent_suggest:
+            return _json_response({
+                "error": (
+                    "usage below agent_suggest_threshold "
+                    f"({agent_suggest * 100:.0f}%), currently at "
+                    f"{percent_used * 100:.1f}%"
+                ),
+                "compressed": False,
+                "percent_used": round(percent_used * 100, 1),
+            })
+
+    # Gate 3: check compression lock / cooldown via context_compressor
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is not None:
+        # The compressor may raise or return a non-None error string
+        # if compression is already in progress or locked.
+        try:
+            can_compress = getattr(compressor, "can_compress", None)
+            if callable(can_compress) and not can_compress():
+                return _json_response({
+                    "error": "compression is not available right now (lock or cooldown active)",
+                    "compressed": False,
+                })
+        except Exception as exc:
+            return _json_response({
+                "error": f"compression check failed: {exc}",
+                "compressed": False,
+            })
+
+    # Trigger compression — delegate to the agent's existing method.
+    try:
+        _compress_context = getattr(agent, "_compress_context", None)
+        if _compress_context is None:
+            return _json_response({
+                "error": "_compress_context not available on agent",
+                "compressed": False,
+            })
+
+        live_messages = kw.get("messages")
+        if live_messages is None:
+            live_messages = getattr(agent, "_session_messages", None)
+        if live_messages is None:
+            live_messages = getattr(agent, "conversation_history", None)
+        if not isinstance(live_messages, list):
+            return _json_response({
+                "error": (
+                    "live conversation messages are not available; "
+                    "request_compression must be called from the tool loop"
+                ),
+                "compressed": False,
+            })
+
+        pre_count = len(live_messages)
+        if pre_count == 0:
+            return _json_response({
+                "error": "no live messages available to compress",
+                "compressed": False,
+            })
+
+        current_tool_call_id = str(kw.get("tool_call_id") or "")
+        tail_start = _latest_inflight_tool_tail_start(live_messages, current_tool_call_id)
+        protected_inflight_tail = []
+        compression_messages = live_messages
+        if tail_start is not None:
+            protected_inflight_tail = list(live_messages[tail_start:])
+            compression_messages = list(live_messages[:tail_start])
+            if not compression_messages:
+                return _json_response({
+                    "error": "no pre-tool history available to compress",
+                    "compressed": False,
+                })
+
+        old_session_id = getattr(agent, "session_id", "") or ""
+        current_system_prompt = getattr(agent, "_cached_system_prompt", "") or ""
+        before_tokens = _estimate_request_tokens(agent, live_messages, current_system_prompt)
+
+        # Pass None as system_message so _compress_context rebuilds from the
+        # normal prompt source. Passing the cached full prompt here duplicates
+        # identity/instruction blocks on rebuild (same reason /compress passes
+        # None in the CLI/TUI manual paths).
+        result = _compress_context(
+            compression_messages,
+            None,
+            approx_tokens=before_tokens or None,
+            task_id=kw.get("task_id") or getattr(agent, "_current_task_id", None) or "default",
+            force=force,
+            aggressive=force,  # use aggressive tail when caller passes force=True
+            focus_topic=f"Agent-requested: {reason}",
+        )
+
+        post_messages = []
+        new_system_prompt = current_system_prompt
+        if result and isinstance(result, (list, tuple)) and len(result) >= 1:
+            if isinstance(result[0], list):
+                post_messages = result[0]
+            if len(result) >= 2 and isinstance(result[1], str):
+                new_system_prompt = result[1]
+
+        if not post_messages:
+            return _json_response({
+                "compressed": False,
+                "reason": reason,
+                "tokens_saved": 0,
+                "messages_before": pre_count,
+                "messages_after": 0,
+                "error": "compression returned no messages",
+            })
+
+        # Make the compression effective for the *current* tool loop by
+        # replacing the mutable live list in-place. The outer run loop holds
+        # this exact list and will append the request_compression tool result
+        # after this handler returns. If the current assistant tool-call group
+        # is already in the transcript, re-attach it after the compressed
+        # prefix so the executor can append the real tool result without a
+        # synthetic sanitizer stub for the in-flight call.
+        if protected_inflight_tail:
+            live_messages[:] = list(post_messages) + protected_inflight_tail
+        elif post_messages is not live_messages:
+            live_messages[:] = post_messages
+        try:
+            agent._session_messages = live_messages
+        except Exception:
+            pass
+        try:
+            agent.conversation_history = live_messages
+        except Exception:
+            pass
+        if new_system_prompt:
+            agent._cached_system_prompt = new_system_prompt
+
+        after_tokens = _estimate_request_tokens(agent, live_messages, new_system_prompt)
+        dropped = max(0, pre_count - len(live_messages))
+        if before_tokens and after_tokens:
+            saved_tokens = max(0, before_tokens - after_tokens)
+        else:
+            # Fallback only when rough estimator is unavailable.
+            saved_tokens = dropped * 150
+
+        new_session_id = getattr(agent, "session_id", "") or ""
+        applied = bool(dropped or saved_tokens > 0 or new_session_id != old_session_id)
+        if applied:
+            # The run loop uses this to clear its caller-history baseline and
+            # refresh the active system prompt after tool execution.
+            agent._request_compression_applied = True
+
+        return _json_response({
+            "compressed": applied,
+            "applied": applied,
+            "reason": reason,
+            "tokens_saved": saved_tokens,
+            "tokens_before_estimate": before_tokens,
+            "tokens_after_estimate": after_tokens,
+            "messages_before": pre_count,
+            "messages_after": len(live_messages),
+            "messages_removed": dropped,
+            "protected_inflight_tool_messages": len(protected_inflight_tail),
+            "old_session_id": old_session_id,
+            "new_session_id": new_session_id,
+        })
+    except Exception as exc:
+        return _json_response({
+            "error": f"compression failed: {exc}",
+            "compressed": False,
+        })
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_context_length(agent: Any) -> int:
+    """Resolve the effective context length for the current model."""
+    # Try context_compressor first
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is not None:
+        cl = getattr(compressor, "context_length", None)
+        if cl and isinstance(cl, (int, float)) and cl > 0:
+            return int(cl)
+
+    # Fallback: model_metadata helper
+    try:
+        from agent.model_metadata import get_model_context_length
+        model = getattr(agent, "model", None)
+        provider = getattr(agent, "provider", None)
+        if model:
+            return get_model_context_length(model, provider=provider)
+    except Exception:
+        pass
+
+    return 200_000  # safest fallback — worst case is 200K
+
+
+def _estimate_request_tokens(agent: Any, messages: list, system_prompt: str = "") -> int:
+    """Best-effort rough request token estimate for compression diagnostics."""
+    try:
+        from agent.model_metadata import estimate_request_tokens_rough
+
+        return int(estimate_request_tokens_rough(
+            messages,
+            system_prompt=system_prompt or "",
+            tools=getattr(agent, "tools", None) or None,
+        ))
+    except Exception:
+        return 0
+
+
+def _read_compression_config(agent: Any) -> Dict[str, Any]:
+    """Read the compression section of the active profile config.
+
+    AIAgent does not expose ``self.config``, so we load it directly
+    from ``load_config()`` via the CLI config module.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        return dict(cfg.get("compression", {}))
+    except Exception:
+        return {}
+
+
+# ============================================================================
+# Registry — self-registering module (discovered by tools.registry)
+# ============================================================================
+
+from tools.registry import registry  # noqa: E402
+
+# Availability checks are config-gated, not env-var-gated.
+def _check_context_status_reqs() -> bool:
+    """context_status is safe and read-only, so expose it whenever the toolset is enabled."""
+    return True
+
+
+def _check_request_compression_reqs() -> bool:
+    """Expose request_compression only when the user opted into agent-triggered compaction."""
+    cfg = _read_compression_config(None)
+    return bool(cfg.get("enabled", True) and cfg.get("allow_agent_trigger", False))
+
+# context_status: pure read, no state needed (agent injected at call time)
+registry.register(
+    name="context_status",
+    toolset="context_usage",
+    schema=CONTEXT_STATUS_SCHEMA,
+    handler=context_status_handler,
+    check_fn=_check_context_status_reqs,
+    requires_env=[],
+    is_async=False,
+    description="Check current context window usage for this session",
+    emoji="📊",
+)
+
+# request_compression: agent can request compression voluntarily
+registry.register(
+    name="request_compression",
+    toolset="context_usage",
+    schema=COMPRESS_SCHEMA,
+    handler=request_compression_handler,
+    check_fn=_check_request_compression_reqs,
+    requires_env=[],
+    is_async=False,
+    description="Request context compression to free up the conversation window",
+    emoji="🗜️",
+)

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -46,6 +46,12 @@ TOOL_CALL_NAME = "tool_call"
 
 BRIDGE_TOOL_NAMES = frozenset({TOOL_SEARCH_NAME, TOOL_DESCRIBE_NAME, TOOL_CALL_NAME})
 
+# Opt-in runtime-control toolsets that must remain directly model-callable once
+# enabled. ``request_compression`` needs the live agent tool-loop context
+# (messages, current tool_call_id), which the generic ``tool_call`` bridge does
+# not carry through ``model_tools.handle_function_call``.
+ALWAYS_VISIBLE_TOOLSETS = frozenset({"context_usage"})
+
 # When estimating tokens from char count without a real tokenizer, this is
 # the cheap rule of thumb that's stable across providers. Roughly 4 chars
 # per token for English+JSON. Underestimating leads to false negatives
@@ -177,6 +183,8 @@ def is_deferrable_tool_name(name: str) -> bool:
         from tools.registry import registry
         entry = registry.get_entry(name)
         if entry is None:
+            return False
+        if entry.toolset in ALWAYS_VISIBLE_TOOLSETS:
             return False
         if entry.toolset.startswith("mcp-"):
             return True

--- a/toolsets.py
+++ b/toolsets.py
@@ -229,6 +229,12 @@ TOOLSETS = {
         "tools": ["project_list", "project_create", "project_switch"],
         "includes": []
     },
+
+    "context_usage": {
+        "description": "Monitor context window usage and request compression to manage session length",
+        "tools": ["context_status", "request_compression"],
+        "includes": []
+    },
     
     "clarify": {
         "description": "Ask the user clarifying questions (multiple-choice or open-ended)",


### PR DESCRIPTION
## Summary
- Add a `context_usage` tool module with read-only `context_status` and opt-in `request_compression`.
- Gate agent-triggered compression behind `compression.allow_agent_trigger` and optional `compression.agent_suggest_threshold`.
- Apply requested compression to the live tool-loop message list and rebase conversation persistence after compaction.
- Preserve the in-flight assistant tool-call group while compressing, so `request_compression` cannot insert synthetic missing-result stubs for the current tool call.
- Keep `context_usage` out of default core/platform bundles; it is selectable through `hermes tools`, default-off for new installs, and kept directly visible when opted in so runtime-only context is available.

## Test Plan
- `scripts/run_tests.sh -j 4 tests/tools/test_tool_search.py tests/tools/test_context_usage_tool.py tests/test_toolsets.py tests/test_toolset_distributions.py tests/run_agent/test_compression_persistence.py tests/agent/test_context_compressor.py tests/test_cli_manual_compress.py tests/hermes_cli/test_tool_token_estimation.py tests/cron/test_scheduler.py` (383 passed, 6 skipped)
- `git diff --check`
- `python3 -m py_compile tools/context_usage_tool.py tools/tool_search.py agent/tool_executor.py agent/agent_runtime_helpers.py agent/conversation_compression.py`
- Static staged-diff scan for hardcoded secrets, shell injection, eval/exec, pickle loads, and SQL string formatting

## Notes
- This PR intentionally excludes the separate OpenRouter/provider-routing `allow_fallbacks` / `by_model` work so the request-compression change stays reviewable.
