### PR TITLE
fix(state): exclude end_reason='branched' fork children from resume walk

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3199,19 +3199,26 @@ class SessionDB:
                     best = current
 
                 # Walk to the most-recently-started child — but skip explicit
-                # branch (`_branched_from`), delegate/subagent (`_delegate_from`),
-                # and tool children. They also carry a ``parent_session_id`` yet
-                # are NOT compression continuations; following them would hijack
-                # the resume target to an unrelated session (e.g. a subagent
-                # run). This mirrors the child-exclusion in ``get_compression_tip``.
+                # branch, delegate/subagent (`_delegate_from`), and tool
+                # children. They also carry a ``parent_session_id`` yet are NOT
+                # compression continuations; following them would hijack the
+                # resume target to an unrelated session (e.g. a subagent run).
+                # Branch children are excluded via the canonical
+                # ``_BRANCH_CHILD_SQL`` (both the ``_branched_from`` marker and
+                # the ``end_reason='branched'`` heuristic arm) so this exclusion
+                # can never drift from ``get_compression_tip`` /
+                # ``_LISTABLE_CHILD_SQL``. An api_server fork
+                # (``end_session(id, "branched")`` + a child created with no
+                # marker) carries only the heuristic, so the marker arm alone
+                # would let it slip through and hijack the resume.
                 try:
                     child_row = self._conn.execute(
-                        "SELECT id FROM sessions "
-                        "WHERE parent_session_id = ? "
-                        "  AND json_extract(COALESCE(model_config, '{}'), '$._branched_from') IS NULL "
-                        "  AND json_extract(COALESCE(model_config, '{}'), '$._delegate_from') IS NULL "
-                        "  AND COALESCE(source, '') != 'tool' "
-                        "ORDER BY started_at DESC, id DESC LIMIT 1",
+                        "SELECT c.id FROM sessions c "
+                        "WHERE c.parent_session_id = ? "
+                        f"  AND NOT ({_BRANCH_CHILD_SQL.format(a='c')}) "
+                        "  AND json_extract(COALESCE(c.model_config, '{}'), '$._delegate_from') IS NULL "
+                        "  AND COALESCE(c.source, '') != 'tool' "
+                        "ORDER BY c.started_at DESC, c.id DESC LIMIT 1",
                         (current,),
                     ).fetchone()
                 except Exception:

--- a/tests/hermes_state/test_resolve_resume_session_id.py
+++ b/tests/hermes_state/test_resolve_resume_session_id.py
@@ -135,6 +135,33 @@ def test_compression_tip_not_confused_with_delegation_child(db):
     assert db.resolve_resume_session_id("conv") == "conv"
 
 
+def test_does_not_redirect_into_branched_fork_child(db):
+    # An api_server /branch fork (gateway/platforms/api_server.py:1598) ends the
+    # original with end_reason='branched' and creates a child carrying the
+    # transcript forward — but, unlike the TUI /branch path, it does NOT set the
+    # `_branched_from` model_config marker. The child is therefore a branch only
+    # by the `end_reason='branched'` heuristic arm of `_BRANCH_CHILD_SQL`.
+    # Resuming the original must stay on the original transcript, never get
+    # hijacked into the divergent fork.
+    base = int(time.time()) - 10_000
+    db.create_session("orig", source="cli")
+    db.append_message("orig", role="user", content="parent turn")
+    db.end_session("orig", "branched")
+    # No model_config marker — mirrors api_server.create_session(..., parent_session_id=...).
+    db.create_session("fork", source="api_server", parent_session_id="orig")
+    db.append_message("fork", role="assistant", content="divergent fork turn")
+    conn = db._conn
+    assert conn is not None
+    conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'orig'",
+        (base, base + 50),
+    )
+    conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'fork'", (base + 100,))
+    conn.commit()
+
+    assert db.resolve_resume_session_id("orig") == "orig"
+
+
 def test_prefers_most_recent_child_when_fork_exists(db):
     # If a session was somehow forked (two children), pick the latest one.
     # In practice, compression only produces single-chain shape, but the helper


### PR DESCRIPTION
## This is a sibling follow-up to commit 6dfb8326f (#52731)

- **What #52731 covered:** added delegate/branch/tool child exclusion to the descendant walk in `resolve_resume_session_id`, with a commit message stating it "mirrors `_BRANCH_CHILD_SQL` / the same exclusion the rest of `hermes_state.py` uses".
- **What it did NOT touch:** it implemented only the `_branched_from` *marker* arm of `_BRANCH_CHILD_SQL`, and omitted the second `end_reason='branched'` *heuristic* arm.
- **What this adds:** completes the stated intent so the walk's branch exclusion covers both arms, matching `get_compression_tip` / `_LISTABLE_CHILD_SQL`.

## What does this PR do?

The descendant walk in `SessionDB.resolve_resume_session_id` (`hermes_state.py`) excluded branch children using only the `_branched_from` model_config marker — the **first** arm of the canonical `_BRANCH_CHILD_SQL` (`hermes_state.py:43`). It missed the **second** arm: a child whose parent ended `end_reason='branched'` and whose `started_at >= parent.ended_at`.

`_BRANCH_CHILD_SQL` has both arms, and `get_compression_tip` / `_LISTABLE_CHILD_SQL` (the visibility/listing model) use it — so the inline walk under-excluded relative to the exclusion it claims to mirror.

**Concrete escapee — the api_server `/branch` fork.** `gateway/platforms/api_server.py:1598` forks a session by:

```python
db.end_session(source_id, "branched")
db.create_session(fork_id, "api_server", ..., parent_session_id=source_id)
```

Unlike the TUI `/branch` path, it does **not** set a `_branched_from` marker on the child. So that fork is a branch child only by the `end_reason='branched'` heuristic. Under the marker-only exclusion it slipped through the walk, and `resolve_resume_session_id(orig)` redirected into the divergent **fork** transcript instead of staying on the original session.

This PR replaces the lone `_branched_from IS NULL` predicate with the negation of the canonical two-arm `_BRANCH_CHILD_SQL` helper (`NOT (_BRANCH_CHILD_SQL.format(a='c'))`), the same idiom `_LISTABLE_CHILD_SQL` already uses. The exclusion now covers both arms via a single source of truth and can never drift again. The delegate (`_delegate_from`) and tool exclusions are preserved unchanged.

## Related Issue

Fixes #52731

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: in `resolve_resume_session_id`'s descendant walk, exclude branch children via `NOT (_BRANCH_CHILD_SQL.format(a='c'))` (both the marker and `end_reason='branched'` arms) instead of the marker arm alone. Delegate/tool exclusions unchanged.
- `tests/hermes_state/test_resolve_resume_session_id.py`: add `test_does_not_redirect_into_branched_fork_child`, mirroring the api_server fork shape (parent ended `branched`, child with no marker, `started_at >= ended_at`).

## How to Test

Reproduction (headless, SessionDB only):

1. `db.create_session("orig")`; `db.append_message("orig", ...)`; `db.end_session("orig", "branched")`.
2. `db.create_session("fork", source="api_server", parent_session_id="orig")` (no `_branched_from` marker); `db.append_message("fork", ...)`; set `fork.started_at >= orig.ended_at`.
3. **Before the fix:** `resolve_resume_session_id("orig")` returns `"fork"` (wrong). Control: `get_compression_tip("orig")` returns `"orig"` (correct — it requires `end_reason='compression'`).
4. **After the fix:** `resolve_resume_session_id("orig")` returns `"orig"` (correct).

Test suite:

```
pytest tests/hermes_state/ -q   # 38 passed (37 prior + new regression test)
```

The new test fails before the production change (`assert 'fork' == 'orig'`) and passes after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A