### PR TITLE
fix(projects): sanitize branch names to produce valid git refnames

### DIFF
--- a/hermes_cli/projects_db.py
+++ b/hermes_cli/projects_db.py
@@ -709,6 +709,17 @@ def project_for_path(
 
 # Deterministic branch slug: lowercase, separators collapsed, capped.
 _BRANCH_SAFE_RE = re.compile(r"[^a-z0-9._-]+")
+_DOTDOT_RE = re.compile(r"\.{2,}")
+_LOCK_SUFFIX_RE = re.compile(r"\.lock$")
+
+
+def _sanitize_refname_component(s: str) -> str:
+    """Sanitize a string so it is safe inside a git branch refname."""
+    s = _BRANCH_SAFE_RE.sub("-", s)
+    s = _DOTDOT_RE.sub(".", s)
+    s = _LOCK_SUFFIX_RE.sub("", s)
+    s = s.strip("-.")
+    return s
 
 
 def branch_name_for(project: Project, task_id: str, *, title: str = "") -> str:
@@ -720,8 +731,8 @@ def branch_name_for(project: Project, task_id: str, *, title: str = "") -> str:
     slug = project.slug or _slugify(project.name)
     base = f"{slug}/{task_id}"
     if title:
-        tslug = _BRANCH_SAFE_RE.sub("-", str(title).strip().lower()).strip("-")
-        tslug = tslug[:40].strip("-")
+        tslug = _sanitize_refname_component(str(title).strip().lower())
+        tslug = tslug[:40].strip("-.")
         if tslug:
             base = f"{base}-{tslug}"
     return base

--- a/tests/hermes_cli/test_projects_db.py
+++ b/tests/hermes_cli/test_projects_db.py
@@ -154,6 +154,67 @@ def test_branch_name_for_is_deterministic():
     assert pdb.branch_name_for(proj, "t_abc") == pdb.branch_name_for(proj, "t_abc")
 
 
+def test_branch_name_for_sanitizes_git_refname():
+    """branch_name_for must produce valid git refnames for all title inputs."""
+    proj = pdb.Project(id="p_1", slug="myproj", name="My Project", created_at=0)
+
+    # Double-dot collapsed to single dot
+    branch = pdb.branch_name_for(proj, "t_1", title="fix 2.0..rc1")
+    assert ".." not in branch
+    assert branch == "myproj/t_1-fix-2.0.rc1"
+
+    # Trailing .lock stripped
+    branch = pdb.branch_name_for(proj, "t_2", title="update yarn.lock")
+    assert not branch.endswith(".lock")
+    assert branch == "myproj/t_2-update-yarn"
+
+    # Triple dot collapsed
+    branch = pdb.branch_name_for(proj, "t_3", title="v3...beta")
+    assert ".." not in branch
+    assert branch == "myproj/t_3-v3.beta"
+
+    # Leading dot stripped
+    branch = pdb.branch_name_for(proj, "t_4", title=".hidden config")
+    assert branch == "myproj/t_4-hidden-config"
+
+    # .lock in the middle is preserved (only trailing .lock is invalid)
+    branch = pdb.branch_name_for(proj, "t_5", title="cleanup v2.0.lock.bak")
+    assert "lock" in branch
+
+    # Single dots preserved for version numbers
+    branch = pdb.branch_name_for(proj, "t_6", title="v2.0.0 release")
+    assert branch == "myproj/t_6-v2.0.0-release"
+
+    # Degenerate title (only dots) → no slug appended
+    branch = pdb.branch_name_for(proj, "t_7", title="....")
+    assert branch == "myproj/t_7"
+
+    # Just ".lock" → no slug appended
+    branch = pdb.branch_name_for(proj, "t_8", title=".lock")
+    assert branch == "myproj/t_8"
+
+
+def test_branch_name_for_passes_git_check_ref_format():
+    """Every branch name must pass git check-ref-format --branch."""
+    import subprocess
+
+    proj = pdb.Project(id="p_1", slug="app", name="App", created_at=0)
+    titles = [
+        "fix 2.0..rc1", "update yarn.lock", "v3...beta",
+        ".hidden", "trailing.", "normal title", "v1.2.3",
+        "....", ".lock", "", "a" * 100,
+    ]
+    for title in titles:
+        branch = pdb.branch_name_for(proj, "t_x", title=title)
+        result = subprocess.run(
+            ["git", "check-ref-format", "--branch", branch],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, (
+            f"git check-ref-format rejected {branch!r} (title={title!r})"
+        )
+
+
 def test_per_profile_isolation(tmp_path):
     # Two distinct DB paths stand in for two profiles' HERMES_HOME.
     a = pdb.connect(db_path=tmp_path / "a" / "projects.db")


### PR DESCRIPTION
## Summary

`branch_name_for` in `projects_db.py` uses `_BRANCH_SAFE_RE = re.compile(r"[^a-z0-9._-]+")` to sanitize task titles into branch name components. This regex allows dots through unchanged, which produces branch names that violate git refname rules:

- **Consecutive dots** (`..`) — e.g. title `"fix 2.0..rc1"` → branch `myproj/t_abc-fix-2.0..rc1` → `fatal: not a valid branch name`
- **Trailing `.lock`** — e.g. title `"update yarn.lock"` → branch `myproj/t_abc-update-yarn.lock` → `fatal: not a valid branch name`
- **Trailing dot** — e.g. title `"foo."` → branch ending in `.` → `fatal: not a valid branch name`

When `_ensure_git_worktree` runs `git worktree add -b <branch>`, it raises `RuntimeError` and the task becomes permanently undispatchable.

## Changes

- Add `_sanitize_refname_component` helper that:
  - Collapses consecutive dots (`..`, `...`) to a single dot
  - Strips trailing `.lock` suffix
  - Strips leading/trailing dots and hyphens
- Replace the raw `_BRANCH_SAFE_RE.sub()` call in `branch_name_for` with `_sanitize_refname_component`
- Degenerate titles (e.g. `"...."`  or `".lock"`) gracefully degrade to just `<slug>/<task-id>` with no title component

## Test plan

- [x] `test_branch_name_for_sanitizes_git_refname` — 8 edge cases: double-dot, trailing .lock, triple-dot, leading dot, .lock in middle, version dots preserved, degenerate title, just ".lock"
- [x] `test_branch_name_for_passes_git_check_ref_format` — runs actual `git check-ref-format --branch` against 11 different title inputs to verify every generated branch is valid
- [x] Existing `test_branch_name_for_is_deterministic` still passes
- [x] All 17 projects_db tests pass