### PR TITLE
fix(gateway): include configured Telegram DM topics in channel directory

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -124,6 +124,8 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
                 platforms["discord"] = _build_discord(adapter)
             elif platform == Platform.SLACK:
                 platforms["slack"] = await _build_slack(adapter)
+            elif platform == Platform.TELEGRAM:
+                platforms["telegram"] = _build_telegram(adapter)
         except Exception as e:
             logger.warning("Channel directory: failed to build %s: %s", platform.value, e)
 
@@ -260,6 +262,41 @@ async def _build_slack(adapter) -> List[Dict[str, Any]]:
             seen_ids.add(entry.get("id"))
 
     return channels
+
+
+def _build_telegram(adapter) -> List[Dict[str, str]]:
+    """Include configured DM topics alongside session-discovered entries.
+
+    Reads ``extra.dm_topics`` from the Telegram adapter config so that
+    configured topics always appear in the channel directory, even when
+    they have no active session entries in sessions.json.
+    """
+    entries = _build_from_sessions("telegram")
+    seen_ids = {e["id"] for e in entries}
+
+    dm_topics_config = getattr(adapter, "_dm_topics_config", None) or []
+    for chat_entry in dm_topics_config:
+        chat_id = chat_entry.get("chat_id")
+        if chat_id is None:
+            continue
+        chat_id_str = str(chat_id)
+        for topic in chat_entry.get("topics", []):
+            topic_name = topic.get("name", "")
+            thread_id = topic.get("thread_id")
+            if not thread_id:
+                continue
+            entry_id = f"{chat_id_str}:{thread_id}"
+            if entry_id in seen_ids:
+                continue
+            seen_ids.add(entry_id)
+            entries.append({
+                "id": entry_id,
+                "name": topic_name,
+                "type": "dm",
+                "thread_id": str(thread_id),
+            })
+
+    return entries
 
 
 def _build_from_sessions(platform_name: str) -> List[Dict[str, str]]:

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -15,6 +15,7 @@ from gateway.channel_directory import (
     _apply_channel_aliases,
     _build_from_sessions,
     _build_slack,
+    _build_telegram,
 )
 
 
@@ -495,6 +496,125 @@ class TestBuildSlack:
             entries = asyncio.run(_build_slack(_make_slack_adapter({"T1": client})))
 
         assert entries == []
+
+
+class TestBuildTelegram:
+    """_build_telegram merges configured DM topics with session entries."""
+
+    def _make_adapter(self, dm_topics_config):
+        return SimpleNamespace(_dm_topics_config=dm_topics_config)
+
+    def _write_sessions(self, tmp_path, sessions_data):
+        sessions_path = tmp_path / "sessions" / "sessions.json"
+        sessions_path.parent.mkdir(parents=True)
+        sessions_path.write_text(json.dumps(sessions_data))
+
+    def test_configured_topics_appear_without_sessions(self, tmp_path):
+        """DM topics with thread_ids appear even when no session entries exist."""
+        from gateway.channel_directory import _build_telegram
+
+        adapter = self._make_adapter([{
+            "chat_id": -1001,
+            "topics": [
+                {"name": "General", "thread_id": 306210},
+                {"name": "SmartHome", "thread_id": 306211},
+            ],
+        }])
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = _build_telegram(adapter)
+
+        ids = {e["id"] for e in entries}
+        assert "-1001:306210" in ids
+        assert "-1001:306211" in ids
+        names = {e["name"] for e in entries}
+        assert "General" in names
+        assert "SmartHome" in names
+
+    def test_session_entries_still_included(self, tmp_path):
+        """Session-discovered entries are preserved alongside config topics."""
+        from gateway.channel_directory import _build_telegram
+
+        self._write_sessions(tmp_path, {
+            "s1": {
+                "origin": {"platform": "telegram", "chat_id": "-1001", "chat_name": "Chat"},
+                "chat_type": "group",
+            },
+        })
+        adapter = self._make_adapter([{
+            "chat_id": -1001,
+            "topics": [{"name": "General", "thread_id": 306210}],
+        }])
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = _build_telegram(adapter)
+
+        ids = {e["id"] for e in entries}
+        assert "-1001" in ids  # from session
+        assert "-1001:306210" in ids  # from config
+
+    def test_no_duplicate_when_session_already_has_topic(self, tmp_path):
+        """Config topics that already exist in session entries are not duplicated."""
+        from gateway.channel_directory import _build_telegram
+
+        self._write_sessions(tmp_path, {
+            "topic_s": {
+                "origin": {
+                    "platform": "telegram",
+                    "chat_id": "-1001",
+                    "chat_name": "Chat",
+                    "thread_id": "306210",
+                },
+                "chat_type": "group",
+            },
+        })
+        adapter = self._make_adapter([{
+            "chat_id": -1001,
+            "topics": [{"name": "General", "thread_id": 306210}],
+        }])
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = _build_telegram(adapter)
+
+        count = sum(1 for e in entries if e["id"] == "-1001:306210")
+        assert count == 1
+
+    def test_topics_without_thread_id_skipped(self, tmp_path):
+        """Topics that haven't been created yet (no thread_id) are skipped."""
+        from gateway.channel_directory import _build_telegram
+
+        adapter = self._make_adapter([{
+            "chat_id": -1001,
+            "topics": [
+                {"name": "General", "thread_id": 306210},
+                {"name": "Pending"},  # no thread_id
+            ],
+        }])
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = _build_telegram(adapter)
+
+        ids = {e["id"] for e in entries}
+        assert "-1001:306210" in ids
+        assert len(entries) == 1
+
+    def test_no_dm_topics_config_attribute(self, tmp_path):
+        """Adapter without _dm_topics_config falls back to session-only."""
+        from gateway.channel_directory import _build_telegram
+
+        self._write_sessions(tmp_path, {
+            "s1": {
+                "origin": {"platform": "telegram", "chat_id": "123", "chat_name": "Alice"},
+                "chat_type": "dm",
+            },
+        })
+        adapter = SimpleNamespace()  # no _dm_topics_config
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = _build_telegram(adapter)
+
+        assert len(entries) == 1
+        assert entries[0]["id"] == "123"
 
 
 class TestChannelAliases:


### PR DESCRIPTION
## What does this PR do?

Telegram DM topics configured in `platforms.telegram.extra.dm_topics` are loaded by the adapter at startup, but `channel_directory.json` is built solely from `sessions/sessions.json`. When a configured topic has no active session entry, it disappears from the directory — making it unaddressable via `send_message` until the first inbound message recreates the session entry.

This fix adds a `_build_telegram` builder (parallel to the existing `_build_discord` and `_build_slack`) that reads `_dm_topics_config` from the Telegram adapter and merges configured topics into the directory alongside session-discovered entries.

## Related Issue

Fixes #52629

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/channel_directory.py`: Add `_build_telegram()` that reads configured DM topics from the adapter's `_dm_topics_config` and merges them with session-based entries, deduplicating by composite ID. Wire it into `build_channel_directory()` alongside the Discord and Slack branches.
- `tests/gateway/test_channel_directory.py`: Add `TestBuildTelegram` (5 tests) covering: topics without sessions, session+config merge, deduplication, missing thread_id skip, and fallback when adapter lacks `_dm_topics_config`.

## How to Test

1. Configure `platforms.telegram.extra.dm_topics` with multiple topics in `config.yaml`.
2. Start the gateway — verify `channel_directory.json` contains all configured topics even if none have active sessions.
3. Run `python -m pytest tests/gateway/test_channel_directory.py -q` — all 44 tests should pass.
4. Verify `send_message(action="list")` shows configured DM topics deterministically.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/channel_directory.py` (callers: `gateway/run.py` ×3, blast radius: LOW)
- Blast radius: LOW — additive change, existing session-based behavior preserved
- Related patterns: `_build_discord` and `_build_slack` follow the same adapter-enumeration pattern
