### PR TITLE
fix(plugins): tolerate non-mapping plugin.yaml manifests (salvage of #14086 by @LeonSGP43)

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -268,10 +268,22 @@ def _read_manifest(plugin_dir: Path) -> dict:
         import yaml
 
         with open(manifest_file, encoding="utf-8") as f:
-            return yaml.safe_load(f) or {}
+            manifest = yaml.safe_load(f)
     except Exception as e:
         logger.warning("Failed to read plugin.yaml in %s: %s", plugin_dir, e)
         return {}
+    if manifest is None:
+        return {}
+    if not isinstance(manifest, dict):
+        # A plugin.yaml whose top level is a list/scalar (malformed) would
+        # otherwise propagate a non-dict into callers that do manifest.get(...),
+        # raising AttributeError mid-scan and aborting plugin discovery.
+        logger.warning(
+            "Failed to read plugin.yaml in %s: top-level YAML must be a mapping",
+            plugin_dir,
+        )
+        return {}
+    return manifest
 
 
 def _copy_example_files(plugin_dir: Path, console) -> None:

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -390,6 +390,21 @@ class TestReadManifest:
         result = _read_manifest(tmp_path)
         assert result == {}
 
+    def test_non_mapping_top_level_returns_empty_and_logs(self, tmp_path, caplog):
+        """A plugin.yaml whose top level is a list/scalar (not a mapping) must
+        return {} and warn — not a non-dict that explodes on manifest.get(...)
+        mid-scan and aborts plugin discovery. (#14086)"""
+        (tmp_path / "plugin.yaml").write_text("- just\n- a\n- list\n")
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins_cmd"):
+            result = _read_manifest(tmp_path)
+        assert result == {}
+        assert any("must be a mapping" in r.message for r in caplog.records)
+
+    def test_scalar_top_level_returns_empty(self, tmp_path):
+        (tmp_path / "plugin.yaml").write_text("just-a-string\n")
+        result = _read_manifest(tmp_path)
+        assert result == {}
+
 
 # ── cmd_install tests ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Salvage of #14086 by @LeonSGP43 — rebased onto current `origin/main` with regression tests.

`_read_manifest` returns `yaml.safe_load(f) or {}`, which passes a **non-dict** (list/scalar) straight through when a `plugin.yaml`'s top level isn't a mapping. Callers then do `manifest.get(...)`, raising `AttributeError` mid-scan and aborting plugin discovery.

## Root Cause

**Symptom** — A single malformed `plugin.yaml` (top-level list or scalar instead of a mapping) crashes plugin discovery with `AttributeError: 'list' object has no attribute 'get'`, taking out *all* plugins, not just the bad one.

**Root cause** — In `_read_manifest` (`hermes_cli/plugins_cmd.py`), `yaml.safe_load(f) or {}` only guards the `None` (empty file) case. A YAML list or scalar parses to a `list`/`str`, which is truthy, so it's returned as-is. Downstream code assumes a dict and calls `.get(...)`.

**Evidence** — The added test writes a top-level YAML list; without the fix `_read_manifest` returns the list (then explodes at the first `.get`), with the fix it returns `{}` and logs a warning.

**Fix + why this level** — After parsing, return `{}` for `None`, and for any non-dict return `{}` with a warning. This is the correct level — `_read_manifest` is the single manifest-reading choke point, so one type guard protects every caller (discovery, install, info) instead of scattering `isinstance` checks at each `.get` site.

**Scope / risk** — One function. Valid mapping manifests and empty files behave exactly as before (verified by the existing `TestReadManifest` tests); only malformed non-mapping YAML changes (now → `{}` + warning instead of a crash).

## Changes from original

- Rebased onto current main (clean single commit).
- Added regression tests `test_non_mapping_top_level_returns_empty_and_logs` and `test_scalar_top_level_returns_empty` — both **fail without the fix**.

## Verification

```
python3 -m pytest tests/hermes_cli/test_plugins_cmd.py -k ReadManifest -q
6 passed

# without the fix (stashed):
AssertionError (returns the raw list/scalar)
2 failed
```

## Real behavior proof

```
# plugin.yaml with a top-level YAML list:
# With fix:    _read_manifest -> {}  (+ "top-level YAML must be a mapping")
# Without fix: -> ['just','a','list'] -> AttributeError on manifest.get(...) aborts discovery
```

Credit: salvage of #14086 by @LeonSGP43 — rebased onto current main with guardrail tests.
