### PR TITLE
fix(cli): show custom providers in auxiliary model picker

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3369,11 +3369,13 @@ def _aux_select_for_task(task: str) -> None:
     inside the aux picker — users set up new providers through the normal
     ``hermes model`` flow, then route aux tasks to them here.
     """
-    from hermes_cli.config import load_config
+    from hermes_cli.config import get_compatible_custom_providers, load_config
     from hermes_cli.model_switch import list_authenticated_providers
 
     cfg = load_config()
     aux = cfg.get("auxiliary", {}) if isinstance(cfg.get("auxiliary"), dict) else {}
+    user_providers = cfg.get("providers") if isinstance(cfg.get("providers"), dict) else {}
+    custom_providers = get_compatible_custom_providers(cfg)
     task_cfg = aux.get(task, {}) if isinstance(aux.get(task), dict) else {}
     current_provider = str(task_cfg.get("provider") or "auto").strip() or "auto"
     current_model = str(task_cfg.get("model") or "").strip()
@@ -3387,6 +3389,8 @@ def _aux_select_for_task(task: str) -> None:
             current_provider=current_provider,
             current_model=current_model,
             current_base_url=current_base_url,
+            user_providers=user_providers,
+            custom_providers=custom_providers,
         )
     except Exception as exc:
         print(f"Could not detect authenticated providers: {exc}")


### PR DESCRIPTION
## Summary
- pass configured `providers` and `custom_providers` into the auxiliary model picker
- make `hermes model` → Configure auxiliary models list saved named custom providers like the main model picker does

## Test Plan
- `PYTHONPYCACHEPREFIX=/tmp/hermes-pycache python3 -m py_compile hermes_cli/main.py`
- `.venv/bin/python -m pytest tests/hermes_cli/test_aux_config.py -q -o 'addopts='`

## Notes
This fixes the CLI picker enumeration path only. Runtime resolution of named custom providers is handled elsewhere.
