### PR TITLE
fix(gateway): pass session_db to compress temp agents so persistence works

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9542,7 +9542,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             ]
 
                             if len(_hyg_msgs) >= 4:
-                                _hyg_session_db = getattr(self.session_store, "_db", None)
                                 _hyg_agent = AIAgent(
                                     **_hyg_runtime,
                                     model=_hyg_model,
@@ -9551,15 +9550,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     skip_memory=True,
                                     enabled_toolsets=["memory"],
                                     session_id=session_entry.session_id,
-                                    session_db=_hyg_session_db,
+                                    session_db=self._session_db,
                                 )
                                 try:
                                     # The hygiene agent rotates the session
                                     # forward to a continuation id that becomes
                                     # the gateway session's live row. It must
-                                    # never finalize on close() (today it has no
-                                    # session_db so close() no-ops, but this
-                                    # guards a future where one is wired in).
+                                    # never finalize on close() — close() would
+                                    # end the newly rotated session the gateway
+                                    # entry now points at.
                                     _hyg_agent._end_session_on_close = False
                                     _hyg_agent._print_fn = lambda *a, **kw: None
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9542,6 +9542,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             ]
 
                             if len(_hyg_msgs) >= 4:
+                                _hyg_session_db = getattr(self.session_store, "_db", None)
                                 _hyg_agent = AIAgent(
                                     **_hyg_runtime,
                                     model=_hyg_model,
@@ -9550,6 +9551,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     skip_memory=True,
                                     enabled_toolsets=["memory"],
                                     session_id=session_entry.session_id,
+                                    session_db=_hyg_session_db,
                                 )
                                 try:
                                     # The hygiene agent rotates the session

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2810,6 +2810,12 @@ class GatewaySlashCommandsMixin:
                     partial = False
                     head = msgs
 
+            # Pass session_db so the temp agent can persist its session
+            # rotation to the database. Without it, compress_context computes
+            # the compressed messages in memory but never writes them to the
+            # session store — the next user message reloads the full original
+            # transcript and the apparent compression is lost (#fix/compress-gateway-persistence).
+            _tmp_session_db = getattr(self.session_store, "_db", None)
             tmp_agent = AIAgent(
                 **runtime_kwargs,
                 model=model,
@@ -2818,9 +2824,14 @@ class GatewaySlashCommandsMixin:
                 skip_memory=True,
                 enabled_toolsets=["memory"],
                 session_id=session_entry.session_id,
+                session_db=_tmp_session_db,
             )
             try:
                 tmp_agent._print_fn = lambda *a, **kw: None
+                # Prevent close() from ending the newly rotated session —
+                # the gateway session entry now points at the new id and
+                # must remain open for the next user turn.
+                tmp_agent._end_session_on_close = False
 
                 # Estimate with system prompt + tool schemas included so the
                 # figure reflects real request pressure, not a transcript-only

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2810,12 +2810,6 @@ class GatewaySlashCommandsMixin:
                     partial = False
                     head = msgs
 
-            # Pass session_db so the temp agent can persist its session
-            # rotation to the database. Without it, compress_context computes
-            # the compressed messages in memory but never writes them to the
-            # session store — the next user message reloads the full original
-            # transcript and the apparent compression is lost (#fix/compress-gateway-persistence).
-            _tmp_session_db = getattr(self.session_store, "_db", None)
             tmp_agent = AIAgent(
                 **runtime_kwargs,
                 model=model,
@@ -2824,7 +2818,7 @@ class GatewaySlashCommandsMixin:
                 skip_memory=True,
                 enabled_toolsets=["memory"],
                 session_id=session_entry.session_id,
-                session_db=_tmp_session_db,
+                session_db=self._session_db,
             )
             try:
                 tmp_agent._print_fn = lambda *a, **kw: None

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -54,6 +54,7 @@ def _make_runner(history: list[dict[str, str]]):
     runner.session_store.rewrite_transcript = MagicMock()
     runner.session_store.update_session = MagicMock()
     runner.session_store._save = MagicMock()
+    runner._session_db = None
     return runner
 
 
@@ -245,5 +246,62 @@ async def test_compress_command_surfaces_aux_model_failure_even_when_recovered()
     assert "auxiliary.compression.model" in result
     # The user's context is explicitly called out as intact
     assert "intact" in result
+    agent_instance.shutdown_memory_provider.assert_called_once()
+    agent_instance.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_compress_command_passes_session_db_and_persists_rotated_session():
+    """session_db must be wired into the /compress temp agent so that
+    _compress_context can actually rotate the session and persist the
+    compressed transcript — without it compression is a silent no-op."""
+    history = _make_history()
+    compressed = [
+        history[0],
+        {"role": "assistant", "content": "compressed summary"},
+        history[-1],
+    ]
+    runner = _make_runner(history)
+    runner._session_db = object()
+    agent_instance = MagicMock()
+    agent_instance.shutdown_memory_provider = MagicMock()
+    agent_instance.close = MagicMock()
+    agent_instance._cached_system_prompt = ""
+    agent_instance.tools = None
+    agent_instance.context_compressor.has_content_to_compress.return_value = True
+    agent_instance.compression_in_place = False
+    agent_instance.session_id = "sess-1"
+
+    def _compress(messages, *_args, **_kwargs):
+        agent_instance.session_id = "sess-2"
+        return compressed, ""
+
+    agent_instance._compress_context.side_effect = _compress
+
+    def _estimate(messages, **_kwargs):
+        if messages == history:
+            return 100
+        if messages == compressed:
+            return 60
+        raise AssertionError(f"unexpected transcript: {messages!r}")
+
+    with (
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}),
+        patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+        patch("run_agent.AIAgent", return_value=agent_instance) as mock_agent_cls,
+        patch("agent.model_metadata.estimate_request_tokens_rough", side_effect=_estimate),
+    ):
+        result = await runner._handle_compress_command(_make_event())
+
+    assert "Compressed:" in result
+    mock_agent_cls.assert_called_once()
+    assert mock_agent_cls.call_args.kwargs["session_db"] is runner._session_db
+    runner.session_store._save.assert_called_once()
+    runner.session_store.rewrite_transcript.assert_called_once_with(
+        "sess-2", compressed
+    )
+    runner.session_store.update_session.assert_called_once_with(
+        build_session_key(_make_source()), last_prompt_tokens=0
+    )
     agent_instance.shutdown_memory_provider.assert_called_once()
     agent_instance.close.assert_called_once()

--- a/tests/gateway/test_compress_focus.py
+++ b/tests/gateway/test_compress_focus.py
@@ -54,6 +54,7 @@ def _make_runner(history: list[dict[str, str]]):
     runner.session_store.rewrite_transcript = MagicMock()
     runner.session_store.update_session = MagicMock()
     runner.session_store._save = MagicMock()
+    runner._session_db = None
     return runner
 
 

--- a/tests/gateway/test_compress_plugin_engine.py
+++ b/tests/gateway/test_compress_plugin_engine.py
@@ -101,6 +101,7 @@ def _make_runner(history: list[dict[str, str]]):
     runner.session_store.rewrite_transcript = MagicMock()
     runner.session_store.update_session = MagicMock()
     runner.session_store._save = MagicMock()
+    runner._session_db = None
     return runner
 
 


### PR DESCRIPTION
## Summary
Gateway `/compress` and hygiene auto-compression were silent no-ops: the temp AIAgent had no `session_db`, so `compress_context` computed the summary in memory but never persisted the session rotation — the next user message reloaded the full original transcript.

## Changes
- `gateway/slash_commands.py`: pass `session_db=self._session_db` to the `/compress` temp agent; set `_end_session_on_close=False` so close() doesn't end the newly rotated session.
- `gateway/run.py`: pass `session_db=self._session_db` to the hygiene auto-compression temp agent; update the stale comment that said "today it has no session_db."
- `tests/gateway/test_compress_command.py`: regression test verifying `session_db` is passed and the rotated session is persisted.

## Root cause
`compress_context()` in `agent/conversation_compression.py` gates all session-rotation logic on `if agent._session_db:` (L519). Without it, the LLM summary is generated but never written to the database — `end_session`, `create_session`, and `archive_and_compact` are all skipped. The gateway's existing `rewrite_transcript` guard (from #49925) correctly prevents data loss, but compression still appeared to do nothing.

## Validation
| | Before | After |
|---|---|---|
| `/compress` | shows "Compressed: 970 → 11" then context overflow on next message | compressed context persists across turns |
| Hygiene auto-compress | logs "did not rotate (no session_db)" warning, no-op | session rotates, transcript persists |

`scripts/run_tests.sh tests/gateway/test_compress_command.py` — 5/5 passed.

## Credits
- @nycomar (#50542) — original fix for both paths
- @LeonSGP43 (#51624) — regression test (adapted here)
- @crayfish-ai (#51995) — hygiene-only fix using `self._session_db` (correct DB reference)
- @richarddxmmqfans-oss (#50935) — both paths + rewrite guard (guard already on main via #49925)

Salvage uses `self._session_db` (GatewayRunner's own SessionDB, consistent with existing usage in slash_commands.py) rather than the original `getattr(self.session_store, "_db", None)`.

Closes #50542, #51995, #50935, #51624
Fixes #51469
