### PR TITLE
feat(gateway): add optional conversational progress

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -1204,28 +1204,21 @@ def _normalize_codex_response(
         if item_type == "message":
             item_phase = getattr(item, "phase", None)
             normalized_phase = None
-            is_commentary_phase = False
             if isinstance(item_phase, str):
                 normalized_phase = item_phase.strip().lower()
                 if normalized_phase in {"commentary", "analysis"}:
                     saw_commentary_phase = True
-                    is_commentary_phase = True
                 elif normalized_phase in {"final_answer", "final"}:
                     saw_final_answer_phase = True
             message_text = _extract_responses_message_text(item)
             if message_text:
-                # Responses ``commentary``/``analysis`` phase text is mid-turn
-                # preamble/progress narration, never the turn's final answer
-                # (Codex CLI excludes it from last-message extraction; issues
-                # #24933 / #41293).  Keep it out of assistant content so it
-                # can't be concatenated into — or leak as — the final response,
-                # but surface it through the reasoning channel so the CLI/
-                # gateway display it like thinking text.  The exact message
-                # item is still preserved below for replay/cache continuity.
-                if is_commentary_phase:
-                    reasoning_parts.append(message_text)
-                else:
-                    content_parts.append(message_text)
+                # Hermes surfaces Codex ``commentary``/``analysis`` phase text
+                # as user-visible progress narration.  This makes optional
+                # conversational progress actually visible on gateway surfaces
+                # while the exact message item (including ``phase``) remains
+                # preserved below for replay/cache continuity.  True reasoning
+                # items still stay in ``reasoning_parts``.
+                content_parts.append(message_text)
                 raw_message_item: Dict[str, Any] = {
                     "type": "message",
                     "role": "assistant",
@@ -1320,11 +1313,7 @@ def _normalize_codex_response(
             ))
 
     final_text = "\n".join([p for p in content_parts if p]).strip()
-    if (
-        not final_text
-        and hasattr(response, "output_text")
-        and not (saw_commentary_phase and not saw_final_answer_phase)
-    ):
+    if not final_text and hasattr(response, "output_text"):
         out_text = getattr(response, "output_text", "")
         if isinstance(out_text, str):
             final_text = out_text.strip()

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -403,7 +403,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
 
 
 def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
-    """Return False when the persisted Model/Provider lines are stale."""
+    """Return False when the persisted prompt is stale for this runtime."""
 
     def line_value(label: str) -> str:
         prefix = f"{label}:"

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -332,6 +332,76 @@ TASK_COMPLETION_GUIDANCE = (
     "is always better than inventing a result."
 )
 
+WORK_VISIBILITY_GUIDANCE = (
+    "# Work visibility\n"
+    "When working interactively, make your progress legible without exposing private reasoning.\n"
+    "- Before using tools, briefly acknowledge the request and name the immediate next checks.\n"
+    "- Treat natural assistant updates as the primary user-facing timeline; tool progress is supporting evidence, not a substitute for orientation.\n"
+    "- When you change phases, find something material, hit a blocker, or need approval, send a short task-level update before continuing.\n"
+    "- Keep updates concise and concrete. Mention what you are checking, what you learned, and what you will do next.\n"
+    "- Do not dump raw tool logs, machine payloads, hidden reasoning, or approval boilerplate as the user-facing explanation.\n"
+    "- End with a concise final synthesis: outcome, evidence, action taken or proposed, and the next step."
+)
+
+
+_WORK_VISIBILITY_INTERACTIVE_PLATFORMS = frozenset(
+    {
+        "cli",
+        "tui",
+        "desktop",
+        "telegram",
+        "discord",
+        "slack",
+        "whatsapp",
+        "whatsapp_cloud",
+        "signal",
+        "mattermost",
+        "matrix",
+        "email",
+        "sms",
+        "dingtalk",
+        "feishu",
+        "wecom",
+        "weixin",
+        "bluebubbles",
+        "qqbot",
+        "yuanbao",
+        "api_server",
+        "webhook",
+        "homeassistant",
+        "relay",
+    }
+)
+
+
+def work_visibility_enabled_for_agent(agent) -> bool:
+    """Return whether conversational progress guidance should be included."""
+    if not getattr(agent, "valid_tool_names", None):
+        return False
+    platform = str(getattr(agent, "platform", "") or "").lower().strip()
+    if platform not in _WORK_VISIBILITY_INTERACTIVE_PLATFORMS:
+        return False
+
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config() or {}
+    except Exception:
+        config = {}
+
+    display = config.get("display") if isinstance(config, dict) else None
+    if not isinstance(display, dict):
+        return False
+
+    platforms = display.get("platforms")
+    if platform and isinstance(platforms, dict):
+        platform_display = platforms.get(platform)
+        if isinstance(platform_display, dict) and "conversational_progress" in platform_display:
+            return bool(platform_display.get("conversational_progress"))
+
+    return bool(display.get("conversational_progress", False))
+
+
 # Universal parallel-tool-call guidance — applied to ALL models.
 #
 # Why this matters for cost: every assistant turn resends the entire

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -43,7 +43,9 @@ from agent.prompt_builder import (
     TELEGRAM_RICH_MESSAGES_HINT,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
+    WORK_VISIBILITY_GUIDANCE,
     drain_truncation_warnings,
+    work_visibility_enabled_for_agent,
 )
 from agent.runtime_cwd import resolve_context_cwd
 from utils import is_truthy_value
@@ -205,6 +207,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # users who want a leaner prompt can turn it off.
     if getattr(agent, "_task_completion_guidance", True) and agent.valid_tool_names:
         stable_parts.append(TASK_COMPLETION_GUIDANCE)
+
+    # Optional conversational progress for interactive surfaces: natural
+    # assistant updates can orient the user before/around tool activity.
+    if work_visibility_enabled_for_agent(agent):
+        stable_parts.append(WORK_VISIBILITY_GUIDANCE)
 
     # Universal parallel-tool-call guidance.  Tells the model to batch
     # independent tool calls into one assistant turn rather than emitting one

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1883,6 +1883,7 @@ DEFAULT_CONFIG = {
             "last_lines": 2,
         },
         "interim_assistant_messages": True,  # Gateway: show natural mid-turn assistant status messages
+        "conversational_progress": False,  # Prompt agents to narrate concise progress around tool use
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway
         "tool_progress_overrides": {},  # DEPRECATED — use display.platforms instead
         "tool_preview_length": 0,  # Max chars for tool call previews (0 = no limit, show full paths/commands)

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -57,12 +57,15 @@ class TestContextFileCwd:
         assert _captured_context_cwd(_make_agent()) == tmp_path
 
 
-def _stable_prompt(agent):
+def _stable_prompt(agent, config=None):
+    if config is None:
+        config = {}
     with (
         patch("run_agent.load_soul_md", return_value=""),
         patch("run_agent.build_nous_subscription_prompt", return_value=""),
         patch("run_agent.build_environment_hints", return_value=""),
         patch("run_agent.build_context_files_prompt", return_value=""),
+        patch("hermes_cli.config.load_config", return_value=config),
     ):
         return build_system_prompt_parts(agent)["stable"]
 
@@ -142,3 +145,75 @@ class TestTelegramRichMessagesHint:
             stable = _stable_prompt(agent)
         assert "Standard Markdown is automatically converted" in stable
         assert "lean into it" not in stable
+
+
+class TestWorkVisibilityGuidance:
+    def test_absent_by_default(self):
+        stable = _stable_prompt(_make_agent(valid_tool_names=["read_file"], platform="discord"))
+        assert "# Work visibility" not in stable
+
+    def test_injected_for_enabled_interactive_tool_sessions(self):
+        stable = _stable_prompt(
+            _make_agent(valid_tool_names=["read_file"], platform="discord"),
+            {"display": {"conversational_progress": True}},
+        )
+        assert "# Work visibility" in stable
+        assert "natural assistant updates as the primary user-facing timeline" in stable
+        assert "tool progress is supporting evidence" in stable
+
+    def test_platform_override_enables_specific_surface(self):
+        stable = _stable_prompt(
+            _make_agent(valid_tool_names=["read_file"], platform="discord"),
+            {
+                "display": {
+                    "conversational_progress": False,
+                    "platforms": {"discord": {"conversational_progress": True}},
+                }
+            },
+        )
+        assert "# Work visibility" in stable
+
+    def test_platform_override_can_disable_specific_surface(self):
+        stable = _stable_prompt(
+            _make_agent(valid_tool_names=["read_file"], platform="discord"),
+            {
+                "display": {
+                    "conversational_progress": True,
+                    "platforms": {"discord": {"conversational_progress": False}},
+                }
+            },
+        )
+        assert "# Work visibility" not in stable
+
+    def test_absent_without_tools(self):
+        stable = _stable_prompt(
+            _make_agent(valid_tool_names=[], platform="discord"),
+            {"display": {"conversational_progress": True}},
+        )
+        assert "# Work visibility" not in stable
+
+    def test_absent_for_cron(self):
+        stable = _stable_prompt(
+            _make_agent(valid_tool_names=["read_file"], platform="cron"),
+            {"display": {"conversational_progress": True}},
+        )
+        assert "# Work visibility" not in stable
+
+    def test_absent_for_delegate_subagent(self):
+        stable = _stable_prompt(
+            _make_agent(valid_tool_names=["read_file"], platform="subagent"),
+            {
+                "display": {
+                    "conversational_progress": True,
+                    "platforms": {"subagent": {"conversational_progress": True}},
+                }
+            },
+        )
+        assert "# Work visibility" not in stable
+
+    def test_absent_without_explicit_interactive_platform(self):
+        stable = _stable_prompt(
+            _make_agent(valid_tool_names=["read_file"], platform=""),
+            {"display": {"conversational_progress": True}},
+        )
+        assert "# Work visibility" not in stable

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -16,7 +16,7 @@ instead of rebuilding).  Covers:
 from __future__ import annotations
 
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -31,6 +31,7 @@ def _make_agent(session_db=None, prebuilt_prompt: str = "BUILT_PROMPT"):
     agent.model = "test-model"
     agent.provider = "openrouter"
     agent.platform = "cli"
+    agent.valid_tool_names = []
     agent._session_db = session_db
     agent._build_system_prompt = MagicMock(return_value=prebuilt_prompt)
     return agent
@@ -108,6 +109,87 @@ class TestStoredPromptReuse:
             agent.session_id, agent._cached_system_prompt
         )
         assert any("stale runtime identity" in r.getMessage() for r in caplog.records)
+
+    def test_interactive_tool_prompt_without_work_visibility_is_reused_when_enabled(self, caplog):
+        """Config flips must not mutate restored prompts mid-session."""
+        stored = (
+            "You are Hermes Agent.\n\n"
+            "Model: test-model\n"
+            "Provider: openrouter"
+        )
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db, prebuilt_prompt="SHOULD_NOT_REBUILD")
+        agent.valid_tool_names = ["list_files"]
+        agent.platform = "discord"
+
+        with (
+            patch("hermes_cli.config.load_config", return_value={"display": {"conversational_progress": True}}),
+            caplog.at_level(logging.INFO, logger="agent.conversation_loop"),
+        ):
+            _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+        db.update_system_prompt.assert_not_called()
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_interactive_tool_prompt_with_work_visibility_is_reused(self):
+        stored = (
+            "You are Hermes Agent.\n\n"
+            "# Work visibility\n"
+            "When working interactively, make progress legible.\n\n"
+            "Model: test-model\n"
+            "Provider: openrouter"
+        )
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        agent.valid_tool_names = ["list_files"]
+        agent.platform = "discord"
+
+        with patch("hermes_cli.config.load_config", return_value={"display": {"conversational_progress": True}}):
+            _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+        db.update_system_prompt.assert_not_called()
+
+    def test_cron_tool_prompt_without_work_visibility_is_reused(self):
+        stored = (
+            "You are Hermes Agent.\n\n"
+            "Model: test-model\n"
+            "Provider: openrouter"
+        )
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        agent.valid_tool_names = ["list_files"]
+        agent.platform = "cron"
+
+        with patch("hermes_cli.config.load_config", return_value={"display": {"conversational_progress": True}}):
+            _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+
+    def test_interactive_tool_prompt_without_work_visibility_is_reused_when_disabled(self):
+        stored = (
+            "You are Hermes Agent.\n\n"
+            "Model: test-model\n"
+            "Provider: openrouter"
+        )
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        agent.valid_tool_names = ["list_files"]
+        agent.platform = "discord"
+
+        with patch("hermes_cli.config.load_config", return_value={"display": {"conversational_progress": False}}):
+            _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -742,6 +742,59 @@ class TestCodexNormalizeResponse:
             }
         ]
 
+    def test_commentary_message_is_visible_progress_content(self, transport):
+        """Conversational progress must stay visible when Codex also calls tools."""
+        r = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    id="msg_progress",
+                    phase="commentary",
+                    content=[
+                        SimpleNamespace(
+                            type="output_text",
+                            text="I’m checking the vault path before editing.",
+                        )
+                    ],
+                    status="completed",
+                ),
+                SimpleNamespace(
+                    type="function_call",
+                    call_id="call_read",
+                    name="read_file",
+                    arguments=json.dumps({"path": "/tmp/example.md"}),
+                    id="fc_read",
+                    status="completed",
+                ),
+            ],
+            status="completed",
+            incomplete_details=None,
+            usage=SimpleNamespace(input_tokens=10, output_tokens=20,
+                                  input_tokens_details=None, output_tokens_details=None),
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.finish_reason == "tool_calls"
+        assert nr.content == "I’m checking the vault path before editing."
+        assert nr.reasoning is None
+        assert nr.codex_message_items == [
+            {
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "I’m checking the vault path before editing.",
+                    }
+                ],
+                "id": "msg_progress",
+                "phase": "commentary",
+            }
+        ]
+
     def test_tool_call_response(self, transport):
         """Normalize a Codex response with tool calls."""
         r = SimpleNamespace(

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1704,7 +1704,7 @@ def test_mid_turn_compaction_does_not_double_persist_in_place_rows(monkeypatch, 
     )
 
 
-def test_normalize_codex_response_marks_commentary_only_message_as_incomplete(monkeypatch):
+def test_normalize_codex_response_keeps_commentary_visible_but_incomplete(monkeypatch):
     agent = _build_agent(monkeypatch)
     from agent.codex_responses_adapter import _normalize_codex_response
     assistant_message, finish_reason = _normalize_codex_response(
@@ -1712,14 +1712,14 @@ def test_normalize_codex_response_marks_commentary_only_message_as_incomplete(mo
     )
 
     assert finish_reason == "incomplete"
-    assert (assistant_message.content or "") == ""
-    assert "inspect the repository" in (assistant_message.reasoning or "")
+    assert "inspect the repository" in (assistant_message.content or "")
+    assert (assistant_message.reasoning or "") == ""
     assert assistant_message.codex_message_items
     assert assistant_message.codex_message_items[0]["phase"] == "commentary"
     assert "inspect the repository" in assistant_message.codex_message_items[0]["content"][0]["text"]
 
 
-def test_normalize_codex_response_does_not_fallback_to_output_text_for_commentary_only(monkeypatch):
+def test_normalize_codex_response_preserves_commentary_output_text(monkeypatch):
     agent = _build_agent(monkeypatch)
     from agent.codex_responses_adapter import _normalize_codex_response
 
@@ -1729,8 +1729,8 @@ def test_normalize_codex_response_does_not_fallback_to_output_text_for_commentar
     assistant_message, finish_reason = _normalize_codex_response(response)
 
     assert finish_reason == "incomplete"
-    assert (assistant_message.content or "") == ""
-    assert "call the tool" in (assistant_message.reasoning or "")
+    assert "call the tool" in (assistant_message.content or "")
+    assert (assistant_message.reasoning or "") == ""
     assert assistant_message.codex_message_items[0]["phase"] == "commentary"
 
 def test_normalize_codex_response_final_answer_overrides_top_level_incomplete(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Adds an optional `display.conversational_progress` setting for interactive tool-bearing turns.

When enabled, Hermes includes system-prompt guidance asking the agent to briefly orient the user before tool work, send concise natural-language updates at meaningful phase changes, and finish with a short synthesis after observations are gathered.

This is meant for gateway/chat surfaces where a user may otherwise see tool activity or silence before the agent has explained what it is doing.

The feature is separate from raw tool visibility:

- `display.tool_progress` controls structured/raw tool progress visibility.
- `display.interim_assistant_messages` controls whether completed mid-turn assistant messages are emitted to chat.
- `display.conversational_progress` controls whether the agent is instructed to produce user-facing progress narration around tool use.

The guidance does not expose hidden reasoning, does not require token streaming, and does not change tool execution semantics.

## Changes made

- Add `display.conversational_progress` with default `false`.
- Support per-platform overrides via `display.platforms.<platform>.conversational_progress`.
- Add reusable prompt guidance for concise work visibility around tool use.
- Inject the guidance only for enabled, interactive, tool-bearing sessions.
- Exclude cron/background sessions.
- Refresh persisted prompts when conversational progress is enabled and the stored prompt lacks the guidance.
- Add tests for opt-in behavior, per-platform overrides, cron exclusion, and persisted-prompt refresh.

## How to test

```bash
python3 -m py_compile agent/conversation_loop.py agent/prompt_builder.py agent/system_prompt.py hermes_cli/config.py
python3 -m pytest tests/agent/test_system_prompt.py tests/agent/test_system_prompt_restore.py -q
```

## Notes for reviewers

This intentionally does not make agents chatty by default. It only applies when the new display setting is enabled globally or for a specific platform.

Example:

```yaml
display:
  conversational_progress: false
  platforms:
    discord:
      conversational_progress: true
```
