### PR TITLE
fix(system_prompt): use dynamic HERMES_HOME paths instead of hardcoded ~/.hermes

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -24,6 +24,7 @@ Pure helpers that read the agent's state.  AIAgent keeps thin forwarders.
 from __future__ import annotations
 
 import json
+import os
 from typing import Any, Dict, List, Optional
 
 from agent.prompt_builder import (
@@ -348,10 +349,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             pass
 
     # Active-profile hint — names the Hermes profile the agent is running
-    # under so it doesn't conflate ~/.hermes/skills/ (default profile) with
-    # ~/.hermes/profiles/<active>/skills/ (this profile's). Deterministic
-    # for the lifetime of the agent — profile name doesn't change
-    # mid-session, so this doesn't break the prompt cache.
+    # under so it doesn't conflate default profile paths with
+    # this profile's paths. Deterministic for the lifetime of the agent —
+    # profile name doesn't change mid-session, so this doesn't break
+    # the prompt cache.
     # See file_safety._resolve_active_profile_name + classify_cross_profile_target
     # for the matching tool-side guard.
     try:
@@ -359,21 +360,29 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         active_profile = _resolve_active_profile_name()
     except Exception:
         active_profile = "default"
+
+    # Resolve actual Hermes root path (respects HERMES_HOME).
+    try:
+        from hermes_constants import get_default_hermes_root
+        hermes_root = str(get_default_hermes_root())
+    except Exception:
+        hermes_root = os.path.expanduser("~/.hermes")
+
     if active_profile == "default":
         stable_parts.append(
-            "Active Hermes profile: default. Other profiles (if any) live "
-            "under ~/.hermes/profiles/<name>/. Each profile has its own "
-            "skills/, plugins/, cron/, and memories/ that affect a different "
-            "session than this one. Do not modify another profile's "
-            "skills/plugins/cron/memories unless the user explicitly directs "
-            "you to."
+            f"Active Hermes profile: default. Other profiles (if any) live "
+            f"under {hermes_root}/profiles/<name>/. Each profile has its own "
+            f"skills/, plugins/, cron/, and memories/ that affect a different "
+            f"session than this one. Do not modify another profile's "
+            f"skills/plugins/cron/memories unless the user explicitly directs "
+            f"you to."
         )
     else:
         stable_parts.append(
             f"Active Hermes profile: {active_profile}. This session reads "
-            f"and writes ~/.hermes/profiles/{active_profile}/. The default "
-            f"profile's data lives at ~/.hermes/skills/, ~/.hermes/plugins/, "
-            f"~/.hermes/cron/, ~/.hermes/memories/ — those belong to a "
+            f"and writes {hermes_root}/profiles/{active_profile}/. The default "
+            f"profile's data lives at {hermes_root}/skills/, {hermes_root}/plugins/, "
+            f"{hermes_root}/cron/, {hermes_root}/memories/ — those belong to a "
             f"different session run from a different shell. Do NOT modify "
             f"another profile's skills/plugins/cron/memories unless the user "
             f"explicitly directs you to. The cross-profile write guard will "


### PR DESCRIPTION
## Problem

When Hermes is installed to a non-standard location (e.g., `/opt/hermes` instead of `~/.hermes`), the system prompt injected into the agent still contains hardcoded `~/.hermes` paths, even though `HERMES_HOME` is correctly set and all runtime tools work properly.

This misleads the agent about actual file locations, potentially causing:
- Confusion when the agent references paths in reasoning
- Incorrect path assumptions in cross-profile operations
- Issues for Docker deployments, custom installations, or any non-default layout

## Root Cause

In `agent/system_prompt.py` (lines 360-380), the active-profile hint uses literal `~/.hermes` strings:

```python
f"and writes ~/.hermes/profiles/{active_profile}/. The default "
f"profile's data lives at ~/.hermes/skills/, ~/.hermes/plugins/, "
f"~/.hermes/cron/, ~/.hermes/memories/"
```

The tools layer (e.g., `file_safety.py`) correctly uses `get_hermes_home()` — only the system prompt display was hardcoded.

## Fix

Use the existing `get_default_hermes_root()` function from `hermes_constants` to dynamically resolve the actual Hermes root path. This function already handles:
- Standard deployments (`~/.hermes`)
- Docker/custom deployments (any `HERMES_HOME`)
- Profile mode (extracts root from `<root>/profiles/<name>`)

## Changes

- Added `import os` to `agent/system_prompt.py`
- Resolve `hermes_root` via `get_default_hermes_root()` with fallback to `~/.hermes`
- Replaced all hardcoded `~/.hermes` references in the profile hint with `{hermes_root}`

## Testing

- Python syntax validated via `ast.parse`
- `get_default_hermes_root()` verified:
  - `HERMES_HOME=/opt/hermes/profiles/coder` returns `/opt/hermes`
  - `HERMES_HOME` unset returns `~/.hermes`

## Related

Fixes #52669