### PR TITLE
fix(tui-gateway): decode subprocess output as UTF-8 to stop cp950 crashes

### DIFF
--- a/tests/tui_gateway/test_subprocess_encoding.py
+++ b/tests/tui_gateway/test_subprocess_encoding.py
@@ -1,0 +1,28 @@
+"""Regression: tui_gateway subprocess I/O must decode child output as UTF-8,
+not the OS locale codepage. On non-UTF-8 Windows consoles (e.g. cp950) the
+default text-mode decode raises UnicodeDecodeError in the subprocess reader
+threads, killing them and stalling the gateway on a fixed cadence (#52649).
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+def test_git_branch_lookup_decodes_as_utf8_replace():
+    import tui_gateway.server as srv
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append(kwargs)
+        m = MagicMock()
+        m.returncode = 0
+        m.stdout = "main"
+        return m
+
+    with patch.object(srv.subprocess, "run", side_effect=fake_run):
+        srv._git_branch_for_cwd("/some/repo")
+
+    assert captured, "expected subprocess.run to be called"
+    for kwargs in captured:
+        assert kwargs.get("encoding") == "utf-8"
+        assert kwargs.get("errors") == "replace"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -266,6 +266,14 @@ class _SlashWorker:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            # Decode child output as UTF-8 (what Hermes emits) instead of the
+            # OS locale codepage. On non-UTF-8 Windows consoles (e.g. cp950)
+            # the default text-mode decode raises UnicodeDecodeError inside the
+            # reader threads on any non-ASCII byte, killing _drain_stdout /
+            # _drain_stderr and stalling the worker (#52649). errors="replace"
+            # keeps a stray byte from ever crashing the stream.
+            encoding="utf-8",
+            errors="replace",
             bufsize=1,
             cwd=os.getcwd(),
             env=os.environ.copy(),
@@ -1369,6 +1377,12 @@ def _git_branch_for_cwd(cwd: str) -> str:
             ["git", "-C", cwd, "branch", "--show-current"],
             capture_output=True,
             text=True,
+            # Decode as UTF-8, not the OS locale codepage: a non-ASCII branch
+            # name on a cp950 console otherwise raises UnicodeDecodeError in the
+            # subprocess reader thread (#52649). This runs on the periodic
+            # session-status refresh, so the crash repeats on a fixed cadence.
+            encoding="utf-8",
+            errors="replace",
             timeout=1.5,
             check=False,
             stdin=subprocess.DEVNULL,
@@ -1381,6 +1395,8 @@ def _git_branch_for_cwd(cwd: str) -> str:
             ["git", "-C", cwd, "rev-parse", "--short", "HEAD"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=1.5,
             check=False,
             stdin=subprocess.DEVNULL,


### PR DESCRIPTION
## Summary

Addresses #52649. On non-UTF-8 Windows consoles (e.g. cp950 / zh-TW) the text-mode subprocess I/O in `tui_gateway/server.py` decoded child output with the **OS locale codepage**, not UTF-8. Since Hermes (and git) emit UTF-8, any non-ASCII byte raised `UnicodeDecodeError` inside the subprocess reader threads — exactly the threads named in the report:

- `_drain_stdout` / `_drain_stderr` — the slash-worker `Popen(..., text=True)` (no `encoding`)
- `_readerthread` — the `subprocess.run(..., capture_output=True, text=True)` calls in `_git_branch_for_cwd`, which run on the periodic session-status refresh (hence the fixed ~580 s crash cadence)

A crashed reader thread stalls the worker → the watchdog sees a stale log → kills and respawns (with a brief console popup), 10–20×/hour.

## Fix

Pass `encoding="utf-8", errors="replace"` to:
- the slash-worker `subprocess.Popen`
- both `subprocess.run` calls in `_git_branch_for_cwd`

`errors="replace"` means a stray byte can never crash the stream, and UTF-8 is what these children actually emit. No behavior change on UTF-8 consoles.

Scope note: this fixes the subprocess sites in `tui_gateway/server.py` that match the reported crash threads. Other text-mode subprocess reads elsewhere could warrant the same hardening, but are out of scope here.

## Tests

`tests/tui_gateway/test_subprocess_encoding.py`: the `_git_branch_for_cwd` git lookups are invoked with `encoding="utf-8"` and `errors="replace"`. Runs on any platform (no cp950 console required).
