### PR TITLE
fix(mem0): pass top_k to SDK in OSSBackend.get_all for accurate count

### DIFF
--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -194,7 +194,11 @@ class OSSBackend(Mem0Backend):
         return _unwrap_results(response)
 
     def get_all(self, *, filters: dict, page: int = 1, page_size: int = 100) -> dict:
-        response = self._memory.get_all(filters=filters)
+        # Use a high top_k so the SDK returns everything — we need the full
+        # result set for accurate counting and client-side pagination.
+        # The SDK's default top_k is 20 (mem0ai/mem0#memory/main.py), which
+        # would truncate results and give a wrong count.
+        response = self._memory.get_all(filters=filters, top_k=10000)
         all_results = _unwrap_results(response)
         total = len(all_results)
         start = (page - 1) * page_size

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -461,3 +461,80 @@ class TestMem0WriteMetadata:
         adds = [c for c in provider._backend.captured if c[0] == "add"]
         assert adds, "expected an add call from sync_turn"
         assert adds[-1][2]["metadata"] == {"channel": "discord"}
+
+
+class TestOSSBackendGetAll:
+    """OSSBackend.get_all() must pass top_k to the SDK so the result
+    count is not truncated by the default limit of 20."""
+
+    def _make_backend(self, memory_mock=None):
+        from unittest import mock
+        from plugins.memory.mem0._backend import OSSBackend
+
+        oss_config = {
+            "vector_store": {"provider": "qdrant", "config": {"path": "/tmp"}},
+            "llm": {"provider": "openai", "config": {"model": "gpt-4o-mini"}},
+            "embedder": {"provider": "openai", "config": {"model": "text-embedding-3-small"}},
+        }
+        backend = OSSBackend.__new__(OSSBackend)
+        backend._memory = memory_mock or mock.MagicMock()
+        return backend
+
+    def test_passes_top_k_to_sdk(self):
+        """Verify OSSBackend.get_all() passes top_k=10000 to the SDK."""
+        from unittest import mock
+
+        memory = mock.MagicMock()
+        memory.get_all.return_value = {"results": [], "count": 0}
+        backend = self._make_backend(memory)
+
+        backend.get_all(filters={"user_id": "u1"})
+
+        memory.get_all.assert_called_once()
+        assert memory.get_all.call_args.kwargs.get("top_k") == 10000
+
+    def test_count_reflects_total_not_sdk_default(self):
+        """When there are more results than the SDK default of 20,
+        count must reflect the full total, not the truncated length."""
+        from unittest import mock
+
+        # Simulate 50 memories — the SDK would only return 20 by default.
+        all_memories = [{"id": f"mem-{i}", "memory": f"fact {i}"} for i in range(50)]
+        memory = mock.MagicMock()
+        memory.get_all.return_value = {"results": all_memories, "count": 50}
+        backend = self._make_backend(memory)
+
+        result = backend.get_all(filters={"user_id": "u1"})
+        assert result["count"] == 50
+        assert len(result["results"]) == 50
+
+    def test_client_side_pagination(self):
+        """Page and page_size slice the full result set correctly while
+        preserving the total count."""
+        from unittest import mock
+
+        all_memories = [{"id": f"mem-{i}", "memory": f"fact {i}"} for i in range(50)]
+        memory = mock.MagicMock()
+        memory.get_all.return_value = {"results": all_memories, "count": 50}
+        backend = self._make_backend(memory)
+
+        # Page 2, size 10 → items 10-19
+        result = backend.get_all(filters={"user_id": "u1"}, page=2, page_size=10)
+        assert result["count"] == 50
+        assert len(result["results"]) == 10
+        assert result["results"][0]["id"] == "mem-10"
+        assert result["results"][-1]["id"] == "mem-19"
+
+    def test_pagination_beyond_total_returns_empty(self):
+        """Page beyond the total number of pages returns an empty list
+        while keeping the correct total count."""
+        from unittest import mock
+
+        all_memories = [{"id": f"mem-{i}", "memory": f"fact {i}"} for i in range(5)]
+        memory = mock.MagicMock()
+        memory.get_all.return_value = {"results": all_memories, "count": 5}
+        backend = self._make_backend(memory)
+
+        result = backend.get_all(filters={"user_id": "u1"}, page=10, page_size=10)
+        assert result["count"] == 5
+        assert result["results"] == []


### PR DESCRIPTION
## Problem

`OSSBackend.get_all()` calls `Memory.get_all(filters=filters)` without passing `top_k`. The Mem0 SDK defaults `top_k` to 20 ([source: mem0ai/mem0/memory/main.py](https://github.com/mem0ai/mem0/blob/main/mem0/memory/main.py)), so the response is always truncated to at most 20 results.

Since `OSSBackend` computes `count = len(all_results)` from the raw SDK response, the reported `count` is wrong whenever there are more than 20 stored memories — it caps at 20.

## Root Cause

In `plugins/memory/mem0/_backend.py`, `OSSBackend.get_all()`:

```python
def get_all(self, *, filters, page=1, page_size=100):
    response = self._memory.get_all(filters=filters)  # ← no top_k!
    all_results = _unwrap_results(response)
    total = len(all_results)  # ← always ≤ 20
    ...
```

The Mem0 SDK's `Memory.get_all()` signature is:

```python
def get_all(self, *, filters=None, top_k: int = 20, show_expired=False):
```

The `PlatformBackend` does not have this problem — it uses `MemoryClient.get_all(filters, page, page_size)` which handles pagination server-side and returns an accurate `count`.

## Fix

Pass `top_k=10000` to `self._memory.get_all()` so the full result set is returned. `OSSBackend` already applies client-side pagination (page/page_size slicing) on the full set, so `count = len(all_results)` is correct again.

## Testing

4 new tests in `TestOSSBackendGetAll`:

| Test | What it verifies |
|------|-----------------|
| `test_passes_top_k_to_sdk` | `top_k=10000` is forwarded to the SDK |
| `test_count_reflects_total_not_sdk_default` | 50 memories → `count=50` (not 20) |
| `test_client_side_pagination` | Page 2, size 10 returns items 10-19 with `count=50` |
| `test_pagination_beyond_total_returns_empty` | Out-of-range page returns `[]` with correct count |

All 46 mem0 tests pass.

Fixes #52921