### PR TITLE
fix(cli): detect incomplete Baileys install in hermes whatsapp setup

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2564,7 +2564,42 @@ def cmd_whatsapp(args):
             return
         print("  ✓ Dependencies installed")
     else:
-        print("✓ Bridge dependencies already installed")
+        # Verify the critical Baileys package is actually populated.
+        # A prior failed or interrupted npm install can leave node_modules/
+        # present but @whiskeysockets/baileys empty, causing the bridge to
+        # crash with ERR_MODULE_NOT_FOUND at startup (#52713).
+        _baileys_pkg = bridge_dir / "node_modules" / "@whiskeysockets" / "baileys" / "package.json"
+        if not _baileys_pkg.exists():
+            print("\n→ WhatsApp bridge packages appear incomplete — reinstalling...")
+            import shutil
+            shutil.rmtree(bridge_dir / "node_modules", ignore_errors=True)
+            npm = find_node_executable("npm")
+            if not npm:
+                print("  ✗ npm not found on PATH — install Node.js first")
+                return
+            try:
+                result = subprocess.run(
+                    [npm, "install", "--no-fund", "--no-audit", "--progress=false"],
+                    cwd=str(bridge_dir),
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    env=with_hermes_node_path(),
+                )
+            except KeyboardInterrupt:
+                print("\n  ✗ Install cancelled")
+                return
+            if result.returncode != 0:
+                err = (result.stderr or "").strip()
+                preview = "\n".join(err.splitlines()[-30:]) if err else "(no output)"
+                print("  ✗ npm reinstall failed:")
+                print(preview)
+                return
+            print("  ✓ Dependencies reinstalled")
+        else:
+            print("✓ Bridge dependencies already installed")
 
     # ── Step 5: Check for existing session ───────────────────────────────
     session_dir = get_hermes_home() / "whatsapp" / "session"

--- a/tests/hermes_cli/test_whatsapp_baileys_module_check.py
+++ b/tests/hermes_cli/test_whatsapp_baileys_module_check.py
@@ -1,0 +1,143 @@
+"""Tests for incomplete Baileys package detection during ``hermes whatsapp``.
+
+Regression coverage for #52713: a prior failed or interrupted ``npm install``
+can leave ``node_modules/`` present but ``@whiskeysockets/baileys`` empty,
+causing the bridge to crash with ``ERR_MODULE_NOT_FOUND`` at startup.  The
+CLI must detect this and trigger a reinstall instead of printing
+"✓ Bridge dependencies already installed" and proceeding.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def bridge_env(tmp_path, monkeypatch):
+    """Set up a fake bridge directory with bridge.js and package.json."""
+    home = tmp_path / "home"
+    hermes = home / ".hermes"
+    hermes.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes))
+    for key in list(os.environ):
+        if key.startswith("WHATSAPP_"):
+            monkeypatch.delenv(key, raising=False)
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    (bridge_dir / "bridge.js").write_text("// bridge\n")
+    (bridge_dir / "package.json").write_text(
+        '{"dependencies": {"@whiskeysockets/baileys": "git+ssh://test"}}\n'
+    )
+    return bridge_dir
+
+
+def _patch_cmd_deps(bridge_dir, monkeypatch, npm_calls=None):
+    """Stub all external dependencies for cmd_whatsapp."""
+    if npm_calls is None:
+        npm_calls = []
+
+    import gateway.platforms.whatsapp_common as wa_common
+    monkeypatch.setattr(wa_common, "resolve_whatsapp_bridge_dir", lambda: bridge_dir)
+
+    def fake_subprocess_run(cmd, **kwargs):
+        npm_calls.append(cmd)
+        cwd = kwargs.get("cwd", "")
+        if "npm" in str(cmd) and str(bridge_dir) in str(cwd):
+            baileys_dir = bridge_dir / "node_modules" / "@whiskeysockets" / "baileys"
+            baileys_dir.mkdir(parents=True, exist_ok=True)
+            (baileys_dir / "package.json").write_text("{}")
+        return MagicMock(returncode=0, stderr="", stdout="")
+
+    monkeypatch.setattr("subprocess.run", fake_subprocess_run)
+
+    import hermes_constants
+    monkeypatch.setattr(hermes_constants, "find_node_executable", lambda _n: "/usr/bin/npm")
+    monkeypatch.setattr(hermes_constants, "with_hermes_node_path", lambda: os.environ.copy())
+
+
+def _run_cmd_whatsapp(monkeypatch):
+    """Run cmd_whatsapp with enough inputs to reach the dependency step."""
+    from hermes_cli.main import cmd_whatsapp
+
+    # Provide inputs for: mode choice, allowed users, phone number, session prompts
+    inputs = iter(["1", "15551234567", "n"])
+
+    def fake_input(_prompt=""):
+        try:
+            return next(inputs)
+        except StopIteration:
+            return "n"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    monkeypatch.setattr("hermes_cli.main._require_tty", lambda *_a, **_kw: None)
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        try:
+            cmd_whatsapp(MagicMock())
+        except (KeyboardInterrupt, StopIteration):
+            pass
+
+    return buf.getvalue()
+
+
+def test_incomplete_baileys_triggers_reinstall(bridge_env, monkeypatch):
+    """When node_modules exists but Baileys package.json is missing, reinstall."""
+    bridge_dir = bridge_env
+    node_modules = bridge_dir / "node_modules"
+    node_modules.mkdir()
+    (node_modules / "@whiskeysockets").mkdir(parents=True)
+    # Empty baileys dir — no package.json
+
+    npm_calls = []
+    _patch_cmd_deps(bridge_dir, monkeypatch, npm_calls)
+
+    output = _run_cmd_whatsapp(monkeypatch)
+    assert "incomplete" in output.lower() or "reinstall" in output.lower(), (
+        f"Expected reinstall message but got: {output}"
+    )
+    assert len(npm_calls) >= 1, "Expected npm install to be called"
+
+
+def test_valid_baileys_skips_reinstall(bridge_env, monkeypatch):
+    """When node_modules and Baileys package.json both exist, skip install."""
+    bridge_dir = bridge_env
+    node_modules = bridge_dir / "node_modules"
+    node_modules.mkdir()
+    baileys_dir = node_modules / "@whiskeysockets" / "baileys"
+    baileys_dir.mkdir(parents=True)
+    (baileys_dir / "package.json").write_text("{}")
+
+    npm_calls = []
+    _patch_cmd_deps(bridge_dir, monkeypatch, npm_calls)
+
+    output = _run_cmd_whatsapp(monkeypatch)
+    assert "already installed" in output, (
+        f"Expected 'already installed' but got: {output}"
+    )
+    # Filter out bridge.js calls — only check for npm install calls
+    npm_install_calls = [c for c in npm_calls if "npm" in str(c) and "bridge.js" not in str(c)]
+    assert len(npm_install_calls) == 0, "npm install should not have been called"
+
+
+def test_missing_node_modules_installs_normally(bridge_env, monkeypatch):
+    """When node_modules is entirely absent, install from scratch."""
+    bridge_dir = bridge_env
+    # No node_modules at all
+
+    npm_calls = []
+    _patch_cmd_deps(bridge_dir, monkeypatch, npm_calls)
+
+    output = _run_cmd_whatsapp(monkeypatch)
+    assert "Installing" in output or "Dependencies" in output, (
+        f"Expected install message but got: {output}"
+    )
+    assert len(npm_calls) >= 1, "Expected npm install to be called"


### PR DESCRIPTION
## What does this PR do?

Fixes the `ERR_MODULE_NOT_FOUND` crash during `hermes whatsapp` setup when a prior failed or interrupted `npm install` leaves `node_modules/` present but `@whiskeysockets/baileys` empty. The CLI now verifies the critical Baileys package is actually populated before declaring "Bridge dependencies already installed" and triggers a clean reinstall if it's missing.

## Related Issue

Fixes #52713

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: After the `node_modules` directory existence check, verify that `node_modules/@whiskeysockets/baileys/package.json` exists. If missing, clear the incomplete `node_modules/` and run `npm install` fresh. This prevents the bridge from crashing with `ERR_MODULE_NOT_FOUND` at startup.
- `tests/hermes_cli/test_whatsapp_baileys_module_check.py`: 3 regression tests covering incomplete Baileys detection, valid installation skip, and fresh install from scratch.

## How to Test

1. Run `hermes whatsapp` with a clean state — should install dependencies normally.
2. Manually break the install: `rm -rf ~/.hermes/scripts/whatsapp-bridge/node_modules/@whiskeysockets/baileys`
3. Run `hermes whatsapp` again — should detect incomplete packages and reinstall instead of crashing.
4. Run `pytest tests/hermes_cli/test_whatsapp_baileys_module_check.py -v` — all 3 tests should pass.
5. Run `pytest tests/hermes_cli/test_whatsapp* tests/gateway/test_whatsapp* -v` — all existing WhatsApp tests should still pass (275 tests).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
