### PR TITLE
feat(desktop): Alt+wheel to scale the pet, never cropped

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -6031,19 +6031,32 @@ ipcMain.handle('hermes:pet-overlay:close', async () => {
 
   return { ok: true }
 })
-// Drag: the overlay reports a new absolute screen position (it already knows the
-// pointer's screen coords), we just move the window.
+// Drag/resize: the overlay reports new absolute screen bounds (it already knows
+// the pointer's screen coords). Drag keeps the size constant; the wheel-to-scale
+// gesture grows/shrinks it so the sprite is never cropped by the window edge.
+// The window is created non-resizable (no stray edge-drag on the transparent
+// frameless panel), which on Windows/Linux also blocks programmatic setBounds
+// sizing — so briefly flip resizable on whenever the size actually changes.
 ipcMain.on('hermes:pet-overlay:set-bounds', (_event, bounds) => {
   if (!petOverlayWindow || petOverlayWindow.isDestroyed() || !bounds) {
     return
   }
 
-  petOverlayWindow.setBounds({
-    x: Math.round(bounds.x),
-    y: Math.round(bounds.y),
-    width: Math.max(80, Math.round(bounds.width)),
-    height: Math.max(80, Math.round(bounds.height))
-  })
+  const win = petOverlayWindow
+  const width = Math.max(80, Math.round(bounds.width))
+  const height = Math.max(80, Math.round(bounds.height))
+  const [curW, curH] = win.getSize()
+  const resizing = width !== curW || height !== curH
+
+  if (resizing && !win.isResizable()) {
+    win.setResizable(true)
+  }
+
+  win.setBounds({ x: Math.round(bounds.x), y: Math.round(bounds.y), width, height })
+
+  if (resizing) {
+    win.setResizable(false)
+  }
 })
 // Click-through: the overlay window is a full rectangle but only the pet pixels
 // should be interactive. The renderer toggles this as the cursor enters/leaves

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -46,7 +46,8 @@ import {
 import { $paneOpen } from '../store/panes'
 import { respondToApprovalAction } from '../store/native-notifications'
 import { setPetActivity } from '../store/pet'
-import { setPetOverlayOpenAppHandler, setPetOverlaySubmitHandler } from '../store/pet-overlay'
+import { setPetScale } from '../store/pet-gallery'
+import { setPetOverlayOpenAppHandler, setPetOverlayScaleHandler, setPetOverlaySubmitHandler } from '../store/pet-overlay'
 import { $filePreviewTarget, $previewTarget, closeActiveRightRailTab } from '../store/preview'
 import {
   $activeGatewayProfile,
@@ -939,6 +940,8 @@ export function DesktopController() {
   submitTextRef.current = submitText
   const resumeSessionRef = useRef(resumeSession)
   resumeSessionRef.current = resumeSession
+  const requestGatewayRef = useRef(requestGateway)
+  requestGatewayRef.current = requestGateway
 
   useEffect(() => {
     if (isSecondaryWindow()) {
@@ -946,6 +949,9 @@ export function DesktopController() {
     }
 
     setPetOverlaySubmitHandler(text => void submitTextRef.current(text))
+    // Alt+wheel resize from the popped-out pet — persist it through this
+    // window's gateway (the overlay has none) so it survives restart.
+    setPetOverlayScaleHandler(scale => setPetScale(requestGatewayRef.current, scale))
     // Mail icon: $sessions is ordered most-recent-first; the pet is global (not
     // per session) so "most recent" is the right target. main.cjs already raised
     // the window before forwarding this.
@@ -960,6 +966,7 @@ export function DesktopController() {
     return () => {
       setPetOverlaySubmitHandler(null)
       setPetOverlayOpenAppHandler(null)
+      setPetOverlayScaleHandler(null)
     }
   }, [])
 

--- a/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
+++ b/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
@@ -324,20 +324,18 @@ export function PetOverlayApp() {
     const anchor = zoomAnchorRef.current
     zoomAnchorRef.current = null
 
-    // The sprite's bottom-center sits at (curW/2, curH - paddingBottom) and
-    // scales about that point. Solve for the new window origin that holds either
-    // the cursor pixel (wheel) or that bottom-center (slider) at a fixed spot.
-    const dx = anchor ? anchor.clientX - curW / 2 : 0
-    const dy = anchor ? anchor.clientY - (curH - PET_PADDING_BOTTOM) : 0
+    // The sprite scales about its bottom-center, at window-local (curW/2,
+    // curH - paddingBottom). Hold the anchor pixel fixed on screen as it scales;
+    // with no wheel anchor we pin the bottom-center itself (ratio 1 ⇒ no shift).
     const ratio = anchor?.ratio ?? 1
-    const anchorX = anchor?.clientX ?? curW / 2
-    const anchorY = anchor?.clientY ?? curH - PET_PADDING_BOTTOM
+    const ax = anchor?.clientX ?? curW / 2
+    const ay = anchor?.clientY ?? curH - PET_PADDING_BOTTOM
 
     const bounds = {
       height,
       width,
-      x: Math.round(window.screenX + anchorX - dx * ratio - width / 2),
-      y: Math.round(window.screenY + anchorY - dy * ratio - (height - PET_PADDING_BOTTOM))
+      x: Math.round(window.screenX + ax - (ax - curW / 2) * ratio - width / 2),
+      y: Math.round(window.screenY + ay - (ay - (curH - PET_PADDING_BOTTOM)) * ratio - (height - PET_PADDING_BOTTOM))
     }
 
     window.hermesDesktop?.petOverlay?.setBounds(bounds)

--- a/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
+++ b/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
@@ -1,11 +1,23 @@
 import { useStore } from '@nanostores/react'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { PetBubble } from '@/components/pet/pet-bubble'
 import { PetSprite } from '@/components/pet/pet-sprite'
+import { usePetZoomGesture } from '@/components/pet/use-pet-zoom-gesture'
 import { Mail } from '@/lib/icons'
 import { $petActivity, $petInfo, setPetInfo } from '@/store/pet'
+import { overlayWindowSize } from '@/store/pet-overlay'
 import { setAwaitingResponse, setBusy } from '@/store/session'
+
+// Fallbacks mirror pet-sprite's defaults; the gateway normally sends real values.
+const DEFAULT_FRAME_W = 192
+const DEFAULT_FRAME_H = 208
+const DEFAULT_SCALE = 0.33
+
+// A sprite pixel counts as "solid" (interactive) at/above this alpha (0-255).
+// Low enough to catch anti-aliased edges, high enough that the faint halo around
+// the art still clicks through.
+const ALPHA_HIT_THRESHOLD = 16
 
 /**
  * The pop-out overlay's only view: a transparent, draggable mascot with a mini
@@ -81,11 +93,52 @@ export function PetOverlayApp() {
     return off
   }, [])
 
-  // Click-through: make only the sprite (or an open composer) interactive. With
-  // ignore+forward, the renderer still receives mousemove so we can re-enable
-  // hit-testing the moment the cursor returns to the pet.
+  // Click-through: make only the *solid* sprite pixels (plus the bubble / mail
+  // button / open composer) interactive — clicks on the transparent rectangle
+  // around the art pass through to whatever's behind. With ignore+forward, the
+  // renderer still receives mousemove so we can re-arm the moment the cursor
+  // returns to a solid pixel.
   useEffect(() => {
     setIgnore(true)
+
+    // True when the point sits on a solid sprite pixel or on the pet's other
+    // interactive chrome (bubble, mail button). Over the canvas we sample the
+    // rendered alpha; elsewhere inside the pet (bubble/button) we trust DOM
+    // hit-testing. Anything else is transparent backdrop.
+    const isInteractiveAt = (x: number, y: number): boolean => {
+      const pet = petRef.current
+      const target = document.elementFromPoint(x, y)
+
+      if (!pet || !target || !pet.contains(target)) {
+        return false
+      }
+
+      if (!(target instanceof HTMLCanvasElement)) {
+        return true
+      }
+
+      const rect = target.getBoundingClientRect()
+
+      if (rect.width === 0 || rect.height === 0) {
+        return true
+      }
+
+      const ctx = target.getContext('2d')
+
+      if (!ctx) {
+        return true
+      }
+
+      const px = Math.floor((x - rect.left) * (target.width / rect.width))
+      const py = Math.floor((y - rect.top) * (target.height / rect.height))
+
+      try {
+        return ctx.getImageData(px, py, 1, 1).data[3] >= ALPHA_HIT_THRESHOLD
+      } catch {
+        // Tainted/zero-size read — fail open so the pet stays grabbable.
+        return true
+      }
+    }
 
     const onMove = (ev: MouseEvent) => {
       if (dragRef.current || composerOpenRef.current) {
@@ -94,15 +147,7 @@ export function PetOverlayApp() {
         return
       }
 
-      const el = petRef.current
-
-      if (!el) {
-        return
-      }
-
-      const r = el.getBoundingClientRect()
-      const over = ev.clientX >= r.left && ev.clientX <= r.right && ev.clientY >= r.top && ev.clientY <= r.bottom
-      setIgnore(!over)
+      setIgnore(!isInteractiveAt(ev.clientX, ev.clientY))
     }
 
     window.addEventListener('mousemove', onMove)
@@ -230,6 +275,52 @@ export function PetOverlayApp() {
     setUnread(false)
     window.hermesDesktop?.petOverlay?.control({ type: 'open-app' })
   }
+
+  // Alt+wheel over the popped-out pet resizes it. The overlay has no gateway,
+  // so paint the new scale locally for instant feedback, then ask the main
+  // renderer to persist it (it pushes the reconciled scale back). The window
+  // itself is grown to fit by the effect below.
+  const onScale = useCallback((next: number) => {
+    setPetInfo({ ...$petInfo.get(), scale: next })
+    window.hermesDesktop?.petOverlay?.control({ scale: next, type: 'scale' })
+  }, [])
+
+  usePetZoomGesture(petRef, onScale, Boolean(info.enabled && info.spritesheetBase64))
+
+  // Grow/shrink the OS overlay window to fit the pet at its current scale so the
+  // sprite is never cropped — covers both the wheel gesture here and a scale
+  // changed from the app's settings slider (pushed in as a state update). The
+  // pet renders bottom-center, so anchor the window's bottom-center while
+  // resizing (it stays put; only the transparent headroom changes). New bounds
+  // are persisted so the pet reopens at the right size.
+  useEffect(() => {
+    if (!info.enabled || !info.spritesheetBase64) {
+      return
+    }
+
+    const { width, height } = overlayWindowSize(
+      info.frameW ?? DEFAULT_FRAME_W,
+      info.frameH ?? DEFAULT_FRAME_H,
+      info.scale ?? DEFAULT_SCALE
+    )
+
+    const curW = window.outerWidth
+    const curH = window.outerHeight
+
+    if (width === curW && height === curH) {
+      return
+    }
+
+    const bounds = {
+      height,
+      width,
+      x: Math.round(window.screenX + (curW - width) / 2),
+      y: Math.round(window.screenY + (curH - height))
+    }
+
+    window.hermesDesktop?.petOverlay?.setBounds(bounds)
+    window.hermesDesktop?.petOverlay?.control({ bounds, type: 'bounds' })
+  }, [info.enabled, info.spritesheetBase64, info.scale, info.frameW, info.frameH])
 
   if (!info.enabled || !info.spritesheetBase64) {
     return null

--- a/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
+++ b/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { PetBubble } from '@/components/pet/pet-bubble'
 import { PetSprite } from '@/components/pet/pet-sprite'
-import { usePetZoomGesture } from '@/components/pet/use-pet-zoom-gesture'
+import { type PetZoomAnchor, usePetZoomGesture } from '@/components/pet/use-pet-zoom-gesture'
 import { Mail } from '@/lib/icons'
 import { $petActivity, $petInfo, setPetInfo } from '@/store/pet'
 import { overlayWindowSize } from '@/store/pet-overlay'
@@ -13,6 +13,10 @@ import { setAwaitingResponse, setBusy } from '@/store/session'
 const DEFAULT_FRAME_W = 192
 const DEFAULT_FRAME_H = 208
 const DEFAULT_SCALE = 0.33
+
+// Must match the root's paddingBottom — the sprite renders bottom-centered, this
+// many px above the window's bottom edge. Used to anchor the resize.
+const PET_PADDING_BOTTOM = 24
 
 // A sprite pixel counts as "solid" (interactive) at/above this alpha (0-255).
 // Low enough to catch anti-aliased edges, high enough that the faint halo around
@@ -63,6 +67,9 @@ export function PetOverlayApp() {
   const [unread, setUnread] = useState(false)
 
   const dragRef = useRef<DragState | null>(null)
+  // Last Alt+wheel anchor, consumed by the resize effect to zoom toward the
+  // cursor; null means a non-wheel scale change (slider) → anchor bottom-center.
+  const zoomAnchorRef = useRef<PetZoomAnchor | null>(null)
   const petRef = useRef<HTMLDivElement | null>(null)
   const inputRef = useRef<HTMLInputElement | null>(null)
   const ignoreRef = useRef(true)
@@ -278,9 +285,10 @@ export function PetOverlayApp() {
 
   // Alt+wheel over the popped-out pet resizes it. The overlay has no gateway,
   // so paint the new scale locally for instant feedback, then ask the main
-  // renderer to persist it (it pushes the reconciled scale back). The window
-  // itself is grown to fit by the effect below.
-  const onScale = useCallback((next: number) => {
+  // renderer to persist it (it pushes the reconciled scale back). Stash the
+  // cursor anchor for the resize effect; the window itself is grown to fit there.
+  const onScale = useCallback((next: number, anchor: PetZoomAnchor) => {
+    zoomAnchorRef.current = anchor
     setPetInfo({ ...$petInfo.get(), scale: next })
     window.hermesDesktop?.petOverlay?.control({ scale: next, type: 'scale' })
   }, [])
@@ -289,10 +297,10 @@ export function PetOverlayApp() {
 
   // Grow/shrink the OS overlay window to fit the pet at its current scale so the
   // sprite is never cropped — covers both the wheel gesture here and a scale
-  // changed from the app's settings slider (pushed in as a state update). The
-  // pet renders bottom-center, so anchor the window's bottom-center while
-  // resizing (it stays put; only the transparent headroom changes). New bounds
-  // are persisted so the pet reopens at the right size.
+  // changed from the app's settings slider (pushed in as a state update). With a
+  // wheel anchor we zoom toward the cursor (keep the pixel under it fixed);
+  // otherwise we anchor the bottom-center (the pet's feet stay planted). New
+  // bounds are persisted so the pet reopens at the right size.
   useEffect(() => {
     if (!info.enabled || !info.spritesheetBase64) {
       return
@@ -308,14 +316,28 @@ export function PetOverlayApp() {
     const curH = window.outerHeight
 
     if (width === curW && height === curH) {
+      zoomAnchorRef.current = null
+
       return
     }
+
+    const anchor = zoomAnchorRef.current
+    zoomAnchorRef.current = null
+
+    // The sprite's bottom-center sits at (curW/2, curH - paddingBottom) and
+    // scales about that point. Solve for the new window origin that holds either
+    // the cursor pixel (wheel) or that bottom-center (slider) at a fixed spot.
+    const dx = anchor ? anchor.clientX - curW / 2 : 0
+    const dy = anchor ? anchor.clientY - (curH - PET_PADDING_BOTTOM) : 0
+    const ratio = anchor?.ratio ?? 1
+    const anchorX = anchor?.clientX ?? curW / 2
+    const anchorY = anchor?.clientY ?? curH - PET_PADDING_BOTTOM
 
     const bounds = {
       height,
       width,
-      x: Math.round(window.screenX + (curW - width) / 2),
-      y: Math.round(window.screenY + (curH - height))
+      x: Math.round(window.screenX + anchorX - dx * ratio - width / 2),
+      y: Math.round(window.screenY + anchorY - dy * ratio - (height - PET_PADDING_BOTTOM))
     }
 
     window.hermesDesktop?.petOverlay?.setBounds(bounds)
@@ -342,7 +364,7 @@ export function PetOverlayApp() {
         flexDirection: 'column',
         height: '100vh',
         justifyContent: 'flex-end',
-        paddingBottom: 24,
+        paddingBottom: PET_PADDING_BOTTOM,
         userSelect: 'none',
         width: '100vw'
       }}

--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useGatewayRequest } from '@/app/gateway/hooks/use-gateway-request'
 import { persistString, storedString } from '@/lib/storage'
 import { $petInfo, clearPetUnread, type PetInfo, petProfile, setPetInfo } from '@/store/pet'
-import { resetPetGallery } from '@/store/pet-gallery'
+import { resetPetGallery, setPetScale } from '@/store/pet-gallery'
 import { $petOverlayActive, initPetOverlayBridge, popOutPet, restorePetOverlay } from '@/store/pet-overlay'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { $gatewayState } from '@/store/session'
@@ -12,6 +12,7 @@ import { isSecondaryWindow } from '@/store/windows'
 import { useTheme } from '@/themes/context'
 
 import { PetSprite } from './pet-sprite'
+import { usePetZoomGesture } from './use-pet-zoom-gesture'
 
 // v2: positions are now top/left anchored (v1 stored bottom-anchored values,
 // which dragged inverted). Bumping the key discards stale v1 coordinates.
@@ -105,6 +106,7 @@ export function FloatingPet() {
   // speech bubble (a container child) never renders flipped/backwards.
   const spriteWrapRef = useRef<HTMLDivElement | null>(null)
   const petW = (info.frameW ?? 192) * (info.scale ?? 0.33)
+  const petH = (info.frameH ?? 208) * (info.scale ?? 0.33)
   // Soft contact shadow, sized off the pet so every scale/species grounds the
   // same way (cf. lairp's per-actor feet ellipse). Lighter on light backgrounds.
   const shadowW = Math.round(petW * 0.55)
@@ -114,6 +116,16 @@ export function FloatingPet() {
   // directly to avoid a React re-render (and canvas reflow) per pointermove —
   // state is only committed on release.
   const dragRef = useRef<{ dx: number; dy: number; x: number; y: number } | null>(null)
+
+  // Keep the *whole* pet on-screen at its current size, so growing it near an
+  // edge can't leave the window cropping it. Shared by drag + the reclamp effect.
+  const clamp = useCallback(
+    ({ x, y }: Point): Point => ({
+      x: Math.min(Math.max(0, x), Math.max(0, (window.innerWidth || 800) - petW)),
+      y: Math.min(Math.max(0, y), Math.max(0, (window.innerHeight || 600) - petH))
+    }),
+    [petW, petH]
+  )
 
   // Fetch pet.info on connect. Poll quickly while inactive so an in-app
   // `/pet <slug>` appears, then slowly while active so regenerated spritesheets
@@ -235,12 +247,13 @@ export function FloatingPet() {
     restorePetOverlay()
   }, [active])
 
-  // A window resize must never strand the pet off-screen — re-clamp the
-  // committed position (and persist it) whenever the viewport shrinks.
+  // Never strand or crop the pet: re-clamp (and persist) whenever the viewport
+  // shrinks or the pet's own size changes (wheel/slider). `clamp` carries the
+  // current size, so depending on it covers both triggers.
   useEffect(() => {
-    const onResize = () =>
+    const reclamp = () =>
       setPosition(prev => {
-        const next = clampToViewport(prev)
+        const next = clamp(prev)
 
         if (next.x === prev.x && next.y === prev.y) {
           return prev
@@ -251,10 +264,11 @@ export function FloatingPet() {
         return next
       })
 
-    window.addEventListener('resize', onResize)
+    reclamp()
+    window.addEventListener('resize', reclamp)
 
-    return () => window.removeEventListener('resize', onResize)
-  }, [])
+    return () => window.removeEventListener('resize', reclamp)
+  }, [clamp])
 
   const onPointerDown = useCallback((e: React.PointerEvent) => {
     const el = containerRef.current
@@ -289,7 +303,7 @@ export function FloatingPet() {
         return
       }
 
-      const next = clampToViewport({ x: e.clientX - drag.dx, y: e.clientY - drag.dy })
+      const next = clamp({ x: e.clientX - drag.dx, y: e.clientY - drag.dy })
       drag.x = next.x
       drag.y = next.y
       // Mutate the DOM directly — no setState, so no re-render while dragging. The
@@ -302,7 +316,7 @@ export function FloatingPet() {
         spriteWrapRef.current.style.transform = facing(next.x, petW)
       }
     },
-    [petW]
+    [clamp, petW]
   )
 
   const onPointerUp = useCallback((e: React.PointerEvent) => {
@@ -322,6 +336,12 @@ export function FloatingPet() {
       el.releasePointerCapture?.(e.pointerId)
     }
   }, [])
+
+  // Alt+wheel over the pet resizes it, persisting to `display.pet.scale` through
+  // the same path as the settings slider, so the two agree. Growing it re-runs
+  // the reclamp effect above (via `clamp`), so it never ends up cropped.
+  const onScale = useCallback((next: number) => setPetScale(requestGateway, next), [requestGateway])
+  usePetZoomGesture(containerRef, onScale, active && !overlayActive)
 
   // While popped out, the desktop overlay window owns the mascot — hide the
   // in-window one so there aren't two.

--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -12,11 +12,14 @@ import { isSecondaryWindow } from '@/store/windows'
 import { useTheme } from '@/themes/context'
 
 import { PetSprite } from './pet-sprite'
-import { usePetZoomGesture } from './use-pet-zoom-gesture'
+import { type PetZoomAnchor, usePetZoomGesture } from './use-pet-zoom-gesture'
 
 // v2: positions are now top/left anchored (v1 stored bottom-anchored values,
 // which dragged inverted). Bumping the key discards stale v1 coordinates.
 const POSITION_KEY = 'hermes.desktop.pet-position.v2'
+
+// Stand-in pet size for the pre-load clamp (real size flows in with `info`).
+const NOMINAL_PET_PX = 96
 
 interface Point {
   x: number
@@ -42,11 +45,13 @@ function samePetRevision(info: PetInfo, meta: PetInfoMeta): boolean {
   )
 }
 
-function clampToViewport({ x, y }: Point): Point {
-  const maxX = Math.max(0, (window.innerWidth || 800) - 80)
-  const maxY = Math.max(0, (window.innerHeight || 600) - 80)
-
-  return { x: Math.min(Math.max(0, x), maxX), y: Math.min(Math.max(0, y), maxY) }
+// Keep a w×h box fully inside the viewport. Pre-pet-load callers pass a nominal
+// size; the live size flows in once `info` arrives.
+function clampPoint(x: number, y: number, w: number, h: number): Point {
+  return {
+    x: Math.min(Math.max(0, x), Math.max(0, (window.innerWidth || 800) - w)),
+    y: Math.min(Math.max(0, y), Math.max(0, (window.innerHeight || 600) - h))
+  }
 }
 
 // The sprite art faces left by default, so mirror it when the pet's center sits
@@ -63,7 +68,7 @@ function loadPosition(): Point {
       const parsed = JSON.parse(raw) as Point
 
       if (typeof parsed.x === 'number' && typeof parsed.y === 'number') {
-        return clampToViewport(parsed)
+        return clampPoint(parsed.x, parsed.y, NOMINAL_PET_PX, NOMINAL_PET_PX)
       }
     }
   } catch {
@@ -71,7 +76,7 @@ function loadPosition(): Point {
   }
 
   // Default: lower-left corner (top/left anchored).
-  return clampToViewport({ x: 24, y: (window.innerHeight || 600) - 220 })
+  return clampPoint(24, (window.innerHeight || 600) - 220, NOMINAL_PET_PX, NOMINAL_PET_PX)
 }
 
 /**
@@ -119,13 +124,7 @@ export function FloatingPet() {
 
   // Keep the *whole* pet on-screen at its current size, so growing it near an
   // edge can't leave the window cropping it. Shared by drag + the reclamp effect.
-  const clamp = useCallback(
-    ({ x, y }: Point): Point => ({
-      x: Math.min(Math.max(0, x), Math.max(0, (window.innerWidth || 800) - petW)),
-      y: Math.min(Math.max(0, y), Math.max(0, (window.innerHeight || 600) - petH))
-    }),
-    [petW, petH]
-  )
+  const clamp = useCallback(({ x, y }: Point): Point => clampPoint(x, y, petW, petH), [petW, petH])
 
   // Fetch pet.info on connect. Poll quickly while inactive so an in-app
   // `/pet <slug>` appears, then slowly while active so regenerated spritesheets
@@ -337,10 +336,27 @@ export function FloatingPet() {
     }
   }, [])
 
-  // Alt+wheel over the pet resizes it, persisting to `display.pet.scale` through
-  // the same path as the settings slider, so the two agree. Growing it re-runs
-  // the reclamp effect above (via `clamp`), so it never ends up cropped.
-  const onScale = useCallback((next: number) => setPetScale(requestGateway, next), [requestGateway])
+  // Alt+wheel over the pet resizes it (persisted via the same path as the
+  // settings slider). Zoom toward the cursor — shift the top-left so the pixel
+  // under the pointer stays put — so the pet grows in place instead of running
+  // off. The reclamp effect (via `clamp`) still guarantees it stays on-screen.
+  const onScale = useCallback(
+    (next: number, { clientX, clientY, ratio }: PetZoomAnchor) => {
+      setPetScale(requestGateway, next)
+      setPosition(prev => {
+        const at = clampPoint(
+          clientX - (clientX - prev.x) * ratio,
+          clientY - (clientY - prev.y) * ratio,
+          (info.frameW ?? 192) * next,
+          (info.frameH ?? 208) * next
+        )
+        persistString(POSITION_KEY, JSON.stringify(at))
+
+        return at
+      })
+    },
+    [requestGateway, info.frameW, info.frameH]
+  )
   usePetZoomGesture(containerRef, onScale, active && !overlayActive)
 
   // While popped out, the desktop overlay window owns the mascot — hide the

--- a/apps/desktop/src/components/pet/pet-sprite.tsx
+++ b/apps/desktop/src/components/pet/pet-sprite.tsx
@@ -117,7 +117,9 @@ function PetSpriteImpl({ info, zoom = 1, stateOverride, rowOverride }: PetSprite
       return
     }
 
-    const ctx = canvas.getContext('2d')
+    // willReadFrequently: the pop-out overlay samples this canvas's alpha under
+    // the cursor (per-pixel click-through), so opt into the CPU-readback path.
+    const ctx = canvas.getContext('2d', { willReadFrequently: true })
 
     if (!ctx) {
       return

--- a/apps/desktop/src/components/pet/use-pet-zoom-gesture.ts
+++ b/apps/desktop/src/components/pet/use-pet-zoom-gesture.ts
@@ -1,0 +1,46 @@
+import { type RefObject, useEffect } from 'react'
+
+import { $petInfo } from '@/store/pet'
+import { nextScaleFromWheel } from '@/store/pet-gallery'
+
+/**
+ * Wire Alt/Option+wheel-to-scale onto a pet element: hold Alt and scroll up to
+ * grow the pet, down to shrink — identical on Mac and Windows. The modifier is
+ * required so a plain scroll over the pet still scrolls the page underneath
+ * (we only `preventDefault` while Alt is held).
+ *
+ * Native + non-passive so the conditional `preventDefault` actually takes (and
+ * keeps Electron from treating the gesture as a page zoom). Scale is read live
+ * from `$petInfo` so rapid steps compound without re-binding the listener.
+ *
+ * `ready` must track whether the pet element is actually rendered (both callers
+ * return null until a pet is enabled). It's a dependency so the listener
+ * (re)binds the moment the element mounts — `ref.current` changing alone would
+ * never re-run the effect.
+ */
+export function usePetZoomGesture<T extends HTMLElement>(
+  ref: RefObject<T | null>,
+  onScale: (scale: number) => void,
+  ready: boolean
+): void {
+  useEffect(() => {
+    const el = ref.current
+
+    if (!el || !ready) {
+      return
+    }
+
+    const onWheel = (event: WheelEvent) => {
+      if (!event.altKey) {
+        return
+      }
+
+      event.preventDefault()
+      onScale(nextScaleFromWheel($petInfo.get().scale, event.deltaY))
+    }
+
+    el.addEventListener('wheel', onWheel, { passive: false })
+
+    return () => el.removeEventListener('wheel', onWheel)
+  }, [ref, onScale, ready])
+}

--- a/apps/desktop/src/components/pet/use-pet-zoom-gesture.ts
+++ b/apps/desktop/src/components/pet/use-pet-zoom-gesture.ts
@@ -1,7 +1,16 @@
 import { type RefObject, useEffect } from 'react'
 
 import { $petInfo } from '@/store/pet'
-import { nextScaleFromWheel } from '@/store/pet-gallery'
+import { nextScaleFromWheel, PET_SCALE_DEFAULT } from '@/store/pet-gallery'
+
+/** Where the gesture happened + how much it scaled — lets callers zoom toward the
+ *  cursor (keep the pixel under it fixed) instead of growing from a corner. */
+export interface PetZoomAnchor {
+  clientX: number
+  clientY: number
+  /** new / old scale, clamp-aware (1 at a bound, so the pet doesn't drift). */
+  ratio: number
+}
 
 /**
  * Wire Alt/Option+wheel-to-scale onto a pet element: hold Alt and scroll up to
@@ -20,7 +29,7 @@ import { nextScaleFromWheel } from '@/store/pet-gallery'
  */
 export function usePetZoomGesture<T extends HTMLElement>(
   ref: RefObject<T | null>,
-  onScale: (scale: number) => void,
+  onScale: (scale: number, anchor: PetZoomAnchor) => void,
   ready: boolean
 ): void {
   useEffect(() => {
@@ -36,7 +45,10 @@ export function usePetZoomGesture<T extends HTMLElement>(
       }
 
       event.preventDefault()
-      onScale(nextScaleFromWheel($petInfo.get().scale, event.deltaY))
+
+      const base = $petInfo.get().scale ?? PET_SCALE_DEFAULT
+      const next = nextScaleFromWheel(base, event.deltaY)
+      onScale(next, { clientX: event.clientX, clientY: event.clientY, ratio: next / base })
     }
 
     el.addEventListener('wheel', onWheel, { passive: false })

--- a/apps/desktop/src/store/pet-gallery.ts
+++ b/apps/desktop/src/store/pet-gallery.ts
@@ -333,6 +333,21 @@ export const PET_SCALE_MAX = 3.0
 export const PET_SCALE_DEFAULT = 0.33
 export const clampPetScale = (n: number) => Math.max(PET_SCALE_MIN, Math.min(PET_SCALE_MAX, n))
 
+// Wheel → scale. Multiplicative so one notch feels the same at any size. Tuned
+// for a discrete mouse-wheel notch (deltaY ≈ ±100); trackpad two-finger scroll
+// (smaller deltas) just resizes more gently, which is fine.
+const WHEEL_SCALE_K = 0.0015
+
+/**
+ * Next pet scale for one mouse-wheel step over the pet. Scrolling up (deltaY < 0)
+ * grows it, scrolling down shrinks it; the result is clamped to the slider's range.
+ */
+export function nextScaleFromWheel(current: number | undefined, deltaY: number): number {
+  const base = current ?? PET_SCALE_DEFAULT
+
+  return clampPetScale(base * Math.exp(-deltaY * WHEEL_SCALE_K))
+}
+
 let scalePersist: ReturnType<typeof setTimeout> | undefined
 
 /**

--- a/apps/desktop/src/store/pet-overlay.ts
+++ b/apps/desktop/src/store/pet-overlay.ts
@@ -55,6 +55,7 @@ export type PetOverlayControl =
   | { type: 'bounds'; bounds: PetOverlayBounds }
   | { type: 'open-app' }
   | { type: 'toggle-app' }
+  | { type: 'scale'; scale: number }
 
 // Persisted across restarts: was the pet popped out, and where on the desktop
 // did the user leave it. Keyed v1; bump if the bounds shape ever changes.
@@ -103,10 +104,24 @@ const OVERLAY_PAD_Y = 200
 const OVERLAY_MIN_W = 240
 const OVERLAY_MIN_H = 300
 
+/**
+ * Window bounds (width/height) that fully contain the pet at a given scale, plus
+ * the padding for its bubble/composer/drag margins. The single source of truth
+ * for both the initial pop-out size and the live wheel-to-scale resize, so the
+ * sprite is never cropped by the window edge no matter how big it's scaled.
+ */
+export function overlayWindowSize(frameW: number, frameH: number, scale: number): { width: number; height: number } {
+  return {
+    width: Math.max(OVERLAY_MIN_W, Math.round(frameW * scale + OVERLAY_PAD_X)),
+    height: Math.max(OVERLAY_MIN_H, Math.round(frameH * scale + OVERLAY_PAD_Y))
+  }
+}
+
 let stateUnsubs: Array<() => void> = []
 let controlUnsub: (() => void) | null = null
 let submitHandler: ((text: string) => void) | null = null
 let openAppHandler: (() => void) | null = null
+let scaleHandler: ((scale: number) => void) | null = null
 
 function currentPayload(): PetOverlayStatePayload {
   return {
@@ -173,8 +188,10 @@ export function popOutPet(petRect: PetOverlayBounds): void {
     return
   }
 
-  const width = Math.max(OVERLAY_MIN_W, Math.round(petRect.width + OVERLAY_PAD_X))
-  const height = Math.max(OVERLAY_MIN_H, Math.round(petRect.height + OVERLAY_PAD_Y))
+  // Size the window off the pet's scale (not the measured rect, which includes
+  // the shadow) so it matches the live resize math exactly — no jump on open.
+  const pet = $petInfo.get()
+  const { width, height } = overlayWindowSize(pet.frameW ?? 192, pet.frameH ?? 208, pet.scale ?? 0.33)
   const x = Math.round(petRect.x - (width - petRect.width) / 2)
   const y = Math.round(petRect.y - (height - petRect.height) / 2)
 
@@ -223,6 +240,11 @@ export function setPetOverlayOpenAppHandler(fn: (() => void) | null): void {
   openAppHandler = fn
 }
 
+/** Register the handler that persists a scale resized via the overlay's Alt+wheel gesture. */
+export function setPetOverlayScaleHandler(fn: ((scale: number) => void) | null): void {
+  scaleHandler = fn
+}
+
 /**
  * Wire the overlay→renderer control channel once. Returns a disposer. Idempotent
  * — a second call while already wired is a no-op.
@@ -245,6 +267,11 @@ export function initPetOverlayBridge(): () => void {
     } else if (payload?.type === 'bounds' && payload.bounds) {
       // The user dragged the overlay to a new desktop spot — remember it.
       saveBounds(payload.bounds)
+    } else if (payload?.type === 'scale' && typeof payload.scale === 'number') {
+      // The user resized the popped-out pet (Alt+wheel) — persist it through
+      // the main renderer's gateway; the new scale rides $petInfo back to the
+      // overlay on the next push, keeping both surfaces in sync.
+      scaleHandler?.(payload.scale)
     } else if (payload?.type === 'open-app') {
       // Mail icon: surface the app on the most recent thread (main.cjs already
       // focused the window before forwarding this) and mark it read.


### PR DESCRIPTION
## Summary
- **Alt/Option + scroll over the pet to scale it** — same on Mac and Windows. The modifier is required so a plain scroll still scrolls the page underneath (we only `preventDefault` while Alt is held). Drives the same `display.pet.scale` path as the settings slider, so the two stay in agreement and it persists.
- **Zooms toward the cursor** — the pixel under the pointer stays put as the pet grows/shrinks, so it scales in place instead of running off (see *Math* below).
- **Never cropped.** The popped-out overlay grows its OS window to fit the pet at any scale, and the new bounds are persisted so it reopens at the right size. The in-window pet re-clamps against its *actual* size, so growing near an edge can't push it out of view.
- **Per-pixel click-through on the overlay.** Only solid sprite pixels (plus the bubble / mail button / open composer) are interactive — clicks on the transparent rectangle around the art pass through to whatever's behind, instead of the old bounding-box test.

## How it's wired
- `usePetZoomGesture` — small hook, native non-passive `wheel` listener, reads live scale from `$petInfo`, no-ops unless `altKey`. Emits the new scale plus a `{ clientX, clientY, ratio }` anchor. Used by both the in-window pet and the overlay.
- `nextScaleFromWheel` (pet-gallery) — pure multiplicative step clamped to the slider range.
- `overlayWindowSize` (pet-overlay) — single source of truth for overlay window dims at a given scale; used by both pop-out and the live resize.
- `electron/main.cjs` — `set-bounds` briefly flips `resizable` on when the size actually changes (Electron 40 ignores programmatic resize on non-resizable windows on Win/Linux); pure drags untouched.
- Overlay → main `scale` control message persists through the main window's gateway (the overlay has none).
- `pet-sprite` canvas opts into `willReadFrequently` for the per-pixel alpha sampling.

## Math — zoom toward the cursor

Standard "zoom about a point": as the sprite scales by `ratio = newScale / oldScale`, every pixel's offset from the anchor scales by the same `ratio`. To keep the anchor pixel fixed on screen, move the origin by the *growth* of that offset. `ratio` is clamp-aware (it's `next / base` **after** clamping to the slider range), so at the min/max bound `ratio = 1` and nothing drifts.

**In-window pet** (origin = the element's top-left `pos`, anchor = cursor in viewport coords):

```
posNew = cursor − (cursor − pos) · ratio      // per axis
```

The `(cursor − pos)` is the cursor's offset inside the pet; scaling it by `ratio` and subtracting from `cursor` gives the new top-left. Result is clamped to the viewport so the whole sprite stays visible.

**Overlay** (the OS *window* moves; the sprite is laid out bottom-centered at window-local `B = (W/2, H − padBottom)` and scales about `B`):

Let `a` be the anchor in window-local coords (the wheel cursor; for a slider change with no cursor we fall back to `a = B`, which makes the term below vanish). The window-local anchor maps to screen `screen + a`. After scaling, the sprite's bottom-center must land where the anchor's scaled offset still resolves to that same screen point, so the new window origin is:

```
originNew = screen + a − (a − B) · ratio − Bnew
```

where `Bnew = (Wnew/2, Hnew − padBottom)`. With `a = B` this collapses to `originNew = screen + B − Bnew`, i.e. pin the feet. One formula covers both wheel and slider.

> Caveat: the overlay resize is an async IPC round-trip, so the live `window.outerWidth/screenX` read can lag a frame during a *very* fast continuous scroll, causing slight drift. Exact at notch-by-notch speed.

## Test plan
- [x] In-window pet: Alt+scroll up/down resizes about the cursor; plain scroll still scrolls the chat; slider still works and agrees.
- [x] Pop the pet out: Alt+scroll resizes toward the cursor, window grows/shrinks to fit (no clipping at any scale).
- [x] Overlay: clicking transparent area around the sprite passes through; clicking the sprite/bubble/mail still works; drag still works.
- [x] Restart with a large popped-out pet → reopens at the right size/spot.