### PR TITLE
feat(tui): make diff colors and banner fields skin-configurable

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -654,7 +654,10 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
     if len(model_short) > 28:
         model_short = model_short[:25] + "..."
     ctx_str = f" [dim {dim}]·[/] [dim {dim}]{_format_context_length(context_length)} context[/]" if context_length else ""
-    left_lines.append(f"[{accent}]{model_short}[/]{ctx_str} [dim {dim}]·[/] [dim {dim}]Nous Research[/]")
+    # Vendor credit is sourced from the skin's branding (overridable per skin).
+    vendor = _bskin.get_branding("vendor_label", "Nous Research") if _bskin else "Nous Research"
+    vendor_suffix = f" [dim {dim}]·[/] [dim {dim}]{vendor}[/]" if vendor else ""
+    left_lines.append(f"[{accent}]{model_short}[/]{ctx_str}{vendor_suffix}")
 
     if os.getenv("HERMES_YOLO_MODE"):
         left_lines.append(f"[bold red]⚠ YOLO mode[/] [dim {dim}]— all approval prompts bypassed[/]")

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -193,6 +193,10 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
             "response_label": " ⚕ Hermes ",
             "prompt_symbol": "❯",
             "help_header": "(^_^)? Available Commands",
+            # Banner brand fields, overridable per skin like the entries above.
+            "icon": "⚕",
+            "vendor_label": "Nous Research",
+            "tagline": "Messenger of the Digital Gods",
         },
         "tool_prefix": "┊",
     },

--- a/ui-tui/src/__tests__/branding.test.tsx
+++ b/ui-tui/src/__tests__/branding.test.tsx
@@ -1,0 +1,70 @@
+import { PassThrough } from 'stream'
+
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { Banner } from '../components/branding.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME, fromSkin } from '../theme.js'
+
+// Render a node against a mocked 80-col stdout and return the plain text.
+const renderPlain = (node: React.ReactNode): string => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: 80, isTTY: false, rows: 24 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(node, {
+    patchConsole: false,
+    stderr: stderr as NodeJS.WriteStream,
+    stdin: stdin as NodeJS.ReadStream,
+    stdout: stdout as NodeJS.WriteStream
+  })
+
+  instance.unmount()
+  instance.cleanup()
+
+  return stripAnsi(output)
+}
+
+describe('Banner branding', () => {
+  it('renders the bundled vendor + tagline by default', () => {
+    const out = renderPlain(<Banner maxWidth={80} t={DEFAULT_THEME} />)
+
+    expect(out).toContain('Nous Research')
+    expect(out).toContain('Messenger of the Digital Gods')
+  })
+
+  it('omits the vendor and tagline when a skin sets both empty', () => {
+    const t = fromSkin({}, { tagline: '', vendor_label: '' })
+    const out = renderPlain(<Banner maxWidth={80} t={t} />)
+
+    expect(out).not.toContain('Nous Research')
+    expect(out).not.toContain('Messenger')
+  })
+
+  it('keeps the tagline when only the vendor is empty', () => {
+    const t = fromSkin({}, { vendor_label: '' })
+    const out = renderPlain(<Banner maxWidth={80} t={t} />)
+
+    expect(out).not.toContain('Nous Research')
+    expect(out).toContain('Messenger of the Digital Gods')
+  })
+
+  it('renders a custom vendor credit', () => {
+    const t = fromSkin({}, { tagline: 'Local Agent', vendor_label: 'Acme Labs' })
+    const out = renderPlain(<Banner maxWidth={80} t={t} />)
+
+    expect(out).toContain('Acme Labs')
+    expect(out).toContain('Local Agent')
+    expect(out).not.toContain('Nous Research')
+  })
+})

--- a/ui-tui/src/__tests__/theme.test.ts
+++ b/ui-tui/src/__tests__/theme.test.ts
@@ -308,4 +308,68 @@ describe('fromSkin', () => {
     expect(color.ok).toBe('#008000')
     expect(color.statusGood).toBe('#008000')
   })
+
+  it('overrides diff colors from skin keys', async () => {
+    const { fromSkin } = await importThemeWithCleanEnv()
+
+    const { color } = fromSkin(
+      {
+        diff_added: '#101010',
+        diff_removed: '#202020',
+        diff_added_text: '#303030',
+        diff_removed_text: '#404040'
+      },
+      {}
+    )
+
+    expect(color.diffAdded).toBe('#101010')
+    expect(color.diffRemoved).toBe('#202020')
+    expect(color.diffAddedWord).toBe('#303030')
+    expect(color.diffRemovedWord).toBe('#404040')
+  })
+
+  it('falls back to default diff colors when unset', async () => {
+    const { DEFAULT_THEME, fromSkin } = await importThemeWithCleanEnv()
+    const { color } = fromSkin({ banner_title: '#FF0000' }, {})
+
+    expect(color.diffAdded).toBe(DEFAULT_THEME.color.diffAdded)
+    expect(color.diffRemovedWord).toBe(DEFAULT_THEME.color.diffRemovedWord)
+  })
+
+  it('leaves the selected-completion text unset by default', async () => {
+    const { fromSkin } = await importThemeWithCleanEnv()
+
+    expect(fromSkin({}, {}).color.completionCurrentText).toBe('')
+  })
+
+  it('maps completion_current_text from skins', async () => {
+    const { fromSkin } = await importThemeWithCleanEnv()
+
+    expect(fromSkin({ completion_current_text: '#abcdef' }, {}).color.completionCurrentText).toBe('#abcdef')
+  })
+
+  it('exposes the bundled tagline/vendor brand defaults', async () => {
+    const { fromSkin } = await importThemeWithCleanEnv()
+    const { brand } = fromSkin({}, {})
+
+    expect(brand.vendor).toBe('Nous Research')
+    expect(brand.tagline).toBe('Messenger of the Digital Gods')
+  })
+
+  it('overrides branding icon/tagline/vendor from skins', async () => {
+    const { fromSkin } = await importThemeWithCleanEnv()
+    const { brand } = fromSkin({}, { icon: 'Ξ', tagline: 'Test Tagline', vendor_label: 'Acme' })
+
+    expect(brand.icon).toBe('Ξ')
+    expect(brand.tagline).toBe('Test Tagline')
+    expect(brand.vendor).toBe('Acme')
+  })
+
+  it('honors empty vendor/tagline overrides', async () => {
+    const { fromSkin } = await importThemeWithCleanEnv()
+    const { brand } = fromSkin({}, { tagline: '', vendor_label: '' })
+
+    expect(brand.tagline).toBe('')
+    expect(brand.vendor).toBe('')
+  })
 })

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -249,7 +249,7 @@ export function FloatingOverlays({
                       otherwise shaves the last char off the display column
                       (e.g. /goal renders as /goa). */}
                   <Box flexShrink={0}>
-                    <Text bold color={theme.color.label}>
+                    <Text bold color={active && theme.color.completionCurrentText ? theme.color.completionCurrentText : theme.color.label}>
                       {' '}
                       {item.display}
                     </Text>
@@ -257,7 +257,7 @@ export function FloatingOverlays({
                   {item.meta ? (
                     <Text
                       backgroundColor={active ? theme.color.completionMetaCurrentBg : theme.color.completionMetaBg}
-                      color={theme.color.muted}
+                      color={active && theme.color.completionCurrentText ? theme.color.completionCurrentText : theme.color.muted}
                     >
                       {' '}
                       {item.meta}

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -44,11 +44,22 @@ export function ArtLines({ lines }: { lines: [string, string][] }) {
 // Terminals can't scale glyphs, so "responsive" means picking a layout that
 // fits the available columns. Thresholds are picked so each tier reads
 // comfortably without forcing wrap or truncation drift on box-drawing edges.
-const TAG_FULL = 'Nous Research · Messenger of the Digital Gods'
-const TAG_MID = 'Messenger of the Digital Gods'
-const TAG_TINY = 'Nous Research'
 const HIDE_BELOW = 34
 const COMPACT_FROM = 58
+
+// Banner tagline tiers, composed from the skin's brand fields (vendor credit +
+// tagline). Each tier degrades gracefully when one half is empty, and the call
+// sites render nothing when a tier is empty.
+function taglines(t: Theme): { full: string; mid: string; tiny: string } {
+  const vendor = t.brand.vendor.trim()
+  const tag = t.brand.tagline.trim()
+
+  return {
+    full: vendor && tag ? `${vendor} · ${tag}` : vendor || tag,
+    mid: tag || vendor,
+    tiny: vendor || tag
+  }
+}
 
 const clip = (s: string, w: number) =>
   w <= 0 ? '' : s.length > w ? `${s.slice(0, Math.max(0, w - 1))}…` : s
@@ -76,7 +87,7 @@ function CompactBanner({ cols, t }: { cols: number; t: Theme }) {
   return (
     <Box flexDirection="column" height={3} marginBottom={1} opaque width={w}>
       <Text bold color={t.color.primary}>{ruleIn(t.brand.name, w)}</Text>
-      <Text color={t.color.muted}>{centerIn(TAG_FULL, w)}</Text>
+      <Text color={t.color.muted}>{centerIn(taglines(t).full, w)}</Text>
       <Text color={t.color.primary}>{'─'.repeat(w)}</Text>
     </Box>
   )
@@ -90,6 +101,10 @@ export function Banner({ maxWidth, t }: { maxWidth?: number; t: Theme }) {
     return null
   }
 
+  const { full, mid, tiny } = taglines(t)
+  const icon = t.brand.icon.trim()
+  const iconPfx = icon ? `${icon} ` : ''
+
   const logoLines = logo(t.color, t.bannerLogo || undefined)
   const logoW = t.bannerLogo ? artWidth(logoLines) : LOGO_WIDTH
 
@@ -97,9 +112,11 @@ export function Banner({ maxWidth, t }: { maxWidth?: number; t: Theme }) {
     return (
       <Box flexDirection="column" marginBottom={1}>
         <ArtLines lines={logoLines} />
-        <Text color={t.color.muted} wrap="truncate-end">
-          {t.brand.icon} {TAG_FULL}
-        </Text>
+        {full ? (
+          <Text color={t.color.muted} wrap="truncate-end">
+            {iconPfx}{full}
+          </Text>
+        ) : null}
       </Box>
     )
   }
@@ -109,12 +126,12 @@ export function Banner({ maxWidth, t }: { maxWidth?: number; t: Theme }) {
   }
 
   const name = cols >= 52 ? t.brand.name : (t.brand.name.split(' ')[0] ?? t.brand.name)
-  const tag = cols >= 64 ? TAG_FULL : cols >= 46 ? TAG_MID : TAG_TINY
+  const tag = cols >= 64 ? full : cols >= 46 ? mid : tiny
 
   return (
     <Box flexDirection="column" marginBottom={1}>
-      <Text bold color={t.color.primary} wrap="truncate-end">{t.brand.icon} {name}</Text>
-      <Text color={t.color.muted} wrap="truncate-end">{t.brand.icon} {tag}</Text>
+      <Text bold color={t.color.primary} wrap="truncate-end">{iconPfx}{name}</Text>
+      {tag ? <Text color={t.color.muted} wrap="truncate-end">{iconPfx}{tag}</Text> : null}
     </Box>
   )
 }
@@ -298,7 +315,7 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
 
           <Text color={t.color.accent}>
             {info.model.split('/').pop()}
-            <Text color={t.color.muted}> · Nous Research</Text>
+            {t.brand.vendor.trim() ? <Text color={t.color.muted}> · {t.brand.vendor}</Text> : null}
           </Text>
 
           <Text color={t.color.muted} wrap="truncate-end">
@@ -329,7 +346,7 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
           <Box flexDirection="column" marginBottom={1}>
             <Text color={t.color.accent} wrap="truncate-end">
               {info.model.split('/').pop()}
-              <Text color={t.color.muted}> · Nous Research</Text>
+              {t.brand.vendor.trim() ? <Text color={t.color.muted}> · {t.brand.vendor}</Text> : null}
             </Text>
             <Text color={t.color.muted} wrap="truncate-end">
               {info.cwd || process.cwd()}

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -8,6 +8,10 @@ export interface ThemeColors {
   completionCurrentBg: string
   completionMetaBg: string
   completionMetaCurrentBg: string
+  // Foreground for the *selected* completion row. Empty string = unset: the
+  // row keeps its label/muted text (today's behavior) and only the background
+  // flips. A skin sets `completion_current_text` to recolor the active row.
+  completionCurrentText: string
 
   label: string
   ok: string
@@ -42,6 +46,11 @@ export interface ThemeBrand {
   goodbye: string
   tool: string
   helpHeader: string
+  // Banner tagline and vendor credit, sourced from the skin's branding so
+  // they're overridable per skin like the other brand fields. Both render
+  // only when non-empty.
+  tagline: string
+  vendor: string
 }
 
 export interface Theme {
@@ -243,7 +252,9 @@ const BRAND: ThemeBrand = {
   welcome: 'Type your message or /help for commands.',
   goodbye: 'Goodbye! ⚕',
   tool: '┊',
-  helpHeader: '(^_^)? Commands'
+  helpHeader: '(^_^)? Commands',
+  tagline: 'Messenger of the Digital Gods',
+  vendor: 'Nous Research'
 }
 
 const cleanPromptSymbol = (s: string | undefined, fallback: string) => {
@@ -270,6 +281,7 @@ export const DARK_THEME: Theme = {
     completionCurrentBg: '#333355',
     completionMetaBg: '#1a1a2e',
     completionMetaCurrentBg: '#333355',
+    completionCurrentText: '',
 
     label: '#DAA520',
     ok: '#4caf50',
@@ -318,6 +330,7 @@ export const LIGHT_THEME: Theme = {
     completionCurrentBg: mix('#F5F5F5', '#A0651C', 0.25),
     completionMetaBg: '#F5F5F5',
     completionMetaCurrentBg: mix('#F5F5F5', '#A0651C', 0.25),
+    completionCurrentText: '',
 
     label: '#7A5A0F',
     ok: '#2E7D32',
@@ -548,6 +561,7 @@ export function fromSkin(
       completionCurrentBg,
       completionMetaBg,
       completionMetaCurrentBg,
+      completionCurrentText: c('completion_current_text') ?? '',
 
       label: c('ui_label') ?? d.color.label,
       ok: c('ui_ok') ?? d.color.ok,
@@ -566,21 +580,27 @@ export function fromSkin(
       statusCritical: d.color.statusCritical,
       selectionBg: c('selection_bg') ?? c('completion_menu_current_bg') ?? (hasSkinColors ? completionCurrentBg : d.color.selectionBg),
 
-      diffAdded: d.color.diffAdded,
-      diffRemoved: d.color.diffRemoved,
-      diffAddedWord: d.color.diffAddedWord,
-      diffRemovedWord: d.color.diffRemovedWord,
+      // Diff colors: skins may override line backgrounds (diff_added/
+      // diff_removed) and foregrounds (diff_added_text/diff_removed_text);
+      // unset keys fall back to the adaptive light/dark defaults.
+      diffAdded: c('diff_added') ?? d.color.diffAdded,
+      diffRemoved: c('diff_removed') ?? d.color.diffRemoved,
+      diffAddedWord: c('diff_added_text') ?? d.color.diffAddedWord,
+      diffRemovedWord: c('diff_removed_text') ?? d.color.diffRemovedWord,
       shellDollar: c('shell_dollar') ?? d.color.shellDollar
     },
 
     brand: {
       name: branding.agent_name ?? d.brand.name,
-      icon: d.brand.icon,
+      icon: branding.icon ?? d.brand.icon,
       prompt: cleanPromptSymbol(branding.prompt_symbol, d.brand.prompt),
       welcome: branding.welcome ?? d.brand.welcome,
       goodbye: branding.goodbye ?? d.brand.goodbye,
       tool: toolPrefix || d.brand.tool,
-      helpHeader: branding.help_header ?? (helpHeader || d.brand.helpHeader)
+      helpHeader: branding.help_header ?? (helpHeader || d.brand.helpHeader),
+      // `?? ` (not `||`) so an explicit "" from a skin is preserved.
+      tagline: branding.tagline ?? d.brand.tagline,
+      vendor: branding.vendor_label ?? d.brand.vendor
     },
 
     bannerLogo,

--- a/website/docs/user-guide/features/skins.md
+++ b/website/docs/user-guide/features/skins.md
@@ -6,7 +6,7 @@ description: "Customize the Hermes CLI with built-in and user-defined skins"
 
 # Skins & Themes
 
-Skins control the **visual presentation** of the Hermes CLI: banner colors, spinner faces and verbs, response-box labels, branding text, and the tool activity prefix.
+Skins control the **visual presentation** of the Hermes CLI and TUI: banner colors, spinner faces and verbs, response-box labels, branding text, the tool activity prefix, and — in the TUI — inline-diff colors.
 
 Conversational style and visual style are separate concepts:
 
@@ -73,6 +73,23 @@ Controls all color values throughout the CLI. Values are hex color strings.
 | `completion_menu_meta_bg` | Background color for the completion meta column | `#1a1a2e` |
 | `completion_menu_meta_current_bg` | Background color for the active completion meta column | `#333355` |
 
+### Diff colors (TUI)
+
+These keys let a skin recolor the TUI's inline-diff rendering. They are
+**optional** — when a key is unset the TUI uses its adaptive light/dark default,
+so the bundled look is unchanged unless a skin opts in.
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `diff_added` | Background of added (`+`) diff lines | adaptive green |
+| `diff_removed` | Background of removed (`-`) diff lines | adaptive red |
+| `diff_added_text` | Foreground of added (`+`) diff lines | adaptive green |
+| `diff_removed_text` | Foreground of removed (`-`) diff lines | adaptive red |
+| `completion_current_text` | Foreground of the **selected** completion / `/command` row. Unset = the row keeps its normal text color and only the background changes. | _unset_ |
+
+Both inline tool diffs (edits, patches) and assistant-authored ` ```diff ` blocks
+pick up the `diff_*` colors automatically.
+
 ### Spinner (`spinner:`)
 
 Controls the animated spinner shown while waiting for API responses.
@@ -98,6 +115,9 @@ Text strings used throughout the CLI interface.
 | `response_label` | Label on the response box header | ` ⚕ Hermes ` |
 | `prompt_symbol` | Symbol before the user input prompt (bare token, renderers add a trailing space) | `❯` |
 | `help_header` | Header text for the `/help` command output | `(^_^)? Available Commands` |
+| `icon` | Glyph shown before the agent name in the TUI banner | `⚕` |
+| `tagline` | Banner tagline shown under the wordmark. Override per skin; `""` omits the line. | `Messenger of the Digital Gods` |
+| `vendor_label` | Credit shown after the model name and as the leading half of the banner tagline. Override per skin; `""` omits it. | `Nous Research` |
 
 ### Other top-level keys
 
@@ -210,6 +230,35 @@ branding:
   response_label: " ⚡ Cyber "
 
 tool_prefix: "▏"
+```
+
+### Banner branding fields
+
+`agent_name`, `icon`, `vendor_label`, and `tagline` are overridable per skin
+like any other branding field. Their defaults are:
+
+```yaml
+branding:
+  agent_name: "Hermes Agent"
+  icon: "⚕"
+  vendor_label: "Nous Research"
+  tagline: "Messenger of the Digital Gods"
+```
+
+Set any of these in your skin to customize the banner; unset fields keep these
+defaults.
+
+### Theme inline diffs
+
+Recolor the TUI's inline diffs (file edits, patches, and assistant ` ```diff `
+blocks) to match your palette. Unset keys keep the adaptive light/dark defaults:
+
+```yaml
+colors:
+  diff_added: "#10261a"        # added-line background
+  diff_removed: "#2a1416"      # removed-line background
+  diff_added_text: "#7ee787"   # added-line text
+  diff_removed_text: "#ff7b72" # removed-line text
 ```
 
 ## Hermes Mod — Visual Skin Editor


### PR DESCRIPTION
## What does this PR do?

Adds a small set of **opt-in skin keys** so more of the TUI's appearance can be customized through the existing data-driven skin system. Every key is optional and **defaults are unchanged** — skins that don't set them render exactly as before, so there is no visual change out of the box.

New keys:

- **Inline diff colors** — `diff_added`, `diff_removed`, `diff_added_text`, `diff_removed_text` are read from the skin instead of being pinned to fixed theme values. Both inline tool diffs and assistant ` ```diff ` blocks pick them up.
- **Selected completion row** — `completion_current_text` sets the foreground of the active `/command` row (unset = today's behavior, only the background changes).
- **Banner brand fields** — `icon`, `tagline`, and `vendor_label` are sourced from the skin's `branding`, consistent with the existing `agent_name` / `response_label` / etc., so they're customizable per skin.

This extends the same mechanism already documented in the skins guide; no new architecture.

## Related Issue

No existing PR/issue covers diff-color or banner-field configurability (searched open + closed). TUI status-bar skin colors are already addressed by #31722, so this PR intentionally leaves them out.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update

## Changes Made

- `ui-tui/src/theme.ts` — `fromSkin` reads the new `diff_*` and `completion_current_text` keys; `ThemeBrand` gains `tagline`/`vendor`; brand `icon`/`tagline`/`vendor` resolve from skin `branding`.
- `ui-tui/src/components/branding.tsx` — banner tagline tiers and the model-line credit are composed from brand fields and render only when non-empty.
- `ui-tui/src/components/appOverlays.tsx` — the selected completion row honors `completion_current_text`.
- `hermes_cli/skin_engine.py` — the default skin documents the `icon` / `vendor_label` / `tagline` branding fields.
- `hermes_cli/banner.py` — the classic banner credit is sourced from skin `branding`.
- `website/docs/user-guide/features/skins.md` — document the new keys with examples.
- Tests: `ui-tui/src/__tests__/theme.test.ts` (key mappings) and new `ui-tui/src/__tests__/branding.test.tsx` (banner render).

## How to Test

1. **Defaults unchanged:** launch the TUI with the default skin — banner, inline diffs, and the completion menu render identically to before.
2. **Overrides apply:** add `~/.hermes/skins/mybrand.yaml` with custom `diff_*` colors and `branding` values, then `/skin mybrand` and confirm the inline diffs and banner reflect the overrides.
3. `cd ui-tui && npm run typecheck && npm run lint && npm run build`
4. `scripts/run_tests.sh tests/hermes_cli/test_skin_engine.py tests/hermes_cli/test_banner.py tests/agent/test_display.py -- -q`

Tested on macOS.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] Tests pass (`scripts/run_tests.sh` on the relevant suites + full TUI vitest suite)
- [x] I've added tests for my changes
- [x] Tested on macOS
- [x] Updated documentation (`website/docs/user-guide/features/skins.md`)
- [x] `cli-config.yaml.example` — N/A (skin keys, not config.yaml keys)
- [x] Cross-platform impact considered — N/A (no OS-specific code; `check-windows-footguns.py` clean)
