### PR TITLE
fix(qqbot): add is_reconnect param to QQAdapter.connect for gateway reconnect compat

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,8 +278,16 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
-        """Authenticate, obtain gateway URL, and open the WebSocket."""
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """
+        Authenticate, obtain gateway URL, and open the WebSocket.
+
+        Args:
+            is_reconnect: False on a cold first boot; True when the
+                reconnect watcher is re-establishing this platform after
+                an outage. QQBot has no server-side update queue so this
+                flag is accepted for interface conformance only.
+        """
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
             self._set_fatal_error("qq_missing_dependency", message, retryable=True)

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -190,6 +190,21 @@ class TestVoiceAttachmentSSRFProtection:
         assert kwargs.get("follow_redirects") is True
         assert kwargs.get("event_hooks", {}).get("response") == [_ssrf_redirect_guard]
 
+    def test_connect_accepts_is_reconnect_param(self):
+        """connect() must accept is_reconnect for interface conformance with
+        the base adapter, which the reconnect watcher calls with
+        is_reconnect=True."""
+        from gateway.platforms.qqbot import QQAdapter
+
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+        adapter._ensure_token = mock.AsyncMock(side_effect=RuntimeError("stop after client init"))
+
+        # Both forms must not raise TypeError.
+        connected_default = asyncio.run(adapter.connect())
+        connected_explicit = asyncio.run(adapter.connect(is_reconnect=True))
+        assert connected_default is False
+        assert connected_explicit is False
+
 
 # ---------------------------------------------------------------------------
 # WebSocket proxy handling


### PR DESCRIPTION
## Problem

The gateway reconnect watcher calls `adapter.connect(is_reconnect=True)` on every platform adapter during reconnection. QQAdapter's `connect()` did not accept the `is_reconnect` keyword argument, causing:

```
TypeError: QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

This leads to an infinite retry loop — every reconnect attempt fails with the same TypeError, the watcher backs off and retries, ad infinitum.

## Root Cause

The base adapter's `connect()` abstract method was updated to include the `is_reconnect` parameter (commit `43b8ba4181` or earlier). All other platform adapters (Telegram, Discord, Feishu, WeChat, Signal, etc.) were updated to match the new signature. QQAdapter was missed.

## Fix

Add `*, is_reconnect: bool = False` to `QQAdapter.connect()`'s signature. QQBot has no server-side update queue (unlike Telegram's Bot API), so the flag is accepted for interface conformance only — it is not used within the method.

## Testing

- New regression test: `test_connect_accepts_is_reconnect_param` verifies both `adapter.connect()` and `adapter.connect(is_reconnect=True)` complete without raising `TypeError`.
- All 116 existing QQBot tests continue to pass (the 46 pre-existing failures on this machine are all due to missing `aiohttp`/`httpx` packages, none related to this change).

## References

- Fixes: #52914