### PR TITLE
fix(tools): preserve boundary spaces in fuzzy replacements

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -43,6 +43,25 @@ class TestWhitespaceDifference:
         assert count == 1
         assert "bar" in new
 
+    def test_boundary_space_after_normalized_match_is_preserved(self):
+        new, count, strategy, err = fuzzy_find_and_replace("foo   bar baz", "foo bar", "XY")
+        assert err is None
+        assert count == 1
+        assert strategy == "whitespace_normalized"
+        assert new == "XY baz"
+
+    def test_operator_space_after_normalized_call_match_is_preserved(self):
+        content = "result = compute(a,  b) + tail"
+        new, count, strategy, err = fuzzy_find_and_replace(
+            content,
+            "compute(a, b)",
+            "compute(a, b, c)",
+        )
+        assert err is None
+        assert count == 1
+        assert strategy == "whitespace_normalized"
+        assert new == "result = compute(a, b, c) + tail"
+
 
 class TestIndentDifference:
     def test_different_indentation(self):

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -768,9 +768,13 @@ def _map_normalized_positions(original: str, normalized: str,
         else:
             orig_end = orig_start + (norm_end - norm_start)
         
-        # Expand to include trailing whitespace that was normalized
-        while orig_end < len(original) and original[orig_end] in ' \t':
-            orig_end += 1
+        # Expand only over trailing whitespace that was part of the
+        # normalized match. If the matched region ended on a non-whitespace
+        # character, the following whitespace belongs to the next token and
+        # must be preserved.
+        if orig_end > orig_start and original[orig_end - 1] in ' \t':
+            while orig_end < len(original) and original[orig_end] in ' \t':
+                orig_end += 1
         
         original_matches.append((orig_start, min(orig_end, len(original))))
     


### PR DESCRIPTION
## Summary
- Preserve the boundary space after a whitespace-normalized fuzzy replacement when the matched region ends on a non-whitespace character
- Add focused regressions for adjacent-token and operator-spacing cases

Closes #52491

## Verification
- `scripts/run_tests.sh tests/tools/test_fuzzy_match.py`
- Manual repro for the two issue examples
- Static diff security scan: no findings
- Independent delegated code review: passed
