### PR TITLE
fix(cli): reject xai media models as main model

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -303,6 +303,14 @@ DEFAULT_CONTEXT_LENGTHS = {
     # usable context window for Composer 2.5 on Grok Build (SuperGrok /
     # Premium+); /v1/responses additionally enforces a ~262144 input+output
     # budget, but the usable context (what we track here) is 200k.
+    # Grok Imagine models are media-generation backends, not viable main chat
+    # models. Keep their real small context windows here so startup/persisted
+    # config checks do not fall through to the generic "grok" chat fallback.
+    "grok-imagine-video-1.5-preview": 1024,
+    "grok-imagine-video-1.5-2026-05-30": 1024,
+    "grok-imagine-video": 1024,
+    "grok-imagine-image-quality": 8000,
+    "grok-imagine-image": 8000,
     "grok-composer": 200000,    # grok-composer-2.5-fast (Grok Build CLI)
     "grok-build-latest": 500000,  # alias of grok-4.5 (early access)
     "grok-build": 256000,       # grok-build-0.1

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -519,6 +519,14 @@ DEFAULT_CONTEXT_LENGTHS = {
     # usable context window for Composer 2.5 on Grok Build (SuperGrok /
     # Premium+); /v1/responses additionally enforces a ~262144 input+output
     # budget, but the usable context (what we track here) is 200k.
+    # Grok Imagine models are media-generation backends, not viable main chat
+    # models. Keep their real small context windows here so startup/persisted
+    # config checks do not fall through to the generic "grok" chat fallback.
+    "grok-imagine-video-1.5-preview": 1024,
+    "grok-imagine-video-1.5-2026-05-30": 1024,
+    "grok-imagine-video": 1024,
+    "grok-imagine-image-quality": 8000,
+    "grok-imagine-image": 8000,
     "grok-composer": 200000,    # grok-composer-2.5-fast (Grok Build CLI)
     "grok-build-latest": 500000,  # alias of grok-4.5 (early access)
     "grok-build": 256000,       # grok-build-0.1

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1278,6 +1278,16 @@ def switch_model(
     # Override rejection if model is in the user's saved provider config.
     # API /v1/models may not list cloud/aliased models even though the server supports them.
     if not validation.get("accepted"):
+        if validation.get("hard_reject"):
+            msg = validation.get("message", "Invalid model")
+            return ModelSwitchResult(
+                success=False,
+                new_model=new_model,
+                target_provider=target_provider,
+                provider_label=provider_label,
+                is_global=is_global,
+                error_message=msg,
+            )
         override = False
         if user_providers:
             # user_providers is a dict: {provider_slug: config_dict}

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1279,7 +1279,12 @@ def switch_model(
     # API /v1/models may not list cloud/aliased models even though the server supports them.
     if not validation.get("accepted"):
         if validation.get("hard_reject"):
-            msg = validation.get("message", "Invalid model")
+            validation_message = validation.get("message")
+            msg = (
+                validation_message
+                if isinstance(validation_message, str)
+                else "Invalid model"
+            )
             return ModelSwitchResult(
                 success=False,
                 new_model=new_model,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2079,7 +2079,12 @@ def switch_model(
     # API /v1/models may not list cloud/aliased models even though the server supports them.
     if not validation.get("accepted"):
         if validation.get("hard_reject"):
-            msg = validation.get("message", "Invalid model")
+            validation_message = validation.get("message")
+            msg = (
+                validation_message
+                if isinstance(validation_message, str)
+                else "Invalid model"
+            )
             return ModelSwitchResult(
                 success=False,
                 new_model=new_model,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2078,6 +2078,16 @@ def switch_model(
     # Override rejection if model is in the user's saved provider config.
     # API /v1/models may not list cloud/aliased models even though the server supports them.
     if not validation.get("accepted"):
+        if validation.get("hard_reject"):
+            msg = validation.get("message", "Invalid model")
+            return ModelSwitchResult(
+                success=False,
+                new_model=new_model,
+                target_provider=target_provider,
+                provider_label=provider_label,
+                is_global=is_global,
+                error_message=msg,
+            )
         override = False
         if user_providers:
             from hermes_cli.config import is_provider_enabled

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4196,6 +4196,9 @@ def validate_requested_model(
             # Auto-correct if the top match is very similar (e.g. typo)
             auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.9)
             if auto:
+                floor_rejection = _reject_below_main_context_floor(auto[0])
+                if floor_rejection is not None:
+                    return floor_rejection
                 return {
                     "accepted": True,
                     "persist": True,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4084,7 +4084,15 @@ def validate_requested_model(
         }
 
     def _reject_below_main_context_floor(model_id: str) -> Optional[dict[str, Any]]:
-        if normalized not in {"xai", "xai-oauth"}:
+        endpoint = (base_url or "").strip()
+        if endpoint and "://" not in endpoint:
+            endpoint = f"https://{endpoint}"
+        try:
+            endpoint_host = urllib.parse.urlparse(endpoint).hostname or ""
+        except ValueError:
+            endpoint_host = ""
+        is_xai_endpoint = endpoint_host.lower() == "api.x.ai"
+        if normalized not in {"xai", "xai-oauth"} and not is_xai_endpoint:
             return None
         model_key = model_id.strip().lower()
         is_media_model = model_key.startswith("grok-imagine-")
@@ -4246,9 +4254,6 @@ def validate_requested_model(
             catalog_models = []
         if catalog_models:
             if requested_for_lookup in set(catalog_models):
-                floor_rejection = _reject_below_main_context_floor(requested_for_lookup)
-                if floor_rejection is not None:
-                    return floor_rejection
                 return {
                     "accepted": True,
                     "persist": True,
@@ -4304,9 +4309,6 @@ def validate_requested_model(
                         f"{suggestion_text}"
                     ),
                 }
-            floor_rejection = _reject_below_main_context_floor(requested_for_lookup)
-            if floor_rejection is not None:
-                return floor_rejection
             return {
                 "accepted": True,
                 "persist": True,
@@ -4461,9 +4463,6 @@ def validate_requested_model(
                 for m in api_models
             ]
         if requested_for_lookup in set(api_models):
-            floor_rejection = _reject_below_main_context_floor(requested_for_lookup)
-            if floor_rejection is not None:
-                return floor_rejection
             # API confirmed the model exists
             return {
                 "accepted": True,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -161,9 +161,41 @@ def _xai_merge_curated_extras(ids: list[str]) -> list[str]:
     return out
 
 
-def _is_xai_main_model_candidate(model_id: str) -> bool:
+def _is_xai_main_model_candidate(
+    model_id: str,
+    models_dev_entry: Optional[dict[str, Any]] = None,
+) -> bool:
     """True when an xAI model belongs in the main-agent model picker."""
-    return not str(model_id or "").strip().lower().startswith("grok-imagine-")
+    key = str(model_id or "").strip().lower()
+    if not key or key.startswith("grok-imagine-"):
+        return False
+
+    context_window: Optional[int] = None
+    if isinstance(models_dev_entry, dict):
+        limit = models_dev_entry.get("limit")
+        if isinstance(limit, dict):
+            raw_context = limit.get("context")
+            if isinstance(raw_context, (int, float)) and raw_context > 0:
+                context_window = int(raw_context)
+
+    try:
+        from agent.model_metadata import DEFAULT_CONTEXT_LENGTHS, MINIMUM_CONTEXT_LENGTH
+
+        if context_window is None:
+            for default_model, length in sorted(
+                DEFAULT_CONTEXT_LENGTHS.items(), key=lambda item: len(item[0]), reverse=True
+            ):
+                if default_model in key:
+                    context_window = length
+                    break
+        return not (
+            isinstance(context_window, int)
+            and 0 < context_window < MINIMUM_CONTEXT_LENGTH
+        )
+    except Exception:
+        # Picker construction must remain import-safe. Validation still
+        # applies the hard context-floor rejection before persistence.
+        return True
 
 
 def _xai_curated_models() -> list[str]:
@@ -184,8 +216,8 @@ def _xai_curated_models() -> list[str]:
         models = xai.get("models") if isinstance(xai, dict) else None
         if isinstance(models, dict) and models:
             ids = [
-                mid for mid in models.keys()
-                if isinstance(mid, str) and _is_xai_main_model_candidate(mid)
+                mid for mid, entry in models.items()
+                if isinstance(mid, str) and _is_xai_main_model_candidate(mid, entry)
             ]
             if ids:
                 return _xai_merge_curated_extras(_xai_promote_top(sorted(ids)))

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -161,6 +161,11 @@ def _xai_merge_curated_extras(ids: list[str]) -> list[str]:
     return out
 
 
+def _is_xai_main_model_candidate(model_id: str) -> bool:
+    """True when an xAI model belongs in the main-agent model picker."""
+    return not str(model_id or "").strip().lower().startswith("grok-imagine-")
+
+
 def _xai_curated_models() -> list[str]:
     """Derive the xAI-direct curated list from models.dev disk cache.
 
@@ -178,7 +183,10 @@ def _xai_curated_models() -> list[str]:
         xai = data.get("xai") if isinstance(data, dict) else None
         models = xai.get("models") if isinstance(xai, dict) else None
         if isinstance(models, dict) and models:
-            ids = [mid for mid in models.keys() if isinstance(mid, str)]
+            ids = [
+                mid for mid in models.keys()
+                if isinstance(mid, str) and _is_xai_main_model_candidate(mid)
+            ]
             if ids:
                 return _xai_merge_curated_extras(_xai_promote_top(sorted(ids)))
     except Exception:
@@ -4025,6 +4033,7 @@ def validate_requested_model(
 
     Returns a dict with:
       - accepted: whether the CLI should switch to the requested model now
+      - hard_reject: optional true when callers must not override rejection
       - persist: whether it is safe to save to config
       - recognized: whether it matched a known provider catalog
       - message: optional warning / guidance for the user
@@ -4073,6 +4082,58 @@ def validate_requested_model(
             "recognized": False,
             "message": "Model names cannot contain spaces.",
         }
+
+    def _reject_below_main_context_floor(model_id: str) -> Optional[dict[str, Any]]:
+        if normalized not in {"xai", "xai-oauth"}:
+            return None
+        model_key = model_id.strip().lower()
+        is_media_model = model_key.startswith("grok-imagine-")
+        if not (is_media_model or model_key.startswith("grok-")):
+            return None
+        context_window: Optional[int] = None
+        try:
+            from agent.model_metadata import (
+                MINIMUM_CONTEXT_LENGTH,
+                get_model_context_length,
+            )
+            context_window = get_model_context_length(
+                model_id,
+                provider=normalized,
+                base_url=base_url or "",
+                api_key=api_key or "",
+            )
+        except Exception:
+            context_window = None
+            MINIMUM_CONTEXT_LENGTH = 64_000
+        below_floor = (
+            isinstance(context_window, int)
+            and context_window > 0
+            and context_window < MINIMUM_CONTEXT_LENGTH
+        )
+        if not (is_media_model or below_floor):
+            return None
+        if below_floor:
+            context_detail = (
+                f"`{model_id}` has a context window of {context_window:,} tokens, "
+                f"below Hermes Agent's {MINIMUM_CONTEXT_LENGTH:,}-token "
+                "minimum for the main agent model."
+            )
+        else:
+            context_detail = f"`{model_id}` is a Grok Imagine media-generation model."
+        guidance = f"Choose a model with at least {MINIMUM_CONTEXT_LENGTH:,} tokens for `/model`."
+        if is_media_model:
+            guidance += " Use Grok Imagine through the image/video generation tool path instead."
+        return {
+            "accepted": False,
+            "hard_reject": True,
+            "persist": False,
+            "recognized": True,
+            "message": f"{context_detail} {guidance}",
+        }
+
+    floor_rejection = _reject_below_main_context_floor(requested_for_lookup)
+    if floor_rejection is not None:
+        return floor_rejection
 
     if normalized == "lmstudio":
         from hermes_cli.auth import AuthError
@@ -4185,6 +4246,9 @@ def validate_requested_model(
             catalog_models = []
         if catalog_models:
             if requested_for_lookup in set(catalog_models):
+                floor_rejection = _reject_below_main_context_floor(requested_for_lookup)
+                if floor_rejection is not None:
+                    return floor_rejection
                 return {
                     "accepted": True,
                     "persist": True,
@@ -4194,6 +4258,9 @@ def validate_requested_model(
             # Auto-correct if the top match is very similar (e.g. typo)
             auto = get_close_matches(requested_for_lookup, catalog_models, n=1, cutoff=0.9)
             if auto:
+                floor_rejection = _reject_below_main_context_floor(auto[0])
+                if floor_rejection is not None:
+                    return floor_rejection
                 return {
                     "accepted": True,
                     "persist": True,
@@ -4237,6 +4304,9 @@ def validate_requested_model(
                         f"{suggestion_text}"
                     ),
                 }
+            floor_rejection = _reject_below_main_context_floor(requested_for_lookup)
+            if floor_rejection is not None:
+                return floor_rejection
             return {
                 "accepted": True,
                 "persist": True,
@@ -4391,6 +4461,9 @@ def validate_requested_model(
                 for m in api_models
             ]
         if requested_for_lookup in set(api_models):
+            floor_rejection = _reject_below_main_context_floor(requested_for_lookup)
+            if floor_rejection is not None:
+                return floor_rejection
             # API confirmed the model exists
             return {
                 "accepted": True,
@@ -4407,6 +4480,9 @@ def validate_requested_model(
             # Auto-correct if the top match is very similar (e.g. typo)
             auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.9)
             if auto:
+                floor_rejection = _reject_below_main_context_floor(auto[0])
+                if floor_rejection is not None:
+                    return floor_rejection
                 return {
                     "accepted": True,
                     "persist": True,
@@ -4503,6 +4579,11 @@ def validate_requested_model(
     if catalog_models:
         catalog_lower = {m.lower(): m for m in catalog_models}
         if requested_for_lookup.lower() in catalog_lower:
+            floor_rejection = _reject_below_main_context_floor(
+                catalog_lower[requested_for_lookup.lower()]
+            )
+            if floor_rejection is not None:
+                return floor_rejection
             return {
                 "accepted": True,
                 "persist": True,
@@ -4515,6 +4596,9 @@ def validate_requested_model(
         )
         if auto:
             corrected = catalog_lower[auto[0]]
+            floor_rejection = _reject_below_main_context_floor(corrected)
+            if floor_rejection is not None:
+                return floor_rejection
             return {
                 "accepted": True,
                 "persist": True,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -6113,6 +6113,9 @@ def validate_requested_model(
             # Auto-correct if the top match is very similar (e.g. typo)
             auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.9)
             if auto:
+                floor_rejection = _reject_below_main_context_floor(auto[0])
+                if floor_rejection is not None:
+                    return floor_rejection
                 return {
                     "accepted": True,
                     "persist": True,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -234,9 +234,41 @@ def _xai_finalize_catalog(ids: list[str]) -> list[str]:
     return _xai_promote_top(_xai_merge_curated_extras(ids))
 
 
-def _is_xai_main_model_candidate(model_id: str) -> bool:
+def _is_xai_main_model_candidate(
+    model_id: str,
+    models_dev_entry: Optional[dict[str, Any]] = None,
+) -> bool:
     """True when an xAI model belongs in the main-agent model picker."""
-    return not str(model_id or "").strip().lower().startswith("grok-imagine-")
+    key = str(model_id or "").strip().lower()
+    if not key or key.startswith("grok-imagine-"):
+        return False
+
+    context_window: Optional[int] = None
+    if isinstance(models_dev_entry, dict):
+        limit = models_dev_entry.get("limit")
+        if isinstance(limit, dict):
+            raw_context = limit.get("context")
+            if isinstance(raw_context, (int, float)) and raw_context > 0:
+                context_window = int(raw_context)
+
+    try:
+        from agent.model_metadata import DEFAULT_CONTEXT_LENGTHS, MINIMUM_CONTEXT_LENGTH
+
+        if context_window is None:
+            for default_model, length in sorted(
+                DEFAULT_CONTEXT_LENGTHS.items(), key=lambda item: len(item[0]), reverse=True
+            ):
+                if default_model in key:
+                    context_window = length
+                    break
+        return not (
+            isinstance(context_window, int)
+            and 0 < context_window < MINIMUM_CONTEXT_LENGTH
+        )
+    except Exception:
+        # Picker construction must remain import-safe. Validation still
+        # applies the hard context-floor rejection before persistence.
+        return True
 
 
 def _xai_curated_models() -> list[str]:
@@ -252,8 +284,8 @@ def _xai_curated_models() -> list[str]:
         models = xai.get("models") if isinstance(xai, dict) else None
         if isinstance(models, dict) and models:
             ids = [
-                mid for mid in models.keys()
-                if isinstance(mid, str) and _is_xai_main_model_candidate(mid)
+                mid for mid, entry in models.items()
+                if isinstance(mid, str) and _is_xai_main_model_candidate(mid, entry)
             ]
             if ids:
                 return _xai_finalize_catalog(sorted(ids))

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -5908,7 +5908,15 @@ def validate_requested_model(
         }
 
     def _reject_below_main_context_floor(model_id: str) -> Optional[dict[str, Any]]:
-        if normalized not in {"xai", "xai-oauth"}:
+        endpoint = (base_url or "").strip()
+        if endpoint and "://" not in endpoint:
+            endpoint = f"https://{endpoint}"
+        try:
+            endpoint_host = urllib.parse.urlparse(endpoint).hostname or ""
+        except ValueError:
+            endpoint_host = ""
+        is_xai_endpoint = endpoint_host.lower() == "api.x.ai"
+        if normalized not in {"xai", "xai-oauth"} and not is_xai_endpoint:
             return None
         model_key = model_id.strip().lower()
         is_media_model = model_key.startswith("grok-imagine-")
@@ -6163,9 +6171,6 @@ def validate_requested_model(
             catalog_models = []
         if catalog_models:
             if requested_for_lookup in set(catalog_models):
-                floor_rejection = _reject_below_main_context_floor(requested_for_lookup)
-                if floor_rejection is not None:
-                    return floor_rejection
                 return {
                     "accepted": True,
                     "persist": True,
@@ -6221,9 +6226,6 @@ def validate_requested_model(
                         f"{suggestion_text}"
                     ),
                 }
-            floor_rejection = _reject_below_main_context_floor(requested_for_lookup)
-            if floor_rejection is not None:
-                return floor_rejection
             return {
                 "accepted": True,
                 "persist": True,
@@ -6378,9 +6380,6 @@ def validate_requested_model(
                 for m in api_models
             ]
         if requested_for_lookup in set(api_models):
-            floor_rejection = _reject_below_main_context_floor(requested_for_lookup)
-            if floor_rejection is not None:
-                return floor_rejection
             # API confirmed the model exists
             return {
                 "accepted": True,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -234,6 +234,11 @@ def _xai_finalize_catalog(ids: list[str]) -> list[str]:
     return _xai_promote_top(_xai_merge_curated_extras(ids))
 
 
+def _is_xai_main_model_candidate(model_id: str) -> bool:
+    """True when an xAI model belongs in the main-agent model picker."""
+    return not str(model_id or "").strip().lower().startswith("grok-imagine-")
+
+
 def _xai_curated_models() -> list[str]:
     """Offline curated floor for xAI / xAI OAuth pickers.
 
@@ -246,7 +251,10 @@ def _xai_curated_models() -> list[str]:
         xai = data.get("xai") if isinstance(data, dict) else None
         models = xai.get("models") if isinstance(xai, dict) else None
         if isinstance(models, dict) and models:
-            ids = [mid for mid in models.keys() if isinstance(mid, str)]
+            ids = [
+                mid for mid in models.keys()
+                if isinstance(mid, str) and _is_xai_main_model_candidate(mid)
+            ]
             if ids:
                 return _xai_finalize_catalog(sorted(ids))
     except Exception:
@@ -5849,6 +5857,7 @@ def validate_requested_model(
 
     Returns a dict with:
       - accepted: whether the CLI should switch to the requested model now
+      - hard_reject: optional true when callers must not override rejection
       - persist: whether it is safe to save to config
       - recognized: whether it matched a known provider catalog
       - message: optional warning / guidance for the user
@@ -5897,6 +5906,58 @@ def validate_requested_model(
             "recognized": False,
             "message": "Model names cannot contain spaces.",
         }
+
+    def _reject_below_main_context_floor(model_id: str) -> Optional[dict[str, Any]]:
+        if normalized not in {"xai", "xai-oauth"}:
+            return None
+        model_key = model_id.strip().lower()
+        is_media_model = model_key.startswith("grok-imagine-")
+        if not (is_media_model or model_key.startswith("grok-")):
+            return None
+        context_window: Optional[int] = None
+        try:
+            from agent.model_metadata import (
+                MINIMUM_CONTEXT_LENGTH,
+                get_model_context_length,
+            )
+            context_window = get_model_context_length(
+                model_id,
+                provider=normalized,
+                base_url=base_url or "",
+                api_key=api_key or "",
+            )
+        except Exception:
+            context_window = None
+            MINIMUM_CONTEXT_LENGTH = 64_000
+        below_floor = (
+            isinstance(context_window, int)
+            and context_window > 0
+            and context_window < MINIMUM_CONTEXT_LENGTH
+        )
+        if not (is_media_model or below_floor):
+            return None
+        if below_floor:
+            context_detail = (
+                f"`{model_id}` has a context window of {context_window:,} tokens, "
+                f"below Hermes Agent's {MINIMUM_CONTEXT_LENGTH:,}-token "
+                "minimum for the main agent model."
+            )
+        else:
+            context_detail = f"`{model_id}` is a Grok Imagine media-generation model."
+        guidance = f"Choose a model with at least {MINIMUM_CONTEXT_LENGTH:,} tokens for `/model`."
+        if is_media_model:
+            guidance += " Use Grok Imagine through the image/video generation tool path instead."
+        return {
+            "accepted": False,
+            "hard_reject": True,
+            "persist": False,
+            "recognized": True,
+            "message": f"{context_detail} {guidance}",
+        }
+
+    floor_rejection = _reject_below_main_context_floor(requested_for_lookup)
+    if floor_rejection is not None:
+        return floor_rejection
 
     if normalized == "lmstudio":
         from hermes_cli.auth import AuthError
@@ -6102,6 +6163,9 @@ def validate_requested_model(
             catalog_models = []
         if catalog_models:
             if requested_for_lookup in set(catalog_models):
+                floor_rejection = _reject_below_main_context_floor(requested_for_lookup)
+                if floor_rejection is not None:
+                    return floor_rejection
                 return {
                     "accepted": True,
                     "persist": True,
@@ -6111,6 +6175,9 @@ def validate_requested_model(
             # Auto-correct if the top match is very similar (e.g. typo)
             auto = get_close_matches(requested_for_lookup, catalog_models, n=1, cutoff=0.9)
             if auto:
+                floor_rejection = _reject_below_main_context_floor(auto[0])
+                if floor_rejection is not None:
+                    return floor_rejection
                 return {
                     "accepted": True,
                     "persist": True,
@@ -6154,6 +6221,9 @@ def validate_requested_model(
                         f"{suggestion_text}"
                     ),
                 }
+            floor_rejection = _reject_below_main_context_floor(requested_for_lookup)
+            if floor_rejection is not None:
+                return floor_rejection
             return {
                 "accepted": True,
                 "persist": True,
@@ -6308,6 +6378,9 @@ def validate_requested_model(
                 for m in api_models
             ]
         if requested_for_lookup in set(api_models):
+            floor_rejection = _reject_below_main_context_floor(requested_for_lookup)
+            if floor_rejection is not None:
+                return floor_rejection
             # API confirmed the model exists
             return {
                 "accepted": True,
@@ -6324,6 +6397,9 @@ def validate_requested_model(
             # Auto-correct if the top match is very similar (e.g. typo)
             auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.9)
             if auto:
+                floor_rejection = _reject_below_main_context_floor(auto[0])
+                if floor_rejection is not None:
+                    return floor_rejection
                 return {
                     "accepted": True,
                     "persist": True,
@@ -6433,6 +6509,11 @@ def validate_requested_model(
     if catalog_models:
         catalog_lower = {m.lower(): m for m in catalog_models}
         if requested_for_lookup.lower() in catalog_lower:
+            floor_rejection = _reject_below_main_context_floor(
+                catalog_lower[requested_for_lookup.lower()]
+            )
+            if floor_rejection is not None:
+                return floor_rejection
             return {
                 "accepted": True,
                 "persist": True,
@@ -6445,6 +6526,9 @@ def validate_requested_model(
         )
         if auto:
             corrected = catalog_lower[auto[0]]
+            floor_rejection = _reject_below_main_context_floor(corrected)
+            if floor_rejection is not None:
+                return floor_rejection
             return {
                 "accepted": True,
                 "persist": True,

--- a/tests/hermes_cli/test_xai_main_model_context_floor.py
+++ b/tests/hermes_cli/test_xai_main_model_context_floor.py
@@ -65,6 +65,30 @@ def test_validate_rejects_media_model_on_custom_provider_pointed_at_xai():
     assert "context window of 1,024 tokens" in result["message"]
 
 
+def test_validate_does_not_autocorrect_media_model_on_custom_xai_endpoint():
+    with (
+        patch(
+            "hermes_cli.models.probe_api_models",
+            return_value={
+                "models": ["grok-4.3", "grok-imagine-video"],
+                "probed_url": "https://api.x.ai/v1/models",
+            },
+        ),
+        patch("agent.model_metadata.get_model_context_length", return_value=1_024),
+    ):
+        result = validate_requested_model(
+            "grok-iamgine-video",
+            "custom:xai-direct",
+            api_key="dummy",
+            base_url="https://api.x.ai/v1",
+        )
+
+    assert result["accepted"] is False
+    assert result["persist"] is False
+    assert result.get("hard_reject") is True
+    assert "context window of 1,024 tokens" in result["message"]
+
+
 def test_validate_does_not_apply_xai_floor_to_other_custom_endpoints():
     with patch(
         "hermes_cli.models.probe_api_models",

--- a/tests/hermes_cli/test_xai_main_model_context_floor.py
+++ b/tests/hermes_cli/test_xai_main_model_context_floor.py
@@ -214,11 +214,14 @@ def test_xai_media_context_defaults_stay_below_main_floor_without_models_dev():
             )
 
 
-def test_xai_curated_catalog_hides_grok_imagine_media_models():
+def test_xai_curated_catalog_hides_all_below_floor_models():
     data = {
         "xai": {
             "models": {
                 "grok-4.3": {},
+                "grok-2-vision": {},
+                "grok-future-chat": {"limit": {"context": 131_072}},
+                "grok-future-tiny": {"limit": {"context": 32_000}},
                 "grok-imagine-image": {},
                 "grok-imagine-video": {},
                 "grok-imagine-video-1.5-preview": {},
@@ -230,4 +233,7 @@ def test_xai_curated_catalog_hides_grok_imagine_media_models():
         result = models_mod._xai_curated_models()
 
     assert "grok-4.3" in result
+    assert "grok-future-chat" in result
+    assert "grok-2-vision" not in result
+    assert "grok-future-tiny" not in result
     assert not any(model.startswith("grok-imagine-") for model in result)

--- a/tests/hermes_cli/test_xai_main_model_context_floor.py
+++ b/tests/hermes_cli/test_xai_main_model_context_floor.py
@@ -50,6 +50,52 @@ def test_validate_rejects_direct_xai_media_model_below_main_context_floor():
     assert "context window of 1,024 tokens" in result["message"]
 
 
+def test_validate_rejects_media_model_on_custom_provider_pointed_at_xai():
+    with patch("agent.model_metadata.get_model_context_length", return_value=1_024):
+        result = validate_requested_model(
+            "grok-imagine-video",
+            "custom:xai-direct",
+            api_key="dummy",
+            base_url="https://api.x.ai/v1",
+        )
+
+    assert result["accepted"] is False
+    assert result["persist"] is False
+    assert result.get("hard_reject") is True
+    assert "context window of 1,024 tokens" in result["message"]
+
+
+def test_validate_does_not_apply_xai_floor_to_other_custom_endpoints():
+    with patch(
+        "hermes_cli.models.probe_api_models",
+        return_value={
+            "models": ["grok-imagine-video"],
+            "probed_url": "https://models.example.test/v1/models",
+        },
+    ):
+        result = validate_requested_model(
+            "grok-imagine-video",
+            "custom:example",
+            api_key="dummy",
+            base_url="https://models.example.test/v1",
+        )
+
+    assert result["accepted"] is True
+
+
+def test_validate_rejects_xai_media_model_when_context_lookup_raises():
+    with patch(
+        "agent.model_metadata.get_model_context_length",
+        side_effect=RuntimeError("probe failed"),
+    ):
+        result = validate_requested_model("grok-imagine-video", "xai-oauth")
+
+    assert result["accepted"] is False
+    assert result["persist"] is False
+    assert result.get("hard_reject") is True
+    assert "Grok Imagine media-generation model" in result["message"]
+
+
 def test_validate_still_accepts_xai_chat_model_above_main_context_floor():
     with patch(
         "hermes_cli.models.provider_model_ids",

--- a/tests/hermes_cli/test_xai_main_model_context_floor.py
+++ b/tests/hermes_cli/test_xai_main_model_context_floor.py
@@ -1,0 +1,163 @@
+from unittest.mock import patch
+
+import hermes_cli.models as models_mod
+from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
+from hermes_cli.model_switch import switch_model
+from hermes_cli.models import validate_requested_model
+
+
+def _xai_context_length(model_id: str, **_kwargs):
+    context_windows = {
+        "grok-imagine-video": 1_024,
+        "grok-imagine-image-quality": 8_000,
+        "grok-4.3": 1_000_000,
+    }
+    return context_windows.get(model_id, 131_072)
+
+
+def test_validate_rejects_xai_media_models_below_main_context_floor():
+    with (
+        patch(
+            "hermes_cli.models.provider_model_ids",
+            return_value=[
+                "grok-4.3",
+                "grok-imagine-video",
+                "grok-imagine-image-quality",
+            ],
+        ),
+        patch("agent.model_metadata.get_model_context_length", side_effect=_xai_context_length),
+    ):
+        video = validate_requested_model("grok-imagine-video", "xai-oauth")
+        image = validate_requested_model("grok-imagine-image-quality", "xai-oauth")
+
+    assert video["accepted"] is False
+    assert video["persist"] is False
+    assert "context window of 1,024 tokens" in video["message"]
+    assert "64,000-token minimum" in video["message"]
+
+    assert image["accepted"] is False
+    assert image["persist"] is False
+    assert "context window of 8,000 tokens" in image["message"]
+    assert "Grok Imagine" in image["message"]
+
+
+def test_validate_rejects_direct_xai_media_model_below_main_context_floor():
+    with patch("agent.model_metadata.get_model_context_length", side_effect=_xai_context_length):
+        result = validate_requested_model("grok-imagine-video", "xai")
+
+    assert result["accepted"] is False
+    assert result["persist"] is False
+    assert "context window of 1,024 tokens" in result["message"]
+
+
+def test_validate_still_accepts_xai_chat_model_above_main_context_floor():
+    with patch(
+        "hermes_cli.models.provider_model_ids",
+        return_value=["grok-4.3", "grok-imagine-video"],
+    ):
+        result = validate_requested_model("grok-4.3", "xai-oauth")
+
+    assert result["accepted"] is True
+    assert result["persist"] is True
+    assert result["recognized"] is True
+    assert result["message"] is None
+
+
+def test_validate_rejects_unlisted_xai_media_model_even_with_high_context_fallback():
+    with (
+        patch("hermes_cli.models.provider_model_ids", return_value=["grok-4.3"]),
+        patch("agent.model_metadata.get_model_context_length", return_value=131_072),
+    ):
+        result = validate_requested_model("grok-imagine-video-1.5-preview", "xai-oauth")
+
+    assert result["accepted"] is False
+    assert "Grok Imagine media-generation model" in result["message"]
+
+
+def test_validate_rejects_direct_xai_live_model_below_main_context_floor():
+    with (
+        patch("hermes_cli.models.fetch_api_models", return_value=["grok-2-vision"]),
+        patch("agent.model_metadata.get_model_context_length", return_value=8_192),
+    ):
+        result = validate_requested_model(
+            "grok-2-vision",
+            "xai",
+            api_key="dummy",
+            base_url="https://api.x.ai/v1",
+        )
+
+    assert result["accepted"] is False
+    assert result.get("hard_reject") is True
+    assert "context window of 8,192 tokens" in result["message"]
+
+
+def test_validate_direct_xai_does_not_autocorrect_to_media_model():
+    with (
+        patch("hermes_cli.models.fetch_api_models", return_value=["grok-imagine-video"]),
+        patch("agent.model_metadata.get_model_context_length", return_value=1_024),
+    ):
+        result = validate_requested_model(
+            "grok-imagien-video",
+            "xai",
+            api_key="dummy",
+            base_url="https://api.x.ai/v1",
+        )
+
+    assert result["accepted"] is False
+    assert result.get("hard_reject") is True
+    assert "context window of 1,024 tokens" in result["message"]
+
+
+def test_switch_model_does_not_override_xai_context_floor_from_configured_models():
+    with (
+        patch(
+            "hermes_cli.models.provider_model_ids",
+            return_value=["grok-4.3", "grok-imagine-video"],
+        ),
+        patch("agent.model_metadata.get_model_context_length", side_effect=_xai_context_length),
+    ):
+        result = switch_model(
+            "grok-imagine-video",
+            current_provider="xai-oauth",
+            current_model="grok-4.3",
+            user_providers={"xai-oauth": {"models": {"grok-imagine-video": {}}}},
+        )
+
+    assert result.success is False
+    assert "context window of 1,024 tokens" in result.error_message
+
+
+def test_xai_media_context_defaults_stay_below_main_floor_without_models_dev():
+    media_models = [
+        "grok-imagine-image",
+        "grok-imagine-image-quality",
+        "grok-imagine-video",
+        "grok-imagine-video-1.5-preview",
+        "grok-imagine-video-1.5-2026-05-30",
+    ]
+
+    with patch("agent.models_dev.lookup_models_dev_context", return_value=None):
+        for model_id in media_models:
+            assert (
+                get_model_context_length(model_id, provider="xai-oauth")
+                < MINIMUM_CONTEXT_LENGTH
+            )
+
+
+def test_xai_curated_catalog_hides_grok_imagine_media_models():
+    data = {
+        "xai": {
+            "models": {
+                "grok-4.3": {},
+                "grok-imagine-image": {},
+                "grok-imagine-video": {},
+                "grok-imagine-video-1.5-preview": {},
+            }
+        }
+    }
+
+    with patch("agent.models_dev._load_disk_cache", return_value=data):
+        result = models_mod._xai_curated_models()
+
+    assert "grok-4.3" in result
+    assert not any(model.startswith("grok-imagine-") for model in result)


### PR DESCRIPTION
## What does this PR do?

Prevents xAI Grok Imagine media-generation models from being selected or saved as Hermes' main agent model. These models have small media/backend context windows and can fail the next agent initialization after `/model` reports a successful switch.

The fix removes `grok-imagine-*` entries from the main xAI model picker, records their below-floor context defaults centrally, and makes xAI model validation a hard rejection when the resolved context is below Hermes' main-agent minimum.

## Related Issue

Fixes #52595

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added central context defaults for Grok Imagine image/video model IDs so they do not fall through to the generic Grok chat fallback.
- Filtered all known below-floor xAI models out of the main-model catalog used by `/model`, using models.dev entry metadata with Hermes' offline defaults as fallback.
- Added hard-reject validation for xAI/Grok models below Hermes' main-agent context floor, including live exact matches, autocorrect paths, hidden model soft-accept paths, configured-provider overrides, and custom endpoints verified as `api.x.ai`.
- Added regression coverage for xAI OAuth, direct xAI, picker filtering, configured-provider override, below-floor live model rejection, custom xAI endpoints, and the shipped Grok Imagine video aliases.

## How to Test

1. Duplicate checks:
   - `gh pr list --repo NousResearch/hermes-agent --state all --search "52595" --limit 20`
   - `gh pr list --repo NousResearch/hermes-agent --state all --search "Grok Imagine 64K context xai model picker" --limit 20`
2. Focused proof:
   - `scripts/run_tests.sh tests/hermes_cli/test_xai_main_model_context_floor.py`
3. Adjacent validation/switch proof:
   - `scripts/run_tests.sh tests/hermes_cli/test_xai_main_model_context_floor.py tests/hermes_cli/test_provider_live_curated_merge.py tests/hermes_cli/test_model_switch_configured_provider_routing.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_xai_retirement.py tests/hermes_cli/test_user_providers_model_switch.py`
4. Manual behavior probe confirmed:
   - `provider_model_ids("xai-oauth")` returns no `grok-imagine-*` entries.
   - `validate_requested_model()` rejects `grok-imagine-video`, `grok-imagine-image`, `grok-imagine-image-quality`, `grok-imagine-video-1.5-preview`, `grok-imagine-video-1.5-2026-05-30`, and `grok-2-vision` as main models.
   - `switch_model()` does not allow configured-provider overrides to bypass the hard rejection.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local checkout via `scripts/run_tests.sh`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused proof:

```text
.venv/bin/python -m pytest tests/hermes_cli/test_xai_main_model_context_floor.py -q
13 passed in 0.87s
```

Adjacent proof:

```text
.venv/bin/python -m pytest tests/hermes_cli/test_xai_main_model_context_floor.py tests/hermes_cli/test_provider_live_curated_merge.py tests/hermes_cli/test_model_switch_configured_provider_routing.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_xai_retirement.py tests/hermes_cli/test_user_providers_model_switch.py -q
137 passed in 146.05s
```

## 2026-07-10 shepherding refresh

Rebased the original human-authored commit onto current `main` (`7acaff5ef`) after 2,250 upstream commits of drift. Current main still allows models.dev `grok-imagine-*` entries into the xAI picker and still soft-accepts plausible hidden Grok slugs, so #52595 remains reproducible in the validation path.

Fresh proof:

- six focused/adjacent xAI and model-switch files — 137/137 passed
- focused Ruff — passed
- changed-line Windows-footgun scan — passed
- `git diff --check` — passed

Live exact and root-cause duplicate searches found no competing open PR for #52595 or the xAI media-model/context-floor bug.

Private review follow-up: removed redundant context-floor guard calls and closed both custom-xAI endpoint paths, including typo autocorrection to a media model, while preserving non-xAI custom endpoints. The picker now uses the same context-floor policy as validation, hiding known legacy (`grok-2-vision`) and future below-floor models without an import-time network lookup. Added targeted regressions for these paths.


## 2026-07-13 shepherding refresh

- Rebased all four original Harjoth-authored commits from 255 commits behind onto current `origin/main`, preserving authorship/history. Final head `c491b53a8` is zero commits behind.
- Current main still admits models.dev `grok-imagine-*` entries into the xAI main-model picker and can soft-accept below-floor hidden Grok slugs; issue #52595 remains open. Exact issue and root-cause searches still find only this PR.
- Rebase compatibility repair: current diff-aware typing exposed that the hard-reject validation message could be non-string. The follow-up now accepts only a string message and otherwise uses `Invalid model`, keeping `ModelSwitchResult.error_message` type-safe.
- Proof:
  - Six focused/adjacent xAI and model-switch files — **137 passed**.
  - Issue-shaped regression file after the type repair — **13 passed**.
  - Ruff, Windows-footgun scan, and `git diff --check` — passed.
  - Whole-file local ty reports 17 broad pre-existing diagnostics outside changed lines; GitHub's base/head Ruff+ty diff gate passes.
- GitHub Actions run `29301869335` is fully green: attribution/history, Ruff+ty, Windows, e2e, all eight Python slices, supply-chain scans, both Docker architectures, and the aggregate required-check gate passed.
