### PR TITLE
fix(profiles): match alias wrapper by exact profile token

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -504,7 +504,16 @@ def find_alias_for_profile(profile_name: str) -> Optional[str]:
         return None
     canon = normalize_profile_name(profile_name)
     is_windows = sys.platform == "win32"
-    needle = f"hermes -p {canon}"
+    # Match the profile token exactly, not as a substring: a bare
+    # ``f"hermes -p {canon}" in content`` check lets ``erp-dev`` match the
+    # ``erp-devops`` wrapper (whose body is ``hermes -p erp-devops "$@"``),
+    # because one profile name is a prefix of the other. Require a whitespace
+    # (or end-of-string) boundary after the name so only the exact argv token
+    # matches. Both wrapper forms always follow the profile with a space:
+    # ``-p <profile> "$@"`` (POSIX) and ``-p <profile> %*`` (Windows). The
+    # ``hermes`` executable may be an absolute path (``/usr/bin/hermes``), so
+    # we don't anchor before ``hermes``.
+    needle = re.compile(rf"hermes -p {re.escape(canon)}(?=\s|$)")
 
     custom: Optional[str] = None
     profile_named: Optional[str] = None
@@ -520,7 +529,7 @@ def find_alias_for_profile(profile_name: str) -> Optional[str]:
             content = entry.read_text()
         except (OSError, UnicodeDecodeError):
             continue
-        if needle not in content:
+        if not needle.search(content):
             continue
         alias = entry.stem if is_windows else entry.name
         if alias == canon:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -906,6 +906,35 @@ class TestFindAliasForProfile:
         assert info.alias_path is not None
         assert info.alias_path.name == "qiaobusi"
 
+    def test_overlapping_prefix_does_not_cross_match_posix(self, profile_env, monkeypatch):
+        # erp-dev is a prefix of erp-devops; a substring search for
+        # "hermes -p erp-dev" wrongly matches the erp-devops wrapper body
+        # (exec hermes -p erp-devops "$@"). Each profile must resolve to its
+        # own wrapper. See https://github.com/NousResearch/hermes-agent/issues/52838
+        monkeypatch.setattr("sys.platform", "darwin")
+        from hermes_cli.profiles import create_wrapper_script, find_alias_for_profile
+        create_wrapper_script("erp-dev")
+        create_wrapper_script("erp-devops")
+        assert find_alias_for_profile("erp-dev") == "erp-dev"
+        assert find_alias_for_profile("erp-devops") == "erp-devops"
+
+    def test_overlapping_prefix_does_not_cross_match_windows(self, profile_env, monkeypatch):
+        monkeypatch.setattr("sys.platform", "win32")
+        from hermes_cli.profiles import create_wrapper_script, find_alias_for_profile
+        create_wrapper_script("erp-dev")
+        create_wrapper_script("erp-devops")
+        assert find_alias_for_profile("erp-dev") == "erp-dev"
+        assert find_alias_for_profile("erp-devops") == "erp-devops"
+
+    def test_overlapping_prefix_custom_alias_only_for_longer(self, profile_env, monkeypatch):
+        # A custom alias on erp-devops must not be reported as erp-dev's alias.
+        monkeypatch.setattr("sys.platform", "darwin")
+        from hermes_cli.profiles import create_wrapper_script, find_alias_for_profile
+        create_wrapper_script("erp-dev")
+        create_wrapper_script("ops", target="erp-devops")
+        assert find_alias_for_profile("erp-dev") == "erp-dev"
+        assert find_alias_for_profile("erp-devops") == "ops"
+
 
 # ===================================================================
 # TestRenameProfile


### PR DESCRIPTION
## What does this PR do?

`find_alias_for_profile()` reverse-looks-up which wrapper script activates a profile by checking whether the wrapper body contains the substring `hermes -p <profile>`. That substring check breaks when one profile name is a prefix of another: searching for `hermes -p erp-dev` matches the `erp-devops` wrapper (`exec hermes -p erp-devops "$@"`), so `erp-dev`'s alias is wrongly reported as `erp-devops`.

The fix matches the profile as a whole argv token by requiring a trailing whitespace/end-of-string boundary, so `erp-dev` no longer matches `erp-devops`. Both wrapper forms always put a space after the profile name — `-p <profile> "$@"` (POSIX) and `-p <profile> %*` (Windows) — so the boundary holds on both platforms. The match is not anchored before `hermes`, so it still works when the executable resolves to an absolute path (`/usr/bin/hermes -p ...`).

## Related Issue

Fixes #52838

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py` — `find_alias_for_profile()`: replace the substring `needle` check with a boundary-anchored regex `hermes -p {re.escape(canon)}(?=\s|$)`.
- `tests/hermes_cli/test_profiles.py` — add regression tests for the `erp-dev`/`erp-devops` overlap (POSIX, Windows, and the custom-alias case).

## How to Test

1. `pytest tests/hermes_cli/test_profiles.py::TestFindAliasForProfile -q` → 9 passed.
2. Reverting only the `profiles.py` change makes the three new overlap tests fail (`erp-dev` resolves to `erp-devops`), confirming they catch the bug.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior fix, docstring still accurate)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — covered by POSIX + Windows tests
- [x] I've updated tool descriptions/schemas — N/A