### PR TITLE
fix: mute audio in browser automation Chrome launch

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -130,6 +130,7 @@ def _chrome_debug_args(port: int) -> list[str]:
         f"--user-data-dir={chrome_debug_data_dir()}",
         "--no-first-run",
         "--no-default-browser-check",
+        "--mute-audio",
     ]
 
 
@@ -181,7 +182,7 @@ def manual_chrome_debug_command(port: int = DEFAULT_BROWSER_CDP_PORT, system: st
         data_dir = chrome_debug_data_dir()
         return (
             f'open -a "Google Chrome" --args --remote-debugging-port={port} '
-            f'--user-data-dir="{data_dir}" --no-first-run --no-default-browser-check'
+            f'--user-data-dir="{data_dir}" --no-first-run --no-default-browser-check --mute-audio'
         )
 
     return None


### PR DESCRIPTION
## Problem

When the agent uses browser automation (`browser_navigate`) to visit video sites (YouTube, Bilibili, etc.), Chrome plays audio through the speakers because `--mute-audio` is not passed to the Chrome launch arguments.

This is a different code path from #49505, which fixed audio in the hidden title-fetching window. The `_chrome_debug_args()` function in `browser_connect.py` was not covered by that fix.

## Fix

Add `--mute-audio` to `_chrome_debug_args()` (the primary Chrome launch path) and `manual_chrome_debug_command()` (the macOS manual launch string).

## Testing

- Existing tests use `startswith` checks on `--remote-debugging-port=9222`, so they pass without modification
- Manual verification: launch Hermes with browser tool, navigate to a YouTube video, confirm no audio plays

## Related

- #49505 — fixed hidden title-window audio (separate code path)
- User report: agent browsing video sites plays audio in background, disrupting user work