### PR TITLE
fix(desktop): bundle simple-git into the packaged app

### DIFF
--- a/apps/desktop/electron/git-review-ops.cjs
+++ b/apps/desktop/electron/git-review-ops.cjs
@@ -10,7 +10,22 @@ const { execFile } = require('node:child_process')
 const fs = require('node:fs/promises')
 const path = require('node:path')
 
-const simpleGit = require('simple-git')
+// Workspace dedup hoists simple-git into the repo-root node_modules, which
+// electron-builder's explicit `files:` collector can't reach, so it never lands
+// in the asar. scripts/stage-native-deps.cjs ships its dependency closure under
+// resources/native-deps/node_modules via extraResources; resolve from there
+// when the bare require fails in a packaged build. Mirrors the node-pty fallback
+// in main.cjs.
+let simpleGit
+try {
+  simpleGit = require('simple-git')
+} catch (err) {
+  if (err && err.code === 'MODULE_NOT_FOUND' && process.resourcesPath) {
+    simpleGit = require(path.join(process.resourcesPath, 'native-deps', 'node_modules', 'simple-git'))
+  } else {
+    throw err
+  }
+}
 
 const { resolveRequestedPathForIpc } = require('./hardening.cjs')
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -172,6 +172,13 @@
         "to": "native-deps"
       },
       {
+        "from": "build/native-deps/node_modules",
+        "to": "native-deps/node_modules",
+        "filter": [
+          "**/*"
+        ]
+      },
+      {
         "from": "assets/icon.ico",
         "to": "icon.ico"
       }

--- a/apps/desktop/scripts/stage-native-deps.cjs
+++ b/apps/desktop/scripts/stage-native-deps.cjs
@@ -148,11 +148,80 @@ function stageOne(spec) {
   console.log(`[stage-native-deps] ${path.relative(APP_ROOT, spec.to)}: ${copied} files`)
 }
 
+// Pure-JS runtime deps that the Electron main process require()s directly
+// (e.g. simple-git in electron/git-review-ops.cjs).  Same hoisting problem as
+// the native deps above -- workspace dedup lifts them into the repo-root
+// node_modules, out of reach of electron-builder's explicit `files:` collector,
+// so they never land in the asar.  We stage each module's full dependency
+// closure into build/native-deps/node_modules/ (a real node_modules layout so
+// transitive require()s resolve), ship it via extraResources, and the consumer
+// falls back to process.resourcesPath when the bare require fails in a packaged
+// build -- mirroring the node-pty pattern in main.cjs.
+const JS_DEP_CLOSURES = ['simple-git']
+
+// Locate a module's on-disk root dir + parsed package.json. We resolve the
+// package entry (not `<name>/package.json`, which modern packages hide behind an
+// `exports` map -- e.g. simple-git) and walk up to the first package.json whose
+// `name` matches, so scoped packages and dist/-nested entries both resolve.
+function resolveModule(name, req, rootName) {
+  let entry
+  try {
+    entry = req.resolve(name)
+  } catch (err) {
+    throw new Error(
+      `stage-native-deps: cannot resolve '${name}' (closure of '${rootName}'): ` +
+        `${err.message}.  Run \`npm install\` at the workspace root first.`
+    )
+  }
+  let dir = path.dirname(entry)
+  for (;;) {
+    const pj = path.join(dir, 'package.json')
+    if (fs.existsSync(pj)) {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(pj, 'utf8'))
+        if (pkg.name === name) return { dir, pkg }
+      } catch { /* keep walking */ }
+    }
+    const parent = path.dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  throw new Error(`stage-native-deps: could not locate package root for '${name}'`)
+}
+
+// Copy a module's full dependency closure into destNodeModules, preserving the
+// node_modules layout (scoped packages keep their @scope/ dir).  Resolution is
+// done per-module via createRequire so nested installs are handled, not just the
+// flat hoisted case.
+function stageClosure(rootName, destNodeModules) {
+  const { createRequire } = require('node:module')
+  const rootReq = createRequire(path.join(REPO_ROOT, 'package.json'))
+  const visited = new Set()
+  const queue = [{ name: rootName, req: rootReq }]
+  while (queue.length) {
+    const { name, req } = queue.shift()
+    if (visited.has(name)) continue
+    visited.add(name)
+    const { dir: modDir, pkg } = resolveModule(name, req, rootName)
+    const dest = path.join(destNodeModules, ...name.split('/'))
+    ensureDir(path.dirname(dest))
+    fs.cpSync(modDir, dest, { recursive: true })
+    const childReq = createRequire(path.join(modDir, 'package.json'))
+    for (const dep of Object.keys(pkg.dependencies || {})) {
+      if (!visited.has(dep)) queue.push({ name: dep, req: childReq })
+    }
+  }
+  console.log(`[stage-native-deps] node_modules/${rootName} closure: ${visited.size} modules`)
+}
+
 function main() {
   rmrf(STAGE_ROOT)
   ensureDir(STAGE_ROOT)
   for (const spec of NATIVE_DEPS) {
     stageOne(spec)
+  }
+  for (const rootName of JS_DEP_CLOSURES) {
+    stageClosure(rootName, path.join(STAGE_ROOT, 'node_modules'))
   }
 }
 


### PR DESCRIPTION
## Problem

The packaged desktop app crashes on launch with:

```
A JavaScript error occurred in the main process
Uncaught Exception:
Error: Cannot find module 'simple-git'
Require stack:
- .../Hermes.app/Contents/Resources/app.asar/electron/git-review-ops.cjs
- .../Hermes.app/Contents/Resources/app.asar/electron/main.cjs
```

`electron/git-review-ops.cjs` (git review pane) does a bare `require('simple-git')`, but npm workspace dedup hoists `simple-git` into the **repo-root** `node_modules`. electron-builder's explicit `files:` allowlist (`dist/assets/electron/public/package.json`) can't reach the hoisted root, so `simple-git` never lands in the asar — and there's no runtime fallback. Result: the asar ships **zero** `node_modules`, and the main process throws on first launch.

This is the exact same hoisting problem already solved for `node-pty` (see `scripts/stage-native-deps.cjs` + `main.cjs`'s `process.resourcesPath` fallback); `simple-git` was simply never wired into that mechanism when the git review feature landed.

> Note: the `packaged electron entrypoints do not require unpackaged npm modules` guard in `bootstrap-platform.test.cjs` only scans `main.cjs`/`preload.cjs`/`bootstrap-platform.cjs`, so this bare require in `git-review-ops.cjs` slipped past it.

## Fix

Mirror the existing `node-pty` handling end-to-end:

- **`scripts/stage-native-deps.cjs`** — stage `simple-git`'s full dependency closure into `build/native-deps/node_modules/` using a real `node_modules` layout so transitive requires (`@kwsites/*`, `@simple-git/*`, `debug`, `ms`) resolve. The closure is walked dynamically (resolve the package entry, then walk up to the owning `package.json`) rather than hardcoded, so it stays correct as `simple-git`'s deps change.
- **`package.json`** — ship the closure via a dedicated `extraResources` entry whose `from` root is `build/native-deps/node_modules`. This matters: electron-builder drops `**/node_modules/**` by default, so a parent-dir copy (`from: build/native-deps`) silently skips it. Rooting the `from` at the `node_modules` dir means the copied relative paths don't contain a `node_modules` segment, and an explicit `filter: ["**/*"]` is added for good measure.
- **`electron/git-review-ops.cjs`** — fall back to `process.resourcesPath/native-deps/node_modules/simple-git` when the bare require throws `MODULE_NOT_FOUND` in a packaged build, exactly as `main.cjs` does for `node-pty`. Dev runs (where `simple-git` resolves normally) are unaffected.

## Testing

- `node --test electron/git-review-ops.test.cjs` — 4/4 pass
- `node --test electron/bootstrap-platform.test.cjs` — 10/10 pass
- `npm run pack` then verified `Resources/native-deps/node_modules/simple-git` is present and loadable from the packaged path, and the rebuilt app launches without the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)