### PR TITLE
feat(whatsapp): human-like reply context for any quoted media type

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1237,6 +1237,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 if len(quoted_text) > 300:
                     quoted_text = quoted_text[:297] + "..."
                 body = f"[Replying to: \"{quoted_text}\"]\n{body}"
+            # If the quoted message had media, include the cached media path so
+            # vision/audio tools can inspect the original content.
+            quoted_media_urls = data.get("quotedMediaUrls") or []
+            quoted_media_type = data.get("quotedMediaType") or ""
+            if quoted_media_urls:
+                body = f"[Replying to {quoted_media_type or 'media'}: {', '.join(quoted_media_urls)}]\n{body}"
             MAX_TEXT_INJECT_BYTES = 100 * 1024
             if msg_type == MessageType.DOCUMENT and cached_urls:
                 for doc_path in cached_urls:
@@ -1270,6 +1276,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 source=source,
                 raw_message=data,
                 message_id=data.get("messageId"),
+                reply_to_message_id=data.get("quotedMessageId") or None,
                 media_urls=cached_urls,
                 media_types=media_types,
             )

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -166,6 +166,55 @@ function getContextInfo(messageContent) {
   return {};
 }
 
+// Extract the user-visible content of a quoted message so the agent sees
+// replies in a natural, human-like form instead of raw message ids.
+function extractQuotedText(quotedMessage) {
+  if (!quotedMessage || typeof quotedMessage !== 'object') return null;
+  let text = null;
+  if (quotedMessage.conversation) {
+    text = String(quotedMessage.conversation);
+  } else if (quotedMessage.extendedTextMessage?.text) {
+    text = String(quotedMessage.extendedTextMessage.text);
+  } else if (quotedMessage.imageMessage?.caption) {
+    text = `sent an image: ${quotedMessage.imageMessage.caption}`;
+  } else if (quotedMessage.videoMessage?.caption) {
+    text = `sent a video: ${quotedMessage.videoMessage.caption}`;
+  } else if (quotedMessage.documentMessage) {
+    const name = quotedMessage.documentMessage.fileName || 'a document';
+    text = `sent a document: ${name}`;
+  } else if (quotedMessage.audioMessage || quotedMessage.pttMessage) {
+    text = 'sent a voice message';
+  } else if (quotedMessage.locationMessage) {
+    const loc = quotedMessage.locationMessage;
+    text = `shared a location: ${loc.degreesLatitude}, ${loc.degreesLongitude}`;
+  } else if (quotedMessage.stickerMessage) {
+    text = 'sent a sticker';
+  }
+  return text ? text.trim() : null;
+}
+
+// In-memory store of recently seen inbound messages so replies can reference
+// the original text and cached media paths. Key: "chatId:messageId".
+const recentInboundMessages = new Map();
+const MAX_STORED_MESSAGES = 200;
+
+function rememberInboundMessage(chatId, messageId, payload) {
+  const key = `${chatId}:${messageId}`;
+  recentInboundMessages.set(key, {
+    timestamp: Date.now(),
+    ...payload,
+  });
+  // Evict oldest entries when we exceed the cap.
+  if (recentInboundMessages.size > MAX_STORED_MESSAGES) {
+    const oldestKey = recentInboundMessages.keys().next().value;
+    recentInboundMessages.delete(oldestKey);
+  }
+}
+
+function lookupInboundMessage(chatId, messageId) {
+  return recentInboundMessages.get(`${chatId}:${messageId}`) || null;
+}
+
 mkdirSync(SESSION_DIR, { recursive: true });
 
 // Build LID → phone reverse map from session files (lid-mapping-{phone}.json)
@@ -440,6 +489,34 @@ async function startSocket() {
         continue;
       }
 
+      // Remember this message so replies can include original text/media context.
+      rememberInboundMessage(chatId, msg.key.id, { body, hasMedia, mediaType, mediaUrls });
+
+      // Resolve quoted-message context using the in-memory store for media and
+      // falling back to the quotedMessage object for text-only messages.
+      let quotedText = extractQuotedText(contextInfo?.quotedMessage) || null;
+      let quotedMediaUrls = [];
+      let quotedMediaType = '';
+      if (quotedMessageId) {
+        const original = lookupInboundMessage(chatId, quotedMessageId) || lookupInboundMessage(quotedRemoteJid || chatId, quotedMessageId);
+        if (original) {
+          if (original.hasMedia && original.mediaUrls.length) {
+            quotedMediaUrls = original.mediaUrls;
+            quotedMediaType = original.mediaType;
+            if (!quotedText) {
+              quotedText = original.mediaType === 'image' ? 'sent an image' :
+                           original.mediaType === 'video' ? 'sent a video' :
+                           original.mediaType === 'audio' ? 'sent an audio message' :
+                           original.mediaType === 'ptt' ? 'sent a voice message' :
+                           original.mediaType === 'document' ? 'sent a document' :
+                           'sent media';
+            }
+          } else if (original.body && !quotedText) {
+            quotedText = original.body;
+          }
+        }
+      }
+
       const event = {
         messageId: msg.key.id,
         chatId,
@@ -456,6 +533,9 @@ async function startSocket() {
         quotedParticipant,
         quotedRemoteJid,
         hasQuotedMessage,
+        quotedText,
+        quotedMediaUrls,
+        quotedMediaType,
         botIds,
         timestamp: msg.messageTimestamp,
       };


### PR DESCRIPTION
WhatsApp replies previously referenced only the quoted message id. This PR makes the agent see the original quoted message content the way a human would, for **any** media type.\n\nChanges:\n- Bridge: extract user-visible text from the `quotedMessage` object (plain text, extended text, image/video captions, document names, audio/voice labels, location, sticker).\n- Bridge: keep an in-memory store of the last 200 inbound messages so replies to uncaptioned images/videos/documents/audio include the cached local media path.\n- Adapter: map `quotedMessageId` to `MessageEvent.reply_to_message_id`.\n- Adapter: inject quoted text and quoted media paths into the agent prompt body.\n\nTested locally:\n- Inbound WhatsApp replies now include the original message text.\n- Image/video/media replies include the cached file path so vision tools can inspect the original.\n- All 27 tests in `tests/gateway/test_whatsapp_formatting.py` pass.