### PR TITLE
fix(kanban): accept multi-word title in kanban create CLI

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -304,7 +304,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
 
     # --- create ---
     p_create = sub.add_parser("create", help="Create a new task")
-    p_create.add_argument("title", help="Task title")
+    p_create.add_argument("title", nargs="+", help="Task title (multi-word OK)")
     p_create.add_argument("--body", default=None, help="Optional opening post")
     p_create.add_argument("--assignee", default=None, help="Profile name to assign")
     p_create.add_argument("--parent", action="append", default=[],
@@ -1313,7 +1313,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
     with kb.connect_closing() as conn:
         task_id = kb.create_task(
             conn,
-            title=args.title,
+            title=" ".join(args.title).strip() if isinstance(args.title, list) else (args.title or "").strip(),
             body=args.body,
             assignee=args.assignee,
             created_by=args.created_by or _profile_author(),

--- a/tests/test_kanban_cli_parsing.py
+++ b/tests/test_kanban_cli_parsing.py
@@ -1,0 +1,72 @@
+"""Tests for kanban CLI argument parsing — multi-word title support.
+
+Regression tests for https://github.com/NousResearch/hermes-agent/issues/52696.
+``/kanban create`` previously accepted only a single positional token as the
+title, which broke quick-command aliases that append free-form user text
+without shell-style quoting.
+"""
+
+import argparse
+import pytest
+
+
+@pytest.fixture()
+def kanban_subparser():
+    """Return a fresh ``create`` subparser with the real argument spec."""
+    top = argparse.ArgumentParser(prog="hermes")
+    subs = top.add_subparsers(dest="command")
+    p_create = subs.add_parser("create", help="Create a new task")
+    p_create.add_argument("title", nargs="+", help="Task title (multi-word OK)")
+    p_create.add_argument("--body", default=None, help="Optional opening post")
+    p_create.add_argument("--assignee", default=None, help="Profile name to assign")
+    p_create.add_argument("--parent", action="append", default=[])
+    p_create.add_argument("--workspace", default="scratch")
+    p_create.add_argument("--branch", default=None)
+    p_create.add_argument("--tenant", default=None)
+    p_create.add_argument("--priority", type=int, default=0)
+    p_create.add_argument("--triage", action="store_true")
+    return top
+
+
+def _join_title(args):
+    """Mirror the handler logic that joins the title list."""
+    return " ".join(args.title).strip() if isinstance(args.title, list) else (args.title or "").strip()
+
+
+class TestKanbanCreateMultiWordTitle:
+    """``kanban create`` must accept multi-word titles without quoting."""
+
+    def test_single_word_title(self, kanban_subparser):
+        args = kanban_subparser.parse_args(["create", "Draft"])
+        assert _join_title(args) == "Draft"
+
+    def test_multi_word_title(self, kanban_subparser):
+        args = kanban_subparser.parse_args(["create", "Draft", "onboarding", "checklist"])
+        assert _join_title(args) == "Draft onboarding checklist"
+
+    def test_title_with_body_flag(self, kanban_subparser):
+        args = kanban_subparser.parse_args(
+            ["create", "Draft", "onboarding", "checklist", "--body", "Details here"]
+        )
+        assert _join_title(args) == "Draft onboarding checklist"
+        assert args.body == "Details here"
+
+    def test_flags_before_title(self, kanban_subparser):
+        """Quick-command alias pattern: flags first, then free-form user text."""
+        args = kanban_subparser.parse_args(
+            ["create", "--assignee", "default", "Draft", "onboarding", "checklist"]
+        )
+        assert _join_title(args) == "Draft onboarding checklist"
+        assert args.assignee == "default"
+
+    def test_flags_mixed_with_title(self, kanban_subparser):
+        args = kanban_subparser.parse_args(
+            ["create", "--priority", "3", "Fix", "login", "bug", "--triage"]
+        )
+        assert _join_title(args) == "Fix login bug"
+        assert args.priority == 3
+        assert args.triage is True
+
+    def test_title_with_hyphens(self, kanban_subparser):
+        args = kanban_subparser.parse_args(["create", "fix-unicode-decode-error"])
+        assert _join_title(args) == "fix-unicode-decode-error"


### PR DESCRIPTION
## What does this PR do?

Accepts multi-word titles in `/kanban create` without requiring shell-style quoting. The positional `title` argument now uses `nargs="+"` so argparse consumes all non-flag tokens as the title, then joins them in the handler. This fixes quick-command aliases that append free-form user text without quoting.

## Related Issue

Fixes #52696

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban.py`: Changed `title` argument from `nargs` default (single token) to `nargs="+"` so multi-word titles are accepted without quoting. Updated the handler to join the title list into a single string.
- `tests/test_kanban_cli_parsing.py`: Added 6 regression tests covering single-word, multi-word, mixed flags+title, and quick-command alias patterns.

## How to Test

1. Run `python -m pytest tests/test_kanban_cli_parsing.py -v` — all 6 tests should pass.
2. Run `hermes kanban create Draft onboarding checklist --assignee default` — should create a task with title "Draft onboarding checklist" (previously would fail with "unrecognized arguments: onboarding checklist").
3. Run `hermes kanban create --assignee default Draft onboarding checklist` — flags before title should also work (quick-command alias pattern).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/kanban.py:build_parser` (title argument at line 307) and `_cmd_create` (handler at line 1316)
- Blast radius: LOW — change is scoped to the `kanban create` CLI subcommand parser; no impact on kanban MCP tools, gateway, or other CLI commands
- Related patterns: `argparse.REMAINDER` was considered but `nargs="+"` is safer — it stops at the next `--flag` token so optional arguments like `--body` are not swallowed
