### PR TITLE
Make hindsight_retain respect retain_async

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1718,7 +1718,11 @@ class HindsightMemoryProvider(MemoryProvider):
                 logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
                              self._bank_id, len(content), context)
                 self._run_hindsight_operation(
-                    lambda client: client.aretain_batch(bank_id=self._bank_id, items=[item])
+                    lambda client: client.aretain_batch(
+                        bank_id=self._bank_id,
+                        items=[item],
+                        retain_async=self._retain_async,
+                    )
                 )
                 logger.debug("Tool hindsight_retain: success")
                 return json.dumps({"result": "Memory stored successfully."})

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -646,6 +646,7 @@ class TestToolHandlers:
         provider._client.aretain_batch.assert_called_once()
         call_kwargs = provider._client.aretain_batch.call_args.kwargs
         assert call_kwargs["bank_id"] == "test-bank"
+        assert call_kwargs["retain_async"] is True
         item = call_kwargs["items"][0]
         assert item["content"] == "user likes dark mode"
         # bank_id/retain_async are call-level args, never item keys.


### PR DESCRIPTION
## Summary
- Pass the configured retain_async flag through explicit hindsight_retain tool calls
- Assert the call-level retain_async argument in the Hindsight provider test

## Testing
- PYTHONPYCACHEPREFIX=/tmp/hermes-pycache python3 -m compileall -q plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py
- Not run: pytest, because pytest/uv were not installed in the local PATH at the time of the change