### PR TITLE
feat: add Devin ACP provider support

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -377,8 +377,8 @@ def init_agent(
     if (
         api_mode is None
         and agent.api_mode == "chat_completions"
-        and agent.provider != "copilot-acp"
-        and not str(agent.base_url or "").lower().startswith("acp://copilot")
+        and agent.provider not in {"copilot-acp", "devin-acp"}
+        and not str(agent.base_url or "").lower().startswith("acp://")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
         and not agent._is_azure_openai_url()
         and (
@@ -743,7 +743,7 @@ def init_agent(
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
             if _provider_timeout is not None:
                 client_kwargs["timeout"] = _provider_timeout
-            if agent.provider == "copilot-acp":
+            if agent.provider in {"copilot-acp", "devin-acp"}:
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
             effective_base = base_url

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1351,7 +1351,7 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     client_kwargs = dict(client_kwargs)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
-    if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
+    if agent.provider in {"copilot-acp", "devin-acp"} or str(client_kwargs.get("base_url", "")).startswith("acp://"):
         from agent.copilot_acp_client import CopilotACPClient
 
         client = CopilotACPClient(**client_kwargs)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3902,37 +3902,33 @@ def resolve_provider_client(
             or _read_main_model(),
             provider,
         )
-        if provider == "copilot-acp":
-            api_key = str(creds.get("api_key", "")).strip()
-            base_url = str(creds.get("base_url", "")).strip()
-            command = str(creds.get("command", "")).strip() or None
-            args = list(creds.get("args") or [])
-            if not final_model:
-                logger.warning(
-                    "resolve_provider_client: copilot-acp requested but no model "
-                    "was provided or configured"
-                )
-                return None, None
-            if not api_key or not base_url:
-                logger.warning(
-                    "resolve_provider_client: copilot-acp requested but external "
-                    "process credentials are incomplete"
-                )
-                return None, None
-            from agent.copilot_acp_client import CopilotACPClient
-
-            client = CopilotACPClient(
-                api_key=api_key,
-                base_url=base_url,
-                command=command,
-                args=args,
+        if not final_model:
+            logger.warning(
+                "resolve_provider_client: %s requested but no model was provided or configured",
+                provider,
             )
-            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
-            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
-                    else (client, final_model))
-        logger.warning("resolve_provider_client: external-process provider %s not "
-                       "directly supported", provider)
-        return None, None
+            return None, None
+        api_key = str(creds.get("api_key", "")).strip()
+        base_url = str(creds.get("base_url", "")).strip()
+        command = str(creds.get("command", "")).strip() or None
+        args = list(creds.get("args") or [])
+        if not api_key or not base_url:
+            logger.warning(
+                "resolve_provider_client: %s requested but external process credentials are incomplete",
+                provider,
+            )
+            return None, None
+        from agent.copilot_acp_client import CopilotACPClient
+
+        client = CopilotACPClient(
+            api_key=api_key,
+            base_url=base_url,
+            command=command,
+            args=args,
+        )
+        logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                else (client, final_model))
 
     elif pconfig.auth_type == "aws_sdk":
         # AWS SDK providers (Bedrock) — use the Anthropic Bedrock client via

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -992,8 +992,9 @@ def run_conversation(
                 # stream.  Mirror the ACP exclusion used for Responses
                 # API upgrade (lines ~1083-1085).
                 elif (
-                    agent.provider == "copilot-acp"
-                    or str(agent.base_url or "").lower().startswith("acp://copilot")
+                    agent.provider in {"copilot-acp", "devin-acp"}
+                    or str(agent.base_url or "").lower().startswith("acp://")
+                    or str(agent.base_url or "").lower().startswith("acp://devin")
                     or str(agent.base_url or "").lower().startswith("acp+tcp://")
                 ):
                     _use_streaming = False

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -45,7 +45,7 @@ def _resolve_requests_verify() -> bool | str:
 # Only these are stripped — Ollama-style "model:tag" colons (e.g. "qwen3.5:27b")
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
-    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp", "devin-acp",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "kilocode", "alibaba", "novita",
     "qwen-oauth",
@@ -1760,7 +1760,7 @@ def get_model_context_length(
     # This catches account-specific models (e.g. claude-opus-4.6-1m) that
     # don't exist in models.dev. For models that ARE in models.dev, this
     # returns the provider-enforced limit which is what users can actually use.
-    if effective_provider in {"copilot", "copilot-acp", "github-copilot"}:
+    if effective_provider in {"copilot", "copilot-acp", "devin-acp", "github-copilot"}:
         try:
             from hermes_cli.models import get_copilot_model_context
             ctx = get_copilot_model_context(model, api_key=api_key)

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -17,7 +17,7 @@ The active provider is chosen by configuration with this precedence:
 3. If exactly one capability-eligible provider is registered AND available,
    use it.
 4. Legacy preference order — ``firecrawl`` → ``parallel`` → ``tavily`` →
-   ``exa`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
+   ``exa`` → ``native`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
    availability. Matches the historic ``tools.web_tools._get_backend()``
    candidate order so installs that never set a config key keep landing
    on the same provider they did before the plugin migration.
@@ -117,13 +117,14 @@ def _read_config_key(*path: str) -> Optional[str]:
 # ``web.backend`` / ``web.<capability>_backend`` config key at all. Matches
 # the historic candidate order in :func:`tools.web_tools._get_backend`
 # (paid providers first so existing paid setups don't get downgraded to
-# a free tier on upgrade). Filtered by ``is_available()`` at walk time so
+# a local/free tier on upgrade). Filtered by ``is_available()`` at walk time so
 # we don't surface a provider the user has no credentials for.
 _LEGACY_PREFERENCE = (
     "firecrawl",
     "parallel",
     "tavily",
     "exa",
+    "native",
     "searxng",
     "brave-free",
     "ddgs",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -228,6 +228,27 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+        extra={
+            "command_env_vars": ("HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH"),
+            "default_command": "copilot",
+            "args_env_var": "HERMES_COPILOT_ACP_ARGS",
+            "default_args": ["--acp", "--stdio"],
+            "api_key_placeholder": "copilot-acp",
+        },
+    ),
+    "devin-acp": ProviderConfig(
+        id="devin-acp",
+        name="Devin ACP",
+        auth_type="external_process",
+        inference_base_url="acp://devin",
+        base_url_env_var="DEVIN_ACP_BASE_URL",
+        extra={
+            "command_env_vars": ("HERMES_DEVIN_ACP_COMMAND", "DEVIN_CLI_PATH"),
+            "default_command": "devin",
+            "args_env_var": "HERMES_DEVIN_ACP_ARGS",
+            "default_args": ["acp"],
+            "api_key_placeholder": "devin-acp",
+        },
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -5871,33 +5892,64 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     }
 
 
+def _resolve_external_process_command(pconfig: ProviderConfig) -> str:
+    extra = pconfig.extra if isinstance(pconfig.extra, dict) else {}
+    for env_name in extra.get("command_env_vars", ()):  # type: ignore[arg-type]
+        command = os.getenv(str(env_name), "").strip()
+        if command:
+            return command
+    default_command = str(extra.get("default_command") or "").strip()
+    if default_command:
+        return default_command
+    if pconfig.id == "copilot-acp":
+        return "copilot"
+    if pconfig.id == "devin-acp":
+        return "devin"
+    return ""
+
+
+def _resolve_external_process_args(pconfig: ProviderConfig) -> list[str]:
+    extra = pconfig.extra if isinstance(pconfig.extra, dict) else {}
+    args_env_var = str(extra.get("args_env_var") or "").strip()
+    raw_args = os.getenv(args_env_var, "").strip() if args_env_var else ""
+    if raw_args:
+        return shlex.split(raw_args)
+    default_args = extra.get("default_args")
+    if isinstance(default_args, (list, tuple)) and default_args:
+        return [str(arg) for arg in default_args]
+    if pconfig.id == "copilot-acp":
+        return ["--acp", "--stdio"]
+    if pconfig.id == "devin-acp":
+        return ["acp"]
+    return []
+
+
+def _resolve_external_process_base_url(pconfig: ProviderConfig) -> str:
+    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    return base_url or pconfig.inference_base_url
+
+
 def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for providers that run a local subprocess."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
-    if not base_url:
-        base_url = pconfig.inference_base_url
+    command = _resolve_external_process_command(pconfig)
+    args = _resolve_external_process_args(pconfig)
+    base_url = _resolve_external_process_base_url(pconfig)
 
     resolved_command = shutil.which(command) if command else None
+    configured = bool(resolved_command or base_url.startswith("acp+tcp://") or base_url.startswith("acp://"))
     return {
-        "configured": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "configured": configured,
         "provider": provider_id,
         "name": pconfig.name,
         "command": command,
         "args": args,
         "resolved_command": resolved_command,
         "base_url": base_url,
-        "logged_in": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "logged_in": configured,
     }
 
 
@@ -5920,7 +5972,8 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_gemini_oauth_auth_status()
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
-    if target == "copilot-acp":
+    pconfig = PROVIDER_REGISTRY.get(target)
+    if pconfig and pconfig.auth_type == "external_process":
         return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
@@ -6070,29 +6123,30 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             code="invalid_provider",
         )
 
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
-    if not base_url:
-        base_url = pconfig.inference_base_url
+    base_url = _resolve_external_process_base_url(pconfig)
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    command = _resolve_external_process_command(pconfig)
+    args = _resolve_external_process_args(pconfig)
     resolved_command = shutil.which(command) if command else None
-    if not resolved_command and not base_url.startswith("acp+tcp://"):
+    if not resolved_command and not base_url.startswith("acp+tcp://") and not base_url.startswith("acp://"):
+        missing_name = {
+            "copilot-acp": "GitHub Copilot CLI",
+            "devin-acp": "Devin CLI",
+        }.get(provider_id, command or provider_id)
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            f"Could not find the {missing_name} command '{command}'. "
+            f"Install {missing_name} or set the provider-specific command env vars.",
             provider=provider_id,
-            code="missing_copilot_cli",
+            code="missing_external_process_command",
         )
+
+    api_key_placeholder = "copilot-acp"
+    if isinstance(pconfig.extra, dict):
+        api_key_placeholder = str(pconfig.extra.get("api_key_placeholder") or api_key_placeholder).strip() or api_key_placeholder
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": api_key_placeholder,
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -551,6 +551,7 @@ from hermes_cli.model_setup_flows import (
     _model_flow_named_custom,
     _model_flow_copilot,
     _model_flow_copilot_acp,
+    _model_flow_devin_acp,
     _model_flow_kimi,
     _model_flow_stepfun,
     _model_flow_bedrock_api_key,
@@ -2949,6 +2950,8 @@ def select_provider_and_model(args=None):
         _model_flow_google_gemini_cli(config, current_model)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "devin-acp":
+        _model_flow_devin_acp(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -79,6 +79,7 @@ _DOT_TO_HYPHEN_PROVIDERS: frozenset[str] = frozenset({
 _STRIP_VENDOR_ONLY_PROVIDERS: frozenset[str] = frozenset({
     "copilot",
     "copilot-acp",
+    "devin-acp",
     "openai-codex",
 })
 
@@ -422,7 +423,7 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
     #     and live-catalog lookups.  Without this, vendor-prefixed or
     #     dash-notation Claude IDs survive to the Copilot API and hit
     #     HTTP 400 "model_not_supported".  See issue #6879.
-    if provider in {"copilot", "copilot-acp"}:
+    if provider in {"copilot", "copilot-acp", "devin-acp"}:
         try:
             from hermes_cli.models import normalize_copilot_model_id
 

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1797,6 +1797,66 @@ def _model_flow_copilot_acp(config, current_model=""):
 
     print(f"Default model set to: {selected} (via {pconfig.name})")
 
+
+def _model_flow_devin_acp(config, current_model=""):
+    """Devin ACP flow using the local Devin CLI."""
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        deactivate_provider,
+        get_external_process_provider_status,
+        resolve_external_process_provider_credentials,
+    )
+    from hermes_cli.config import load_config, save_config
+
+    del config
+
+    provider_id = "devin-acp"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+
+    status = get_external_process_provider_status(provider_id)
+    resolved_command = status.get("resolved_command") or status.get("command") or "devin"
+    effective_base = status.get("base_url") or pconfig.inference_base_url
+
+    print("  Devin ACP delegates Hermes turns to `devin acp`.")
+    print("  Hermes will launch Devin as an external ACP subprocess for each request.")
+    print(f"  Command: {resolved_command}")
+    print(f"  Backend marker: {effective_base}")
+    print()
+
+    try:
+        creds = resolve_external_process_provider_credentials(provider_id)
+    except Exception as exc:
+        print(f"  ⚠ {exc}")
+        print(
+            "  Set HERMES_DEVIN_ACP_COMMAND or DEVIN_CLI_PATH if Devin CLI is installed elsewhere."
+        )
+        return
+
+    effective_base = creds.get("base_url") or effective_base
+    selected = (current_model or "").strip() or "devin-acp"
+    try:
+        answer = input(f"Model name [{selected}]: ").strip()
+        if answer:
+            selected = answer
+    except (KeyboardInterrupt, EOFError):
+        print("No change.")
+        return
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = effective_base
+    model["api_mode"] = "chat_completions"
+    model["default"] = selected
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via {pconfig.name})")
+
+
 def _model_flow_kimi(config, current_model=""):
     """Kimi / Moonshot model selection with automatic endpoint routing.
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1525,7 +1525,7 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        if hermes_slug in {"openai-codex", "copilot", "copilot-acp"}:
+        if hermes_slug in {"openai-codex", "copilot", "copilot-acp", "devin-acp"}:
             # Use live OAuth-backed discovery so the gateway /model picker
             # matches what the user's authenticated Codex/Copilot backend
             # actually serves — including ChatGPT-Pro-only Codex slugs

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -220,6 +220,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "devin-acp": [
+        "devin-acp",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -2178,14 +2181,14 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         return get_codex_model_ids(access_token=access_token)
     if normalized == "xai-oauth":
         return list(_PROVIDER_MODELS.get("xai-oauth", _PROVIDER_MODELS.get("xai", [])))
-    if normalized in {"copilot", "copilot-acp"}:
+    if normalized in {"copilot", "copilot-acp", "devin-acp"}:
         try:
             live = _fetch_github_models(_resolve_copilot_catalog_api_key())
             if live:
                 return live
         except Exception:
             pass
-        if normalized == "copilot-acp":
+        if normalized in {"copilot-acp", "devin-acp"}:
             return list(_PROVIDER_MODELS.get("copilot", []))
     if normalized == "nous":
         # Try live Nous Portal /models endpoint

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -94,6 +94,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "devin-acp": HermesOverlay(
+        transport="codex_responses",
+        auth_type="external_process",
+        base_url_override="acp://devin",
+        base_url_env_var="DEVIN_ACP_BASE_URL",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -284,7 +290,8 @@ ALIASES: Dict[str, str] = {
     "copilot": "github-copilot",
     "github": "github-copilot",
     "github-copilot-acp": "copilot-acp",
-
+    "devin": "devin-acp",
+    "openrouter": "openrouter",
     # opencode (models.dev ID for OpenCode Zen)
     "opencode-zen": "opencode",
     "zen": "opencode",
@@ -368,6 +375,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "devin-acp": "Devin ACP",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1555,10 +1555,10 @@ def resolve_runtime_provider(
             logger.info("Google Gemini OAuth credentials failed; "
                         "falling through to next provider.")
 
-    if provider == "copilot-acp":
+    if provider in {"copilot-acp", "devin-acp"}:
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -74,6 +74,9 @@ _DEFAULT_PROVIDER_MODELS = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "devin-acp": [
+        "devin-acp",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",

--- a/plugins/model-providers/devin-acp/__init__.py
+++ b/plugins/model-providers/devin-acp/__init__.py
@@ -1,0 +1,34 @@
+"""Devin ACP provider profile.
+
+Devin ACP uses an external ACP subprocess — not the standard REST/OpenAI
+transport. The profile captures the registry metadata so Hermes can treat it as
+an external-process backend.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class DevinACPProfile(ProviderProfile):
+    """Devin ACP — external process, no REST models endpoint."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Model listing is handled by the ACP subprocess."""
+        return None
+
+
+devin_acp = DevinACPProfile(
+    name="devin-acp",
+    aliases=("devin", "devin-acp-agent"),
+    api_mode="chat_completions",
+    env_vars=(),
+    base_url="acp://devin",
+    auth_type="external_process",
+)
+
+register_provider(devin_acp)

--- a/plugins/model-providers/devin-acp/plugin.yaml
+++ b/plugins/model-providers/devin-acp/plugin.yaml
@@ -1,0 +1,5 @@
+name: devin-acp-provider
+kind: model-provider
+version: 1.0.0
+description: Devin via ACP subprocess
+author: Nous Research

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -959,7 +959,8 @@ class DiscordAdapter(BasePlatformAdapter):
                         if _parent_id:
                             _channel_ids.add(_parent_id)
                         if "*" not in _free_channels and not (_channel_ids & _free_channels):
-                            return
+                            if adapter_self._discord_require_mention_for(message.channel):
+                                return
 
                 await self._handle_message(message, role_authorized=_role_authorized)
 
@@ -3983,10 +3984,96 @@ class DiscordAdapter(BasePlatformAdapter):
         """Return whether Discord channel messages require a bot mention."""
         configured = self.config.extra.get("require_mention")
         if configured is not None:
-            if isinstance(configured, str):
-                return configured.lower() not in {"false", "0", "no", "off"}
-            return bool(configured)
+            return self._discord_bool(configured, default=True)
         return os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in {"false", "0", "no", "off"}
+
+    @staticmethod
+    def _discord_bool(value: Any, *, default: bool) -> bool:
+        if value is None:
+            return default
+        if isinstance(value, str):
+            stripped = value.strip().lower()
+            if stripped in {"true", "1", "yes", "on"}:
+                return True
+            if stripped in {"false", "0", "no", "off"}:
+                return False
+            return default
+        return bool(value)
+
+    def _discord_scope_ids(self, channel: Any) -> tuple[list[str], str | None, str | None]:
+        """Return channel candidates, category id, and guild id for scoped config.
+
+        Channel candidates are ordered most-specific first.  For a thread this
+        means the thread id, then its parent channel id.  Category and guild
+        scope then follow in the caller, giving channel > category > guild
+        precedence.
+        """
+        channel_ids: list[str] = []
+        channel_id = str(getattr(channel, "id", "") or "")
+        if channel_id:
+            channel_ids.append(channel_id)
+
+        parent = getattr(channel, "parent", None)
+        parent_id = str(getattr(channel, "parent_id", "") or "") or str(getattr(parent, "id", "") or "")
+        if parent_id and parent_id not in channel_ids:
+            channel_ids.append(parent_id)
+
+        category = getattr(channel, "category", None)
+        category_id = (
+            str(getattr(channel, "category_id", "") or "")
+            or str(getattr(category, "id", "") or "")
+        )
+        if not category_id and parent is not None:
+            parent_category = getattr(parent, "category", None)
+            category_id = (
+                str(getattr(parent, "category_id", "") or "")
+                or str(getattr(parent_category, "id", "") or "")
+                or str(getattr(parent, "parent_id", "") or "")
+            )
+
+        guild = getattr(channel, "guild", None) or getattr(parent, "guild", None)
+        guild_id = str(getattr(guild, "id", "") or "")
+        return channel_ids, category_id or None, guild_id or None
+
+    def _discord_scoped_bool_value(
+        self,
+        key: str,
+        channel: Any,
+    ) -> bool | None:
+        """Resolve a bool from channel_defaults > category_defaults > guild_defaults."""
+        channel_ids, category_id, guild_id = self._discord_scope_ids(channel)
+        scopes = (
+            ("channel_defaults", channel_ids),
+            ("category_defaults", [category_id] if category_id else []),
+            ("guild_defaults", [guild_id] if guild_id else []),
+        )
+        for scope_name, ids in scopes:
+            scope_cfg = self.config.extra.get(scope_name)
+            if not isinstance(scope_cfg, dict):
+                continue
+            for scope_id in ids:
+                raw = scope_cfg.get(str(scope_id))
+                if not isinstance(raw, dict) or key not in raw:
+                    continue
+                return self._discord_bool(raw.get(key), default=False)
+        return None
+
+    def _discord_scoped_bool(
+        self,
+        key: str,
+        channel: Any,
+        *,
+        default: bool,
+    ) -> bool:
+        scoped = self._discord_scoped_bool_value(key, channel)
+        return default if scoped is None else scoped
+
+    def _discord_require_mention_for(self, channel: Any) -> bool:
+        return self._discord_scoped_bool(
+            "require_mention",
+            channel,
+            default=self._discord_require_mention(),
+        )
 
     def _discord_allow_any_attachment(self) -> bool:
         """Return whether Discord attachments bypass the SUPPORTED_DOCUMENT_TYPES allowlist.
@@ -4082,6 +4169,14 @@ class DiscordAdapter(BasePlatformAdapter):
         if s:
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
+
+    def _discord_thread_response_for(self, channel: Any, channel_ids: set[str]) -> bool:
+        """Return whether a message in ``channel`` should auto-thread its reply."""
+        scoped = self._discord_scoped_bool_value("thread_response", channel)
+        if scoped is not None:
+            return scoped
+        thread_response_channels = self._discord_thread_response_channels()
+        return "*" in thread_response_channels or bool(channel_ids & thread_response_channels)
 
     def _discord_thread_require_mention(self) -> bool:
         """Return whether thread participation requires @mention to follow up.
@@ -4944,7 +5039,8 @@ class DiscordAdapter(BasePlatformAdapter):
             if parent_channel_id:
                 channel_ids.add(parent_channel_id)
 
-            require_mention = self._discord_require_mention()
+            scoped_require_mention = self._discord_scoped_bool_value("require_mention", message.channel)
+            require_mention = self._discord_require_mention_for(message.channel)
             # Voice-linked text channels act as free-response while voice is active.
             # Only the exact bound channel gets the exemption, not sibling threads.
             voice_linked_ids = {str(ch_id) for ch_id in self._voice_text_channels.values()}
@@ -4954,6 +5050,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 "*" in free_channels
                 or bool(channel_ids & free_channels)
                 or is_voice_linked_channel
+                or scoped_require_mention is False
             )
 
             # Skip the mention check if the message is in a thread where
@@ -4978,8 +5075,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            thread_response_channels = self._discord_thread_response_channels()
-            force_thread = "*" in thread_response_channels or bool(channel_ids & thread_response_channels)
+            force_thread = self._discord_thread_response_for(message.channel, channel_ids)
             skip_thread = bool(channel_ids & no_thread_channels) or (is_free_channel and not force_thread)
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
@@ -6643,9 +6739,15 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
 
     Env vars take precedence over YAML — every assignment is guarded by
     ``not os.getenv(...)`` so explicit env vars survive a config.yaml
-    update.  Returns ``None`` because no extras are seeded into
-    ``PlatformConfig.extra`` directly (everything flows through env).
+    update.  Scoped defaults are returned as ``PlatformConfig.extra`` because
+    they need per-message channel/category/guild context.
     """
+    returned_extra: dict[str, Any] = {}
+    for scoped_key in ("channel_defaults", "category_defaults", "guild_defaults"):
+        scoped_cfg = discord_cfg.get(scoped_key)
+        if isinstance(scoped_cfg, dict):
+            returned_extra[scoped_key] = scoped_cfg
+
     if "require_mention" in discord_cfg and not os.getenv("DISCORD_REQUIRE_MENTION"):
         os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
     if "thread_require_mention" in discord_cfg and not os.getenv("DISCORD_THREAD_REQUIRE_MENTION"):
@@ -6730,7 +6832,7 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     if _discord_rtm is not None and not os.getenv("DISCORD_REPLY_TO_MODE"):
         _rtm_str = "off" if _discord_rtm is False else str(_discord_rtm).lower()
         os.environ["DISCORD_REPLY_TO_MODE"] = _rtm_str
-    return None  # all settings flow through env; nothing to merge into extras
+    return returned_extra or None
 
 
 def _is_connected(config) -> bool:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4066,6 +4066,23 @@ class DiscordAdapter(BasePlatformAdapter):
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
 
+    def _discord_thread_response_channels(self) -> set:
+        """Return Discord channel IDs where channel messages should create threads.
+
+        This can overlap with ``free_response_channels``.  In that case the bot
+        accepts mention-less messages in the channel, then creates/reuses a
+        thread for the response instead of replying directly in the channel.
+        """
+        raw = self.config.extra.get("thread_response_channels")
+        if raw is None:
+            raw = os.getenv("DISCORD_THREAD_RESPONSE_CHANNELS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        s = str(raw).strip() if raw is not None else ""
+        if s:
+            return {part.strip() for part in s.split(",") if part.strip()}
+        return set()
+
     def _discord_thread_require_mention(self) -> bool:
         """Return whether thread participation requires @mention to follow up.
 
@@ -4961,7 +4978,9 @@ class DiscordAdapter(BasePlatformAdapter):
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
+            thread_response_channels = self._discord_thread_response_channels()
+            force_thread = "*" in thread_response_channels or bool(channel_ids & thread_response_channels)
+            skip_thread = bool(channel_ids & no_thread_channels) or (is_free_channel and not force_thread)
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
@@ -6615,7 +6634,8 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     ``DISCORD_IGNORED_CHANNELS``, ``DISCORD_ALLOWED_CHANNELS``,
     ``DISCORD_NO_THREAD_CHANNELS``, ``DISCORD_HISTORY_BACKFILL``,
     ``DISCORD_HISTORY_BACKFILL_LIMIT``, ``DISCORD_ALLOW_MENTION_*``,
-    ``DISCORD_REPLY_TO_MODE``, ``DISCORD_THREAD_REQUIRE_MENTION``).
+    ``DISCORD_REPLY_TO_MODE``, ``DISCORD_THREAD_REQUIRE_MENTION``,
+    ``DISCORD_THREAD_RESPONSE_CHANNELS``).
     Rather than rewrite ~50 call sites inside the adapter to read from
     ``PlatformConfig.extra`` instead, this hook keeps the existing
     env-driven model and merely owns the YAML→env translation here, next to
@@ -6651,6 +6671,11 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         if isinstance(frc, list):
             frc = ",".join(str(v) for v in frc)
         os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
+    trc = discord_cfg.get("thread_response_channels")
+    if trc is not None and not os.getenv("DISCORD_THREAD_RESPONSE_CHANNELS"):
+        if isinstance(trc, list):
+            trc = ",".join(str(v) for v in trc)
+        os.environ["DISCORD_THREAD_RESPONSE_CHANNELS"] = str(trc)
     if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
         os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
     if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):

--- a/plugins/web/brave_free/provider.py
+++ b/plugins/web/brave_free/provider.py
@@ -15,6 +15,7 @@ Config keys this provider responds to::
 Auth env var::
 
     BRAVE_SEARCH_API_KEY=...    # https://brave.com/search/api/ (free tier)
+    BRAVE_API_KEY=...           # accepted as a legacy alias
 """
 
 from __future__ import annotations
@@ -49,7 +50,10 @@ class BraveFreeWebSearchProvider(WebSearchProvider):
 
     def is_available(self) -> bool:
         """Return True when ``BRAVE_SEARCH_API_KEY`` is set to a non-empty value."""
-        return bool(os.getenv("BRAVE_SEARCH_API_KEY", "").strip())
+        return bool(
+            os.getenv("BRAVE_SEARCH_API_KEY", "").strip()
+            or os.getenv("BRAVE_API_KEY", "").strip()
+        )
 
     def supports_search(self) -> bool:
         return True
@@ -65,7 +69,10 @@ class BraveFreeWebSearchProvider(WebSearchProvider):
         """
         import httpx
 
-        api_key = os.getenv("BRAVE_SEARCH_API_KEY", "").strip()
+        api_key = (
+            os.getenv("BRAVE_SEARCH_API_KEY", "").strip()
+            or os.getenv("BRAVE_API_KEY", "").strip()
+        )
         if not api_key:
             return {"success": False, "error": "BRAVE_SEARCH_API_KEY is not set"}
 

--- a/plugins/web/native/__init__.py
+++ b/plugins/web/native/__init__.py
@@ -1,0 +1,10 @@
+"""Native lightweight web extract plugin."""
+
+from __future__ import annotations
+
+from plugins.web.native.provider import NativeWebExtractProvider
+
+
+def register(ctx) -> None:
+    """Register the native lightweight extract provider."""
+    ctx.register_web_search_provider(NativeWebExtractProvider())

--- a/plugins/web/native/plugin.yaml
+++ b/plugins/web/native/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-native
+version: 1.0.0
+description: "Native lightweight URL extraction via rs-trafilatura/trafilatura. No external extract API key."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - native

--- a/plugins/web/native/provider.py
+++ b/plugins/web/native/provider.py
@@ -1,0 +1,247 @@
+"""Native lightweight web content extraction.
+
+This provider is intentionally extract-only. It fetches safe public URLs via
+``httpx`` and extracts the main page content locally. ``rs-trafilatura`` is
+preferred for speed and low overhead; ``trafilatura`` and then readability
+fallbacks are used when available.
+
+Config keys this provider responds to::
+
+    web:
+      extract_backend: "native"
+
+No API key is required.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from html import unescape
+from typing import Any, Dict, List
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+_USER_AGENT = (
+    "Mozilla/5.0 (compatible; HermesNativeExtract/1.0; "
+    "+https://github.com/nkowne63/hermes-agent)"
+)
+
+
+def _dependency_status() -> str | None:
+    for module_name in ("rs_trafilatura", "trafilatura", "readability"):
+        try:
+            __import__(module_name)
+            return module_name
+        except ImportError:
+            continue
+    return None
+
+
+def _html_to_text(html: str) -> str:
+    text = re.sub(r"(?is)<(script|style|noscript|svg).*?</\1>", " ", html)
+    text = re.sub(r"(?is)<br\s*/?>", "\n", text)
+    text = re.sub(r"(?is)</(p|div|section|article|li|h[1-6]|tr)>", "\n", text)
+    text = re.sub(r"(?is)<[^>]+>", " ", text)
+    text = unescape(text)
+    lines = [" ".join(line.split()) for line in text.splitlines()]
+    return "\n".join(line for line in lines if line).strip()
+
+
+def _title_from_html(html: str) -> str:
+    match = re.search(r"(?is)<title[^>]*>(.*?)</title>", html)
+    if not match:
+        return ""
+    return " ".join(unescape(re.sub(r"(?is)<[^>]+>", " ", match.group(1))).split())
+
+
+def _extract_with_rs_trafilatura(html: str, url: str) -> str | None:
+    try:
+        import rs_trafilatura  # type: ignore
+    except ImportError:
+        return None
+
+    extract = getattr(rs_trafilatura, "extract", None)
+    if not callable(extract):
+        return None
+
+    for kwargs in (
+        {"url": url, "output_markdown": True, "include_tables": True},
+        {"url": url, "output_format": "markdown"},
+        {"url": url, "format": "markdown"},
+        {"url": url},
+    ):
+        try:
+            result = extract(html, **kwargs)
+        except TypeError:
+            continue
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("rs-trafilatura extract failed for %s: %s", url, exc)
+            return None
+        if isinstance(result, str) and result.strip():
+            return result.strip()
+    return None
+
+
+def _extract_with_trafilatura(html: str, url: str) -> str | None:
+    try:
+        import trafilatura  # type: ignore
+    except ImportError:
+        return None
+
+    try:
+        result = trafilatura.extract(
+            html,
+            url=url,
+            output_format="markdown",
+            include_comments=False,
+            include_tables=True,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("trafilatura extract failed for %s: %s", url, exc)
+        return None
+    return result.strip() if isinstance(result, str) and result.strip() else None
+
+
+def _extract_with_readability(html: str) -> str | None:
+    try:
+        from readability import Document  # type: ignore
+    except ImportError:
+        return None
+
+    try:
+        summary = Document(html).summary()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("readability extract failed: %s", exc)
+        return None
+    text = _html_to_text(summary)
+    return text or None
+
+
+def _extract_content(html: str, url: str) -> tuple[str, str]:
+    title = _title_from_html(html)
+    content = (
+        _extract_with_rs_trafilatura(html, url)
+        or _extract_with_trafilatura(html, url)
+        or _extract_with_readability(html)
+        or _html_to_text(html)
+    )
+    return title, content
+
+
+class NativeWebExtractProvider(WebSearchProvider):
+    """Extract public web pages locally without a hosted extract API."""
+
+    @property
+    def name(self) -> str:
+        return "native"
+
+    @property
+    def display_name(self) -> str:
+        return "Native Extract"
+
+    def is_available(self) -> bool:
+        return _dependency_status() is not None
+
+    def supports_search(self) -> bool:
+        return False
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return [{"url": url, "title": "", "content": "", "error": "Interrupted"} for url in urls]
+
+            if _dependency_status() is None:
+                try:
+                    from tools.lazy_deps import ensure
+
+                    ensure("web.native_extract", prompt=False)
+                except Exception as exc:  # noqa: BLE001
+                    return [
+                        {
+                            "url": url,
+                            "title": "",
+                            "content": "",
+                            "error": (
+                                "Native extract dependencies are not installed. "
+                                "Install rs-trafilatura or trafilatura. "
+                                f"Details: {exc}"
+                            ),
+                        }
+                        for url in urls
+                    ]
+
+            import httpx
+
+            max_chars = int(kwargs.get("max_chars") or 300_000)
+            timeout = float(kwargs.get("timeout") or 20.0)
+            results: List[Dict[str, Any]] = []
+            with httpx.Client(
+                timeout=timeout,
+                follow_redirects=True,
+                headers={"User-Agent": _USER_AGENT},
+            ) as client:
+                for url in urls:
+                    try:
+                        response = client.get(url)
+                        response.raise_for_status()
+                        content_type = response.headers.get("content-type", "")
+                        if "html" not in content_type and "xml" not in content_type and response.text.lstrip().startswith("<") is False:
+                            text = response.text.strip()
+                            title = ""
+                        else:
+                            title, text = _extract_content(response.text, str(response.url))
+                        if max_chars > 0:
+                            text = text[:max_chars]
+                        results.append(
+                            {
+                                "url": str(response.url),
+                                "title": title,
+                                "content": text,
+                                "raw_content": text,
+                                "metadata": {
+                                    "sourceURL": str(response.url),
+                                    "title": title,
+                                    "backend": "native",
+                                    "extractor": _dependency_status() or "html",
+                                },
+                            }
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning("Native extract failed for %s: %s", url, exc)
+                        results.append(
+                            {
+                                "url": url,
+                                "title": "",
+                                "content": "",
+                                "raw_content": "",
+                                "error": f"Native extract failed: {exc}",
+                            }
+                        )
+            return results
+        except Exception as exc:  # noqa: BLE001
+            return [
+                {
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "error": f"Native extract failed: {exc}",
+                }
+                for url in urls
+            ]
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Native Extract",
+            "badge": "free · local · extract only",
+            "tag": "Lightweight local HTML-to-markdown extraction via rs-trafilatura/trafilatura.",
+            "env_vars": [],
+        }

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -56,10 +56,19 @@ class FakeDMChannel:
 
 
 class FakeTextChannel:
-    def __init__(self, channel_id: int = 1, name: str = "general", guild_name: str = "Hermes Server"):
+    def __init__(
+        self,
+        channel_id: int = 1,
+        name: str = "general",
+        guild_name: str = "Hermes Server",
+        guild_id: int = 10,
+        category_id: int | None = None,
+    ):
         self.id = channel_id
         self.name = name
-        self.guild = SimpleNamespace(name=guild_name)
+        self.guild = SimpleNamespace(id=guild_id, name=guild_name)
+        self.category_id = category_id
+        self.parent_id = category_id
         self.topic = None
 
     def history(self, *, limit, before, after=None, oldest_first=None):
@@ -70,10 +79,19 @@ class FakeTextChannel:
 
 
 class FakeForumChannel:
-    def __init__(self, channel_id: int = 1, name: str = "support-forum", guild_name: str = "Hermes Server"):
+    def __init__(
+        self,
+        channel_id: int = 1,
+        name: str = "support-forum",
+        guild_name: str = "Hermes Server",
+        guild_id: int = 10,
+        category_id: int | None = None,
+    ):
         self.id = channel_id
         self.name = name
-        self.guild = SimpleNamespace(name=guild_name)
+        self.guild = SimpleNamespace(id=guild_id, name=guild_name)
+        self.category_id = category_id
+        self.parent_id = category_id
         self.type = 15
         self.topic = None
 
@@ -548,6 +566,117 @@ async def test_discord_free_response_channel_skips_auto_thread(adapter, monkeypa
     assert event.source.chat_type == "group"
 
 
+@pytest.mark.asyncio
+async def test_discord_category_default_allows_mentionless_thread_response(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_THREAD_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    adapter.config.extra["category_defaults"] = {
+        "1501180412385558690": {
+            "require_mention": False,
+            "thread_response": True,
+        }
+    }
+
+    channel = FakeTextChannel(channel_id=321, category_id=1501180412385558690)
+    fake_thread = FakeThread(channel_id=654, name="auto-thread", parent=channel)
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    message = make_message(channel=channel, content="category-scoped no mention")
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_id == "654"
+    assert event.source.thread_id == "654"
+    assert event.source.chat_type == "thread"
+
+
+@pytest.mark.asyncio
+async def test_discord_guild_default_requires_mention_and_auto_threads(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_THREAD_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    adapter.config.extra["guild_defaults"] = {
+        "828550767811493920": {
+            "require_mention": True,
+            "thread_response": True,
+        }
+    }
+
+    channel = FakeTextChannel(channel_id=321, guild_id=828550767811493920)
+    adapter._auto_create_thread = AsyncMock()
+
+    await adapter._handle_message(make_message(channel=channel, content="guild-scoped no mention"))
+
+    adapter.handle_message.assert_not_awaited()
+    adapter._auto_create_thread.assert_not_awaited()
+
+    bot_user = adapter._client.user
+    fake_thread = FakeThread(channel_id=654, name="auto-thread", parent=channel)
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+    message = make_message(
+        channel=channel,
+        content=f"<@{bot_user.id}> guild-scoped mention",
+        mentions=[bot_user],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "guild-scoped mention"
+    assert event.source.thread_id == "654"
+
+
+@pytest.mark.asyncio
+async def test_discord_channel_defaults_override_category_and_guild(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_THREAD_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    adapter.config.extra["guild_defaults"] = {
+        "828550767811493920": {
+            "require_mention": True,
+            "thread_response": True,
+        }
+    }
+    adapter.config.extra["category_defaults"] = {
+        "1501180412385558690": {
+            "require_mention": False,
+            "thread_response": True,
+        }
+    }
+    adapter.config.extra["channel_defaults"] = {
+        "321": {
+            "require_mention": False,
+            "thread_response": False,
+        }
+    }
+
+    channel = FakeTextChannel(
+        channel_id=321,
+        guild_id=828550767811493920,
+        category_id=1501180412385558690,
+    )
+    adapter._auto_create_thread = AsyncMock()
+
+    message = make_message(channel=channel, content="channel override no thread")
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.thread_id is None
+    assert event.source.chat_type == "group"
+
+
 
 
 @pytest.mark.asyncio
@@ -925,5 +1054,3 @@ async def test_discord_auto_thread_skips_backfill(adapter, monkeypatch):
 
     adapter._auto_create_thread.assert_awaited_once()
     adapter._fetch_channel_context.assert_not_awaited()
-
-

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -30,6 +30,7 @@ class TestProviderRegistry:
 
     @pytest.mark.parametrize("provider_id,name,auth_type", [
         ("copilot-acp", "GitHub Copilot ACP", "external_process"),
+        ("devin-acp", "Devin ACP", "external_process"),
         ("copilot", "GitHub Copilot", "api_key"),
         ("huggingface", "Hugging Face", "api_key"),
         ("zai", "Z.AI / GLM", "api_key"),
@@ -70,6 +71,14 @@ class TestProviderRegistry:
         pconfig = PROVIDER_REGISTRY["copilot"]
         assert pconfig.api_key_env_vars == ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
         assert pconfig.base_url_env_var == "COPILOT_API_BASE_URL"
+
+    def test_devin_acp_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["devin-acp"]
+        assert pconfig.base_url_env_var == "DEVIN_ACP_BASE_URL"
+        assert pconfig.inference_base_url == "acp://devin"
+        assert pconfig.extra["command_env_vars"] == ("HERMES_DEVIN_ACP_COMMAND", "DEVIN_CLI_PATH")
+        assert pconfig.extra["args_env_var"] == "HERMES_DEVIN_ACP_ARGS"
+        assert pconfig.extra["default_args"] == ["acp"]
 
     def test_kimi_env_vars(self):
         pconfig = PROVIDER_REGISTRY["kimi-coding"]
@@ -373,6 +382,19 @@ class TestApiKeyProviderStatus:
         assert status["args"] == ["--acp", "--stdio", "--debug"]
         assert status["base_url"] == "acp://copilot"
 
+    def test_devin_acp_status_detects_local_cli(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DEVIN_ACP_ARGS", "acp --debug")
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+
+        status = get_external_process_provider_status("devin-acp")
+
+        assert status["configured"] is True
+        assert status["logged_in"] is True
+        assert status["command"] == "devin"
+        assert status["resolved_command"] == "/usr/local/bin/devin"
+        assert status["args"] == ["acp", "--debug"]
+        assert status["base_url"] == "acp://devin"
+
     def test_get_auth_status_dispatches_to_external_process(self, monkeypatch):
         monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/opt/bin/{command}")
 
@@ -380,6 +402,14 @@ class TestApiKeyProviderStatus:
 
         assert status["configured"] is True
         assert status["provider"] == "copilot-acp"
+
+    def test_get_auth_status_dispatches_to_devin_external_process(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/opt/bin/{command}")
+
+        status = get_auth_status("devin-acp")
+
+        assert status["configured"] is True
+        assert status["provider"] == "devin-acp"
 
     def test_non_api_key_provider(self):
         status = get_api_key_provider_status("nous")
@@ -477,6 +507,19 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["base_url"] == "acp://copilot"
         assert creds["command"] == "/usr/local/bin/copilot"
         assert creds["args"] == ["--acp", "--stdio"]
+        assert creds["source"] == "process"
+
+    def test_resolve_devin_acp_with_local_cli(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DEVIN_ACP_ARGS", "acp --debug")
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+
+        creds = resolve_external_process_provider_credentials("devin-acp")
+
+        assert creds["provider"] == "devin-acp"
+        assert creds["api_key"] == "devin-acp"
+        assert creds["base_url"] == "acp://devin"
+        assert creds["command"] == "/usr/local/bin/devin"
+        assert creds["args"] == ["acp", "--debug"]
         assert creds["source"] == "process"
 
     def test_resolve_kimi_with_key(self, monkeypatch):
@@ -683,6 +726,21 @@ class TestRuntimeProviderResolution:
         assert result["base_url"] == "acp://copilot"
         assert result["command"] == "/usr/local/bin/copilot"
         assert result["args"] == ["--acp", "--stdio", "--debug"]
+
+    def test_runtime_devin_acp_uses_process_runtime(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+        monkeypatch.setenv("HERMES_DEVIN_ACP_ARGS", "acp --debug")
+
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        result = resolve_runtime_provider(requested="devin-acp")
+
+        assert result["provider"] == "devin-acp"
+        assert result["api_mode"] == "chat_completions"
+        assert result["api_key"] == "devin-acp"
+        assert result["base_url"] == "acp://devin"
+        assert result["command"] == "/usr/local/bin/devin"
+        assert result["args"] == ["acp", "--debug"]
 
 
 # =============================================================================

--- a/tests/tools/test_web_providers_native.py
+++ b/tests/tools/test_web_providers_native.py
@@ -1,0 +1,73 @@
+"""Tests for the native lightweight web extract provider."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+
+class _FakeResponse:
+    def __init__(self, *, url: str, text: str, content_type: str = "text/html"):
+        self.url = url
+        self.text = text
+        self.headers = {"content-type": content_type}
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeClient:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def get(self, url):
+        return _FakeResponse(
+            url=url,
+            text=(
+                "<html><head><title>Example</title></head>"
+                "<body><nav>skip</nav><article><h1>Example</h1>"
+                "<p>Hello from native extract.</p></article></body></html>"
+            ),
+        )
+
+
+def test_native_provider_extracts_locally(monkeypatch):
+    from plugins.web.native import provider as native_provider
+    from plugins.web.native.provider import NativeWebExtractProvider
+
+    monkeypatch.setattr(native_provider, "_dependency_status", lambda: "rs_trafilatura")
+    monkeypatch.setattr(native_provider, "_extract_content", lambda html, url: ("Example", "Hello markdown"))
+    monkeypatch.setitem(sys.modules, "httpx", SimpleNamespace(Client=_FakeClient))
+
+    result = NativeWebExtractProvider().extract(["https://example.com"])
+
+    assert result == [
+        {
+            "url": "https://example.com",
+            "title": "Example",
+            "content": "Hello markdown",
+            "raw_content": "Hello markdown",
+            "metadata": {
+                "sourceURL": "https://example.com",
+                "title": "Example",
+                "backend": "native",
+                "extractor": "rs_trafilatura",
+            },
+        }
+    ]
+
+
+def test_native_provider_is_extract_only():
+    from plugins.web.native.provider import NativeWebExtractProvider
+
+    provider = NativeWebExtractProvider()
+    assert provider.name == "native"
+    assert provider.supports_search() is False
+    assert provider.supports_extract() is True

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1115,9 +1115,11 @@ def _build_child_agent(
         effective_acp_args = []
 
     if override_acp_command:
-        # If explicitly forcing an ACP transport override, the provider MUST be copilot-acp
-        # so run_agent.py initializes the CopilotACPClient.
-        effective_provider = "copilot-acp"
+        # If explicitly forcing an ACP transport override, keep the current
+        # external-process provider when we already have one; otherwise fall
+        # back to Copilot ACP so run_agent.py still initializes an ACP client.
+        if effective_provider not in {"copilot-acp", "devin-acp"}:
+            effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 
     # Resolve reasoning config: delegation override > parent inherit

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -91,6 +91,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "search.exa": ("exa-py==2.10.2",),
     "search.firecrawl": ("firecrawl-py==4.17.0",),
     "search.parallel": ("parallel-web==0.6.0",),
+    "web.native_extract": ("rs-trafilatura==0.1.1",),
 
     # ─── TTS providers ─────────────────────────────────────────────────────
     # Pinned to exact versions to match pyproject.toml's no-ranges policy

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -133,6 +133,9 @@ def _env_value(name: str) -> str:
 def _has_env(name: str) -> bool:
     return bool(_env_value(name))
 
+def _has_brave_search_key() -> bool:
+    return _has_env("BRAVE_SEARCH_API_KEY") or _has_env("BRAVE_API_KEY")
+
 def _load_web_config() -> dict:
     """Load the ``web:`` section from ~/.hermes/config.yaml."""
     try:
@@ -187,7 +190,7 @@ def _get_backend(capability: str = "search") -> str:
         ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL")),
         ("firecrawl", _is_tool_gateway_ready()),
         ("searxng", _has_env("SEARXNG_URL")),
-        ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
+        ("brave-free", _has_brave_search_key()),
         # Keyless Parallel free MCP — always available, the intended no-key
         # default for both search and extract. Ahead of ddgs (search-only, so it
         # can't service web_extract); ddgs stays reachable via web.backend=ddgs.
@@ -266,7 +269,7 @@ def _is_backend_available(backend: str) -> bool:
     if backend == "searxng":
         return _has_env("SEARXNG_URL")
     if backend == "brave-free":
-        return _has_env("BRAVE_SEARCH_API_KEY")
+        return _has_brave_search_key()
     if backend == "ddgs":
         return _ddgs_package_importable()
     if backend == "xai":

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -136,6 +136,15 @@ def _has_env(name: str) -> bool:
 def _has_brave_search_key() -> bool:
     return _has_env("BRAVE_SEARCH_API_KEY") or _has_env("BRAVE_API_KEY")
 
+def _native_extract_importable() -> bool:
+    for module_name in ("rs_trafilatura", "trafilatura", "readability"):
+        try:
+            __import__(module_name)
+            return True
+        except ImportError:
+            continue
+    return False
+
 def _load_web_config() -> dict:
     """Load the ``web:`` section from ~/.hermes/config.yaml."""
     try:
@@ -148,7 +157,7 @@ def _load_web_config() -> dict:
 # ``web.search_backend`` / ``web.extract_backend``). Kept as a single source of
 # truth for config validation across the selection helpers.
 _KNOWN_WEB_BACKENDS = frozenset(
-    {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}
+    {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai", "native"}
 )
 
 # Backends that only service web_search (their provider's ``supports_extract()``
@@ -266,6 +275,8 @@ def _is_backend_available(backend: str) -> bool:
         return check_firecrawl_api_key()
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
+    if backend == "native":
+        return _native_extract_importable()
     if backend == "searxng":
         return _has_env("SEARXNG_URL")
     if backend == "brave-free":
@@ -1148,8 +1159,8 @@ async def web_extract_tool(
                             "error": (
                                 f"{provider.display_name} is a search-only "
                                 "backend and cannot extract URL content. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                "Set web.extract_backend to native, "
+                                "firecrawl, tavily, exa, or parallel."
                             ),
                         },
                         ensure_ascii=False,
@@ -1161,8 +1172,8 @@ async def web_extract_tool(
                             "success": False,
                             "error": (
                                 "No web extract provider configured. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                "Set web.extract_backend to native, "
+                                "firecrawl, tavily, exa, or parallel."
                             ),
                         },
                         ensure_ascii=False,


### PR DESCRIPTION
Adds Devin ACP provider support and wires it through auth/runtime/streaming paths.

Verification:
- uv run pytest tests/hermes_cli/test_api_key_providers.py -q
- uv run hermes chat -q 'Reply with exactly OK and nothing else.' --provider devin-acp --ignore-user-config --source tool -Q

The second check returned: OK