### PR TITLE
fix(gateway): read multiplex_profiles from nested gateway: section in load_gateway_config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -854,6 +854,10 @@ def load_gateway_config() -> GatewayConfig:
             # other session-scope flags above).
             if "multiplex_profiles" in yaml_cfg:
                 gw_data["multiplex_profiles"] = yaml_cfg["multiplex_profiles"]
+            elif isinstance(yaml_cfg.get("gateway"), dict):
+                nested_mp = yaml_cfg["gateway"].get("multiplex_profiles")
+                if nested_mp is not None:
+                    gw_data["multiplex_profiles"] = nested_mp
 
             gateway_section = yaml_cfg.get("gateway")
             if isinstance(gateway_section, dict) and "max_concurrent_sessions" in gateway_section:

--- a/tests/test_gateway_multiplex_profiles_nested_config.py
+++ b/tests/test_gateway_multiplex_profiles_nested_config.py
@@ -1,0 +1,47 @@
+"""Regression test for #52562 — nested gateway.multiplex_profiles config must be loaded."""
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+
+def _load_with_yaml_dict(yaml_dict: dict):
+    """Patch filesystem so load_gateway_config() sees *yaml_dict* as config.yaml."""
+    from gateway.config import load_gateway_config
+
+    fake_home = Path("/tmp/fake_hermes_home_52562")
+
+    def fake_exists(self):
+        return str(self).endswith("config.yaml")
+
+    with patch("gateway.config.get_hermes_home", return_value=fake_home), \
+         patch.object(Path, "exists", fake_exists), \
+         patch("builtins.open", create=True) as mock_file:
+        mock_file.return_value.__enter__ = lambda s: s
+        mock_file.return_value.__exit__ = MagicMock(return_value=False)
+        with patch("yaml.safe_load", return_value=yaml_dict):
+            return load_gateway_config()
+
+
+class TestMultiplexProfilesNested:
+    def test_top_level_multiplex_profiles(self):
+        cfg = _load_with_yaml_dict({"multiplex_profiles": True})
+        assert cfg.multiplex_profiles is True
+
+    def test_nested_gateway_multiplex_profiles(self):
+        """Regression for #52562."""
+        cfg = _load_with_yaml_dict({"gateway": {"multiplex_profiles": True}})
+        assert cfg.multiplex_profiles is True
+
+    def test_top_level_takes_precedence(self):
+        cfg = _load_with_yaml_dict({
+            "multiplex_profiles": False,
+            "gateway": {"multiplex_profiles": True},
+        })
+        assert cfg.multiplex_profiles is False
+
+    def test_default_is_false(self):
+        cfg = _load_with_yaml_dict({})
+        assert cfg.multiplex_profiles is False
+
+    def test_nested_false_not_overridden_by_absent_top_level(self):
+        cfg = _load_with_yaml_dict({"gateway": {"multiplex_profiles": False}})
+        assert cfg.multiplex_profiles is False


### PR DESCRIPTION
## What does this PR do?

Fixes `load_gateway_config()` not reading `multiplex_profiles` when set via `hermes config set gateway.multiplex_profiles true`. The command writes the key nested under `gateway:`, but `load_gateway_config()` only checked the top-level `yaml_cfg["multiplex_profiles"]`, so multiplexing silently stayed off.

## Related Issue

Fixes #52562

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/config.py`: Add fallback to read `multiplex_profiles` from nested `gateway:` section in `load_gateway_config()`, matching the pattern already used by `max_concurrent_sessions`.
- `tests/test_gateway_multiplex_profiles_nested_config.py`: Regression tests covering top-level, nested, precedence, default, and nested-false cases.

## How to Test

1. Run `python -m pytest tests/test_gateway_multiplex_profiles_nested_config.py -q` — all 5 tests should pass.
2. Set `hermes config set gateway.multiplex_profiles true` and verify `load_gateway_config().multiplex_profiles` returns `True`.
3. Run `python -m pytest tests/test_gateway_streaming_nested_config.py -q` to confirm existing nested-config tests still pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/config.py:load_gateway_config()` (callers: gateway startup, CLI config commands)
- Blast radius: LOW — config parsing only, no runtime behavior change
- Related patterns: `max_concurrent_sessions` nested fallback at line 858-863 uses the same pattern
