### PR TITLE
fix(tools): preserve remote file tool paths

### DIFF
--- a/tests/tools/test_file_staleness.py
+++ b/tests/tools/test_file_staleness.py
@@ -13,10 +13,10 @@ import os
 import tempfile
 import time
 import unittest
-from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 from tools import file_state
+from tools.environments.local import LocalEnvironment
 from tools.file_tools import (
     read_file_tool,
     write_file_tool,
@@ -165,7 +165,7 @@ class TestStalenessCheck(unittest.TestCase):
             f.write("live copy\n")
 
         fake_ops = _make_fake_ops("live copy\n", 10)
-        fake_ops.env = SimpleNamespace(cwd=live_dir)
+        fake_ops.env = LocalEnvironment(cwd=live_dir)
         fake_ops.cwd = start_dir
         mock_ops.return_value = fake_ops
 

--- a/tests/tools/test_file_state_registry.py
+++ b/tests/tools/test_file_state_registry.py
@@ -100,6 +100,18 @@ class FileStateRegistryUnitTests(unittest.TestCase):
         self.assertIsNotNone(warn)
         self.assertIn("modified since you last read", warn)
 
+    def test_remote_tracking_ignores_coincidental_host_mtime(self):
+        p = self._mk()
+        file_state.record_read("A", p, track_mtime=False)
+        time.sleep(0.01)
+        os.utime(p, None)
+        with open(p, "w", encoding="utf-8") as f:
+            f.write("host-only change\n")
+
+        self.assertIsNone(
+            file_state.check_stale("A", p, track_mtime=False)
+        )
+
     def test_own_write_updates_stamp_so_next_write_is_clean(self):
         p = self._mk()
         file_state.record_read("A", p)

--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -1,4 +1,4 @@
-"""Regression tests for file-tool path resolution base correctness.
+"""Regression tests for file-tool path resolution correctness.
 
 The bug (observed in a worktree dev session, May 2026): when the resolution
 base for a relative path is itself RELATIVE — e.g. ``TERMINAL_CWD="."`` from a
@@ -13,9 +13,15 @@ Core invariant these tests pin:
   The resolution base for a relative path MUST always be absolute. A relative
   ``TERMINAL_CWD`` (``.``, ``./sub``, ``..``) must be anchored deterministically,
   never left to resolve against whatever the process cwd happens to be.
+
+Remote backend invariant these tests pin:
+  Paths passed to non-local file backends MUST stay backend-lexical. Host
+  canonicalization, host mtime tracking, and host ``~`` expansion must not leak
+  into Docker/SSH/Modal/Daytona file operations.
 """
 
 import os
+import ntpath
 from pathlib import Path, PurePosixPath
 
 import pytest
@@ -398,6 +404,65 @@ class _FakeOwnedEnv:
         self.cwd_owner = cwd_owner
 
 
+class _FakeRemoteFileOps:
+    """FileOperations stand-in whose env is deliberately not LocalEnvironment."""
+
+    env = object()
+
+    def __init__(self):
+        self.read_paths: list[str] = []
+        self.write_paths: list[str] = []
+        self.patch_paths: list[str] = []
+        self.patch_payloads: list[str] = []
+        self.search_paths: list[str] = []
+
+    def read_file(self, path: str, offset: int = 1, limit: int = 500):
+        from tools.file_operations import ReadResult
+
+        self.read_paths.append(path)
+        return ReadResult(content="1|old", total_lines=1, file_size=3)
+
+    def write_file(self, path: str, content: str):
+        from tools.file_operations import WriteResult
+
+        self.write_paths.append(path)
+        return WriteResult(bytes_written=len(content))
+
+    def patch_replace(
+        self,
+        path: str,
+        old_string: str,
+        new_string: str,
+        replace_all: bool = False,
+    ):
+        from tools.file_operations import PatchResult
+
+        self.patch_paths.append(path)
+        return PatchResult(success=True, files_modified=[path])
+
+    def patch_v4a(self, patch: str):
+        from tools.file_operations import PatchResult
+
+        self.patch_payloads.append(patch)
+        return PatchResult(success=True, files_modified=[])
+
+    def search(
+        self,
+        pattern: str,
+        path: str = ".",
+        target: str = "content",
+        file_glob: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+        output_mode: str = "content",
+        context: int = 0,
+    ):
+        from tools.file_operations import SearchResult
+
+        self.search_paths.append(path)
+        return SearchResult(matches=[])
+
+
 @pytest.fixture
 def _two_worktree_sessions(tmp_path, monkeypatch):
     """Two worktree sessions sharing one terminal env owned by session B."""
@@ -485,3 +550,564 @@ def test_preserved_cwd_does_not_override_non_owning_sessions_worktree(
     resolved_a = ft._resolve_path_for_task("target.py", task_id="sess-a")
     assert resolved_a == (wt_a / "target.py")
     assert not str(resolved_a).startswith(str(wt_b))
+
+
+def test_remote_write_file_preserves_backend_absolute_path(monkeypatch):
+    """Remote absolute paths must not be canonicalized through host symlinks."""
+    import json
+
+    ops = _FakeRemoteFileOps()
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+    # macOS 10.15+ resolves host /home through /System/Volumes/Data/home.  The
+    # terminal backend still expects the literal remote /home path.
+    monkeypatch.setattr(
+        ft,
+        "_resolve_path_for_task",
+        lambda filepath, task_id="default": Path(
+            "/System/Volumes/Data/home/myuser/now.txt"
+        ),
+    )
+
+    out = json.loads(
+        ft.write_file_tool(
+            "/home/myuser/now.txt",
+            "stamp\n",
+            task_id="remote-task",
+        )
+    )
+
+    assert not out.get("error"), out
+    assert "_warning" not in out
+    assert ops.write_paths == ["/home/myuser/now.txt"]
+    assert out["resolved_path"] == "/home/myuser/now.txt"
+    assert out["files_modified"] == ["/home/myuser/now.txt"]
+
+
+def test_remote_patch_replace_preserves_backend_absolute_path(monkeypatch):
+    """replace-mode patch should pass backend paths through like write_file."""
+    import json
+
+    ops = _FakeRemoteFileOps()
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+    monkeypatch.setattr(
+        ft,
+        "_resolve_path_for_task",
+        lambda filepath, task_id="default": Path(
+            "/System/Volumes/Data/home/myuser/app.py"
+        ),
+    )
+
+    out = json.loads(
+        ft.patch_tool(
+            mode="replace",
+            path="/home/myuser/app.py",
+            old_string="old",
+            new_string="new",
+            task_id="remote-task",
+        )
+    )
+
+    assert not out.get("error"), out
+    assert "_warning" not in out
+    assert ops.patch_paths == ["/home/myuser/app.py"]
+    assert out["resolved_path"] == "/home/myuser/app.py"
+    assert out["files_modified"] == ["/home/myuser/app.py"]
+
+
+def test_remote_write_file_uses_backend_cwd_without_host_resolve(monkeypatch):
+    """Relative remote paths are joined lexically to the backend cwd."""
+    import json
+
+    ops = _FakeRemoteFileOps()
+    ops.cwd = "/home/myuser/project"
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+    monkeypatch.setattr(
+        ft,
+        "_resolve_path_for_task",
+        lambda filepath, task_id="default": Path(
+            "/System/Volumes/Data/home/myuser/project/nested/now.txt"
+        ),
+    )
+
+    out = json.loads(
+        ft.write_file_tool(
+            "nested/now.txt",
+            "stamp\n",
+            task_id="remote-task",
+        )
+    )
+
+    expected = "/home/myuser/project/nested/now.txt"
+    assert not out.get("error"), out
+    assert "_warning" not in out
+    assert ops.write_paths == [expected]
+    assert out["resolved_path"] == expected
+    assert out["files_modified"] == [expected]
+
+
+def test_remote_relative_without_backend_root_does_not_use_host_cwd(monkeypatch, tmp_path):
+    """Without a remote root, relative paths stay relative rather than host-anchored."""
+    host_cwd = tmp_path / "host-project"
+    host_cwd.mkdir()
+    monkeypatch.chdir(host_cwd)
+    ops = _FakeRemoteFileOps()
+
+    assert (
+        ft._lexical_path_for_task("nested/app.py", "remote-task", ops)
+        == "nested/app.py"
+    )
+
+
+def test_remote_read_and_write_use_same_backend_file_state_key(monkeypatch):
+    """Remote reads and writes must share the same cross-agent file-state path."""
+    import json
+
+    ops = _FakeRemoteFileOps()
+    recorded: list[str] = []
+    checked: list[str] = []
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+    monkeypatch.setattr(
+        ft,
+        "_resolve_path_for_task",
+        lambda filepath, task_id="default": Path("/System/Volumes/Data/home/u/app.py"),
+    )
+    monkeypatch.setattr(
+        ft.file_state,
+        "record_read",
+        lambda task_id, path, partial=False: recorded.append(path),
+    )
+    monkeypatch.setattr(
+        ft.file_state,
+        "check_stale",
+        lambda task_id, path: checked.append(path) or None,
+    )
+
+    assert not json.loads(
+        ft.read_file_tool("/home/u/app.py", task_id="remote-task")
+    ).get("error")
+    assert not json.loads(
+        ft.write_file_tool("/home/u/app.py", "new", task_id="remote-task")
+    ).get("error")
+
+    assert ops.read_paths == ["/home/u/app.py"]
+    assert ops.write_paths == ["/home/u/app.py"]
+    assert recorded == ["/home/u/app.py"]
+    assert checked == ["/home/u/app.py"]
+
+
+def test_remote_read_docx_does_not_use_host_extractor(monkeypatch, tmp_path):
+    """Host document extraction should not run for non-local backend paths."""
+    import json
+    import tools.read_extract as read_extract
+
+    ops = _FakeRemoteFileOps()
+    calls: list[str] = []
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+    monkeypatch.setattr(
+        ft,
+        "_resolve_path_for_task",
+        lambda filepath, task_id="default": tmp_path / "remote.docx",
+    )
+
+    def host_extract(path: str):
+        calls.append(path)
+        raise read_extract.ExtractionError("host extractor should not run")
+
+    monkeypatch.setattr(read_extract, "extract_document_text", host_extract)
+
+    out = json.loads(ft.read_file_tool("/home/u/remote.docx", task_id="remote-task"))
+
+    assert not out.get("error"), out
+    assert calls == []
+    assert ops.read_paths == ["/home/u/remote.docx"]
+
+
+def test_remote_file_state_records_backend_paths_with_real_registry(monkeypatch):
+    """The registry should track backend paths even when host stat cannot see them."""
+    import json
+
+    ft.file_state.get_registry().clear()
+    ops = _FakeRemoteFileOps()
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+
+    out = json.loads(ft.read_file_tool("/remote/shared.txt", task_id="agent-a"))
+    ft.file_state.note_write("agent-b", "/remote/shared.txt")
+    warn = ft.file_state.check_stale("agent-a", "/remote/shared.txt")
+
+    assert not out.get("error"), out
+    assert "/remote/shared.txt" in ft.file_state.known_reads("agent-a")
+    assert warn is not None
+    assert "sibling subagent" in warn
+
+
+def test_file_ops_without_real_env_are_host_backed():
+    """MagicMock-style fakes should not fabricate a remote backend env."""
+    from unittest.mock import MagicMock
+
+    ops = MagicMock()
+
+    assert ft._file_ops_uses_host_paths(ops)
+    assert ft._resolve_path_for_file_ops("/tmp/out.txt", "default", ops) == "/tmp/out.txt"
+
+
+def test_file_state_does_not_record_failed_remote_read(monkeypatch):
+    """Failed backend reads must not become stale-write baselines."""
+    import json
+    from tools.file_operations import ReadResult
+
+    class FailingRemoteOps(_FakeRemoteFileOps):
+        def read_file(self, path: str, offset: int = 1, limit: int = 500):
+            self.read_paths.append(path)
+            return ReadResult(error=f"File not found: {path}")
+
+    ft.file_state.get_registry().clear()
+    ops = FailingRemoteOps()
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+
+    out = json.loads(ft.read_file_tool("/remote/missing.txt", task_id="agent-a"))
+
+    assert "error" in out
+    assert ops.read_paths == ["/remote/missing.txt"]
+    assert "/remote/missing.txt" not in ft.file_state.known_reads("agent-a")
+
+
+def test_remote_read_does_not_host_resolve_before_backend_detection(monkeypatch):
+    """Remote reads should classify paths after backend detection, not host resolve."""
+    import json
+
+    ops = _FakeRemoteFileOps()
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+
+    def host_resolve_should_not_run(filepath, task_id="default"):
+        raise AssertionError("remote read should not host-resolve before backend detection")
+
+    monkeypatch.setattr(ft, "_resolve_path_for_task", host_resolve_should_not_run)
+
+    out = json.loads(ft.read_file_tool("/home/u/app.py", task_id="remote-task"))
+
+    assert not out.get("error"), out
+    assert ops.read_paths == ["/home/u/app.py"]
+
+
+def test_remote_write_after_remote_write_ignores_host_mtime(monkeypatch, tmp_path):
+    """Remote writes must not seed per-task stale checks from host mtimes."""
+    import json
+
+    with ft._read_tracker_lock:
+        ft._read_tracker.clear()
+    ft.file_state.get_registry().clear()
+
+    host_path = tmp_path / "home" / "u" / "app.py"
+    host_path.parent.mkdir(parents=True)
+    host_path.write_text("host v1\n")
+
+    ops = _FakeRemoteFileOps()
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+    monkeypatch.setattr(
+        ft,
+        "_resolve_path_for_task",
+        lambda filepath, task_id="default": host_path,
+    )
+
+    assert not json.loads(
+        ft.write_file_tool("/home/u/app.py", "remote v1\n", task_id="remote-task")
+    ).get("error")
+
+    new_ts = host_path.stat().st_mtime + 10
+    os.utime(host_path, (new_ts, new_ts))
+
+    out = json.loads(
+        ft.write_file_tool("/home/u/app.py", "remote v2\n", task_id="remote-task")
+    )
+
+    assert not out.get("error"), out
+    assert "_warning" not in out
+    assert ops.write_paths == ["/home/u/app.py", "/home/u/app.py"]
+
+
+def test_read_binary_extension_does_not_create_backend(monkeypatch):
+    """Cheap binary read rejection should not start a remote backend."""
+    import json
+
+    calls = []
+    monkeypatch.setattr(
+        ft,
+        "_get_file_ops",
+        lambda task_id="default": calls.append(task_id) or _FakeRemoteFileOps(),
+    )
+
+    out = json.loads(ft.read_file_tool("/tmp/picture.png", task_id="remote-task"))
+
+    assert "binary file" in out["error"]
+    assert calls == []
+
+
+def test_remote_tilde_hermes_path_hits_container_mirror_guard(monkeypatch):
+    """Remote '~/.hermes' writes should hit the Docker mirror soft guard."""
+    import json
+
+    calls = []
+    monkeypatch.setattr(
+        ft,
+        "_get_file_ops",
+        lambda task_id="default": calls.append(task_id) or _FakeRemoteFileOps(),
+    )
+    monkeypatch.setattr(
+        ft,
+        "_get_container_mirror_prefix_for_task",
+        lambda task_id="default": "/root/.hermes",
+    )
+    monkeypatch.setattr(
+        ft,
+        "_expand_tilde",
+        lambda path: path.replace("~", "/Users/host", 1),
+    )
+
+    out = json.loads(
+        ft.write_file_tool("~/.hermes/SOUL.md", "x", task_id="remote-task")
+    )
+
+    assert "Sandbox-mirror write blocked" in out["error"]
+    assert calls == []
+
+
+def test_remote_lexical_paths_stay_posix_on_windows_host(monkeypatch):
+    """Remote lexical resolution must not inherit host path semantics."""
+    ops = _FakeRemoteFileOps()
+    ops.cwd = "/home/myuser/project"
+    monkeypatch.setattr(ft.os, "path", ntpath)
+
+    assert (
+        ft._lexical_path_for_task("/home/myuser/app.py", "remote-task", ops)
+        == "/home/myuser/app.py"
+    )
+    assert (
+        ft._lexical_path_for_task("nested/app.py", "remote-task", ops)
+        == "/home/myuser/project/nested/app.py"
+    )
+
+
+def test_remote_lexical_prefers_registered_cwd_when_live_cwd_owned_by_other_session(monkeypatch):
+    """A stale shared backend cwd from another session must not shadow this session."""
+    ops = _FakeRemoteFileOps()
+    ops.env = _FakeOwnedEnv("/home/b/project", "sess-b")
+    ops.cwd = "/home/b/project"
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    terminal_tool.register_task_env_overrides("sess-a", {"cwd": "/home/a/project"})
+
+    assert (
+        ft._lexical_path_for_task("nested/app.py", "sess-a", ops)
+        == "/home/a/project/nested/app.py"
+    )
+
+
+def test_remote_registered_posix_cwd_survives_windows_host(monkeypatch):
+    """A Linux backend cwd remains absolute even when the host path module is Windows."""
+    ops = _FakeRemoteFileOps()
+    ops.env = _FakeOwnedEnv("/home/b/project", "sess-b")
+    ops.cwd = "/home/b/project"
+    monkeypatch.setattr(ft.os, "path", ntpath)
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    terminal_tool.register_task_env_overrides("sess-a", {"cwd": "/home/a/project"})
+
+    assert (
+        ft._lexical_path_for_task("nested/app.py", "sess-a", ops)
+        == "/home/a/project/nested/app.py"
+    )
+
+
+def test_remote_search_uses_registered_cwd_when_live_cwd_owned_by_other_session(monkeypatch):
+    """search_files should not inherit another session's shared backend cwd."""
+    import json
+
+    ops = _FakeRemoteFileOps()
+    ops.env = _FakeOwnedEnv("/home/b/project", "sess-b")
+    ops.cwd = "/home/b/project"
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    terminal_tool.register_task_env_overrides("sess-a", {"cwd": "/home/a/project"})
+
+    out = json.loads(
+        ft.search_tool(
+            pattern="needle",
+            path="nested",
+            task_id="sess-a",
+        )
+    )
+
+    assert not out.get("error"), out
+    assert ops.search_paths == ["/home/a/project/nested"]
+
+
+def test_local_search_keeps_caller_relative_path(monkeypatch, tmp_path):
+    """Host-backed search preserves the caller path shape for local results."""
+    import json
+    from tools.environments.local import LocalEnvironment
+
+    class RecordingLocalOps(_FakeRemoteFileOps):
+        def __init__(self):
+            super().__init__()
+            self.env = LocalEnvironment(cwd=str(tmp_path))
+
+    (tmp_path / "nested").mkdir()
+    monkeypatch.chdir(tmp_path)
+    ops = RecordingLocalOps()
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+
+    out = json.loads(ft.search_tool(pattern="needle", path="nested", task_id="default"))
+
+    assert not out.get("error"), out
+    assert ops.search_paths == ["nested"]
+
+
+def test_remote_write_file_does_not_expand_tilde_to_host_home(monkeypatch):
+    """Remote '~' paths should be expanded by the backend, not the host."""
+    import json
+
+    ops = _FakeRemoteFileOps()
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+    monkeypatch.setattr(ft, "_expand_tilde", lambda path: path.replace("~", "/Users/host", 1))
+
+    out = json.loads(
+        ft.write_file_tool(
+            "~/now.txt",
+            "stamp\n",
+            task_id="remote-task",
+        )
+    )
+
+    assert not out.get("error"), out
+    assert "_warning" not in out
+    assert ops.write_paths == ["~/now.txt"]
+    assert out["resolved_path"] == "~/now.txt"
+    assert out["files_modified"] == ["~/now.txt"]
+
+
+def test_remote_lexical_tilde_paths_are_left_for_backend_expansion():
+    """Do not normalize '~' paths; normpath can collapse them to non-tilde paths."""
+    ops = _FakeRemoteFileOps()
+
+    assert ft._lexical_path_for_task("~/../x", "remote-task", ops) == "~/../x"
+    assert ft._lexical_path_for_task("~/a/../b", "remote-task", ops) == "~/a/../b"
+
+
+def test_remote_patch_v4a_rewrites_relative_headers_to_backend_cwd(monkeypatch):
+    """V4A headers are rewritten before reaching a non-local backend."""
+    import json
+
+    ops = _FakeRemoteFileOps()
+    ops.cwd = "/home/myuser/project"
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+
+    out = json.loads(
+        ft.patch_tool(
+            mode="patch",
+            patch=(
+                "*** Begin Patch\n"
+                "*** Update File: nested/app.py\n"
+                "@@\n"
+                "-old\n"
+                "+new\n"
+                "*** End Patch\n"
+            ),
+            task_id="remote-task",
+        )
+    )
+
+    assert not out.get("error"), out
+    assert len(ops.patch_payloads) == 1
+    assert "*** Update File: /home/myuser/project/nested/app.py" in ops.patch_payloads[0]
+    assert out["files_modified"] == ["/home/myuser/project/nested/app.py"]
+
+
+def test_remote_patch_v4a_reports_move_as_resolved_pair(monkeypatch):
+    """Successful V4A moves should preserve the parser's 'src -> dst' shape."""
+    import json
+
+    ops = _FakeRemoteFileOps()
+    ops.cwd = "/home/myuser/project"
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+
+    out = json.loads(
+        ft.patch_tool(
+            mode="patch",
+            patch=(
+                "*** Begin Patch\n"
+                "*** Move File: old.py -> nested/new.py\n"
+                "*** End Patch\n"
+            ),
+            task_id="remote-task",
+        )
+    )
+
+    assert not out.get("error"), out
+    assert len(ops.patch_payloads) == 1
+    assert (
+        "*** Move File: /home/myuser/project/old.py -> "
+        "/home/myuser/project/nested/new.py"
+    ) in ops.patch_payloads[0]
+    assert out["files_modified"] == [
+        "/home/myuser/project/old.py -> /home/myuser/project/nested/new.py"
+    ]
+
+
+def test_remote_patch_v4a_move_marks_individual_paths_stale(monkeypatch):
+    """Internal stale markers should receive real paths, not display strings."""
+    import json
+
+    ops = _FakeRemoteFileOps()
+    ops.cwd = "/home/myuser/project"
+    marked: list[str] = []
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+    monkeypatch.setattr(
+        ft,
+        "_mark_verification_stale",
+        lambda task_id, paths, session_id=None: marked.extend(paths),
+    )
+
+    out = json.loads(
+        ft.patch_tool(
+            mode="patch",
+            patch=(
+                "*** Begin Patch\n"
+                "*** Move File: old.py -> nested/new.py\n"
+                "*** End Patch\n"
+            ),
+            task_id="remote-task",
+        )
+    )
+
+    assert not out.get("error"), out
+    assert out["files_modified"] == [
+        "/home/myuser/project/old.py -> /home/myuser/project/nested/new.py"
+    ]
+    assert marked == [
+        "/home/myuser/project/old.py",
+        "/home/myuser/project/nested/new.py",
+    ]
+
+
+def test_patch_v4a_rejects_traversal_in_move_header(monkeypatch):
+    """Traversal in either side of a V4A Move header must be blocked."""
+    import json
+    from unittest.mock import MagicMock
+
+    ops = MagicMock()
+    ops.env = object()
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+
+    out = json.loads(
+        ft.patch_tool(
+            mode="patch",
+            patch=(
+                "*** Begin Patch\n"
+                "*** Move File: ../../../etc/shadow -> safe.txt\n"
+                "*** End Patch\n"
+            ),
+            task_id="remote-task",
+        )
+    )
+
+    assert "error" in out
+    assert "traversal" in out["error"].lower()
+    ops.patch_v4a.assert_not_called()

--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -583,6 +583,30 @@ def test_remote_write_file_preserves_backend_absolute_path(monkeypatch):
     assert out["files_modified"] == ["/home/myuser/now.txt"]
 
 
+def test_remote_write_guards_do_not_host_resolve_backend_path(monkeypatch):
+    """SSH-style remote paths use the same lexical path for guards and writes."""
+    import json
+
+    ops = _FakeRemoteFileOps()
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+
+    def host_resolve_should_not_run(filepath, task_id="default"):
+        raise AssertionError("remote write guard must not host-resolve backend paths")
+
+    monkeypatch.setattr(ft, "_resolve_path_for_task", host_resolve_should_not_run)
+
+    out = json.loads(
+        ft.write_file_tool(
+            "/home/myuser/now.txt",
+            "stamp\n",
+            task_id="ssh-task",
+        )
+    )
+
+    assert not out.get("error"), out
+    assert ops.write_paths == ["/home/myuser/now.txt"]
+
+
 def test_remote_patch_replace_preserves_backend_absolute_path(monkeypatch):
     """replace-mode patch should pass backend paths through like write_file."""
     import json
@@ -612,6 +636,32 @@ def test_remote_patch_replace_preserves_backend_absolute_path(monkeypatch):
     assert ops.patch_paths == ["/home/myuser/app.py"]
     assert out["resolved_path"] == "/home/myuser/app.py"
     assert out["files_modified"] == ["/home/myuser/app.py"]
+
+
+def test_remote_patch_guards_do_not_host_resolve_backend_path(monkeypatch):
+    """Remote patch preflight uses the backend path detector consistently."""
+    import json
+
+    ops = _FakeRemoteFileOps()
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+
+    def host_resolve_should_not_run(filepath, task_id="default"):
+        raise AssertionError("remote patch guard must not host-resolve backend paths")
+
+    monkeypatch.setattr(ft, "_resolve_path_for_task", host_resolve_should_not_run)
+
+    out = json.loads(
+        ft.patch_tool(
+            mode="replace",
+            path="/home/myuser/app.py",
+            old_string="old",
+            new_string="new",
+            task_id="ssh-task",
+        )
+    )
+
+    assert not out.get("error"), out
+    assert ops.patch_paths == ["/home/myuser/app.py"]
 
 
 def test_remote_write_file_uses_backend_cwd_without_host_resolve(monkeypatch):
@@ -658,13 +708,45 @@ def test_remote_relative_without_backend_root_does_not_use_host_cwd(monkeypatch,
     )
 
 
+def test_remote_relative_path_uses_last_known_cwd_after_env_rebuild(monkeypatch):
+    """A rebuilt remote backend keeps the session's last-known cwd anchor."""
+    ops = _FakeRemoteFileOps()
+    ops.cwd = "/"
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    monkeypatch.setattr(
+        ft,
+        "_last_known_cwd_for",
+        lambda task_id="default": "/home/myuser/project",
+    )
+    monkeypatch.setattr(ft, "_configured_terminal_cwd", lambda: None)
+
+    assert (
+        ft._lexical_path_for_task("nested/app.py", "remote-task", ops)
+        == "/home/myuser/project/nested/app.py"
+    )
+
+
+def test_remote_restart_ignores_host_configured_terminal_cwd(monkeypatch):
+    """A rebuilt backend must not join a host worktree cwd to remote paths."""
+    ops = _FakeRemoteFileOps()
+    ops.cwd = "/"
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    monkeypatch.setattr(ft, "_last_known_cwd_for", lambda task_id="default": None)
+    monkeypatch.setenv("TERMINAL_CWD", "/Users/dev/repo")
+
+    assert (
+        ft._lexical_path_for_task("nested/app.py", "remote-task", ops)
+        == "/nested/app.py"
+    )
+
+
 def test_remote_read_and_write_use_same_backend_file_state_key(monkeypatch):
     """Remote reads and writes must share the same cross-agent file-state path."""
     import json
 
     ops = _FakeRemoteFileOps()
-    recorded: list[str] = []
-    checked: list[str] = []
+    recorded: list[tuple[str, bool]] = []
+    checked: list[tuple[str, bool]] = []
     monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
     monkeypatch.setattr(
         ft,
@@ -674,12 +756,16 @@ def test_remote_read_and_write_use_same_backend_file_state_key(monkeypatch):
     monkeypatch.setattr(
         ft.file_state,
         "record_read",
-        lambda task_id, path, partial=False: recorded.append(path),
+        lambda task_id, path, partial=False, track_mtime=True: recorded.append(
+            (path, track_mtime)
+        ),
     )
     monkeypatch.setattr(
         ft.file_state,
         "check_stale",
-        lambda task_id, path: checked.append(path) or None,
+        lambda task_id, path, track_mtime=True: checked.append(
+            (path, track_mtime)
+        ) or None,
     )
 
     assert not json.loads(
@@ -691,8 +777,145 @@ def test_remote_read_and_write_use_same_backend_file_state_key(monkeypatch):
 
     assert ops.read_paths == ["/home/u/app.py"]
     assert ops.write_paths == ["/home/u/app.py"]
-    assert recorded == ["/home/u/app.py"]
-    assert checked == ["/home/u/app.py"]
+    assert recorded == [("/home/u/app.py", False)]
+    assert checked == [("/home/u/app.py", False)]
+
+
+def test_remote_read_still_blocks_dotenv(monkeypatch):
+    """Credential guards apply before a non-local backend reads project .env."""
+    import json
+
+    ops = _FakeRemoteFileOps()
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+
+    out = json.loads(
+        ft.read_file_tool("/home/u/project/.env", task_id="remote-task")
+    )
+
+    assert "error" in out
+    assert "secret-bearing environment file" in out["error"]
+    assert ops.read_paths == []
+
+
+def test_remote_read_uses_backend_cwd_without_host_resolve(monkeypatch):
+    """Relative remote reads are joined lexically to the backend cwd."""
+    import json
+
+    ops = _FakeRemoteFileOps()
+    ops.cwd = "/home/u/project"
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+
+    def host_resolve_should_not_run(filepath, task_id="default"):
+        raise AssertionError("remote reads must not host-resolve backend paths")
+
+    monkeypatch.setattr(ft, "_resolve_path_for_task", host_resolve_should_not_run)
+
+    out = json.loads(
+        ft.read_file_tool("nested/app.py", task_id="ssh-task")
+    )
+
+    assert not out.get("error"), out
+    assert ops.read_paths == ["/home/u/project/nested/app.py"]
+
+
+def test_local_read_resolves_path_once(monkeypatch, tmp_path):
+    """Host-backed reads do not repeat the filesystem resolution walk."""
+    import json
+    from tools.environments.local import LocalEnvironment
+
+    ops = _FakeRemoteFileOps()
+    ops.env = LocalEnvironment(cwd=str(tmp_path))
+    calls: list[tuple[str, str]] = []
+    resolved = tmp_path / "app.py"
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+    monkeypatch.setattr(
+        ft,
+        "_resolve_path_for_task",
+        lambda filepath, task_id="default": calls.append((filepath, task_id)) or resolved,
+    )
+
+    out = json.loads(ft.read_file_tool("app.py", task_id="local-task"))
+
+    assert not out.get("error"), out
+    assert calls == [("app.py", "local-task")]
+
+
+def test_remote_search_result_guard_does_not_host_resolve(monkeypatch):
+    """Search-result filtering applies read guards to backend-lexical paths."""
+    ops = _FakeRemoteFileOps()
+
+    def host_resolve_should_not_run(filepath, task_id="default"):
+        raise AssertionError("remote search guard must not host-resolve backend paths")
+
+    monkeypatch.setattr(ft, "_resolve_path_for_task", host_resolve_should_not_run)
+
+    error = ft._search_result_read_block_error(
+        "/home/u/project/.env",
+        "ssh-task",
+        ops,
+    )
+
+    assert error is not None
+    assert "secret-bearing environment file" in error
+
+
+def test_remote_search_precheck_does_not_host_resolve(monkeypatch):
+    """Search preflight and dispatch share the backend-lexical path."""
+    import json
+
+    ops = _FakeRemoteFileOps()
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+
+    def host_resolve_should_not_run(filepath, task_id="default"):
+        raise AssertionError("remote search precheck must not host-resolve backend paths")
+
+    monkeypatch.setattr(ft, "_resolve_path_for_task", host_resolve_should_not_run)
+
+    out = json.loads(
+        ft.search_tool(
+            pattern="needle",
+            path="/home/u/project",
+            task_id="ssh-task",
+        )
+    )
+
+    assert not out.get("error"), out
+    assert ops.search_paths == ["/home/u/project"]
+
+
+def test_remote_search_reuses_backend_path_kind_for_result_guards(monkeypatch):
+    """Search result filtering must not reflect on the backend per match."""
+    import json
+
+    from tools.file_operations import SearchMatch, SearchResult
+
+    ops = _FakeRemoteFileOps()
+    ops.search = lambda **kwargs: SearchResult(
+        matches=[
+            SearchMatch(path=f"/home/u/project/file-{index}.py", line_number=1, content="x")
+            for index in range(20)
+        ]
+    )
+    calls = 0
+
+    def uses_host_paths(file_ops):
+        nonlocal calls
+        calls += 1
+        return False
+
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ops)
+    monkeypatch.setattr(ft, "_file_ops_uses_host_paths", uses_host_paths)
+
+    out = json.loads(
+        ft.search_tool(
+            pattern="needle",
+            path="/home/u/project",
+            task_id="ssh-task",
+        )
+    )
+
+    assert not out.get("error"), out
+    assert calls == 1
 
 
 def test_remote_read_docx_does_not_use_host_extractor(monkeypatch, tmp_path):
@@ -868,6 +1091,25 @@ def test_remote_tilde_hermes_path_hits_container_mirror_guard(monkeypatch):
     )
 
     assert "Sandbox-mirror write blocked" in out["error"]
+    assert calls == []
+
+
+def test_remote_sensitive_path_rejected_without_backend(monkeypatch):
+    """An obvious sensitive target is rejected before backend creation."""
+    import json
+
+    calls = []
+    monkeypatch.setattr(
+        ft,
+        "_get_file_ops",
+        lambda task_id="default": calls.append(task_id),
+    )
+
+    out = json.loads(
+        ft.write_file_tool("/etc/shadow", "x", task_id="remote-task")
+    )
+
+    assert "sensitive system path" in out["error"]
     assert calls == []
 
 

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -102,10 +102,13 @@ class FileStateRegistry:
         *,
         partial: bool = False,
         mtime: Optional[float] = None,
+        track_mtime: bool = True,
     ) -> None:
         if _disabled():
             return
-        if mtime is None:
+        if not track_mtime:
+            mtime = _UNKNOWN_MTIME
+        elif mtime is None:
             try:
                 mtime = os.path.getmtime(resolved)
             except OSError:
@@ -122,6 +125,7 @@ class FileStateRegistry:
         resolved: str,
         *,
         mtime: Optional[float] = None,
+        track_mtime: bool = True,
     ) -> None:
         """Record a successful write.
 
@@ -131,7 +135,9 @@ class FileStateRegistry:
         """
         if _disabled():
             return
-        if mtime is None:
+        if not track_mtime:
+            mtime = _UNKNOWN_MTIME
+        elif mtime is None:
             try:
                 mtime = os.path.getmtime(resolved)
             except OSError:
@@ -144,7 +150,13 @@ class FileStateRegistry:
             self._reads[task_id][resolved] = (float(mtime), now, False)
             _cap_dict(self._reads[task_id], _MAX_PATHS_PER_AGENT)
 
-    def check_stale(self, task_id: str, resolved: str) -> Optional[str]:
+    def check_stale(
+        self,
+        task_id: str,
+        resolved: str,
+        *,
+        track_mtime: bool = True,
+    ) -> Optional[str]:
         """Return a model-facing warning if this write would be stale.
 
         Three staleness classes, in order of severity:
@@ -191,7 +203,7 @@ class FileStateRegistry:
         # Case 2: external / unknown modification (mtime drifted).
         if stamp is not None:
             read_mtime, _read_ts, partial = stamp
-            if read_mtime != _UNKNOWN_MTIME:
+            if track_mtime and read_mtime != _UNKNOWN_MTIME:
                 try:
                     current_mtime = os.path.getmtime(resolved)
                 except OSError:
@@ -296,16 +308,45 @@ def _cap_dict(d: dict, limit: int) -> None:
 
 
 # ── Convenience wrappers (short names used at call sites) ────────────
-def record_read(task_id: str, resolved_or_path: str | Path, *, partial: bool = False) -> None:
-    _registry.record_read(task_id, str(resolved_or_path), partial=partial)
+def record_read(
+    task_id: str,
+    resolved_or_path: str | Path,
+    *,
+    partial: bool = False,
+    track_mtime: bool = True,
+) -> None:
+    _registry.record_read(
+        task_id,
+        str(resolved_or_path),
+        partial=partial,
+        track_mtime=track_mtime,
+    )
 
 
-def note_write(task_id: str, resolved_or_path: str | Path) -> None:
-    _registry.note_write(task_id, str(resolved_or_path))
+def note_write(
+    task_id: str,
+    resolved_or_path: str | Path,
+    *,
+    track_mtime: bool = True,
+) -> None:
+    _registry.note_write(
+        task_id,
+        str(resolved_or_path),
+        track_mtime=track_mtime,
+    )
 
 
-def check_stale(task_id: str, resolved_or_path: str | Path) -> Optional[str]:
-    return _registry.check_stale(task_id, str(resolved_or_path))
+def check_stale(
+    task_id: str,
+    resolved_or_path: str | Path,
+    *,
+    track_mtime: bool = True,
+) -> Optional[str]:
+    return _registry.check_stale(
+        task_id,
+        str(resolved_or_path),
+        track_mtime=track_mtime,
+    )
 
 
 def lock_path(resolved_or_path: str | Path):

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -55,6 +55,11 @@ _MAX_PATHS_PER_AGENT = 4096
 # Global last-writer map cap.  Same policy.
 _MAX_GLOBAL_WRITERS = 4096
 
+# Non-local terminal backends use paths that may not exist on the host.  We
+# still track read/write ordering for sibling-agent warnings, but cannot do
+# host mtime drift checks for those paths.
+_UNKNOWN_MTIME = -1.0
+
 
 class FileStateRegistry:
     """Process-wide coordinator for cross-agent file edits."""
@@ -104,7 +109,7 @@ class FileStateRegistry:
             try:
                 mtime = os.path.getmtime(resolved)
             except OSError:
-                return
+                mtime = _UNKNOWN_MTIME
         now = time.time()
         with self._state_lock:
             agent_reads = self._reads[task_id]
@@ -130,7 +135,7 @@ class FileStateRegistry:
             try:
                 mtime = os.path.getmtime(resolved)
             except OSError:
-                return
+                mtime = _UNKNOWN_MTIME
         now = time.time()
         with self._state_lock:
             self._last_writer[resolved] = (task_id, now)
@@ -163,12 +168,6 @@ class FileStateRegistry:
         if stamp is None and last_writer is None:
             return None
 
-        try:
-            current_mtime = os.path.getmtime(resolved)
-        except OSError:
-            # File doesn't exist — write will create it; not stale.
-            return None
-
         # Case 1: sibling subagent modified after our last read.
         if last_writer is not None:
             writer_tid, writer_ts = last_writer
@@ -192,12 +191,17 @@ class FileStateRegistry:
         # Case 2: external / unknown modification (mtime drifted).
         if stamp is not None:
             read_mtime, _read_ts, partial = stamp
-            if current_mtime != read_mtime:
-                return (
-                    f"{resolved} was modified since you last read it "
-                    "on disk (external edit or unrecorded writer). "
-                    "Re-read the file before writing."
-                )
+            if read_mtime != _UNKNOWN_MTIME:
+                try:
+                    current_mtime = os.path.getmtime(resolved)
+                except OSError:
+                    current_mtime = None
+                if current_mtime is not None and current_mtime != read_mtime:
+                    return (
+                        f"{resolved} was modified since you last read it "
+                        "on disk (external edit or unrecorded writer). "
+                        "Re-read the file before writing."
+                    )
             if partial:
                 return (
                     f"{resolved} was last read with offset/limit pagination "

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2,10 +2,12 @@
 """File Tools Module - LLM agent file manipulation tools."""
 
 import errno
+import inspect
 import json
 import logging
 import os
 import posixpath
+import re
 import sys
 import threading
 from pathlib import Path, PurePosixPath
@@ -269,6 +271,23 @@ def _registered_task_cwd_override(task_id: str = "default") -> str | None:
     return _sentinel_free_abs_cwd(overrides.get("cwd"))
 
 
+def _registered_task_cwd_override_lexical(task_id: str = "default") -> str | None:
+    """Return a POSIX absolute cwd override for non-local backend paths."""
+    try:
+        from tools.terminal_tool import resolve_task_overrides
+
+        overrides = resolve_task_overrides(task_id)
+    except Exception:
+        return None
+
+    raw = str(overrides.get("cwd") or "").strip()
+    if raw.lower() in _TERMINAL_CWD_SENTINELS:
+        return None
+    if raw.startswith("~") or not posixpath.isabs(raw):
+        return None
+    return posixpath.normpath(raw)
+
+
 def _live_cwd_if_owned(env, task_id: str) -> str | None:
     """The env's live cwd, but only when THIS session owns it.
 
@@ -464,6 +483,180 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
     return resolved.resolve()
 
 
+def _lexical_path_for_task(
+    filepath: str,
+    task_id: str = "default",
+    file_ops=None,
+) -> str:
+    """Resolve *filepath* without dereferencing host symlinks.
+
+    Non-local file operations run inside a terminal backend (Docker, SSH,
+    Modal, Daytona, etc.).  A backend path like ``/home/user/file`` must not be
+    canonicalized through the host filesystem first: on macOS, for example,
+    ``/home`` is a host symlink to ``/System/Volumes/Data/home`` even though the
+    remote Linux backend expects the literal ``/home`` path.
+    """
+    raw = str(filepath or "")
+    if raw.startswith("~"):
+        return raw
+    if posixpath.isabs(raw):
+        return posixpath.normpath(raw)
+
+    env = getattr(file_ops, "env", None)
+    root = _live_cwd_if_owned(env, task_id) if env is not None else None
+    if not root:
+        root = _registered_task_cwd_override_lexical(task_id)
+    if not root:
+        root = getattr(file_ops, "cwd", None) if file_ops is not None else None
+    if root and not str(root).startswith("~") and posixpath.isabs(str(root)):
+        return posixpath.normpath(posixpath.join(str(root), raw))
+    return posixpath.normpath(raw)
+
+
+def _container_mirror_tilde_target(
+    filepath: str,
+    mirror_prefix: str | None,
+) -> str | None:
+    """Return the backend-expanded path for ``~`` under a container mirror."""
+    if not mirror_prefix:
+        return None
+    raw = str(filepath or "")
+    if raw == "~":
+        return mirror_prefix
+    if raw.startswith("~/"):
+        return posixpath.normpath(posixpath.join(mirror_prefix, raw[2:]))
+    return None
+
+
+def _file_ops_static_env(file_ops) -> tuple[bool, object | None]:
+    """Return a declared ``file_ops.env`` without triggering dynamic mocks."""
+    try:
+        inspect.getattr_static(file_ops, "env")
+    except AttributeError:
+        return False, None
+    return True, getattr(file_ops, "env", None)
+
+
+def _file_ops_uses_host_paths(file_ops) -> bool:
+    """Return True when *file_ops* points at the local host filesystem."""
+    _has_env, env = _file_ops_static_env(file_ops)
+    if env is None:
+        return True
+    try:
+        from tools.environments.local import LocalEnvironment
+    except ImportError:
+        return True
+    return isinstance(env, LocalEnvironment)
+
+
+def _resolve_path_for_file_ops(
+    filepath: str,
+    task_id: str = "default",
+    file_ops=None,
+) -> str:
+    """Return the path that should be passed to ``file_ops``.
+
+    Local backends keep the historical host-canonical path.  Non-local
+    backends receive a lexical backend path so host symlinks and host-only
+    mount aliases cannot rewrite remote absolute paths.
+    """
+    if file_ops is not None:
+        has_env, _env = _file_ops_static_env(file_ops)
+        if not has_env:
+            return str(filepath)
+    if file_ops is not None and not _file_ops_uses_host_paths(file_ops):
+        return _lexical_path_for_task(filepath, task_id, file_ops)
+    return str(_resolve_path_for_task(filepath, task_id))
+
+
+_V4A_FILE_HEADER_RE = re.compile(
+    r"^(\*\*\*\s*(?:Update|Add|Delete)\s+File:\s*)(.+)$"
+)
+_V4A_MOVE_HEADER_RE = re.compile(
+    r"^(\*\*\*\s*Move\s+File:\s*)(.+?)(\s*->\s*)(.+)$"
+)
+
+
+def _rewrite_v4a_patch_paths_for_file_ops(
+    patch: str,
+    task_id: str,
+    file_ops,
+) -> str:
+    """Rewrite remote V4A path headers to backend-safe lexical paths."""
+    if _file_ops_uses_host_paths(file_ops):
+        return patch
+
+    rewritten: list[str] = []
+    for line in patch.split("\n"):
+        file_match = _V4A_FILE_HEADER_RE.match(line)
+        if file_match:
+            rewritten.append(
+                file_match.group(1)
+                + _resolve_path_for_file_ops(file_match.group(2).strip(), task_id, file_ops)
+            )
+            continue
+
+        move_match = _V4A_MOVE_HEADER_RE.match(line)
+        if move_match:
+            src = _resolve_path_for_file_ops(move_match.group(2).strip(), task_id, file_ops)
+            dst = _resolve_path_for_file_ops(move_match.group(4).strip(), task_id, file_ops)
+            rewritten.append(
+                f"{move_match.group(1)}{src}{move_match.group(3)}{dst}"
+            )
+            continue
+
+        rewritten.append(line)
+    return "\n".join(rewritten)
+
+
+def _resolved_v4a_report_paths(
+    patch: str,
+    path_to_resolved: dict[str, str | None],
+) -> list[str]:
+    """Return resolved V4A paths while preserving move ``src -> dst`` shape."""
+    reported: list[str] = []
+    for line in patch.split("\n"):
+        file_match = _V4A_FILE_HEADER_RE.match(line)
+        if file_match:
+            path = file_match.group(2).strip()
+            reported.append(path_to_resolved.get(path) or path)
+            continue
+
+        move_match = _V4A_MOVE_HEADER_RE.match(line)
+        if move_match:
+            src = move_match.group(2).strip()
+            dst = move_match.group(4).strip()
+            reported.append(
+                f"{path_to_resolved.get(src) or src} -> "
+                f"{path_to_resolved.get(dst) or dst}"
+            )
+    return reported
+
+
+def _resolved_v4a_internal_paths(
+    patch: str,
+    path_to_resolved: dict[str, str | None],
+) -> list[str]:
+    """Return resolved V4A paths as individual filesystem paths."""
+    reported: list[str] = []
+    for line in patch.split("\n"):
+        file_match = _V4A_FILE_HEADER_RE.match(line)
+        if file_match:
+            path = file_match.group(2).strip()
+            reported.append(path_to_resolved.get(path) or path)
+            continue
+
+        move_match = _V4A_MOVE_HEADER_RE.match(line)
+        if move_match:
+            src = move_match.group(2).strip()
+            dst = move_match.group(4).strip()
+            reported.extend([
+                path_to_resolved.get(src) or src,
+                path_to_resolved.get(dst) or dst,
+            ])
+    return reported
+
+
 def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "default") -> str | None:
     """Warn when a relative path resolved OUTSIDE the task's workspace root.
 
@@ -503,6 +696,18 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
             )
     except Exception:
         return None
+
+
+def _path_resolution_warning_for_file_ops(
+    filepath: str,
+    resolved: str,
+    task_id: str,
+    file_ops,
+) -> str | None:
+    """Return workspace-divergence warnings only for host-backed file paths."""
+    if not _file_ops_uses_host_paths(file_ops):
+        return None
+    return _path_resolution_warning(filepath, Path(resolved), task_id)
 
 
 def _is_blocked_device_path(path: str) -> bool:
@@ -777,10 +982,22 @@ def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | 
     if warning is not None:
         return warning
 
-    return get_container_mirror_warning(
+    mirror_prefix = _get_container_mirror_prefix_for_task(task_id)
+    warning = get_container_mirror_warning(
         resolved,
-        mirror_prefix=_get_container_mirror_prefix_for_task(task_id),
+        mirror_prefix=mirror_prefix,
     )
+    if warning is not None:
+        return warning
+
+    tilde_target = _container_mirror_tilde_target(filepath, mirror_prefix)
+    if tilde_target is not None:
+        return get_container_mirror_warning(
+            tilde_target,
+            mirror_prefix=mirror_prefix,
+        )
+
+    return None
 
 
 def _is_expected_write_exception(exc: Exception) -> bool:
@@ -1218,20 +1435,64 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 ),
             })
 
-        _resolved = _resolve_path_for_task(path, task_id)
-
-        # ── Structured-document extraction ────────────────────────────
-        # Try before the binary-extension guard so .docx/.xlsx can render as text.
-        # Malformed documents fall through to the normal path/binary guard.
         from tools.read_extract import ExtractionError, extract_document_text, is_extractable_document
 
-        if is_extractable_document(str(_resolved)):
+        extractable_document = is_extractable_document(str(path))
+
+        # ── Binary file guard ─────────────────────────────────────────
+        # Block binary files by extension (no I/O). Extractable documents
+        # continue below so local backends can render them as text and remote
+        # backends can still read the backend path without starting up just to
+        # reject obvious binaries.
+        if has_binary_extension(str(path)) and not extractable_document:
+            _ext = Path(str(path)).suffix.lower()
+            return json.dumps({
+                "error": (
+                    f"Cannot read binary file '{path}' ({_ext}). "
+                    "Use vision_analyze for images, or terminal to inspect binary files."
+                ),
+            })
+
+        file_ops = _get_file_ops(task_id)
+        uses_host_paths = _file_ops_uses_host_paths(file_ops)
+
+        if uses_host_paths:
+            _resolved = _resolve_path_for_task(path, task_id)
+            extractable_document = is_extractable_document(str(_resolved))
+
+            # ── Hermes internal path guard ────────────────────────────────
+            # Prevent prompt injection via catalog or hub metadata files,
+            # and block credential stores under HERMES_HOME.  Pass the
+            # already-resolved path so a relative-path read against
+            # TERMINAL_CWD == HERMES_HOME (e.g. "auth.json") still hits the
+            # denylist — get_read_block_error's own resolve() runs against
+            # the Python process cwd, which can differ.
+            block_error = get_read_block_error(str(_resolved))
+            if block_error:
+                return json.dumps({"error": block_error})
+        else:
+            _resolved = None
+
+        try:
+            resolved_str = _resolve_path_for_file_ops(path, task_id, file_ops)
+        except Exception:
+            if uses_host_paths:
+                resolved_str = str(_resolved)
+            else:
+                try:
+                    resolved_str = _lexical_path_for_task(path, task_id, file_ops)
+                except Exception:
+                    resolved_str = path
+
+        # ── Structured-document extraction ────────────────────────────
+        # Try before the normal read so .docx/.xlsx can render as text on local
+        # files.  Malformed documents fall through to the normal backend read.
+        if uses_host_paths and extractable_document:
             try:
                 extracted_text = extract_document_text(str(_resolved))
             except ExtractionError:
                 logger.debug("document extraction failed for %s", path, exc_info=True)
             else:
-                file_ops = _get_file_ops(task_id)
                 lines = extracted_text.splitlines()
                 total_lines = len(lines)
                 end_line = offset + limit - 1
@@ -1279,33 +1540,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                     result_dict["content"] = redact_sensitive_text(result_dict["content"], file_read=True)
                 return json.dumps(result_dict, ensure_ascii=False)
 
-        # ── Binary file guard ─────────────────────────────────────────
-        # Block binary files by extension (no I/O).
-        if has_binary_extension(str(_resolved)):
-            _ext = _resolved.suffix.lower()
-            return json.dumps({
-                "error": (
-                    f"Cannot read binary file '{path}' ({_ext}). "
-                    "Use vision_analyze for images, or terminal to inspect binary files."
-                ),
-            })
-
-        # ── Hermes internal path guard ────────────────────────────────
-        # Prevent prompt injection via catalog or hub metadata files,
-        # and block credential stores under HERMES_HOME.  Pass the
-        # already-resolved path so a relative-path read against
-        # TERMINAL_CWD == HERMES_HOME (e.g. "auth.json") still hits the
-        # denylist — get_read_block_error's own resolve() runs against
-        # the Python process cwd, which can differ.
-        block_error = get_read_block_error(str(_resolved))
-        if block_error:
-            return json.dumps({"error": block_error})
-
         # ── Dedup check ───────────────────────────────────────────────
         # If we already read this exact (path, offset, limit) and the
         # file hasn't been modified since, return a lightweight stub
         # instead of re-sending the same content.  Saves context tokens.
-        resolved_str = str(_resolved)
         dedup_key = (resolved_str, offset, limit)
         with _read_tracker_lock:
             task_data = _read_tracker.setdefault(task_id, {
@@ -1322,7 +1560,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 task_data["read_timestamps"] = {}
             cached_mtime = task_data.get("dedup", {}).get(dedup_key)
 
-        if cached_mtime is not None:
+        if uses_host_paths and cached_mtime is not None:
             try:
                 current_mtime = os.path.getmtime(resolved_str)
                 if current_mtime == cached_mtime:
@@ -1362,8 +1600,8 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 pass  # stat failed — fall through to full read
 
         # ── Perform the read ──────────────────────────────────────────
-        file_ops = _get_file_ops(task_id)
-        result = file_ops.read_file(path, offset, limit)
+        read_target = resolved_str if not uses_host_paths else path
+        result = file_ops.read_file(read_target, offset, limit)
         result_dict = result.to_dict()
 
         # ── Character-count guard ─────────────────────────────────────
@@ -1449,12 +1687,13 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
             # 1. Dedup: skip identical re-reads of unchanged files.
             # 2. Staleness: warn on write/patch if the file changed since
             #    the agent last read it (external edit, concurrent agent, etc.).
-            try:
-                _mtime_now = os.path.getmtime(resolved_str)
-                task_data["dedup"][dedup_key] = _mtime_now
-                task_data.setdefault("read_timestamps", {})[resolved_str] = _mtime_now
-            except OSError:
-                pass  # Can't stat — skip tracking for this entry
+            if uses_host_paths:
+                try:
+                    _mtime_now = os.path.getmtime(resolved_str)
+                    task_data["dedup"][dedup_key] = _mtime_now
+                    task_data.setdefault("read_timestamps", {})[resolved_str] = _mtime_now
+                except OSError:
+                    pass  # Can't stat — skip tracking for this entry
 
             # Bound the per-task containers so a long CLI session doesn't
             # accumulate megabytes of dict/set state.  See _cap_read_tracker_data.
@@ -1467,11 +1706,12 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         # truncated (large file with more content than limit covered).
         # Outside the _read_tracker_lock so the registry's own locking
         # isn't nested under ours.
-        try:
-            _partial = (offset > 1) or bool(result_dict.get("truncated"))
-            file_state.record_read(task_id, resolved_str, partial=_partial)
-        except Exception:
-            logger.debug("file_state.record_read failed", exc_info=True)
+        if not result_dict.get("error"):
+            try:
+                _partial = (offset > 1) or bool(result_dict.get("truncated"))
+                file_state.record_read(task_id, resolved_str, partial=_partial)
+            except Exception:
+                logger.debug("file_state.record_read failed", exc_info=True)
 
         if count >= 4:
             # Hard block: stop returning content to break the loop
@@ -1545,7 +1785,13 @@ def notify_other_tool_call(task_id: str = "default"):
                 task_data["dedup_hits"].clear()
 
 
-def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
+def _invalidate_dedup_for_path(
+    filepath: str,
+    task_id: str,
+    *,
+    resolved_path: str | None = None,
+    uses_host_paths: bool = True,
+) -> None:
     """Remove all dedup cache entries whose resolved path matches *filepath*.
 
     Called after write_file and patch so that a subsequent read_file on
@@ -1558,8 +1804,10 @@ def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
     Must be called with ``_read_tracker_lock`` **not** held — acquires it
     internally.
     """
+    if not uses_host_paths:
+        return
     try:
-        resolved = str(_resolve_path(filepath))
+        resolved = resolved_path or str(_resolve_path(filepath, task_id))
     except (OSError, ValueError):
         return
     with _read_tracker_lock:
@@ -1575,7 +1823,13 @@ def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
             del dedup[k]
 
 
-def _update_read_timestamp(filepath: str, task_id: str) -> None:
+def _update_read_timestamp(
+    filepath: str,
+    task_id: str,
+    *,
+    resolved_path: str | None = None,
+    uses_host_paths: bool = True,
+) -> None:
     """Record the file's current modification time after a successful write.
 
     Called after write_file and patch so that consecutive edits by the
@@ -1586,9 +1840,16 @@ def _update_read_timestamp(filepath: str, task_id: str) -> None:
     subsequent reads return fresh content (fixes #13144).
     """
     # Invalidate dedup first (before acquiring lock for timestamp update).
-    _invalidate_dedup_for_path(filepath, task_id)
+    _invalidate_dedup_for_path(
+        filepath,
+        task_id,
+        resolved_path=resolved_path,
+        uses_host_paths=uses_host_paths,
+    )
+    if not uses_host_paths:
+        return
     try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
+        resolved = resolved_path or str(_resolve_path_for_task(filepath, task_id))
         current_mtime = os.path.getmtime(resolved)
     except (OSError, ValueError):
         return
@@ -1599,15 +1860,23 @@ def _update_read_timestamp(filepath: str, task_id: str) -> None:
             _cap_read_tracker_data(task_data)
 
 
-def _check_file_staleness(filepath: str, task_id: str) -> str | None:
+def _check_file_staleness(
+    filepath: str,
+    task_id: str,
+    *,
+    resolved_path: str | None = None,
+    uses_host_paths: bool = True,
+) -> str | None:
     """Check whether a file was modified since the agent last read it.
 
     Returns a warning string if the file is stale (mtime changed since
     the last read_file call for this task), or None if the file is fresh
     or was never read.  Does not block — the write still proceeds.
     """
+    if not uses_host_paths:
+        return None
     try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
+        resolved = resolved_path or str(_resolve_path_for_task(filepath, task_id))
     except (OSError, ValueError):
         return None
     with _read_tracker_lock:
@@ -1689,24 +1958,33 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             "file contents before writing."
         )
     try:
+        file_ops = _get_file_ops(task_id)
+        uses_host_paths = _file_ops_uses_host_paths(file_ops)
         # Resolve once for the registry lock + stale check.  Failures here
         # fall back to the legacy path — write proceeds, per-task staleness
         # check below still runs.
         try:
-            _resolved = str(_resolve_path_for_task(path, task_id))
+            _resolved = _resolve_path_for_file_ops(path, task_id, file_ops)
         except Exception:
             _resolved = None
 
         if _resolved is None:
-            stale_warning = _check_file_staleness(path, task_id)
-            file_ops = _get_file_ops(task_id)
+            stale_warning = _check_file_staleness(
+                path,
+                task_id,
+                uses_host_paths=uses_host_paths,
+            )
             result = file_ops.write_file(path, content)
             result_dict = result.to_dict()
             if stale_warning:
                 result_dict["_warning"] = stale_warning
             if not result_dict.get("error"):
                 _mark_verification_stale(task_id, [path], session_id=session_id)
-            _update_read_timestamp(path, task_id)
+            _update_read_timestamp(
+                path,
+                task_id,
+                uses_host_paths=uses_host_paths,
+            )
             return json.dumps(result_dict, ensure_ascii=False)
 
         # Serialize the read→modify→write region per-path so concurrent
@@ -1716,11 +1994,20 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             # Cross-agent staleness wins over per-task warning when both
             # fire — its message names the sibling subagent.
             cross_warning = file_state.check_stale(task_id, _resolved)
-            stale_warning = _check_file_staleness(path, task_id)
+            stale_warning = _check_file_staleness(
+                path,
+                task_id,
+                resolved_path=_resolved,
+                uses_host_paths=uses_host_paths,
+            )
             # Workspace-divergence warning: relative path resolving outside the
             # terminal's cwd (the worktree-cwd bug). Lowest priority of the three.
-            cwd_warning = _path_resolution_warning(path, Path(_resolved), task_id)
-            file_ops = _get_file_ops(task_id)
+            cwd_warning = _path_resolution_warning_for_file_ops(
+                path,
+                _resolved,
+                task_id,
+                file_ops,
+            )
             result = file_ops.write_file(_resolved, content)
             result_dict = result.to_dict()
             effective_warning = cross_warning or stale_warning or cwd_warning
@@ -1735,7 +2022,12 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
                 _mark_verification_stale(task_id, [_resolved], session_id=session_id)
             # Refresh stamps after the successful write so consecutive
             # writes by this task don't trigger false staleness warnings.
-            _update_read_timestamp(path, task_id)
+            _update_read_timestamp(
+                path,
+                task_id,
+                resolved_path=_resolved,
+                uses_host_paths=uses_host_paths,
+            )
             if not result_dict.get("error"):
                 file_state.note_write(task_id, _resolved)
         return json.dumps(result_dict, ensure_ascii=False)
@@ -1763,7 +2055,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         _paths_to_check.append(path)
     if mode == "patch" and patch:
         import re as _re
+
         from tools.path_security import has_traversal_component
+
         def _reject_v4a_traversal(v4a_path: str) -> str | None:
             # V4A path headers come from patch CONTENT, not the explicit
             # ``path=`` arg — so they're more attacker-influenceable (skill
@@ -1811,6 +2105,8 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             if cross_warning:
                 return tool_error(cross_warning)
     try:
+        file_ops = _get_file_ops(task_id)
+        uses_host_paths = _file_ops_uses_host_paths(file_ops)
         # Resolve paths for locking.  Ordered + deduplicated so concurrent
         # callers lock in the same order — prevents deadlock on overlapping
         # multi-file V4A patches.
@@ -1818,7 +2114,7 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         _seen: set[str] = set()
         for _p in _paths_to_check:
             try:
-                _r = str(_resolve_path_for_task(_p, task_id))
+                _r = _resolve_path_for_file_ops(_p, task_id, file_ops)
             except Exception:
                 _r = None
             if _r and _r not in _seen:
@@ -1837,23 +2133,31 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             # Collect warnings — cross-agent registry first (names sibling),
             # then per-task tracker as a fallback.
             stale_warnings: list[str] = []
-            _path_to_resolved: dict[str, str] = {}
+            _path_to_resolved: dict[str, str | None] = {}
             for _p in _paths_to_check:
                 try:
-                    _r = str(_resolve_path_for_task(_p, task_id))
+                    _r = _resolve_path_for_file_ops(_p, task_id, file_ops)
                 except Exception:
                     _r = None
                 _path_to_resolved[_p] = _r
                 _cross = file_state.check_stale(task_id, _r) if _r else None
-                _sw = _cross or _check_file_staleness(_p, task_id)
+                _sw = _cross or _check_file_staleness(
+                    _p,
+                    task_id,
+                    resolved_path=_r,
+                    uses_host_paths=uses_host_paths,
+                )
                 if not _sw and _r:
                     # Workspace-divergence warning (worktree-cwd bug): relative
                     # path resolving outside the terminal's cwd.
-                    _sw = _path_resolution_warning(_p, Path(_r), task_id)
+                    _sw = _path_resolution_warning_for_file_ops(
+                        _p,
+                        _r,
+                        task_id,
+                        file_ops,
+                    )
                 if _sw:
                     stale_warnings.append(_sw)
-
-            file_ops = _get_file_ops(task_id)
 
             if mode == "replace":
                 if not path:
@@ -1870,7 +2174,12 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             elif mode == "patch":
                 if not patch:
                     return tool_error("patch content required")
-                result = file_ops.patch_v4a(patch)
+                patch_for_ops = _rewrite_v4a_patch_paths_for_file_ops(
+                    patch,
+                    task_id,
+                    file_ops,
+                )
+                result = file_ops.patch_v4a(patch_for_ops)
             else:
                 return tool_error(f"Unknown mode: {mode}")
 
@@ -1880,19 +2189,35 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             # Report the ABSOLUTE path(s) actually patched so a wrong-cwd
             # mismatch (e.g. a worktree session editing the main checkout) is
             # visible in the response instead of silently landing elsewhere.
-            _resolved_modified = [
-                _path_to_resolved.get(_p) or _p for _p in _paths_to_check
-            ]
+            if mode == "patch" and patch:
+                _resolved_modified = _resolved_v4a_report_paths(
+                    patch,
+                    _path_to_resolved,
+                )
+                _internal_modified = _resolved_v4a_internal_paths(
+                    patch,
+                    _path_to_resolved,
+                )
+            else:
+                _resolved_modified = [
+                    _path_to_resolved.get(_p) or _p for _p in _paths_to_check
+                ]
+                _internal_modified = _resolved_modified
             # Refresh stored timestamps for all successfully-patched paths so
             # consecutive edits by this task don't trigger false warnings.
             if not result_dict.get("error"):
                 result_dict["files_modified"] = _resolved_modified
                 if len(_resolved_modified) == 1:
                     result_dict["resolved_path"] = _resolved_modified[0]
-                _mark_verification_stale(task_id, _resolved_modified, session_id=session_id)
+                _mark_verification_stale(task_id, _internal_modified, session_id=session_id)
                 for _p in _paths_to_check:
-                    _update_read_timestamp(_p, task_id)
                     _r = _path_to_resolved.get(_p)
+                    _update_read_timestamp(
+                        _p,
+                        task_id,
+                        resolved_path=_r,
+                        uses_host_paths=uses_host_paths,
+                    )
                     if _r:
                         file_state.note_write(task_id, _r)
                 # Successful patch: clear any prior consecutive-failure
@@ -1992,8 +2317,14 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             return json.dumps({"error": block_error}, ensure_ascii=False)
 
         file_ops = _get_file_ops(task_id)
+        search_path = path
+        if not _file_ops_uses_host_paths(file_ops):
+            try:
+                search_path = _resolve_path_for_file_ops(path, task_id, file_ops)
+            except Exception:
+                search_path = path
         result = file_ops.search(
-            pattern=pattern, path=path, target=target, file_glob=file_glob,
+            pattern=pattern, path=search_path, target=target, file_glob=file_glob,
             limit=limit, offset=offset, output_mode=output_mode, context=context
         )
         omitted = _filter_read_blocked_search_results(result, task_id)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -506,8 +506,15 @@ def _lexical_path_for_task(
     root = _live_cwd_if_owned(env, task_id) if env is not None else None
     if not root:
         root = _registered_task_cwd_override_lexical(task_id)
+    backend_cwd = getattr(file_ops, "cwd", None) if file_ops is not None else None
+    if not root and backend_cwd == "/":
+        # A freshly recreated remote backend commonly reports its default root
+        # cwd before the session drives it again. Preserve the previous cwd in
+        # that specific case; do not let a shared stale registry override an
+        # explicit non-root backend cwd or invent a root when none is known.
+        root = _last_known_cwd_for(task_id)
     if not root:
-        root = getattr(file_ops, "cwd", None) if file_ops is not None else None
+        root = backend_cwd
     if root and not str(root).startswith("~") and posixpath.isabs(str(root)):
         return posixpath.normpath(posixpath.join(str(root), raw))
     return posixpath.normpath(raw)
@@ -786,7 +793,12 @@ def _is_blocked_device(filepath: str, base_dir: str | Path | None = None) -> boo
     return False
 
 
-def _search_result_read_block_error(path: str, task_id: str = "default") -> str | None:
+def _search_result_read_block_error(
+    path: str,
+    task_id: str = "default",
+    file_ops=None,
+    uses_host_paths: bool | None = None,
+) -> str | None:
     """Return the read-safety error for a search result path.
 
     Search backends may return paths relative to the task cwd, while
@@ -795,20 +807,37 @@ def _search_result_read_block_error(path: str, task_id: str = "default") -> str 
     resolution before applying the shared read guard.
     """
     try:
-        resolved = _resolve_path_for_task(path, task_id)
+        if file_ops is None:
+            resolved = _resolve_path_for_task(path, task_id)
+        elif uses_host_paths is False:
+            resolved = _lexical_path_for_task(path, task_id, file_ops)
+        elif uses_host_paths is True:
+            resolved = _resolve_path_for_task(path, task_id)
+        else:
+            resolved = _resolve_path_for_file_ops(path, task_id, file_ops)
     except (OSError, ValueError, RuntimeError):
         return get_read_block_error(path)
     return get_read_block_error(str(resolved))
 
 
-def _filter_read_blocked_search_results(result, task_id: str = "default") -> int:
+def _filter_read_blocked_search_results(
+    result,
+    task_id: str = "default",
+    file_ops=None,
+    uses_host_paths: bool | None = None,
+) -> int:
     """Remove credential/cache/env paths from a SearchResult in-place."""
     omitted = 0
 
     if hasattr(result, "matches") and result.matches:
         allowed_matches = []
         for match in result.matches:
-            if _search_result_read_block_error(match.path, task_id):
+            if _search_result_read_block_error(
+                match.path,
+                task_id,
+                file_ops,
+                uses_host_paths,
+            ):
                 omitted += 1
                 continue
             allowed_matches.append(match)
@@ -817,7 +846,12 @@ def _filter_read_blocked_search_results(result, task_id: str = "default") -> int
     if hasattr(result, "files") and result.files:
         allowed_files = []
         for file_path in result.files:
-            if _search_result_read_block_error(file_path, task_id):
+            if _search_result_read_block_error(
+                file_path,
+                task_id,
+                file_ops,
+                uses_host_paths,
+            ):
                 omitted += 1
                 continue
             allowed_files.append(file_path)
@@ -826,7 +860,12 @@ def _filter_read_blocked_search_results(result, task_id: str = "default") -> int
     if hasattr(result, "counts") and result.counts:
         allowed_counts = {}
         for file_path, count in result.counts.items():
-            if _search_result_read_block_error(file_path, task_id):
+            if _search_result_read_block_error(
+                file_path,
+                task_id,
+                file_ops,
+                uses_host_paths,
+            ):
                 omitted += 1
                 continue
             allowed_counts[file_path] = count
@@ -864,12 +903,20 @@ def _get_hermes_config_resolved() -> str | None:
     return _hermes_config_resolved
 
 
-def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
+def _check_sensitive_path(
+    filepath: str,
+    task_id: str = "default",
+    *,
+    candidate_path: str | None = None,
+) -> str | None:
     """Return an error message if the path targets a sensitive system location."""
-    try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
-    except (OSError, ValueError):
-        resolved = filepath
+    if candidate_path is None:
+        try:
+            resolved = str(_resolve_path_for_task(filepath, task_id))
+        except (OSError, ValueError):
+            resolved = filepath
+    else:
+        resolved = candidate_path
     normalized = os.path.normpath(_expand_tilde(filepath))
     _err = (
         f"Refusing to write to sensitive system path: {filepath}\n"
@@ -928,7 +975,12 @@ def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | Non
     return None
 
 
-def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | None:
+def _check_cross_profile_path(
+    filepath: str,
+    task_id: str = "default",
+    *,
+    candidate_path: str | None = None,
+) -> str | None:
     """Return a soft-guard warning when ``filepath`` lands in another Hermes
     profile's scoped area, a host-side sandbox-mirror of authoritative profile
     state, or the Docker container's sandbox mirror of Hermes state.
@@ -969,10 +1021,13 @@ def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | 
     # Resolve via the task's cwd so a relative ``skills/foo/SKILL.md``
     # in a session that cd'd into ``~/.hermes/profiles/other/`` is
     # classified against the right base.
-    try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
-    except (OSError, ValueError):
-        resolved = filepath
+    if candidate_path is None:
+        try:
+            resolved = str(_resolve_path_for_task(filepath, task_id))
+        except (OSError, ValueError):
+            resolved = filepath
+    else:
+        resolved = candidate_path
 
     warning = get_cross_profile_warning(resolved)
     if warning is not None:
@@ -1459,30 +1514,30 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         if uses_host_paths:
             _resolved = _resolve_path_for_task(path, task_id)
             extractable_document = is_extractable_document(str(_resolved))
-
-            # ── Hermes internal path guard ────────────────────────────────
-            # Prevent prompt injection via catalog or hub metadata files,
-            # and block credential stores under HERMES_HOME.  Pass the
-            # already-resolved path so a relative-path read against
-            # TERMINAL_CWD == HERMES_HOME (e.g. "auth.json") still hits the
-            # denylist — get_read_block_error's own resolve() runs against
-            # the Python process cwd, which can differ.
-            block_error = get_read_block_error(str(_resolved))
-            if block_error:
-                return json.dumps({"error": block_error})
+            has_declared_env, _env = _file_ops_static_env(file_ops)
+            # Production ShellFileOperations always declares ``env`` and uses
+            # the canonical host path.  Env-less test doubles intentionally
+            # keep the caller path shape so read/write staleness keys agree.
+            resolved_str = str(_resolved) if has_declared_env else str(path)
         else:
             _resolved = None
-
-        try:
-            resolved_str = _resolve_path_for_file_ops(path, task_id, file_ops)
-        except Exception:
-            if uses_host_paths:
-                resolved_str = str(_resolved)
-            else:
+            try:
+                resolved_str = _resolve_path_for_file_ops(path, task_id, file_ops)
+            except Exception:
                 try:
                     resolved_str = _lexical_path_for_task(path, task_id, file_ops)
                 except Exception:
                     resolved_str = path
+
+        # ── Hermes internal path guard ────────────────────────────────
+        # Prevent prompt injection via catalog or hub metadata files and block
+        # credential stores on every backend.  Use the exact host-canonical or
+        # backend-lexical path that file_ops will read; a relative task path may
+        # otherwise be resolved against the Python process cwd and miss the
+        # denylist, while host-resolving a remote path can corrupt its meaning.
+        block_error = get_read_block_error(resolved_str)
+        if block_error:
+            return json.dumps({"error": block_error})
 
         # ── Structured-document extraction ────────────────────────────
         # Try before the normal read so .docx/.xlsx can render as text on local
@@ -1709,7 +1764,12 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         if not result_dict.get("error"):
             try:
                 _partial = (offset > 1) or bool(result_dict.get("truncated"))
-                file_state.record_read(task_id, resolved_str, partial=_partial)
+                file_state.record_read(
+                    task_id,
+                    resolved_str,
+                    partial=_partial,
+                    track_mtime=uses_host_paths,
+                )
             except Exception:
                 logger.debug("file_state.record_read failed", exc_info=True)
 
@@ -1944,13 +2004,21 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
     Pass ``True`` after explicit user direction — same shape as ``force``
     on the terminal tool.
     """
-    sensitive_err = _check_sensitive_path(path, task_id)
+    # Cheap lexical preflight rejects obvious sensitive/profile targets before
+    # a remote backend is created. The authoritative second pass below uses the
+    # exact backend path, so relative remote targets remain classified safely.
+    sensitive_err = _check_sensitive_path(path, task_id, candidate_path=path)
     if sensitive_err:
         return tool_error(sensitive_err)
     if not cross_profile:
-        cross_warning = _check_cross_profile_path(path, task_id)
+        cross_warning = _check_cross_profile_path(
+            path,
+            task_id,
+            candidate_path=path,
+        )
         if cross_warning:
             return tool_error(cross_warning)
+
     if _is_internal_file_tool_content(content):
         return tool_error(
             "Refusing to write internal read_file display text as file content. "
@@ -1967,6 +2035,28 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             _resolved = _resolve_path_for_file_ops(path, task_id, file_ops)
         except Exception:
             _resolved = None
+
+        # Apply write guards to the same path representation that the backend
+        # receives.  In particular, SSH paths must stay lexical instead of
+        # passing through the host-only _resolve_path_for_task fallback.
+        _guard_resolved = _resolved
+        if _guard_resolved is None and not uses_host_paths:
+            _guard_resolved = path
+        sensitive_err = _check_sensitive_path(
+            path,
+            task_id,
+            candidate_path=_guard_resolved,
+        )
+        if sensitive_err:
+            return tool_error(sensitive_err)
+        if not cross_profile:
+            cross_warning = _check_cross_profile_path(
+                path,
+                task_id,
+                candidate_path=_guard_resolved,
+            )
+            if cross_warning:
+                return tool_error(cross_warning)
 
         if _resolved is None:
             stale_warning = _check_file_staleness(
@@ -1993,7 +2083,11 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         with file_state.lock_path(_resolved):
             # Cross-agent staleness wins over per-task warning when both
             # fire — its message names the sibling subagent.
-            cross_warning = file_state.check_stale(task_id, _resolved)
+            cross_warning = file_state.check_stale(
+                task_id,
+                _resolved,
+                track_mtime=uses_host_paths,
+            )
             stale_warning = _check_file_staleness(
                 path,
                 task_id,
@@ -2029,7 +2123,11 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
                 uses_host_paths=uses_host_paths,
             )
             if not result_dict.get("error"):
-                file_state.note_write(task_id, _resolved)
+                file_state.note_write(
+                    task_id,
+                    _resolved,
+                    track_mtime=uses_host_paths,
+                )
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         if _is_expected_write_exception(e):
@@ -2096,20 +2194,31 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 if _err:
                     return _err
                 _paths_to_check.append(v4a_path)
+    # As in write_file_tool, reject obvious lexical targets before a remote
+    # backend is created; exact backend-resolved paths are checked below.
     for _p in _paths_to_check:
-        sensitive_err = _check_sensitive_path(_p, task_id)
+        sensitive_err = _check_sensitive_path(
+            _p,
+            task_id,
+            candidate_path=_p,
+        )
         if sensitive_err:
             return tool_error(sensitive_err)
         if not cross_profile:
-            cross_warning = _check_cross_profile_path(_p, task_id)
+            cross_warning = _check_cross_profile_path(
+                _p,
+                task_id,
+                candidate_path=_p,
+            )
             if cross_warning:
                 return tool_error(cross_warning)
     try:
         file_ops = _get_file_ops(task_id)
         uses_host_paths = _file_ops_uses_host_paths(file_ops)
-        # Resolve paths for locking.  Ordered + deduplicated so concurrent
-        # callers lock in the same order — prevents deadlock on overlapping
+        # Resolve each path once for guards, locking, dispatch, and reporting.
+        # Ordered + deduplicated locks prevent deadlock on overlapping
         # multi-file V4A patches.
+        _path_to_resolved: dict[str, str | None] = {}
         _resolved_paths: list[str] = []
         _seen: set[str] = set()
         for _p in _paths_to_check:
@@ -2117,6 +2226,27 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 _r = _resolve_path_for_file_ops(_p, task_id, file_ops)
             except Exception:
                 _r = None
+            _path_to_resolved[_p] = _r
+
+            _guard_resolved = _r
+            if _guard_resolved is None and not uses_host_paths:
+                _guard_resolved = _p
+            sensitive_err = _check_sensitive_path(
+                _p,
+                task_id,
+                candidate_path=_guard_resolved,
+            )
+            if sensitive_err:
+                return tool_error(sensitive_err)
+            if not cross_profile:
+                cross_warning = _check_cross_profile_path(
+                    _p,
+                    task_id,
+                    candidate_path=_guard_resolved,
+                )
+                if cross_warning:
+                    return tool_error(cross_warning)
+
             if _r and _r not in _seen:
                 _resolved_paths.append(_r)
                 _seen.add(_r)
@@ -2133,14 +2263,17 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             # Collect warnings — cross-agent registry first (names sibling),
             # then per-task tracker as a fallback.
             stale_warnings: list[str] = []
-            _path_to_resolved: dict[str, str | None] = {}
             for _p in _paths_to_check:
-                try:
-                    _r = _resolve_path_for_file_ops(_p, task_id, file_ops)
-                except Exception:
-                    _r = None
-                _path_to_resolved[_p] = _r
-                _cross = file_state.check_stale(task_id, _r) if _r else None
+                _r = _path_to_resolved[_p]
+                _cross = (
+                    file_state.check_stale(
+                        task_id,
+                        _r,
+                        track_mtime=uses_host_paths,
+                    )
+                    if _r
+                    else None
+                )
                 _sw = _cross or _check_file_staleness(
                     _p,
                     task_id,
@@ -2219,7 +2352,11 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                         uses_host_paths=uses_host_paths,
                     )
                     if _r:
-                        file_state.note_write(task_id, _r)
+                        file_state.note_write(
+                            task_id,
+                            _r,
+                            track_mtime=uses_host_paths,
+                        )
                 # Successful patch: clear any prior consecutive-failure
                 # counters for the touched paths so a future failure on
                 # the same path starts the escalation cycle fresh.
@@ -2308,26 +2445,46 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
                 "already_searched": count,
             }, ensure_ascii=False)
 
+        # Preserve the cheap local credential fast-fail: direct host paths must
+        # be denied before a backend is created.  Remote tasks skip this host
+        # resolution and use the authoritative backend-lexical check below.
+        if _terminal_env_type_for_task(task_id) == "local":
+            block_error = get_read_block_error(path)
+            if block_error:
+                return json.dumps({"error": block_error}, ensure_ascii=False)
+
+        file_ops = _get_file_ops(task_id)
+        uses_host_paths = _file_ops_uses_host_paths(file_ops)
         try:
-            resolved_path = _resolve_path_for_task(path, task_id)
-        except (OSError, ValueError, RuntimeError):
-            resolved_path = None
-        block_error = get_read_block_error(str(resolved_path) if resolved_path else path)
+            if uses_host_paths:
+                guarded_path = str(_resolve_path_for_task(path, task_id))
+            else:
+                guarded_path = _lexical_path_for_task(path, task_id, file_ops)
+        except Exception:
+            if uses_host_paths:
+                guarded_path = path
+            else:
+                try:
+                    guarded_path = _lexical_path_for_task(path, task_id, file_ops)
+                except Exception:
+                    guarded_path = path
+        block_error = get_read_block_error(guarded_path)
         if block_error:
             return json.dumps({"error": block_error}, ensure_ascii=False)
 
-        file_ops = _get_file_ops(task_id)
         search_path = path
-        if not _file_ops_uses_host_paths(file_ops):
-            try:
-                search_path = _resolve_path_for_file_ops(path, task_id, file_ops)
-            except Exception:
-                search_path = path
+        if not uses_host_paths:
+            search_path = guarded_path
         result = file_ops.search(
             pattern=pattern, path=search_path, target=target, file_glob=file_glob,
             limit=limit, offset=offset, output_mode=output_mode, context=context
         )
-        omitted = _filter_read_blocked_search_results(result, task_id)
+        omitted = _filter_read_blocked_search_results(
+            result,
+            task_id,
+            file_ops,
+            uses_host_paths,
+        )
         if hasattr(result, 'matches'):
             for m in result.matches:
                 if hasattr(m, 'content') and m.content:


### PR DESCRIPTION
## What does this PR do?

Fixes #52823.

Non-local terminal backends can have paths that are valid inside the backend but misleading on the host. On macOS, for example, resolving a remote `/home/...` path through the host can canonicalize it to `/System/Volumes/Data/home/...`, so `write_file` reports success while passing the wrong path to the backend.

This PR preserves backend path semantics for non-local file operations while keeping the existing host-canonical behavior for local file operations.

The shared resolver affects all four file tools, so the fix intentionally covers `read_file`, `write_file`, `patch`, and `search_files` together rather than leaving sibling call paths vulnerable. The V4A and file-state changes keep patch dispatch, safety guards, and cross-agent tracking consistent with the same backend path; splitting those pieces would leave partially-correct behavior on remote backends.

Duplicate-work check (refreshed 2026-07-10):
- Issue #52823 remains open and now references this PR and #57481.
- #57481 changes only absolute-path handling in `_resolve_path_for_task`, relies on process-global `TERMINAL_ENV`, and adds no automated regression coverage.
- This PR additionally handles backend-relative paths and the `read_file`, `write_file`, `patch`, `search_files`, V4A move/report, and file-state call sites using the actual task backend, with focused tests. It is therefore not superseded by #57481.
- #29816 remains unrelated: it addresses WSL/9P fsync durability for #29786, not remote path resolution.

## Related Issue

Fixes #52823

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New skill
- [ ] Other (please describe):

## Changes Made

- Adds backend-aware lexical path resolution for non-local file operations so absolute remote paths and backend-relative paths are not canonicalized through the host filesystem.
- Extends the existing container-safe path behavior to use the actual task backend, covering SSH as well as Docker/Singularity/Modal/Daytona. Relative paths prefer the live/registered session cwd, preserve the last-known cwd when a rebuilt backend is still at `/`, and otherwise retain an explicit backend cwd.
- Applies the backend-aware path handling to `write_file`, `patch`, `read_file`, and non-local `search_files` dispatch while preserving caller-relative search paths for local backends.
- Rewrites V4A patch path headers for non-local backends, including `Move File` headers, and validates traversal on both move endpoints.
- Records successful remote reads/writes in file-state using backend paths without treating failed reads as valid stale-write baselines or stat-ing coincidentally matching host paths; sibling-agent ordering remains tracked while host-mtime drift checks stay local-only.
- Preserves remote credential-read, sensitive-write, cross-profile, and search-result guards by applying them to backend-lexical paths. Search-result filtering reuses the path-kind decision once per search rather than reflecting on the backend for each match.
- Adds focused regression coverage for remote absolute paths, backend cwd resolution/rebuilds, tilde paths, V4A move/report behavior, local search path shape, failed remote reads, safety filtering, and file-state tracking.

> **Note on remote backends:** the mtime-based read **dedup stub**, the `read_timestamps` staleness baseline, and file-state host-mtime drift checks are intentionally skipped for non-local backends — host `mtime` is meaningless for a remote path. Sibling-agent read/write ordering and the `read_file` consecutive-read **hard loop-break (`count >= 4`) still fire**, so concurrent edits and runaway re-reads remain bounded. Local behavior is unchanged. `_file_ops_static_env` (via `inspect.getattr_static`) reads a *declared* `env` without triggering dynamic mocks, so ops without a declared backend env default to host/local semantics. A rebuilt remote backend reuses only a recorded backend cwd; it never falls back to the host session's `TERMINAL_CWD`. Structured-document extraction remains host-only; non-local `.docx`/`.xlsx` reads go through the backend file reader rather than attempting to open the remote path on the host. `vision_analyze` path handling in `tools/image_source.py` is outside this file-tool bug's scope.

> **macOS local-test note:** direct `pytest` runs that use the default macOS temp root can hit pre-existing failures because `/var/folders/...` resolves under `/private/var/...`, which the repo's sensitive-path guard blocks. The repo's clean `scripts/run_tests.sh` runner avoids that environmental collision. The device-alias security regression test (`test_read_file_tool_rejects_task_cwd_relative_device_alias_symlink`) passes in the clean focused suite.

## How to Test

- Issue-shaped repro:
  ```bash
  .venv/bin/python - <<'PY'
  import json
  from pathlib import Path
  from unittest.mock import patch

  import tools.file_tools as ft

  class FakeRemoteOps:
      env = object()
      def __init__(self):
          self.write_paths = []
      def write_file(self, path, content):
          from tools.file_operations import WriteResult
          self.write_paths.append(path)
          return WriteResult(bytes_written=len(content))

  ops = FakeRemoteOps()
  with patch.object(ft, '_get_file_ops', lambda task_id='default': ops), patch.object(
      ft,
      '_resolve_path_for_task',
      lambda filepath, task_id='default': Path('/System/Volumes/Data/home/myuser/now.txt'),
  ):
      out = json.loads(ft.write_file_tool('/home/myuser/now.txt', 'stamp\n', task_id='remote-task'))

  print({
      'path_passed_to_backend': ops.write_paths[0] if ops.write_paths else None,
      'resolved_path': out.get('resolved_path'),
      'warning': out.get('_warning'),
      'error': out.get('error'),
  })
  PY
  ```
  Output:
  ```text
  {'path_passed_to_backend': '/home/myuser/now.txt', 'resolved_path': '/home/myuser/now.txt', 'warning': None, 'error': None}
  ```

- Focused tests after rebasing onto current `main`:
  ```bash
  scripts/run_tests.sh tests/agent/test_file_safety_credentials.py tests/tools/test_file_tools_cwd_resolution.py tests/tools/test_file_tools.py tests/tools/test_file_state_registry.py tests/tools/test_resolve_path.py tests/tools/test_file_staleness.py tests/tools/test_patch_failure_tracking.py tests/tools/test_file_operations_edge_cases.py tests/tools/test_file_read_guards.py tests/tools/test_file_write_safety.py tests/agent/test_file_safety_container_mirror.py
  ```
  Result: 311 passed across 11 focused file-tool, credential-safety, write-safety, and container-mirror suites.

- Lint and cross-platform guard:
  ```bash
  .venv/bin/ruff check tools/file_tools.py tools/file_state.py tests/tools/test_file_tools_cwd_resolution.py tests/agent/test_file_safety_credentials.py
  .venv/bin/python scripts/check-windows-footguns.py tools/file_tools.py tools/file_state.py tests/tools/test_file_tools_cwd_resolution.py
  ```
  Result: passed.

- Whitespace:
  ```bash
  git diff --check
  ```
  Result: passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested on my platform (macOS, with fake non-local backend regressions)
- [ ] I have updated documentation as needed
