### PR TITLE
fix(tools,cli,gateway): add encoding="utf-8" to subprocess.run with text=True

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1155,7 +1155,7 @@ def _probe_container(cmd: list, backend: str, via_sudo: bool = False):
     all other exceptions propagate naturally.
     """
     try:
-        return subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        return subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", timeout=15)
     except subprocess.TimeoutExpired:
         label = f"sudo {backend}" if via_sudo else backend
         print(

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1440,7 +1440,7 @@ def setup_terminal_backend(config: dict):
                 ssh_cmd.extend(["-p", port])
             ssh_cmd.append(f"{user}@{host}" if user else host)
             ssh_cmd.append("echo ok")
-            result = subprocess.run(ssh_cmd, capture_output=True, text=True, timeout=10)
+            result = subprocess.run(ssh_cmd, capture_output=True, text=True, encoding="utf-8", timeout=10)
             if result.returncode == 0:
                 print_success("  SSH connection successful!")
             else:

--- a/skills/creative/comfyui/scripts/auto_fix_deps.py
+++ b/skills/creative/comfyui/scripts/auto_fix_deps.py
@@ -51,7 +51,7 @@ def run_cmd(cmd: list[str], *, dry_run: bool = False) -> tuple[int, str]:
     if dry_run:
         return 0, "[dry-run]"
     log(f"$ {' '.join(cmd)}")
-    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    proc = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", check=False)
     out = (proc.stdout or "") + (proc.stderr or "")
     return proc.returncode, out
 

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -220,7 +220,7 @@ class SingularityEnvironment(BaseEnvironment):
         cmd.extend([str(self.image), self.instance_id])
 
         try:
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL)
+            result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", timeout=120, stdin=subprocess.DEVNULL)
             if result.returncode != 0:
                 raise RuntimeError(f"Failed to start instance: {result.stderr}")
             self._instance_started = True

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1187,7 +1187,7 @@ def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], 
     command = [ffmpeg, "-y", "-i", file_path, converted_path]
 
     try:
-        subprocess.run(command, check=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL)
+        subprocess.run(command, check=True, capture_output=True, text=True, encoding="utf-8", timeout=300, stdin=subprocess.DEVNULL)
         return converted_path, None
     except subprocess.TimeoutExpired:
         logger.error("ffmpeg conversion timed out for %s", file_path)
@@ -1233,9 +1233,9 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
             # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.
             use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
             if use_shell:
-                subprocess.run(command, shell=True, check=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL)
+                subprocess.run(command, shell=True, check=True, capture_output=True, text=True, encoding="utf-8", timeout=300, stdin=subprocess.DEVNULL)
             else:
-                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL)
+                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True, encoding="utf-8", timeout=300, stdin=subprocess.DEVNULL)
             
 
             txt_files = sorted(Path(output_dir).glob("*.txt"))

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1859,7 +1859,7 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
         "--device", device,
     ]
 
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL)
+    result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", timeout=120, stdin=subprocess.DEVNULL)
     if result.returncode != 0:
         stderr = result.stderr.strip()
         # Filter out the "OK:" line from stderr

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -389,7 +389,7 @@ class TermuxAudioRecorder:
             "-c", str(CHANNELS),
         ]
         try:
-            subprocess.run(command, capture_output=True, text=True, timeout=15, check=True, stdin=subprocess.DEVNULL)
+            subprocess.run(command, capture_output=True, text=True, encoding="utf-8", timeout=15, check=True, stdin=subprocess.DEVNULL)
         except subprocess.CalledProcessError as e:
             details = (e.stderr or e.stdout or str(e)).strip()
             raise RuntimeError(f"Termux microphone start failed: {details}") from e
@@ -406,7 +406,7 @@ class TermuxAudioRecorder:
         mic_cmd = _termux_microphone_command()
         if not mic_cmd:
             return
-        subprocess.run([mic_cmd, "-q"], capture_output=True, text=True, timeout=15, check=False, stdin=subprocess.DEVNULL)
+        subprocess.run([mic_cmd, "-q"], capture_output=True, text=True, encoding="utf-8", timeout=15, check=False, stdin=subprocess.DEVNULL)
 
     def stop(self) -> Optional[str]:
         with self._lock:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8993,7 +8993,7 @@ def _(rid, params: dict) -> dict:
             str(pdf_path), str(out_prefix),
         ]
         try:
-            res = subprocess.run(argv, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL)
+            res = subprocess.run(argv, capture_output=True, text=True, encoding="utf-8", timeout=120, stdin=subprocess.DEVNULL)
         except subprocess.TimeoutExpired:
             return _err(rid, 5028, "pdftoppm timed out (>120s)")
         if res.returncode != 0:


### PR DESCRIPTION
## Summary

`subprocess.run(..., text=True)` without explicit `encoding` uses the system locale, which varies across platforms:
- **Linux**: typically UTF-8
- **Windows**: cp1252 or mbcs (system locale)

This causes mojibake on Windows when processing UTF-8 output from ffmpeg, whisper, and other tools.

### Files changed (11 call sites, 8 files)

| File | Line | Tool |
|------|------|------|
| `tools/tts_tool.py` | 1862 | ffmpeg |
| `tools/transcription_tools.py` | 1190, 1236, 1238 | whisper/ffmpeg |
| `tools/environments/singularity.py` | 223 | singularity |
| `tools/voice_mode.py` | 392, 409 | microphone check |
| `hermes_cli/setup.py` | 1443 | ssh probe |
| `hermes_cli/main.py` | 1158 | hermes update |
| `tui_gateway/server.py` | 8996 | codex CLI |
| `skills/creative/comfyui/scripts/auto_fix_deps.py` | 54 | pip install |

### Test plan

- `python3 -m py_compile` on all 8 changed files
- Existing tests pass unchanged (UTF-8 is already the expected encoding on Linux)