### PR TITLE
docs(nix): mark Nix/NixOS as no longer explicitly supported

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -94,7 +94,7 @@ You do **not** need to install Python, Node.js, ripgrep, or ffmpeg manually. The
 :::
 
 :::tip Nix users
-If you use Nix (on NixOS, macOS, or Linux), there's a dedicated setup path with a Nix flake, declarative NixOS module, and optional container mode. See the **[Nix & NixOS Setup](./nix-setup.md)** guide.
+Nix is **no longer an explicitly supported install path** (best-effort only). If you already use Nix (on NixOS, macOS, or Linux), there's a dedicated setup path with a Nix flake, declarative NixOS module, and optional container mode. See the **[Nix & NixOS Setup](./nix-setup.md)** guide.
 :::
 
 ---

--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -6,6 +6,10 @@ description: "Install and deploy Hermes Agent with Nix — from quick `nix run` 
 
 # Nix & NixOS Setup
 
+:::warning No longer explicitly supported
+Nix and NixOS are **no longer an explicitly supported install path** for Hermes Agent. The flake and NixOS module documented here may lag behind `main` and are maintained on a best-effort basis. For a supported setup, use the standard [installation](./installation.md) path (`curl | bash` installer, Docker, or Windows). This page is kept for users already running on Nix.
+:::
+
 Hermes Agent ships a Nix flake with three levels of integration:
 
 | Level | Who it's for | What you get |

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -215,7 +215,7 @@ Rolling back may cause config incompatibilities if new options were added. Run `
 
 ### Note for Nix users
 
-If you installed via Nix flake, updates are managed through the Nix package manager:
+Nix is no longer an explicitly supported install path (best-effort only) — see [Nix Setup](./nix-setup.md). If you installed via Nix flake, updates are managed through the Nix package manager:
 
 ```bash
 # Update the flake input

--- a/website/docs/guides/build-a-hermes-plugin.md
+++ b/website/docs/guides/build-a-hermes-plugin.md
@@ -1196,6 +1196,10 @@ pip install hermes-plugin-calculator
 
 ## Distribute for NixOS
 
+:::warning Nix is no longer explicitly supported
+Nix/NixOS is no longer an explicitly supported install path (best-effort only) — see [Nix Setup](/getting-started/nix-setup). This section is kept for users already deploying on NixOS.
+:::
+
 NixOS users can install your plugin declaratively if you provide a `pyproject.toml` with entry points:
 
 **Entry-point plugins** (recommended for distribution):


### PR DESCRIPTION
## Summary
Nix/NixOS is now documented as no longer an explicitly supported install path (best-effort only).

## Changes
- `getting-started/nix-setup.md`: deprecation `:::warning` banner at the top of the page.
- `getting-started/installation.md`: "Nix users" tip now leads with the deprecation.
- `getting-started/updating.md`: "Note for Nix users" section opens with it.
- `guides/build-a-hermes-plugin.md`: warning added to the "Distribute for NixOS" section.

Supported install paths remain the `curl | bash` installer, Docker, and Windows.

## Validation
`npx docusaurus build` → SUCCESS (both `build` and `build/zh-Hans`). No new broken links/anchors from these edits; admonition syntax balanced in all 4 files.

## Infographic

![nix-no-longer-supported](https://v3b.fal.media/files/b/0a9fd238/nUQ90RtxICu8_TamxHExu_E4XlKwBS.png)
