### PR TITLE
fix(auxiliary): screen terminal fallback layers by context window

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3132,6 +3132,7 @@ def _try_payment_fallback(
     skip_chain_labels = {_alias_to_label.get(s, s) for s in skip_labels}
 
     tried = []
+    min_ctx = _task_minimum_context_length(task)
     for label, try_fn in _get_provider_chain():
         if label in skip_chain_labels:
             continue
@@ -3141,6 +3142,15 @@ def _try_payment_fallback(
             continue
         client, model = try_fn()
         if client is not None:
+            if min_ctx is not None and model:
+                fb_ctx = _candidate_context_window(label, model)
+                if fb_ctx is not None and fb_ctx < min_ctx:
+                    logger.info(
+                        "Auxiliary %s: skipping %s (%s context=%d < min=%d), continuing chain",
+                        task, label, model, fb_ctx, min_ctx,
+                    )
+                    tried.append(f"{label} (context too small: {fb_ctx}<{min_ctx})")
+                    continue
             logger.info(
                 "Auxiliary %s: %s on %s — falling back to %s (%s)",
                 task or "call", reason, failed_provider, label, model or "default",
@@ -3197,11 +3207,21 @@ def _try_main_agent_model_fallback(
         return None, None, ""
 
     label = f"main-agent({main_provider})"
+    effective_model = resolved_model or main_model
+    min_ctx = _task_minimum_context_length(task)
+    if min_ctx is not None and effective_model:
+        fb_ctx = _candidate_context_window(main_provider, effective_model)
+        if fb_ctx is not None and fb_ctx < min_ctx:
+            logger.info(
+                "Auxiliary %s: skipping %s (%s context=%d < min=%d)",
+                task or "call", label, effective_model, fb_ctx, min_ctx,
+            )
+            return None, None, ""
     logger.info(
         "Auxiliary %s: %s on %s — falling back to main agent model %s (%s)",
-        task or "call", reason, failed_provider, label, resolved_model or main_model,
+        task or "call", reason, failed_provider, label, effective_model,
     )
-    return client, resolved_model or main_model, label
+    return client, effective_model, label
 
 
 # ── Context-window screening for runtime fallback chains (issue #52392) ──

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4507,3 +4507,111 @@ class TestCompressionFallbackContextFilter:
         # Empty / unknown tasks have no minimum
         assert _task_minimum_context_length("") is None
         assert _task_minimum_context_length(None) is None
+
+    # ── L6: payment fallback chain (auto path terminal layer) ─────────
+
+    def test_payment_fallback_skips_too_small_for_compression(self, monkeypatch):
+        """_try_payment_fallback must skip candidates whose context window
+        is below the task minimum, mirroring the screening in
+        _try_configured_fallback_chain and _try_main_fallback_chain."""
+        from agent.auxiliary_client import _try_payment_fallback
+
+        small_client = MagicMock(name="small_client")
+        large_client = MagicMock(name="large_client")
+
+        chain_calls = iter([
+            (small_client, "tiny-8k"),
+            (large_client, "huge-1m"),
+        ])
+
+        def fake_ctx(provider, model, base_url="", api_key=""):
+            return {"tiny-8k": 8192, "huge-1m": 1_048_576}.get(model, 256_000)
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_provider_chain",
+            lambda: [("small-prov", lambda: next(chain_calls)),
+                     ("large-prov", lambda: next(chain_calls))],
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._is_provider_unhealthy",
+            lambda label: False,
+        )
+
+        with patch("agent.auxiliary_client._candidate_context_window",
+                   side_effect=fake_ctx):
+            client, model, label = _try_payment_fallback(
+                "failed-prov", task="compression")
+
+        assert client is large_client, (
+            f"Expected large_client (1M context), got {client}. "
+            "Payment fallback returned an undersized candidate without "
+            "screening by context window.")
+        assert model == "huge-1m"
+        assert "large-prov" in label
+
+    # ── L7: main-agent model fallback (explicit-provider terminal layer) ─
+
+    def test_main_agent_fallback_skips_too_small_for_compression(self, monkeypatch):
+        """_try_main_agent_model_fallback must reject the main model when
+        its context window is below the task minimum."""
+        from agent.auxiliary_client import _try_main_agent_model_fallback
+
+        small_client = MagicMock(name="small_main")
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_provider",
+            lambda: "local-ollama",
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_model",
+            lambda: "small-32k",
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._is_provider_unhealthy",
+            lambda label: False,
+        )
+
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(small_client, "small-32k")), \
+             patch("agent.auxiliary_client._candidate_context_window",
+                   return_value=32_000):
+            client, model, label = _try_main_agent_model_fallback(
+                "openrouter", task="compression")
+
+        assert client is None, (
+            f"Expected None (32K < 64K minimum), got {client}. "
+            "Main-agent fallback returned an undersized model without "
+            "screening by context window.")
+        assert model is None
+        assert label == ""
+
+    def test_main_agent_fallback_accepts_large_model_for_compression(self, monkeypatch):
+        """_try_main_agent_model_fallback should return the main model
+        when its context window meets the task minimum."""
+        from agent.auxiliary_client import _try_main_agent_model_fallback
+
+        large_client = MagicMock(name="large_main")
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_provider",
+            lambda: "anthropic",
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_model",
+            lambda: "claude-sonnet-4-6",
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._is_provider_unhealthy",
+            lambda label: False,
+        )
+
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(large_client, "claude-sonnet-4-6")), \
+             patch("agent.auxiliary_client._candidate_context_window",
+                   return_value=200_000):
+            client, model, label = _try_main_agent_model_fallback(
+                "openrouter", task="compression")
+
+        assert client is large_client
+        assert model == "claude-sonnet-4-6"
+        assert "main-agent" in label


### PR DESCRIPTION
## Summary

The context-window screening added in #52661 (for issue #52392) covers `_try_configured_fallback_chain` and `_try_main_fallback_chain`, but the two **terminal** fallback layers are left unscreened:

- **`_try_payment_fallback`** (auto path, layer 3) — iterates `_get_provider_chain()` and returns the first reachable `(client, model)` with no context-window check.
- **`_try_main_agent_model_fallback`** (explicit-provider path, layer 2) — resolves the main agent model with no context-window check.

When the screened layers are exhausted (all configured/main chain entries either fail or are too small), a `task="compression"` call falls through to these terminal layers. If the terminal candidate is reachable but undersized (e.g. a 32K local/custom provider, or a small main model), the compression call proceeds with an inadequate context window — dropping middle turns without a summary and churning the prompt cache.

This PR mirrors the existing `_task_minimum_context_length` / `_candidate_context_window` screen in both terminal layers so undersized candidates are skipped.

## Changes

- `_try_payment_fallback`: compute `min_ctx` before the chain loop; skip candidates where `fb_ctx < min_ctx`, continuing to the next chain entry.
- `_try_main_agent_model_fallback`: check the resolved main model against `min_ctx`; return `(None, None, "")` when it is too small.

## Test plan

- [x] New test `test_payment_fallback_skips_too_small_for_compression` — verifies the payment chain skips an 8K candidate and selects a 1M candidate for compression
- [x] New test `test_main_agent_fallback_skips_too_small_for_compression` — verifies the main-agent fallback rejects a 32K model for compression
- [x] New test `test_main_agent_fallback_accepts_large_model_for_compression` — verifies a 200K main model is accepted
- [x] All 247 existing auxiliary_client tests pass (no regressions)

Closes #52392