### PR TITLE
fix(agent): repair DeepSeek double-serialized & trailing-content tool-call JSON (#52740)

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -210,6 +210,23 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     # the most common local-model repair case (#12068).
     try:
         parsed = json.loads(raw_stripped, strict=False)
+        # Pattern 2 (#52740): double-serialised arguments. Some models emit
+        # the whole tool-call payload as a JSON *string* that itself encodes
+        # the arguments object (e.g. ``"{\"path\": ...}"``). Tool-call
+        # arguments are always an object/array at the top level, so a bare
+        # string is a serialisation bug — unwrap one level if it decodes to
+        # a structured value.
+        if isinstance(parsed, str):
+            try:
+                unwrapped = json.loads(parsed, strict=False)
+            except (json.JSONDecodeError, TypeError, ValueError):
+                unwrapped = None
+            if isinstance(unwrapped, (dict, list)):
+                logger.warning(
+                    "Repaired double-serialised tool_call arguments for %s",
+                    tool_name,
+                )
+                return json.dumps(unwrapped, separators=(",", ":"))
         reserialised = json.dumps(parsed, separators=(",", ":"))
         if reserialised != raw_stripped:
             logger.warning(
@@ -217,6 +234,21 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
                 tool_name,
             )
         return reserialised
+    except (json.JSONDecodeError, TypeError, ValueError):
+        pass
+
+    # Pattern 4 (#52740): trailing content after a complete JSON value. Some
+    # models append prose or a second object after the arguments object,
+    # which ``json.loads`` rejects with "Extra data". Decode the leading
+    # value and discard the trailing bytes.
+    try:
+        decoded, end = json.JSONDecoder().raw_decode(raw_stripped)
+        if isinstance(decoded, (dict, list)) and end < len(raw_stripped):
+            logger.warning(
+                "Repaired trailing content in tool_call arguments for %s",
+                tool_name,
+            )
+            return json.dumps(decoded, separators=(",", ":"))
     except (json.JSONDecodeError, TypeError, ValueError):
         pass
 

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -140,3 +140,65 @@ class TestRepairToolCallArguments:
         parsed = json.loads(result)
         assert "line" in parsed["msg"]
 
+
+class TestDeepSeekSerializationPatterns:
+    """DeepSeek tool-call JSON serialization failures (#52740).
+
+    Covers Pattern 2 (double-serialization) and Pattern 4 (trailing
+    content). Pattern 1 (truncation) is unrecoverable and falls back to
+    ``{}``; Pattern 3 (quote-escape corruption) is intentionally left to a
+    follow-up that needs the reporter's concrete samples.
+
+    Both repairs rely on the tool-call spec invariant that arguments are a
+    JSON object/array at the top level. Pattern 2 unwraps a single level of
+    double-serialization (the reported shape); deeper nesting is left as-is.
+    """
+
+    # -- Pattern 2: double-serialization --
+
+    def test_double_serialized_object_is_unwrapped(self):
+        inner = '{"path": "a.txt", "content": "hello world"}'
+        raw = json.dumps(inner)  # serialised twice
+        result = _repair_tool_call_arguments(raw, "skill_manage")
+        assert json.loads(result) == {"path": "a.txt", "content": "hello world"}
+
+    def test_double_serialized_with_inner_quotes(self):
+        inner = '{"command": "git commit -m \\"fix\\""}'
+        raw = json.dumps(inner)
+        result = _repair_tool_call_arguments(raw, "run_command")
+        assert json.loads(result) == {"command": 'git commit -m "fix"'}
+
+    def test_double_serialized_array(self):
+        raw = json.dumps('[1, 2, 3]')
+        result = _repair_tool_call_arguments(raw, "t")
+        assert json.loads(result) == [1, 2, 3]
+
+    def test_single_serialized_object_unaffected(self):
+        """Regression: a normal (single-serialised) object is untouched."""
+        raw = '{"path": "a.txt", "content": "hi"}'
+        result = _repair_tool_call_arguments(raw, "t")
+        assert json.loads(result) == {"path": "a.txt", "content": "hi"}
+
+    def test_bare_non_json_string_not_unwrapped(self):
+        """A top-level string that is not itself JSON stays as-is (no crash)."""
+        raw = json.dumps("just some text")
+        result = _repair_tool_call_arguments(raw, "t")
+        assert json.loads(result) == "just some text"
+
+    # -- Pattern 4: trailing content --
+
+    def test_trailing_prose_after_object(self):
+        raw = '{"command": "ls -la"}\n\nDone.'
+        result = _repair_tool_call_arguments(raw, "run_command")
+        assert json.loads(result) == {"command": "ls -la"}
+
+    def test_two_concatenated_objects_keeps_first(self):
+        raw = '{"a": 1}{"b": 2}'
+        result = _repair_tool_call_arguments(raw, "t")
+        assert json.loads(result) == {"a": 1}
+
+    def test_trailing_content_output_is_strict_valid(self):
+        raw = '{"path": "x.py"} trailing junk'
+        result = _repair_tool_call_arguments(raw, "t")
+        # must parse under strict=True
+        assert json.loads(result) == {"path": "x.py"}


### PR DESCRIPTION
## What does this PR do?

Repairs two of the four DeepSeek tool-call JSON serialization failure patterns reported in #52740, inside `_repair_tool_call_arguments` (`agent/message_sanitization.py`).

- **Pattern 2 — double-serialization (56 occurrences).** Some models emit the whole tool-call payload as a JSON *string* that itself encodes the arguments object (e.g. `"{\"path\": ...}"`). The existing Pass 0 parsed this to a `str` and re-serialized it back to the same string literal, so the tool received a string instead of `{path, content}` — which is exactly the "mismatches target files" symptom for `skill_manage`/`patch`. We now detect a top-level `str` after parsing and unwrap one level when it decodes to a structured value (object/array). Tool-call arguments are always an object/array at the top level, so this is safe.
- **Pattern 4 — trailing content (2 occurrences).** A complete JSON value followed by prose or a second object made `json.loads` raise "Extra data", so the whole call fell through to the `{}` last resort. We now `raw_decode()` the leading value and discard the trailing bytes.

### Scope boundary (intentional)

- **Pattern 1 (truncation → `{}`, 65)** is unrecoverable — truncated content can't be reconstructed — so the existing `{}` fallback is kept.
- **Pattern 3 (quote-escape corruption → `{}`, 153, 55%)** is intentionally **out of scope** here. A safe repair depends on the exact byte shapes of the corrupted quoting, and a naive `\"`-normalization heuristic risks corrupting legitimately-escaped backslashes. @FranktasticFL — the issue mentions "Full analysis + detection scripts available"; could you share the concrete Pattern 3 sample inputs / detection script? I'd like the repair to be driven by real failing strings rather than guessed shapes, and will follow up with a separate PR for it.

## Related Issue

Fixes #52740 (partial — Patterns 2 & 4; see scope boundary above)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/message_sanitization.py` — `_repair_tool_call_arguments`: unwrap double-serialized string payloads (Pattern 2) inside Pass 0; add a `raw_decode` pass for trailing content (Pattern 4). Both log at WARNING level, consistent with the other repair passes.
- `tests/run_agent/test_repair_tool_call_arguments.py` — new `TestDeepSeekSerializationPatterns` (8 cases): double-serialized object/array/inner-quotes, single-serialized regression, bare-non-JSON-string passthrough, trailing prose, two concatenated objects, strict-valid output.

## How to Test

1. `pytest tests/run_agent/test_repair_tool_call_arguments.py tests/run_agent/test_streaming_tool_call_repair.py -q` → all pass (29 + 12).
2. Before this change, `_repair_tool_call_arguments(json.dumps('{"path":"a.txt"}'))` returned the string `"{\"path\": \"a.txt\"}"` and `_repair_tool_call_arguments('{"command":"ls"}\n\nDone.')` returned `{}`. After, they return `{"path":"a.txt"}` and `{"command":"ls"}` respectively.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(agent):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
