### PR TITLE
fix: preserve desktop link labels across ports

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -270,10 +270,16 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
   }
 
   const text = childrenToText(children)
-  const fallbackLabel = text && normalizeExternalUrl(text) !== target ? text : undefined
+  const explicitLabel = text && normalizeExternalUrl(text) !== target ? text : undefined
 
   return (
-    <PrettyLink className={cn('wrap-anywhere', className)} fallbackLabel={fallbackLabel} href={target} {...props} />
+    <PrettyLink
+      className={cn('wrap-anywhere', className)}
+      fallbackLabel={explicitLabel}
+      href={target}
+      label={explicitLabel}
+      {...props}
+    />
   )
 }
 

--- a/apps/desktop/src/lib/external-link.test.tsx
+++ b/apps/desktop/src/lib/external-link.test.tsx
@@ -92,6 +92,24 @@ describe('external link helpers', () => {
     expect(bridge).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps title cache entries separate for different ports on the same host', async () => {
+    const bridge = vi
+      .fn()
+      .mockResolvedValueOnce('Open WebUI')
+      .mockResolvedValueOnce('Hermes Agent - Dashboard')
+
+    installDesktopBridge({ fetchLinkTitle: bridge as unknown as Window['hermesDesktop']['fetchLinkTitle'] })
+
+    const openWebUi = 'https://macbook-pro.taild5b79a.ts.net/'
+    const dashboard = 'https://macbook-pro.taild5b79a.ts.net:9119/'
+
+    const [a, b] = await Promise.all([fetchLinkTitle(openWebUi), fetchLinkTitle(dashboard)])
+
+    expect(a).toBe('Open WebUI')
+    expect(b).toBe('Hermes Agent - Dashboard')
+    expect(bridge).toHaveBeenCalledTimes(2)
+  })
+
   it('opens links via the desktop bridge', () => {
     const openExternal = vi.fn().mockResolvedValue(undefined)
     installDesktopBridge({ openExternal: openExternal as unknown as Window['hermesDesktop']['openExternal'] })
@@ -127,6 +145,20 @@ describe('external link helpers', () => {
       expect(link.textContent).toContain('From Fajardo: Full-Day Culebra Islands Catamaran Tour')
     })
     expect(link.textContent).not.toContain('getyourguide.com')
+  })
+
+  it('uses explicit labels instead of fetched titles', async () => {
+    const bridge = vi.fn().mockResolvedValue('Open WebUI')
+    installDesktopBridge({ fetchLinkTitle: bridge as unknown as Window['hermesDesktop']['fetchLinkTitle'] })
+
+    const url = 'https://macbook-pro.taild5b79a.ts.net:9119/kanban'
+
+    render(<PrettyLink href={url} label="Hermes Dashboard / Kanban" />)
+
+    const link = screen.getByTitle(url)
+    expect(link.textContent).toBe('Hermes Dashboard / Kanban')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(bridge).not.toHaveBeenCalled()
   })
 
   it('shows host/path fallback when title is unavailable', () => {

--- a/apps/desktop/src/lib/external-link.tsx
+++ b/apps/desktop/src/lib/external-link.tsx
@@ -51,9 +51,10 @@ function titleCacheKey(value: string): string {
   }
 
   const host = url.hostname.replace(/^www\./i, '').toLowerCase()
+  const port = url.port ? `:${url.port}` : ''
   const pathname = url.pathname === '/' ? '/' : url.pathname.replace(/\/+$/, '') || '/'
 
-  return `${host}${pathname}${url.search || ''}`
+  return `${host}${port}${pathname}${url.search || ''}`
 }
 
 export function shortHostLabel(value: string): string {
@@ -253,8 +254,9 @@ interface PrettyLinkProps extends Omit<ComponentProps<'a'>, 'href' | 'target'> {
 
 export function PrettyLink({ className, fallbackLabel, href, label, ...rest }: PrettyLinkProps) {
   const target = useMemo(() => normalizeExternalUrl(href), [href])
-  const fetched = useLinkTitle(label ? null : target)
-  const display = fetched || label?.trim() || fallbackLabel?.trim() || urlSlugTitleLabel(target)
+  const explicitLabel = label?.trim()
+  const fetched = useLinkTitle(explicitLabel ? null : target)
+  const display = explicitLabel || fetched || fallbackLabel?.trim() || urlSlugTitleLabel(target)
 
   return (
     <ExternalLink className={cn('wrap-break-word', className)} href={target} title={target} {...rest}>


### PR DESCRIPTION
## Summary
- keep Desktop link-title cache entries separate for the same host on different ports
- make explicit Markdown link labels win over fetched page titles
- add regressions for the Open WebUI vs Hermes Dashboard/Kanban mislabel case

## Verification
- npm --workspace apps/desktop run test:ui -- src/lib/external-link.test.tsx
- npm --workspace apps/desktop run typecheck
- npm --workspace apps/desktop exec eslint src/lib/external-link.tsx src/lib/external-link.test.tsx src/components/assistant-ui/markdown-text.tsx