### PR TITLE
fix(gemini): accept string-form image_url in native multimodal content (salvage of #13787 by @UgwujaGeorge)

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -209,7 +209,13 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
             if isinstance(text, str) and text:
                 parts.append({"text": text})
         elif ptype == "image_url":
-            url = ((item.get("image_url") or {}).get("url") or "")
+            image_ref = item.get("image_url")
+            if isinstance(image_ref, dict):
+                url = image_ref.get("url") or ""
+            elif isinstance(image_ref, str):
+                url = image_ref
+            else:
+                continue
             if not isinstance(url, str) or not url.startswith("data:"):
                 continue
             try:

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -408,3 +408,35 @@ def test_explicit_max_tokens_is_respected():
 
     req = build_gemini_request(messages=[{"role": "user", "content": "hi"}], max_tokens=4096)
     assert req["generationConfig"]["maxOutputTokens"] == 4096
+
+
+def test_extract_multimodal_parts_accepts_string_form_image_url():
+    """OpenAI-style multimodal content may carry image_url as a bare string
+    (e.g. {"type": "image_url", "image_url": "data:image/png;base64,..."})
+    rather than the nested {"url": ...} object. The native Gemini adapter
+    must not crash on that shape (regression for AttributeError on str.get)."""
+    import base64 as _b64
+
+    from agent.gemini_native_adapter import _extract_multimodal_parts
+
+    raw = b"\x89PNG\r\n\x1a\n"
+    data_uri = "data:image/png;base64," + _b64.b64encode(raw).decode("ascii")
+
+    # String form must not raise and must produce an inlineData part.
+    parts_str = _extract_multimodal_parts(
+        [{"type": "image_url", "image_url": data_uri}]
+    )
+    assert len(parts_str) == 1
+    assert parts_str[0]["inlineData"]["mimeType"] == "image/png"
+    assert _b64.b64decode(parts_str[0]["inlineData"]["data"]) == raw
+
+    # Object form continues to work identically.
+    parts_obj = _extract_multimodal_parts(
+        [{"type": "image_url", "image_url": {"url": data_uri}}]
+    )
+    assert parts_obj == parts_str
+
+    # Non-str/dict image_url is skipped, not fatal.
+    assert _extract_multimodal_parts(
+        [{"type": "image_url", "image_url": 123}]
+    ) == []


### PR DESCRIPTION
## Summary

Salvage of #13787 by @UgwujaGeorge — rebased onto current `origin/main` with a regression test.

The native Google AI Studio adapter crashes with `AttributeError` when OpenAI-style multimodal content carries `image_url` as a bare string instead of the nested `{"url": ...}` object.

## Root Cause

**Symptom** — A turn with image content shaped as `{"type": "image_url", "image_url": "data:image/png;base64,..."}` raises `AttributeError: 'str' object has no attribute 'get'` inside the native Gemini adapter, aborting the request.

**Root cause** — In `_extract_multimodal_parts` (`agent/gemini_native_adapter.py`), the `image_url` branch assumes the OpenAI *object* form unconditionally:
```python
url = ((item.get("image_url") or {}).get("url") or "")
```
The OpenAI chat schema permits `image_url` to be **either** a string **or** an object `{"url": ...}`. When it's a string, `.get("url")` is called on a `str` and raises.

**Evidence** — On current main (`agent/gemini_native_adapter.py:212`), the new regression test reproduces the exact crash; with the fix stashed it fails with the `AttributeError` shown below, and passes with the fix applied.

**Fix + why this level** — Normalize `image_url` to a URL string at the point of extraction: accept the dict form (`.get("url")`), the string form (use as-is), and skip anything else (instead of crashing). This is the correct layer because it's the single choke point that translates OpenAI multimodal content into Gemini `inlineData` parts — fixing upstream callers would require touching every content producer.

**Scope / risk** — Touches only the `image_url` branch of `_extract_multimodal_parts`. Object-form input produces byte-identical output to before; only the previously-fatal string form and non-str/dict forms change behavior (now handled/skipped). No other content types affected.

## Changes from original

- Rebased onto current main (clean single commit).
- Added regression test `test_extract_multimodal_parts_accepts_string_form_image_url` (string form, object-form parity, non-str/dict skip) — **fails without the fix, passes with it**.

## Verification

```
python3 -m pytest tests/agent/test_gemini_native_adapter.py -k multimodal_parts_accepts_string -q
1 passed

# without the fix (stashed):
AttributeError: 'str' object has no attribute 'get'
agent/gemini_native_adapter.py:212: AttributeError
1 failed
```

## Real behavior proof

Captured from a real run on this branch:
```
string-form image_url -> [{'inlineData': {'mimeType': 'image/png', 'data': 'iVBORw0KGgo='}}]
object-form image_url -> [{'inlineData': {'mimeType': 'image/png', 'data': 'iVBORw0KGgo='}}]
```
Both shapes now yield identical inlineData parts.

Credit: salvage of #13787 by @UgwujaGeorge — rebased onto current main with a guardrail test.
