### PR TITLE
fix(verification): skip stop-loop nudge when session has no exec tools

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4547,6 +4547,7 @@ def run_conversation(
                             session_id=getattr(agent, "session_id", None),
                             changed_paths=getattr(agent, "_turn_file_mutation_paths", set()),
                             attempts=getattr(agent, "_verification_stop_nudges", 0),
+                            available_tools=getattr(agent, "valid_tool_names", set()),
                         )
                     else:
                         _verify_nudge = None

--- a/agent/verification_stop.py
+++ b/agent/verification_stop.py
@@ -112,10 +112,19 @@ def build_verify_on_stop_nudge(
     changed_paths: Iterable[str],
     attempts: int = 0,
     max_attempts: int = 2,
+    available_tools: set[str] | None = None,
 ) -> str | None:
     """Return a synthetic follow-up when edited code lacks fresh verification."""
     paths = sorted({str(p) for p in changed_paths if p})
     if not paths or attempts >= max_attempts:
+        return None
+
+    # If the session has no terminal/execute_code tools, the agent cannot run
+    # verification commands. Skip the nudge to avoid burning tokens on
+    # hopeless loops (#52631).
+    if available_tools is not None and not (
+        available_tools & {"terminal", "execute_code"}
+    ):
         return None
 
     snapshot = _verification_snapshot(session_id=session_id, changed_paths=paths)

--- a/tests/agent/test_verification_stop.py
+++ b/tests/agent/test_verification_stop.py
@@ -163,3 +163,42 @@ def test_nudge_attempts_are_bounded(tmp_path, monkeypatch):
         attempts=2,
         max_attempts=2,
     ) is None
+
+def test_no_nudge_when_no_exec_tools(tmp_path, monkeypatch):
+    """Sessions without terminal/execute_code tools should skip the nudge."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    changed = str(tmp_path / "src" / "app.ts")
+    mark_workspace_edited(session_id="s1", cwd=tmp_path, paths=[changed])
+
+    # With terminal tool present -> nudge fires
+    nudge = build_verify_on_stop_nudge(
+        session_id="s1",
+        changed_paths=[changed],
+        available_tools={"terminal", "read_file", "write_file"},
+    )
+    assert nudge is not None
+
+    # With only file tools (no terminal/execute_code) -> skip
+    nudge = build_verify_on_stop_nudge(
+        session_id="s1",
+        changed_paths=[changed],
+        available_tools={"read_file", "write_file", "search_files"},
+    )
+    assert nudge is None
+
+    # With execute_code tool -> nudge fires
+    nudge = build_verify_on_stop_nudge(
+        session_id="s1",
+        changed_paths=[changed],
+        available_tools={"execute_code", "read_file"},
+    )
+    assert nudge is not None
+
+    # With available_tools=None (backward compat) -> nudge fires
+    nudge = build_verify_on_stop_nudge(
+        session_id="s1",
+        changed_paths=[changed],
+        available_tools=None,
+    )
+    assert nudge is not None


### PR DESCRIPTION
## What does this PR do?

Skip the `verification_required` stop-loop nudge when the session has no `terminal` or `execute_code` tools. Previously, sessions with only file-writing tools (e.g., cron jobs with `enabled_toolsets: ["skills", "file", "session_search"]`) would trigger the verification nudge, but the agent had no way to run verification commands — burning ~4K tokens across 2 extra turns until `max_attempts` was exhausted, and producing confusing "Ad-hoc verification" boilerplate in the delivery output.

## Related Issue

Fixes #52631

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/verification_stop.py`: Add `available_tools` parameter to `build_verify_on_stop_nudge()`. When the set contains neither `terminal` nor `execute_code`, return `None` immediately — the agent cannot satisfy the verification request.
- `agent/conversation_loop.py`: Pass `agent.valid_tool_names` as `available_tools` to the nudge builder.
- `tests/agent/test_verification_stop.py`: Add `test_no_nudge_when_no_exec_tools` covering four scenarios: terminal present (nudge fires), only file tools (skip), execute_code present (nudge fires), and `None` for backward compat (nudge fires).

## How to Test

1. Run `python -m pytest tests/agent/test_verification_stop.py -v` — all 11 tests should pass, including the new `test_no_nudge_when_no_exec_tools`.
2. The new test validates four scenarios:
   - `available_tools={"terminal", "read_file", "write_file"}` → nudge fires (has exec tool)
   - `available_tools={"read_file", "write_file", "search_files"}` → nudge skipped (no exec tool)
   - `available_tools={"execute_code", "read_file"}` → nudge fires (has exec tool)
   - `available_tools=None` → nudge fires (backward compat, no restriction)
3. Existing tests remain unchanged and pass — the new parameter defaults to `None`, preserving backward compatibility.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_verification_stop.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/verification_stop.py` (callers: 1 in conversation_loop.py)
- Blast radius: LOW — adds an optional parameter with `None` default; no existing callers affected
- Related patterns: Guard clause on tool availability before expensive nudge construction
