### PR TITLE
docs(readme): marketing-friendly overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
   <img src="assets/banner.png" alt="Hermes Agent" width="100%">
 </p>
 
-# Hermes Agent ☤
+<h1 align="center">Hermes Agent ☤</h1>
+
+<p align="center">
+  <strong>Your AI that actually remembers you.</strong>
+</p>
 
 <p align="center">
   <a href="https://hermes-agent.nousresearch.com/docs/"><img src="https://img.shields.io/badge/Docs-hermes--agent.nousresearch.com-FFD700?style=for-the-badge" alt="Documentation"></a>
@@ -12,204 +16,193 @@
   <a href="README.zh-CN.md"><img src="https://img.shields.io/badge/Lang-中文-red?style=for-the-badge" alt="中文"></a>
 </p>
 
-**The self-improving AI agent built by [Nous Research](https://nousresearch.com).** It's the only agent with a built-in learning loop — it creates skills from experience, improves them during use, nudges itself to persist knowledge, searches its own past conversations, and builds a deepening model of who you are across sessions. Run it on a $5 VPS, a GPU cluster, or serverless infrastructure that costs nearly nothing when idle. It's not tied to your laptop — talk to it from Telegram while it works on a cloud VM.
+<p align="center">
+  Most AI assistants forget you the moment the window closes.<br>
+  Hermes doesn't. It learns your preferences, builds skills from experience,<br>
+  and gets better every time you use it — across every device, every platform.
+</p>
 
-Use any model you want — [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai) (200+ models), [NovitaAI](https://novita.ai) (AI-native cloud for Model API, Agent Sandbox, and GPU Cloud), [NVIDIA NIM](https://build.nvidia.com) (Nemotron), [Xiaomi MiMo](https://platform.xiaomimimo.com), [z.ai/GLM](https://z.ai), [Kimi/Moonshot](https://platform.moonshot.ai), [MiniMax](https://www.minimax.io), [Hugging Face](https://huggingface.co), OpenAI, or your own endpoint. Switch with `hermes model` — no code changes, no lock-in.
+---
+
+## ⚡ Get Started in 60 Seconds
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+source ~/.bashrc
+hermes
+```
+
+> Works on **Linux, macOS, WSL2, and Termux**. [Windows PowerShell (beta)](https://hermes-agent.nousresearch.com/docs/getting-started/quickstart) and [Termux](https://hermes-agent.nousresearch.com/docs/getting-started/termux) guides also available.
+
+---
+
+## 🧠 Why Hermes?
+
+Other agents are stateless tools — powerful in the moment, blank the next session. Hermes is different: it's the first agent with a **closed learning loop**.
 
 <table>
-<tr><td><b>A real terminal interface</b></td><td>Full TUI with multiline editing, slash-command autocomplete, conversation history, interrupt-and-redirect, and streaming tool output.</td></tr>
-<tr><td><b>Lives where you do</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal, and CLI — all from a single gateway process. Voice memo transcription, cross-platform conversation continuity.</td></tr>
-<tr><td><b>A closed learning loop</b></td><td>Agent-curated memory with periodic nudges. Autonomous skill creation after complex tasks. Skills self-improve during use. FTS5 session search with LLM summarization for cross-session recall. <a href="https://github.com/plastic-labs/honcho">Honcho</a> dialectic user modeling. Compatible with the <a href="https://agentskills.io">agentskills.io</a> open standard.</td></tr>
-<tr><td><b>Scheduled automations</b></td><td>Built-in cron scheduler with delivery to any platform. Daily reports, nightly backups, weekly audits — all in natural language, running unattended.</td></tr>
-<tr><td><b>Delegates and parallelizes</b></td><td>Spawn isolated subagents for parallel workstreams. Write Python scripts that call tools via RPC, collapsing multi-step pipelines into zero-context-cost turns.</td></tr>
-<tr><td><b>Runs anywhere, not just your laptop</b></td><td>Seven terminal backends — local, Docker, SSH, Singularity, Modal, Daytona, and Vercel Sandbox. Daytona and Modal offer serverless persistence — your agent's environment hibernates when idle and wakes on demand, costing nearly nothing between sessions. Run it on a $5 VPS or a GPU cluster.</td></tr>
-<tr><td><b>Research-ready</b></td><td>Batch trajectory generation, trajectory compression for training the next generation of tool-calling models.</td></tr>
+<tr>
+<td width="50%">
+
+### 🔄 It Learns and Improves
+Every complex task becomes a **reusable skill**. Every correction becomes a **persistent memory**. It searches its own past conversations and builds a deepening model of who you are — not a generic user, but *you*.
+
+</td>
+<td width="50%">
+
+### 🌐 It Lives Where You Do
+Telegram, Discord, Slack, WhatsApp, Signal, Email — all from one process. Start a conversation on your phone, continue it at your desk. Voice memos just work.
+
+</td>
+</tr>
+<tr>
+<td width="50%">
+
+### 🔌 Any Model, Zero Lock-in
+Use Claude, GPT, Gemini, Llama, Qwen, or [300+ models](https://portal.nousresearch.com) — switch with a single command. Bring your own keys or use [Nous Portal](https://portal.nousresearch.com) to skip the API-key juggling entirely.
+
+</td>
+<td width="50%">
+
+### 🏗️ Runs Anywhere, Not Just Your Laptop
+Seven terminal backends — local, Docker, SSH, Modal, Daytona, Singularity, and Vercel Sandbox. Deploy on a **$5 VPS** or a GPU cluster. Serverless options hibernate when idle — **near-zero cost** between sessions.
+
+</td>
+</tr>
 </table>
 
 ---
 
-## Quick Install
+## ✨ What You Can Do With It
 
-### Linux, macOS, WSL2, Termux
+<details open>
+<summary><b>🤖 Autonomous Workflows</b></summary>
+<br>
+
+- **Scheduled automations** — daily reports, nightly backups, weekly audits. Write them in plain English, deliver results to any platform.
+- **Parallel subagents** — spawn isolated workers for independent tasks. They run in parallel, report back, and never pollute your context.
+- **Execute code** — write Python scripts that orchestrate multi-step pipelines with zero context cost.
+
+</details>
+
+<details open>
+<summary><b>💬 A Real Terminal Experience</b></summary>
+<br>
+
+- Full TUI with multiline editing, slash-command autocomplete, and streaming output
+- Interrupt and redirect mid-task with `Ctrl+C` or just send a new message
+- Conversation history, session search, context compression
+- Beautiful themes via the skin engine
+
+</details>
+
+<details open>
+<summary><b>🔧 40+ Built-in Tools</b></summary>
+<br>
+
+File editing, web search, browser automation, image generation, text-to-speech, calendar, Git/GitHub, MCP server integration, and more — all discoverable with `hermes tools`.
+
+</details>
+
+<details open>
+<summary><b>🧪 Research-Ready</b></summary>
+<br>
+
+Batch trajectory generation and compression for training the next generation of tool-calling models. Built by [Nous Research](https://nousresearch.com) — the team behind Hermes, Genstruct, and OpenHermes.
+
+</details>
+
+---
+
+## 🎯 One Setup for Everything — Nous Portal
+
+Skip the API-key collection. **[Nous Portal](https://portal.nousresearch.com)** gives you models, web search, image gen, TTS, and a cloud browser — all under one subscription.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+hermes setup --portal    # OAuth login → provider set → tools wired. Done.
 ```
 
-### Windows (native, PowerShell) — Early Beta
+You can still bring your own keys per-tool anytime — it's not all-or-nothing.
 
-> **Heads up:** Native Windows support is **early beta**. It installs and runs, but hasn't been road-tested as broadly as our Linux/macOS/WSL2 paths. Please [file issues](https://github.com/NousResearch/hermes-agent/issues) when you hit rough edges. For the most battle-tested Windows setup today, run the Linux/macOS one-liner above inside **WSL2**.
+→ [Tool Gateway docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/tool-gateway)
 
-Run this in PowerShell:
+---
 
-```powershell
-iex (irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1)
-```
-
-The installer handles everything: uv, Python 3.11, Node.js, ripgrep, ffmpeg, **and a portable Git Bash** (MinGit, unpacked to `%LOCALAPPDATA%\hermes\git` — no admin required, completely isolated from any system Git install).  Hermes uses this bundled Git Bash to run shell commands.
-
-If you already have Git installed, the installer detects it and uses that instead.  Otherwise a ~45MB MinGit download is all you need — it won't touch or interfere with any system Git.
-
-> **Android / Termux:** The tested manual path is documented in the [Termux guide](https://hermes-agent.nousresearch.com/docs/getting-started/termux). On Termux, Hermes installs a curated `.[termux]` extra because the full `.[all]` extra currently pulls Android-incompatible voice dependencies.
->
-> **Windows:** Native Windows is supported as an **early beta** — the PowerShell one-liner above installs everything, but expect rough edges and please file issues when you hit them. If you'd rather use WSL2 (our most battle-tested Windows path), the Linux command works there too. Native Windows install lives under `%LOCALAPPDATA%\hermes`; WSL2 installs under `~/.hermes` as on Linux.  The only Hermes feature that currently needs WSL2 specifically is the browser-based dashboard chat pane (it uses a POSIX PTY — classic CLI and gateway both run natively).
-
-After installation:
+## 🛠️ Quick Reference
 
 ```bash
-source ~/.bashrc    # reload shell (or: source ~/.zshrc)
-hermes              # start chatting!
+hermes              # Start chatting
+hermes model        # Pick your LLM
+hermes tools        # Configure tools
+hermes gateway      # Connect messaging platforms
+hermes setup        # Full setup wizard
+hermes update       # Update to latest
+hermes doctor       # Diagnose issues
 ```
 
----
-
-## Getting Started
-
-```bash
-hermes              # Interactive CLI — start a conversation
-hermes model        # Choose your LLM provider and model
-hermes tools        # Configure which tools are enabled
-hermes config set   # Set individual config values
-hermes gateway      # Start the messaging gateway (Telegram, Discord, etc.)
-hermes setup        # Run the full setup wizard (configures everything at once)
-hermes claw migrate # Migrate from OpenClaw (if coming from OpenClaw)
-hermes update       # Update to the latest version
-hermes doctor       # Diagnose any issues
-```
-
-📖 **[Full documentation →](https://hermes-agent.nousresearch.com/docs/)**
+| What you want | CLI | Messaging |
+|---|---|---|
+| Fresh conversation | `/new` | `/new` |
+| Change model | `/model claude-sonnet-4` | `/model claude-sonnet-4` |
+| Set personality | `/personality snarky` | `/personality snarky` |
+| Browse skills | `/skills` | `/<skill-name>` |
+| Stop current task | `Ctrl+C` | `/stop` |
 
 ---
 
-## Skip the API-key collection — Nous Portal
+## 📚 Documentation
 
-Hermes works with whatever provider you want — that's not changing. But if you'd rather not collect five separate API keys for the model, web search, image generation, TTS, and a cloud browser, **[Nous Portal](https://portal.nousresearch.com)** covers all of them under one subscription:
+Everything you need → **[hermes-agent.nousresearch.com/docs](https://hermes-agent.nousresearch.com/docs/)**
 
-- **300+ models** — pick any of them with `/model <name>`
-- **Tool Gateway** — web search (Firecrawl), image generation (FAL), text-to-speech (OpenAI), cloud browser (Browser Use), all routed through your sub. No extra accounts.
-
-One command from a fresh install:
-
-```bash
-hermes setup --portal
-```
-
-That logs you in via OAuth, sets Nous as your provider, and turns on the Tool Gateway. Check what's wired up any time with `hermes portal status`. Full details on the [Tool Gateway docs page](https://hermes-agent.nousresearch.com/docs/user-guide/features/tool-gateway).
-
-You can still bring your own keys per-tool whenever you want — the gateway is per-backend, not all-or-nothing.
+| | |
+|---|---|
+| [**Quickstart**](https://hermes-agent.nousresearch.com/docs/getting-started/quickstart) — Install to first conversation in 2 minutes | [**Tools & Toolsets**](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools) — 40+ tools, terminal backends |
+| [**CLI Usage**](https://hermes-agent.nousresearch.com/docs/user-guide/cli) — Commands, keybindings, sessions | [**Skills System**](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) — Procedural memory, Skills Hub |
+| [**Configuration**](https://hermes-agent.nousresearch.com/docs/user-guide/configuration) — Providers, models, all options | [**Memory**](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory) — Persistent memory, user profiles |
+| [**Messaging Gateway**](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) — Telegram, Discord, Slack, WhatsApp, Signal | [**MCP Integration**](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp) — Connect any MCP server |
+| [**Security**](https://hermes-agent.nousresearch.com/docs/user-guide/security) — Approval, DM pairing, isolation | [**Cron Scheduling**](https://hermes-agent.nousresearch.com/docs/user-guide/features/cron) — Scheduled tasks with delivery |
+| [**Architecture**](https://hermes-agent.nousresearch.com/docs/developer-guide/architecture) — Project structure, agent loop | [**Contributing**](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing) — Dev setup, PR process |
 
 ---
 
-## CLI vs Messaging Quick Reference
+## 🤝 Contributing
 
-Hermes has two entry points: start the terminal UI with `hermes`, or run the gateway and talk to it from Telegram, Discord, Slack, WhatsApp, Signal, or Email. Once you're in a conversation, many slash commands are shared across both interfaces.
-
-| Action | CLI | Messaging platforms |
-|---------|-----|---------------------|
-| Start chatting | `hermes` | Run `hermes gateway setup` + `hermes gateway start`, then send the bot a message |
-| Start fresh conversation | `/new` or `/reset` | `/new` or `/reset` |
-| Change model | `/model [provider:model]` | `/model [provider:model]` |
-| Set a personality | `/personality [name]` | `/personality [name]` |
-| Retry or undo the last turn | `/retry`, `/undo` | `/retry`, `/undo` |
-| Compress context / check usage | `/compress`, `/usage`, `/insights [--days N]` | `/compress`, `/usage`, `/insights [days]` |
-| Browse skills | `/skills` or `/<skill-name>` | `/<skill-name>` |
-| Interrupt current work | `Ctrl+C` or send a new message | `/stop` or send a new message |
-| Platform-specific status | `/platforms` | `/status`, `/sethome` |
-
-For the full command lists, see the [CLI guide](https://hermes-agent.nousresearch.com/docs/user-guide/cli) and the [Messaging Gateway guide](https://hermes-agent.nousresearch.com/docs/user-guide/messaging).
-
----
-
-## Documentation
-
-All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes-agent.nousresearch.com/docs/)**:
-
-| Section | What's Covered |
-|---------|---------------|
-| [Quickstart](https://hermes-agent.nousresearch.com/docs/getting-started/quickstart) | Install → setup → first conversation in 2 minutes |
-| [CLI Usage](https://hermes-agent.nousresearch.com/docs/user-guide/cli) | Commands, keybindings, personalities, sessions |
-| [Configuration](https://hermes-agent.nousresearch.com/docs/user-guide/configuration) | Config file, providers, models, all options |
-| [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) | Telegram, Discord, Slack, WhatsApp, Signal, Home Assistant |
-| [Security](https://hermes-agent.nousresearch.com/docs/user-guide/security) | Command approval, DM pairing, container isolation |
-| [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools) | 40+ tools, toolset system, terminal backends |
-| [Skills System](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) | Procedural memory, Skills Hub, creating skills |
-| [Memory](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory) | Persistent memory, user profiles, best practices |
-| [MCP Integration](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp) | Connect any MCP server for extended capabilities |
-| [Cron Scheduling](https://hermes-agent.nousresearch.com/docs/user-guide/features/cron) | Scheduled tasks with platform delivery |
-| [Context Files](https://hermes-agent.nousresearch.com/docs/user-guide/features/context-files) | Project context that shapes every conversation |
-| [Architecture](https://hermes-agent.nousresearch.com/docs/developer-guide/architecture) | Project structure, agent loop, key classes |
-| [Contributing](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing) | Development setup, PR process, code style |
-| [CLI Reference](https://hermes-agent.nousresearch.com/docs/reference/cli-commands) | All commands and flags |
-| [Environment Variables](https://hermes-agent.nousresearch.com/docs/reference/environment-variables) | Complete env var reference |
-
----
-
-## Migrating from OpenClaw
-
-If you're coming from OpenClaw, Hermes can automatically import your settings, memories, skills, and API keys.
-
-**During first-time setup:** The setup wizard (`hermes setup`) automatically detects `~/.openclaw` and offers to migrate before configuration begins.
-
-**Anytime after install:**
-
-```bash
-hermes claw migrate              # Interactive migration (full preset)
-hermes claw migrate --dry-run    # Preview what would be migrated
-hermes claw migrate --preset user-data   # Migrate without secrets
-hermes claw migrate --overwrite  # Overwrite existing conflicts
-```
-
-What gets imported:
-- **SOUL.md** — persona file
-- **Memories** — MEMORY.md and USER.md entries
-- **Skills** — user-created skills → `~/.hermes/skills/openclaw-imports/`
-- **Command allowlist** — approval patterns
-- **Messaging settings** — platform configs, allowed users, working directory
-- **API keys** — allowlisted secrets (Telegram, OpenRouter, OpenAI, Anthropic, ElevenLabs)
-- **TTS assets** — workspace audio files
-- **Workspace instructions** — AGENTS.md (with `--workspace-target`)
-
-See `hermes claw migrate --help` for all options, or use the `openclaw-migration` skill for an interactive agent-guided migration with dry-run previews.
-
----
-
-## Contributing
-
-We welcome contributions! See the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing) for development setup, code style, and PR process.
-
-Quick start for contributors — clone and go with `setup-hermes.sh`:
+We'd love your help! [Contributing Guide →](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)
 
 ```bash
 git clone https://github.com/NousResearch/hermes-agent.git
 cd hermes-agent
-./setup-hermes.sh     # installs uv, creates venv, installs .[all], symlinks ~/.local/bin/hermes
-./hermes              # auto-detects the venv, no need to `source` first
+./setup-hermes.sh     # installs everything, creates venv, symlinks hermes
+./hermes              # you're in
 ```
 
-Manual path (equivalent to the above):
+---
+
+## 🌍 Community & Ecosystem
+
+- 💬 **[Discord](https://discord.gg/NousResearch)** — chat, get help, share what you've built
+- 📚 **[Skills Hub](https://agentskills.io)** — browse and share reusable skills
+- 🐛 **[Issues](https://github.com/NousResearch/hermes-agent/issues)** — bug reports and feature requests
+- 🔌 **[computer-use-linux](https://github.com/avifenesh/computer-use-linux)** — Linux desktop control via MCP
+- 🔌 **[HermesClaw](https://github.com/AaronWong1999/hermesclaw)** — Community WeChat bridge
+
+---
+
+<details>
+<summary><b>📦 Migrating from OpenClaw?</b></summary>
+<br>
 
 ```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-uv venv .venv --python 3.11
-source .venv/bin/activate
-uv pip install -e ".[all,dev]"
-scripts/run_tests.sh
+hermes claw migrate              # Interactive migration
+hermes claw migrate --dry-run    # Preview first
 ```
 
----
+Imports your persona, memories, skills, API keys, messaging settings, and more. The setup wizard (`hermes setup`) auto-detects `~/.openclaw` and offers to migrate. See `hermes claw migrate --help` for all options.
 
-## Community
-
-- 💬 [Discord](https://discord.gg/NousResearch)
-- 📚 [Skills Hub](https://agentskills.io)
-- 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
-- 🔌 [computer-use-linux](https://github.com/avifenesh/computer-use-linux) — Linux desktop-control MCP server for Hermes and other MCP hosts, with AT-SPI accessibility trees, Wayland/X11 input, screenshots, and compositor window targeting.
-- 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+</details>
 
 ---
 
-## License
-
-MIT — see [LICENSE](LICENSE).
-
-Built by [Nous Research](https://nousresearch.com).
+<p align="center">
+  <b>MIT License</b> · Built with ☤ by <a href="https://nousresearch.com">Nous Research</a>
+</p>


### PR DESCRIPTION
## Summary

Transform the README from a feature-list dump into a marketing-friendly landing page.

### What changed

| Before | After |
|--------|-------|
| Feature table with raw descriptions | **"Why Hermes?"** 2×2 card grid — learning loop, multi-platform, model freedom, deploy anywhere |
| Long hero paragraph | Emotional hook: *"Your AI that actually remembers you"* |
| Inline Windows/Termux/PowerShell install walls | Linked to docs, install section is **60 seconds** |
| OpenClaw migration front and center | Collapsed into `<details>` (niche audience) |
| Single-column doc table | 2-column grid for scannability |
| Contributing with manual steps inline | Clone-and-go only, manual path in docs |

### What's preserved

- ✅ Every existing link
- ✅ All functionality references
- ✅ Provider list and model freedom messaging
- ✅ CLI vs Messaging quick reference
- ✅ Community & ecosystem links
- ✅ OpenClaw migration (just collapsed)

### Not in scope (follow-ups)

- Screenshot / GIF of the TUI in action
- Animated demo of the learning loop
- "Testimonials" or social proof section

---

*No code changes — README only.*