### PR TITLE
fix(agent,tools,cli,plugins): add 'from e' to re-raised exceptions in except-as-e blocks

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -959,7 +959,7 @@ def init_agent(
                 else:
                     print("⚠️  Warning: API key appears invalid or missing")
         except Exception as e:
-            raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
+            raise RuntimeError(f"Failed to initialize OpenAI client: {e}") from e
     
     # Provider fallback chain — ordered list of backup providers tried
     # when the primary is exhausted (rate-limit, overload, connection

--- a/hermes_cli/memory_oauth.py
+++ b/hermes_cli/memory_oauth.py
@@ -43,7 +43,7 @@ def _scope_to_profile(profile: Optional[str]):
     try:
         profiles_mod.validate_profile_name(requested)
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     if not profiles_mod.profile_exists(requested):
         raise HTTPException(status_code=404, detail=f"Profile '{requested}' does not exist.")
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7652,7 +7652,7 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
                 db.set_session_title(sid, body.title or "")
             except ValueError as e:
                 # Title too long, invalid characters, or already in use.
-                raise HTTPException(status_code=400, detail=str(e))
+                raise HTTPException(status_code=400, detail=str(e)) from e
         if body.archived is not None:
             db.set_session_archived(sid, body.archived)
         result = {"ok": True, "title": db.get_session_title(sid) or ""}
@@ -7801,7 +7801,7 @@ def _cron_profile_home(profile: Optional[str]) -> Tuple[str, Path]:
         canon = profiles_mod.normalize_profile_name(raw)
         profiles_mod.validate_profile_name(canon)
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     if not profiles_mod.profile_exists(canon):
         raise HTTPException(status_code=404, detail=f"Profile '{canon}' does not exist.")
     return canon, profiles_mod.get_profile_dir(canon)
@@ -9868,7 +9868,7 @@ def _resolve_profile_dir(name: str) -> Path:
     try:
         profiles_mod.validate_profile_name(name)
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     if not profiles_mod.profile_exists(name):
         raise HTTPException(status_code=404, detail=f"Profile '{name}' does not exist.")
     return profiles_mod.get_profile_dir(name)
@@ -10149,9 +10149,9 @@ async def set_active_profile_endpoint(body: ProfileActiveUpdate):
     try:
         profiles_mod.set_active_profile(body.name)
     except FileNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail=str(e)) from e
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         _log.exception("POST /api/profiles/active failed")
         raise HTTPException(status_code=500, detail=str(e))
@@ -10206,9 +10206,9 @@ async def open_profile_terminal_endpoint(name: str):
                     detail="No supported terminal emulator found",
                 )
     except FileNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail=str(e)) from e
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except HTTPException:
         raise
     except Exception as e:
@@ -10223,7 +10223,7 @@ async def rename_profile_endpoint(name: str, body: ProfileRename):
     try:
         path = profiles_mod.rename_profile(name, body.new_name)
     except FileNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail=str(e)) from e
     except (ValueError, FileExistsError) as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
@@ -10241,9 +10241,9 @@ async def delete_profile_endpoint(name: str):
     try:
         path = profiles_mod.delete_profile(name, yes=True)
     except FileNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail=str(e)) from e
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         _log.exception("DELETE /api/profiles/%s failed", name)
         raise HTTPException(status_code=500, detail=str(e))
@@ -10257,7 +10257,7 @@ async def get_profile_soul(name: str):
         try:
             return {"content": soul_path.read_text(encoding="utf-8"), "exists": True}
         except OSError as e:
-            raise HTTPException(status_code=500, detail=f"Could not read SOUL.md: {e}")
+            raise HTTPException(status_code=500, detail=f"Could not read SOUL.md: {e}") from e
     return {"content": "", "exists": False}
 
 
@@ -10944,7 +10944,7 @@ async def update_config_raw(body: RawConfigUpdate, profile: Optional[str] = None
             save_config(parsed)
         return {"ok": True}
     except yaml.YAMLError as e:
-        raise HTTPException(status_code=400, detail=f"Invalid YAML: {e}")
+        raise HTTPException(status_code=400, detail=f"Invalid YAML: {e}") from e
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -635,7 +635,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
                 pass
         return body
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     finally:
         conn.close()
 
@@ -754,7 +754,7 @@ async def upload_task_attachment(
         att = kanban_db.get_attachment(conn, att_id)
         return {"attachment": _attachment_dict(att) if att else None}
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     finally:
         conn.close()
 
@@ -834,7 +834,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     conn, task_id, payload.assignee or None,
                 )
             except RuntimeError as e:
-                raise HTTPException(status_code=409, detail=str(e))
+                raise HTTPException(status_code=409, detail=str(e)) from e
             if not ok:
                 raise HTTPException(status_code=404, detail="task not found")
 
@@ -1122,7 +1122,7 @@ def add_link(payload: LinkBody, board: Optional[str] = Query(None)):
         kanban_db.link_tasks(conn, payload.parent_id, payload.child_id)
         return {"ok": True}
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     finally:
         conn.close()
 

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -57,7 +57,7 @@ class DaytonaEnvironment(BaseEnvironment):
         except ImportError:
             pass
         except Exception as e:
-            raise ImportError(str(e))
+            raise ImportError(str(e)) from e
         from daytona import (
             Daytona,
             CreateSandboxFromImageParams,

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -88,7 +88,7 @@ def _ensure_modal_sdk() -> None:
     except ImportError:
         pass
     except Exception as e:
-        raise ImportError(str(e))
+        raise ImportError(str(e)) from e
 
 
 def _resolve_modal_image(image_spec: Any) -> Any:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -90,7 +90,7 @@ def _import_edge_tts():
     except ImportError:
         pass
     except Exception as e:
-        raise ImportError(str(e))
+        raise ImportError(str(e)) from e
     import edge_tts
     return edge_tts
 
@@ -111,7 +111,7 @@ def _import_elevenlabs():
         # so older code paths still get a clean ImportError.
         pass
     except Exception as e:  # FeatureUnavailable or any unexpected error
-        raise ImportError(str(e))
+        raise ImportError(str(e)) from e
     from elevenlabs.client import ElevenLabs
     return ElevenLabs
 
@@ -134,7 +134,7 @@ def _import_mistral_client():
     except ImportError:
         pass
     except Exception as e:  # FeatureUnavailable or any unexpected error
-        raise ImportError(str(e))
+        raise ImportError(str(e)) from e
     from mistralai.client import Mistral
     return Mistral
 


### PR DESCRIPTION
## Summary

In `except ... as e:` blocks, re-raising a new exception without `from e` discards the original traceback. Python 3 chains exceptions automatically when `from e` is used, preserving the full causal chain in logs and tracebacks.

## Changes (7 files, 23 fixes)

| File | Count | Pattern |
|------|-------|---------|
| `agent/agent_init.py` | 1 | `raise RuntimeError(...) from e` |
| `tools/tts_tool.py` | 3 | `raise ImportError(str(e)) from e` |
| `tools/environments/daytona.py` | 1 | `raise ImportError(str(e)) from e` |
| `tools/environments/modal.py` | 1 | `raise ImportError(str(e)) from e` |
| `hermes_cli/web_server.py` | 12 | `raise HTTPException(..., detail=str(e)) from e` |
| `hermes_cli/memory_oauth.py` | 1 | `raise HTTPException(..., detail=str(e)) from e` |
| `plugins/kanban/dashboard/plugin_api.py` | 4 | `raise HTTPException(..., detail=str(e)) from e` |

## Before/After

```python
# Before — original exception lost from chain
except ValueError as e:
    raise HTTPException(status_code=400, detail=str(e))

# After — full causal chain preserved in traceback
except ValueError as e:
    raise HTTPException(status_code=400, detail=str(e)) from e
```
