### PR TITLE
fix: honor model alias in status output

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -64,7 +64,7 @@ def _configured_model_label(config: dict) -> str:
     """Return the configured default model from config.yaml."""
     model_cfg = config.get("model")
     if isinstance(model_cfg, dict):
-        model = (model_cfg.get("default") or model_cfg.get("name") or "").strip()
+        model = (model_cfg.get("default") or model_cfg.get("model") or model_cfg.get("name") or "").strip()
     elif isinstance(model_cfg, str):
         model = model_cfg.strip()
     else:

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -1,6 +1,10 @@
 from types import SimpleNamespace
 
-from hermes_cli.status import show_status
+from hermes_cli.status import _configured_model_label, show_status
+
+
+def test_configured_model_label_honors_model_alias():
+    assert _configured_model_label({"model": {"model": "gpt-5.4"}}) == "gpt-5.4"
 
 
 def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):


### PR DESCRIPTION
## Summary

Updates `hermes status` model display so dict-based model config also honors the `model.model` alias between `model.default` and `model.name`.

This keeps status output aligned with existing config usage without changing provider resolution or agent execution.

## Validation

- Added a focused `_configured_model_label` test for `model.model`.
- `git diff --check -- hermes_cli/status.py tests/hermes_cli/test_status.py`
- `python -m py_compile hermes_cli/status.py`
- `python -m py_compile tests/hermes_cli/test_status.py`

Note: `python -m pytest tests/hermes_cli/test_status.py -q` could not be run in the local Codex environment because pytest/repo dependencies were unavailable.
