### PR TITLE
fix: support profile default skills

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -55,6 +55,63 @@ _BUNDLE_USER_INSTRUCTION = "\nUser instruction: "
 _BUNDLE_FIRST_SKILL_BLOCK = "\n\n[Loaded as part of the "
 
 
+def normalize_skill_identifiers(skills: Any) -> list[str]:
+    """Normalize skill config/flag values into an ordered, deduplicated list."""
+    if not skills:
+        return []
+
+    if isinstance(skills, str):
+        raw_values = [skills]
+    elif isinstance(skills, (list, tuple, set)):
+        raw_values = [str(item) for item in skills if item is not None]
+    else:
+        raw_values = [str(skills)]
+
+    parsed: list[str] = []
+    seen: set[str] = set()
+    for raw in raw_values:
+        for part in raw.replace("\n", ",").split(","):
+            normalized = part.strip()
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            parsed.append(normalized)
+    return parsed
+
+
+def config_default_skill_identifiers(config: Any) -> list[str]:
+    """Return profile-scoped default skills from ``skills.defaults``."""
+    if not isinstance(config, dict):
+        return []
+    skills_cfg = config.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return []
+    return normalize_skill_identifiers(skills_cfg.get("defaults"))
+
+
+def merge_preloaded_skill_identifiers(
+    default_skills: Any,
+    explicit_skills: Any,
+) -> list[str]:
+    """Compose profile defaults with explicit startup skills.
+
+    Defaults come first so the profile's baseline role is loaded before any
+    per-invocation additions. Duplicate identifiers are removed while keeping
+    first-seen order.
+    """
+    merged: list[str] = []
+    seen: set[str] = set()
+    for skill in (
+        *normalize_skill_identifiers(default_skills),
+        *normalize_skill_identifiers(explicit_skills),
+    ):
+        if skill in seen:
+            continue
+        seen.add(skill)
+        merged.append(skill)
+    return merged
+
+
 def extract_user_instruction_from_skill_message(content: Any) -> Optional[str]:
     """Recover the user's instruction from a slash-skill-expanded turn.
 
@@ -741,7 +798,7 @@ def build_preloaded_skills_prompt(
             pass  # Non-critical
 
         activation_note = (
-            f'[IMPORTANT: The user launched this CLI session with the "{skill_name}" skill '
+            f'[IMPORTANT: The user launched this Hermes session with the "{skill_name}" skill '
             "preloaded. Treat its instructions as active guidance for the duration of this "
             "session unless the user overrides them.]"
         )

--- a/cli.py
+++ b/cli.py
@@ -3605,26 +3605,9 @@ def _get_plugin_cmd_handler_names() -> set:
 
 def _parse_skills_argument(skills: str | list[str] | tuple[str, ...] | None) -> list[str]:
     """Normalize a CLI skills flag into a deduplicated list of skill identifiers."""
-    if not skills:
-        return []
+    from agent.skill_commands import normalize_skill_identifiers
 
-    if isinstance(skills, str):
-        raw_values = [skills]
-    elif isinstance(skills, (list, tuple)):
-        raw_values = [str(item) for item in skills if item is not None]
-    else:
-        raw_values = [str(skills)]
-
-    parsed: list[str] = []
-    seen: set[str] = set()
-    for raw in raw_values:
-        for part in raw.split(","):
-            normalized = part.strip()
-            if not normalized or normalized in seen:
-                continue
-            seen.add(normalized)
-            parsed.append(normalized)
-    return parsed
+    return normalize_skill_identifiers(skills)
 
 
 def save_config_value(key_path: str, value: any) -> bool:
@@ -16094,7 +16077,7 @@ def main(
             from hermes_cli.tools_config import _get_platform_tools
             toolsets_list = sorted(_get_platform_tools(CLI_CONFIG, "cli"))
     
-    parsed_skills = _parse_skills_argument(skills)
+    explicit_skills = _parse_skills_argument(skills)
 
     # Create CLI instance
     cli = HermesCLI(
@@ -16112,27 +16095,51 @@ def main(
         ignore_rules=ignore_rules,
     )
 
+    from agent.skill_commands import (
+        config_default_skill_identifiers,
+        merge_preloaded_skill_identifiers,
+    )
+
+    default_skills = (
+        []
+        if cli.ignore_rules
+        else config_default_skill_identifiers(CLI_CONFIG)
+    )
+    parsed_skills = merge_preloaded_skill_identifiers(
+        default_skills,
+        explicit_skills,
+    )
+
     if parsed_skills:
         skills_prompt, loaded_skills, missing_skills = build_preloaded_skills_prompt(
             parsed_skills,
             task_id=cli.session_id,
         )
         if missing_skills:
-            missing_display = ", ".join(missing_skills)
-            # If at least one skill loaded, degrade gracefully: skip the
-            # unknown ones and continue. A typo'd skill name should not crash
-            # the worker (which auto-blocks the Kanban task after retries).
-            # Only when EVERY requested skill is missing do we hard-fail, so a
-            # fully-misconfigured worker fails loudly instead of running blind.
-            if loaded_skills:
+            explicit_set = set(explicit_skills)
+            missing_explicit = [name for name in missing_skills if name in explicit_set]
+            missing_defaults = [name for name in missing_skills if name not in explicit_set]
+            if missing_defaults:
+                missing_display = ", ".join(missing_defaults)
                 logger.warning(
-                    "Unknown skill(s) requested, skipping: %s. "
+                    "Profile default skill(s) not found and skipped: %s",
+                    missing_display,
+                )
+                if not quiet:
+                    _cprint(
+                        f"⚠️  Profile default skill(s) not found and skipped: {missing_display}"
+                    )
+            loaded_explicit = any(name not in missing_explicit for name in explicit_skills)
+            if missing_explicit and loaded_explicit:
+                logger.warning(
+                    "Unknown explicit skill(s) requested, skipping: %s. "
                     "Continuing with: %s. "
                     "List available skills with `hermes skills list`.",
-                    missing_display,
+                    ", ".join(missing_explicit),
                     ", ".join(loaded_skills),
                 )
-            else:
+            elif missing_explicit:
+                missing_display = ", ".join(missing_explicit)
                 raise ValueError(f"Unknown skill(s): {missing_display}")
         if skills_prompt:
             cli.system_prompt = "\n\n".join(

--- a/cli.py
+++ b/cli.py
@@ -16102,7 +16102,7 @@ def main(
 
     default_skills = (
         []
-        if cli.ignore_rules
+        if getattr(cli, "ignore_rules", False)
         else config_default_skill_identifiers(CLI_CONFIG)
     )
     parsed_skills = merge_preloaded_skill_identifiers(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -44,6 +44,7 @@ from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
 from hermes_cli.fallback_config import get_fallback_chain
 from hermes_time import now as _hermes_now
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -2346,7 +2347,27 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     elif isinstance(skills, str):
         skills = [skills]
 
-    skill_names = [str(name).strip() for name in skills if str(name).strip()]
+    from agent.skill_commands import (
+        config_default_skill_identifiers,
+        merge_preloaded_skill_identifiers,
+        normalize_skill_identifiers,
+    )
+
+    explicit_skill_names = normalize_skill_identifiers(skills)
+    default_skill_names: list[str] = []
+    if not is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")):
+        try:
+            default_skill_names = config_default_skill_identifiers(load_config() or {})
+        except Exception as exc:
+            logger.warning(
+                "Cron job '%s': failed to load profile default skills: %s",
+                job.get("name", job.get("id")),
+                exc,
+            )
+    skill_names = merge_preloaded_skill_identifiers(
+        default_skill_names,
+        explicit_skill_names,
+    )
     if not skill_names:
         return _scan_assembled_cron_prompt(
             prompt,
@@ -2363,6 +2384,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
 
     parts = []
     skipped: list[str] = []
+    default_skill_set = set(default_skill_names) - set(explicit_skill_names)
     for skill_name in skill_names:
         # Cron jobs historically accepted only skill names here, but the CLI/gateway
         # slash-command path lets bundles shadow skills with the same slug. Mirror
@@ -2419,8 +2441,13 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         )
 
     if skipped:
+        source = "profile or job"
+        if all(name in default_skill_set for name in skipped):
+            source = "profile default"
+        elif all(name not in default_skill_set for name in skipped):
+            source = "job"
         notice = (
-            f"[IMPORTANT: The following skill(s) were listed for this job but could not be found "
+            f"[IMPORTANT: The following {source} skill(s) could not be found "
             f"and were skipped: {', '.join(skipped)}. "
             f"Start your response with a brief notice so the user is aware, e.g.: "
             f"'⚠️ Skill(s) not found and skipped: {', '.join(skipped)}']"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3002,6 +3002,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         import threading as _threading
         self._agent_cache: "OrderedDict[str, tuple]" = OrderedDict()
         self._agent_cache_lock = _threading.Lock()
+        self._profile_default_skills_prompt_cache: Dict[tuple, str] = {}
 
         # Per-session model overrides from /model command.
         # Key: session_key, Value: dict with model/provider/api_key/base_url/api_mode
@@ -18280,6 +18281,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             if cfg_channel_prompt:
                 combined_ephemeral = (combined_ephemeral + "\n\n" + cfg_channel_prompt).strip()
+            if not is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")):
+                try:
+                    from agent.skill_commands import (
+                        build_preloaded_skills_prompt,
+                        config_default_skill_identifiers,
+                    )
+
+                    default_skills = config_default_skill_identifiers(user_config)
+                    if default_skills:
+                        cache = getattr(self, "_profile_default_skills_prompt_cache", None)
+                        if not isinstance(cache, dict):
+                            cache = {}
+                            self._profile_default_skills_prompt_cache = cache
+                        prompt_cache_key = (
+                            session_id,
+                            tuple(default_skills),
+                            os.environ.get("HERMES_HOME", ""),
+                        )
+                        default_skills_prompt = cache.get(prompt_cache_key)
+                        if default_skills_prompt is None:
+                            default_skills_prompt, _loaded_skills, missing_skills = (
+                                build_preloaded_skills_prompt(
+                                    default_skills,
+                                    task_id=session_id or session_key,
+                                )
+                            )
+                            if missing_skills:
+                                logger.warning(
+                                    "[Gateway] Profile default skill(s) not found and skipped: %s",
+                                    ", ".join(missing_skills),
+                                )
+                            cache[prompt_cache_key] = default_skills_prompt
+                        if default_skills_prompt:
+                            combined_ephemeral = (
+                                combined_ephemeral + "\n\n" + default_skills_prompt
+                            ).strip()
+                except Exception as exc:
+                    logger.warning(
+                        "[Gateway] Failed to load profile default skill(s): %s",
+                        exc,
+                    )
 
             max_iterations = _current_max_iterations()
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3003,6 +3003,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._agent_cache: "OrderedDict[str, tuple]" = OrderedDict()
         self._agent_cache_lock = _threading.Lock()
         self._profile_default_skills_prompt_cache: Dict[tuple, str] = {}
+        self._profile_default_skills_cache_sessions: Dict[str, set[str]] = {}
 
         # Per-session model overrides from /model command.
         # Key: session_key, Value: dict with model/provider/api_key/base_url/api_mode
@@ -7813,6 +7814,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # be garbage-collected.  Otherwise the cache grows
                         # unbounded across the gateway's lifetime.
                         self._evict_cached_agent(key)
+                        self._evict_profile_default_skills_prompt(
+                            session_id=entry.session_id,
+                        )
                         # Permanently finalizing this session — drop its
                         # per-session control state so the dicts don't grow
                         # unbounded across the gateway's lifetime. (Idle
@@ -11049,6 +11053,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # compaction summaries. Mirrors /reset and the compression-exhausted
             # path (#9893). Covers daily/idle/suspended auto-reset.
             self._evict_cached_agent(session_key)
+            self._evict_profile_default_skills_prompt(
+                session_key=session_key,
+                keep_session_id=session_entry.session_id,
+            )
             session_entry.was_auto_reset = False
         
         # Emit session:start for new or auto-reset sessions
@@ -12078,8 +12086,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "Auto-resetting session %s after compression exhaustion.",
                     session_entry.session_id,
                 )
+                old_session_id = session_entry.session_id
                 new_entry = await self.async_session_store.reset_session(session_key)
                 self._evict_cached_agent(session_key)
+                self._evict_profile_default_skills_prompt(
+                    session_id=old_session_id,
+                )
                 self._session_model_overrides.pop(session_key, None)
                 self._set_session_reasoning_override(session_key, None)
                 if hasattr(self, "_pending_model_notes"):
@@ -16530,6 +16542,84 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             cached[0], cached[1], _live, _snapshot_sid,
                         )
 
+    def _get_profile_default_skills_prompt(
+        self,
+        *,
+        session_key: str,
+        session_id: Optional[str],
+        default_skills: List[str],
+    ) -> str:
+        """Render profile defaults once per durable conversation."""
+        from agent.skill_commands import build_preloaded_skills_prompt
+
+        cache = getattr(self, "_profile_default_skills_prompt_cache", None)
+        if not isinstance(cache, dict):
+            cache = {}
+            self._profile_default_skills_prompt_cache = cache
+
+        prompt_cache_key = None
+        if session_id:
+            prompt_cache_key = (
+                session_id,
+                tuple(default_skills),
+                os.environ.get("HERMES_HOME", ""),
+            )
+            cached = cache.get(prompt_cache_key)
+            if cached is not None:
+                return cached
+
+        prompt, _loaded_skills, missing_skills = build_preloaded_skills_prompt(
+            default_skills,
+            task_id=session_id or session_key,
+        )
+        if missing_skills:
+            logger.warning(
+                "[Gateway] Profile default skill(s) not found and skipped: %s",
+                ", ".join(missing_skills),
+            )
+
+        if prompt_cache_key is not None:
+            cache[prompt_cache_key] = prompt
+            session_index = getattr(
+                self, "_profile_default_skills_cache_sessions", None
+            )
+            if not isinstance(session_index, dict):
+                session_index = {}
+                self._profile_default_skills_cache_sessions = session_index
+            session_index.setdefault(session_key, set()).add(session_id)
+        return prompt
+
+    def _evict_profile_default_skills_prompt(
+        self,
+        *,
+        session_id: Optional[str] = None,
+        session_key: Optional[str] = None,
+        keep_session_id: Optional[str] = None,
+    ) -> None:
+        """Drop rendered default skills when their conversation ends."""
+        cache = getattr(self, "_profile_default_skills_prompt_cache", None)
+        session_index = getattr(self, "_profile_default_skills_cache_sessions", None)
+        if not isinstance(cache, dict):
+            return
+
+        evicted_session_ids: set[str] = set()
+        if session_id:
+            evicted_session_ids.add(session_id)
+        if session_key and isinstance(session_index, dict):
+            evicted_session_ids.update(session_index.get(session_key, set()))
+        if keep_session_id:
+            evicted_session_ids.discard(keep_session_id)
+
+        for cache_key in list(cache):
+            if cache_key and cache_key[0] in evicted_session_ids:
+                cache.pop(cache_key, None)
+
+        if isinstance(session_index, dict):
+            for indexed_key, indexed_ids in list(session_index.items()):
+                indexed_ids.difference_update(evicted_session_ids)
+                if not indexed_ids:
+                    session_index.pop(indexed_key, None)
+
     def _evict_cached_agent(self, session_key: str) -> None:
         """Remove a cached agent for a session (called on /new, /model, etc).
 
@@ -18284,35 +18374,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")):
                 try:
                     from agent.skill_commands import (
-                        build_preloaded_skills_prompt,
                         config_default_skill_identifiers,
                     )
 
                     default_skills = config_default_skill_identifiers(user_config)
                     if default_skills:
-                        cache = getattr(self, "_profile_default_skills_prompt_cache", None)
-                        if not isinstance(cache, dict):
-                            cache = {}
-                            self._profile_default_skills_prompt_cache = cache
-                        prompt_cache_key = (
-                            session_id,
-                            tuple(default_skills),
-                            os.environ.get("HERMES_HOME", ""),
+                        default_skills_prompt = self._get_profile_default_skills_prompt(
+                            session_key=session_key,
+                            session_id=session_id,
+                            default_skills=default_skills,
                         )
-                        default_skills_prompt = cache.get(prompt_cache_key)
-                        if default_skills_prompt is None:
-                            default_skills_prompt, _loaded_skills, missing_skills = (
-                                build_preloaded_skills_prompt(
-                                    default_skills,
-                                    task_id=session_id or session_key,
-                                )
-                            )
-                            if missing_skills:
-                                logger.warning(
-                                    "[Gateway] Profile default skill(s) not found and skipped: %s",
-                                    ", ".join(missing_skills),
-                                )
-                            cache[prompt_cache_key] = default_skills_prompt
                         if default_skills_prompt:
                             combined_ephemeral = (
                                 combined_ephemeral + "\n\n" + default_skills_prompt

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -119,6 +119,10 @@ class GatewaySlashCommandsMixin:
         # Snapshot the old entry so on_session_finalize can report the
         # expiring session id before reset_session() rotates it.
         old_entry = self.session_store._entries.get(session_key)
+        if old_entry is not None:
+            self._evict_profile_default_skills_prompt(
+                session_id=old_entry.session_id,
+            )
 
         # Close tool resources on the old agent (terminal sandboxes, browser
         # daemons, background processes) before evicting from cache.

--- a/tests/agent/test_profile_default_skills.py
+++ b/tests/agent/test_profile_default_skills.py
@@ -1,0 +1,30 @@
+from agent.skill_commands import (
+    config_default_skill_identifiers,
+    merge_preloaded_skill_identifiers,
+    normalize_skill_identifiers,
+)
+
+
+def test_normalize_skill_identifiers_accepts_strings_lists_and_newlines():
+    assert normalize_skill_identifiers(["alpha,beta", "gamma\nbeta", None]) == [
+        "alpha",
+        "beta",
+        "gamma",
+    ]
+
+
+def test_config_default_skill_identifiers_reads_skills_defaults():
+    config = {"skills": {"defaults": ["profile-a", "profile-b,profile-c"]}}
+
+    assert config_default_skill_identifiers(config) == [
+        "profile-a",
+        "profile-b",
+        "profile-c",
+    ]
+
+
+def test_merge_preloaded_skill_identifiers_keeps_defaults_first_and_dedupes():
+    assert merge_preloaded_skill_identifiers(
+        ["profile-a", "profile-b"],
+        ["explicit", "profile-a"],
+    ) == ["profile-a", "profile-b", "explicit"]

--- a/tests/cli/test_cli_preloaded_skills.py
+++ b/tests/cli/test_cli_preloaded_skills.py
@@ -54,6 +54,7 @@ class _DummyCLI:
         self.session_id = "session-123"
         self.system_prompt = "base prompt"
         self.preloaded_skills = []
+        self.ignore_rules = kwargs.get("ignore_rules", False)
 
     def show_banner(self):
         return None
@@ -77,6 +78,7 @@ def test_main_applies_preloaded_skills_to_system_prompt(monkeypatch):
         created["cli"] = _DummyCLI(**kwargs)
         return created["cli"]
 
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
     monkeypatch.setattr(cli_mod, "HermesCLI", fake_cli)
     monkeypatch.setattr(
         cli_mod,
@@ -92,9 +94,82 @@ def test_main_applies_preloaded_skills_to_system_prompt(monkeypatch):
     assert cli_obj.preloaded_skills == ["hermes-agent-dev", "github-auth"]
 
 
+def test_main_applies_profile_default_skills_before_explicit(monkeypatch):
+    import cli as cli_mod
+
+    created = {}
+    captured = {}
+
+    def fake_cli(**kwargs):
+        created["cli"] = _DummyCLI(**kwargs)
+        return created["cli"]
+
+    def fake_preload(skills, task_id=None):
+        captured["skills"] = skills
+        return "skill prompt", ["profile-skill", "extra-skill"], []
+
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {"skills": {"defaults": ["profile-skill"]}})
+    monkeypatch.setattr(cli_mod, "HermesCLI", fake_cli)
+    monkeypatch.setattr(cli_mod, "build_preloaded_skills_prompt", fake_preload)
+
+    with pytest.raises(SystemExit):
+        cli_mod.main(skills="extra-skill,profile-skill", list_tools=True)
+
+    assert captured["skills"] == ["profile-skill", "extra-skill"]
+    assert created["cli"].preloaded_skills == ["profile-skill", "extra-skill"]
+
+
+def test_main_skips_missing_profile_default_skill(monkeypatch):
+    import cli as cli_mod
+
+    created = {}
+
+    def fake_cli(**kwargs):
+        created["cli"] = _DummyCLI(**kwargs)
+        return created["cli"]
+
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {"skills": {"defaults": ["ghost-skill"]}})
+    monkeypatch.setattr(cli_mod, "HermesCLI", fake_cli)
+    monkeypatch.setattr(cli_mod, "_cprint", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        cli_mod,
+        "build_preloaded_skills_prompt",
+        lambda skills, task_id=None: ("", [], ["ghost-skill"]),
+    )
+
+    with pytest.raises(SystemExit):
+        cli_mod.main(list_tools=True)
+
+    assert created["cli"].system_prompt == "base prompt"
+    assert created["cli"].preloaded_skills == []
+
+
+def test_main_ignore_rules_suppresses_profile_default_skills(monkeypatch):
+    import cli as cli_mod
+
+    created = {}
+
+    def fake_cli(**kwargs):
+        created["cli"] = _DummyCLI(**kwargs)
+        return created["cli"]
+
+    def fail_preload(*args, **kwargs):
+        raise AssertionError("profile defaults should not preload")
+
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {"skills": {"defaults": ["profile-skill"]}})
+    monkeypatch.setattr(cli_mod, "HermesCLI", fake_cli)
+    monkeypatch.setattr(cli_mod, "build_preloaded_skills_prompt", fail_preload)
+
+    with pytest.raises(SystemExit):
+        cli_mod.main(ignore_rules=True, list_tools=True)
+
+    assert created["cli"].preloaded_skills == []
+
+
 def test_main_raises_for_unknown_preloaded_skill(monkeypatch):
     import cli as cli_mod
 
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
     monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kwargs: _DummyCLI(**kwargs))
     monkeypatch.setattr(
         cli_mod,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2927,6 +2927,37 @@ class TestBuildJobPromptMissingSkill:
     def _missing_skill_view(self, name: str) -> str:
         return json.dumps({"success": False, "error": f"Skill '{name}' not found."})
 
+    def test_profile_default_skills_precede_job_skills(self):
+        """Profile defaults load before per-job skills, with duplicates removed."""
+
+        def _skill_view(name: str) -> str:
+            return json.dumps({"success": True, "content": f"Content for {name}."})
+
+        with patch(
+            "cron.scheduler.load_config",
+            return_value={"skills": {"defaults": ["profile-skill", "job-skill"]}},
+        ), patch("tools.skills_tool.skill_view", side_effect=_skill_view):
+            result = _build_job_prompt(
+                {"skills": ["job-skill", "extra-skill"], "prompt": "go"}
+            )
+
+        profile_pos = result.index("Content for profile-skill.")
+        job_pos = result.index("Content for job-skill.")
+        extra_pos = result.index("Content for extra-skill.")
+        assert profile_pos < job_pos < extra_pos
+
+    def test_missing_profile_default_skill_does_not_raise(self):
+        """A bad profile default warns inside the prompt but still runs the job."""
+        with patch(
+            "cron.scheduler.load_config",
+            return_value={"skills": {"defaults": ["ghost-skill"]}},
+        ), patch("tools.skills_tool.skill_view", side_effect=self._missing_skill_view):
+            result = _build_job_prompt({"prompt": "do something"})
+
+        assert "profile default skill" in result
+        assert "ghost-skill" in result
+        assert "do something" in result
+
     def test_missing_skill_does_not_raise(self):
         """Job should run even when a referenced skill is not installed."""
         with patch("tools.skills_tool.skill_view", side_effect=self._missing_skill_view):

--- a/tests/gateway/test_profile_default_skills.py
+++ b/tests/gateway/test_profile_default_skills.py
@@ -1,0 +1,72 @@
+from gateway.run import GatewayRunner
+
+
+def _make_runner() -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._profile_default_skills_prompt_cache = {}
+    runner._profile_default_skills_cache_sessions = {}
+    return runner
+
+
+def test_reset_renders_profile_default_skill_for_new_session(monkeypatch, tmp_path):
+    import agent.skill_commands as skill_commands
+
+    loaded_skill = {
+        "content": "Session: ${HERMES_SESSION_ID}",
+        "raw_content": "Session: ${HERMES_SESSION_ID}",
+    }
+    monkeypatch.setattr(
+        skill_commands,
+        "_load_skill_payload",
+        lambda _identifier, task_id=None: (
+            loaded_skill,
+            tmp_path,
+            "profile-skill",
+        ),
+    )
+    monkeypatch.setattr(
+        skill_commands,
+        "_load_skills_config",
+        lambda: {"template_vars": True},
+    )
+
+    runner = _make_runner()
+    session_key = "agent:main:discord:dm:42"
+    old_prompt = runner._get_profile_default_skills_prompt(
+        session_key=session_key,
+        session_id="session-old",
+        default_skills=["profile-skill"],
+    )
+    runner._evict_profile_default_skills_prompt(session_id="session-old")
+    new_prompt = runner._get_profile_default_skills_prompt(
+        session_key=session_key,
+        session_id="session-new",
+        default_skills=["profile-skill"],
+    )
+
+    assert "Session: session-old" in old_prompt
+    assert "Session: session-new" in new_prompt
+    assert "Session: session-old" not in new_prompt
+    assert {key[0] for key in runner._profile_default_skills_prompt_cache} == {
+        "session-new"
+    }
+
+
+def test_auto_reset_evicts_prior_prompts_for_stable_route():
+    runner = _make_runner()
+    runner._profile_default_skills_prompt_cache = {
+        ("session-old", ("profile-skill",), ""): "old",
+        ("session-new", ("profile-skill",), ""): "new",
+    }
+    runner._profile_default_skills_cache_sessions = {
+        "agent:main:discord:dm:42": {"session-old", "session-new"}
+    }
+
+    runner._evict_profile_default_skills_prompt(
+        session_key="agent:main:discord:dm:42",
+        keep_session_id="session-new",
+    )
+
+    assert list(runner._profile_default_skills_prompt_cache) == [
+        ("session-new", ("profile-skill",), "")
+    ]

--- a/tests/tui_gateway/test_profile_default_skills.py
+++ b/tests/tui_gateway/test_profile_default_skills.py
@@ -1,0 +1,25 @@
+import tui_gateway.server as srv
+
+
+def test_tui_startup_skills_merge_profile_defaults_before_env(monkeypatch):
+    monkeypatch.delenv("HERMES_IGNORE_RULES", raising=False)
+    monkeypatch.setenv("HERMES_TUI_SKILLS", "extra-skill,profile-skill")
+
+    startup_skills, explicit_skills = srv._resolve_tui_startup_skills(
+        {"skills": {"defaults": ["profile-skill", "profile-helper"]}}
+    )
+
+    assert startup_skills == ["profile-skill", "profile-helper", "extra-skill"]
+    assert explicit_skills == ["extra-skill", "profile-skill"]
+
+
+def test_tui_ignore_rules_suppresses_profile_default_skills(monkeypatch):
+    monkeypatch.setenv("HERMES_IGNORE_RULES", "1")
+    monkeypatch.setenv("HERMES_TUI_SKILLS", "extra-skill")
+
+    startup_skills, explicit_skills = srv._resolve_tui_startup_skills(
+        {"skills": {"defaults": ["profile-skill"]}}
+    )
+
+    assert startup_skills == ["extra-skill"]
+    assert explicit_skills == ["extra-skill"]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4157,15 +4157,27 @@ def _cfg_max_turns(cfg: dict, default: int) -> int:
 
 
 def _parse_tui_skills_env() -> list[str]:
-    raw = os.environ.get("HERMES_TUI_SKILLS", "")
-    skills: list[str] = []
-    seen: set[str] = set()
-    for part in raw.replace("\n", ",").split(","):
-        item = part.strip()
-        if item and item not in seen:
-            seen.add(item)
-            skills.append(item)
-    return skills
+    from agent.skill_commands import normalize_skill_identifiers
+
+    return normalize_skill_identifiers(os.environ.get("HERMES_TUI_SKILLS", ""))
+
+
+def _resolve_tui_startup_skills(cfg: dict) -> tuple[list[str], list[str]]:
+    from agent.skill_commands import (
+        config_default_skill_identifiers,
+        merge_preloaded_skill_identifiers,
+    )
+
+    explicit_skills = _parse_tui_skills_env()
+    default_skills = (
+        []
+        if is_truthy_value(os.environ.get("HERMES_IGNORE_RULES"))
+        else config_default_skill_identifiers(cfg)
+    )
+    return (
+        merge_preloaded_skill_identifiers(default_skills, explicit_skills),
+        explicit_skills,
+    )
 
 
 def _load_fallback_model():
@@ -4549,7 +4561,7 @@ def _make_agent(
     cfg = _load_cfg()
     agent_cfg = cfg.get("agent") or {}
     system_prompt = _prompt_text(agent_cfg.get("system_prompt", ""))
-    startup_skills = _parse_tui_skills_env()
+    startup_skills, explicit_startup_skills = _resolve_tui_startup_skills(cfg)
     if startup_skills:
         from agent.skill_commands import build_preloaded_skills_prompt
 
@@ -4558,20 +4570,27 @@ def _make_agent(
             task_id=session_id or key,
         )
         if missing_skills:
-            missing_display = ", ".join(missing_skills)
-            # Degrade gracefully when some skills loaded; only hard-fail when
-            # every requested skill is missing. Mirrors cli.py — a typo'd skill
-            # name should not crash the worker and auto-block the Kanban task.
-            if loaded_skills:
+            explicit_set = set(explicit_startup_skills)
+            missing_explicit = [name for name in missing_skills if name in explicit_set]
+            missing_defaults = [name for name in missing_skills if name not in explicit_set]
+            if missing_defaults:
                 logger.warning(
-                    "Unknown skill(s) requested, skipping: %s. "
+                    "Profile default skill(s) not found and skipped: %s",
+                    ", ".join(missing_defaults),
+                )
+            loaded_explicit = any(
+                name not in missing_explicit for name in explicit_startup_skills
+            )
+            if missing_explicit and loaded_explicit:
+                logger.warning(
+                    "Unknown explicit skill(s) requested, skipping: %s. "
                     "Continuing with: %s. "
                     "List available skills with `hermes skills list`.",
-                    missing_display,
+                    ", ".join(missing_explicit),
                     ", ".join(loaded_skills),
                 )
-            else:
-                raise ValueError(f"Unknown skill(s): {missing_display}")
+            elif missing_explicit:
+                raise ValueError(f"Unknown skill(s): {', '.join(missing_explicit)}")
         if skills_prompt:
             system_prompt = "\n\n".join(
                 part for part in (system_prompt, skills_prompt) if part

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -558,6 +558,19 @@ See [Code Execution](features/code-execution.md) and the [Terminal section of th
 
 ## Skill Settings
 
+### Profile default skills
+
+Put skills under `skills.defaults` in a profile's `config.yaml` to preload them for every new session in that profile:
+
+```yaml
+skills:
+  defaults:
+    - obsidian-markdown
+    - obsidian-vault-navigator
+```
+
+Defaults load before any explicit `--skills` / `-s` values, and duplicates are removed while preserving order. Missing default skills warn and are skipped so the session can still start. Use `--ignore-rules` when you need to suppress profile defaults along with other automatic prompt injection.
+
 Skills can declare their own configuration settings via their SKILL.md frontmatter. These are non-secret values (paths, preferences, domain settings) stored under the `skills.config` namespace in `config.yaml`.
 
 ```yaml

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -312,6 +312,19 @@ complete quarantined bundle and records the source URL, exact content hash,
 scanner version, findings, timestamp, and fresh-or-cached status in
 `skills/.hub/lock.json`.
 
+## Profile Default Skills
+
+Profiles can preload a stable set of skills for every new session. Add them to that profile's `config.yaml`:
+
+```yaml
+skills:
+  defaults:
+    - obsidian-markdown
+    - obsidian-vault-navigator
+```
+
+Hermes loads these defaults before any explicit `--skills` / `-s` values for the current launch, then removes duplicates while preserving order. Missing default skills warn and are skipped instead of blocking startup. `--ignore-rules` suppresses profile defaults together with the other automatic context injections.
+
 ## External Skill Directories
 
 If you maintain skills outside of Hermes — for example, a shared `~/.agents/skills/` directory used by multiple AI tools — you can tell Hermes to scan those directories too.


### PR DESCRIPTION
Problem\nProfiles could only preload skills when each launch passed --skills/-s or used channel-specific bindings. A profile could not declare durable default skills that apply to every new session.\n\nSummary\n- Add skills.defaults parsing and ordered merge helpers so profile defaults load before explicit startup skills with dedupe.\n- Apply profile defaults across CLI, TUI/Desktop backend, gateway sessions, and cron prompt construction.\n- Keep missing defaults as warnings while preserving strict behavior when every explicit startup skill is invalid.\n- Scope the gateway prompt cache to durable session IDs and evict it on reset, expiry, and compression reset so sessions on the same route cannot reuse stale defaults.\n- Let --ignore-rules suppress profile defaults and tolerate compatible minimal CLI startup adapters that omit the optional attribute.\n- Document the setting.\n\nValidation\n- 21 focused profile-default-skill, single-query CLI, gateway, TUI backend, and cron tests\n- Ruff on the changed Python files\n- Python compilation on the changed runtime modules\n\nFixes #52773