### PR TITLE
fix(backup): include projects.db and kanban.db in pre-update snapshot

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -762,6 +762,15 @@ _QUICK_STATE_FILES = (
     "channel_directory.json",
     "channel_aliases.json",
     "processes.json",
+    # Per-profile user-created stores that live outside the git checkout and are
+    # therefore destroyed if the post-update CREATE TABLE IF NOT EXISTS runs
+    # against a missing file (issue #52889).  projects.db is always at
+    # $HERMES_HOME/projects.db (projects_db.projects_db_path).  kanban.db lives
+    # at the shared-root for the default profile ($HERMES_HOME/kanban.db); on
+    # non-root profiles its real path is outside HERMES_HOME and the entry is
+    # silently skipped — handled here best-effort, same as the pairing stores.
+    "projects.db",                      # per-profile project store
+    "kanban.db",                        # kanban board (default/root profile)
     # Pairing stores (generic + per-platform JSONs outside state.db)
     "pairing",                          # legacy location (gateway/pairing.py)
     "platforms/pairing",                # new location (gateway/pairing.py)

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1666,6 +1666,71 @@ class TestQuickSnapshot:
         # Cleanup the seeded escape source so the test is hermetic.
         escape_src.unlink()
 
+
+class TestQuickSnapshotProjectsKanban:
+    """Regression for #52889: projects.db / kanban.db must survive an upgrade.
+
+    Both are per-profile user-created stores outside the git checkout. If they
+    are not in the pre-update snapshot, the post-update ``CREATE TABLE IF NOT
+    EXISTS`` runs against a missing file and every project / board row is lost.
+    """
+
+    @pytest.fixture
+    def hermes_home(self, tmp_path):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        # Minimal critical file so the snapshot is non-empty.
+        (home / "config.yaml").write_text("model:\n  provider: openrouter\n")
+
+        for name, table, row in (
+            ("projects.db", "projects", ("p1", "demo")),
+            ("kanban.db", "tasks", ("t1", "todo")),
+        ):
+            conn = sqlite3.connect(str(home / name))
+            conn.execute(f"CREATE TABLE {table} (id TEXT PRIMARY KEY, data TEXT)")
+            conn.execute(f"INSERT INTO {table} VALUES (?, ?)", row)
+            conn.commit()
+            conn.close()
+        return home
+
+    def test_in_quick_state_files(self):
+        from hermes_cli.backup import _QUICK_STATE_FILES
+        assert "projects.db" in _QUICK_STATE_FILES
+        assert "kanban.db" in _QUICK_STATE_FILES
+
+    def test_projects_db_snapshotted(self, hermes_home):
+        from hermes_cli.backup import create_quick_snapshot
+        snap_id = create_quick_snapshot(hermes_home=hermes_home)
+        copy = hermes_home / "state-snapshots" / snap_id / "projects.db"
+        assert copy.exists()
+        conn = sqlite3.connect(str(copy))
+        rows = conn.execute("SELECT * FROM projects").fetchall()
+        conn.close()
+        assert rows == [("p1", "demo")]
+
+    def test_kanban_db_snapshotted(self, hermes_home):
+        from hermes_cli.backup import create_quick_snapshot
+        snap_id = create_quick_snapshot(hermes_home=hermes_home)
+        copy = hermes_home / "state-snapshots" / snap_id / "kanban.db"
+        assert copy.exists()
+
+    def test_restore_recreates_emptied_projects_db(self, hermes_home):
+        from hermes_cli.backup import create_quick_snapshot, restore_quick_snapshot
+        snap_id = create_quick_snapshot(hermes_home=hermes_home)
+
+        # Simulate the upgrade wiping the store back to an empty schema.
+        conn = sqlite3.connect(str(hermes_home / "projects.db"))
+        conn.execute("DELETE FROM projects")
+        conn.commit()
+        conn.close()
+
+        assert restore_quick_snapshot(snap_id, hermes_home=hermes_home) is True
+        conn = sqlite3.connect(str(hermes_home / "projects.db"))
+        rows = conn.execute("SELECT * FROM projects").fetchall()
+        conn.close()
+        assert rows == [("p1", "demo")]
+
+
 class TestPreUpdateBackup:
     """Tests for create_pre_update_backup — the auto-backup ``hermes update``
     runs before touching anything."""


### PR DESCRIPTION
## What does this PR do?

The pre-update quick snapshot (`_QUICK_STATE_FILES` in `hermes_cli/backup.py`) preserves `state.db`, `config.yaml`, `auth.json` and the pairing stores before `hermes update` pulls, but it never listed `projects.db` or `kanban.db`. Both are per-profile, user-created SQLite stores that live **outside** the git checkout.

When a desktop upgrade restarts the backend and `projects_db.connect()` (or the kanban store) runs `CREATE TABLE IF NOT EXISTS` against a missing or zeroed file, every project, folder mapping, the active-project pointer and all board rows are silently re-created empty — with no backup and no recovery path. Every upgrade destroys all projects.

This adds both files to `_QUICK_STATE_FILES` so they are snapshotted alongside `state.db` and restored automatically if anything goes wrong, exactly as the issue suggests.

## Related Issue

Fixes #52889

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/backup.py`: add `"projects.db"` and `"kanban.db"` to `_QUICK_STATE_FILES`. The existing `.db` branch already routes them through `_safe_copy_db` (WAL-safe copy), so no other code path changes.
- `tests/hermes_cli/test_backup.py`: add `TestQuickSnapshotProjectsKanban` — asserts both files are in the manifest set, both get snapshotted (with row-level verification for `projects.db`), and an emptied `projects.db` is restored from the snapshot.

## Implementation note

The snapshot list is resolved **relative to `HERMES_HOME`** (`src = home / rel`). `projects.db` always resolves to `$HERMES_HOME/projects.db` (per `projects_db.projects_db_path`), so it is covered for every profile. `kanban.db` sits at the **shared root**, which equals `HERMES_HOME` for the default/root profile; on non-root profiles its real path is outside `HERMES_HOME` and the entry is silently skipped — the same best-effort behavior the pairing entries already rely on. A fully profile-aware kanban path (resolving via `kanban_db.kanban_db_path`) would need separate handling outside the relative-to-home model and is left as a follow-up; this PR fixes the reported data-loss for the default install where the bug bites.

## How to Test

1. `uv run python -m pytest tests/hermes_cli/test_backup.py -q` → 141 passed.
2. Manual: create a project (`hermes project create`), run a pre-update snapshot, empty `projects.db`, restore the snapshot — the project rows come back.

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the suite and all tests pass (`tests/hermes_cli/test_backup.py`, 141 passed, ruff clean)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 14
- [x] Cross-platform impact considered — snapshot paths are `HERMES_HOME`-relative; behavior identical on Windows/macOS/Linux