### PR TITLE
fix(state): reconcile session counts on rewind

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4581,6 +4581,27 @@ class SessionDB:
     # Rewind (soft-delete) — see /rewind slash command + issue #21910
     # =========================================================================
 
+    @staticmethod
+    def _active_message_counts(conn, session_id: str) -> Tuple[int, int]:
+        message_count = 0
+        tool_call_count = 0
+        rows = conn.execute(
+            "SELECT tool_calls FROM messages "
+            "WHERE session_id = ? AND active = 1",
+            (session_id,),
+        )
+        for (tool_calls_json,) in rows:
+            message_count += 1
+            if not tool_calls_json:
+                continue
+            try:
+                parsed = json.loads(tool_calls_json)
+            except (ValueError, TypeError):
+                continue
+            if parsed is not None:
+                tool_call_count += len(parsed) if isinstance(parsed, list) else 1
+        return message_count, tool_call_count
+
     def rewind_to_message(
         self, session_id: str, target_message_id: int
     ) -> Dict[str, Any]:
@@ -4608,6 +4629,10 @@ class SessionDB:
         the number of rewind operations performed against the session.
         Idempotent on the ``active`` flag: re-rewinding past the same
         target is a no-op on row state but still bumps the counter.
+
+        Also reconciles ``sessions.message_count`` and
+        ``sessions.tool_call_count`` to the rows that stay active so the
+        denormalized counters keep matching the live transcript.
         """
 
         # 1) Validate target up-front (read-only, outside the write txn).
@@ -4645,10 +4670,23 @@ class SessionDB:
                     f"UPDATE messages SET active = 0 WHERE id IN ({placeholders})",
                     ids,
                 )
+            # Rebuild the denormalized session counters from the rows that
+            # stay active so they keep tracking the live (active=1) set after
+            # the rewind. message_count is the active-row count and
+            # tool_call_count sums each active row's tool_calls the same way
+            # append_message and _insert_message_rows do (a list's length, or
+            # one for a non-list). Without this the columns stay frozen at
+            # their pre-rewind values and every later message widens the gap,
+            # inflating the session-list counts and hiding the rewind from the
+            # cross-process agent-cache staleness check that keys off
+            # message_count.
+            message_count, tool_call_count = self._active_message_counts(
+                conn, session_id
+            )
             conn.execute(
-                "UPDATE sessions SET rewind_count = COALESCE(rewind_count, 0) + 1 "
-                "WHERE id = ?",
-                (session_id,),
+                "UPDATE sessions SET message_count = ?, tool_call_count = ?, "
+                "rewind_count = COALESCE(rewind_count, 0) + 1 WHERE id = ?",
+                (message_count, tool_call_count, session_id),
             )
             return ids
 
@@ -4672,8 +4710,9 @@ class SessionDB:
         """Mark inactive messages with id >= *since_message_id* active again.
 
         Returns the number of rows flipped back to ``active=1``.
-        Intended for undo-of-rewind and test cleanup; not wired to a
-        slash command in v1.
+        Intended for undo-of-rewind and test cleanup. It is not wired to
+        a slash command in v1. The session counters are rebuilt in the
+        same transaction.
         """
         def _do(conn):
             cursor = conn.execute(
@@ -4688,6 +4727,14 @@ class SessionDB:
                     f"UPDATE messages SET active = 1 WHERE id IN ({placeholders})",
                     ids,
                 )
+            message_count, tool_call_count = self._active_message_counts(
+                conn, session_id
+            )
+            conn.execute(
+                "UPDATE sessions SET message_count = ?, tool_call_count = ? "
+                "WHERE id = ?",
+                (message_count, tool_call_count, session_id),
+            )
             return len(ids)
 
         return self._execute_write(_do)
@@ -6074,6 +6121,13 @@ class SessionDB:
         held open by the live agent — is never sniped out from under
         the runtime.
 
+        A session whose ``message_count`` is 0 but which still has message
+        rows on disk is NOT empty. The counter tracks the live (active)
+        set, so a session rewound all the way back
+        (:meth:`rewind_to_message`) reports 0 while its ``active = 0``
+        audit rows remain. The row-existence check keeps those sessions
+        out of the count.
+
         Backs the ``GET /api/sessions/empty/count`` endpoint that lets the
         web dashboard hide its "Delete empty" button when there's nothing
         to clean up, and pre-populate the confirm dialog with the actual
@@ -6084,7 +6138,11 @@ class SessionDB:
                 "SELECT COUNT(*) FROM sessions "
                 "WHERE message_count = 0 "
                 "AND ended_at IS NOT NULL "
-                "AND archived = 0"
+                "AND archived = 0 "
+                "AND NOT EXISTS ("
+                "    SELECT 1 FROM messages"
+                "    WHERE messages.session_id = sessions.id"
+                ")"
             )
             return cursor.fetchone()[0]
 
@@ -6099,6 +6157,12 @@ class SessionDB:
         * Selects candidate IDs first (``message_count = 0`` AND
           ``ended_at IS NOT NULL`` AND ``archived = 0``) so we never
           touch a live session or one the user deliberately archived.
+        * Additionally requires that the session has no message rows at
+          all. ``message_count`` tracks the live (active) set, so a
+          fully-rewound session reports 0 while its ``active = 0`` audit
+          rows are still on disk (:meth:`rewind_to_message`). Deleting it
+          would destroy the rewound history that soft-delete exists to
+          preserve, so it never enters the kill list.
         * Orphans any child whose parent is in the kill list — children
           of an empty parent are kept and re-parented to ``NULL`` rather
           than cascade-deleted, matching ``delete_session`` /
@@ -6124,7 +6188,11 @@ class SessionDB:
                 "SELECT id FROM sessions "
                 "WHERE message_count = 0 "
                 "AND ended_at IS NOT NULL "
-                "AND archived = 0"
+                "AND archived = 0 "
+                "AND NOT EXISTS ("
+                "    SELECT 1 FROM messages"
+                "    WHERE messages.session_id = sessions.id"
+                ")"
             )
             session_ids = {row["id"] for row in cursor.fetchall()}
 
@@ -6139,10 +6207,10 @@ class SessionDB:
             )
 
             for sid in session_ids:
-                # DELETE FROM messages is paranoia — by construction
-                # these rows have ``message_count = 0`` — but if a
-                # bookkeeping bug ever lets the counter drift below the
-                # real row count, we still leave a clean FK state.
+                # DELETE FROM messages is paranoia: the NOT EXISTS in the
+                # candidate SELECT (same transaction) means these sessions
+                # have no message rows at all. If that ever changes, we
+                # still leave a clean FK state.
                 conn.execute(
                     "DELETE FROM messages WHERE session_id = ?", (sid,)
                 )

--- a/tests/gateway/test_undo_rewind_session.py
+++ b/tests/gateway/test_undo_rewind_session.py
@@ -63,6 +63,44 @@ def test_rewind_soft_deletes_rows_for_audit(store):
     assert store._db.get_session(sid)["rewind_count"] == 1
 
 
+def test_rewind_reconciles_message_count(store):
+    sid = _seed(store, "gw-mc")
+    assert store._db.get_session(sid)["message_count"] == 6
+    store.rewind_session(sid, 1)
+    # message_count must follow the active (live) transcript, not the
+    # pre-rewind total. q3 + a3 went inactive, so four rows remain.
+    sess = store._db.get_session(sid)
+    assert sess["message_count"] == 4
+    assert sess["message_count"] == len(store.load_transcript(sid))
+    # A message sent after the undo counts up from the reconciled value.
+    store._db.append_message(sid, "user", "q3-again")
+    assert store._db.get_session(sid)["message_count"] == 5
+
+
+def test_rewind_and_restore_reconcile_session_counts(store):
+    sid = "gw-tc"
+    store._db.create_session(sid, source="telegram")
+    store._db.append_message(sid, "user", "q1")
+    store._db.append_message(sid, "assistant", "a1")
+    store._db.append_message(sid, "user", "q2")
+    store._db.append_message(
+        sid, "assistant", "a2", tool_calls=[{"id": "t1"}, {"id": "t2"}]
+    )
+    q3_id = store._db.append_message(sid, "user", "q3")
+    store._db.append_message(sid, "assistant", "a3", tool_calls=[{"id": "t3"}])
+
+    store.rewind_session(sid, 1)
+    rewound = store._db.get_session(sid)
+    assert rewound["message_count"] == 4
+    assert rewound["tool_call_count"] == 2
+
+    assert store._db.restore_rewound(sid, q3_id) == 2
+    restored = store._db.get_session(sid)
+    assert restored["message_count"] == 6
+    assert restored["tool_call_count"] == 3
+    assert len(store.load_transcript(sid)) == 6
+
+
 def test_rewind_clamps_to_oldest_turn(store):
     sid = _seed(store, "gw-4", turns=2)
     res = store.rewind_session(sid, 99)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2859,6 +2859,11 @@ class TestDeleteEmptySessions:
        NULL) rather than cascade-deleted, matching the
        ``delete_session`` / ``prune_sessions`` contract.
     5. The pre-DB count matches the post-DB delete return value.
+    6. A session whose ``message_count`` is 0 but which still holds
+       message rows on disk is NOT empty. ``message_count`` tracks the
+       live (active) set, so a session rewound all the way back reports
+       0 while its ``active = 0`` audit rows remain. Deleting it would
+       destroy the history ``rewind_to_message`` promises to keep.
     """
 
     def test_count_and_delete_empties_only(self, db):
@@ -2906,6 +2911,26 @@ class TestDeleteEmptySessions:
         assert db.count_empty_sessions() == 0
         assert db.delete_empty_sessions() == 0
         assert db.get_session("archived_empty") is not None
+
+    def test_skips_fully_rewound_sessions_with_audit_rows(self, db):
+        """A session rewound back to its first user message has
+        ``message_count = 0`` (the counter tracks the live set) but its
+        rewound rows are still on disk with ``active = 0`` for audit.
+        The sweep must not treat it as empty, since deleting it would
+        destroy exactly the history the soft-delete exists to preserve."""
+        db.create_session(session_id="rewound", source="cli")
+        first_id = db.append_message("rewound", role="user", content="q1")
+        db.append_message("rewound", role="assistant", content="a1")
+        db.rewind_to_message("rewound", first_id)
+        db.end_session("rewound", end_reason="done")
+
+        assert db.get_session("rewound")["message_count"] == 0
+        assert db.count_empty_sessions() == 0
+        assert db.delete_empty_sessions() == 0
+        assert db.get_session("rewound") is not None
+        # The audit rows survive the sweep.
+        kept = db.get_messages("rewound", include_inactive=True)
+        assert [m["content"] for m in kept] == ["q1", "a1"]
 
     def test_returns_zero_when_nothing_to_delete(self, db):
         """No-op path: no candidate rows → return 0, no error."""


### PR DESCRIPTION
## What does this PR do?

`rewind_to_message` (the `/undo` primitive) flipped the rewound rows to `active = 0` and bumped `rewind_count`, but left `sessions.message_count` and `sessions.tool_call_count` at their pre-rewind values. Every later `append_message` then counted up from the stale number, so both columns drifted further from the active transcript on each undo plus new-message cycle.

This restores the active-count invariant that `archive_and_compact` already upholds, so the session list shows correct counts and the cross-process agent-cache staleness guard (#45966), which keys off `message_count`, can treat an undo as a real change instead of silently missing it. The single-process undo path was already correct (the gateway evicts its cached agent, the TUI truncates its in-memory history), so this is a denormalized-counter consistency fix rather than a transcript-corruption fix.

The empty-session guard closes an interaction the reconciliation exposes: a session rewound back to its first user message now correctly reports `message_count = 0`, but its rewound rows are still on disk with `active = 0`, kept as the audit history `rewind_to_message` promises to preserve. `count_empty_sessions` and `delete_empty_sessions` (the dashboard's "Delete empty" sweep) selected on `message_count = 0` alone and hard-delete every message row of a candidate, so they would have swept such a session together with its audit rows once it ended. Both now also require that the session has no message rows at all (`NOT EXISTS`, checked in the same transaction as the delete), the same counter-vs-rows defense the session-resume lookup already uses.

## Related Issue

Fixes #52640

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py`: in `rewind_to_message`, after the rewound rows flip to `active = 0`, recompute `message_count` and `tool_call_count` from the rows that stay active and fold them into the same `UPDATE sessions` that bumps `rewind_count`. `tool_call_count` sums each active row's `tool_calls` the same way `append_message` and `_insert_message_rows` do (a list's length, or one for a non-list). Added a docstring note describing the reconciliation.
- `tests/gateway/test_undo_rewind_session.py`: added `test_rewind_reconciles_message_count` and `test_rewind_reconciles_tool_call_count`.
- `hermes_state.py`: `count_empty_sessions` and `delete_empty_sessions` additionally require `NOT EXISTS (SELECT 1 FROM messages WHERE messages.session_id = sessions.id)`, so a fully-rewound session (live count 0, audit rows on disk) is never a "Delete empty" candidate. Docstrings and the in-loop comment updated to state the new invariant.
- `tests/test_hermes_state.py`: added `test_skips_fully_rewound_sessions_with_audit_rows` (a rewound-to-zero, ended session is neither counted nor deleted, and its inactive rows survive the sweep).

## How to Test

1. On `main`, the new tests fail: after a one-turn rewind of a 6-message session the column stays at `6` (and `tool_call_count` stays at `3`) instead of `4` and `2`.
2. With this change, `rewind_to_message` reports `message_count = 4` and `tool_call_count = 2`, matching `SELECT COUNT(*) FROM messages WHERE active = 1`.
3. For the sweep guard: `test_skips_fully_rewound_sessions_with_audit_rows` fails without the second commit (the sweep deletes the rewound session and its audit rows) and passes with it.
4. Run `pytest tests/test_hermes_state.py tests/gateway/test_undo_rewind_session.py tests/tui_gateway/test_undo_command.py tests/hermes_cli/test_web_server.py -q`. 595 passed, 17 skipped. ruff clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Reproduction against `SessionDB`, before and after the change:

```
# on main (bug)
After 3 turns:        message_count=6  active=6
After /undo (rewind): message_count=6  active=4
After new message:    message_count=7  active=5

# with this PR
After 3 turns:        message_count=6  active=6
After /undo (rewind): message_count=4  active=4
After new message:    message_count=5  active=5
```


