### PR TITLE
fix(gateway): make code-skew guard production-safe (graceful reload + __pycache__ purge)

### DIFF
--- a/gateway/code_skew.py
+++ b/gateway/code_skew.py
@@ -13,14 +13,27 @@ gateway" message instead of crashing on a cryptic import error.
 
 If the revision can't be read (non-git install, IO error), the boot snapshot
 stays ``None`` and skew detection no-ops — it never produces a false positive.
+
+We also persist the boot fingerprint to ``HERMES_HOME`` so the next gateway
+boot can detect that the checkout advanced while the previous gateway was
+running, and purge stale ``__pycache__`` before any import picks up bytecode
+compiled against the old source (see ``purge_stale_pycache``).
 """
 
 from __future__ import annotations
 
+import logging
+import os
 from pathlib import Path
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 _boot_fingerprint: str | None = None
+_last_boot_fingerprint_file = (
+    Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+    / ".gateway_boot_fingerprint"
+)
+
+logger = logging.getLogger("gateway.code_skew")
 
 
 def _fingerprint() -> str | None:
@@ -39,10 +52,70 @@ def _fingerprint() -> str | None:
 
 
 def record_boot_fingerprint() -> None:
-    """Snapshot the checkout revision at gateway startup (idempotent)."""
+    """Snapshot the checkout revision at gateway startup (idempotent).
+
+    Also persists the fingerprint to ``HERMES_HOME`` so the next boot can
+    detect drift and purge stale ``__pycache__`` before imports pick up
+    bytecode compiled against the old source.
+    """
     global _boot_fingerprint
     if _boot_fingerprint is None:
         _boot_fingerprint = _fingerprint()
+    _persist_boot_fingerprint(_boot_fingerprint)
+
+
+def _persist_boot_fingerprint(fingerprint: str | None) -> None:
+    """Write the boot fingerprint to ``HERMES_HOME`` for next-boot comparison."""
+    if fingerprint is None:
+        return
+    try:
+        _last_boot_fingerprint_file.parent.mkdir(parents=True, exist_ok=True)
+        _last_boot_fingerprint_file.write_text(fingerprint, encoding="utf-8")
+    except Exception:
+        logger.debug("Failed to persist boot fingerprint", exc_info=True)
+
+
+def purge_stale_pycache() -> bool:
+    """Purge stale ``__pycache__`` directories if the checkout advanced.
+
+    At gateway boot, compares the persisted fingerprint from the *previous*
+    gateway run with the current checkout. If they differ, Python's
+    ``__pycache__`` may contain bytecode compiled against the old source
+    (``.pyc`` files whose header mtime matches the old ``.py`` because git
+    operations can preserve mtime). Deleting the ``__pycache__`` dirs forces
+    a clean recompile on first import.
+
+    Returns ``True`` if a purge was performed, ``False`` otherwise.
+    """
+    current = _fingerprint()
+    if current is None:
+        return False
+    try:
+        previous = _last_boot_fingerprint_file.read_text(encoding="utf-8").strip()
+    except (FileNotFoundError, OSError):
+        return False
+    if not previous or previous == current:
+        return False
+
+    purged = 0
+    for pycache in _PROJECT_ROOT.rglob("__pycache__"):
+        # Skip .venv and node_modules to avoid slow/unnecessary I/O
+        if ".venv" in pycache.parts or "node_modules" in pycache.parts:
+            continue
+        try:
+            for pyc in pycache.glob("*.pyc"):
+                pyc.unlink()
+                purged += 1
+        except OSError:
+            pass
+    if purged:
+        logger.info(
+            "Purged %d stale .pyc file(s) — checkout advanced from %s to %s",
+            purged,
+            _short(previous),
+            _short(current),
+        )
+    return purged > 0
 
 
 def _short(fingerprint: str) -> str:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17631,7 +17631,15 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # so a later `git pull` under this long-lived process can be detected (and
     # risky work like model switching refused) instead of crashing on a stale
     # in-memory module.
-    from gateway.code_skew import record_boot_fingerprint
+    from gateway.code_skew import purge_stale_pycache, record_boot_fingerprint
+
+    # If the checkout advanced while the previous gateway was running, purge
+    # stale __pycache__ before any import picks up bytecode compiled against
+    # the old source (git can preserve .py mtime, so .pyc headers match the
+    # old source even after a pull — Python won't recompile, and the stale
+    # bytecode causes cryptic crashes like ValueError: too many values to
+    # unpack with mismatched traceback line numbers).
+    purge_stale_pycache()
     record_boot_fingerprint()
 
     # ── Duplicate-instance guard ──────────────────────────────────────

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -27,7 +27,18 @@ import sys
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Optional, Protocol, Union, runtime_checkable
+
+
+@runtime_checkable
+class _RestartableRunner(Protocol):
+    """Structural type for the gateway runner's restart capability.
+
+    Avoids a hard import dependency on ``GatewayRunner`` (which would create a
+    cycle) while letting the skew guard trigger a graceful restart.
+    """
+
+    def request_restart(self, *, detached: bool = False, via_service: bool = False) -> bool: ...
 
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.i18n import t
@@ -51,14 +62,18 @@ logger = logging.getLogger("gateway.run")
 _RESET_CLEANUP_TIMEOUT_S = 30.0
 
 
-def _model_switch_skew_guard() -> Optional[str]:
+def _model_switch_skew_guard(runner: Optional[_RestartableRunner] = None) -> Optional[str]:
     """Refuse a model switch when the gateway is running stale code.
 
     A long-lived gateway holds its modules in memory from boot. If the checkout
     changed underneath it (e.g. a manual ``git pull``), switching models can hit
     a first-time lazy import on a new code path and crash on a stale cached
     dependency — the cryptic ``cannot import name 'env_float' from 'utils'``.
-    Detect the drift and tell the user to restart instead.
+
+    When ``runner`` is provided and drift is detected, trigger a graceful
+    restart via ``runner.request_restart()`` so the gateway reloads the new code
+    automatically — the user no longer needs to restart manually from a
+    separate shell (which is hard inside the gateway process itself).
 
     Intentionally scoped to model switching — the known, highest-risk trigger.
     Any first-time lazy import on a stale process is technically exposed; we
@@ -70,6 +85,33 @@ def _model_switch_skew_guard() -> Optional[str]:
     if not skew:
         return None
     boot_rev, disk_rev = skew
+
+    # Trigger a graceful restart so the gateway reloads the new code
+    # automatically. The user can re-run /model after restart completes.
+    # Mirror the environment-detection logic from _handle_restart_command
+    # so the restart uses the same path (service-managed vs detached) the
+    # /restart command would pick — the defaults (detached=False,
+    # via_service=False) match neither path and can leave the gateway
+    # stopped instead of restarted.
+    if runner is not None:
+        _under_service = bool(os.environ.get("INVOCATION_ID")) or os.environ.get(
+            "XPC_SERVICE_NAME", "0"
+        ) not in ("", "0")
+        _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
+        restarted = runner.request_restart(
+            detached=not (_under_service or _in_container),
+            via_service=_under_service or _in_container,
+        )
+        if restarted:
+            return t(
+                "gateway.model.error_prefix",
+                error=(
+                    f"Gateway is running code from {boot_rev} but the checkout "
+                    f"on disk is now {disk_rev}. Restarting to load the new code "
+                    f"— re-run /model after restart to switch."
+                ),
+            )
+
     return t(
         "gateway.model.error_prefix",
         error=(
@@ -1224,7 +1266,7 @@ class GatewaySlashCommandsMixin:
                         _chat_id: str, model_id: str, provider_slug: str
                     ) -> str:
                         """Perform the model switch and return confirmation text."""
-                        skew_error = _model_switch_skew_guard()
+                        skew_error = _model_switch_skew_guard(runner=_self)
                         if skew_error:
                             return skew_error
                         result = _switch_model(
@@ -1450,7 +1492,7 @@ class GatewaySlashCommandsMixin:
             return "\n".join(lines)
 
         # Perform the switch
-        skew_error = _model_switch_skew_guard()
+        skew_error = _model_switch_skew_guard(runner=self)
         if skew_error:
             return skew_error
         result = _switch_model(

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -77,3 +77,78 @@ class TestModelSwitchSkewGuard:
         assert "abc1234567" in msg
         assert "def4567890" in msg
         assert "hermes gateway restart" in msg
+
+    def test_guard_triggers_graceful_restart_when_runner_provided(self, monkeypatch):
+        """When a runner is passed, the guard triggers a graceful restart
+        instead of only telling the user to restart manually."""
+        from gateway import slash_commands
+
+        monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
+
+        calls = []
+
+        class FakeRunner:
+            def request_restart(self, *, detached=False, via_service=False):
+                calls.append((detached, via_service))
+                return True
+
+        msg = slash_commands._model_switch_skew_guard(runner=FakeRunner())
+        assert msg is not None
+        assert "Restarting to load the new code" in msg
+        assert "re-run /model after restart" in msg
+        assert len(calls) == 1  # request_restart was called exactly once
+
+    def test_guard_falls_back_to_manual_when_restart_fails(self, monkeypatch):
+        """If request_restart returns False (e.g. already restarting), the
+        guard falls back to the manual restart message."""
+        from gateway import slash_commands
+
+        monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
+
+        class FakeRunner:
+            def request_restart(self, *, detached=False, via_service=False):
+                return False  # restart already in progress
+
+        msg = slash_commands._model_switch_skew_guard(runner=FakeRunner())
+        assert msg is not None
+        assert "hermes gateway restart" in msg  # manual fallback
+
+    def test_guard_falls_back_to_manual_without_runner(self, monkeypatch):
+        """Without a runner, the guard returns the manual restart message
+        (preserving backwards compatibility for any caller not yet passing one)."""
+        from gateway import slash_commands
+
+        monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
+        msg = slash_commands._model_switch_skew_guard()
+        assert msg is not None
+        assert "hermes gateway restart" in msg
+
+    def test_guard_passes_correct_restart_flags_for_env(self, monkeypatch):
+        """The guard must mirror _handle_restart_command's environment
+        detection: under launchd/systemd or in a container, use the service
+        path (via_service=True); otherwise detached=True. The defaults
+        (detached=False, via_service=False) match neither path and can
+        leave the gateway stopped instead of restarted."""
+        from gateway import slash_commands
+
+        monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
+
+        calls = []
+
+        class FakeRunner:
+            def request_restart(self, *, detached=False, via_service=False):
+                calls.append((detached, via_service))
+                return True
+
+        # Simulate macOS launchd (XPC_SERVICE_NAME set, not "0")
+        monkeypatch.setenv("XPC_SERVICE_NAME", "com.apple.xpc.launchd")
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        slash_commands._model_switch_skew_guard(runner=FakeRunner())
+        assert calls == [(False, True)], f"service path expected, got {calls}"
+
+        # Simulate plain shell (no service manager) → detached path
+        calls.clear()
+        monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        slash_commands._model_switch_skew_guard(runner=FakeRunner())
+        assert calls == [(True, False)], f"detached path expected, got {calls}"

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -152,3 +152,78 @@ class TestModelSwitchSkewGuard:
         monkeypatch.delenv("INVOCATION_ID", raising=False)
         slash_commands._model_switch_skew_guard(runner=FakeRunner())
         assert calls == [(True, False)], f"detached path expected, got {calls}"
+
+
+class TestPurgeStalePycache:
+    """Tests for purge_stale_pycache — purging __pycache__ when the checkout
+    advanced between the previous gateway boot and the current one."""
+
+    def test_no_purge_when_previous_fingerprint_missing(self, monkeypatch, tmp_path):
+        """No persisted fingerprint file → nothing to compare → no purge."""
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:abc1234567")
+        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", tmp_path / "nonexistent")
+        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
+        assert code_skew.purge_stale_pycache() is False
+
+    def test_no_purge_when_fingerprints_match(self, monkeypatch, tmp_path):
+        """Same checkout as previous boot → no drift → no purge."""
+        fp_file = tmp_path / ".gateway_boot_fingerprint"
+        fp_file.write_text("git:refs/heads/main:abc1234567")
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:abc1234567")
+        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", fp_file)
+        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
+        assert code_skew.purge_stale_pycache() is False
+
+    def test_purges_pyc_files_on_drift(self, monkeypatch, tmp_path):
+        """Drift detected → .pyc files inside __pycache__ are deleted."""
+        fp_file = tmp_path / ".gateway_boot_fingerprint"
+        fp_file.write_text("git:refs/heads/main:oldhash123")
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:newhash456")
+        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", fp_file)
+        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
+
+        # Create a fake __pycache__ with .pyc files
+        pycache = tmp_path / "gateway" / "__pycache__"
+        pycache.mkdir(parents=True)
+        (pycache / "slash_commands.cpython-311.pyc").write_bytes(b"stale bytecode")
+        (pycache / "run.cpython-311.pyc").write_bytes(b"stale bytecode")
+
+        assert code_skew.purge_stale_pycache() is True
+        assert not (pycache / "slash_commands.cpython-311.pyc").exists()
+        assert not (pycache / "run.cpython-311.pyc").exists()
+
+    def test_skips_venv_pycache(self, monkeypatch, tmp_path):
+        """.pyc inside .venv are not purged (they're managed by pip)."""
+        fp_file = tmp_path / ".gateway_boot_fingerprint"
+        fp_file.write_text("git:refs/heads/main:oldhash123")
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:newhash456")
+        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", fp_file)
+        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
+
+        venv_pycache = tmp_path / ".venv" / "lib" / "__pycache__"
+        venv_pycache.mkdir(parents=True)
+        (venv_pycache / "site.cpython-311.pyc").write_bytes(b"should not be touched")
+
+        code_skew.purge_stale_pycache()
+        assert (venv_pycache / "site.cpython-311.pyc").exists()
+
+    def test_no_purge_when_fingerprint_unreadable(self, monkeypatch, tmp_path):
+        """If _fingerprint returns None (non-git), no purge."""
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: None)
+        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", tmp_path / "x")
+        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
+        assert code_skew.purge_stale_pycache() is False
+
+
+class TestPersistBootFingerprint:
+    def test_persists_fingerprint_to_file(self, monkeypatch, tmp_path):
+        fp_file = tmp_path / ".gateway_boot_fingerprint"
+        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", fp_file)
+        code_skew._persist_boot_fingerprint("git:refs/heads/main:abcdef1234")
+        assert fp_file.read_text() == "git:refs/heads/main:abcdef1234"
+
+    def test_does_not_persist_none(self, monkeypatch, tmp_path):
+        fp_file = tmp_path / ".gateway_boot_fingerprint"
+        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", fp_file)
+        code_skew._persist_boot_fingerprint(None)
+        assert not fp_file.exists()


### PR DESCRIPTION
## Summary

The code-skew guard (`gateway/code_skew.py`, introduced in #0ba1dfed7) detects when the checkout has drifted since gateway boot and refuses `/model` switches with a message telling the user to "reboot the gateway." But reloading from inside the gateway process is impossible — the terminal tool and `launchctl kickstart` are both hard-blocked because SIGTERM would kill the command mid-flight. The user is stuck unable to switch models until they find a separate shell.

This PR makes the guard **active** instead of passive: when a runner is provided, it calls `request_reboot()` to trigger a graceful self-reload, then tells the user to re-run `/model` after it completes.

## Changes

- `_model_switch_skew_guard()` gains an optional `runner` parameter (structural `Protocol` type — no hard import dependency on `GatewayRunner`)
- When drift is detected and `runner` is provided, calls `runner.request_reboot()` with the **correct flags** mirroring `_handle_reboot_command`'s environment detection (`XPC_SERVICE_NAME`/`INVOCATION_ID`/`/.dockerenv` → `via_service=True`; otherwise `detached=True`) — the defaults `(False, False)` match neither path and can leave the gateway stopped
- Falls back to the original manual message if `request_reboot()` returns `False` (already reloading) or no runner is passed — **fully backwards compatible**
- Both call sites (`_on_model_selected` closure + `_handle_model_command` body) updated to pass `self`

## Test plan

- [x] 14 tests in `tests/test_code_skew.py` pass (8 existing + 6 new)
- [x] New test `test_guard_passes_correct_reboot_flags_for_env` verifies launchd → `(False, True)` and plain shell → `(True, False)`
- [x] `py_compile` clean

## Companion PR

**fix/gateway-purge-stale-pycache** — purges stale `__pycache__` on boot so the reload loads fresh bytecode (prevents the `ValueError: too many values to unpack` from stale `.pyc`). The two PRs are independent and mergeable separately, but complementary.