### PR TITLE
feat: add Volcengine Ark (火山引擎) as built-in provider

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1335,6 +1335,23 @@ def anthropic_prompt_cache_policy(
         if is_minimax_provider or is_minimax_host:
             return True, True
 
+    # Volcengine Ark (火山引擎) on its Anthropic-compatible /api/coding
+    # endpoint serves non-Claude model families (deepseek-v4, glm-5.2,
+    # doubao-seed, kimi-k2, minimax-m3), so the blanket is_claude gate above
+    # excludes them. Ark honors Anthropic cache_control on /api/coding and
+    # reports hits via cache_read_input_tokens. Opt these in explicitly via
+    # provider id or host so users get the same cost reduction as Claude
+    # traffic; without this branch Ark serves 0% cache hits and re-bills the
+    # full prompt + history on every turn, burning the subscription quota.
+    # Caching is per-model (empirically ~8/11 models, prefix-size thresholds
+    # ~4k–48k) and probabilistic — emitting markers is always safe; models
+    # that don't cache simply ignore them.
+    if is_anthropic_wire:
+        is_ark_provider = provider_lower in {"volcengine-ark", "ark", "volcengine"}
+        is_ark_host = base_url_host_matches(eff_base_url, "ark.cn-beijing.volces.com")
+        if is_ark_provider or is_ark_host:
+            return True, True
+
     # Qwen/Alibaba on OpenCode (Zen/Go) and native DashScope: OpenAI-wire
     # transport that accepts Anthropic-style cache_control markers and
     # rewards them with real cache hits.  Without this branch

--- a/plugins/model-providers/volcengine-ark/__init__.py
+++ b/plugins/model-providers/volcengine-ark/__init__.py
@@ -1,0 +1,85 @@
+"""Volcengine Ark (火山引擎) — ByteDance unified model platform.
+
+Ark is ByteDance's API gateway that gives access to models from multiple
+vendors (doubao-seed, deepseek-v4, glm-5.2, kimi-k2, minimax-m3) through
+a single API key.
+
+The platform provides two subscription plans:
+  - Agent Plan: General-purpose AI agent usage, AFP billing, multi-modal
+  - Coding Plan: Coding-focused, token quotas, AI coding tools only
+
+Both plans share the same Anthropic-compatible /api/coding endpoint.
+
+IMPORTANT — model list maintenance:
+  Ark's /models endpoint returns 124+ stale model IDs from the full
+  platform catalog, not the user's actual subscription. This provider
+  hardcodes the current Agent Plan text-generation model list and must
+  be updated when Ark adds/removes models.
+
+  Last updated: 2026-06-26 (11 models)
+"""
+
+import logging
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+logger = logging.getLogger(__name__)
+
+# ── Hardcoded model list (Agent Plan text generation, as of 2026-06-26) ──
+# Ark's auto-discovery returns 124 stale models. We hardcode the actual
+# working list to avoid confusion. Update when the provider's lineup changes.
+_ARK_MODELS = [
+    "deepseek-v4-flash",
+    "deepseek-v4-pro",
+    "glm-5.2",
+    "doubao-seed-2.0-pro",
+    "doubao-seed-2.0-lite",
+    "doubao-seed-2.0-mini",
+    "doubao-seed-2.0-code",
+    "kimi-k2.7-code",
+    "kimi-k2.6",
+    "minimax-m3",
+    "minimax-m2.7",
+]
+
+
+class VolcengineArkProfile(ProviderProfile):
+    """Volcengine Ark — hardcoded model list to avoid stale auto-discovery."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Return hardcoded model list.
+
+        We intentionally skip the API call because Ark's /models endpoint
+        returns 124+ stale model IDs from the full platform catalog rather
+        than the user's actual subscription.
+        """
+        return list(_ARK_MODELS)
+
+
+volcengine_ark = VolcengineArkProfile(
+    name="volcengine-ark",
+    aliases=(
+        "ark",
+        "volcengine",
+        "volcano",
+        "bytedance",
+    ),
+    display_name="Volcengine Ark (火山引擎)",
+    description="ByteDance model platform — doubao-seed, deepseek-v4, glm-5.2, kimi-k2, minimax",
+    signup_url="https://console.volcengine.com/ark/region:ark+cn-beijing/",
+    api_mode="anthropic_messages",
+    env_vars=("ARK_API_KEY",),
+    base_url="https://ark.cn-beijing.volces.com/api/coding",
+    auth_type="api_key",
+    default_aux_model="deepseek-v4-flash",
+)
+
+register_provider(volcengine_ark)

--- a/plugins/model-providers/volcengine-ark/__init__.py
+++ b/plugins/model-providers/volcengine-ark/__init__.py
@@ -30,18 +30,28 @@ logger = logging.getLogger(__name__)
 # ── Hardcoded model list (Agent Plan text generation, as of 2026-06-26) ──
 # Ark's auto-discovery returns 124 stale models. We hardcode the actual
 # working list to avoid confusion. Update when the provider's lineup changes.
+#
+# Prompt-caching on Ark's Anthropic /api/coding endpoint is per-model AND
+# prefix-size-dependent (the hit shows up as usage.cache_read_input_tokens).
+# Measured 2026-06-26 by sending an identical cached prefix twice per model
+# at sizes 4k..64k tokens. Two caveats worth knowing:
+#   - Each model has its own minimum cacheable prefix (4k..48k below).
+#   - Hits are probabilistic, not guaranteed (Ark routes implicitly; a
+#     supported model can miss on any given call). This diverges from
+#     Anthropic's deterministic cache_control guarantee.
+# So this is empirical and does NOT match Ark's /api/v3 implicit-cache docs.
 _ARK_MODELS = [
-    "deepseek-v4-flash",
-    "deepseek-v4-pro",
-    "glm-5.2",
-    "doubao-seed-2.0-pro",
-    "doubao-seed-2.0-lite",
-    "doubao-seed-2.0-mini",
-    "doubao-seed-2.0-code",
-    "kimi-k2.7-code",
-    "kimi-k2.6",
-    "minimax-m3",
-    "minimax-m2.7",
+    "deepseek-v4-flash",       # no cache (0 across 4k..64k)
+    "deepseek-v4-pro",         # caches >= ~4k
+    "glm-5.2",                 # caches >= ~4k
+    "doubao-seed-2.0-pro",     # caches only >= ~48k (high threshold)
+    "doubao-seed-2.0-lite",    # caches >= ~4k (flaky hit rate)
+    "doubao-seed-2.0-mini",    # caches >= ~8k
+    "doubao-seed-2.0-code",    # caches >= ~8k
+    "kimi-k2.7-code",          # caches >= ~4k
+    "kimi-k2.6",               # no cache (0 across 4k..64k)
+    "minimax-m3",              # caches >= ~4k
+    "minimax-m2.7",            # no cache (0 across 4k..64k)
 ]
 
 
@@ -79,7 +89,14 @@ volcengine_ark = VolcengineArkProfile(
     env_vars=("ARK_API_KEY",),
     base_url="https://ark.cn-beijing.volces.com/api/coding",
     auth_type="api_key",
-    default_aux_model="deepseek-v4-flash",
+    # Aux model runs high-frequency background tasks (titles, compression,
+    # etc.) where a cached system/context prefix pays off. deepseek-v4-flash
+    # is cheap but never caches on /api/coding (see _ARK_MODELS notes), so
+    # every aux call re-bills the full prefix. doubao-seed-2.0-lite is the
+    # cheapest model that DOES cache, and at the lowest prefix threshold
+    # (~4k) — the best cost pick for aux. Swap back to a non-caching model
+    # only if you specifically want flash's latency over cache savings.
+    default_aux_model="doubao-seed-2.0-lite",
 )
 
 register_provider(volcengine_ark)

--- a/plugins/model-providers/volcengine-ark/plugin.yaml
+++ b/plugins/model-providers/volcengine-ark/plugin.yaml
@@ -1,0 +1,5 @@
+name: volcengine-ark-provider
+kind: model-provider
+version: 1.0.0
+description: Volcengine Ark (火山引擎) — ByteDance unified model platform with doubao-seed, deepseek-v4, glm-5.2, kimi-k2, minimax-m3
+author: hermes-agent contributors

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -161,6 +161,56 @@ class TestMiniMaxAnthropicWire:
         assert agent._anthropic_prompt_cache_policy() == (False, False)
 
 
+class TestVolcengineArkAnthropicWire:
+    """Volcengine Ark (火山引擎) on its Anthropic-compatible /api/coding endpoint.
+
+    Ark serves non-Claude model families (deepseek-v4, glm-5.2, doubao-seed,
+    kimi-k2, minimax-m3), so the blanket ``is_claude`` gate on the
+    third-party-gateway branch excludes them — same shape as the MiniMax gap.
+    Ark honors cache_control on /api/coding (hits via
+    cache_read_input_tokens); allowlist it explicitly via provider id or host.
+    """
+
+    def test_ark_deepseek_on_provider_caches_native_layout(self):
+        agent = _make_agent(
+            provider="volcengine-ark",
+            base_url="https://ark.cn-beijing.volces.com/api/coding",
+            api_mode="anthropic_messages",
+            model="deepseek-v4-pro",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_ark_glm_on_short_alias_caches(self):
+        agent = _make_agent(
+            provider="ark",
+            base_url="https://ark.cn-beijing.volces.com/api/coding",
+            api_mode="anthropic_messages",
+            model="glm-5.2",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_custom_provider_pointed_at_ark_host_caches(self):
+        # Host match alone should be sufficient (e.g. custom:ark wiring).
+        agent = _make_agent(
+            provider="custom",
+            base_url="https://ark.cn-beijing.volces.com/api/coding",
+            api_mode="anthropic_messages",
+            model="doubao-seed-2.0-lite",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_ark_provider_on_openai_wire_does_not_cache(self):
+        # chat_completions transport — Ark's cache_control caching applies to
+        # the Anthropic /api/coding route. Stay off for OpenAI-wire.
+        agent = _make_agent(
+            provider="volcengine-ark",
+            base_url="https://ark.cn-beijing.volces.com/api/v3",
+            api_mode="chat_completions",
+            model="deepseek-v4-pro",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+
 class TestOpenAIWireFormatOnCustomProvider:
     """A custom provider using chat_completions (OpenAI wire) should NOT get caching."""
 


### PR DESCRIPTION
## Summary

Adds **Volcengine Ark (火山引擎)** — ByteDance's unified AI model platform — as a first-class built-in provider. Users can discover and configure it directly from Settings → Providers.

```
Settings → Providers → "Volcengine Ark (火山引擎)" → paste ARK_API_KEY → done
```

## What's included

- `plugins/model-providers/volcengine-ark/__init__.py` — `ProviderProfile` subclass + `plugin.yaml` manifest
  - Anthropic-compatible `/api/coding` endpoint via `api_mode="anthropic_messages"`
  - Overrides `fetch_models()` to return the maintained text-model list (11 models)
  - Aliases: `ark`, `volcengine`, `volcano`, `bytedance`
  - Display name includes Chinese (火山引擎) for discoverability
- `agent/agent_runtime_helpers.py` — prompt-caching enablement so adopting Ark gives **complete** support (routing + caching) in one change
  - Ark serves non-Claude model families, so the `is_claude` gate in `anthropic_prompt_cache_policy()` excluded it → 0% cache hits, re-billing the full prefix every turn
  - Adds an explicit Ark allowlist branch (provider id / host) returning native Anthropic layout — same class and fix as MiniMax's #17332
  - Covered by `TestVolcengineArkAnthropicWire` (4 cases) in `tests/run_agent/test_anthropic_prompt_cache_policy.py`

## Validated end-to-end (real measurements, not just code)

I ran this against a live Ark subscription through the actual Hermes CLI, not only as a unit. Sharing the results because they're useful feedback on Ark's behavior regardless of whether this exact PR lands.

**Discovery + registration:** loaded under Hermes' runtime, the provider is discovered as `volcengine-ark`, `VolcengineArkProfile` instantiates with the right fields, and `fetch_models()` returns the 11 hardcoded models. ✅

**Prompt caching — measured per model.** Ark's `/api/coding` endpoint speaks the Anthropic Messages protocol, so I sent an identical `cache_control`-marked prefix twice per model and read `usage.cache_read_input_tokens`, sweeping prefix sizes 4k→64k tokens (2026-06-26):

| Model | Caching on `/api/coding` |
|---|---|
| `deepseek-v4-pro` | ✅ caches ≥ ~4k |
| `glm-5.2` | ✅ caches ≥ ~4k |
| `doubao-seed-2.0-lite` | ✅ caches ≥ ~4k (flaky hit rate) |
| `kimi-k2.7-code` | ✅ caches ≥ ~4k |
| `minimax-m3` | ✅ caches ≥ ~4k |
| `doubao-seed-2.0-mini` | ✅ caches ≥ ~8k |
| `doubao-seed-2.0-code` | ✅ caches ≥ ~8k |
| `doubao-seed-2.0-pro` | ✅ caches ≥ ~48k (high threshold) |
| `deepseek-v4-flash` | ❌ no cache (0 across 4k–64k) |
| `kimi-k2.6` | ❌ no cache (0 across 4k–64k) |
| `minimax-m2.7` | ❌ no cache (0 across 4k–64k) |

Two findings worth knowing:
- **Caching is per-model and prefix-size-dependent** (per-model minimum 4k–48k tokens) — 8/11 cache, 3 never did across 12 samples each.
- **Hits are probabilistic, not deterministic.** A supported model can miss on any given call; `doubao-seed-2.0-lite` returned 0 at one size and cached at others. This matches Ark's own docs (隐式缓存「不保证命中,分布式路由影响命中概率」) and **diverges from Anthropic's deterministic `cache_control` guarantee** — worth flagging for anyone relying on cache behavior here. Note this is Ark's `/api/coding` surface; Ark also has separate `/api/v3` implicit and `/api/v3/context` explicit caching with different model support.

**Aux model:** `default_aux_model` was `deepseek-v4-flash`, which never caches — so high-frequency background tasks (titles, compression) re-bill the full prefix every call. Switched to `doubao-seed-2.0-lite`, the cheapest model that caches and at the lowest prefix threshold.

**This PR wires the emission**, not just measures it: the `anthropic_prompt_cache_policy()` Ark branch (see "What's included") makes Hermes actually send the `cache_control` markers. Without it Ark's non-Claude models hit the `is_claude` gate and get 0% caching even when routed correctly.

## Prerequisite: resolver fix in #53055 (separate PR)

In the interest of honest feedback: as a pure 2-file plugin this provider **404s at runtime** without a one-time framework fix, which is now in its own PR — **#53055** (issue **#53054**). Root cause is a real gap in the runtime resolver, not in this plugin:

- `_resolve_runtime_from_pool_entry` (`hermes_cli/runtime_provider.py`) derives `api_mode` for a selected provider from config or from `_detect_api_mode_for_url(base_url)`. The `ProviderProfile.api_mode` declared by a plugin is **dropped at the bridge** — `ProviderConfig` (`hermes_cli/auth.py`) had no `api_mode` field.
- `_detect_api_mode_for_url` recognizes `anthropic_messages` only for `/anthropic` paths and `api.kimi.com` + `/coding`. Ark's `ark.cn-beijing.volces.com` + `/api/coding` matches neither, so it silently falls back to `chat_completions` → posts OpenAI-style `/chat/completions` to Ark's Anthropic-only endpoint → nginx 404.

Note this is **not** "the first `anthropic_messages` plugin" — MiniMax is one too. MiniMax only avoids the bug by coincidence: its `base_url` ends in `/anthropic`, so the URL heuristic re-derives the right mode and its declared `api_mode` field is never actually read. Ark's `/api/coding` endpoint isn't URL-self-describing, so it's the first to expose that the declaration is dropped. #53055 makes the declaration authoritative for any such plugin (additive, non-regressing, with tests). **This provider PR depends on #53055.**

## Design decisions

1. **`anthropic_messages` protocol** — Ark's `/api/coding` endpoint speaks the Anthropic Messages API and supports prompt caching (validated above); the OpenAI-protocol path on Ark exposes the Responses API, which Hermes doesn't use. A `ProviderProfile` declares a single `api_mode`, so we default to the one that gives Hermes caching.
2. **One unified subscription** — Ark's Agent Plan and Coding Plan share the same `base_url`, API key, protocol, and model IDs; they differ only in Volcengine-side billing/quota, which the client can't and shouldn't detect. So this is a single provider entry rather than two near-identical profiles (unlike `alibaba` vs `alibaba-coding-plan`, which hit *different* endpoints).
3. **Hardcoded model list** — Ark's `/models` endpoint returns a large stale catalog rather than the user's active models, so `fetch_models()` is overridden to return the current maintained list (update when Ark's lineup changes).
4. **Minimal core footprint** — the provider itself is pure plugin (no `tips.py` or unrelated edits). The required `api_mode` resolver wiring lives in its own PR (#53055), not here, so this PR stays a self-contained plugin.

## Relation to prior attempts

Volcengine Ark has been requested repeatedly and attempted several times, but no prior PR has landed. This one differs by being the only **single-focus** implementation built on the current **pluggable `plugins/model-providers/`** architecture (which postdates those PRs):

- **#8952** (Apr 2026) — *add Volcengine and BytePlus support*: ~600 LOC editing core (`hermes_cli/auth.py`, `main.py`, `gateway/run.py`, `model_metadata.py`); predates the pluggable-provider refactor; bundles BytePlus.
- **#14070** — *add Volcengine and BytePlus support*: same bundled, pre-plugin approach.
- **#32549** (May 2026) — *Add Volcengine and BytePlus providers*: ~800 LOC editing `hermes_cli/` core (`ark_providers.py`, `model_setup_flows.py`, `providers.py`); does not use the `plugins/model-providers/` mechanism; bundles BytePlus.

By contrast this PR is a self-contained `ProviderProfile` plugin (2 files) scoped to Volcengine Ark only, plus the small resolver wiring noted above. Happy to consolidate the older PRs into this one if maintainers prefer.

## Related issues

- Closes #29331 — feat: add Volcengine (火山引擎) as built-in provider
- Closes #40195 — Feature Request: Add official ByteDance / BytePlus ModelArk provider
- Closes #51319 — Feature Request: 新增豆包 (Doubao/Volcano Engine) 作为原生 Provider

