### PR TITLE
feat(agent): persist compression handoff snapshots

### DIFF
--- a/agent/context_handoff.py
+++ b/agent/context_handoff.py
@@ -1,0 +1,200 @@
+"""Durable context handoff snapshots for compression recovery.
+
+The handoff file is a best-effort local safety rail: before lossy compression,
+or when compression aborts/fails, Hermes records enough prompt-safe state for a
+fresh session to verify where work left off instead of trusting a possibly
+truncated compression summary.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_MAX_TAIL_MESSAGES = 24
+_MAX_CONTENT_CHARS = 4_000
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b([A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PASS|CREDENTIAL|PRIVATE[_-]?KEY)[A-Z0-9_]*)\s*[:=]\s*([^\s\n]+)"
+)
+_BEARER_RE = re.compile(r"(?i)\b(bearer\s+)[A-Za-z0-9._\-]{12,}")
+
+
+@dataclass(frozen=True)
+class ContextHandoffResult:
+    """Paths written by :func:`write_context_handoff`."""
+
+    json_path: Path
+    markdown_path: Path
+
+
+def _redact_text(value: str) -> str:
+    """Return text with obvious credential assignments redacted."""
+    redacted = _SECRET_ASSIGNMENT_RE.sub(lambda m: f"{m.group(1)}=[REDACTED]", value)
+    return _BEARER_RE.sub(lambda m: f"{m.group(1)}[REDACTED]", redacted)
+
+
+def _json_safe(value: Any) -> Any:
+    """Coerce arbitrary message payloads into JSON-safe, redacted values."""
+    if isinstance(value, str):
+        text = _redact_text(value)
+        if len(text) > _MAX_CONTENT_CHARS:
+            return text[:_MAX_CONTENT_CHARS] + "…[truncated]"
+        return text
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value[:50]]
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    return _redact_text(str(value))
+
+
+def _message_tail(messages: list[dict[str, Any]] | list[Any]) -> list[dict[str, Any]]:
+    """Return the redacted tail of the current conversation messages."""
+    tail: list[dict[str, Any]] = []
+    for raw in list(messages or [])[-_MAX_TAIL_MESSAGES:]:
+        if isinstance(raw, dict):
+            role = str(raw.get("role") or "unknown")
+            content = _json_safe(raw.get("content"))
+            item: dict[str, Any] = {"role": role, "content": content}
+            if raw.get("name"):
+                item["name"] = _json_safe(raw.get("name"))
+            if raw.get("tool_call_id"):
+                item["tool_call_id"] = _json_safe(raw.get("tool_call_id"))
+            tail.append(item)
+        else:
+            tail.append({"role": "unknown", "content": _json_safe(raw)})
+    return tail
+
+
+def _todo_snapshot(agent: Any) -> str:
+    """Read the current todo snapshot if the agent exposes one."""
+    store = getattr(agent, "_todo_store", None)
+    if store is None or not hasattr(store, "format_for_injection"):
+        return ""
+    try:
+        return _redact_text(str(store.format_for_injection() or ""))
+    except Exception:
+        return ""
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Atomically replace ``path`` with ``content``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        Path(tmp_name).replace(path)
+    except Exception:
+        try:
+            Path(tmp_name).unlink(missing_ok=True)
+        finally:
+            raise
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    """Render a compact human-readable handoff note."""
+    lines = [
+        "# Hermes Context Handoff",
+        "",
+        f"- Reason: `{payload.get('reason') or ''}`",
+        f"- Session: `{payload.get('session_id') or ''}`",
+        f"- Created: `{payload.get('created_at') or ''}`",
+        f"- Model: `{payload.get('model') or ''}`",
+        f"- Platform: `{payload.get('platform') or ''}`",
+    ]
+    if payload.get("approx_tokens") is not None:
+        lines.append(f"- Approx tokens: `{payload['approx_tokens']}`")
+    if payload.get("focus_topic"):
+        lines.append(f"- Focus: `{payload['focus_topic']}`")
+    if payload.get("error"):
+        lines.append(f"- Error: `{payload['error']}`")
+    if payload.get("todo_snapshot"):
+        lines.extend([
+            "",
+            "## Todo snapshot",
+            "",
+            "```",
+            payload["todo_snapshot"],
+            "```",
+        ])
+    lines.extend(["", "## Recent messages", ""])
+    for msg in payload.get("messages_tail", []):
+        role = msg.get("role", "unknown")
+        content = msg.get("content", "")
+        if not isinstance(content, str):
+            content = json.dumps(content, ensure_ascii=False)
+        lines.extend([f"### {role}", "", content, ""])
+    lines.extend([
+        "## Resume discipline",
+        "",
+        "新会话读取本文件后，先真实校验 git / PR / CI / 部署状态，再继续执行；不要只相信压缩摘要。",
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def write_context_handoff(
+    agent: Any,
+    messages: list[dict[str, Any]] | list[Any],
+    *,
+    reason: str,
+    approx_tokens: int | None = None,
+    focus_topic: str | None = None,
+    error: str | None = None,
+) -> ContextHandoffResult | None:
+    """Persist a profile-scoped context handoff snapshot.
+
+    The function is intentionally best-effort and returns ``None`` on failure so
+    compression behavior never regresses because the local safety file could not
+    be written.
+    """
+    try:
+        handoff_dir = get_hermes_home() / "handoffs"
+        json_path = handoff_dir / "latest.json"
+        markdown_path = handoff_dir / "latest.md"
+        payload: dict[str, Any] = {
+            "schema_version": 1,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "reason": reason,
+            "session_id": str(getattr(agent, "session_id", "") or ""),
+            "model": str(getattr(agent, "model", "") or ""),
+            "provider": str(getattr(agent, "provider", "") or ""),
+            "platform": str(getattr(agent, "platform", "") or ""),
+            "gateway_session_key": str(
+                getattr(agent, "_gateway_session_key", "") or ""
+            ),
+            "turn_id": str(getattr(agent, "_current_turn_id", "") or ""),
+            "approx_tokens": approx_tokens,
+            "focus_topic": _redact_text(focus_topic or "") or None,
+            "error": _redact_text(error or "") or None,
+            "todo_snapshot": _todo_snapshot(agent),
+            "messages_tail": _message_tail(messages),
+        }
+        json_content = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+        _atomic_write(json_path, json_content + "\n")
+        _atomic_write(markdown_path, _render_markdown(payload))
+        logger.info(
+            "context handoff written: session=%s reason=%s path=%s",
+            payload["session_id"] or "none",
+            reason,
+            json_path,
+        )
+        return ContextHandoffResult(json_path=json_path, markdown_path=markdown_path)
+    except Exception as exc:
+        logger.warning("context handoff write failed: %s", exc)
+        return None

--- a/agent/context_handoff.py
+++ b/agent/context_handoff.py
@@ -148,6 +148,30 @@ def _render_markdown(payload: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def load_latest_context_handoff_prompt(*, max_chars: int = 12_000) -> str:
+    """Return the latest handoff markdown block for prompt injection, if present."""
+    try:
+        path = get_hermes_home() / "handoffs" / "latest.md"
+        if not path.is_file():
+            return ""
+        content = path.read_text(encoding="utf-8", errors="replace").strip()
+        if not content:
+            return ""
+        if len(content) > max_chars:
+            content = content[:max_chars] + "\n…[handoff truncated]"
+        return (
+            "# Previous-session handoff\n\n"
+            "A local compression handoff exists from a previous session. Treat it "
+            "as recovery context, not as proof of completion. Before continuing "
+            "work from it, verify current git / PR / CI / deployment state with "
+            "tools. Do not trust lossy compression summaries alone.\n\n"
+            f"{content}"
+        )
+    except Exception as exc:
+        logger.debug("latest context handoff load failed: %s", exc)
+        return ""
+
+
 def write_context_handoff(
     agent: Any,
     messages: list[dict[str, Any]] | list[Any],

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from typing import Any, Optional, Tuple
 
 from agent.model_metadata import estimate_request_tokens_rough
+from agent.context_handoff import write_context_handoff
 
 logger = logging.getLogger(__name__)
 
@@ -460,15 +461,35 @@ def compress_context(
         except Exception:
             pass
 
+    # Persist a prompt-safe local handoff before lossy compression.  This is
+    # intentionally best-effort: a failed local write must never block normal
+    # compression, but when compression later aborts/truncates this file gives a
+    # fresh session a verified starting point instead of relying on the summary.
+    write_context_handoff(
+        agent,
+        messages,
+        reason="pre_compression",
+        approx_tokens=approx_tokens,
+        focus_topic=focus_topic,
+    )
+
     try:
         compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic, force=force)
     except TypeError:
         # Plugin context engine with strict signature that doesn't accept
         # focus_topic / force — fall back to calling without them.
         compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens)
-    except BaseException:
+    except BaseException as exc:
         # ANY exception during compress() must release the lock so the
         # session isn't permanently blocked from future compression.
+        write_context_handoff(
+            agent,
+            messages,
+            reason="compression_exception",
+            approx_tokens=approx_tokens,
+            focus_topic=focus_topic,
+            error=f"{type(exc).__name__}: {exc}",
+        )
         _release_lock()
         raise
 
@@ -479,6 +500,14 @@ def compress_context(
     # the no-op via len(returned) == len(input).
     if getattr(agent.context_compressor, "_last_compress_aborted", False):
         _err = getattr(agent.context_compressor, "_last_summary_error", None) or "unknown error"
+        write_context_handoff(
+            agent,
+            messages,
+            reason="compression_aborted",
+            approx_tokens=approx_tokens,
+            focus_topic=focus_topic,
+            error=str(_err),
+        )
         if getattr(agent, "_last_compression_summary_warning", None) != _err:
             agent._last_compression_summary_warning = _err
             agent._emit_warning(

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -44,6 +44,7 @@ from agent.prompt_builder import (
     drain_truncation_warnings,
 )
 from agent.runtime_cwd import resolve_context_cwd
+from agent.context_handoff import load_latest_context_handoff_prompt
 
 
 def _ra():
@@ -58,6 +59,7 @@ def _ra():
     through ``run_agent`` on every call preserves the patch contract.
     """
     import run_agent
+
     return run_agent
 
 
@@ -110,7 +112,9 @@ def _resolve_platform_hint(agent: Any, platform_key: str, default_hint: str) -> 
     return base
 
 
-def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> Dict[str, str]:
+def build_system_prompt_parts(
+    agent: Any, system_message: Optional[str] = None
+) -> Dict[str, str]:
     """Assemble the system prompt as three ordered parts.
 
     Returns a dict with three keys:
@@ -216,6 +220,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # macOS-only wording (Mac, Space, cmd+s).
     if "computer_use" in agent.valid_tool_names:
         from agent.prompt_builder import computer_use_guidance
+
         stable_parts.append(computer_use_guidance())
 
     nous_subscription_prompt = _r.build_nous_subscription_prompt(agent.valid_tool_names)
@@ -231,13 +236,21 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if agent.valid_tool_names:
         _enforce = agent._tool_use_enforcement
         _inject = False
-        if _enforce is True or (isinstance(_enforce, str) and _enforce.lower() in {"true", "always", "yes", "on"}):
+        if _enforce is True or (
+            isinstance(_enforce, str)
+            and _enforce.lower() in {"true", "always", "yes", "on"}
+        ):
             _inject = True
-        elif _enforce is False or (isinstance(_enforce, str) and _enforce.lower() in {"false", "never", "no", "off"}):
+        elif _enforce is False or (
+            isinstance(_enforce, str)
+            and _enforce.lower() in {"false", "never", "no", "off"}
+        ):
             _inject = False
         elif isinstance(_enforce, list):
             model_lower = (agent.model or "").lower()
-            _inject = any(p.lower() in model_lower for p in _enforce if isinstance(p, str))
+            _inject = any(
+                p.lower() in model_lower for p in _enforce if isinstance(p, str)
+            )
         else:
             # "auto" or any unrecognised value — use hardcoded defaults
             model_lower = (agent.model or "").lower()
@@ -254,15 +267,23 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             # Also applied to xAI Grok — same failure modes (claims completion
             # without tool calls, suggests workarounds instead of using
             # existing tools, replies with plans instead of executing).
-            if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower:
+            if (
+                "gpt" in _model_lower
+                or "codex" in _model_lower
+                or "grok" in _model_lower
+            ):
                 stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
 
-    has_skills_tools = any(name in agent.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
+    has_skills_tools = any(
+        name in agent.valid_tool_names
+        for name in ["skills_list", "skill_view", "skill_manage"]
+    )
     if has_skills_tools:
         avail_toolsets = {
             toolset
             for toolset in (
-                _r.get_toolset_for_tool(tool_name) for tool_name in agent.valid_tool_names
+                _r.get_toolset_for_tool(tool_name)
+                for tool_name in agent.valid_tool_names
             )
             if toolset
         }
@@ -340,6 +361,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if getattr(agent, "_environment_probe", True):
         try:
             from tools.env_probe import get_environment_probe_line
+
             _probe_line = get_environment_probe_line()
             if _probe_line:
                 stable_parts.append(_probe_line)
@@ -356,6 +378,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # for the matching tool-side guard.
     try:
         from agent.file_safety import _resolve_active_profile_name
+
         active_profile = _resolve_active_profile_name()
     except Exception:
         active_profile = "default"
@@ -391,6 +414,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # Check plugin registry for platform-specific LLM guidance
         try:
             from gateway.platform_registry import platform_registry
+
             _entry = platform_registry.get(platform_key)
             if _entry and _entry.platform_hint:
                 _default_hint = _entry.platform_hint
@@ -415,10 +439,14 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # dir — the user's real cwd there, but the install dir for the gateway
         # daemon, which is why the gateway sets TERMINAL_CWD.
         context_files_prompt = _r.build_context_files_prompt(
-            cwd=resolve_context_cwd(), skip_soul=_soul_loaded,
-            context_length=_ctx_len)
+            cwd=resolve_context_cwd(), skip_soul=_soul_loaded, context_length=_ctx_len
+        )
         if context_files_prompt:
             context_parts.append(context_files_prompt)
+
+    handoff_prompt = load_latest_context_handoff_prompt()
+    if handoff_prompt:
+        context_parts.append(handoff_prompt)
 
     # ── Volatile tier (changes per session/turn — never cached) ───
     volatile_parts: List[str] = []
@@ -444,6 +472,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             pass
 
     from hermes_time import now as _hermes_now
+
     now = _hermes_now()
     # Date-only (not minute-precision) so the system prompt is byte-stable
     # for the full day.  Minute-precision changes invalidate prefix-cache KV
@@ -461,8 +490,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     volatile_parts.append(timestamp_line)
 
     return {
-        "stable":   "\n\n".join(p.strip() for p in stable_parts   if p and p.strip()),
-        "context":  "\n\n".join(p.strip() for p in context_parts  if p and p.strip()),
+        "stable": "\n\n".join(p.strip() for p in stable_parts if p and p.strip()),
+        "context": "\n\n".join(p.strip() for p in context_parts if p and p.strip()),
         "volatile": "\n\n".join(p.strip() for p in volatile_parts if p and p.strip()),
     }
 
@@ -483,7 +512,9 @@ def build_system_prompt(agent: Any, system_message: Optional[str] = None) -> str
     warm across turns.
     """
     parts = build_system_prompt_parts(agent, system_message=system_message)
-    joined = "\n\n".join(p for p in (parts["stable"], parts["context"], parts["volatile"]) if p)
+    joined = "\n\n".join(
+        p for p in (parts["stable"], parts["context"], parts["volatile"]) if p
+    )
 
     # Surface context-file truncation warnings through the normal agent status
     # channel so gateway/CLI users see them in chat instead of only in logs.
@@ -521,7 +552,7 @@ def format_tools_for_system_message(agent: Any) -> str:
             "name": func["name"],
             "description": func.get("description", ""),
             "parameters": func.get("parameters", {}),
-            "required": None  # Match the format in the example
+            "required": None,  # Match the format in the example
         }
         formatted_tools.append(formatted_tool)
 

--- a/tests/agent/test_context_handoff.py
+++ b/tests/agent/test_context_handoff.py
@@ -1,0 +1,90 @@
+"""Tests for durable context handoff snapshots."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from agent.context_handoff import write_context_handoff
+
+
+def _agent(session_id: str = "sess-123") -> SimpleNamespace:
+    """Build a minimal agent-like object for handoff tests."""
+    return SimpleNamespace(
+        session_id=session_id,
+        model="test/model",
+        provider="test-provider",
+        platform="qqbot",
+        _gateway_session_key="qq:chat",
+        _current_turn_id="turn-abc",
+        _todo_store=SimpleNamespace(format_for_injection=lambda: "TODO: keep going"),
+    )
+
+
+def test_write_context_handoff_creates_json_and_markdown(tmp_path: Path, monkeypatch):
+    """Handoff writer persists a recoverable JSON state and human-readable note."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    messages = [
+        {"role": "user", "content": "实现自动交接"},
+        {"role": "assistant", "content": "我会读取文件并测试"},
+        {"role": "tool", "content": "SECRET_TOKEN=should-not-leak\nall good"},
+    ]
+
+    result = write_context_handoff(
+        _agent(),
+        messages,
+        reason="pre_compression",
+        approx_tokens=123456,
+        focus_topic="auto handoff",
+    )
+
+    assert result is not None
+    assert result.json_path.exists()
+    assert result.markdown_path.exists()
+    assert result.json_path.parent == tmp_path / "handoffs"
+
+    payload = json.loads(result.json_path.read_text())
+    assert payload["schema_version"] == 1
+    assert payload["reason"] == "pre_compression"
+    assert payload["session_id"] == "sess-123"
+    assert payload["approx_tokens"] == 123456
+    assert payload["focus_topic"] == "auto handoff"
+    assert (
+        payload["messages_tail"][-1]["content"] == "SECRET_TOKEN=[REDACTED]\nall good"
+    )
+    assert payload["todo_snapshot"] == "TODO: keep going"
+
+    markdown = result.markdown_path.read_text()
+    assert "Hermes Context Handoff" in markdown
+    assert "pre_compression" in markdown
+    assert "SECRET_TOKEN=should-not-leak" not in markdown
+    assert "SECRET_TOKEN=[REDACTED]" in markdown
+
+
+def test_write_context_handoff_uses_stable_latest_files(tmp_path: Path, monkeypatch):
+    """Latest handoff paths are overwritten atomically for easy resume discovery."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    first = write_context_handoff(
+        _agent(),
+        [{"role": "user", "content": "first"}],
+        reason="pre_compression",
+    )
+    second = write_context_handoff(
+        _agent(),
+        [{"role": "user", "content": "second"}],
+        reason="compression_aborted",
+        error="boom",
+    )
+
+    assert first is not None and second is not None
+    latest_json = tmp_path / "handoffs" / "latest.json"
+    latest_md = tmp_path / "handoffs" / "latest.md"
+    assert second.json_path == latest_json
+    assert second.markdown_path == latest_md
+    payload = json.loads(latest_json.read_text())
+    assert payload["reason"] == "compression_aborted"
+    assert payload["error"] == "boom"
+    assert payload["messages_tail"][0]["content"] == "second"
+    assert "compression_aborted" in latest_md.read_text()

--- a/tests/agent/test_context_handoff_compression.py
+++ b/tests/agent/test_context_handoff_compression.py
@@ -1,0 +1,130 @@
+"""Regression tests for compression-triggered context handoff writes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from run_agent import AIAgent
+
+
+def _make_agent(engine) -> AIAgent:
+    """Create a minimal AIAgent shell for direct _compress_context tests."""
+    agent = object.__new__(AIAgent)
+    agent.context_compressor = engine
+    agent.session_id = "sess-handoff"
+    agent.model = "test/model"
+    agent.provider = "test-provider"
+    agent.platform = "qqbot"
+    agent.logs_dir = MagicMock()
+    agent.quiet_mode = True
+    agent._todo_store = SimpleNamespace(format_for_injection=lambda: "继续实现 hook")
+    agent._memory_manager = None
+    agent._session_db = None
+    agent._cached_system_prompt = None
+    agent.log_prefix = ""
+    agent.tools = []
+    agent._gateway_session_key = "qq:chat"
+    agent._current_turn_id = "turn-1"
+    agent._compression_feasibility_checked = True
+    agent._last_compaction_in_place = False
+    agent.status_callback = None
+    agent.event_callback = None
+    agent._custom_providers = {}
+    agent._vprint = lambda *a, **kw: None
+    agent._emit_status = lambda *a, **kw: None
+    agent._emit_warning = lambda *a, **kw: None
+    agent._invalidate_system_prompt = lambda *a, **kw: None
+    agent._build_system_prompt = lambda *a, **kw: "new-system-prompt"
+    agent.commit_memory_session = lambda *a, **kw: None
+    return agent
+
+
+def _messages() -> list[dict[str, str]]:
+    """Return messages used by compression handoff tests."""
+    return [
+        {"role": "user", "content": "继续 Hermes Auto Handoff"},
+        {"role": "assistant", "content": "先写测试"},
+    ]
+
+
+def _latest_payload(home: Path) -> dict:
+    """Load the latest handoff payload from a temp Hermes home."""
+    return json.loads((home / "handoffs" / "latest.json").read_text())
+
+
+def test_compress_context_writes_pre_compression_handoff(tmp_path: Path, monkeypatch):
+    """Successful compression writes a pre-compression handoff snapshot."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    engine = MagicMock()
+    engine.compress.return_value = [{"role": "user", "content": "summary"}]
+    engine.compression_count = 1
+    engine._last_compress_aborted = False
+    engine._last_summary_error = None
+    engine._last_aux_model_failure_model = None
+    engine._last_aux_model_failure_error = None
+    engine.last_prompt_tokens = 0
+    engine.last_completion_tokens = 0
+    agent = _make_agent(engine)
+
+    compressed, system_prompt = agent._compress_context(
+        _messages(),
+        "system",
+        approx_tokens=99,
+        focus_topic="handoff",
+    )
+
+    assert compressed[0] == {"role": "user", "content": "summary"}
+    assert compressed[-1] == {"role": "user", "content": "继续实现 hook"}
+    assert system_prompt == "new-system-prompt"
+    payload = _latest_payload(tmp_path)
+    assert payload["reason"] == "pre_compression"
+    assert payload["approx_tokens"] == 99
+    assert payload["focus_topic"] == "handoff"
+
+
+def test_compress_context_overwrites_handoff_when_summary_aborts(
+    tmp_path: Path, monkeypatch
+):
+    """Summary abort writes a failure-specific handoff while preserving messages."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    engine = MagicMock()
+    engine.compress.return_value = _messages()
+    engine.compression_count = 0
+    engine._last_compress_aborted = True
+    engine._last_summary_error = "aux 502"
+    engine._last_aux_model_failure_model = None
+    engine._last_aux_model_failure_error = None
+    agent = _make_agent(engine)
+    messages = _messages()
+
+    returned, _ = agent._compress_context(messages, "system", approx_tokens=1000)
+
+    assert returned is messages
+    payload = _latest_payload(tmp_path)
+    assert payload["reason"] == "compression_aborted"
+    assert payload["error"] == "aux 502"
+
+
+def test_compress_context_writes_handoff_before_reraising_exception(
+    tmp_path: Path, monkeypatch
+):
+    """Unexpected compressor exceptions still leave a handoff before re-raise."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    engine = MagicMock()
+    engine.compress.side_effect = RuntimeError("boom")
+    engine.compression_count = 0
+    agent = _make_agent(engine)
+
+    try:
+        agent._compress_context(_messages(), "system", approx_tokens=123)
+    except RuntimeError as exc:
+        assert str(exc) == "boom"
+    else:
+        raise AssertionError("expected RuntimeError")
+
+    payload = _latest_payload(tmp_path)
+    assert payload["reason"] == "compression_exception"
+    assert "RuntimeError: boom" == payload["error"]

--- a/tests/agent/test_context_handoff_prompt.py
+++ b/tests/agent/test_context_handoff_prompt.py
@@ -1,0 +1,52 @@
+"""Tests for injecting latest handoff into a fresh system prompt."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent.context_handoff import load_latest_context_handoff_prompt
+
+
+def test_load_latest_context_handoff_prompt_returns_empty_without_file(
+    tmp_path: Path, monkeypatch
+):
+    """No latest handoff means no prompt block and no cache churn from errors."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    assert load_latest_context_handoff_prompt() == ""
+
+
+def test_load_latest_context_handoff_prompt_includes_verification_discipline(
+    tmp_path: Path, monkeypatch
+):
+    """Existing handoff is loaded with instructions to verify live state first."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    handoff_dir = tmp_path / "handoffs"
+    handoff_dir.mkdir()
+    (handoff_dir / "latest.md").write_text(
+        "# Hermes Context Handoff\n\n- Reason: `compression_aborted`\n",
+        encoding="utf-8",
+    )
+
+    prompt = load_latest_context_handoff_prompt()
+
+    assert "Previous-session handoff" in prompt
+    assert "compression_aborted" in prompt
+    assert "verify current git / PR / CI / deployment state" in prompt
+    assert "Do not trust lossy compression summaries alone" in prompt
+
+
+def test_load_latest_context_handoff_prompt_truncates_large_file(
+    tmp_path: Path, monkeypatch
+):
+    """Huge handoff markdown is capped before prompt injection."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    handoff_dir = tmp_path / "handoffs"
+    handoff_dir.mkdir()
+    (handoff_dir / "latest.md").write_text("x" * 100, encoding="utf-8")
+
+    prompt = load_latest_context_handoff_prompt(max_chars=10)
+
+    assert "x" * 10 in prompt
+    assert "[handoff truncated]" in prompt
+    assert "x" * 50 not in prompt


### PR DESCRIPTION
## Summary

- add a profile-scoped context handoff writer under `$HERMES_HOME/handoffs/latest.{json,md}`
- write a handoff snapshot before lossy context compression starts
- overwrite the handoff with failure-specific state when compression aborts or raises
- redact obvious credential assignments from persisted message tails
- load the latest handoff markdown into fresh system prompts with explicit verify-before-continuing guidance

## Why

Compression summaries can fail, truncate, or become unavailable at exactly the moment a long-running task needs continuity. A durable handoff gives the next session a local recovery point and explicitly reminds it to verify git/PR/CI/deployment state instead of trusting a lossy summary.

## Tests

- `python -m pytest tests/agent/test_context_handoff.py tests/agent/test_context_handoff_compression.py tests/agent/test_context_handoff_prompt.py tests/run_agent/test_compress_focus_plugin_fallback.py tests/agent/test_compression_rotation_state.py -q -o 'addopts='`
- `python -m pytest tests/agent/test_context_compressor.py tests/agent/test_compression_progress.py tests/agent/test_compressed_summary_metadata.py tests/agent/test_context_compressor_summary_continuity.py tests/agent/test_context_compressor_temporal_anchoring.py -q -o 'addopts='`
- `python -m pytest tests/agent/test_prompt_builder.py tests/agent/test_skill_commands_reload.py tests/agent/test_context_handoff.py tests/agent/test_context_handoff_compression.py tests/agent/test_context_handoff_prompt.py -q -o 'addopts='`
- `python -m ruff check agent/context_handoff.py agent/conversation_compression.py agent/system_prompt.py tests/agent/test_context_handoff.py tests/agent/test_context_handoff_compression.py tests/agent/test_context_handoff_prompt.py`
