### PR TITLE
fix(cron): reject a zero interval (every 0m) instead of creating a runaway job

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -327,6 +327,15 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     if schedule_lower.startswith("every "):
         duration_str = schedule[6:].strip()
         minutes = parse_duration(duration_str)
+        # Reject a zero interval: compute_next_run would set next_run = now on
+        # every tick, so the job becomes due forever and re-fires each ticker
+        # loop — a runaway (for agent-backed jobs, a paid agent turn every
+        # tick). A simple typo like "every 0m" should fail loudly at create.
+        if minutes <= 0:
+            raise ValueError(
+                f"Interval must be at least 1 minute (got {duration_str!r}). "
+                f"Use e.g. 'every 30m', 'every 2h', 'every 1d'."
+            )
         return {
             "kind": "interval",
             "minutes": minutes,

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -90,6 +90,12 @@ class TestParseSchedule:
         assert result["kind"] == "interval"
         assert result["minutes"] == 30
 
+    def test_zero_interval_rejected(self):
+        # A zero interval re-fires every ticker loop (runaway). Reject at parse.
+        for expr in ("every 0m", "every 0h", "every 0d"):
+            with pytest.raises(ValueError):
+                parse_schedule(expr)
+
     def test_cron_expression(self):
         pytest.importorskip("croniter")
         result = parse_schedule("0 9 * * *")


### PR DESCRIPTION
## Summary

`parse_schedule("every 0m")` (and `every 0h` / `every 0d`) returned a recurring interval of **0 minutes**. `compute_next_run` for an interval sets `next_run = now + minutes`, i.e. `now`, so the job is due on every ticker loop and re-fires indefinitely — a runaway. For an agent-backed job that's a paid agent turn on every tick, forever, from a simple typo. Nothing rejected it at create time.

Reproduced on current main: `parse_schedule("every 0m")` → `{"kind": "interval", "minutes": 0, ...}`, and `compute_next_run({"kind": "interval", "minutes": 0})` → `now`.

## Fix

Reject a non-positive interval at parse time with a clear error (`Interval must be at least 1 minute ...`). Valid intervals (`every 1m`, `every 30m`, `every 2h`) and all other schedule kinds (once / cron / ISO) are unchanged.

## Tests

`tests/cron/test_jobs.py::TestParseSchedule::test_zero_interval_rejected`: `every 0m` / `every 0h` / `every 0d` raise `ValueError`; existing schedule tests stay green.
