### PR TITLE
fix(tui): prevent unresolved model placeholder from being persisted as sticky session binding

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1501,13 +1501,14 @@ def _ensure_session_db_row(session: dict) -> None:
     if tier := session.get("create_service_tier_override"):
         model_config["service_tier"] = tier
     try:
-        db.create_session(
-            key,
+        create_kwargs: dict = dict(
             source=_session_source(session),
-            model=row_model,
             model_config=model_config or None,
             cwd=_session_cwd(session) if session.get("explicit_cwd") else None,
         )
+        if row_model:
+            create_kwargs["model"] = row_model
+        db.create_session(key, **create_kwargs)
     except Exception:
         logger.debug("failed to persist desktop session row", exc_info=True)
     finally:
@@ -1772,7 +1773,7 @@ def _resolve_model() -> str:
         return str(m.get("default", "") or "").strip()
     if isinstance(m, str) and m:
         return m.strip()
-    return "anthropic/claude-sonnet-4"
+    return ""
 
 
 def _config_model_target() -> tuple[str, str]:


### PR DESCRIPTION
Fixes #52461

## Description

`_resolve_model()` in `tui_gateway/server.py` returned a hardcoded placeholder `"anthropic/claude-sonnet-4"` when no model was configured via env or config.yaml. This placeholder was persisted into the session's model binding via `_ensure_session_db_row()`, permanently pinning the session to a nonexistent model and causing 404s on every resume — even after the config was fixed and the process restarted.

This PR:
- Changes `_resolve_model()` to return an empty string when no model is configured, rather than a hardcoded placeholder.
- Adds a guard in `_ensure_session_db_row()` so that an empty/unresolved model is not written to the session DB as a sticky model binding.

## Verification

- Python compile check passes
- 7 related tests pass (resolve_model, ensure_session_db_row variants)
- No secrets, personal refs, or em-dashes in diff
- Conventional commit format
- Branch is current with origin/main
- Focused diff: only `tui_gateway/server.py`

---
_Solidified via basic quality gates before opening._