### PR TITLE
feat: add google/gemma-4-31b-it:free to model catalog

### DIFF
--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-16T18:04:33Z",
+  "updated_at": "2026-06-26T10:00:00Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -142,6 +142,10 @@
         },
         {
           "id": "inclusionai/ring-2.6-1t:free",
+          "description": "free"
+        },
+        {
+          "id": "google/gemma-4-31b-it:free",
           "description": "free"
         }
       ]


### PR DESCRIPTION
Add [google/gemma-4-31b-it:free](https://openrouter.ai/google/gemma-4-31b-it:free) to the model catalog.

Gemma 4 31B Instruct by Google DeepMind — 30.7B multimodal, 256K context, native tool calling, free tier on OpenRouter.

Model metadata:
- ID: `google/gemma-4-31b-it:free`
- Pricing: $0/$0 (free)
- Tools: `tools`, `tool_choice` in supported_parameters
- Context: 256K tokens