### PR TITLE
fix(dashboard): drop desktop-inherited HERMES_WEB_DIST in standalone dashboard

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11979,6 +11979,22 @@ def cmd_dashboard(args):
     # build gate, and start_server.
     _headless_backend = getattr(args, "headless_backend", False)
 
+# ── Frontend isolation from a desktop-inherited HERMES_WEB_DIST ────
+    # The Desktop Electron app spawns its dashboard backend with BOTH
+    # HERMES_DESKTOP=1 and HERMES_WEB_DIST=<app.asar/dist> (the packaged
+    # desktop frontend).  A standalone `hermes dashboard` launched from a
+    # shell that inherited that HERMES_WEB_DIST (e.g. a terminal opened by
+    # Desktop) would then serve the desktop frontend instead of the
+    # dashboard's own bundled web_dist, producing a white screen titled
+    # "Hermes" with "Desktop IPC bridge is unavailable." (issue #52945).
+    # The Web Dashboard always ships its own frontend at
+    # hermes_cli/web_dist, so drop an inherited HERMES_WEB_DIST unless this
+    # process IS the desktop-spawned backend (HERMES_DESKTOP=1, which
+    # legitimately points at the packaged dist).
+    if os.environ.get("HERMES_DESKTOP") != "1":
+        os.environ.pop("HERMES_WEB_DIST", None)
+
+
     # ── Unified profile launch routing ────────────────────────────────
     # The dashboard is a MACHINE management surface: it can read/write any
     # profile via the per-request ?profile= scoping. Running one dashboard

--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -232,3 +232,45 @@ class TestUnifiedDashboardRouting:
                 "thread_name": "dashboard-mcp-discovery",
             }
         ]
+
+
+class TestDashboardWebDistIsolation:
+    """`hermes dashboard` must serve its OWN bundled frontend, not a
+    HERMES_WEB_DIST inherited from a Desktop Electron parent (issue #52945).
+    Desktop spawns its backend with HERMES_DESKTOP=1 + HERMES_WEB_DIST set to
+    the packaged app.asar/dist; a standalone dashboard launched from a shell
+    that inherited that env would otherwise white-screen on the desktop
+    frontend."""
+
+    def test_standalone_dashboard_drops_inherited_web_dist(self, main_mod, monkeypatch):
+        monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+        monkeypatch.setenv("HERMES_WEB_DIST", "/Applications/Hermes.app/Contents/Resources/app.asar/dist")
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+        )
+        # Bail right after the isolation block so we don't start a server.
+        monkeypatch.setitem(sys.modules, "fastapi", None)
+
+        with pytest.raises((SystemExit, AttributeError, ImportError, TypeError)):
+            main_mod.cmd_dashboard(_args())
+
+        # The inherited desktop dist was dropped → web_server falls back to the
+        # bundled hermes_cli/web_dist.
+        assert "HERMES_WEB_DIST" not in main_mod.os.environ
+
+    def test_desktop_spawned_backend_keeps_web_dist(self, main_mod, monkeypatch):
+        """The desktop-spawned backend itself (HERMES_DESKTOP=1) legitimately
+        points HERMES_WEB_DIST at the packaged dist; the guard must NOT strip
+        it for that process."""
+        monkeypatch.setenv("HERMES_DESKTOP", "1")
+        packaged = "/Applications/Hermes.app/Contents/Resources/app.asar/dist"
+        monkeypatch.setenv("HERMES_WEB_DIST", packaged)
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+        )
+        monkeypatch.setitem(sys.modules, "fastapi", None)
+
+        with pytest.raises((SystemExit, AttributeError, ImportError, TypeError)):
+            main_mod.cmd_dashboard(_args())
+
+        assert main_mod.os.environ.get("HERMES_WEB_DIST") == packaged


### PR DESCRIPTION
## Summary

- `hermes dashboard` now drops a `HERMES_WEB_DIST` inherited from a Desktop Electron parent, so it serves its own bundled frontend instead of the packaged desktop one.
- Fixes the white-screen / "Desktop IPC bridge is unavailable." failure when launching the dashboard from a Desktop-spawned shell.

## Motivation

Closes #52945.

The Desktop Electron app spawns its dashboard backend with **both** `HERMES_DESKTOP=1` and `HERMES_WEB_DIST=<app.asar/dist>` (the packaged desktop frontend — see `apps/desktop/electron/main.cjs` lines 5220-5221 and 5453-5454). A standalone `hermes dashboard` launched from a terminal/shell that inherited that `HERMES_WEB_DIST` then loads the **desktop** frontend out of `hermes_cli/web_server.py` (`WEB_DIST = Path(os.environ["HERMES_WEB_DIST"]) ...`), instead of the dashboard's own `hermes_cli/web_dist/`. Result: a white page titled `Hermes` (should be `Hermes Agent - Dashboard`) reporting `Desktop IPC bridge is unavailable.`

## Root Cause

**Symptom** — `hermes dashboard --no-open` serves a white screen / desktop frontend with "Desktop IPC bridge is unavailable." when a Desktop Electron app is also running.

**Root cause** — `HERMES_WEB_DIST` is a single env var shared by both surfaces with no isolation. `cmd_dashboard()` never sanitizes an inherited value, and `web_server.WEB_DIST` trusts it unconditionally. The Web Dashboard has its own bundled frontend and should never use the desktop's packaged dist.

**Evidence** — `apps/desktop/electron/main.cjs:5220-5221` / `:5453-5454` set `HERMES_DESKTOP: '1'` and `HERMES_WEB_DIST: webDist` together for the spawned backend; `hermes_cli/web_server.py:114` reads `HERMES_WEB_DIST` with no guard.

**Fix + why this level** — Pop an inherited `HERMES_WEB_DIST` at `cmd_dashboard()` entry **unless** the process itself is the desktop-spawned backend (`HERMES_DESKTOP=1`), which legitimately points at the packaged dist. Guarding on `HERMES_DESKTOP` is why the naive one-line `os.environ.pop(...)` suggested in the issue is *not* safe — it would strip the dist from the desktop's own backend and break its frontend resolution. Fixing at the dashboard entry (vs `web_server.py`) keeps the desktop backend path untouched.

**Scope / risk** — Touches only `cmd_dashboard()`. The desktop-spawned backend (`HERMES_DESKTOP=1`) keeps its `HERMES_WEB_DIST`. Explicit `HERMES_WEB_DIST=... hermes dashboard` for dev is still dropped in favor of the bundled dist for a standalone run; use `--isolated`/a desktop context if a custom dist is required. `--skip-build` callers fall back to the bundled `hermes_cli/web_dist` as before.

## Verification

- `python3 -m pytest tests/hermes_cli/test_dashboard_unified_launch.py -q` — 11 passed
- Confirmed the new `test_standalone_dashboard_drops_inherited_web_dist` **fails without the fix** and passes with it; `test_desktop_spawned_backend_keeps_web_dist` guards the desktop path.

## Tests

- `TestDashboardWebDistIsolation::test_standalone_dashboard_drops_inherited_web_dist` — asserts an inherited desktop dist is removed (fails on current main without the fix).
- `TestDashboardWebDistIsolation::test_desktop_spawned_backend_keeps_web_dist` — asserts `HERMES_DESKTOP=1` keeps the packaged dist.
