### PR TITLE
fix(whatsapp): propagate quotedMessageId to reply_to_id

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1270,6 +1270,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 source=source,
                 raw_message=data,
                 message_id=data.get("messageId"),
+                reply_to_id=data.get("quotedMessageId") or None,
                 media_urls=cached_urls,
                 media_types=media_types,
             )


### PR DESCRIPTION
The Baileys bridge already reports `quotedMessageId` for reply messages, but the WhatsApp plugin adapter ignored it and never set `MessageEvent.reply_to_id`. This caused inbound WhatsApp replies to look like top-level messages in the agent context and broke reply-threading in both DMs and groups.

Changes:
- Map `data['quotedMessageId']` to `reply_to_id` when building a `MessageEvent` from the bridge payload.

Tested locally: WhatsApp replies now carry the original message id and the agent sees the reply context correctly.