### PR TITLE
fix(qqbot): add GROUP_MESSAGE intent (1<<24) for group message reception

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
@@ -735,10 +735,11 @@ class QQAdapter(BasePlatformAdapter):
             "op": 2,
             "d": {
                 "token": f"QQBot {token}",
-                "intents": (1 << 25)
-                           | (1 << 30)
-                           | (1 << 12)
-                           | (1 << 26),  # C2C_GROUP_AT_MESSAGES + PUBLIC_GUILD_MESSAGES + DIRECT_MESSAGE + INTERACTION
+                "intents": (1 << 24)  # GROUP_MESSAGE
+                           | (1 << 25)  # GROUP_AT_MESSAGE
+                           | (1 << 30)  # PUBLIC_GUILD_MESSAGES
+                           | (1 << 12)  # DIRECT_MESSAGE
+                           | (1 << 26),  # INTERACTION
                 "shard": [0, 1],
                 "properties": {
                     "$os": "macOS",


### PR DESCRIPTION
## Summary

QQ Bot 后台已开启群消息和主动消息权限，但 Gateway WebSocket identify 的 intents 缺少 `GROUP_MESSAGE` (bit 24)，导致 Bot 只能收到 @ 提及消息，无法感知群内普通消息。

## Root Cause

`gateway/platforms/qqbot/adapter.py` identify payload 中 intents 仅包含 `GROUP_AT_MESSAGE` (bit 25)、`PUBLIC_GUILD_MESSAGES` (bit 30)、`DIRECT_MESSAGE` (bit 12)、`INTERACTION` (bit 26)，缺少 `GROUP_MESSAGE` (bit 24)。

## Changes

1. intents 添加 `(1 << 24)` GROUP_MESSAGE
2. `connect()` 添加 `*, is_reconnect: bool = False` 参数

## Related

- PR #50780: 修复了 GROUP_MESSAGE_CREATE 事件类型变更，但未修复 WebSocket intents 位掩码（事件端和握手端需同时修改）
- Issue #52914: is_reconnect 参数缺失导致无限重试循环（本 PR 一并修复）

## Verified

Windows + Hermes v0.17.0 环境验证通过，QQ Bot 可正常接收群内所有消息。