### PR TITLE
fix: resume/cron messages send stale DB fields, breaking provider pro…

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -391,7 +391,19 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
         role = msg.get("role")
         if role == "assistant":
             known_tool_ids = set()
-            for tc in (msg.get("tool_calls") or []):
+            # tool_calls arrives as a JSON string when messages are loaded
+            # from state.db (resume, cron, gateway replay).  Parse it so
+            # the known_tool_ids loop below can match tool_call_ids —
+            # otherwise iterating a string character-by-character produces
+            # an empty set and every tool message gets misclassified as
+            # "stray" and dropped, corrupting the message sequence.
+            raw_tc = msg.get("tool_calls")
+            if isinstance(raw_tc, str):
+                try:
+                    raw_tc = json.loads(raw_tc)
+                except (json.JSONDecodeError, TypeError):
+                    raw_tc = []
+            for tc in (raw_tc or []):
                 tc_id = tc.get("id") if isinstance(tc, dict) else None
                 if tc_id:
                     known_tool_ids.add(tc_id)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -739,6 +739,16 @@ def run_conversation(
         for idx, msg in enumerate(messages):
             api_msg = msg.copy()
 
+            # Strip internal-only DB fields that live messages never carry.
+            # These leak into api_msg from state.db loaded messages (resume,
+            # cron, gateway replay) and break the provider's byte-level
+            # prompt cache — every extra field shifts the serialized bytes.
+            for _db_field in ('id', 'session_id', 'token_count',
+                              'reasoning_details', 'codex_reasoning_items',
+                              'codex_message_items', 'platform_message_id',
+                              'observed', 'active', 'compacted', 'name'):
+                api_msg.pop(_db_field, None)
+
             # Inject ephemeral context into the current turn's user message.
             # Sources: memory manager prefetch + plugin pre_llm_call hooks
             # with target="user_message" (the default).  Both are


### PR DESCRIPTION
…mpt cache

Two interleaved bugs in the resume/cron/gateway-replay code path that together cause 100% provider prompt-cache misses on the first resumed turn:

1. repair_message_sequence: when tool_calls arrives as a JSON string (from state.db), iterating it character-by-character produces an empty known_tool_ids set, causing every tool message to be misclassified as stray and dropped — corrupting the message sequence and invalidating the prompt cache.

2. api_messages construction: msg.copy() copies internal-only DB fields (id, session_id, token_count, name, etc.) into the API payload. Live conversation messages never carry these fields, so the serialized bytes differ byte-for-byte from what was cached — every extra field guarantees a cache miss.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

