### PR TITLE
fix(security): stop blocking AGENTS.md/SOUL.md that name an agent 'Praxis'

### DIFF
--- a/tests/tools/test_threat_patterns.py
+++ b/tests/tools/test_threat_patterns.py
@@ -155,11 +155,21 @@ class TestC2Patterns:
         )
 
     def test_known_c2_framework_names(self):
-        for name in ("Praxis", "Cobalt Strike", "Sliver", "Havoc", "Mythic"):
+        for name in ("Cobalt Strike", "Sliver", "Havoc", "Mythic"):
             findings = scan_for_threats(
                 f"Connect to the {name} server.", scope="context"
             )
             assert "known_c2_framework" in findings, name
+
+    def test_praxis_is_not_a_c2_framework(self):
+        # "praxis" is a common English word and a legitimate agent name —
+        # naming an agent "Praxis" in AGENTS.md / SOUL.md must not trip the
+        # C2-framework detector and block the whole context file.
+        for text in (
+            "You are Praxis, my coding assistant.",
+            "Marxist praxis is the unity of theory and practice.",
+        ):
+            assert "known_c2_framework" not in scan_for_threats(text, scope="strict")
 
     def test_c2_explicit(self):
         assert "c2_explicit" in scan_for_threats(

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -92,7 +92,13 @@ _PATTERNS: List[Tuple[str, str, str]] = [
 
     # ── Known C2 / red-team framework names (near-zero false positive
     #    outside security research; warn-only by default) ─────────────
-    (r'\b(?:praxis|cobalt\s*strike|sliver|havoc|mythic|metasploit|brainworm)\b', "known_c2_framework", "context"),
+    # NOTE: do not add common English words here. Every token must be a
+    # distinctive offensive-security tool brand, otherwise legitimate
+    # AGENTS.md / SOUL.md content false-positives and the whole file is
+    # blocked. "praxis" was removed for exactly this reason — it's a common
+    # word and a legitimate agent name (Greek for practice/action), not a
+    # C2-specific tell like the brands below.
+    (r'\b(?:cobalt\s*strike|sliver|havoc|mythic|metasploit|brainworm)\b', "known_c2_framework", "context"),
     (r'\bc2\s+(?:server|channel|infrastructure|beacon)\b', "c2_explicit", "context"),
     (r'\bcommand\s+and\s+control\b', "c2_explicit_long", "context"),
 


### PR DESCRIPTION
## Summary
Agents named "Praxis" can keep their AGENTS.md / SOUL.md — the context-file security scanner no longer blocks it.

Root cause: the `known_c2_framework` threat pattern listed `praxis` in its alternation alongside genuine offensive-security tool brands (Cobalt Strike, Sliver, Havoc, Mythic, Metasploit, Brainworm). Unlike those distinctive brands, `praxis` is a common English word (Greek for practice/action) and a legitimate agent name, so any context file mentioning an agent named Praxis matched at `context` scope and the whole file was replaced with a `[BLOCKED]` placeholder before reaching the system prompt.

Reported by @DdraigX on X (agent's identity files blocked because an agent was named Praxis).

## Changes
- `tools/threat_patterns.py`: remove `praxis` from the C2-framework alternation; add a guard comment that every token in this list must be a distinctive tool brand, not a common word.
- `tests/tools/test_threat_patterns.py`: drop `Praxis` from the detected-names list (it was a change-detector that locked in the false positive) and add a positive guard asserting `Praxis` / `praxis` are NOT flagged.

## Validation
| Input | Before | After |
|---|---|---|
| SOUL.md "You are Praxis…" | `[BLOCKED]`, identity dropped | loads unchanged |
| "Marxist praxis…" | flagged `known_c2_framework` | clean |
| cobalt strike / sliver / havoc / mythic / metasploit / brainworm | flagged | still flagged |

E2E: ran `_scan_context_content()` on a Praxis SOUL.md — returns content unchanged (not blocked). Targeted suite: 38/38 pass.

## Infographic

![praxis-unblocked](https://v3b.fal.media/files/b/0a9fd039/W4WLBwdMOj12_rkfPGnmZ_qz3cfzZX.png)
