### PR TITLE
feat: support provider lockdown in model picker

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1151,6 +1151,7 @@ class GatewaySlashCommandsMixin:
         current_api_key = ""
         user_provs = None
         custom_provs = None
+        provider_lockdown = False
         config_path = _hermes_home / "config.yaml"
         try:
             cfg = _load_gateway_config()
@@ -1160,6 +1161,7 @@ class GatewaySlashCommandsMixin:
                     current_model = model_cfg.get("default", "")
                     current_provider = model_cfg.get("provider", current_provider)
                     current_base_url = model_cfg.get("base_url", "")
+                    provider_lockdown = bool(model_cfg.get("provider_lockdown", False))
                 user_provs = cfg.get("providers")
                 try:
                     from hermes_cli.config import get_compatible_custom_providers
@@ -1206,6 +1208,7 @@ class GatewaySlashCommandsMixin:
                         user_providers=user_provs,
                         custom_providers=custom_provs,
                         max_models=50,
+                        provider_lockdown=provider_lockdown,
                     )
                 except Exception:
                     providers = []

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2239,6 +2239,7 @@ def list_picker_providers(
     custom_providers: list | None = None,
     max_models: int | None = None,
     current_model: str = "",
+    provider_lockdown: bool = False,
 ) -> List[dict]:
     """Interactive-picker variant of :func:`list_authenticated_providers`.
 
@@ -2269,6 +2270,17 @@ def list_picker_providers(
         max_models=max_models,
         current_model=current_model,
     )
+
+    if provider_lockdown:
+        current_slug = current_provider.strip().lower()
+        house_slug = "replabs"
+        providers = [
+            p for p in providers
+            if (
+                str(p.get("slug", "")).strip().lower() in {current_slug, house_slug}
+                or str(p.get("source", "")).strip().lower() in {"hermes", "user-config"}
+            )
+        ]
 
     filtered: List[dict] = []
     for p in providers:

--- a/tests/gateway/test_model_command_async_offload.py
+++ b/tests/gateway/test_model_command_async_offload.py
@@ -80,6 +80,15 @@ def _isolated_config(tmp_path, monkeypatch):
     return hermes_home
 
 
+@pytest.fixture
+def _lockdown_config(_isolated_config):
+    (_isolated_config / "config.yaml").write_text(
+        "model:\n  default: gpt-5.5\n  provider: openai-codex\n  provider_lockdown: true\nproviders:\n  replabs:\n    default_model: z-ai/glm-5.2\n",
+        encoding="utf-8",
+    )
+    return _isolated_config
+
+
 # --------------------------------------------------------------------------- #
 # Text-fallback path  ->  list_authenticated_providers
 # --------------------------------------------------------------------------- #
@@ -166,3 +175,30 @@ async def test_picker_path_offloads_list_picker_providers(_isolated_config, monk
         "list_picker_providers must be dispatched via asyncio.to_thread "
         "(it was called inline on the event loop instead)"
     )
+
+
+@pytest.mark.asyncio
+async def test_picker_path_passes_provider_lockdown_from_model_config(_lockdown_config, monkeypatch):
+    captured = {}
+    fake_providers = [{"slug": "replabs", "name": "RepLabs", "models": ["z-ai/glm-5.2"], "total_models": 1}]
+
+    def _fake_list_picker_providers(**kwargs):
+        captured.update(kwargs)
+        return fake_providers
+
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_picker_providers",
+        _fake_list_picker_providers,
+    )
+
+    runner = _make_runner()
+    runner.adapters = {Platform.TELEGRAM: _FakePickerAdapter()}
+    monkeypatch.setattr(runner, "_thread_metadata_for_source", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(runner, "_reply_anchor_for_event", lambda *a, **k: None, raising=False)
+
+    result = await runner._handle_model_command(_make_event())
+
+    assert result is None
+    assert captured["provider_lockdown"] is True
+    assert captured["current_provider"] == "openai-codex"
+    assert captured["current_model"] == "gpt-5.5"

--- a/tests/hermes_cli/test_provider_lockdown_picker.py
+++ b/tests/hermes_cli/test_provider_lockdown_picker.py
@@ -1,0 +1,36 @@
+from hermes_cli import model_switch
+
+
+def test_list_picker_providers_lockdown_keeps_replabs_current_and_user_owned(monkeypatch):
+    providers = [
+        {"slug": "openrouter", "source": "built-in", "models": ["a"], "total_models": 1},
+        {"slug": "replabs", "source": "user-config", "models": ["z-ai/glm-5.2"], "total_models": 1},
+        {"slug": "openai-codex", "source": "hermes", "models": ["gpt-5.5"], "total_models": 1},
+        {"slug": "custom-local", "source": "user-config", "models": ["local"], "total_models": 1},
+        {"slug": "anthropic", "source": "built-in", "models": ["claude"], "total_models": 1},
+    ]
+
+    monkeypatch.setattr(model_switch, "list_authenticated_providers", lambda **_: providers)
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models", lambda: [("a", "A")])
+
+    out = model_switch.list_picker_providers(
+        current_provider="openai-codex",
+        current_model="gpt-5.5",
+        provider_lockdown=True,
+    )
+
+    assert [p["slug"] for p in out] == ["replabs", "openai-codex", "custom-local"]
+
+
+def test_list_picker_providers_without_lockdown_keeps_catalog(monkeypatch):
+    providers = [
+        {"slug": "openrouter", "source": "built-in", "models": ["a"], "total_models": 1},
+        {"slug": "anthropic", "source": "built-in", "models": ["claude"], "total_models": 1},
+    ]
+
+    monkeypatch.setattr(model_switch, "list_authenticated_providers", lambda **_: providers)
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models", lambda: [("a", "A")])
+
+    out = model_switch.list_picker_providers(provider_lockdown=False)
+
+    assert [p["slug"] for p in out] == ["openrouter", "anthropic"]


### PR DESCRIPTION
## Summary

Adds native support for `model.provider_lockdown` in the interactive `/model` picker.

When `provider_lockdown=True`, `list_picker_providers()` keeps only:

- the current provider,
- the `replabs` house-provider row,
- user-owned/authenticated providers (`source in {"hermes", "user-config"}`).

The gateway reads `model.provider_lockdown` from config and passes it into the picker path.

## Why

Hosted RepLabs Revs run stock Hermes plus one injected `providers.replabs` row. The platform needs `/model` to show the house model plus the user's own providers, while hiding the platform/internal OpenRouter catalog.

## Verification

```bash
uv run --no-sync python -m pytest tests/hermes_cli/test_provider_lockdown_picker.py tests/gateway/test_model_command_async_offload.py -q
# 5 passed

uv run --no-sync ruff check hermes_cli/model_switch.py gateway/slash_commands.py tests/hermes_cli/test_provider_lockdown_picker.py tests/gateway/test_model_command_async_offload.py
# All checks passed!
```
