### PR TITLE
fix(desktop): stage JS deps into node_modules before electron-builder packaging

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,7 +18,7 @@
     "profile:main": "wait-on http://127.0.0.1:5174 && cross-env XCURSOR_SIZE=24 HERMES_DESKTOP_DEV_SERVER=http://127.0.0.1:5174 electron --inspect=9229 .",
     "profile:main:cpu": "wait-on http://127.0.0.1:5174 && cross-env XCURSOR_SIZE=24 NODE_OPTIONS=--cpu-prof HERMES_DESKTOP_DEV_SERVER=http://127.0.0.1:5174 electron .",
     "start": "npm run build && electron .",
-    "build": "node scripts/assert-root-install.cjs && node scripts/write-build-stamp.cjs && node scripts/stage-native-deps.cjs && tsc -b && vite build &&  node scripts/bundle-electron-main.mjs && npm run postbuild",
+    "build": "node scripts/assert-root-install.cjs && node scripts/write-build-stamp.cjs && node scripts/stage-native-deps.cjs && node scripts/stage-js-deps.cjs && tsc -b && vite build &&  node scripts/bundle-electron-main.mjs && npm run postbuild",
     "postbuild": "node scripts/assert-dist-built.cjs",
     "prebuilder": "node scripts/patch-electron-builder-mac-binary.cjs",
     "builder": "cross-env NODE_OPTIONS=--max-old-space-size=16384 node scripts/run-electron-builder.cjs",

--- a/apps/desktop/scripts/stage-js-deps.cjs
+++ b/apps/desktop/scripts/stage-js-deps.cjs
@@ -1,0 +1,138 @@
+'use strict'
+
+/**
+ * Stage JavaScript dependencies for electron-builder packaging.
+ *
+ * Workspace dedup hoists npm packages into the root `node_modules/`, which
+ * electron-builder's default file collector (when `files:` is explicitly set
+ * in package.json) cannot reach.  The result: packaged builds ship with no
+ * JS dependencies and any `require()` of an npm package in the main process
+ * fails at runtime ("Cannot find module '<name>'").
+ *
+ * Rather than restructure the workspace dedup or balloon the package with
+ * the whole node_modules tree, we copy ONLY the runtime-essential JS deps
+ * into apps/desktop/node_modules/ and let the `files` list in package.json
+ * pick them up from there.
+ *
+ * Runs as part of `npm run build`. Idempotent -- always re-stages on each
+ * build to pick up dep updates.
+ *
+ * Layout note: we copy the full package tree (package + all transitive deps)
+ * so that Node's module resolution finds everything the package needs at
+ * runtime.  Only packages that are `require()`d in the Electron main process
+ * (electron/*.cjs) are staged -- renderer deps are bundled by Vite.
+ */
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+const APP_ROOT = path.resolve(__dirname, '..')
+const REPO_ROOT = path.resolve(APP_ROOT, '..', '..')
+
+// Packages that the Electron main process requires() at runtime.
+// Keep this list minimal -- only add packages that are require()d in
+// electron/*.cjs and are NOT bundled by Vite.
+const JS_DEPS = [
+  'simple-git',
+]
+
+function rmrf(target) {
+  fs.rmSync(target, { recursive: true, force: true })
+}
+
+function ensureDir(target) {
+  fs.mkdirSync(target, { recursive: true })
+}
+
+function walk(root) {
+  const results = []
+  const stack = [root]
+  while (stack.length) {
+    const current = stack.pop()
+    let entries
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      const full = path.join(current, entry.name)
+      if (entry.isDirectory()) {
+        stack.push(full)
+      } else if (entry.isFile()) {
+        results.push(full)
+      }
+    }
+  }
+  return results
+}
+
+/**
+ * Resolve the full transitive dependency tree of a package by reading its
+ * package.json and recursing into dependencies.  Returns a Set of package
+ * names (the package itself + all transitive deps).
+ */
+function resolveTransitiveDeps(pkgName, seen = new Set()) {
+  if (seen.has(pkgName)) return seen
+  seen.add(pkgName)
+
+  const pkgJsonPath = path.join(REPO_ROOT, 'node_modules', pkgName, 'package.json')
+  if (!fs.existsSync(pkgJsonPath)) return seen
+
+  let pkg
+  try {
+    pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'))
+  } catch {
+    return seen
+  }
+
+  const deps = { ...pkg.dependencies, ...pkg.peerDependencies }
+  for (const dep of Object.keys(deps || {})) {
+    resolveTransitiveDeps(dep, seen)
+  }
+
+  return seen
+}
+
+function stageOne(pkgName) {
+  const from = path.join(REPO_ROOT, 'node_modules', pkgName)
+  const to = path.join(APP_ROOT, 'node_modules', pkgName)
+
+  if (!fs.existsSync(from)) {
+    throw new Error(
+      `stage-js-deps: source missing at ${from}.  Run \`npm install\` ` +
+        `at the workspace root first.`
+    )
+  }
+
+  rmrf(to)
+  ensureDir(to)
+
+  const files = walk(from)
+  let copied = 0
+  for (const abs of files) {
+    const rel = path.relative(from, abs)
+    const dest = path.join(to, rel)
+    ensureDir(path.dirname(dest))
+    fs.copyFileSync(abs, dest)
+    copied += 1
+  }
+  console.log(`[stage-js-deps] node_modules/${pkgName}: ${copied} files`)
+}
+
+function main() {
+  // Collect all transitive deps across all listed packages
+  const allDeps = new Set()
+  for (const pkg of JS_DEPS) {
+    resolveTransitiveDeps(pkg, allDeps)
+  }
+
+  // Stage each dep into apps/desktop/node_modules/
+  for (const pkg of allDeps) {
+    stageOne(pkg)
+  }
+
+  console.log(`[stage-js-deps] staged ${allDeps.size} packages`)
+}
+
+main()


### PR DESCRIPTION
Fixes #52764

## Description
When a git pull adds an npm dependency to the Electron main process (e.g. simple-git in e2b801872), `hermes desktop --build-only` produces an asar with zero npm dependencies because:
1. `before-build.cjs` returns `false` to skip electron-builder's node_modules collector
2. The `files` list in package.json does not include `node_modules/**`
3. Workspace hoisting puts deps in root `node_modules/`, not the desktop workspace's local one

This adds `stage-js-deps.cjs`, a prebuild script that copies simple-git (and its full transitive dependency tree) from the hoisted root `node_modules/` into `apps/desktop/node_modules/` before electron-builder runs. It follows the same pattern as `stage-native-deps.cjs` and is wired into the `npm run build` pipeline.

The script resolves transitive deps automatically, so any future npm dependency added to the Electron main process will be staged correctly by just adding its name to the `JS_DEPS` list.

## Verification
- S1 (Secrets): clean
- S2 (Personal refs): clean
- C1 (Conventional commits): `fix(desktop): ...`
- C2 (British English, no em-dashes): clean
- B1 (Branch current with origin/main): passed
- F1 (Focused diff): 2 files, 139 insertions, 1 deletion

---
_Solidified via simplify-swarm + hermaguard before opening._