### PR TITLE
fix(auxiliary): refresh auto-routed OAuth credentials on 401

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5757,14 +5757,27 @@ def call_llm(
                     refreshed_client.chat.completions.create(**kwargs), task)
 
         # ── Auth refresh retry ───────────────────────────────────────
+        # Derive the real provider when the task resolved to "auto" (auxiliary
+        # and compression calls dispatch as "auto" but bind to a concrete OAuth
+        # backend, e.g. api.anthropic.com). Without this the auto-routed client
+        # is excluded from refresh and a 401 on a stale singleton OAuth token
+        # (Anthropic) retries forever instead of refreshing.
+        _refresh_provider = resolved_provider
+        if _refresh_provider in {"auto", "", None}:
+            _refresh_provider = _recoverable_pool_provider(
+                resolved_provider, client, main_runtime=main_runtime)
         if (_is_auth_error(first_err)
-                and resolved_provider not in {"auto", "", None}
+                and _refresh_provider
                 and not client_is_nous):
-            if _refresh_provider_credentials(resolved_provider):
+            if _refresh_provider_credentials(_refresh_provider):
                 logger.info(
                     "Auxiliary %s: refreshed %s credentials after auth error, retrying",
-                    task or "call", resolved_provider,
+                    task or "call", _refresh_provider,
                 )
+                # The client may be cached under the "auto" key; provider-keyed
+                # eviction misses it, so evict by instance to force a rebuild
+                # that picks up the refreshed token.
+                _evict_cached_client_instance(client)
                 return _retry_same_provider_sync(
                     task=task,
                     resolved_provider=resolved_provider,
@@ -6260,14 +6273,27 @@ async def async_call_llm(
                     await refreshed_client.chat.completions.create(**kwargs), task)
 
         # ── Auth refresh retry (mirrors sync call_llm) ───────────────
+        # Derive the real provider when the task resolved to "auto" (auxiliary
+        # and compression calls dispatch as "auto" but bind to a concrete OAuth
+        # backend, e.g. api.anthropic.com). Without this the auto-routed client
+        # is excluded from refresh and a 401 on a stale singleton OAuth token
+        # (Anthropic) retries forever instead of refreshing.
+        _refresh_provider = resolved_provider
+        if _refresh_provider in {"auto", "", None}:
+            _refresh_provider = _recoverable_pool_provider(
+                resolved_provider, client, main_runtime=main_runtime)
         if (_is_auth_error(first_err)
-                and resolved_provider not in {"auto", "", None}
+                and _refresh_provider
                 and not client_is_nous):
-            if _refresh_provider_credentials(resolved_provider):
+            if _refresh_provider_credentials(_refresh_provider):
                 logger.info(
                     "Auxiliary %s (async): refreshed %s credentials after auth error, retrying",
-                    task or "call", resolved_provider,
+                    task or "call", _refresh_provider,
                 )
+                # The client may be cached under the "auto" key; provider-keyed
+                # eviction misses it, so evict by instance to force a rebuild
+                # that picks up the refreshed token.
+                _evict_cached_client_instance(client)
                 return await _retry_same_provider_async(
                     task=task,
                     resolved_provider=resolved_provider,

--- a/tests/agent/test_auxiliary_auto_anthropic_refresh.py
+++ b/tests/agent/test_auxiliary_auto_anthropic_refresh.py
@@ -1,0 +1,102 @@
+"""Regression test for the auto->anthropic auth-refresh derivation.
+
+Bug: auxiliary/compression calls dispatch with provider="auto" but bind to a
+concrete Anthropic OAuth backend. The old gate was:
+
+    if _is_auth_error(first_err) and resolved_provider not in {"auto","",None}:
+
+so an "auto"-routed Anthropic client that 401'd on an expired OAuth token was
+EXCLUDED from the refresh path and retried forever on the stale token.
+
+Fix: derive the real provider via _recoverable_pool_provider(resolved, client)
+before the eligibility check. This test pins that derivation for the Anthropic
+host so the refresh branch is reachable for auto-routed clients.
+"""
+
+import pytest
+
+from agent.auxiliary_client import (
+    _recoverable_pool_provider,
+    _evict_cached_client_instance,
+    _is_auth_error,
+)
+
+
+class _AnthropicishClient:
+    base_url = "https://api.anthropic.com/v1/"
+
+
+class _UnknownClient:
+    base_url = "https://example.invalid/v1/"
+
+
+class TestAutoAnthropicDerivation:
+    def test_auto_with_anthropic_host_maps_to_anthropic(self):
+        # This is the exact path my patch relies on: provider resolved to
+        # "auto", client bound to api.anthropic.com -> must yield "anthropic"
+        # so _refresh_provider_credentials("anthropic") gets called.
+        assert _recoverable_pool_provider("auto", _AnthropicishClient()) == "anthropic"
+
+    def test_empty_provider_with_anthropic_host_maps_to_anthropic(self):
+        assert _recoverable_pool_provider("", _AnthropicishClient()) == "anthropic"
+
+    def test_explicit_anthropic_passes_through(self):
+        assert _recoverable_pool_provider("anthropic", _UnknownClient()) == "anthropic"
+
+    def test_auto_with_unknown_host_returns_none(self):
+        # No host match, no main_runtime -> None, so the refresh gate stays
+        # closed (old behavior preserved for genuinely unrecoverable clients).
+        assert _recoverable_pool_provider("auto", _UnknownClient()) is None
+
+
+class TestRefreshGateReachability:
+    """Simulate the patched gate end-to-end without live OAuth.
+
+    Reproduces the boolean logic at lines ~5560/6046: derive provider, then
+    decide whether the refresh branch is entered.
+    """
+
+    @staticmethod
+    def _gate_enters_refresh(resolved_provider, client, first_err, client_is_nous=False):
+        refresh_provider = resolved_provider
+        if refresh_provider in {"auto", "", None}:
+            refresh_provider = _recoverable_pool_provider(resolved_provider, client)
+        return bool(
+            _is_auth_error(first_err)
+            and refresh_provider
+            and not client_is_nous
+        )
+
+    def test_auto_anthropic_401_enters_refresh(self):
+        exc = Exception("Error code: 401 - Unauthorized")
+        exc.status_code = 401
+        # OLD code: resolved="auto" -> excluded -> False (the bug).
+        # NEW code: derives "anthropic" -> enters refresh -> True.
+        assert self._gate_enters_refresh("auto", _AnthropicishClient(), exc) is True
+
+    def test_auto_unknown_host_401_does_not_enter_refresh(self):
+        exc = Exception("Error code: 401 - Unauthorized")
+        exc.status_code = 401
+        assert self._gate_enters_refresh("auto", _UnknownClient(), exc) is False
+
+    def test_auto_anthropic_non_auth_error_does_not_enter_refresh(self):
+        exc = Exception("Error code: 500 - Internal server error")
+        exc.status_code = 500
+        assert self._gate_enters_refresh("auto", _AnthropicishClient(), exc) is False
+
+    def test_nous_client_never_enters_refresh(self):
+        exc = Exception("Error code: 401 - Unauthorized")
+        exc.status_code = 401
+        assert self._gate_enters_refresh(
+            "auto", _AnthropicishClient(), exc, client_is_nous=True
+        ) is False
+
+
+class TestEvictByInstanceExists:
+    def test_evict_none_is_noop(self):
+        # Patch calls _evict_cached_client_instance(client) before retry; the
+        # auto-keyed entry must be evictable by instance. None must be safe.
+        assert _evict_cached_client_instance(None) is False
+
+    def test_evict_unknown_instance_returns_false(self):
+        assert _evict_cached_client_instance(object()) is False


### PR DESCRIPTION
## Problem

Auxiliary and compression calls dispatch with `provider="auto"` but bind to a concrete OAuth backend (e.g. `api.anthropic.com`). The auth-refresh gate in **both** `call_llm` (sync, ~L5760) and `async_call_llm` (~L6263) reads:

```python
if (_is_auth_error(first_err)
        and resolved_provider not in {"auto", "", None}
        and not client_is_nous):
    if _refresh_provider_credentials(resolved_provider):
```

So an `"auto"`-routed Anthropic client that 401s on an expired **singleton** OAuth token is excluded from the refresh path and retries forever on the stale token.

The other recovery paths can't cover it:
- `_recover_provider_pool` bails on `not pool.has_credentials()` — Anthropic OAuth is a singleton, not a credential pool.
- A 401 isn't payment/connection/rate-limit, so `should_fallback` is False — the call just dies on the stale token.

`_refresh_provider_credentials("anthropic")` is the only path that refreshes the singleton token (`read_claude_code_credentials` → `_refresh_oauth_token` → `resolve_anthropic_token`), and it's unreachable for auto-routed clients.

## Fix

Before the eligibility check, derive the real provider via the existing `_recoverable_pool_provider(resolved_provider, client)` when it resolved to `"auto"`/`""`/`None`. That maps `api.anthropic.com → "anthropic"`, making the refresh reachable. Also evict the cached client **by instance** (`_evict_cached_client_instance(client)`) — it may be cached under the `"auto"` key, which provider-keyed eviction would miss, leaving the retry on a poisoned client.

Applied to **both** sync and async sites so the whole bug class is covered (sibling call paths included).

## Tests

Adds `tests/agent/test_auxiliary_auto_anthropic_refresh.py` — behavior assertions against the **real** derivation helper, no line-number snapshots:
- `auto` + `api.anthropic.com` → `"anthropic"`; empty provider → `"anthropic"`; explicit passthrough; unknown host → `None` (gate stays closed for genuinely unrecoverable clients).
- Patched-gate reachability: `auto`/anthropic/401 enters refresh (**True** — was False, the bug); non-auth error (500) does not; nous client never does.

Verified on fresh `main`:
- New + sibling (`test_auxiliary_client_xai_oauth_recovery.py`): **24 passed**
- Full `test_auxiliary_client.py`: **244 passed**, no regression