### PR TITLE
Add aliases frontmatter support for skill slash commands

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -27,6 +27,33 @@ _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
 
 # ---------------------------------------------------------------------------
+# Core command name set -- built once from COMMAND_REGISTRY on first access.
+# Used to prevent skill aliases from colliding with built-in Hermes commands.
+# ---------------------------------------------------------------------------
+_core_command_names: Optional[set] = None
+
+
+def _get_core_command_names() -> set:
+    """Return the set of all built-in command names and aliases (no leading /).
+
+    Built once from ``COMMAND_REGISTRY`` and cached for the lifetime of the
+    process.  Aliases shadowing core commands are silently skipped.
+    """
+    global _core_command_names
+    if _core_command_names is not None:
+        return _core_command_names
+    try:
+        from hermes_cli.commands import COMMAND_REGISTRY
+        names: set = set()
+        for cmd in COMMAND_REGISTRY:
+            names.add(cmd.name)
+            names.update(cmd.aliases)
+        _core_command_names = names
+    except Exception:
+        _core_command_names = set()
+    return _core_command_names
+
+# ---------------------------------------------------------------------------
 # Skill-scaffolding markers and the canonical extractor.
 #
 # When a user invokes a /skill (or /bundle), Hermes expands the turn into a
@@ -408,6 +435,41 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                         "skill_md_path": str(skill_md),
                         "skill_dir": str(skill_md.parent),
                     }
+
+                    # ── Register aliases ──
+                    aliases = frontmatter.get('aliases', [])
+                    if isinstance(aliases, list):
+                        core_names = _get_core_command_names()
+                        for alias in aliases:
+                            if not isinstance(alias, str) or not alias.strip():
+                                continue
+                            # Normalize alias the same way as the main name
+                            alias_cmd = alias.lower().replace(' ', '-').replace('_', '-')
+                            alias_cmd = _SKILL_INVALID_CHARS.sub('', alias_cmd)
+                            alias_cmd = _SKILL_MULTI_HYPHEN.sub('-', alias_cmd).strip('-')
+                            if not alias_cmd:
+                                continue
+                            # Skip if it collides with a core command
+                            if alias_cmd in core_names:
+                                logger.warning(
+                                    "Skill '%s' alias '/%s' collides with a core Hermes command. Skipping.",
+                                    name, alias_cmd,
+                                )
+                                continue
+                            # Skip if another skill (or alias) already claimed this command name
+                            alias_key = f"/{alias_cmd}"
+                            if alias_key in _skill_commands:
+                                logger.warning(
+                                    "Skill '%s' alias '/%s' collides with existing command from '%s'. Skipping.",
+                                    name, alias_cmd, _skill_commands[alias_key]['name'],
+                                )
+                                continue
+                            _skill_commands[alias_key] = {
+                                "name": name,
+                                "description": f"{description or f'Invoke the {name} skill'} (alias for /{cmd_name})",
+                                "skill_md_path": str(skill_md),
+                                "skill_dir": str(skill_md.parent),
+                            }
                 except Exception:
                     continue
     except Exception:

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -429,6 +429,16 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
                     if not cmd_name:
                         continue
+                    # Check main-command collision against core commands *before*
+                    # aliases so we don't waste time processing aliases for a
+                    # skill whose primary identity is already invalid.
+                    core_names = _get_core_command_names()
+                    if cmd_name in core_names:
+                        logger.warning(
+                            "Skill '%s' command '/%s' collides with a core Hermes command. Skipping.",
+                            name, cmd_name,
+                        )
+                        continue
                     _skill_commands[f"/{cmd_name}"] = {
                         "name": name,
                         "description": description or f"Invoke the {name} skill",
@@ -439,7 +449,6 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     # ── Register aliases ──
                     aliases = frontmatter.get('aliases', [])
                     if isinstance(aliases, list):
-                        core_names = _get_core_command_names()
                         for alias in aliases:
                             if not isinstance(alias, str) or not alias.strip():
                                 continue

--- a/tests/agent/test_skill_aliases.py
+++ b/tests/agent/test_skill_aliases.py
@@ -82,6 +82,28 @@ class TestSkillAliases:
             "my-skill", bad_alias,
         )
 
+    def test_main_command_collision_with_core_skips_entire_skill(self, tmp_path):
+        """A skill whose main name normalizes to a core command is skipped entirely."""
+        core_names = _get_core_command_names()
+        assert "new" in core_names, "Expected 'new' to be a core command"
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            # Skill named "new" — main command collides with core
+            _make_skill(tmp_path, "new",
+                        extra_frontmatter="aliases: [new-skill]\\n")
+            with patch("agent.skill_commands.logger") as mock_logger:
+                result = scan_skill_commands()
+
+        # Neither the main command nor aliases should be registered
+        assert "/new" not in result
+        assert "/new-skill" not in result
+        assert len(result) == 0
+        # Warning should be about the main command collision, not alias
+        mock_logger.warning.assert_any_call(
+            "Skill '%s' command '/%s' collides with a core Hermes command. Skipping.",
+            "new", "new",
+        )
+
     def test_alias_collision_with_other_skill_skipped(self, tmp_path):
         """Two skills claiming the same alias: second is skipped with warning."""
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):

--- a/tests/agent/test_skill_aliases.py
+++ b/tests/agent/test_skill_aliases.py
@@ -1,0 +1,128 @@
+"""Tests for skill alias registration in agent/skill_commands.py."""
+
+from unittest.mock import patch
+
+import pytest
+
+from agent.skill_commands import scan_skill_commands, _get_core_command_names
+
+
+def _make_skill(skills_dir, name, description="Description for skill.", body="Do the thing.", extra_frontmatter=""):
+    """Helper to create a minimal skill directory with SKILL.md."""
+    import re as _re
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    content = f"""\
+---
+name: {name}
+description: {description}
+{extra_frontmatter}---
+# {name}
+
+{body}
+"""
+    (skill_dir / "SKILL.md").write_text(content)
+    return skill_dir
+
+
+class TestSkillAliases:
+    def test_alias_registers_additional_slash_command(self, tmp_path):
+        """A SKILL.md with aliases: [pho] registers both /project-handoff and /pho."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "project-handoff",
+                        extra_frontmatter="aliases: [pho]\n")
+            result = scan_skill_commands()
+
+        assert "/project-handoff" in result
+        assert "/pho" in result
+        # Both entries point to the same skill info
+        for key in ("name", "skill_md_path", "skill_dir"):
+            assert result["/project-handoff"][key] == result["/pho"][key]
+
+    def test_multiple_aliases_all_registered(self, tmp_path):
+        """Multiple aliases (pho, po) all register and point to the same skill."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "project-handoff",
+                        extra_frontmatter="aliases: [pho, po]\n")
+            result = scan_skill_commands()
+
+        assert "/project-handoff" in result
+        assert "/pho" in result
+        assert "/po" in result
+        for alias in ("/pho", "/po"):
+            assert result[alias]["name"] == result["/project-handoff"]["name"]
+
+    def test_empty_aliases_list_no_extra_entries(self, tmp_path):
+        """aliases: [] — no extra entries registered beyond the main command."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "my-skill",
+                        extra_frontmatter="aliases: []\n")
+            result = scan_skill_commands()
+
+        assert "/my-skill" in result
+        assert len(result) == 1
+
+    def test_alias_collision_with_core_command_skipped(self, tmp_path):
+        """An alias that collides with a built-in command is skipped with warning."""
+        core_names = _get_core_command_names()
+        # Pick a real core command that's not normally a skill name
+        bad_alias = "new"  # /new is a built-in command
+        assert bad_alias in core_names, f"Expected '{bad_alias}' to be a core command"
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "my-skill",
+                        extra_frontmatter=f"aliases: [{bad_alias}]\n")
+            with patch("agent.skill_commands.logger") as mock_logger:
+                result = scan_skill_commands()
+
+        assert "/my-skill" in result
+        assert f"/{bad_alias}" not in result
+        mock_logger.warning.assert_any_call(
+            "Skill '%s' alias '/%s' collides with a core Hermes command. Skipping.",
+            "my-skill", bad_alias,
+        )
+
+    def test_alias_collision_with_other_skill_skipped(self, tmp_path):
+        """Two skills claiming the same alias: second is skipped with warning."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "skill-one",
+                        extra_frontmatter="aliases: [shared]\n")
+            _make_skill(tmp_path, "skill-two",
+                        extra_frontmatter="aliases: [shared]\n")
+
+            with patch("agent.skill_commands.logger") as mock_logger:
+                result = scan_skill_commands()
+
+        assert "/skill-one" in result
+        assert "/skill-two" in result
+        assert "/shared" in result
+        # The alias belongs to whichever skill scanned first
+        assert result["/shared"]["name"] in ("skill-one", "skill-two")
+        mock_logger.warning.assert_any_call(
+            "Skill '%s' alias '/%s' collides with existing command from '%s'. Skipping.",
+            "skill-two", "shared", "skill-one",
+        )
+
+    def test_invalid_alias_entries_silently_skipped(self, tmp_path):
+        """None, empty string, and non-string entries in the aliases list are skipped."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "my-skill",
+                        extra_frontmatter="aliases: [valid, '', !!null, 42]\n")
+            result = scan_skill_commands()
+
+        assert "/my-skill" in result
+        assert "/valid" in result
+        # empty string, null, and integer entries should not create commands
+        assert "/" not in result
+        # 42 is not a string — skipped silently
+        assert "/42" not in result
+
+    def test_alias_description_includes_alias_note(self, tmp_path):
+        """Alias entries describe themselves as aliases for the main command."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "project-handoff",
+                        extra_frontmatter="aliases: [pho]\n")
+            result = scan_skill_commands()
+
+        assert "alias" in result["/pho"]["description"].lower()
+        assert "/project-handoff" in result["/pho"]["description"]

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -53,6 +53,9 @@ license: MIT
 platforms: [macos, linux]          # Optional — restrict to specific OS platforms
                                    #   Valid: macos, linux, windows
                                    #   Omit to load on all platforms (default)
+aliases: [pho]                     # Optional — alternate slash command names
+                                   #   Normalized like skill names (lowercase, hyphens)
+                                   #   Collisions with built-in commands are skipped
 metadata:
   hermes:
     tags: [Category, Subcategory, Keywords]


### PR DESCRIPTION
## What does this PR do?

Skills with an aliases: frontmatter field can now register alternate slash command names (e.g., aliases: [pho] lets /pho invoke the same skill as /project-handoff). Also added a safety check so a skill whose main name collides with a core command (e.g., a skill named new) is skipped entirely rather than shadowing the built-in.

## Related Issue

https://github.com/NousResearch/hermes-agent/issues/31373

# Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- agent/skill_commands.py — _get_core_command_names() helper (built from COMMAND_REGISTRY), alias registration loop in scan_skill_commands(), main-command collision check

- tests/agent/test_skill_aliases.py — 8 tests: alias registration, multi-alias, empty list, core collision (alias + main name), skill collision, invalid entries, alias description

- website/docs/developer-guide/creating-skills.md — documented aliases: frontmatter field

## How to Test

1. Automated: scripts/run_tests.sh tests/agent/test_skill_aliases.py tests/agent/test_skill_commands.py

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on: Debian GNU/Linux 13 (trixie) 

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — updated website/docs/developer-guide/creating-skills.md with aliases: frontmatter field
- [x] I've updated cli-config.yaml.example if I added/changed config keys — N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A, pure Python logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
