### PR TITLE
fix(tools): clarify execute_code terminal approval guidance

### DIFF
--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -182,6 +182,21 @@ class TestModeAwareSchema(unittest.TestCase):
         self.assertIn("script approval guard", desc)
         self.assertIn("Call terminal directly", desc)
 
+    def test_terminal_disabled_schema_omits_terminal_tool_reference(self):
+        """When terminal is not an enabled sandbox tool, the schema must not
+        point the model at the terminal tool (cross-tool-reference pitfall) —
+        but it should still warn against subprocess-wrapping to dodge review."""
+        no_terminal = {"web_search", "read_file", "write_file", "search_files", "patch"}
+        desc = build_execute_code_schema(
+            enabled_sandbox_tools=no_terminal, mode="project"
+        )["description"]
+        self.assertNotIn("Call terminal directly", desc)
+        self.assertNotIn("terminal's command-level guard", desc)
+        self.assertNotIn("wrap a single terminal command", desc)
+        # The subprocess-bypass guidance still stands without naming the tool.
+        self.assertIn("script approval guard", desc)
+        self.assertIn("subprocess", desc)
+
     def test_neither_description_uses_sandbox_language(self):
         """REGRESSION GUARD for commit 39b83f34.
 

--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -35,6 +35,7 @@ def _force_local_terminal(monkeypatch):
 from tools.code_execution_tool import (
     SANDBOX_ALLOWED_TOOLS,
     DEFAULT_EXECUTION_MODE,
+    EXECUTE_CODE_SCHEMA,
     EXECUTION_MODES,
     _get_execution_mode,
     _is_usable_python,
@@ -179,8 +180,24 @@ class TestModeAwareSchema(unittest.TestCase):
     def test_description_discourages_terminal_wrappers(self):
         desc = build_execute_code_schema(mode="project")["description"]
         self.assertIn("Do not wrap a single terminal command", desc)
-        self.assertIn("script approval guard", desc)
+        self.assertIn("in gateway/ask sessions", desc)
+        self.assertIn("whole-script approval", desc)
+        self.assertIn("still runs its command-level checks", desc)
+        self.assertIn("raw subprocess commands cannot be inspected", desc)
         self.assertIn("Call terminal directly", desc)
+        self.assertEqual(desc.count("whole-script approval"), 1)
+
+    def test_module_level_schema_includes_no_wrap_guidance(self):
+        self.assertIn(
+            "Do not wrap a single terminal command",
+            EXECUTE_CODE_SCHEMA["description"],
+        )
+
+    def test_no_wrap_guidance_is_mode_independent(self):
+        for mode in EXECUTION_MODES:
+            desc = build_execute_code_schema(mode=mode)["description"]
+            self.assertIn("Do not wrap a single terminal command", desc)
+            self.assertEqual(desc.count("whole-script approval"), 1)
 
     def test_terminal_disabled_schema_omits_terminal_tool_reference(self):
         """When terminal is not an enabled sandbox tool, the schema must not
@@ -191,11 +208,29 @@ class TestModeAwareSchema(unittest.TestCase):
             enabled_sandbox_tools=no_terminal, mode="project"
         )["description"]
         self.assertNotIn("Call terminal directly", desc)
-        self.assertNotIn("terminal's command-level guard", desc)
+        self.assertNotIn("hermes_tools.terminal", desc)
         self.assertNotIn("wrap a single terminal command", desc)
         # The subprocess-bypass guidance still stands without naming the tool.
-        self.assertIn("script approval guard", desc)
+        self.assertIn("whole-script approval", desc)
         self.assertIn("subprocess", desc)
+
+    def test_empty_sandbox_tool_set_omits_terminal_reference(self):
+        desc = build_execute_code_schema(
+            enabled_sandbox_tools=set(), mode="project"
+        )["description"]
+        self.assertNotIn("Call terminal directly", desc)
+        self.assertNotIn("hermes_tools.terminal", desc)
+        self.assertIn("whole-script approval", desc)
+
+    def test_no_wrap_note_branches_are_mutually_exclusive(self):
+        with_terminal = build_execute_code_schema(mode="project")["description"]
+        without_terminal = build_execute_code_schema(
+            enabled_sandbox_tools={"read_file"}, mode="project"
+        )["description"]
+        self.assertIn("Call terminal directly for one command.", with_terminal)
+        self.assertNotIn("purely to avoid", with_terminal)
+        self.assertIn("purely to avoid", without_terminal)
+        self.assertNotIn("Call terminal directly", without_terminal)
 
     def test_neither_description_uses_sandbox_language(self):
         """REGRESSION GUARD for commit 39b83f34.

--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -176,6 +176,12 @@ class TestModeAwareSchema(unittest.TestCase):
         self.assertIn("temp dir", desc)
 
 
+    def test_description_discourages_terminal_wrappers(self):
+        desc = build_execute_code_schema(mode="project")["description"]
+        self.assertIn("Do not wrap a single terminal command", desc)
+        self.assertIn("script approval guard", desc)
+        self.assertIn("Call terminal directly", desc)
+
     def test_neither_description_uses_sandbox_language(self):
         """REGRESSION GUARD for commit 39b83f34.
 

--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -156,6 +156,21 @@ class TestModeAwareSchema(unittest.TestCase):
         self.assertIn("script approval guard", desc)
         self.assertIn("Call terminal directly", desc)
 
+    def test_terminal_disabled_schema_omits_terminal_tool_reference(self):
+        """When terminal is not an enabled sandbox tool, the schema must not
+        point the model at the terminal tool (cross-tool-reference pitfall) —
+        but it should still warn against subprocess-wrapping to dodge review."""
+        no_terminal = {"web_search", "read_file", "write_file", "search_files", "patch"}
+        desc = build_execute_code_schema(
+            enabled_sandbox_tools=no_terminal, mode="project"
+        )["description"]
+        self.assertNotIn("Call terminal directly", desc)
+        self.assertNotIn("terminal's command-level guard", desc)
+        self.assertNotIn("wrap a single terminal command", desc)
+        # The subprocess-bypass guidance still stands without naming the tool.
+        self.assertIn("script approval guard", desc)
+        self.assertIn("subprocess", desc)
+
     def test_neither_description_uses_sandbox_language(self):
         """REGRESSION GUARD for commit 39b83f34.
 

--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -33,6 +33,7 @@ def _force_local_terminal(monkeypatch):
 from tools.code_execution_tool import (
     SANDBOX_ALLOWED_TOOLS,
     DEFAULT_EXECUTION_MODE,
+    EXECUTE_CODE_SCHEMA,
     EXECUTION_MODES,
     _get_execution_mode,
     _is_usable_python,
@@ -153,8 +154,24 @@ class TestModeAwareSchema(unittest.TestCase):
     def test_description_discourages_terminal_wrappers(self):
         desc = build_execute_code_schema(mode="project")["description"]
         self.assertIn("Do not wrap a single terminal command", desc)
-        self.assertIn("script approval guard", desc)
+        self.assertIn("in gateway/ask sessions", desc)
+        self.assertIn("whole-script approval", desc)
+        self.assertIn("still runs its command-level checks", desc)
+        self.assertIn("raw subprocess commands cannot be inspected", desc)
         self.assertIn("Call terminal directly", desc)
+        self.assertEqual(desc.count("whole-script approval"), 1)
+
+    def test_module_level_schema_includes_no_wrap_guidance(self):
+        self.assertIn(
+            "Do not wrap a single terminal command",
+            EXECUTE_CODE_SCHEMA["description"],
+        )
+
+    def test_no_wrap_guidance_is_mode_independent(self):
+        for mode in EXECUTION_MODES:
+            desc = build_execute_code_schema(mode=mode)["description"]
+            self.assertIn("Do not wrap a single terminal command", desc)
+            self.assertEqual(desc.count("whole-script approval"), 1)
 
     def test_terminal_disabled_schema_omits_terminal_tool_reference(self):
         """When terminal is not an enabled sandbox tool, the schema must not
@@ -165,11 +182,29 @@ class TestModeAwareSchema(unittest.TestCase):
             enabled_sandbox_tools=no_terminal, mode="project"
         )["description"]
         self.assertNotIn("Call terminal directly", desc)
-        self.assertNotIn("terminal's command-level guard", desc)
+        self.assertNotIn("hermes_tools.terminal", desc)
         self.assertNotIn("wrap a single terminal command", desc)
         # The subprocess-bypass guidance still stands without naming the tool.
-        self.assertIn("script approval guard", desc)
+        self.assertIn("whole-script approval", desc)
         self.assertIn("subprocess", desc)
+
+    def test_empty_sandbox_tool_set_omits_terminal_reference(self):
+        desc = build_execute_code_schema(
+            enabled_sandbox_tools=set(), mode="project"
+        )["description"]
+        self.assertNotIn("Call terminal directly", desc)
+        self.assertNotIn("hermes_tools.terminal", desc)
+        self.assertIn("whole-script approval", desc)
+
+    def test_no_wrap_note_branches_are_mutually_exclusive(self):
+        with_terminal = build_execute_code_schema(mode="project")["description"]
+        without_terminal = build_execute_code_schema(
+            enabled_sandbox_tools={"read_file"}, mode="project"
+        )["description"]
+        self.assertIn("Call terminal directly for one command.", with_terminal)
+        self.assertNotIn("purely to avoid", with_terminal)
+        self.assertIn("purely to avoid", without_terminal)
+        self.assertNotIn("Call terminal directly", without_terminal)
 
     def test_neither_description_uses_sandbox_language(self):
         """REGRESSION GUARD for commit 39b83f34.

--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -150,6 +150,12 @@ class TestModeAwareSchema(unittest.TestCase):
         self.assertIn("temp dir", desc)
 
 
+    def test_description_discourages_terminal_wrappers(self):
+        desc = build_execute_code_schema(mode="project")["description"]
+        self.assertIn("Do not wrap a single terminal command", desc)
+        self.assertIn("script approval guard", desc)
+        self.assertIn("Call terminal directly", desc)
+
     def test_neither_description_uses_sandbox_language(self):
         """REGRESSION GUARD for commit 39b83f34.
 

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -30,6 +30,16 @@ def test_terminal_schema_advertises_persistent_env_state():
     assert "once per session" in description
 
 
+def test_terminal_schema_discourages_single_command_wrappers():
+    description = terminal_tool.TERMINAL_TOOL_DESCRIPTION
+
+    assert "Use terminal directly for a single shell command" in description
+    assert "may add whole-script approval" in description
+    assert "without avoiding this tool's command-level checks" in description
+    # Keep this standalone schema usable when execute_code is disabled.
+    assert "execute_code" not in description
+
+
 def test_printf_literal_sudo_does_not_trigger_rewrite(monkeypatch):
     monkeypatch.delenv("SUDO_PASSWORD", raising=False)
     monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -2121,6 +2121,25 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
             "so project deps (pandas, etc.) and relative paths work like in terminal()."
         )
 
+    # Discourage wrapping a single command in execute_code purely to dodge
+    # command-level approval. Only name the ``terminal`` tool when it is an
+    # available sandbox tool — otherwise we'd point the model at a tool it
+    # can't call (the cross-tool-reference pitfall; the dynamic rebuild in
+    # model_tools passes the actually-available sandbox set).
+    if "terminal" in enabled_sandbox_tools:
+        no_wrap_note = (
+            "Do not wrap a single terminal command or subprocess in execute_code. "
+            "The script approval guard cannot review inner shell commands the way "
+            "terminal's command-level guard can, so these wrappers require broader "
+            "one-shot review. Call terminal directly for one command.\n\n"
+        )
+    else:
+        no_wrap_note = (
+            "Do not wrap a single subprocess call in execute_code purely to avoid "
+            "command-level review — the script approval guard cannot inspect the "
+            "inner commands, so these wrappers require broader one-shot review.\n\n"
+        )
+
     description = (
         "Run a Python script that calls Hermes tools programmatically. "
         "Use when you need 3+ tool calls with logic between them: "
@@ -2128,10 +2147,7 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
         "conditional branching, or loops (N pages/files, retry on failure). "
         "Use normal tool calls for single calls, results you must reason "
         "over in full, or anything needing user interaction.\n\n"
-        "Do not wrap a single terminal command or subprocess in execute_code. "
-        "The script approval guard cannot review inner shell commands the way "
-        "terminal's command-level guard can, so these wrappers require broader "
-        "one-shot review. Call terminal directly for one command.\n\n"
+        f"{no_wrap_note}"
         f"Available via `from hermes_tools import ...`:\n\n"
         f"{tool_lines}\n\n"
         "Limits: 5-minute timeout, 50KB stdout cap, max 50 tool calls per script. "

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -2069,8 +2069,7 @@ _TOOL_DOC_LINES = [
      "    Replaces old_string with new_string in the file."),
     ("terminal",
      "  terminal(command: str, timeout=None, workdir=None) -> dict\n"
-     "    Foreground only (no background/pty). Use direct terminal calls for one shell command; wrapping\n"
-     "    them here uses broader script approval. Returns {\"output\": \"...\", \"exit_code\": N}"),
+     "    Foreground only (no background/pty). Returns {\"output\": \"...\", \"exit_code\": N}"),
 ]
 
 
@@ -2129,15 +2128,16 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
     if "terminal" in enabled_sandbox_tools:
         no_wrap_note = (
             "Do not wrap a single terminal command or subprocess in execute_code. "
-            "The script approval guard cannot review inner shell commands the way "
-            "terminal's command-level guard can, so these wrappers require broader "
-            "one-shot review. Call terminal directly for one command.\n\n"
+            "The wrapper obscures the command's intent and, in gateway/ask sessions, "
+            "adds whole-script approval. hermes_tools.terminal still runs its "
+            "command-level checks, while raw subprocess commands cannot be inspected "
+            "individually. Call terminal directly for one command.\n\n"
         )
     else:
         no_wrap_note = (
             "Do not wrap a single subprocess call in execute_code purely to avoid "
-            "command-level review — the script approval guard cannot inspect the "
-            "inner commands, so these wrappers require broader one-shot review.\n\n"
+            "command-level review. Raw subprocess commands cannot be inspected "
+            "individually, so gateway/ask sessions require whole-script approval.\n\n"
         )
 
     description = (

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -2069,7 +2069,8 @@ _TOOL_DOC_LINES = [
      "    Replaces old_string with new_string in the file."),
     ("terminal",
      "  terminal(command: str, timeout=None, workdir=None) -> dict\n"
-     "    Foreground only (no background/pty). Returns {\"output\": \"...\", \"exit_code\": N}"),
+     "    Foreground only (no background/pty). Use direct terminal calls for one shell command; wrapping\n"
+     "    them here uses broader script approval. Returns {\"output\": \"...\", \"exit_code\": N}"),
 ]
 
 
@@ -2127,6 +2128,10 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
         "conditional branching, or loops (N pages/files, retry on failure). "
         "Use normal tool calls for single calls, results you must reason "
         "over in full, or anything needing user interaction.\n\n"
+        "Do not wrap a single terminal command or subprocess in execute_code. "
+        "The script approval guard cannot review inner shell commands the way "
+        "terminal's command-level guard can, so these wrappers require broader "
+        "one-shot review. Call terminal directly for one command.\n\n"
         f"Available via `from hermes_tools import ...`:\n\n"
         f"{tool_lines}\n\n"
         "Limits: 5-minute timeout, 50KB stdout cap, max 50 tool calls per script. "

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1975,8 +1975,7 @@ _TOOL_DOC_LINES = [
      "    Replaces old_string with new_string in the file."),
     ("terminal",
      "  terminal(command: str, timeout=None, workdir=None) -> dict\n"
-     "    Foreground only (no background/pty). Use direct terminal calls for one shell command; wrapping\n"
-     "    them here uses broader script approval. Returns {\"output\": \"...\", \"exit_code\": N}"),
+     "    Foreground only (no background/pty). Returns {\"output\": \"...\", \"exit_code\": N}"),
 ]
 
 
@@ -2035,15 +2034,16 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
     if "terminal" in enabled_sandbox_tools:
         no_wrap_note = (
             "Do not wrap a single terminal command or subprocess in execute_code. "
-            "The script approval guard cannot review inner shell commands the way "
-            "terminal's command-level guard can, so these wrappers require broader "
-            "one-shot review. Call terminal directly for one command.\n\n"
+            "The wrapper obscures the command's intent and, in gateway/ask sessions, "
+            "adds whole-script approval. hermes_tools.terminal still runs its "
+            "command-level checks, while raw subprocess commands cannot be inspected "
+            "individually. Call terminal directly for one command.\n\n"
         )
     else:
         no_wrap_note = (
             "Do not wrap a single subprocess call in execute_code purely to avoid "
-            "command-level review — the script approval guard cannot inspect the "
-            "inner commands, so these wrappers require broader one-shot review.\n\n"
+            "command-level review. Raw subprocess commands cannot be inspected "
+            "individually, so gateway/ask sessions require whole-script approval.\n\n"
         )
 
     description = (

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1975,7 +1975,8 @@ _TOOL_DOC_LINES = [
      "    Replaces old_string with new_string in the file."),
     ("terminal",
      "  terminal(command: str, timeout=None, workdir=None) -> dict\n"
-     "    Foreground only (no background/pty). Returns {\"output\": \"...\", \"exit_code\": N}"),
+     "    Foreground only (no background/pty). Use direct terminal calls for one shell command; wrapping\n"
+     "    them here uses broader script approval. Returns {\"output\": \"...\", \"exit_code\": N}"),
 ]
 
 
@@ -2033,6 +2034,10 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
         "conditional branching, or loops (N pages/files, retry on failure). "
         "Use normal tool calls for single calls, results you must reason "
         "over in full, or anything needing user interaction.\n\n"
+        "Do not wrap a single terminal command or subprocess in execute_code. "
+        "The script approval guard cannot review inner shell commands the way "
+        "terminal's command-level guard can, so these wrappers require broader "
+        "one-shot review. Call terminal directly for one command.\n\n"
         f"Available via `from hermes_tools import ...`:\n\n"
         f"{tool_lines}\n\n"
         "Limits: 5-minute timeout, 50KB stdout cap, max 50 tool calls per script. "

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -2027,6 +2027,25 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
             "so project deps (pandas, etc.) and relative paths work like in terminal()."
         )
 
+    # Discourage wrapping a single command in execute_code purely to dodge
+    # command-level approval. Only name the ``terminal`` tool when it is an
+    # available sandbox tool — otherwise we'd point the model at a tool it
+    # can't call (the cross-tool-reference pitfall; the dynamic rebuild in
+    # model_tools passes the actually-available sandbox set).
+    if "terminal" in enabled_sandbox_tools:
+        no_wrap_note = (
+            "Do not wrap a single terminal command or subprocess in execute_code. "
+            "The script approval guard cannot review inner shell commands the way "
+            "terminal's command-level guard can, so these wrappers require broader "
+            "one-shot review. Call terminal directly for one command.\n\n"
+        )
+    else:
+        no_wrap_note = (
+            "Do not wrap a single subprocess call in execute_code purely to avoid "
+            "command-level review — the script approval guard cannot inspect the "
+            "inner commands, so these wrappers require broader one-shot review.\n\n"
+        )
+
     description = (
         "Run a Python script that calls Hermes tools programmatically. "
         "Use when you need 3+ tool calls with logic between them: "
@@ -2034,10 +2053,7 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
         "conditional branching, or loops (N pages/files, retry on failure). "
         "Use normal tool calls for single calls, results you must reason "
         "over in full, or anything needing user interaction.\n\n"
-        "Do not wrap a single terminal command or subprocess in execute_code. "
-        "The script approval guard cannot review inner shell commands the way "
-        "terminal's command-level guard can, so these wrappers require broader "
-        "one-shot review. Call terminal directly for one command.\n\n"
+        f"{no_wrap_note}"
         f"Available via `from hermes_tools import ...`:\n\n"
         f"{tool_lines}\n\n"
         "Limits: 5-minute timeout, 50KB stdout cap, max 50 tool calls per script. "

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1079,6 +1079,7 @@ TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on a Linux environment. Fi
 
 Do NOT use cat/head/tail (use read_file), grep/rg/find/ls (use search_files), sed/awk (use patch), or echo/heredoc file creation (use write_file). Reserve terminal for: builds, installs, git, processes, scripts, network, package managers, and anything that needs a shell.
 NEVER pipe a build/test command through tail/head/cat to shorten output (e.g. `cargo build | tail -20`): output is auto-truncated with the full text saved to a file, and the pipe makes exit_code report the LAST pipeline command's status (tail's 0), masking real failures. Run the command bare; the same applies to `cmd || echo failed`, which also masks the exit code.
+Use terminal directly for a single shell command. Wrapping one command in a broader script or orchestration layer obscures intent and may add whole-script approval without avoiding this tool's command-level checks.
 Environment state persists: activate a virtualenv or export variables once per session, not before every command.
 
 Foreground (default): returns INSTANTLY when the command finishes, even with a high timeout — set timeout generously for long builds.

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1069,6 +1069,7 @@ import sys
 TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on a Linux environment. Filesystem, current working directory, and exported environment variables persist between calls.
 
 Do NOT use cat/head/tail (use read_file), grep/rg/find/ls (use search_files), sed/awk (use patch), or echo/heredoc file creation (use write_file). Reserve terminal for: builds, installs, git, processes, scripts, network, package managers, and anything that needs a shell.
+Use terminal directly for a single shell command. Wrapping one command in a broader script or orchestration layer obscures intent and may add whole-script approval without avoiding this tool's command-level checks.
 Environment state persists: activate a virtualenv or export variables once per session, not before every command.
 
 Foreground (default): returns INSTANTLY when the command finishes, even with a high timeout — set timeout generously for long builds.


### PR DESCRIPTION
## What does this PR do?

Clarifies the approval interaction between direct `terminal` calls, `execute_code` wrappers, and raw subprocesses so the model does not wrap a single command to avoid review.

A one-command `execute_code` wrapper obscures the command's intent and, in gateway/ask sessions, adds whole-script approval. A wrapped `hermes_tools.terminal()` call still runs the normal terminal command-level checks, while raw subprocess commands cannot be inspected individually. The schema therefore recommends calling `terminal` directly for one command. Interactive CLI sessions are not claimed to add an outer approval prompt.

The standalone terminal schema carries equivalent generic guidance without naming `execute_code`, so it remains valid when the code-execution toolset is disabled. The `execute_code` schema names `terminal` only when that tool is actually enabled.

## Related Issue

Fixes #52738

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/code_execution_tool.py`: adds one precise, dynamically gated warning against single-command terminal/subprocess wrappers, with gateway/ask approval scope stated explicitly.
- `tools/terminal_tool.py`: recommends direct terminal use for one command using cross-tool-safe, deployment-neutral wording.
- `tests/tools/test_code_execution_modes.py`: covers the registered schema, both execution modes, mutually exclusive tool-availability branches, no duplicate guidance, terminal-disabled sessions, and an explicitly empty tool set.
- `tests/tools/test_terminal_tool.py`: pins the standalone terminal guidance and absence of a hard-coded `execute_code` reference.

## How to Test

1. Run the focused approval/schema suites:

   ```bash
   scripts/run_tests.sh tests/tools/test_code_execution.py tests/tools/test_code_execution_modes.py tests/tools/test_terminal_tool.py
   ```

   Result: 144 passed.

2. Run static and cross-platform checks:

   ```bash
   .venv/bin/ruff check tools/code_execution_tool.py tools/terminal_tool.py tests/tools/test_code_execution_modes.py tests/tools/test_terminal_tool.py
   .venv/bin/python scripts/check-windows-footguns.py tools/code_execution_tool.py tools/terminal_tool.py tests/tools/test_code_execution_modes.py tests/tools/test_terminal_tool.py
   git diff --check origin/main...HEAD
   ```

   Result: Ruff passed, no Windows footguns found, diff check clean.

3. Duplicate-work checks:

   ```bash
   gh pr list --repo NousResearch/hermes-agent --state all --search "52738"
   gh pr list --repo NousResearch/hermes-agent --state all --search "execute_code terminal approval inner shell command schema guidance"
   ```

   Both searches find no competing implementation.

## 2026-07-11 shepherding refresh

Rebased both original human-authored commits onto current `main` (`6142203bd7`) after 2,217 upstream commits. Current main still lacks this approval-interaction guidance, so #52738 remains reproducible.

Two private Grogu passes identified and this refresh repaired four concrete gaps in the original branch: duplicate wording inside the `execute_code` schema, an imprecise claim that wrapped `hermes_tools.terminal()` calls skip command-level checks, the missing standalone-terminal side of #52738, and an overbroad claim that whole-script approval applies outside gateway/ask contexts. Commit `b1fcac808` contains those corrections and expanded contract coverage.

The issue's suggested inline annotation was implemented as a single paragraph before the available-tools list instead: this avoids repeating the same paid schema guidance beside the terminal stub while keeping it visible before tool selection. The existing user-facing approval-dialog text in `check_execute_code_guard` remains unchanged because it is constructed only after the gateway/ask gates where its one-shot description is accurate.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run focused tests and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Relevant tool descriptions/schemas are updated
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A
- [x] Cross-platform impact considered and checked
- [x] No dependency or configuration changes

## Screenshots / Logs

Not applicable; this is model-facing schema guidance covered by tests.
