### PR TITLE
perf(model): reuse provider models cache in memory

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2468,6 +2468,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
 #     to a live fetch — the picker keeps working.
 
 _PROVIDER_MODELS_CACHE_TTL = 3600  # 1h
+_provider_models_cache_snapshot: tuple[Path, int, int, dict] | None = None
 
 
 def _provider_models_cache_path() -> Path:
@@ -2548,25 +2549,45 @@ def _credential_fingerprint(provider: str) -> str:
 
 def _load_provider_models_cache() -> dict:
     """Return the full cache dict, or {} on any error."""
+    global _provider_models_cache_snapshot
     try:
         path = _provider_models_cache_path()
-        if not path.exists():
+        try:
+            stat = path.stat()
+        except FileNotFoundError:
+            _provider_models_cache_snapshot = None
             return {}
+        if (
+            _provider_models_cache_snapshot is not None
+            and _provider_models_cache_snapshot[0] == path
+            and _provider_models_cache_snapshot[1] == stat.st_mtime_ns
+            and _provider_models_cache_snapshot[2] == stat.st_size
+        ):
+            return dict(_provider_models_cache_snapshot[3])
         with open(path, encoding="utf-8") as f:
             data = json.load(f)
-        return data if isinstance(data, dict) else {}
+        if not isinstance(data, dict):
+            _provider_models_cache_snapshot = None
+            return {}
+        _provider_models_cache_snapshot = (path, stat.st_mtime_ns, stat.st_size, dict(data))
+        return data
     except Exception:
+        _provider_models_cache_snapshot = None
         return {}
 
 
 def _save_provider_models_cache(data: dict) -> None:
     """Persist the cache dict. Best-effort — silent on any error."""
+    global _provider_models_cache_snapshot
     try:
         from utils import atomic_json_write
         path = _provider_models_cache_path()
         path.parent.mkdir(parents=True, exist_ok=True)
         atomic_json_write(path, data, indent=None)
+        stat = path.stat()
+        _provider_models_cache_snapshot = (path, stat.st_mtime_ns, stat.st_size, dict(data))
     except Exception:
+        _provider_models_cache_snapshot = None
         pass
 
 
@@ -2631,11 +2652,13 @@ def clear_provider_models_cache(provider: Optional[str] = None) -> None:
     entry is removed. Used by ``/model --refresh`` and
     ``hermes model --refresh``.
     """
+    global _provider_models_cache_snapshot
     try:
         if provider is None:
             path = _provider_models_cache_path()
             if path.exists():
                 path.unlink()
+            _provider_models_cache_snapshot = None
             return
         cache = _load_provider_models_cache()
         normalized = normalize_provider(provider) or provider or ""
@@ -2643,6 +2666,7 @@ def clear_provider_models_cache(provider: Optional[str] = None) -> None:
             del cache[normalized]
             _save_provider_models_cache(cache)
     except Exception:
+        _provider_models_cache_snapshot = None
         pass
 
 

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -1,5 +1,6 @@
 """Tests for the hermes_cli models module."""
 
+import json
 from unittest.mock import patch, MagicMock
 
 from hermes_cli.nous_account import NousPortalAccountInfo
@@ -17,6 +18,73 @@ LIVE_OPENROUTER_MODELS = [
     ("qwen/qwen3.7-max", ""),
     ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
 ]
+
+
+class TestProviderModelsCache:
+    def setup_method(self):
+        _models_mod._provider_models_cache_snapshot = None
+
+    def teardown_method(self):
+        _models_mod._provider_models_cache_snapshot = None
+
+    def test_load_reuses_in_memory_snapshot(self, tmp_path, monkeypatch):
+        cache_path = tmp_path / "provider_models_cache.json"
+        cache_path.write_text(
+            json.dumps({"openai": {"models": ["gpt-5.5"], "fp": "fp", "at": 1}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(_models_mod, "_provider_models_cache_path", lambda: cache_path)
+
+        with patch("builtins.open", wraps=open) as mock_open:
+            first = _models_mod._load_provider_models_cache()
+            second = _models_mod._load_provider_models_cache()
+
+        assert first == second
+        assert first["openai"]["models"] == ["gpt-5.5"]
+        assert mock_open.call_count == 1
+
+    def test_load_refreshes_snapshot_when_file_changes(self, tmp_path, monkeypatch):
+        cache_path = tmp_path / "provider_models_cache.json"
+        cache_path.write_text(
+            json.dumps({"openai": {"models": ["old"], "fp": "fp", "at": 1}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(_models_mod, "_provider_models_cache_path", lambda: cache_path)
+
+        assert _models_mod._load_provider_models_cache()["openai"]["models"] == ["old"]
+        cache_path.write_text(
+            json.dumps({"openai": {"models": ["newer"], "fp": "fp", "at": 2}}),
+            encoding="utf-8",
+        )
+
+        assert _models_mod._load_provider_models_cache()["openai"]["models"] == ["newer"]
+
+    def test_save_updates_in_memory_snapshot(self, tmp_path, monkeypatch):
+        cache_path = tmp_path / "provider_models_cache.json"
+        monkeypatch.setattr(_models_mod, "_provider_models_cache_path", lambda: cache_path)
+
+        _models_mod._save_provider_models_cache(
+            {"anthropic": {"models": ["claude-sonnet-4.6"], "fp": "fp", "at": 1}}
+        )
+
+        with patch("builtins.open", side_effect=AssertionError("cache should be in memory")):
+            data = _models_mod._load_provider_models_cache()
+
+        assert data["anthropic"]["models"] == ["claude-sonnet-4.6"]
+
+    def test_clear_all_invalidates_in_memory_snapshot(self, tmp_path, monkeypatch):
+        cache_path = tmp_path / "provider_models_cache.json"
+        cache_path.write_text(
+            json.dumps({"openai": {"models": ["gpt-5.5"], "fp": "fp", "at": 1}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(_models_mod, "_provider_models_cache_path", lambda: cache_path)
+
+        assert _models_mod._load_provider_models_cache()
+        _models_mod.clear_provider_models_cache()
+
+        assert not cache_path.exists()
+        assert _models_mod._load_provider_models_cache() == {}
 
 
 


### PR DESCRIPTION
## Summary

- keep an in-process snapshot of `provider_models_cache.json` keyed by path, `mtime_ns`, and size
- reuse that snapshot across repeated `cached_provider_model_ids()` calls in a single model listing
- refresh the snapshot after cache writes and clear it when `/model --refresh` clears the cache

This is separate from #44577: that PR caches custom-provider live HTTP discovery in `model_switch.py` sections 3/4. This PR keeps the existing built-in provider disk cache behavior, but avoids reparsing the same JSON file for each provider row during one listing.

## Tests

```text
python -m py_compile hermes_cli/models.py tests/hermes_cli/test_models.py
python -m pytest tests/hermes_cli/test_models.py::TestProviderModelsCache tests/hermes_cli/test_inventory.py::test_list_authenticated_providers_refresh_busts_cache -q
# 5 passed
python -m pytest tests/hermes_cli/test_models.py -q
# 88 passed
python -m pytest tests/hermes_cli/test_inventory.py::test_list_authenticated_providers_refresh_busts_cache tests/hermes_cli/test_inventory.py::test_build_models_payload_forwards_refresh_flag -q
# 2 passed
```

`C:\Program Files\Git\bin\bash.exe scripts/run_tests.sh ...` was attempted first on this Windows checkout, but the current wrapper did not find `.venv\Scripts\python.exe`; the targeted pytest commands above used that same local venv directly.