### PR TITLE
fix(cli): detect Twilio SMS in interactive tools platform discovery (salvage of #14112 by @LeonSGP43)

### DIFF
--- a/hermes_cli/platforms.py
+++ b/hermes_cli/platforms.py
@@ -27,6 +27,7 @@ PLATFORMS: OrderedDict[str, PlatformInfo] = OrderedDict([
     ("whatsapp_cloud", PlatformInfo(label="📱 WhatsApp Business (Cloud)", default_toolset="hermes-whatsapp")),
     ("signal",         PlatformInfo(label="📡 Signal",          default_toolset="hermes-signal")),
     ("bluebubbles",    PlatformInfo(label="💙 BlueBubbles",     default_toolset="hermes-bluebubbles")),
+    ("sms",            PlatformInfo(label="📱 SMS (Twilio)",    default_toolset="hermes-sms")),
     ("email",          PlatformInfo(label="📧 Email",           default_toolset="hermes-email")),
     ("homeassistant",  PlatformInfo(label="🏠 Home Assistant",  default_toolset="hermes-homeassistant")),
     ("mattermost",     PlatformInfo(label="💬 Mattermost",      default_toolset="hermes-mattermost")),

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1565,6 +1565,10 @@ def _get_enabled_platforms() -> List[str]:
         enabled.append("slack")
     if get_env_value("WHATSAPP_ENABLED"):
         enabled.append("whatsapp")
+    # Mirror gateway SMS auto-enable (TWILIO_ACCOUNT_SID) so interactive
+    # `hermes tools` discovery includes the Twilio SMS platform.
+    if get_env_value("TWILIO_ACCOUNT_SID"):
+        enabled.append("sms")
     if get_env_value("QQ_APP_ID"):
         enabled.append("qqbot")
     return enabled

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1015,6 +1015,48 @@ def test_first_install_nous_auto_configures_video_gen(monkeypatch):
 class TestPlatformToolsetConsistency:
     """Every platform in tools_config.PLATFORMS must have a matching toolset."""
 
+    def test_sms_platform_registered_with_hermes_sms_toolset(self):
+        """SMS must be in the static platform registry with hermes-sms.
+
+        Registry membership alone is not enough for interactive discovery
+        (see test_get_enabled_platforms_detects_twilio_sms), but it is
+        required so tools_command can index PLATFORMS['sms'] safely.
+        Salvage continuity for #14112 / #52898.
+        """
+        from hermes_cli.tools_config import PLATFORMS
+
+        assert "sms" in PLATFORMS
+        assert PLATFORMS["sms"]["default_toolset"] == "hermes-sms"
+
+    def test_get_enabled_platforms_detects_twilio_sms(self, monkeypatch):
+        """Interactive discovery must treat TWILIO_ACCOUNT_SID as SMS-enabled.
+
+        Regression for the real remaining gap on #52898: gateway auto-enables
+        SMS from Twilio SID, but _get_enabled_platforms omitted SMS so
+        `hermes tools` never offered the platform menu entry.
+        """
+        from hermes_cli import tools_config as tc
+
+        def fake_get_env(key: str):
+            if key == "TWILIO_ACCOUNT_SID":
+                return "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            return None
+
+        monkeypatch.setattr(tc, "get_env_value", fake_get_env)
+        enabled = tc._get_enabled_platforms()
+        assert "cli" in enabled
+        assert "sms" in enabled
+        assert enabled.count("sms") == 1
+
+    def test_get_enabled_platforms_skips_sms_without_twilio(self, monkeypatch):
+        """No Twilio SID means SMS must not appear in discovery."""
+        from hermes_cli import tools_config as tc
+
+        monkeypatch.setattr(tc, "get_env_value", lambda key: None)
+        enabled = tc._get_enabled_platforms()
+        assert enabled == ["cli"]
+        assert "sms" not in enabled
+
     def test_all_platforms_have_toolset_definitions(self):
         """Each platform's default_toolset must exist in TOOLSETS."""
         from hermes_cli.tools_config import PLATFORMS


### PR DESCRIPTION
## Summary

Salvage of #14112 by @LeonSGP43 — **re-scoped** after maintainer review (`teknium1` / hermes-sweeper on #52898).

Static registry / gateway toolset resolution for SMS was already healthy on current `main` (`hermes-sms` composite + plugin-platform default_ts fallback). The real remaining gap is **interactive discovery**: `_get_enabled_platforms()` never treated Twilio as an enabled platform, so `hermes tools` could not the surface SMS even when SMS was configured.

## Motivation

- Gateway already auto-enables SMS when `TWILIO_ACCOUNT_SID` is set (`gateway/config.py`).
- `tools_command` builds its platform menu from `_get_enabled_platforms()` and then indexes `PLATFORMS[pkey]`.
- Without SMS in both places, interactive tools config silently skips SMS.

## Changes

1. Register `sms` → `hermes-sms` in `hermes_cli/platforms.py` (needed for menu/summary + PLATFORMS consistency with gateway).
2. `_get_enabled_platforms()`: append `"sms"` when `TWILIO_ACCOUNT_SID` is present (mirrors gateway auto-enable).
3. Focused regression tests for registry membership + env-based discovery on/off.

## Non-goals

- Not claiming a broken gateway default-toolset path (already fixed / never broken on current main as reviewed).

## Verification

```
python3 -m pytest tests/hermes_cli/test_tools_config.py -k 'PlatformToolset or get_enabled_platforms or sms_platform' -q
6 passed
```

Credit: salvage of #14112 by @LeonSGP43 — rebased and re-scoped onto current main for the interactive discovery path.