### PR TITLE
feat(gateway): add external media publishing

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -517,6 +517,11 @@ class GatewayConfig:
     
     # Delivery settings
     always_log_local: bool = True  # Always save cron outputs to local files
+    # Optional external object-storage publishing for outbound MEDIA delivery.
+    # Default off: no files leave the platform adapter unless the operator opts
+    # in. The dict is copied into each PlatformConfig.extra so adapters can
+    # decide locally whether to upload generated media before sending.
+    media_delivery: Dict[str, Any] = field(default_factory=dict)
     # Drop outbound "silence narration" messages (e.g. *(silent)*, 🔇, a bare
     # ".") pre-send. These are model hallucinations emitted when a persona has
     # nothing actionable to say; in bot-to-bot channels they mirror back and
@@ -648,6 +653,7 @@ class GatewayConfig:
             "quick_commands": self.quick_commands,
             "sessions_dir": str(self.sessions_dir),
             "always_log_local": self.always_log_local,
+            "media_delivery": self.media_delivery,
             "filter_silence_narration": self.filter_silence_narration,
             "stt_enabled": self.stt_enabled,
             "group_sessions_per_user": self.group_sessions_per_user,
@@ -735,6 +741,7 @@ class GatewayConfig:
             quick_commands=quick_commands,
             sessions_dir=sessions_dir,
             always_log_local=_coerce_bool(data.get("always_log_local"), True),
+            media_delivery=data.get("media_delivery", {}) if isinstance(data.get("media_delivery", {}), dict) else {},
             filter_silence_narration=_coerce_bool(
                 data.get("filter_silence_narration"), True
             ),
@@ -875,6 +882,10 @@ def load_gateway_config() -> GatewayConfig:
 
             if "always_log_local" in yaml_cfg:
                 gw_data["always_log_local"] = yaml_cfg["always_log_local"]
+
+            media_delivery_cfg = yaml_cfg.get("media_delivery")
+            if isinstance(media_delivery_cfg, dict):
+                gw_data["media_delivery"] = media_delivery_cfg
 
             if "filter_silence_narration" in yaml_cfg:
                 gw_data["filter_silence_narration"] = yaml_cfg[
@@ -1140,6 +1151,13 @@ def load_gateway_config() -> GatewayConfig:
 
     # Override with environment variables
     _apply_env_overrides(config)
+
+    # Make global media_delivery settings available to platform adapters via
+    # PlatformConfig.extra. Keep platform-local overrides intact. Run after env
+    # overrides so platforms created from env-only credentials receive it too.
+    if isinstance(config.media_delivery, dict) and config.media_delivery:
+        for _platform_cfg in config.platforms.values():
+            _platform_cfg.extra.setdefault("media_delivery", config.media_delivery)
     
     # --- Validate loaded values ---
     _validate_gateway_config(config)

--- a/gateway/media_publisher.py
+++ b/gateway/media_publisher.py
@@ -1,0 +1,353 @@
+"""Optional outbound media publishing for gateway adapters.
+
+The default gateway behavior sends local ``MEDIA:`` files as native platform
+attachments.  Some platforms (notably Discord) can fail large or flaky uploads.
+This module provides a default-off external publishing layer: upload local media
+objects to configured storage, verify the public URL, then let the adapter send
+links instead of binary attachments.
+"""
+from __future__ import annotations
+
+import asyncio
+import datetime as _dt
+import hashlib
+import hmac
+import mimetypes
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Optional
+from urllib.parse import quote
+import urllib.request
+
+_IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
+_VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
+_AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
+_SUPPORTED_MODES = {"link_first", "link_on_failure", "attach_and_link"}
+
+
+@dataclass(frozen=True)
+class PublishedMedia:
+    local_path: str
+    url: str
+    display_name: str
+    mime_type: str
+    size_bytes: int
+
+
+@dataclass(frozen=True)
+class ExternalMediaConfig:
+    enabled: bool = False
+    provider: str = "r2"
+    mode: str = "link_on_failure"
+    images: bool = True
+    videos: bool = True
+    audio: bool = False
+    documents: bool = False
+    size_threshold_bytes: int = 0
+    remote_prefix: str = "hermes/media/%Y/%m/%d/"
+    verify: bool = True
+    public_base_url: str = ""
+    bucket: str = ""
+    account_id: str = ""
+    access_key_id: str = ""
+    secret_access_key: str = ""
+    api_token: str = ""
+    wrangler: bool = False
+
+    @classmethod
+    def disabled(cls) -> "ExternalMediaConfig":
+        return cls(enabled=False)
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return bool(value)
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _env(name: str) -> str:
+    return os.getenv(name, "").strip()
+
+
+def _merge_dicts(*items: Any) -> dict[str, Any]:
+    merged: dict[str, Any] = {}
+    for item in items:
+        if isinstance(item, dict):
+            merged.update(item)
+    return merged
+
+
+def external_media_config_for(adapter: Any, media_kind: str) -> ExternalMediaConfig:
+    """Return the effective external-media config for an adapter/kind.
+
+    Config is intentionally default-off.  Supported shapes:
+
+    ``media_delivery.external_upload`` global config copied into platform extra
+    by ``gateway.config``;
+    ``media_delivery.external_upload.platforms.<platform>`` platform override;
+    ``platforms.<platform>.extra.external_media`` adapter-local override.
+    """
+    platform = getattr(getattr(adapter, "platform", None), "value", None) or str(getattr(adapter, "platform", ""))
+    extra = getattr(getattr(adapter, "config", None), "extra", {}) or {}
+    media_delivery = extra.get("media_delivery") if isinstance(extra, dict) else {}
+    external = {}
+    if isinstance(media_delivery, dict):
+        external = media_delivery.get("external_upload") or {}
+    platform_override = {}
+    if isinstance(external, dict):
+        platforms = external.get("platforms") or {}
+        if isinstance(platforms, dict):
+            platform_override = platforms.get(platform) or {}
+    local_override = extra.get("external_media") if isinstance(extra, dict) else {}
+    raw = _merge_dicts(external, platform_override, local_override)
+    if not raw:
+        return ExternalMediaConfig.disabled()
+
+    mode = str(raw.get("mode") or "link_on_failure").strip().lower()
+    if mode not in _SUPPORTED_MODES:
+        mode = "link_on_failure"
+
+    threshold = _as_int(raw.get("size_threshold_bytes"), -1)
+    if threshold < 0:
+        threshold_mb = raw.get("size_threshold_mb", 0)
+        threshold = max(0, _as_int(threshold_mb, 0)) * 1024 * 1024
+
+    # Secrets may come from env so config.yaml can stay non-secret.
+    return ExternalMediaConfig(
+        enabled=_as_bool(raw.get("enabled"), False),
+        provider=str(raw.get("provider") or "r2").strip().lower(),
+        mode=mode,
+        images=_as_bool(raw.get("images"), True),
+        videos=_as_bool(raw.get("videos"), True),
+        audio=_as_bool(raw.get("audio"), False),
+        documents=_as_bool(raw.get("documents"), False),
+        size_threshold_bytes=threshold,
+        remote_prefix=str(raw.get("remote_prefix") or "hermes/media/%Y/%m/%d/"),
+        verify=_as_bool(raw.get("verify"), True),
+        public_base_url=str(raw.get("public_base_url") or _env("CLOUDFLARE_R2_PUBLIC_BASE_URL") or _env("R2_PUBLIC_BASE_URL")),
+        bucket=str(raw.get("bucket") or _env("CLOUDFLARE_R2_BUCKET") or _env("R2_BUCKET")),
+        account_id=str(raw.get("account_id") or _env("CLOUDFLARE_ACCOUNT_ID")),
+        access_key_id=str(raw.get("access_key_id") or _env("CLOUDFLARE_R2_ACCESS_KEY_ID") or _env("R2_ACCESS_KEY_ID")),
+        secret_access_key=str(raw.get("secret_access_key") or _env("CLOUDFLARE_R2_SECRET_ACCESS_KEY") or _env("R2_SECRET_ACCESS_KEY")),
+        api_token=str(raw.get("api_token") or _env("CLOUDFLARE_API_TOKEN")),
+        wrangler=_as_bool(raw.get("wrangler"), False),
+    )
+
+
+def _kind_for_path(path: str) -> str:
+    ext = Path(path).suffix.lower()
+    if ext in _IMAGE_EXTS:
+        return "images"
+    if ext in _VIDEO_EXTS:
+        return "videos"
+    if ext in _AUDIO_EXTS:
+        return "audio"
+    return "documents"
+
+
+def _kind_enabled(cfg: ExternalMediaConfig, kind: str) -> bool:
+    return bool(getattr(cfg, kind, False))
+
+
+def _remote_key(cfg: ExternalMediaConfig, path: Path) -> str:
+    prefix = _dt.datetime.now().strftime(cfg.remote_prefix).strip("/")
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+    safe_stem = "".join(ch if ch.isalnum() or ch in {"-", "_", "."} else "-" for ch in path.stem)[:80]
+    name = f"{safe_stem}-{digest}{path.suffix.lower()}" if safe_stem else f"{digest}{path.suffix.lower()}"
+    return f"{prefix}/{name}" if prefix else name
+
+
+def _public_url(cfg: ExternalMediaConfig, key: str) -> str:
+    base = cfg.public_base_url.rstrip("/")
+    return f"{base}/{quote(key, safe='/')}"
+
+
+def _sign(key: bytes, msg: str) -> bytes:
+    return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
+
+
+def _sigv4_authorization(cfg: ExternalMediaConfig, method: str, key: str, payload: bytes, content_type: str, amz_date: str, date_stamp: str) -> str:
+    region = "auto"
+    service = "s3"
+    host = f"{cfg.account_id}.r2.cloudflarestorage.com"
+    canonical_uri = f"/{quote(cfg.bucket, safe='')}/{quote(key, safe='/')}"
+    payload_hash = hashlib.sha256(payload).hexdigest()
+    canonical_headers = (
+        f"content-type:{content_type}\n"
+        f"host:{host}\n"
+        f"x-amz-content-sha256:{payload_hash}\n"
+        f"x-amz-date:{amz_date}\n"
+    )
+    signed_headers = "content-type;host;x-amz-content-sha256;x-amz-date"
+    canonical_request = "\n".join([
+        method,
+        canonical_uri,
+        "",
+        canonical_headers,
+        signed_headers,
+        payload_hash,
+    ])
+    credential_scope = f"{date_stamp}/{region}/{service}/aws4_request"
+    string_to_sign = "\n".join([
+        "AWS4-HMAC-SHA256",
+        amz_date,
+        credential_scope,
+        hashlib.sha256(canonical_request.encode("utf-8")).hexdigest(),
+    ])
+    signing_key = _sign(_sign(_sign(_sign(("AWS4" + cfg.secret_access_key).encode("utf-8"), date_stamp), region), service), "aws4_request")
+    signature = hmac.new(signing_key, string_to_sign.encode("utf-8"), hashlib.sha256).hexdigest()
+    return (
+        "AWS4-HMAC-SHA256 "
+        f"Credential={cfg.access_key_id}/{credential_scope}, "
+        f"SignedHeaders={signed_headers}, Signature={signature}"
+    )
+
+
+def _upload_r2_sigv4(cfg: ExternalMediaConfig, local_path: Path, key: str) -> str:
+    if not (cfg.account_id and cfg.bucket and cfg.access_key_id and cfg.secret_access_key and cfg.public_base_url):
+        raise RuntimeError("R2 external media upload requires account_id, bucket, public_base_url, access_key_id, and secret_access_key")
+    payload = local_path.read_bytes()
+    content_type = mimetypes.guess_type(local_path.name)[0] or "application/octet-stream"
+    now = _dt.datetime.now(_dt.UTC)
+    amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+    date_stamp = now.strftime("%Y%m%d")
+    host = f"{cfg.account_id}.r2.cloudflarestorage.com"
+    object_url = f"https://{host}/{quote(cfg.bucket, safe='')}/{quote(key, safe='/')}"
+    req = urllib.request.Request(object_url, data=payload, method="PUT")
+    req.add_header("Content-Type", content_type)
+    req.add_header("Host", host)
+    req.add_header("X-Amz-Date", amz_date)
+    req.add_header("X-Amz-Content-Sha256", hashlib.sha256(payload).hexdigest())
+    req.add_header("Authorization", _sigv4_authorization(cfg, "PUT", key, payload, content_type, amz_date, date_stamp))
+    with urllib.request.urlopen(req, timeout=60) as resp:  # noqa: S310 - user-configured storage endpoint
+        if resp.status not in {200, 201, 204}:
+            raise RuntimeError(f"R2 upload failed with HTTP {resp.status}")
+    return _public_url(cfg, key)
+
+
+def _upload_r2_wrangler(cfg: ExternalMediaConfig, local_path: Path, key: str) -> str:
+    if not (cfg.account_id and cfg.api_token and cfg.bucket and cfg.public_base_url):
+        raise RuntimeError("wrangler R2 external media upload requires account_id, api_token, bucket, and public_base_url")
+    env = os.environ.copy()
+    env["CLOUDFLARE_ACCOUNT_ID"] = cfg.account_id
+    env["CLOUDFLARE_API_TOKEN"] = cfg.api_token
+    proc = subprocess.run(
+        ["wrangler", "r2", "object", "put", f"{cfg.bucket}/{key}", "--file", str(local_path), "--remote"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=env,
+        timeout=120,
+        check=False,
+    )
+    if proc.returncode != 0:
+        safe = "\n".join(line for line in proc.stdout.splitlines() if "token" not in line.lower())
+        raise RuntimeError(f"wrangler R2 upload failed ({proc.returncode}): {safe[-500:]}")
+    return _public_url(cfg, key)
+
+
+def _verify_public_url(url: str) -> None:
+    req = urllib.request.Request(url, method="HEAD")
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:  # noqa: S310 - URL was just produced by configured storage
+            if resp.status < 200 or resp.status >= 400:
+                raise RuntimeError(f"published media URL returned HTTP {resp.status}")
+    except Exception:
+        # Some object-store custom domains reject HEAD but serve GET.
+        req = urllib.request.Request(url, method="GET")
+        req.add_header("Range", "bytes=0-0")
+        with urllib.request.urlopen(req, timeout=20) as resp:  # noqa: S310
+            if resp.status < 200 or resp.status >= 400:
+                raise RuntimeError(f"published media URL returned HTTP {resp.status}")
+
+
+def upload_media_file(cfg: ExternalMediaConfig, local_path: str) -> PublishedMedia:
+    path = Path(local_path).expanduser().resolve()
+    if not path.is_file():
+        raise FileNotFoundError(str(path))
+    key = _remote_key(cfg, path)
+    if cfg.provider != "r2":
+        raise RuntimeError(f"Unsupported external media provider: {cfg.provider}")
+    if cfg.wrangler:
+        url = _upload_r2_wrangler(cfg, path, key)
+    else:
+        url = _upload_r2_sigv4(cfg, path, key)
+    if cfg.verify:
+        _verify_public_url(url)
+    return PublishedMedia(
+        local_path=str(path),
+        url=url,
+        display_name=path.name,
+        mime_type=mimetypes.guess_type(path.name)[0] or "application/octet-stream",
+        size_bytes=path.stat().st_size,
+    )
+
+
+async def publish_media_files(adapter: Any, paths: Iterable[str], media_kind: Optional[str] = None) -> list[PublishedMedia]:
+    cfg = external_media_config_for(adapter, media_kind or "")
+    if not cfg.enabled:
+        return []
+    published: list[PublishedMedia] = []
+    for item in paths:
+        path = Path(item).expanduser()
+        if not path.is_file():
+            continue
+        kind = media_kind or _kind_for_path(str(path))
+        if not _kind_enabled(cfg, kind):
+            continue
+        size = path.stat().st_size
+        if size < cfg.size_threshold_bytes:
+            continue
+        published.append(await asyncio.to_thread(upload_media_file, cfg, str(path)))
+    return published
+
+
+def format_published_media_message(items: list[PublishedMedia], *, heading: str = "Media") -> str:
+    if not items:
+        return ""
+    if len(items) == 1:
+        item = items[0]
+        return f"{heading}: {item.url}"
+    lines = [f"{heading} ({len(items)} files):"]
+    for item in items:
+        lines.append(f"- {item.display_name}: {item.url}")
+    return "\n".join(lines)
+
+
+def example_config_block() -> dict[str, Any]:
+    """Return a documentation-friendly default-off config shape."""
+    return {
+        "media_delivery": {
+            "external_upload": {
+                "enabled": False,
+                "provider": "r2",
+                "mode": "link_on_failure",
+                "images": True,
+                "videos": True,
+                "documents": False,
+                "size_threshold_mb": 8,
+                "remote_prefix": "hermes/media/%Y/%m/%d/",
+                "public_base_url": "https://media.example.com",
+                "bucket": "hermes-media",
+            }
+        }
+    }

--- a/gateway/media_publisher.py
+++ b/gateway/media_publisher.py
@@ -313,14 +313,14 @@ def _upload_r2_wrangler(cfg: ExternalMediaConfig, local_path: Path, key: str) ->
 
 
 def _verify_public_url(url: str) -> None:
-    req = urllib.request.Request(url, method="HEAD")
+    req = urllib.request.Request(url, method="HEAD", headers={"User-Agent": "HermesAgent/1.0"})
     try:
         with _urlopen_no_proxy(req, timeout=20) as resp:  # noqa: S310 - URL was just produced by configured storage
             if resp.status < 200 or resp.status >= 400:
                 raise RuntimeError(f"published media URL returned HTTP {resp.status}")
     except Exception:
         # Some object-store custom domains reject HEAD but serve GET.
-        req = urllib.request.Request(url, method="GET")
+        req = urllib.request.Request(url, method="GET", headers={"User-Agent": "HermesAgent/1.0"})
         req.add_header("Range", "bytes=0-0")
         with _urlopen_no_proxy(req, timeout=20) as resp:  # noqa: S310
             if resp.status < 200 or resp.status >= 400:

--- a/gateway/media_publisher.py
+++ b/gateway/media_publisher.py
@@ -13,6 +13,7 @@ import datetime as _dt
 import hashlib
 import hmac
 import mimetypes
+import json
 import os
 import subprocess
 from dataclasses import dataclass
@@ -55,6 +56,7 @@ class ExternalMediaConfig:
     secret_access_key: str = ""
     api_token: str = ""
     wrangler: bool = False
+    credential_file: str = ""
 
     @classmethod
     def disabled(cls) -> "ExternalMediaConfig":
@@ -86,6 +88,32 @@ def _as_int(value: Any, default: int = 0) -> int:
 
 def _env(name: str) -> str:
     return os.getenv(name, "").strip()
+
+
+def _read_r2_credentials(path_value: Any) -> dict[str, Any]:
+    """Read optional Cloudflare R2 credentials without requiring secrets in config.yaml."""
+    candidates: list[Path] = []
+    if path_value:
+        candidates.append(Path(str(path_value)).expanduser())
+    candidates.extend([
+        Path.home() / ".hermes/secrets/cloudflare/r2.json",
+        Path.home() / ".config/cloudflare/r2.json",
+    ])
+    for path in candidates:
+        try:
+            if path.is_file():
+                data = json.loads(path.read_text())
+                return data if isinstance(data, dict) else {}
+        except Exception:
+            continue
+    return {}
+
+
+def _first_value(*values: Any) -> str:
+    for value in values:
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return ""
 
 
 def _merge_dicts(*items: Any) -> dict[str, Any]:
@@ -131,7 +159,19 @@ def external_media_config_for(adapter: Any, media_kind: str) -> ExternalMediaCon
         threshold_mb = raw.get("size_threshold_mb", 0)
         threshold = max(0, _as_int(threshold_mb, 0)) * 1024 * 1024
 
-    # Secrets may come from env so config.yaml can stay non-secret.
+    credential_file = str(raw.get("credential_file") or raw.get("credentials_file") or "").strip()
+    r2_creds = _read_r2_credentials(credential_file) if str(raw.get("provider") or "r2").strip().lower() == "r2" else {}
+    public_domain = _first_value(
+        raw.get("public_base_url"),
+        _env("CLOUDFLARE_R2_PUBLIC_BASE_URL"),
+        _env("R2_PUBLIC_BASE_URL"),
+        r2_creds.get("customDomain"),
+        r2_creds.get("publicDomain"),
+    )
+    if public_domain and not public_domain.startswith(("http://", "https://")):
+        public_domain = f"https://{public_domain}"
+
+    # Secrets may come from env or a private credential file so config.yaml can stay non-secret.
     return ExternalMediaConfig(
         enabled=_as_bool(raw.get("enabled"), False),
         provider=str(raw.get("provider") or "r2").strip().lower(),
@@ -143,13 +183,14 @@ def external_media_config_for(adapter: Any, media_kind: str) -> ExternalMediaCon
         size_threshold_bytes=threshold,
         remote_prefix=str(raw.get("remote_prefix") or "hermes/media/%Y/%m/%d/"),
         verify=_as_bool(raw.get("verify"), True),
-        public_base_url=str(raw.get("public_base_url") or _env("CLOUDFLARE_R2_PUBLIC_BASE_URL") or _env("R2_PUBLIC_BASE_URL")),
-        bucket=str(raw.get("bucket") or _env("CLOUDFLARE_R2_BUCKET") or _env("R2_BUCKET")),
-        account_id=str(raw.get("account_id") or _env("CLOUDFLARE_ACCOUNT_ID")),
-        access_key_id=str(raw.get("access_key_id") or _env("CLOUDFLARE_R2_ACCESS_KEY_ID") or _env("R2_ACCESS_KEY_ID")),
-        secret_access_key=str(raw.get("secret_access_key") or _env("CLOUDFLARE_R2_SECRET_ACCESS_KEY") or _env("R2_SECRET_ACCESS_KEY")),
-        api_token=str(raw.get("api_token") or _env("CLOUDFLARE_API_TOKEN")),
+        public_base_url=public_domain,
+        bucket=_first_value(raw.get("bucket"), _env("CLOUDFLARE_R2_BUCKET"), _env("R2_BUCKET"), r2_creds.get("bucket")),
+        account_id=_first_value(raw.get("account_id"), _env("CLOUDFLARE_ACCOUNT_ID"), r2_creds.get("accountId")),
+        access_key_id=_first_value(raw.get("access_key_id"), _env("CLOUDFLARE_R2_ACCESS_KEY_ID"), _env("R2_ACCESS_KEY_ID"), r2_creds.get("accessKeyId")),
+        secret_access_key=_first_value(raw.get("secret_access_key"), _env("CLOUDFLARE_R2_SECRET_ACCESS_KEY"), _env("R2_SECRET_ACCESS_KEY"), r2_creds.get("secretAccessKey")),
+        api_token=_first_value(raw.get("api_token"), _env("CLOUDFLARE_API_TOKEN"), r2_creds.get("apiToken")),
         wrangler=_as_bool(raw.get("wrangler"), False),
+        credential_file=credential_file,
     )
 
 
@@ -179,6 +220,12 @@ def _remote_key(cfg: ExternalMediaConfig, path: Path) -> str:
 def _public_url(cfg: ExternalMediaConfig, key: str) -> str:
     base = cfg.public_base_url.rstrip("/")
     return f"{base}/{quote(key, safe='/')}"
+
+
+def _urlopen_no_proxy(req: urllib.request.Request, timeout: int):
+    """Open storage URLs directly; OS proxy settings can break R2 custom domains."""
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    return opener.open(req, timeout=timeout)
 
 
 def _sign(key: bytes, msg: str) -> bytes:
@@ -238,7 +285,7 @@ def _upload_r2_sigv4(cfg: ExternalMediaConfig, local_path: Path, key: str) -> st
     req.add_header("X-Amz-Date", amz_date)
     req.add_header("X-Amz-Content-Sha256", hashlib.sha256(payload).hexdigest())
     req.add_header("Authorization", _sigv4_authorization(cfg, "PUT", key, payload, content_type, amz_date, date_stamp))
-    with urllib.request.urlopen(req, timeout=60) as resp:  # noqa: S310 - user-configured storage endpoint
+    with _urlopen_no_proxy(req, timeout=60) as resp:  # noqa: S310 - user-configured storage endpoint
         if resp.status not in {200, 201, 204}:
             raise RuntimeError(f"R2 upload failed with HTTP {resp.status}")
     return _public_url(cfg, key)
@@ -268,14 +315,14 @@ def _upload_r2_wrangler(cfg: ExternalMediaConfig, local_path: Path, key: str) ->
 def _verify_public_url(url: str) -> None:
     req = urllib.request.Request(url, method="HEAD")
     try:
-        with urllib.request.urlopen(req, timeout=20) as resp:  # noqa: S310 - URL was just produced by configured storage
+        with _urlopen_no_proxy(req, timeout=20) as resp:  # noqa: S310 - URL was just produced by configured storage
             if resp.status < 200 or resp.status >= 400:
                 raise RuntimeError(f"published media URL returned HTTP {resp.status}")
     except Exception:
         # Some object-store custom domains reject HEAD but serve GET.
         req = urllib.request.Request(url, method="GET")
         req.add_header("Range", "bytes=0-0")
-        with urllib.request.urlopen(req, timeout=20) as resp:  # noqa: S310
+        with _urlopen_no_proxy(req, timeout=20) as resp:  # noqa: S310
             if resp.status < 200 or resp.status >= 400:
                 raise RuntimeError(f"published media URL returned HTTP {resp.status}")
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2481,6 +2481,31 @@ DEFAULT_CONFIG = {
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.
+    # Gateway outbound media publishing. Default-off: platform adapters keep
+    # using native attachment delivery unless operators opt in to external
+    # object storage such as Cloudflare R2.
+    "media_delivery": {
+        "external_upload": {
+            "enabled": False,
+            "provider": "r2",
+            "mode": "link_on_failure",
+            "images": True,
+            "videos": True,
+            "audio": False,
+            "documents": False,
+            "size_threshold_mb": 8,
+            "remote_prefix": "hermes/media/%Y/%m/%d/",
+            "verify": True,
+            "public_base_url": "",
+            "bucket": "",
+            "account_id": "",
+            "access_key_id": "",
+            "secret_access_key": "",
+            "api_token": "",
+            "wrangler": False,
+        },
+    },
+
     "code_execution": {
         # Execution mode:
         #   project (default) — scripts run in the session's working directory

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1955,7 +1955,7 @@ class DiscordAdapter(BasePlatformAdapter):
         message = format_published_media_message(published, heading=heading)
         if caption:
             message = f"{caption.strip()}\n{message}" if message else caption.strip()
-        return await self.send(chat_id, message or "Media uploaded")
+        return await self.send(chat_id, message or "Media uploaded", metadata={"non_conversational": True})
 
     async def _maybe_publish_media_file(
         self,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -120,6 +120,12 @@ from gateway.platforms.base import (
     validate_inbound_media_size,
 )
 from tools.url_safety import is_safe_url
+from gateway.media_publisher import (
+    PublishedMedia,
+    external_media_config_for,
+    format_published_media_message,
+    publish_media_files,
+)
 
 
 async def _wait_for_ready_or_bot_exit(
@@ -1938,6 +1944,28 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to edit Discord message %s: %s", self.name, message_id, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def _send_published_media_links(
+        self,
+        chat_id: str,
+        published: List[PublishedMedia],
+        caption: Optional[str] = None,
+        heading: str = "Media",
+    ) -> SendResult:
+        """Send already-published media URLs as a Discord text message."""
+        message = format_published_media_message(published, heading=heading)
+        if caption:
+            message = f"{caption.strip()}\n{message}" if message else caption.strip()
+        return await self.send(chat_id, message or "Media uploaded")
+
+    async def _maybe_publish_media_file(
+        self,
+        file_path: str,
+        media_kind: str,
+    ) -> Optional[PublishedMedia]:
+        """Publish a local MEDIA file when external upload is configured."""
+        published = await publish_media_files(self, [file_path], media_kind=media_kind)
+        return published[0] if published else None
+
     async def _send_file_attachment(
         self,
         chat_id: str,
@@ -2000,6 +2028,28 @@ class DiscordAdapter(BasePlatformAdapter):
             await super().send_multiple_images(chat_id, images, metadata, human_delay)
             return
 
+
+        media_cfg = external_media_config_for(self, "images")
+        if media_cfg.enabled and media_cfg.mode == "link_first":
+            local_paths: List[str] = []
+            captions: List[str] = []
+            for image_url, alt_text in images:
+                if alt_text:
+                    captions.append(alt_text)
+                if image_url.startswith("file://"):
+                    local_paths.append(_unquote(image_url[7:]))
+            if local_paths:
+                try:
+                    published = await publish_media_files(self, local_paths, media_kind="images")
+                    if published:
+                        caption = captions[0] if captions else None
+                        await self._send_published_media_links(chat_id, published, caption, heading="Images")
+                        # Send non-local URL images through the existing path below.
+                        images = [(u, a) for (u, a) in images if not u.startswith("file://")]
+                        if not images:
+                            return
+                except Exception as e:
+                    logger.warning("[%s] External multi-image upload failed; falling back to Discord attachments: %s", self.name, e)
         try:
             channel = self._client.get_channel(int(chat_id))
             if not channel:
@@ -3051,12 +3101,39 @@ class DiscordAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send a local image file natively as a Discord file attachment."""
+        """Send a local image file, optionally via configured external storage."""
+        media_cfg = external_media_config_for(self, "images")
+        if media_cfg.enabled and media_cfg.mode == "link_first":
+            try:
+                published = await self._maybe_publish_media_file(image_path, "images")
+                if published:
+                    return await self._send_published_media_links(chat_id, [published], caption, heading="Image")
+            except Exception as e:
+                logger.warning("[%s] External image upload failed; falling back to Discord attachment: %s", self.name, e)
+
         try:
-            return await self._send_file_attachment(chat_id, image_path, caption)
+            result = await self._send_file_attachment(chat_id, image_path, caption)
+            if result.success:
+                if media_cfg.enabled and media_cfg.mode == "attach_and_link":
+                    try:
+                        published = await self._maybe_publish_media_file(image_path, "images")
+                        if published:
+                            await self._send_published_media_links(chat_id, [published], None, heading="Image link")
+                    except Exception as e:
+                        logger.warning("[%s] External image upload after attachment failed: %s", self.name, e)
+                return result
+            raise RuntimeError(result.error or "Discord attachment send failed")
         except FileNotFoundError:
             return SendResult(success=False, error=f"Image file not found: {image_path}")
         except Exception as e:  # pragma: no cover - defensive logging
+            if media_cfg.enabled and media_cfg.mode in {"link_on_failure", "attach_and_link"}:
+                try:
+                    published = await self._maybe_publish_media_file(image_path, "images")
+                    if published:
+                        logger.info("[%s] Discord image attachment failed; sent external media link instead", self.name)
+                        return await self._send_published_media_links(chat_id, [published], caption, heading="Image")
+                except Exception as upload_err:
+                    logger.error("[%s] External image fallback upload failed: %s", self.name, upload_err, exc_info=True)
             logger.error("[%s] Failed to send local image, falling back to base adapter: %s", self.name, e, exc_info=True)
             return await super().send_image_file(chat_id, image_path, caption, reply_to, metadata=metadata)
 
@@ -3216,12 +3293,30 @@ class DiscordAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send a local video file natively as a Discord attachment."""
+        """Send a local video file, optionally via configured external storage."""
+        media_cfg = external_media_config_for(self, "videos")
+        if media_cfg.enabled and media_cfg.mode == "link_first":
+            try:
+                published = await self._maybe_publish_media_file(video_path, "videos")
+                if published:
+                    return await self._send_published_media_links(chat_id, [published], caption, heading="Video")
+            except Exception as e:
+                logger.warning("[%s] External video upload failed; falling back to Discord attachment: %s", self.name, e)
         try:
-            return await self._send_file_attachment(chat_id, video_path, caption)
+            result = await self._send_file_attachment(chat_id, video_path, caption)
+            if result.success:
+                return result
+            raise RuntimeError(result.error or "Discord attachment send failed")
         except FileNotFoundError:
             return SendResult(success=False, error=f"Video file not found: {video_path}")
         except Exception as e:  # pragma: no cover - defensive logging
+            if media_cfg.enabled and media_cfg.mode in {"link_on_failure", "attach_and_link"}:
+                try:
+                    published = await self._maybe_publish_media_file(video_path, "videos")
+                    if published:
+                        return await self._send_published_media_links(chat_id, [published], caption, heading="Video")
+                except Exception as upload_err:
+                    logger.error("[%s] External video fallback upload failed: %s", self.name, upload_err, exc_info=True)
             logger.error("[%s] Failed to send local video, falling back to base adapter: %s", self.name, e, exc_info=True)
             return await super().send_video(chat_id, video_path, caption, reply_to, metadata=metadata)
 
@@ -3234,12 +3329,30 @@ class DiscordAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send an arbitrary file natively as a Discord attachment."""
+        """Send an arbitrary file, optionally via configured external storage."""
+        media_cfg = external_media_config_for(self, "documents")
+        if media_cfg.enabled and media_cfg.mode == "link_first":
+            try:
+                published = await self._maybe_publish_media_file(file_path, "documents")
+                if published:
+                    return await self._send_published_media_links(chat_id, [published], caption, heading="File")
+            except Exception as e:
+                logger.warning("[%s] External document upload failed; falling back to Discord attachment: %s", self.name, e)
         try:
-            return await self._send_file_attachment(chat_id, file_path, caption, file_name=file_name)
+            result = await self._send_file_attachment(chat_id, file_path, caption, file_name=file_name)
+            if result.success:
+                return result
+            raise RuntimeError(result.error or "Discord attachment send failed")
         except FileNotFoundError:
             return SendResult(success=False, error=f"File not found: {file_path}")
         except Exception as e:  # pragma: no cover - defensive logging
+            if media_cfg.enabled and media_cfg.mode in {"link_on_failure", "attach_and_link"}:
+                try:
+                    published = await self._maybe_publish_media_file(file_path, "documents")
+                    if published:
+                        return await self._send_published_media_links(chat_id, [published], caption, heading="File")
+                except Exception as upload_err:
+                    logger.error("[%s] External document fallback upload failed: %s", self.name, upload_err, exc_info=True)
             logger.error("[%s] Failed to send document, falling back to base adapter: %s", self.name, e, exc_info=True)
             return await super().send_document(chat_id, file_path, caption, file_name, reply_to, metadata=metadata)
 

--- a/tests/gateway/test_external_media_publisher.py
+++ b/tests/gateway/test_external_media_publisher.py
@@ -1,0 +1,149 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.media_publisher import (
+    PublishedMedia,
+    external_media_config_for,
+    format_published_media_message,
+)
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+def test_gateway_config_media_delivery_defaults_off():
+    cfg = GatewayConfig.from_dict({})
+
+    assert cfg.media_delivery == {}
+    assert cfg.to_dict()["media_delivery"] == {}
+
+
+def test_gateway_config_loads_media_delivery_block():
+    raw = {
+        "media_delivery": {
+            "external_upload": {
+                "enabled": True,
+                "provider": "r2",
+                "mode": "link_first",
+                "platforms": {"discord": {"images": True}},
+            }
+        },
+        "platforms": {"discord": {"enabled": True, "token": "x"}},
+    }
+
+    cfg = GatewayConfig.from_dict(raw)
+
+    assert cfg.media_delivery["external_upload"]["enabled"] is True
+    assert cfg.media_delivery["external_upload"]["mode"] == "link_first"
+    assert Platform.DISCORD in cfg.platforms
+
+
+def test_external_media_config_default_disabled_for_adapter():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    cfg = external_media_config_for(adapter, "images")
+
+    assert cfg.enabled is False
+    assert cfg.provider == "r2"
+
+
+def test_external_media_config_merges_platform_override():
+    adapter = DiscordAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={
+                "media_delivery": {
+                    "external_upload": {
+                        "enabled": True,
+                        "provider": "r2",
+                        "mode": "link_on_failure",
+                        "images": False,
+                        "public_base_url": "https://cdn.example.com",
+                        "platforms": {
+                            "discord": {
+                                "mode": "link_first",
+                                "images": True,
+                            }
+                        },
+                    }
+                }
+            },
+        )
+    )
+
+    cfg = external_media_config_for(adapter, "images")
+
+    assert cfg.enabled is True
+    assert cfg.mode == "link_first"
+    assert cfg.images is True
+    assert cfg.public_base_url == "https://cdn.example.com"
+
+
+def test_format_published_media_message_multiple_items():
+    msg = format_published_media_message(
+        [
+            PublishedMedia("/tmp/a.png", "https://cdn.example/a.png", "a.png", "image/png", 1),
+            PublishedMedia("/tmp/b.png", "https://cdn.example/b.png", "b.png", "image/png", 2),
+        ],
+        heading="Images",
+    )
+
+    assert "Images (2 files):" in msg
+    assert "a.png: https://cdn.example/a.png" in msg
+    assert "b.png: https://cdn.example/b.png" in msg
+
+
+@pytest.mark.asyncio
+async def test_discord_send_image_file_link_first_uses_published_url(monkeypatch, tmp_path):
+    image = tmp_path / "photo.png"
+    image.write_bytes(b"fake-png")
+    adapter = DiscordAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={
+                "media_delivery": {
+                    "external_upload": {
+                        "enabled": True,
+                        "mode": "link_first",
+                        "provider": "r2",
+                    }
+                }
+            },
+        )
+    )
+    adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="42"))
+
+    async def fake_publish(_adapter, paths, media_kind=None):
+        assert _adapter is adapter
+        assert list(paths) == [str(image)]
+        assert media_kind == "images"
+        return [PublishedMedia(str(image), "https://cdn.example/photo.png", "photo.png", "image/png", 8)]
+
+    monkeypatch.setattr("plugins.platforms.discord.adapter.publish_media_files", fake_publish)
+
+    result = await adapter.send_image_file("123", str(image), caption="caption")
+
+    assert result.success is True
+    adapter.send.assert_awaited_once()
+    awaited = adapter.send.await_args
+    assert awaited is not None
+    sent_content = awaited.args[1]
+    assert "caption" in sent_content
+    assert "https://cdn.example/photo.png" in sent_content
+
+
+@pytest.mark.asyncio
+async def test_discord_send_image_file_default_uses_native_attachment(monkeypatch, tmp_path):
+    image = tmp_path / "photo.png"
+    image.write_bytes(b"fake-png")
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    native = AsyncMock(return_value=SimpleNamespace(success=True, message_id="99"))
+    monkeypatch.setattr(adapter, "_send_file_attachment", native)
+
+    result = await adapter.send_image_file("123", str(image), caption="caption")
+
+    assert result.success is True
+    native.assert_awaited_once_with("123", str(image), "caption")

--- a/tests/gateway/test_external_media_publisher.py
+++ b/tests/gateway/test_external_media_publisher.py
@@ -81,6 +81,40 @@ def test_external_media_config_merges_platform_override():
     assert cfg.public_base_url == "https://cdn.example.com"
 
 
+
+
+def test_external_media_config_reads_private_r2_credential_file(tmp_path):
+    cred = tmp_path / "r2.json"
+    cred.write_text(
+        '{"bucket":"b","accountId":"acct","apiToken":"tok","customDomain":"media.example.com"}'
+    )
+    adapter = DiscordAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={
+                "media_delivery": {
+                    "external_upload": {
+                        "enabled": True,
+                        "provider": "r2",
+                        "wrangler": True,
+                        "credential_file": str(cred),
+                    }
+                }
+            },
+        )
+    )
+
+    cfg = external_media_config_for(adapter, "images")
+
+    assert cfg.enabled is True
+    assert cfg.bucket == "b"
+    assert cfg.account_id == "acct"
+    assert cfg.api_token == "tok"
+    assert cfg.public_base_url == "https://media.example.com"
+    assert cfg.wrangler is True
+
+
 def test_format_published_media_message_multiple_items():
     msg = format_published_media_message(
         [

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -111,6 +111,12 @@ media_delivery:
     account_id: ${CLOUDFLARE_ACCOUNT_ID}
     access_key_id: ${CLOUDFLARE_R2_ACCESS_KEY_ID}
     secret_access_key: ${CLOUDFLARE_R2_SECRET_ACCESS_KEY}
+
+    # Or keep all R2 secrets in a private local JSON file. Supported keys:
+    # bucket, accountId, apiToken, publicDomain/customDomain,
+    # accessKeyId, secretAccessKey.
+    credential_file: ~/.hermes/secrets/cloudflare/r2.json
+    wrangler: false                  # true = use wrangler + apiToken instead of SigV4 keys
 ```
 
 Modes:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -83,6 +83,46 @@ Multiple references in a single value work: `url: "${HOST}:${PORT}"`. If a refer
 
 For AI provider setup (OpenRouter, Anthropic, Copilot, custom endpoints, self-hosted LLMs, fallback models, etc.), see [AI Providers](/integrations/providers).
 
+## Outbound Media Delivery
+
+By default, Hermes sends `MEDIA:/path/to/file` outputs through each platform's native attachment API. You can opt in to external object-storage publishing when a platform's attachment channel is unreliable or size-limited. The first supported provider is Cloudflare R2.
+
+This feature is **off by default**. If `media_delivery.external_upload.enabled` is absent or `false`, adapters keep their existing native attachment behavior.
+
+```yaml
+media_delivery:
+  external_upload:
+    enabled: false                 # default: do not publish externally
+    provider: r2
+    mode: link_on_failure          # link_first | link_on_failure | attach_and_link
+    images: true
+    videos: true
+    audio: false
+    documents: false
+    size_threshold_mb: 8           # only publish files >= this size (0 = all enabled kinds)
+    remote_prefix: hermes/media/%Y/%m/%d/
+    verify: true                   # HEAD/GET the public URL before sending it
+
+    # Non-secret settings may live here:
+    public_base_url: https://media.example.com
+    bucket: hermes-media
+
+    # Secrets can be referenced from environment variables instead of committed:
+    account_id: ${CLOUDFLARE_ACCOUNT_ID}
+    access_key_id: ${CLOUDFLARE_R2_ACCESS_KEY_ID}
+    secret_access_key: ${CLOUDFLARE_R2_SECRET_ACCESS_KEY}
+```
+
+Modes:
+
+- `link_first` — upload first and send links instead of native attachments.
+- `link_on_failure` — try native attachments first, then publish and send a link if the attachment upload fails.
+- `attach_and_link` — send the native attachment and also post a durable external link when upload succeeds.
+
+:::warning Public URL boundary
+External media URLs may be publicly reachable depending on your storage/domain settings. Use this for generated images, reports, and non-sensitive artifacts. Do not enable automatic publishing for private documents, credentials, financial records, identity documents, or internal screenshots unless your bucket/domain has appropriate access control.
+:::
+
 ### Provider Timeouts
 
 You can set `providers.<id>.request_timeout_seconds` for a provider-wide request timeout, plus `providers.<id>.models.<model>.timeout_seconds` for a model-specific override. Applies to the primary turn client on every transport (OpenAI-wire, native Anthropic, Anthropic-compatible), the fallback chain, rebuilds after credential rotation, and (for OpenAI-wire) the per-request timeout kwarg — so the configured value wins over the legacy `HERMES_API_TIMEOUT` env var.


### PR DESCRIPTION
## Summary

Adds a default-off external media publishing layer for gateway outbound `MEDIA:` delivery, with Cloudflare R2 as the first provider and Discord integration for generated/local media.

Why: Discord attachment uploads can fail or hard-limit large files (for example `413 Payload Too Large`, broken pipes, or disconnected uploads). This lets operators opt in to publishing media to object storage and sending durable links instead of relying solely on platform attachment APIs.

## What changed

- Adds `gateway/media_publisher.py`:
  - default-off `ExternalMediaConfig`
  - Cloudflare R2 upload via S3-compatible SigV4 or optional `wrangler`
  - public URL verification via `HEAD` with `GET Range` fallback
  - link formatting helpers for platform adapters
- Adds `media_delivery.external_upload` config support:
  - loaded from `config.yaml`
  - copied into platform adapter `extra` after env/platform setup
  - documented in `DEFAULT_CONFIG`
- Wires Discord outbound local media:
  - images: `link_first`, `link_on_failure`, `attach_and_link`
  - multi-image local batches: `link_first`
  - videos/documents: optional external fallback, documents disabled by default
- Documents the public-URL privacy boundary and configuration in the user guide.
- Adds regression tests for default-off behavior and Discord link-first delivery.

## Default behavior / compatibility

This feature is disabled unless configured:

```yaml
media_delivery:
  external_upload:
    enabled: true
```

With no config, Discord keeps the existing native attachment path.

## Related issues / follow-up plan

- Relates to #50846 / #50793: large Discord media needs graceful external-storage fallback.
- Relates to #46454: large media delivery should surface a reliable delivery path instead of silent attachment failures.
- Related precedent: #378 / here.now showed agent-generated content publishing via object storage/CDN is useful for Hermes workflows.
- Follow-up issue: #52698 tracks platform upload-size preflight as a focused next PR.

## Test plan

```bash
python -m pytest tests/gateway/test_external_media_publisher.py tests/gateway/test_discord_send.py -q
python -m py_compile gateway/media_publisher.py gateway/config.py hermes_cli/config.py plugins/platforms/discord/adapter.py
```

Result: `25 passed`.

## Follow-ups

This PR intentionally keeps scope focused. Follow-up issues/PRs can add:

- platform file-size preflight by adapter/kind (#52698)
- upload progress/status messages
- additional storage providers / presigned URL providers
- richer privacy controls for public media URLs
