### PR TITLE
fix(discord): recall prior thread context after bot replies

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4276,6 +4276,25 @@ class DiscordAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             return 50
 
+    def _discord_thread_history_recall(self) -> bool:
+        """Return whether Discord threads may recall context before our last turn.
+
+        The normal channel backfill stops at Hermes' last response so the model
+        transcript is not duplicated every turn.  Discord threads are different:
+        humans often summon Hermes after discussing a task, then continue with
+        short follow-ups like "add this" or "fix it".  If Hermes has already
+        answered once, the strict self-message partition hides the earlier
+        thread discussion and the agent cannot recover the assignment.  Keep
+        this scoped to threads and skip Hermes-authored messages so the agent
+        sees the missing human context without replaying its own prior output.
+        """
+        configured = self.config.extra.get("thread_history_recall")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() not in {"false", "0", "no", "off"}
+            return bool(configured)
+        return os.getenv("DISCORD_THREAD_HISTORY_RECALL", "true").lower() in {"true", "1", "yes", "on"}
+
     async def _fetch_channel_context(
         self,
         channel: Any,
@@ -4368,7 +4387,20 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # ── Primary window: recent channel activity since the last bot turn ──
             collected: List[Tuple[str, str]] = []  # (message_id, line)
+            # For Discord threads, optionally continue past the most recent
+            # Hermes response and collect earlier human context too.  This is
+            # what lets a user say "add this" / "fix it" after a prior Hermes
+            # answer without past thread context disappearing behind our own
+            # partition point.
+            earlier_collected: List[Tuple[str, str]] = []
             seen_ids: set = set()
+            recall_thread_history = (
+                self._discord_thread_history_recall()
+                and DISCORD_AVAILABLE
+                and discord is not None
+                and isinstance(channel, discord.Thread)
+            )
+            saw_self_partition = False
             # IMPORTANT: pass oldest_first=False explicitly.  discord.py 2.x
             # silently flips the default to True when `after=` is supplied,
             # which would select the *earliest* N messages after our last
@@ -4398,12 +4430,16 @@ class DiscordAdapter(BasePlatformAdapter):
                 # session transcript.  (Redundant when _after_obj is set, but
                 # needed for cold start.)
                 if msg.author == self._client.user:
+                    if recall_thread_history:
+                        saw_self_partition = True
+                        continue
                     break
                 line = _keep(msg)
                 if line is None:
                     continue
                 mid = str(getattr(msg, "id", ""))
-                collected.append((mid, line))
+                target = earlier_collected if saw_self_partition else collected
+                target.append((mid, line))
                 if mid:
                     seen_ids.add(mid)
 
@@ -4444,16 +4480,22 @@ class DiscordAdapter(BasePlatformAdapter):
                     if mid:
                         seen_ids.add(mid)
 
-            if not collected and not reply_collected:
+            if not collected and not reply_collected and not earlier_collected:
                 return ""
 
             # channel.history returns newest-first; reverse each window for
-            # chronological order, then present reply context first (it is
-            # older) followed by the recent activity.
+            # chronological order, then present older context first followed by
+            # recent activity.
             collected.reverse()
             reply_collected.reverse()
+            earlier_collected.reverse()
 
             blocks: List[str] = []
+            if earlier_collected:
+                blocks.append(
+                    "[Earlier thread messages before Hermes' last reply]\n"
+                    + "\n".join(line for _id, line in earlier_collected)
+                )
             if reply_collected:
                 blocks.append(
                     "[Context around the replied-to message]\n"

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -115,6 +115,7 @@ def adapter(monkeypatch):
         "DISCORD_IGNORED_CHANNELS",
         "DISCORD_HISTORY_BACKFILL",
         "DISCORD_HISTORY_BACKFILL_LIMIT",
+        "DISCORD_THREAD_HISTORY_RECALL",
         "DISCORD_ALLOW_BOTS",
     ):
         monkeypatch.delenv(_var, raising=False)
@@ -182,6 +183,15 @@ class FakeHistoryChannel(FakeTextChannel):
                 yield message
 
         return _iter()
+
+
+class FakeHistoryThread(FakeThread):
+    def __init__(self, history_messages, channel_id: int = 1, name: str = "thread", parent=None, guild_name: str = "Hermes Server"):
+        super().__init__(channel_id=channel_id, name=name, parent=parent, guild_name=guild_name)
+        self._history_messages = list(history_messages)
+
+    def history(self, *, limit, before, after=None, oldest_first=None):
+        return FakeHistoryChannel.history(self, limit=limit, before=before, after=after, oldest_first=oldest_first)
 
 
 @pytest.mark.asyncio
@@ -665,6 +675,39 @@ async def test_fetch_channel_context_stops_at_self_message_and_reverses_to_chron
         "[Recent channel messages]\n"
         "[Gemini [bot]] latest bot note\n"
         "[Alice] latest human note"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_context_recalls_earlier_thread_messages_before_self_boundary(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "none")
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    meghann = SimpleNamespace(id=56, display_name="Meghann", name="Meghann", bot=False)
+    brett = SimpleNamespace(id=57, display_name="Brett", name="Brett", bot=False)
+
+    thread = FakeHistoryThread(
+        [
+            make_history_message(author=meghann, content="ok fix it", msg_id=6),
+            make_history_message(author=adapter._client.user, content="I cannot see prior thread history", msg_id=5),
+            make_history_message(author=meghann, content="add to mission control and begin implementation", msg_id=4),
+            make_history_message(author=brett, content="screenshot says live video is black", msg_id=3),
+        ],
+        channel_id=456,
+        name="mission-control-triage",
+    )
+
+    result = await adapter._fetch_channel_context(
+        thread,
+        before=make_message(channel=thread, content="trigger", msg_type=discord_platform.discord.MessageType.reply),
+    )
+
+    assert result == (
+        "[Earlier thread messages before Hermes' last reply]\n"
+        "[Brett] screenshot says live video is black\n"
+        "[Meghann] add to mission control and begin implementation\n\n"
+        "[Recent channel messages]\n"
+        "[Meghann] ok fix it"
     )
 
 


### PR DESCRIPTION
## Summary
- allow Discord thread history backfill to continue past Hermes' last reply in threads
- skip Hermes-authored messages while recalling earlier human thread context
- add regression coverage for short follow-ups like “fix it” after Hermes previously answered it could not see history

## Tests
- `python -m pytest tests/gateway/test_discord_free_response.py -q`
- `python -m ruff check plugins/platforms/discord/adapter.py tests/gateway/test_discord_free_response.py`
- `python -m py_compile plugins/platforms/discord/adapter.py tests/gateway/test_discord_free_response.py`
