### PR TITLE
fix(feishu): render markdown tables via interactive card

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -548,6 +548,21 @@ def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _build_markdown_card_payload(content: str) -> str:
+    """Build an interactive-card payload that renders markdown, including
+    GFM tables, which the Feishu post (rich_text) renderer cannot display.
+
+    Card JSON 2.0's ``markdown`` element renders bold, lists, links, code
+    blocks, and pipe tables. The whole reply goes into a single markdown
+    element so prose and tables keep their original order.
+    """
+    card = {
+        "schema": "2.0",
+        "body": {"elements": [{"tag": "markdown", "content": content}]},
+    }
+    return json.dumps(card, ensure_ascii=False)
+
+
 def _build_markdown_post_payload(content: str) -> str:
     rows = _build_markdown_post_rows(content)
     return json.dumps(
@@ -1843,7 +1858,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         content = self.format_message(content)
         try:
-            msg_type, payload = self._build_outbound_payload(content)
+            msg_type, payload = self._build_outbound_payload(content, for_edit=True)
             body = self._build_update_message_body(msg_type=msg_type, content=payload)
             request = self._build_update_message_request(message_id=message_id, request_body=body)
             response = await asyncio.to_thread(self._client.im.v1.message.update, request)
@@ -4374,11 +4389,15 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound payload construction and send pipeline
     # =========================================================================
 
-    def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
+    def _build_outbound_payload(self, content: str, *, for_edit: bool = False) -> tuple[str, str]:
+        # The Feishu post (rich_text) renderer cannot display markdown tables,
+        # but the interactive-card ``markdown`` element renders GFM pipe tables
+        # fine, so newly sent table content is wrapped in a card. The message
+        # *update* API cannot convert an existing text/post message into a card,
+        # so in-place editors pass for_edit=True to keep the plain-text form.
         if _MARKDOWN_TABLE_RE.search(content):
+            if not for_edit:
+                return "interactive", _build_markdown_card_payload(content)
             text_payload = {"text": content}
             return "text", json.dumps(text_payload, ensure_ascii=False)
         if _MARKDOWN_HINT_RE.search(content):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -4944,3 +4944,53 @@ class TestChatLockEviction(unittest.TestCase):
                 held.release()
 
         asyncio.run(_run())
+
+
+class TestFeishuOutboundTableRouting(unittest.TestCase):
+    """_build_outbound_payload routes markdown tables to an interactive card.
+
+    The Feishu post (rich_text) renderer cannot display markdown tables, but the
+    interactive-card markdown element can, so newly sent table content must be
+    delivered as a card while in-place edits keep the plain-text form.
+    """
+
+    _TABLE = (
+        "## Indices\n\n"
+        "| Index | Code | Close |\n"
+        "|---|---|---|\n"
+        "| Nasdaq | ^IXIC | 25,358.60 |\n"
+    )
+
+    @staticmethod
+    @patch.dict(os.environ, {"FEISHU_APP_ID": "cli_app", "FEISHU_APP_SECRET": "secret_app"}, clear=True)
+    def _adapter():
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        return FeishuAdapter(PlatformConfig())
+
+    def test_new_table_message_becomes_interactive_card(self):
+        msg_type, payload = self._adapter()._build_outbound_payload(self._TABLE)
+        self.assertEqual(msg_type, "interactive")
+        card = json.loads(payload)
+        self.assertEqual(card["schema"], "2.0")
+        elements = card["body"]["elements"]
+        self.assertEqual(len(elements), 1)
+        self.assertEqual(elements[0]["tag"], "markdown")
+        # The whole reply (prose + table) is preserved verbatim in one element.
+        self.assertEqual(elements[0]["content"], self._TABLE)
+
+    def test_table_edit_in_place_stays_plain_text(self):
+        # message.update cannot turn an existing text/post message into a card.
+        msg_type, payload = self._adapter()._build_outbound_payload(self._TABLE, for_edit=True)
+        self.assertEqual(msg_type, "text")
+        self.assertEqual(json.loads(payload)["text"], self._TABLE)
+
+    def test_non_table_markdown_still_uses_post(self):
+        msg_type, _ = self._adapter()._build_outbound_payload("**bold** and [link](https://x.io)")
+        self.assertEqual(msg_type, "post")
+
+    def test_plain_text_unchanged(self):
+        msg_type, payload = self._adapter()._build_outbound_payload("just text")
+        self.assertEqual(msg_type, "text")
+        self.assertEqual(json.loads(payload)["text"], "just text")


### PR DESCRIPTION
## What & why

The Feishu adapter's `_build_outbound_payload` detects markdown tables and
force-downgrades the **entire** message to plain text, so users see raw
`| a | b |` pipe syntax instead of a rendered table. The existing comment
explains the motivation:

> Feishu post-type 'md' elements do not render markdown tables.

That holds for the **post (rich_text)** message type — but Feishu's
**interactive-card `markdown` element does render GFM pipe tables**. This PR
routes newly sent table content into a schema-2.0 interactive card whose single
`markdown` element preserves the whole reply (prose + table) in order, so tables
render natively instead of leaking pipe syntax.

## Changes

- Add `_build_markdown_card_payload()` — wraps content in a schema-2.0 card with
  a single `markdown` element.
- `_build_outbound_payload(content, *, for_edit=False)` — table content now
  returns an `interactive` card on the send path. Non-table `post`/`text`
  routing is unchanged.
- `edit_message` passes `for_edit=True`. The message **update** API cannot
  convert an existing text/post message into a card, so in-place streamed edits
  keep the plain-text path and avoid update-type-mismatch failures.

## Known limitation

Streamed in-chat replies are edited in place via `edit_message`, and the update
API cannot turn an existing message into a card, so a table that appears
mid-stream still renders as text during the stream. Non-streamed sends (cron /
skill broadcasts — the common case) now render as cards. A follow-up could
re-deliver streamed finals as fresh cards once the adapter gains a delete/recall
path (`prefers_fresh_final_streaming`).

## How to test

- **Unit**: `pytest tests/gateway/test_feishu.py` — 4 new tests cover the
  table→card routing, the `for_edit` plain-text path, and the unchanged
  post/text routing; full file: 209 passed.
- **Manual**: send a message containing a GFM pipe table through a Feishu bot.
  Before: raw pipe syntax. After: a bordered table rendered inside a card.

## Platforms tested

Linux (Debian, Python 3.11), Feishu (China) tenant, websocket connection mode.
Verified live end-to-end — the card `markdown` element renders the table
correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
