### PR TITLE
fix(desktop): respect profile scope for cron jobs and messaging sessions

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -414,7 +414,9 @@ export function DesktopController() {
   // still resolves into the Pinned section via sessionByAnyId.
   const refreshCronSessions = useCallback(async () => {
     try {
-      const { sessions } = await listAllProfileSessions(CRON_SECTION_LIMIT, 1, 'exclude', 'recent', 'all', {
+      const cronProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
+
+      const { sessions } = await listAllProfileSessions(CRON_SECTION_LIMIT, 1, 'exclude', 'recent', cronProfile, {
         source: 'cron'
       })
 
@@ -422,7 +424,7 @@ export function DesktopController() {
     } catch {
       // Non-fatal: the cron section just stays empty/stale.
     }
-  }, [])
+  }, [profileScope])
 
   // Messaging-platform sessions as their own slice, fetched separately from
   // local recents so each platform renders a self-managed section and never
@@ -430,7 +432,9 @@ export function DesktopController() {
   // seeds every platform; the sidebar splits the rows per source.
   const refreshMessagingSessions = useCallback(async () => {
     try {
-      const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', 'all', {
+      const msgProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
+
+      const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', msgProfile, {
         excludeSources: MESSAGING_EXCLUDED_SOURCES
       })
 
@@ -445,7 +449,7 @@ export function DesktopController() {
     } catch {
       // Non-fatal: the messaging sections just stay empty/stale.
     }
-  }, [])
+  }, [profileScope])
 
   // Page a single platform's section independently (mirrors the per-profile
   // pager): fetch that source's next window and merge it back in place, leaving
@@ -453,8 +457,9 @@ export function DesktopController() {
   const loadMoreMessagingForPlatform = useCallback(async (platform: string) => {
     const inPlatform = (s: SessionInfo) => normalizeSessionSource(s.source) === platform
     const loaded = $messagingSessions.get().filter(inPlatform).length
+    const loadProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
 
-    const result = await listAllProfileSessions(loaded + SIDEBAR_SESSIONS_PAGE_SIZE, 1, 'exclude', 'recent', 'all', {
+    const result = await listAllProfileSessions(loaded + SIDEBAR_SESSIONS_PAGE_SIZE, 1, 'exclude', 'recent', loadProfile, {
       source: platform
     })
 
@@ -467,7 +472,7 @@ export function DesktopController() {
 
     const total = result.total ?? incoming.length
     setMessagingPlatformTotals(prev => ({ ...prev, [platform]: Math.max(total, incoming.length) }))
-  }, [])
+  }, [profileScope])
 
   // Cron *jobs* drive the sidebar "Cron jobs" section. Jobs are created
   // synchronously (agent tool call or the cron UI), so refreshing here right

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -585,8 +585,10 @@ export function testMessagingPlatform(platformId: string): Promise<MessagingPlat
 }
 
 export function getCronJobs(): Promise<CronJob[]> {
+  const qs = _apiProfile ? `?profile=${encodeURIComponent(_apiProfile)}` : ''
+
   return window.hermesDesktop.api<CronJob[]>({
-    path: '/api/cron/jobs'
+    path: `/api/cron/jobs${qs}`
   })
 }
 


### PR DESCRIPTION
## Problem

When a non-default profile is selected in the Desktop App sidebar, cron jobs from ALL profiles are displayed instead of just the active profile's jobs. This violates profile isolation and confuses users who expect to see only their current profile's data.

## Root Cause

Four functions in the Desktop App frontend were hardcoded to fetch data from `'all'` profiles, ignoring the active profile context:

1. `refreshCronSessions()` - always passed `profile='all'`
2. `refreshMessagingSessions()` - always passed `profile='all'`  
3. `loadMoreMessagingForPlatform()` - always passed `profile='all'`
4. `getCronJobs()` - didn't pass any profile parameter (backend defaulted to `'all'`)

## Solution

Updated these functions to respect the `profileScope` computed store, which reflects the currently selected profile in the sidebar. Each function now:

- Uses `profileScope` instead of hardcoded `'all'`
- Includes `profileScope` in the `useCallback` dependency array to ensure refetch on profile change

## Testing

- Verified lint passes: `npm run lint`
- Verified relevant tests pass: `npm test` for cron and messaging components
- Manual testing confirmed: switching profiles now shows only that profile's cron jobs and messaging sessions

## Impact

- Fixes #52401 (Desktop App shows wrong profile's cron jobs)
- Improves profile isolation UX
- No breaking changes - single-profile users unaffected
