### PR TITLE
fix(classifier): treat Anthropic 'out of extra usage' 400 as billing (salvage of #13170 by @jack4git)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -107,6 +107,7 @@ _BILLING_PATTERNS = [
     "exceeded your current quota",
     "account is deactivated",
     "plan does not include",
+    "out of extra usage",  # Anthropic 2026-04-04 third-party enforcement (HTTP 400)
     "out of funds",
     "run out of funds",
     "balance_depleted",

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -843,6 +843,19 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.timeout
 
+    def test_anthropic_out_of_extra_usage_is_billing(self):
+        """Anthropic's 2026-04-04 third-party enforcement returns HTTP 400
+        with body 'You're out of extra usage...'. Without classifying it as
+        billing it stays format_error (a generic 400) and the credential
+        rotation / payment-fallback chain never engages — the run just
+        dies on a hard 400. (#13170)"""
+        msg = "You're out of extra usage. Add more at claude.ai/settings/usage and keep going."
+        e = MockAPIError(msg, status_code=400, body={"error": {"message": msg}})
+        result = classify_api_error(e, provider="anthropic", model="claude-opus-4-7")
+        assert result.reason == FailoverReason.billing
+        assert result.should_fallback is True
+        assert result.should_rotate_credential is True
+
     def test_connection_error_builtin(self):
         e = ConnectionError("Connection reset by peer")
         result = classify_api_error(e)


### PR DESCRIPTION
## Summary

Salvage of #13170 by @jack4git — rebased onto current `origin/main` with a regression test.

Anthropic's 2026-04-04 third-party enforcement returns **HTTP 400** with body `"You're out of extra usage..."`. The classifier treats it as a generic `format_error`, so the credential-rotation / payment-fallback chain never engages and the run just dies on the 400.

## Root Cause

**Symptom** — When an Anthropic credential is out of extra usage, the API returns HTTP 400 with `"You're out of extra usage. Add more at claude.ai/settings/usage..."`. Hermes classifies this as `format_error` and does not rotate to another credential or fall back — the turn fails hard.

**Root cause** — `_BILLING_PATTERNS` in `agent/error_classifier.py` lists the usual exhaustion markers (`insufficient credits`, `out of funds`, `plan does not include`, …) but not `"out of extra usage"`. Because the message carries a 400 status, `classify_api_error` lands on the non-retryable `format_error` path (400s are normally request-validation errors) instead of `billing`.

**Evidence** — On current main the added test asserts `reason == billing`; it fails (returns `format_error`, no `should_rotate_credential`) without the fix. Real-run probe below confirms the flip.

**Fix + why this level** — Add `"out of extra usage"` to `_BILLING_PATTERNS`. This is the correct level — billing-pattern matching runs even for 400-status bodies, so the single list addition routes the error to the billing path (`should_fallback=True`, `should_rotate_credential=True`) without special-casing status codes elsewhere.

**Scope / risk** — One pattern string added to the billing list. Only messages containing the exact Anthropic phrase change classification (400→billing); all other 400s remain `format_error`. No effect on other providers.

## Changes from original

- Rebased onto current main (clean single commit); pattern inserted near the existing `out of funds` entry.
- Carried the original's regression test `test_anthropic_out_of_extra_usage_is_billing` (adapted to main's `MockAPIError` signature) — **fails without the fix**.

## Verification

```
python3 -m pytest tests/agent/test_error_classifier.py -q
162 passed

# without the fix (stashed):
AssertionError (reason == format_error, not billing)
1 failed
```

## Real behavior proof

```
# With fix:    reason=FailoverReason.billing  should_fallback=True  should_rotate_credential=True
# Without fix: reason=FailoverReason.format_error  (no credential rotation -> hard 400)
```

Credit: salvage of #13170 by @jack4git — rebased onto current main with a guardrail test.
