### PR TITLE
fix(process): use [INTERNAL] marker for background process notifications (#52694)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2261,21 +2261,26 @@ def _format_gateway_process_notification(evt: dict) -> "str | None":
     _cmd = evt.get("command", "unknown")
 
     if evt_type == "watch_disabled":
-        return f"[IMPORTANT: {evt.get('message', '')}]"
+        return (
+            f"[INTERNAL BACKGROUND PROCESS NOTIFICATION \u2014 NOT A USER MESSAGE]\n"
+            f"{evt.get('message', '')}\n"
+            f"[/INTERNAL BACKGROUND PROCESS NOTIFICATION]"
+        )
 
     if evt_type == "watch_match":
         _pat = evt.get("pattern", "?")
         _out = evt.get("output", "")
         _sup = evt.get("suppressed", 0)
         text = (
-            f"[IMPORTANT: Background process {_sid} matched "
-            f"watch pattern \"{_pat}\".\n"
+            f"[INTERNAL BACKGROUND PROCESS NOTIFICATION \u2014 NOT A USER MESSAGE]\n"
+            f"Background process {_sid} matched "
+            f'watch pattern \"{_pat}\".\n'
             f"Command: {_cmd}\n"
             f"Matched output:\n{_out}"
         )
         if _sup:
             text += f"\n({_sup} earlier matches were suppressed by rate limit)"
-        text += "]"
+        text += "\n[/INTERNAL BACKGROUND PROCESS NOTIFICATION]"
         return text
 
     if evt_type == "async_delegation":

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7191,7 +7191,8 @@ def test_notification_poller_delivers_completion(monkeypatch):
 
         # Should have triggered an agent turn
         assert len(turns) == 1
-        assert "[IMPORTANT: Background process proc_poller_test completed normally" in turns[0]
+        assert "[INTERNAL BACKGROUND PROCESS NOTIFICATION" in turns[0]
+        assert "Background process proc_poller_test completed normally" in turns[0]
     finally:
         server._sessions.pop("sid_poll", None)
         while not process_registry.completion_queue.empty():

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1016,10 +1016,13 @@ def test_format_completion_event():
         "output": "done",
     }
     result = format_process_notification(evt)
-    assert "[IMPORTANT: Background process proc_abc completed normally" in result
+    assert "[INTERNAL BACKGROUND PROCESS NOTIFICATION" in result
+    assert "NOT A USER MESSAGE" in result
+    assert "Background process proc_abc completed normally" in result
     assert "exit code 0" in result
     assert "Command: sleep 5" in result
-    assert "Output:\ndone]" in result
+    assert "Output:\ndone" in result
+    assert "[/INTERNAL BACKGROUND PROCESS NOTIFICATION]" in result
 
 
 def test_format_killed_completion_event_names_source_and_signal():
@@ -1084,7 +1087,9 @@ def test_format_watch_disabled_event():
         "message": "Watch disabled for proc_xyz: too many matches",
     }
     result = format_process_notification(evt)
-    assert "[IMPORTANT: Watch disabled for proc_xyz" in result
+    assert "[INTERNAL BACKGROUND PROCESS NOTIFICATION" in result
+    assert "Watch disabled for proc_xyz" in result
+    assert "[/INTERNAL BACKGROUND PROCESS NOTIFICATION]" in result
 
 
 def test_format_returns_none_for_empty_event():

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1939,7 +1939,7 @@ def _format_async_delegation(evt: dict) -> str:
 
 
 def format_process_notification(evt: dict) -> "str | None":
-    """Format a process notification event into a [IMPORTANT: ...] message.
+    """Format a process notification event into an [INTERNAL BACKGROUND PROCESS NOTIFICATION] message.
 
     Handles completion events (notify_on_complete), watch pattern matches,
     and watch disabled events from the unified completion_queue.
@@ -1949,21 +1949,26 @@ def format_process_notification(evt: dict) -> "str | None":
     _cmd = evt.get("command", "unknown")
 
     if evt_type == "watch_disabled":
-        return f"[IMPORTANT: {evt.get('message', '')}]"
+        return (
+            f"[INTERNAL BACKGROUND PROCESS NOTIFICATION \u2014 NOT A USER MESSAGE]\n"
+            f"{evt.get('message', '')}\n"
+            f"[/INTERNAL BACKGROUND PROCESS NOTIFICATION]"
+        )
 
     if evt_type == "watch_match":
         _pat = evt.get("pattern", "?")
         _out = evt.get("output", "")
         _sup = evt.get("suppressed", 0)
         text = (
-            f"[IMPORTANT: Background process {_sid} matched "
-            f"watch pattern \"{_pat}\".\n"
+            f"[INTERNAL BACKGROUND PROCESS NOTIFICATION \u2014 NOT A USER MESSAGE]\n"
+            f"Background process {_sid} matched "
+            f'watch pattern \"{_pat}\".\n'
             f"Command: {_cmd}\n"
             f"Matched output:\n{_out}"
         )
         if _sup:
             text += f"\n({_sup} earlier matches were suppressed by rate limit)"
-        text += "]"
+        text += "\n[/INTERNAL BACKGROUND PROCESS NOTIFICATION]"
         return text
 
     if evt_type == "async_delegation":
@@ -1987,10 +1992,12 @@ def format_process_notification(evt: dict) -> "str | None":
     else:
         _status = "exited"
     return (
-        f"[IMPORTANT: Background process {_sid} {_status} "
+        f"[INTERNAL BACKGROUND PROCESS NOTIFICATION \u2014 NOT A USER MESSAGE]\n"
+        f"Background process {_sid} {_status} "
         f"(exit code {_exit}{_signal}).\n"
         f"Command: {_cmd}\n"
-        f"Output:\n{_out}]"
+        f"Output:\n{_out}\n"
+        f"[/INTERNAL BACKGROUND PROCESS NOTIFICATION]"
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Background process completion and watch-pattern notifications used `[IMPORTANT: ...]` markers that the model could misinterpret as user messages or approval signals. This PR replaces them with clearly-tagged `[INTERNAL BACKGROUND PROCESS NOTIFICATION — NOT A USER MESSAGE]` ... `[/INTERNAL BACKGROUND PROCESS NOTIFICATION]` markers, making the synthetic/internal nature of these notifications unambiguous to the model.

## Related Issue

Fixes #52694

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/process_registry.py`: Updated `format_process_notification()` to use `[INTERNAL BACKGROUND PROCESS NOTIFICATION]` markers for all three event types (completion, watch_match, watch_disabled). Updated docstring.
- `gateway/run.py`: Updated `_format_gateway_process_notification()` with matching marker changes for watch_disabled and watch_match paths.
- `tests/tools/test_process_registry.py`: Updated assertions in `test_format_completion_event` and `test_format_watch_disabled_event` to verify the new markers.
- `tests/test_tui_gateway_server.py`: Updated assertion in `test_notification_poller_delivers_completion` to verify the new marker.

## How to Test

1. Run the notification format tests: `python -m pytest tests/tools/test_process_registry.py -k "format" -v`
2. Run the TUI notification poller test: `python -m pytest tests/test_tui_gateway_server.py::test_notification_poller_delivers_completion -v`
3. Run the async delegation tests: `python -m pytest tests/tools/test_async_delegation.py -v`
4. All tests should pass with the new `[INTERNAL BACKGROUND PROCESS NOTIFICATION]` markers.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/process_registry.py:format_process_notification`, `gateway/run.py:_format_gateway_process_notification`
- Blast radius: LOW — notification text formatting only, no routing or control-flow changes
- Related patterns: `MessageEvent.internal=True` already gates routing; this PR improves the model-facing text label
