### PR TITLE
fix(kanban): display timestamps in user's configured timezone

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -45,9 +45,10 @@ _STATUS_ICONS = {
 
 
 def _fmt_ts(ts: Optional[int]) -> str:
-    if not ts:
-        return ""
-    return time.strftime("%Y-%m-%d %H:%M", time.localtime(ts))
+    # Delegate to the canonical helper in kanban_db, which renders the
+    # timestamp in the user's configured IANA timezone rather than the
+    # host's local one (UTC on most servers).
+    return kb.fmt_ts(ts)
 
 
 def _fmt_task_line(t: kb.Task) -> str:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -104,6 +104,29 @@ KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
 
 
+def fmt_ts(ts: Optional[int]) -> str:
+    """Format a Unix timestamp in the user's configured IANA timezone.
+
+    Resolves via ``hermes_time`` (HERMES_TIMEZONE env var or
+    ``config.yaml`` ``timezone`` key) and falls back to the server's local
+    time when the user hasn't configured one. The previous implementation
+    used ``time.localtime()``, which rendered host-TZ (typically UTC) and
+    silently shifted displayed wall-clock time for non-UTC users.
+    """
+    if not ts:
+        return ""
+    try:
+        from hermes_time import get_timezone
+        from datetime import datetime
+
+        tz = get_timezone()
+        if tz is not None:
+            return datetime.fromtimestamp(int(ts), tz=tz).strftime("%Y-%m-%d %H:%M")
+    except Exception:
+        pass
+    return time.strftime("%Y-%m-%d %H:%M", time.localtime(ts))
+
+
 def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None:
     """Fire a kanban lifecycle plugin hook, fully best-effort.
 
@@ -7624,7 +7647,7 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
             )
         for offset, run in enumerate(shown):
             idx = first_shown_idx + offset
-            ts = time.strftime("%Y-%m-%d %H:%M", time.localtime(run.started_at))
+            ts = fmt_ts(run.started_at)
             profile = run.profile or "(unknown)"
             outcome = run.outcome or run.status
             lines.append(f"### Attempt {idx} — {outcome} ({profile}, {ts})")
@@ -7699,9 +7722,7 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
         if role_rows:
             lines.append(f"## Recent work by @{task.assignee}")
             for row in role_rows:
-                ts = time.strftime(
-                    "%Y-%m-%d %H:%M", time.localtime(int(row["ended_at"]))
-                )
+                ts = fmt_ts(int(row["ended_at"]))
                 s = (row["summary"] or "").strip().splitlines()
                 first = s[0][:200] if s else "(no summary)"
                 lines.append(f"- {row['id']} — {row['title']} ({ts}): {first}")
@@ -7725,7 +7746,7 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
                 f"omitted; showing most recent {len(shown_c)})_"
             )
         for c in shown_c:
-            ts = time.strftime("%Y-%m-%d %H:%M", time.localtime(c.created_at))
+            ts = fmt_ts(c.created_at)
             # Render author with explicit "comment from worker" framing so
             # operator-controlled HERMES_PROFILE values like "hermes-system"
             # or "operator" can't be misread by the next worker as a system


### PR DESCRIPTION
## Summary

The kanban CLI formatted Unix timestamps with \`time.strftime(..., time.localtime(ts))\`, which renders in the **host's** timezone (UTC on most servers). Storage is correct — \`created_at\` is stored as UTC seconds-since-epoch — but display was host-local, so non-UTC users saw \"yesterday\" events as today and vice versa.

The rest of Hermes already has \`hermes_time\` resolving the user's IANA timezone from \`HERMES_TIMEZONE\` env var or \`config.yaml\` \`timezone\` key (falls back to server-local). The kanban CLI never wired it up.

## Reproduction

Before this patch, with \`HERMES_TIMEZONE=America/Los_Angeles\` (host TZ = UTC):

\`\`\`
\$ hermes kanban show t_0cc3e903
  created:   2026-06-25 00:54 by user
  started:   2026-06-25 00:54
  completed: 2026-06-25 01:05
\`\`\`

The task was submitted yesterday in PDT; the CLI rendered UTC.

## Fix

After this patch:

\`\`\`
\$ hermes kanban show t_0cc3e903
  created:   2026-06-24 17:54 by user
  started:   2026-06-24 17:54
  completed: 2026-06-24 18:05
\`\`\`

## Changes

- \`hermes_cli/kanban_db.py\` — new \`fmt_ts(ts)\` canonical helper that resolves through \`hermes_time.get_timezone()\`. Replaces 3 inline \`time.strftime(...)\` call sites:
  - run \`started_at\` (in recent-attempts block)
  - recent-work \`ended_at\` (assignee-recent-work block)
  - comment \`created_at\` (comment thread block)
- \`hermes_cli/kanban.py\` — \`_fmt_ts\` collapses to a one-liner delegating to \`kb.fmt_ts\` (no duplicated formatting logic).

## What did NOT change

- \`created_at\` storage format (still UTC Unix int — correct, timezone-agnostic)
- Gateway + dashboard paths (they pass raw \`created_at\` to the browser, which formats in the user's local TZ)
- Any other kanban CLI commands

## Risk

Low. The fix is functionally equivalent for users on UTC and correct for any configured TZ. The \`try/except\` fallback in \`fmt_ts\` preserves the old \`time.localtime()\` behavior if \`hermes_time\` fails to resolve, so a misconfigured install still renders something readable.