### PR TITLE
fix(browser): expose Camofox captured downloads via browser_list_downloads and browser_save_download

### DIFF
--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -791,4 +791,74 @@ def camofox_console(clear: bool = False, task_id: Optional[str] = None) -> str:
     })
 
 
+def camofox_list_downloads(
+    task_id: Optional[str] = None,
+    include_data: bool = False,
+    max_bytes: Optional[int] = None,
+) -> str:
+    """List captured downloads for the current Camofox tab."""
+    session = _get_session(task_id)
+    params: Dict[str, Any] = {
+        "userId": session["user_id"],
+        "includeData": "true" if include_data else "false",
+    }
+    if max_bytes is not None:
+        params["maxBytes"] = int(max_bytes)
+
+    data = _get(f"/tabs/{session['tab_id']}/downloads", params=params)
+    downloads = data.get("downloads", []) if isinstance(data, dict) else []
+    return json.dumps({
+        "success": True,
+        "downloads": downloads,
+        "count": len(downloads),
+        "tab_id": session["tab_id"],
+    })
+
+
+def camofox_get_download_content(
+    download_id: str,
+    output_path: Optional[str] = None,
+    task_id: Optional[str] = None,
+    max_bytes: int = 50 * 1024 * 1024,
+) -> str:
+    """Fetch a captured download and write it to disk."""
+    import tempfile
+    listing = json.loads(camofox_list_downloads(
+        task_id=task_id,
+        include_data=True,
+        max_bytes=max_bytes,
+    ))
+    match = next(
+        (item for item in listing.get("downloads", []) if item.get("id") == download_id),
+        None,
+    )
+    if match is None:
+        return tool_error(
+            f"download {download_id!r} not found in tab {listing.get('tab_id')}",
+            success=False,
+        )
+
+    raw = base64.b64decode(match.get("dataBase64", ""))
+    if not output_path:
+        filename = os.path.basename(
+            str(match.get("suggestedFilename") or f"{download_id}.bin")
+        )
+        output_path = os.path.join(tempfile.gettempdir(), filename)
+
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+    with open(output_path, "wb") as f:
+        f.write(raw)
+
+    return json.dumps({
+        "success": True,
+        "download_id": download_id,
+        "output_path": output_path,
+        "suggested_filename": match.get("suggestedFilename"),
+        "mime_type": match.get("mimeType"),
+        "bytes": len(raw),
+        "tab_id": listing.get("tab_id"),
+    })
+
+
+
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1743,6 +1743,28 @@ BROWSER_TOOL_SCHEMAS = [
             "required": []
         }
     },
+    {
+        "name": "browser_list_downloads",
+        "description": "List captured downloads for the current Camofox tab. Returns download IDs, filenames, sizes, URLs, status/failure metadata, and total count.",
+        "parameters": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        }
+    },
+    {
+        "name": "browser_save_download",
+        "description": "Save a captured download to a local file. Accepts parameters: download_id, optional output_path, optional max_bytes.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "download_id": {"type": "string", "description": "The download ID from browser_list_downloads"},
+                "output_path": {"type": "string", "description": "Optional local file path to write the download to. If omitted, a tempfile path is used."},
+                "max_bytes": {"type": "integer", "description": "Maximum download bytes to fetch (default: 52428800 = 50MB)"}
+            },
+            "required": ["download_id"]
+        }
+    },
 ]
 
 
@@ -3202,6 +3224,48 @@ def browser_get_images(task_id: Optional[str] = None) -> str:
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
+def browser_list_downloads(task_id: Optional[str] = None) -> str:
+    """
+    List captured downloads for the current Camofox tab.
+
+    Only supported when the browser backend is Camofox. Returns an
+    unsupported-backend error for other backends.
+    """
+    if _is_camofox_mode():
+        from tools.browser_camofox import camofox_list_downloads
+        return camofox_list_downloads(task_id=task_id)
+    return json.dumps({
+        "success": False,
+        "error": "browser_list_downloads is only supported with the Camofox backend.",
+    })
+
+
+def browser_save_download(
+    download_id: str,
+    output_path: Optional[str] = None,
+    task_id: Optional[str] = None,
+    max_bytes: int = 50 * 1024 * 1024,
+) -> str:
+    """
+    Save a captured download to a local file.
+
+    Only supported when the browser backend is Camofox. Returns an
+    unsupported-backend error for other backends.
+    """
+    if _is_camofox_mode():
+        from tools.browser_camofox import camofox_get_download_content
+        return camofox_get_download_content(
+            download_id=download_id,
+            output_path=output_path,
+            task_id=task_id,
+            max_bytes=max_bytes,
+        )
+    return json.dumps({
+        "success": False,
+        "error": "browser_save_download is only supported with the Camofox backend.",
+    })
+
+
 def browser_vision(question: str, annotate: bool = False, task_id: Optional[str] = None) -> Union[str, Dict[str, Any]]:
     """
     Take a screenshot of the current page for visual inspection.
@@ -4002,4 +4066,25 @@ registry.register(
     handler=lambda args, **kw: browser_console(clear=args.get("clear", False), expression=args.get("expression"), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="🖥️",
+)
+registry.register(
+    name="browser_list_downloads",
+    toolset="browser",
+    schema=_BROWSER_SCHEMA_MAP["browser_list_downloads"],
+    handler=lambda args, **kw: browser_list_downloads(task_id=kw.get("task_id")),
+    check_fn=check_browser_requirements,
+    emoji="📦",
+)
+registry.register(
+    name="browser_save_download",
+    toolset="browser",
+    schema=_BROWSER_SCHEMA_MAP["browser_save_download"],
+    handler=lambda args, **kw: browser_save_download(
+        download_id=args.get("download_id", ""),
+        output_path=args.get("output_path"),
+        task_id=kw.get("task_id"),
+        max_bytes=int(args.get("max_bytes", 50 * 1024 * 1024)),
+    ),
+    check_fn=check_browser_requirements,
+    emoji="💾",
 )


### PR DESCRIPTION
## Summary

Hermes can drive a Camofox browser session through the existing tools (`browser_navigate`, `browser_click`, `browser_snapshot`, etc.), but when a page triggers a file download there is no Hermes-side way to inspect the captured file or persist it as a local artifact. This PR completes that workflow by adding two backend helpers and two public browser tools.

Camofox already exposes `GET /tabs/{tab_id}/downloads` with a base64 payload — Hermes had no tool surface to list or persist those files.

---

## Changes

**`tools/browser_camofox.py`**
- `camofox_list_downloads()` — calls `GET /tabs/{tab_id}/downloads` and normalises the response into a stable JSON envelope with download IDs, filenames, MIME types, byte sizes, status/failure metadata, and the owning `tab_id`.
- `camofox_get_download_content()` — resolves a download by ID, base64-decodes `dataBase64`, and writes the bytes to a requested path or `tempfile.gettempdir()` with the server-reported `suggestedFilename`, returning the final path plus metadata so other tools can consume it.

**`tools/browser_tool.py`**
- Added `browser_list_downloads()` and `browser_save_download()` to the public browser tool surface.
- Added JSON schema entries to `BROWSER_TOOL_SCHEMAS`.
- Added registry entries with `check_fn=check_browser_requirements` and emoji hints (📦 / 💾).
- Non-Camofox backends return an explicit `unsupported-backend` error so the feature is opt-in by backend rather than silently no-ops.

---

## How to Test

1. Start Camofox with `CAMOFOX_URL` configured.
2. `browser_navigate("https://...")` → `browser_click(...)` to trigger a download.
3. `browser_list_downloads()` — verify a download entry appears with `id`, `suggestedFilename`, `mimeType`, and a nonzero `size`.
4. `browser_save_download(download_id="<id>")` — verify the file is written to disk.
5. With a non-Camofox backend, call both new tools and verify the explicit `unsupported-backend` error is returned instead of a silent failure.

---

## Sample Output

`browser_list_downloads()`:
```json
{
  "success": true,
  "downloads": [
    {
      "id": "dl_abc123",
      "url": "https://portal.example/reports/invoice.pdf",
      "suggestedFilename": "invoice_2026-06-26.pdf",
      "mimeType": "application/pdf",
      "state": "complete",
      "error": ""
    }
  ],
  "count": 1,
  "tab_id": "h_1a2b3c4d5e"
}
```

`browser_save_download()`:
```json
{
  "success": true,
  "download_id": "dl_abc123",
  "output_path": "/tmp/invoice_2026-06-26.pdf",
  "suggested_filename": "invoice_2026-06-26.pdf",
  "mime_type": "application/pdf",
  "bytes": 143521,
  "tab_id": "h_1a2b3c4d5e"
}
```

Non-Camofox backend error:
```json
{
  "success": false,
  "error": "browser_list_downloads is only supported with the Camofox backend."
}
```

---

## Checklist

- [x] Follows Contributing Guide and Conventional Commits
- [x] No duplicate PRs — searched existing
- [x] Changes scoped to this feature only (2 files)
- [x] Tool descriptions/schemas updated — added two `browser_*` entries to `BROWSER_TOOL_SCHEMAS`
- [x] Tested on Ubuntu 24.04
- [x] Cross-platform impact considered — Camofox is Linux-targeted; other backends get explicit `unsupported-backend` error
- [ ] `pytest tests/ -q` — pending CI
- [ ] Tests added — pending follow-up

---

## Risk & Impact

**Low.** Additive only — two new tools and two new backend helpers. Existing `browser_*` tools and non-Camofox backends are byte-for-byte unchanged. The explicit `unsupported-backend` error on non-Camofox paths prevents silent failures.

**Type:** ✨ New feature
**Fixes:** #52939