### PR TITLE
fix(gateway): don't tear down agents while holding the agent-cache lock (event-loop deadlock)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15811,6 +15811,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 user_id_alt=getattr(source, "user_id_alt", None),
             )
             agent = None
+            # Agent whose cache entry we invalidate below due to a cross-process
+            # write. Its teardown is deferred until AFTER _agent_cache_lock is
+            # released (see post-lock block) so slow socket / sandbox / MCP close
+            # can't freeze the whole gateway event loop while the cache lock is
+            # held.
+            _stale_evicted_agent = None
             _cache_lock = getattr(self, "_agent_cache_lock", None)
             _cache = getattr(self, "_agent_cache", None)
 
@@ -15852,7 +15858,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             evicted = self._agent_cache.pop(session_key, None)
                             _ev_agent = evicted[0] if isinstance(evicted, tuple) and evicted else None
                             if _ev_agent and _ev_agent is not _AGENT_PENDING_SENTINEL:
-                                self._cleanup_agent_resources(_ev_agent)
+                                # Defer teardown to AFTER the lock is released —
+                                # running _cleanup_agent_resources here holds
+                                # _agent_cache_lock across blocking socket /
+                                # sandbox / MCP teardown, which can freeze the
+                                # whole gateway event loop (every other session's
+                                # `with _cache_lock` blocks indefinitely). Mirrors
+                                # _evict_cached_agent / _enforce_agent_cache_cap,
+                                # which already offload cleanup off-lock.
+                                _stale_evicted_agent = _ev_agent
                         else:
                             agent = cached[0]
                             # Refresh LRU order so the cap enforcement evicts
@@ -15867,6 +15881,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             # (cached agent may have been created with old config)
                             agent.max_iterations = max_iterations
                             logger.debug("Reusing cached agent for session %s", session_key)
+
+            # Tear down a cross-process-invalidated agent OUTSIDE the cache lock,
+            # on a daemon thread, so slow teardown (socket / sandbox / MCP close)
+            # can never block the event loop while _agent_cache_lock is held.
+            # This was the root cause of a full gateway freeze: cleanup ran under
+            # the lock, hung on socket teardown, and every subsequent
+            # `with _cache_lock` deadlocked the loop (2026-06-25).
+            if _stale_evicted_agent is not None:
+                try:
+                    threading.Thread(
+                        target=self._cleanup_agent_resources,
+                        args=(_stale_evicted_agent,),
+                        daemon=True,
+                        name=f"agent-xproc-evict-{str(session_key)[:20]}",
+                    ).start()
+                except Exception:
+                    # Interpreter shutdown or thread-spawn failure — best-effort
+                    # inline fallback (matches _evict_cached_agent).
+                    try:
+                        self._cleanup_agent_resources(_stale_evicted_agent)
+                    except Exception:
+                        pass
 
             if agent is None:
                 # Config changed or first message — create fresh agent


### PR DESCRIPTION
## Problem

The gateway can fully deadlock — port open but every request hangs, process pinned at ~100% CPU — and only a kill+restart recovers it.

Root cause is in the per-message run path. On a **cross-process cache invalidation** (`message_count changed … possible cross-process write`), the code pops the stale cached agent and then calls the **full** `_cleanup_agent_resources()` **synchronously while holding `_agent_cache_lock`**:

```python
with _cache_lock:
    ...
    if _ev_agent and _ev_agent is not _AGENT_PENDING_SENTINEL:
        self._cleanup_agent_resources(_ev_agent)   # memory shutdown + agent.close(): sockets, sandboxes, MCP…
```

`_cleanup_agent_resources()` does `agent.close()` — terminal sandboxes, browser daemons, background processes, httpx clients — plus memory-provider shutdown and MCP teardown. If any of that blocks (a slow/hung socket or sandbox close), `_agent_cache_lock` is **never released**. Because every session acquires `_agent_cache_lock` on every turn, the next acquire freezes the single asyncio event loop and the entire gateway stops serving — all platforms, the health/API port included.

This is the exact hazard the surrounding code already designs around. `_evict_cached_agent` and `_enforce_agent_cache_cap` deliberately offload cleanup to daemon threads, documented as:

> Cleanup runs on a daemon thread so we never block holding `_agent_cache_lock` on slow socket teardown.

The cross-process-invalidation branch was the one place that ran teardown inline under the lock.

## Fix

Under the lock, only `pop()` the stale entry; run the teardown **after** the lock is released, on a daemon thread (with an inline best-effort fallback for interpreter shutdown) — mirroring `_evict_cached_agent` / `_enforce_agent_cache_cap`. A hung teardown can now at worst leak one evicted agent's resources in the background instead of deadlocking the whole event loop.

No behavior change otherwise: same teardown (`_cleanup_agent_resources`, full hard close, as before), just off the lock.

## Notes

- Diagnosed from a live freeze: a stack sample showed the event-loop thread blocked in `lock.acquire()` inside an asyncio task, with the logs showing repeated `possible cross-process write` invalidations immediately prior.
- +37 / −1, isolated to `gateway/run.py`.
