### PR TITLE
fix(agent,cli,scripts): remove redundant exception types in except tuples

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -663,7 +663,7 @@ def compress_context(
                     try:
                         new_title = agent._session_db.get_next_title_in_lineage(old_title)
                         agent._session_db.set_session_title(agent.session_id, new_title)
-                    except (ValueError, Exception) as e:
+                    except Exception as e:
                         logger.debug("Could not propagate title on compression: %s", e)
 
             # Shared post-write steps (both modes target agent.session_id, which

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -433,7 +433,7 @@ class CLIAgentSetupMixin:
                         _cprint(f"  Session title applied: {self._pending_title}")
                         self._pending_title = None
                     # else: row creation failed transiently — keep _pending_title for retry
-                except (ValueError, Exception) as e:
+                except Exception as e:
                     _cprint(f"  Could not apply pending title: {e}")
                     # Keep _pending_title so it can be retried after row creation succeeds
             return True

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1897,7 +1897,7 @@ class CLICommandsMixin:
                     s.connect(("127.0.0.1", _port))
                     s.close()
                     print("   Status: ✓ reachable")
-                except (OSError, Exception):
+                except Exception:
                     print("   Status: ⚠ not reachable (browser may not be running)")
             else:
                 try:

--- a/hermes_time.py
+++ b/hermes_time.py
@@ -74,7 +74,7 @@ def _get_zoneinfo(name: str) -> Optional[ZoneInfo]:
         return None
     try:
         return ZoneInfo(name)
-    except (KeyError, Exception) as exc:
+    except Exception as exc:
         logger.warning(
             "Invalid timezone '%s': %s. Falling back to server local time.",
             name, exc,

--- a/scripts/discord-voice-doctor.py
+++ b/scripts/discord-voice-doctor.py
@@ -80,7 +80,7 @@ def check_packages():
             import nacl.secret
             nacl.secret.Aead(bytes(32))
             check("PyNaCl", True, f"v{ver}")
-        except (AttributeError, Exception):
+        except Exception:
             check("PyNaCl (Aead)", False, f"v{ver} — need >=1.5.0")
             ok = False
     except ImportError:


### PR DESCRIPTION
## Problem

Five except clauses use tuples like `except (ValueError, Exception)` where the subclass is redundant — `ValueError`, `KeyError`, `AttributeError`, and `OSError` are all subclasses of `Exception` in Python 3.

## Fix

Remove the redundant subclass from each tuple, leaving just `except Exception`.

| File | Before | After |
|------|--------|-------|
| `agent/conversation_compression.py:666` | `(ValueError, Exception)` | `Exception` |
| `scripts/discord-voice-doctor.py:83` | `(AttributeError, Exception)` | `Exception` |
| `hermes_cli/cli_commands_mixin.py:1900` | `(OSError, Exception)` | `Exception` |
| `hermes_cli/cli_agent_setup_mixin.py:436` | `(ValueError, Exception)` | `Exception` |
| `hermes_time.py:77` | `(KeyError, Exception)` | `Exception` |

## Changes

5 files, 5 lines changed (each line removes one redundant exception type).