### PR TITLE
fix(auxiliary): classify z.ai 429 'subscription plan' as payment error (salvage of #13234 by @thapecroth)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3470,6 +3470,9 @@ def _is_rate_limit_error(exc: Exception) -> bool:
             "balance_depleted", "no usable credits",
             "model_not_supported_on_free_tier",
             "not available on the free tier",
+            # Mirror _is_payment_error entitlement phrases so z.ai 429/1311
+            # plan-blocks are not dual-classified as rate limits.
+            "subscription plan", "does not yet include", "plan does not include",
         )):
             return True
     return False

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3410,6 +3410,11 @@ def _is_payment_error(exc: Exception) -> bool:
             "not available on the free tier",
             "requires a subscription", "upgrade for access",
             "upgrade for higher limits", "reached your session usage limit",
+            # z.ai returns 429 (code 1311) when the active plan lacks access
+            # to the requested model (e.g. GLM-5V-Turbo on the coding plan).
+            # Permanent, not transient -> classify as billing so the payment-
+            # fallback chain switches backend instead of cooling down.
+            "subscription plan", "does not yet include", "plan does not include",
             # Daily / monthly / weekly quota exhaustion keywords
             "quota exceeded", "quota_exceeded",
             "too many tokens per day", "daily limit",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1232,6 +1232,18 @@ class TestIsPaymentError:
         assert _is_payment_error(exc) is True
 
 
+    def test_429_zai_subscription_plan_is_payment(self):
+        """z.ai 429 code 1311 plan entitlement is billing, not transient RL."""
+        exc = Exception(
+            "Error code: 429 - {'error': {'code': '1311', 'message': "
+            "'Your current subscription plan does not yet include access to "
+            "GLM-5V-Turbo'}}"
+        )
+        exc.status_code = 429
+        assert _is_payment_error(exc) is True
+        assert _is_rate_limit_error(exc) is False
+
+
 
 
     def test_403_subscription_required_is_payment(self):
@@ -1368,6 +1380,17 @@ class TestIsRateLimitError:
         exc = Exception("Rate limit exceeded, try again in 2 seconds")
         exc.status_code = 429
         assert _is_rate_limit_error(exc) is True
+
+
+    def test_429_zai_subscription_plan_is_not_rate_limit(self):
+        exc = Exception(
+            "Error code: 429 - {'error': {'code': '1311', 'message': "
+            "'Your current subscription plan does not yet include access to "
+            "GLM-5V-Turbo'}}"
+        )
+        exc.status_code = 429
+        assert _is_rate_limit_error(exc) is False
+        assert _is_payment_error(exc) is True
 
 
 


### PR DESCRIPTION
## Summary

Salvage of #13234 by @thapecroth — rebased onto current `origin/main`, scoped to the billing-classification fix.

z.ai returns **HTTP 429 (code 1311)** when the active plan doesn't include the requested model (e.g. GLM-5V-Turbo on the coding plan). `_is_payment_error` treats it as a transient rate limit, so the agent does a useless cooldown-and-retry against the same plan-blocked model instead of falling back to a different backend.

## Root Cause

**Symptom** — With a z.ai plan that lacks access to a requested model, requests fail with 429. Hermes cools down and retries the same model repeatedly rather than switching providers; the turn eventually fails.

**Root cause** — `_is_payment_error` (`agent/auxiliary_client.py`) keys "is this billing vs transient rate limit?" off a keyword list. z.ai's message — "Your current subscription plan does not yet include access to model …" — matches none of the existing keywords (`requires a subscription` doesn't substring-match `subscription plan`), so it's classified as a transient 429 and the payment-fallback chain never engages.

**Evidence** — The added test feeds the real z.ai 429 message; without the fix `_is_payment_error` returns `False`, with it `True`.

**Fix + why this level** — Add `"subscription plan"`, `"does not yet include"`, `"plan does not include"` to the billing keyword set. This is the correct level — `_is_payment_error` is the single classifier that the fallback chain consults; one keyword addition routes the permanent-plan-block to the right path without touching retry/cooldown logic.

**Scope / risk** — Three keyword strings added to an existing `any(...)` membership test. Only messages containing those phrases change classification (429→payment); all other errors are unaffected. I deliberately left out the original PR's separate `_log_400_diag` helper to keep this surgical and on the single titled bug.

## Changes from original

- Rebased onto current main (clean single commit).
- Scoped to the billing-keyword fix (dropped the unrelated 400-diagnostics logging helper from the original).
- Added regression test `test_429_zai_subscription_plan_is_payment` — **fails without the fix**.

## Verification

```
python3 -m pytest tests/agent/test_auxiliary_client.py -k IsPaymentError -q
18 passed

# without the fix (stashed):
AssertionError (returns False)
1 failed
```

## Real behavior proof

```
# z.ai 429: "Your current subscription plan does not yet include access to model GLM-5V-Turbo."
# With fix:    _is_payment_error -> True  (fallback switches backend)
# Without fix: _is_payment_error -> False (useless cooldown on a plan-blocked model)
```

Credit: salvage of #13234 by @thapecroth — rebased onto current main with a guardrail test.
