### PR TITLE
fix(dashboard): avoid repeated TUI installs on small hosts

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1779,6 +1779,10 @@ DEFAULT_CONFIG = {
     # Web dashboard settings
     "dashboard": {
         "theme": "default",  # Dashboard visual theme: "default", "midnight", "ember", "mono", "cyberpunk", "rose"
+        # Browser/dashboard Chat embeds the same TUI through /api/pty. Keep it
+        # enabled by default for desktop/browser chat, but allow small hosts to
+        # disable the PTY/TUI child without affecting dashboard management pages.
+        "embedded_chat_enabled": True,
         # Hide the token/cost analytics surfaces (Analytics page, token bars and
         # cost figures on the Models page) by default.  The numbers shown there
         # are a local debug estimate: they only count successful main-agent

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1436,41 +1436,88 @@ def _termux_workspace_install_context(
     return ws_root, tuple(workspace_args)
 
 
+_TUI_REQUIRED_DEV_DEPENDENCIES = frozenset({"esbuild"})
+
+
+def _npm_package_path(package_name: str) -> str:
+    """Return the package-lock path for a hoisted dependency name."""
+    return f"node_modules/{package_name}"
+
+
+def _tui_lock_package_scope(root: Path, packages: dict) -> set[str]:
+    """Return package-lock entries relevant to launching/building ``root``.
+
+    A Hermes checkout has one root ``package-lock.json`` for every JavaScript
+    workspace (web, desktop, ui-tui, installers).  The dashboard/TUI launcher
+    deliberately runs ``npm install --workspace ui-tui`` so startup does not
+    pull Electron/desktop/web packages into the hot path on small machines.
+    Comparing the full root lock against npm's hidden lock therefore reports
+    hundreds of intentionally-missing packages forever.  Follow the dependency
+    closure from the ``ui-tui`` workspace instead.
+    """
+    ws_root = _workspace_root(root)
+    if ws_root == root:
+        return {name for name in packages if name}
+
+    try:
+        workspace = root.relative_to(ws_root).as_posix()
+    except ValueError:
+        return {name for name in packages if name}
+
+    scoped: set[str] = set()
+    queue: list[str] = [workspace]
+
+    def enqueue(name: str | None) -> None:
+        if not name or name in scoped or name not in packages:
+            return
+        scoped.add(name)
+        queue.append(name)
+
+    while queue:
+        name = queue.pop(0)
+        pkg = packages.get(name)
+        if not isinstance(pkg, dict):
+            continue
+
+        # Local workspace links (e.g. node_modules/@hermes/ink ->
+        # ui-tui/packages/hermes-ink) carry their real dependencies on the
+        # resolved target package entry, not on the link entry.
+        resolved = pkg.get("resolved")
+        if pkg.get("link") and isinstance(resolved, str):
+            enqueue(resolved)
+
+        for field in (
+            "dependencies",
+            "devDependencies",
+            "optionalDependencies",
+            "peerDependencies",
+        ):
+            deps = pkg.get(field)
+            if not isinstance(deps, dict):
+                continue
+            for dep_name in deps:
+                if (
+                    field == "devDependencies"
+                    and dep_name not in _TUI_REQUIRED_DEV_DEPENDENCIES
+                ):
+                    continue
+                enqueue(_npm_package_path(dep_name))
+
+    return scoped
+
+
 def _tui_need_npm_install(root: Path) -> bool:
-    """True when @hermes/ink is missing or node_modules is behind package-lock.json.
+    """True when TUI deps are missing or behind the relevant lock entries.
 
-    Prebuilt bundle mode: when ``dist/entry.js`` exists and there is no
-    ``package-lock.json`` (nix install layout only ships ``dist/`` +
-    ``package.json``), skip reinstall entirely — the bundle is self-contained
-    and there is nothing to install.
-
-    With npm workspaces the single ``package-lock.json`` and the hoisted
-    ``node_modules/`` live at the workspace root (the parent of the
-    ``ui-tui/`` directory).  The lockfile / ink / marker checks use that
-    workspace root; only the prebuilt-bundle sentinel stays relative to
-    *root* (``ui-tui/dist/entry.js``).
-
-    Compares ``package-lock.json`` against ``node_modules/.package-lock.json``
-    (npm's hidden lockfile) by **content**, not mtime: git checkouts and npm
-    rewrites can bump the root lockfile's timestamp even when installed deps
-    already match, which used to trigger a spurious "Installing TUI
-    dependencies" on every launch.
-
-    For each entry in the root lock's ``packages`` map:
-      - missing from hidden lock → reinstall (unless the entry is marked
-        ``optional`` or ``peer``, which npm may intentionally skip per platform)
-      - present but with differing fields (excluding npm-written runtime
-        annotations like ``ideallyInert``) → reinstall
-
-    Extra entries that exist only in the hidden lock are ignored — stale
-    transitives left over from a removed dependency don't break runtime and
-    we'd rather not force a reinstall for them. Falls back to mtime
-    comparison if either lockfile is unparseable.
+    In workspace checkouts this intentionally validates only the dependency
+    closure reachable from ``ui-tui``.  The root lock also contains web,
+    desktop, Electron, and installer workspaces that ``npm install --workspace
+    ui-tui`` is not supposed to install; treating those absent packages as a
+    TUI failure makes dashboard chat run npm on every launch.
     """
     # Prebuilt self-contained bundle (nix / packaged release): no lockfile
     # shipped, dist/entry.js is the single runtime artefact.
     entry = root / "dist" / "entry.js"
-    # With npm workspaces the lockfile lives at the workspace root.
     ws_root = _workspace_root(root)
     lock = ws_root / "package-lock.json"
     if entry.is_file() and not lock.is_file():
@@ -1497,15 +1544,19 @@ def _tui_need_npm_install(root: Path) -> bool:
     def comparable(pkg: dict) -> dict:
         return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
 
-    for name, pkg in wanted.items():
-        if not name:
-            continue
+    required_dev_paths = {
+        _npm_package_path(dep) for dep in _TUI_REQUIRED_DEV_DEPENDENCIES
+    }
 
+    for name in sorted(_tui_lock_package_scope(root, wanted)):
+        pkg = wanted.get(name)
         if not isinstance(pkg, dict):
             continue
 
         if name not in installed:
             if pkg.get("optional") or pkg.get("peer"):
+                continue
+            if pkg.get("dev") and name not in required_dev_paths:
                 continue
             return True
 
@@ -1513,8 +1564,8 @@ def _tui_need_npm_install(root: Path) -> bool:
             installed[name]
         ):
             return True
-
     return False
+
 
 
 _TUI_BUILD_INPUT_DIRS = (

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -34,6 +34,10 @@ from typing import List, Optional, Tuple
 from agent.skill_utils import is_excluded_skill_path
 
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+_WRAPPER_PROFILE_RE = re.compile(r"(?:^|[\s/\\])hermes(?:\.exe)?\s+-p\s+([a-z0-9][a-z0-9_-]{0,63}|default)\b")
+# Hermes wrapper scripts are tiny. Skipping larger executables in ~/.local/bin
+# keeps profile enumeration from reading binaries like uv/codex once per profile.
+_WRAPPER_SCAN_MAX_BYTES = 64 * 1024
 
 # Directories bootstrapped inside every new profile
 _PROFILE_DIRS = [
@@ -486,6 +490,59 @@ def _migrate_profile_config_if_outdated(profile_dir: Path) -> None:
         pass
 
 
+def _iter_wrapper_candidates(wrapper_dir: Path):
+    """Yield plausible Hermes wrapper files without reading large binaries."""
+    if not wrapper_dir.is_dir():
+        return
+    is_windows = sys.platform == "win32"
+    for entry in sorted(wrapper_dir.iterdir()):
+        if not entry.is_file():
+            continue
+        # Only our own wrappers are named with the alias and (on Windows) .bat.
+        if is_windows and entry.suffix != ".bat":
+            continue
+        if not is_windows and entry.suffix:
+            continue
+        try:
+            if entry.stat().st_size > _WRAPPER_SCAN_MAX_BYTES:
+                continue
+        except OSError:
+            continue
+        yield entry
+
+
+def _read_wrapper_profile(entry: Path) -> Optional[str]:
+    """Return the profile id referenced by a Hermes alias wrapper, if any."""
+    try:
+        content = entry.read_text()
+    except (OSError, UnicodeDecodeError):
+        return None
+    match = _WRAPPER_PROFILE_RE.search(content)
+    if not match:
+        return None
+    return normalize_profile_name(match.group(1))
+
+
+def _scan_profile_aliases() -> dict[str, str]:
+    """Return profile id -> preferred wrapper alias from one wrapper-dir scan."""
+    wrapper_dir = _get_wrapper_dir()
+    aliases: dict[str, str] = {}
+    profile_named: dict[str, str] = {}
+    is_windows = sys.platform == "win32"
+    for entry in _iter_wrapper_candidates(wrapper_dir) or []:
+        profile = _read_wrapper_profile(entry)
+        if not profile:
+            continue
+        alias = entry.stem if is_windows else entry.name
+        if alias == profile:
+            profile_named[profile] = alias
+        elif profile not in aliases:
+            aliases[profile] = alias
+    for profile, alias in profile_named.items():
+        aliases.setdefault(profile, alias)
+    return aliases
+
+
 def find_alias_for_profile(profile_name: str) -> Optional[str]:
     """Return the alias name of the wrapper that activates *profile_name*, or None.
 
@@ -499,35 +556,8 @@ def find_alias_for_profile(profile_name: str) -> Optional[str]:
     so ``profile list``/``show`` surface the command the user actually typed.
     Results are sorted for deterministic output when several aliases match.
     """
-    wrapper_dir = _get_wrapper_dir()
-    if not wrapper_dir.is_dir():
-        return None
     canon = normalize_profile_name(profile_name)
-    is_windows = sys.platform == "win32"
-    needle = f"hermes -p {canon}"
-
-    custom: Optional[str] = None
-    profile_named: Optional[str] = None
-    for entry in sorted(wrapper_dir.iterdir()):
-        if not entry.is_file():
-            continue
-        # Only our own wrappers are named with the alias and (on Windows) .bat.
-        if is_windows and entry.suffix != ".bat":
-            continue
-        if not is_windows and entry.suffix:
-            continue
-        try:
-            content = entry.read_text()
-        except (OSError, UnicodeDecodeError):
-            continue
-        if needle not in content:
-            continue
-        alias = entry.stem if is_windows else entry.name
-        if alias == canon:
-            profile_named = alias
-        elif custom is None:
-            custom = alias
-    return custom if custom is not None else profile_named
+    return _scan_profile_aliases().get(canon)
 
 
 # ---------------------------------------------------------------------------
@@ -593,11 +623,50 @@ def _read_distribution_meta(profile_dir: Path) -> tuple:
 
 
 def _read_config_model(profile_dir: Path) -> tuple:
-    """Read model/provider from a profile's config.yaml. Returns (model, provider)."""
+    """Read model/provider from a profile's config.yaml. Returns (model, provider).
+
+    Profile listing/dashboard hot paths call this for every profile. Avoid a
+    full YAML parse of large config files when we only need two scalar values.
+    Fall back to YAML for odd legacy shapes.
+    """
     config_path = profile_dir / "config.yaml"
     if not config_path.exists():
         return None, None
     try:
+        lines = config_path.read_text(encoding="utf-8").splitlines()
+        in_model = False
+        model = None
+        provider = None
+        model_scalar = None
+        for raw in lines:
+            stripped = raw.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            indent = len(raw) - len(raw.lstrip(" "))
+            if indent == 0:
+                if stripped.startswith("model:"):
+                    rest = stripped[len("model:"):].strip()
+                    if rest:
+                        model_scalar = rest.strip("'\"")
+                        break
+                    in_model = True
+                    continue
+                if in_model:
+                    break
+            if in_model and indent > 0:
+                if stripped.startswith("default:"):
+                    model = stripped[len("default:"):].strip().strip("'\"") or None
+                elif stripped.startswith("model:"):
+                    model = stripped[len("model:"):].strip().strip("'\"") or model
+                elif stripped.startswith("provider:"):
+                    provider = stripped[len("provider:"):].strip().strip("'\"") or None
+                if model and provider:
+                    return model, provider
+        if model_scalar is not None:
+            return model_scalar, None
+        if model or provider:
+            return model, provider
+
         import yaml
         with open(config_path, "r", encoding="utf-8") as f:
             cfg = yaml.safe_load(f) or {}
@@ -741,6 +810,7 @@ def list_profiles() -> List[ProfileInfo]:
     """Return info for all profiles, including the default."""
     profiles = []
     wrapper_dir = _get_wrapper_dir()
+    alias_map = _scan_profile_aliases()
 
     # Default profile
     default_home = _get_default_hermes_home()
@@ -776,7 +846,7 @@ def list_profiles() -> List[ProfileInfo]:
             if not _PROFILE_ID_RE.match(name):
                 continue
             model, provider = _read_config_model(entry)
-            alias_name = find_alias_for_profile(name)
+            alias_name = alias_map.get(name)
             if alias_name:
                 is_windows = sys.platform == "win32"
                 alias_path = wrapper_dir / (f"{alias_name}.bat" if is_windows else alias_name)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -252,13 +252,26 @@ app.include_router(_memory_oauth_router)
 _SESSION_TOKEN = os.environ.get("HERMES_DASHBOARD_SESSION_TOKEN") or secrets.token_urlsafe(32)
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
 
-# In-browser Chat tab (/chat, /api/pty, /api/ws, …).  Always enabled: the
-# desktop app and the dashboard's own Chat tab both drive the agent over the
-# `/api/ws` + `/api/pty` WebSockets, so the embedded-chat surface is an
-# unconditional part of the dashboard.  Kept as a module-level constant (rather
-# than inlining ``True`` at every gate) so the WS endpoints and the SPA token
-# injection share a single, testable seam.
-_DASHBOARD_EMBEDDED_CHAT_ENABLED = True
+# In-browser Chat tab (/chat, /api/pty, /api/ws, …). Enabled by default:
+# the desktop app and the dashboard's own Chat tab both drive the agent over the
+# `/api/ws` + `/api/pty` WebSockets. Small always-on hosts can disable this via
+# ``dashboard.embedded_chat_enabled: false`` so management pages keep working
+# without spawning the Node/TUI/PTY child.
+def _dashboard_embedded_chat_enabled() -> bool:
+    try:
+        value = cfg_get(
+            load_config(), "dashboard", "embedded_chat_enabled", default=True
+        )
+    except Exception:
+        return True
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() not in {"0", "false", "no", "off", "disabled"}
+    return bool(value)
+
+
+_DASHBOARD_EMBEDDED_CHAT_ENABLED = _dashboard_embedded_chat_enabled()
 
 # Simple rate limiter for the reveal endpoint
 _reveal_timestamps: List[float] = []

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -70,6 +70,124 @@ def test_no_install_when_only_optional_peer_package_missing_from_hidden_lock(tmp
     assert main_mod._tui_need_npm_install(tmp_path) is False
 
 
+def test_workspace_install_ignores_non_tui_workspace_missing_packages(tmp_path: Path, main_mod) -> None:
+    """Scoped ui-tui installs intentionally omit web/desktop packages."""
+    tui = tmp_path / "ui-tui"
+    tui.mkdir()
+    (tui / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    lock = {
+        "packages": {
+            "ui-tui": {
+                "dependencies": {
+                    "@hermes/ink": "file:./packages/hermes-ink",
+                    "ink": "^1.0.0",
+                }
+            },
+            "node_modules/@hermes/ink": {
+                "resolved": "ui-tui/packages/hermes-ink",
+                "link": True,
+            },
+            "ui-tui/packages/hermes-ink": {
+                "dependencies": {"chalk": "^5.0.0"},
+            },
+            "node_modules/ink": {"version": "1.0.0"},
+            "node_modules/chalk": {"version": "5.0.0"},
+            "apps/desktop": {"version": "1.0.0"},
+            "node_modules/electron": {"version": "99.0.0"},
+        }
+    }
+    installed = {
+        "packages": {
+            "ui-tui": lock["packages"]["ui-tui"],
+            "node_modules/@hermes/ink": lock["packages"]["node_modules/@hermes/ink"],
+            "ui-tui/packages/hermes-ink": lock["packages"]["ui-tui/packages/hermes-ink"],
+            "node_modules/ink": lock["packages"]["node_modules/ink"],
+            "node_modules/chalk": lock["packages"]["node_modules/chalk"],
+        }
+    }
+    import json
+
+    (tmp_path / "package-lock.json").write_text(json.dumps(lock))
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(json.dumps(installed))
+
+    assert main_mod._tui_need_npm_install(tui) is False
+
+
+def test_workspace_install_still_detects_missing_tui_dependency(tmp_path: Path, main_mod) -> None:
+    tui = tmp_path / "ui-tui"
+    tui.mkdir()
+    (tui / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    lock = {
+        "packages": {
+            "ui-tui": {"dependencies": {"ink": "^1.0.0"}},
+            "node_modules/ink": {"version": "1.0.0", "dependencies": {"chalk": "^5.0.0"}},
+            "node_modules/chalk": {"version": "5.0.0"},
+            "apps/desktop": {"version": "1.0.0"},
+        }
+    }
+    installed = {
+        "packages": {
+            "ui-tui": lock["packages"]["ui-tui"],
+            "node_modules/ink": lock["packages"]["node_modules/ink"],
+        }
+    }
+    import json
+
+    (tmp_path / "package-lock.json").write_text(json.dumps(lock))
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(json.dumps(installed))
+
+    assert main_mod._tui_need_npm_install(tui) is True
+
+
+def test_workspace_install_ignores_non_build_dev_dependencies(tmp_path: Path, main_mod) -> None:
+    tui = tmp_path / "ui-tui"
+    tui.mkdir()
+    (tui / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    lock = {
+        "packages": {
+            "ui-tui": {"devDependencies": {"eslint": "^9", "esbuild": "^1"}},
+            "node_modules/eslint": {"version": "9.0.0", "dependencies": {"ajv": "^8"}},
+            "node_modules/ajv": {"version": "8.0.0"},
+            "node_modules/esbuild": {"version": "1.0.0"},
+        }
+    }
+    installed = {
+        "packages": {
+            "ui-tui": lock["packages"]["ui-tui"],
+            "node_modules/esbuild": lock["packages"]["node_modules/esbuild"],
+        }
+    }
+    import json
+
+    (tmp_path / "package-lock.json").write_text(json.dumps(lock))
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(json.dumps(installed))
+
+    assert main_mod._tui_need_npm_install(tui) is False
+
+
+def test_workspace_install_requires_esbuild_for_rebuilds(tmp_path: Path, main_mod) -> None:
+    tui = tmp_path / "ui-tui"
+    tui.mkdir()
+    (tui / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    lock = {
+        "packages": {
+            "ui-tui": {"devDependencies": {"esbuild": "^1"}},
+            "node_modules/esbuild": {"version": "1.0.0"},
+        }
+    }
+    installed = {"packages": {"ui-tui": lock["packages"]["ui-tui"]}}
+    import json
+
+    (tmp_path / "package-lock.json").write_text(json.dumps(lock))
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(json.dumps(installed))
+
+    assert main_mod._tui_need_npm_install(tui) is True
+
+
 def test_no_install_when_only_peer_annotation_differs(tmp_path: Path, main_mod) -> None:
     """npm 9 drops the ``peer`` flag from the hidden lock on dev-deps that are
     *also* declared as peers.  That's a cosmetic difference — the package is

--- a/tests/hermes_cli/test_web_server_pty_import.py
+++ b/tests/hermes_cli/test_web_server_pty_import.py
@@ -35,6 +35,25 @@ def test_web_server_exposes_pty_bridge_symbols():
     assert issubclass(web_server.PtyUnavailableError, BaseException)
 
 
+def test_dashboard_embedded_chat_can_be_disabled_from_config(monkeypatch):
+    monkeypatch.setattr(
+        web_server,
+        "load_config",
+        lambda: {"dashboard": {"embedded_chat_enabled": False}},
+    )
+
+    assert web_server._dashboard_embedded_chat_enabled() is False
+
+
+def test_dashboard_embedded_chat_defaults_enabled_on_bad_config(monkeypatch):
+    def boom():
+        raise RuntimeError("bad config")
+
+    monkeypatch.setattr(web_server, "load_config", boom)
+
+    assert web_server._dashboard_embedded_chat_enabled() is True
+
+
 @pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows-only")
 def test_web_server_uses_win_pty_bridge_on_windows():
     """On native Windows, web_server.PtyBridge must be the ConPTY backend."""

--- a/tests/test_profiles_alias_scan.py
+++ b/tests/test_profiles_alias_scan.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+
+
+def test_read_config_model_uses_lightweight_model_block(tmp_path):
+    from hermes_cli import profiles
+
+    profile_dir = tmp_path / "profile"
+    profile_dir.mkdir()
+    (profile_dir / "config.yaml").write_text(
+        "model:\n"
+        "  default: gpt-test\n"
+        "  provider: codex-test\n"
+        "providers:\n"
+        "  ignored: true\n"
+    )
+
+    assert profiles._read_config_model(profile_dir) == ("gpt-test", "codex-test")
+
+
+def test_scan_profile_aliases_skips_large_extensionless_binaries(tmp_path, monkeypatch):
+    from hermes_cli import profiles
+
+    wrapper_dir = tmp_path / "bin"
+    wrapper_dir.mkdir()
+    (wrapper_dir / "uv").write_bytes(b"x" * (profiles._WRAPPER_SCAN_MAX_BYTES + 1))
+    (wrapper_dir / "ana").write_text("#!/bin/sh\nexec hermes -p ana-creative-producer \"$@\"\n")
+    (wrapper_dir / "ana-creative-producer").write_text(
+        "#!/bin/sh\nexec hermes -p ana-creative-producer \"$@\"\n"
+    )
+
+    monkeypatch.setattr(profiles, "_get_wrapper_dir", lambda: wrapper_dir)
+
+    assert profiles._scan_profile_aliases()["ana-creative-producer"] == "ana"
+    assert profiles.find_alias_for_profile("ana-creative-producer") == "ana"
+
+
+def test_list_profiles_scans_alias_wrappers_once(tmp_path, monkeypatch):
+    from hermes_cli import profiles
+
+    hermes_home = tmp_path / ".hermes"
+    profile_root = hermes_home / "profiles"
+    profile_root.mkdir(parents=True)
+    for name in ["alpha", "beta", "gamma"]:
+        p = profile_root / name
+        p.mkdir()
+        (p / "config.yaml").write_text("model:\n  default: test-model\n  provider: test-provider\n")
+
+    wrapper_dir = tmp_path / "bin"
+    wrapper_dir.mkdir()
+    (wrapper_dir / "beta-alias").write_text("#!/bin/sh\nexec hermes -p beta \"$@\"\n")
+
+    scan_count = 0
+    original_scan = profiles._scan_profile_aliases
+
+    def counted_scan():
+        nonlocal scan_count
+        scan_count += 1
+        return original_scan()
+
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr(profiles, "_get_profiles_root", lambda: profile_root)
+    monkeypatch.setattr(profiles, "_get_wrapper_dir", lambda: wrapper_dir)
+    monkeypatch.setattr(profiles, "_scan_profile_aliases", counted_scan)
+    monkeypatch.setattr(profiles, "_check_gateway_running", lambda _path: False)
+    monkeypatch.setattr(profiles, "_count_skills", lambda _path: 0)
+    monkeypatch.setattr(profiles, "_read_distribution_meta", lambda _path: (None, None, None))
+    monkeypatch.setattr(profiles, "read_profile_meta", lambda _path: {"description": "", "description_auto": False})
+
+    listed = profiles.list_profiles()
+    by_name = {p.name: p for p in listed}
+
+    assert scan_count == 1
+    assert by_name["beta"].alias_name == "beta-alias"
+    assert by_name["alpha"].alias_name is None
+    assert by_name["gamma"].alias_name is None


### PR DESCRIPTION
## Summary

This fixes two dashboard-on-small-host footguns and one profile-list hot path problem observed on a 4GB Raspberry Pi running the dashboard permanently:

1. Scope `_tui_need_npm_install()` to the `ui-tui` dependency closure instead of comparing the full monorepo `package-lock.json` against a scoped `npm install --workspace ui-tui` hidden lock.
2. Add `dashboard.embedded_chat_enabled` so constrained hosts can disable dashboard embedded chat (`/api/pty`) without disabling normal dashboard management pages.
3. Speed up profile listing/dashboard profile enumeration by scanning wrapper aliases once, skipping large extensionless binaries, and avoiding full YAML parses when only model/provider are needed.

## Problem

On a constrained always-on host, dashboard chat/TUI startup can repeatedly run:

```bash
npm install --workspace ui-tui --silent --no-fund --no-audit --progress=false
npm run build --workspace ui-tui
```

Even after a successful install/build, `_tui_need_npm_install(ui-tui)` can keep returning `True` because the root `package-lock.json` contains unrelated workspaces such as desktop/web/electron packages that are intentionally absent after a scoped `ui-tui` install.

Observed on the Pi before this patch:

```text
need_install True
need_rebuild False
wanted packages: 1302
installed packages: 662
missing nonoptional packages: 533
```

After the patch and one successful scoped install/build:

```text
need_install False
need_rebuild False
```

The same host also hit profile-list/dashboard profile enumeration slowness due repeated alias wrapper scans and full YAML parsing per profile.

## Changes

### TUI install check

- Adds `_tui_lock_package_scope(root, packages)` to follow the dependency closure from `ui-tui` in the root lock.
- Ignores unrelated workspace packages missing from the hidden lock.
- Keeps detecting missing runtime dependencies.
- Keeps requiring the real build tool dependency (`esbuild`) needed by `ui-tui/scripts/build.mjs`.
- Avoids reinstalling over dev/lint/test-only transitive packages missing from a scoped install.

### Dashboard embedded chat switch

- Adds default config:

```yaml
dashboard:
  embedded_chat_enabled: true
```

- `hermes_cli.web_server` reads the config at startup.
- When false, `/api/pty` closes with `4404 embedded chat disabled` before resolving/spawning the TUI child.
- Normal dashboard pages remain available.

### Profile listing speed

- Scans wrapper aliases once per profile list.
- Skips large extensionless files in wrapper dir so binaries like `uv`/`codex` are not read as text repeatedly.
- Reads `model.default`/`model.provider` with a lightweight scalar scan before falling back to full YAML.

## Tests run

```bash
./venv/bin/python -m pytest \
  tests/hermes_cli/test_tui_npm_install.py \
  tests/hermes_cli/test_web_server_pty_import.py \
  tests/test_profiles_alias_scan.py \
  -q -o 'addopts='
```

Result:

```text
41 passed, 1 skipped
```

Live verification on the affected host:

```text
need_install False
need_rebuild False
HERMES_DASHBOARD_READY port=9119
HTTP / -> 302 /login?next=%2F
no npm logs after dashboard restart
no node --expose-gc ui-tui/dist/entry.js child after dashboard restart
```

## Notes / risk

- `dashboard.embedded_chat_enabled=false` disables dashboard browser chat / embedded terminal chat only. It does not disable dashboard config/auth/session/cron/kanban management pages.
- The default remains enabled to preserve existing desktop/dashboard behavior.
- The TUI install check is intentionally conservative for runtime deps and `esbuild`, but no longer treats absent desktop/web/electron packages as a reason to reinstall `ui-tui` forever.
