### PR TITLE
fix(agent): redact request dumps before JSON serialization (#52905)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1832,6 +1832,62 @@ def extract_reasoning(agent, assistant_message) -> Optional[str]:
     return None
 
 
+_REQUEST_DUMP_SENSITIVE_EXACT_KEYS = frozenset({
+    "authorization",
+    "proxy_authorization",
+    "cookie",
+    "set_cookie",
+    "x_api_key",
+    "api_key",
+    "apikey",
+    "token",
+    "bearer_token",
+    "session_token",
+    "csrf_token",
+    "jwt",
+})
+_REQUEST_DUMP_SENSITIVE_KEY_PARTS = (
+    "authorization",
+    "cookie",
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "auth_token",
+    "api_key",
+    "apikey",
+    "secret",
+    "password",
+    "credential",
+    "private_key",
+)
+
+
+def _request_dump_key_is_sensitive(key: Any) -> bool:
+    normalized = re.sub(r"[^a-z0-9]+", "_", str(key).lower()).strip("_")
+    if normalized in _REQUEST_DUMP_SENSITIVE_EXACT_KEYS:
+        return True
+    return any(part in normalized for part in _REQUEST_DUMP_SENSITIVE_KEY_PARTS)
+
+
+def _redact_request_dump_payload(value: Any, key: Any = None) -> Any:
+    """Redact secrets before persisting request debug dumps."""
+    if key is not None and _request_dump_key_is_sensitive(key):
+        return value if value is None or value == "" else "[REDACTED]"
+
+    if isinstance(value, dict):
+        return {
+            item_key: _redact_request_dump_payload(item_value, item_key)
+            for item_key, item_value in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_redact_request_dump_payload(item) for item in value]
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+
+    from agent.redact import redact_sensitive_text
+    text = value if isinstance(value, str) else str(value)
+    return redact_sensitive_text(text, force=True)
+
 
 def dump_api_request_debug(
     agent,
@@ -1897,6 +1953,8 @@ def dump_api_request_debug(
 
             dump_payload["error"] = error_info
 
+        dump_payload = _redact_request_dump_payload(dump_payload)
+
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         # Sanitize the session ID into a traversal-free path segment — it can
         # originate from untrusted input (X-Hermes-Session-Id header), and an
@@ -1908,12 +1966,9 @@ def dump_api_request_debug(
         # full request body (system prompt, tool defs, context-embedded
         # values), and this path fires unconditionally on API errors — so it
         # otherwise lands any context-embedded secret in cleartext on disk.
-        # Run the serialized dump through the same scrubber used for logs/tool
-        # output, then hand the resulting payload back to the shared atomic
-        # JSON writer so request dumps keep the same write semantics as before.
-        from agent.redact import redact_sensitive_text
-        _serialized = json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str)
-        _redacted_payload = json.loads(redact_sensitive_text(_serialized, force=True))
+        # Redact while the payload is still structured: regexing serialized
+        # JSON can corrupt string quoting when values contain header-like text.
+        _redacted_payload = dump_payload
         atomic_json_write(dump_file, _redacted_payload, default=str)
 
         agent._vprint(f"{agent.log_prefix}🧾 Request debug dump written to: {dump_file}")

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1865,7 +1865,9 @@ _REQUEST_DUMP_SENSITIVE_KEY_PARTS = (
 
 
 def _request_dump_key_is_sensitive(key: Any) -> bool:
-    normalized = re.sub(r"[^a-z0-9]+", "_", str(key).lower()).strip("_")
+    key_text = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", str(key))
+    key_text = re.sub(r"(?<=[A-Z])(?=[A-Z][a-z])", "_", key_text)
+    normalized = re.sub(r"[^a-z0-9]+", "_", key_text.lower()).strip("_")
     if normalized in _REQUEST_DUMP_SENSITIVE_EXACT_KEYS:
         return True
     return any(part in normalized for part in _REQUEST_DUMP_SENSITIVE_KEY_PARTS)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1840,6 +1840,8 @@ _REQUEST_DUMP_SENSITIVE_EXACT_KEYS = frozenset({
     "x_api_key",
     "api_key",
     "apikey",
+    "x_api_token",
+    "api_token",
     "token",
     "bearer_token",
     "session_token",

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1251,6 +1251,56 @@ def _api_error_debug_info(error: Exception) -> Dict[str, Any]:
     return info
 
 
+_REQUEST_DUMP_SENSITIVE_EXACT_KEYS = frozenset({"token", "jwt"})
+_REQUEST_DUMP_SENSITIVE_KEY_PARTS = (
+    "api_token",
+    "bearer_token",
+    "session_token",
+    "csrf_token",
+    "authorization",
+    "cookie",
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "auth_token",
+    "api_key",
+    "apikey",
+    "secret",
+    "password",
+    "credential",
+    "private_key",
+)
+
+
+def _request_dump_key_is_sensitive(key: Any) -> bool:
+    key_text = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", str(key))
+    key_text = re.sub(r"(?<=[A-Z])(?=[A-Z][a-z])", "_", key_text)
+    normalized = re.sub(r"[^a-z0-9]+", "_", key_text.lower()).strip("_")
+    if normalized in _REQUEST_DUMP_SENSITIVE_EXACT_KEYS:
+        return True
+    return any(part in normalized for part in _REQUEST_DUMP_SENSITIVE_KEY_PARTS)
+
+
+def _redact_request_dump_payload(value: Any, key: Any = None) -> Any:
+    """Redact secrets before persisting request debug dumps."""
+    if key is not None and _request_dump_key_is_sensitive(key):
+        return value if value is None or value == "" else "[REDACTED]"
+
+    if isinstance(value, dict):
+        return {
+            item_key: _redact_request_dump_payload(item_value, item_key)
+            for item_key, item_value in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_redact_request_dump_payload(item) for item in value]
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+
+    from agent.redact import redact_sensitive_text
+    text = value if isinstance(value, str) else str(value)
+    return redact_sensitive_text(text, force=True)
+
+
 def dump_api_request_debug(
     agent, api_kwargs: Dict[str, Any], *, reason: str, error: Optional[Exception] = None
 ) -> Optional[Path]:
@@ -1283,9 +1333,8 @@ def dump_api_request_debug(
         dump_file = agent.logs_dir / f"request_dump_{safe_sid}_{datetime.now().strftime('%Y%m%d_%H%M%S_%f')}.json"
         # Redact secrets first: this fires unconditionally on API errors and captures the full
         # request body, so context-embedded secrets would otherwise land in cleartext on disk.
-        from agent.redact import redact_sensitive_text
-        _serialized = json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str)
-        _redacted_payload = json.loads(redact_sensitive_text(_serialized, force=True))
+        # Keep JSON structure intact: scrub string leaves before serialization.
+        _redacted_payload = _redact_request_dump_payload(dump_payload)
         atomic_json_write(dump_file, _redacted_payload, default=str)
         agent._vprint(f"{agent.log_prefix}🧾 Request debug dump written to: {dump_file}")
         if env_var_enabled("HERMES_DUMP_REQUEST_STDOUT"):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1797,6 +1797,7 @@ def test_dump_api_request_debug_redacts_secrets(monkeypatch, tmp_path):
 
     prefixed_key = "sk-proj-" + ("a" * 40)
     opaque_header_secret = "Bearer opaque-provider-token-without-known-prefix"
+    opaque_api_token_secret = "opaque-api-token-without-known-prefix"
     opaque_key_list_secret = "opaque-extra-body-key-without-known-prefix"
     opaque_token_secret = "opaque-token-without-known-prefix"
     opaque_cookie_secret = "opaque-session-cookie-without-known-prefix"
@@ -1821,6 +1822,7 @@ def test_dump_api_request_debug_redacts_secrets(monkeypatch, tmp_path):
             ],
             "extra_headers": {
                 "Authorization": opaque_header_secret,
+                "X-Api-Token": opaque_api_token_secret,
                 "X-Authorization": opaque_x_authorization_secret,
                 "X-Trace": "trace-ok",
             },
@@ -1841,6 +1843,7 @@ def test_dump_api_request_debug_redacts_secrets(monkeypatch, tmp_path):
     raw_dump = dump_file.read_text()
     assert prefixed_key not in raw_dump
     assert opaque_header_secret not in raw_dump
+    assert opaque_api_token_secret not in raw_dump
     assert opaque_key_list_secret not in raw_dump
     assert opaque_cookie_secret not in raw_dump
     assert opaque_token_secret not in raw_dump
@@ -1851,6 +1854,7 @@ def test_dump_api_request_debug_redacts_secrets(monkeypatch, tmp_path):
     payload = json.loads(raw_dump)
     assert payload["request"]["headers"]["Authorization"] == "[REDACTED]"
     assert payload["request"]["body"]["extra_headers"]["Authorization"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_headers"]["X-Api-Token"] == "[REDACTED]"
     assert payload["request"]["body"]["extra_headers"]["X-Authorization"] == "[REDACTED]"
     assert payload["request"]["body"]["extra_headers"]["X-Trace"] == "trace-ok"
     assert payload["request"]["body"]["extra_body"]["api_key"] == "[REDACTED]"

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1802,6 +1802,9 @@ def test_dump_api_request_debug_redacts_secrets(monkeypatch, tmp_path):
     opaque_token_secret = "opaque-token-without-known-prefix"
     opaque_cookie_secret = "opaque-session-cookie-without-known-prefix"
     opaque_x_authorization_secret = "opaque-x-authorization-without-known-prefix"
+    opaque_access_token_secret = "opaque-camel-access-token"
+    opaque_refresh_token_secret = "opaque-camel-refresh-token"
+    opaque_private_key_secret = "opaque-camel-private-key"
     error = SimpleNamespace(
         status_code=401,
         body={"api_key": prefixed_key},
@@ -1828,9 +1831,12 @@ def test_dump_api_request_debug_redacts_secrets(monkeypatch, tmp_path):
             },
             "extra_body": {
                 "api_key": [opaque_key_list_secret],
+                "accessToken": opaque_access_token_secret,
                 "client_secret": "plain-secret-value-without-known-prefix",
                 "max_tokens": 4096,
                 "nested": [f"github_pat_{'b' * 40}"],
+                "privateKey": opaque_private_key_secret,
+                "refreshToken": opaque_refresh_token_secret,
                 "session_cookie": opaque_cookie_secret,
                 "token": opaque_token_secret,
             },
@@ -1848,6 +1854,9 @@ def test_dump_api_request_debug_redacts_secrets(monkeypatch, tmp_path):
     assert opaque_cookie_secret not in raw_dump
     assert opaque_token_secret not in raw_dump
     assert opaque_x_authorization_secret not in raw_dump
+    assert opaque_access_token_secret not in raw_dump
+    assert opaque_refresh_token_secret not in raw_dump
+    assert opaque_private_key_secret not in raw_dump
     assert "plain-secret-value-without-known-prefix" not in raw_dump
     assert f"github_pat_{'b' * 40}" not in raw_dump
 
@@ -1858,11 +1867,14 @@ def test_dump_api_request_debug_redacts_secrets(monkeypatch, tmp_path):
     assert payload["request"]["body"]["extra_headers"]["X-Authorization"] == "[REDACTED]"
     assert payload["request"]["body"]["extra_headers"]["X-Trace"] == "trace-ok"
     assert payload["request"]["body"]["extra_body"]["api_key"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_body"]["accessToken"] == "[REDACTED]"
     assert payload["request"]["body"]["extra_body"]["client_secret"] == "[REDACTED]"
     assert payload["request"]["body"]["extra_body"]["max_tokens"] == 4096
+    assert payload["request"]["body"]["extra_body"]["privateKey"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_body"]["refreshToken"] == "[REDACTED]"
     assert payload["request"]["body"]["extra_body"]["session_cookie"] == "[REDACTED]"
     assert payload["request"]["body"]["extra_body"]["token"] == "[REDACTED]"
-    assert "[REDACTED]" in payload["error"]["body"]["api_key"]
+    assert payload["error"]["body"]["api_key"] == "[REDACTED]"
 
 
 # --- Reasoning-only response tests (fix for empty content retry loop) ---

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1786,6 +1786,79 @@ def test_dump_api_request_debug_uses_chat_completions_url(monkeypatch, tmp_path)
     assert payload["request"]["url"] == "http://127.0.0.1:9208/v1/chat/completions"
 
 
+def test_dump_api_request_debug_redacts_secrets(monkeypatch, tmp_path):
+    """Request debug dumps must be safe to attach to bug reports."""
+    import json
+    import agent.redact as redact_mod
+
+    monkeypatch.setattr(redact_mod, "_REDACT_ENABLED", False)
+    agent = _build_agent(monkeypatch)
+    agent.logs_dir = tmp_path
+
+    prefixed_key = "sk-proj-" + ("a" * 40)
+    opaque_header_secret = "Bearer opaque-provider-token-without-known-prefix"
+    opaque_key_list_secret = "opaque-extra-body-key-without-known-prefix"
+    opaque_token_secret = "opaque-token-without-known-prefix"
+    opaque_cookie_secret = "opaque-session-cookie-without-known-prefix"
+    opaque_x_authorization_secret = "opaque-x-authorization-without-known-prefix"
+    error = SimpleNamespace(
+        status_code=401,
+        body={"api_key": prefixed_key},
+        response=SimpleNamespace(
+            status_code=401,
+            text=f"upstream rejected Authorization: Bearer {prefixed_key}",
+        ),
+    )
+
+    dump_file = agent._dump_api_request_debug(
+        {
+            "model": "gpt-5-codex",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": f"please echo {prefixed_key}",
+                }
+            ],
+            "extra_headers": {
+                "Authorization": opaque_header_secret,
+                "X-Authorization": opaque_x_authorization_secret,
+                "X-Trace": "trace-ok",
+            },
+            "extra_body": {
+                "api_key": [opaque_key_list_secret],
+                "client_secret": "plain-secret-value-without-known-prefix",
+                "max_tokens": 4096,
+                "nested": [f"github_pat_{'b' * 40}"],
+                "session_cookie": opaque_cookie_secret,
+                "token": opaque_token_secret,
+            },
+        },
+        reason="non_retryable_client_error",
+        error=error,
+    )
+
+    assert dump_file is not None
+    raw_dump = dump_file.read_text()
+    assert prefixed_key not in raw_dump
+    assert opaque_header_secret not in raw_dump
+    assert opaque_key_list_secret not in raw_dump
+    assert opaque_cookie_secret not in raw_dump
+    assert opaque_token_secret not in raw_dump
+    assert opaque_x_authorization_secret not in raw_dump
+    assert "plain-secret-value-without-known-prefix" not in raw_dump
+    assert f"github_pat_{'b' * 40}" not in raw_dump
+
+    payload = json.loads(raw_dump)
+    assert payload["request"]["headers"]["Authorization"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_headers"]["Authorization"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_headers"]["X-Authorization"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_headers"]["X-Trace"] == "trace-ok"
+    assert payload["request"]["body"]["extra_body"]["api_key"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_body"]["client_secret"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_body"]["max_tokens"] == 4096
+    assert payload["request"]["body"]["extra_body"]["session_cookie"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_body"]["token"] == "[REDACTED]"
+    assert "[REDACTED]" in payload["error"]["body"]["api_key"]
 
 
 # --- Reasoning-only response tests (fix for empty content retry loop) ---

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1792,6 +1792,9 @@ def test_dump_api_request_debug_redacts_secrets(monkeypatch, tmp_path):
     import agent.redact as redact_mod
 
     monkeypatch.setattr(redact_mod, "_REDACT_ENABLED", False)
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     agent = _build_agent(monkeypatch)
     agent.logs_dir = tmp_path
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2624,3 +2624,109 @@ def test_run_codex_stream_retired_request_stops_firing_callbacks(monkeypatch):
 
     assert streamed == ["keep"]
     assert "DROPPED" not in streamed
+
+
+def test_dump_api_request_debug_redacts_secrets(monkeypatch, tmp_path, capsys):
+    """Request debug dumps must be safe to attach to bug reports."""
+    import json
+    import agent.redact as redact_mod
+
+    monkeypatch.setattr(redact_mod, "_REDACT_ENABLED", False)
+    monkeypatch.setenv("HERMES_DUMP_REQUEST_STDOUT", "1")
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    agent = _build_agent(monkeypatch)
+    agent.logs_dir = tmp_path
+
+    prefixed_key = "sk-proj-" + ("a" * 40)
+    opaque_header_secret = "Bearer opaque-provider-token-without-known-prefix"
+    opaque_api_token_secret = "opaque-api-token-without-known-prefix"
+    opaque_key_list_secret = "opaque-extra-body-key-without-known-prefix"
+    opaque_token_secret = "opaque-token-without-known-prefix"
+    opaque_cookie_secret = "opaque-session-cookie-without-known-prefix"
+    opaque_x_authorization_secret = "opaque-x-authorization-without-known-prefix"
+    opaque_access_token_secret = "opaque-camel-access-token"
+    opaque_refresh_token_secret = "opaque-camel-refresh-token"
+    opaque_private_key_secret = "opaque-camel-private-key"
+    error = SimpleNamespace(
+        status_code=401,
+        body={"api_key": prefixed_key},
+        response=SimpleNamespace(
+            status_code=401,
+            text=f"upstream rejected Authorization: Bearer {prefixed_key}",
+        ),
+    )
+
+    dump_file = agent._dump_api_request_debug(
+        {
+            "model": "gpt-5-codex",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": f"please echo {prefixed_key}",
+                }
+            ],
+            "extra_headers": {
+                "Authorization": opaque_header_secret,
+                "X-Api-Token": opaque_api_token_secret,
+                "X-Authorization": opaque_x_authorization_secret,
+                "X-Trace": "trace-ok",
+            },
+            "extra_body": {
+                "api_key": [opaque_key_list_secret],
+                "accessToken": opaque_access_token_secret,
+                "client_secret": "plain-secret-value-without-known-prefix",
+                "max_tokens": 4096,
+                "nested": [f"github_pat_{'b' * 40}"],
+                "privateKey": opaque_private_key_secret,
+                "refreshToken": opaque_refresh_token_secret,
+                "session_cookie": opaque_cookie_secret,
+                "token": opaque_token_secret,
+            },
+        },
+        reason="non_retryable_client_error",
+        error=error,
+    )
+
+    assert dump_file is not None
+    raw_dump = dump_file.read_text()
+    printed = capsys.readouterr().out
+    assert json.dumps(json.loads(raw_dump), ensure_ascii=False, indent=2) in printed
+    assert prefixed_key not in raw_dump
+    assert opaque_header_secret not in raw_dump
+    assert opaque_api_token_secret not in raw_dump
+    assert opaque_key_list_secret not in raw_dump
+    assert opaque_cookie_secret not in raw_dump
+    assert opaque_token_secret not in raw_dump
+    assert opaque_x_authorization_secret not in raw_dump
+    assert opaque_access_token_secret not in raw_dump
+    assert opaque_refresh_token_secret not in raw_dump
+    assert opaque_private_key_secret not in raw_dump
+    assert "plain-secret-value-without-known-prefix" not in raw_dump
+    assert f"github_pat_{'b' * 40}" not in raw_dump
+
+    payload = json.loads(raw_dump)
+    assert payload["request"]["headers"]["Authorization"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_headers"]["Authorization"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_headers"]["X-Api-Token"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_headers"]["X-Authorization"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_headers"]["X-Trace"] == "trace-ok"
+    assert payload["request"]["body"]["extra_body"]["api_key"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_body"]["accessToken"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_body"]["client_secret"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_body"]["max_tokens"] == 4096
+    assert payload["request"]["body"]["extra_body"]["privateKey"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_body"]["refreshToken"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_body"]["session_cookie"] == "[REDACTED]"
+    assert payload["request"]["body"]["extra_body"]["token"] == "[REDACTED]"
+    assert payload["error"]["body"]["api_key"] == "[REDACTED]"
+
+
+@pytest.mark.parametrize("key", ["customApiToken", "X-Custom-Api-Token", "clientBearerToken", "sessionToken"])
+def test_request_dump_recognizes_scoped_opaque_token_keys(key):
+    from agent.agent_runtime_helpers import _redact_request_dump_payload
+
+    source = {key: ["opaque-credential"], "max_tokens": 4096}
+    assert _redact_request_dump_payload(source) == {key: "[REDACTED]", "max_tokens": 4096}
+    assert source[key] == ["opaque-credential"]


### PR DESCRIPTION
## Summary

Redact request debug dumps while they are structured, before JSON serialization. The existing text pass can consume JSON quoting around header-like strings and prevent the dump from being written. Opaque secrets in nested or list-valued credential fields also need their key context to be recognized.

Normalize separators, camelCase, and acronym boundaries; redact sensitive fields and scrub other string leaves with the shared forced redactor. Include scoped API/bearer/session/CSRF token keys while retaining benign metadata such as `max_tokens`. Atomic file writes and optional stdout use the same redacted copy; original request data is unchanged.

This is the residual follow-up to merged #46637, related to #46583 and closed #33322. [Confirmed routing](https://github.com/NousResearch/hermes-agent/pull/52905#issuecomment-4806928332). Teknium's opaque-token-header correction remains credited in the commit trailer.

## Validation

The real dump regression failed on the base before the fix. Three additional scoped-token cases failed against the original PR matcher and now pass. The full request/Responses test file passes 68 tests, and the shared redactor passes 116. Final focused dump/key tests pass all seven after removing redundant matcher entries. Disk/stdout parity, forced redaction despite configuration, isolated test home, and unchanged input values are covered. Ruff and whitespace checks pass.

Not checked: full repository suite, live provider calls, native Windows/macOS, or CodeRabbit (self-authored PR without a P0/P1 review route). Redaction recognizes credential keys and known text patterns; it is not a guarantee that arbitrary unlabeled private data is safe to publish.

## Agent disclosure

Earlier corrections: GPT-5.6-sol-xhigh in Codex. Maintenance: GPT-6 in Codex desktop (parent reasoning level unavailable). The account owner loosely reviews these actions and receives the usual GitHub notifications.
