### PR TITLE
fix(config): treat explicit false values in HERMES_MANAGED as unmanaged (salvage of #12880 by @BK-Z1)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -307,6 +307,7 @@ from hermes_cli.default_soul import DEFAULT_SOUL_MD, is_legacy_template_soul
 # =============================================================================
 
 _MANAGED_TRUE_VALUES = ("true", "1", "yes")
+_MANAGED_FALSE_VALUES = ("false", "0", "no", "off")
 _MANAGED_SYSTEM_NAMES = {
     "brew": "Homebrew",
     "homebrew": "Homebrew",
@@ -320,6 +321,11 @@ def get_managed_system() -> Optional[str]:
     raw = os.getenv("HERMES_MANAGED", "").strip()
     if raw:
         normalized = raw.lower()
+        # Explicit falsey values mean "not managed" — don't treat them as an
+        # opaque package-manager name (HERMES_MANAGED=false previously made
+        # is_managed() return True and blocked updates).
+        if normalized in _MANAGED_FALSE_VALUES:
+            return None
         if normalized in _MANAGED_TRUE_VALUES:
             return "NixOS"
         return _MANAGED_SYSTEM_NAMES.get(normalized, raw)

--- a/tests/hermes_cli/test_managed_installs.py
+++ b/tests/hermes_cli/test_managed_installs.py
@@ -1,9 +1,12 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from hermes_cli.config import (
     format_managed_message,
     get_managed_system,
+    is_managed,
     recommended_update_command,
 )
 from hermes_cli.main import cmd_update
@@ -15,6 +18,17 @@ def test_get_managed_system_homebrew(monkeypatch):
 
     assert get_managed_system() == "Homebrew"
     assert recommended_update_command() == "brew upgrade hermes-agent"
+
+
+@pytest.mark.parametrize("false_value", ["false", "0", "no", "off", "FALSE", "False"])
+def test_get_managed_system_treats_false_values_as_unmanaged(monkeypatch, false_value):
+    """HERMES_MANAGED=false (and other falsey strings) must mean 'not managed'.
+    Previously any non-empty value was treated as an opaque package-manager
+    name, so HERMES_MANAGED=false made is_managed() return True and blocked
+    `hermes update`. (#12880)"""
+    monkeypatch.setenv("HERMES_MANAGED", false_value)
+    assert get_managed_system() is None
+    assert is_managed() is False
 
 
 def test_format_managed_message_homebrew(monkeypatch):


### PR DESCRIPTION
## Summary

Salvage of #12880 by @BK-Z1 — rebased onto current `origin/main` with regression tests.

`HERMES_MANAGED=false` (and other falsey strings) is treated as an opaque package-manager name, so `is_managed()` returns `True` and `hermes update` is blocked on installs that explicitly opted **out** of managed mode.

## Root Cause

**Symptom** — Setting `HERMES_MANAGED=false` to declare a self-managed install does the opposite: `is_managed()` returns `True`, update commands refuse to run ("this install is managed by …").

**Root cause** — In `get_managed_system()` (`hermes_cli/config.py`), any non-empty `HERMES_MANAGED` value that isn't in `_MANAGED_TRUE_VALUES` and isn't a known system name falls through to `return _MANAGED_SYSTEM_NAMES.get(normalized, raw)` — i.e. the raw string `"false"` is returned as the "managing system". `is_managed()` is `get_managed_system() is not None`, so `"false"` → managed.

**Evidence** — Probe on main: `HERMES_MANAGED=false` → `get_managed_system()=='false'`, `is_managed()==True`. The parametrized test covers `false/0/no/off/FALSE/False`; all fail without the fix.

**Fix + why this level** — Add `_MANAGED_FALSE_VALUES = ("false","0","no","off")` and return `None` for those before the name lookup. This is the correct level — `get_managed_system()` is the single source `is_managed()` and the update guard consult, so one guard fixes every downstream check. Case-insensitive via the existing `.lower()`.

**Scope / risk** — One early-return in `get_managed_system`. Truthy values (`true/1/yes`) and real system names (`brew/homebrew/nix/nixos`) behave exactly as before (verified); only explicit falsey strings flip from "managed" to "unmanaged" — the intended behavior.

## Changes from original

- Rebased onto current main (clean single commit).
- Added parametrized regression test `test_get_managed_system_treats_false_values_as_unmanaged` (false/0/no/off + case variants) — **fails without the fix**.

## Verification

```
python3 -m pytest tests/hermes_cli/test_managed_installs.py -q
11 passed

# without the fix (stashed): 6 failed (false/0/no/off/FALSE/False all classified managed)
```

## Real behavior proof

```
# With fix:    HERMES_MANAGED=false -> get_managed_system()=None, is_managed()=False
#              HERMES_MANAGED=brew  -> Homebrew / True   (unchanged)
# Without fix: HERMES_MANAGED=false -> 'false' / True    (blocks `hermes update`)
```

Credit: salvage of #12880 by @BK-Z1 — rebased onto current main with parametrized guardrail tests.
