### PR TITLE
feat(discord): add opt-in threaded runs

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2208,6 +2208,11 @@ DEFAULT_CONFIG = {
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
+        "threaded_runs": {
+            "enabled": False,           # Enable explicit/profile-channel Discord threaded runs
+            "explicit_prefixes": True,  # Allow "thread: <task>" style prefixes when enabled
+            "auto_thread_profile_channels": [],  # Channel IDs where new user tasks create scoped threads
+        },
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -56,6 +56,10 @@ _DISCORD_NONCONVERSATIONAL_METADATA_KEYS = frozenset({
     "non_conversational",
     "non_conversational_history",
 })
+_DISCORD_THREADED_RUN_PREFIX_RE = re.compile(
+    r"^\s*(?:discord\s+thread|threaded\s+run|thread|new\s+thread|start\s+thread)\s*:\s*(?P<text>\S[\s\S]*)$",
+    re.IGNORECASE,
+)
 # Upgrade-bridge fallback only. The primary mechanism is the persisted
 # non-conversational message-ID set populated from explicitly marked sends
 # (metadata["non_conversational"]). These regexes exist solely to recognize
@@ -4611,6 +4615,82 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
                 return None
 
+    def _discord_threaded_runs_config(self) -> dict:
+        raw = self.config.extra.get("threaded_runs")
+        return raw if isinstance(raw, dict) else {}
+
+    def _discord_threaded_runs_enabled(self) -> bool:
+        raw = os.getenv("DISCORD_THREADED_RUNS_ENABLED")
+        if raw is None:
+            raw = self._discord_threaded_runs_config().get("enabled", False)
+        return str(raw).strip().lower() in {"true", "1", "yes", "on"}
+
+    def _discord_threaded_run_prefixes_enabled(self) -> bool:
+        if not self._discord_threaded_runs_enabled():
+            return False
+        raw = os.getenv("DISCORD_THREADED_RUN_PREFIXES")
+        if raw is None:
+            raw = self._discord_threaded_runs_config().get("explicit_prefixes", True)
+        return str(raw).strip().lower() not in {"false", "0", "no", "off"}
+
+    def _parse_discord_threaded_run(self, text: str) -> Optional[str]:
+        if not self._discord_threaded_run_prefixes_enabled():
+            return None
+        match = _DISCORD_THREADED_RUN_PREFIX_RE.match(text or "")
+        if not match:
+            return None
+        return match.group("text").strip()
+
+    def _discord_auto_thread_profile_channels(self) -> set[str]:
+        raw = os.getenv("DISCORD_AUTO_THREAD_PROFILE_CHANNELS")
+        if raw is None:
+            raw = self._discord_threaded_runs_config().get("auto_thread_profile_channels", [])
+        if isinstance(raw, bool):
+            return {"*"} if raw else set()
+        if isinstance(raw, (list, tuple, set)):
+            values = [str(v).strip() for v in raw]
+        else:
+            text = str(raw or "").strip()
+            if text.lower() in {"", "false", "0", "no", "off", "none"}:
+                return set()
+            if text.lower() in {"true", "1", "yes", "on", "*"}:
+                return {"*"}
+            values = [part.strip() for part in text.split(",")]
+        return {value for value in values if value}
+
+    def _should_auto_thread_profile_channel(
+        self,
+        *,
+        channel_ids: set[str],
+        text: str,
+        is_thread: bool,
+        is_dm: bool,
+    ) -> bool:
+        if not self._discord_threaded_runs_enabled():
+            return False
+        if is_thread or is_dm:
+            return False
+        if not (text or "").strip() or (text or "").lstrip().startswith("/"):
+            return False
+        no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
+        no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
+        if "*" in no_thread_channels or bool(channel_ids & no_thread_channels):
+            return False
+        profile_channels = self._discord_auto_thread_profile_channels()
+        return "*" in profile_channels or bool(channel_ids & profile_channels)
+
+    async def _create_discord_threaded_run_from_message(
+        self,
+        message: 'DiscordMessage',
+        task_text: str,
+    ) -> Optional[Any]:
+        original_content = message.content
+        try:
+            message.content = task_text
+            return await self._auto_create_thread(message)
+        finally:
+            message.content = original_content
+
     async def create_handoff_thread(
         self,
         parent_chat_id: str,
@@ -5216,6 +5296,7 @@ class DiscordAdapter(BasePlatformAdapter):
             normalized_content = normalized_content.replace(f"<@{self._client.user.id}>", "").strip()
             normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
             message.content = normalized_content
+        channel_ids = set()
         if not isinstance(message.channel, discord.DMChannel):
             channel_ids = {str(message.channel.id)}
             if parent_channel_id:
@@ -5266,11 +5347,41 @@ class DiscordAdapter(BasePlatformAdapter):
             if require_mention and not is_free_channel and not in_bot_thread:
                 if self._client.user not in message.mentions and not mention_prefix:
                     return
+
+        discord_threaded_run_text = self._parse_discord_threaded_run(normalized_content)
+        if discord_threaded_run_text and is_thread:
+            normalized_content = discord_threaded_run_text
+        profile_channel_threaded_run_text = (
+            normalized_content
+            if self._should_auto_thread_profile_channel(
+                channel_ids=channel_ids,
+                text=normalized_content,
+                is_thread=is_thread,
+                is_dm=isinstance(message.channel, discord.DMChannel),
+            )
+            else None
+        )
+
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).
         # Messages already inside threads or DMs are unaffected.
         # no_thread_channels: channels where bot responds directly without thread.
         auto_threaded_channel = None
+        if (
+            (discord_threaded_run_text or profile_channel_threaded_run_text)
+            and not is_thread
+            and not isinstance(message.channel, discord.DMChannel)
+        ):
+            threaded_run_text = discord_threaded_run_text or profile_channel_threaded_run_text or ""
+            thread = await self._create_discord_threaded_run_from_message(message, threaded_run_text)
+            if thread:
+                parent_channel_id = str(message.channel.id)
+                is_thread = True
+                thread_id = str(thread.id)
+                auto_threaded_channel = thread
+                normalized_content = threaded_run_text
+                self._threads.mark(thread_id)
+
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
@@ -7035,9 +7146,13 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
 
     Env vars take precedence over YAML — every assignment is guarded by
     ``not os.getenv(...)`` so explicit env vars survive a config.yaml
-    update.  Returns ``None`` because no extras are seeded into
-    ``PlatformConfig.extra`` directly (everything flows through env).
+    update.  Returns selected non-env settings for ``PlatformConfig.extra``.
     """
+    seeded_extra = {}
+    threaded_runs = discord_cfg.get("threaded_runs")
+    if isinstance(threaded_runs, dict):
+        seeded_extra["threaded_runs"] = dict(threaded_runs)
+
     if "require_mention" in discord_cfg and not os.getenv("DISCORD_REQUIRE_MENTION"):
         os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
     if "thread_require_mention" in discord_cfg and not os.getenv("DISCORD_THREAD_REQUIRE_MENTION"):
@@ -7117,7 +7232,7 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     if _discord_rtm is not None and not os.getenv("DISCORD_REPLY_TO_MODE"):
         _rtm_str = "off" if _discord_rtm is False else str(_discord_rtm).lower()
         os.environ["DISCORD_REPLY_TO_MODE"] = _rtm_str
-    return None  # all settings flow through env; nothing to merge into extras
+    return seeded_extra or None
 
 
 def _is_connected(config) -> bool:

--- a/tests/e2e/test_discord_adapter.py
+++ b/tests/e2e/test_discord_adapter.py
@@ -16,6 +16,7 @@ from tests.e2e.conftest import (
     get_response_text,
     make_discord_message,
     make_fake_dm_channel,
+    make_fake_text_channel,
     make_fake_thread,
 )
 
@@ -102,6 +103,123 @@ class TestAutoThreadingPreservesCommand:
         await dispatch(discord_adapter, msg)
 
         msg.create_thread.assert_awaited_once()
+        response = get_response_text(discord_adapter)
+        assert response is not None
+        assert "/new" in response
+
+
+class TestDiscordThreadedRuns:
+    async def test_thread_prefix_creates_discord_thread_and_dispatches_inside_it(
+        self, discord_adapter, bot_user, monkeypatch
+    ):
+        monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+        discord_adapter.config.extra["threaded_runs"] = {
+            "enabled": True,
+            "explicit_prefixes": True,
+            "auto_thread_profile_channels": [],
+        }
+        fake_thread = make_fake_thread(thread_id=90002, name="investigate")
+        discord_adapter._text_batch_delay_seconds = 0
+        discord_adapter.handle_message = AsyncMock()
+        msg = make_discord_message(
+            content=f"<@{BOT_USER_ID}> thread: investigate Market Weather routing",
+            mentions=[bot_user],
+        )
+        msg.create_thread = AsyncMock(return_value=fake_thread)
+
+        await discord_adapter._handle_message(msg)
+
+        msg.create_thread.assert_awaited_once()
+        create_kwargs = msg.create_thread.await_args.kwargs
+        assert create_kwargs["name"] == "investigate Market Weather routing"
+        discord_adapter.handle_message.assert_awaited_once()
+        event = discord_adapter.handle_message.await_args.args[0]
+        assert event.text == "investigate Market Weather routing"
+        assert event.source.chat_type == "thread"
+        assert event.source.chat_id == "90002"
+        assert event.source.thread_id == "90002"
+
+    async def test_thread_prefix_remains_inline_when_threaded_runs_disabled(
+        self, discord_adapter, bot_user, monkeypatch
+    ):
+        monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+        discord_adapter.config.extra["threaded_runs"] = {
+            "enabled": False,
+            "explicit_prefixes": True,
+            "auto_thread_profile_channels": [],
+        }
+        discord_adapter._text_batch_delay_seconds = 0
+        discord_adapter.handle_message = AsyncMock()
+        msg = make_discord_message(
+            content=f"<@{BOT_USER_ID}> thread: handle this inline",
+            mentions=[bot_user],
+        )
+
+        await discord_adapter._handle_message(msg)
+
+        msg.create_thread.assert_not_awaited()
+        discord_adapter.handle_message.assert_awaited_once()
+        event = discord_adapter.handle_message.await_args.args[0]
+        assert event.text == "thread: handle this inline"
+        assert event.source.chat_type == "group"
+        assert event.source.thread_id is None
+
+    async def test_profile_channel_message_auto_threads_when_configured(
+        self, discord_adapter, bot_user, monkeypatch
+    ):
+        monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+        profile_channel = make_fake_text_channel(
+            channel_id=123456789012345678,
+            name="agent-lobby",
+        )
+        discord_adapter.config.extra["threaded_runs"] = {
+            "enabled": True,
+            "explicit_prefixes": True,
+            "auto_thread_profile_channels": ["123456789012345678"],
+        }
+        fake_thread = make_fake_thread(thread_id=90003, name="review latest", parent=profile_channel)
+        discord_adapter._text_batch_delay_seconds = 0
+        discord_adapter.handle_message = AsyncMock()
+        msg = make_discord_message(
+            content=f"<@{BOT_USER_ID}> review latest wake",
+            channel=profile_channel,
+            mentions=[bot_user],
+        )
+        msg.create_thread = AsyncMock(return_value=fake_thread)
+
+        await discord_adapter._handle_message(msg)
+
+        msg.create_thread.assert_awaited_once()
+        discord_adapter.handle_message.assert_awaited_once()
+        event = discord_adapter.handle_message.await_args.args[0]
+        assert event.text == "review latest wake"
+        assert event.source.chat_type == "thread"
+        assert event.source.chat_id == "90003"
+        assert event.source.thread_id == "90003"
+        assert event.source.parent_chat_id == "123456789012345678"
+
+    async def test_profile_channel_slash_command_stays_inline(
+        self, discord_adapter, bot_user, monkeypatch
+    ):
+        monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+        profile_channel = make_fake_text_channel(
+            channel_id=123456789012345678,
+            name="agent-lobby",
+        )
+        discord_adapter.config.extra["threaded_runs"] = {
+            "enabled": True,
+            "explicit_prefixes": True,
+            "auto_thread_profile_channels": ["123456789012345678"],
+        }
+        msg = make_discord_message(
+            content=f"<@{BOT_USER_ID}> /help",
+            channel=profile_channel,
+            mentions=[bot_user],
+        )
+
+        await dispatch(discord_adapter, msg)
+
+        msg.create_thread.assert_not_awaited()
         response = get_response_text(discord_adapter)
         assert response is not None
         assert "/new" in response

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1079,6 +1079,14 @@ class TestDiscordChannelPromptsConfig:
         assert raw["discord"]["channel_prompts"] == {}
 
 
+class TestDiscordThreadedRunsConfig:
+    def test_default_config_disables_threaded_runs(self):
+        threaded_runs = DEFAULT_CONFIG["discord"]["threaded_runs"]
+        assert threaded_runs["enabled"] is False
+        assert threaded_runs["explicit_prefixes"] is True
+        assert threaded_runs["auto_thread_profile_channels"] == []
+
+
 class TestUserMessagePreviewConfig:
     def test_default_config_preview_line_counts(self):
         preview = DEFAULT_CONFIG["display"]["user_message_preview"]


### PR DESCRIPTION
## What does this PR do?

Adds opt-in Discord threaded runs.

When enabled, Hermes can create a Discord Thread from the user's initial message and dispatch the agent turn inside that new thread before the agent starts working. This lets a Discord channel act as a lightweight task launcher while each task gets its own scoped, replyable conversation.

The feature supports:

- explicit prefixes such as `thread: <task>`, `new thread: <task>`, and `discord thread: <task>`;
- optional profile/lobby channel auto-threading for configured channel IDs;
- existing inline behavior for DMs, slash commands, existing Discord Threads, disabled channels, and no-thread channels.

This is separate from existing `discord.auto_thread` mention behavior, which remains unchanged.

## Changes made

- Add `discord.threaded_runs` config with default `enabled: false`.
- Add explicit threaded-run prefix parsing when threaded runs are enabled.
- Add config-driven profile/lobby channel auto-threading via `auto_thread_profile_channels`.
- Create the Discord Thread before dispatch and route the initial task into the new thread.
- Preserve normal inline behavior for slash commands, DMs, existing threads, and no-thread channels.
- Keep existing `discord.auto_thread` behavior intact.
- Add Discord adapter tests for explicit prefixes, disabled behavior, configured profile-channel auto-threading, and slash command inline behavior.
- Add a config test for the opt-in default.

## How to test

```bash
python3 -m py_compile plugins/platforms/discord/adapter.py hermes_cli/config.py
python3 -m pytest tests/e2e/test_discord_adapter.py tests/hermes_cli/test_config.py -q
```

## Example config

```yaml
discord:
  threaded_runs:
    enabled: true
    explicit_prefixes: true
    auto_thread_profile_channels:
      - "123456789012345678"
```

With explicit prefixes enabled, a message like:

```text
thread: inspect the failing job and summarize the likely cause
```

creates a Discord Thread and dispatches the agent turn inside it with the prefix stripped.
