### PR TITLE
Settle TUI resume scroll after hydration (salvage #52902)

### DIFF
--- a/ui-tui/src/__tests__/useSessionLifecycle.test.ts
+++ b/ui-tui/src/__tests__/useSessionLifecycle.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { turnController } from '../app/turnController.js'
 import { getTurnState, resetTurnState } from '../app/turnStore.js'
@@ -10,6 +10,7 @@ import { patchUiState, resetUiState } from '../app/uiStore.js'
 import {
   hydrateLiveSessionInflight,
   liveSessionInflightMessages,
+  scheduleResumeScrollToBottom,
   writeActiveSessionFile
 } from '../app/useSessionLifecycle.js'
 
@@ -59,5 +60,86 @@ describe('live session activation in-flight state', () => {
 
     expect(turnController.bufRef).toBe('')
     expect(getTurnState().streaming).toBe('')
+  })
+})
+
+describe('resume scroll settle', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('re-snaps while sticky and stops when the user scrolls away', () => {
+    vi.useFakeTimers()
+    let sticky = true
+    let lastManualScrollAt = 0
+    const scrollToBottom = vi.fn()
+    const cancel = scheduleResumeScrollToBottom(
+      {
+        current: {
+          getLastManualScrollAt: () => lastManualScrollAt,
+          isSticky: () => sticky,
+          scrollToBottom
+        }
+      } as any,
+      [0, 80, 240]
+    )
+
+    vi.advanceTimersByTime(0)
+    expect(scrollToBottom).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(80)
+    expect(scrollToBottom).toHaveBeenCalledTimes(2)
+
+    sticky = false
+    lastManualScrollAt = Date.now() + 1
+    vi.advanceTimersByTime(160)
+    expect(scrollToBottom).toHaveBeenCalledTimes(2)
+
+    cancel()
+  })
+
+  it('cancels pending resume snaps', () => {
+    vi.useFakeTimers()
+    const scrollToBottom = vi.fn()
+    const cancel = scheduleResumeScrollToBottom(
+      {
+        current: {
+          getLastManualScrollAt: () => 0,
+          isSticky: () => true,
+          scrollToBottom
+        }
+      } as any,
+      [20]
+    )
+
+    cancel()
+    vi.advanceTimersByTime(20)
+
+    expect(scrollToBottom).not.toHaveBeenCalled()
+  })
+
+  it('keeps the immediate resume snap even before sticky state settles', () => {
+    vi.useFakeTimers()
+    let sticky = false
+    const scrollToBottom = vi.fn()
+    const cancel = scheduleResumeScrollToBottom(
+      {
+        current: {
+          getLastManualScrollAt: () => 0,
+          isSticky: () => sticky,
+          scrollToBottom
+        }
+      } as any,
+      [0, 80]
+    )
+
+    vi.advanceTimersByTime(0)
+    expect(scrollToBottom).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(80)
+    expect(scrollToBottom).toHaveBeenCalledTimes(1)
+
+    sticky = true
+    cancel()
   })
 })

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -2,7 +2,7 @@ import { writeFileSync } from 'node:fs'
 
 import type { ScrollBoxHandle } from '@hermes/ink'
 import { evictInkCaches } from '@hermes/ink'
-import { type RefObject, useCallback } from 'react'
+import { type RefObject, useCallback, useEffect, useRef } from 'react'
 
 import { buildSetupRequiredSections, SETUP_REQUIRED_TITLE } from '../content/setup.js'
 import { introMsg, toTranscriptMessages } from '../domain/messages.js'
@@ -68,6 +68,34 @@ export const hydrateLiveSessionInflight = (inflight?: null | SessionInflightTurn
   turnController.hydrateStreamingText(assistant)
 }
 
+export const scheduleResumeScrollToBottom = (
+  scrollRef: RefObject<null | ScrollBoxHandle>,
+  delays: readonly number[] = [0, 80, 240]
+) => {
+  const startedAt = Date.now()
+  const timers = delays.map((delay, index) =>
+    setTimeout(() => {
+      const scroll = scrollRef.current
+
+      if (!scroll) {
+        return
+      }
+
+      const manuallyScrolledAfterResume = scroll.getLastManualScrollAt() > startedAt
+
+      if (!manuallyScrolledAfterResume && (index === 0 || scroll.isSticky())) {
+        scroll.scrollToBottom()
+      }
+    }, delay)
+  )
+
+  return () => {
+    for (const timer of timers) {
+      clearTimeout(timer)
+    }
+  }
+}
+
 const trimTail = (items: Msg[]) => {
   const q = [...items]
 
@@ -120,8 +148,11 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
       targetSid ? rpc<SessionCloseResponse>('session.close', { session_id: targetSid }) : Promise.resolve(null),
     [rpc]
   )
+  const cancelResumeScrollRef = useRef<null | (() => void)>(null)
 
   const resetSession = useCallback(() => {
+    cancelResumeScrollRef.current?.()
+    cancelResumeScrollRef.current = null
     turnController.fullReset()
     setVoiceRecording(false)
     setVoiceProcessing(false)
@@ -134,6 +165,14 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
     // the user resumes back to the prior session.
     evictInkCaches('half')
   }, [composerActions, setHistoryItems, setLastUserMsg, setStickyPrompt, setVoiceProcessing, setVoiceRecording])
+
+  useEffect(
+    () => () => {
+      cancelResumeScrollRef.current?.()
+      cancelResumeScrollRef.current = null
+    },
+    []
+  )
 
   const resetVisibleHistory = useCallback(
     (info: null | SessionInfo = null) => {
@@ -279,7 +318,8 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
             usage: usageFrom(info)
           })
           hydrateLiveSessionInflight(r.inflight)
-          setTimeout(() => scrollRef.current?.scrollToBottom(), 0)
+          cancelResumeScrollRef.current?.()
+          cancelResumeScrollRef.current = scheduleResumeScrollToBottom(scrollRef)
         })
         .catch((e: Error) => {
           sys(`error: ${e.message}`)
@@ -332,12 +372,13 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
               usage: usageFrom(info)
             })
             hydrateLiveSessionInflight(r.inflight)
+            cancelResumeScrollRef.current?.()
+            cancelResumeScrollRef.current = scheduleResumeScrollToBottom(scrollRef)
 
             if (previousSid && previousSid !== r.session_id) {
               void closeSession(previousSid)
             }
 
-            setTimeout(() => scrollRef.current?.scrollToBottom(), 0)
           })
           .catch((e: Error) => {
             sys(`error: ${e.message}`)


### PR DESCRIPTION
## Summary
Dashboard-hosted TUI sessions no longer settle into a blank/partial viewport after a resume — the transcript stays pinned to the bottom across hydration/layout settle.

Root cause: the resume/activate path snapped to bottom with a single `setTimeout(scrollToBottom, 0)`, which fired before Ink finished hydrating and laying out the restored transcript, leaving a half-empty screen.

## Changes
- `ui-tui/src/app/useSessionLifecycle.ts`: replace the two one-shot `setTimeout(scrollToBottom, 0)` calls (resume + activate paths) with `scheduleResumeScrollToBottom` — re-snaps across delays `[0, 80, 240]`, keeps the immediate snap, re-snaps later only while sticky, and cancels follow-ups once the user manually scrolls away. Cancel ref is cleaned up on `resetSession` and component unmount.
- `ui-tui/src/__tests__/useSessionLifecycle.test.ts`: lifecycle tests for sticky re-snap, cancellation, and cold-start behavior.

## Validation
- `npm run test -- --run src/__tests__/useSessionLifecycle.test.ts` → 6/6 pass
- `npm run typecheck` → clean

Salvage of #52902 by @shannonsands — cherry-picked onto current main with authorship preserved.

## Infographic

![settle-tui-resume-scroll](https://v3b.fal.media/files/b/0a9fd18d/0SaoxtGMJUI_d4OtKk8Tn_A5pc1Ixu.png)
