### PR TITLE
fix(state): resume compacted sessions at the live tip, skip delegate/branch children [salvage #45035 + #48682]

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3198,11 +3198,19 @@ class SessionDB:
                 if row is not None:
                     best = current
 
-                # Walk to the most-recently-started child.
+                # Walk to the most-recently-started child — but skip explicit
+                # branch (`_branched_from`), delegate/subagent (`_delegate_from`),
+                # and tool children. They also carry a ``parent_session_id`` yet
+                # are NOT compression continuations; following them would hijack
+                # the resume target to an unrelated session (e.g. a subagent
+                # run). This mirrors the child-exclusion in ``get_compression_tip``.
                 try:
                     child_row = self._conn.execute(
                         "SELECT id FROM sessions "
                         "WHERE parent_session_id = ? "
+                        "  AND json_extract(COALESCE(model_config, '{}'), '$._branched_from') IS NULL "
+                        "  AND json_extract(COALESCE(model_config, '{}'), '$._delegate_from') IS NULL "
+                        "  AND COALESCE(source, '') != 'tool' "
                         "ORDER BY started_at DESC, id DESC LIMIT 1",
                         (current,),
                     ).fetchone()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3119,9 +3119,14 @@ class SessionDB:
         it before compression. See #15000.
 
         This helper walks ``parent_session_id`` forward from ``session_id`` and
-        returns the first descendant in the chain that has at least one message
-        row. If the original session already has messages, or no descendant
-        has any, the original ``session_id`` is returned unchanged.
+        returns the descendant in the chain that has the **most recent** messages.
+        Unlike the original logic, it does NOT short-circuit when the starting
+        session already has messages — a descendant that was created by
+        compression may hold the continuation content and should be preferred
+        by the WebUI and gateway for ``--resume`` and session loading.
+
+        If no descendant (including the starting session) has any messages,
+        the original ``session_id`` is returned unchanged.
 
         The chain is always walked via the child whose ``started_at`` is
         latest; that matches the single-chain shape that compression creates.
@@ -3149,22 +3154,23 @@ class SessionDB:
             session_id = tip
 
         with self._lock:
-            # If this session already has messages, nothing to redirect.
-            try:
-                row = self._conn.execute(
-                    "SELECT 1 FROM messages WHERE session_id = ? LIMIT 1",
-                    (session_id,),
-                ).fetchone()
-            except Exception:
-                return session_id
-            if row is not None:
-                return session_id
-
-            # Walk descendants: at each step, pick the most-recently-started
-                # child session; stop once we find one with messages.
             current = session_id
             seen = {current}
+            best = None  # tracks the last (deepest) node with messages
+
             for _ in range(32):
+                # Check if the current node has messages.
+                try:
+                    row = self._conn.execute(
+                        "SELECT 1 FROM messages WHERE session_id = ? LIMIT 1",
+                        (current,),
+                    ).fetchone()
+                except Exception:
+                    return session_id
+                if row is not None:
+                    best = current
+
+                # Walk to the most-recently-started child.
                 try:
                     child_row = self._conn.execute(
                         "SELECT id FROM sessions "
@@ -3175,22 +3181,14 @@ class SessionDB:
                 except Exception:
                     return session_id
                 if child_row is None:
-                    return session_id
+                    break
                 child_id = child_row["id"] if hasattr(child_row, "keys") else child_row[0]
                 if not child_id or child_id in seen:
-                    return session_id
+                    break
                 seen.add(child_id)
-                try:
-                    msg_row = self._conn.execute(
-                        "SELECT 1 FROM messages WHERE session_id = ? LIMIT 1",
-                        (child_id,),
-                    ).fetchone()
-                except Exception:
-                    return session_id
-                if msg_row is not None:
-                    return child_id
                 current = child_id
-        return session_id
+
+            return best if best is not None else session_id
 
     def get_messages_as_conversation(
         self,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -51,8 +51,7 @@ _BRANCH_CHILD_SQL = (
 _COMPRESSION_CHILD_SQL = (
     "EXISTS (SELECT 1 FROM sessions p"
     "        WHERE p.id = {a}.parent_session_id"
-    "        AND p.end_reason = 'compression'"
-    "        AND {a}.started_at >= p.ended_at)"
+    "        AND p.end_reason = 'compression')"
 )
 
 # Rows that surface in pickers: roots + branch children (subagent runs and
@@ -2049,7 +2048,6 @@ class SessionDB:
                     JOIN sessions child ON child.id = a.id
                     JOIN sessions parent ON parent.id = child.parent_session_id
                     WHERE parent.end_reason = 'compression'
-                      AND child.started_at >= parent.ended_at
                   ),
                   descendants(id) AS (
                     SELECT ?
@@ -2059,7 +2057,6 @@ class SessionDB:
                     JOIN sessions parent ON parent.id = d.id
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.end_reason = 'compression'
-                      AND child.started_at >= parent.ended_at
                   ),
                   lineage(id) AS (
                     SELECT id FROM ancestors
@@ -2155,37 +2152,64 @@ class SessionDB:
     def get_compression_tip(self, session_id: str) -> Optional[str]:
         """Walk the compression-continuation chain forward and return the tip.
 
-        A compression continuation is a child session where:
-        1. The parent's ``end_reason = 'compression'``
-        2. The child was created AFTER the parent was ended (started_at >= ended_at)
+        A compression continuation is a child of a session whose
+        ``end_reason = 'compression'``.  Older builds tried to distinguish
+        continuations from branches/subagents by requiring
+        ``child.started_at >= parent.ended_at``.  That ordering is too brittle:
+        gateway + compression races can insert the real continuation row before
+        the parent row's ``ended_at`` is written, while a stale websocket later
+        creates/reuses a sibling that *does* satisfy the timestamp test.  The
+        visible symptom is brutal: desktop resume follows the stale sibling and
+        the user's latest messages look "lost" even though they are persisted in
+        the real continuation chain.
 
-        The second condition distinguishes compression continuations from
-        delegate subagents or branch children, which can also have a
-        ``parent_session_id`` but were created while the parent was still live.
-
-        Returns the session_id of the latest continuation in the chain, or the
-        input ``session_id`` if it isn't part of a compression chain (or if the
-        input itself doesn't exist).
+        Instead, only follow children of compression-ended parents, exclude
+        explicit branch/delegate/tool children, and prefer children that are
+        themselves continuing the compression chain (``end_reason='compression'``)
+        or still live over stale closed siblings such as ``ws_orphan_reap``.
+        Returns the latest continuation tip, or the input id when no
+        continuation exists.
         """
         current = session_id
+        seen = {current} if current else set()
         # Bound the walk defensively — compression chains this deep are
         # pathological and shouldn't happen in practice. 100 = plenty.
         for _ in range(100):
             with self._lock:
                 cursor = self._conn.execute(
-                    "SELECT id FROM sessions "
-                    "WHERE parent_session_id = ? "
-                    "  AND started_at >= ("
-                    "      SELECT ended_at FROM sessions "
-                    "      WHERE id = ? AND end_reason = 'compression'"
-                    "  ) "
-                    "ORDER BY started_at DESC LIMIT 1",
-                    (current, current),
+                    """
+                    SELECT child.id
+                    FROM sessions parent
+                    JOIN sessions child ON child.parent_session_id = parent.id
+                    WHERE parent.id = ?
+                      AND parent.end_reason = 'compression'
+                      AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL
+                      AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL
+                      AND COALESCE(child.source, '') != 'tool'
+                    ORDER BY
+                      CASE
+                        WHEN child.end_reason = 'compression' THEN 0
+                        WHEN child.ended_at IS NULL THEN 1
+                        ELSE 2
+                      END,
+                      COALESCE(
+                        (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = child.id),
+                        child.started_at
+                      ) DESC,
+                      child.started_at DESC,
+                      child.id DESC
+                    LIMIT 1
+                    """,
+                    (current,),
                 )
                 row = cursor.fetchone()
             if row is None:
                 return current
-            current = row["id"]
+            child_id = row["id"]
+            if not child_id or child_id in seen:
+                return current
+            seen.add(child_id)
+            current = child_id
         return current
 
     def distinct_session_cwds(self, include_archived: bool = False) -> List[Dict[str, Any]]:
@@ -2315,10 +2339,12 @@ class SessionDB:
             # still surfacing old compression roots whose live tip is fresh.
             #
             # The CTE seeds from rows the outer WHERE admits (roots + branch
-            # children), then recursively joins forward through
-            # compression-continuation edges using the same criteria as
-            # get_compression_tip (parent.end_reason='compression' AND
-            # child.started_at >= parent.ended_at).
+            # children), then recursively joins forward through robust
+            # compression-continuation edges. Do NOT require
+            # child.started_at >= parent.ended_at here: real desktop/gateway
+            # races can insert the continuation row before the parent's
+            # ended_at is written, while stale websocket siblings may satisfy
+            # the timestamp test and hijack resume/list projection.
             outer_where = where_sql
             id_params: List[Any] = []
             if id_needle:
@@ -2350,7 +2376,9 @@ class SessionDB:
                     JOIN sessions parent ON parent.id = c.cur_id
                     JOIN sessions child ON child.parent_session_id = c.cur_id
                     WHERE parent.end_reason = 'compression'
-                      AND child.started_at >= parent.ended_at
+                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
+                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
+                      AND COALESCE(child.source, '') != 'tool'
                 ),
                 chain_max AS (
                     SELECT

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -81,6 +81,9 @@ AUTHOR_MAP = {
     "joaomarcosdias444@gmail.com": "JoaoMarcos44",
     "286497132+srojk34@users.noreply.github.com": "srojk34",
     "srojk34@users.noreply.github.com": "srojk34",  # legacy prefix-less noreply (PR #50098 salvage; #38763)
+    "pinkiilqwq@users.noreply.github.com": "PINKIIILQWQ",  # PR #45035 salvage (resume-to-tip; #38763)
+    "pink@PinkdeMacBook-Air.local": "PINKIIILQWQ",  # PR #45035 local git identity (resume-to-tip; #38763)
+    "ailang323@163.com": "ailang323",  # PR #48682 salvage (compression-tip predicate; #38763)
     "59806492+sitkarev@users.noreply.github.com": "sitkarev",
     "zheng@omegasys.eu": "omegazheng",
     "220877172+james47kjv@users.noreply.github.com": "james47kjv",

--- a/tests/hermes_state/test_resolve_resume_session_id.py
+++ b/tests/hermes_state/test_resolve_resume_session_id.py
@@ -159,3 +159,51 @@ def test_redirects_from_message_bearing_parent_to_child(db):
     db.append_message("continued", role="assistant", content="new reply")
 
     assert db.resolve_resume_session_id("original") == "continued"
+
+
+def test_compression_tip_handles_pre_ended_real_child_and_ws_orphan_sibling(db):
+    # Real desktop repro shape from a long GUI session:
+    #
+    #   root --compression--> real continuation --compression--> live tip
+    #     \
+    #      `-- stale websocket sibling ended by ws_orphan_reap
+    #
+    # The real continuation row can be inserted before root.ended_at is written,
+    # so the old child.started_at >= parent.ended_at discriminator rejects it and
+    # follows the stale websocket sibling instead. That makes the GUI look like
+    # the latest conversation was lost. Resuming root must land on live_tip.
+    base = int(time.time()) - 10_000
+    db.create_session("root", source="tui")
+    db.append_message("root", role="user", content="pre-compression")
+    db.end_session("root", "compression")
+
+    db.create_session("real_cont", source="tui", parent_session_id="root")
+    db.append_message("real_cont", role="user", content="real continuation")
+    db.end_session("real_cont", "compression")
+
+    db.create_session("ws_orphan", source="tui", parent_session_id="root")
+    db.append_message("ws_orphan", role="user", content="stale websocket")
+    db.end_session("ws_orphan", "ws_orphan_reap")
+
+    db.create_session("live_tip", source="tui", parent_session_id="real_cont")
+    db.append_message("live_tip", role="user", content="latest real turn")
+
+    conn = db._conn
+    assert conn is not None
+    conn.execute("UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'root'", (base, base + 1000))
+    # The real continuation starts before root.ended_at, exactly the race that
+    # broke the old timestamp-based chain walk.
+    conn.execute("UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'real_cont'", (base + 500, base + 2000))
+    conn.execute("UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'ws_orphan'", (base + 1000, base + 3000))
+    conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'live_tip'", (base + 2000,))
+    conn.commit()
+
+    assert db.get_compression_tip("root") == "live_tip"
+    assert db.resolve_resume_session_id("root") == "live_tip"
+
+    listed = db.list_sessions_rich(limit=10, order_by_last_active=True)
+    ids = {row["id"] for row in listed}
+    assert "live_tip" in ids
+    assert "real_cont" not in ids
+    assert "ws_orphan" not in ids
+

--- a/tests/hermes_state/test_resolve_resume_session_id.py
+++ b/tests/hermes_state/test_resolve_resume_session_id.py
@@ -116,7 +116,15 @@ def test_compression_tip_not_confused_with_delegation_child(db):
     base = int(time.time()) - 10_000
     db.create_session("conv", source="cli")
     db.append_message("conv", role="user", content="parent turn")
-    db.create_session("subagent", source="cli", parent_session_id="conv")
+    # Real delegate/subagent sessions carry the `_delegate_from` marker
+    # (set in delegate_tool.py) — that marker, not timing, is what
+    # distinguishes them from a compression continuation.
+    db.create_session(
+        "subagent",
+        source="subagent",
+        parent_session_id="conv",
+        model_config={"_delegate_from": "conv"},
+    )
     db.append_message("subagent", role="assistant", content="delegated work")
     conn = db._conn
     assert conn is not None

--- a/tests/hermes_state/test_resolve_resume_session_id.py
+++ b/tests/hermes_state/test_resolve_resume_session_id.py
@@ -138,3 +138,24 @@ def test_prefers_most_recent_child_when_fork_exists(db):
     ])
     db.append_message("newer_fork", role="user", content="x")
     assert db.resolve_resume_session_id("parent") == "newer_fork"
+
+
+def test_redirects_from_message_bearing_parent_to_child(db):
+    """Fix for problem 2: parent has messages AND child also has messages.
+
+    After context compression the parent holds old messages but the child
+    is the active continuation session.  resolve_resume_session_id should
+    prefer the latest descendant with messages, not short-circuit on the
+    parent.
+    """
+    _make_chain(db, [
+        ("original", None),
+        ("continued", "original"),
+    ])
+    # Both parent and child have messages
+    db.append_message("original", role="user", content="old msg")
+    db.append_message("original", role="assistant", content="old reply")
+    db.append_message("continued", role="user", content="new msg")
+    db.append_message("continued", role="assistant", content="new reply")
+
+    assert db.resolve_resume_session_id("original") == "continued"

--- a/tests/hermes_state/test_resolve_resume_session_id.py
+++ b/tests/hermes_state/test_resolve_resume_session_id.py
@@ -48,9 +48,9 @@ def test_redirects_from_empty_head_to_descendant_with_messages(db):
         db.append_message("bulk", role="user", content=f"msg {i}")
 
     assert db.resolve_resume_session_id("head") == "bulk"
-
-
-def test_returns_self_when_session_has_messages(db):
+def test_returns_self_when_only_parent_has_messages(db):
+    # When a session already has messages AND no descendant has messages,
+    # it should still be returned.  The chain walk finds no better candidate.
     _make_chain(db, [("root", None), ("child", "root")])
     db.append_message("root", role="user", content="hi")
     assert db.resolve_resume_session_id("root") == "root"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6100,7 +6100,7 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
     """Drops `tool` rows like session.list does, returns the first hit."""
 
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200):
+        def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False):
             return [
                 {"id": "tool-1", "source": "tool", "title": "noise", "started_at": 100},
                 {"id": "tui-1", "source": "tui", "title": "real", "started_at": 99},
@@ -6119,7 +6119,7 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
 
 def test_session_most_recent_returns_null_when_only_tool_rows(monkeypatch):
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200):
+        def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False):
             return [{"id": "tool-1", "source": "tool", "started_at": 1}]
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
@@ -6137,7 +6137,7 @@ def test_session_most_recent_folds_db_exception_into_null_result(monkeypatch):
     'no answer' (Copilot review on #17130)."""
 
     class _BrokenDB:
-        def list_sessions_rich(self, *, source=None, limit=200):
+        def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False):
             raise RuntimeError("db locked")
 
     monkeypatch.setattr(server, "_get_db", lambda: _BrokenDB())

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4926,7 +4926,7 @@ def _(rid, params: dict) -> dict:
         fetch_limit = max(limit * 2, 200)
         rows = [
             s
-            for s in db.list_sessions_rich(source=None, limit=fetch_limit)
+            for s in db.list_sessions_rich(source=None, limit=fetch_limit, order_by_last_active=True)
             if (s.get("source") or "").strip().lower() not in deny
         ][:limit]
         return _ok(
@@ -4973,7 +4973,7 @@ def _(rid, params: dict) -> dict:
         # users (lots of recent ``tool`` rows) don't get a false
         # "no eligible session" answer.  ``session.list`` uses a
         # similar over-fetch strategy.
-        rows = db.list_sessions_rich(source=None, limit=200)
+        rows = db.list_sessions_rich(source=None, limit=200, order_by_last_active=True)
         for row in rows:
             src = (row.get("source") or "").strip().lower()
             if src in deny:


### PR DESCRIPTION
## Summary
Resuming a long, compaction-split conversation now lands on the **latest** message-bearing session instead of a stale parent — and never gets hijacked into an unrelated delegate/branch/tool child.

Salvage of two complementary contributor fixes for the same user-facing symptom ("I came back to a long session and my latest reply isn't there"), cherry-picked onto current main with authorship preserved:

- **#45035** by @PINKIIILQWQ — `resolve_resume_session_id` no longer short-circuits on a message-bearing parent; it walks the continuation chain to the deepest message-bearing descendant.
- **#48682** by @ailang323 — `get_compression_tip` drops the brittle `child.started_at >= parent.ended_at` discriminator (which followed a stale websocket sibling during the gateway/compaction race) and excludes branch/delegate/tool children explicitly.

These touch different functions and are both real bugs; together they make resume land on the right tip.

## Changes
- `hermes_state.py`: `resolve_resume_session_id` walks to the latest message-bearing continuation (#45035); `get_compression_tip` + lineage CTEs drop the timestamp predicate and exclude `_branched_from` / `_delegate_from` / `source='tool'` children (#48682).
- `hermes_state.py` (follow-up, ours): the resume descendant walk applies the **same** child-exclusion as `get_compression_tip`, so a delegate/subagent child can't hijack the resume target. Without this, the two salvaged fixes were inconsistent — the tip walk excluded subagents but the resume walk still followed them.
- `tui_gateway/server.py`: `session.most_recent` orders by last-active (#48682).
- Tests: realistic `_delegate_from` marker on the delegation fixture; 3 `list_sessions_rich` mocks updated for the `order_by_last_active` kwarg.
- `scripts/release.py`: AUTHOR_MAP entries for both salvage authors.

## Validation
| | Before | After |
|---|---|---|
| Resume a compacted session | lands on stale parent (latest turns "lost") | lands on live continuation tip |
| Parent with a delegate/subagent child | resume could follow the subagent | resume stays on the conversation |
| Continuation inserted before parent `ended_at` (race) | brittle timestamp test followed stale sibling | child-marker exclusion follows the real continuation |

- 305/305 targeted tests green (`test_resolve_resume_session_id`, `test_session_archiving`, `test_tui_gateway_server`).
- Rebased onto current main; diff is the 5 intended files only.

## Supersedes
- #44979 (@tsagi2045) — TUI-only `get_compression_tip` canonicalization, subsumed by the backend fix here. Will close with credit.

(Desktop UI continuity PRs #45042, #44418 are a separate review — not included here.)

## Infographic

![bold-graphic](https://v3b.fal.media/files/b/0a9fc527/Rhwc0Zy50xvhk1uJfLEKT_s7Tp4cfY.png)
