### PR TITLE
feat(gateway): preserve session history for API runs

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1489,6 +1489,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "responses_api": True,
                 "responses_streaming": True,
                 "run_submission": True,
+                "runs_session_history": True,
                 "run_status": True,
                 "run_events_sse": True,
                 "run_stop": True,
@@ -4191,7 +4192,26 @@ class APIServerAdapter(BasePlatformAdapter):
         if not raw_input:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
 
-        user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) else "")
+        def _is_message_array(value: Any) -> bool:
+            return (
+                isinstance(value, list)
+                and len(value) > 0
+                and all(isinstance(item, dict) and "role" in item for item in value)
+            )
+
+        input_is_message_array = _is_message_array(raw_input)
+        if isinstance(raw_input, str):
+            user_message = raw_input
+        elif input_is_message_array:
+            current = next(
+                (msg for msg in reversed(raw_input) if isinstance(msg, dict) and msg.get("role") == "user"),
+                raw_input[-1],
+            )
+            user_message = current.get("content", "") if isinstance(current, dict) else ""
+        else:
+            # Multimodal content parts (e.g. [{type: 'text'}, {type: 'image_url'}])
+            # are the current user message, not a chat-history array.
+            user_message = raw_input
         if not user_message:
             return web.json_response(_openai_error("No user message found in input"), status=400)
 
@@ -4199,7 +4219,8 @@ class APIServerAdapter(BasePlatformAdapter):
         previous_response_id = body.get("previous_response_id")
 
         # Accept explicit conversation_history from the request body.
-        # Precedence: explicit conversation_history > previous_response_id.
+        # Precedence: explicit conversation_history > previous_response_id >
+        # server-owned session history > legacy multi-message input arrays.
         conversation_history: List[Dict[str, str]] = []
         raw_history = body.get("conversation_history")
         if raw_history:
@@ -4227,10 +4248,23 @@ class APIServerAdapter(BasePlatformAdapter):
                 if instructions is None:
                     instructions = stored.get("instructions")
 
-        # When input is a multi-message array, extract all but the last
-        # message as conversation history (the last becomes user_message).
-        # Only fires when no explicit history was provided.
-        if not conversation_history and isinstance(raw_input, list) and len(raw_input) > 1:
+        run_id = f"run_{uuid.uuid4().hex}"
+        session_id = body.get("session_id") or stored_session_id or run_id
+
+        # Native session continuity for external API clients: if the caller
+        # provides a stable session_id and only the current user input, let the
+        # API server load the canonical Hermes transcript. This
+        # matches Telegram/native gateway semantics and avoids client-side
+        # flattening that loses tool_calls/tool result context (notably
+        # skill_view and helper-script usage).
+        if not conversation_history and session_id and not (input_is_message_array and len(raw_input) > 1):
+            conversation_history = self._conversation_history_for_session(str(session_id))
+
+        # Legacy compatibility: when input is a multi-message array, extract all
+        # but the last message as conversation history (the last becomes the
+        # current user message). Only fires when no explicit/server history was
+        # found.
+        if not conversation_history and input_is_message_array and len(raw_input) > 1:
             for msg in raw_input[:-1]:
                 if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
                     content = msg["content"]
@@ -4242,10 +4276,8 @@ class APIServerAdapter(BasePlatformAdapter):
                         )
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
-        run_id = f"run_{uuid.uuid4().hex}"
-        session_id = body.get("session_id") or stored_session_id or run_id
         # Approval queues gate host-side tool execution and must be isolated
-        # per API run.  Client-provided session IDs and memory session keys are
+        # per API run. Client-provided session IDs and memory session keys are
         # conversation/memory scopes, not authorization namespaces: multiple
         # concurrent runs can intentionally share them, and resolving an
         # approval for one run must not unblock another run's dangerous command.

--- a/tests/gateway/test_api_server_multimodal.py
+++ b/tests/gateway/test_api_server_multimodal.py
@@ -7,6 +7,7 @@ path (including the ``run_agent`` prologue that used to crash on list content)
 executes against a real aiohttp app.
 """
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -133,6 +134,8 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
     return app
 
 
@@ -306,3 +309,94 @@ class TestResponsesMultimodalHTTP:
             assert resp.status == 400
             body = await resp.json()
         assert body["error"]["code"] == "unsupported_content_type"
+
+
+class _CapturingAgent:
+    session_prompt_tokens = 0
+    session_completion_tokens = 0
+    session_total_tokens = 0
+
+    def __init__(self):
+        self.captured = None
+
+    def run_conversation(self, **kwargs):
+        self.captured = kwargs
+        return {"final_response": "ok", "messages": [], "api_calls": 1}
+
+
+async def _wait_for_capture(agent: _CapturingAgent):
+    for _ in range(50):
+        if agent.captured is not None:
+            return agent.captured
+        await asyncio.sleep(0.01)
+    raise AssertionError("API run did not reach fake agent")
+
+
+class TestRunsSessionHistoryHTTP:
+    @pytest.mark.asyncio
+    async def test_runs_load_server_session_history_for_stable_session_id(self, adapter):
+        app = _create_app(adapter)
+        agent = _CapturingAgent()
+        stored_history = [
+            {"role": "user", "content": "load the skill"},
+            {"role": "assistant", "content": "skill loaded"},
+        ]
+
+        with (
+            patch.object(adapter, "_create_agent", return_value=agent),
+            patch.object(adapter, "_conversation_history_for_session", return_value=stored_history) as load_history,
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "model": "hermes-agent",
+                        "session_id": "workspace-session-1",
+                        "input": "continue from there",
+                    },
+                )
+                assert resp.status == 202, await resp.text()
+                captured = await _wait_for_capture(agent)
+
+        load_history.assert_called_once_with("workspace-session-1")
+        assert captured["user_message"] == "continue from there"
+        assert captured["conversation_history"] == stored_history
+        assert captured["task_id"] == "workspace-session-1"
+
+    @pytest.mark.asyncio
+    async def test_runs_keep_legacy_message_array_history(self, adapter):
+        app = _create_app(adapter)
+        agent = _CapturingAgent()
+
+        with (
+            patch.object(adapter, "_create_agent", return_value=agent),
+            patch.object(adapter, "_conversation_history_for_session", return_value=[{"role": "user", "content": "server"}]) as load_history,
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "model": "hermes-agent",
+                        "session_id": "workspace-session-2",
+                        "input": [
+                            {"role": "user", "content": "client history"},
+                            {"role": "user", "content": "current turn"},
+                        ],
+                    },
+                )
+                assert resp.status == 202, await resp.text()
+                captured = await _wait_for_capture(agent)
+
+        load_history.assert_not_called()
+        assert captured["user_message"] == "current turn"
+        assert captured["conversation_history"] == [{"role": "user", "content": "client history"}]
+
+    @pytest.mark.asyncio
+    async def test_capabilities_advertise_runs_session_history(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            assert resp.status == 200, await resp.text()
+            body = await resp.json()
+
+        assert body["features"]["runs_session_history"] is True

--- a/tests/gateway/test_api_server_multimodal.py
+++ b/tests/gateway/test_api_server_multimodal.py
@@ -22,6 +22,7 @@ from gateway.platforms.api_server import (
     cors_middleware,
     security_headers_middleware,
 )
+from hermes_state import SessionDB
 
 
 # ---------------------------------------------------------------------------
@@ -334,34 +335,41 @@ async def _wait_for_capture(agent: _CapturingAgent):
 
 class TestRunsSessionHistoryHTTP:
     @pytest.mark.asyncio
-    async def test_runs_load_server_session_history_for_stable_session_id(self, adapter):
+    async def test_runs_load_server_session_history_for_stable_session_id(self, adapter, tmp_path):
         app = _create_app(adapter)
         agent = _CapturingAgent()
-        stored_history = [
+        session_id = "workspace-session-1"
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id=session_id, source="api_server")
+        db.append_message(session_id, role="user", content="load the skill")
+        db.append_message(session_id, role="assistant", content="skill loaded")
+        adapter._session_db = db
+
+        try:
+            with patch.object(adapter, "_create_agent", return_value=agent):
+                async with TestClient(TestServer(app)) as cli:
+                    resp = await cli.post(
+                        "/v1/runs",
+                        json={
+                            "model": "hermes-agent",
+                            "session_id": session_id,
+                            "input": "continue from there",
+                        },
+                    )
+                    assert resp.status == 202, await resp.text()
+                    captured = await _wait_for_capture(agent)
+        finally:
+            db.close()
+
+        assert captured["user_message"] == "continue from there"
+        assert [
+            {"role": message["role"], "content": message["content"]}
+            for message in captured["conversation_history"]
+        ] == [
             {"role": "user", "content": "load the skill"},
             {"role": "assistant", "content": "skill loaded"},
         ]
-
-        with (
-            patch.object(adapter, "_create_agent", return_value=agent),
-            patch.object(adapter, "_conversation_history_for_session", return_value=stored_history) as load_history,
-        ):
-            async with TestClient(TestServer(app)) as cli:
-                resp = await cli.post(
-                    "/v1/runs",
-                    json={
-                        "model": "hermes-agent",
-                        "session_id": "workspace-session-1",
-                        "input": "continue from there",
-                    },
-                )
-                assert resp.status == 202, await resp.text()
-                captured = await _wait_for_capture(agent)
-
-        load_history.assert_called_once_with("workspace-session-1")
-        assert captured["user_message"] == "continue from there"
-        assert captured["conversation_history"] == stored_history
-        assert captured["task_id"] == "workspace-session-1"
+        assert captured["task_id"] == session_id
 
     @pytest.mark.asyncio
     async def test_runs_keep_legacy_message_array_history(self, adapter):


### PR DESCRIPTION
## What does this PR do?

Adds native session-history continuity for `/v1/runs` when callers provide a stable `session_id`.

Previously, API clients using `/v1/runs` with only the current input could start each run with empty history unless they resent or flattened prior conversation context client-side. That loses Hermes-native transcript structure, especially tool calls and tool results, which can break follow-up turns involving skills, helper scripts, approvals, or other tool-mediated state.

This change lets the API server load the canonical Hermes session transcript for the provided `session_id`, matching the behavior expected from native gateway sessions.

This overlaps with #20295, but this branch also:
- keeps legacy multi-message-array input behavior as fallback compatibility
- distinguishes message arrays from multimodal/current-message content arrays
- advertises support through `/v1/capabilities` as `runs_session_history: true`
- adds focused API-server regression coverage

## Related Issue

Related to #20295.

Also related context:
- #9165 previously attempted similar `/v1/runs` session continuity work and is closed.
- #44004 / #44103 cover a separate but adjacent stateless-client continuity problem around compressed session tip resolution.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`
  - Adds `/v1/runs` server-side session-history loading when a stable `session_id` is provided and no explicit `conversation_history` or `previous_response_id` history is available.
  - Distinguishes chat-history message arrays from current-message content arrays.
  - Preserves legacy multi-message-array extraction as fallback compatibility.
  - Adds `runs_session_history: true` to `/v1/capabilities`.

- `tests/gateway/test_api_server_multimodal.py`
  - Adds focused `/v1/runs` tests for server-owned session-history loading.
  - Adds coverage that legacy multi-message-array history is still used instead of server history.
  - Adds coverage for the `runs_session_history` capabilities flag.

## How to Test

1. Run the focused API-server tests:

```

uv run --extra dev --extra messaging pytest tests/gateway/test_api_server_[multimodal.py](http://multimodal.py/) -q -o 'addopts='

```

2. Confirm the test result:

```

26 passed, 9 warnings in 2.56s

```

3. Manually verify `/v1/capabilities` includes:

```

{

"features": {

"runs_session_history": true

}

}

```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused test run:

```

uv run --extra dev --extra messaging pytest tests/gateway/test_api_server_multimodal.py -q -o 'addopts='

```

```

26 passed, 9 warnings in 2.56s

```