### PR TITLE
fix(mcp): honor HERMES_HOME fallback when empty in mcp serve (salvage of #8350 by @iacker)

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -65,7 +65,9 @@ def _get_sessions_dir() -> Path:
         from hermes_constants import get_hermes_home
         return get_hermes_home() / "sessions"
     except ImportError:
-        return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "sessions"
+        hermes_home = os.environ.get("HERMES_HOME")
+        base_dir = Path(hermes_home) if hermes_home else Path.home() / ".hermes"
+        return base_dir / "sessions"
 
 
 def _get_session_db():
@@ -108,9 +110,9 @@ def _load_channel_directory() -> dict:
         from hermes_constants import get_hermes_home
         directory_file = get_hermes_home() / "channel_directory.json"
     except ImportError:
-        directory_file = Path(
-            os.environ.get("HERMES_HOME", Path.home() / ".hermes")
-        ) / "channel_directory.json"
+        hermes_home = os.environ.get("HERMES_HOME")
+        base_dir = Path(hermes_home) if hermes_home else Path.home() / ".hermes"
+        directory_file = base_dir / "channel_directory.json"
 
     if not directory_file.exists():
         return {}
@@ -372,7 +374,9 @@ class EventBridge:
             from hermes_constants import get_hermes_home
             db_file = get_hermes_home() / "state.db"
         except ImportError:
-            db_file = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
+            hermes_home = os.environ.get("HERMES_HOME")
+            base_dir = Path(hermes_home) if hermes_home else Path.home() / ".hermes"
+            db_file = base_dir / "state.db"
 
         try:
             db_mtime = db_file.stat().st_mtime if db_file.exists() else 0.0

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -277,6 +277,34 @@ class TestHelpers:
         result = _get_sessions_dir()
         assert result == tmp_path / "sessions"
 
+    def test_get_sessions_dir_empty_hermes_home_falls_back_to_home(
+        self, monkeypatch
+    ):
+        """An empty HERMES_HOME must fall back to ~/.hermes, not produce a
+        relative ``sessions`` path. Regression for the ImportError fallback
+        branch, where ``os.environ.get("HERMES_HOME", default)`` returned the
+        empty string (env var present but blank), so the default never applied
+        and ``Path("") / "sessions"`` collapsed to a relative path. (#8350)"""
+        import builtins
+        import mcp_serve
+        from pathlib import Path
+
+        monkeypatch.setenv("HERMES_HOME", "")
+
+        # Force the ImportError fallback branch (the buggy one).
+        real_import = builtins.__import__
+
+        def _no_hermes_constants(name, *args, **kwargs):
+            if name == "hermes_constants":
+                raise ImportError("forced for test")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _no_hermes_constants)
+
+        result = mcp_serve._get_sessions_dir()
+        assert result == Path.home() / ".hermes" / "sessions"
+        assert result.is_absolute()
+
     def test_coerce_int_handles_invalid_and_out_of_range_values(self):
         from mcp_serve import _coerce_int
 


### PR DESCRIPTION
## Summary

Salvage of #8350 by @iacker — rebased onto current `origin/main`, scoped to the `mcp_serve.py` path helpers.

`mcp_serve.py`'s `ImportError` fallback paths collapse to **relative** paths when `HERMES_HOME` is set but empty, instead of falling back to `~/.hermes`.

## Root Cause

**Symptom** — When `hermes_constants` can't be imported (the documented fallback path used in some MCP-serve deployments) and `HERMES_HOME` is present-but-empty in the environment, sessions/channel-directory/state-db discovery resolve to relative paths like `sessions`, `channel_directory.json`, `state.db` in the CWD — so the MCP server reads/writes the wrong location (or nothing).

**Root cause** — Three fallback sites use:
```python
Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "sessions"
```
`os.environ.get(key, default)` only returns `default` when the key is **absent**. A present-but-empty `HERMES_HOME` (`HERMES_HOME=`) returns `""`, so the `~/.hermes` default never applies and `Path("") / "sessions"` collapses to the relative `PosixPath('sessions')`.

**Evidence** — Captured on this branch with the fix; the regression test reproduces the relative-path bug on current main (forcing the `ImportError` branch + empty `HERMES_HOME`).

**Fix + why this level** — Read the env var first, then explicitly fall back only when it's falsy:
```python
hermes_home = os.environ.get("HERMES_HOME")
base_dir = Path(hermes_home) if hermes_home else Path.home() / ".hermes"
```
Applied at all three fallback sites (`_get_sessions_dir`, `_load_channel_directory`, `_poll_once`'s state.db). This is the correct level — it's exactly the fallback branches that mishandle the empty string; the primary `get_hermes_home()` path is already correct.

**Scope / risk** — Touches only the three `ImportError` fallback branches in `mcp_serve.py`. When `HERMES_HOME` is unset or a normal path, behavior is byte-identical to before; only the empty-string case changes (now → `~/.hermes` instead of relative). I deliberately dropped the original PR's `scripts/discord-voice-doctor.py` changes to keep this surgical and on-topic.

## Changes from original

- Rebased onto current main (clean single commit).
- Scoped to `mcp_serve.py` only (dropped the unrelated discord-voice-doctor edits).
- Added regression test `test_get_sessions_dir_empty_hermes_home_falls_back_to_home` — **fails without the fix** (relative path), passes with it.

## Verification

```
python3 -m pytest tests/test_mcp_serve.py -q
46 passed, 40 skipped

# without the fix (stashed):
AssertionError: PosixPath('sessions') != PosixPath('/.../.hermes/sessions')
1 failed
```

## Real behavior proof

Captured on this branch — empty `HERMES_HOME` with `hermes_constants` import forced to fail:
```
empty HERMES_HOME -> sessions dir: PosixPath('/Users/.../.hermes/sessions')
```
(Was `PosixPath('sessions')` before the fix.)

Credit: salvage of #8350 by @iacker — rebased onto current main with a guardrail test.
