### PR TITLE
fix(desktop): prevent electron-builder from hoisting node_modules out of extraResources

### DIFF
--- a/apps/desktop/electron/git-review-ops.cjs
+++ b/apps/desktop/electron/git-review-ops.cjs
@@ -10,7 +10,28 @@ const { execFile } = require('node:child_process')
 const fs = require('node:fs/promises')
 const path = require('node:path')
 
-const simpleGit = require('simple-git')
+let simpleGit
+try {
+  simpleGit = require('simple-git')
+} catch {
+  // Packaged builds ship no node_modules inside the asar: package.json sets
+  // `files:` (excludes node_modules) and scripts/before-build.cjs returns false
+  // to skip electron-builder's dependency collector. simple-git and its pure-JS
+  // dep tree are staged under resources/native-deps/npm/node_modules via
+  // scripts/stage-native-deps.cjs; resolve from there when the bare require
+  // fails in the packaged asar. Dev resolves the workspace-hoisted copy normally
+  // and never reaches this branch. Mirrors the node-pty fallback in main.cjs.
+  const resourcesPath = process.resourcesPath
+  try {
+    simpleGit = require(path.join(resourcesPath, 'native-deps', 'npm', 'node_modules', 'simple-git'))
+  } catch {
+    // electron-builder may hoist node_modules out of extraResources directories,
+    // moving build/native-deps/npm/node_modules → resources/node_modules. When the
+    // primary fallback above fails, try the hoisted location as a last resort
+    // so a packaging quirk does not crash the app (#50440).
+    simpleGit = require(path.join(resourcesPath, 'node_modules', 'simple-git'))
+  }
+}
 
 const { resolveRequestedPathForIpc } = require('./hardening.cjs')
 

--- a/apps/desktop/scripts/stage-native-deps.cjs
+++ b/apps/desktop/scripts/stage-native-deps.cjs
@@ -66,6 +66,31 @@ const NATIVE_DEPS = [
   }
 ]
 
+// Pure-JS runtime deps that the packaged MAIN process require()s but that the
+// asar excludes (same reason as NATIVE_DEPS above: `files:` + before-build.cjs
+// returning false skip electron-builder's node_modules collector). Unlike
+// node-pty these have no .node binaries, so we stage each package's WHOLE
+// directory into a real node_modules layout under build/native-deps/npm/node_modules
+// and let Node's normal resolver satisfy the inner cross-package requires.
+//
+// We nest node_modules inside npm/ so electron-builder does not recognise
+// it as a project node_modules and restructure it during packaging (#50440).
+// The staged layout at runtime becomes resources/native-deps/npm/node_modules/;
+// git-review-ops.cjs require()s simple-git from this path.
+//
+// This list is the closed runtime dependency set of simple-git@3.x. If
+// simple-git's deps change (check `npm ls simple-git`) update this list.
+// git-review-ops.cjs require()s simple-git from this staged tree at runtime.
+const VENDOR_DEPS = [
+  'simple-git',
+  '@kwsites/file-exists',
+  '@kwsites/promise-deferred',
+  '@simple-git/args-pathspec',
+  '@simple-git/argv-parser',
+  'debug',
+  'ms'
+]
+
 function rmrf(target) {
   fs.rmSync(target, { recursive: true, force: true })
 }
@@ -148,12 +173,40 @@ function stageOne(spec) {
   console.log(`[stage-native-deps] ${path.relative(APP_ROOT, spec.to)}: ${copied} files`)
 }
 
+// Copy one pure-JS package's whole directory into the staged node_modules tree,
+// excluding the package's own nested node_modules (the vendored set is flat /
+// hoisted, so every cross-package require resolves against the staged root).
+function stageVendorOne(pkgName) {
+  // Workspace dedup hoists these to the repo root's node_modules (flat, no
+  // nesting -- verified for the simple-git tree). Resolve there directly; a
+  // bare require.resolve can't reach package.json when the dep declares an
+  // `exports` map that doesn't expose it (simple-git does).
+  const pkgRoot = path.join(REPO_ROOT, 'node_modules', pkgName)
+  if (!fs.existsSync(path.join(pkgRoot, 'package.json'))) {
+    throw new Error(
+      `stage-native-deps: vendor dep "${pkgName}" not found at ${pkgRoot}.  Run ` +
+        `\`npm install\` at the workspace root first.`
+    )
+  }
+  const dest = path.join(STAGE_ROOT, 'npm', 'node_modules', pkgName)
+  ensureDir(path.dirname(dest))
+  fs.cpSync(pkgRoot, dest, {
+    recursive: true,
+    dereference: true,
+    filter: src => path.basename(src) !== 'node_modules'
+  })
+}
+
 function main() {
   rmrf(STAGE_ROOT)
   ensureDir(STAGE_ROOT)
   for (const spec of NATIVE_DEPS) {
     stageOne(spec)
   }
+  for (const pkgName of VENDOR_DEPS) {
+    stageVendorOne(pkgName)
+  }
+  console.log(`[stage-native-deps] node_modules vendor: ${VENDOR_DEPS.length} packages`)
 }
 
 main()


### PR DESCRIPTION
## Problem

electron-builder recognises node_modules directories inside extraResources and hoists them to resources/node_modules, leaving resources/native-deps/ without its staged JS vendor deps (simple-git and its dependency tree). This causes a hard crash on launch when git-review-ops.cjs cannot find simple-git.

Error: Uncaught Exception: Error: Cannot find module 'simple-git'

Introduced in e2b8018 (feat: add git worktree and review IPC).

## Root Cause

stage-native-deps.cjs stages vendor JS deps into build/native-deps/node_modules/. During packaging, electron-builder's extraResources processing hoists the inner node_modules/ directory to resources/node_modules/, while git-review-ops.cjs expects it at resources/native-deps/node_modules/.

## Fix

### 1. git-review-ops.cjs - Multi-level fallback
- Dev mode (workspace-hoisted): require('simple-git')
- Packaged primary: resources/native-deps/npm/node_modules/simple-git
- Packaged fallback: resources/node_modules/simple-git (hoisted location)

### 2. stage-native-deps.cjs - Nest node_modules inside npm/
Changed staging path from build/native-deps/node_modules/ to build/native-deps/npm/node_modules/. The npm/ wrapper prevents electron-builder from recognizing the inner directory as a project node_modules, preserving the extraResources tree structure.

## Test Plan
- Existing test suite passes (16/16: git-review-ops + git-worktree-ops)
- Staging script idempotent across multiple runs
- Cross-package resolution verified
- git-review-ops.cjs loads in dev mode