### PR TITLE
fix(hermes_state): persist billing route after mid-session /model switch (#48248)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1697,6 +1697,27 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         old_model, old_provider, new_model, new_provider,
     )
 
+    # ── Persist billing route to session DB ──
+    # The agent's _session_db / session_id may not be set in all contexts
+    # (tests, bare agents without a session DB, etc.).  This ensures the
+    # dashboard Model cards show the actual provider after a mid-session
+    # /model switch instead of the stale session-creation provider.
+    # See #48248 for the full bug description.
+    _session_db = getattr(agent, "_session_db", None)
+    _session_id = getattr(agent, "session_id", None)
+    if _session_db is not None and _session_id:
+        try:
+            _session_db.update_session_billing_route(
+                _session_id,
+                provider=agent.provider,
+                base_url=agent.base_url,
+                billing_mode=getattr(agent, "api_mode", None),
+            )
+        except Exception:
+            logger.warning(
+                "Failed to persist billing route after model switch",
+                exc_info=True,
+            )
 
 
 def invoke_tool(agent, function_name: str, function_args: dict, effective_task_id: str,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1584,6 +1584,36 @@ class SessionDB:
             )
         self._execute_write(_do)
 
+    def update_session_billing_route(
+        self,
+        session_id: str,
+        *,
+        provider: str,
+        base_url: str,
+        billing_mode: Optional[str] = None,
+    ) -> None:
+        """Unconditionally update the billing provider/base_url for a session.
+
+        Unlike ``update_token_counts`` which uses ``COALESCE(billing_provider, ?)``
+        (only filling in NULL), this unconditionally sets the billing fields so
+        that the dashboard reflects the user's latest /model switch.
+
+        Also nulls ``system_prompt`` so the cached snapshot (which embeds a
+        stale ``Model:`` / ``Provider:`` header) is rebuilt — matching the
+        behavior of ``update_session_model`` (see #48173, #48248).
+        """
+        def _do(conn):
+            conn.execute(
+                """UPDATE sessions SET
+                   billing_provider = ?,
+                   billing_base_url = ?,
+                   billing_mode = COALESCE(?, billing_mode),
+                   system_prompt = NULL
+                   WHERE id = ?""",
+                (provider, base_url, billing_mode, session_id),
+            )
+        self._execute_write(_do)
+
     def update_token_counts(
         self,
         session_id: str,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -210,6 +210,54 @@ class TestSessionLifecycle:
                                model="xiaomi/mimo-v2.5-pro")
         assert db.get_session("s1")["model"] == "xiaomi/mimo-v2.5"
 
+    def test_update_session_billing_route_overwrites_after_switch(self, db):
+        """A mid-session provider switch must overwrite the billing route.
+
+        update_token_counts writes billing fields with
+        COALESCE(billing_provider, ?) (first-writer-wins), so after a
+        provider switch the dashboard kept attributing cost to the original
+        provider (#48248). update_session_billing_route sets them
+        unconditionally and nulls system_prompt so the next turn rebuilds
+        the Model:/Provider: header (#48173).
+        """
+        db.create_session(session_id="s1", source="telegram")
+        # First token update seeds the billing route.
+        db.update_token_counts("s1", input_tokens=10, output_tokens=5,
+                               billing_provider="openrouter",
+                               billing_base_url="https://openrouter.ai/api/v1",
+                               billing_mode="api_key")
+        sess = db.get_session("s1")
+        assert sess["billing_provider"] == "openrouter"
+        # A later token update never changes it (COALESCE first-writer-wins).
+        db.update_token_counts("s1", input_tokens=10, output_tokens=5,
+                               billing_provider="ollama",
+                               billing_base_url="http://localhost:11434/v1",
+                               billing_mode="local")
+        assert db.get_session("s1")["billing_provider"] == "openrouter"
+
+        # Seed a stale prompt snapshot, then switch the billing route.
+        db.update_system_prompt("s1", "Model: x/old\nProvider: openrouter")
+        assert db.get_session("s1")["system_prompt"] is not None
+        db.update_session_billing_route(
+            "s1", provider="ollama",
+            base_url="http://localhost:11434/v1", billing_mode="local",
+        )
+        sess = db.get_session("s1")
+        assert sess["billing_provider"] == "ollama"
+        assert sess["billing_base_url"] == "http://localhost:11434/v1"
+        assert sess["billing_mode"] == "local"
+        assert sess["system_prompt"] is None, \
+            "system_prompt must be nulled so the next turn rebuilds Model:/Provider:"
+
+        # billing_mode defaults to COALESCE — omitting it preserves the value.
+        db.update_session_billing_route(
+            "s1", provider="openai",
+            base_url="https://api.openai.com/v1",
+        )
+        sess = db.get_session("s1")
+        assert sess["billing_provider"] == "openai"
+        assert sess["billing_mode"] == "local"  # preserved (COALESCE on None)
+
     def test_parent_session(self, db):
         db.create_session(session_id="parent", source="cli")
         db.create_session(session_id="child", source="cli", parent_session_id="parent")


### PR DESCRIPTION
## Summary
A mid-session provider switch (`/model` across providers, e.g. openrouter → ollama) now updates the session's billing route so the dashboard attributes cost to the provider actually serving the turn. Previously the billing columns were written first-writer-wins, so they kept the original provider forever after a switch.

Salvages #48254 by @x7peeps. Fixes #48248. Related to #48173 (prompt staleness — already mitigated on main by `_stored_prompt_matches_runtime`, but this also nulls the snapshot for belt-and-suspenders correctness).

## Changes
- `hermes_state.py`: new `update_session_billing_route()` — sets `billing_provider` / `billing_base_url` / `billing_mode` **unconditionally** (not `COALESCE` first-writer-wins) and nulls `system_prompt` so the next turn rebuilds the `Model:`/`Provider:` header. `billing_mode` is `COALESCE`-guarded so omitting it preserves the current value.
- `agent/agent_runtime_helpers.py`: `switch_model()` calls it after a switch (guarded — no-ops when the agent has no session DB).
- `tests/test_hermes_state.py`: regression covering unconditional overwrite, prompt-null, and `billing_mode` preservation.

## Root cause
`update_token_counts` writes `billing_provider = COALESCE(billing_provider, ?)` on both the increment (CLI) and absolute (gateway) paths — first-writer-wins. The first turn seeds the billing columns; a later provider switch never overwrites them. The dedicated method writes them unconditionally on the switch event itself, leaving the hot per-call token path (and its COALESCE semantics for unrelated callers) untouched.

## Validation
- `scripts/run_tests.sh tests/test_hermes_state.py` → 279 passed.
- **Live E2E** (real `SessionDB`, temp `HERMES_HOME`): seed `billing_provider=openrouter/api_key` + a stale `Model:`/`Provider:` prompt → call the switch path with `ollama/local` → columns become `ollama` / `http://localhost:11434/v1` / `local` and `system_prompt` is `NULL`. Verdict: PASS.

> Cluster note: #48256 (NULL the snapshot in `switch_model`) and #48196 (NULL it in `update_session_model`) target the prompt-staleness half of #48173, which `_stored_prompt_matches_runtime` already rebuilds on restore — redundant, not salvaged here. #48258 fixes the same billing bug by ripping `COALESCE` out of `update_token_counts` directly, which would let any caller omitting billing args wipe the columns — riskier than this dedicated-method approach.

## Infographic
![Billing route fixed on mid-session switch](https://v3b.fal.media/files/b/0a9fc0ec/7G6cWmeHdEyButpSoiZDe_vP3H0MUt.png)
