### PR TITLE
fix(skills-config): normalize scalar/None disabled-skill entries (salvage of #14094 by @LeonSGP43)

### DIFF
--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -24,6 +24,21 @@ PLATFORMS = {k: info.label for k, info in _PLATFORMS.items() if k != "api_server
 
 # ─── Config Helpers ───────────────────────────────────────────────────────────
 
+def _normalize_string_set(values) -> Set[str]:
+    """Coerce a config value (None / scalar / list) into a set of non-empty
+    trimmed strings. A bare scalar (``disabled: my-skill``) becomes a
+    single-element set instead of a set of its characters; None becomes empty.
+    """
+    if values is None:
+        return set()
+    if isinstance(values, str):
+        values = [values]
+    try:
+        return {str(v).strip() for v in values if str(v).strip()}
+    except TypeError:
+        return set()
+
+
 def get_disabled_skills(config: dict, platform: Optional[str] = None) -> Set[str]:
     """Return disabled skill names: the global list unioned with the
     platform-specific list when a platform is given.
@@ -33,13 +48,15 @@ def get_disabled_skills(config: dict, platform: Optional[str] = None) -> Set[str
     mirrors ``agent.skill_utils.get_disabled_skill_names``.
     """
     skills_cfg = config.get("skills", {})
-    global_disabled = set(skills_cfg.get("disabled", []))
+    if not isinstance(skills_cfg, dict):
+        return set()
+    global_disabled = _normalize_string_set(skills_cfg.get("disabled"))
     if platform is None:
         return global_disabled
     platform_disabled = cfg_get(skills_cfg, "platform_disabled", platform)
     if platform_disabled is None:
         return global_disabled
-    return global_disabled | set(platform_disabled)
+    return global_disabled | _normalize_string_set(platform_disabled)
 
 
 def save_disabled_skills(config: dict, disabled: Set[str], platform: Optional[str] = None):

--- a/tests/hermes_cli/test_skills_config.py
+++ b/tests/hermes_cli/test_skills_config.py
@@ -50,6 +50,23 @@ class TestGetDisabledSkills:
         from hermes_cli.skills_config import get_disabled_skills
         assert get_disabled_skills({"skills": {"disabled": []}}) == set()
 
+    def test_scalar_disabled_is_normalized_to_single_skill(self):
+        """A bare scalar `disabled: my-skill` must become {"my-skill"}, not a
+        set of its characters. (#14094)"""
+        from hermes_cli.skills_config import get_disabled_skills
+        assert get_disabled_skills({"skills": {"disabled": "my-skill"}}) == {"my-skill"}
+
+    def test_null_skills_section_returns_empty(self):
+        """`skills: null` (valid YAML) must not crash with AttributeError on
+        .get(); it returns an empty set."""
+        from hermes_cli.skills_config import get_disabled_skills
+        assert get_disabled_skills({"skills": None}) == set()
+
+    def test_scalar_platform_disabled_is_normalized(self):
+        from hermes_cli.skills_config import get_disabled_skills
+        config = {"skills": {"platform_disabled": {"telegram": "tg-skill"}}}
+        assert get_disabled_skills(config, platform="telegram") == {"tg-skill"}
+
 
 # ---------------------------------------------------------------------------
 # save_disabled_skills


### PR DESCRIPTION
## Summary

Salvage of #14094 by @LeonSGP43 — rebased onto current `origin/main` (preserving main's global|platform *union* semantics) with regression tests.

`get_disabled_skills` does `set(skills_cfg.get("disabled", []))`. A scalar `disabled: my-skill` becomes a set of its **characters**, and `skills: null` raises `AttributeError` on `.get()`.

## Root Cause

**Symptom** — Two config-shape footguns: (1) `disabled: my-skill` (a common single-skill mistake) silently disables skills named `m`, `y`, `-`, `s`, … instead of `my-skill`; (2) `skills: null` (valid YAML) crashes skill-disable resolution with `AttributeError`.

**Root cause** — In `get_disabled_skills` (`hermes_cli/skills_config.py`), `skills_cfg = config.get("skills", {})` can be `None` (→ `.get` AttributeError), and `set(scalar_string)` iterates the string into characters. Same for `platform_disabled` values.

**Evidence** — The added tests cover scalar `disabled`, `skills: null`, and scalar `platform_disabled`; all three fail without the fix (char-set / AttributeError).

**Fix + why this level** — Add `_normalize_string_set()` (None→empty, scalar→single-element, list→trimmed set) and guard the `skills` section with `isinstance(..., dict)`. Applied at `get_disabled_skills`, the single resolver every caller uses. Main's union semantics (`global | platform`) are preserved exactly — only the coercion is hardened.

**Scope / risk** — One helper + guards in one function. List-shaped configs behave identically (verified by the existing 30 tests); only scalar/None shapes change (now tolerant instead of wrong/crashing).

## Changes from original

- Rebased onto current main. The original used a global-fallback shape; main unions global+platform — I kept main's union semantics and applied only the normalization/guard hardening.
- Carried the original's 3 regression tests — all **fail without the fix**.

## Verification

```
python3 -m pytest tests/hermes_cli/test_skills_config.py -q
33 passed

# without the fix (stashed): scalar char-set + None AttributeError
3 failed
```

## Real behavior proof

```
# With fix:    {"disabled":"my-skill"} -> {"my-skill"}; {"skills":None} -> set(); platform scalar -> {"tg-skill"}
# Without fix: "my-skill" -> {'m','y','-','s','k','i','l'}; {"skills":None} -> AttributeError
```

Credit: salvage of #14094 by @LeonSGP43 — rebased onto current main with guardrail tests.
