### PR TITLE
fix: add Discord threaded free-response channels

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1190,18 +1190,8 @@ class DiscordAdapter(BasePlatformAdapter):
                     # (preserves old DISCORD_IGNORE_NO_MENTION=true behavior)
                     # EXCEPT in free-response channels where the bot should
                     # answer regardless of who is mentioned.
-                    _ignore_no_mention = os.getenv(
-                        "DISCORD_IGNORE_NO_MENTION", "true"
-                    ).lower() in {"true", "1", "yes"}
-                    if _ignore_no_mention and not _self_mentioned and not _other_bots_mentioned:
-                        _channel_id = str(message.channel.id)
-                        _parent_id = None
-                        if hasattr(message.channel, "parent_id") and message.channel.parent_id:
-                            _parent_id = str(message.channel.parent_id)
-                        _free_channels = adapter_self._discord_free_response_channels()
-                        _channel_keys = adapter_self._discord_channel_keys(message, _parent_id)
-                        if "*" not in _free_channels and not (_channel_keys & _free_channels):
-                            return
+                    if adapter_self._discord_should_ignore_human_mentions(message):
+                        return
 
                 await self._handle_message(message, role_authorized=_role_authorized)
 
@@ -4815,16 +4805,8 @@ class DiscordAdapter(BasePlatformAdapter):
             and getattr(att, "waveform", None) is not None
         )
 
-    def _discord_free_response_channels(self) -> set:
-        """Return Discord channel IDs/names where no bot mention is required.
-
-        A single ``"*"`` entry (either from a list or a comma-separated
-        string) is preserved in the returned set so callers can short-circuit
-        on wildcard membership, consistent with ``allowed_channels``.
-        """
-        raw = self.config.extra.get("free_response_channels")
-        if raw is None:
-            raw = os.getenv("DISCORD_FREE_RESPONSE_CHANNELS", "")
+    @staticmethod
+    def _discord_channel_id_set(raw: Any) -> set:
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
         # Coerce non-list scalars (str/int/float) to str before splitting.
@@ -4837,6 +4819,45 @@ class DiscordAdapter(BasePlatformAdapter):
         if s:
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
+
+    def _discord_free_response_channels(self) -> set:
+        """Return channels where no bot mention or auto-thread is required."""
+        raw = self.config.extra.get("free_response_channels")
+        if raw is None:
+            raw = os.getenv("DISCORD_FREE_RESPONSE_CHANNELS", "")
+        return self._discord_channel_id_set(raw)
+
+    def _discord_free_response_thread_channels(self) -> set:
+        """Return mention-free channels that retain automatic threading."""
+        raw = self.config.extra.get("free_response_thread_channels")
+        if raw is None:
+            raw = os.getenv("DISCORD_FREE_RESPONSE_THREAD_CHANNELS", "")
+        return self._discord_channel_id_set(raw)
+
+    def _discord_should_ignore_human_mentions(self, message: Any) -> bool:
+        """Gate messages addressed to another human outside free-response channels."""
+        ignore = os.getenv("DISCORD_IGNORE_NO_MENTION", "true").lower() in {
+            "true",
+            "1",
+            "yes",
+        }
+        if not ignore or self._self_is_explicitly_mentioned(message):
+            return False
+
+        mentions = getattr(message, "mentions", []) or []
+        if not mentions or any(getattr(user, "bot", False) for user in mentions):
+            return False
+
+        parent_id = getattr(getattr(message, "channel", None), "parent_id", None)
+        free_channels = (
+            self._discord_free_response_channels()
+            | self._discord_free_response_thread_channels()
+        )
+        channel_keys = self._discord_channel_keys(
+            message,
+            str(parent_id) if parent_id else None,
+        )
+        return "*" not in free_channels and not (channel_keys & free_channels)
 
     def _raw_mentioned_user_ids(self, message: Any) -> set:
         """Extract Discord user-mention IDs directly from raw message content.
@@ -6133,6 +6154,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # Config (all settable via discord.* in config.yaml or DISCORD_* env vars):
         #   discord.require_mention: Require @mention in server channels (default: true)
         #   discord.free_response_channels: Channel IDs where bot responds without mention
+        #   discord.free_response_thread_channels: Like free-response, but keeps auto-threading
         #   discord.ignored_channels: Channel IDs where bot NEVER responds (even when mentioned)
         #   discord.allowed_channels: If set, bot ONLY responds in these channels (whitelist)
         #   discord.no_thread_channels: Channel IDs where bot responds directly without creating thread
@@ -6170,9 +6192,6 @@ class DiscordAdapter(BasePlatformAdapter):
                 normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
             message.content = normalized_content
         if not isinstance(message.channel, discord.DMChannel):
-            channel_ids = {str(message.channel.id)}
-            if parent_channel_id:
-                channel_ids.add(parent_channel_id)
             channel_keys = self._discord_channel_keys(message, parent_channel_id)
 
             # Check allowed channels - if set, only respond in these channels
@@ -6191,6 +6210,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 return
 
             free_channels = self._discord_free_response_channels()
+            free_thread_channels = self._discord_free_response_thread_channels()
 
             require_mention = self._discord_require_mention()
             # Voice-linked text channels act as free-response while voice is active.
@@ -6198,11 +6218,16 @@ class DiscordAdapter(BasePlatformAdapter):
             voice_linked_ids = {str(ch_id) for ch_id in self._voice_text_channels.values()}
             current_channel_id = str(message.channel.id)
             is_voice_linked_channel = current_channel_id in voice_linked_ids
-            is_free_channel = (
+            is_inline_free_channel = (
                 "*" in free_channels
                 or bool(channel_keys & free_channels)
                 or is_voice_linked_channel
             )
+            is_threaded_free_channel = (
+                "*" in free_thread_channels
+                or bool(channel_keys & free_thread_channels)
+            )
+            is_free_channel = is_inline_free_channel or is_threaded_free_channel
 
             # Skip the mention check if the message is in a thread where
             # the bot has previously participated (auto-created or replied in)
@@ -6226,7 +6251,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
+            skip_thread = bool(channel_keys & no_thread_channels) or is_inline_free_channel
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
@@ -8249,9 +8274,10 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     The DiscordAdapter reads its runtime configuration via ``os.getenv()``
     throughout the connect / handle code paths (``DISCORD_ALLOWED_USERS``,
     ``DISCORD_REQUIRE_MENTION``, ``DISCORD_FREE_RESPONSE_CHANNELS``,
-    ``DISCORD_AUTO_THREAD``, ``DISCORD_REACTIONS``,
-    ``DISCORD_IGNORED_CHANNELS``, ``DISCORD_ALLOWED_CHANNELS``,
-    ``DISCORD_NO_THREAD_CHANNELS``, ``DISCORD_HISTORY_BACKFILL``,
+    ``DISCORD_FREE_RESPONSE_THREAD_CHANNELS``, ``DISCORD_AUTO_THREAD``,
+    ``DISCORD_REACTIONS``, ``DISCORD_IGNORED_CHANNELS``,
+    ``DISCORD_ALLOWED_CHANNELS``, ``DISCORD_NO_THREAD_CHANNELS``,
+    ``DISCORD_HISTORY_BACKFILL``,
     ``DISCORD_HISTORY_BACKFILL_LIMIT``, ``DISCORD_ALLOW_MENTION_*``,
     ``DISCORD_REPLY_TO_MODE``, ``DISCORD_THREAD_REQUIRE_MENTION``,
     ``DISCORD_BOTS_REQUIRE_INLINE_MENTION``).
@@ -8298,6 +8324,11 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         if isinstance(frc, list):
             frc = ",".join(str(v) for v in frc)
         os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
+    frtc = discord_cfg.get("free_response_thread_channels")
+    if frtc is not None and not os.getenv("DISCORD_FREE_RESPONSE_THREAD_CHANNELS"):
+        if isinstance(frtc, list):
+            frtc = ",".join(str(v) for v in frtc)
+        os.environ["DISCORD_FREE_RESPONSE_THREAD_CHANNELS"] = str(frtc)
     if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
         os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
     if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
@@ -8398,8 +8429,9 @@ def register(ctx) -> None:
         setup_fn=interactive_setup,
         # YAML→env config bridge — owns the translation of ``config.yaml``
         # ``discord:`` keys (require_mention, free_response_channels,
-        # auto_thread, reactions, ignored_channels, allowed_channels,
-        # no_thread_channels, allow_mentions.*, reply_to_mode,
+        # free_response_thread_channels, auto_thread, reactions,
+        # ignored_channels, allowed_channels, no_thread_channels,
+        # allow_mentions.*, reply_to_mode,
         # thread_require_mention) into ``DISCORD_*`` env vars that the
         # adapter reads via ``os.getenv()``.  Replaces the hardcoded block
         # that used to live in ``gateway/config.py``.  Hook contract: #24836.

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -399,6 +399,24 @@ def test_config_bridges_no_thread_channels(monkeypatch, tmp_path):
     assert os.getenv("DISCORD_NO_THREAD_CHANNELS") == "333"
 
 
+def test_config_bridges_free_response_thread_channels(monkeypatch, tmp_path):
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "discord": {
+            "free_response_thread_channels": ["444", "555"],
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_THREAD_CHANNELS", "")
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("DISCORD_FREE_RESPONSE_THREAD_CHANNELS") == "444,555"
+
+
 def test_config_env_var_takes_precedence(monkeypatch, tmp_path):
     """Env vars should take precedence over config.yaml values."""
     import yaml

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -109,6 +109,7 @@ def adapter(monkeypatch):
         "DISCORD_REQUIRE_MENTION",
         "DISCORD_THREAD_REQUIRE_MENTION",
         "DISCORD_FREE_RESPONSE_CHANNELS",
+        "DISCORD_FREE_RESPONSE_THREAD_CHANNELS",
         "DISCORD_AUTO_THREAD",
         "DISCORD_NO_THREAD_CHANNELS",
         "DISCORD_ALLOWED_CHANNELS",
@@ -315,6 +316,43 @@ def test_discord_free_response_channels_int_list(adapter, monkeypatch):
     adapter.config.extra["free_response_channels"] = [1491973769726791812, 99999]
 
     assert adapter._discord_free_response_channels() == {"1491973769726791812", "99999"}
+
+
+def test_discord_free_response_thread_channels_int_list(adapter, monkeypatch):
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_THREAD_CHANNELS", raising=False)
+    adapter.config.extra["free_response_thread_channels"] = [1491973769726791812, 99999]
+
+    assert adapter._discord_free_response_thread_channels() == {
+        "1491973769726791812",
+        "99999",
+    }
+
+
+def test_threaded_free_response_allows_human_mention_without_bot_mention(
+    adapter, monkeypatch
+):
+    monkeypatch.setenv("DISCORD_IGNORE_NO_MENTION", "true")
+    adapter.config.extra["free_response_thread_channels"] = ["789"]
+    human = SimpleNamespace(id=1234, bot=False)
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="can you ask them?",
+        mentions=[human],
+    )
+
+    assert adapter._discord_should_ignore_human_mentions(message) is False
+
+
+def test_human_mention_is_still_filtered_outside_free_response(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_IGNORE_NO_MENTION", "true")
+    human = SimpleNamespace(id=1234, bot=False)
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="can you ask them?",
+        mentions=[human],
+    )
+
+    assert adapter._discord_should_ignore_human_mentions(message) is True
 
 
 @pytest.mark.asyncio
@@ -683,6 +721,31 @@ async def test_discord_free_response_channel_skips_auto_thread(adapter, monkeypa
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "casual chat in free-response channel"
     assert event.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_discord_free_response_thread_channel_keeps_auto_thread(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_THREAD_CHANNELS", "789")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+
+    fake_thread = FakeThread(channel_id=999, name="auto-thread")
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="threaded chat without mention",
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "threaded chat without mention"
+    assert event.source.chat_type == "thread"
+    assert event.source.thread_id == "999"
 
 
 
@@ -1485,4 +1548,3 @@ async def test_discord_non_reply_free_channel_skips_backfill(adapter, monkeypatc
     await adapter._handle_message(message)
 
     adapter._fetch_channel_context.assert_not_awaited()
-

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -284,6 +284,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `DISCORD_COMMAND_SYNC_POLICY` | Discord slash-command startup sync policy: `safe` (diff and reconcile), `bulk` (legacy `tree.sync()`), or `off` |
 | `DISCORD_REQUIRE_MENTION` | Require an @mention before responding in server channels |
 | `DISCORD_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where mention is not required |
+| `DISCORD_FREE_RESPONSE_THREAD_CHANNELS` | Comma-separated channel IDs where mention is not required and auto-threading remains enabled |
 | `DISCORD_AUTO_THREAD` | Auto-thread long replies when supported |
 | `DISCORD_ALLOW_ANY_ATTACHMENT` | When `true`, accept attachments of any file type (not just the built-in PDF/text/zip/office allowlist). Unknown types are cached and surfaced to the agent as a local path so it can inspect them via `terminal` / `read_file` / `ffprobe`. Default `false`. |
 | `DISCORD_MAX_ATTACHMENT_BYTES` | Maximum bytes per attachment the gateway will cache. Default `33554432` (32 MiB). Set to `0` for no cap (attachments are held in memory while being written). |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1880,11 +1880,13 @@ Configure Discord-specific behavior for the messaging gateway:
 discord:
   require_mention: true          # Require @mention to respond in server channels
   free_response_channels: ""     # Comma-separated channel IDs where bot responds without @mention
+  free_response_thread_channels: [] # Mention-free channels that still auto-thread
   auto_thread: true              # Auto-create threads on @mention in channels
 ```
 
 - `require_mention` — when `true` (default), the bot only responds in server channels when mentioned with `@BotName`. DMs always work without mention.
 - `free_response_channels` — comma-separated list of channel IDs where the bot responds to every message without requiring a mention.
+- `free_response_thread_channels` — channel IDs where mention is not required, but the first message still creates an auto-thread.
 - `auto_thread` — when `true` (default), mentions in channels automatically create a thread for the conversation, keeping channels clean (similar to Slack threading).
 
 ## Security

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -281,6 +281,7 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_REQUIRE_MENTION` | No | `true` | When `true`, the bot only responds in server channels when `@mentioned`. Set to `false` to respond to all messages in every channel. |
 | `DISCORD_THREAD_REQUIRE_MENTION` | No | `false` | When `true`, the in-thread mention shortcut is disabled — threads are gated the same as channels, requiring `@mention` even after the bot has already participated. Use this when multiple bots share a thread and you want each to fire only on explicit `@mention`. |
 | `DISCORD_FREE_RESPONSE_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds without requiring an `@mention`, even when `DISCORD_REQUIRE_MENTION` is `true`. |
+| `DISCORD_FREE_RESPONSE_THREAD_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds without requiring an `@mention` and still creates auto-threads. |
 | `DISCORD_IGNORE_NO_MENTION` | No | `true` | When `true`, the bot stays silent if a message `@mentions` other users but does **not** mention the bot. Prevents the bot from jumping into conversations directed at other people. Only applies in server channels, not DMs. |
 | `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
 | `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. |
@@ -317,6 +318,7 @@ discord:
   require_mention: true           # Require @mention in server channels
   thread_require_mention: false   # If true, require @mention in threads too (multi-bot threads)
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
+  free_response_thread_channels: [] # Mention-free channels that still auto-thread
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing
   ignored_channels: []            # Channel IDs where bot never responds
@@ -374,7 +376,21 @@ discord:
 
 If a thread's parent channel is in this list, the thread also becomes mention-free.
 
-Free-response channels also **skip auto-threading** — the bot replies inline rather than spinning off a new thread per message. This keeps the channel usable as a lightweight chat surface. If you want threading behavior, don't list the channel as free-response (use normal `@mention` flow instead).
+Free-response channels also **skip auto-threading** — the bot replies inline rather than spinning off a new thread per message. This keeps the channel usable as a lightweight chat surface.
+
+#### `discord.free_response_thread_channels`
+
+**Type:** string or list — **Default:** `""`
+
+Channel IDs where the bot responds to all messages without needing an `@mention`, while still using the normal auto-thread flow for the first message:
+
+```yaml
+discord:
+  free_response_thread_channels:
+    - 1234567890
+```
+
+Use this when a channel should be mention-free but each conversation should still move into its own thread.
 
 #### `discord.auto_thread`
 
@@ -382,7 +398,7 @@ Free-response channels also **skip auto-threading** — the bot replies inline r
 
 When enabled, every `@mention` in a regular text channel automatically creates a new thread for the conversation. This keeps the main channel clean and gives each conversation its own isolated session history. Once a thread is created, subsequent messages in that thread don't require `@mention` — the bot knows it's already participating. Set [`thread_require_mention`](#discordthread_require_mention) to `true` to disable this in-thread shortcut for multi-bot setups.
 
-Messages sent in existing threads or DMs are unaffected by this setting. Channels listed in `discord.free_response_channels` or `discord.no_thread_channels` also bypass auto-threading and get inline replies instead.
+Messages sent in existing threads or DMs are unaffected by this setting. Channels listed in `discord.free_response_channels` or `discord.no_thread_channels` also bypass auto-threading and get inline replies instead. Channels listed in `discord.free_response_thread_channels` keep auto-threading enabled.
 
 #### `discord.reactions`
 
@@ -862,5 +878,4 @@ Leave `everyone` and `roles` at `false` unless you know exactly why you need the
 :::
 
 For more information on securing your Hermes Agent deployment, see the [Security Guide](../security.md).
-
 


### PR DESCRIPTION
Summary\n- Add discord.free_response_thread_channels / DISCORD_FREE_RESPONSE_THREAD_CHANNELS for mention-free Discord channels that still use automatic threading.\n- Keep existing free_response_channels behavior inline by skipping thread creation only for the original list.\n- Apply the new setting to the early human-mention gate, while retaining mention filtering in all other channels.\n- Add Discord adapter regression tests and document the setting.\n\nValidation\n- 80 focused Discord tests\n- Ruff on the changed adapter and tests\n\nFixes #52766