### PR TITLE
fix(security): block google_token.json, google_oauth_pending.json, and pairing/ in read_file guard

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -156,8 +156,11 @@ def get_read_block_error(path: str) -> Optional[str]:
       * Credential / secret stores under HERMES_HOME and the global Hermes
         root: ``auth.json``, ``auth.lock``, ``.anthropic_oauth.json``,
         ``.env``, ``webhook_subscriptions.json``, ``auth/google_oauth.json``,
-        and anything under ``mcp-tokens/``. These hold plaintext provider keys,
-        OAuth tokens, and HMAC secrets that the agent never needs to read
+        ``google_token.json``, ``google_oauth_pending.json``,
+        ``cache/bws_cache.json``, anything under ``mcp-tokens/``, and the
+        DM-pairing tree (``pairing/`` and ``platforms/pairing/``). These hold
+        plaintext provider keys, OAuth access/refresh tokens, HMAC secrets,
+        and pairing-approval state that the agent never needs to read
         directly — provider tools / gateway adapters consume them through
         internal channels.
       * Project-local environment files anywhere on disk: ``.env``,
@@ -232,6 +235,15 @@ def get_read_block_error(path: str) -> Optional[str]:
         ".env",
         "webhook_subscriptions.json",
         os.path.join("auth", "google_oauth.json"),
+        # Google Workspace skill OAuth stores at the HERMES_HOME root: the
+        # auto-refreshing access/refresh token (google_token.json) and the
+        # pending-exchange session/verifier file (google_oauth_pending.json).
+        # Both are already credential-classified by the gateway media-delivery
+        # denylist (gateway/platforms/base.py::_media_delivery_denied_paths),
+        # which documents that it "mirrors the canonical read guard" here — but
+        # this read guard had drifted behind it.
+        "google_token.json",
+        "google_oauth_pending.json",
         # Bitwarden Secrets Manager disk cache: stores plaintext secret values
         # to avoid re-fetching across back-to-back CLI invocations. The file
         # was introduced by #31968 but not added to this guard.
@@ -274,6 +286,39 @@ def get_read_block_error(path: str) -> Optional[str]:
             "and cannot be read directly. (Defense-in-depth — not a "
             "security boundary; the terminal tool can still bypass.)"
         )
+
+    # DM-pairing store: directory prefix match — every child is pairing
+    # approval state (approved-user lists, pending one-time codes, rate-limit
+    # records). The write deny guard (is_write_denied) and the gateway
+    # media-delivery denylist already treat this tree as credential material;
+    # the read guard mirrors them so the agent can't read approved-user
+    # identifiers or pending pairing codes back into the transcript. Both the
+    # legacy ``<home>/pairing`` and the consolidated ``<home>/platforms/pairing``
+    # layouts are covered — gateway/pairing.py resolves the live directory via
+    # ``get_hermes_dir("platforms/pairing", "pairing")``, so new installs use
+    # the ``platforms/`` location.
+    for hd in hermes_dirs:
+        for rel in ("pairing", os.path.join("platforms", "pairing")):
+            try:
+                pairing_dir = (hd / rel).resolve()
+            except Exception:
+                continue
+            if resolved == pairing_dir:
+                return (
+                    f"Access denied: {path} is the Hermes DM-pairing "
+                    "directory and cannot be read directly. (Defense-in-depth "
+                    "— not a security boundary; the terminal tool can still "
+                    "bypass.)"
+                )
+            try:
+                resolved.relative_to(pairing_dir)
+            except ValueError:
+                continue
+            return (
+                f"Access denied: {path} is a Hermes DM-pairing credential "
+                "file and cannot be read directly. (Defense-in-depth — not a "
+                "security boundary; the terminal tool can still bypass.)"
+            )
 
     # Block common secret-bearing project-local .env files anywhere on disk.
     # The agent helping a user with their project rarely needs to read raw

--- a/tests/agent/test_file_safety_credentials.py
+++ b/tests/agent/test_file_safety_credentials.py
@@ -337,3 +337,162 @@ def test_profile_mode_blocks_root_credentials(tmp_path, monkeypatch):
     root_tok.parent.mkdir(parents=True, exist_ok=True)
     root_tok.write_text("x")
     assert "MCP token" in (get_read_block_error(str(root_tok)) or "")
+
+
+# ---------------------------------------------------------------------------
+# Widening: google_token.json, google_oauth_pending.json, pairing/
+#
+# These paths are already classified as credential material by the gateway
+# media-delivery denylist (gateway/platforms/base.py), whose comment states it
+# "mirrors the canonical read guard in agent/file_safety.py" — but the read
+# guard had drifted behind it. The write deny guard (is_write_denied) likewise
+# blocks the pairing tree. A prompt-injection reaching read_file could
+# otherwise pull Google OAuth access/refresh tokens or DM-pairing approval
+# state into the transcript.
+# ---------------------------------------------------------------------------
+
+
+def test_google_token_json_blocked(fake_home):
+    """google_token.json holds the Google Workspace OAuth access/refresh
+    token — blocked (matches the gateway media-delivery denylist)."""
+    from agent.file_safety import get_read_block_error
+
+    tok = _create(fake_home, "google_token.json")
+    err = get_read_block_error(str(tok))
+    assert err is not None
+    assert "credential store" in err
+
+
+def test_google_oauth_pending_json_blocked(fake_home):
+    """google_oauth_pending.json holds the in-flight OAuth session/verifier
+    state — blocked."""
+    from agent.file_safety import get_read_block_error
+
+    pending = _create(fake_home, "google_oauth_pending.json")
+    err = get_read_block_error(str(pending))
+    assert err is not None
+    assert "credential store" in err
+
+
+def test_pairing_legacy_file_blocked(fake_home):
+    """A file under the legacy ``pairing/`` tree (approved-user list) is
+    blocked — every child is pairing approval state."""
+    from agent.file_safety import get_read_block_error
+
+    approved = _create(fake_home, Path("pairing") / "telegram-approved.json")
+    err = get_read_block_error(str(approved))
+    assert err is not None
+    assert "pairing" in err.lower()
+
+
+def test_pairing_platforms_file_blocked(fake_home):
+    """A file under the consolidated ``platforms/pairing/`` tree (where new
+    installs store pairing data) is blocked too."""
+    from agent.file_safety import get_read_block_error
+
+    pending = _create(
+        fake_home, Path("platforms") / "pairing" / "telegram-pending.json"
+    )
+    err = get_read_block_error(str(pending))
+    assert err is not None
+    assert "pairing" in err.lower()
+
+
+def test_pairing_dir_itself_blocked(fake_home):
+    """Listing the pairing directory itself exfiltrates approved-user
+    identifiers — blocked."""
+    from agent.file_safety import get_read_block_error
+
+    pairing_dir = fake_home / "pairing"
+    pairing_dir.mkdir(parents=True, exist_ok=True)
+    err = get_read_block_error(str(pairing_dir))
+    assert err is not None
+    assert "pairing" in err.lower()
+
+
+def test_non_pairing_dir_not_blocked(fake_home):
+    """A same-named ``pairing`` segment nested deeper (e.g. a skill mock) is
+    not the gateway pairing store and stays readable."""
+    from agent.file_safety import get_read_block_error
+
+    nested = _create(fake_home, Path("skills") / "my-skill" / "pairing" / "x.json")
+    assert get_read_block_error(str(nested)) is None
+
+
+def test_google_and_pairing_outside_home_not_blocked(fake_home, tmp_path):
+    """Hermes-specific names outside HERMES_HOME stay readable — the gate is
+    per-location for these (same principle as auth.json / mcp-tokens)."""
+    from agent.file_safety import get_read_block_error
+
+    project = tmp_path / "myproject"
+    project.mkdir()
+
+    tok = project / "google_token.json"
+    tok.write_text("not a real token", encoding="utf-8")
+    assert get_read_block_error(str(tok)) is None
+
+    approved = project / "pairing" / "approved.json"
+    approved.parent.mkdir()
+    approved.write_text("not real pairing data", encoding="utf-8")
+    assert get_read_block_error(str(approved)) is None
+
+
+def test_profile_mode_blocks_root_google_and_pairing(tmp_path, monkeypatch):
+    """Under a profile, the root-level google_token.json and pairing tree are
+    inherited and must ALSO be blocked — same widening as auth.json/.env."""
+    import agent.file_safety as fs
+
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "coder"
+    profile.mkdir(parents=True)
+    monkeypatch.setattr(fs, "_hermes_home_path", lambda: profile)
+    monkeypatch.setattr(fs, "_hermes_root_path", lambda: root)
+
+    from agent.file_safety import get_read_block_error
+
+    # Profile-local Google token: blocked
+    profile_tok = profile / "google_token.json"
+    profile_tok.write_text("x")
+    assert "credential store" in (get_read_block_error(str(profile_tok)) or "")
+
+    # Root-level Google token: ALSO blocked (the widening)
+    root_tok = root / "google_token.json"
+    root_tok.write_text("x")
+    assert "credential store" in (get_read_block_error(str(root_tok)) or "")
+
+    # Root-level pairing file: blocked
+    root_pairing = root / "pairing" / "telegram-approved.json"
+    root_pairing.parent.mkdir(parents=True, exist_ok=True)
+    root_pairing.write_text("x")
+    assert "pairing" in (get_read_block_error(str(root_pairing)) or "").lower()
+
+
+def test_read_file_tool_blocks_google_token(fake_home, tmp_path, monkeypatch):
+    """The real read_file tool must not return Google OAuth token material
+    sitting at HERMES_HOME/google_token.json."""
+    import json
+
+    import tools.file_tools as ft
+
+    tok = _create(fake_home, "google_token.json")
+    tok.write_text(
+        json.dumps(
+            {
+                "refresh_token": "REFRESH_TOKEN_MARKER",
+                "token": "ACCESS_TOKEN_MARKER",
+                "client_secret": "CLIENT_SECRET_MARKER",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        ft, "_get_live_tracking_cwd", lambda task_id="default": None
+    )
+
+    out = json.loads(ft.read_file_tool(str(tok), task_id="google-token-test"))
+    assert "error" in out
+    assert "credential store" in out["error"]
+    assert "REFRESH_TOKEN_MARKER" not in json.dumps(out)
+    assert "ACCESS_TOKEN_MARKER" not in json.dumps(out)
+    assert "CLIENT_SECRET_MARKER" not in json.dumps(out)


### PR DESCRIPTION
## What does this PR do?

Aligns the `read_file` credential read-guard with the credential set the gateway media-delivery denylist already enforces.

`gateway/platforms/base.py::_media_delivery_denied_paths` classifies `google_token.json`, `google_oauth_pending.json`, and the DM-pairing tree as credential material, and its own comment states it *"mirrors the canonical read guard in agent/file_safety.py … so the delivery (read/exfil) side can't trail the write side."* But `agent/file_safety.py::get_read_block_error()` had drifted behind it — it blocked `auth.json`, `.env`, `auth/google_oauth.json`, `webhook_subscriptions.json`, `cache/bws_cache.json`, and `mcp-tokens/`, yet not those three. The write deny guard (`is_write_denied`) likewise already blocks the pairing tree.

Net effect of the gap: a prompt-injection (or a misdirected agent) reaching `read_file` could pull Google OAuth access/refresh tokens or DM-pairing approval state into the transcript, even though the exact same paths are denied on the write and media-delivery sides.

This restores the documented read↔write↔media "mirror" invariant. It is **defense-in-depth, not a security boundary** — the terminal tool runs as the same OS user and can still read these files; the guard returns a clear denial to tool-respecting models and leaves an audit trail. Same posture and wording as the existing `mcp-tokens/` block. `config.yaml` is intentionally left readable (covered by an existing test). The fix lives in the shared guard, so it also covers the ACP shim (`agent/copilot_acp_client.py`), which calls the same function.

## Related Issue

N/A — no existing tracking issue; internal credential-guard consistency hardening.

Fixes #

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `agent/file_safety.py` — in `get_read_block_error()`:
  - Add `google_token.json` and `google_oauth_pending.json` as exact-file matches under HERMES_HOME and the global Hermes root (profile-aware, same as the existing entries).
  - Add the DM-pairing tree as a directory-prefix block, covering **both** the legacy `<home>/pairing` and the consolidated `<home>/platforms/pairing` layouts (`gateway/pairing.py` resolves the live dir via `get_hermes_dir("platforms/pairing", "pairing")`, so new installs use `platforms/pairing`).
  - Update the function docstring's credential list.
- `tests/agent/test_file_safety_credentials.py` — 9 new regression tests.

## How to Test

Run the credential read-guard suite:

    pytest tests/agent/test_file_safety_credentials.py -q
    # 28 passed, 1 skipped   (the skip is an environment-gated symlink test)

New cases added (all pass):
- `test_google_token_json_blocked`, `test_google_oauth_pending_json_blocked`
- `test_pairing_legacy_file_blocked`, `test_pairing_platforms_file_blocked`, `test_pairing_dir_itself_blocked`
- `test_non_pairing_dir_not_blocked`, `test_google_and_pairing_outside_home_not_blocked` (per-location gating, same principle as `auth.json`/`mcp-tokens`)
- `test_profile_mode_blocks_root_google_and_pairing` (profile + root widening)
- `test_read_file_tool_blocks_google_token` — drives the real `read_file_tool` against a HERMES_HOME `google_token.json` containing token markers and asserts the error is returned and **no token material leaks** into the result.

Sibling guard suite unaffected:

    pytest tests/agent/test_file_safety.py -q   # passes

Regression-safety: I baselined the affected test modules on this branch against pristine `main`. This branch adds exactly the 9 new tests above and introduces **zero new failures** — the failure/skip set is identical to `main` (the remaining failures are pre-existing and live in modules this PR does not touch, e.g. symlink-gated and OS-pseudo-path tests).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(security): …`)
- [ ] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- Ran the affected modules (above) — all pass; baselined against main so this change adds no new failures. Did not assert the entire tree green: unrelated pre-existing failures exist in untouched modules. -->
- [x] I've added tests for my changes
- [x] I've tested on my platform: logic is pure-`pathlib`/stdlib path handling (platform-agnostic); verified via the suites above.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `get_read_block_error()` docstring
- [x] `cli-config.yaml.example` — N/A (no config keys added/changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact — both pairing layouts handled via `pathlib`; no OS-specific assumptions
- [x] Tool descriptions/schemas — N/A (no schema change; only the path-deny set)

## Screenshots / Logs

    $ pytest tests/agent/test_file_safety_credentials.py -q
    ........s....................                                            [100%]
    28 passed, 1 skipped