### PR TITLE
fix(desktop): clear file tree immediately on session switch, skip refresh when cwd unchanged

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
@@ -1,8 +1,8 @@
 import { useStore } from '@nanostores/react'
 import { atom } from 'nanostores'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 
-import { $connection } from '@/store/session'
+import { $activeSessionId, $connection, $sessions } from '@/store/session'
 
 import { clearProjectDirCache, readProjectDir } from './ipc'
 
@@ -360,6 +360,58 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
       window.clearInterval(timer)
     }
   }, [cwd, usingFallback])
+
+  // When the active session changes (session switch), proactively compare
+  // the target session's cached cwd to the current tree's cwd. If they
+  // differ, immediately clear the tree and show loading — this prevents the
+  // old project's file tree from lingering while the resume is in flight
+  // (before $currentCwd updates). If cwd is the same (same project,
+  // directory unchanged), keep the current tree intact.
+  const activeSessionId = useStore($activeSessionId)
+  const prevSessionIdRef = useRef(activeSessionId)
+
+  useEffect(() => {
+    if (activeSessionId === prevSessionIdRef.current) {
+      return
+    }
+
+    const prevId = prevSessionIdRef.current
+    prevSessionIdRef.current = activeSessionId
+
+    // Skip initial mount (both null → null, or null → first session).
+    if (!prevId && !activeSessionId) {
+      return
+    }
+
+    // Look up the target session's cwd from the in-memory session list
+    // cache so we don't wait for the resume response.
+    const targetCwd = activeSessionId
+      ? ($sessions.get().find(
+          s => s.id === activeSessionId || s._lineage_root_id === activeSessionId
+        )?.cwd ?? '')
+      : ''
+
+    // Same cwd → same project/directory → keep the current tree.
+    if (targetCwd && targetCwd === cwd) {
+      return
+    }
+
+    // Different cwd → immediately clear the tree so the user sees a loading
+    // state instead of stale files from the previous project.
+    clearProjectDirCache()
+    setProjectTree(current => ({
+      collapseNonce: current.collapseNonce,
+      cwd,
+      data: [],
+      loaded: false,
+      openState: {},
+      requestId: nextRootRequestId + 1,
+      resolvedCwd: '',
+      rootError: null,
+      rootLoading: Boolean(cwd)
+    }))
+    nextRootRequestId += 1
+  }, [activeSessionId, cwd])
 
   return useMemo(
     () => ({


### PR DESCRIPTION
## What does this PR do?

Fixes two issues with the desktop file tree during session switches:

1. **Stale tree flash**: When switching to a session in a different project, the old project's file tree lingered for several seconds because `$currentCwd` only updates after the session resume response arrives. The tree now clears **immediately** when the session switch starts (detected via `$activeSessionId`), showing a loading state instead of stale files.

2. **Same-project overhead**: Switching between sessions that share the same working directory no longer re-fetches the directory listing. The new effect looks up the target session's cached `cwd` from `$sessions` and skips the refresh when it matches the current tree's cwd.

## Related Issue

Fixes #52677

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/right-sidebar/files/use-project-tree.ts`
  - Import `$activeSessionId` and `$sessions` from session store
  - Add `useRef` to track previous session id
  - Add a `useEffect` that watches `$activeSessionId` changes. When a session switch is detected:
    - Looks up the target session's cached `cwd` from the in-memory session list
    - If it matches current tree's `cwd` → no-op (same project/directory)
    - If it differs → immediately clears the tree, gitignore cache, and sets loading state
  - Clear happens synchronously before the async resume completes, preventing stale tree flash

## How to Test

1. Open Hermes Desktop with two sessions in different projects
2. Switch between them → file tree clears immediately, shows loading spinner, then loads new tree (no more 2-5s stale data display)
3. Switch between two sessions in the **same project/directory** → file tree stays intact (no reload)
4. Create a new chat → tree shows empty state correctly

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Windows 11
