### PR TITLE
fix(gateway): show stable sender ID alongside name in non-thread group prompts (salvage of #13166 by @tangyuanjc)

### DIFF
--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -551,15 +551,20 @@ def build_session_context_prompt(
             f"**Session type:** {session_label} — messages are prefixed "
             "with [sender name]. Multiple users may participate."
         )
-    elif context.source.user_name:
-        lines.append(
-            f"**User:** {_format_untrusted_prompt_value(context.source.user_name)}"
-        )
-    elif context.source.user_id:
-        uid = context.source.user_id
-        if redact_pii:
-            uid = _hash_sender_id(uid)
-        lines.append(f"**User ID:** {_format_untrusted_prompt_value(uid)}")
+    else:
+        # Show display name AND the stable sender ID when both are available.
+        # Identity-sensitive lanes (audit, per-user routing) need the stable
+        # ID, not just a mutable display name; previously the elif chain
+        # dropped the ID whenever a name was present.
+        if context.source.user_name:
+            lines.append(
+                f"**User:** {_format_untrusted_prompt_value(context.source.user_name)}"
+            )
+        if context.source.user_id:
+            uid = context.source.user_id
+            if redact_pii:
+                uid = _hash_sender_id(uid)
+            lines.append(f"**User ID:** {_format_untrusted_prompt_value(uid)}")
 
     # Platform-specific behavioral notes
     if context.source.platform == Platform.SLACK:


### PR DESCRIPTION
## Summary

Salvage of #13166 by @tangyuanjc — rebased onto current `origin/main` with a regression test.

In non-thread group sessions, the system-prompt identity block shows the display name **or** the stable sender ID, never both — so when a name is present, the stable `user_id` is dropped.

## Root Cause

**Symptom** — For group messages (e.g. Feishu), the session context prompt shows `**User:** Jc` but omits the stable sender ID. Identity-sensitive logic (audit, per-user routing) that needs the stable ID has nothing to work with whenever a display name exists.

**Root cause** — In `build_session_context_prompt` (`gateway/session.py`), the identity block is an `elif` chain:
```python
elif context.source.user_name:
    lines.append(f"**User:** {context.source.user_name}")
elif context.source.user_id:
    ...append User ID...
```
Because it's `elif`, a present `user_name` short-circuits and the `user_id` branch never runs — the stable ID is silently dropped whenever a display name is available.

**Evidence** — The added test builds a Feishu group source with both `user_name="Jc"` and `user_id="ou_sender_123"`; without the fix the prompt contains only `**User:** Jc`, with the fix it contains both lines.

**Fix + why this level** — Replace the `elif` short-circuit with an `else:` block containing two independent `if`s, so name and ID are emitted independently when each is present. This is the correct level — it's the single prompt-assembly point for single-user (non-shared) sessions; the shared-multi-user branch above is untouched (it deliberately pins neither).

**Scope / risk** — Only the single-user identity block changes. The shared-multi-user path is unchanged; PII redaction (`_hash_sender_id`) on the ID is preserved; a name-only or id-only source behaves exactly as before. Only the both-present case gains the extra line.

## Changes from original

- Rebased onto current main (clean single commit).
- Carried the original's regression test `test_non_thread_group_shows_user_id_when_available` — **fails without the fix**.

## Verification

```
python3 -m pytest tests/gateway/test_session.py -q
89 passed

# without the fix (stashed):
AssertionError: '**User ID:** ou_sender_123' not in prompt
1 failed
```

## Real behavior proof

```
# Feishu group sender user_name="Jc", user_id="ou_sender_123":
# With fix:    **User:** Jc  /  **User ID:** ou_sender_123
# Without fix: **User:** Jc   (ID dropped)
```

Credit: salvage of #13166 by @tangyuanjc — rebased onto current main with a guardrail test.
