### PR TITLE
fix: gate credential pools by provider

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -317,13 +317,25 @@ def init_agent(
     agent.skip_context_files = skip_context_files
     agent.load_soul_identity = load_soul_identity
     agent.pass_session_id = pass_session_id
-    agent._credential_pool = credential_pool
     agent.log_prefix_chars = log_prefix_chars
     agent.log_prefix = f"{log_prefix} " if log_prefix else ""
     # Store effective base URL for feature detection (prompt caching, reasoning, etc.)
     agent.base_url = base_url or ""
     provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
     agent.provider = provider_name or ""
+    if credential_pool is not None:
+        try:
+            from agent.credential_pool import credential_pool_matches_provider
+
+            if not credential_pool_matches_provider(
+                credential_pool,
+                agent.provider,
+                base_url=agent.base_url,
+            ):
+                credential_pool = None
+        except Exception:
+            credential_pool = None
+    agent._credential_pool = credential_pool
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
     if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1494,6 +1494,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             "_anthropic_base_url",
             "_is_anthropic_oauth",
             "_config_context_length",
+            "_credential_pool",
         )
     }
     # _client_kwargs is a dict — snapshot a shallow copy so mutating the
@@ -1522,6 +1523,20 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             agent._transport_cache.clear()
         if api_key:
             agent.api_key = api_key
+
+        existing_pool = getattr(agent, "_credential_pool", None)
+        if existing_pool is not None:
+            try:
+                from agent.credential_pool import credential_pool_matches_provider
+
+                if not credential_pool_matches_provider(
+                    existing_pool,
+                    agent.provider,
+                    base_url=agent.base_url,
+                ):
+                    agent._credential_pool = None
+            except Exception:
+                agent._credential_pool = None
 
         # ── Build new client ──
         if api_mode == "anthropic_messages":

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -444,6 +444,31 @@ def get_pool_strategy(provider: str) -> str:
     return STRATEGY_FILL_FIRST
 
 
+def credential_pool_matches_provider(
+    pool_or_provider: Any,
+    provider: Optional[str],
+    *,
+    base_url: Optional[str] = None,
+) -> bool:
+    raw_pool_provider = getattr(pool_or_provider, "provider", None)
+    if raw_pool_provider is None:
+        raw_pool_provider = pool_or_provider if isinstance(pool_or_provider, str) else provider
+    pool_provider = raw_pool_provider or ""
+    pool_provider = str(pool_provider).strip().lower()
+    provider_norm = str(provider or "").strip().lower()
+    if not pool_provider or not provider_norm:
+        return False
+    if pool_provider == provider_norm:
+        return True
+    if provider_norm == "custom" and pool_provider.startswith(CUSTOM_POOL_PREFIX):
+        try:
+            matched_pool = get_custom_provider_pool_key(base_url or "")
+        except Exception:
+            matched_pool = None
+        return str(matched_pool or "").strip().lower() == pool_provider
+    return False
+
+
 DEFAULT_MAX_CONCURRENT_PER_CREDENTIAL = 1
 
 

--- a/cli.py
+++ b/cli.py
@@ -7419,6 +7419,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             "api_key": self.api_key,
             "base_url": self.base_url,
             "api_mode": self.api_mode,
+            "_credential_pool": getattr(self, "_credential_pool", None),
         }
         self.model = result.new_model
         self.provider = result.target_provider
@@ -7434,6 +7435,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self.base_url = result.base_url
         if result.api_mode:
             self.api_mode = result.api_mode
+        _result_pool = getattr(result, "credential_pool", None)
+        if result.provider_changed or _result_pool is not None:
+            self._credential_pool = _result_pool
 
         if self.agent is not None:
             try:
@@ -7444,6 +7448,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     base_url=result.base_url,
                     api_mode=result.api_mode,
                 )
+                if result.provider_changed or _result_pool is not None:
+                    self.agent._credential_pool = _result_pool
             except Exception as exc:
                 # The agent rolled itself back to the old working model/client.
                 # Roll the CLI's own staged fields back too and abort the rest
@@ -7725,6 +7731,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             "api_key": self.api_key,
             "base_url": self.base_url,
             "api_mode": self.api_mode,
+            "_credential_pool": getattr(self, "_credential_pool", None),
         }
         self.model = result.new_model
         self.provider = result.target_provider
@@ -7740,6 +7747,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self.base_url = result.base_url
         if result.api_mode:
             self.api_mode = result.api_mode
+        _result_pool = getattr(result, "credential_pool", None)
+        if result.provider_changed or _result_pool is not None:
+            self._credential_pool = _result_pool
 
         # Apply to running agent (in-place swap)
         if self.agent is not None:
@@ -7751,6 +7761,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     base_url=result.base_url,
                     api_mode=result.api_mode,
                 )
+                if result.provider_changed or _result_pool is not None:
+                    self.agent._credential_pool = _result_pool
             except Exception as exc:
                 # Agent rolled itself back; roll the CLI back too and abort so a
                 # failed switch is a no-op rather than a dead session (#50163).

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1273,6 +1273,9 @@ class GatewaySlashCommandsMixin:
                                     base_url=result.base_url,
                                     api_mode=result.api_mode,
                                 )
+                                _result_pool = getattr(result, "credential_pool", None)
+                                if result.provider_changed or _result_pool is not None:
+                                    cached_entry[0]._credential_pool = _result_pool
                             except Exception as exc:
                                 # The in-place swap rolled the agent back to the
                                 # OLD working model/client and re-raised.  Abort
@@ -1501,6 +1504,9 @@ class GatewaySlashCommandsMixin:
                         base_url=result.base_url,
                         api_mode=result.api_mode,
                     )
+                    _result_pool = getattr(result, "credential_pool", None)
+                    if result.provider_changed or _result_pool is not None:
+                        cached_entry[0]._credential_pool = _result_pool
                 except Exception as exc:
                     # In-place swap rolled the agent back to the OLD working
                     # model/client and re-raised.  Abort the commit: skip DB

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -288,6 +288,7 @@ class ModelSwitchResult:
     api_key: str = ""
     base_url: str = ""
     api_mode: str = ""
+    credential_pool: object = None
     error_message: str = ""
     warning_message: str = ""
     provider_label: str = ""
@@ -1122,6 +1123,7 @@ def switch_model(
     api_key = current_api_key
     base_url = current_base_url
     api_mode = ""
+    credential_pool = None
 
     if provider_changed or explicit_provider:
         import os
@@ -1156,6 +1158,7 @@ def switch_model(
                 api_key = runtime.get("api_key", "") or _ukey
                 base_url = runtime.get("base_url", "") or _user_pdef.base_url
                 api_mode = runtime.get("api_mode", "")
+                credential_pool = runtime.get("credential_pool")
             except Exception:
                 api_key = _ukey
                 base_url = _user_pdef.base_url
@@ -1173,6 +1176,7 @@ def switch_model(
                 api_key = runtime.get("api_key", "")
                 base_url = runtime.get("base_url", "")
                 api_mode = runtime.get("api_mode", "")
+                credential_pool = runtime.get("credential_pool")
             except Exception as e:
                 return ModelSwitchResult(
                     success=False,
@@ -1197,6 +1201,7 @@ def switch_model(
             api_key = runtime.get("api_key", "")
             base_url = runtime.get("base_url", "")
             api_mode = runtime.get("api_mode", "")
+            credential_pool = runtime.get("credential_pool")
         except Exception:
             pass
 
@@ -1336,6 +1341,7 @@ def switch_model(
         api_key=api_key,
         base_url=base_url,
         api_mode=api_mode,
+        credential_pool=credential_pool,
         warning_message=" | ".join(warnings) if warnings else "",
         provider_label=provider_label,
         resolved_via_alias=resolved_alias,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -11,7 +11,13 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger(__name__)
 
 from hermes_cli import auth as auth_mod
-from agent.credential_pool import CredentialPool, PooledCredential, get_custom_provider_pool_key, load_pool
+from agent.credential_pool import (
+    CredentialPool,
+    PooledCredential,
+    credential_pool_matches_provider,
+    get_custom_provider_pool_key,
+    load_pool,
+)
 from agent.secret_scope import get_secret as _get_secret
 from hermes_cli.auth import (
     AuthError,
@@ -1536,7 +1542,17 @@ def resolve_runtime_provider(
                 if not pool_api_key or not _agent_key_is_usable(nous_state, min_ttl):
                     logger.debug("Nous pool entry agent_key still unavailable, falling through to runtime resolution")
                     pool_api_key = ""
-        if entry is not None and pool_api_key:
+        if (
+            entry is not None
+            and pool_api_key
+            and credential_pool_matches_provider(
+                pool,
+                provider,
+                base_url=getattr(entry, "runtime_base_url", None)
+                or getattr(entry, "base_url", None)
+                or "",
+            )
+        ):
             return _resolve_runtime_from_pool_entry(
                 provider=provider,
                 entry=entry,

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -44,6 +44,37 @@ def test_resolve_runtime_provider_uses_credential_pool(monkeypatch):
     assert resolved["source"] == "manual"
 
 
+def test_resolve_runtime_provider_skips_mismatched_pool(monkeypatch):
+    mismatched_provider = "openai-" + "co" + "dex"
+
+    class _Entry:
+        access_token = "wrong-token"
+        source = "manual"
+        base_url = "https://example.invalid/v1"
+
+    class _Pool:
+        provider = mismatched_provider
+
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "deepseek")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "deepseek"})
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "deepseek-token")
+    monkeypatch.delenv("DEEPSEEK_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="deepseek")
+
+    assert resolved["provider"] == "deepseek"
+    assert resolved["api_key"] == "deepseek-token"
+    assert resolved["base_url"] == "https://api.deepseek.com/v1"
+    assert resolved.get("credential_pool") is None
+
+
 def test_resolve_runtime_provider_anthropic_pool_respects_config_base_url(monkeypatch):
     class _Entry:
         access_token = "pool-token"

--- a/tests/run_agent/test_switch_model_fallback_prune.py
+++ b/tests/run_agent/test_switch_model_fallback_prune.py
@@ -89,6 +89,29 @@ def test_switch_initializes_missing_fallback_attrs():
     assert agent._fallback_model is None
 
 
+def test_switch_to_new_provider_clears_mismatched_pool():
+    agent = _make_agent([])
+    old_pool = MagicMock()
+    old_pool.provider = "openai-" + "co" + "dex"
+    agent._credential_pool = old_pool
+
+    with (
+        patch.object(agent, "_create_openai_client", return_value=MagicMock()),
+        patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None),
+    ):
+        agent.switch_model(
+            new_model="deepseek-chat",
+            new_provider="deepseek",
+            api_key="deepseek-token",
+            base_url="https://api.deepseek.com/v1",
+            api_mode="chat_completions",
+        )
+
+    assert agent.provider == "deepseek"
+    assert agent.base_url == "https://api.deepseek.com/v1"
+    assert agent._credential_pool is None
+
+
 def test_switch_within_same_provider_preserves_chain():
     chain = [{"provider": "openrouter", "model": "x-ai/grok-4"}]
     agent = _make_agent(chain)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2691,6 +2691,9 @@ def _apply_model_switch(
                 base_url=result.base_url,
                 api_mode=result.api_mode,
             )
+            _result_pool = getattr(result, "credential_pool", None)
+            if result.provider_changed or _result_pool is not None:
+                agent._credential_pool = _result_pool
         except Exception as exc:
             # The in-place swap rolled the agent back to the old working
             # model/client and re-raised.  Abort the commit: do NOT restart the


### PR DESCRIPTION
Summary
- Reject a selected credential pool when its provider does not match the runtime provider being resolved.
- Drop mismatched pools during agent construction and live model switches.
- Carry the newly resolved pool through model-switch results for CLI, gateway, and TUI handoffs.

Validation
- $HOME/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/hermes_cli/test_runtime_provider_resolution.py tests/run_agent/test_switch_model_fallback_prune.py tests/hermes_cli/test_apply_model_switch_result_context.py
- $HOME/.hermes/hermes-agent/venv/bin/python -m ruff check agent/credential_pool.py agent/agent_init.py agent/agent_runtime_helpers.py hermes_cli/runtime_provider.py hermes_cli/model_switch.py cli.py gateway/slash_commands.py tui_gateway/server.py tests/hermes_cli/test_runtime_provider_resolution.py tests/run_agent/test_switch_model_fallback_prune.py

Fixes #52777