### PR TITLE
fix: avoid recursive chown through symlinks

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -180,6 +180,19 @@ done
 #
 # The canonical list of hermes-owned subdirs is the same one the s6-setuidgid
 # mkdir -p block below seeds. Keep them in sync if the seed list changes.
+chown_hermes_tree() {
+    target="$1"
+    if [ ! -e "$target" ]; then
+        return 0
+    fi
+    if [ -L "$target" ]; then
+        echo "[stage2] Skipping recursive chown of symlinked path $target"
+        return 0
+    fi
+    find -P "$target" ! -type l -exec chown hermes:hermes {} + 2>/dev/null || \
+        echo "[stage2] Warning: chown $target failed (rootless container?) — continuing"
+}
+
 actual_hermes_uid=$(id -u hermes)
 needs_chown=false
 if [ "$(stat -c %u "$HERMES_HOME" 2>/dev/null)" != "$actual_hermes_uid" ]; then
@@ -200,10 +213,7 @@ if [ "$needs_chown" = true ]; then
     # created and managed exclusively by hermes (see the s6-setuidgid mkdir
     # -p block below for the canonical list).
     for sub in cron sessions logs hooks memories skills skins plans workspace home profiles pairing platforms/pairing lazy-packages; do
-        if [ -e "$HERMES_HOME/$sub" ]; then
-            chown -R hermes:hermes "$HERMES_HOME/$sub" 2>/dev/null || \
-                echo "[stage2] Warning: chown $HERMES_HOME/$sub failed (rootless container?) — continuing"
-        fi
+        chown_hermes_tree "$HERMES_HOME/$sub"
     done
 fi
 
@@ -234,7 +244,7 @@ fi
 # the profiles dir. Idempotent; skipped on rootless containers where
 # chown would fail.
 if [ -d "$HERMES_HOME/profiles" ]; then
-    chown -R hermes:hermes "$HERMES_HOME/profiles" 2>/dev/null || true
+    chown_hermes_tree "$HERMES_HOME/profiles"
 fi
 
 # Always reset ownership of $HERMES_HOME/cron on every boot for the same
@@ -242,7 +252,7 @@ fi
 # (jobs.json) must stay readable by the unprivileged hermes runtime even
 # after root-context maintenance commands or scheduler writes.
 if [ -d "$HERMES_HOME/cron" ]; then
-    chown -R hermes:hermes "$HERMES_HOME/cron" 2>/dev/null || true
+    chown_hermes_tree "$HERMES_HOME/cron"
 fi
 
 # Reset ownership of hermes-owned top-level state files on every boot.

--- a/tests/tools/test_stage2_hook_symlink_chown.py
+++ b/tests/tools/test_stage2_hook_symlink_chown.py
@@ -1,0 +1,63 @@
+"""Contract tests for symlink-safe recursive ownership repair in stage2."""
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STAGE2_HOOK = REPO_ROOT / "docker" / "stage2-hook.sh"
+
+
+@pytest.fixture(scope="module")
+def stage2_text() -> str:
+    if not STAGE2_HOOK.exists():
+        pytest.skip("docker/stage2-hook.sh not present in this checkout")
+    return STAGE2_HOOK.read_text()
+
+
+def _chown_helper(text: str) -> str:
+    match = re.search(r"(chown_hermes_tree\(\) \{\n(?:.*\n)*?\})", text)
+    assert match, "stage2-hook.sh must define chown_hermes_tree"
+    return match.group(1)
+
+
+def test_recursive_chown_uses_symlink_safe_helper(stage2_text: str) -> None:
+    helper = _chown_helper(stage2_text)
+    assert '[ -L "$target" ]' in helper
+    assert 'find -P "$target" ! -type l -exec chown hermes:hermes {} +' in helper
+    assert 'chown -R hermes:hermes "$HERMES_HOME/$sub"' not in stage2_text
+    assert 'chown_hermes_tree "$HERMES_HOME/$sub"' in stage2_text
+    assert 'chown_hermes_tree "$HERMES_HOME/profiles"' in stage2_text
+    assert 'chown_hermes_tree "$HERMES_HOME/cron"' in stage2_text
+
+
+def test_recursive_chown_helper_skips_symlinked_home(stage2_text: str, tmp_path: Path) -> None:
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash not available")
+
+    hermes_home = tmp_path / "data"
+    outside_home = tmp_path / "real-home"
+    hermes_home.mkdir()
+    outside_home.mkdir()
+    (outside_home / "ssh-key").write_text("secret", encoding="utf-8")
+    (hermes_home / "home").symlink_to(outside_home, target_is_directory=True)
+
+    log_path = tmp_path / "calls.log"
+    script = (
+        "set -e\n"
+        f"{_chown_helper(stage2_text)}\n"
+        f'find() {{ echo "find:$*" >> "{log_path}"; }}\n'
+        f'chown() {{ echo "chown:$*" >> "{log_path}"; }}\n'
+        f'chown_hermes_tree "{hermes_home}/home"\n'
+    )
+
+    proc = subprocess.run([bash, "-c", script], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    assert "Skipping recursive chown of symlinked path" in proc.stdout
+    assert not log_path.exists()
+


### PR DESCRIPTION
## Summary
- route recursive stage2 ownership repair through a symlink-safe helper
- skip top-level symlinked Hermes data paths instead of recursively chowning their targets
- use `find -P` and exclude symlink entries so nested symlinks are not followed
- add regression tests for the stage2 chown contract

## Problem
`docker/stage2-hook.sh` recursively chowned Hermes-owned subdirectories. If `$HERMES_HOME/home` was a symlink to a real user home, startup could recurse through that path and rewrite ownership outside the Hermes data volume.

## Fix
Recursive ownership repair now goes through `chown_hermes_tree`, which skips symlinked top-level targets and uses non-following traversal for real directories. The always-on `profiles` and `cron` repairs use the same helper.

Closes #52781

## Validation
- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/tools/test_stage2_hook_symlink_chown.py tests/tools/test_stage2_hook_toplevel_chown.py tests/tools/test_stage2_hook_log_dir_seed.py tests/tools/test_stage2_hook_puid_pgid.py`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check tests/tools/test_stage2_hook_symlink_chown.py`
- `git diff --check`