### PR TITLE
fix(agent): persist user message on receipt + retry/discard stale turns (#45110)

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -302,6 +302,15 @@ def build_turn_context(
     current_turn_user_idx = len(messages) - 1
     agent._persist_user_message_idx = current_turn_user_idx
 
+    # Persist the inbound user turn to state.db on receipt, BEFORE any model
+    # call (#45110). A stall, streaming client disconnect, or process crash
+    # can prevent the first assistant response from completing — without this,
+    # the prompt vanishes from the session history.
+    try:
+        agent._persist_inbound_user_message(user_msg)
+    except Exception:
+        logger.debug("_persist_inbound_user_message raised", exc_info=True)
+
     if not agent.quiet_mode:
         _print_preview = summarize_user_message_for_log(user_message)
         agent._safe_print(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9258,6 +9258,87 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         return source
 
+    async def _ask_retry_or_discard(
+        self, event, source, session_key: str, stale_content: str,
+    ) -> str:
+        """Ask the user whether to retry or discard a stale user turn.
+
+        Returns "retry", "discard", or "" (timeout / no response).
+        Uses the clarify system so it works across all gateway platforms
+        with button UI where available.
+        """
+        import uuid as _uuid
+        from tools.clarify_gateway import (
+            register as _clarify_register,
+            wait_for_response as _clarify_wait,
+            get_clarify_timeout as _clarify_timeout,
+            clear_session as _clarify_clear,
+        )
+
+        _adapter = self.adapters.get(source.platform)
+        if not _adapter or not hasattr(_adapter, "send_clarify"):
+            return "discard"
+
+        _preview = stale_content.strip()
+        if len(_preview) > 100:
+            _preview = _preview[:100] + "..."
+
+        _question = (
+            f"Your previous message didn't get a response:\n\n"
+            f"\"{_preview}\"\n\n"
+            f"Retry it or discard it?"
+        )
+        _choices = ["Retry", "Discard"]
+        _clarify_id = _uuid.uuid4().hex[:10]
+        _loop = asyncio.get_running_loop()
+        _reply_anchor = self._reply_anchor_for_event(event)
+        _metadata = self._thread_metadata_for_source(source, _reply_anchor)
+
+        _clarify_register(
+            clarify_id=_clarify_id,
+            session_key=session_key,
+            question=_question,
+            choices=_choices,
+        )
+
+        try:
+            _adapter.pause_typing_for_chat(source.chat_id)
+        except Exception:
+            pass
+
+        _send_ok = False
+        try:
+            _fut = safe_schedule_threadsafe(
+                _adapter.send_clarify(
+                    chat_id=source.chat_id,
+                    question=_question,
+                    choices=_choices,
+                    clarify_id=_clarify_id,
+                    session_key=session_key,
+                    metadata=_metadata,
+                ),
+                _loop,
+                logger=logger,
+                log_message="retry/discard clarify send failed",
+            )
+            if _fut is not None:
+                _result = _fut.result(timeout=15)
+                _send_ok = bool(getattr(_result, "success", False))
+        except Exception as exc:
+            logger.warning("retry/discard clarify send failed: %s", exc)
+
+        if not _send_ok:
+            _clarify_clear(session_key)
+            return "discard"
+
+        _timeout = _clarify_timeout()
+        _response = await asyncio.to_thread(
+            _clarify_wait, _clarify_id, float(_timeout),
+        )
+        if not _response:
+            return ""
+        return _response.strip().lower()
+
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
@@ -9501,6 +9582,54 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Load conversation history from transcript
         history = self.session_store.load_transcript(session_entry.session_id)
+
+        # ── Stale-turn detection (#45110) ──────────────────────────
+        # If the previous turn's user message was persisted on receipt but
+        # the assistant response never completed (stall, disconnect, crash),
+        # the transcript ends with a user message and no following assistant
+        # message. Instead of loading it as history (which would create a
+        # double-user-message sequence on the next turn), offer the user a
+        # choice: retry the failed message or discard it.
+        if (
+            history
+            and len(history) >= 1
+            and history[-1].get("role") == "user"
+        ):
+            _stale_msg = history[-1]
+            _stale_content = _stale_msg.get("content", "")
+            if isinstance(_stale_content, str) and _stale_content.strip():
+                # Ask the user what to do with the orphaned turn
+                _stale_choice = await self._ask_retry_or_discard(
+                    event, source, _quick_key, _stale_content[:200],
+                )
+                if _stale_choice == "discard":
+                    # Soft-delete the stale user message
+                    self.session_store.rewind_session(
+                        session_entry.session_id, n=1,
+                    )
+                    # Reload history without the discarded message
+                    history = self.session_store.load_transcript(
+                        session_entry.session_id,
+                    )
+                    logger.info(
+                        "Discarded stale user turn for session %s",
+                        session_entry.session_id,
+                    )
+                elif _stale_choice == "retry":
+                    # Use the stale message as this turn's input
+                    message_text = _stale_content
+                    persist_user_message = _stale_content
+                    # Soft-delete the stale copy so it doesn't appear twice
+                    self.session_store.rewind_session(
+                        session_entry.session_id, n=1,
+                    )
+                    history = self.session_store.load_transcript(
+                        session_entry.session_id,
+                    )
+                    logger.info(
+                        "Retrying stale user turn for session %s",
+                        session_entry.session_id,
+                    )
         
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts

--- a/run_agent.py
+++ b/run_agent.py
@@ -1686,6 +1686,74 @@ class AIAgent:
         except Exception as e:
             logger.warning("Session DB append_message failed: %s", e)
 
+    def _persist_inbound_user_message(self, user_msg: Dict[str, Any]) -> None:
+        """Persist the inbound user turn to ``state.db`` on receipt.
+
+        Called from ``agent/turn_context.py`` immediately after the user
+        message is appended to the live ``messages`` list, BEFORE the first
+        model call. Guarantees the prompt survives even if the first
+        assistant response never completes — a stall, a client disconnect
+        on a streaming gateway turn, or a process crash mid-generation
+        (#45110).
+
+        Idempotency: the caller is responsible for calling this once per
+        user turn (``build_turn_context`` does by construction). To prevent
+        ``_flush_messages_to_session_db`` from writing the same dict again,
+        we register ``id(user_msg)`` in ``_flushed_db_message_ids`` and
+        advance the flush cursor.
+        """
+        if not self._session_db:
+            return
+        if not isinstance(user_msg, dict) or user_msg.get("role") != "user":
+            return
+        try:
+            self._ensure_db_session()
+        except Exception:
+            logger.debug(
+                "ensure_session failed during inbound user-message persist",
+                exc_info=True,
+            )
+            return
+        content = user_msg.get("content")
+        if isinstance(content, list):
+            _txt = []
+            for p in content:
+                if isinstance(p, dict) and p.get("type") == "text":
+                    _txt.append(str(p.get("text", "")))
+                elif isinstance(p, dict) and p.get("type") in {"image", "image_url", "input_image"}:
+                    _txt.append("[screenshot]")
+            content = "\n".join(_txt) if _txt else None
+        try:
+            self._session_db.append_message(
+                session_id=self.session_id,
+                role="user",
+                content=content,
+                tool_name=None,
+                tool_calls=None,
+                tool_call_id=user_msg.get("tool_call_id"),
+                finish_reason=None,
+                reasoning=None,
+                reasoning_content=None,
+                reasoning_details=None,
+                codex_reasoning_items=None,
+                codex_message_items=None,
+                timestamp=user_msg.get("timestamp"),
+            )
+            flushed_ids = getattr(self, "_flushed_db_message_ids", None)
+            if isinstance(flushed_ids, set):
+                flushed_ids.add(id(user_msg))
+            else:
+                self._flushed_db_message_ids = {id(user_msg)}
+            self._flushed_db_message_session_id = self.session_id
+            if getattr(self, "_last_flushed_db_idx", 0) == 0:
+                self._last_flushed_db_idx = 1
+        except Exception as exc:
+            logger.debug(
+                "Direct inbound user-message persist failed; "
+                "crash-resilience call will retry: %s",
+                exc,
+            )
+
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
         """
         Get messages up to (but not including) the last assistant turn.


### PR DESCRIPTION
## Summary
When the first assistant response never completes (stall, client disconnect, crash), the user's prompt is now persisted to state.db on receipt, and the user is offered a retry/discard choice on their next message instead of silently losing the turn.

## Root cause (#45110)
`_persist_session` only runs on successful turn-exit paths. If the first assistant response never completes, nothing from the turn is persisted — the prompt vanishes. Follow-up turns hit an agent with a hole in its history, causing confabulation.

## Changes
- `run_agent.py`: new `_persist_inbound_user_message(user_msg)` method — writes the user message directly to SQLite via `append_message` on receipt, before any model call. Registers `id(user_msg)` in `_flushed_db_message_ids` + advances the flush cursor so `_persist_session` does NOT write a duplicate row.
- `agent/turn_context.py`: calls `_persist_inbound_user_message` immediately after `messages.append(user_msg)`, wrapped in try/except.
- `gateway/run.py`: stale-turn detection after `load_transcript` — if history ends with a user message (no assistant response), the previous turn was abandoned. Uses the clarify system to ask the user "Retry or Discard?" with button UI on supported platforms. Retry: re-injects the stored content as the current turn's input after soft-deleting the stale copy. Discard: `rewind_session(n=1)` soft-deletes it. Both paths keep conversation history clean.

## Validation
| | Before | After |
|---|---|---|
| Turn completes normally | prompt persisted | prompt persisted (unchanged) |
| Client disconnect before first response | prompt lost silently | prompt persisted on receipt |
| User retries after stall | double-user-message (merged by repair_sequence) | user is asked Retry/Discard |
| User discards stale turn | n/a | stale message soft-deleted, history clean |

- `scripts/run_tests.sh tests/agent/test_turn_context.py tests/gateway/test_compress_command.py` — all pass.
- E2E: real SessionDB — verified early persist (no duplicate), stale detection, discard via rewind_session, and retry re-persist. All pass.

Closes #45110
