### PR TITLE
fix(skill_utils): raise extract_skill_description cap from 60 to 1024 (salvage of #13995 by @giwaov)

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -769,13 +769,19 @@ def resolve_skill_config_values(
 
 
 def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
-    """Extract a truncated description from parsed frontmatter."""
+    """Extract a description from parsed frontmatter, capped at 1024 characters.
+
+    The previous 60-character cap truncated most skill descriptions mid-word
+    in the system-prompt skill index, starving the routing model of the
+    detail it needs to pick the right skill. 1024 chars preserves the full
+    intent of typical descriptions while still bounding prompt growth.
+    """
     raw_desc = frontmatter.get("description", "")
     if not raw_desc:
         return ""
     desc = str(raw_desc).strip().strip("'\"")
-    if len(desc) > 60:
-        return desc[:57] + "..."
+    if len(desc) > 1024:
+        return desc[:1021] + "..."
     return desc
 
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -316,7 +316,7 @@ class TestParseSkillFile:
         long_desc = "A" * 100
         skill_file.write_text(f"---\ndescription: {long_desc}\n---\n")
         _, _, desc = _parse_skill_file(skill_file)
-        assert len(desc) <= 60
+        assert len(desc) <= 1024
         assert desc.endswith("...")
 
     def test_nonexistent_file_returns_defaults(self, tmp_path):

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -313,7 +313,7 @@ class TestParseSkillFile:
 
     def test_long_description_truncated(self, tmp_path):
         skill_file = tmp_path / "SKILL.md"
-        long_desc = "A" * 100
+        long_desc = "A" * 1100
         skill_file.write_text(f"---\ndescription: {long_desc}\n---\n")
         _, _, desc = _parse_skill_file(skill_file)
         assert len(desc) <= 1024

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -8,6 +8,7 @@ from agent.skill_utils import (
     get_external_skills_dirs,
     is_excluded_skill_path,
     is_external_skill_path,
+    extract_skill_description,
     is_skill_support_path,
     iter_skill_index_files,
     resolve_skill_config_values,
@@ -386,3 +387,22 @@ class TestNormalizeSkillLookupName:
         monkeypatch.setattr("agent.skill_utils.get_skills_dir", lambda: tmp_path / "skills")
         outside = str(tmp_path / "outside" / "skill")
         assert normalize_skill_lookup_name(outside) == outside
+
+
+def test_extract_skill_description_cap_allows_up_to_1024_chars():
+    """Skill descriptions feed the system-prompt routing index. The old
+    60-char cap truncated almost everything mid-word; the cap is 1024 now.
+    A 600-char description (well over the old cap) must survive intact."""
+    medium = "x" * 600
+    assert extract_skill_description({"description": medium}) == medium
+
+    # Over 1024 is still truncated with an ellipsis to bound prompt growth.
+    huge = "y" * 2000
+    out = extract_skill_description({"description": huge})
+    assert len(out) == 1024
+    assert out.endswith("...")
+    assert out[:1021] == "y" * 1021
+
+    # Short descriptions are unchanged.
+    assert extract_skill_description({"description": "short"}) == "short"
+    assert extract_skill_description({}) == ""


### PR DESCRIPTION
## Summary

Salvage of #13995 by @giwaov — rebased onto current `origin/main` with a regression test. Fixes #13944.

`extract_skill_description` truncates skill descriptions to 57 chars + "..." (a 60-char cap). That index feeds the system-prompt skill router, so most descriptions get cut mid-word and the model loses the detail it needs to route to the right skill.

## Root Cause

**Symptom** — Skill descriptions shown in the system-prompt skill index are truncated to ~57 characters, dropping the trigger phrases ("Use when…", "Triggers: …") that the routing model relies on.

**Root cause** — `extract_skill_description` (`agent/skill_utils.py:710`) hard-caps at 60 chars:
```python
if len(desc) > 60:
    return desc[:57] + "..."
```
60 chars is far below a typical skill description (often 150–400 chars of routing guidance), so nearly every description is mangled before it reaches the prompt.

**Evidence** — The added regression test shows a 600-char description (well over the old cap, typical for a real skill) is fully preserved with the fix and truncated to `"x"*57 + "..."` without it.

**Fix + why this level** — Raise the cap to 1024 chars (`desc[:1021] + "..."`). This is the correct level — it's the single extraction choke point used by `prompt_builder` when building the skill index, so one change fixes routing everywhere without touching callers. 1024 preserves full intent for realistic descriptions while still bounding prompt growth for pathological inputs.

**Scope / risk** — One function, one constant. Descriptions ≤1024 chars are now returned verbatim; only >1024 are truncated. Short descriptions and the empty case are unchanged.

## Changes from original

- Rebased onto current main (clean single commit).
- Added regression test `test_extract_skill_description_cap_allows_up_to_1024_chars` (600-char survives, 2000-char truncates to 1024 with ellipsis, short/empty unchanged) — **fails without the fix**.

## Verification

```
python3 -m pytest tests/agent/test_skill_utils.py -k extract_skill_description -q
1 passed

# without the fix (stashed): 600-char description truncated to "xxxxxxxxxx..."
1 failed
```

## Real behavior proof

Captured on this branch:
```
600-char preserved: 600
2000-char capped: 1024
```
(Was 60 for both before the fix.)

Credit: salvage of #13995 by @giwaov — rebased onto current main with a guardrail test.
