### PR TITLE
fix(agent): reload credential pool on switch_model provider change

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1592,6 +1592,23 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
                 pass
         raise
 
+    # ── Reload credential pool for new provider ──
+    # When switching providers (e.g. via /model in the desktop picker), the
+    # pool stays bound to the original provider. Without a reload,
+    # ``recover_with_credential_pool()`` sees a ``pool.provider !=
+    # agent.provider`` mismatch and short-circuits — so a transient 401 on
+    # the new provider can never be recovered via pool rotation.
+    if old_provider != new_provider:
+        try:
+            from agent.credential_pool import load_pool
+            agent._credential_pool = load_pool(new_provider)
+        except Exception as _cp_exc:
+            import logging as _logging
+            _logging.getLogger(__name__).debug(
+                "Credential pool reload failed after provider switch %s -> %s: %s",
+                old_provider, new_provider, _cp_exc,
+            )
+
     # ── Re-evaluate prompt caching ──
     agent._use_prompt_caching, agent._use_native_cache_layout = (
         agent._anthropic_prompt_cache_policy(

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from run_agent import AIAgent
 from agent.context_compressor import ContextCompressor
+from agent.credential_pool import CredentialPool
 
 
 def _make_agent_with_compressor(config_context_length=None) -> AIAgent:
@@ -70,6 +71,46 @@ def test_switch_model_without_config_context_length():
         agent.switch_model("new-model", "openrouter", api_key="sk-new", base_url="https://openrouter.ai/api/v1")
 
         # Verify get_model_context_length was called with None
-        mock_ctx_len.assert_called_once()
-        call_kwargs = mock_ctx_len.call_args.kwargs
-        assert call_kwargs.get("config_context_length") is None
+    mock_ctx_len.assert_called_once()
+    call_kwargs = mock_ctx_len.call_args.kwargs
+    assert call_kwargs.get("config_context_length") is None
+
+
+def test_switch_model_reloads_credential_pool_on_provider_change():
+    """When switching providers, _credential_pool must be refreshed."""
+    agent = _make_agent_with_compressor()
+
+    # Set up an old pool bound to the original provider
+    old_pool = MagicMock(spec=CredentialPool)
+    old_pool.provider = "openrouter"
+    agent._credential_pool = old_pool
+
+    # Mock load_pool to return a new pool for the target provider
+    new_pool = MagicMock(spec=CredentialPool)
+    new_pool.provider = "anthropic"
+
+    with patch("agent.credential_pool.load_pool", return_value=new_pool) as mock_load:
+        agent.switch_model("claude-sonnet-4", "anthropic", api_key="sk-anthropic")
+
+    # load_pool should be called with the NEW provider
+    mock_load.assert_called_once_with("anthropic")
+    # Agent's pool should now be the new pool
+    assert agent._credential_pool is new_pool
+    # Old pool should no longer be referenced
+    assert agent._credential_pool is not old_pool
+
+
+def test_switch_model_does_not_reload_pool_for_same_provider():
+    """When switching models on the same provider, pool should not be reloaded."""
+    agent = _make_agent_with_compressor()
+    existing_pool = MagicMock(spec=CredentialPool)
+    existing_pool.provider = "openrouter"
+    agent._credential_pool = existing_pool
+
+    with patch("agent.credential_pool.load_pool") as mock_load:
+        agent.switch_model("gpt-4o-mini", "openrouter", api_key="sk-other", base_url="https://openrouter.ai/api/v1")
+
+    # load_pool should NOT be called when provider stays the same
+    mock_load.assert_not_called()
+    # Pool should remain unchanged
+    assert agent._credential_pool is existing_pool


### PR DESCRIPTION
When switching providers (e.g. via /model in the desktop picker), switch_model() updated agent.model/agent.provider/agent.base_url but never refreshed agent._credential_pool. The pool stayed bound to the original provider, so recover_with_credential_pool() saw a pool.provider != agent.provider mismatch and short-circuited — so a transient 401 on the new provider could never be recovered via pool rotation. Worse, the original provider pool entries got marked STATUS_EXHAUSTED and persisted to auth.json across restarts.

Now reloads the credential pool when the provider actually changes (is skipped for same-provider model switches).

Fixes #52763

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

