### PR TITLE
fix(agent): use Hermes root in profile prompt

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import json
 import os
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from agent.prompt_builder import (
@@ -46,6 +45,7 @@ from agent.prompt_builder import (
     drain_truncation_warnings,
 )
 from agent.runtime_cwd import resolve_context_cwd
+from hermes_constants import display_hermes_root
 from utils import is_truthy_value
 
 
@@ -141,20 +141,6 @@ def _tui_embedded_pane_clarifier(hint: str) -> str:
     if not is_truthy_value(os.getenv("HERMES_DESKTOP_TERMINAL")):
         return hint
     return hint + _TUI_EMBEDDED_PANE_CLARIFIER
-
-
-def _display_hermes_root() -> str:
-    """Return the root Hermes directory used in prompt-visible profile hints."""
-    try:
-        from hermes_constants import get_default_hermes_root
-
-        root = get_default_hermes_root()
-    except Exception:
-        root = Path("~/.hermes").expanduser()
-    try:
-        return "~/" + str(root.relative_to(Path.home()))
-    except ValueError:
-        return str(root)
 
 
 def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> Dict[str, str]:
@@ -406,7 +392,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         active_profile = _resolve_active_profile_name()
     except Exception:
         active_profile = "default"
-    hermes_root = _display_hermes_root()
+    hermes_root = display_hermes_root()
     if active_profile == "default":
         stable_parts.append(
             "Active Hermes profile: default. Other profiles (if any) live "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -392,7 +392,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         active_profile = _resolve_active_profile_name()
     except Exception:
         active_profile = "default"
-    hermes_root = display_hermes_root()
+    try:
+        hermes_root = display_hermes_root()
+    except Exception:
+        hermes_root = "~/.hermes"
     if active_profile == "default":
         stable_parts.append(
             "Active Hermes profile: default. Other profiles (if any) live "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from agent.prompt_builder import (
@@ -140,6 +141,20 @@ def _tui_embedded_pane_clarifier(hint: str) -> str:
     if not is_truthy_value(os.getenv("HERMES_DESKTOP_TERMINAL")):
         return hint
     return hint + _TUI_EMBEDDED_PANE_CLARIFIER
+
+
+def _display_hermes_root() -> str:
+    """Return the root Hermes directory used in prompt-visible profile hints."""
+    try:
+        from hermes_constants import get_default_hermes_root
+
+        root = get_default_hermes_root()
+    except Exception:
+        root = Path("~/.hermes").expanduser()
+    try:
+        return "~/" + str(root.relative_to(Path.home()))
+    except ValueError:
+        return str(root)
 
 
 def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> Dict[str, str]:
@@ -380,10 +395,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             pass
 
     # Active-profile hint — names the Hermes profile the agent is running
-    # under so it doesn't conflate ~/.hermes/skills/ (default profile) with
-    # ~/.hermes/profiles/<active>/skills/ (this profile's). Deterministic
-    # for the lifetime of the agent — profile name doesn't change
-    # mid-session, so this doesn't break the prompt cache.
+    # under so it doesn't conflate the default profile's scoped directories
+    # with this profile's. Deterministic for the lifetime of the agent —
+    # profile name doesn't change mid-session, so this doesn't break the
+    # prompt cache.
     # See file_safety._resolve_active_profile_name + classify_cross_profile_target
     # for the matching tool-side guard.
     try:
@@ -391,21 +406,22 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         active_profile = _resolve_active_profile_name()
     except Exception:
         active_profile = "default"
+    hermes_root = _display_hermes_root()
     if active_profile == "default":
         stable_parts.append(
             "Active Hermes profile: default. Other profiles (if any) live "
-            "under ~/.hermes/profiles/<name>/. Each profile has its own "
-            "skills/, plugins/, cron/, and memories/ that affect a different "
-            "session than this one. Do not modify another profile's "
-            "skills/plugins/cron/memories unless the user explicitly directs "
-            "you to."
+            f"under {hermes_root}/profiles/<name>/. Each profile has its own "
+            f"skills/, plugins/, cron/, and memories/ that affect a different "
+            f"session than this one. Do not modify another profile's "
+            f"skills/plugins/cron/memories unless the user explicitly directs "
+            f"you to."
         )
     else:
         stable_parts.append(
             f"Active Hermes profile: {active_profile}. This session reads "
-            f"and writes ~/.hermes/profiles/{active_profile}/. The default "
-            f"profile's data lives at ~/.hermes/skills/, ~/.hermes/plugins/, "
-            f"~/.hermes/cron/, ~/.hermes/memories/ — those belong to a "
+            f"and writes {hermes_root}/profiles/{active_profile}/. The default "
+            f"profile's data lives at {hermes_root}/skills/, {hermes_root}/plugins/, "
+            f"{hermes_root}/cron/, {hermes_root}/memories/ — those belong to a "
             f"different session run from a different shell. Do NOT modify "
             f"another profile's skills/plugins/cron/memories unless the user "
             f"explicitly directs you to. The cross-profile write guard will "

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -628,6 +628,23 @@ def _legacy_path_has_content(path: Path) -> bool:
     return True
 
 
+def _display_home_relative(path: Path) -> str:
+    """Use a ``~/`` shorthand when *path* is inside the user's home."""
+    try:
+        return "~/" + str(path.relative_to(Path.home()))
+    except ValueError:
+        return str(path)
+
+
+def display_hermes_root() -> str:
+    """Return a user-friendly display string for the root Hermes directory.
+
+    Unlike :func:`display_hermes_home`, this resolves profile homes back to
+    their shared root before applying the readable ``~/`` shorthand.
+    """
+    return _display_home_relative(get_default_hermes_root())
+
+
 def display_hermes_home() -> str:
     """Return a user-friendly display string for the current HERMES_HOME.
 
@@ -641,11 +658,7 @@ def display_hermes_home() -> str:
     ``~/.hermes``.  For code that needs a real ``Path``, use
     :func:`get_hermes_home` instead.
     """
-    home = get_hermes_home()
-    try:
-        return "~/" + str(home.relative_to(Path.home()))
-    except ValueError:
-        return str(home)
+    return _display_home_relative(get_hermes_home())
 
 
 def secure_parent_dir(path: Path) -> None:

--- a/tests/agent/test_system_prompt_profile_paths.py
+++ b/tests/agent/test_system_prompt_profile_paths.py
@@ -97,3 +97,17 @@ def test_default_profile_without_override_preserves_home_shorthand(tmp_path, mon
     line = _active_profile_line(stable)
     assert "Active Hermes profile: default." in line
     assert "under ~/.hermes/profiles/<name>/." in line
+
+
+def test_profile_root_resolution_failure_does_not_block_prompt(monkeypatch):
+    system_prompt = _stub_prompt_runtime(monkeypatch)
+
+    def _raise_resolution_error():
+        raise OSError("unresolvable Hermes root")
+
+    monkeypatch.setattr(system_prompt, "display_hermes_root", _raise_resolution_error)
+
+    stable = system_prompt.build_system_prompt_parts(_minimal_agent())["stable"]
+
+    line = _active_profile_line(stable)
+    assert "under ~/.hermes/profiles/<name>/." in line

--- a/tests/agent/test_system_prompt_profile_paths.py
+++ b/tests/agent/test_system_prompt_profile_paths.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from types import SimpleNamespace
 
 
@@ -69,3 +70,30 @@ def test_default_profile_prompt_uses_custom_hermes_root(monkeypatch):
     assert "Active Hermes profile: default." in line
     assert "under /opt/hermes/profiles/<name>/." in line
     assert "~/.hermes" not in line
+
+
+def test_named_profile_prompt_preserves_home_shorthand(tmp_path, monkeypatch):
+    home_profile = tmp_path / ".hermes" / "profiles" / "coder"
+    home_profile.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home_profile))
+    system_prompt = _stub_prompt_runtime(monkeypatch)
+
+    stable = system_prompt.build_system_prompt_parts(_minimal_agent())["stable"]
+
+    line = _active_profile_line(stable)
+    assert "Active Hermes profile: coder." in line
+    assert "reads and writes ~/.hermes/profiles/coder/." in line
+    assert "default profile's data lives at ~/.hermes/skills/" in line
+
+
+def test_default_profile_without_override_preserves_home_shorthand(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    system_prompt = _stub_prompt_runtime(monkeypatch)
+
+    stable = system_prompt.build_system_prompt_parts(_minimal_agent())["stable"]
+
+    line = _active_profile_line(stable)
+    assert "Active Hermes profile: default." in line
+    assert "under ~/.hermes/profiles/<name>/." in line

--- a/tests/agent/test_system_prompt_profile_paths.py
+++ b/tests/agent/test_system_prompt_profile_paths.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+
+def _minimal_agent() -> SimpleNamespace:
+    return SimpleNamespace(
+        context_compressor=None,
+        load_soul_identity=False,
+        skip_context_files=True,
+        valid_tool_names=[],
+        _kanban_worker_guidance=None,
+        provider="",
+        model="",
+        _tool_use_enforcement="auto",
+        platform="cli",
+        _platform_hint_overrides={},
+        _memory_store=None,
+        _memory_enabled=False,
+        _user_profile_enabled=False,
+        _memory_manager=None,
+        pass_session_id=False,
+        session_id=None,
+    )
+
+
+def _stub_prompt_runtime(monkeypatch):
+    import agent.system_prompt as system_prompt
+
+    runtime = SimpleNamespace(
+        load_soul_md=lambda *_args, **_kwargs: None,
+        build_nous_subscription_prompt=lambda *_args, **_kwargs: "",
+        build_environment_hints=lambda *_args, **_kwargs: "",
+        build_context_files_prompt=lambda *_args, **_kwargs: "",
+    )
+    monkeypatch.setattr(system_prompt, "_ra", lambda: runtime)
+    return system_prompt
+
+
+def _active_profile_line(stable_prompt: str) -> str:
+    return next(
+        line
+        for line in stable_prompt.splitlines()
+        if line.startswith("Active Hermes profile:")
+    )
+
+
+def test_named_profile_prompt_uses_custom_hermes_root(monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", "/opt/hermes/profiles/coder")
+    system_prompt = _stub_prompt_runtime(monkeypatch)
+
+    stable = system_prompt.build_system_prompt_parts(_minimal_agent())["stable"]
+
+    line = _active_profile_line(stable)
+    assert "Active Hermes profile: coder." in line
+    assert "reads and writes /opt/hermes/profiles/coder/." in line
+    assert "default profile's data lives at /opt/hermes/skills/" in line
+    assert "/opt/hermes/plugins/" in line
+    assert "/opt/hermes/cron/" in line
+    assert "/opt/hermes/memories/" in line
+    assert "~/.hermes" not in line
+
+
+def test_default_profile_prompt_uses_custom_hermes_root(monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", "/opt/hermes")
+    system_prompt = _stub_prompt_runtime(monkeypatch)
+
+    stable = system_prompt.build_system_prompt_parts(_minimal_agent())["stable"]
+
+    line = _active_profile_line(stable)
+    assert "Active Hermes profile: default." in line
+    assert "under /opt/hermes/profiles/<name>/." in line
+    assert "~/.hermes" not in line

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -10,6 +10,8 @@ import hermes_constants
 from hermes_constants import (
     VALID_REASONING_EFFORTS,
     agent_browser_runnable,
+    display_hermes_home,
+    display_hermes_root,
     find_hermes_node_executable,
     find_node_executable,
     find_node_executable_on_path,
@@ -99,6 +101,26 @@ class TestGetDefaultHermesRoot:
         monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
 
         assert get_default_hermes_root() == home / "AppData" / "Local" / "hermes"
+
+
+class TestDisplayHermesRoot:
+    def test_home_relative_root_uses_shorthand(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        assert display_hermes_root() == "~/.hermes"
+
+    def test_custom_profile_displays_custom_root(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", "/opt/hermes/profiles/coder")
+
+        assert display_hermes_root() == "/opt/hermes"
+
+    def test_display_hermes_home_still_uses_shorthand(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        assert display_hermes_home() == "~/.hermes"
 
 
 class TestGetHermesHome:

--- a/tests/tools/test_cross_profile_guard.py
+++ b/tests/tools/test_cross_profile_guard.py
@@ -252,7 +252,7 @@ class TestSystemPromptActiveProfile:
         src = Path("agent/system_prompt.py").read_text(encoding="utf-8")
         assert "Active Hermes profile" in src
         assert "cross_profile=True" in src
-        assert "get_default_hermes_root" in src
+        assert "display_hermes_root" in src
         assert "hermes_root" in src
         # Both branches present (default and named profile).
         assert "Active Hermes profile: default" in src

--- a/tests/tools/test_cross_profile_guard.py
+++ b/tests/tools/test_cross_profile_guard.py
@@ -229,7 +229,7 @@ class TestSkillManageCrossProfileErrorUX:
 class TestSystemPromptActiveProfile:
     def test_default_profile_line_in_prompt(self, tmp_path, monkeypatch):
         """When active profile is 'default', the prompt names it and warns
-        about ~/.hermes/profiles/<name>/."""
+        about the root profiles/<name>/ path."""
         # Don't set HERMES_HOME — falls back to default.
         import agent.file_safety as fs
         monkeypatch.setattr(fs, "_hermes_home_path", lambda: tmp_path / "fake")
@@ -249,10 +249,11 @@ class TestSystemPromptActiveProfile:
         # paths, (3) says "do not modify another profile's" without
         # explicit user direction.
         from pathlib import Path
-        src = Path("agent/system_prompt.py").read_text()
+        src = Path("agent/system_prompt.py").read_text(encoding="utf-8")
         assert "Active Hermes profile" in src
         assert "cross_profile=True" in src
-        assert "~/.hermes/profiles/" in src
+        assert "get_default_hermes_root" in src
+        assert "hermes_root" in src
         # Both branches present (default and named profile).
         assert "Active Hermes profile: default" in src
         assert "Active Hermes profile: {active_profile}" in src


### PR DESCRIPTION
## What does this PR do?

Fixes the active-profile system prompt so it describes the actual Hermes root instead of always saying `~/.hermes`.

When `HERMES_HOME=/opt/hermes/profiles/coder`, the stable prompt now says the active profile writes under `/opt/hermes/profiles/coder/` and the default profile data lives under `/opt/hermes/{skills,plugins,cron,memories}/`. Normal home-based installs retain the readable `~/.hermes` shorthand. If root display resolution fails, prompt construction falls back safely to `~/.hermes`.

## Related Issue

Fixes #52669

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor (centralizes existing path-display formatting)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `hermes_constants.py`: adds `display_hermes_root()` beside `display_hermes_home()` and shares their home-relative formatting through one helper.
- `agent/system_prompt.py`: renders the active-profile hint from `display_hermes_root()` with a fail-safe fallback so path-resolution errors cannot block prompt construction.
- `tests/agent/test_system_prompt_profile_paths.py`: covers named/default profiles for custom and home-relative roots, plus the resolution-failure fallback.
- `tests/test_hermes_constants.py`: adds direct coverage for root display and preserves the existing home display contract.
- `tests/tools/test_cross_profile_guard.py`: updates the source contract to require the shared root-display helper.

## Duplicate-work checks

- #52670 was a competing fix for #52669 and was voluntarily closed in favor of this PR.
- #57223 is related but not a duplicate: it addresses native-Windows `%LOCALAPPDATA%\hermes` display, while this PR addresses custom/profile `HERMES_HOME` root resolution. Repository triage likewise classified them as different scopes that may later be unified.
- #38010 adds a separate environment-hint block and does not change the active-profile prompt text fixed here.

## Scope boundary

This PR is limited to the active-profile prompt block reported in #52669. It does not change the pre-existing ContextVar-only override behavior shared by profile resolution and the cross-profile guard, or the separate `KANBAN_GUIDANCE` path literal; those require system-wide treatment rather than a prompt-only patch.

## How to Test

```bash
scripts/run_tests.sh tests/agent/test_system_prompt_profile_paths.py tests/tools/test_cross_profile_guard.py tests/test_hermes_constants.py -- -q
.venv/bin/ruff check hermes_constants.py agent/system_prompt.py tests/agent/test_system_prompt_profile_paths.py tests/tools/test_cross_profile_guard.py
.venv/bin/ty check hermes_constants.py agent/system_prompt.py tests/agent/test_system_prompt_profile_paths.py tests/tools/test_cross_profile_guard.py
.venv/bin/python scripts/check-windows-footguns.py hermes_constants.py agent/system_prompt.py tests/agent/test_system_prompt_profile_paths.py tests/tools/test_cross_profile_guard.py
git diff --check
```

Local result: **112 passed**, Ruff clean, `ty` clean, Windows-footgun scan clean, whitespace clean.

GitHub result on `0d737166f`: all required checks pass; all eight Python slices, E2E, history/attribution, security, lint/type, lockfile, amd64 Docker, arm64 Docker, and CI timing are green.

## Review status

The normal push hook ran on each update. Grogu's first two passes identified helper duplication, missing home-layout coverage, and an unguarded resolution failure; all were repaired. Final Grogu review found no functional bugs and rated the branch **8/10, ready to ship with minor polish**. Mario was unavailable because the local Codex reviewer binary is older than its configured model, so it produced no code findings.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and documented related work
- [x] My PR contains only changes related to this fix
- [x] Focused tests pass
- [x] Tests cover custom, home-relative, named, default, and failure cases
- [x] Cross-platform impact considered

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A
- [x] Tool descriptions/schemas update N/A