### PR TITLE
fix(exa): set standard User-Agent to avoid Cloudflare 403 (salvage of #13948 by @winniesi)

### DIFF
--- a/plugins/web/exa/provider.py
+++ b/plugins/web/exa/provider.py
@@ -71,6 +71,12 @@ def _get_exa_client() -> Any:
 
     client = Exa(api_key=api_key)
     client.headers["x-exa-integration"] = "hermes-agent"
+    # Set a standard User-Agent so Cloudflare doesn't 403 (error code 1010)
+    # the SDK's default header. Without this, Exa API requests behind
+    # Cloudflare are rejected outright.
+    client.headers["User-Agent"] = (
+        "Hermes-Agent/1.0 (+https://github.com/NousResearch/hermes-agent)"
+    )
     _wt._exa_client = client
     return client
 

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -192,6 +192,40 @@ class TestIsAvailable:
         monkeypatch.setenv("EXA_API_KEY", "real")
         assert p.is_available() is True
 
+    def test_exa_client_sets_user_agent_header(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Regression: Cloudflare 403s (error 1010) the Exa SDK's default
+        User-Agent. _get_exa_client must set a standard User-Agent header on
+        the client so requests behind Cloudflare aren't rejected."""
+        import sys
+        import types
+
+        captured = {}
+
+        class _FakeExa:
+            def __init__(self, api_key=None):
+                captured["api_key"] = api_key
+                self.headers = {}
+
+        fake_module = types.ModuleType("exa_py")
+        fake_module.Exa = _FakeExa
+        monkeypatch.setitem(sys.modules, "exa_py", fake_module)
+        # _get_exa_client tries lazy-installing the SDK first; we've already
+        # injected a fake exa_py, so stub the ensure call to a no-op.
+        import tools.lazy_deps as _lazy
+        monkeypatch.setattr(_lazy, "ensure", lambda *a, **k: None)
+        monkeypatch.setenv("EXA_API_KEY", "real-key")
+
+        import tools.web_tools as _wt
+        monkeypatch.setattr(_wt, "_exa_client", None, raising=False)
+
+        from plugins.web.exa.provider import _get_exa_client
+
+        client = _get_exa_client()
+        assert "User-Agent" in client.headers
+        assert "Hermes-Agent" in client.headers["User-Agent"]
+        # Existing integration header preserved.
+        assert client.headers["x-exa-integration"] == "hermes-agent"
+
     def test_parallel_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import get_provider


### PR DESCRIPTION
## Summary

Salvage of #13948 by @winniesi — re-targeted onto the current code location (`plugins/web/exa/provider.py`; the original patched the now-moved `tools/web_tools.py`) and rebased onto `origin/main` with a regression test.

The Exa SDK client is created without a `User-Agent` header, so Cloudflare in front of the Exa API returns **403 (error code 1010)** on the SDK's default header, breaking Exa web search/extract.

## Root Cause

**Symptom** — Exa search/extract requests fail with HTTP 403 (Cloudflare error 1010 — "browser/UA blocked").

**Root cause** — In `_get_exa_client` (`plugins/web/exa/provider.py`), the client is built and given only `client.headers["x-exa-integration"] = "hermes-agent"`. No `User-Agent` is set, so the SDK's default UA is used, which Cloudflare's bot rules reject with 1010.

**Evidence** — The added regression test builds the client through `_get_exa_client` (with `exa_py.Exa` mocked) and asserts a `User-Agent` header is present; it fails without the fix (only `x-exa-integration` is set).

**Fix + why this level** — Set a standard `User-Agent` header on the client right where the other custom header is already set. This is the correct level — it's the single client-construction choke point, so every Exa request (search and extract) inherits the header; patching individual call sites would miss paths.

**Scope / risk** — One header assignment in client construction. The existing `x-exa-integration` header is preserved. No behavior change beyond the added header; non-Exa providers untouched.

## Changes from original

- Re-targeted from the original `tools/web_tools.py` (the Exa client moved to `plugins/web/exa/provider.py`) onto current main.
- Added regression test `test_exa_client_sets_user_agent_header` — **fails without the fix**.

## Verification

```
python3 -m pytest tests/plugins/web/test_web_search_provider_plugins.py -q
51 passed

# without the fix (stashed): headers == {'x-exa-integration': 'hermes-agent'} (no User-Agent)
1 failed
```

## Real behavior proof

Captured on this branch (key redacted):
```
client headers: {'x-exa-integration': 'hermes-agent', 'User-Agent': 'Hermes-Agent/1.0 (+https://github.com/NousResearch/hermes-agent)'}
```

Credit: salvage of #13948 by @winniesi — re-targeted onto the current location and rebased onto main with a guardrail test.
