### PR TITLE
fix(gateway): block inbound document cache redelivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -15,6 +15,7 @@ import re
 import socket as _socket
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 from abc import ABC, abstractmethod
@@ -1010,6 +1011,24 @@ _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS = (
 )
 
 
+def _media_delivery_inbound_document_roots() -> List[Path]:
+    """Return inbound document-cache roots that must never be re-uploaded.
+
+    Uploaded chat documents are cached here so the agent can inspect them.
+    They are not agent-produced deliverables. If the model repeats one of
+    these paths in its final answer, the bare-path attachment detector must not
+    echo the user's original file back into the chat.
+    """
+    roots = [
+        DOCUMENT_CACHE_DIR,
+        _HERMES_HOME / "document_cache",
+        _HERMES_HOME / "cache" / "documents",
+    ]
+    tmp = Path(os.environ.get("TMPDIR") or tempfile.gettempdir())
+    roots.append(tmp / "hermes" / "cache" / "documents")
+    return roots
+
+
 def _media_delivery_allowed_roots() -> List[Path]:
     """Return roots from which model-emitted local media may be delivered."""
     roots = [Path(root) for root in MEDIA_DELIVERY_SAFE_ROOTS]
@@ -1108,6 +1127,31 @@ def _path_under_denied_prefix(resolved: Path) -> bool:
     return False
 
 
+def _path_under_inbound_document_cache(resolved: Path) -> bool:
+    """Return True when ``resolved`` is an inbound document-cache file."""
+    for root in _media_delivery_inbound_document_roots():
+        try:
+            resolved_root = root.expanduser().resolve(strict=False)
+        except (OSError, RuntimeError, ValueError):
+            continue
+        if _path_is_within(resolved, resolved_root):
+            return True
+    try:
+        tmp_root = Path(os.environ.get("TMPDIR") or tempfile.gettempdir()).resolve(strict=False)
+        rel = resolved.relative_to(tmp_root)
+        parts = rel.parts
+        if (
+            len(parts) >= 4
+            and parts[0].startswith("hermes")
+            and parts[1] == "cache"
+            and parts[2] == "documents"
+        ):
+            return True
+    except (OSError, RuntimeError, ValueError):
+        pass
+    return False
+
+
 def _file_is_recently_produced(resolved: Path, window_seconds: float) -> bool:
     """Return True if the file's mtime is within ``window_seconds`` of now.
 
@@ -1177,6 +1221,9 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
         return None
 
     if not resolved.is_file():
+        return None
+
+    if _path_under_inbound_document_cache(resolved):
         return None
 
     # Cache / operator allowlist is always honored — these are unconditionally

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1009,6 +1009,53 @@ class TestMediaDeliveryDefaultMode:
         out = BasePlatformAdapter.filter_local_delivery_paths([str(notes)])
         assert out == [str(notes.resolve())]
 
+    def test_inbound_document_cache_file_is_not_deliverable(self, tmp_path, monkeypatch):
+        """Uploaded documents are readable by the agent but must not echo back
+        as native attachments when the model repeats their cache path.
+        """
+        self._patch_roots(monkeypatch)
+
+        doc_cache = tmp_path / "doc_cache"
+        doc_cache.mkdir()
+        doc = doc_cache / "doc_abc_notes.md"
+        doc.write_text("# uploaded by user\n")
+        monkeypatch.setattr(
+            "gateway.platforms.base.DOCUMENT_CACHE_DIR",
+            doc_cache,
+        )
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(doc)) is None
+        assert BasePlatformAdapter.filter_local_delivery_paths([str(doc)]) == []
+
+    def test_inbound_document_cache_media_tag_is_not_deliverable(self, tmp_path, monkeypatch):
+        """The same guard applies when the model emits an explicit MEDIA tag."""
+        self._patch_roots(monkeypatch)
+
+        doc_cache = tmp_path / "doc_cache"
+        doc_cache.mkdir()
+        doc = doc_cache / "doc_abc_report.pdf"
+        doc.write_bytes(b"%PDF-1.4")
+        monkeypatch.setattr(
+            "gateway.platforms.base.DOCUMENT_CACHE_DIR",
+            doc_cache,
+        )
+
+        media, _ = BasePlatformAdapter.extract_media(f"MEDIA:{doc}")
+        assert media == [(str(doc), False)]
+        assert BasePlatformAdapter.filter_media_delivery_paths(media) == []
+
+    def test_temp_inbound_document_cache_file_is_not_deliverable(self, tmp_path, monkeypatch):
+        """Container/temp Hermes document caches use /tmp/hermes*/cache/documents."""
+        self._patch_roots(monkeypatch)
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+
+        doc_cache = tmp_path / "hermes-test-run" / "cache" / "documents"
+        doc_cache.mkdir(parents=True)
+        doc = doc_cache / "doc_abc_upload.md"
+        doc.write_text("# uploaded by user\n")
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(doc)) is None
+
     def test_root_home_deliverable_is_accepted(self, tmp_path, monkeypatch):
         """The motivating bug (#38106): a root-run gateway has ``$HOME=/root``,
         which is on the system-prefix denylist. A plain deliverable the agent


### PR DESCRIPTION
## Summary

- prevent inbound cached documents from being re-delivered as native media attachments when their local cache path appears in a model response
- cover bare path, explicit MEDIA tag, and temporary Hermes document cache layouts

## Why

Uploaded documents are cached locally so the agent can read them, but those cache paths are not agent-produced deliverables. If a model repeats an inbound cache path, the gateway should not echo the user's original upload back into the chat as a fresh attachment.

## Validation

- python3 -m py_compile gateway/platforms/base.py
- /home/gidon/.hermes/hermes-agent/.venv/bin/ruff check gateway/platforms/base.py tests/gateway/test_platform_base.py
- /home/gidon/.hermes/hermes-agent/.venv/bin/pytest -q tests/gateway/test_platform_base.py
