### PR TITLE
fix(agent,tools,cli,cron): remove redundant IOError from except tuples

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1118,7 +1118,7 @@ def _write_claude_code_credentials(
             except OSError:
                 pass
             raise
-    except (OSError, IOError) as e:
+    except OSError as e:
         logger.debug("Failed to write refreshed credentials: %s", e)
 
 

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -686,7 +686,7 @@ def _locked_update_approvals() -> Iterator[Dict[str, Any]]:
         finally:
             try:
                 fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
-            except (OSError, IOError):
+            except OSError:
                 pass
 
 

--- a/cli.py
+++ b/cli.py
@@ -5198,7 +5198,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # the input to be silently dropped (#17666).
             try:
                 return path.read_text(encoding="utf-8")
-            except (OSError, IOError):
+            except OSError:
                 logger.warning("Paste file gone or unreadable, returning placeholder: %s", path)
                 return match.group(0)
 

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -122,7 +122,7 @@ def _jobs_lock():
                     fcntl.flock(lock_fd, fcntl.LOCK_EX)
                 elif msvcrt is not None:
                     getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_LOCK"), 1)
-            except (OSError, IOError) as e:
+            except OSError as e:
                 # Never let a locking failure take down cron writes — fall back to
                 # in-process-only protection (still held via _jobs_file_lock).
                 logger.warning("jobs.json cross-process lock unavailable (%s); "
@@ -136,7 +136,7 @@ def _jobs_lock():
                             fcntl.flock(lock_fd, fcntl.LOCK_UN)
                         elif msvcrt is not None:
                             getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_UNLCK"), 1)
-                    except (OSError, IOError):
+                    except OSError:
                         pass
                     finally:
                         lock_fd.close()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2853,7 +2853,7 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
             fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         elif msvcrt:
             msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
-    except (OSError, IOError):
+    except OSError:
         logger.debug("Tick skipped — another instance holds the lock")
         if lock_fd is not None:
             lock_fd.close()
@@ -3028,12 +3028,12 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         if fcntl:
             try:
                 fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            except (OSError, IOError):
+            except OSError:
                 pass
         elif msvcrt:
             try:
                 msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-            except (OSError, IOError):
+            except OSError:
                 pass
         lock_fd.close()
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1006,13 +1006,13 @@ def _file_lock(
             if fcntl:
                 try:
                     fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-                except (OSError, IOError):
+                except OSError:
                     pass
             elif msvcrt:
                 try:
                     lock_file.seek(0)
                     msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
-                except (OSError, IOError):
+                except OSError:
                     pass
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -795,7 +795,7 @@ def _is_container() -> bool:
             cgroup_content = f.read()
         if "docker" in cgroup_content or "lxc" in cgroup_content or "kubepods" in cgroup_content:
             return True
-    except (OSError, IOError):
+    except OSError:
         pass
     return False
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4972,7 +4972,7 @@ def _compute_desktop_content_hash(project_root: Path) -> str:
             with open(path, "rb") as f:
                 for chunk in iter(lambda: f.read(65536), b""):
                     h.update(chunk)
-        except (OSError, IOError):
+        except OSError:
             pass
         h.update(b"\0")
 

--- a/optional-skills/creative/meme-generation/scripts/generate_meme.py
+++ b/optional-skills/creative/meme-generation/scripts/generate_meme.py
@@ -185,12 +185,12 @@ def find_font(size: int) -> ImageFont.FreeTypeFont:
         if os.path.exists(path):
             try:
                 return ImageFont.truetype(path, size)
-            except (OSError, IOError):
+            except OSError:
                 continue
     # Last resort: Pillow default
     try:
         return ImageFont.truetype("DejaVuSans-Bold", size)
-    except (OSError, IOError):
+    except OSError:
         return ImageFont.load_default()
 
 

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -292,7 +292,7 @@ class FileSyncManager:
         finally:
             try:
                 fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            except (OSError, IOError):
+            except OSError:
                 pass
             lock_fd.close()
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -231,13 +231,13 @@ class MemoryStore:
             if fcntl:
                 try:
                     fcntl.flock(fd, fcntl.LOCK_UN)
-                except (OSError, IOError):
+                except OSError:
                     pass
             elif msvcrt:
                 try:
                     fd.seek(0)
                     msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
-                except (OSError, IOError):
+                except OSError:
                     pass
             fd.close()
 
@@ -637,7 +637,7 @@ class MemoryStore:
             return []
         try:
             raw = path.read_text(encoding="utf-8")
-        except (OSError, IOError):
+        except OSError:
             return []
 
         if not raw.strip():
@@ -677,7 +677,7 @@ class MemoryStore:
             return None
         try:
             raw = path.read_text(encoding="utf-8")
-        except (OSError, IOError):
+        except OSError:
             return None
         if not raw.strip():
             return None
@@ -699,7 +699,7 @@ class MemoryStore:
         bak_path = path.with_suffix(path.suffix + f".bak.{ts}")
         try:
             bak_path.write_text(raw, encoding="utf-8")
-        except (OSError, IOError):
+        except OSError:
             return str(bak_path) + " (BACKUP FAILED — file unchanged on disk)"
         return str(bak_path)
 
@@ -731,7 +731,7 @@ class MemoryStore:
                 except OSError:
                     pass
                 raise
-        except (OSError, IOError) as e:
+        except OSError as e:
             raise RuntimeError(f"Failed to write memory file {path}: {e}")
 
 

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -111,13 +111,13 @@ def _usage_file_lock():
         if fcntl:
             try:
                 fcntl.flock(fd, fcntl.LOCK_UN)
-            except (OSError, IOError):
+            except OSError:
                 pass
         elif msvcrt:
             try:
                 fd.seek(0)
                 msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
-            except (OSError, IOError):
+            except OSError:
                 pass
         fd.close()
 

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -88,7 +88,7 @@ def _read_manifest() -> Dict[str, str]:
                 # v1 format: plain name — empty hash triggers migration
                 result[line] = ""
         return result
-    except (OSError, IOError):
+    except OSError:
         return {}
 
 
@@ -209,7 +209,7 @@ def _dir_hash(directory: Path) -> str:
                 rel = fpath.relative_to(directory)
                 hasher.update(str(rel).encode("utf-8"))
                 hasher.update(fpath.read_bytes())
-    except (OSError, IOError):
+    except OSError:
         pass
     return hasher.hexdigest()
 
@@ -518,7 +518,7 @@ def sync_skills(quiet: bool = False) -> dict:
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 shutil.move(str(_orphan), str(dest))
                 logger.info("Recovered orphaned skill backup: %s", _orphan)
-            except (OSError, IOError):
+            except OSError:
                 logger.warning(
                     "Could not recover orphaned skill backup %s", _orphan,
                     exc_info=True,
@@ -554,7 +554,7 @@ def sync_skills(quiet: bool = False) -> dict:
                     manifest[skill_name] = bundled_hash
                     if not quiet:
                         print(f"  + {skill_name}")
-            except (OSError, IOError) as e:
+            except OSError as e:
                 if not quiet:
                     print(f"  ! Failed to copy {skill_name}: {e}")
                 # Do NOT add to manifest — next sync should retry
@@ -603,9 +603,9 @@ def sync_skills(quiet: bool = False) -> dict:
                         # Remove backup after successful copy
                         try:
                             _rmtree_writable(backup)
-                        except (OSError, IOError):
+                        except OSError:
                             logger.debug("Could not remove backup %s", backup, exc_info=True)
-                    except (OSError, IOError):
+                    except OSError:
                         # Restore from backup. A partially-written dest must
                         # not shadow the user's copy or block the restore —
                         # clear it first, then move the backup home.
@@ -613,7 +613,7 @@ def sync_skills(quiet: bool = False) -> dict:
                             if dest.exists():
                                 try:
                                     _rmtree_writable(dest)
-                                except (OSError, IOError):
+                                except OSError:
                                     logger.warning(
                                         "Could not clear partial copy %s during restore",
                                         dest, exc_info=True,
@@ -621,7 +621,7 @@ def sync_skills(quiet: bool = False) -> dict:
                             if not dest.exists():
                                 shutil.move(str(backup), str(dest))
                         raise
-                except (OSError, IOError) as e:
+                except OSError as e:
                     if not quiet:
                         print(f"  ! Failed to update {skill_name}: {e}")
             else:
@@ -644,7 +644,7 @@ def sync_skills(quiet: bool = False) -> dict:
             try:
                 dest_desc.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(desc_md, dest_desc)
-            except (OSError, IOError) as e:
+            except OSError as e:
                 logger.debug("Could not copy %s: %s", desc_md, e)
 
     _write_manifest(manifest)
@@ -774,7 +774,7 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
             try:
                 _rmtree_writable(dest)
                 deleted_user_copy = True
-            except (OSError, IOError) as e:
+            except OSError as e:
                 return {
                     "ok": False,
                     "action": "not_reset",
@@ -1084,7 +1084,7 @@ def remove_pristine_bundled_skills(dry_run: bool = False) -> dict:
             continue
         try:
             _rmtree_writable(dest)
-        except (OSError, IOError) as e:
+        except OSError as e:
             skipped.append({"name": name, "reason": f"delete failed: {e}"})
             continue
         if name in manifest:


### PR DESCRIPTION
## Summary

`IOError` is an alias for `OSError` since Python 3.3 ([PEP 3151](https://peps.python.org/pep-3151/)). `except (OSError, IOError)` is functionally identical to `except OSError`.

This PR removes the redundant `IOError` across **34 call sites in 13 files**:

- `agent/anthropic_adapter.py` (1)
- `agent/shell_hooks.py` (1)
- `tools/skill_usage.py` (2)
- `tools/memory_tool.py` (6)
- `tools/skills_sync.py` (11)
- `tools/environments/file_sync.py` (1)
- `hermes_cli/config.py` (1)
- `hermes_cli/main.py` (1)
- `hermes_cli/auth.py` (2)
- `cron/scheduler.py` (3)
- `cron/jobs.py` (2)
- `optional-skills/creative/meme-generation/scripts/generate_meme.py` (2)
- `cli.py` (1)

## Changes

- `except (OSError, IOError)` → `except OSError`
- `except (IOError, OSError)` → `except OSError`

No behavioral change — `IOError` is literally `OSError` in Python 3.