### PR TITLE
fix(lsp): add idle client reaper to prevent memory leak

### DIFF
--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -169,7 +169,9 @@ class LSPService:
         self._loop = _BackgroundLoop()
         if self._enabled:
             self._loop.start()
-
+            # Fire-and-forget: schedule on the background loop, don't block __init__
+            assert self._loop._loop is not None  # guaranteed after start()
+            asyncio.run_coroutine_threadsafe(self._start_reaper(), self._loop._loop)
         # Per-(server_id, workspace_root) state
         self._clients: Dict[Tuple[str, str], LSPClient] = {}
         self._broken: set = set()
@@ -565,6 +567,33 @@ class LSPService:
         finally:
             with self._state_lock:
                 self._spawning.pop(key, None)
+
+    async def _start_reaper(self):
+        """Periodically reap idle LSP clients to prevent memory leaks."""
+        while True:
+            await asyncio.sleep(300)  # check every 5 minutes
+            try:
+                await self._reap_idle()
+            except Exception:
+                pass
+
+    async def _reap_idle(self):
+        """Shutdown clients that haven't been used within _idle_timeout seconds."""
+        now = time.time()
+        to_reap = []
+        with self._state_lock:
+            for key, last in list(self._last_used.items()):
+                if now - last > self._idle_timeout:
+                    to_reap.append(key)
+        for key in to_reap:
+            with self._state_lock:
+                client = self._clients.pop(key, None)
+                self._last_used.pop(key, None)
+            if client and client.is_running:
+                try:
+                    await client.shutdown()
+                except Exception:
+                    pass
 
     async def _shutdown_async(self) -> None:
         with self._state_lock:


### PR DESCRIPTION
## Problem

`LSPService` tracks idle time via `_last_used` but never reaps stale LSP clients. The only cleanup path is `atexit` — which never fires on a long-running gateway (systemd daemon). 

After 15 hours, 27 LSP server instances accumulated consuming ~4 GB RAM:
- 8× gopls (2.3 GB)
- 9× yaml-language-server (~600 MB)  
- 7× typescript-language-server (~400 MB)
- 3× pyright (~700 MB)

## Fix

Two new methods on `LSPService`:

- **`_start_reaper()`** — infinite async loop, `await asyncio.sleep(300)`, calls `_reap_idle` every 5 minutes
- **`_reap_idle()`** — walks `_last_used`, pops clients idle > `_idle_timeout` (600s), calls `client.shutdown()`, removes from `_clients`

Scheduled as fire-and-forget via `asyncio.run_coroutine_threadsafe` on the background event loop — does not block `__init__`.

**Zero new fields.** Reuses existing `_last_used`, `_idle_timeout`, and `_state_lock` state that was already being tracked but never acted upon.

## Changes

- `agent/lsp/manager.py` — +30 lines, 3 edits (init wiring + 2 methods)