### PR TITLE
fix(installer): stop desktop release lockers before rebuild

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2331,6 +2331,38 @@ function Clear-ElectronBuildCache {
     return $removed
 }
 
+function Stop-DesktopProcessesLockingRelease {
+    param([string]$DesktopDir)
+
+    $releaseDir = Join-Path $DesktopDir 'release'
+    if (-not (Test-Path -LiteralPath $releaseDir)) { return }
+
+    $releasePrefix = [System.IO.Path]::GetFullPath($releaseDir).TrimEnd('\') + '\'
+    $myPid = $PID
+    $lockers = @()
+
+    try {
+        $lockers = @(Get-CimInstance Win32_Process -ErrorAction Stop |
+            Where-Object {
+                $_.ProcessId -ne $myPid -and
+                $_.ExecutablePath -and
+                $_.ExecutablePath.StartsWith($releasePrefix, [System.StringComparison]::OrdinalIgnoreCase)
+            })
+    } catch {
+        Write-Warn "Could not enumerate desktop release processes: $($_.Exception.Message)"
+    }
+
+    foreach ($proc in $lockers) {
+        Write-Info "  stopping PID $($proc.ProcessId) ($($proc.Name)) running from desktop release"
+        Stop-Process -Id $proc.ProcessId -Force -ErrorAction SilentlyContinue
+    }
+
+    if ($lockers.Count -gt 0) {
+        # Windows can keep image handles live briefly after Stop-Process returns.
+        Start-Sleep -Milliseconds 800
+    }
+}
+
 # Last-resort Electron mirror after GitHub download fails (#47266).
 $script:DesktopElectronFallbackMirror = "https://npmmirror.com/mirrors/electron/"
 
@@ -2544,12 +2576,14 @@ function Install-Desktop {
         $env:CSC_IDENTITY_AUTO_DISCOVERY = "false"
         $env:WIN_CSC_LINK = ""
         $env:WIN_CSC_KEY_PASSWORD = ""
+        Stop-DesktopProcessesLockingRelease -DesktopDir $desktopDir
         & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog
         $code = $LASTEXITCODE
         if ($code -ne 0) {
             $purged = @()
             $restored = $false
             if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
+                Stop-DesktopProcessesLockingRelease -DesktopDir $desktopDir
                 $purged = @(Clear-ElectronBuildCache -DesktopDir $desktopDir)
                 $restored = Restore-ElectronDist -InstallDir $InstallDir
             }
@@ -2571,6 +2605,7 @@ function Install-Desktop {
             $prevMirror = $env:ELECTRON_MIRROR
             $env:ELECTRON_MIRROR = $mirror
             try {
+                Stop-DesktopProcessesLockingRelease -DesktopDir $desktopDir
                 & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog
                 $code = $LASTEXITCODE
             } finally {


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows bootstrap installer/Desktop update failure where `apps/desktop` rebuilds into `release\win-unpacked` while the previous unpacked Desktop app is still running from that same release tree. Windows keeps the Electron runtime files locked, so the installer reaches `npm run pack` and dies with errors like:

```text
[before-pack] could not clean ...\apps\desktop\release\win-unpacked (EPERM, Permission denied: ...\win-unpacked); continuing
EBUSY: resource busy or locked, unlink ...\win-unpacked\v8_context_snapshot.bin
apps/desktop build failed (exit 1)
```

The CLI `hermes desktop` path already handles this class in #42100 by stopping processes running from the Desktop release tree before rebuilding. This brings the same narrow lock-release behavior to the PowerShell installer path before `npm run pack`.

The scope is intentionally tight: it only stops processes whose executable path starts under this install's `apps\desktop\release\` directory. It does not kill global `Hermes.exe`, Node, Python, gateway, or unrelated Electron processes.

## Related Issue

No GitHub issue. Seen in Discord support thread `1519842932386037941`.

Related prior fix: #42100 covered the CLI `hermes desktop` build path; this PR covers the bootstrap installer `scripts/install.ps1` path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/install.ps1`
  - Add `Stop-DesktopProcessesLockingRelease`, which enumerates Windows processes via `Win32_Process` and stops only processes whose executable path is under `apps\desktop\release\`.
  - Call the helper before the installer runs `npm run pack`.
  - Call it again before retry/mirror rebuild paths that may also touch the unpacked release tree.

## How to Test

1. On Windows, install/launch Hermes Desktop from `apps\desktop\release\win-unpacked`.
2. With the old Desktop process still running, rerun the bootstrap installer/Desktop update path that rebuilds `apps/desktop`.
3. Confirm the installer stops only the process from this install's Desktop release tree before `npm run pack`, allowing electron-builder to replace `win-unpacked`.

Local checks run:

```text
git diff --check -- scripts/install.ps1
powershell.exe -NoProfile -Command Parser::ParseFile(...)
```

Result: both passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux static check plus Windows PowerShell parser check; runtime behavior is Windows-specific

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Support log excerpt showed the installer failing in `Stage-Desktop` while rebuilding `apps/desktop/release/win-unpacked`:

```text
[before-pack] could not clean ...\apps\desktop\release\win-unpacked (EPERM, Permission denied: ...\win-unpacked); continuing
EBUSY: resource busy or locked, unlink ...\win-unpacked\v8_context_snapshot.bin
apps/desktop build failed (exit 1)
```
