### PR TITLE
fix(telegram): rename topics from explicit titles

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9082,6 +9082,7 @@ class GatewayRunner:
         # Set session title if provided with /new <title>
         _title_arg = event.get_command_args().strip()
         _title_note = ""
+        sanitized = None
         if _title_arg and self._session_db and new_entry:
             from hermes_state import SessionDB
             try:
@@ -9112,6 +9113,15 @@ class GatewayRunner:
                 self._record_telegram_topic_binding(source, new_entry)
             except Exception:
                 logger.debug("Failed to rebind Telegram topic after /new", exc_info=True)
+            if _title_arg and sanitized:
+                try:
+                    await self._rename_telegram_topic_for_session_title(
+                        source,
+                        new_entry.session_id,
+                        sanitized,
+                    )
+                except Exception:
+                    logger.debug("Failed to rename Telegram topic after /new title", exc_info=True)
 
         # Fire plugin on_session_reset hook (new session guaranteed to exist)
         try:
@@ -12535,6 +12545,11 @@ class GatewayRunner:
             # Set the title
             try:
                 if self._session_db.set_session_title(session_id, sanitized):
+                    await self._rename_telegram_topic_for_session_title(
+                        source,
+                        session_id,
+                        sanitized,
+                    )
                     return t("gateway.title.set_to", title=sanitized)
                 else:
                     return t("gateway.title.not_found")

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -1326,3 +1326,71 @@ def test_session_split_restores_source_thread_id_from_binding(tmp_path):
     meta = GatewayRunner._thread_metadata_for_source(runner, source)
     assert meta is not None
     assert meta["thread_id"] == "17585"
+
+
+@pytest.mark.asyncio
+async def test_title_command_renames_current_telegram_topic(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+
+    result = await runner._handle_title_command(
+        _make_event("/title Manual Topic Name", thread_id="42")
+    )
+
+    assert "Manual Topic Name" in result
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_awaited_once_with(
+        chat_id="208214988",
+        thread_id="42",
+        name="Manual Topic Name",
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_with_title_renames_rebound_telegram_topic(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("old-topic", source="telegram", user_id="208214988")
+    db.create_session("new-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="old-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner.session_store.reset_session = MagicMock(
+        return_value=SessionEntry(
+            session_key="agent:main:telegram:dm:208214988:42",
+            session_id="new-topic",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+            origin=_make_source(thread_id="42"),
+        )
+    )
+
+    result = await runner._handle_reset_command(
+        _make_event("/new Fresh Debug Thread", thread_id="42")
+    )
+
+    assert "Fresh Debug Thread" in str(result)
+    binding = db.get_telegram_topic_binding(chat_id="208214988", thread_id="42")
+    assert binding["session_id"] == "new-topic"
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_awaited_once_with(
+        chat_id="208214988",
+        thread_id="42",
+        name="Fresh Debug Thread",
+    )


### PR DESCRIPTION
## Summary
- rename Telegram DM topics when `/title <name>` sets an explicit session title
- rename Telegram DM topics when `/new <name>` creates/rebinds a topic session with an explicit title
- add regression coverage for both explicit-title paths

## Test Plan
- `python -m pytest tests/gateway/test_telegram_topic_mode.py -q -o 'addopts='`
