### PR TITLE
fix(lsp): clear stale delta baseline after a clean edit

### DIFF
--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -369,13 +369,16 @@ class LSPService:
                 diags = [d for d in diags if _diag_key(d) not in seen]
             # Roll baseline forward — next call returns deltas relative
             # to the just-emitted state, mirroring claude-code's
-            # diagnosticTracking.
+            # diagnosticTracking.  An empty snapshot is a real result
+            # (the file is now clean), not a "skip": roll it forward too
+            # so a baseline captured before a since-fixed error doesn't
+            # linger and either re-surface or mask the next edit's
+            # genuine diagnostics.
             try:
                 fresh = self._loop.run(self._current_diags_async(file_path), timeout=2.0) or []
             except Exception:  # noqa: BLE001
                 fresh = []
-            if fresh:
-                self._delta_baseline[abs_path] = fresh
+            self._delta_baseline[abs_path] = fresh
 
         if diags:
             eventlog.log_diagnostics(server_id, file_path, len(diags))
@@ -478,8 +481,16 @@ class LSPService:
         srv = find_server_for_file(file_path)
         if not (ws and gated and srv):
             return []
+        # Resolve the per-server root exactly as _get_or_spawn() does:
+        # clients are keyed by (server_id, per_server_root), which can
+        # differ from the git workspace root for nested projects.  Keying
+        # on the bare workspace root here would miss the live client and
+        # return a false-empty snapshot, wrongly clearing the baseline.
+        per_server_root = srv.resolve_root(file_path, ws)
+        if per_server_root is None:
+            return []
         with self._state_lock:
-            client = self._clients.get((srv.server_id, ws))
+            client = self._clients.get((srv.server_id, per_server_root))
         if client is None:
             return []
         return list(client.diagnostics_for(file_path))

--- a/tests/agent/lsp/_mock_lsp_server.py
+++ b/tests/agent/lsp/_mock_lsp_server.py
@@ -13,6 +13,11 @@ Behaviour (all behaviours selectable via env var ``MOCK_LSP_SCRIPT``):
   diagnostics on every open/change, exit cleanly on shutdown.
 - ``"errors"`` — same as ``clean`` but the published diagnostics
   carry one severity-1 entry pointing at line 0:0.
+- ``"sequence"`` — emit a per-publish sequence of states read from the
+  ``MOCK_LSP_SEQUENCE`` env var (comma-separated ``error``/``clean``,
+  e.g. ``"error,clean,error"``).  Each ``didOpen``/``didChange`` advances
+  to the next state; the final state repeats for any further pushes.  Lets
+  a test drive an old-error → clean → later-edit lifecycle deterministically.
 - ``"crash"`` — exit immediately after responding to ``initialize``
   (simulates a crashing server).
 - ``"slow"`` — same as ``clean`` but sleeps 1s before responding to
@@ -56,6 +61,14 @@ def write_message(obj):
 
 def main():
     script = os.environ.get("MOCK_LSP_SCRIPT", "clean")
+    # For the "sequence" script: a per-publish list of "error"/"clean"
+    # states and a cursor that advances on each didOpen/didChange.
+    sequence = [
+        s.strip()
+        for s in os.environ.get("MOCK_LSP_SEQUENCE", "").split(",")
+        if s.strip()
+    ]
+    publish_index = 0
 
     while True:
         msg = read_message()
@@ -96,20 +109,24 @@ def main():
             td = params.get("textDocument") or {}
             uri = td.get("uri", "")
             version = td.get("version", 0)
+            error_diag = {
+                "range": {
+                    "start": {"line": 0, "character": 0},
+                    "end": {"line": 0, "character": 5},
+                },
+                "severity": 1,
+                "code": "MOCK001",
+                "source": "mock-lsp",
+                "message": "synthetic error from mock-lsp",
+            }
             diagnostics = []
             if script == "errors":
-                diagnostics = [
-                    {
-                        "range": {
-                            "start": {"line": 0, "character": 0},
-                            "end": {"line": 0, "character": 5},
-                        },
-                        "severity": 1,
-                        "code": "MOCK001",
-                        "source": "mock-lsp",
-                        "message": "synthetic error from mock-lsp",
-                    }
-                ]
+                diagnostics = [error_diag]
+            elif script == "sequence" and sequence:
+                state = sequence[min(publish_index, len(sequence) - 1)]
+                publish_index += 1
+                if state == "error":
+                    diagnostics = [error_diag]
             write_message(
                 {
                     "jsonrpc": "2.0",

--- a/tests/agent/lsp/test_service.py
+++ b/tests/agent/lsp/test_service.py
@@ -7,6 +7,7 @@ on.
 """
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -24,17 +25,27 @@ from agent.lsp.servers import (
 MOCK_SERVER = str(Path(__file__).parent / "_mock_lsp_server.py")
 
 
-def _install_mock_server(monkeypatch, script: str = "errors", server_id: str = "pyright"):
+def _install_mock_server(monkeypatch, script: str = "errors", server_id: str = "pyright",
+                         sequence: str = "", resolve_root=None):
     """Replace one registered server with a wrapper that spawns the mock.
 
     We reuse ``pyright`` so .py files route to it.  This keeps the
     test free of any LSP toolchain dependency.
+
+    ``sequence`` is forwarded as ``MOCK_LSP_SEQUENCE`` for the
+    ``"sequence"`` script (a per-publish list of ``error``/``clean``).
+
+    ``resolve_root`` overrides the server's root resolver — pass one that
+    returns a nested directory to exercise the per-server-root vs git-root
+    distinction.  Defaults to "always the git workspace root".
     """
     target_index = next(i for i, s in enumerate(SERVERS) if s.server_id == server_id)
     original = SERVERS[target_index]
 
     def _spawn(root: str, ctx: ServerContext) -> SpawnSpec:
         env = {"MOCK_LSP_SCRIPT": script}
+        if sequence:
+            env["MOCK_LSP_SEQUENCE"] = sequence
         return SpawnSpec(
             command=[sys.executable, MOCK_SERVER],
             workspace_root=root,
@@ -46,7 +57,7 @@ def _install_mock_server(monkeypatch, script: str = "errors", server_id: str = "
     replacement = ServerDef(
         server_id=server_id,
         extensions=original.extensions,
-        resolve_root=lambda fp, ws: ws,  # always use workspace root
+        resolve_root=resolve_root or (lambda fp, ws: ws),  # default: git root
         build_spawn=_spawn,
         seed_first_push=False,
         description="mock " + server_id,
@@ -172,5 +183,133 @@ def test_service_status_includes_clients(mock_pyright):
         info = svc.get_status()
         assert info["enabled"] is True
         assert any(c["server_id"] == "pyright" for c in info["clients"])
+    finally:
+        svc.shutdown()
+
+
+@pytest.fixture
+def mock_pyright_sequence(monkeypatch, tmp_path):
+    """Like ``mock_pyright`` but the server emits a per-publish sequence
+    of ``error``/``clean`` states (``MOCK_LSP_SEQUENCE``), so a test can
+    drive an old-error → clean → later-edit lifecycle deterministically.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    (repo / "pyproject.toml").write_text("")
+    monkeypatch.chdir(str(repo))
+    gen = _install_mock_server(
+        monkeypatch, "sequence", "pyright", sequence="error,clean,error"
+    )
+    next(gen)
+    yield repo
+    try:
+        next(gen)
+    except StopIteration:
+        pass
+
+
+def test_service_clears_stale_baseline_after_clean_edit(mock_pyright_sequence):
+    """Regression for stale LSP diagnostics surviving a clean edit.
+
+    Sequence of server publishes: error → clean → error.
+
+    1. ``snapshot_baseline`` captures the pre-edit error as the baseline.
+    2. A clean edit yields no diagnostics; the empty fresh snapshot must
+       roll the baseline *forward* (clearing it) rather than leaving the
+       now-fixed error cached.
+    3. A later edit re-introduces the same error.  With a stale baseline
+       still holding the old error, the delta filter would wrongly mask
+       this genuine new diagnostic; with the baseline correctly cleared,
+       it is surfaced.
+    """
+    repo = mock_pyright_sequence
+    f = repo / "x.py"
+    f.write_text("print('hi')\n")
+
+    svc = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=3.0,
+        install_strategy="manual",
+    )
+    try:
+        assert svc.enabled_for(str(f))
+
+        # 1. Baseline captures the pre-existing error (publish #1).
+        svc.snapshot_baseline(str(f))
+
+        # 2. Clean edit (publish #2): delta is empty, and the empty fresh
+        #    snapshot must clear the cached baseline.
+        assert svc.get_diagnostics_sync(str(f)) == []
+
+        # 3. Later edit re-introduces the error (publish #3).  It must be
+        #    reported — a stale baseline would suppress it.
+        later = svc.get_diagnostics_sync(str(f))
+        assert len(later) == 1
+        assert later[0]["code"] == "MOCK001"
+    finally:
+        svc.shutdown()
+
+
+@pytest.fixture
+def mock_pyright_nested_root(monkeypatch, tmp_path):
+    """Install the mock with a per-server root that differs from the git
+    root: git root is ``repo/``, but the server resolves to the nested
+    ``repo/pkg/`` package.  Exercises the ``_current_diags_async`` client
+    lookup, which must key on the per-server root, not the git root.
+    """
+    repo = tmp_path / "repo"
+    pkg = repo / "pkg"
+    pkg.mkdir(parents=True)
+    (repo / ".git").mkdir()
+    (pkg / "pyproject.toml").write_text("")
+    monkeypatch.chdir(str(repo))
+
+    def _nested_root(fp, ws):
+        # Server root is the directory containing the edited file (the
+        # nested package), not the git workspace root.
+        return os.path.dirname(os.path.abspath(fp))
+
+    gen = _install_mock_server(
+        monkeypatch, "errors", "pyright", resolve_root=_nested_root
+    )
+    next(gen)
+    yield pkg
+    try:
+        next(gen)
+    except StopIteration:
+        pass
+
+
+def test_service_baseline_rolls_forward_under_nested_root(mock_pyright_nested_root):
+    """Pre-existing diagnostics must stay filtered across repeated polls
+    even when the server's root differs from the git root.
+
+    The roll-forward reads the live diagnostics via ``_current_diags_async``;
+    if that lookup uses the wrong client key it returns a false-empty
+    snapshot, clears the baseline, and the pre-existing error wrongly
+    re-surfaces on the next unchanged poll.
+    """
+    pkg = mock_pyright_nested_root
+    f = pkg / "x.py"
+    f.write_text("print('hi')\n")
+
+    svc = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=3.0,
+        install_strategy="manual",
+    )
+    try:
+        assert svc.enabled_for(str(f))
+        # Baseline captures the pre-existing error.
+        svc.snapshot_baseline(str(f))
+        # First poll: error is in the baseline, so delta is empty.
+        assert svc.get_diagnostics_sync(str(f)) == []
+        # Second unchanged poll: the same pre-existing error must remain
+        # filtered — the baseline must not have been cleared by a
+        # false-empty roll-forward.
+        assert svc.get_diagnostics_sync(str(f)) == []
     finally:
         svc.shutdown()


### PR DESCRIPTION
## What does this PR do?

After an edit that *fixes* the last error in a file, the LSP delta tracker kept
the now-stale diagnostic in its per-file baseline. `get_diagnostics_sync()` only
rolled the baseline forward when the post-edit snapshot was non-empty (`if fresh:`),
so a clean edit left the old entry cached. On the next poll that stale entry could
re-surface as "introduced by this edit", or mask a genuinely new diagnostic at the
same location — the behavior reported in #52858.

While fixing this I also found `_current_diags_async()` looked up the live client
by the *git workspace root*, but clients are stored under the *per-server root*
(`_get_or_spawn()`). For a nested project these differ, so the roll-forward read a
false-empty snapshot and wrongly cleared the baseline. Both are fixed here.

## Related Issue

Fixes #52858

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/lsp/manager.py`: `get_diagnostics_sync()` now always rolls the delta
  baseline forward, including empty snapshots (a clean file is a real result, not
  a "skip").
- `agent/lsp/manager.py`: `_current_diags_async()` resolves the per-server root
  (`srv.resolve_root`) and keys the client lookup the same way `_get_or_spawn()`
  does, so nested projects read real diagnostics instead of an empty snapshot.
- `tests/agent/lsp/_mock_lsp_server.py`: added a `sequence` script mode
  (`MOCK_LSP_SEQUENCE`) that emits a per-publish error/clean sequence.
- `tests/agent/lsp/test_service.py`: regression tests for the old-error → clean →
  later-edit lifecycle and for the nested project-root vs git-root case.

## How to Test

1. `pytest tests/agent/lsp/test_service.py -q` → 7 passed.
2. Revert either fix in isolation and the matching new test fails:
   re-adding the `if fresh:` guard fails `test_service_clears_stale_baseline_after_clean_edit`;
   keying `_current_diags_async` on the git root fails
   `test_service_baseline_rolls_forward_under_nested_root`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(lsp):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the relevant tests and they pass (`pytest tests/agent/lsp/test_service.py -q`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] N/A — no docs/config/architecture changes
- [x] I've considered cross-platform impact — N/A (pure Python, no platform-specific code)