### PR TITLE
fix(transports): evict old computer-use screenshots on chat_completions path

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -115,6 +115,64 @@ def _model_consumes_thought_signature(model: Any) -> bool:
     return "gemini" in m or "gemma" in m
 
 
+# Keep only the most recent N computer-use screenshots in the outbound request.
+# Mirrors agent.anthropic_adapter._evict_old_screenshots, which runs on every
+# Anthropic request. The OpenAI/chat_completions path historically had no such
+# always-on guard — base64 screenshots (~250K chars / ~60K tokens each) only got
+# pruned when *full context compression* happened to fire, so a screenshot-heavy
+# computer_use session on an OpenAI-format provider (e.g. gpt-5.5 via Codex)
+# could balloon context into the millions of tokens and burn a usage allowance
+# before compression caught up. This evicts on every request, cheaply, like the
+# Anthropic side already does.
+_MAX_KEEP_IMAGES = 3
+_SCREENSHOT_REMOVED_TEXT = "[screenshot removed to save context]"
+
+
+def _content_has_openai_image(content: Any) -> bool:
+    """True if an OpenAI-format message content list carries an image_url part."""
+    if not isinstance(content, list):
+        return False
+    return any(
+        isinstance(p, dict) and p.get("type") in {"image_url", "image", "input_image"}
+        for p in content
+    )
+
+
+def _strip_images_from_content(content: list) -> list:
+    """Replace image parts with a text placeholder; keep all other parts."""
+    stripped = []
+    for p in content:
+        if isinstance(p, dict) and p.get("type") in {"image_url", "image", "input_image"}:
+            stripped.append({"type": "text", "text": _SCREENSHOT_REMOVED_TEXT})
+        else:
+            stripped.append(p)
+    return stripped
+
+
+def _evict_old_screenshots_openai(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Keep only the most recent ``_MAX_KEEP_IMAGES`` screenshots.
+
+    Walks messages newest-first, counts tool/user messages whose content list
+    carries an image part, and replaces image parts in the older ones with a
+    text placeholder. Returns the original list unchanged when there is nothing
+    to evict (<= N image-bearing messages); otherwise returns a deep-copied list
+    with the old images stripped — never mutates the caller's canonical history.
+    """
+    image_msg_indices = [
+        i for i, msg in enumerate(messages)
+        if isinstance(msg, dict) and _content_has_openai_image(msg.get("content"))
+    ]
+    if len(image_msg_indices) <= _MAX_KEEP_IMAGES:
+        return messages
+
+    # Older = all but the most recent N.
+    to_strip = set(image_msg_indices[:-_MAX_KEEP_IMAGES])
+    out = copy.deepcopy(messages)
+    for i in to_strip:
+        out[i]["content"] = _strip_images_from_content(out[i]["content"])
+    return out
+
+
 class ChatCompletionsTransport(ProviderTransport):
     """Transport for api_mode='chat_completions'.
 
@@ -193,7 +251,7 @@ class ChatCompletionsTransport(ProviderTransport):
                     break
 
         if not needs_sanitize:
-            return messages
+            return _evict_old_screenshots_openai(messages)
 
         sanitized = copy.deepcopy(messages)
         for msg in sanitized:
@@ -216,7 +274,7 @@ class ChatCompletionsTransport(ProviderTransport):
                         tc.pop("response_item_id", None)
                         if strip_extra_content:
                             tc.pop("extra_content", None)
-        return sanitized
+        return _evict_old_screenshots_openai(sanitized)
 
     def convert_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Tools are already in OpenAI format — identity."""

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -1044,3 +1044,89 @@ class TestChatCompletionsGeminiNativeExtraBodyStrip:
         )
         eb = kw.get("extra_body")
         assert eb and "tags" in eb
+
+
+def _img_part(b64="iVBORw0KGgo="):
+    return {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}}
+
+
+def _screenshot_tool_msg(call_id, b64="iVBORw0KGgo="):
+    """A computer_use tool-result message in OpenAI format with an image part."""
+    return {
+        "role": "tool",
+        "tool_call_id": call_id,
+        "name": "computer_use",
+        "content": [
+            {"type": "text", "text": "screen capture summary"},
+            _img_part(b64),
+        ],
+    }
+
+
+class TestChatCompletionsScreenshotEviction:
+    """Always-on screenshot eviction on the OpenAI/chat_completions path.
+
+    Mirrors the Anthropic adapter's _evict_old_screenshots so a screenshot-heavy
+    computer_use session on an OpenAI-format provider (e.g. gpt-5.5 via Codex)
+    can't balloon context with stale base64 images.
+    """
+
+    def _build_session(self, n_screenshots):
+        msgs = [{"role": "user", "content": "start"}]
+        for i in range(n_screenshots):
+            msgs.append({
+                "role": "assistant", "content": "",
+                "tool_calls": [{"id": f"c{i}", "type": "function",
+                                "function": {"name": "computer_use", "arguments": "{}"}}],
+            })
+            msgs.append(_screenshot_tool_msg(f"c{i}"))
+        msgs.append({"role": "assistant", "content": "done"})
+        return msgs
+
+    def _count_images(self, msgs):
+        n = 0
+        for m in msgs:
+            c = m.get("content")
+            if isinstance(c, list):
+                n += sum(1 for p in c if isinstance(p, dict) and p.get("type") == "image_url")
+        return n
+
+    def test_keeps_only_most_recent_three(self, transport):
+        msgs = self._build_session(5)
+        out = transport.convert_messages(msgs)
+        # 5 screenshots in -> only the most recent 3 keep their image
+        assert self._count_images(out) == 3
+
+    def test_old_screenshots_replaced_with_placeholder(self, transport):
+        msgs = self._build_session(5)
+        out = transport.convert_messages(msgs)
+        placeholder_msgs = [
+            m for m in out
+            if isinstance(m.get("content"), list)
+            and any(isinstance(p, dict) and p.get("type") == "text"
+                    and "screenshot removed" in p.get("text", "")
+                    for p in m["content"])
+        ]
+        assert len(placeholder_msgs) == 2  # the 2 oldest
+
+    def test_under_limit_is_untouched_and_not_copied(self, transport):
+        msgs = self._build_session(3)  # exactly the keep limit
+        out = transport.convert_messages(msgs)
+        assert out is msgs  # no copy, no eviction
+        assert self._count_images(out) == 3
+
+    def test_does_not_mutate_original(self, transport):
+        msgs = self._build_session(5)
+        before = self._count_images(msgs)
+        transport.convert_messages(msgs)
+        # Canonical history must be untouched — only the outbound copy is pruned.
+        assert self._count_images(msgs) == before == 5
+
+    def test_eviction_runs_even_when_sanitizing(self, transport):
+        # Mix in a codex field so the sanitize path (deepcopy branch) is taken,
+        # and confirm eviction still happens on that branch.
+        msgs = self._build_session(5)
+        msgs[1]["codex_reasoning_items"] = [{"id": "rs_1"}]
+        out = transport.convert_messages(msgs)
+        assert "codex_reasoning_items" not in out[1]
+        assert self._count_images(out) == 3


### PR DESCRIPTION
## Problem

The Anthropic adapter prunes all but the most recent N computer-use screenshots on every request (`_evict_old_screenshots`), but the OpenAI/chat_completions transport had **no always-on equivalent**. Stale base64 screenshots (~250K chars / ~60K tokens each) were only pruned when full context compression happened to fire.

In a screenshot-heavy `computer_use` session on an OpenAI-format provider (e.g. gpt-5.5 via Codex OAuth), context ballooned past **11M tokens** before compression caught up — burning the per-seat usage allowance and tripping a 429 `usage_limit_reached` while other seats on the same account were unaffected.

## Fix

Add `_evict_old_screenshots_openai` mirroring the Anthropic behavior: keep the most recent 3 image-bearing messages, replace older `image_url` parts with a text placeholder. Runs on every request via `convert_messages`, on both the fast-path and sanitize-path returns. Deep-copies before mutating so canonical session history is never altered (prompt caching preserved).

## Tests

Adds `TestChatCompletionsScreenshotEviction` (5 tests): keeps newest 3, placeholders the rest, no-op under limit, no mutation of original, eviction runs even on the sanitize path. 509 related tests pass (`tests/tools/test_computer_use.py` + `tests/agent/transports/`).