### PR TITLE
fix(interrupt): keep partial streamed reply when stopped mid-response

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2011,9 +2011,21 @@ def run_conversation(
                     agent.thinking_callback("")
                 api_elapsed = time.time() - api_start_time
                 agent._vprint(f"{agent.log_prefix}⚡ Interrupted during API call.", force=True)
-                agent._persist_session(messages, conversation_history)
                 interrupted = True
-                final_response = f"{INTERRUPT_WAITING_FOR_MODEL_PREFIX}{api_elapsed:.1f}s elapsed)."
+                # Preserve any assistant text already streamed to the user
+                # before the stop landed. Dropping it leaves history with no
+                # record of the half-finished reply on screen, so the next turn
+                # the model "forgets" what it just said — exactly what users hit
+                # when they stop to redirect mid-response.
+                _partial = agent._strip_think_blocks(
+                    getattr(agent, "_current_streamed_assistant_text", "") or ""
+                ).strip()
+                if _partial:
+                    messages.append({"role": "assistant", "content": _partial})
+                    final_response = _partial
+                else:
+                    final_response = f"{INTERRUPT_WAITING_FOR_MODEL_PREFIX}{api_elapsed:.1f}s elapsed)."
+                agent._persist_session(messages, conversation_history)
                 break
 
             except Exception as api_error:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4077,6 +4077,54 @@ class TestRunConversation:
         assert result["final_response"] == "Fresh partial content from this turn"
         assert result["api_calls"] == 1
 
+    def test_interrupt_during_stream_preserves_partial_assistant_text(self, agent):
+        """Stopping mid-response keeps the streamed reply in history (not 'forgotten')."""
+        self._setup_agent(agent)
+
+        def _fake_api_call(api_kwargs):
+            # Model streamed some visible text, then the user hit stop.
+            agent._current_streamed_assistant_text = "Sure, here's how to do it: first"
+            raise InterruptedError("Agent interrupted during streaming API call")
+
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=_fake_api_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("how do I do X")
+
+        assert result["interrupted"] is True
+        # Partial reply is surfaced and persisted as an assistant turn so the
+        # next turn remembers what the model said.
+        assert result["final_response"] == "Sure, here's how to do it: first"
+        assert result["messages"][-1] == {
+            "role": "assistant",
+            "content": "Sure, here's how to do it: first",
+        }
+
+    def test_interrupt_before_any_stream_keeps_sentinel(self, agent):
+        """An interrupt with no streamed text falls back to the metadata sentinel."""
+        from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+
+        self._setup_agent(agent)
+
+        def _fake_api_call(api_kwargs):
+            agent._current_streamed_assistant_text = ""
+            raise InterruptedError("Agent interrupted during streaming API call")
+
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=_fake_api_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hi")
+
+        assert result["interrupted"] is True
+        assert result["final_response"].startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX)
+        assert result["messages"][-1]["role"] == "user"
+
     def test_nous_401_refreshes_after_remint_and_retries(self, agent):
         self._setup_agent(agent)
         agent.provider = "nous"


### PR DESCRIPTION
## Summary

Pressing **stop/esc to redirect mid-response** made the agent "forget" what it
was saying. When a turn is interrupted while the model is streaming,
`InterruptedError` was caught, `final_response` was set to the throwaway
`"Operation interrupted: waiting for model response (Xs elapsed)."` sentinel, and
`messages` were persisted **without** the assistant text already streamed to the
screen. The next turn had no record of the half-finished reply, so the model
restarted blind — reported as "if I stop a message it forgets about it."

The fix recovers the on-screen text from `agent._current_streamed_assistant_text`
in the `InterruptedError` branch (`agent/conversation_loop.py`) and appends it as
the assistant turn, also surfacing it as `final_response`. The metadata sentinel
is kept **only** when nothing was streamed yet, so the ACP/client suppression
behavior (`INTERRUPT_WAITING_FOR_MODEL_PREFIX` startswith check) is unchanged.

## Root cause / history

- **Lossy from day one** — the streaming `except InterruptedError` handler was
  introduced in [`c98ee9852`](https://github.com/NousResearch/hermes-agent/commit/c98ee985259470a271dfbcb5fc7715263965f315)
  (*"feat: implement interactive prompts for sudo password and command approval"*,
  Feb 21 2026) with `final_response = "Operation interrupted."` and no capture of
  the streamed text.
- **The fix that missed this path** — [`397eae5d9`](https://github.com/NousResearch/hermes-agent/commit/397eae5d93dc549350e1bc9eb1368b3b7510df5d)
  (*"fix: recover partial streamed content on connection failure"*, Apr 13 2026)
  added the `_current_streamed_assistant_text` salvage, but only for the
  stream-**failure** twin — the user-**interrupt** branch right above it was never
  wired up. This PR completes that work.
- **No-op for this bug** — [`2394e1872`](https://github.com/NousResearch/hermes-agent/commit/2394e18729b085937d865e848ce069dbfc8de001)
  (sentinel wording) and the refactors [`053025238`](https://github.com/NousResearch/hermes-agent/commit/053025238434cfbf121873977b39888d7f27d1c1)
  / [`f5bd09af4`](https://github.com/NousResearch/hermes-agent/commit/f5bd09af4b37c4d77c1900a6d66eea80d008e8a3)
  only moved/renamed the handler.

## Test plan

- [x] `test_interrupt_during_stream_preserves_partial_assistant_text` — partial
  reply is appended to history + returned as `final_response`.
- [x] `test_interrupt_before_any_stream_keeps_sentinel` — no streamed text falls
  back to the metadata sentinel, tail stays the user turn.
- [x] Existing interrupt/streaming/alternation suites green (streaming,
  partial_stream_finish_reason, turn_finalizer_interrupt_alternation,
  interrupt_propagation, concurrent_interrupt — 60 passed).
