### PR TITLE
fix(tui): route /learn through command.dispatch in TUI gateway

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1214,7 +1214,7 @@ def test_slash_exec_plugin_handler_error_returns_output(server):
     assert worker.calls == []
 
 
-@pytest.mark.parametrize("cmd", ["retry", "queue hello", "q hello", "steer fix the test", "plan"])
+@pytest.mark.parametrize("cmd", ["retry", "queue hello", "q hello", "steer fix the test", "plan", "learn https://example.com/api"])
 def test_slash_exec_routes_pending_input_commands_to_dispatch(server, cmd):
     """slash.exec must route _pending_input commands to command.dispatch
     internally instead of returning the old 4018 "use command.dispatch"
@@ -1254,6 +1254,12 @@ def test_slash_exec_routes_pending_input_commands_to_dispatch(server, cmd):
     # Internal routing must yield the same payload as command.dispatch.
     assert routed.get("result") == direct.get("result")
     assert routed.get("error") == direct.get("error")
+
+
+def test_pending_input_commands_includes_learn(server):
+    """Guard: _PENDING_INPUT_COMMANDS must list 'learn' — removing it would
+    silently re-break /learn in the TUI/Desktop (IPC queue has no reader)."""
+    assert "learn" in server._PENDING_INPUT_COMMANDS
 
 
 def test_command_dispatch_queue_sends_message(server):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9289,6 +9289,7 @@ _PENDING_INPUT_COMMANDS: frozenset[str] = frozenset(
         "plan",
         "goal",
         "undo",
+        "learn",
     }
 )
 


### PR DESCRIPTION
## Summary

Fixes #51829

`/learn` uses `_pending_input` to inject its generated prompt, but the TUI slash worker subprocess has no reader for that queue — the prompt is silently dropped.

Add `"learn"` to `_PENDING_INPUT_COMMANDS` so `slash.exec` routes it to `command.dispatch`, which already handles `/learn` correctly and returns `{type: send}`.

## What changed

- **`tui_gateway/server.py`**: Added `"learn"` to `_PENDING_INPUT_COMMANDS` frozenset
- **`tests/tui_gateway/test_protocol.py`**: Added `"learn https://example.com/api"` to the parametrized routing test + dedicated guard test

## Why this works

The existing `command.dispatch` handler (line 9554) already implements `/learn` correctly — it calls `build_learn_prompt()` and returns `{type: send, message: ...}`. The only problem was that `slash.exec` was not routing `/learn` to `command.dispatch` because it was not in `_PENDING_INPUT_COMMANDS`.

## Test results

```
tests/tui_gateway/test_protocol.py — 7 passed (6 parametrized + 1 guard)
tests/agent/test_learn_prompt.py — 11 passed
```

## Note

This is the same pattern used for `/retry`, `/queue`, `/steer`, `/plan`, `/goal`, and `/undo` — all commands that inject into `_pending_input` in the CLI. `/learn` was simply missed when that set was created.