### PR TITLE
fix(webhook): add sender_blocklist to prevent self-triggered loops

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -549,6 +549,39 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"status": "ignored", "event": event_type}
             )
 
+        # Sender blocklist — short-circuits before agent dispatch to prevent
+        # self-comment loops. payload.user.login is intentionally omitted: its
+        # semantics vary by provider and risk matching the wrong identity.
+        sender_blocklist = route_config.get("sender_blocklist", [])
+        if sender_blocklist:
+            def _login(field: object) -> str:
+                """Extract login string safely regardless of payload shape."""
+                if isinstance(field, dict):
+                    return field.get("login") or ""
+                if isinstance(field, str):
+                    return field
+                return ""
+
+            sender = (
+                _login(payload.get("sender"))
+                or _login(payload.get("actor"))
+                or ""
+            )
+            if sender in sender_blocklist:
+                logger.info(
+                    "[webhook] Ignoring event from blocked sender %s route=%s "
+                    "(sender_blocklist). Check config if events are unexpectedly silent.",
+                    sender,
+                    route_name,
+                )
+                return web.json_response(
+                    {
+                        "status": "ignored",
+                        "reason": "sender_blocklist",
+                        "sender": sender,
+                    }
+                )
+
         # Format prompt from template
         prompt_template = route_config.get("prompt", "")
         prompt = self._render_prompt(

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -467,6 +467,128 @@ class TestEventFilter:
             )
             assert resp.status == 202
 
+    @pytest.mark.asyncio
+    async def test_sender_blocklist_rejects_blocked_sender(self):
+        """Payload from a sender in sender_blocklist returns 200 status=ignored."""
+        routes = {
+            "gh": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "test",
+                "sender_blocklist": ["my-bot"],
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/gh",
+                json={"action": "created", "sender": {"login": "my-bot"}},
+                headers={"X-GitHub-Event": "issue_comment"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["status"] == "ignored"
+            assert data["reason"] == "sender_blocklist"
+            assert data["sender"] == "my-bot"
+            adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sender_blocklist_allows_other_senders(self):
+        """Payload from a sender NOT in sender_blocklist proceeds normally."""
+        routes = {
+            "gh": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "test",
+                "sender_blocklist": ["my-bot"],
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/gh",
+                json={"action": "created", "sender": {"login": "human-user"}},
+                headers={"X-GitHub-Event": "issue_comment"},
+            )
+            assert resp.status == 202
+            adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sender_blocklist_empty_allows_all(self):
+        """No sender_blocklist → no filtering, all senders pass through."""
+        routes = {
+            "gh": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "test",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/gh",
+                json={"action": "created", "sender": {"login": "anyone"}},
+                headers={"X-GitHub-Event": "issue_comment"},
+            )
+            assert resp.status == 202
+            adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sender_blocklist_checks_actor_field(self):
+        """Falls back to payload.actor.login when sender is absent (GitHub alternate)."""
+        routes = {
+            "gh": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "test",
+                "sender_blocklist": ["my-bot"],
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/gh",
+                json={"action": "created", "actor": {"login": "my-bot"}},
+                headers={"X-GitHub-Event": "issue_comment"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["status"] == "ignored"
+            assert data["sender"] == "my-bot"
+
+    @pytest.mark.asyncio
+    async def test_sender_blocklist_handles_string_sender_field(self):
+        """sender field as a plain string (not a dict) does not raise AttributeError."""
+        routes = {
+            "gh": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "test",
+                "sender_blocklist": ["my-bot"],
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/gh",
+                json={"action": "created", "sender": "my-bot"},
+                headers={"X-GitHub-Event": "issue_comment"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["status"] == "ignored"
+            assert data["sender"] == "my-bot"
+
 
 # ===================================================================
 # HTTP handling


### PR DESCRIPTION
## Problem

When a webhook route's agent posts a reply to an external service (e.g. a review comment on a pull request), the service fires a new webhook event for that comment. The adapter has no way to filter by sender, so the event triggers another agent run, which posts another comment — a feedback loop that runs until manually killed.

This is the same class of bug fixed for Telegram in #52667 and tracked for Discord in openclaw#15874. The webhook platform was not covered.

## Fix

Route config now accepts an optional `sender_blocklist` list. Before dispatching an agent run, the adapter checks the event payload's sender identity against the list and returns `200 {status: ignored, reason: sender_blocklist}` with no agent spawned. Zero effect on routes that omit `sender_blocklist`.

Example config:

```yaml
platforms:
  webhook:
    enabled: true
    extra:
      routes:
        github-pr-review:
          events: [issue_comment, pull_request_review]
          sender_blocklist: [my-bot-username]
          prompt: "..."
```

## Why not a bot-identity check (like #52667)?

The Telegram fix compares against a known bot ID retrieved from the platform API at startup. That approach requires knowing the platform's identity model.

The webhook adapter is intentionally provider-agnostic — it accepts GitHub, GitLab, Bitbucket, Stripe, or any HTTP service — and has no inherent concept of self. There is no universal identity to check against.

A GitHub-specific approach (querying the authenticated user via the GitHub API at startup) was considered and rejected: it would hardcode a provider assumption into a provider-agnostic adapter and silently fail on GitLab or any other service.

## Implementation details

Sender identity is read from:
- `payload.sender.login` — GitHub/GitLab standard field
- `payload.actor.login` — GitHub alternate events

`payload.user.login` was considered as a fallback but omitted intentionally: its semantics vary by provider and risk matching the wrong identity (e.g. PR author vs. event actor). Conservative is safer.

Both fields are extracted via a type-safe helper that handles dict `{"login": "..."}" and plain-string `"username"` shapes without raising `AttributeError` on non-standard payloads.

Logs at `INFO` (not `DEBUG`) so ignored events appear in the default gateway log without `-v`. The log message includes a hint for users debugging unexpected silence.

Mirrors the existing `events` filter immediately above it in structure and response shape.

## Tradeoffs

`sender_blocklist` adds a config field, which is a larger blast radius than a pure identity check would be. It is opt-in with zero effect when unset, but it is a new surface users need to know about.

Note: a self-loop burst could temporarily hit rate limits on the same route before the fix kicks in (rate limiting runs before payload parsing). Acceptable tradeoff but worth being aware of.

If there is a cleaner approach that avoids the config addition — or if the webhook platform is not the intended surface for agent-driven workflows that post back to the originating service — feedback is welcome before this merges.

## Tests

5 new cases in `tests/gateway/test_webhook_adapter.py`:
- blocked sender returns `200 status=ignored`, no agent run started
- allowed sender proceeds normally (`202`)
- empty blocklist is a no-op (all senders pass through)
- `actor` field fallback works when `sender` is absent
- plain string `sender` field handled without `AttributeError`