### PR TITLE
feat: show cron ticker status in TUI status bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4304,6 +4304,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if context_length:
                 snapshot["context_percent"] = max(0, min(100, round((context_tokens / context_length) * 100)))
 
+
+        # Cron ticker heartbeat — cross-process liveness check using the
+        # same heartbeat file that ``hermes cron status`` consults.  None
+        # means "unknown" (never run, or can't read the file); we skip the
+        # indicator entirely in that case to avoid false alarms.
+        try:
+            from cron.jobs import get_ticker_heartbeat_age
+            _hb_age = get_ticker_heartbeat_age()
+            if _hb_age is None:
+                snapshot["cron_running"] = None
+            else:
+                # 200s stale threshold matches hermes_cli/cron.py (~3× 60s tick)
+                snapshot["cron_running"] = _hb_age <= 200.0
+                snapshot["cron_heartbeat_age"] = _hb_age
+        except Exception:
+            snapshot["cron_running"] = None
+
         return snapshot
 
     @staticmethod
@@ -4738,6 +4755,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 bg_subagent_count = snapshot.get("active_background_subagents", 0)
                 if bg_subagent_count:
                     parts.append(f"⛓ {bg_subagent_count}")
+                _cron_running = snapshot.get("cron_running")
+                if _cron_running is not None:
+                    parts.append("⏱ cron" if _cron_running else "⚠ cron")
                 parts.append(duration_label)
                 if yolo_active:
                     parts.append("⚠ YOLO")
@@ -4763,6 +4783,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             bg_subagent_count = snapshot.get("active_background_subagents", 0)
             if bg_subagent_count:
                 parts.append(f"⛓ {bg_subagent_count}")
+            _cron_running = snapshot.get("cron_running")
+            if _cron_running is not None:
+                parts.append("⏱ cron" if _cron_running else "⚠ cron")
             parts.append(duration_label)
             prompt_elapsed = snapshot.get("prompt_elapsed")
             if prompt_elapsed:
@@ -4827,6 +4850,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     if bg_subagent_count:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append(("class:status-bar-strong", f"⛓ {bg_subagent_count}"))
+                    _cron_running = snapshot.get("cron_running")
+                    if _cron_running is not None:
+                        _cron_label = "⏱ cron" if _cron_running else "⚠ cron"
+                        _cron_class = "class:status-bar-strong" if _cron_running else "class:status-bar-yolo"
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append((_cron_class, _cron_label))
                     frags.extend([
                         ("class:status-bar-dim", " · "),
                         ("class:status-bar-dim", duration_label),
@@ -4870,6 +4899,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     if bg_subagent_count:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-strong", f"⛓ {bg_subagent_count}"))
+                    _cron_running = snapshot.get("cron_running")
+                    if _cron_running is not None:
+                        _cron_label = "⏱ cron" if _cron_running else "⚠ cron"
+                        _cron_class = "class:status-bar-strong" if _cron_running else "class:status-bar-yolo"
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append((_cron_class, _cron_label))
                     frags.extend([
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", duration_label),

--- a/cli.py
+++ b/cli.py
@@ -4310,16 +4310,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # means "unknown" (never run, or can't read the file); we skip the
         # indicator entirely in that case to avoid false alarms.
         try:
-            from cron.jobs import get_ticker_heartbeat_age
+            from cron.jobs import get_ticker_heartbeat_age, TICKER_INTERVAL_SECONDS
             _hb_age = get_ticker_heartbeat_age()
             if _hb_age is None:
-                snapshot["cron_running"] = None
+                snapshot["cron_ticker_state"] = None
             else:
-                # 200s stale threshold matches hermes_cli/cron.py (~3× 60s tick)
-                snapshot["cron_running"] = _hb_age <= 200.0
+                # Derive stale threshold from the shared cadence constant so it
+                # never drifts from hermes_cli/cron.py's formula: 3× interval + 20s.
+                _stale_after = TICKER_INTERVAL_SECONDS * 3 + 20
+                if _hb_age > _stale_after:
+                    snapshot["cron_ticker_state"] = "stale"
+                else:
+                    snapshot["cron_ticker_state"] = "alive"
                 snapshot["cron_heartbeat_age"] = _hb_age
         except Exception:
-            snapshot["cron_running"] = None
+            snapshot["cron_ticker_state"] = None
 
         return snapshot
 
@@ -4755,9 +4760,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 bg_subagent_count = snapshot.get("active_background_subagents", 0)
                 if bg_subagent_count:
                     parts.append(f"⛓ {bg_subagent_count}")
-                _cron_running = snapshot.get("cron_running")
-                if _cron_running is not None:
-                    parts.append("⏱ cron" if _cron_running else "⚠ cron")
+                _cron_ticker = snapshot.get("cron_ticker_state")
+                if _cron_ticker is not None:
+                    parts.append("⏱ cron" if _cron_ticker == "alive" else "⚠ cron")
                 parts.append(duration_label)
                 if yolo_active:
                     parts.append("⚠ YOLO")
@@ -4783,9 +4788,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             bg_subagent_count = snapshot.get("active_background_subagents", 0)
             if bg_subagent_count:
                 parts.append(f"⛓ {bg_subagent_count}")
-            _cron_running = snapshot.get("cron_running")
-            if _cron_running is not None:
-                parts.append("⏱ cron" if _cron_running else "⚠ cron")
+            _cron_ticker = snapshot.get("cron_ticker_state")
+            if _cron_ticker is not None:
+                parts.append("⏱ cron" if _cron_ticker == "alive" else "⚠ cron")
             parts.append(duration_label)
             prompt_elapsed = snapshot.get("prompt_elapsed")
             if prompt_elapsed:
@@ -4850,10 +4855,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     if bg_subagent_count:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append(("class:status-bar-strong", f"⛓ {bg_subagent_count}"))
-                    _cron_running = snapshot.get("cron_running")
-                    if _cron_running is not None:
-                        _cron_label = "⏱ cron" if _cron_running else "⚠ cron"
-                        _cron_class = "class:status-bar-strong" if _cron_running else "class:status-bar-yolo"
+                    _cron_ticker = snapshot.get("cron_ticker_state")
+                    if _cron_ticker is not None:
+                        _cron_label = "⏱ cron" if _cron_ticker == "alive" else "⚠ cron"
+                        _cron_class = "class:status-bar-strong" if _cron_ticker == "alive" else "class:status-bar-yolo"
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append((_cron_class, _cron_label))
                     frags.extend([
@@ -4899,10 +4904,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     if bg_subagent_count:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-strong", f"⛓ {bg_subagent_count}"))
-                    _cron_running = snapshot.get("cron_running")
-                    if _cron_running is not None:
-                        _cron_label = "⏱ cron" if _cron_running else "⚠ cron"
-                        _cron_class = "class:status-bar-strong" if _cron_running else "class:status-bar-yolo"
+                    _cron_ticker = snapshot.get("cron_ticker_state")
+                    if _cron_ticker is not None:
+                        _cron_label = "⏱ cron" if _cron_ticker == "alive" else "⚠ cron"
+                        _cron_class = "class:status-bar-strong" if _cron_ticker == "alive" else "class:status-bar-yolo"
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((_cron_class, _cron_label))
                     frags.extend([

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -671,3 +671,216 @@ class TestIdleSinceLastTurn:
         cli_obj._prompt_duration = 7.0
         text = cli_obj._build_status_bar_text(width=160)
         assert "✓ 42s" in text
+
+
+class TestCronTickerStatusBar:
+    """Cron ticker liveness indicator on the classic CLI status bar."""
+
+    def test_cron_alive_shows_ticking_indicator(self):
+        """When cron ticker is alive, the status bar shows ⏱ cron."""
+        cli_obj = _make_cli()
+        from unittest.mock import patch
+        with patch.object(cli_obj, "_get_status_bar_snapshot") as mock_snap:
+            mock_snap.return_value = {
+                "model": "anthropic/claude-sonnet-4-20250514",
+                "model_short": "claude-sonnet-4",
+                "context_tokens": 12450,
+                "context_length": 200000,
+                "context_percent": 6,
+                "prompt_tokens": 10230,
+                "completion_tokens": 2220,
+                "total_tokens": 12450,
+                "api_calls": 7,
+                "duration_label": "15m",
+                "cron_ticker_state": "alive",
+                "cron_heartbeat_age": 45.0,
+            }
+            text = cli_obj._build_status_bar_text(width=120)
+            assert "⏱ cron" in text
+
+    def test_cron_stale_shows_warning_indicator(self):
+        """When cron ticker is stale, the status bar shows ⚠ cron."""
+        cli_obj = _make_cli()
+        from unittest.mock import patch
+        with patch.object(cli_obj, "_get_status_bar_snapshot") as mock_snap:
+            mock_snap.return_value = {
+                "model": "anthropic/claude-sonnet-4-20250514",
+                "model_short": "claude-sonnet-4",
+                "context_tokens": 12450,
+                "context_length": 200000,
+                "context_percent": 6,
+                "prompt_tokens": 10230,
+                "completion_tokens": 2220,
+                "total_tokens": 12450,
+                "api_calls": 7,
+                "duration_label": "15m",
+                "cron_ticker_state": "stale",
+                "cron_heartbeat_age": 350.0,
+            }
+            text = cli_obj._build_status_bar_text(width=120)
+            assert "⚠ cron" in text
+            assert "⏱ cron" not in text
+
+    def test_cron_null_hides_indicator(self):
+        """When cron_ticker_state is None, no cron indicator is shown."""
+        cli_obj = _make_cli()
+        from unittest.mock import patch
+        with patch.object(cli_obj, "_get_status_bar_snapshot") as mock_snap:
+            mock_snap.return_value = {
+                "model": "anthropic/claude-sonnet-4-20250514",
+                "model_short": "claude-sonnet-4",
+                "context_tokens": 12450,
+                "context_length": 200000,
+                "context_percent": 6,
+                "prompt_tokens": 10230,
+                "completion_tokens": 2220,
+                "total_tokens": 12450,
+                "api_calls": 7,
+                "duration_label": "15m",
+                "cron_ticker_state": None,
+            }
+            text = cli_obj._build_status_bar_text(width=120)
+            assert "⏱ cron" not in text
+            assert "⚠ cron" not in text
+
+    def test_cron_missing_key_hides_indicator(self):
+        """When cron_ticker_state key is absent, no cron indicator is shown."""
+        cli_obj = _make_cli()
+        from unittest.mock import patch
+        with patch.object(cli_obj, "_get_status_bar_snapshot") as mock_snap:
+            mock_snap.return_value = {
+                "model": "anthropic/claude-sonnet-4-20250514",
+                "model_short": "claude-sonnet-4",
+                "context_tokens": 12450,
+                "context_length": 200000,
+                "context_percent": 6,
+                "prompt_tokens": 10230,
+                "completion_tokens": 2220,
+                "total_tokens": 12450,
+                "api_calls": 7,
+                "duration_label": "15m",
+            }
+            text = cli_obj._build_status_bar_text(width=120)
+            assert "⏱ cron" not in text
+            assert "⚠ cron" not in text
+
+    def test_cron_hidden_on_narrow_terminal(self):
+        """Cron indicator is hidden on very narrow terminals but doesn't crash."""
+        cli_obj = _make_cli()
+        from unittest.mock import patch
+        with patch.object(cli_obj, "_get_status_bar_snapshot") as mock_snap:
+            mock_snap.return_value = {
+                "model": "anthropic/claude-sonnet-4-20250514",
+                "model_short": "claude-sonnet-4",
+                "context_tokens": 12450,
+                "context_length": 200000,
+                "context_percent": 6,
+                "prompt_tokens": 10230,
+                "completion_tokens": 2220,
+                "total_tokens": 12450,
+                "api_calls": 7,
+                "duration_label": "15m",
+                "cron_ticker_state": "alive",
+                "cron_heartbeat_age": 30.0,
+            }
+            text = cli_obj._build_status_bar_text(width=40)
+            # Key point: no crash, model still visible
+            assert "claude-sonnet" in text or "sonnet" in text
+
+    def test_snapshot_derives_stale_from_ticker_interval(self):
+        """The snapshot's stale threshold derives from TICKER_INTERVAL_SECONDS."""
+        from unittest.mock import patch
+        cli_obj = _make_cli()
+        with patch("cron.jobs.get_ticker_heartbeat_age", return_value=190.0),              patch("cron.jobs.TICKER_INTERVAL_SECONDS", 60):
+            snapshot = cli_obj._get_status_bar_snapshot()
+            assert snapshot.get("cron_ticker_state") == "alive"
+
+        with patch("cron.jobs.get_ticker_heartbeat_age", return_value=210.0),              patch("cron.jobs.TICKER_INTERVAL_SECONDS", 60):
+            snapshot = cli_obj._get_status_bar_snapshot()
+            assert snapshot.get("cron_ticker_state") == "stale"
+
+    def test_snapshot_tracks_ticker_interval_changes(self):
+        """If TICKER_INTERVAL_SECONDS changes, the threshold tracks it."""
+        from unittest.mock import patch
+        cli_obj = _make_cli()
+        # With a 120s interval, stale_after = 120*3+20 = 380
+        with patch("cron.jobs.get_ticker_heartbeat_age", return_value=300.0),              patch("cron.jobs.TICKER_INTERVAL_SECONDS", 120):
+            snapshot = cli_obj._get_status_bar_snapshot()
+            assert snapshot.get("cron_ticker_state") == "alive"
+
+        with patch("cron.jobs.get_ticker_heartbeat_age", return_value=400.0),              patch("cron.jobs.TICKER_INTERVAL_SECONDS", 120):
+            snapshot = cli_obj._get_status_bar_snapshot()
+            assert snapshot.get("cron_ticker_state") == "stale"
+
+    def test_fragments_show_cron_alive(self):
+        """Status bar fragments include the cron indicator when alive."""
+        from unittest.mock import MagicMock, patch
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj._status_bar_visible = True
+        with patch.object(cli_obj, "_get_status_bar_snapshot") as mock_snap:
+            mock_snap.return_value = {
+                "model": "anthropic/claude-sonnet-4-20250514",
+                "model_short": "claude-sonnet-4",
+                "context_tokens": 12450,
+                "context_length": 200000,
+                "context_percent": 6,
+                "prompt_tokens": 10230,
+                "completion_tokens": 2220,
+                "total_tokens": 12450,
+                "api_calls": 7,
+                "duration_label": "15m",
+                "cron_ticker_state": "alive",
+                "cron_heartbeat_age": 30.0,
+            }
+            mock_app = MagicMock()
+            mock_app.output.get_size.return_value = MagicMock(columns=120)
+            with patch("prompt_toolkit.application.get_app", return_value=mock_app):
+                frags = cli_obj._get_status_bar_fragments()
+            frag_text = "".join(text for _, text in frags)
+            assert "⏱ cron" in frag_text
+
+    def test_fragments_show_cron_stale_with_yolo_class(self):
+        """Status bar fragments use the warning class for stale cron."""
+        from unittest.mock import MagicMock, patch
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj._status_bar_visible = True
+        with patch.object(cli_obj, "_get_status_bar_snapshot") as mock_snap:
+            mock_snap.return_value = {
+                "model": "anthropic/claude-sonnet-4-20250514",
+                "model_short": "claude-sonnet-4",
+                "context_tokens": 12450,
+                "context_length": 200000,
+                "context_percent": 6,
+                "prompt_tokens": 10230,
+                "completion_tokens": 2220,
+                "total_tokens": 12450,
+                "api_calls": 7,
+                "duration_label": "15m",
+                "cron_ticker_state": "stale",
+                "cron_heartbeat_age": 350.0,
+            }
+            mock_app = MagicMock()
+            mock_app.output.get_size.return_value = MagicMock(columns=120)
+            with patch("prompt_toolkit.application.get_app", return_value=mock_app):
+                frags = cli_obj._get_status_bar_fragments()
+            frag_text = "".join(text for _, text in frags)
+            assert "⚠ cron" in frag_text
+            stale_classes = [cls for cls, text in frags if "⚠ cron" in text]
+            assert len(stale_classes) == 1
+            assert "yolo" in stale_classes[0] or "warn" in stale_classes[0]

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -691,7 +691,7 @@ class TestCronTickerStatusBar:
                 "completion_tokens": 2220,
                 "total_tokens": 12450,
                 "api_calls": 7,
-                "duration_label": "15m",
+                "duration": "15m",
                 "cron_ticker_state": "alive",
                 "cron_heartbeat_age": 45.0,
             }
@@ -713,7 +713,7 @@ class TestCronTickerStatusBar:
                 "completion_tokens": 2220,
                 "total_tokens": 12450,
                 "api_calls": 7,
-                "duration_label": "15m",
+                "duration": "15m",
                 "cron_ticker_state": "stale",
                 "cron_heartbeat_age": 350.0,
             }
@@ -736,7 +736,7 @@ class TestCronTickerStatusBar:
                 "completion_tokens": 2220,
                 "total_tokens": 12450,
                 "api_calls": 7,
-                "duration_label": "15m",
+                "duration": "15m",
                 "cron_ticker_state": None,
             }
             text = cli_obj._build_status_bar_text(width=120)
@@ -758,7 +758,7 @@ class TestCronTickerStatusBar:
                 "completion_tokens": 2220,
                 "total_tokens": 12450,
                 "api_calls": 7,
-                "duration_label": "15m",
+                "duration": "15m",
             }
             text = cli_obj._build_status_bar_text(width=120)
             assert "⏱ cron" not in text
@@ -779,7 +779,7 @@ class TestCronTickerStatusBar:
                 "completion_tokens": 2220,
                 "total_tokens": 12450,
                 "api_calls": 7,
-                "duration_label": "15m",
+                "duration": "15m",
                 "cron_ticker_state": "alive",
                 "cron_heartbeat_age": 30.0,
             }
@@ -836,7 +836,7 @@ class TestCronTickerStatusBar:
                 "completion_tokens": 2220,
                 "total_tokens": 12450,
                 "api_calls": 7,
-                "duration_label": "15m",
+                "duration": "15m",
                 "cron_ticker_state": "alive",
                 "cron_heartbeat_age": 30.0,
             }
@@ -871,7 +871,7 @@ class TestCronTickerStatusBar:
                 "completion_tokens": 2220,
                 "total_tokens": 12450,
                 "api_calls": 7,
-                "duration_label": "15m",
+                "duration": "15m",
                 "cron_ticker_state": "stale",
                 "cron_heartbeat_age": 350.0,
             }

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2954,6 +2954,21 @@ def _get_usage(agent) -> dict:
         usage["active_subagents"] = _async_active_count()
     except Exception:
         pass
+    # Cron ticker liveness — mirrors the classic CLI status bar's cron
+    # indicator.  Three states: "alive" (fresh heartbeat), "stale"
+    # (heartbeat too old — ticker thread likely dead or failing), or
+    # None/absent (gateway never ran or heartbeat file unreadable).
+    # Uses the same TICKER_INTERVAL_SECONDS-derived threshold as
+    # hermes_cli/cron.py and cli.py so the three surfaces never drift.
+    try:
+        from cron.jobs import get_ticker_heartbeat_age, TICKER_INTERVAL_SECONDS
+        _hb_age = get_ticker_heartbeat_age()
+        if _hb_age is not None:
+            _stale_after = TICKER_INTERVAL_SECONDS * 3 + 20
+            usage["cron_ticker_state"] = "stale" if _hb_age > _stale_after else "alive"
+            usage["cron_heartbeat_age"] = _hb_age
+    except Exception:
+        pass
     # Dev-only live credits-spent readout (L0 usage-aware-credits). Gated on
     # HERMES_DEV_CREDITS so the payload stays clean when the flag is off.
     if is_truthy_value(os.environ.get("HERMES_DEV_CREDITS")):

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -399,3 +399,80 @@ describe('StatusRule idle-since read-out', () => {
     expect(findComponentByName(element, 'IdleSince')).toBeNull()
   })
 })
+
+
+describe('StatusRule cron ticker indicator', () => {
+  it('renders ⏱ cron when the ticker is alive', () => {
+    const element = StatusRule({
+      ...baseProps,
+      usage: { ...baseProps.usage, cron_ticker_state: 'alive', cron_heartbeat_age: 45 }
+    })
+
+    expect(textContent(element)).toContain('⏱ cron')
+  })
+
+  it('renders ⚠ cron when the ticker is stale', () => {
+    const element = StatusRule({
+      ...baseProps,
+      usage: { ...baseProps.usage, cron_ticker_state: 'stale', cron_heartbeat_age: 350 }
+    })
+
+    expect(textContent(element)).toContain('⚠ cron')
+  })
+
+  it('omits the segment when cron_ticker_state is null', () => {
+    const element = StatusRule({
+      ...baseProps,
+      usage: { ...baseProps.usage, cron_ticker_state: null }
+    })
+
+    expect(textContent(element)).not.toContain('cron')
+  })
+
+  it('omits the segment when cron_ticker_state is absent', () => {
+    const element = StatusRule({ ...baseProps })
+
+    expect(textContent(element)).not.toContain('cron')
+  })
+
+  it('shows heartbeat age in seconds alongside the indicator', () => {
+    const element = StatusRule({
+      ...baseProps,
+      usage: { ...baseProps.usage, cron_ticker_state: 'alive', cron_heartbeat_age: 123 }
+    })
+
+    expect(textContent(element)).toContain('⏱ cron 123s')
+  })
+
+  it('drops the cron segment before the subagent segment on a narrow terminal', () => {
+    const element = StatusRule({
+      ...baseProps,
+      cols: 44,
+      usage: { ...baseProps.usage, active_subagents: 1, cron_ticker_state: 'alive', cron_heartbeat_age: 30 }
+    })
+
+    // Both cron and subagents are below their breakpoints at 44 cols
+    expect(textContent(element)).not.toContain('cron')
+    expect(textContent(element)).not.toContain('⛓')
+  })
+
+  it('uses warn color for stale ticker state', () => {
+    const element = StatusRule({
+      ...baseProps,
+      usage: { ...baseProps.usage, cron_ticker_state: 'stale', cron_heartbeat_age: 350 }
+    })
+
+    const cronText = findElementWithText(element, '⚠ cron')
+    expect(cronText?.props.color).toBe(DEFAULT_THEME.color.warn)
+  })
+
+  it('uses muted color for alive ticker state', () => {
+    const element = StatusRule({
+      ...baseProps,
+      usage: { ...baseProps.usage, cron_ticker_state: 'alive', cron_heartbeat_age: 45 }
+    })
+
+    const cronText = findElementWithText(element, '⏱ cron')
+    expect(cronText?.props.color).toBe(DEFAULT_THEME.color.muted)
+  })
+})

--- a/ui-tui/src/__tests__/statusRule.test.ts
+++ b/ui-tui/src/__tests__/statusRule.test.ts
@@ -69,7 +69,8 @@ describe('statusBarSegments', () => {
       voice: true,
       bg: true,
       subagents: true,
-      cost: true
+      cost: true,
+      cronTicker: true,
     })
   })
 

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -248,6 +248,7 @@ export interface StatusBarSegments {
   bg: boolean
   compactCtx: boolean
   compressions: boolean
+  cronTicker: boolean
   duration: boolean
   subagents: boolean
   voice: boolean
@@ -263,6 +264,7 @@ export function statusBarSegments(cols: number): StatusBarSegments {
     compressions: w >= 80,
     voice: w >= 84,
     bg: w >= 88,
+    cronTicker: w >= 90,
     subagents: w >= 92
   }
 }
@@ -510,6 +512,14 @@ export function StatusRule({
   const showVoice = segs.voice && !!voiceLabel && fits(SEP + stringWidth(voiceLabel))
   const showSessionCount = !!sessionCountText && fits(SEP + stringWidth(sessionCountText))
   const showBg = segs.bg && bgCount > 0 && fits(SEP + stringWidth(`${bgCount} bg`))
+  const cronTickerState = usage.cron_ticker_state ?? null
+  const cronHbAge = usage.cron_heartbeat_age
+  const cronLabel = cronTickerState === 'alive'
+    ? typeof cronHbAge === 'number' ? `⏱ cron ${Math.round(cronHbAge)}s` : '⏱ cron'
+    : cronTickerState === 'stale'
+      ? typeof cronHbAge === 'number' ? `⚠ cron ${Math.round(cronHbAge)}s` : '⚠ cron'
+      : ''
+  const showCronTicker = segs.cronTicker && !!cronLabel && fits(SEP + stringWidth(cronLabel))
   const subagentCount = typeof usage.active_subagents === 'number' ? usage.active_subagents : 0
   const showSubagents = segs.subagents && subagentCount > 0 && fits(SEP + stringWidth(`⛓ ${subagentCount}`))
   // Parked-background reassurance: a top-level delegate_task runs in the
@@ -625,6 +635,15 @@ export function StatusRule({
           <Text color={t.color.muted} wrap="truncate-end">
             {' │ '}
             {bgCount} bg
+          </Text>
+        ) : null}
+        {showCronTicker ? (
+          <Text
+            color={cronTickerState === 'stale' ? t.color.warn : t.color.muted}
+            wrap="truncate-end"
+          >
+            {' │ '}
+            {cronLabel}
           </Text>
         ) : null}
         {showSubagents ? (

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -175,6 +175,8 @@ export interface Usage {
   context_used?: number
   cost_status?: string
   cost_usd?: number
+  cron_heartbeat_age?: number
+  cron_ticker_state?: 'alive' | 'stale' | null
   dev_credits_spent_micros?: number
   input: number
   output: number


### PR DESCRIPTION
### Summary
Add a cron liveness indicator to the TUI status bar so users can see at a glance whether the cron scheduler is actually running, instead of discovering it's dead only after scheduled jobs fail to fire (see #37179).

Closes #52815.

### Changes
- Reads the existing heartbeat file from `cron.jobs.get_ticker_heartbeat_age()` — the same one `hermes cron status` already uses
- Cross-process safe: gateway ticker, standalone cron daemon, and manual `hermes cron tick` all update the same file
- Appears in all four status bar width tiers (narrow/medium text + narrow/medium fragment modes)

### States
| State | Display | Meaning |
|-------|---------|---------|
| Alive | `⏱ cron` (green/strong) | Heartbeat fresh (<200s old, matching the threshold used by `hermes cron status`) |
| Stalled | `⚠ cron` (yellow/warning) | Heartbeat stale — ticker probably died |
| Unknown | hidden | No heartbeat file yet (never run, or can't read it) |

### Why not just check the gateway PID?
The gateway process can be alive while the cron ticker thread inside it silently dies (#37179). The heartbeat file is written on every tick iteration, so it reflects actual ticker liveness rather than just process existence.

### Sizing
Only shown when the heartbeat file is readable — if the user has never used cron or it's on a fresh install, the indicator stays hidden and doesn't consume status bar space.