### PR TITLE
fix(computer-use): diagnose macOS SCK display_count=0 and improve 0×0 capture guidance

### DIFF
--- a/tests/tools/test_computer_use_capture_fixes.py
+++ b/tests/tools/test_computer_use_capture_fixes.py
@@ -1,0 +1,112 @@
+
+class TestComputerUseDoctorDisplayGuard:
+    def test_display_count_zero_marks_degraded(self):
+        from tools.computer_use.doctor import _apply_display_count_guard
+
+        report = {
+            "overall": "ok",
+            "checks": [
+                {
+                    "name": "screen_capture_capability",
+                    "status": "pass",
+                    "message": "ScreenCaptureKit reachable; 0 display(s) shareable.",
+                    "data": {"display_count": 0},
+                },
+            ],
+        }
+        out = _apply_display_count_guard(report)
+        assert out["overall"] == "degraded"
+        assert out["checks"][0]["status"] == "fail"
+        assert "0 shareable" in out["checks"][0]["message"]
+        assert out["checks"][0].get("hint")
+
+    def test_display_count_positive_unchanged(self):
+        from tools.computer_use.doctor import _apply_display_count_guard
+
+        report = {
+            "overall": "ok",
+            "checks": [
+                {
+                    "name": "screen_capture_capability",
+                    "status": "pass",
+                    "data": {"display_count": 1},
+                },
+            ],
+        }
+        out = _apply_display_count_guard(report)
+        assert out["overall"] == "ok"
+        assert out["checks"][0]["status"] == "pass"
+
+
+class TestCaptureDimensionInference:
+    def test_dimensions_from_gws_structured(self):
+        from tools.computer_use.cua_backend import _dimensions_from_gws_structured
+
+        assert _dimensions_from_gws_structured(
+            {"screenshot_width": 1567, "screenshot_height": 1018}
+        ) == (1567, 1018)
+
+    def test_capture_without_png_infers_structured_size(self):
+        from unittest.mock import MagicMock
+
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._session = MagicMock()
+
+        windows_payload = {
+            "windows": [{
+                "app_name": "Demo", "pid": 9, "window_id": 1,
+                "is_on_screen": True, "title": "Demo", "z_index": 0,
+            }],
+        }
+
+        def fake_call_tool(name, args):
+            if name == "list_windows":
+                return {
+                    "data": "", "images": [], "image_mime_types": [],
+                    "structuredContent": windows_payload, "isError": False,
+                }
+            if name == "get_window_state":
+                return {
+                    "data": '✅ Demo — 1 elements, turn 1\n  - [1] AXButton "Go"\n',
+                    "images": [],
+                    "image_mime_types": [],
+                    "structuredContent": {
+                        "screenshot_width": 800,
+                        "screenshot_height": 600,
+                        "elements": [{
+                            "element_index": 1,
+                            "role": "AXButton",
+                            "label": "Go",
+                            "frame": {"x": 1, "y": 2, "w": 3, "h": 4},
+                        }],
+                    },
+                    "isError": False,
+                }
+            raise AssertionError(name)
+
+        backend._session.call_tool.side_effect = fake_call_tool
+        cap = backend.capture(mode="som")
+        assert cap.png_b64 is None
+        assert cap.width == 800 and cap.height == 600
+        assert len(cap.elements) == 1
+
+    def test_empty_list_windows_surfaces_actionable_title(self):
+        from unittest.mock import MagicMock
+
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._session = MagicMock()
+        backend._session.call_tool.return_value = {
+            "data": "",
+            "images": [],
+            "image_mime_types": [],
+            "structuredContent": {"windows": []},
+            "isError": False,
+        }
+        cap = backend.capture(mode="ax")
+        assert cap.width == 0 and cap.height == 0
+        assert "list_windows" in cap.window_title
+        assert "computer-use doctor" in cap.window_title

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -433,6 +433,37 @@ def _image_dimensions_from_bytes(raw: bytes) -> Tuple[int, int]:
     return 0, 0
 
 
+def _dimensions_from_gws_structured(sc: Dict[str, Any]) -> Tuple[int, int]:
+    """Logical window/screenshot size when PNG bytes are missing (SCK asleep)."""
+    for wkey, hkey in (
+        ("screenshot_width", "screenshot_height"),
+        ("width", "height"),
+    ):
+        try:
+            w = int(sc.get(wkey) or 0)
+            h = int(sc.get(hkey) or 0)
+        except (TypeError, ValueError):
+            continue
+        if w > 0 and h > 0:
+            return w, h
+    return 0, 0
+
+
+def _dimensions_from_element_bounds(elements: List[UIElement]) -> Tuple[int, int]:
+    """Infer a logical canvas size from AX element frames."""
+    max_x = 0
+    max_y = 0
+    for element in elements:
+        x, y, w, h = element.bounds
+        if w <= 0 or h <= 0:
+            continue
+        max_x = max(max_x, x + w)
+        max_y = max(max_y, y + h)
+    if max_x > 0 and max_y > 0:
+        return max_x, max_y
+    return 0, 0
+
+
 def _split_tree_text(full_text: str) -> Tuple[str, str]:
     """Split get_window_state text into (summary_line, tree_markdown)."""
     lines = full_text.split("\n", 1)
@@ -1043,8 +1074,17 @@ class CuaDriverBackend(ComputerUseBackend):
         windows.sort(key=lambda w: w["z_index"])
 
         if not windows:
-            return CaptureResult(mode=mode, width=0, height=0, png_b64=None,
-                                 elements=[], app="", window_title="", png_bytes_len=0)
+            return CaptureResult(
+                mode=mode, width=0, height=0, png_b64=None,
+                elements=[], app="",
+                window_title=(
+                    "<no on-screen windows returned by cua-driver list_windows; "
+                    "wake the built-in display (ScreenCaptureKit often reports "
+                    "display_count=0 while asleep), confirm with "
+                    "`hermes computer-use doctor`, then retry>"
+                ),
+                png_bytes_len=0,
+            )
 
         # Filter by app name (case-insensitive substring) if requested.
         # When the filter matches nothing, surface that explicitly instead of
@@ -1121,6 +1161,7 @@ class CuaDriverBackend(ComputerUseBackend):
         elements: List[UIElement] = []
         width = height = 0
         window_title = ""
+        gws_structured: Dict[str, Any] = {}
 
         if mode == "vision":
             # Plain screenshot, no AX walk. cua-driver dropped the standalone
@@ -1168,6 +1209,7 @@ class CuaDriverBackend(ComputerUseBackend):
                     },
                 )
                 png_b64, image_mime_type = _image_from_tool_result(gws_out)
+                gws_structured = gws_out.get("structuredContent") or {}
                 # Still grab the window title — it's cheap and useful in the
                 # vision response — but deliberately leave `elements` empty so
                 # vision stays free of AX-tree noise.
@@ -1187,6 +1229,7 @@ class CuaDriverBackend(ComputerUseBackend):
                 },
             )
             text = gws_out["data"] if isinstance(gws_out["data"], str) else ""
+            gws_structured = gws_out.get("structuredContent") or {}
             summary, tree = _split_tree_text(text)
 
             # Parse element count from summary e.g. "✅ AppName — 42 elements, turn 3..."
@@ -1235,6 +1278,21 @@ class CuaDriverBackend(ComputerUseBackend):
                     height = detected_height
             except Exception:
                 png_bytes_len = len(png_b64) * 3 // 4
+
+        if not png_b64 and (width == 0 or height == 0):
+            inferred_w, inferred_h = _dimensions_from_gws_structured(gws_structured)
+            if inferred_w <= 0 or inferred_h <= 0:
+                inferred_w, inferred_h = _dimensions_from_element_bounds(elements)
+            if (inferred_w <= 0 or inferred_h <= 0) and elements:
+                try:
+                    screen = self.get_screen_size()
+                    inferred_w = int(screen.get("width") or 0)
+                    inferred_h = int(screen.get("height") or 0)
+                except Exception:
+                    inferred_w = inferred_h = 0
+            if inferred_w > 0 and inferred_h > 0:
+                width = inferred_w
+                height = inferred_h
 
         return CaptureResult(
             mode=mode,

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -159,6 +159,49 @@ def _drive_health_report(
     )
 
 
+def _apply_display_count_guard(report: Dict[str, Any]) -> Dict[str, Any]:
+    """Treat ScreenCaptureKit display_count=0 as degraded even when cua-driver passes.
+
+    RCA: permissions can be granted while the built-in panel is asleep, so
+    screenshots are missing and captures report 0×0. Hermes doctor should not
+    read overall=ok in that state.
+    """
+    checks = report.get("checks")
+    if not isinstance(checks, list):
+        return report
+
+    for check in checks:
+        if not isinstance(check, dict):
+            continue
+        if check.get("name") != "screen_capture_capability":
+            continue
+        data = check.get("data")
+        if not isinstance(data, dict):
+            continue
+        try:
+            display_count = int(data.get("display_count", -1))
+        except (TypeError, ValueError):
+            display_count = -1
+        if display_count != 0:
+            break
+
+        check["status"] = "fail"
+        check["message"] = (
+            "ScreenCaptureKit reports 0 shareable displays — screenshots will "
+            "be missing and computer_use capture may show 0×0. Wake the built-in "
+            "display or attach a shareable monitor."
+        )
+        check["hint"] = (
+            "Run: system_profiler SPDisplaysDataType | grep 'Display Asleep'; "
+            "wake with trackpad/key, then re-run `hermes computer-use doctor`."
+        )
+        if report.get("overall") == "ok":
+            report["overall"] = "degraded"
+        break
+
+    return report
+
+
 def _print_text_report(report: Dict[str, Any], color: bool) -> None:
     """Render the report in the same style as `cua-driver call health_report`
     would (one line per check + a summary footer)."""
@@ -253,6 +296,7 @@ def run_doctor(
 
     try:
         report = _drive_health_report(binary, include=include, skip=skip)
+        report = _apply_display_count_guard(report)
     except RuntimeError as e:
         print(f"cua-driver health_report failed: {e}", file=sys.stderr)
         return 2

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -574,6 +574,13 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
             f"is below the {_MIN_PROVIDER_IMAGE_DIMENSION}x{_MIN_PROVIDER_IMAGE_DIMENSION} "
             "provider minimum)"
         )
+    elif not cap.png_b64 and total_elements > 0 and cap.mode in ("som", "vision"):
+        summary_lines.append(
+            "  (screenshot unavailable: ScreenCaptureKit often omits PNG when "
+            "display_count=0 or the built-in panel is asleep — run "
+            "`hermes computer-use doctor` and wake the display; "
+            "element-index actions still work)"
+        )
     summary = "\n".join(summary_lines)
 
     if cap.png_b64 and cap.mode != "ax" and not image_too_small:
@@ -662,6 +669,8 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
     }
     if truncated_elements:
         payload["truncated_elements"] = truncated_elements
+    if not cap.png_b64 and total_elements > 0 and cap.mode in ("som", "vision"):
+        payload["screenshot_unavailable"] = True
     return json.dumps(payload)
 
 


### PR DESCRIPTION
## Summary

macOS `computer_use` can return **0×0** captures while TCC permissions are granted: `cua-driver` health_report may still pass, but ScreenCaptureKit reports **`display_count=0`** when the built-in panel is asleep. In that state `get_window_state` often returns AX elements **without** a PNG, so Hermes previously reported misleading **overall=ok** from doctor and unhelpful empty captures.

This PR improves Hermes-side diagnostics and recovery guidance (driver limitation remains upstream in cua-driver/SCK).

## Changes

- **`doctor.py`**: `_apply_display_count_guard` — when `screen_capture_capability.data.display_count == 0`, mark the check **fail**, set an actionable hint (wake display / `system_profiler`), and downgrade `overall` from `ok` → `degraded`.
- **`cua_backend.py`**: When PNG bytes are missing, infer logical `width`/`height` from `get_window_state` structured `screenshot_width`/`screenshot_height`, element bounds, or `get_screen_size()` fallback. Empty `list_windows` now returns an explicit `window_title` message pointing at doctor + wake display.
- **`tool.py`**: Surface `screenshot_unavailable` in JSON and a summary line when elements exist but vision/SOM PNG is missing.
- **Tests**: `tests/tools/test_computer_use_capture_fixes.py` (doctor guard + dimension inference + empty list_windows messaging).

## Verification

```bash
python3 -m pytest tests/tools/test_computer_use_capture_fixes.py -v -o 'addopts='
```

**5 passed** on macOS (local).

## Issue tracking

No dedicated upstream issue filed yet for **macOS `display_count=0` / asleep panel → misleading doctor pass + 0×0 capture**. Closest related reports:

- #51164 — subsequent captures 0×0 (session staleness; different root cause, overlapping symptom)
- #52014 — asks for better warnings when capture content is misleading (Windows explorer-only; same *class* of integration diagnostics)

Happy to open a tracking issue if maintainers prefer one before merge.

## Out of scope

- Does not fix cua-driver/SCK when displays are non-shareable (wake display / hardware still required for PNG).
- **Not included**: accidental local `apps/desktop/electron/main.cjs` bundle churn (reverted/stashed before this branch).