### PR TITLE
fix(gateway): harden Windows restart path

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5119,20 +5119,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # On Windows there's no bash/setsid chain — spawn a tiny Python
         # watcher directly via sys.executable instead.  The watcher polls
-        # current_pid, waits for our exit, then runs `hermes gateway
-        # restart` with detach flags so the respawn survives the CLI
-        # that triggered the /restart command closing its console.
+        # current_pid, waits for our exit, then runs the HQ Admin Helper
+        # gateway_restart action when available.  That path cooperates with
+        # the durable Windows Scheduled Task owner and avoids the generic
+        # `hermes gateway restart` race.  Non-HQ installs fall back to the
+        # stock CLI restart command.
         if sys.platform == "win32":
             import textwrap
             from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
 
-            cmd_argv = [*hermes_cmd, "gateway", "restart"]
+            admin_invoker = _hermes_home / "scripts" / "invoke_hermes_admin_helper.ps1"
+            use_admin_helper = admin_invoker.exists()
+            if use_admin_helper:
+                cmd_argv = [
+                    "powershell.exe",
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                    str(admin_invoker),
+                    "-Action",
+                    "gateway_restart",
+                    "-TimeoutSeconds",
+                    "120",
+                ]
+            else:
+                cmd_argv = [*hermes_cmd, "gateway", "restart"]
+            fallback_argv = [*hermes_cmd, "gateway", "restart"]
             watcher = textwrap.dedent(
                 """
                 import os, subprocess, sys, time
                 from hermes_cli._subprocess_compat import windows_detach_flags_without_breakaway
                 pid = int(sys.argv[1])
-                cmd = sys.argv[2:]
+                use_admin_helper = sys.argv[2] == '1'
+                raw_args = sys.argv[3:]
+                try:
+                    split_at = raw_args.index('--fallback--')
+                    cmd = raw_args[:split_at]
+                    fallback_cmd = raw_args[split_at + 1:]
+                except ValueError:
+                    cmd = raw_args
+                    fallback_cmd = []
                 deadline = time.monotonic() + 120
 
                 def _alive(p):
@@ -5166,12 +5193,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if not _alive(pid):
                         break
                     time.sleep(0.2)
-                subprocess.Popen(
-                    cmd,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    creationflags=windows_detach_flags_without_breakaway(),
-                )
+                flags = windows_detach_flags_without_breakaway()
+
+                def _launch(command):
+                    subprocess.Popen(
+                        command,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        creationflags=flags,
+                    )
+
+                if use_admin_helper:
+                    try:
+                        completed = subprocess.run(
+                            cmd,
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL,
+                            creationflags=flags,
+                            timeout=150,
+                        )
+                        if completed.returncode == 0:
+                            sys.exit(0)
+                    except Exception:
+                        pass
+                    if fallback_cmd:
+                        _launch(fallback_cmd)
+                else:
+                    _launch(cmd)
                 """
             ).strip()
             watcher_env = os.environ.copy()
@@ -5189,7 +5237,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     pythonpath.append(watcher_env["PYTHONPATH"])
                 watcher_env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath))
             subprocess.Popen(
-                [sys.executable, "-c", watcher, str(current_pid), *cmd_argv],
+                [
+                    sys.executable,
+                    "-c",
+                    watcher,
+                    str(current_pid),
+                    "1" if use_admin_helper else "0",
+                    *cmd_argv,
+                    "--fallback--",
+                    *fallback_argv,
+                ],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 env=watcher_env,
@@ -5313,7 +5370,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._restart_task_started = True
 
         async def _run_restart() -> None:
-            await asyncio.sleep(0.05)
+            await asyncio.sleep(1.5)
             await self.stop(restart=True, detached_restart=detached, service_restart=via_service)
 
         task = asyncio.create_task(_run_restart())

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -177,9 +177,11 @@ def test_load_restart_drain_timeout_prefers_env_then_config_then_default(
 
 
 @pytest.mark.asyncio
-async def test_request_restart_is_idempotent():
+async def test_request_restart_is_idempotent(monkeypatch):
     runner, _adapter = make_restart_runner()
     runner.stop = AsyncMock()
+    sleep = AsyncMock()
+    monkeypatch.setattr(gateway_run.asyncio, "sleep", sleep)
 
     assert runner.request_restart(detached=True, via_service=False) is True
     first_task = next(iter(runner._background_tasks))
@@ -187,6 +189,7 @@ async def test_request_restart_is_idempotent():
 
     await first_task
 
+    sleep.assert_awaited_once_with(1.5)
     runner.stop.assert_awaited_once_with(
         restart=True, detached_restart=True, service_restart=False
     )
@@ -257,6 +260,7 @@ async def test_windows_detached_restart_scrubs_gateway_marker(monkeypatch, tmp_p
 
     monkeypatch.setattr(gateway_run.sys, "platform", "win32")
     monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["hermes"])
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
     monkeypatch.setenv("_HERMES_GATEWAY", "1")
     monkeypatch.setenv("VIRTUAL_ENV", str(venv_dir))
@@ -280,9 +284,55 @@ async def test_windows_detached_restart_scrubs_gateway_marker(monkeypatch, tmp_p
     assert len(popen_calls) == 1
     cmd, kwargs = popen_calls[0]
     assert cmd[-3:] == ["hermes", "gateway", "restart"]
+    assert "--fallback--" in cmd
     assert kwargs["env"].get("_HERMES_GATEWAY") is None
     assert kwargs["env"]["VIRTUAL_ENV"] == str(venv_dir)
     assert str(site_packages) in kwargs["env"]["PYTHONPATH"].split(gateway_run.os.pathsep)
+    assert kwargs["stdout"] is subprocess.DEVNULL
+    assert kwargs["stderr"] is subprocess.DEVNULL
+
+
+@pytest.mark.asyncio
+async def test_windows_detached_restart_prefers_hq_admin_helper(monkeypatch, tmp_path):
+    runner, _adapter = make_restart_runner()
+    popen_calls = []
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    admin_invoker = scripts_dir / "invoke_hermes_admin_helper.ps1"
+    admin_invoker.write_text("# test helper", encoding="utf-8")
+
+    monkeypatch.setattr(gateway_run.sys, "platform", "win32")
+    monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["hermes"])
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
+    monkeypatch.setenv("_HERMES_GATEWAY", "1")
+
+    import hermes_cli._subprocess_compat as subprocess_compat
+
+    monkeypatch.setattr(
+        subprocess_compat,
+        "windows_detach_popen_kwargs",
+        lambda: {},
+    )
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append((cmd, kwargs))
+        return MagicMock()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    await runner._launch_detached_restart_command()
+
+    assert len(popen_calls) == 1
+    cmd, kwargs = popen_calls[0]
+    assert cmd[4] == "1"
+    assert "powershell.exe" in cmd
+    assert str(admin_invoker) in cmd
+    assert cmd[cmd.index("-Action") + 1] == "gateway_restart"
+    assert cmd[cmd.index("-TimeoutSeconds") + 1] == "120"
+    fallback_at = cmd.index("--fallback--")
+    assert cmd[fallback_at + 1 : fallback_at + 4] == ["hermes", "gateway", "restart"]
+    assert kwargs["env"].get("_HERMES_GATEWAY") is None
     assert kwargs["stdout"] is subprocess.DEVNULL
     assert kwargs["stderr"] is subprocess.DEVNULL
 


### PR DESCRIPTION
## Summary
- Prefer the HQ Admin Helper for Windows detached gateway restarts when available.
- Keep the stock CLI restart path as fallback for non-HQ installs.
- Delay slash-command restart shutdown to give the response time to flush.
- Add/update gateway restart regression tests.

## Test Plan
- `C:/Users/82109/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe -m py_compile gateway/run.py tests/gateway/test_restart_drain.py`
- `PYTHONPATH=C:/Users/82109/AppData/Local/hermes/worktrees/hq-gateway-windows-restart-20260626-093823 C:/Users/82109/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe -m pytest tests/gateway/test_restart_drain.py -q -n 0`

## Notes
- Prepared from a clean worktree based on current `origin/main`.
- Original HQ local commit: `e2061bfc2 fix(gateway): harden Windows restart path`.
- Cherry-picked PR commit: `14e4e37c4 fix(gateway): harden Windows restart path`.