### PR TITLE
feat: add safe profile sync

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -266,6 +266,7 @@ from hermes_cli.subcommands._shared import add_accept_hooks_flag as _add_accept_
 from hermes_cli.subcommands.cron import build_cron_parser
 from hermes_cli.subcommands.gateway import build_gateway_parser
 from hermes_cli.subcommands.profile import build_profile_parser
+from hermes_cli.subcommands.profile_sync import build_profile_sync_parser
 from hermes_cli.subcommands.model import build_model_parser
 from hermes_cli.subcommands.setup import build_setup_parser
 from hermes_cli.subcommands.postinstall import build_postinstall_parser
@@ -11580,7 +11581,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "config", "cron", "curator", "dashboard", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
         "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate", "moa",
-        "model", "pairing", "pets", "plugins", "portal", "postinstall", "profile", "proxy",
+        "model", "pairing", "pets", "plugins", "portal", "postinstall", "profile", "profile-sync", "proxy",
         "prompt-size",
         "send", "sessions", "setup",
         "skills", "slack", "status", "tools", "uninstall", "update",
@@ -13095,6 +13096,11 @@ def main():
     # profile command  (parser built in hermes_cli/subcommands/profile.py)
     # =========================================================================
     build_profile_parser(subparsers, cmd_profile=cmd_profile)
+
+    # =========================================================================
+    # profile-sync command  (parser built in hermes_cli/subcommands/profile_sync.py)
+    # =========================================================================
+    build_profile_sync_parser(subparsers)
 
     # =========================================================================
     # completion command

--- a/hermes_cli/profile_sync.py
+++ b/hermes_cli/profile_sync.py
@@ -1,0 +1,415 @@
+"""Safe profile sync inspection and allowlisted skill sync for Hermes profiles.
+
+This module is a seat belt around the common desire to "sync profiles" without
+accidentally copying credentials, sessions, cron state, auth stores, or other
+live profile state. Memory comparison is read-only until merge rules exist.
+The only supported write path is skills-only ``--apply --with-backup``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from agent.skill_utils import is_excluded_skill_path
+from hermes_cli.profiles import get_profile_dir, normalize_profile_name, profile_exists
+
+
+_MEMORY_FILES = ("memories/MEMORY.md", "memories/USER.md")
+_EXCLUDED_SKILL_FILE_NAMES = {".usage.json"}
+_EXCLUDED_SKILL_DIR_NAMES = {"__pycache__", ".git"}
+_EXCLUDED_STATE = [
+    ".env",
+    "auth.json",
+    "config.yaml",
+    "state.db",
+    "sessions/",
+    "cron/",
+    "logs/",
+    "gateway pid/state files",
+    "memories/ (apply disabled until merge rules exist)",
+]
+
+
+@dataclass(frozen=True)
+class FileFingerprint:
+    exists: bool
+    sha256: str = ""
+    bytes: int = 0
+    entry_count: int | None = None
+
+
+@dataclass(frozen=True)
+class SkillFingerprint:
+    relative_dir: str
+    sha256: str
+    file_count: int
+    bytes: int
+
+
+def build_parser(subparsers) -> argparse.ArgumentParser:
+    parser = subparsers.add_parser(
+        "profile-sync",
+        help="Profile memory/skill comparison and skills-only sync",
+        description=(
+            "Compare profile memories and skills without copying risky profile data. "
+            "The only write mode is `skills --apply --with-backup`; memory sync is "
+            "intentionally read-only until merge rules exist. This command never "
+            "touches .env, auth.json, sessions, cron, config.yaml, logs, gateways, "
+            "or live runtime state."
+        ),
+    )
+    sub = parser.add_subparsers(dest="profile_sync_action")
+
+    def add_common(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--source", required=True, help="Source profile name, e.g. engineer")
+        p.add_argument("--target", required=True, help="Target profile name, e.g. default")
+        p.add_argument(
+            "--json",
+            action="store_true",
+            help="Emit machine-readable JSON instead of a text report",
+        )
+
+    diff = sub.add_parser("diff", help="Dry-run memory + skill comparison")
+    add_common(diff)
+    diff.set_defaults(func=_cmd_profile_sync_exit)
+
+    skills = sub.add_parser("skills", help="Skill-library comparison or skills-only sync")
+    add_common(skills)
+    skills.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Preview only. This is the default unless --apply is supplied.",
+    )
+    skills.add_argument(
+        "--apply",
+        action="store_true",
+        help="Copy missing/changed skills from source to target. Requires --with-backup.",
+    )
+    skills.add_argument(
+        "--with-backup",
+        action="store_true",
+        help="Create a timestamped backup of the target skills directory before applying.",
+    )
+    skills.set_defaults(func=_cmd_profile_sync_exit)
+
+    memories = sub.add_parser("memories", help="Dry-run MEMORY.md / USER.md comparison")
+    add_common(memories)
+    memories.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Read-only mode (currently the only supported mode)",
+    )
+    memories.add_argument(
+        "--apply",
+        action="store_true",
+        help="Reserved; memory apply is intentionally disabled until merge rules exist.",
+    )
+    memories.set_defaults(func=_cmd_profile_sync_exit)
+
+    parser.set_defaults(func=_cmd_profile_sync_exit)
+    return parser
+
+
+def _resolve_profile(name: str) -> tuple[str, Path]:
+    canon = normalize_profile_name(name)
+    if not profile_exists(canon):
+        raise ValueError(f"profile '{name}' does not exist")
+    return canon, get_profile_dir(canon)
+
+
+def _hash_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _fingerprint_file(path: Path, *, count_entries: bool = False) -> FileFingerprint:
+    try:
+        data = path.read_bytes()
+    except FileNotFoundError:
+        return FileFingerprint(False)
+    entry_count = None
+    if count_entries:
+        try:
+            text = data.decode("utf-8", errors="ignore")
+            entry_count = len([chunk for chunk in text.split("§") if chunk.strip()])
+        except Exception:
+            entry_count = None
+    return FileFingerprint(True, _hash_bytes(data), len(data), entry_count)
+
+
+def _iter_skill_files(skill_dir: Path) -> Iterable[Path]:
+    for path in sorted(skill_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        rel_parts = path.relative_to(skill_dir).parts
+        if any(part in _EXCLUDED_SKILL_DIR_NAMES for part in rel_parts):
+            continue
+        if path.name in _EXCLUDED_SKILL_FILE_NAMES:
+            continue
+        yield path
+
+
+def _fingerprint_skill(skill_dir: Path, relative_dir: str) -> SkillFingerprint:
+    digest = hashlib.sha256()
+    file_count = 0
+    total_bytes = 0
+    for path in _iter_skill_files(skill_dir):
+        rel = path.relative_to(skill_dir).as_posix()
+        data = path.read_bytes()
+        digest.update(rel.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(data)
+        digest.update(b"\0")
+        file_count += 1
+        total_bytes += len(data)
+    return SkillFingerprint(relative_dir, digest.hexdigest(), file_count, total_bytes)
+
+
+def _load_skills(profile_dir: Path) -> dict[str, SkillFingerprint]:
+    root = profile_dir / "skills"
+    if not root.is_dir():
+        return {}
+    out: dict[str, SkillFingerprint] = {}
+    for skill_md in sorted(root.rglob("SKILL.md")):
+        skill_dir = skill_md.parent
+        try:
+            if is_excluded_skill_path(skill_dir):
+                continue
+        except Exception:
+            # Exclusion helper is defensive; if it cannot classify, include the
+            # skill in the report rather than silently hiding it.
+            pass
+        rel = skill_dir.relative_to(root).as_posix()
+        out[rel] = _fingerprint_skill(skill_dir, rel)
+    return out
+
+
+def _compare_skills(source_dir: Path, target_dir: Path) -> dict[str, object]:
+    source = _load_skills(source_dir)
+    target = _load_skills(target_dir)
+    source_keys = set(source)
+    target_keys = set(target)
+    common = source_keys & target_keys
+    changed = sorted(k for k in common if source[k].sha256 != target[k].sha256)
+    missing = sorted(source_keys - target_keys)
+    extra = sorted(target_keys - source_keys)
+    return {
+        "source_count": len(source),
+        "target_count": len(target),
+        "missing_in_target": missing,
+        "extra_in_target": extra,
+        "changed": changed,
+        "would_copy": sorted(missing + changed),
+        "would_delete": [],
+    }
+
+
+def _compare_memories(source_dir: Path, target_dir: Path) -> dict[str, object]:
+    files = []
+    for rel in _MEMORY_FILES:
+        src = _fingerprint_file(source_dir / rel, count_entries=True)
+        dst = _fingerprint_file(target_dir / rel, count_entries=True)
+        status = "same"
+        if src.exists and not dst.exists:
+            status = "missing_in_target"
+        elif dst.exists and not src.exists:
+            status = "extra_in_target"
+        elif src.sha256 != dst.sha256:
+            status = "changed"
+        files.append(
+            {
+                "path": rel,
+                "status": status,
+                "source_exists": src.exists,
+                "target_exists": dst.exists,
+                "source_bytes": src.bytes,
+                "target_bytes": dst.bytes,
+                "source_entries": src.entry_count,
+                "target_entries": dst.entry_count,
+            }
+        )
+    return {"files": files, "apply_supported": False}
+
+
+def _backup_target_skills(target_dir: Path) -> str:
+    skills_dir = target_dir / "skills"
+    backup_root = target_dir / "backups" / "profile-sync"
+    backup_root.mkdir(parents=True, exist_ok=True)
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    archive_base = backup_root / f"skills-{stamp}"
+    if skills_dir.exists():
+        return shutil.make_archive(str(archive_base), "zip", root_dir=str(skills_dir))
+    empty_marker = backup_root / f"skills-{stamp}.empty.txt"
+    empty_marker.write_text("Target skills directory did not exist before profile-sync apply.\n", encoding="utf-8")
+    return str(empty_marker)
+
+
+def _copy_skill_dir(source_root: Path, target_root: Path, rel: str) -> None:
+    source_skill = source_root / rel
+    target_skill = target_root / rel
+    if not (source_skill / "SKILL.md").is_file():
+        raise ValueError(f"refusing to copy non-skill directory: {source_skill}")
+    target_skill.parent.mkdir(parents=True, exist_ok=True)
+    tmp_skill = target_skill.parent / f".{target_skill.name}.profile-sync-tmp"
+    if tmp_skill.exists():
+        shutil.rmtree(tmp_skill)
+    shutil.copytree(source_skill, tmp_skill, ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "*.pyo", ".git"))
+    if target_skill.exists():
+        shutil.rmtree(target_skill)
+    tmp_skill.replace(target_skill)
+
+
+def _apply_skills(source_dir: Path, target_dir: Path, skills_report: dict[str, object], *, with_backup: bool) -> dict[str, object]:
+    if not with_backup:
+        raise ValueError("skills --apply requires --with-backup")
+    source_root = source_dir / "skills"
+    target_root = target_dir / "skills"
+    if not source_root.is_dir():
+        raise ValueError(f"source skills directory does not exist: {source_root}")
+    target_root.mkdir(parents=True, exist_ok=True)
+
+    to_copy = list(skills_report.get("would_copy", []))
+    backup_path = _backup_target_skills(target_dir)
+    copied: list[str] = []
+    for rel in to_copy:
+        if not isinstance(rel, str):
+            continue
+        _copy_skill_dir(source_root, target_root, rel)
+        copied.append(rel)
+    return {
+        "applied": True,
+        "backup_path": backup_path,
+        "copied": copied,
+        "deleted": [],
+        "note": "skills-only sync; extra target skills kept; memories/config/auth/sessions/cron/logs untouched",
+    }
+
+
+def _build_report(args) -> dict[str, object]:
+    source_name, source_dir = _resolve_profile(args.source)
+    target_name, target_dir = _resolve_profile(args.target)
+    action = getattr(args, "profile_sync_action", None) or "diff"
+    apply_requested = bool(getattr(args, "apply", False))
+    if action == "diff" and apply_requested:
+        raise ValueError("profile-sync diff is read-only; use `profile-sync skills --apply --with-backup`")
+    if action == "memories" and apply_requested:
+        raise ValueError("memory apply is disabled until merge rules exist")
+
+    report: dict[str, object] = {
+        "mode": "apply" if apply_requested else "dry-run",
+        "action": action,
+        "source": {"name": source_name, "path": str(source_dir)},
+        "target": {"name": target_name, "path": str(target_dir)},
+        "safety": {
+            "read_only": not apply_requested,
+            "write_scope": "skills-only" if apply_requested else "none",
+            "excluded_state": list(_EXCLUDED_STATE),
+        },
+    }
+    if action in {"diff", "skills"}:
+        skills = _compare_skills(source_dir, target_dir)
+        report["skills"] = skills
+        if action == "skills" and apply_requested:
+            report["apply"] = _apply_skills(
+                source_dir,
+                target_dir,
+                skills,
+                with_backup=bool(getattr(args, "with_backup", False)),
+            )
+            # Re-read after apply so callers can verify convergence.
+            report["post_apply_skills"] = _compare_skills(source_dir, target_dir)
+    if action in {"diff", "memories"}:
+        report["memories"] = _compare_memories(source_dir, target_dir)
+    return report
+
+
+def _print_list(label: str, items: list[str], *, limit: int = 50) -> None:
+    print(f"  {label}: {len(items)}")
+    for item in items[:limit]:
+        print(f"    - {item}")
+    if len(items) > limit:
+        print(f"    ... {len(items) - limit} more")
+
+
+def _print_text_report(report: dict[str, object]) -> None:
+    source = report["source"]  # type: ignore[index]
+    target = report["target"]  # type: ignore[index]
+    mode = report.get("mode", "dry-run")
+    title = "Profile sync apply" if mode == "apply" else "Profile sync dry-run"
+    print(title)
+    print(f"Source: {source['name']} ({source['path']})")  # type: ignore[index]
+    print(f"Target: {target['name']} ({target['path']})")  # type: ignore[index]
+    if mode == "apply":
+        print("Safety: skills-only apply; backup required; memories/config/auth/session/cron/log/runtime state excluded")
+    else:
+        print("Safety: read-only; excluded .env/auth/config/session/cron/log/runtime state")
+
+    skills = report.get("skills")
+    if isinstance(skills, dict):
+        print("\nSkills")
+        print(f"  source_count: {skills['source_count']}")
+        print(f"  target_count: {skills['target_count']}")
+        _print_list("missing_in_target", list(skills["missing_in_target"]))
+        _print_list("extra_in_target", list(skills["extra_in_target"]))
+        _print_list("changed", list(skills["changed"]))
+        _print_list("would_copy", list(skills["would_copy"]))
+        _print_list("would_delete", list(skills["would_delete"]))
+
+    apply_result = report.get("apply")
+    if isinstance(apply_result, dict):
+        print("\nApplied")
+        print(f"  backup_path: {apply_result['backup_path']}")
+        _print_list("copied", list(apply_result["copied"]))
+        _print_list("deleted", list(apply_result["deleted"]))
+        print(f"  note: {apply_result['note']}")
+        post = report.get("post_apply_skills")
+        if isinstance(post, dict):
+            print("\nPost-apply skills check")
+            _print_list("missing_in_target", list(post["missing_in_target"]))
+            _print_list("changed", list(post["changed"]))
+
+    memories = report.get("memories")
+    if isinstance(memories, dict):
+        print("\nMemories")
+        for item in memories["files"]:  # type: ignore[index]
+            print(
+                "  {path}: {status} "
+                "(source entries={source_entries}, target entries={target_entries}, "
+                "source bytes={source_bytes}, target bytes={target_bytes})".format(**item)
+            )
+        print("  apply_supported: false")
+
+    if mode == "apply":
+        print("\nNo memory/config/auth/session/cron/log/runtime files were modified.")
+    else:
+        print("\nNo files were modified.")
+
+
+def _cmd_profile_sync_exit(args) -> None:
+    raise SystemExit(cmd_profile_sync(args))
+
+
+def cmd_profile_sync(args) -> int:
+    action = getattr(args, "profile_sync_action", None)
+    if action is None:
+        print("profile-sync requires a subcommand: diff, skills, or memories", file=sys.stderr)
+        return 2
+    try:
+        report = _build_report(args)
+    except Exception as exc:
+        print(f"profile-sync: {exc}", file=sys.stderr)
+        return 1
+    if getattr(args, "json", False):
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        _print_text_report(report)
+    return 0

--- a/hermes_cli/subcommands/profile_sync.py
+++ b/hermes_cli/subcommands/profile_sync.py
@@ -1,0 +1,19 @@
+"""``hermes profile-sync`` subcommand parser."""
+
+from __future__ import annotations
+
+from hermes_cli.profile_sync import build_parser
+
+__all__ = ["build_profile_sync_parser"]
+
+
+def build_profile_sync_parser(subparsers, *, cmd_profile_sync=None) -> None:
+    """Attach the read-only profile-sync subcommand to ``subparsers``."""
+    parser = build_parser(subparsers)
+    if cmd_profile_sync is not None:
+        # build_parser sets profile_sync.cmd_profile_sync directly on subcommands.
+        # Keep the injected handler hook for consistency with other extracted
+        # parser modules and tests that assert handler wiring.
+        for action in getattr(parser, "_subparsers", None)._group_actions if getattr(parser, "_subparsers", None) else []:
+            for subparser in getattr(action, "choices", {}).values():
+                subparser.set_defaults(func=cmd_profile_sync)

--- a/tests/hermes_cli/test_profile_sync.py
+++ b/tests/hermes_cli/test_profile_sync.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from hermes_cli import profile_sync
+
+
+def _write_skill(root: Path, rel: str, body: str, *, extra_name: str | None = None) -> None:
+    skill_dir = root / "skills" / rel
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+    if extra_name:
+        (skill_dir / extra_name).write_text("extra", encoding="utf-8")
+
+
+def _patch_profile_dirs(monkeypatch, source: Path, target: Path) -> None:
+    monkeypatch.setattr(profile_sync, "profile_exists", lambda name: True)
+    monkeypatch.setattr(
+        profile_sync,
+        "get_profile_dir",
+        lambda name: source if name == "source" else target,
+    )
+
+
+class _BaseArgs:
+    source = "source"
+    target = "target"
+    json = False
+    apply = False
+    with_backup = False
+
+
+def test_profile_sync_skills_dry_run_reports_missing_extra_and_changed(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    _write_skill(source, "cat/alpha", "---\nname: alpha\n---\nsource\n")
+    _write_skill(source, "cat/shared", "---\nname: shared\n---\nsource\n")
+    _write_skill(target, "cat/shared", "---\nname: shared\n---\ntarget\n")
+    _write_skill(target, "cat/extra", "---\nname: extra\n---\ntarget\n")
+    _patch_profile_dirs(monkeypatch, source, target)
+
+    class Args(_BaseArgs):
+        profile_sync_action = "skills"
+
+    report = profile_sync._build_report(Args())
+    skills = report["skills"]
+
+    assert report["mode"] == "dry-run"
+    assert skills["missing_in_target"] == ["cat/alpha"]
+    assert skills["extra_in_target"] == ["cat/extra"]
+    assert skills["changed"] == ["cat/shared"]
+    assert skills["would_copy"] == ["cat/alpha", "cat/shared"]
+    assert skills["would_delete"] == []
+    assert report["safety"]["read_only"] is True
+    assert ".env" in report["safety"]["excluded_state"]
+    assert "auth.json" in report["safety"]["excluded_state"]
+
+
+def test_profile_sync_memories_dry_run_reports_entry_counts(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    (source / "memories").mkdir(parents=True)
+    (target / "memories").mkdir(parents=True)
+    (source / "memories" / "MEMORY.md").write_text("one\n§\ntwo\n", encoding="utf-8")
+    (target / "memories" / "MEMORY.md").write_text("one\n", encoding="utf-8")
+    (source / "memories" / "USER.md").write_text("same", encoding="utf-8")
+    (target / "memories" / "USER.md").write_text("same", encoding="utf-8")
+    _patch_profile_dirs(monkeypatch, source, target)
+
+    class Args(_BaseArgs):
+        profile_sync_action = "memories"
+
+    report = profile_sync._build_report(Args())
+    files = {item["path"]: item for item in report["memories"]["files"]}
+
+    assert files["memories/MEMORY.md"]["status"] == "changed"
+    assert files["memories/MEMORY.md"]["source_entries"] == 2
+    assert files["memories/MEMORY.md"]["target_entries"] == 1
+    assert files["memories/USER.md"]["status"] == "same"
+    assert report["memories"]["apply_supported"] is False
+
+
+def test_profile_sync_memories_apply_is_refused(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    _patch_profile_dirs(monkeypatch, source, target)
+
+    class Args(_BaseArgs):
+        profile_sync_action = "memories"
+        apply = True
+
+    try:
+        profile_sync._build_report(Args())
+    except ValueError as exc:
+        assert "memory apply is disabled" in str(exc)
+    else:
+        raise AssertionError("memory apply should be refused")
+
+
+def test_profile_sync_skills_apply_requires_backup(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    _write_skill(source, "cat/alpha", "---\nname: alpha\n---\nsource\n")
+    _patch_profile_dirs(monkeypatch, source, target)
+
+    class Args(_BaseArgs):
+        profile_sync_action = "skills"
+        apply = True
+        with_backup = False
+
+    try:
+        profile_sync._build_report(Args())
+    except ValueError as exc:
+        assert "requires --with-backup" in str(exc)
+    else:
+        raise AssertionError("skills apply without backup should be refused")
+
+
+def test_profile_sync_skills_apply_copies_missing_and_changed_keeps_extra_and_backs_up(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    _write_skill(source, "cat/alpha", "---\nname: alpha\n---\nsource\n")
+    _write_skill(source, "cat/shared", "---\nname: shared\n---\nsource\n", extra_name="note.md")
+    _write_skill(target, "cat/shared", "---\nname: shared\n---\ntarget\n")
+    _write_skill(target, "cat/extra", "---\nname: extra\n---\ntarget\n")
+    _patch_profile_dirs(monkeypatch, source, target)
+
+    class Args(_BaseArgs):
+        profile_sync_action = "skills"
+        apply = True
+        with_backup = True
+
+    report = profile_sync._build_report(Args())
+
+    assert report["mode"] == "apply"
+    assert report["apply"]["copied"] == ["cat/alpha", "cat/shared"]
+    assert report["apply"]["deleted"] == []
+    assert Path(report["apply"]["backup_path"]).exists()
+    assert (target / "skills" / "cat" / "alpha" / "SKILL.md").read_text(encoding="utf-8").endswith("source\n")
+    assert (target / "skills" / "cat" / "shared" / "SKILL.md").read_text(encoding="utf-8").endswith("source\n")
+    assert (target / "skills" / "cat" / "shared" / "note.md").exists()
+    assert (target / "skills" / "cat" / "extra" / "SKILL.md").exists()
+    assert report["post_apply_skills"]["missing_in_target"] == []
+    assert report["post_apply_skills"]["changed"] == []

--- a/tests/hermes_cli/test_profile_sync.py
+++ b/tests/hermes_cli/test_profile_sync.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import hashlib
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 from hermes_cli import profile_sync
@@ -150,3 +154,84 @@ def test_profile_sync_skills_apply_copies_missing_and_changed_keeps_extra_and_ba
     assert (target / "skills" / "cat" / "extra" / "SKILL.md").exists()
     assert report["post_apply_skills"]["missing_in_target"] == []
     assert report["post_apply_skills"]["changed"] == []
+
+
+def _hash_tree(root: Path) -> dict[str, str]:
+    return {
+        path.relative_to(root).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def test_profile_sync_memories_apply_exits_nonzero_through_cli_entrypoint(tmp_path):
+    hermes_home = tmp_path / "hermes-home"
+    (hermes_home / "profiles" / "engineer" / "skills").mkdir(parents=True)
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    env["PYTHONPATH"] = os.getcwd()
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "profile-sync",
+            "memories",
+            "--source",
+            "engineer",
+            "--target",
+            "default",
+            "--apply",
+        ],
+        cwd=os.getcwd(),
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "memory apply is disabled until merge rules exist" in result.stderr
+
+
+def test_profile_sync_skills_apply_leaves_non_skill_profile_state_untouched(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    _write_skill(source, "cat/alpha", "---\nname: alpha\n---\nsource\n")
+    _write_skill(target, "cat/alpha", "---\nname: alpha\n---\ntarget\n")
+
+    sentinel_files = {
+        ".env": "ENV_SENTINEL=value\n",
+        "auth.json": '{"auth":"keep"}\n',
+        "config.yaml": "model:\n  default: keep\n",
+        "state.db": "sqlite-ish sentinel\n",
+        "memories/MEMORY.md": "target memory\n§\nkeep\n",
+        "memories/USER.md": "target user\n§\nkeep\n",
+        "sessions/session.jsonl": "session sentinel\n",
+        "cron/jobs.json": "cron sentinel\n",
+    }
+    for rel, content in sentinel_files.items():
+        path = target / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    before_hashes = _hash_tree(target)
+    _patch_profile_dirs(monkeypatch, source, target)
+
+    class Args(_BaseArgs):
+        profile_sync_action = "skills"
+        apply = True
+        with_backup = True
+
+    report = profile_sync._build_report(Args())
+
+    assert report["apply"]["copied"] == ["cat/alpha"]
+    after_hashes = _hash_tree(target)
+    for rel in sentinel_files:
+        assert rel in after_hashes
+        assert after_hashes[rel] == before_hashes[rel]
+    assert (target / "sessions").is_dir()
+    assert (target / "cron").is_dir()


### PR DESCRIPTION
Summary

This PR adds a safe profile-sync CLI for comparing Hermes profiles and syncing skills only between profiles.

It solves the immediate need to keep profile skill libraries aligned, for example engineer → default / Eddie Junior, without copying or corrupting profile identity, memory, credentials, config, sessions, cron jobs, logs, or gateway state.

Before this slice, there was no narrow, auditable path for cross-profile skill sync. The unsafe alternative was broad file copying between profile directories.

Commits

- ac7b81fe0 feat: add safe profile sync
- 5ce247ecc test: cover profile sync safety gaps

User-facing commands

Full read-only comparison:

```bash
hermes profile-sync diff --source engineer --target default
```

Compare skills only:

```bash
hermes profile-sync skills --source engineer --target default --dry-run
```

Apply skills sync with required backup:

```bash
hermes profile-sync skills --source engineer --target default --apply --with-backup
```

Compare memories only, read-only:

```bash
hermes profile-sync memories --source engineer --target default --dry-run
```

Memory apply is intentionally refused:

```bash
hermes profile-sync memories --source engineer --target default --apply
```

Expected output:

```text
profile-sync: memory apply is disabled until merge rules exist
```

with non-zero exit.

Safety boundaries

Allowed write scope:

Only this target path is writable in apply mode:

```text
<target-profile>/skills/
```

The apply path copies:
- skills missing in the target
- skills changed between source and target

It does not delete target-only skills.

Backup required:

Skills apply refuses to run unless `--with-backup` is supplied.

Backup path shape:

```text
<target-profile>/backups/profile-sync/skills-YYYYMMDD-HHMMSS.zip
```

If the target skills directory does not exist, it writes an empty-marker backup note instead.

Explicitly excluded state:

The command does not write or sync:

```text
.env
auth.json
config.yaml
state.db
sessions/
cron/
logs/
gateway pid/state files
memories/MEMORY.md
memories/USER.md
```

Refusal paths fail closed through the real CLI entrypoint. This includes:
- memory apply refusal
- skills apply without backup

Test coverage

The two-commit slice includes targeted pytest coverage for:
- dry-run skill comparison:
  - missing skills
  - extra target skills
  - changed skills
  - would_copy
  - would_delete == []
  - read-only safety flag

- memory dry-run:
  - detects changed memory files
  - reports entry counts
  - reports apply_supported: false

- memory apply refusal:
  - internal refusal path raises
  - subprocess/entrypoint test proves non-zero exit
  - verifies output includes: memory apply is disabled until merge rules exist

- skills apply guard:
  - --apply without --with-backup is refused

- skills apply behaviour:
  - copies missing skills
  - replaces changed skills
  - creates backup
  - preserves target-only skills
  - post-apply comparison has no missing/changed source skills

- sentinel untouched-state safety:
  - skills apply does not alter known contents/hashes for:
    - .env
    - auth.json
    - config.yaml
    - state.db
    - sessions/
    - cron/
    - memories/MEMORY.md
    - memories/USER.md

Final targeted test result:

```text
7 passed
```

Known limitations

- Sync apply is skills-only.
- No memory merge or memory apply.
- No config/auth/session/cron/log/gateway-state sync.
- No deletion of target-only skills.
- No semantic merge for changed skills; source version replaces target version after backup.
- Backup creation exists, but there is no backup listing, inspection, or restore command yet.
- Existing long-running sessions may need a new session or /reset to load updated skill content.
- This does not restart gateways and does not attempt to reload active gateway processes.

Why memory merge is intentionally excluded

Memory is profile identity/state, not a static reusable asset like a skill.

Blindly copying memory files between profiles can corrupt:
- who the profile thinks the user is
- profile-specific preferences
- assistant role boundaries
- operational history
- live workflow assumptions
- personal/business context separation

A safe memory sync needs merge rules first:
- dedupe strategy
- conflict handling
- source/target precedence
- profile identity boundaries
- stale-entry handling
- audit trail
- rollback plan

Until those rules exist, memory comparison is useful, but memory apply is deliberately blocked.

Suggested follow-up issues, not implementation

Issue 1 — Backup listing and inspection

Add read-only backup ergonomics:

```bash
hermes profile-sync backups --target default
hermes profile-sync inspect-backup --target default --backup skills-YYYYMMDD-HHMMSS.zip
```

Purpose: make --with-backup operationally auditable.

Issue 2 — Guarded skill restore

Add a restore path only after backup inspection exists:

```bash
hermes profile-sync restore-skills --target default --backup skills-YYYYMMDD-HHMMSS.zip --with-backup
```

Purpose: provide rollback without manual zip handling.

Issue 3 — Skill conflict report

Before apply, show changed skill paths with richer context:
- source hash
- target hash
- file count
- changed files within skill

Purpose: better operator visibility before overwrite.

Issue 4 — Memory merge design document

Write a design-only proposal for memory merge rules before any implementation.

Must cover:
- dedupe
- conflict resolution
- profile identity protection
- audit logs
- rollback
- default-deny apply behaviour

Issue 5 — Optional dry-run JSON schema stability

Stabilise and document the JSON output contract for automation:

```bash
hermes profile-sync diff --source engineer --target default --json
```

Purpose: allow future dashboards or CI checks to consume profile-sync safely.
