### PR TITLE
fix(hindsight): recover from embedded daemon readiness false-negative

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -140,6 +140,90 @@ def _check_local_runtime() -> tuple[bool, str | None]:
         return False, str(exc)
 
 
+def _probe_http_health(url: str, timeout: float = 5.0) -> bool:
+    """Return True when a local Hindsight API URL answers /health."""
+    if not url:
+        return False
+    try:
+        import urllib.request
+
+        req = urllib.request.Request(f"{url.rstrip('/')}/health", method="GET")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return getattr(resp, "status", resp.getcode()) == 200
+    except Exception:
+        return False
+
+
+def _install_embedded_readiness_fallback(client, profile: str) -> None:
+    """Patch a HindsightEmbedded instance to recover from false startup timeouts.
+
+    Some hindsight-embed versions can return False from ensure_running() even
+    after the daemon reached "Application startup complete" and /health is
+    already green. Without this fallback, every proxied method call raises
+    "Failed to start daemon" despite a usable local API. Keep the workaround
+    instance-local so we do not monkey-patch the third-party package globally.
+    """
+    original = client.__dict__.get("_ensure_started") or getattr(type(client), "_ensure_started", None)
+    if original is None or client.__dict__.get("_hermes_readiness_fallback", False):
+        return
+
+    def _connect_if_healthy() -> bool:
+        manager = getattr(client, "_manager", None)
+        if manager is None:
+            return False
+        try:
+            daemon_url = manager.get_url(profile)
+        except Exception:
+            return False
+        if not _probe_http_health(daemon_url):
+            return False
+        if (
+            client.__dict__.get("_hermes_direct_health_client", False)
+            and client.__dict__.get("_started", False)
+            and client.__dict__.get("_client") is not None
+        ):
+            return True
+
+        from hindsight_client import Hindsight
+
+        stale_client = client.__dict__.get("_client")
+        if stale_client is not None:
+            try:
+                stale_client.close()
+            except Exception:
+                logger.debug("Error closing stale embedded Hindsight client", exc_info=True)
+
+        client._client = Hindsight(base_url=daemon_url, timeout=float(_DEFAULT_TIMEOUT))
+        client._started = True
+        client._hermes_direct_health_client = True
+        logger.info(
+            "Hindsight embedded daemon for profile %r is healthy; using existing daemon at %s",
+            profile,
+            daemon_url,
+        )
+        return True
+
+    def _ensure_started_with_health_fallback():
+        if _connect_if_healthy():
+            return None
+        try:
+            return original(client)
+        except TypeError:
+            try:
+                return original()
+            except RuntimeError as exc:
+                if "Failed to start daemon" not in str(exc) or not _connect_if_healthy():
+                    raise
+                return None
+        except RuntimeError as exc:
+            if "Failed to start daemon" not in str(exc) or not _connect_if_healthy():
+                raise
+            return None
+
+    client._ensure_started = _ensure_started_with_health_fallback
+    client._hermes_readiness_fallback = True
+
+
 def _ensure_cloud_client_dependency() -> None:
     """Install the Hindsight cloud client lazily before importing it."""
     try:
@@ -1050,6 +1134,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._idle_timeout = idle_timeout
                 kwargs["idle_timeout"] = idle_timeout
                 self._client = HindsightEmbedded(**kwargs)
+                _install_embedded_readiness_fallback(self._client, kwargs["profile"])
             else:
                 _ensure_cloud_client_dependency()
                 from hindsight_client import Hindsight
@@ -1942,7 +2027,10 @@ class HindsightMemoryProvider(MemoryProvider):
                         except Exception:
                             pass
                     try:
-                        self._client.close()
+                        if getattr(self._client, "__dict__", {}).get("_hermes_direct_health_client", False):
+                            setattr(self._client, "_closed", True)
+                        else:
+                            self._client.close()
                     except RuntimeError:
                         pass
                 else:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -23,6 +23,7 @@ from plugins.memory.hindsight import (
     RETAIN_SCHEMA,
     _load_config,
     _build_embedded_profile_env,
+    _install_embedded_readiness_fallback,
     _normalize_observation_scopes,
     _normalize_retain_tags,
     _resolve_bank_id_template,
@@ -423,6 +424,7 @@ class TestConfig:
         class FakeHindsightEmbedded:
             def __init__(self, **kwargs):
                 captured.update(kwargs)
+                self._ensure_started = lambda: None
 
         monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
         monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
@@ -442,6 +444,56 @@ class TestConfig:
 
         assert captured["idle_timeout"] == 0
         assert captured["llm_provider"] == "openai"
+
+    def test_embedded_readiness_fallback_uses_healthy_daemon_after_start_timeout(self, monkeypatch):
+        class FakeManager:
+            def get_url(self, profile):
+                assert profile == "default"
+                return "http://127.0.0.1:8984"
+
+        class FakeEmbeddedClient:
+            def __init__(self):
+                self._manager = FakeManager()
+                self._client = None
+                self._started = False
+
+            def _ensure_started(self):
+                raise RuntimeError("Failed to start daemon for profile 'default'")
+
+        class FakeHindsight:
+            def __init__(self, base_url, **kwargs):
+                self.base_url = base_url
+                self.kwargs = kwargs
+
+        fake = FakeEmbeddedClient()
+        monkeypatch.setattr("plugins.memory.hindsight._probe_http_health", lambda url: url == "http://127.0.0.1:8984")
+        monkeypatch.setitem(sys.modules, "hindsight_client", SimpleNamespace(Hindsight=FakeHindsight))
+
+        _install_embedded_readiness_fallback(fake, "default")
+        fake._ensure_started()
+
+        assert fake._started is True
+        assert fake._client.base_url == "http://127.0.0.1:8984"
+
+    def test_embedded_readiness_fallback_keeps_real_failure_when_health_fails(self, monkeypatch):
+        class FakeManager:
+            def get_url(self, profile):
+                return "http://127.0.0.1:8984"
+
+        class FakeEmbeddedClient:
+            def __init__(self):
+                self._manager = FakeManager()
+
+            def _ensure_started(self):
+                raise RuntimeError("Failed to start daemon for profile 'default'")
+
+        fake = FakeEmbeddedClient()
+        monkeypatch.setattr("plugins.memory.hindsight._probe_http_health", lambda url: False)
+
+        _install_embedded_readiness_fallback(fake, "default")
+
+        with pytest.raises(RuntimeError, match="Failed to start daemon"):
+            fake._ensure_started()
 
 
 class TestPostSetup:


### PR DESCRIPTION
## Problem

Some `hindsight-embed` versions report a startup timeout via `HindsightEmbedded._ensure_started()` even after the daemon has reached **"Application startup complete"** and `/health` is already green. Every proxied method call then raises:

```
RuntimeError: Failed to start daemon for profile '<name>'
```

…despite a perfectly usable local API. `hermes memory status` reports `available ✓` the whole time, so users hit a silent dead end with no operational workaround short of switching to `local_external`.

## Root cause

The embedded daemon readiness check can return a false negative — the daemon is healthy, but the manager's internal state doesn't reflect it (stale PID, race during startup, etc.).

## Fix

Add an **instance-local readiness fallback** (no global monkey-patching):

1. **`_probe_http_health(url)`** — lightweight `urllib` GET to `{url}/health`, returns `True` on HTTP 200.
2. **`_install_embedded_readiness_fallback(client, profile)`** — wraps the instance's `_ensure_started`:
   - First tries `_probe_http_health(manager.get_url(profile))`.
   - If healthy: replaces `client._client` with a direct `hindsight_client.Hindsight(base_url=daemon_url, timeout=...)`, sets `_started = True`, marks `_hermes_direct_health_client = True`.
   - If unhealthy: defers to the original `_ensure_started`, and on `RuntimeError("Failed to start daemon …")` tries the health probe one more time before re-raising.
3. **Safe `getattr`**: uses `client.__dict__` / `getattr(type(client), ...)` instead of bare `getattr(client, ...)` to avoid triggering `HindsightEmbedded.__getattr__` → `_ensure_started()` recursion.
4. **Shutdown care**: when `_hermes_direct_health_client` is set, `close()` is skipped (the direct client manages its own lifecycle); the embedded wrapper is marked `_closed` instead.

## Relationship to existing work

This is **complementary** to #50341 (`port_health_grace_timeout`), which extends the wait window for slow `/health` probes. This PR handles the case where the readiness check has **already returned false** but the daemon is in fact healthy — a false negative, not a slow positive.

## Tests

```bash
bash scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py
# 118 tests passed, 0 failed (100% complete) in 1.1s (30 workers)
```

Two new test cases:
- `test_embedded_readiness_fallback_uses_healthy_daemon_after_start_timeout` — verifies a direct `Hindsight` client is created and `_started=True` when `/health` is green despite a startup-timeout `RuntimeError`.
- `test_embedded_readiness_fallback_keeps_real_failure_when_health_fails` — verifies the original `RuntimeError` is re-raised when `/health` is not reachable.

Also added `self._ensure_started = lambda: None` to the existing `FakeHindsightEmbedded` in `test_get_client_passes_idle_timeout_to_hindsight_embedded` so the fallback installer doesn't trigger `__getattr__` on the fake.

## Verification

- [x] `scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py` — 118/118 passed
- [x] Live smoke test: `hindsight_retain` → `hindsight_recall` → `hindsight_reflect` all succeed after applying the patch on Hermes v0.17.0