### PR TITLE
fix(mcp): bump initial connect retries 3->6 for slow upstream warmups (salvage of #11646 by @handsdiff)

### DIFF
--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)

--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -3,7 +3,7 @@
 import asyncio
 import os
 import signal
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
 


### PR DESCRIPTION
## Summary

Bumps `_MAX_INITIAL_CONNECT_RETRIES` from **3 → 6** so the initial MCP connection covers a realistic reverse-proxy / DNS warmup window on a freshly-booted VM.

Salvage of #11646 by @handsdiff, re-targeted onto current `main`.

## Root Cause

**Symptom** — On environments where an MCP server's upstream target is still warming up at agent boot (cloud VMs where a reverse-proxy route takes ~30s to become ready), the very first connect attempt receives a transient error (e.g. a 405 from a placeholder route, or DNS not yet propagated). The MCP task gives up, sets `_error`, and — because there's no lazy reconnect on the initial-connect path — the server stays **down for the entire session** until a manual agent restart.

**Root cause** — `tools/mcp_tool.py`: `_MAX_INITIAL_CONNECT_RETRIES = 3` with 1s-based exponential backoff yields a cumulative retry window of only `1+2+4 = 7s`. A ~30s warmup outlasts that budget, so the retry loop exhausts before the upstream is ready.

**Evidence** — The retry loop multiplies backoff by 2 each attempt (`backoff = min(backoff * 2, _MAX_BACKOFF_SECONDS)`), so the cumulative wait before giving up is `2**N - 1` seconds for N retries (capped per-step at `_MAX_BACKOFF_SECONDS = 60`, not hit below N=6). N=3 → 7s; N=6 → 63s. The new regression test computes this budget and asserts it covers ~30s — it **fails at the old value 3** and passes at 6 (captured below).

**Fix + why this level** — Raise only `_MAX_INITIAL_CONNECT_RETRIES` to 6. This is the correct layer: the bug is purely that the initial-connect budget is too short, not that the backoff math or the reconnect path is wrong. `_MAX_RECONNECT_RETRIES` (the *once-healthy-then-dropped* path) is deliberately left unchanged. The per-step `_MAX_BACKOFF_SECONDS=60` cap still bounds any single sleep.

**Scope / risk** — Touches one constant + its tests. Worst case on a genuinely-unreachable server is a longer one-time startup wait (63s vs 7s) before it's reported failed — bounded, and only on the cold-start path. No change to reconnect behavior, tool timeouts, or transport selection.

## Verification

- `pytest tests/tools/test_mcp_stability.py` — **20 passed**
- `pytest tests/tools/test_mcp_stability.py tests/tools/test_mcp_tool.py::TestMCPServerTask::test_no_command_raises` — **24 passed** (`test_no_command_raises` needs no change: `start()` validates the missing `command` before entering the retry loop).
- Patched `asyncio.sleep` in the existing `test_initial_connect_gives_up_after_max_retries` so the now-63s real backoff doesn't exceed the conftest 30s per-test timeout. The delays add nothing to what that test asserts (total attempt count = `_MAX_INITIAL_CONNECT_RETRIES + 1`).

## Real behavior proof

- **Behavior addressed:** initial-connect retry budget too short (7s) to cover a ~30s VM warmup.
- **Real environment:** repo `.venv`, current `origin/main` (`0f81b0d45`).
- **Regression test:** `tests/tools/test_mcp_stability.py::TestMCPInitialConnectionRetry::test_initial_retry_window_covers_vm_warmup` — asserts the cumulative budget `>= 30s`; **fails without the fix, passes with it.**

Captured AFTER the fix (value = 6):
```
$ .venv/bin/python -m pytest tests/tools/test_mcp_stability.py::TestMCPInitialConnectionRetry -q
.....                                                                    [100%]
5 passed in 2.64s
```

Captured with the constant reverted to the old value 3 (proves the test guards the regression):
```
E  AssertionError: initial-connect retry budget is only 7s (_MAX_INITIAL_CONNECT_RETRIES=3); too short to cover a ~30s VM warmup window
E  assert 7 >= 30
FAILED tests/tools/test_mcp_stability.py::...::test_initial_retry_window_covers_vm_warmup
1 failed in 0.33s
```

- **What was NOT tested:** a live end-to-end against a real slow-warmup upstream (no such server available in CI); the change is a bounded constant bump validated by the budget arithmetic + existing retry behavior tests.

## Salvage credit

Original fix and rationale by @handsdiff in #11646. This salvage re-applies the constant bump onto current `main`, preserves the rationale in the code comment, and adds the fail-without-fix regression test.

Closes #11646.
