### PR TITLE
fix(usage): capture reasoning_tokens from completion_tokens_details (chat-completions usage)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -795,10 +795,31 @@ def normalize_usage(
             )
         input_tokens = max(0, prompt_total - cache_read_tokens - cache_write_tokens)
 
-    reasoning_tokens = 0
+    # Reasoning tokens surface under different keys depending on the API shape:
+    # the Responses / Codex path exposes ``output_tokens_details.reasoning_tokens``,
+    # while OpenAI Chat Completions (and OpenAI-compatible gateways/proxies that
+    # front reasoning models through the Responses API but hand back
+    # chat-completion-shaped usage) expose ``completion_tokens_details.reasoning_tokens``.
+    # Read BOTH so reasoning is captured regardless of wire shape — without the
+    # completion_tokens_details fallback, OpenAI-compatible custom providers that
+    # return chat-completion usage recorded reasoning_tokens=0. Handles dict- and
+    # object-shaped usage payloads.
+    def _reasoning_from(details):
+        if details is None:
+            return 0
+        if isinstance(details, dict):
+            return _to_int(details.get("reasoning_tokens", 0))
+        return _to_int(getattr(details, "reasoning_tokens", 0))
+
     output_details = getattr(response_usage, "output_tokens_details", None)
-    if output_details:
-        reasoning_tokens = _to_int(getattr(output_details, "reasoning_tokens", 0))
+    if output_details is None and isinstance(response_usage, dict):
+        output_details = response_usage.get("output_tokens_details")
+    reasoning_tokens = _reasoning_from(output_details)
+    if not reasoning_tokens:
+        completion_details = getattr(response_usage, "completion_tokens_details", None)
+        if completion_details is None and isinstance(response_usage, dict):
+            completion_details = response_usage.get("completion_tokens_details")
+        reasoning_tokens = _reasoning_from(completion_details)
 
     return CanonicalUsage(
         input_tokens=input_tokens,


### PR DESCRIPTION
## Problem

`normalize_usage()` in `agent/usage_pricing.py` extracts `reasoning_tokens` **only** from `output_tokens_details` — the OpenAI **Responses** API / Anthropic usage shape:

```python
output_details = getattr(response_usage, "output_tokens_details", None)
if output_details:
    reasoning_tokens = _to_int(getattr(output_details, "reasoning_tokens", 0))
```

But OpenAI **Chat Completions** responses (and OpenAI-compatible gateways/proxies — e.g. a LiteLLM proxy that fronts a reasoning model via the Responses API upstream but hands back chat-completion-shaped usage) put reasoning under **`completion_tokens_details.reasoning_tokens`**. That key is never read, so for those providers `reasoning_tokens` is silently recorded as `0`.

This was hit in practice by a `provider: custom` deployment pointing at a LiteLLM gateway serving a gpt-5.x reasoning model over the chat-completions wire: usage came back as a `CompletionUsage` with `completion_tokens_details.reasoning_tokens` populated, but the session recorded `reasoning_tokens=0`.

## Fix

Read reasoning from **both** `completion_tokens_details` and `output_tokens_details`, and handle dict- or object-shaped usage payloads. `output_tokens` is unchanged (it already includes reasoning per the OpenAI convention), so this is purely about populating the `reasoning_tokens` breakdown for observability/insights — it does not alter cost math.

## Verification

- `output_tokens_details.reasoning_tokens` (Responses shape) → captured (no regression).
- `completion_tokens_details.reasoning_tokens` (Chat Completions shape) → now captured (was 0).
- Anthropic-shaped usage (no reasoning details) → `0` (unchanged).
- dict-shaped usage payloads → handled.
- Verified end-to-end against a live gpt-5.x-mini run through a LiteLLM custom-provider gateway: the session's `reasoning_tokens` went from `0` to the real value.
