### PR TITLE
fix(desktop): show remote backend updates without counts

### DIFF
--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -241,10 +241,12 @@ export function useStatusbarItems({
 
     const backendVersion = statusSnapshot?.version
     const behind = backendUpdateStatus?.behind ?? 0
+    const updateAvailable = backendUpdateStatus?.updateAvailable || behind > 0
     const applying = backendUpdateApply.applying || backendUpdateApply.stage === 'restart'
 
     const base = copy.backendLabel(backendVersion ?? copy.unknown)
-    const behindHint = !applying && behind > 0 ? ` (+${behind})` : ''
+    const behindHint =
+      !applying && behind > 0 ? ` (+${behind})` : !applying && updateAvailable ? ` (${copy.update})` : ''
 
     const label = applying
       ? `${base} · ${backendUpdateApply.stage === 'restart' ? copy.restart : copy.update}`
@@ -253,13 +255,14 @@ export function useStatusbarItems({
     const tooltip = [
       applying ? backendUpdateApply.message || copy.updateInProgress : null,
       !applying && behind > 0 && copy.commitsBehind(behind, 'main'),
+      !applying && behind <= 0 && updateAvailable && copy.update,
       backendVersion && copy.backendVersion(backendVersion)
     ]
       .filter(Boolean)
       .join(' · ')
 
     return {
-      className: !applying && behind > 0 ? 'text-primary hover:text-primary' : undefined,
+      className: !applying && updateAvailable ? 'text-primary hover:text-primary' : undefined,
       hidden: !backendVersion,
       icon: applying ? <Loader2 className="size-3 animate-spin" /> : <Hash className="size-3" />,
       id: 'version-backend',
@@ -272,6 +275,7 @@ export function useStatusbarItems({
     connection?.mode,
     statusSnapshot?.version,
     backendUpdateStatus?.behind,
+    backendUpdateStatus?.updateAvailable,
     backendUpdateApply.applying,
     backendUpdateApply.message,
     backendUpdateApply.stage,

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -60,6 +60,7 @@ export function UpdatesOverlay() {
   }, [check, checking, open, status])
 
   const behind = status?.behind ?? 0
+  const updateAvailable = status?.updateAvailable || behind > 0
 
   const phase: 'idle' | 'applying' | 'manual' | 'guiSkew' | 'error' =
     apply.stage === 'manual'
@@ -124,6 +125,7 @@ export function UpdatesOverlay() {
             onRetryCheck={() => void check()}
             status={status}
             target={target}
+            updateAvailable={updateAvailable}
           />
         )}
       </DialogContent>
@@ -139,7 +141,8 @@ function IdleView({
   onLater,
   onRetryCheck,
   status,
-  target
+  target,
+  updateAvailable
 }: {
   behind: number
   checking: boolean
@@ -149,6 +152,7 @@ function IdleView({
   onRetryCheck: () => void
   status: DesktopUpdateStatus | null
   target: UpdateTarget
+  updateAvailable: boolean
 }) {
   const { t } = useI18n()
   const u = t.updates
@@ -198,7 +202,7 @@ function IdleView({
     )
   }
 
-  if (behind === 0) {
+  if (!updateAvailable) {
     return (
       <CenteredStatus
         body={target === 'backend' ? u.latestBodyBackend : u.latestBody}

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -276,6 +276,7 @@ export interface DesktopUpdateCommit {
 
 export interface DesktopUpdateStatus {
   supported: boolean
+  updateAvailable?: boolean
   branch?: string
   currentBranch?: string
   reason?: string

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -199,9 +199,29 @@ describe('checkBackendUpdates', () => {
 
     expect(checkHermesUpdateSpy).toHaveBeenCalled()
     expect(result?.behind).toBe(2)
+    expect(result?.updateAvailable).toBe(true)
     expect(result?.commits?.[0]?.sha).toBe('abc1234')
     expect(result?.supported).toBe(true)
     expect($backendUpdateStatus.get()?.commits?.[0]?.summary).toBe('feat: x')
+  })
+
+  it('preserves backend update_available when the backend cannot count commits', async () => {
+    setRemote(true)
+    checkHermesUpdateSpy.mockResolvedValue({
+      install_method: 'nixos',
+      current_version: '0.16.0',
+      behind: -1,
+      update_available: true,
+      can_apply: false,
+      update_command: 'managed outside dashboard',
+      message: 'Update available.'
+    })
+
+    const result = await checkBackendUpdates()
+
+    expect(result?.behind).toBe(0)
+    expect(result?.updateAvailable).toBe(true)
+    expect(result?.targetSha).toBe('backend:0.16.0')
   })
 
   it('honours can_apply=false (docker/nix): not supported, carries message', async () => {

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -247,6 +247,7 @@ function mapBackendCheck(res: BackendUpdateCheckResponse): DesktopUpdateStatus {
   return {
     supported: res.can_apply,
     message: res.message ?? undefined,
+    updateAvailable: res.update_available,
     behind: behind > 0 ? behind : 0,
     targetSha: res.update_available ? `backend:${res.current_version}` : undefined,
     commits: res.commits,

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -197,7 +197,10 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
     if _is_official_ssh_remote(origin_url):
         head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
-        return _check_via_rev(head_rev) if head_rev else None
+        checked = _check_via_rev(head_rev) if head_rev else None
+        if checked == UPDATE_AVAILABLE_NO_COUNT:
+            return 1
+        return checked
 
     # Installer checkouts are shallow (`git clone --depth 1`). On a shallow
     # clone the history stops at a single commit, so a plain `git fetch` would

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -125,7 +125,7 @@ def test_check_for_updates_official_ssh_origin_uses_https_probe(tmp_path):
     with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
         result = banner._check_via_local_git(repo_dir)
 
-    assert result == banner.UPDATE_AVAILABLE_NO_COUNT
+    assert result == 1
     assert ["git", "fetch", "origin", "--quiet"] not in calls
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes the remote Desktop backend update indicator when the connected backend reports that an update is available but cannot provide an exact commit count.

The backend update API already distinguishes `update_available` from `behind`; for presence-only update checks it can return `behind: -1` with `update_available: true`. Desktop was collapsing that into `behind: 0`, which made the remote backend statusbar/overlay look up to date even when the backend reported an available update.

This also aligns official-SSH git backend update checks with the Desktop client checker by returning `1` when the backend HEAD differs from upstream, without running `git fetch` or hitting SSH auth.

## Related Issue

Discord support thread: `1519895846533988454` (`No remote gateway updates count`)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Preserve backend `update_available` in Desktop update state instead of deriving availability only from a positive `behind` count.
- Show the remote backend statusbar item as update-available when the backend has an update but no exact count.
- Keep the remote backend update overlay in the available-update state instead of showing “You’re all set” for unknown-count updates.
- Return `1` for official-SSH git backend checkouts when HEAD differs from upstream, matching the Desktop client update count behavior while still avoiding SSH fetch/auth prompts.
- Add coverage for presence-only backend update responses and update the official-SSH update-check expectation.

## How to Test

1. `scripts/run_tests.sh -j 4 tests/hermes_cli/test_update_check.py tests/hermes_cli/test_dashboard_admin_endpoints.py::TestUpdateCheckEndpoint`
2. `venv/bin/python -m pytest tests/hermes_cli/test_dashboard_admin_endpoints.py::TestUpdateCheckEndpoint -q`
3. `npm exec vitest run src/store/updates.test.ts -- --environment jsdom --maxWorkers 4` from `apps/desktop/`
4. `npm --prefix apps/desktop run typecheck`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/WSL checkout with targeted Python + Desktop TypeScript tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted checks passed:

- `scripts/run_tests.sh -j 4 tests/hermes_cli/test_update_check.py tests/hermes_cli/test_dashboard_admin_endpoints.py::TestUpdateCheckEndpoint` → `15 passed`
- `venv/bin/python -m pytest tests/hermes_cli/test_dashboard_admin_endpoints.py::TestUpdateCheckEndpoint -q` → `7 passed`
- `npm exec vitest run src/store/updates.test.ts -- --environment jsdom --maxWorkers 4` → `22 passed`
- `npm --prefix apps/desktop run typecheck` → passed
