### PR TITLE
fix(agent): warn on resume when session provider differs from current default

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1131,6 +1131,7 @@ def init_agent(
         "max_iterations": agent.max_iterations,
         "reasoning_config": reasoning_config,
         "max_tokens": max_tokens,
+        "provider": getattr(agent, "provider", None),
     }
     
     # In-memory todo list for task planning (one per agent/session)

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -328,6 +328,27 @@ class CLIAgentSetupMixin:
                 self._session_db._conn.commit()
             except Exception:
                 pass
+            # Warn if the session's original provider is no longer the
+            # current default — the user may not realise the session
+            # silently switched providers on resume.  See #52943.
+            try:
+                import json as _json
+                _mc = session_meta.get("model_config")
+                if _mc:
+                    _mc_dict = _json.loads(_mc) if isinstance(_mc, str) else _mc
+                    _orig_prov = _mc_dict.get("provider")
+                    if _orig_prov and _orig_prov != self.provider:
+                        _warn = (
+                            f"Session was created with provider '{_orig_prov}' "
+                            f"which differs from the current default "
+                            f"'{self.provider}'. Resuming with the current provider."
+                        )
+                        if _quiet_mode:
+                            print(f"Warning: {_warn}", file=sys.stderr)
+                        else:
+                            ChatConsole().print(f"[bold yellow]Warning:[/] {_warn}")
+            except Exception:
+                pass
         
         try:
             runtime = runtime_override or {


### PR DESCRIPTION
## Problem

When a session was created with a provider (e.g. `zai`) that was later removed from config, `/resume` silently created a new session with the current default provider — no error, no warning.

## Fix

1. **Store provider in `model_config`** at session creation time (`agent/agent_init.py`)
2. **Check stored provider on resume** and emit a warning when it differs from the current default (`hermes_cli/cli_agent_setup_mixin.py`)

The warning is shown in both interactive and quiet modes.

Fixes #52943

## Changes

- `agent/agent_init.py`: add `"provider"` key to `_session_init_model_config`
- `hermes_cli/cli_agent_setup_mixin.py`: compare stored provider with current default after resume, warn if mismatch
