### PR TITLE
fix(desktop): hide bash bootstrap console on Windows

### DIFF
--- a/apps/desktop/electron/bootstrap-runner.cjs
+++ b/apps/desktop/electron/bootstrap-runner.cjs
@@ -378,13 +378,13 @@ function spawnPowerShell(scriptPath, args, { emit, stageName, abortSignal, herme
 
 function spawnBash(scriptPath, args, { emit, stageName, abortSignal, hermesHome } = {}) {
   return new Promise((resolve, reject) => {
-    const child = spawn('bash', [scriptPath, ...args], {
+    const child = spawn('bash', [scriptPath, ...args], hiddenWindowsChildOptions({
       stdio: ['ignore', 'pipe', 'pipe'],
       env: {
         ...process.env,
         HERMES_HOME: hermesHome || process.env.HERMES_HOME || ''
       }
-    })
+    }))
 
     let stdout = ''
     let stderr = ''

--- a/apps/desktop/electron/windows-child-process.test.cjs
+++ b/apps/desktop/electron/windows-child-process.test.cjs
@@ -64,9 +64,10 @@ test('intentional or interactive desktop child processes stay documented', () =>
   assert.match(source, /spawn\('cmd\.exe', \['\/c', 'start'/)
 })
 
-test('bootstrap PowerShell runner hides Windows console children', () => {
+test('bootstrap shell runners hide Windows console children', () => {
   const source = readElectronFile('bootstrap-runner.cjs')
 
   assert.match(source, /function hiddenWindowsChildOptions\(options = \{\}\)/)
-  requireHiddenChildOptions(source, 'spawn(ps, fullArgs')
+  requireHiddenChildOptions(source, 'const child = spawn(\n      ps,\n      fullArgs')
+  requireHiddenChildOptions(source, "spawn('bash'")
 })


### PR DESCRIPTION
## What does this PR do?

Wraps the Electron bootstrap `spawnBash` child-process options in `hiddenWindowsChildOptions()`, matching the existing PowerShell bootstrap runner behavior. This prevents non-interactive bash bootstrap/install helper processes from flashing a visible console window on Windows while preserving the existing stdio/env handling.

## Related Issue

Fixes #52832

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/bootstrap-runner.cjs`: route `spawnBash` options through `hiddenWindowsChildOptions()`.
- `apps/desktop/electron/windows-child-process.test.cjs`: extend the Windows child-process guard test so both bootstrap shell runners are covered.

## How to Test

1. Verified the pre-fix static reproduction failed because `spawnBash` did not wrap its options with `hiddenWindowsChildOptions()`; after the fix it passes.
2. `node --test electron/windows-child-process.test.cjs`
3. `node --test electron/bootstrap-runner.test.cjs electron/windows-child-process.test.cjs`
4. `npm run --prefix apps/desktop lint`
5. `npm run --prefix apps/desktop typecheck`
6. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / PowerShell

Note: I did not run `pytest tests/ -q` because this change is scoped to Electron desktop JavaScript. I ran the relevant Electron tests plus desktop lint/typecheck instead.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## Screenshots / Logs

```text
node --test electron/windows-child-process.test.cjs
# tests 3
# pass 3
# fail 0

node --test electron/bootstrap-runner.test.cjs electron/windows-child-process.test.cjs
# tests 8
# pass 8
# fail 0

npm run --prefix apps/desktop lint
# eslint src/ electron/

npm run --prefix apps/desktop typecheck
# tsc -p . --noEmit
```