### PR TITLE
fix(gateway): honor nested gateway.multiplex_profiles from config.yaml

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -854,6 +854,10 @@ def load_gateway_config() -> GatewayConfig:
             # other session-scope flags above).
             if "multiplex_profiles" in yaml_cfg:
                 gw_data["multiplex_profiles"] = yaml_cfg["multiplex_profiles"]
+            else:
+                _mp = yaml_cfg.get("gateway", {}).get("multiplex_profiles")
+                if _mp is not None:
+                    gw_data["multiplex_profiles"] = _mp
 
             gateway_section = yaml_cfg.get("gateway")
             if isinstance(gateway_section, dict) and "max_concurrent_sessions" in gateway_section:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -415,6 +415,34 @@ class TestLoadGatewayConfig:
 
         assert config.thread_sessions_per_user is False
 
+    def test_multiplex_profiles_from_top_level_key(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("multiplex_profiles: true\n", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.multiplex_profiles is True
+
+    def test_multiplex_profiles_from_nested_gateway_key(self, tmp_path, monkeypatch):
+        """hermes config set gateway.multiplex_profiles true writes the key
+        nested under gateway:.  load_gateway_config must honor it."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n  multiplex_profiles: true\n", encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.multiplex_profiles is True
+
     def test_bridges_top_level_max_concurrent_sessions_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()


### PR DESCRIPTION
## What does this PR do?

Fixes `load_gateway_config()` ignoring `multiplex_profiles` when set via the nested `gateway.multiplex_profiles` config key (the form written by `hermes config set gateway.multiplex_profiles true`). The gateway silently stayed in single-tenant mode even after the user explicitly enabled multiplexing.

## Related Issue

Fixes #52562

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/config.py`: Add nested `gateway.multiplex_profiles` fallback in `load_gateway_config()`, matching the existing pattern used by `max_concurrent_sessions` (line 858-860).
- `tests/gateway/test_config.py`: Add two tests — top-level key still works, and nested `gateway:` key is now honored.

## How to Test

1. Create `config.yaml` with `gateway:\n  multiplex_profiles: true`
2. Start the gateway — it should report multiplex mode enabled
3. Run `pytest tests/gateway/test_config.py::TestLoadGatewayConfig -k multiplex -v` — both tests should pass
4. Run `pytest tests/gateway/test_config.py -q` — all 74 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/config.py:load_gateway_config` (callers: gateway startup, setup wizard)
- Blast radius: LOW — single config key fallback, no behavioral change for existing top-level configs
- Related patterns: `max_concurrent_sessions` nested fallback (line 858-860), `streaming` nested fallback (line 867-869)
