### PR TITLE
fix(agent,cli): remove redundant exception subclass from except tuples

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -663,7 +663,7 @@ def compress_context(
                     try:
                         new_title = agent._session_db.get_next_title_in_lineage(old_title)
                         agent._session_db.set_session_title(agent.session_id, new_title)
-                    except (ValueError, Exception) as e:
+                    except Exception as e:
                         logger.debug("Could not propagate title on compression: %s", e)
 
             # Shared post-write steps (both modes target agent.session_id, which

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -433,7 +433,7 @@ class CLIAgentSetupMixin:
                         _cprint(f"  Session title applied: {self._pending_title}")
                         self._pending_title = None
                     # else: row creation failed transiently — keep _pending_title for retry
-                except (ValueError, Exception) as e:
+                except Exception as e:
                     _cprint(f"  Could not apply pending title: {e}")
                     # Keep _pending_title so it can be retried after row creation succeeds
             return True

--- a/hermes_time.py
+++ b/hermes_time.py
@@ -74,7 +74,7 @@ def _get_zoneinfo(name: str) -> Optional[ZoneInfo]:
         return None
     try:
         return ZoneInfo(name)
-    except (KeyError, Exception) as exc:
+    except Exception as exc:
         logger.warning(
             "Invalid timezone '%s': %s. Falling back to server local time.",
             name, exc,

--- a/scripts/discord-voice-doctor.py
+++ b/scripts/discord-voice-doctor.py
@@ -80,7 +80,7 @@ def check_packages():
             import nacl.secret
             nacl.secret.Aead(bytes(32))
             check("PyNaCl", True, f"v{ver}")
-        except (AttributeError, Exception):
+        except Exception:
             check("PyNaCl (Aead)", False, f"v{ver} — need >=1.5.0")
             ok = False
     except ImportError:


### PR DESCRIPTION
## Summary

In `except (SomeError, Exception)`, `SomeError` is already covered by `Exception` since it is a subclass. The tuple member is redundant.

This PR cleans up 4 call sites:

| File | Before | After |
|------|--------|-------|
| `agent/conversation_compression.py:666` | `except (ValueError, Exception) as e:` | `except Exception as e:` |
| `scripts/discord-voice-doctor.py:83` | `except (AttributeError, Exception):` | `except Exception:` |
| `hermes_cli/cli_agent_setup_mixin.py:436` | `except (ValueError, Exception) as e:` | `except Exception as e:` |
| `hermes_time.py:77` | `except (KeyError, Exception) as exc:` | `except Exception as exc:` |

## Changes

- `except (ValueError, Exception)` → `except Exception`
- `except (KeyError, Exception)` → `except Exception`
- `except (AttributeError, Exception)` → `except Exception`

No behavioral change — the removed types are all `Exception` subclasses.