### PR TITLE
fix(copilot_acp): honor line=1 pagination in fs/read_text_file (salvage of #13518 by @86cloudyun-afk)

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -635,7 +635,7 @@ class CopilotACPClient:
                     content = ""
                 line = params.get("line")
                 limit = params.get("limit")
-                if isinstance(line, int) and line > 1:
+                if isinstance(line, int) and line >= 1:
                     lines = content.splitlines(keepends=True)
                     start = line - 1
                     end = start + limit if isinstance(limit, int) and limit > 0 else None

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -98,6 +98,25 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.assertNotIn("abc123def456", content)
         self.assertIn("OPENAI_API_KEY=", content)
 
+    def test_read_text_file_honors_first_page_pagination(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            text_file = root / "sample.txt"
+            text_file.write_text("one\ntwo\nthree\n")
+
+            response = self._dispatch(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 33,
+                    "method": "fs/read_text_file",
+                    "params": {"path": str(text_file), "line": 1, "limit": 1},
+                },
+                cwd=str(root),
+            )
+
+        content = ((response.get("result") or {}).get("content") or "")
+        self.assertEqual(content, "one\n")
+
     def test_write_text_file_reuses_write_denylist(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir) / "home"


### PR DESCRIPTION
## Summary

Salvage of #13518 by @86cloudyun-afk — rebased onto current `origin/main`.

The Copilot ACP client ignores `line=1` pagination in `fs/read_text_file`: a request for `{line: 1, limit: 1}` returns the **entire file** instead of just the first line.

## Root Cause

**Symptom** — An ACP `fs/read_text_file` request with `line: 1, limit: 1` returns the whole file rather than the single requested line. Pagination silently fails for the first page only.

**Root cause** — In `_handle_server_message` (`agent/copilot_acp_client.py:638`), the pagination slice is gated on `line > 1`:
```python
if isinstance(line, int) and line > 1:
```
`line` is 1-based, so `line == 1` is a perfectly valid first-page request, but the strict `> 1` skips slicing entirely and returns the full `content`. Any client paging from the top gets everything.

**Evidence** — On current main, the added regression test sends `{line: 1, limit: 1}` against a 3-line file and asserts the result is `"one\n"`; it fails (returns all three lines) without the fix.

**Fix + why this level** — Change the guard to `line >= 1`. This is the correct level because the slice math (`start = line - 1`) is already 0-based-correct for `line == 1` (`start == 0`); only the entry guard was wrong. No downstream change needed.

**Scope / risk** — Single-line guard change in the ACP read handler. `line` values > 1 behave exactly as before; only the previously-broken `line == 1` case now paginates correctly. `line <= 0` / non-int still falls through to full content as before.

## Changes from original

- Rebased onto current main (clean single commit).
- Carried the original's regression test `test_read_text_file_honors_first_page_pagination` — confirmed it **fails without the fix** (returns 3 lines) and passes with it.

## Verification

```
python3 -m pytest tests/agent/test_copilot_acp_client.py -q
8 passed

# without the fix (stashed): returns "one\ntwo\nthree\n"
AssertionError: 'one\ntwo\nthree\n' != 'one\n'
1 failed
```

Credit: salvage of #13518 by @86cloudyun-afk — rebased onto current main with the original guardrail test verified red-without / green-with.
