### PR TITLE
feat(bedrock): support application-inference-profile ARNs for Claude

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -117,6 +117,102 @@ def _is_claude_model(model: str | None) -> bool:
     return "claude" in (model or "").lower()
 
 
+# Substrings that identify a NON-Claude vendor in a configured Bedrock model
+# name. Shared by the routing decision (bedrock_adapter.is_anthropic_bedrock_model)
+# and the capability classifier (_classification_model) so the two never drift
+# out of sync — a profile ARN that one treats as non-Claude the other must too.
+NON_CLAUDE_VENDOR_SUBSTRINGS = (
+    "nova", "llama", "deepseek", "titan", "mistral", "command", "jamba",
+)
+
+
+# Map a configured Bedrock display name ("Opus 4.8") to a canonical Claude
+# slug ("claude-opus-4-8") so the capability classifiers below can recognise
+# the model family. Application inference-profile ARNs are opaque IDs that
+# embed no family/version, so the ARN itself classifies as "not Claude" and
+# wrongly routes to the legacy manual-thinking path. We recover the family
+# from the operator-supplied bedrock.models.<arn>.name label instead.
+def _canonical_claude_slug_from_name(name: str) -> Optional[str]:
+    import re
+
+    n = (name or "").lower()
+    fam_match = re.search(r"opus|sonnet|haiku", n)
+    if fam_match is None:
+        return None
+    family = fam_match.group(0)
+    # Anchor the version to the family token so unrelated digits elsewhere in
+    # the label (dates, "v2", account ids) can't be read as a version.
+    # Tolerate whitespace around the major.minor separator ("4.8", "4 . 8").
+    m = re.search(r"\s*(\d+)\s*[.\-]\s*(\d+)", n[fam_match.end():])
+    if not m:
+        return f"claude-{family}"
+    return f"claude-{family}-{m.group(1)}-{m.group(2)}"
+
+
+def _is_inference_profile_arn(model: str | None) -> bool:
+    return "inference-profile" in (model or "").lower()
+
+
+def _classification_model(model: str | None) -> str:
+    """Return a model string usable by the capability classifiers.
+
+    For opaque Bedrock application-inference-profile ARNs (which embed no
+    model family), resolve the configured ``bedrock.models.<arn>.name`` to a
+    canonical Claude slug. Falls back to the newest Claude contract for an
+    unrecognised profile ARN, since Bedrock application inference profiles are
+    Anthropic-only in practice. All other model strings pass through verbatim,
+    so native Anthropic / regional-profile behaviour is unchanged.
+    """
+    raw = model or ""
+    if _is_claude_model(raw) or not _is_inference_profile_arn(raw):
+        return raw
+    try:
+        from hermes_cli.config import load_config
+
+        models_cfg = (load_config().get("bedrock", {}) or {}).get("models", {}) or {}
+        name = ""
+        for arn, meta in models_cfg.items():
+            if str(arn).strip().lower() == raw.strip().lower():
+                name = str((meta or {}).get("name", "")).strip()
+                break
+        if name:
+            slug = _canonical_claude_slug_from_name(name)
+            if slug:
+                return slug
+            # Name configured but maps to no Claude family. If it names a known
+            # non-Claude vendor, pass the ARN through (it routes to Converse,
+            # which never reaches this thinking path anyway). Otherwise the
+            # name is unrecognised — routing assumes Claude→SDK for it, so we
+            # MUST classify as Claude too or we'd 400 with a legacy thinking
+            # block. Stay consistent with is_anthropic_bedrock_model.
+            if any(v in name.lower() for v in NON_CLAUDE_VENDOR_SUBSTRINGS):
+                return raw
+            logger.warning(
+                "Bedrock profile ARN %s has configured name %r that maps to no "
+                "known Claude family; assuming newest Claude for classification.",
+                raw, name,
+            )
+            return "claude-opus-4-8"
+    except Exception as e:
+        logger.warning(
+            "Bedrock profile ARN %s: config lookup failed (%s); "
+            "assuming newest Claude for capability classification.",
+            raw, e,
+        )
+        return "claude-opus-4-8"
+    # Profile ARN with no config entry at all → assume the newest Claude
+    # (modern adaptive contract). Bedrock application inference profiles are
+    # Anthropic-only in practice, so this is the safe default; log it so a
+    # misconfigured ARN is diagnosable rather than silently assumed.
+    logger.warning(
+        "Bedrock profile ARN %s not found in bedrock.models config; "
+        "assuming newest Claude for capability classification. Add a "
+        "bedrock.models.<arn>.name entry to classify it explicitly.",
+        raw,
+    )
+    return "claude-opus-4-8"
+
+
 _FAST_MODE_SUPPORTED_SUBSTRINGS = ("opus-4-6", "opus-4.6")
 
 # ── Max output token limits per Anthropic model ───────────────────────
@@ -2381,12 +2477,18 @@ def build_anthropic_kwargs(
     anthropic_tools = convert_tools_to_anthropic(tools) if tools else []
 
     model = normalize_model_name(model, preserve_dots=preserve_dots)
+    # Classification string for capability checks. For opaque Bedrock
+    # inference-profile ARNs this resolves to a canonical Claude slug; for
+    # every other model it is just ``model``. The real ``model`` (the ARN) is
+    # still sent as the API model field below — only the feature classifiers
+    # use ``clf_model``.
+    clf_model = _classification_model(model)
     # effective_max_tokens = output cap for this call (≠ total context window)
     # Use the resolver helper so non-positive values (negative ints,
     # fractional floats, NaN, non-numeric) fail locally with a clear error
     # rather than 400-ing at the Anthropic API. See openclaw/openclaw#66664.
     effective_max_tokens = _resolve_anthropic_messages_max_tokens(
-        max_tokens, model, context_length=context_length
+        max_tokens, clf_model, context_length=context_length
     )
 
     # Clamp output cap to fit inside the total context window.
@@ -2510,10 +2612,10 @@ def build_anthropic_kwargs(
     # 4.6 behavior and preserving the activity-feed UX during long tool runs.
     _is_kimi_coding = _is_kimi_family_endpoint(base_url, model)
     if reasoning_config and isinstance(reasoning_config, dict) and not _is_kimi_coding:
-        if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
+        if reasoning_config.get("enabled") is not False and "haiku" not in clf_model.lower():
             effort = str(reasoning_config.get("effort", "medium")).lower()
             budget = THINKING_BUDGET.get(effort, 8000)
-            if _supports_adaptive_thinking(model):
+            if _supports_adaptive_thinking(clf_model):
                 kwargs["thinking"] = {
                     "type": "adaptive",
                     "display": "summarized",
@@ -2521,7 +2623,7 @@ def build_anthropic_kwargs(
                 adaptive_effort = ADAPTIVE_EFFORT_MAP.get(effort, "medium")
                 # Downgrade xhigh→max on models that don't list xhigh as a
                 # supported level (Opus/Sonnet 4.6). Opus 4.7+ keeps xhigh.
-                if adaptive_effort == "xhigh" and not _supports_xhigh_effort(model):
+                if adaptive_effort == "xhigh" and not _supports_xhigh_effort(clf_model):
                     adaptive_effort = "max"
                 kwargs["output_config"] = {
                     "effort": adaptive_effort,
@@ -2537,7 +2639,7 @@ def build_anthropic_kwargs(
     # Callers (auxiliary_client, etc.) may set these for older models;
     # drop them here as a safety net so upstream 4.6 → 4.7 migrations
     # don't require coordinated edits everywhere.
-    if _forbids_sampling_params(model):
+    if _forbids_sampling_params(clf_model):
         for _sampling_key in ("temperature", "top_p", "top_k"):
             kwargs.pop(_sampling_key, None)
 

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -445,6 +445,14 @@ def is_anthropic_bedrock_model(model_id: str) -> bool:
       - ``us.anthropic.claude-*`` (US inference profiles)
       - ``global.anthropic.claude-*`` (global inference profiles)
       - ``eu.anthropic.claude-*`` (EU inference profiles)
+      - ``application-inference-profile`` ARNs whose configured
+        ``bedrock.models.<arn>.name`` resolves to a Claude model
+        (e.g. "Opus 4.8", "Sonnet 4.6", "Haiku 4.5"). Application
+        inference-profile ARNs are opaque IDs that don't embed the
+        provider, so we consult the config mapping to recover it.
+        Falls back to treating any application-inference-profile ARN as
+        Claude, since Bedrock application inference profiles are
+        Anthropic-only in practice.
     """
     model_lower = model_id.lower()
     # Strip regional prefix if present
@@ -452,12 +460,87 @@ def is_anthropic_bedrock_model(model_id: str) -> bool:
         if model_lower.startswith(prefix):
             model_lower = model_lower[len(prefix):]
             break
-    return model_lower.startswith("anthropic.claude")
+    if model_lower.startswith("anthropic.claude"):
+        return True
+
+    # Application inference-profile ARNs are opaque (e.g.
+    # ``arn:aws:bedrock:...:application-inference-profile/4jqtkehs0zy3``)
+    # and do NOT embed the provider/model family. Without this branch a
+    # Claude model behind a profile ARN is misrouted to the Converse API
+    # path, silently disabling prompt caching and thinking budgets and
+    # re-billing the full (large) system prompt on every API call.
+    if "application-inference-profile" in model_lower or "inference-profile" in model_lower:
+        try:
+            from hermes_cli.config import load_config
+
+            models_cfg = (load_config().get("bedrock", {}) or {}).get("models", {}) or {}
+            name = ""
+            for arn, meta in models_cfg.items():
+                if str(arn).strip().lower() == model_id.strip().lower():
+                    name = str((meta or {}).get("name", "")).strip().lower()
+                    break
+            if name:
+                # Recognised Claude family names map to the SDK path.
+                if any(fam in name for fam in ("opus", "sonnet", "haiku", "claude")):
+                    return True
+                # A name that clearly names another provider → not Claude.
+                from agent.anthropic_adapter import NON_CLAUDE_VENDOR_SUBSTRINGS
+                if any(other in name for other in NON_CLAUDE_VENDOR_SUBSTRINGS):
+                    return False
+                logger.warning(
+                    "Bedrock profile ARN %s has configured name %r matching no "
+                    "known vendor; assuming Claude (AnthropicBedrock SDK path).",
+                    model_id, name,
+                )
+            else:
+                logger.warning(
+                    "Bedrock profile ARN %s not found in bedrock.models config; "
+                    "assuming Claude (AnthropicBedrock SDK path). Add a "
+                    "bedrock.models.<arn>.name entry to route it explicitly.",
+                    model_id,
+                )
+        except Exception as e:
+            logger.warning(
+                "Bedrock profile ARN %s: config lookup failed (%s); "
+                "assuming Claude (AnthropicBedrock SDK path).",
+                model_id, e,
+            )
+        # Default: Bedrock application inference profiles are Anthropic-only
+        # in practice → route to the AnthropicBedrock SDK path.
+        return True
+
+    return False
 
 
 # ---------------------------------------------------------------------------
 # Message format conversion: OpenAI → Bedrock Converse
 # ---------------------------------------------------------------------------
+
+_BEDROCK_EMPTY_TEXT_PLACEHOLDER = "[empty]"
+
+
+def _non_whitespace_text(value: Any) -> str:
+    """Return Bedrock-safe text for Converse text content blocks."""
+    text = "" if value is None else str(value)
+    return text if text.strip() else _BEDROCK_EMPTY_TEXT_PLACEHOLDER
+
+
+def _sanitize_converse_text_blocks(value: Any) -> Any:
+    """Replace empty/whitespace Converse text fields recursively.
+
+    Bedrock rejects any ``{"text": ""}`` or whitespace-only text field,
+    including nested ``toolResult.content`` entries.
+    """
+    if isinstance(value, dict):
+        if "text" in value:
+            value["text"] = _non_whitespace_text(value.get("text"))
+        for child in value.values():
+            _sanitize_converse_text_blocks(child)
+    elif isinstance(value, list):
+        for child in value:
+            _sanitize_converse_text_blocks(child)
+    return value
+
 
 def convert_tools_to_converse(tools: List[Dict]) -> List[Dict]:
     """Convert OpenAI-format tool definitions to Bedrock Converse ``toolConfig``.
@@ -497,26 +580,26 @@ def _convert_content_to_converse(content) -> List[Dict]:
       - Plain text strings → [{"text": "..."}]
       - Content arrays with text/image_url parts → mixed text/image blocks
 
-    Filters out empty text blocks — Bedrock's Converse API rejects messages
-    where a text content block has an empty ``text`` field (ValidationException:
+    Sanitizes empty text blocks — Bedrock's Converse API rejects messages
+    where a text content block is empty or whitespace-only (ValidationException:
     "text content blocks must be non-empty"). Ref: issue #9486.
     """
     if content is None:
-        return [{"text": " "}]
+        return [{"text": _BEDROCK_EMPTY_TEXT_PLACEHOLDER}]
     if isinstance(content, str):
-        return [{"text": content}] if content.strip() else [{"text": " "}]
+        return [{"text": _non_whitespace_text(content)}]
     if isinstance(content, list):
         blocks = []
         for part in content:
             if isinstance(part, str):
-                blocks.append({"text": part})
+                blocks.append({"text": _non_whitespace_text(part)})
                 continue
             if not isinstance(part, dict):
                 continue
             part_type = part.get("type", "")
             if part_type == "text":
                 text = part.get("text", "")
-                blocks.append({"text": text if text else " "})
+                blocks.append({"text": _non_whitespace_text(text)})
             elif part_type == "image_url":
                 image_url = part.get("image_url", {})
                 url = image_url.get("url", "") if isinstance(image_url, dict) else ""
@@ -538,8 +621,8 @@ def _convert_content_to_converse(content) -> List[Dict]:
                     # Remote URL — Converse doesn't support URLs directly,
                     # include as text reference for the model.
                     blocks.append({"text": f"[Image: {url}]"})
-        return blocks if blocks else [{"text": " "}]
-    return [{"text": str(content)}]
+        return blocks if blocks else [{"text": _BEDROCK_EMPTY_TEXT_PLACEHOLDER}]
+    return [{"text": _non_whitespace_text(content)}]
 
 
 def convert_messages_to_converse(
@@ -587,7 +670,7 @@ def convert_messages_to_converse(
             tool_result_block = {
                 "toolResult": {
                     "toolUseId": tool_call_id,
-                    "content": [{"text": result_content}],
+                    "content": [{"text": _non_whitespace_text(result_content)}],
                 }
             }
             # In Converse, tool results go in a "user" role message
@@ -626,7 +709,7 @@ def convert_messages_to_converse(
                 })
 
             if not content_blocks:
-                content_blocks = [{"text": " "}]
+                content_blocks = [{"text": _BEDROCK_EMPTY_TEXT_PLACEHOLDER}]
 
             # Merge with previous assistant message if needed (strict alternation)
             if converse_msgs and converse_msgs[-1]["role"] == "assistant":
@@ -652,11 +735,14 @@ def convert_messages_to_converse(
 
     # Converse requires the first message to be from the user
     if converse_msgs and converse_msgs[0]["role"] != "user":
-        converse_msgs.insert(0, {"role": "user", "content": [{"text": " "}]})
+        converse_msgs.insert(0, {"role": "user", "content": [{"text": _BEDROCK_EMPTY_TEXT_PLACEHOLDER}]})
 
     # Converse requires the last message to be from the user
     if converse_msgs and converse_msgs[-1]["role"] != "user":
-        converse_msgs.append({"role": "user", "content": [{"text": " "}]})
+        converse_msgs.append({"role": "user", "content": [{"text": _BEDROCK_EMPTY_TEXT_PLACEHOLDER}]})
+
+    _sanitize_converse_text_blocks(system_blocks)
+    _sanitize_converse_text_blocks(converse_msgs)
 
     return (system_blocks if system_blocks else None, converse_msgs)
 
@@ -1092,6 +1178,89 @@ def reset_discovery_cache():
     _discovery_cache.clear()
 
 
+def _configured_bedrock_model_name(model_id: str, metadata: Any = None) -> str:
+    """Return the configured display name for a Bedrock model ID."""
+    if isinstance(metadata, str) and metadata.strip():
+        return metadata.strip()
+    if isinstance(metadata, dict):
+        for key in ("name", "label", "display_name", "display"):
+            value = metadata.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return model_id.rsplit("/", 1)[-1]
+
+
+def _configured_bedrock_model_entries() -> Optional[List[Dict[str, Any]]]:
+    """Return explicit Bedrock model entries when live discovery is disabled."""
+    try:
+        from hermes_cli.config import load_config
+
+        bedrock_cfg = load_config().get("bedrock", {})
+    except Exception:
+        return None
+    if not isinstance(bedrock_cfg, dict):
+        return None
+
+    discovery_cfg = bedrock_cfg.get("discovery", {})
+    if not isinstance(discovery_cfg, dict):
+        discovery_cfg = {}
+    if discovery_cfg.get("enabled", True) is not False:
+        return None
+
+    raw_models = bedrock_cfg.get("models") or discovery_cfg.get("models")
+    entries: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+
+    def _append(model_id: Any, metadata: Any = None) -> None:
+        model_id_str = str(model_id or "").strip()
+        if not model_id_str or model_id_str in seen:
+            return
+        seen.add(model_id_str)
+        entries.append(
+            {
+                "id": model_id_str,
+                "name": _configured_bedrock_model_name(model_id_str, metadata),
+                "provider": "configured",
+                "input_modalities": ["TEXT", "IMAGE"],
+                "output_modalities": ["TEXT"],
+                "streaming": True,
+            }
+        )
+
+    if isinstance(raw_models, dict):
+        for model_id, metadata in raw_models.items():
+            _append(model_id, metadata)
+    elif isinstance(raw_models, list):
+        for item in raw_models:
+            if isinstance(item, str):
+                _append(item)
+            elif isinstance(item, dict):
+                model_id = item.get("id") or item.get("model") or item.get("model_id")
+                _append(model_id, item)
+
+    return entries or None
+
+
+def configured_bedrock_model_labels() -> Dict[str, str]:
+    """Return configured Bedrock model display labels keyed by model ID."""
+    entries = _configured_bedrock_model_entries() or []
+    return {
+        str(entry["id"]): str(entry.get("name") or entry["id"])
+        for entry in entries
+        if entry.get("id")
+    }
+
+
+def _configured_bedrock_models_or_none() -> Optional[List[Dict[str, Any]]]:
+    """Return explicit Bedrock models when live discovery is disabled.
+
+    ``bedrock.discovery.enabled: false`` lets operators keep Hermes' picker
+    aligned with a managed model set such as Claude Code's pinned Bedrock
+    application inference profiles.
+    """
+    return _configured_bedrock_model_entries()
+
+
 def discover_bedrock_models(
     region: str,
     provider_filter: Optional[List[str]] = None,
@@ -1111,6 +1280,10 @@ def discover_bedrock_models(
     Mirrors OpenClaw's ``discoverBedrockModels()`` in
     ``extensions/amazon-bedrock/discovery.ts``.
     """
+    configured = _configured_bedrock_models_or_none()
+    if configured is not None:
+        return configured
+
     import time
 
     cache_key = f"{region}:{','.join(sorted(provider_filter or []))}"

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6481,6 +6481,7 @@ def _prompt_model_selection(
     confirm_provider: str = "",
     confirm_base_url: str = "",
     confirm_api_key: str = "",
+    model_labels: Optional[Dict[str, str]] = None,
 ) -> Optional[str]:
     """Interactive model selection. Puts current_model first with a marker. Returns chosen model ID or None.
 
@@ -6489,7 +6490,12 @@ def _prompt_model_selection(
 
     If *unavailable_models* is provided, those models are shown grayed out
     and unselectable, with an upgrade link to *portal_url*.
+
+    If *model_labels* is provided (``{model_id: human_label}``), the label is
+    shown alongside an otherwise-opaque model id (e.g. a Bedrock
+    application-inference-profile ARN whose id carries no model name).
     """
+    _labels = model_labels or {}
     from hermes_cli.models import _format_price_per_mtok
 
     _unavailable = unavailable_models or []
@@ -6551,6 +6557,10 @@ def _prompt_model_selection(
             if has_cache:
                 price_part += f"  {cache:>{cache_col}}"
             base = f"{mid:<{name_col}}{price_part}"
+        elif _labels.get(mid):
+            # Opaque ids (e.g. Bedrock profile ARNs): lead with the human
+            # label and append a short id tail to disambiguate.
+            base = f"{_labels[mid]}  ({mid.rsplit('/', 1)[-1]})"
         else:
             base = mid
         if mid == current_model:

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2090,6 +2090,8 @@ def _model_flow_bedrock(config, current_model=""):
     print("    2. Bedrock API Key")
     print("       Enter your Bedrock API Key directly — also supports")
     print("       team scenarios where an admin distributes keys")
+    print("    3. Application inference profiles (enter ARNs manually)")
+    print("       For opaque profile ARNs that don't appear in discovery")
     print()
     try:
         auth_choice = input("  Choice [1]: ").strip()
@@ -2099,6 +2101,10 @@ def _model_flow_bedrock(config, current_model=""):
 
     if auth_choice == "2":
         _model_flow_bedrock_api_key(config, region, current_model)
+        return
+
+    if auth_choice == "3":
+        _model_flow_bedrock_inference_profiles(config, region, current_model)
         return
 
     # 3. Model discovery — try live API first, fall back to static list
@@ -2219,6 +2225,159 @@ def _model_flow_bedrock(config, current_model=""):
         print(f"  Default model set to: {selected} (via AWS Bedrock, {region})")
     else:
         print("  No change.")
+
+
+# Known Claude families selectable for an application-inference-profile ARN.
+# The label is stored as ``bedrock.models.<arn>.name`` and resolved back to a
+# canonical model slug by the adapters (is_anthropic_bedrock_model for routing,
+# _classification_model for thinking config). Keep newest-first.
+_BEDROCK_PROFILE_FAMILIES = [
+    "Opus 4.8",
+    "Opus 4.7",
+    "Opus 4.6",
+    "Sonnet 4.6",
+    "Haiku 4.5",
+]
+
+
+def _model_flow_bedrock_inference_profiles(config, region, current_model=""):
+    """Register AWS Bedrock application-inference-profile ARNs manually.
+
+    Application inference profiles are opaque ARNs (e.g.
+    ``arn:aws:bedrock:...:application-inference-profile/abc123``) that don't
+    appear in ``bedrock:ListFoundationModels`` discovery and embed no model
+    family. The user enters each ARN and picks which Claude model it is; the
+    mapping is stored as ``bedrock.models.<arn>.name`` so the adapters can
+    route correctly (AnthropicBedrock SDK vs Converse) and send the right
+    thinking config.
+    """
+    from hermes_cli.auth import (
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+    )
+    from hermes_cli.config import load_config, save_config
+
+    print()
+    print("  Enter one or more application inference profile ARNs.")
+    print("  For each, choose which model the profile points to.")
+    print()
+
+    models: dict[str, dict] = {}
+    while True:
+        try:
+            arn = input("  Inference profile ARN: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return
+        if not arn:
+            print("  ⚠ Empty ARN — skipping.")
+        else:
+            if "inference-profile" not in arn.lower():
+                print("  ⚠ ARN does not contain 'inference-profile' — continuing anyway.")
+
+            print()
+            for idx, fam in enumerate(_BEDROCK_PROFILE_FAMILIES, start=1):
+                print(f"    {idx}. {fam}")
+            print(f"    {len(_BEDROCK_PROFILE_FAMILIES) + 1}. Other / type a name")
+            try:
+                fam_choice = input(f"  Model [{_BEDROCK_PROFILE_FAMILIES[0]}]: ").strip()
+            except (KeyboardInterrupt, EOFError):
+                print()
+                return
+
+            family = _BEDROCK_PROFILE_FAMILIES[0]
+            if not fam_choice:
+                pass  # blank → accept the default (shown in the prompt)
+            elif fam_choice.isdigit():
+                pick = int(fam_choice)
+                if 1 <= pick <= len(_BEDROCK_PROFILE_FAMILIES):
+                    family = _BEDROCK_PROFILE_FAMILIES[pick - 1]
+                elif pick == len(_BEDROCK_PROFILE_FAMILIES) + 1:
+                    try:
+                        typed = input("  Model name: ").strip()
+                    except (KeyboardInterrupt, EOFError):
+                        print()
+                        return
+                    if typed:
+                        family = typed
+                    else:
+                        print(f"  ⚠ Empty name — defaulting to {family}.")
+                else:
+                    print(f"  ⚠ '{fam_choice}' out of range — defaulting to {family}.")
+            else:
+                print(f"  ⚠ '{fam_choice}' is not a valid choice — defaulting to {family}.")
+
+            if arn in models:
+                print(
+                    f"  ⚠ Replacing previous mapping for this ARN "
+                    f"({models[arn]['name']} → {family})."
+                )
+            models[arn] = {"name": family}
+            print(f"  ✓ {arn.rsplit('/', 1)[-1]} → {family}")
+            print()
+
+        try:
+            again = input("  Add another ARN? (y/n) [n]: ").strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            again = "n"
+        if again not in ("y", "yes"):
+            break
+
+    if not models:
+        print("  No change.")
+        return
+
+    # Choose which ARN is the default model.
+    arn_list = list(models)
+    if len(arn_list) == 1:
+        selected = arn_list[0]
+    else:
+        selected = _prompt_model_selection(
+            arn_list,
+            current_model=current_model,
+            model_labels={a: models[a]["name"] for a in arn_list},
+            confirm_provider="bedrock",
+            confirm_base_url=f"https://bedrock-runtime.{region}.amazonaws.com",
+        )
+        if not selected:
+            selected = arn_list[0]
+
+    _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = "bedrock"
+    model["default"] = selected
+    model["base_url"] = f"https://bedrock-runtime.{region}.amazonaws.com"
+    model.pop("api_mode", None)  # bedrock_converse is auto-detected
+    clear_model_endpoint_credentials(model, clear_api_mode=False)
+
+    bedrock_cfg = cfg.get("bedrock", {})
+    if not isinstance(bedrock_cfg, dict):
+        bedrock_cfg = {}
+    bedrock_cfg["region"] = region
+    bedrock_cfg["models"] = models
+    # Manual ARN list is authoritative — don't let live discovery overwrite it.
+    discovery_cfg = bedrock_cfg.get("discovery")
+    if not isinstance(discovery_cfg, dict):
+        discovery_cfg = {}
+    discovery_cfg["enabled"] = False
+    bedrock_cfg["discovery"] = discovery_cfg
+    cfg["bedrock"] = bedrock_cfg
+
+    save_config(cfg)
+    deactivate_provider()
+
+    print(
+        f"  Default model set to: {models[selected]['name']} "
+        f"(via AWS Bedrock, {region})"
+    )
+
 
 def _select_zai_endpoint(current_base: str) -> str:
     """Present a picker for Z.AI endpoint selection during setup.

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1814,8 +1814,21 @@ def list_authenticated_providers(
                     model_ids = _merge_with_models_dev(hermes_slug, model_ids)
         total = len(model_ids)
         top = model_ids[:max_models] if max_models is not None else model_ids
+        model_labels: dict[str, str] = {}
+        if overlay.auth_type == "aws_sdk" and hermes_slug == "bedrock":
+            try:
+                from agent.bedrock_adapter import configured_bedrock_model_labels
 
-        results.append({
+                configured_labels = configured_bedrock_model_labels()
+                model_labels = {
+                    mid: configured_labels[mid]
+                    for mid in top
+                    if configured_labels.get(mid)
+                }
+            except Exception:
+                model_labels = {}
+
+        row = {
             "slug": hermes_slug,
             "name": get_label(hermes_slug),
             "is_current": hermes_slug == current_provider or pid == current_provider,
@@ -1823,7 +1836,10 @@ def list_authenticated_providers(
             "models": top,
             "total_models": total,
             "source": "hermes",
-        })
+        }
+        if model_labels:
+            row["model_labels"] = model_labels
+        results.append(row)
         seen_slugs.add(pid.lower())
         seen_slugs.add(hermes_slug.lower())
         _record_builtin_endpoint(hermes_slug)
@@ -1889,8 +1905,21 @@ def list_authenticated_providers(
                 _cp_model_ids = curated.get(_cp.slug, [])
         _cp_total = len(_cp_model_ids)
         _cp_top = _cp_model_ids[:max_models] if max_models is not None else _cp_model_ids
+        _cp_model_labels: dict[str, str] = {}
+        if _cp_config and getattr(_cp_config, "auth_type", "") == "aws_sdk" and _cp.slug == "bedrock":
+            try:
+                from agent.bedrock_adapter import configured_bedrock_model_labels
 
-        results.append({
+                _configured_labels = configured_bedrock_model_labels()
+                _cp_model_labels = {
+                    mid: _configured_labels[mid]
+                    for mid in _cp_top
+                    if _configured_labels.get(mid)
+                }
+            except Exception:
+                _cp_model_labels = {}
+
+        _cp_row = {
             "slug": _cp.slug,
             "name": _cp.label,
             "is_current": _cp.slug == current_provider,
@@ -1898,7 +1927,10 @@ def list_authenticated_providers(
             "models": _cp_top,
             "total_models": _cp_total,
             "source": "canonical",
-        })
+        }
+        if _cp_model_labels:
+            _cp_row["model_labels"] = _cp_model_labels
+        results.append(_cp_row)
         seen_slugs.add(_cp.slug.lower())
         _record_builtin_endpoint(_cp.slug)
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1553,6 +1553,151 @@ class TestBuildAnthropicKwargs:
 
 
 # ---------------------------------------------------------------------------
+# Bedrock application-inference-profile ARN classification
+# ---------------------------------------------------------------------------
+
+
+_PROFILE_ARN = (
+    "arn:aws:bedrock:eu-west-1:123456789012:"
+    "application-inference-profile/4jqtkehs0zy3"
+)
+
+
+def _profile_config(name):
+    return {"bedrock": {"models": {_PROFILE_ARN: {"name": name}}}}
+
+
+class TestClassificationModel:
+    """Opaque application-inference-profile ARNs embed no model family, so the
+    capability classifiers must resolve them via ``bedrock.models.<arn>.name``.
+    """
+
+    def test_canonical_slug_from_name(self):
+        from agent.anthropic_adapter import _canonical_claude_slug_from_name
+        assert _canonical_claude_slug_from_name("Opus 4.8") == "claude-opus-4-8"
+        assert _canonical_claude_slug_from_name("Sonnet 4.6") == "claude-sonnet-4-6"
+        assert _canonical_claude_slug_from_name("Haiku 4.5") == "claude-haiku-4-5"
+        # Dotted form normalises the same way.
+        assert _canonical_claude_slug_from_name("Opus 4.7") == "claude-opus-4-7"
+        # No recognised family → None.
+        assert _canonical_claude_slug_from_name("Nova Pro") is None
+
+    def test_canonical_slug_version_anchored_to_family(self):
+        """The version must be the digits that FOLLOW the family token, not
+        the first digit-pair anywhere (dates, 'rev 2', account ids)."""
+        from agent.anthropic_adapter import _canonical_claude_slug_from_name
+        assert _canonical_claude_slug_from_name("Opus rev 2 4.8") == "claude-opus-4-8"
+        assert _canonical_claude_slug_from_name("Claude Opus 4.8 (EU)") == "claude-opus-4-8"
+        # Whitespace around the separator is tolerated.
+        assert _canonical_claude_slug_from_name("OPUS 4 . 8") == "claude-opus-4-8"
+        # A family with no trailing version → bare family slug (still Claude).
+        assert _canonical_claude_slug_from_name("Opus") == "claude-opus"
+
+    def test_profile_arn_resolves_to_configured_family(self):
+        from agent.anthropic_adapter import _classification_model
+        with patch(
+            "hermes_cli.config.load_config", return_value=_profile_config("Opus 4.8")
+        ):
+            assert _classification_model(_PROFILE_ARN) == "claude-opus-4-8"
+
+    def test_unresolved_profile_arn_defaults_to_newest_claude(self):
+        from agent.anthropic_adapter import _classification_model
+        # Empty config → unknown profile ARN → assume newest Claude contract.
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert _classification_model(_PROFILE_ARN) == "claude-opus-4-8"
+
+    def test_config_load_failure_defaults_to_newest_claude(self):
+        from agent.anthropic_adapter import _classification_model
+        # A broken config must not crash request-building; fall back safely.
+        with patch(
+            "hermes_cli.config.load_config", side_effect=RuntimeError("boom")
+        ):
+            assert _classification_model(_PROFILE_ARN) == "claude-opus-4-8"
+
+    def test_non_claude_named_profile_passes_arn_through(self):
+        """A profile tagged with a non-Claude vendor must NOT be coerced to an
+        Opus slug — it routes to Converse and never builds adaptive thinking."""
+        from agent.anthropic_adapter import _classification_model
+        with patch(
+            "hermes_cli.config.load_config", return_value=_profile_config("Nova Pro")
+        ):
+            assert _classification_model(_PROFILE_ARN) == _PROFILE_ARN
+
+    def test_unrecognised_name_assumes_claude_consistent_with_routing(self):
+        """A name that maps to no family AND no known vendor (typo, internal
+        label) must classify as Claude — routing assumes Claude→SDK for it, so
+        classifying as legacy would 400. Consistency with
+        is_anthropic_bedrock_model is the invariant under test."""
+        from agent.anthropic_adapter import _classification_model
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value=_profile_config("Opuss 4.8"),  # typo
+        ):
+            assert _classification_model(_PROFILE_ARN) == "claude-opus-4-8"
+
+    def test_non_profile_models_pass_through_unchanged(self):
+        from agent.anthropic_adapter import _classification_model
+        # Native + regional-profile IDs already carry their family — untouched.
+        assert _classification_model("claude-opus-4-6") == "claude-opus-4-6"
+        assert (
+            _classification_model("eu.anthropic.claude-sonnet-4-6-20250514-v1:0")
+            == "eu.anthropic.claude-sonnet-4-6-20250514-v1:0"
+        )
+
+    def test_profile_arn_builds_adaptive_thinking_kwargs(self):
+        """End-to-end: a profile ARN for Opus 4.8 must produce
+        thinking.type:adaptive (not the legacy 'enabled' that 400s), while the
+        real ARN is still sent as the API model field."""
+        with patch(
+            "hermes_cli.config.load_config", return_value=_profile_config("Opus 4.8")
+        ):
+            kwargs = build_anthropic_kwargs(
+                model=_PROFILE_ARN,
+                messages=[{"role": "user", "content": "hi"}],
+                tools=None,
+                max_tokens=None,
+                reasoning_config={"enabled": True, "effort": "xhigh"},
+            )
+        assert kwargs["model"] == _PROFILE_ARN  # ARN still sent to the API
+        assert kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
+        assert kwargs["output_config"] == {"effort": "xhigh"}
+        assert "temperature" not in kwargs
+
+    def test_profile_arn_for_sonnet_46_downgrades_xhigh(self):
+        """A profile ARN tagged Sonnet 4.6 must downgrade xhigh→max (4.6 has
+        no xhigh level) — proving the resolved family, not the ARN, drives the
+        capability checks."""
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value=_profile_config("Sonnet 4.6"),
+        ):
+            kwargs = build_anthropic_kwargs(
+                model=_PROFILE_ARN,
+                messages=[{"role": "user", "content": "hi"}],
+                tools=None,
+                max_tokens=None,
+                reasoning_config={"enabled": True, "effort": "xhigh"},
+            )
+        assert kwargs["output_config"] == {"effort": "max"}
+
+    def test_profile_arn_for_haiku_omits_thinking(self):
+        """Haiku doesn't support extended thinking — a Haiku-tagged profile ARN
+        must omit the thinking block entirely (would otherwise 400)."""
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value=_profile_config("Haiku 4.5"),
+        ):
+            kwargs = build_anthropic_kwargs(
+                model=_PROFILE_ARN,
+                messages=[{"role": "user", "content": "hi"}],
+                tools=None,
+                max_tokens=None,
+                reasoning_config={"enabled": True, "effort": "high"},
+            )
+        assert "thinking" not in kwargs
+
+
+# ---------------------------------------------------------------------------
 # Model output limit lookup
 # ---------------------------------------------------------------------------
 

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -326,8 +326,7 @@ class TestConvertMessagesToConverse:
         from agent.bedrock_adapter import convert_messages_to_converse
         messages = [{"role": "user", "content": ""}]
         system, msgs = convert_messages_to_converse(messages)
-        # Empty string should get a space placeholder
-        assert msgs[0]["content"][0]["text"].strip() != "" or msgs[0]["content"][0]["text"] == " "
+        assert msgs[0]["content"][0]["text"].strip()
 
     def test_image_data_url_converted(self):
         from agent.bedrock_adapter import convert_messages_to_converse
@@ -707,6 +706,60 @@ class TestBuildConverseKwargs:
 
 class TestDiscoverBedrockModels:
     """Test Bedrock model discovery with mocked AWS API calls."""
+
+    def test_uses_configured_models_when_discovery_disabled(self):
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        configured = [
+            "arn:aws:bedrock:eu-west-1:123456789012:application-inference-profile/opus",
+            "arn:aws:bedrock:eu-west-1:123456789012:application-inference-profile/sonnet",
+        ]
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "bedrock": {
+                    "discovery": {"enabled": False},
+                    "models": configured,
+                }
+            },
+        ), patch("agent.bedrock_adapter._get_bedrock_control_client") as client:
+            models = discover_bedrock_models("eu-west-1")
+
+        assert [m["id"] for m in models] == configured
+        client.assert_not_called()
+
+    def test_uses_configured_model_labels_when_discovery_disabled(self):
+        from agent.bedrock_adapter import (
+            configured_bedrock_model_labels,
+            discover_bedrock_models,
+            reset_discovery_cache,
+        )
+        reset_discovery_cache()
+
+        opus = "arn:aws:bedrock:eu-west-1:123456789012:application-inference-profile/opus"
+        sonnet = "arn:aws:bedrock:eu-west-1:123456789012:application-inference-profile/sonnet"
+        config = {
+            "bedrock": {
+                "discovery": {"enabled": False},
+                "models": {
+                    opus: {"name": "Opus 4.8"},
+                    sonnet: {"name": "Sonnet 4.6"},
+                },
+            }
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=config), patch(
+            "agent.bedrock_adapter._get_bedrock_control_client"
+        ) as client:
+            models = discover_bedrock_models("eu-west-1")
+            labels = configured_bedrock_model_labels()
+
+        assert [m["id"] for m in models] == [opus, sonnet]
+        assert [m["name"] for m in models] == ["Opus 4.8", "Sonnet 4.6"]
+        assert labels == {opus: "Opus 4.8", sonnet: "Sonnet 4.6"}
+        client.assert_not_called()
 
     def test_discovers_foundation_models(self):
         from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
@@ -1304,28 +1357,129 @@ class TestIsAnthropicBedrockModel:
         assert is_anthropic_bedrock_model("eu.anthropic.claude-sonnet-4-6") is True
 
 
-class TestEmptyTextBlockFix:
-    """Test that empty text blocks are replaced with space placeholders."""
+_PROFILE_ARN = (
+    "arn:aws:bedrock:eu-west-1:123456789012:"
+    "application-inference-profile/4jqtkehs0zy3"
+)
 
-    def test_none_content_gets_space(self):
+
+class TestIsAnthropicBedrockModelProfileArns:
+    """Routing for opaque application-inference-profile ARNs, which embed no
+    model family and must be classified via bedrock.models.<arn>.name.
+
+    This is the cost/correctness-critical branch: a wrong answer routes a
+    Claude model to the Converse API (no prompt caching → re-bills the full
+    system prompt every turn) or sends Anthropic-shaped JSON to a non-Claude
+    model.
+    """
+
+    def _with_config(self, name):
+        cfg = (
+            {"bedrock": {"models": {_PROFILE_ARN: {"name": name}}}}
+            if name is not None
+            else {}
+        )
+        return patch("hermes_cli.config.load_config", return_value=cfg)
+
+    def test_claude_named_profile_routes_to_sdk(self):
+        from agent.bedrock_adapter import is_anthropic_bedrock_model
+        with self._with_config("Opus 4.8"):
+            assert is_anthropic_bedrock_model(_PROFILE_ARN) is True
+
+    def test_nova_named_profile_routes_to_converse(self):
+        from agent.bedrock_adapter import is_anthropic_bedrock_model
+        with self._with_config("Nova Pro"):
+            assert is_anthropic_bedrock_model(_PROFILE_ARN) is False
+
+    def test_unconfigured_profile_assumes_claude(self):
+        from agent.bedrock_adapter import is_anthropic_bedrock_model
+        with self._with_config(None):  # empty config — ARN not present
+            assert is_anthropic_bedrock_model(_PROFILE_ARN) is True
+
+    def test_unrecognised_name_assumes_claude(self):
+        from agent.bedrock_adapter import is_anthropic_bedrock_model
+        with self._with_config("some-internal-label"):
+            assert is_anthropic_bedrock_model(_PROFILE_ARN) is True
+
+    def test_config_load_failure_assumes_claude(self):
+        from agent.bedrock_adapter import is_anthropic_bedrock_model
+        with patch(
+            "hermes_cli.config.load_config", side_effect=RuntimeError("boom")
+        ):
+            assert is_anthropic_bedrock_model(_PROFILE_ARN) is True
+
+
+class TestEmptyTextBlockFix:
+    """Test that Bedrock Converse payloads never contain whitespace-only text."""
+
+    def _assert_no_whitespace_text_blocks(self, value):
+        if isinstance(value, dict):
+            if "text" in value:
+                assert str(value["text"]).strip()
+            for child in value.values():
+                self._assert_no_whitespace_text_blocks(child)
+        elif isinstance(value, list):
+            for child in value:
+                self._assert_no_whitespace_text_blocks(child)
+
+    def test_none_content_gets_non_whitespace_placeholder(self):
         from agent.bedrock_adapter import _convert_content_to_converse
         blocks = _convert_content_to_converse(None)
-        assert blocks[0]["text"] == " "
+        self._assert_no_whitespace_text_blocks(blocks)
 
-    def test_empty_string_gets_space(self):
+    def test_empty_string_gets_non_whitespace_placeholder(self):
         from agent.bedrock_adapter import _convert_content_to_converse
         blocks = _convert_content_to_converse("")
-        assert blocks[0]["text"] == " "
+        self._assert_no_whitespace_text_blocks(blocks)
 
-    def test_whitespace_only_gets_space(self):
+    def test_whitespace_only_gets_non_whitespace_placeholder(self):
         from agent.bedrock_adapter import _convert_content_to_converse
         blocks = _convert_content_to_converse("   ")
-        assert blocks[0]["text"] == " "
+        self._assert_no_whitespace_text_blocks(blocks)
+
+    def test_content_list_whitespace_parts_get_non_whitespace_placeholder(self):
+        from agent.bedrock_adapter import _convert_content_to_converse
+        blocks = _convert_content_to_converse([
+            "   ",
+            {"type": "text", "text": "\n\t"},
+        ])
+        self._assert_no_whitespace_text_blocks(blocks)
+
+    def test_message_conversion_sanitizes_all_text_blocks(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "system", "content": [{"type": "text", "text": "  "}]},
+            {"role": "assistant", "content": ""},
+            {"role": "tool", "tool_call_id": "call_1", "content": "\n"},
+        ]
+        system, msgs = convert_messages_to_converse(messages)
+        self._assert_no_whitespace_text_blocks(system)
+        self._assert_no_whitespace_text_blocks(msgs)
 
     def test_real_text_preserved(self):
         from agent.bedrock_adapter import _convert_content_to_converse
         blocks = _convert_content_to_converse("Hello")
         assert blocks[0]["text"] == "Hello"
+
+    def test_sanitizes_nested_tool_result_content(self):
+        """The recursion exists specifically to reach whitespace text nested
+        inside toolResult.content (Bedrock rejects empty text there too)."""
+        from agent.bedrock_adapter import (
+            _BEDROCK_EMPTY_TEXT_PLACEHOLDER,
+            _sanitize_converse_text_blocks,
+        )
+        payload = [
+            {
+                "role": "user",
+                "content": [
+                    {"toolResult": {"toolUseId": "t1", "content": [{"text": "  "}]}}
+                ],
+            }
+        ]
+        _sanitize_converse_text_blocks(payload)
+        nested = payload[0]["content"][0]["toolResult"]["content"][0]["text"]
+        assert nested == _BEDROCK_EMPTY_TEXT_PLACEHOLDER
+        assert nested.strip()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_bedrock_inference_profiles_flow.py
+++ b/tests/hermes_cli/test_bedrock_inference_profiles_flow.py
@@ -1,0 +1,180 @@
+"""Tests for the manual Bedrock application-inference-profile setup flow.
+
+`_model_flow_bedrock_inference_profiles` lets a user register opaque
+application-inference-profile ARNs and tag each with the Claude model it
+points to. The mapping is persisted to ``bedrock.models.<arn>.name`` so the
+adapters can route correctly and send the right thinking config.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def config_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with a minimal string-format config."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("model: some-old-model\n")
+    (home / ".env").write_text("")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_MODEL", raising=False)
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    return home
+
+
+ARN_A = "arn:aws:bedrock:eu-west-1:123456789012:application-inference-profile/aaa"
+ARN_B = "arn:aws:bedrock:eu-west-1:123456789012:application-inference-profile/bbb"
+
+
+def _load(config_home):
+    import yaml
+
+    return yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+
+
+class TestBedrockInferenceProfilesFlow:
+    def test_registers_multiple_arns_and_persists_mapping(self, config_home):
+        from hermes_cli.model_setup_flows import (
+            _model_flow_bedrock_inference_profiles,
+        )
+
+        # ARN_A → family "1" (Opus 4.8), add another;
+        # ARN_B → family "5" (Haiku 4.5), stop.
+        inputs = [ARN_A, "1", "y", ARN_B, "5", "n"]
+
+        with patch("builtins.input", side_effect=inputs), patch(
+            "hermes_cli.auth._prompt_model_selection", return_value=ARN_A
+        ), patch("hermes_cli.auth.deactivate_provider"):
+            _model_flow_bedrock_inference_profiles({}, "eu-west-1")
+
+        cfg = _load(config_home)
+        assert cfg["bedrock"]["models"] == {
+            ARN_A: {"name": "Opus 4.8"},
+            ARN_B: {"name": "Haiku 4.5"},
+        }
+        assert cfg["bedrock"]["region"] == "eu-west-1"
+        assert cfg["bedrock"]["discovery"]["enabled"] is False
+        assert cfg["model"]["provider"] == "bedrock"
+        assert cfg["model"]["default"] == ARN_A
+        assert (
+            cfg["model"]["base_url"]
+            == "https://bedrock-runtime.eu-west-1.amazonaws.com"
+        )
+
+    def test_single_arn_skips_picker_and_is_default(self, config_home):
+        from hermes_cli.model_setup_flows import (
+            _model_flow_bedrock_inference_profiles,
+        )
+
+        inputs = [ARN_A, "2", "n"]  # one ARN, family "2" (Opus 4.7), stop
+
+        # _prompt_model_selection must NOT be called for a single ARN.
+        with patch("builtins.input", side_effect=inputs), patch(
+            "hermes_cli.auth._prompt_model_selection"
+        ) as picker, patch("hermes_cli.auth.deactivate_provider"):
+            _model_flow_bedrock_inference_profiles({}, "us-east-1")
+
+        picker.assert_not_called()
+        cfg = _load(config_home)
+        assert cfg["bedrock"]["models"] == {ARN_A: {"name": "Opus 4.7"}}
+        assert cfg["model"]["default"] == ARN_A
+
+    def test_free_text_family_escape_hatch(self, config_home):
+        from hermes_cli.model_setup_flows import (
+            _BEDROCK_PROFILE_FAMILIES,
+            _model_flow_bedrock_inference_profiles,
+        )
+
+        other = str(len(_BEDROCK_PROFILE_FAMILIES) + 1)  # the "Other" option
+        inputs = [ARN_A, other, "Opus 5.0", "n"]
+
+        with patch("builtins.input", side_effect=inputs), patch(
+            "hermes_cli.auth.deactivate_provider"
+        ):
+            _model_flow_bedrock_inference_profiles({}, "eu-west-1")
+
+        cfg = _load(config_home)
+        assert cfg["bedrock"]["models"][ARN_A] == {"name": "Opus 5.0"}
+
+    def test_no_arns_makes_no_change(self, config_home):
+        from hermes_cli.model_setup_flows import (
+            _model_flow_bedrock_inference_profiles,
+        )
+
+        # Immediately decline to add any ARN (empty ARN, then stop).
+        with patch("builtins.input", side_effect=["", "n"]), patch(
+            "hermes_cli.auth.deactivate_provider"
+        ):
+            _model_flow_bedrock_inference_profiles({}, "eu-west-1")
+
+        cfg = _load(config_home)
+        # Untouched — model stays the original plain string, no bedrock block.
+        assert cfg.get("model") == "some-old-model"
+        assert "bedrock" not in cfg
+
+    def test_invalid_family_choice_defaults_to_first(self, config_home):
+        from hermes_cli.model_setup_flows import (
+            _BEDROCK_PROFILE_FAMILIES,
+            _model_flow_bedrock_inference_profiles,
+        )
+
+        # Out-of-range numeric and non-numeric both fall back to the first
+        # family (with a printed warning).
+        inputs = [ARN_A, "99", "n"]
+        with patch("builtins.input", side_effect=inputs), patch(
+            "hermes_cli.auth.deactivate_provider"
+        ):
+            _model_flow_bedrock_inference_profiles({}, "eu-west-1")
+
+        cfg = _load(config_home)
+        assert cfg["bedrock"]["models"][ARN_A] == {
+            "name": _BEDROCK_PROFILE_FAMILIES[0]
+        }
+
+    def test_duplicate_arn_last_entry_wins(self, config_home):
+        from hermes_cli.model_setup_flows import (
+            _model_flow_bedrock_inference_profiles,
+        )
+
+        # Same ARN entered twice with different families — the second replaces
+        # the first, leaving a single mapping.
+        inputs = [ARN_A, "1", "y", ARN_A, "5", "n"]
+        with patch("builtins.input", side_effect=inputs), patch(
+            "hermes_cli.auth.deactivate_provider"
+        ):
+            _model_flow_bedrock_inference_profiles({}, "eu-west-1")
+
+        cfg = _load(config_home)
+        assert cfg["bedrock"]["models"] == {ARN_A: {"name": "Haiku 4.5"}}
+
+    def test_keyboard_interrupt_on_first_arn_leaves_config_untouched(
+        self, config_home
+    ):
+        from hermes_cli.model_setup_flows import (
+            _model_flow_bedrock_inference_profiles,
+        )
+
+        with patch("builtins.input", side_effect=KeyboardInterrupt), patch(
+            "hermes_cli.auth.deactivate_provider"
+        ):
+            _model_flow_bedrock_inference_profiles({}, "eu-west-1")
+
+        cfg = _load(config_home)
+        assert cfg.get("model") == "some-old-model"
+        assert "bedrock" not in cfg
+
+    def test_multi_arn_picker_receives_model_labels(self, config_home):
+        """Regression: the multi-ARN path calls _prompt_model_selection with
+        model_labels= — that kwarg must exist on the real signature (it would
+        otherwise TypeError in production while a loose mock hid it)."""
+        import inspect
+        from hermes_cli.auth import _prompt_model_selection
+
+        params = inspect.signature(_prompt_model_selection).parameters
+        assert "model_labels" in params, (
+            "_prompt_model_selection must accept model_labels= for the "
+            "Bedrock profile picker"
+        )


### PR DESCRIPTION
## What does this PR do?

Adds first-class support for AWS Bedrock **application inference profile** ARNs (e.g. `arn:aws:bedrock:eu-west-1:123:application-inference-profile/4jqtkehs0zy3`) when the underlying model is Claude.

These ARNs are opaque — they embed no model family or version — so Hermes' string-matching model classifiers misidentified them. For users who pin Claude via such an ARN, that caused two problems:

1. **Cost blowup.** Unrecognised ARNs were routed to the Bedrock **Converse** API, which has no prompt caching. Every agentic turn re-billed the full (large) system prompt as fresh input tokens.
2. **HTTP 400.** Once routed to the AnthropicBedrock SDK, the thinking-config builder still saw the opaque ARN and emitted the legacy `thinking.type: "enabled"`, which Claude 4.6+ rejects:
   > `"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.`

**Approach:** recover the model family from the operator-supplied `bedrock.models.<arn>.name` label (e.g. `"Opus 4.8"` → `claude-opus-4-8`). The resolved slug drives routing and capability detection; the real ARN is still sent as the API `model` field. A new setup option lets users register ARNs and tag each with its model, so the mapping is easy to populate.

## Related Issue

<!-- No tracking issue found; happy to open one if maintainers prefer. -->
Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/anthropic_adapter.py`: new `_classification_model()` resolves an opaque inference-profile ARN to a canonical Claude slug via `bedrock.models.<arn>.name`; it feeds the five capability classifiers in `build_anthropic_kwargs` (`_resolve_anthropic_messages_max_tokens`, the Haiku skip, `_supports_adaptive_thinking`, `_supports_xhigh_effort`, `_forbids_sampling_params`). The real ARN is still sent as the API `model`. Family→slug parsing is anchored to the family token and whitespace-tolerant.
- `agent/bedrock_adapter.py`: `is_anthropic_bedrock_model()` recognises profile ARNs (Claude names → AnthropicBedrock SDK; known non-Claude vendors → Converse; unknown → assume Claude, since application inference profiles are Anthropic-only in practice). Also sanitises empty/whitespace Converse text blocks, including nested `toolResult.content` (ref #9486).
- Shared `NON_CLAUDE_VENDOR_SUBSTRINGS` constant keeps the routing and classification decisions from drifting apart.
- All "assume Claude / assume newest" fallbacks now emit a `logger.warning` so a misconfigured ARN is diagnosable rather than silently assumed.
- `hermes_cli/model_setup_flows.py`: new "Application inference profiles (enter ARNs manually)" option in `hermes model` → Bedrock — loops to register multiple ARNs, picks each model from a dropdown (with a free-text escape hatch), persists `bedrock.models`, and disables live discovery so the manual list isn't overwritten.
- `hermes_cli/auth.py`: `_prompt_model_selection` gains an optional `model_labels` param so opaque ARNs show a friendly model name in the picker.
- `hermes_cli/model_switch.py`: surfaces configured Bedrock labels in the provider/model list.
- Tests across `tests/agent/test_anthropic_adapter.py`, `tests/agent/test_bedrock_adapter.py`, and new `tests/hermes_cli/test_bedrock_inference_profiles_flow.py`.

## How to Test

1. `hermes model` → AWS Bedrock → option **3** (Application inference profiles). Enter an `application-inference-profile` ARN and pick its model (e.g. Opus 4.8). Confirm `config.yaml` gains `bedrock.models.<arn>.name` and `model.default` points at the ARN.
2. Run an agentic turn against that ARN. Before this change it failed with the `thinking.type.enabled` 400; now it sends `thinking.type: adaptive` + `output_config.effort` and succeeds, with prompt caching active.
3. `pytest tests/agent/test_anthropic_adapter.py tests/agent/test_bedrock_adapter.py tests/hermes_cli/test_bedrock_inference_profiles_flow.py -q`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the affected test suites and they pass (3 pre-existing `TestRunOauthSetupToken` failures are environmental and unrelated to this change)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] Docstrings updated — or N/A
- [x] `cli-config.yaml.example`: N/A — the existing `bedrock:` block isn't documented there and these keys are written by the setup wizard, not hand-edited
- [x] Cross-platform impact considered (pure-Python; no platform-specific primitives) — or N/A
- [x] Tool descriptions/schemas — N/A