### PR TITLE
feat(moa): add preset reference context controls

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -828,6 +828,7 @@ def run_conversation(
                     temperature=float(moa_config.get("reference_temperature", 0.6) or 0.6),
                     aggregator_temperature=float(moa_config.get("aggregator_temperature", 0.4) or 0.4),
                     max_tokens=int(moa_config.get("max_tokens", 4096) or 4096),
+                    reference_context=moa_config.get("reference_context"),
                 )
                 if _moa_context:
                     for _msg in reversed(api_messages):

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -9,7 +9,9 @@ iteration.
 from __future__ import annotations
 
 import logging
+import os
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 from typing import Any
 
 from agent.auxiliary_client import call_llm
@@ -106,22 +108,116 @@ def _run_references_parallel(
     return [r for r in results if r is not None]
 
 
-def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _selected_context_file_sections(
+    reference_context: dict[str, Any],
+    *,
+    cwd: str | None = None,
+    context_length: int | None = None,
+) -> str:
+    """Load opt-in context files for MoA reference calls.
+
+    This is deliberately selected-only: the default reference path stays cheap
+    and advisory-safe, while power-user presets can provide persona/project
+    context such as SOUL.md or AGENTS.md to reference models.
+    """
+    files_cfg = reference_context.get("files") if isinstance(reference_context, dict) else {}
+    if not isinstance(files_cfg, dict) or not files_cfg.get("enabled"):
+        return ""
+    names = files_cfg.get("names") or []
+    if not isinstance(names, list) or not names:
+        return ""
+
+    try:
+        from agent import prompt_builder
+    except Exception as exc:
+        logger.debug("Could not import prompt_builder for MoA reference context: %s", exc)
+        return ""
+
+    if cwd is None:
+        try:
+            from agent.runtime_cwd import resolve_context_cwd
+
+            resolved = resolve_context_cwd()
+        except Exception as exc:
+            logger.debug("Could not resolve MoA reference context cwd: %s", exc)
+            resolved = None
+        cwd_path = (resolved or Path(os.getcwd())).resolve()
+    else:
+        cwd_path = Path(cwd).expanduser().resolve()
+    sections: list[str] = []
+    for name in names:
+        try:
+            if name == "SOUL.md":
+                content = prompt_builder.load_soul_md(context_length=context_length)
+                if content:
+                    sections.append(f"## SOUL.md\n\n{content}")
+            elif name in {"AGENTS.md", "agents.md"}:
+                content = prompt_builder._load_agents_md(cwd_path, context_length)  # noqa: SLF001
+                if content:
+                    sections.append(content)
+            elif name in {"CLAUDE.md", "claude.md"}:
+                content = prompt_builder._load_claude_md(cwd_path, context_length)  # noqa: SLF001
+                if content:
+                    sections.append(content)
+            elif name == ".cursorrules":
+                candidate = cwd_path / ".cursorrules"
+                if candidate.exists():
+                    content = candidate.read_text(encoding="utf-8").strip()
+                    if content:
+                        content = prompt_builder._scan_context_content(content, ".cursorrules")  # noqa: SLF001
+                        result = f"## .cursorrules\n\n{content}"
+                        sections.append(
+                            prompt_builder._truncate_content(  # noqa: SLF001
+                                result,
+                                ".cursorrules",
+                                context_length=context_length,
+                                read_path=str(candidate),
+                            )
+                        )
+            elif name in {".hermes.md", "HERMES.md"}:
+                content = prompt_builder._load_hermes_md(cwd_path, context_length)  # noqa: SLF001
+                if content:
+                    sections.append(content)
+        except Exception as exc:
+            logger.debug("Could not load MoA reference context file %s: %s", name, exc)
+
+    if not sections:
+        return ""
+    return (
+        "[Mixture of Agents selected reference context files]\n"
+        "These files were explicitly enabled by the MoA preset for advisory reference models.\n\n"
+        + "\n\n".join(sections)
+    )
+
+
+def _reference_messages(
+    messages: list[dict[str, Any]],
+    *,
+    reference_context: dict[str, Any] | None = None,
+    cwd: str | None = None,
+    context_length: int | None = None,
+) -> list[dict[str, Any]]:
     """Build an advisory-safe view of the conversation for reference models.
 
     Reference calls are advisory: they never call tools and never emit the
-    ``tool_calls`` the main model did. Replaying the full transcript verbatim
-    (a) re-bills the ~8K-token Hermes system prompt per reference per
-    iteration and (b) risks 400s from strict providers (Mistral, Fireworks)
-    that reject orphan ``tool`` messages or ``tool_calls`` the reference never
-    produced. We keep only the user/assistant *text* turns, dropping the
-    system prompt, any ``tool``-role messages, and any ``tool_calls`` payloads.
+    ``tool_calls`` the main model did. By default we keep only user/assistant
+    text, dropping the system prompt, any ``tool``-role messages, and any
+    ``tool_calls`` payloads. Presets may opt into selected system/context-file
+    guidance for persona/project-heavy agents.
     """
-    trimmed: list[dict[str, Any]] = []
+    reference_context = reference_context or {}
+    include_system = reference_context.get("system") == "full"
+    system_parts: list[str] = []
+    text_messages: list[dict[str, Any]] = []
+
     for msg in messages:
         role = msg.get("role")
+        if role == "system":
+            if include_system and isinstance(msg.get("content"), str) and msg["content"].strip():
+                system_parts.append(msg["content"])
+            continue
         if role not in ("user", "assistant"):
-            # Drop system prompt and tool-result messages.
+            # Drop tool-result messages and other non-advisory roles.
             continue
         content = msg.get("content")
         if not isinstance(content, str):
@@ -132,13 +228,28 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         if role == "assistant" and not text.strip():
             # Assistant turn that was purely tool calls — nothing advisory.
             continue
-        trimmed.append({"role": role, "content": text})
-    if not trimmed:
+        text_messages.append({"role": role, "content": text})
+
+    context_block = _selected_context_file_sections(
+        reference_context,
+        cwd=cwd,
+        context_length=context_length,
+    )
+    if context_block:
+        system_parts.append(context_block)
+
+    system_messages = (
+        [{"role": "system", "content": "\n\n".join(system_parts)}]
+        if system_parts
+        else []
+    )
+    trimmed = system_messages + text_messages
+    if not text_messages:
         # Degenerate case (e.g. first turn was stripped): fall back to a
         # minimal user turn so the reference still has something to answer.
         for msg in reversed(messages):
             if msg.get("role") == "user" and isinstance(msg.get("content"), str):
-                return [{"role": "user", "content": msg["content"]}]
+                return system_messages + [{"role": "user", "content": msg["content"]}]
     return trimmed
 
 
@@ -170,14 +281,21 @@ def aggregate_moa_context(
     temperature: float = 0.6,
     aggregator_temperature: float = 0.4,
     max_tokens: int = 4096,
+    reference_context: dict[str, Any] | None = None,
 ) -> str:
     """Run configured reference models and synthesize their advice.
 
     Failures are returned as model-specific notes instead of aborting the normal
     agent loop; the main model can still act with partial context.
     """
+    if not reference_models:
+        return ""
+
     reference_outputs: list[tuple[str, str]] = []
-    ref_messages = _reference_messages(api_messages)
+    ref_messages = _reference_messages(
+        api_messages,
+        reference_context=reference_context,
+    )
     reference_outputs = _run_references_parallel(
         reference_models,
         ref_messages,
@@ -252,13 +370,17 @@ class MoAChatCompletions:
             reference_models = []
 
         reference_outputs: list[tuple[str, str]] = []
-        ref_messages = _reference_messages(messages)
-        reference_outputs = _run_references_parallel(
-            reference_models,
-            ref_messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-        )
+        if reference_models:
+            ref_messages = _reference_messages(
+                messages,
+                reference_context=preset.get("reference_context"),
+            )
+            reference_outputs = _run_references_parallel(
+                reference_models,
+                ref_messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
 
         agg_messages = [dict(m) for m in messages]
         if reference_outputs:

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -730,6 +730,14 @@ export interface MoaModelSlot {
   model: string
 }
 
+export interface MoaReferenceContext {
+  system: 'none' | 'full'
+  files: {
+    enabled: boolean
+    names: string[]
+  }
+}
+
 export interface MoaConfigResponse {
   default_preset: string
   active_preset: string
@@ -738,6 +746,7 @@ export interface MoaConfigResponse {
     aggregator_temperature: number
     enabled: boolean
     max_tokens: number
+    reference_context: MoaReferenceContext
     reference_models: MoaModelSlot[]
     reference_temperature: number
   }>
@@ -745,6 +754,7 @@ export interface MoaConfigResponse {
   aggregator_temperature: number
   enabled: boolean
   max_tokens: number
+  reference_context: MoaReferenceContext
   reference_models: MoaModelSlot[]
   reference_temperature: number
 }

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -20,6 +20,22 @@ DEFAULT_MOA_AGGREGATOR: dict[str, str] = {
     "model": "anthropic/claude-opus-4.8",
 }
 
+DEFAULT_MOA_REFERENCE_CONTEXT: dict[str, Any] = {
+    "system": "none",
+    "files": {"enabled": False, "names": []},
+}
+
+_ALLOWED_REFERENCE_CONTEXT_FILES = {
+    ".cursorrules",
+    ".hermes.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "HERMES.md",
+    "SOUL.md",
+    "agents.md",
+    "claude.md",
+}
+
 
 def _clean_slot(slot: Any) -> dict[str, str] | None:
     if not isinstance(slot, dict):
@@ -31,6 +47,49 @@ def _clean_slot(slot: Any) -> dict[str, str] | None:
     return {"provider": provider, "model": model}
 
 
+def _clean_reference_context(raw: Any) -> dict[str, Any]:
+    """Return a safe, bounded reference-context strategy for one MoA preset."""
+    if not isinstance(raw, dict):
+        raw = {}
+
+    system = str(raw.get("system") or DEFAULT_MOA_REFERENCE_CONTEXT["system"]).strip().lower()
+    if system not in {"none", "full"}:
+        system = DEFAULT_MOA_REFERENCE_CONTEXT["system"]
+
+    files_raw = raw.get("files") if "files" in raw else raw.get("context_files")
+    enabled = False
+    auto_enable_from_names = False
+    raw_names: Any = []
+    if isinstance(files_raw, list):
+        enabled = True
+        auto_enable_from_names = True
+        raw_names = files_raw
+    elif isinstance(files_raw, dict):
+        enabled = bool(files_raw.get("enabled", False))
+        raw_names = files_raw.get("names") or files_raw.get("file_names") or []
+
+    names: list[str] = []
+    if isinstance(raw_names, (list, tuple)):
+        seen: set[str] = set()
+        for item in raw_names:
+            name = str(item or "").strip()
+            if (
+                not name
+                or "/" in name
+                or "\\" in name
+                or ".." in name
+                or name not in _ALLOWED_REFERENCE_CONTEXT_FILES
+                or name in seen
+            ):
+                continue
+            seen.add(name)
+            names.append(name)
+
+    if names and auto_enable_from_names:
+        enabled = True
+    return {"system": system, "files": {"enabled": enabled, "names": names}}
+
+
 def _default_preset() -> dict[str, Any]:
     return {
         "reference_models": deepcopy(DEFAULT_MOA_REFERENCE_MODELS),
@@ -39,6 +98,7 @@ def _default_preset() -> dict[str, Any]:
         "aggregator_temperature": 0.4,
         "max_tokens": 4096,
         "enabled": True,
+        "reference_context": deepcopy(DEFAULT_MOA_REFERENCE_CONTEXT),
     }
 
 
@@ -60,6 +120,7 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         "reference_temperature": float(raw.get("reference_temperature", 0.6) or 0.6),
         "aggregator_temperature": float(raw.get("aggregator_temperature", 0.4) or 0.4),
         "max_tokens": int(raw.get("max_tokens", 4096) or 4096),
+        "reference_context": _clean_reference_context(raw.get("reference_context")),
     }
 
 
@@ -106,6 +167,7 @@ def normalize_moa_config(raw: Any) -> dict[str, Any]:
         "aggregator_temperature": active["aggregator_temperature"],
         "max_tokens": active["max_tokens"],
         "enabled": active["enabled"],
+        "reference_context": deepcopy(active["reference_context"]),
     }
 
 
@@ -162,7 +224,13 @@ def decode_moa_turn(message: Any) -> tuple[str, dict[str, Any] | None]:
     except Exception:
         return message, None
     prompt = str(payload.get("prompt") or "")
-    return prompt, _normalize_preset(payload.get("config") or {})
+    preset = _normalize_preset(payload.get("config") or {})
+    # Hidden /moa markers are text payloads and can be spoofed by pasted or
+    # untrusted content. Do not let them elevate reference calls into sharing
+    # system prompts or local context files; config-selected MoA provider mode
+    # still supports reference_context through the normal trusted config path.
+    preset["reference_context"] = deepcopy(DEFAULT_MOA_REFERENCE_CONTEXT)
+    return prompt, preset
 
 
 def build_moa_turn_prompt(user_prompt: str, config: Any = None, preset: str | None = None) -> str:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -845,6 +845,7 @@ class MoaPresetPayload(BaseModel):
     aggregator_temperature: float = 0.4
     max_tokens: int = 4096
     enabled: bool = True
+    reference_context: dict[str, Any] = {}
 
 
 class MoaConfigPayload(BaseModel):
@@ -859,6 +860,7 @@ class MoaConfigPayload(BaseModel):
     aggregator_temperature: float = 0.4
     max_tokens: int = 4096
     enabled: bool = True
+    reference_context: dict[str, Any] = {}
     profile: Optional[str] = None
 
 
@@ -3867,6 +3869,7 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                             "aggregator_temperature": preset.aggregator_temperature,
                             "max_tokens": preset.max_tokens,
                             "enabled": preset.enabled,
+                            "reference_context": preset.reference_context,
                         }
                         for name, preset in body.presets.items()
                     },
@@ -3879,6 +3882,7 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                     "aggregator_temperature": body.aggregator_temperature,
                     "max_tokens": body.max_tokens,
                     "enabled": body.enabled,
+                    "reference_context": body.reference_context,
                 }
             normalized = normalize_moa_config(raw)
             cfg["moa"] = normalized

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -1,6 +1,7 @@
 from hermes_cli.moa_config import (
     DEFAULT_MOA_AGGREGATOR,
     DEFAULT_MOA_PRESET_NAME,
+    DEFAULT_MOA_REFERENCE_CONTEXT,
     DEFAULT_MOA_REFERENCE_MODELS,
     build_moa_turn_prompt,
     decode_moa_turn,
@@ -18,6 +19,80 @@ def test_normalize_moa_config_uses_default_named_preset():
     assert list(cfg["presets"]) == [DEFAULT_MOA_PRESET_NAME]
     assert cfg["reference_models"] == DEFAULT_MOA_REFERENCE_MODELS
     assert cfg["aggregator"] == DEFAULT_MOA_AGGREGATOR
+    assert cfg["reference_context"] == DEFAULT_MOA_REFERENCE_CONTEXT
+
+
+def test_normalize_moa_config_preserves_reference_context_per_preset():
+    cfg = normalize_moa_config(
+        {
+            "default_preset": "persona",
+            "presets": {
+                "persona": {
+                    "reference_models": [{"provider": "openai-codex", "model": "gpt-5.5"}],
+                    "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+                    "reference_context": {
+                        "system": "full",
+                        "files": {
+                            "enabled": True,
+                            "names": ["SOUL.md", "AGENTS.md", "SOUL.md", "../outside"],
+                        },
+                    },
+                }
+            },
+        }
+    )
+
+    assert cfg["reference_context"] == {
+        "system": "full",
+        "files": {"enabled": True, "names": ["SOUL.md", "AGENTS.md"]},
+    }
+    assert cfg["presets"]["persona"]["reference_context"] == cfg["reference_context"]
+
+
+
+
+def test_reference_context_dict_can_disable_preselected_files():
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "review": {
+                    "reference_context": {
+                        "system": "none",
+                        "files": {"enabled": False, "names": ["SOUL.md"]},
+                    },
+                }
+            }
+        }
+    )
+
+    assert cfg["presets"]["review"]["reference_context"] == {
+        "system": "none",
+        "files": {"enabled": False, "names": ["SOUL.md"]},
+    }
+
+
+def test_hidden_moa_turn_does_not_trust_reference_context_from_payload():
+    marker = build_moa_turn_prompt(
+        "review this",
+        {
+            "default_preset": "rich",
+            "presets": {
+                "rich": {
+                    "reference_context": {
+                        "system": "full",
+                        "files": {"enabled": True, "names": ["SOUL.md", "AGENTS.md"]},
+                    }
+                }
+            },
+        },
+        preset="rich",
+    )
+
+    decoded_prompt, cfg = decode_moa_turn(marker)
+
+    assert decoded_prompt == "review this"
+    assert cfg is not None
+    assert cfg["reference_context"] == DEFAULT_MOA_REFERENCE_CONTEXT
 
 
 def test_normalize_moa_config_preserves_named_presets():

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -414,6 +414,10 @@ class TestWebServerEndpoints:
             "aggregator_temperature": 0.4,
             "max_tokens": 4096,
             "enabled": True,
+            "reference_context": {
+                "system": "full",
+                "files": {"enabled": True, "names": ["SOUL.md", "AGENTS.md"]},
+            },
         }
 
         resp = self.client.put("/api/model/moa", json=payload)
@@ -422,6 +426,7 @@ class TestWebServerEndpoints:
         cfg = load_config()
         assert cfg["moa"]["reference_models"] == payload["reference_models"]
         assert cfg["moa"]["aggregator"] == payload["aggregator"]
+        assert cfg["moa"]["reference_context"] == payload["reference_context"]
 
     # ── GET /api/media (remote image display) ───────────────────────────
 

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -87,6 +87,101 @@ def test_reference_messages_strips_system_and_tool_history():
     ]
 
 
+def test_reference_messages_can_include_full_system_context():
+    from agent.moa_loop import _reference_messages
+
+    messages = [
+        {"role": "system", "content": "system instructions for references"},
+        {"role": "user", "content": "do the thing"},
+    ]
+
+    ref_messages = _reference_messages(
+        messages,
+        reference_context={"system": "full", "files": {"enabled": False, "names": []}},
+    )
+
+    assert ref_messages == [
+        {"role": "system", "content": "system instructions for references"},
+        {"role": "user", "content": "do the thing"},
+    ]
+
+
+def test_reference_messages_can_include_selected_context_files(monkeypatch, tmp_path):
+    from agent.moa_loop import _reference_messages
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "SOUL.md").write_text("Persona rules", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "AGENTS.md").write_text("Project workflow rules", encoding="utf-8")
+    (project / "CLAUDE.md").write_text("Not selected", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    ref_messages = _reference_messages(
+        [{"role": "user", "content": "review this"}],
+        reference_context={
+            "system": "none",
+            "files": {"enabled": True, "names": ["SOUL.md", "AGENTS.md"]},
+        },
+        cwd=str(project),
+    )
+
+    assert ref_messages[0]["role"] == "system"
+    assert "[Mixture of Agents selected reference context files]" in ref_messages[0]["content"]
+    assert "## SOUL.md" in ref_messages[0]["content"]
+    assert "Persona rules" in ref_messages[0]["content"]
+    assert "## AGENTS.md" in ref_messages[0]["content"]
+    assert "Project workflow rules" in ref_messages[0]["content"]
+    assert "Not selected" not in ref_messages[0]["content"]
+    assert ref_messages[-1] == {"role": "user", "content": "review this"}
+
+
+
+
+def test_reference_messages_use_runtime_context_cwd(monkeypatch, tmp_path):
+    from agent.moa_loop import _reference_messages
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "AGENTS.md").write_text("Runtime project workflow rules", encoding="utf-8")
+    monkeypatch.setenv("TERMINAL_CWD", str(project))
+
+    ref_messages = _reference_messages(
+        [{"role": "user", "content": "review this"}],
+        reference_context={
+            "system": "none",
+            "files": {"enabled": True, "names": ["AGENTS.md"]},
+        },
+    )
+
+    assert ref_messages[0]["role"] == "system"
+    assert "Runtime project workflow rules" in ref_messages[0]["content"]
+
+
+def test_reference_messages_cursorrules_is_exact_file_only(tmp_path):
+    from agent.moa_loop import _reference_messages
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".cursorrules").write_text("Exact cursor rules", encoding="utf-8")
+    extra = project / ".cursor" / "rules"
+    extra.mkdir(parents=True)
+    (extra / "extra.mdc").write_text("Extra cursor rule should not leak", encoding="utf-8")
+
+    ref_messages = _reference_messages(
+        [{"role": "user", "content": "review this"}],
+        reference_context={
+            "system": "none",
+            "files": {"enabled": True, "names": [".cursorrules"]},
+        },
+        cwd=str(project),
+    )
+
+    assert "Exact cursor rules" in ref_messages[0]["content"]
+    assert "Extra cursor rule should not leak" not in ref_messages[0]["content"]
+
+
 def test_moa_facade_references_get_trimmed_messages(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2074,6 +2074,14 @@ export interface MoaModelSlot {
   model: string;
 }
 
+export interface MoaReferenceContext {
+  system: "none" | "full";
+  files: {
+    enabled: boolean;
+    names: string[];
+  };
+}
+
 export interface MoaConfigResponse {
   default_preset: string;
   active_preset: string;
@@ -2084,6 +2092,7 @@ export interface MoaConfigResponse {
     aggregator_temperature: number;
     max_tokens: number;
     enabled: boolean;
+    reference_context: MoaReferenceContext;
   }>;
   reference_models: MoaModelSlot[];
   aggregator: MoaModelSlot;
@@ -2091,6 +2100,7 @@ export interface MoaConfigResponse {
   aggregator_temperature: number;
   max_tokens: number;
   enabled: boolean;
+  reference_context: MoaReferenceContext;
 }
 
 export interface ModelAssignmentRequest {

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -749,6 +749,7 @@ function MoaModelsModal({
       aggregator_temperature: draft.aggregator_temperature,
       max_tokens: draft.max_tokens,
       enabled: draft.enabled,
+      reference_context: draft.reference_context,
     };
     setDraft((prev) => ({
       ...prev,

--- a/website/docs/user-guide/features/mixture-of-agents.md
+++ b/website/docs/user-guide/features/mixture-of-agents.md
@@ -52,7 +52,7 @@ Preset matching is exact on purpose. Hermes does not fuzzy-match preset names, s
 For each main model call when provider `moa` is selected, Hermes:
 
 1. resolves the selected preset by name;
-2. runs the configured reference models without tool schemas (they receive only the conversation's user/assistant text — not the Hermes system prompt or tool-call transcript — so reference calls stay cheap and avoid strict-provider rejections);
+2. runs the configured reference models without tool schemas (by default they receive only the conversation's user/assistant text — not the Hermes system prompt or tool-call transcript — so reference calls stay cheap and avoid strict-provider rejections; presets can opt into selected `reference_context`);
 3. appends the reference outputs as private context for the aggregator;
 4. calls the configured aggregator with the normal Hermes tool schema;
 5. treats the aggregator response as the real model response;
@@ -89,6 +89,12 @@ moa:
       aggregator_temperature: 0.4
       max_tokens: 4096
       enabled: true
+      # Optional. Defaults keep reference calls cheap: no system prompt and no files.
+      reference_context:
+        system: none  # none | full
+        files:
+          enabled: false
+          names: []   # e.g. ["SOUL.md", "AGENTS.md", "CLAUDE.md", ".cursorrules"]
 ```
 
 Default preset:
@@ -110,6 +116,8 @@ hermes moa delete review
 
 - MoA is no longer listed under `hermes tools`; there is no `moa` toolset to enable.
 - Setting `enabled: false` on a preset disables the reference fan-out for that preset: the aggregator acts alone, exactly as if you selected it as a plain model. This is the per-preset off switch surfaced in the dashboard and desktop settings.
+- `reference_context` is per-preset and opt-in. Defaults preserve the cheap advisory path (`system: none`, files disabled). Use `system: full` only when reference models need the same system prompt as the acting model. Enable selected files when persona or project context materially affects advice; supported names are `SOUL.md`, `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, `.hermes.md`, and `HERMES.md`. Selecting `.cursorrules` loads that exact file only; `.cursor/rules/*.mdc` files are not included.
+- One-shot `/moa <prompt>` payload markers do not carry `reference_context`, because they are text markers that can be spoofed by pasted content. Select a MoA preset as the active model when you need reference models to receive opted-in system or file context.
 - A preset's aggregator cannot be another MoA preset. Recursive MoA trees are intentionally blocked.
 - Credential failures on one reference model do not abort the turn. Hermes includes the failure in the reference context and continues with whatever models returned.
 - MoA increases model-call count. A single model iteration can involve multiple reference calls plus the aggregator call.


### PR DESCRIPTION
## Summary
- Add per-preset `reference_context` settings for MoA reference models.
- Keep the default reference path unchanged: stripped user/assistant text only, no system prompt and no files.
- Allow opt-in presets to send the full system prompt and/or selected context files (`SOUL.md`, `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, `.hermes.md`, `HERMES.md`) to advisory reference calls.
- Preserve the new config through the web API plus dashboard/desktop TypeScript response shapes, and document the trade-offs.

## Safety/defaults
- Defaults remain cheap and privacy-preserving: `system: none`, files disabled.
- File names are allowlisted and path traversal is ignored.
- `files.enabled: false` remains authoritative even if names are retained.
- Hidden one-shot `/moa <prompt>` payload markers do not trust `reference_context`; select the MoA preset as the active model when opted-in system/file context is needed.
- `.cursorrules` selection loads that exact file only, not `.cursor/rules/*.mdc`.

## Test plan
- `python3 -m py_compile hermes_cli/moa_config.py agent/moa_loop.py agent/conversation_loop.py hermes_cli/web_server.py`
- `python3 -m pytest tests/hermes_cli/test_moa_config.py tests/run_agent/test_moa_loop_mode.py tests/cli/test_moa_command.py tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_moa_models_returns_provider_model_slots tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_put_moa_models_persists_provider_model_slots -q`
- `npm --workspace web run typecheck`
- `npm --workspace apps/desktop run typecheck`

Follow-up to #46081.