### PR TITLE
fix(gateway): block mcp-tokens/ OAuth tokens from native media delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1096,12 +1096,15 @@ def _media_delivery_denied_paths() -> List[Path]:
         # Bitwarden Secrets Manager plaintext disk cache.
         os.path.join("cache", "bws_cache.json"),
     )
-    # Directory trees whose every child is credential material. (MCP OAuth
-    # tokens under mcp-tokens/ are handled by the sibling targeted PR #37222;
-    # session/kanban SQLite stores by #41071 — kept out of this diff to avoid
-    # overlap.)
+    # Directory trees whose every child is credential material. ``mcp-tokens/``
+    # holds per-server MCP OAuth tokens; it mirrors the read guard
+    # (get_read_block_error) and the write guard (is_write_denied) in
+    # agent/file_safety.py, both of which already block the whole tree, so the
+    # delivery side must not trail them. (Session/kanban SQLite stores are
+    # handled by the sibling PR #41071 — kept out of this diff to avoid overlap.)
     _ROOT_CREDENTIAL_DIRS = (
         "pairing",
+        "mcp-tokens",
     )
     for hermes_root in (_HERMES_HOME, _HERMES_ROOT):
         for rel in _ROOT_CREDENTIAL_FILES:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -795,6 +795,29 @@ class TestMediaDeliveryPathValidation:
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(secret)) is None
 
+    def test_recency_trust_denies_mcp_tokens_even_when_fresh(self, tmp_path, monkeypatch):
+        """MCP OAuth tokens under ~/.hermes/mcp-tokens/ are rewritten in place
+        on refresh, so their mtime is ~now on every turn — exactly the case the
+        recency window would otherwise re-trust (cf. the google_token.json
+        re-send exploit). The credential denylist must win over recency trust.
+        """
+        self._patch_roots(monkeypatch)
+        monkeypatch.delenv("HERMES_MEDIA_ALLOW_DIRS", raising=False)
+        monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_FILES", "1")
+        monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_SECONDS", "600")
+
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        mcp_tokens = hermes_dir / "mcp-tokens"
+        mcp_tokens.mkdir(parents=True)
+        token = mcp_tokens / "github.json"
+        token.write_text('{"access_token": "gho_***"}')  # mtime = now -> "recent"
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(token)) is None
+
     def test_recency_trust_allows_pdf_in_project_dir(self, tmp_path, monkeypatch):
         """The motivating case: agent produces a PDF in a project directory.
 
@@ -1021,6 +1044,28 @@ class TestMediaDeliveryDefaultMode:
         pairing.mkdir(parents=True)
         token = pairing / "telegram-approved.json"
         token.write_text('{"approved": ["123"]}')
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(token)) is None
+
+    def test_denylist_blocks_mcp_tokens_directory_contents(self, tmp_path, monkeypatch):
+        """Files under ~/.hermes/mcp-tokens/ hold per-server MCP OAuth tokens
+        and must not be deliverable. The read guard (get_read_block_error) and
+        the write guard (is_write_denied) in agent/file_safety.py already block
+        this tree; the delivery denylist mirrors them so an
+        ``MEDIA:~/.hermes/mcp-tokens/github.json`` tag can't exfiltrate the
+        token JSON to a chat platform as a native attachment.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        mcp_tokens = hermes_dir / "mcp-tokens"
+        mcp_tokens.mkdir(parents=True)
+        token = mcp_tokens / "github.json"
+        token.write_text('{"access_token": "gho_***", "refresh_token": "ghr_***"}')
         monkeypatch.setenv("HOME", str(fake_home))
         monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
         monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)


### PR DESCRIPTION
## What does this PR do?

The native media-delivery guard in `gateway/platforms/base.py` can attach
Hermes' MCP OAuth token files (`~/.hermes/mcp-tokens/*.json`) to a chat reply.

`_media_delivery_denied_paths()` is documented to mirror the credential
read/write guards in `agent/file_safety.py` — *"a credential the agent is
forbidden to write or read must also never be auto-attached to a chat reply."*
It enumerates the per-file credential stores and the `pairing/` tree, but the
`mcp-tokens/` tree was left out (an in-code comment deferred it to a sibling PR
that never landed in-tree). Meanwhile:

- the **read** guard (`get_read_block_error`) blocks the whole `mcp-tokens/` tree,
- the **write** guard (`is_write_denied`) blocks the whole `mcp-tokens/` tree,
- `.json` is in `MEDIA_DELIVERY_EXTS`, so the file is an eligible attachment.

So `validate_media_delivery_path("~/.hermes/mcp-tokens/github.json")` returns the
path (deliverable) in **both** default mode and strict+recency mode. An agent
reply containing `MEDIA:~/.hermes/mcp-tokens/github.json` (e.g. via prompt
injection) exfiltrates a provider OAuth token JSON to Slack/Telegram/Discord.

Fix: add `mcp-tokens` to `_ROOT_CREDENTIAL_DIRS` so the delivery (read/exfil)
side stops trailing the read/write guards. It covers both the active
`HERMES_HOME` and the shared Hermes root (profile mode) and is symlink-resolved
through the existing containment helper. The misleading "handled by sibling PR"
comment is corrected to state why the entry lives here.

## Related Issue

No separate tracked issue — the gap was documented in-code (the
# … sibling PR #37222 … kept out of this diff comment that this PR replaces).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/base.py` — add `"mcp-tokens"` to `_ROOT_CREDENTIAL_DIRS`
  in `_media_delivery_denied_paths()`; rewrite the stale comment to explain it
  mirrors the read/write guards.
- `tests/gateway/test_platform_base.py` — add two regression tests:
  - `TestMediaDeliveryDefaultMode::test_denylist_blocks_mcp_tokens_directory_contents`
  - `TestMediaDeliveryPathValidation::test_recency_trust_denies_mcp_tokens_even_when_fresh`
    (guards the in-place-refresh case where the token mtime is always ~now, which
    the recency window would otherwise re-trust).

## How to Test

**Reproduce (revert the one-line `_ROOT_CREDENTIAL_DIRS` change first):**

```python
from pathlib import Path
import gateway.platforms.base as base
from gateway.platforms.base import BasePlatformAdapter

home = Path("/tmp/hh"); (home / "mcp-tokens").mkdir(parents=True, exist_ok=True)
tok = home / "mcp-tokens" / "github.json"; tok.write_text('{"access_token": "gho_x"}')
base._HERMES_HOME = base._HERMES_ROOT = home
base.MEDIA_DELIVERY_SAFE_ROOTS = ()

print(BasePlatformAdapter.validate_media_delivery_path(str(tok)))
# before fix: prints the token path (deliverable)
# after  fix: prints None
```

**Regression tests:**

```
pytest tests/gateway/test_platform_base.py::TestMediaDeliveryDefaultMode::test_denylist_blocks_mcp_tokens_directory_contents \
       tests/gateway/test_platform_base.py::TestMediaDeliveryPathValidation::test_recency_trust_denies_mcp_tokens_even_when_fresh \
       tests/agent/test_file_safety_credentials.py -q
```

Result: **21 passed, 1 skipped**. Both new tests fail with the fix reverted and
pass with it applied (red→green). The credential read-guard suite
(`test_file_safety_credentials.py`, incl. the existing `mcp-tokens` read tests)
stays green — confirming read/write/delivery guards are now consistent.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway):`)
- [x] I searched existing PRs (scanned origin/upstream branches for `mcp-tokens`/`media` — no duplicate)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected suites and they pass (output above); full hermetic suite runs in CI
- [x] I've added tests for my changes
- [x] I've tested on my platform

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (inline comment updated with the fix)
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact — no OS-specific code; uses the existing symlink-resolved containment helper
- [x] I've updated tool descriptions/schemas — N/A (no tool behavior change)