### PR TITLE
fix(telegram): stabilize streamed overflow markdown delivery

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -250,6 +250,11 @@ class GatewayStreamConsumer:
         # Telegram overflow delivery.  In that case the already-visible prefix
         # is intentional content, not a stale preview to delete.
         self._fallback_preserve_partial_messages = False
+        # True when the streamed/overflow prefix was visibly degraded relative
+        # to the raw final markdown (e.g. Telegram fell back from MarkdownV2 to
+        # plain text). In that case exact-prefix tail dedupe is unsafe: resend
+        # the full final text and delete the stale partial instead.
+        self._fallback_lossy_prefix = False
         # Keep fallback recovery responsive. Telegram's adapter already bounds
         # edit retries at five seconds; a final-delivery fallback must not hold
         # the stream task through a longer flood cooldown before retrying.
@@ -545,6 +550,7 @@ class GatewayStreamConsumer:
         self._fallback_final_send = False
         self._fallback_prefix = ""
         self._fallback_preserve_partial_messages = False
+        self._fallback_lossy_prefix = False
         self._segment_preview_message_ids = set()
         # #29346: a tool/segment boundary means what we delivered was an interim
         # preamble, not the final answer — clear the flags so a premature setter
@@ -1251,6 +1257,8 @@ class GatewayStreamConsumer:
 
     def _continuation_text(self, final_text: str) -> str:
         """Return only the part of final_text the user has not already seen."""
+        if self._fallback_lossy_prefix:
+            return final_text
         prefix = self._fallback_prefix or self._visible_prefix()
         if prefix and final_text.startswith(prefix):
             return final_text[len(prefix):].lstrip()
@@ -1510,6 +1518,7 @@ class GatewayStreamConsumer:
         self._last_sent_text = chunks[-1]
         self._fallback_prefix = ""
         self._fallback_preserve_partial_messages = False
+        self._fallback_lossy_prefix = False
 
     async def _send_empty_fallback_final(self, final_text: str) -> str:
         """Commit a completed answer after Telegram finalization fails.
@@ -2219,14 +2228,20 @@ class GatewayStreamConsumer:
                                 or self._message_id
                             )
                             delivered_prefix = raw_response.get("delivered_prefix")
+                            lossy_markdown_fallback = bool(
+                                raw_response.get("lossy_markdown_fallback")
+                            )
                             if isinstance(delivered_prefix, str) and delivered_prefix:
                                 self._last_sent_text = delivered_prefix
                                 self._fallback_prefix = delivered_prefix
-                                self._fallback_preserve_partial_messages = text.startswith(
-                                    delivered_prefix
+                                self._fallback_lossy_prefix = lossy_markdown_fallback
+                                self._fallback_preserve_partial_messages = (
+                                    text.startswith(delivered_prefix)
+                                    and not lossy_markdown_fallback
                                 )
                             else:
                                 self._fallback_prefix = self._visible_prefix()
+                                self._fallback_lossy_prefix = False
                                 self._fallback_preserve_partial_messages = False
                             self._fallback_final_send = True
                             self._edit_supported = False
@@ -2239,6 +2254,7 @@ class GatewayStreamConsumer:
                         # limiting, use adaptive backoff: double the edit interval
                         # and retry on the next cycle.  Only permanently disable
                         # edits after _MAX_FLOOD_STRIKES consecutive failures.
+                        immediate_final_fallback = False
                         if self._is_flood_error(result):
                             self._flood_strikes += 1
                             self._current_edit_interval = min(
@@ -2269,7 +2285,6 @@ class GatewayStreamConsumer:
                                 # respects the new interval.
                                 self._last_edit_time = time.monotonic()
                                 return False
-
                             if immediate_final_fallback:
                                 logger.debug(
                                     "Turn-final edit hit flood control; "
@@ -2284,6 +2299,15 @@ class GatewayStreamConsumer:
                             self._flood_strikes,
                         )
                         self._fallback_prefix = self._visible_prefix()
+                        if immediate_final_fallback:
+                            # The visible prefix is a raw streaming preview, not
+                            # a finalized Telegram MarkdownV2/rich chunk.  Do
+                            # not send only the tail: that leaves the first
+                            # visible message unformatted.  Mark it lossy so the
+                            # fallback path resends the full final answer and
+                            # best-effort deletes the stale preview.
+                            self._fallback_lossy_prefix = True
+                            self._fallback_preserve_partial_messages = False
                         self._fallback_final_send = True
                         self._edit_supported = False
                         self._already_sent = True

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -638,6 +638,7 @@ class TelegramAdapter(BasePlatformAdapter):
     # Threshold for detecting Telegram client-side message splits.
     # When a chunk is near this limit, a continuation is almost certain.
     _SPLIT_THRESHOLD = 4000
+    FALLBACK_ON_FINAL_EDIT_FLOOD = True
     MEDIA_GROUP_WAIT_SECONDS = 0.8
     _GENERAL_TOPIC_THREAD_ID = "1"
 
@@ -1345,6 +1346,41 @@ class TelegramAdapter(BasePlatformAdapter):
             return isinstance(error, BadRequest)
         except ImportError:
             return False
+
+    @classmethod
+    def _should_fallback_markdown_to_plain_text(cls, error: Exception) -> bool:
+        """True only for permanent markdown-formatting failures.
+
+        Telegram flood control / network faults must bubble to the outer retry
+        logic instead of degrading a streamed preview to plain text. Otherwise
+        users briefly see an unformatted first message, then a later formatted
+        continuation/final message.
+        """
+        err_lower = str(error).lower()
+        if "not modified" in err_lower:
+            return False
+        if getattr(error, "retry_after", None) is not None or "retry after" in err_lower:
+            return False
+        transient_markers = (
+            "timed out",
+            "timeout",
+            "readtimeout",
+            "writetimeout",
+            "connecterror",
+            "connect error",
+            "connection error",
+            "networkerror",
+            "network error",
+            "server disconnected",
+            "temporarily unavailable",
+            "temporary failure",
+            "httpx",
+        )
+        if any(marker in err_lower for marker in transient_markers):
+            return False
+        if cls._is_bad_request_error(error):
+            return True
+        return "parse" in err_lower or "markdown" in err_lower or "entity" in err_lower
 
     @classmethod
     def _should_retry_without_dm_topic_reply_anchor(
@@ -4856,6 +4892,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 # "Message is not modified" is a no-op, not an error
                 if "not modified" in str(fmt_err).lower():
                     return SendResult(success=True, message_id=message_id)
+                if not self._should_fallback_markdown_to_plain_text(fmt_err):
+                    raise
                 # Fallback: strip MarkdownV2 escapes and retry as clean plain text
                 safe_format_error = _redact_telegram_error_text(fmt_err)
                 logger.warning(
@@ -5013,6 +5051,8 @@ class TelegramAdapter(BasePlatformAdapter):
             # if truncate_message returned a single chunk just edit normally.
             chunks = [content]
 
+        lossy_markdown_fallback = False
+
         # Step 1 — edit the existing message with the first chunk.
         first_chunk = chunks[0]
         try:
@@ -5031,11 +5071,18 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                 except Exception as fmt_err:
                     if "not modified" not in str(fmt_err).lower():
+                        if not self._should_fallback_markdown_to_plain_text(fmt_err):
+                            return SendResult(
+                                success=False,
+                                error=str(fmt_err),
+                                retryable=True,
+                            )
                         logger.warning(
                             "[%s] Overflow split: MarkdownV2 first-chunk edit "
                             "failed, falling back to plain text: %s",
                             self.name, _redact_telegram_error_text(fmt_err),
                         )
+                        lossy_markdown_fallback = True
                         await self._bot.edit_message_text(
                             chat_id=normalize_telegram_chat_id(chat_id),
                             message_id=int(message_id),
@@ -5072,6 +5119,7 @@ class TelegramAdapter(BasePlatformAdapter):
         thread_id = self._metadata_thread_id(metadata)
         for chunk in chunks[1:]:
             sent_msg = None
+            continuation_error: Exception | None = None
             reply_to_id = int(prev_id) if prev_id else None
             thread_kwargs = self._thread_kwargs_for_send(
                 chat_id,
@@ -5127,15 +5175,22 @@ class TelegramAdapter(BasePlatformAdapter):
                                 "[%s] Overflow continuation no-reply retry failed: %s",
                                 self.name, _redact_telegram_error_text(_retry_err),
                             )
+                            continuation_error = _retry_err
                             sent_msg = None
                             break
                     if use_markdown:
-                        # try plain text on next loop iteration
-                        continue
+                        if self._should_fallback_markdown_to_plain_text(send_err):
+                            # try plain text on next loop iteration
+                            lossy_markdown_fallback = True
+                            continue
+                        continuation_error = send_err
+                        sent_msg = None
+                        break
                     logger.warning(
                         "[%s] Overflow continuation send failed: %s",
                         self.name, _redact_telegram_error_text(send_err),
                     )
+                    continuation_error = send_err
                     sent_msg = None
                     break
             if sent_msg is None:
@@ -5153,17 +5208,25 @@ class TelegramAdapter(BasePlatformAdapter):
                     re.sub(r" \(\d+/\d+\)$", "", delivered)
                     for delivered in delivered_chunks
                 )
+                error_text = "overflow_continuation_failed"
+                retry_after = None
+                if continuation_error is not None:
+                    retry_after = getattr(continuation_error, "retry_after", None)
+                    if retry_after is not None or "retry after" in str(continuation_error).lower():
+                        error_text = str(continuation_error)
                 return SendResult(
                     success=False,
                     message_id=prev_id,
-                    error="overflow_continuation_failed",
+                    error=error_text,
                     retryable=True,
+                    retry_after=retry_after,
                     raw_response={
                         "partial_overflow": True,
                         "delivered_chunks": 1 + len(continuation_ids),
                         "total_chunks": len(chunks),
                         "last_message_id": prev_id,
                         "delivered_prefix": delivered_prefix,
+                        "lossy_markdown_fallback": lossy_markdown_fallback,
                         "continuation_message_ids": tuple(continuation_ids),
                     },
                     continuation_message_ids=tuple(continuation_ids),

--- a/tests/gateway/test_telegram_overflow_partial.py
+++ b/tests/gateway/test_telegram_overflow_partial.py
@@ -48,3 +48,235 @@ async def test_edit_overflow_split_reports_later_partial_failure_after_some_cont
     assert result.continuation_message_ids == ("202",)
 
 
+@pytest.mark.asyncio
+async def test_edit_overflow_split_reports_partial_failure_when_continuation_fails(telegram_adapter):
+    """A failed continuation must not be reported as final delivery."""
+    content = "word " * 120
+    telegram_adapter._bot.edit_message_text = AsyncMock(return_value=True)
+    telegram_adapter._bot.send_message = AsyncMock(
+        side_effect=[RuntimeError("telegram send failed"), RuntimeError("telegram send failed")]
+    )
+
+    result = await telegram_adapter._edit_overflow_split(
+        "12345", "201", content, finalize=False, metadata={"thread_id": "77"}
+    )
+
+    assert result.success is False
+    assert result.retryable is True
+    assert result.error == "overflow_continuation_failed"
+    assert result.message_id == "201"
+    assert result.raw_response["partial_overflow"] is True
+    assert result.raw_response["delivered_chunks"] == 1
+    assert result.raw_response["total_chunks"] > 1
+    assert result.raw_response["last_message_id"] == "201"
+    assert result.raw_response["delivered_prefix"]
+    assert result.continuation_message_ids == ()
+
+
+@pytest.mark.asyncio
+async def test_edit_overflow_split_marks_lossy_markdown_fallback_when_plain_text_was_used(
+    telegram_adapter,
+):
+    """If Telegram degraded a partial overflow chunk to plain text, the
+    fallback path must know the visible prefix no longer matches the raw final
+    markdown exactly.
+    """
+    content = "**bold** line\n" * 40
+    telegram_adapter._bot.edit_message_text = AsyncMock(
+        side_effect=[RuntimeError("can't parse entities"), True]
+    )
+    telegram_adapter._bot.send_message = AsyncMock(
+        side_effect=[RuntimeError("can't parse entities"), RuntimeError("telegram send failed")]
+    )
+
+    result = await telegram_adapter._edit_overflow_split(
+        "12345", "201", content, finalize=True, metadata={"thread_id": "77"}
+    )
+
+    assert result.success is False
+    assert result.raw_response["partial_overflow"] is True
+    assert result.raw_response["lossy_markdown_fallback"] is True
+
+
+@pytest.mark.asyncio
+async def test_edit_overflow_split_does_not_fallback_first_chunk_to_plain_text_on_retry_after(
+    telegram_adapter,
+):
+    class FakeRetryAfter(Exception):
+        def __init__(self, seconds):
+            super().__init__(f"Flood control exceeded. Retry in {seconds} seconds")
+            self.retry_after = seconds
+
+    content = "**bold** line\n" * 40
+    telegram_adapter._bot.edit_message_text = AsyncMock(side_effect=FakeRetryAfter(78))
+    telegram_adapter._bot.send_message = AsyncMock()
+
+    result = await telegram_adapter._edit_overflow_split(
+        "12345", "201", content, finalize=True, metadata={"thread_id": "77"}
+    )
+
+    assert result.success is False
+    assert "Retry in 78 seconds" in result.error
+    assert telegram_adapter._bot.edit_message_text.await_count == 1
+    telegram_adapter._bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_edit_overflow_split_does_not_fallback_continuation_to_plain_text_on_retry_after(
+    telegram_adapter,
+):
+    class FakeRetryAfter(Exception):
+        def __init__(self, seconds):
+            super().__init__(f"Flood control exceeded. Retry in {seconds} seconds")
+            self.retry_after = seconds
+
+    content = "**bold** line\n" * 40
+    telegram_adapter._bot.edit_message_text = AsyncMock(return_value=True)
+    telegram_adapter._bot.send_message = AsyncMock(side_effect=FakeRetryAfter(78))
+
+    result = await telegram_adapter._edit_overflow_split(
+        "12345", "201", content, finalize=True, metadata={"thread_id": "77"}
+    )
+
+    assert result.success is False
+    assert "Retry in 78 seconds" in result.error
+    # One markdown continuation attempt only; no plain-text retry.
+    assert telegram_adapter._bot.send_message.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_fallback_sends_tail_after_partial_overflow():
+    """A partial overflow edit enters fallback instead of marking final delivered."""
+    adapter = MagicMock()
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.edit_message = AsyncMock(
+        return_value=SendResult(
+            success=False,
+            message_id="preview-1",
+            error="overflow_continuation_failed",
+            retryable=True,
+            raw_response={
+                "partial_overflow": True,
+                "delivered_chunks": 1,
+                "total_chunks": 2,
+                "last_message_id": "preview-1",
+                "delivered_prefix": "hello ",
+            },
+        )
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="tail-1"))
+    adapter.delete_message = AsyncMock(return_value=True)
+
+    consumer = GatewayStreamConsumer(adapter, "chat-1", metadata={"thread_id": "77"})
+    consumer._message_id = "preview-1"
+    consumer._last_sent_text = "hello "
+
+    ok = await consumer._send_or_edit("hello world", finalize=True)
+
+    assert ok is False
+    assert consumer.final_response_sent is False
+    assert consumer.final_content_delivered is False
+    assert consumer._fallback_final_send is True
+    assert consumer._fallback_prefix == "hello "
+
+    await consumer._send_fallback_final("hello world")
+
+    adapter.send.assert_awaited_once()
+    assert adapter.send.await_args.kwargs["content"] == "world"
+    assert adapter.send.await_args.kwargs["metadata"] == {"thread_id": "77", "notify": True}
+    adapter.delete_message.assert_not_awaited()
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_resends_full_text_when_partial_overflow_prefix_was_lossy():
+    """If Telegram showed the partial prefix as plain text after MarkdownV2
+    fallback, the raw final markdown no longer shares an exact prefix. In that
+    case the safest recovery is to resend the full final text and delete the
+    stale partial instead of sending only the tail.
+    """
+    adapter = MagicMock()
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.edit_message = AsyncMock(
+        return_value=SendResult(
+            success=False,
+            message_id="preview-1",
+            error="overflow_continuation_failed",
+            retryable=True,
+            raw_response={
+                "partial_overflow": True,
+                "delivered_chunks": 1,
+                "total_chunks": 2,
+                "last_message_id": "preview-1",
+                "delivered_prefix": "**bold** ",
+                "lossy_markdown_fallback": True,
+            },
+        )
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="tail-1"))
+    adapter.delete_message = AsyncMock(return_value=True)
+
+    consumer = GatewayStreamConsumer(adapter, "chat-1", metadata={"thread_id": "77"})
+    consumer._message_id = "preview-1"
+    consumer._last_sent_text = "**bold** "
+
+    ok = await consumer._send_or_edit("**bold** world", finalize=True)
+
+    assert ok is False
+    assert consumer._fallback_preserve_partial_messages is False
+
+    await consumer._send_fallback_final("**bold** world")
+
+    adapter.send.assert_awaited_once()
+    assert adapter.send.await_args.kwargs["content"] == "**bold** world"
+    adapter.delete_message.assert_awaited_once_with("chat-1", "preview-1")
+    assert consumer.final_response_sent is True
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_resends_full_text_after_final_flood_on_raw_preview():
+    """A turn-final flood-control failure leaves a raw streaming preview on
+    screen.  The fallback must not treat that preview as a safe formatted
+    prefix; resend the full final markdown and delete the stale preview.
+    """
+    adapter = MagicMock()
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.FALLBACK_ON_FINAL_EDIT_FLOOD = True
+    adapter.edit_message = AsyncMock(
+        return_value=SendResult(
+            success=False,
+            message_id="preview-1",
+            error="flood_control: retry after 14 seconds",
+            retry_after=14.0,
+        )
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="final-1"))
+    adapter.delete_message = AsyncMock(return_value=True)
+
+    consumer = GatewayStreamConsumer(adapter, "chat-1", metadata={"thread_id": "77"})
+    final_text = "Przejrzałem aplikację realnie\n\n**Stan ogólny: dobry MVP.**\n"
+    final_text += "x" * 4500
+    raw_preview = final_text[:3900]
+    consumer._message_id = "preview-1"
+    consumer._last_sent_text = raw_preview
+
+    ok = await consumer._send_or_edit(final_text, finalize=True)
+
+    assert ok is False
+    assert consumer._fallback_final_send is True
+    assert consumer._fallback_lossy_prefix is True
+    assert consumer._fallback_preserve_partial_messages is False
+
+    await consumer._send_fallback_final(final_text)
+
+    sent_chunks = [call.kwargs["content"] for call in adapter.send.await_args_list]
+    assert "".join(sent_chunks) == final_text
+    assert sent_chunks[0].startswith("Przejrzałem aplikację realnie")
+    assert all(
+        call.kwargs["metadata"] == {"thread_id": "77", "notify": True}
+        for call in adapter.send.await_args_list
+    )
+    adapter.delete_message.assert_awaited_once_with("chat-1", "preview-1")
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -434,11 +434,50 @@ async def test_finalize_edit_uses_rich_for_table_content():
 
 
 @pytest.mark.asyncio
+async def test_finalize_edit_plain_content_stays_legacy():
+    """Finalizing plain content (no table/task-list/details/math) uses the
+    legacy MarkdownV2 edit_message_text path, not the rich edit endpoint."""
+    adapter = _make_adapter()
+
+    result = await adapter.edit_message(
+        "12345", "555", "Just a normal answer, no rich constructs.", finalize=True,
+    )
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_not_called()
+    adapter._bot.edit_message_text.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_finalize_edit_flood_control_does_not_degrade_to_plain_text():
+    """RetryAfter during MarkdownV2 finalize must bubble to flood-control
+    handling instead of downgrading the visible preview to plain text.
+    """
+    adapter = _make_adapter()
+
+    class FakeRetryAfter(Exception):
+        def __init__(self, seconds):
+            super().__init__(f"Flood control exceeded. Retry in {seconds} seconds")
+            self.retry_after = seconds
+
+    adapter._bot.do_api_request = AsyncMock(return_value=None)
+    adapter._bot.edit_message_text = AsyncMock(side_effect=FakeRetryAfter(135))
+
+    result = await adapter.edit_message(
+        "12345", "555", "**bold**\n\n- item one\n- item two", finalize=True,
+    )
+
+    assert result.success is False
+    assert result.error == "flood_control:135"
+    assert adapter._bot.edit_message_text.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_legacy_edit_error_logs_redacted_bot_token_without_traceback(monkeypatch, caplog):
     import agent.redact as redact
 
     monkeypatch.setattr(redact, "_REDACT_ENABLED", False)
-    token = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef"
+    token = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi"
     adapter = _make_adapter()
     adapter._bot.edit_message_text = AsyncMock(
         side_effect=BadRequest(


### PR DESCRIPTION
## Bug Description

Long streamed Telegram replies could surface a lossy partial message before the clean final delivery completed.

In end-to-end testing this showed up as one or more of the following:

- the prefix of a long reply being duplicated
- the first visible chunk arriving as plain text while a later chunk was correctly formatted
- a long reply being split into multiple messages where the first lost Markdown and the later one was correct

This was most noticeable on richly formatted responses that crossed Telegram's legacy edit limit and exercised overflow-split and retry / flood-control paths.

## Root Cause

Several related delivery paths treated transient send/edit failures too similarly to real Markdown parse failures:

1. partial-overflow handling could preserve and reuse an already-lossy prefix
2. finalize-time MarkdownV2 fallback could downgrade to plain text on retry/flood-control style failures instead of reserving that fallback for true parse/entity errors
3. overflow-split delivery had a parallel downgrade path that could still emit an unformatted first chunk under RetryAfter / flood-control conditions
4. preview/final coordination around overflow could leave an extra visible partial message before clean final delivery

The net effect was that temporary delivery problems could become user-visible formatting loss.

## Fix

This change narrows Telegram fallback behavior so long streamed replies fail more safely and consistently.

- track lossy partial-overflow state and avoid reusing an unreliable prefix during final fallback delivery
- freeze preview / prefer clean final delivery once streamed overflow reaches an unsafe edit boundary
- only downgrade MarkdownV2 to plain text for real markdown/entity parse failures
- do not downgrade to plain text on RetryAfter, flood-control, or other transient delivery failures
- apply the same downgrade rule to both the normal finalize-edit path and the overflow-split path
- add regression coverage for stream-consumer gating, overflow partial handling, and Telegram rich-message finalization behavior

## How to Verify

1. Run Hermes through the Telegram gateway.
2. Send a prompt that produces a long, richly formatted response (for example: lists, code blocks, quotes, and tables).
3. Confirm that:
   - the prefix is not duplicated
   - the first visible chunk is not downgraded to plain text
   - if Telegram splits the response, formatting remains consistent across parts
4. Repeat with a response long enough to exercise overflow-split behavior.
5. Repeat under conditions that trigger RetryAfter / flood-control delays and confirm they do not emit a plain-text first chunk.

## Test Plan

- [x] Added regression tests for this bug class
- [ ] Existing tests still pass
- [x] Manual verification of the fix

Manual / local verification completed:

- `python -m compileall` on the touched gateway, adapter, and test files
- targeted local regression harnesses for stream-consumer and Telegram overflow behavior
- real end-to-end Telegram verification with multiple long formatted responses

Note: the full pytest suite was not available in the local Hermes venv used during debugging because `pytest` was not installed there.

## Risk Assessment

Low to Medium — the change is scoped to Telegram long-message streaming, overflow handling, and markdown/plain-text fallback decisions. The main regression risk is in Telegram-specific long-form delivery rather than the wider gateway.
