### PR TITLE
fix(gateway): scale-to-zero never armed — arm-gate counted disabled placeholder platforms

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3637,7 +3637,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
 
         try:
-            platforms = list(self.config.platforms.keys()) if self.config else []
+            # Only ENABLED platforms count. `config.platforms` is pre-seeded with a
+            # disabled placeholder PlatformConfig for every KNOWN platform (telegram,
+            # discord, slack, …), so `.keys()` is the full ~20-entry catalog regardless
+            # of what this instance actually runs. Passing the bare keys made
+            # `messaging_is_relay_only_or_absent` see those placeholders as live
+            # direct-socket platforms and return False, so scale-to-zero NEVER armed on
+            # a real relay-only instance. Mirror the connect loop, which already gates on
+            # `platform_config.enabled` (see the `if not platform_config.enabled: continue`
+            # in the adapter-connect loop) — arm off the same notion of "active platform."
+            platforms = (
+                [p for p, pc in self.config.platforms.items() if getattr(pc, "enabled", False)]
+                if self.config
+                else []
+            )
         except Exception:  # noqa: BLE001
             platforms = []
         try:
@@ -3649,6 +3662,52 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             relay_only_or_absent=messaging_is_relay_only_or_absent(platforms),
             wake_url=wake_url,
         )
+
+    def _log_scale_to_zero_not_armed_reason(self) -> None:
+        """Log why the idle watcher did NOT arm — but only for an OPTED-IN instance.
+
+        A non-opted instance (no HERMES_SCALE_TO_ZERO stamp) not arming is the normal
+        case and must stay silent. When the Labs stamp IS set but the watcher still
+        didn't arm, that's the surprising case worth one INFO line so "why won't it
+        suspend/wake?" is a log grep, not a box-dive.
+        """
+        from gateway.relay import relay_wake_url
+        from gateway.scale_to_zero import (
+            messaging_is_relay_only_or_absent,
+            scale_to_zero_enabled,
+        )
+
+        try:
+            enabled = scale_to_zero_enabled()
+            if not enabled:
+                return  # not opted in — normal, stay quiet
+            try:
+                active = (
+                    [
+                        getattr(p, "value", p)
+                        for p, pc in self.config.platforms.items()
+                        if getattr(pc, "enabled", False)
+                    ]
+                    if self.config
+                    else []
+                )
+            except Exception:  # noqa: BLE001
+                active = []
+            relay_only = messaging_is_relay_only_or_absent(active)
+            try:
+                wake_url = relay_wake_url()
+            except Exception:  # noqa: BLE001
+                wake_url = None
+            logger.info(
+                "scale-to-zero: NOT armed despite opt-in — "
+                "relay_only_or_absent=%s (enabled platforms=%s), wake_url=%s. "
+                "Need relay-only messaging + a registered wake URL.",
+                relay_only,
+                active or "none",
+                "set" if wake_url else "MISSING",
+            )
+        except Exception:  # noqa: BLE001 - diagnostics must never block startup
+            logger.debug("scale-to-zero: not-armed reason logging failed", exc_info=True)
 
     def _scale_to_zero_is_idle(self) -> bool:
         from gateway.scale_to_zero import is_idle
@@ -6150,6 +6209,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     self._scale_to_zero_idle_timeout_seconds(),
                 )
                 asyncio.create_task(self._scale_to_zero_watcher())
+            else:
+                # Surface WHY an OPTED-IN instance didn't arm (a non-opted instance
+                # not arming is normal — stay silent there). Without this, a failed
+                # arm is invisible and "why won't it suspend/wake?" needs a box-dive.
+                self._log_scale_to_zero_not_armed_reason()
         except Exception:  # noqa: BLE001 - arming must never block startup
             logger.debug("scale-to-zero: arm check failed at startup", exc_info=True)
 

--- a/tests/gateway/test_scale_to_zero_watcher.py
+++ b/tests/gateway/test_scale_to_zero_watcher.py
@@ -149,3 +149,89 @@ def test_bg_work_false_when_quiet():
     r._background_tasks = set()
     # No background tasks, no active processes in this fresh process.
     assert r._scale_to_zero_has_live_background_work() is False
+
+
+# ── _scale_to_zero_should_arm: the CALL SITE feeds config.platforms (the F25 bug) ──
+#
+# config.platforms is pre-seeded with a DISABLED placeholder PlatformConfig for every
+# known platform, so list(config.platforms.keys()) is always the full ~20-entry catalog
+# regardless of what the instance runs. The arm check must filter to ENABLED platforms
+# (mirroring the connect loop) before asking messaging_is_relay_only_or_absent — passing
+# the bare placeholder keys made it see disabled `discord`/`telegram`/… as live direct
+# platforms and refuse to arm on a real relay-only instance. The pure-helper tests in
+# test_scale_to_zero.py pass bare names so they never exercised this call site.
+
+
+def _arm_runner(monkeypatch, platform_states, *, enabled=True, wake_url="https://wake.example"):
+    """Build a GatewayRunner stand-in whose config.platforms mirrors a real load:
+    `platform_states` is {Platform: enabled_bool}; everything runs the REAL
+    _scale_to_zero_should_arm. Only the env flag + wake_url resolution are stubbed."""
+    from types import SimpleNamespace
+
+    from gateway.config import PlatformConfig
+
+    r = GatewayRunner.__new__(GatewayRunner)
+    platforms = {p: PlatformConfig(enabled=en) for p, en in platform_states.items()}
+    r.config = SimpleNamespace(platforms=platforms)
+
+    monkeypatch.setattr("gateway.scale_to_zero.scale_to_zero_enabled", lambda *a, **k: enabled)
+    monkeypatch.setattr("gateway.relay.relay_wake_url", lambda: wake_url)
+    return r
+
+
+def test_arm_true_for_relay_only_with_disabled_placeholders(monkeypatch):
+    """The F25 regression test: relay ENABLED, every other platform present but
+    DISABLED (the real load_gateway_config() shape). Must arm — the disabled
+    placeholders must NOT count as live direct-socket platforms."""
+    from gateway.platforms.base import Platform
+
+    r = _arm_runner(
+        monkeypatch,
+        {
+            Platform.TELEGRAM: False,
+            Platform.DISCORD: False,
+            Platform.SLACK: False,
+            Platform.MATRIX: False,
+            Platform.RELAY: True,
+        },
+    )
+    assert r._scale_to_zero_should_arm() is True
+
+
+def test_no_arm_when_a_direct_platform_is_actually_enabled(monkeypatch):
+    """A genuinely-enabled direct-socket platform (real Discord token) DOES disarm —
+    the filter must not over-broaden to 'ignore everything but relay'."""
+    from gateway.platforms.base import Platform
+
+    r = _arm_runner(
+        monkeypatch,
+        {Platform.DISCORD: True, Platform.RELAY: True},
+    )
+    assert r._scale_to_zero_should_arm() is False
+
+
+def test_arm_when_no_platform_enabled_at_all(monkeypatch):
+    """Chronos-only / no-messaging agent (all placeholders disabled) can scale to zero."""
+    from gateway.platforms.base import Platform
+
+    r = _arm_runner(
+        monkeypatch,
+        {Platform.TELEGRAM: False, Platform.DISCORD: False},
+    )
+    assert r._scale_to_zero_should_arm() is True
+
+
+def test_no_arm_when_not_opted_in(monkeypatch):
+    """Relay-only but the Labs stamp is off ⇒ never arm (fail-safe default)."""
+    from gateway.platforms.base import Platform
+
+    r = _arm_runner(monkeypatch, {Platform.RELAY: True}, enabled=False)
+    assert r._scale_to_zero_should_arm() is False
+
+
+def test_no_arm_without_wake_url(monkeypatch):
+    """Relay-only + opted in but no registered wake URL ⇒ no arm (§3.4(1))."""
+    from gateway.platforms.base import Platform
+
+    r = _arm_runner(monkeypatch, {Platform.RELAY: True}, wake_url=None)
+    assert r._scale_to_zero_should_arm() is False


### PR DESCRIPTION
## Infographic

![scale-to-zero arm fix](https://v3b.fal.media/files/b/0a9fcbdf/70MLExRLxBVYfy1z5KPIW_3ehPYDqN.png)

## Summary

The scale-to-zero idle watcher **never armed** on a correctly-opted-in, relay-only instance, so the gateway never ran its idle decision, never called `go_dormant()`, and never sent `going_idle` to the connector. Fly's autostop still suspended the machine on traffic-idle, but because the connector never flipped the instance to **buffered-only**, an inbound DM took the live delivery path, found no live session for the suspended machine, and was dropped fail-closed **with no wake poke**. The machine slept and never woke.

## Root cause

`_scale_to_zero_should_arm()` passed `list(self.config.platforms.keys())` to `messaging_is_relay_only_or_absent()`. But `config.platforms` is pre-seeded with a **disabled placeholder `PlatformConfig` for every known platform** (telegram, discord, slack, matrix, …), so the key set is always the full ~20-entry catalog regardless of what the instance actually runs. The relay-only check discarded `"relay"`, saw the disabled placeholders as live direct-socket platforms, and returned `False` — so `should_arm()` was `False` and the watcher task was never created.

Verified live on a staging instance (`paradoxical-schooner-7460`):
- `config.platforms` keys = `[telegram, discord, slack, mattermost, matrix, relay]` — **only `relay` is `enabled=True`**, the rest are disabled placeholders.
- `should_arm()` evaluated to `False`; no `scale-to-zero: armed` line in the gateway log between `relay adapter registered` and `Press Ctrl+C to stop`.
- The full dead chain: no watcher → no `go_dormant()` → no `going_idle` → connector flip set (`gg:relay:buffered-only`) empty → DM live-path drop → no wake poke.

## Fix

Filter `config.platforms` to **enabled** entries before the relay-only check, mirroring the adapter-connect loop which already gates on `if not platform_config.enabled: continue`. This arms off the same notion of "active platform" the rest of `start()` already uses — no parallel concept introduced.

Also adds a one-line **not-armed diagnostic**: when an instance *is* opted in (the `HERMES_SCALE_TO_ZERO` stamp is set) but the watcher still doesn't arm, it now logs why (`relay_only_or_absent`, the enabled platforms, wake_url present/missing). A non-opted instance stays silent. Previously the arm path logged only on success, so a failed arm was invisible — this bug needed an on-box predicate eval to diagnose.

## Tests

The existing pure-helper tests (`test_scale_to_zero.py`) passed **bare platform names** to `messaging_is_relay_only_or_absent`, so they never exercised the call site that feeds the placeholder-laden config — which is exactly why the bug shipped green. New behaviour-contract tests in `test_scale_to_zero_watcher.py` drive the **real `_scale_to_zero_should_arm`** against a realistic `config.platforms`:

- `test_arm_true_for_relay_only_with_disabled_placeholders` — relay enabled + all others disabled placeholders **must arm** (the F25 regression; RED without this fix).
- `test_arm_when_no_platform_enabled_at_all` — Chronos-only / no-messaging agent arms (also RED without the fix).
- `test_no_arm_when_a_direct_platform_is_actually_enabled` — a genuinely-enabled Discord **does** disarm (the filter must not over-broaden).
- `test_no_arm_when_not_opted_in` / `test_no_arm_without_wake_url` — the other two arm preconditions still gate correctly.

RED-proven: with the call-site fix reverted, the two arm-positive tests fail; with it restored, all 51 scale-to-zero tests pass.

## Wake mechanism — verified healthy independently

The wakeUrl + Fly autostart path itself is fine: a direct wakeUrl GET resumed the suspended staging instance `suspended → started` in **1.15s** with a clean resume event signature (`proxy start/starting → flyd start/started`, not a cold create). That 1.15s is also the Phase-3 wake-latency measurement. The bug was purely that the gateway never set up the conditions for the connector to issue that poke.

## Scope

`gateway/` only — the scale-to-zero arm gate. Behavior-preserving for every non-opted instance (they never armed before and still don't; the filter only changes the relay-only opted-in case, which is the broken one).
