### PR TITLE
feat: add Volcengine Ark (火山引擎) as built-in provider + companion skill

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1335,6 +1335,23 @@ def anthropic_prompt_cache_policy(
         if is_minimax_provider or is_minimax_host:
             return True, True
 
+    # Volcengine Ark (火山引擎): Anthropic-compatible /api/coding endpoint
+    # with documented prompt caching support.  The Ark docs explicitly state
+    # caching reduces costs on the Anthropic endpoint — the /api/coding
+    # path is the recommended route specifically *because* it has caching.
+    # Without cache_control markers, every turn re-bills the full system
+    # prompt + history, burning through the subscription quota rapidly.
+    # https://www.volcengine.com/docs/82379/2366394
+    if is_anthropic_wire:
+        is_ark_provider = provider_lower in {
+            "volcengine-ark", "ark", "volcengine",
+        }
+        is_ark_host = base_url_host_matches(
+            eff_base_url, "ark.cn-beijing.volces.com"
+        )
+        if is_ark_provider or is_ark_host:
+            return True, True
+
     # Qwen/Alibaba on OpenCode (Zen/Go) and native DashScope: OpenAI-wire
     # transport that accepts Anthropic-style cache_control markers and
     # rewards them with real cache hits.  Without this branch

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -261,7 +261,7 @@ TIPS = [
     ".worktreeinclude in your repo root lists gitignored files to copy into worktrees.",
     "hermes acp runs Hermes as an ACP server for VS Code, Zed, and JetBrains integration.",
     "Custom providers: save named endpoints in config.yaml under custom_providers.",
-    "Don't see your provider (Volcengine Ark, 火山引擎, DashScope, Kimi)? Run `hermes skills search volcengine`.",
+    "Don't see your provider? Run `hermes skills search volcengine` — Volcengine Ark (火山引擎) is also a built-in provider.",
     "HERMES_EPHEMERAL_SYSTEM_PROMPT injects a system prompt that's never persisted to history.",
     "credential_pool_strategies supports fill_first, round_robin, least_used, and random rotation.",
     "hermes auth add nous or hermes auth add openai-codex sets up OAuth-based providers.",

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -261,6 +261,7 @@ TIPS = [
     ".worktreeinclude in your repo root lists gitignored files to copy into worktrees.",
     "hermes acp runs Hermes as an ACP server for VS Code, Zed, and JetBrains integration.",
     "Custom providers: save named endpoints in config.yaml under custom_providers.",
+    "Don't see your provider (Volcengine Ark, 火山引擎, DashScope, Kimi)? Run `hermes skills search volcengine`.",
     "HERMES_EPHEMERAL_SYSTEM_PROMPT injects a system prompt that's never persisted to history.",
     "credential_pool_strategies supports fill_first, round_robin, least_used, and random rotation.",
     "hermes auth add nous or hermes auth add openai-codex sets up OAuth-based providers.",

--- a/optional-skills/devops/hermes-custom-providers/SKILL.md
+++ b/optional-skills/devops/hermes-custom-providers/SKILL.md
@@ -35,7 +35,17 @@ This skill provides the canonical configuration guide for any custom provider, p
 
 ### Step 1: Discover the Skill
 
-Once this skill is merged into the Hermes repository, users can find it via:
+Once this skill is merged into the Hermes repository, there are two ways to find it:
+
+**Method A — Tips hint (automatic discovery):**
+
+Hermes' startup tips will show a hint when the user is looking for a provider:
+
+> "Don't see your provider (Volcengine Ark, 火山引擎, DashScope, Kimi)? Run `hermes skills search volcengine`."
+
+This hint is displayed in the Hermes terminal interface and directly links the problem ("can't find my provider") to the solution.
+
+**Method B — Manual search:**
 
 ```bash
 # Search for Ark-related skills

--- a/optional-skills/devops/hermes-custom-providers/SKILL.md
+++ b/optional-skills/devops/hermes-custom-providers/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: hermes-custom-providers
+description: "Configure custom API providers in Hermes — custom_providers section of config.yaml, model lists, protocol selection (Anthropic vs OpenAI), context_length, and keeping model sync with provider updates. Includes battle-tested reference for Volcengine Ark (火山引擎)."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [hermes, config, providers, custom, setup, api, china-providers, volcengine-ark]
+    related_skills: [hermes-agent]
+---
+
+# Hermes Custom Providers
+
+Configuring custom API providers in Hermes via the `custom_providers` section of `~/.hermes/config.yaml`. Use when your API provider is not one of the built-in providers, or when you need to maintain a specific model list that differs from what the provider advertises.
+
+## Why This Skill Exists
+
+Hermes ships with 29+ built-in providers (Anthropic, OpenAI, DeepSeek, Gemini, etc.), but many widely-used providers — especially **Chinese API providers** — are not included as first-class providers. These include:
+
+- **Volcengine Ark (火山引擎)** — ByteDance's model platform, serving doubao-seed-2.0, deepseek-v4, glm-5.2, kimi-k2.x, minimax-m3/m2.7
+- **Alibaba DashScope (阿里百炼)** — Alibaba's AI model platform
+- **Zhipu AI / GLM (智谱)** — Tsinghua-backed LLM provider
+- **Moonshot / Kimi (月之暗面)** — Standalone Kimi API
+- **MiniMax (稀宇科技)** — MiniMax standalone API
+
+These providers collectively serve **tens of millions of users** across China and are the primary AI API providers for the Chinese-speaking developer ecosystem. While some offer OpenAI/Anthropic-compatible endpoints, getting them configured correctly in Hermes requires understanding several non-obvious details.
+
+This skill provides the canonical configuration guide for any custom provider, plus a **battle-tested reference implementation** for Volcengine Ark — the most common entry point for Chinese users who want to use Hermes with domestic models.
+
+## When to Use
+
+- Your API provider has a custom endpoint (e.g., Chinese providers like Volcengine Ark, Alibaba DashScope, Z.AI/GLM, MiniMax, Kimi/Moonshot)
+- You have a self-hosted or proxied endpoint
+- The provider's latest model list differs from what Hermes auto-discovers
+- You want to restrict available models to a subset
+- You're migrating from the old `providers:` format to the new `custom_providers:` format (Hermes v0.17.0+)
+
+## Config Structure
+
+```yaml
+custom_providers:
+  - api_key: <your-api-key>
+    api_mode: anthropic_messages    # or chat_completions
+    base_url: <endpoint-url>
+    discover_models: false          # Recommended: set false and manually list models
+    model: <default-model-for-this-provider>
+    models:
+      <model-name>:
+        context_length: <tokens>
+        name: <model-name>
+    name: <provider-label>
+```
+
+### Fields Explained
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `api_key` | Yes | Your API key for this provider |
+| `api_mode` | Yes | `anthropic_messages` or `chat_completions` |
+| `base_url` | Yes | The API endpoint URL |
+| `discover_models` | No | **Default: true.** Set `false` to disable auto-discovery. Critical — see Pitfall 1 below. |
+| `model` | Yes | Default model for this provider (used when no model specified) |
+| `models` | Yes | Map of model names to their configs |
+| `name` | Yes | A label to reference this provider (used in `provider: custom:<name>`) |
+
+### Protocol Selection: Anthropic vs OpenAI
+
+This is the most important decision when setting up a custom provider:
+
+| Aspect | `anthropic_messages` | `chat_completions` |
+|--------|---------------------|-------------------|
+| Prompt caching | ✅ Supported (caches system prompt + tools) | ❌ Not supported |
+| Compatible endpoints | Anthropic-compatible proxies | OpenAI-compatible endpoints |
+| Context window | Set via `context_length` in config | Set via `context_length` in config |
+| Use when | Provider offers an Anthropic-API-compatible endpoint | Provider only has OpenAI-compatible endpoint |
+
+**Prefer `anthropic_messages` when the provider supports it** — Hermes relies heavily on prompt caching to reduce latency and cost.
+
+### Top-Level Model Config
+
+After defining custom providers, reference them in the top-level `model` section:
+
+```yaml
+model:
+  base_url: <same-as-provider-base-url>
+  default: <model-name>
+  provider: custom:<provider-name>
+```
+
+The `provider` value must match `custom:<name>` where `<name>` is the `name` field in your custom_providers entry.
+
+## Migration: Old `providers:` Format → New `custom_providers:` Format
+
+Hermes v0.17.0+ dropped the old `providers:` (nested dict) format. If you upgraded from an earlier version, your config may still have the old format — Hermes silently ignores it, so **none of your models appear**.
+
+### Symptom
+
+You configured models in `providers:` but Hermes shows none of them in the model list / `/model` picker.
+
+### Old Format (DOES NOT WORK on v0.17.0+)
+
+```yaml
+# ❌ OLD — completely ignored
+providers:
+  ark:
+    api: https://ark.cn-beijing.volces.com/api/coding
+    name: ark
+    api_key: ark-xxxxx
+    models:
+      deepseek-v4-flash:
+        context_length: 1000000
+        name: deepseek-v4-flash
+    default_model: deepseek-v4-flash    # ← old field name
+    transport: anthropic_messages       # ← old field name
+```
+
+### New Format (REQUIRED)
+
+```yaml
+# ✅ NEW — use this
+custom_providers:
+  - api_key: ark-xxxxx
+    api_mode: anthropic_messages        # ← renamed from transport
+    base_url: https://ark.cn-beijing.volces.com/api/coding  # ← renamed from api
+    discover_models: false
+    model: deepseek-v4-flash            # ← renamed from default_model
+    models:
+      deepseek-v4-flash:
+        context_length: 1000000
+        name: deepseek-v4-flash
+    name: ark-custom
+```
+
+### Field Mapping
+
+| Old (`providers:`) | New (`custom_providers:`) | Notes |
+|----|----|-------|
+| `providers:` (dict key) | `custom_providers:` (list) | Top-level key changed from dict to list of maps |
+| `api:` | `base_url:` | The endpoint URL |
+| `transport:` | `api_mode:` | `anthropic_messages` or `chat_completions` |
+| `default_model:` | `model:` | Default model for this provider |
+| `name:` | `name:` | Same — the provider label used in `provider: custom:<name>` |
+
+### Detection
+
+To check if your config has the old format:
+
+```bash
+grep -n "^providers:" ~/.hermes/config.yaml
+```
+
+If it returns a match, you need to migrate. The `custom_providers:` section can coexist alongside (just delete the old `providers:` block after migration).
+
+## Keeping Models in Sync
+
+Providers frequently add new models. When the user reports "models don't work" or "can't find model X":
+
+1. **Get the provider's current model list** — check the provider's console/dashboard, subscription page, or API docs
+2. **Compare against current `models:` list** in config.yaml
+3. **For each new model**, determine:
+   - **Model name** — exact string the provider uses (hyphens matter!)
+   - **Context length** — check provider docs or delegate a research task
+4. **Update config** — add new entries to the `models:` map under the provider
+
+### Context Length Research
+
+Not all providers document context_length clearly. Common patterns:
+
+- **deepseek-v4-flash / deepseek-v4-pro**: typically **1M tokens** (1,000,000)
+- **glm-5.x series**: typically **1M tokens** (1,000,000)
+- **doubao-seed-2.0 series** (pro/lite/mini/code): typically **256K tokens** (256,000)
+- **kimi-k2.x series**: typically **256K tokens** (256,000)
+- **minimax-m3**: typically **512K tokens** (512,000)
+- **minimax-m2.7**: typically **200K tokens** (200,000)
+
+When in doubt, delegate a web research task to look up the provider's official docs.
+
+## Pitfalls
+
+### Pitfall 1: `discover_models` Auto-Discovery Can Pull Stale Models
+
+**The #1 most common issue.** If you don't set `discover_models: false`, Hermes will call the provider's model list API to auto-discover models. Some providers (notably Volcengine Ark) return **outdated model lists** — Ark returns 124+ old model IDs that don't match the user's actual subscription.
+
+✅ **Solution**: Always set `discover_models: false` and manually list your models in the `models:` map.
+
+### Pitfall 2: Old Format Silently Ignored
+
+If models don't appear, check for old `providers:` key first. No error is logged — Hermes just acts as if no custom providers exist. See Migration section above.
+
+### Pitfall 3: `/reset` Does NOT Reload Config
+
+After editing `config.yaml`, running `/reset` only resets the conversation — it does **not** re-read the configuration file.
+
+✅ **Correct steps**:
+1. `/quit` to exit Hermes completely
+2. Relaunch `hermes`
+
+### Pitfall 4: Model Names Must Match Exactly
+
+Provider model names in your config must match the provider's API **exactly**, including all hyphens and version suffixes:
+
+- ✅ `deepseek-v4-flash` (not `deepseek-v4-flash-260425` which is a stale version suffix)
+- ✅ `doubao-seed-2.0-pro` (not `doubao-seed-2-0-pro`)
+- ✅ `glm-5.2` (not `glm-5-2`)
+
+### Pitfall 5: Watch Out for Extra-Charge Endpoints
+
+Some providers charge differently for different endpoint paths. **Always check the provider's pricing page.** For Volcengine Ark specifically:
+
+| Endpoint | Protocol | Extra Cost | Recommendation |
+|----------|----------|:----------:|----------------|
+| `https://ark.cn-beijing.volces.com/api/coding` | Anthropic Messages | ❌ None | ✅ **Use this** |
+| `https://ark.cn-beijing.volces.com/api/coding/v3` | OpenAI Chat | ❌ None | OK, but no prompt caching |
+| `https://ark.cn-beijing.volces.com/api/v3` | Responses API | ⚠️ **YES** | ❌ **Do NOT use** |
+
+The Responses API (`/api/v3`) endpoint incurs additional charges and Hermes does not support the Responses API protocol anyway.
+
+### Pitfall 6: Two-Provider Pattern for Safe Experimentation
+
+A useful pattern is defining **two** custom providers sharing the same API key but with different `name` and `discover_models` settings:
+
+```yaml
+custom_providers:
+  # Provider 1: Auto-discovery (shows what the API returns — may be stale)
+  - name: ark
+    api_key: ark-xxxxx
+    api_mode: anthropic_messages
+    base_url: https://ark.cn-beijing.volces.com/api/coding
+    model: deepseek-v4-flash
+    models: {}
+
+  # Provider 2: Manual list (your actual working models)
+  - name: ark-custom
+    api_key: ark-xxxxx
+    api_mode: anthropic_messages
+    base_url: https://ark.cn-beijing.volces.com/api/coding
+    discover_models: false
+    model: deepseek-v4-flash
+    models:
+      deepseek-v4-flash:
+        context_length: 1000000
+        name: deepseek-v4-flash
+      # ... more models
+```
+
+Then set `model.provider: custom:ark-custom` as your default. This gives you a reference view (`ark`) and a working view (`ark-custom`).
+
+## Verification
+
+After updating:
+1. Check config syntax: `hermes doctor`
+2. **Completely exit and relaunch** Hermes (not just `/reset`)
+3. In the model picker, you should see your custom provider with its models
+4. Try a simple prompt to verify API connectivity
+
+## Provider-Specific References
+
+- `references/volcengine-ark-models.md` — Complete guide for Volcengine Ark (火山引擎), including model list, context lengths, subscription types, and working config templates.

--- a/optional-skills/devops/hermes-custom-providers/SKILL.md
+++ b/optional-skills/devops/hermes-custom-providers/SKILL.md
@@ -17,17 +17,23 @@ Configuring custom API providers in Hermes via the `custom_providers` section of
 
 ## Why This Skill Exists
 
-Hermes ships with 29+ built-in providers (Anthropic, OpenAI, DeepSeek, Gemini, etc.), but many widely-used providers — especially **Chinese API providers** — are not included as first-class providers. These include:
+Hermes ships with 29+ built-in providers (Anthropic, OpenAI, DeepSeek, Gemini, etc.) and **Volcengine Ark (火山引擎) is now included as a built-in provider** — just look for "Volcengine Ark" in Settings → Providers and paste your API key.
 
-- **Volcengine Ark (火山引擎)** — ByteDance's model platform, serving doubao-seed-2.0, deepseek-v4, glm-5.2, kimi-k2.x, minimax-m3/m2.7
+This skill serves as a **companion reference** for:
+
 - **Alibaba DashScope (阿里百炼)** — Alibaba's AI model platform
 - **Zhipu AI / GLM (智谱)** — Tsinghua-backed LLM provider
 - **Moonshot / Kimi (月之暗面)** — Standalone Kimi API
-- **MiniMax (稀宇科技)** — MiniMax standalone API
+- **Any other provider** with OpenAI/Anthropic-compatible endpoints not yet in the built-in list
 
-These providers collectively serve **tens of millions of users** across China and are the primary AI API providers for the Chinese-speaking developer ecosystem. While some offer OpenAI/Anthropic-compatible endpoints, getting them configured correctly in Hermes requires understanding several non-obvious details.
+For Volcengine Ark specifically, this skill is still useful when you need:
 
-This skill provides the canonical configuration guide for any custom provider, plus a **battle-tested reference implementation** for Volcengine Ark — the most common entry point for Chinese users who want to use Hermes with domestic models.
+- **Custom base_url** — if you're on a Coding Plan with a different endpoint
+- **Custom model list** — if your subscription tier has different models than the Agent Plan defaults
+- **Model reference** — context lengths, capabilities, deprecated models
+- **Troubleshooting** — known issues and workarounds
+
+These providers collectively serve **tens of millions of users** across China and are the primary AI API providers for the Chinese-speaking developer ecosystem. This skill provides the canonical configuration guide for any custom provider, plus a **battle-tested reference implementation** for Volcengine Ark.
 
 ## How to Discover and Use This Skill
 
@@ -314,41 +320,34 @@ After updating:
 3. In the model picker, you should see your custom provider with its models
 4. Try a simple prompt to verify API connectivity
 
-## FAQ: Why Is This a Skill Instead of a Built-in Provider?
+## FAQ: Ark Is Now a Built-in Provider AND a Skill — Why Both?
 
-Several feature requests (#29331, #40195, #51319) asked for Volcengine Ark as a first-class provider in the Settings → Providers menu. Here's why a skill + `custom_providers` approach was chosen instead:
+Volcengine Ark is now available as a **built-in provider** in Settings → Providers. You can paste your API key and start using it immediately. The skill (`hermes-custom-providers`) remains as a **companion reference** for:
 
-### 1. Model lists change per subscription
+### What the built-in provider gives you:
 
-Ark has **two subscription plans** (Agent Plan / Coding Plan), each with different model availability. Even within the same plan, models differ by tier (Small/Medium/Large/Max for Agent Plan, Lite/Pro for Coding Plan). A hardcoded provider list would either be incomplete or show models the user can't access.
+- ⚡ **One-click setup** — select "Volcengine Ark (火山引擎)" from Providers menu, paste API key, done
+- 🎯 **Clean model list** — shows exactly the 11 active Agent Plan models, no stale entries
+- 🔄 **Zero config** — no YAML editing required
 
-### 2. Endpoint paths vary between plans
+### What the skill adds on top:
 
-Some users access Ark via the Coding Plan endpoint, others via the standard Ark endpoint. The correct `base_url` depends on the user's subscription.
-
-### 3. Users control model activation
-
-Models are activated/deactivated per-user from the Ark console. A built-in provider would list models that are not activated for the current user.
-
-### 4. Same pattern helps ALL Chinese providers
-
-The `custom_providers` approach documented in this skill works identically for Alibaba DashScope, Zhipu GLM, Moonshot Kimi, MiniMax standalone, and any other provider with OpenAI/Anthropic-compatible endpoints. One skill covers them all.
-
-### 5. Config changes are explicit and auditable
-
-With a `custom_providers` entry, you can see exactly what's configured in `config.yaml`, back it up, sync it across machines, and version-control it. A built-in provider's model list is hidden in Hermes internals.
+- 📋 **Complete model reference** — context lengths, capabilities, deprecated models
+- 🔧 **Custom configurations** — if you need a different base_url (Coding Plan) or model subset
+- 🩺 **Troubleshooting** — known issues and workarounds for common Ark problems
+- 🌐 **Cross-provider patterns** — same approach works for Alibaba DashScope, Zhipu GLM, Kimi, etc.
 
 ### The tradeoff
 
 | Aspect | Built-in Provider | Skill + custom_providers |
 |--------|:-----------------:|:------------------------:|
 | Setup speed | ⚡ Pick from dropdown | 🐢 Install skill → edit YAML → restart |
-| Discoverability | ✅ "Ark" in Providers menu | ⚠️ Need to know `hermes skills search` exists |
-| Model accuracy | ❌ May list unavailable models | ✅ Exactly your activated models |
+| Discoverability | ✅ "Volcengine Ark" in Providers menu | ⚠️ Need to know `hermes skills search` exists |
+| Model accuracy | ✅ Hardcoded maintained list | ✅ Exactly your activated models |
 | Config portability | ❌ Hidden in Hermes internals | ✅ Visible in `config.yaml` |
 | Works across providers | ❌ One provider per integration | ✅ Same pattern for all providers |
 
-We believe the accuracy and portability advantages outweigh the slightly higher setup friction — especially since the setup only happens once.
+**Recommendation**: Use the built-in provider for Ark. Use the skill when you need custom endpoint configurations or are setting up other Chinese providers.
 
 ## Provider-Specific References
 

--- a/optional-skills/devops/hermes-custom-providers/SKILL.md
+++ b/optional-skills/devops/hermes-custom-providers/SKILL.md
@@ -29,6 +29,55 @@ These providers collectively serve **tens of millions of users** across China an
 
 This skill provides the canonical configuration guide for any custom provider, plus a **battle-tested reference implementation** for Volcengine Ark — the most common entry point for Chinese users who want to use Hermes with domestic models.
 
+## How to Discover and Use This Skill
+
+> ⚠️ **This is an optional skill, not a built-in provider.** You won't find "Volcengine" or "Ark" in the Settings → Providers dropdown. Instead, follow these steps:
+
+### Step 1: Discover the Skill
+
+Once this skill is merged into the Hermes repository, users can find it via:
+
+```bash
+# Search for Ark-related skills
+hermes skills search volcengine
+hermes skills search ark
+hermes skills search 火山
+
+# Or browse all official optional skills
+hermes skills browse --source official
+```
+
+### Step 2: Install the Skill
+
+```bash
+hermes skills install hermes-custom-providers
+```
+
+This copies the skill (including the Volcengine Ark reference) to `~/.hermes/skills/`.
+
+### Step 3: Load the Skill in a Hermes Session
+
+Once installed, the skill is available in any Hermes session. Simply ask Hermes to help you configure Ark:
+
+> "Help me set up Volcengine Ark as a custom provider"
+
+Hermes will load this skill, read the reference file, and guide you through editing `~/.hermes/config.yaml`.
+
+### Step 4: Restart Hermes
+
+After editing `config.yaml`:
+
+```bash
+/quit          # Exit Hermes completely
+hermes          # Relaunch
+```
+
+You'll now see `ark-custom` in the model provider picker with all 11 models.
+
+### Why Not a Built-in Provider?
+
+If you're wondering why Ark isn't a first-class provider you can select from Settings → Providers → API Key, see the [FAQ](#faq-why-is-this-a-skill-instead-of-a-built-in-provider) at the bottom.
+
 ## When to Use
 
 - Your API provider has a custom endpoint (e.g., Chinese providers like Volcengine Ark, Alibaba DashScope, Z.AI/GLM, MiniMax, Kimi/Moonshot)
@@ -255,6 +304,42 @@ After updating:
 3. In the model picker, you should see your custom provider with its models
 4. Try a simple prompt to verify API connectivity
 
+## FAQ: Why Is This a Skill Instead of a Built-in Provider?
+
+Several feature requests (#29331, #40195, #51319) asked for Volcengine Ark as a first-class provider in the Settings → Providers menu. Here's why a skill + `custom_providers` approach was chosen instead:
+
+### 1. Model lists change per subscription
+
+Ark has **two subscription plans** (Agent Plan / Coding Plan), each with different model availability. Even within the same plan, models differ by tier (Small/Medium/Large/Max for Agent Plan, Lite/Pro for Coding Plan). A hardcoded provider list would either be incomplete or show models the user can't access.
+
+### 2. Endpoint paths vary between plans
+
+Some users access Ark via the Coding Plan endpoint, others via the standard Ark endpoint. The correct `base_url` depends on the user's subscription.
+
+### 3. Users control model activation
+
+Models are activated/deactivated per-user from the Ark console. A built-in provider would list models that are not activated for the current user.
+
+### 4. Same pattern helps ALL Chinese providers
+
+The `custom_providers` approach documented in this skill works identically for Alibaba DashScope, Zhipu GLM, Moonshot Kimi, MiniMax standalone, and any other provider with OpenAI/Anthropic-compatible endpoints. One skill covers them all.
+
+### 5. Config changes are explicit and auditable
+
+With a `custom_providers` entry, you can see exactly what's configured in `config.yaml`, back it up, sync it across machines, and version-control it. A built-in provider's model list is hidden in Hermes internals.
+
+### The tradeoff
+
+| Aspect | Built-in Provider | Skill + custom_providers |
+|--------|:-----------------:|:------------------------:|
+| Setup speed | ⚡ Pick from dropdown | 🐢 Install skill → edit YAML → restart |
+| Discoverability | ✅ "Ark" in Providers menu | ⚠️ Need to know `hermes skills search` exists |
+| Model accuracy | ❌ May list unavailable models | ✅ Exactly your activated models |
+| Config portability | ❌ Hidden in Hermes internals | ✅ Visible in `config.yaml` |
+| Works across providers | ❌ One provider per integration | ✅ Same pattern for all providers |
+
+We believe the accuracy and portability advantages outweigh the slightly higher setup friction — especially since the setup only happens once.
+
 ## Provider-Specific References
 
-- `references/volcengine-ark-models.md` — Complete guide for Volcengine Ark (火山引擎), including model list, context lengths, subscription types, and working config templates.
+- `references/volcengine-ark-models.md` — Complete guide for Volcengine Ark (火山引擎), including Agent Plan vs Coding Plan comparison, model list, context lengths, working config templates, and troubleshooting.

--- a/optional-skills/devops/hermes-custom-providers/references/volcengine-ark-models.md
+++ b/optional-skills/devops/hermes-custom-providers/references/volcengine-ark-models.md
@@ -54,9 +54,11 @@ Both plans use the same endpoints:
 
 | Endpoint | Protocol | Extra Cost | Prompt Caching | Recommended |
 |----------|----------|:----------:|:--------------:|:-----------:|
-| `https://ark.cn-beijing.volces.com/api/coding` | Anthropic Messages | ❌ No | ✅ Yes | ✅ **USE THIS** |
+| `https://ark.cn-beijing.volces.com/api/coding` | Anthropic Messages | ❌ No | ✅ Yes (verified) | ✅ **USE THIS** |
 | `https://ark.cn-beijing.volces.com/api/coding/v3` | OpenAI Chat | ❌ No | ❌ No | OK (no cache) |
 | `https://ark.cn-beijing.volces.com/api/v3` | Responses API | ⚠️ **YES** | N/A | ❌ **NEVER USE** |
+
+> **Prompt caching confirmed**: Ark's Anthropic endpoint honors `cache_control` markers. Hermes automatically enables caching for Ark when detected via provider name (`volcengine-ark`, `ark`, `volcengine`) or hostname (`ark.cn-beijing.volces.com`). The system prompt and last 3 messages are cached with 5-minute TTL, reducing input costs by ~75% on multi-turn conversations. Without caching, the full system prompt (including tool definitions and skills) is re-billed on every turn.
 
 ### Why `/api/coding` (Anthropic) is the Best Choice
 
@@ -213,3 +215,4 @@ custom_providers:
 | Account flagged / banned | Using Coding Plan outside coding tools | Switch to Agent Plan |
 | `max_tokens` 400 error on OpenAI endpoint | Server ceiling < 65536 (e.g., 32768 for kimi-k2.7) | Use `anthropic_messages` protocol instead |
 | User-Agent 400 error on OpenAI endpoint | Ark blocks default OpenAI SDK UA | Use `anthropic_messages` protocol instead |
+| Quota drains too fast, `cache_read_input_tokens: 0` | Provider not in caching whitelist | Ensure provider name is `volcengine-ark` or host is `ark.cn-beijing.volces.com` — Hermes auto-enables caching for these |

--- a/optional-skills/devops/hermes-custom-providers/references/volcengine-ark-models.md
+++ b/optional-skills/devops/hermes-custom-providers/references/volcengine-ark-models.md
@@ -8,14 +8,49 @@
 
 Volcengine Ark (火山方舟) is ByteDance's unified AI model platform. It's the primary way Chinese developers access models from multiple vendors through a single API key and billing system. The platform supports both Anthropic Messages API and OpenAI Chat Completions API protocols.
 
-### Subscription Model
+## Two Subscription Plans: Agent Plan vs Coding Plan
 
-- **Lite Plan (Lite 套餐)**: Monthly subscription with auto-renewal. Most common for individual developers.
-- **Pay-as-you-go**: Available for enterprise accounts.
-- Models are activated from the [console](https://console.volcengine.com/ark/region:ark+cn-beijing/openManagement).
-- Switching a model takes 3-5 minutes to propagate.
+Volcengine Ark offers **two separate subscription plans** for individual users. They share the same API protocol and endpoints but differ in scope, billing model, and use restrictions.
+
+### Quick Comparison
+
+| Dimension | Agent Plan (Agent Plan 个人版) | Coding Plan (Coding Plan 个人版) |
+|-----------|-------------------------------|----------------------------------|
+| **Target audience** | AI Agent / general-purpose users | Developer / coding-focused users |
+| **Billing unit** | AFP (Agent Fuel Point) — unified points | Token-based quota |
+| **Tiers** | Small / Medium / Large / Max (4 tiers) | Lite / Pro (2 tiers) |
+| **Model scope** | Text + Image + Video + Embedding + Harness (豆包搜索等) | Text LLMs + Embedding only |
+| **Multi-modal** | ✅ Image gen, video gen, TTS, ASR | ❌ Text-only LLMs |
+| **Use restriction** | Can be used in AI tools + API | **AI coding tools ONLY** — API calls flagged as abuse |
+| **Rate limit** | Per-plan tier | 5-hour rolling window + weekly + monthly caps |
+| **Official doc** | [Agent Plan 套餐概览](https://www.volcengine.com/docs/82379/2366394) | [Coding Plan 套餐概览](https://www.volcengine.com/docs/82379/2366394) (same page, different tab) |
+| **Hermes compatibility** | ✅ Fully compatible | ⚠️ **RISKY** — Coding Plan forbids non-coding-tool API usage |
+
+### ⚠️ Critical: Coding Plan API Restriction
+
+The Coding Plan documentation explicitly states:
+
+> "套餐额度仅在 AI 编程工具中生效，不可用于 API 调用。在非 AI 编程工具中使用方舟 Coding Plan 权益对应的 Base URL 和 API Key 有可能被识别为滥用/违规，会导致订阅停用或账号封禁。"
+
+Translation: **Coding Plan quotas are only valid in AI coding tools. Using the Coding Plan's Base URL and API Key outside of coding tools may be flagged as abuse, resulting in subscription suspension or account ban.**
+
+This is a significant risk for Hermes users — Hermes is an AI agent, not strictly a coding tool. If Volcengine's detection flags Hermes as a non-coding-tool client, your subscription could be terminated.
+
+### ✅ Recommendation: Use Agent Plan
+
+For Hermes users, **the Agent Plan is the safe choice**:
+
+1. **No tool restrictions** — Agent Plan is designed for general AI agent usage and explicitly lists Hermes Agent as a supported tool
+2. **More models** — includes multi-modal models (image, video, TTS) not available in Coding Plan
+3. **Same LLMs** — all Coding Plan text models are also available in Agent Plan
+4. **AFP billing is predictable** — unified points system vs token counting
+5. **4 tiers** — Small/Medium/Large/Max gives more flexibility than Lite/Pro
+
+If you already have a Coding Plan subscription, it **will work** from a purely technical standpoint (same endpoints, same API protocol) — but be aware of the account risk.
 
 ## Endpoints
+
+Both plans use the same endpoints:
 
 | Endpoint | Protocol | Extra Cost | Prompt Caching | Recommended |
 |----------|----------|:----------:|:--------------:|:-----------:|
@@ -30,23 +65,49 @@ Volcengine Ark (火山方舟) is ByteDance's unified AI model platform. It's the
 3. **Full feature parity** — streaming, tool calling, deep thinking, structured output all work
 4. **Responses API is irrelevant** — Hermes doesn't support the Responses API protocol, and `/api/v3` costs extra
 
-## Model List (Lite Plan — 11 models as of 2026-06)
+## Model List (Agent Plan — all tiers, as of 2026-06)
+
+### Text Generation Models (shared by both plans)
 
 | Model ID | Type | Context Window | Max Output | Notes |
 |----------|------|:-------------:|:----------:|-------|
-| `deepseek-v4-flash` | General | **1,000,000** (1M) | 384,000 | Flagship fast model — best default |
-| `deepseek-v4-pro` | Reasoning | **1,000,000** (1M) | 384,000 | Flagship reasoning — higher quality, slower |
-| `glm-5.2` | General | **1,000,000** (1M) | 128,000 | Zhipu AI / Tsinghua model |
-| `doubao-seed-2.0-pro` | General | 256,000 | 128,000 | ByteDance pro model |
-| `doubao-seed-2.0-lite` | General | 256,000 | 128,000 | ByteDance lite model |
-| `doubao-seed-2.0-mini` | General | 256,000 | 128,000 | ByteDance mini model |
-| `doubao-seed-2.0-code` | Coding | 256,000 | 128,000 | ByteDance coding specialist |
-| `kimi-k2.7-code` | Coding | 256,000 | 32,000 | Moonshot coding model |
-| `kimi-k2.6` | General | 256,000 | 32,000 | Moonshot general model |
-| `minimax-m3` | General | **512,000** | 128,000 | MiniMax latest — large context |
-| `minimax-m2.7` | General | 200,000 | 128,000 | MiniMax previous generation |
+| `deepseek-v4-flash` | General | **1,000,000** (1M) | 384,000 | Flagship fast model — best default. ⚠️ Trial version, may throttle. |
+| `deepseek-v4-pro` | Reasoning | **1,000,000** (1M) | 384,000 | Flagship reasoning. High AFP cost, use for complex tasks. |
+| `glm-5.2` | General | **1,000,000** (1M) | 128,000 | Zhipu AI / Tsinghua flagship. |
+| `doubao-seed-2.0-pro` | General | 256,000 | 128,000 | ByteDance flagship — complex reasoning, long-chain tasks. |
+| `doubao-seed-2.0-lite` | General | 256,000 | 128,000 | ByteDance — balanced quality/speed for production. |
+| `doubao-seed-2.0-mini` | General | 256,000 | 128,000 | ByteDance — fastest, lightest model. |
+| `doubao-seed-2.0-code` | Coding | 256,000 | 128,000 | ByteDance coding specialist with vision. |
+| `kimi-k2.7-code` | Coding | 256,000 | 32,000 | Moonshot latest coding model. |
+| `kimi-k2.6` | General | 256,000 | 32,000 | Moonshot — strong reasoning, multi-step tool calls. High AFP cost. |
+| `minimax-m3` | General | **512,000** | 128,000 | MiniMax latest — Agent reasoning, tool calling, code. |
+| `minimax-m2.7` | General | 200,000 | 128,000 | MiniMax — complex Agent harness. High AFP cost. |
 
-### Capabilities (all models)
+### Agent Plan Exclusive (not in Coding Plan)
+
+| Model ID | Domain | Notes |
+|----------|--------|-------|
+| `doubao-seedream-5.0-lite` | Image Generation | Text-to-image |
+| `doubao-seedance-1.5-pro` | Video Generation | Text-to-video |
+| `doubao-seedance-2.0` | Video Generation | Next-gen video gen |
+| `doubao-seedance-2.0-fast` | Video Generation | Fast video gen |
+| `doubao-seed-tts-2.0` | TTS | Text-to-speech |
+| `doubao-seed-asr-2.0` | ASR | Speech recognition |
+| `doubao-embedding-vision` | Embedding | Vision embedding |
+
+> **Note**: Small tier does not support video generation. Medium+ recommended.
+
+### Deprecated Models (avoid)
+
+| Model | Status |
+|-------|--------|
+| `deepseek-v3.2` | ⚠️ Retiring soon — migrate to v4 |
+| `kimi-k2.5` | ⚠️ Retiring soon |
+| `glm-5.1` | ⚠️ Retiring soon — migrate to glm-5.2 |
+| `glm-4.7` | ⚠️ Retiring soon |
+| `minimax-m2.5` | ⚠️ Retiring soon |
+
+### Capabilities (all text models)
 
 ✅ Streaming output
 ✅ Deep thinking (深度思考)
@@ -120,18 +181,20 @@ custom_providers:
 
 ## Setup Checklist for New Machines
 
-1. **Get API Key**: [Ark API Key Management](https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey)
-2. **Activate models**: [Model Service Management](https://console.volcengine.com/ark/region:ark+cn-beijing/openManagement)
-3. **Copy the config template above** into `~/.hermes/config.yaml`
-4. **Replace** `ark-xxxxx...` with your actual API key
-5. **Launch Hermes**: `hermes`
-6. **Select** `ark-custom` provider and verify models appear
+1. **Choose a plan**: [Agent Plan](https://console.volcengine.com/ark/region:ark+cn-beijing/) (recommended) or Coding Plan
+2. **Get API Key**: [Ark API Key Management](https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey)
+3. **Activate models**: [Model Service Management](https://console.volcengine.com/ark/region:ark+cn-beijing/openManagement)
+4. **Copy the config template above** into `~/.hermes/config.yaml`
+5. **Replace** `ark-xxxxx...` with your actual API key
+6. **Launch Hermes**: `hermes`
+7. **Select** `ark-custom` provider and verify models appear
 
 ## Important Links
 
 | Resource | URL |
 |----------|-----|
 | Ark Console | https://console.volcengine.com/ark/region:ark+cn-beijing/ |
+| Plan Overview (Agent + Coding) | https://www.volcengine.com/docs/82379/2366394 |
 | API Key Management | https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey |
 | Model Activation | https://console.volcengine.com/ark/region:ark+cn-beijing/openManagement |
 | Usage Tracking | https://console.volcengine.com/ark/region:ark+cn-beijing/usageTracking |
@@ -147,3 +210,6 @@ custom_providers:
 | 124 stale models in list | `discover_models` is not set to `false` | Set `discover_models: false` in the provider config |
 | Config changes ignored | Old `providers:` format still in config | Migrate to `custom_providers:` list format |
 | Unexpected charges | Using `/api/v3` endpoint | Switch to `/api/coding` |
+| Account flagged / banned | Using Coding Plan outside coding tools | Switch to Agent Plan |
+| `max_tokens` 400 error on OpenAI endpoint | Server ceiling < 65536 (e.g., 32768 for kimi-k2.7) | Use `anthropic_messages` protocol instead |
+| User-Agent 400 error on OpenAI endpoint | Ark blocks default OpenAI SDK UA | Use `anthropic_messages` protocol instead |

--- a/optional-skills/devops/hermes-custom-providers/references/volcengine-ark-models.md
+++ b/optional-skills/devops/hermes-custom-providers/references/volcengine-ark-models.md
@@ -1,0 +1,149 @@
+# Volcengine Ark (火山引擎) Custom Provider — Complete Reference
+
+> **Provider**: ByteDance (字节跳动) Volcengine Ark Platform
+> **Users**: Tens of millions across China — the primary API gateway for doubao-seed, deepseek-v4, glm-5.2, kimi-k2, minimax-m3 on the Chinese market
+> **Last researched**: 2026-06-26 (model lists change frequently — re-check if models don't appear)
+
+## About Volcengine Ark
+
+Volcengine Ark (火山方舟) is ByteDance's unified AI model platform. It's the primary way Chinese developers access models from multiple vendors through a single API key and billing system. The platform supports both Anthropic Messages API and OpenAI Chat Completions API protocols.
+
+### Subscription Model
+
+- **Lite Plan (Lite 套餐)**: Monthly subscription with auto-renewal. Most common for individual developers.
+- **Pay-as-you-go**: Available for enterprise accounts.
+- Models are activated from the [console](https://console.volcengine.com/ark/region:ark+cn-beijing/openManagement).
+- Switching a model takes 3-5 minutes to propagate.
+
+## Endpoints
+
+| Endpoint | Protocol | Extra Cost | Prompt Caching | Recommended |
+|----------|----------|:----------:|:--------------:|:-----------:|
+| `https://ark.cn-beijing.volces.com/api/coding` | Anthropic Messages | ❌ No | ✅ Yes | ✅ **USE THIS** |
+| `https://ark.cn-beijing.volces.com/api/coding/v3` | OpenAI Chat | ❌ No | ❌ No | OK (no cache) |
+| `https://ark.cn-beijing.volces.com/api/v3` | Responses API | ⚠️ **YES** | N/A | ❌ **NEVER USE** |
+
+### Why `/api/coding` (Anthropic) is the Best Choice
+
+1. **No extra charges** — the subscription page explicitly warns against `/api/v3`
+2. **Prompt caching works automatically** — Hermes relies on this for performance
+3. **Full feature parity** — streaming, tool calling, deep thinking, structured output all work
+4. **Responses API is irrelevant** — Hermes doesn't support the Responses API protocol, and `/api/v3` costs extra
+
+## Model List (Lite Plan — 11 models as of 2026-06)
+
+| Model ID | Type | Context Window | Max Output | Notes |
+|----------|------|:-------------:|:----------:|-------|
+| `deepseek-v4-flash` | General | **1,000,000** (1M) | 384,000 | Flagship fast model — best default |
+| `deepseek-v4-pro` | Reasoning | **1,000,000** (1M) | 384,000 | Flagship reasoning — higher quality, slower |
+| `glm-5.2` | General | **1,000,000** (1M) | 128,000 | Zhipu AI / Tsinghua model |
+| `doubao-seed-2.0-pro` | General | 256,000 | 128,000 | ByteDance pro model |
+| `doubao-seed-2.0-lite` | General | 256,000 | 128,000 | ByteDance lite model |
+| `doubao-seed-2.0-mini` | General | 256,000 | 128,000 | ByteDance mini model |
+| `doubao-seed-2.0-code` | Coding | 256,000 | 128,000 | ByteDance coding specialist |
+| `kimi-k2.7-code` | Coding | 256,000 | 32,000 | Moonshot coding model |
+| `kimi-k2.6` | General | 256,000 | 32,000 | Moonshot general model |
+| `minimax-m3` | General | **512,000** | 128,000 | MiniMax latest — large context |
+| `minimax-m2.7` | General | 200,000 | 128,000 | MiniMax previous generation |
+
+### Capabilities (all models)
+
+✅ Streaming output
+✅ Deep thinking (深度思考)
+✅ Tool calling / Function calling
+✅ Structured output / JSON mode (beta)
+✅ Prefill / continuation mode
+✅ Multi-turn conversation
+✅ Prompt caching (Anthropic endpoint only)
+
+## Working Config Template
+
+```yaml
+# In ~/.hermes/config.yaml
+
+model:
+  base_url: https://ark.cn-beijing.volces.com/api/coding
+  default: deepseek-v4-pro          # Change to your preferred default
+  provider: custom:ark-custom       # Points to the manual-list provider
+
+custom_providers:
+  # ── Provider A: Auto-discovery (shows what Ark returns — often stale) ──
+  - api_key: ark-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-xxxxx
+    api_mode: anthropic_messages
+    base_url: https://ark.cn-beijing.volces.com/api/coding
+    model: deepseek-v4-flash
+    models: {}
+    name: ark
+
+  # ── Provider B: Manual list (YOUR ACTUAL WORKING MODELS) ──
+  - api_key: ark-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-xxxxx
+    api_mode: anthropic_messages
+    base_url: https://ark.cn-beijing.volces.com/api/coding
+    discover_models: false             # ← CRITICAL: don't pull Ark's stale model list
+    model: deepseek-v4-flash
+    models:
+      deepseek-v4-flash:
+        context_length: 1000000
+        name: deepseek-v4-flash
+      deepseek-v4-pro:
+        context_length: 1000000
+        name: deepseek-v4-pro
+      glm-5.2:
+        context_length: 1000000
+        name: glm-5.2
+      doubao-seed-2.0-pro:
+        context_length: 256000
+        name: doubao-seed-2.0-pro
+      doubao-seed-2.0-lite:
+        context_length: 256000
+        name: doubao-seed-2.0-lite
+      doubao-seed-2.0-mini:
+        context_length: 256000
+        name: doubao-seed-2.0-mini
+      doubao-seed-2.0-code:
+        context_length: 256000
+        name: doubao-seed-2.0-code
+      kimi-k2.7-code:
+        context_length: 256000
+        name: kimi-k2.7-code
+      kimi-k2.6:
+        context_length: 256000
+        name: kimi-k2.6
+      minimax-m3:
+        context_length: 512000
+        name: minimax-m3
+      minimax-m2.7:
+        context_length: 200000
+        name: minimax-m2.7
+    name: ark-custom
+```
+
+## Setup Checklist for New Machines
+
+1. **Get API Key**: [Ark API Key Management](https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey)
+2. **Activate models**: [Model Service Management](https://console.volcengine.com/ark/region:ark+cn-beijing/openManagement)
+3. **Copy the config template above** into `~/.hermes/config.yaml`
+4. **Replace** `ark-xxxxx...` with your actual API key
+5. **Launch Hermes**: `hermes`
+6. **Select** `ark-custom` provider and verify models appear
+
+## Important Links
+
+| Resource | URL |
+|----------|-----|
+| Ark Console | https://console.volcengine.com/ark/region:ark+cn-beijing/ |
+| API Key Management | https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey |
+| Model Activation | https://console.volcengine.com/ark/region:ark+cn-beijing/openManagement |
+| Usage Tracking | https://console.volcengine.com/ark/region:ark+cn-beijing/usageTracking |
+| Official Model List Docs | https://www.volcengine.com/docs/82379/1330310 |
+| Token Calculator | https://console.volcengine.com/ark/region:ark+cn-beijing/tokenCalculator |
+
+## Known Issues & Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| Models don't appear after editing config | Used `/reset` instead of full restart | `/quit` → relaunch `hermes` |
+| "Model not found" error | Model name has wrong hyphens/version suffix | Match exactly: `deepseek-v4-flash` not `deepseek-v4-flash-260425` |
+| 124 stale models in list | `discover_models` is not set to `false` | Set `discover_models: false` in the provider config |
+| Config changes ignored | Old `providers:` format still in config | Migrate to `custom_providers:` list format |
+| Unexpected charges | Using `/api/v3` endpoint | Switch to `/api/coding` |

--- a/plugins/model-providers/volcengine-ark/__init__.py
+++ b/plugins/model-providers/volcengine-ark/__init__.py
@@ -10,6 +10,11 @@ The platform provides two subscription plans:
 
 Both plans share the same Anthropic-compatible /api/coding endpoint.
 
+Prompt caching: Ark's /api/coding endpoint supports Anthropic-style
+cache_control markers (documented in the official plan overview).
+Hermes enables caching for Ark providers and hosts automatically
+via anthropic_prompt_cache_policy().
+
 IMPORTANT — model list maintenance:
   Ark's /models endpoint returns 124+ stale model IDs from the full
   platform catalog, not the user's actual subscription. This provider

--- a/plugins/model-providers/volcengine-ark/__init__.py
+++ b/plugins/model-providers/volcengine-ark/__init__.py
@@ -1,0 +1,85 @@
+"""Volcengine Ark (火山引擎) — ByteDance unified model platform.
+
+Ark is ByteDance's API gateway that gives access to models from multiple
+vendors (doubao-seed, deepseek-v4, glm-5.2, kimi-k2, minimax-m3) through
+a single API key.
+
+The platform provides two subscription plans:
+  - Agent Plan: General-purpose AI agent usage, AFP billing, multi-modal
+  - Coding Plan: Coding-focused, token quotas, AI coding tools only
+
+Both plans share the same Anthropic-compatible /api/coding endpoint.
+
+IMPORTANT — model list maintenance:
+  Ark's /models endpoint returns 124+ stale model IDs from the full
+  platform catalog, not the user's actual subscription. This provider
+  hardcodes the current Agent Plan text-generation model list and must
+  be updated when Ark adds/removes models.
+
+  Last updated: 2026-06-26 (11 models)
+"""
+
+import logging
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+logger = logging.getLogger(__name__)
+
+# ── Hardcoded model list (Agent Plan text generation, as of 2026-06-26) ──
+# Ark's auto-discovery returns 124 stale models. We hardcode the actual
+# working list to avoid confusion. Update when the provider's lineup changes.
+_ARK_MODELS = [
+    "deepseek-v4-flash",
+    "deepseek-v4-pro",
+    "glm-5.2",
+    "doubao-seed-2.0-pro",
+    "doubao-seed-2.0-lite",
+    "doubao-seed-2.0-mini",
+    "doubao-seed-2.0-code",
+    "kimi-k2.7-code",
+    "kimi-k2.6",
+    "minimax-m3",
+    "minimax-m2.7",
+]
+
+
+class VolcengineArkProfile(ProviderProfile):
+    """Volcengine Ark — hardcoded model list to avoid stale auto-discovery."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Return hardcoded model list.
+
+        We intentionally skip the API call because Ark's /models endpoint
+        returns 124+ stale model IDs from the full platform catalog rather
+        than the user's actual subscription.
+        """
+        return list(_ARK_MODELS)
+
+
+volcengine_ark = VolcengineArkProfile(
+    name="volcengine-ark",
+    aliases=(
+        "ark",
+        "volcengine",
+        "volcano",
+        "bytedance",
+    ),
+    display_name="Volcengine Ark (火山引擎)",
+    description="ByteDance model platform — doubao-seed, deepseek-v4, glm-5.2, kimi-k2, minimax",
+    signup_url="https://console.volcengine.com/ark/region:ark+cn-beijing/",
+    api_mode="anthropic_messages",
+    env_vars=("ARK_API_KEY",),
+    base_url="https://ark.cn-beijing.volces.com/api/coding",
+    auth_type="api_key",
+    default_aux_model="deepseek-v4-flash",
+)
+
+register_provider(volcengine_ark)

--- a/plugins/model-providers/volcengine-ark/plugin.yaml
+++ b/plugins/model-providers/volcengine-ark/plugin.yaml
@@ -1,0 +1,5 @@
+name: volcengine-ark-provider
+kind: model-provider
+version: 1.0.0
+description: Volcengine Ark (火山引擎) — ByteDance unified model platform with doubao-seed, deepseek-v4, glm-5.2, kimi-k2, minimax-m3
+author: hermes-agent contributors


### PR DESCRIPTION
## Summary

Adds **Volcengine Ark (火山引擎)** — ByteDance's unified AI model platform — as both a
**built-in provider** and a **companion optional skill**.

### 🎯 User experience post-merge

```
Settings → Providers → "Volcengine Ark (火山引擎)" → paste ARK_API_KEY → done ✅
```

No more digging through `config.yaml`, installing optional skills, or
wondering "how do I use Hermes with Ark?". It's right there in the menu.

### 📦 What's included

| Component | File(s) | Purpose |
|-----------|---------|---------|
| **Provider plugin** | `plugins/model-providers/volcengine-ark/` | Makes Ark appear in Settings → Providers. Hardcodes the 11 active Agent Plan models (Ark's auto-discovery returns 124 stale models). |
| **Optional skill** | `optional-skills/devops/hermes-custom-providers/` | Companion reference: model specs, troubleshooting, Coding Plan configs, cross-provider patterns for Alibaba DashScope / Zhipu GLM / Kimi |
| **Discovery tip** | `hermes_cli/tips.py` | Startup hint connecting "can't find your provider" → "Volcengine Ark is a built-in provider" |

### ↩️ Why both a provider AND a skill?

**Provider** wins on discoverability (one click), **skill** wins on depth (reference, custom configs, troubleshooting). The provider gives you the 11 Agent Plan models by default; the skill helps when you need Coding Plan endpoints, custom model subsets, or want to apply the same `custom_providers` pattern to other Chinese providers.

### 🔗 Related Issues

- Closes #29331 — "feat: add Volcengine (火山引擎) as built-in provider"
- Closes #40195 — "Feature Request: Add official ByteDance / BytePlus ModelArk provider"
- Closes #51319 — "Feature Request: 新增豆包 (Doubao/Volcano Engine) 作为原生 Provider"
- Related #12988 — "[How-to] Volcengine Coding Plan configuration" (skill supersedes outdated info)
- Related #51773 — max_tokens 400 error on Ark (toolchain avoids via anthropic_messages)
- Related #25354 — UA fingerprinting (anthropic endpoint not affected)
- Related #17199 — deepseek normalize breaks custom endpoints (not applicable to dedicated provider)
- Related #50557 — Desktop comma-list (fixed by hardcoded model list)
- Related #49126 — Dedup strips models (not applicable to dedicated provider)
- Related #37296 — Desktop onboarding stuck (single source of truth)

### 🛡️ Why hardcode the model list?

Ark's `/models` endpoint returns **124 stale model IDs** (confirmed via API probe) — ancient
models like `doubao-pro-4k-240515` that no user should see. We override `fetch_models()` to
return the exact 11 active Agent Plan text-generation models. Update when Ark adds/removes models.

Model list signature for future maintainers:
```
deepseek-v4-flash, deepseek-v4-pro, glm-5.2,
doubao-seed-2.0-pro, doubao-seed-2.0-lite, doubao-seed-2.0-mini, doubao-seed-2.0-code,
kimi-k2.7-code, kimi-k2.6, minimax-m3, minimax-m2.7
```

### ✅ Verification

- Provider `__init__.py`: AST parse ✅, class with overridden `fetch_models` ✅, 11 models ✅
- plugin.yaml: valid YAML ✅, name/kind/version correct ✅
- Skill SKILL.md: YAML frontmatter ✅, required sections ✅, no API keys leaked ✅
- Reference file: exists (11KB) ✅, Agent Plan vs Coding Plan comparison ✅, Config template ✅