### PR TITLE
fix(gateway): write ended_at to SQLite when expiry watcher finalizes a session (#28746)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1386,7 +1386,7 @@ class APIServerAdapter(BasePlatformAdapter):
     def _session_response(session: Dict[str, Any]) -> Dict[str, Any]:
         """Return a stable, client-safe session representation."""
         safe_keys = (
-            "id", "source", "user_id", "model", "title", "started_at", "ended_at",
+            "id", "source", "user_id", "session_key", "model", "title", "started_at", "ended_at",
             "end_reason", "message_count", "tool_call_count", "input_tokens",
             "output_tokens", "cache_read_tokens", "cache_write_tokens",
             "reasoning_tokens", "estimated_cost_usd", "actual_cost_usd",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6471,6 +6471,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         with self.session_store._lock:
                             entry.expiry_finalized = True
                             self.session_store._save()
+                        # Write ended_at to SQLite so the sessions API
+                        # stops returning this session as live.  Without
+                        # this, GET /api/sessions shows ended_at=null even
+                        # after the watcher has finalized the session in
+                        # memory, causing external API clients to keep
+                        # addressing a stale session the gateway has already
+                        # discarded.  Matches the reset_reason used by
+                        # get_or_create_session on the next-message path.
+                        # Refs: #28746.
+                        _db = getattr(self.session_store, "_db", None)
+                        if _db is not None:
+                            try:
+                                _db.end_session(entry.session_id, "idle")
+                            except Exception as _db_exc:
+                                logger.debug(
+                                    "Session expiry: failed to write ended_at for %s: %s",
+                                    entry.session_id, _db_exc,
+                                )
                         logger.debug(
                             "Session expiry finalized for %s",
                             entry.session_id,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1103,6 +1103,7 @@ class SessionStore:
                 "session_id": session_id,
                 "source": source.platform.value,
                 "user_id": source.user_id,
+                "session_key": session_key,
             }
 
         # SQLite operations outside the lock
@@ -1329,6 +1330,7 @@ class SessionStore:
                 "session_id": session_id,
                 "source": old_entry.platform.value if old_entry.platform else "unknown",
                 "user_id": old_entry.origin.user_id if old_entry.origin else None,
+                "session_key": session_key,
             }
 
         if self._db and db_end_session_id:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3051,6 +3051,7 @@ class GatewaySlashCommandsMixin:
                     session_id=session_id,
                     source=source.platform.value if source.platform else "unknown",
                     user_id=source.user_id,
+                    session_key=session_entry.session_key,
                 )
             except Exception:
                 pass  # Session might already exist, ignore errors
@@ -3348,6 +3349,7 @@ class GatewaySlashCommandsMixin:
                 model=(self.config.get("model", {}) or {}).get("default") if isinstance(self.config, dict) else None,
                 model_config={"_branched_from": parent_session_id},
                 parent_session_id=parent_session_id,
+                session_key=current_entry.session_key,
             )
         except Exception as e:
             logger.error("Failed to create branch session: %s", e)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -524,6 +524,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     id TEXT PRIMARY KEY,
     source TEXT NOT NULL,
     user_id TEXT,
+    session_key TEXT,
     model TEXT,
     model_config TEXT,
     system_prompt TEXT,
@@ -1355,17 +1356,19 @@ class SessionDB:
         user_id: str = None,
         parent_session_id: str = None,
         cwd: str = None,
+        session_key: str = None,
     ) -> None:
         """Shared INSERT OR IGNORE for session rows."""
         def _do(conn):
             conn.execute(
-                """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
+                """INSERT OR IGNORE INTO sessions (id, source, user_id, session_key, model, model_config,
                    system_prompt, parent_session_id, cwd, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
                     user_id,
+                    session_key,
                     model,
                     json.dumps(model_config) if model_config else None,
                     system_prompt,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1688,6 +1688,7 @@ AUTHOR_MAP = {
     "qs2816661685@gmail.com": "qingshan89",  # PR #46895 co-author (desktop remote artifact download)
     "yspdev@gmail.com": "AJ",  # PR #44510 co-author (desktop named-profile boot loop)
     "steveonjava@gmail.com": "steveonjava",  # PR #29669 (redact secrets in kanban tool payloads)
+    "dev@tevs.eu": "cgart",  # PR #46165 (session_key in GET /api/sessions)
 }
 
 

--- a/tests/gateway/test_api_server_normalize.py
+++ b/tests/gateway/test_api_server_normalize.py
@@ -2,6 +2,7 @@
 
 from gateway.platforms import api_server
 from gateway.platforms.api_server import _normalize_chat_content
+from gateway.platforms.api_server import APIServerAdapter
 
 
 class TestNormalizeChatContent:
@@ -102,3 +103,34 @@ class TestNormalizeChatContent:
 
         assert result.count("x") == 1000
         assert sum_calls == 0
+
+
+class TestSessionResponse:
+    """_session_response exposes a stable, client-safe set of session fields."""
+
+    def test_session_key_returned(self):
+        """session_key is metadata the client API should surface."""
+        session = {"id": "sess_1", "user_id": "u1", "session_key": "key-abc"}
+        payload = APIServerAdapter._session_response(session)
+        assert payload["session_key"] == "key-abc"
+
+    def test_session_key_omitted_when_absent(self):
+        """Keys missing from the source row are not fabricated."""
+        session = {"id": "sess_1", "user_id": "u1"}
+        payload = APIServerAdapter._session_response(session)
+        assert "session_key" not in payload
+
+    def test_unsafe_keys_stripped(self):
+        """Sensitive snapshots are not echoed back, only existence flags."""
+        session = {
+            "id": "sess_1",
+            "session_key": "key-abc",
+            "system_prompt": "secret prompt",
+            "model_config": {"k": "v"},
+        }
+        payload = APIServerAdapter._session_response(session)
+        assert "system_prompt" not in payload
+        assert "model_config" not in payload
+        assert payload["has_system_prompt"] is True
+        assert payload["has_model_config"] is True
+        assert payload["session_key"] == "key-abc"

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -253,3 +253,77 @@ async def test_idle_expiry_fires_finalize_hook(mock_invoke_hook):
         f"on_session_finalize was not fired during idle expiry; "
         f"got session_ids={session_ids} (regression of #14981)"
     )
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
+async def test_idle_expiry_writes_ended_at_to_db(mock_invoke_hook):
+    """Regression test for #28746.
+
+    When ``_session_expiry_watcher`` finalizes an idle-expired session it must
+    call ``session_store._db.end_session()`` so that ``ended_at`` is written to
+    SQLite and ``GET /api/sessions`` stops returning the session as live.
+
+    Before the fix, the watcher set ``expiry_finalized = True`` in memory but
+    never updated the DB row, causing external API clients to keep injecting
+    turns into a stale session that the gateway had already discarded.
+    """
+    from datetime import datetime, timedelta
+
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._last_session_store_prune_ts = 0.0
+
+    session_key = "agent:main:telegram:group:-1002283267898:1"
+    expired_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-stale",
+        created_at=datetime.now() - timedelta(hours=25),
+        updated_at=datetime.now() - timedelta(hours=25),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    expired_entry.expiry_finalized = False
+
+    mock_db = MagicMock()
+    mock_db.end_session = MagicMock()
+
+    runner.session_store = MagicMock()
+    runner.session_store._ensure_loaded = MagicMock()
+    runner.session_store._entries = {session_key: expired_entry}
+    runner.session_store._is_session_expired = MagicMock(return_value=True)
+    runner.session_store._lock = MagicMock()
+    runner.session_store._lock.__enter__ = MagicMock(return_value=None)
+    runner.session_store._lock.__exit__ = MagicMock(return_value=None)
+    runner.session_store._save = MagicMock()
+    runner.session_store._db = mock_db
+
+    runner._evict_cached_agent = MagicMock()
+    runner._cleanup_agent_resources = MagicMock()
+    runner._sweep_idle_cached_agents = MagicMock(return_value=0)
+
+    _orig_sleep = __import__("asyncio").sleep
+
+    async def _fast_sleep(_):
+        await _orig_sleep(0)
+
+    def _hook_and_stop(*a, **kw):
+        runner._running = False
+        return None
+
+    mock_invoke_hook.side_effect = _hook_and_stop
+
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
+        await runner._session_expiry_watcher(interval=0)
+
+    # The watcher must have called end_session with the expired session_id
+    # and reason "idle" so that ended_at is persisted to SQLite.
+    mock_db.end_session.assert_called_once_with("sess-stale", "idle"), (
+        f"end_session was not called on the DB after idle expiry; "
+        f"calls={mock_db.end_session.call_args_list} (regression of #28746)"
+    )

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -530,9 +530,9 @@ class TestWebServerEndpoints:
         assert row["cwd"] is None
 
     def test_get_sessions_returns_session_key(self):
-        """/api/sessions exposes session_key so external consumers (e.g.
-        Otto-Voice) can map a live session to a specific Telegram chat/group
-        without guessing from user_id alone."""
+        """/api/sessions exposes session_key so external consumers can map
+        a live session to a specific Telegram chat/group without guessing
+        from user_id alone."""
         from hermes_state import SessionDB
 
         db = SessionDB()

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -529,6 +529,33 @@ class TestWebServerEndpoints:
         row = next(s for s in rows if s["id"] == "session-no-cwd")
         assert row["cwd"] is None
 
+    def test_get_sessions_returns_session_key(self):
+        """/api/sessions exposes session_key so external consumers (e.g.
+        Otto-Voice) can map a live session to a specific Telegram chat/group
+        without guessing from user_id alone."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="keyed-session",
+                source="telegram",
+                session_key="agent:main:telegram:group:-1001234567890:1",
+            )
+            db.create_session(session_id="unkeyed-session", source="cli")
+        finally:
+            db.close()
+
+        rows = self.client.get("/api/sessions?limit=20&offset=0").json()["sessions"]
+
+        keyed = next(s for s in rows if s["id"] == "keyed-session")
+        assert keyed["session_key"] == "agent:main:telegram:group:-1001234567890:1"
+
+        # Always present, nullable for rows created without a key.
+        unkeyed = next(s for s in rows if s["id"] == "unkeyed-session")
+        assert "session_key" in unkeyed
+        assert unkeyed["session_key"] is None
+
     def test_get_sessions_forwards_min_messages(self, monkeypatch):
         """The ?min_messages= filter must reach SessionDB.
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -96,6 +96,20 @@ class TestSessionLifecycle:
     def test_get_nonexistent_session(self, db):
         assert db.get_session("nonexistent") is None
 
+    def test_create_session_persists_session_key(self, db):
+        db.create_session(
+            session_id="s1",
+            source="telegram",
+            session_key="agent:main:telegram:group:-1001234567890:1",
+        )
+        session = db.get_session("s1")
+        assert session["session_key"] == "agent:main:telegram:group:-1001234567890:1"
+
+    def test_create_session_session_key_defaults_none(self, db):
+        # Older callers that don't pass session_key get NULL (migration safety).
+        db.create_session(session_id="s1", source="cli")
+        assert db.get_session("s1")["session_key"] is None
+
     def test_end_session(self, db):
         db.create_session(session_id="s1", source="cli")
         db.end_session("s1", end_reason="user_exit")
@@ -2330,7 +2344,13 @@ class TestSchemaInit:
         db = SessionDB(db_path=old_db)
         cursor = db._conn.execute("PRAGMA table_info(sessions)")
         columns = {row[1] for row in cursor.fetchall()}
-        assert {"chat_id", "chat_type", "thread_id", "session_key"}.isdisjoint(columns)
+        # Topic mode stores its per-chat bindings in a separate
+        # telegram_dm_topic_bindings table — it must never eagerly add these
+        # columns to sessions on a plain upgrade. (session_key is now a
+        # standard, always-present sessions column and IS auto-migrated, so it
+        # is intentionally excluded from this guard.)
+        assert {"chat_id", "chat_type", "thread_id"}.isdisjoint(columns)
+        assert "session_key" in columns
         db.close()
 
     def test_apply_telegram_topic_migration_creates_topic_tables_explicitly(self, tmp_path):
@@ -2913,6 +2933,25 @@ class TestTitleSqlWildcards:
 
 class TestListSessionsRich:
     """Tests for enhanced session listing with preview and last_active."""
+
+    def test_session_key_present_when_set(self, db):
+        db.create_session(
+            "s1", "telegram",
+            session_key="agent:main:telegram:group:-1001234567890:1",
+        )
+        sessions = db.list_sessions_rich()
+        assert len(sessions) == 1
+        assert sessions[0]["session_key"] == (
+            "agent:main:telegram:group:-1001234567890:1"
+        )
+
+    def test_session_key_none_for_rows_without_key(self, db):
+        # Rows created without a session_key (e.g. pre-migration) surface None
+        # rather than raising — the column is always present in the dict.
+        db.create_session("s1", "cli")
+        sessions = db.list_sessions_rich()
+        assert "session_key" in sessions[0]
+        assert sessions[0]["session_key"] is None
 
     def test_preview_from_first_user_message(self, db):
         db.create_session("s1", "cli")

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -330,6 +330,20 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 
 `/v1/capabilities` advertises the full surface via `session_*` feature flags and `endpoints.session_*` entries so external UIs can detect support and fall back safely. Inline images are supported in `chat` and `chat/stream` payloads (multimodal-aware path).
 
+Each session object returned by `GET /api/sessions` includes a `session_key` field — the gateway's stable source binding for that session (for example `agent:main:telegram:group:<chat_id>:<thread_id>` or `agent:main:webui:dm:<user_id>`). It is `null` for sessions created without one (plain CLI sessions, or rows predating the field). Use it to map a live session back to the exact channel it came from instead of inferring from `user_id` alone — for Telegram in particular, `user_id` is the sender's personal ID and is identical across DMs and group messages. This is the same value callers can set on inbound requests via the [`X-Hermes-Session-Key`](#long-term-memory-scoping-x-hermes-session-key) header.
+
+```bash
+# list sessions, including each session's source binding
+curl "http://localhost:8642/api/sessions?limit=20" \
+  -H "Authorization: Bearer $API_SERVER_KEY"
+# → {"sessions": [
+#     {"id": "abc123", "source": "telegram", "user_id": "456",
+#      "session_key": "agent:main:telegram:group:<chat_id>:1", ...},
+#     {"id": "def456", "source": "cli", "user_id": null,
+#      "session_key": null, ...}
+#   ]}
+```
+
 ```bash
 # fork a session and run one turn
 curl -X POST http://localhost:8642/api/sessions/$ID/fork \


### PR DESCRIPTION
## Summary

The `_session_expiry_watcher` sets `expiry_finalized = True` and evicts the cached agent when an idle session exceeds its reset policy — but it never called `db.end_session()`. As a result, `ended_at` stayed `NULL` in SQLite indefinitely after the watcher fired.

`GET /api/sessions` uses `ended_at IS NULL` to identify live sessions, so external API clients kept treating a finalized session as live long after the gateway had internally discarded it. This surfaced when building on top of the session API extended in #46165: polling `/api/sessions` by `session_key` suffix correctly resolves the most-recently-active session, but when the gateway has silently expired it via the watcher, the stale session still appears live — `ended_at: null` — causing clients to keep addressing it instead of letting Hermes create a fresh one on the next turn.

## Root cause

`_session_expiry_watcher` (gateway/run.py) was already:
- invoking `on_session_finalize` plugin hooks ✓ (fixed in #14981)
- evicting the cached `AIAgent` ✓
- setting `entry.expiry_finalized = True` and saving `sessions.json` ✓

But it was **not** calling `session_store._db.end_session()` — the one step that writes `ended_at` to SQLite and makes the expiry visible to the API.

The next real inbound message correctly triggers `get_or_create_session()` → `_should_reset()` → close the old row and open a new one. But any API client polling between the watcher firing and the next real message sees the wrong state.

## Fix

After setting `expiry_finalized = True`, call `session_store._db.end_session(session_id, "idle")`. This matches the `end_reason` used by the `get_or_create_session()` auto-reset path (same trigger, same semantics). The call is guarded by `getattr` so JSONL-only deployments (no `_db`) are unaffected.

## Test

Added `test_idle_expiry_writes_ended_at_to_db` in `tests/gateway/test_session_boundary_hooks.py` alongside the existing `#14981` regression test. It verifies `_db.end_session(session_id, "idle")` is called exactly once after the watcher sweeps an expired session.

## Checklist
- [x] Fix targets the correct code path (`_session_expiry_watcher` in `gateway/run.py`)
- [x] Regression test added — asserts the DB invariant, not a snapshot
- [x] `getattr` guard makes the fix a no-op when `_db` is unavailable (JSONL mode)
- [x] `end_reason` matches the existing auto-reset path (`"idle"`)
- [x] Both new and existing boundary-hook tests pass

Closes #28746
