### PR TITLE
feat(memory): add Hindsight multi-bank auto routing

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import subprocess
 import sys
 import threading
 import time
@@ -57,6 +58,27 @@ from utils import base_url_host_matches, is_truthy_value
 # ``logger = logging.getLogger(__name__)``, which resolves to "run_agent"
 # from inside that module.)
 logger = logging.getLogger("run_agent")
+
+
+def _git_origin_remote_from_cwd(cwd: str) -> str:
+    """Best-effort origin URL for memory providers that route by repository."""
+    if not cwd:
+        return ""
+    try:
+        result = subprocess.run(
+            ["git", "config", "--get", "remote.origin.url"],
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=1,
+            stdin=subprocess.DEVNULL,
+        )
+    except Exception:
+        return ""
+    if result.returncode != 0:
+        return ""
+    return (result.stdout or "").strip()
 
 
 def _ra():
@@ -1237,9 +1259,11 @@ def init_agent(
                         from hermes_cli.profiles import get_active_profile_name
                         from agent.runtime_cwd import resolve_agent_cwd
                         _profile = get_active_profile_name()
+                        _agent_cwd = str(resolve_agent_cwd())
                         _init_kwargs["agent_identity"] = _profile
                         _init_kwargs["agent_workspace"] = "hermes"
-                        _init_kwargs["agent_workspace_path"] = str(resolve_agent_cwd())
+                        _init_kwargs["agent_workspace_path"] = _agent_cwd
+                        _init_kwargs["agent_git_remote"] = _git_origin_remote_from_cwd(_agent_cwd)
                     except Exception:
                         pass
                     agent._memory_manager.initialize_all(**_init_kwargs)

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1235,9 +1235,11 @@ def init_agent(
                     # Profile identity for per-profile provider scoping
                     try:
                         from hermes_cli.profiles import get_active_profile_name
+                        from agent.runtime_cwd import resolve_agent_cwd
                         _profile = get_active_profile_name()
                         _init_kwargs["agent_identity"] = _profile
                         _init_kwargs["agent_workspace"] = "hermes"
+                        _init_kwargs["agent_workspace_path"] = str(resolve_agent_cwd())
                     except Exception:
                         pass
                     agent._memory_manager.initialize_all(**_init_kwargs)

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -79,6 +79,8 @@ class MemoryProvider(ABC):
           - agent_workspace (str): Shared workspace name (e.g. "hermes").
           - agent_workspace_path (str): Stable startup working directory / project
             root for providers that route by workspace path.
+          - agent_git_remote (str): Best-effort git remote URL for providers
+            that route by repository origin.
           - parent_session_id (str): For subagents, the parent's session_id.
           - user_id (str): Platform user identifier (gateway sessions).
           - user_id_alt (str): Optional alternate stable platform user identifier.

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -77,6 +77,8 @@ class MemoryProvider(ABC):
           - agent_identity (str): Profile name (e.g. "coder"). Use for
             per-profile provider identity scoping.
           - agent_workspace (str): Shared workspace name (e.g. "hermes").
+          - agent_workspace_path (str): Stable startup working directory / project
+            root for providers that route by workspace path.
           - parent_session_id (str): For subagents, the parent's session_id.
           - user_id (str): Platform user identifier (gateway sessions).
           - user_id_alt (str): Optional alternate stable platform user identifier.

--- a/docs/design/hindsight-bank-routing-phase2.md
+++ b/docs/design/hindsight-bank-routing-phase2.md
@@ -27,18 +27,18 @@ This phase extends the Phase 1 `bank_routing` predicates without adding an LLM r
   "bank_registry_version": "2026-07-10",
   "bank_registry": [
     {
-      "id": "hindsight-product-rigplane",
-      "display_name": "RigPlane product memory",
-      "description": "RigPlane product/commercial/proprietary context, packaging, release, support.",
-      "domains": ["rigplane", "product", "release"],
-      "good_examples": ["rigplane-pro packaging decision", "beta release support note"],
+      "id": "team-product-memory",
+      "display_name": "Team product memory",
+      "description": "Team product context, packaging, release, and support notes.",
+      "domains": ["product", "release", "support"],
+      "good_examples": ["project-alpha packaging decision", "beta release support note"],
       "bad_examples": ["generic user preference", "unrelated homelab DNS note"],
-      "recall_policy": {"enabled": true, "tags": ["project:rigplane"], "tags_match": "any"},
-      "retain_policy": {"enabled": true, "tags": ["project:rigplane"], "max_banks": 1},
-      "match": {"git_repo_glob": "rigplane/rigplane-*", "repo_name_glob": "rigplane-*"},
-      "allowed_profiles": ["frontdesk", "coder"],
+      "recall_policy": {"enabled": true, "tags": ["project:alpha"], "tags_match": "any"},
+      "retain_policy": {"enabled": true, "tags": ["project:alpha"], "max_banks": 1},
+      "match": {"git_repo_glob": "acme/project-*", "repo_name_glob": "project-*"},
+      "allowed_profiles": ["support", "coder"],
       "allowed_platforms": ["cli", "telegram"],
-      "sensitivity": "proprietary"
+      "sensitivity": "team"
     }
   ]
 }

--- a/docs/design/hindsight-bank-routing-phase2.md
+++ b/docs/design/hindsight-bank-routing-phase2.md
@@ -1,0 +1,134 @@
+# Phase 2: Hindsight bank registry and deterministic routing context
+
+## Scope
+
+This phase extends the Phase 1 `bank_routing` predicates without adding an LLM router. Hindsight banks remain hard isolation boundaries. Hermes still orchestrates ordinary single-bank recall/retain calls client-side, and explicit tools keep the current primary-bank behavior.
+
+## Goals
+
+1. Introduce a Hermes-side bank registry schema that describes candidate banks and their deterministic allow/deny policies.
+2. Extract structured routing context once per session/workspace and cache safe, non-secret project identity signals in the profile cache.
+3. Generate recall/retain candidate banks deterministically from the registry plus the extracted context.
+4. Preserve existing `bank_routing` behavior and legacy single-bank fallback.
+
+## Non-goals
+
+- No LLM/semantic router in this phase.
+- No new model tool parameters or tool schemas.
+- No server-side Hindsight changes.
+- No project-local cache by default.
+
+## Bank registry config shape
+
+`~/.hermes/profiles/<profile>/hindsight/config.json` may define:
+
+```json
+{
+  "bank_registry_version": "2026-07-10",
+  "bank_registry": [
+    {
+      "id": "hindsight-product-rigplane",
+      "display_name": "RigPlane product memory",
+      "description": "RigPlane product/commercial/proprietary context, packaging, release, support.",
+      "domains": ["rigplane", "product", "release"],
+      "good_examples": ["rigplane-pro packaging decision", "beta release support note"],
+      "bad_examples": ["generic user preference", "unrelated homelab DNS note"],
+      "recall_policy": {"enabled": true, "tags": ["project:rigplane"], "tags_match": "any"},
+      "retain_policy": {"enabled": true, "tags": ["project:rigplane"], "max_banks": 1},
+      "match": {"git_repo_glob": "rigplane/rigplane-*", "repo_name_glob": "rigplane-*"},
+      "allowed_profiles": ["frontdesk", "coder"],
+      "allowed_platforms": ["cli", "telegram"],
+      "sensitivity": "proprietary"
+    }
+  ]
+}
+```
+
+Notes:
+- `id` is the Hindsight bank id.
+- `match` reuses Phase 1 predicates: `workspace_path_prefix`, `workspace_path_glob`, `workspace`, `workspace_glob`, `repo_name_glob`, `git_remote_glob`, `git_repo_glob`, `profile`, `platform`, and `user`.
+- `recall_policy.enabled` defaults to true; `retain_policy.enabled` defaults to false for conservative retain unless explicitly configured.
+- `recall_policy.types` defaults to observation-only via provider defaults.
+- `allowed_*` fields are hard deterministic guards, not descriptive hints.
+
+## Structured routing context
+
+Minimal cacheable context:
+
+- `workspace_path`
+- `workspace`
+- `repo_name`
+- `git_remote`
+- normalized `git_repo` (`owner/repo` for GitHub remotes)
+- `git_branch`
+- active `profile`
+- `platform`
+- `user`
+- `session`
+- marker fingerprint for `AGENTS.md`, `CLAUDE.md`, `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`
+
+Cache location:
+
+`~/.hermes/profiles/<profile>/cache/hindsight/project-context/<safe-key>.json`
+
+Invalidation inputs:
+
+- registry version
+- workspace path
+- repo name / git remote / normalized git repo
+- git branch
+- marker file mtimes/sizes/hash prefixes
+- TTL for session/topic-derived fields (not included in the first slice)
+
+Security:
+
+- Do not cache env vars, tokens, credential files, raw logs, or conversation transcript text.
+- Project-local cache is out of scope for the first slice.
+
+## Deterministic candidate generation
+
+Input: registry entries + structured context.
+
+Output: ordered candidates with:
+
+- `bank_id`
+- `name`
+- `recall` boolean
+- `retain` boolean
+- `recall_tags`, `recall_tags_match`, `recall_types`
+- `retain_tags`
+- `reason` strings explaining matched signals and hard-deny decisions
+
+Ordering:
+
+1. Highest predicate specificity first.
+2. Stable registry order as tie-breaker.
+3. Existing fallback route only when no registry candidate is selected and fallback is enabled.
+
+Policy:
+
+- Recall can include multiple enabled matching banks.
+- Retain is conservative: only retain-enabled matching banks, with optional per-entry `max_banks`/future global cap.
+- Deny/allowed-profile/platform/user checks happen before a candidate can retain.
+
+## Minimal implementation slice
+
+1. Add pure dataclasses/helpers in the Hindsight provider module:
+   - `HindsightRoutingContext`
+   - `HindsightBankRegistryEntry`
+   - `HindsightBankCandidate`
+   - `_extract_hindsight_routing_context(...)`
+   - `_load_cached_hindsight_routing_context(...)` / `_write_cached_hindsight_routing_context(...)`
+   - `_generate_hindsight_bank_candidates(...)`
+2. Add tests for:
+   - context extraction from a temporary git repo and profile cache reuse/invalidation;
+   - registry candidate generation from `git_repo_glob`/`repo_name_glob`;
+   - retain disabled by default unless policy enables it;
+   - integration with `_resolve_hindsight_routes` only when `bank_registry` exists and `bank_routing` is absent.
+3. Keep Phase 1 `bank_routing` as the more explicit override for existing users.
+
+## Later phases
+
+- Route-decision audit logs and `hermes memory routing explain` CLI.
+- Optional semantic top-k over registry descriptions/examples.
+- LLM router only as a reranker/selector over deterministic candidates, never as final retain authority.

--- a/docs/design/hindsight-bank-routing-phase2.md
+++ b/docs/design/hindsight-bank-routing-phase2.md
@@ -58,7 +58,7 @@ Minimal cacheable context:
 - `workspace_path`
 - `workspace`
 - `repo_name`
-- `git_remote`
+- sanitized `git_remote` with URL userinfo stripped before caching
 - normalized `git_repo` (`owner/repo` for GitHub remotes)
 - `git_branch`
 - active `profile`
@@ -83,6 +83,8 @@ Invalidation inputs:
 Security:
 
 - Do not cache env vars, tokens, credential files, raw logs, or conversation transcript text.
+- Do not cache credentialed raw remotes; `https://user:token@github.com/acme/private.git`
+  is cached as `https://github.com/acme/private.git`.
 - Project-local cache is out of scope for the first slice.
 
 ## Deterministic candidate generation
@@ -115,11 +117,12 @@ Policy:
 
 1. Add pure dataclasses/helpers in the Hindsight provider module:
    - `HindsightRoutingContext`
-   - `HindsightBankRegistryEntry`
    - `HindsightBankCandidate`
    - `_extract_hindsight_routing_context(...)`
-   - `_load_cached_hindsight_routing_context(...)` / `_write_cached_hindsight_routing_context(...)`
+   - `_context_from_cache(...)` / `_write_context_cache(...)`
    - `_generate_hindsight_bank_candidates(...)`
+   - Registry entries remain config dictionaries in this slice rather than
+     materialized `HindsightBankRegistryEntry` objects.
 2. Add tests for:
    - context extraction from a temporary git repo and profile cache reuse/invalidation;
    - registry candidate generation from `git_repo_glob`/`repo_name_glob`;

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -97,7 +97,8 @@ Example:
     "rules": [
       {
         "name": "common-memory-infra",
-        "workspace_path_prefix": "/Users/moroz/Projects/common-memory",
+        "repo_name_glob": "common-memory*",
+        "git_remote_glob": "*github.com*common-memory*",
         "bank_id": "infra",
         "recall": true,
         "retain": true,
@@ -110,7 +111,7 @@ Example:
 }
 ```
 
-Supported route predicates in this provider are `workspace_path_prefix`, `workspace`, `profile`, `platform`, and `user`. A route matches only when all configured predicates match. `workspace_path_prefix` uses longest-prefix precedence so nested projects choose the most specific route. `strategy: "first_match"` selects the best match; any other strategy currently keeps all matching routes.
+Supported route predicates in this provider are `workspace_path_prefix`, `workspace_path_glob`, `workspace`, `workspace_glob`, `repo_name_glob`, `git_remote_glob`, `profile`, `platform`, and `user`. A route matches only when all configured predicates match. Prefer portable predicates such as `repo_name_glob` or `git_remote_glob` for product families and multi-machine setups; `workspace_path_prefix` is host-local and best reserved for fixed local paths. `workspace_path_prefix` and glob predicates contribute to route specificity so nested or more specific projects choose the best route. `strategy: "first_match"` selects the best match; any other strategy currently keeps all matching routes.
 
 Global recall (`bank_routing.recall.include_global`) is recall-only by default so project conversations do not automatically retain into personal/global memory. To retain into a global bank, configure an explicit retain-enabled route. Global recall routes can set `global_tags`, `global_tags_match`, and `global_types`; these do not inherit route/project tags unless explicitly configured.
 

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -67,7 +67,11 @@ Config file: `~/.hermes/hindsight/config.json`
 
 ### Multi-bank routing
 
-Hindsight banks are hard isolation boundaries: every retain/recall operation targets one bank. When `bank_routing` is configured, Hermes acts as the client-side orchestrator: it resolves matching routes from stable startup context, recalls from every recall-enabled route, and retains the same rich JSON turn payload to every retain-enabled route. Tags remain deterministic scope labels inside a bank.
+Hindsight banks are hard isolation boundaries: every retain/recall/reflect operation targets one bank, and banks do not share data. Hindsight does not provide an implicit cross-bank query; any multi-bank behavior must be orchestrated by the client.
+
+When `bank_routing` is configured, Hermes is that client-side orchestrator: it resolves matching routes from stable startup context, recalls from every recall-enabled route, and retains the same rich JSON turn payload to every retain-enabled route. Each routed call is still an ordinary single-bank Hindsight call.
+
+Tags are deterministic scope/filter labels **inside** a bank, not a replacement for bank isolation. Use bank routing when data belongs in separate memory banks (for example `global-user` versus `infra`), and use tags when you need recall scopes within a bank (for example `project:common-memory`, `domain:memory`, or `scope:global`). Strict tag matching modes (`any_strict` / `all_strict`) exclude untagged memories; non-strict modes can include untagged memories per Hindsight semantics.
 
 If no route matches, Hermes falls back to `bank_id_template` / `bank_id`, preserving the legacy single-bank behavior. Explicit tools (`hindsight_retain`, `hindsight_recall`, `hindsight_reflect`) still target the primary resolved route; use Hindsight MCP per-bank endpoints for explicit ad-hoc operations against other banks.
 

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -98,7 +98,7 @@ Example:
       {
         "name": "common-memory-infra",
         "repo_name_glob": "common-memory*",
-        "git_remote_glob": "*github.com*common-memory*",
+        "git_repo_glob": "*/common-memory*",
         "bank_id": "infra",
         "recall": true,
         "retain": true,
@@ -111,7 +111,7 @@ Example:
 }
 ```
 
-Supported route predicates in this provider are `workspace_path_prefix`, `workspace_path_glob`, `workspace`, `workspace_glob`, `repo_name_glob`, `git_remote_glob`, `profile`, `platform`, and `user`. A route matches only when all configured predicates match. Prefer portable predicates such as `repo_name_glob` or `git_remote_glob` for product families and multi-machine setups; `workspace_path_prefix` is host-local and best reserved for fixed local paths. `workspace_path_prefix` and glob predicates contribute to route specificity so nested or more specific projects choose the best route. `strategy: "first_match"` selects the best match; any other strategy currently keeps all matching routes.
+Supported route predicates in this provider are `workspace_path_prefix`, `workspace_path_glob`, `workspace`, `workspace_glob`, `repo_name_glob`, `git_remote_glob`, `git_repo_glob`, `profile`, `platform`, and `user`. A route matches only when all configured predicates match. Prefer portable predicates such as `repo_name_glob` or `git_repo_glob` for product families and multi-machine setups; `git_repo_glob` matches a normalized `owner/repo` string from common GitHub remote forms (`git@github.com:owner/repo.git`, `https://github.com/owner/repo.git`, etc.). Use raw `git_remote_glob` only when matching the exact remote URL form matters. `workspace_path_prefix` is host-local and best reserved for fixed local paths. `workspace_path_prefix` and glob predicates contribute to route specificity so nested or more specific projects choose the best route. `strategy: "first_match"` selects the best match; any other strategy currently keeps all matching routes.
 
 Global recall (`bank_routing.recall.include_global`) is recall-only by default so project conversations do not automatically retain into personal/global memory. To retain into a global bank, configure an explicit retain-enabled route. Global recall routes can set `global_tags`, `global_tags_match`, and `global_types`; these do not inherit route/project tags unless explicitly configured.
 

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -86,7 +86,9 @@ Example:
     "recall": {
       "include_global": true,
       "global_bank_id": "global-user",
-      "global_types": ["observation"]
+      "global_types": ["observation"],
+      "global_tags": ["scope:global"],
+      "global_tags_match": "any"
     },
     "rules": [
       {
@@ -106,7 +108,7 @@ Example:
 
 Supported route predicates in this provider are `workspace_path_prefix`, `workspace`, `profile`, `platform`, and `user`. A route matches only when all configured predicates match. `workspace_path_prefix` uses longest-prefix precedence so nested projects choose the most specific route. `strategy: "first_match"` selects the best match; any other strategy currently keeps all matching routes.
 
-Global recall (`bank_routing.recall.include_global`) is recall-only by default so project conversations do not automatically retain into personal/global memory. To retain into a global bank, configure an explicit retain-enabled route.
+Global recall (`bank_routing.recall.include_global`) is recall-only by default so project conversations do not automatically retain into personal/global memory. To retain into a global bank, configure an explicit retain-enabled route. Global recall routes can set `global_tags`, `global_tags_match`, and `global_types`; these do not inherit route/project tags unless explicitly configured.
 
 ### Recall
 

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -61,8 +61,52 @@ Config file: `~/.hermes/hindsight/config.json`
 |-----|---------|-------------|
 | `bank_id` | `hermes` | Memory bank name (static fallback used when `bank_id_template` is unset or resolves empty) |
 | `bank_id_template` | — | Optional template to derive the bank name dynamically. Placeholders: `{profile}`, `{workspace}`, `{platform}`, `{user}`, `{session}`. Example: `hermes-{profile}` isolates memory per active Hermes profile. Empty placeholders collapse cleanly (e.g. `hermes-{user}` with no user becomes `hermes`). |
+| `bank_routing` | — | Advanced multi-bank routing config. Hermes resolves one or more Hindsight bank routes client-side, then fans out auto-recall and auto-retain while preserving Hindsight bank isolation. |
 | `bank_mission` | — | Reflect mission (identity/framing for reflect reasoning). Applied via Banks API. |
 | `bank_retain_mission` | — | Retain mission (steers what gets extracted). Applied via Banks API. |
+
+### Multi-bank routing
+
+Hindsight banks are hard isolation boundaries: every retain/recall operation targets one bank. When `bank_routing` is configured, Hermes acts as the client-side orchestrator: it resolves matching routes from stable startup context, recalls from every recall-enabled route, and retains the same rich JSON turn payload to every retain-enabled route. Tags remain deterministic scope labels inside a bank.
+
+If no route matches, Hermes falls back to `bank_id_template` / `bank_id`, preserving the legacy single-bank behavior. Explicit tools (`hindsight_retain`, `hindsight_recall`, `hindsight_reflect`) still target the primary resolved route; use Hindsight MCP per-bank endpoints for explicit ad-hoc operations against other banks.
+
+Example:
+
+```json
+{
+  "bank_id": "global-user",
+  "auto_recall": true,
+  "auto_retain": true,
+  "recall_types": ["observation"],
+  "retain_tags": ["source_system:hermes-agent"],
+  "bank_routing": {
+    "strategy": "first_match",
+    "include_fallback": true,
+    "recall": {
+      "include_global": true,
+      "global_bank_id": "global-user",
+      "global_types": ["observation"]
+    },
+    "rules": [
+      {
+        "name": "common-memory-infra",
+        "workspace_path_prefix": "/Users/moroz/Projects/common-memory",
+        "bank_id": "infra",
+        "recall": true,
+        "retain": true,
+        "recall_tags": ["project:common-memory", "domain:memory"],
+        "recall_tags_match": "all_strict",
+        "retain_tags": ["project:common-memory", "domain:memory"]
+      }
+    ]
+  }
+}
+```
+
+Supported route predicates in this provider are `workspace_path_prefix`, `workspace`, `profile`, `platform`, and `user`. A route matches only when all configured predicates match. `workspace_path_prefix` uses longest-prefix precedence so nested projects choose the most specific route. `strategy: "first_match"` selects the best match; any other strategy currently keeps all matching routes.
+
+Global recall (`bank_routing.recall.include_global`) is recall-only by default so project conversations do not automatically retain into personal/global memory. To retain into a global bank, configure an explicit retain-enabled route.
 
 ### Recall
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import fnmatch
 import importlib
 import json
 import logging
@@ -697,13 +698,58 @@ def _normalize_recall_types(value: Any, default: list[str] | None = None) -> lis
     return fallback
 
 
+def _normalize_match_patterns(value: Any) -> list[str]:
+    """Normalize a route match field into non-empty glob patterns."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        return [p.strip() for p in text.split(",") if p.strip()]
+    if isinstance(value, (list, tuple)):
+        return [str(p).strip() for p in value if str(p).strip()]
+    text = str(value).strip()
+    return [text] if text else []
+
+
+def _matches_any_glob(value: str, patterns: Any) -> bool:
+    normalized = _normalize_match_patterns(patterns)
+    if not normalized:
+        return True
+    candidate = str(value or "")
+    return any(fnmatch.fnmatchcase(candidate, pattern) for pattern in normalized)
+
+
+def _repo_name_from_workspace_path(workspace_path: str) -> str:
+    return os.path.basename(str(workspace_path or "").rstrip("/"))
+
+
 def _route_matches(rule: dict[str, Any], *, profile: str, workspace: str,
-                   workspace_path: str, platform: str, user: str) -> bool:
+                   workspace_path: str, platform: str, user: str,
+                   git_remote: str = "") -> bool:
     prefix = str(rule.get("workspace_path_prefix") or "").rstrip("/")
     if prefix:
         current = str(workspace_path or "").rstrip("/")
         if not (current == prefix or current.startswith(prefix + "/")):
             return False
+    if "workspace_path_glob" in rule and not _matches_any_glob(
+        str(workspace_path or ""), rule.get("workspace_path_glob")
+    ):
+        return False
+    if "workspace_glob" in rule and not _matches_any_glob(
+        str(workspace or ""), rule.get("workspace_glob")
+    ):
+        return False
+    if "repo_name_glob" in rule and not _matches_any_glob(
+        _repo_name_from_workspace_path(workspace_path) or workspace,
+        rule.get("repo_name_glob"),
+    ):
+        return False
+    if "git_remote_glob" in rule and not _matches_any_glob(
+        str(git_remote or ""), rule.get("git_remote_glob")
+    ):
+        return False
     for key, actual in {
         "profile": profile,
         "workspace": workspace,
@@ -713,6 +759,14 @@ def _route_matches(rule: dict[str, Any], *, profile: str, workspace: str,
         if key in rule and str(rule.get(key) or "") != str(actual or ""):
             return False
     return True
+
+
+def _route_specificity(rule: dict[str, Any]) -> int:
+    """Return a stable specificity score for first-match route ordering."""
+    candidates = [str(rule.get("workspace_path_prefix") or "")]
+    for key in ("workspace_path_glob", "repo_name_glob", "workspace_glob", "git_remote_glob"):
+        candidates.extend(_normalize_match_patterns(rule.get(key)))
+    return max((len(candidate) for candidate in candidates), default=0)
 
 
 def _resolve_hindsight_routes(
@@ -726,6 +780,7 @@ def _resolve_hindsight_routes(
     platform: str,
     user: str,
     session: str,
+    git_remote: str = "",
 ) -> list[HindsightBankRoute]:
     """Resolve configured Hindsight bank routes for this runtime context."""
     fallback_bank = _resolve_bank_id_template(
@@ -758,9 +813,10 @@ def _resolve_hindsight_routes(
     matches = [
         rule for rule in rules
         if _route_matches(rule, profile=profile, workspace=workspace,
-                          workspace_path=workspace_path, platform=platform, user=user)
+                          workspace_path=workspace_path, platform=platform, user=user,
+                          git_remote=git_remote)
     ]
-    matches.sort(key=lambda rule: len(str(rule.get("workspace_path_prefix") or "")), reverse=True)
+    matches.sort(key=_route_specificity, reverse=True)
     selected = matches[:1] if str(routing.get("strategy", "first_match")) == "first_match" else matches
 
     routes: list[HindsightBankRoute] = []
@@ -849,6 +905,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._agent_identity = ""
         self._agent_workspace = ""
         self._agent_workspace_path = ""
+        self._agent_git_remote = ""
         self._turn_index = 0
         self._client = None
         self._timeout = _DEFAULT_TIMEOUT
@@ -1449,6 +1506,9 @@ class HindsightMemoryProvider(MemoryProvider):
         self._agent_identity = str(kwargs.get("agent_identity") or "").strip()
         self._agent_workspace = str(kwargs.get("agent_workspace") or "").strip()
         self._agent_workspace_path = str(kwargs.get("agent_workspace_path") or kwargs.get("workspace_path") or "").strip()
+        self._agent_git_remote = str(
+            kwargs.get("agent_git_remote") or kwargs.get("git_remote") or ""
+        ).strip()
         self._turn_index = 0
         self._session_turns = []
         self._last_retained_turn_count = 0
@@ -1562,6 +1622,7 @@ class HindsightMemoryProvider(MemoryProvider):
             platform=self._platform,
             user=self._user_id,
             session=self._session_id,
+            git_remote=self._agent_git_remote,
         )
         primary_routes = [route for route in self._hindsight_routes if route.retain or route.recall]
         if primary_routes:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -638,6 +638,35 @@ def _merge_tags(*values: Any) -> list[str]:
     return merged
 
 
+def _config_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return bool(value)
+
+
+def _normalize_recall_types(value: Any, default: list[str] | None = None) -> list[str]:
+    fallback = list(default or ["observation"])
+    if value is None:
+        return fallback
+    if isinstance(value, str):
+        parsed = [t.strip() for t in value.split(",") if t.strip()]
+        return parsed or fallback
+    if isinstance(value, (list, tuple)):
+        parsed = [str(t).strip() for t in value if str(t).strip()]
+        return parsed or fallback
+    return fallback
+
+
 def _route_matches(rule: dict[str, Any], *, profile: str, workspace: str,
                    workspace_path: str, platform: str, user: str) -> bool:
     prefix = str(rule.get("workspace_path_prefix") or "").rstrip("/")
@@ -681,13 +710,7 @@ def _resolve_hindsight_routes(
     default_retain_tags = _normalize_retain_tags(config.get("retain_tags"))
     default_recall_tags = _normalize_retain_tags(config.get("recall_tags"))
     default_recall_tags_match = str(config.get("recall_tags_match") or "any")
-    configured_recall_types = config.get("recall_types")
-    if configured_recall_types is None:
-        default_recall_types = ["observation"]
-    elif isinstance(configured_recall_types, str):
-        default_recall_types = [t.strip() for t in configured_recall_types.split(",") if t.strip()]
-    else:
-        default_recall_types = list(configured_recall_types) or ["observation"]
+    default_recall_types = _normalize_recall_types(config.get("recall_types"))
     routing = config.get("bank_routing")
     if not isinstance(routing, dict):
         return [
@@ -719,12 +742,12 @@ def _resolve_hindsight_routes(
         routes.append(HindsightBankRoute(
             name=str(rule.get("name") or bank_id),
             bank_id=_sanitize_bank_segment(bank_id),
-            recall=bool(rule.get("recall", True)),
-            retain=bool(rule.get("retain", True)),
+            recall=_config_bool(rule.get("recall"), True),
+            retain=_config_bool(rule.get("retain"), True),
             retain_tags=_merge_tags(default_retain_tags, rule.get("retain_tags")),
             recall_tags=_merge_tags(default_recall_tags, rule.get("recall_tags")),
             recall_tags_match=str(rule.get("recall_tags_match") or default_recall_tags_match),
-            recall_types=list(recall_types) if isinstance(recall_types, list) else default_recall_types,
+            recall_types=_normalize_recall_types(recall_types, default_recall_types),
         ))
 
     if not routes and routing.get("include_fallback", True):
@@ -737,7 +760,8 @@ def _resolve_hindsight_routes(
             recall_types=default_recall_types,
         ))
 
-    recall_cfg = routing.get("recall") if isinstance(routing.get("recall"), dict) else {}
+    raw_recall_cfg = routing.get("recall")
+    recall_cfg: dict[str, Any] = raw_recall_cfg if isinstance(raw_recall_cfg, dict) else {}
     if recall_cfg.get("include_global"):
         global_bank = str(recall_cfg.get("global_bank_id") or fallback_bank).strip()
         if global_bank and all(route.bank_id != _sanitize_bank_segment(global_bank) for route in routes):
@@ -746,8 +770,10 @@ def _resolve_hindsight_routes(
                 name=str(recall_cfg.get("global_name") or "global"),
                 bank_id=_sanitize_bank_segment(global_bank),
                 recall=True,
-                retain=bool(recall_cfg.get("global_retain", False)),
-                recall_types=list(global_types) if isinstance(global_types, list) else None,
+                retain=_config_bool(recall_cfg.get("global_retain"), False),
+                recall_tags=_normalize_retain_tags(recall_cfg.get("global_tags")),
+                recall_tags_match=str(recall_cfg.get("global_tags_match") or "any"),
+                recall_types=_normalize_recall_types(global_types, default_recall_types),
             ))
     return routes
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -725,6 +725,20 @@ def _repo_name_from_workspace_path(workspace_path: str) -> str:
     return os.path.basename(str(workspace_path or "").rstrip("/"))
 
 
+def _git_repo_from_remote(git_remote: str) -> str:
+    """Return a stable owner/repo string for common GitHub remote URL forms."""
+    remote = str(git_remote or "").strip()
+    if not remote or "github.com" not in remote:
+        return ""
+    tail = remote.split("github.com", 1)[1].lstrip(":/")
+    if tail.endswith(".git"):
+        tail = tail[:-4]
+    parts = [part for part in tail.split("/") if part]
+    if len(parts) < 2:
+        return ""
+    return "/".join(parts[:2])
+
+
 def _route_matches(rule: dict[str, Any], *, profile: str, workspace: str,
                    workspace_path: str, platform: str, user: str,
                    git_remote: str = "") -> bool:
@@ -750,6 +764,10 @@ def _route_matches(rule: dict[str, Any], *, profile: str, workspace: str,
         str(git_remote or ""), rule.get("git_remote_glob")
     ):
         return False
+    if "git_repo_glob" in rule and not _matches_any_glob(
+        _git_repo_from_remote(git_remote), rule.get("git_repo_glob")
+    ):
+        return False
     for key, actual in {
         "profile": profile,
         "workspace": workspace,
@@ -764,7 +782,13 @@ def _route_matches(rule: dict[str, Any], *, profile: str, workspace: str,
 def _route_specificity(rule: dict[str, Any]) -> int:
     """Return a stable specificity score for first-match route ordering."""
     candidates = [str(rule.get("workspace_path_prefix") or "")]
-    for key in ("workspace_path_glob", "repo_name_glob", "workspace_glob", "git_remote_glob"):
+    for key in (
+        "workspace_path_glob",
+        "repo_name_glob",
+        "workspace_glob",
+        "git_remote_glob",
+        "git_repo_glob",
+    ):
         candidates.extend(_normalize_match_patterns(rule.get(key)))
     return max((len(candidate) for candidate in candidates), default=0)
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -46,6 +46,7 @@ import threading
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List
+from urllib.parse import urlsplit, urlunsplit
 
 from agent.memory_provider import MemoryProvider
 from hermes_constants import get_hermes_home
@@ -786,6 +787,32 @@ def _git_repo_from_remote(git_remote: str) -> str:
     return "/".join(parts[:2])
 
 
+def _sanitize_git_remote_for_routing(git_remote: str) -> str:
+    """Remove URL userinfo while preserving host/path signals for routing."""
+    remote = str(git_remote or "").strip()
+    if not remote:
+        return ""
+    try:
+        parsed = urlsplit(remote)
+    except ValueError:
+        return remote
+    if not parsed.scheme or not parsed.netloc or "@" not in parsed.netloc:
+        return remote
+    hostname = parsed.hostname or ""
+    if not hostname:
+        return remote
+    netloc = hostname
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    if port is not None:
+        netloc = f"{netloc}:{port}"
+    return urlunsplit(
+        (parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment)
+    )
+
+
 def _safe_git_output(workspace_path: str, *args: str) -> str:
     if not workspace_path:
         return ""
@@ -896,6 +923,7 @@ def _extract_hindsight_routing_context(
     resolved_remote = str(git_remote or "").strip() or _safe_git_output(
         workspace_path, "remote", "get-url", "origin"
     )
+    resolved_remote = _sanitize_git_remote_for_routing(resolved_remote)
     resolved_branch = str(git_branch or "").strip() or _safe_git_output(
         workspace_path, "branch", "--show-current"
     )
@@ -1866,9 +1894,9 @@ class HindsightMemoryProvider(MemoryProvider):
         self._agent_identity = str(kwargs.get("agent_identity") or "").strip()
         self._agent_workspace = str(kwargs.get("agent_workspace") or "").strip()
         self._agent_workspace_path = str(kwargs.get("agent_workspace_path") or kwargs.get("workspace_path") or "").strip()
-        self._agent_git_remote = str(
+        self._agent_git_remote = _sanitize_git_remote_for_routing(
             kwargs.get("agent_git_remote") or kwargs.get("git_remote") or ""
-        ).strip()
+        )
         if self._agent_workspace_path:
             routing_context = _extract_hindsight_routing_context(
                 workspace=self._agent_workspace,
@@ -1881,8 +1909,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 cache_root=get_hermes_home() / "cache",
                 registry_version=str(self._config.get("bank_registry_version") or ""),
             )
-            if not self._agent_git_remote:
-                self._agent_git_remote = routing_context.git_remote
+            self._agent_git_remote = routing_context.git_remote
         self._turn_index = 0
         self._session_turns = []
         self._last_retained_turn_count = 0

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -174,9 +174,9 @@ def _meets_minimum_version(actual: str | None, required: str) -> bool:
         return False
 
 
-def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
-                                 timeout: float = 5.0) -> str | None:
-    """GET ``<api_url>/version`` and return the version string (or None on failure).
+def _fetch_hindsight_version_info(api_url: str, api_key: str | None = None,
+                                  timeout: float = 5.0) -> dict | None:
+    """GET ``<api_url>/version`` and return the parsed payload (or None on failure).
 
     Hindsight's `/version` endpoint returns ``{"version": "0.5.6", ...}``.
     Any failure (timeout, 404, malformed JSON, missing key) → None, which
@@ -197,6 +197,13 @@ def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
     except Exception as exc:
         logger.debug("Hindsight /version probe failed for %s: %s", url, exc)
         return None
+    return data if isinstance(data, dict) else None
+
+
+def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
+                                 timeout: float = 5.0) -> str | None:
+    """GET ``<api_url>/version`` and return the version string (or None on failure)."""
+    data = _fetch_hindsight_version_info(api_url, api_key, timeout)
     if not isinstance(data, dict):
         return None
     version = data.get("version") or data.get("api_version")
@@ -216,8 +223,21 @@ def _check_api_supports_update_mode_append(api_url: str,
     with _append_capability_lock:
         if api_url in _append_capability_cache:
             return _append_capability_cache[api_url]
-    version = _fetch_hindsight_api_version(api_url, api_key)
-    supported = _meets_minimum_version(version, _MIN_VERSION_FOR_UPDATE_MODE_APPEND)
+    info = _fetch_hindsight_version_info(api_url, api_key) or {}
+    version = info.get("version") or info.get("api_version")
+    version = str(version) if version else None
+    # update_mode='append' additionally requires the server to keep raw
+    # document text: deployments with HINDSIGHT_API_STORE_DOCUMENT_TEXT
+    # disabled reject append retains outright (400), so treat append as
+    # unsupported there and use the per-process document_id fallback.
+    # Servers too old to report `features` predate the opt-out and are
+    # assumed to store text.
+    features = info.get("features")
+    store_text = True
+    if isinstance(features, dict):
+        store_text = bool(features.get("store_document_text", True))
+    supported = (_meets_minimum_version(version, _MIN_VERSION_FOR_UPDATE_MODE_APPEND)
+                 and store_text)
     with _append_capability_lock:
         # Re-check after acquiring the lock in case a concurrent probe filled it.
         cached = _append_capability_cache.get(api_url)
@@ -226,6 +246,16 @@ def _check_api_supports_update_mode_append(api_url: str,
         else:
             supported = cached
     if not supported:
+        if not store_text:
+            logger.warning(
+                "Hindsight API at %s (version %r) has store_document_text "
+                "disabled; update_mode='append' retains would be rejected. "
+                "Falling back to per-process document_id.",
+                api_url, version,
+            )
+            with _append_capability_lock:
+                _append_capability_cache.setdefault(api_url, supported)
+            return supported
         logger.warning(
             "Hindsight API at %s reports version %r, older than %s. "
             "Falling back to per-process document_id — retains across "

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -33,15 +33,17 @@ from __future__ import annotations
 import asyncio
 import atexit
 import fnmatch
+import hashlib
 import importlib
 import json
 import logging
 import os
 import queue
+import subprocess
 import sys
 import threading
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List
 
@@ -660,6 +662,51 @@ class HindsightBankRoute:
     recall_types: list[str] | None = None
 
 
+@dataclass(frozen=True)
+class HindsightRoutingContext:
+    """Safe structured context used for deterministic bank routing."""
+
+    workspace: str = ""
+    workspace_path: str = ""
+    repo_name: str = ""
+    git_remote: str = ""
+    git_repo: str = ""
+    git_branch: str = ""
+    profile: str = ""
+    platform: str = ""
+    user: str = ""
+    session: str = ""
+    registry_version: str = ""
+    marker_fingerprint: str = ""
+    cache_hit: bool = False
+
+
+@dataclass(frozen=True)
+class HindsightBankCandidate:
+    """Registry-derived candidate bank before it becomes a route."""
+
+    name: str
+    bank_id: str
+    recall: bool = True
+    retain: bool = False
+    retain_tags: list[str] = field(default_factory=list)
+    recall_tags: list[str] = field(default_factory=list)
+    recall_tags_match: str = "any"
+    recall_types: list[str] | None = None
+    reasons: list[str] = field(default_factory=list)
+    specificity: int = 0
+
+
+_ROUTING_MARKER_FILES = (
+    "AGENTS.md",
+    "CLAUDE.md",
+    "pyproject.toml",
+    "package.json",
+    "Cargo.toml",
+    "go.mod",
+)
+
+
 def _merge_tags(*values: Any) -> list[str]:
     merged: list[str] = []
     for value in values:
@@ -739,6 +786,151 @@ def _git_repo_from_remote(git_remote: str) -> str:
     return "/".join(parts[:2])
 
 
+def _safe_git_output(workspace_path: str, *args: str) -> str:
+    if not workspace_path:
+        return ""
+    try:
+        result = subprocess.run(
+            ["git", "-C", workspace_path, *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except Exception:
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def _routing_marker_fingerprint(workspace_path: str) -> str:
+    """Hash non-secret project identity markers for cache invalidation."""
+    from pathlib import Path
+
+    if not workspace_path:
+        return ""
+    root = Path(workspace_path)
+    parts: list[str] = []
+    for name in _ROUTING_MARKER_FILES:
+        path = root / name
+        if not path.is_file():
+            continue
+        try:
+            stat = path.stat()
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+        except Exception:
+            continue
+        parts.append(f"{name}:{stat.st_size}:{stat.st_mtime_ns}:{digest}")
+    return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest() if parts else ""
+
+
+def _routing_context_cache_path(cache_root: Any, *, profile: str, workspace_path: str):
+    from pathlib import Path
+
+    if not cache_root:
+        return None
+    key = hashlib.sha256(
+        f"{profile}\0{workspace_path}".encode("utf-8", errors="replace")
+    ).hexdigest()
+    return Path(cache_root) / "hindsight" / "project-context" / f"{key}.json"
+
+
+def _context_from_cache(path: Any, *, registry_version: str, workspace_path: str,
+                        marker_fingerprint: str, git_remote: str = "",
+                        git_branch: str = "") -> HindsightRoutingContext | None:
+    if path is None or not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if data.get("registry_version") != registry_version:
+        return None
+    if data.get("workspace_path") != workspace_path:
+        return None
+    if data.get("marker_fingerprint") != marker_fingerprint:
+        return None
+    if git_remote and data.get("git_remote") != git_remote:
+        return None
+    if git_branch and data.get("git_branch") != git_branch:
+        return None
+    allowed = set(HindsightRoutingContext.__dataclass_fields__)
+    filtered = {key: value for key, value in data.items() if key in allowed}
+    filtered["cache_hit"] = True
+    try:
+        return HindsightRoutingContext(**filtered)
+    except TypeError:
+        return None
+
+
+def _write_context_cache(path: Any, context: HindsightRoutingContext) -> None:
+    if path is None:
+        return
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = asdict(context)
+        data["cache_hit"] = False
+        path.write_text(json.dumps(data, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    except Exception as exc:
+        logger.debug("Failed to write Hindsight routing context cache: %s", exc)
+
+
+def _extract_hindsight_routing_context(
+    *,
+    workspace: str = "",
+    workspace_path: str = "",
+    profile: str = "",
+    platform: str = "",
+    user: str = "",
+    session: str = "",
+    git_remote: str = "",
+    git_branch: str = "",
+    cache_root: Any = None,
+    registry_version: str = "",
+) -> HindsightRoutingContext:
+    """Extract and optionally cache non-secret project identity signals."""
+    workspace_path = str(workspace_path or "").rstrip("/")
+    repo_name = _repo_name_from_workspace_path(workspace_path) or str(workspace or "")
+    marker_fingerprint = _routing_marker_fingerprint(workspace_path)
+    resolved_remote = str(git_remote or "").strip() or _safe_git_output(
+        workspace_path, "remote", "get-url", "origin"
+    )
+    resolved_branch = str(git_branch or "").strip() or _safe_git_output(
+        workspace_path, "branch", "--show-current"
+    )
+    cache_path = _routing_context_cache_path(
+        cache_root, profile=str(profile or ""), workspace_path=workspace_path
+    )
+    cached = _context_from_cache(
+        cache_path,
+        registry_version=str(registry_version or ""),
+        workspace_path=workspace_path,
+        marker_fingerprint=marker_fingerprint,
+        git_remote=resolved_remote,
+        git_branch=resolved_branch,
+    )
+    if cached is not None:
+        return cached
+    context = HindsightRoutingContext(
+        workspace=str(workspace or ""),
+        workspace_path=workspace_path,
+        repo_name=repo_name,
+        git_remote=resolved_remote,
+        git_repo=_git_repo_from_remote(resolved_remote),
+        git_branch=resolved_branch,
+        profile=str(profile or ""),
+        platform=str(platform or ""),
+        user=str(user or ""),
+        session=str(session or ""),
+        registry_version=str(registry_version or ""),
+        marker_fingerprint=marker_fingerprint,
+        cache_hit=False,
+    )
+    _write_context_cache(cache_path, context)
+    return context
+
+
 def _route_matches(rule: dict[str, Any], *, profile: str, workspace: str,
                    workspace_path: str, platform: str, user: str,
                    git_remote: str = "") -> bool:
@@ -793,6 +985,119 @@ def _route_specificity(rule: dict[str, Any]) -> int:
     return max((len(candidate) for candidate in candidates), default=0)
 
 
+def _policy_enabled(policy: Any, default: bool) -> bool:
+    if isinstance(policy, dict):
+        return _config_bool(policy.get("enabled"), default)
+    return default
+
+
+def _allowed_by_registry_scope(entry: dict[str, Any], context: HindsightRoutingContext) -> bool:
+    for key, actual in (
+        ("allowed_profiles", context.profile),
+        ("allowed_workspaces", context.workspace),
+        ("allowed_platforms", context.platform),
+        ("allowed_users", context.user),
+    ):
+        values = _normalize_match_patterns(entry.get(key))
+        if values and not _matches_any_glob(actual, values):
+            return False
+    return True
+
+
+def _candidate_reasons(match: dict[str, Any], context: HindsightRoutingContext) -> list[str]:
+    reasons: list[str] = []
+    values = {
+        "workspace_path_prefix": context.workspace_path,
+        "workspace_path_glob": context.workspace_path,
+        "workspace": context.workspace,
+        "workspace_glob": context.workspace,
+        "repo_name_glob": context.repo_name,
+        "git_remote_glob": context.git_remote,
+        "git_repo_glob": context.git_repo,
+        "profile": context.profile,
+        "platform": context.platform,
+        "user": context.user,
+    }
+    for key, actual in values.items():
+        if key in match:
+            reasons.append(f"{key} matched {actual!r}")
+    return reasons
+
+
+def _generate_hindsight_bank_candidates(
+    registry: Any,
+    context: HindsightRoutingContext,
+    *,
+    default_recall_types: list[str] | None = None,
+) -> list[HindsightBankCandidate]:
+    """Generate deterministic bank candidates from registry entries."""
+    if isinstance(registry, dict):
+        entries = list(registry.values())
+    elif isinstance(registry, list):
+        entries = registry
+    else:
+        return []
+
+    candidates: list[tuple[int, int, HindsightBankCandidate]] = []
+    for index, raw in enumerate(entries):
+        if not isinstance(raw, dict):
+            continue
+        bank_id = str(raw.get("id") or raw.get("bank_id") or "").strip()
+        if not bank_id:
+            continue
+        raw_match = raw.get("match")
+        match: dict[str, Any] = raw_match if isinstance(raw_match, dict) else {}
+        if not _allowed_by_registry_scope(raw, context):
+            continue
+        if not _route_matches(
+            match,
+            profile=context.profile,
+            workspace=context.workspace,
+            workspace_path=context.workspace_path,
+            platform=context.platform,
+            user=context.user,
+            git_remote=context.git_remote,
+        ):
+            continue
+        raw_recall_policy = raw.get("recall_policy")
+        recall_policy: dict[str, Any] = (
+            raw_recall_policy if isinstance(raw_recall_policy, dict) else {}
+        )
+        raw_retain_policy = raw.get("retain_policy")
+        retain_policy: dict[str, Any] = (
+            raw_retain_policy if isinstance(raw_retain_policy, dict) else {}
+        )
+        recall = _policy_enabled(recall_policy, True)
+        retain = _policy_enabled(retain_policy, False)
+        if not recall and not retain:
+            continue
+        recall_types = None
+        if recall:
+            recall_types = _normalize_recall_types(
+                recall_policy.get("types") or recall_policy.get("recall_types"),
+                default_recall_types,
+            )
+        specificity = _route_specificity(match)
+        candidates.append((
+            -specificity,
+            index,
+            HindsightBankCandidate(
+                name=str(raw.get("display_name") or raw.get("name") or bank_id),
+                bank_id=_sanitize_bank_segment(bank_id),
+                recall=recall,
+                retain=retain,
+                retain_tags=_normalize_retain_tags(retain_policy.get("tags")),
+                recall_tags=_normalize_retain_tags(recall_policy.get("tags")),
+                recall_tags_match=str(recall_policy.get("tags_match") or "any"),
+                recall_types=recall_types,
+                reasons=_candidate_reasons(match, context),
+                specificity=specificity,
+            ),
+        ))
+    candidates.sort(key=lambda item: (item[0], item[1]))
+    return [candidate for _, _, candidate in candidates]
+
+
 def _resolve_hindsight_routes(
     config: dict[str, Any],
     *,
@@ -822,6 +1127,37 @@ def _resolve_hindsight_routes(
     default_recall_types = _normalize_recall_types(config.get("recall_types"))
     routing = config.get("bank_routing")
     if not isinstance(routing, dict):
+        registry = config.get("bank_registry")
+        if isinstance(registry, (dict, list)):
+            registry_context = _extract_hindsight_routing_context(
+                workspace=workspace,
+                workspace_path=workspace_path,
+                profile=profile,
+                platform=platform,
+                user=user,
+                session=session,
+                git_remote=git_remote,
+                registry_version=str(config.get("bank_registry_version") or ""),
+            )
+            candidates = _generate_hindsight_bank_candidates(
+                registry,
+                registry_context,
+                default_recall_types=default_recall_types,
+            )
+            if candidates:
+                return [
+                    HindsightBankRoute(
+                        name=candidate.name,
+                        bank_id=candidate.bank_id,
+                        recall=candidate.recall,
+                        retain=candidate.retain,
+                        retain_tags=_merge_tags(default_retain_tags, candidate.retain_tags),
+                        recall_tags=_merge_tags(default_recall_tags, candidate.recall_tags),
+                        recall_tags_match=candidate.recall_tags_match or default_recall_tags_match,
+                        recall_types=candidate.recall_types or default_recall_types,
+                    )
+                    for candidate in candidates
+                ]
         return [
             HindsightBankRoute(
                 name="fallback",
@@ -1533,6 +1869,20 @@ class HindsightMemoryProvider(MemoryProvider):
         self._agent_git_remote = str(
             kwargs.get("agent_git_remote") or kwargs.get("git_remote") or ""
         ).strip()
+        if self._agent_workspace_path:
+            routing_context = _extract_hindsight_routing_context(
+                workspace=self._agent_workspace,
+                workspace_path=self._agent_workspace_path,
+                profile=self._agent_identity,
+                platform=self._platform,
+                user=self._user_id,
+                session=self._session_id,
+                git_remote=self._agent_git_remote,
+                cache_root=get_hermes_home() / "cache",
+                registry_version=str(self._config.get("bank_registry_version") or ""),
+            )
+            if not self._agent_git_remote:
+                self._agent_git_remote = routing_context.git_remote
         self._turn_index = 0
         self._session_turns = []
         self._last_retained_turn_count = 0

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -780,7 +780,7 @@ def _resolve_hindsight_routes(
             recall_types=_normalize_recall_types(recall_types, default_recall_types),
         ))
 
-    if not routes and routing.get("include_fallback", True):
+    if not routes and _config_bool(routing.get("include_fallback"), True):
         routes.append(HindsightBankRoute(
             name="fallback",
             bank_id=fallback_bank,
@@ -792,7 +792,7 @@ def _resolve_hindsight_routes(
 
     raw_recall_cfg = routing.get("recall")
     recall_cfg: dict[str, Any] = raw_recall_cfg if isinstance(raw_recall_cfg, dict) else {}
-    if recall_cfg.get("include_global"):
+    if _config_bool(recall_cfg.get("include_global"), False):
         global_bank = str(recall_cfg.get("global_bank_id") or fallback_bank).strip()
         if global_bank and all(route.bank_id != _sanitize_bank_segment(global_bank) for route in routes):
             global_types = recall_cfg.get("global_types")
@@ -1709,12 +1709,13 @@ class HindsightMemoryProvider(MemoryProvider):
         if self._recall_max_input_chars and len(query) > self._recall_max_input_chars:
             query = query[:self._recall_max_input_chars]
 
+        recall_routes = [route for route in self._hindsight_routes if route.recall]
+        if not recall_routes:
+            logger.debug("Prefetch: skipped (no recall routes)")
+            return
+
         def _run():
             try:
-                recall_routes = [route for route in self._hindsight_routes if route.recall]
-                if not recall_routes:
-                    recall_routes = [HindsightBankRoute(name="fallback", bank_id=self._bank_id)]
-
                 sections: list[str] = []
                 for route in recall_routes:
                     try:
@@ -2084,8 +2085,6 @@ class HindsightMemoryProvider(MemoryProvider):
             old_retain_routes = [
                 route for route in getattr(self, "_hindsight_routes", []) if route.retain
             ]
-            if not old_retain_routes:
-                old_retain_routes = [HindsightBankRoute(name="fallback", bank_id=self._bank_id)]
             old_metadata = self._build_metadata(
                 message_count=len(old_turns) * 2,
                 turn_index=old_turn_index,

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -40,6 +40,7 @@ import queue
 import sys
 import threading
 
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List
 
@@ -614,6 +615,143 @@ def _resolve_bank_id_template(template: str, fallback: str, **placeholders: str)
     return rendered or fallback
 
 
+@dataclass(frozen=True)
+class HindsightBankRoute:
+    """Resolved Hindsight bank route for auto-recall / auto-retain."""
+
+    name: str
+    bank_id: str
+    recall: bool = True
+    retain: bool = True
+    retain_tags: list[str] = field(default_factory=list)
+    recall_tags: list[str] = field(default_factory=list)
+    recall_tags_match: str = "any"
+    recall_types: list[str] | None = None
+
+
+def _merge_tags(*values: Any) -> list[str]:
+    merged: list[str] = []
+    for value in values:
+        for tag in _normalize_retain_tags(value):
+            if tag not in merged:
+                merged.append(tag)
+    return merged
+
+
+def _route_matches(rule: dict[str, Any], *, profile: str, workspace: str,
+                   workspace_path: str, platform: str, user: str) -> bool:
+    prefix = str(rule.get("workspace_path_prefix") or "").rstrip("/")
+    if prefix:
+        current = str(workspace_path or "").rstrip("/")
+        if not (current == prefix or current.startswith(prefix + "/")):
+            return False
+    for key, actual in {
+        "profile": profile,
+        "workspace": workspace,
+        "platform": platform,
+        "user": user,
+    }.items():
+        if key in rule and str(rule.get(key) or "") != str(actual or ""):
+            return False
+    return True
+
+
+def _resolve_hindsight_routes(
+    config: dict[str, Any],
+    *,
+    fallback_bank_id: str,
+    bank_id_template: str,
+    profile: str,
+    workspace: str,
+    workspace_path: str,
+    platform: str,
+    user: str,
+    session: str,
+) -> list[HindsightBankRoute]:
+    """Resolve configured Hindsight bank routes for this runtime context."""
+    fallback_bank = _resolve_bank_id_template(
+        bank_id_template,
+        fallback=fallback_bank_id,
+        profile=profile,
+        workspace=workspace,
+        platform=platform,
+        user=user,
+        session=session,
+    )
+    default_retain_tags = _normalize_retain_tags(config.get("retain_tags"))
+    default_recall_tags = _normalize_retain_tags(config.get("recall_tags"))
+    default_recall_tags_match = str(config.get("recall_tags_match") or "any")
+    configured_recall_types = config.get("recall_types")
+    if configured_recall_types is None:
+        default_recall_types = ["observation"]
+    elif isinstance(configured_recall_types, str):
+        default_recall_types = [t.strip() for t in configured_recall_types.split(",") if t.strip()]
+    else:
+        default_recall_types = list(configured_recall_types) or ["observation"]
+    routing = config.get("bank_routing")
+    if not isinstance(routing, dict):
+        return [
+            HindsightBankRoute(
+                name="fallback",
+                bank_id=fallback_bank,
+                retain_tags=default_retain_tags,
+                recall_tags=default_recall_tags,
+                recall_tags_match=default_recall_tags_match,
+                recall_types=default_recall_types,
+            )
+        ]
+
+    rules = [rule for rule in list(routing.get("rules") or []) if isinstance(rule, dict)]
+    matches = [
+        rule for rule in rules
+        if _route_matches(rule, profile=profile, workspace=workspace,
+                          workspace_path=workspace_path, platform=platform, user=user)
+    ]
+    matches.sort(key=lambda rule: len(str(rule.get("workspace_path_prefix") or "")), reverse=True)
+    selected = matches[:1] if str(routing.get("strategy", "first_match")) == "first_match" else matches
+
+    routes: list[HindsightBankRoute] = []
+    for rule in selected:
+        bank_id = str(rule.get("bank_id") or "").strip()
+        if not bank_id:
+            continue
+        recall_types = rule.get("recall_types")
+        routes.append(HindsightBankRoute(
+            name=str(rule.get("name") or bank_id),
+            bank_id=_sanitize_bank_segment(bank_id),
+            recall=bool(rule.get("recall", True)),
+            retain=bool(rule.get("retain", True)),
+            retain_tags=_merge_tags(default_retain_tags, rule.get("retain_tags")),
+            recall_tags=_merge_tags(default_recall_tags, rule.get("recall_tags")),
+            recall_tags_match=str(rule.get("recall_tags_match") or default_recall_tags_match),
+            recall_types=list(recall_types) if isinstance(recall_types, list) else default_recall_types,
+        ))
+
+    if not routes and routing.get("include_fallback", True):
+        routes.append(HindsightBankRoute(
+            name="fallback",
+            bank_id=fallback_bank,
+            retain_tags=default_retain_tags,
+            recall_tags=default_recall_tags,
+            recall_tags_match=default_recall_tags_match,
+            recall_types=default_recall_types,
+        ))
+
+    recall_cfg = routing.get("recall") if isinstance(routing.get("recall"), dict) else {}
+    if recall_cfg.get("include_global"):
+        global_bank = str(recall_cfg.get("global_bank_id") or fallback_bank).strip()
+        if global_bank and all(route.bank_id != _sanitize_bank_segment(global_bank) for route in routes):
+            global_types = recall_cfg.get("global_types")
+            routes.append(HindsightBankRoute(
+                name=str(recall_cfg.get("global_name") or "global"),
+                bank_id=_sanitize_bank_segment(global_bank),
+                recall=True,
+                retain=bool(recall_cfg.get("global_retain", False)),
+                recall_types=list(global_types) if isinstance(global_types, list) else None,
+            ))
+    return routes
+
+
 # ---------------------------------------------------------------------------
 # MemoryProvider implementation
 # ---------------------------------------------------------------------------
@@ -654,6 +792,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._thread_id = ""
         self._agent_identity = ""
         self._agent_workspace = ""
+        self._agent_workspace_path = ""
         self._turn_index = 0
         self._client = None
         self._timeout = _DEFAULT_TIMEOUT
@@ -712,6 +851,9 @@ class HindsightMemoryProvider(MemoryProvider):
         self._bank_mission = ""
         self._bank_retain_mission: str | None = None
         self._bank_id_template = ""
+        self._hindsight_routes: list[HindsightBankRoute] = [
+            HindsightBankRoute(name="fallback", bank_id=self._bank_id)
+        ]
 
     @property
     def name(self) -> str:
@@ -1250,6 +1392,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._thread_id = str(kwargs.get("thread_id") or "").strip()
         self._agent_identity = str(kwargs.get("agent_identity") or "").strip()
         self._agent_workspace = str(kwargs.get("agent_workspace") or "").strip()
+        self._agent_workspace_path = str(kwargs.get("agent_workspace_path") or kwargs.get("workspace_path") or "").strip()
         self._turn_index = 0
         self._session_turns = []
         self._last_retained_turn_count = 0
@@ -1352,6 +1495,21 @@ class HindsightMemoryProvider(MemoryProvider):
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
         self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
         self._retain_async = self._config.get("retain_async", True)
+
+        self._hindsight_routes = _resolve_hindsight_routes(
+            self._config,
+            fallback_bank_id=static_bank_id,
+            bank_id_template=self._bank_id_template,
+            profile=self._agent_identity,
+            workspace=self._agent_workspace,
+            workspace_path=self._agent_workspace_path,
+            platform=self._platform,
+            user=self._user_id,
+            session=self._session_id,
+        )
+        primary_routes = [route for route in self._hindsight_routes if route.retain or route.recall]
+        if primary_routes:
+            self._bank_id = primary_routes[0].bank_id
 
         _client_version = "unknown"
         try:
@@ -1497,27 +1655,48 @@ class HindsightMemoryProvider(MemoryProvider):
 
         def _run():
             try:
-                if self._prefetch_method == "reflect":
-                    logger.debug("Prefetch: calling reflect (bank=%s, query_len=%d)", self._bank_id, len(query))
-                    resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget))
-                    text = resp.text or ""
-                else:
-                    recall_kwargs: dict = {
-                        "bank_id": self._bank_id, "query": query,
-                        "budget": self._budget, "max_tokens": self._recall_max_tokens,
-                    }
-                    if self._recall_tags:
-                        recall_kwargs["tags"] = self._recall_tags
-                        recall_kwargs["tags_match"] = self._recall_tags_match
-                    if self._recall_types:
-                        recall_kwargs["types"] = self._recall_types
-                    logger.debug("Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
-                                 self._bank_id, len(query), self._budget)
-                    resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
-                    num_results = len(resp.results) if resp.results else 0
-                    logger.debug("Prefetch: recall returned %d results", num_results)
-                    text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
-                if text:
+                recall_routes = [route for route in self._hindsight_routes if route.recall]
+                if not recall_routes:
+                    recall_routes = [HindsightBankRoute(name="fallback", bank_id=self._bank_id)]
+
+                sections: list[str] = []
+                for route in recall_routes:
+                    try:
+                        if self._prefetch_method == "reflect":
+                            logger.debug("Prefetch: calling reflect (bank=%s, query_len=%d)", route.bank_id, len(query))
+                            resp = self._run_hindsight_operation(lambda client, route=route: client.areflect(bank_id=route.bank_id, query=query, budget=self._budget))
+                            text = resp.text or ""
+                        else:
+                            recall_kwargs: dict = {
+                                "bank_id": route.bank_id, "query": query,
+                                "budget": self._budget, "max_tokens": self._recall_max_tokens,
+                            }
+                            using_provider_recall_tags = route.name == "fallback" and not route.recall_tags
+                            route_tags = route.recall_tags or (self._recall_tags if using_provider_recall_tags else None)
+                            if route_tags:
+                                recall_kwargs["tags"] = route_tags
+                                recall_kwargs["tags_match"] = self._recall_tags_match if using_provider_recall_tags else route.recall_tags_match
+                            route_types = route.recall_types if route.recall_types is not None else self._recall_types
+                            if route_types:
+                                recall_kwargs["types"] = route_types
+                            logger.debug("Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
+                                         route.bank_id, len(query), self._budget)
+                            resp = self._run_hindsight_operation(lambda client, recall_kwargs=recall_kwargs: client.arecall(**recall_kwargs))
+                            num_results = len(resp.results) if resp.results else 0
+                            logger.debug("Prefetch: recall returned %d results", num_results)
+                            text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
+                        if text:
+                            if len(recall_routes) == 1 and route.name == "fallback":
+                                sections.append(text)
+                            else:
+                                sections.append(f"## Hindsight Memory: {route.name} ({route.bank_id})\n{text}")
+                    except Exception as route_exc:
+                        logger.debug(
+                            "Hindsight prefetch failed for bank %s: %s",
+                            route.bank_id, route_exc, exc_info=True,
+                        )
+                if sections:
+                    text = "\n\n".join(sections)
                     with self._prefetch_lock:
                         self._prefetch_result = text
             except Exception as e:
@@ -1660,31 +1839,41 @@ class HindsightMemoryProvider(MemoryProvider):
             turn_index=self._turn_index,
         )
         num_turns = len(turns_to_retain)
-        bank_id = self._bank_id
+        retain_routes = [route for route in self._hindsight_routes if route.retain]
+        if not retain_routes:
+            logger.debug("sync_turn: no retain-enabled routes")
+            return
         retain_async_flag = self._retain_async
         retain_context = self._retain_context
 
         def _do_retain() -> None:
-            item = self._build_retain_kwargs(
-                content,
-                context=retain_context,
-                metadata=metadata_snapshot,
-                tags=lineage_tags or None,
-            )
-            item.pop("bank_id", None)
-            item.pop("retain_async", None)
-            if update_mode is not None:
-                item["update_mode"] = update_mode
-            logger.debug("Hindsight retain: bank=%s, doc=%s, mode=%s, async=%s, content_len=%d, num_turns=%d",
-                         bank_id, document_id, update_mode, retain_async_flag, len(content), num_turns)
-            self._run_hindsight_operation(
-                lambda client: client.aretain_batch(
-                    bank_id=bank_id,
-                    items=[item],
-                    document_id=document_id,
-                    retain_async=retain_async_flag,
-                )
-            )
+            for route in retain_routes:
+                try:
+                    item = self._build_retain_kwargs(
+                        content,
+                        context=retain_context,
+                        metadata=metadata_snapshot,
+                        tags=_merge_tags(route.retain_tags, lineage_tags),
+                    )
+                    item.pop("bank_id", None)
+                    item.pop("retain_async", None)
+                    if update_mode is not None:
+                        item["update_mode"] = update_mode
+                    logger.debug("Hindsight retain: bank=%s, doc=%s, mode=%s, async=%s, content_len=%d, num_turns=%d",
+                                 route.bank_id, document_id, update_mode, retain_async_flag, len(content), num_turns)
+                    self._run_hindsight_operation(
+                        lambda client, route=route, item=item: client.aretain_batch(
+                            bank_id=route.bank_id,
+                            items=[item],
+                            document_id=document_id,
+                            retain_async=retain_async_flag,
+                        )
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Hindsight retain failed for routed bank %s: %s",
+                        route.bank_id, e, exc_info=True,
+                    )
             logger.debug("Hindsight retain succeeded")
 
         self._ensure_writer()
@@ -1820,10 +2009,27 @@ class HindsightMemoryProvider(MemoryProvider):
         # everything before mutating self._* so metadata + tags + doc_id
         # all reference the old session consistently.
         if self._session_turns:
-            old_turns = list(self._session_turns)
             old_session_id = self._session_id
             old_parent_session_id = self._parent_session_id
             old_turn_index = self._turn_index
+            # Resolve doc_id + update_mode against the OLD session BEFORE
+            # we rotate _session_id, so the flush lands in the old
+            # session's document either way (legacy: per-process unique;
+            # ≥0.5.0: stable session-scoped + append).
+            old_document_id, old_update_mode = self._resolve_retain_target(
+                self._document_id
+            )
+            if old_update_mode == "append":
+                old_turns = self._session_turns[self._last_retained_turn_count:]
+            else:
+                old_turns = list(self._session_turns)
+            if not old_turns:
+                logger.debug("Hindsight flush-on-switch skipped; no unretained turns")
+            old_retain_routes = [
+                route for route in getattr(self, "_hindsight_routes", []) if route.retain
+            ]
+            if not old_retain_routes:
+                old_retain_routes = [HindsightBankRoute(name="fallback", bank_id=self._bank_id)]
             old_metadata = self._build_metadata(
                 message_count=len(old_turns) * 2,
                 turn_index=old_turn_index,
@@ -1834,40 +2040,37 @@ class HindsightMemoryProvider(MemoryProvider):
             if old_parent_session_id:
                 old_lineage_tags.append(f"parent:{old_parent_session_id}")
             old_content = "[" + ",".join(old_turns) + "]"
-            # Resolve doc_id + update_mode against the OLD session BEFORE
-            # we rotate _session_id, so the flush lands in the old
-            # session's document either way (legacy: per-process unique;
-            # ≥0.5.0: stable session-scoped + append).
-            old_document_id, old_update_mode = self._resolve_retain_target(
-                self._document_id
-            )
 
             def _flush():
-                try:
-                    item = self._build_retain_kwargs(
-                        old_content,
-                        context=self._retain_context,
-                        metadata=old_metadata,
-                        tags=old_lineage_tags or None,
-                    )
-                    item.pop("bank_id", None)
-                    item.pop("retain_async", None)
-                    if old_update_mode is not None:
-                        item["update_mode"] = old_update_mode
-                    logger.debug(
-                        "Hindsight flush-on-switch: bank=%s, doc=%s, mode=%s, num_turns=%d",
-                        self._bank_id, old_document_id, old_update_mode, len(old_turns),
-                    )
-                    self._run_hindsight_operation(
-                        lambda client: client.aretain_batch(
-                            bank_id=self._bank_id,
-                            items=[item],
-                            document_id=old_document_id,
-                            retain_async=self._retain_async,
+                for route in old_retain_routes:
+                    try:
+                        item = self._build_retain_kwargs(
+                            old_content,
+                            context=self._retain_context,
+                            metadata=old_metadata,
+                            tags=_merge_tags(route.retain_tags, old_lineage_tags),
                         )
-                    )
-                except Exception as e:
-                    logger.warning("Hindsight flush-on-switch failed: %s", e, exc_info=True)
+                        item.pop("bank_id", None)
+                        item.pop("retain_async", None)
+                        if old_update_mode is not None:
+                            item["update_mode"] = old_update_mode
+                        logger.debug(
+                            "Hindsight flush-on-switch: bank=%s, doc=%s, mode=%s, num_turns=%d",
+                            route.bank_id, old_document_id, old_update_mode, len(old_turns),
+                        )
+                        self._run_hindsight_operation(
+                            lambda client, route=route, item=item: client.aretain_batch(
+                                bank_id=route.bank_id,
+                                items=[item],
+                                document_id=old_document_id,
+                                retain_async=self._retain_async,
+                            )
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "Hindsight flush-on-switch failed for routed bank %s: %s",
+                            route.bank_id, e, exc_info=True,
+                        )
 
             # Route the flush through the same writer queue sync_turn
             # uses. That serializes it behind any still-queued retains
@@ -1875,7 +2078,7 @@ class HindsightMemoryProvider(MemoryProvider):
             # two threads on aretain_batch against the same document, and
             # keeps shutdown's drain semantics intact. Skip enqueue if
             # shutdown has already fired — the writer is draining/gone.
-            if not self._shutting_down.is_set():
+            if old_turns and old_retain_routes and not self._shutting_down.is_set():
                 self._ensure_writer()
                 self._register_atexit()
                 self._retain_queue.put(_flush)
@@ -1888,8 +2091,11 @@ class HindsightMemoryProvider(MemoryProvider):
             self._prefetch_result = ""
 
         # 3. Now rotate to the new session.
-        if parent_session_id:
-            self._parent_session_id = str(parent_session_id).strip()
+        parent_id = str(parent_session_id or "").strip()
+        if parent_id and parent_id != new_id:
+            self._parent_session_id = parent_id
+        elif parent_id == new_id:
+            self._parent_session_id = ""
         self._session_id = new_id
         start_ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         self._document_id = f"{self._session_id}-{start_ts}"

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1914,6 +1914,64 @@ class TestBankRouting:
         assert [route.bank_id for route in routes] == ["infra"]
         assert routes[0].name == "common-memory"
 
+    def test_route_resolution_matches_portable_workspace_globs(self):
+        config = {
+            "bank_routing": {
+                "rules": [
+                    {"name": "workspace", "workspace_glob": "rigplane-*", "bank_id": "workspace-bank"},
+                    {"name": "repo", "repo_name_glob": "rigplane-*", "bank_id": "repo-bank"},
+                    {
+                        "name": "path",
+                        "workspace_path_glob": "/work/*/rigplane-*",
+                        "bank_id": "path-bank",
+                    },
+                ],
+                "strategy": "all_matches",
+            }
+        }
+
+        routes = _resolve_hindsight_routes(
+            config,
+            fallback_bank_id="global-user",
+            bank_id_template="",
+            profile="default",
+            workspace="rigplane-desktop",
+            workspace_path="/work/alice/rigplane-pro",
+            platform="cli",
+            user="",
+            session="s1",
+        )
+
+        assert [route.bank_id for route in routes] == ["path-bank", "workspace-bank", "repo-bank"]
+
+    def test_route_resolution_matches_git_remote_glob(self):
+        config = {
+            "bank_routing": {
+                "rules": [
+                    {
+                        "name": "rigplane-git",
+                        "git_remote_glob": "*github.com*rigplane/rigplane-*",
+                        "bank_id": "rigplane-bank",
+                    }
+                ]
+            }
+        }
+
+        routes = _resolve_hindsight_routes(
+            config,
+            fallback_bank_id="global-user",
+            bank_id_template="",
+            profile="default",
+            workspace="hermes",
+            workspace_path="/some/host/path/rigplane-pro",
+            platform="cli",
+            user="",
+            session="s1",
+            git_remote="git@github.com:rigplane/rigplane-pro.git",
+        )
+
+        assert [route.bank_id for route in routes] == ["rigplane-bank"]
+
     def test_provider_initialize_stores_resolved_routes(self, tmp_path, monkeypatch):
         config = {
             "mode": "cloud",

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -871,11 +871,11 @@ class TestPrefetch:
                 "rules": [
                     {
                         "name": "infra",
-                        "workspace_path_prefix": "/Users/moroz/Projects/rigplane-pro",
+                        "workspace_path_prefix": "/work/acme/project-alpha",
                         "bank_id": "infra",
                         "retain": True,
                         "recall": True,
-                        "recall_tags": ["project:rigplane", "domain:infra"],
+                        "recall_tags": ["project:alpha", "domain:infra"],
                         "recall_tags_match": "all_strict",
                         "recall_types": ["observation"],
                     }
@@ -886,8 +886,8 @@ class TestPrefetch:
             session_id="test-session",
             hermes_home="unused",
             platform="cli",
-            agent_workspace="rigplane-pro",
-            agent_workspace_path="/Users/moroz/Projects/rigplane-pro",
+            agent_workspace="project-alpha",
+            agent_workspace_path="/work/acme/project-alpha",
         )
         p._client = _make_mock_client()
 
@@ -903,7 +903,7 @@ class TestPrefetch:
 
         calls = [call.kwargs for call in p._client.arecall.call_args_list]
         assert [call["bank_id"] for call in calls] == ["infra", "global-user"]
-        assert calls[0]["tags"] == ["project:rigplane", "domain:infra"]
+        assert calls[0]["tags"] == ["project:alpha", "domain:infra"]
         assert calls[0]["tags_match"] == "all_strict"
         assert calls[0]["types"] == ["observation"]
         assert calls[1]["types"] == ["observation"]
@@ -1222,15 +1222,15 @@ class TestSyncTurn:
                 "rules": [
                     {
                         "name": "infra",
-                        "workspace_path_prefix": "/Users/moroz/Projects/rigplane-pro",
+                        "workspace_path_prefix": "/work/acme/project-alpha",
                         "bank_id": "infra",
                         "retain": True,
                         "recall": True,
-                        "retain_tags": ["project:rigplane", "domain:infra"],
+                        "retain_tags": ["project:alpha", "domain:infra"],
                     },
                     {
                         "name": "skip-retain",
-                        "workspace": "rigplane-pro",
+                        "workspace": "project-alpha",
                         "bank_id": "scratch",
                         "retain": False,
                         "recall": True,
@@ -1243,8 +1243,8 @@ class TestSyncTurn:
             session_id="session-1",
             hermes_home="unused",
             platform="cli",
-            agent_workspace="rigplane-pro",
-            agent_workspace_path="/Users/moroz/Projects/rigplane-pro",
+            agent_workspace="project-alpha",
+            agent_workspace_path="/work/acme/project-alpha",
             parent_session_id="parent-1",
         )
         p._client = _make_mock_client()
@@ -1259,7 +1259,7 @@ class TestSyncTurn:
         item = calls[0]["items"][0]
         assert item["tags"] == [
             "source:hermes",
-            "project:rigplane",
+            "project:alpha",
             "domain:infra",
             "session:session-1",
             "parent:parent-1",
@@ -1872,7 +1872,7 @@ class TestBankRouting:
             bank_id_template="",
             profile="default",
             workspace="hermes",
-            workspace_path="/Users/moroz/Projects/unknown",
+            workspace_path="/work/acme/unknown",
             platform="cli",
             user="",
             session="s1",
@@ -1889,12 +1889,12 @@ class TestBankRouting:
                 "rules": [
                     {
                         "name": "projects",
-                        "workspace_path_prefix": "/Users/moroz/Projects",
+                        "workspace_path_prefix": "/work/acme",
                         "bank_id": "all-projects",
                     },
                     {
-                        "name": "common-memory",
-                        "workspace_path_prefix": "/Users/moroz/Projects/common-memory",
+                        "name": "docs-suite",
+                        "workspace_path_prefix": "/work/acme/docs-suite",
                         "bank_id": "infra",
                     },
                 ]
@@ -1907,24 +1907,24 @@ class TestBankRouting:
             bank_id_template="",
             profile="default",
             workspace="hermes",
-            workspace_path="/Users/moroz/Projects/common-memory/server",
+            workspace_path="/work/acme/docs-suite/server",
             platform="cli",
             user="",
             session="s1",
         )
 
         assert [route.bank_id for route in routes] == ["infra"]
-        assert routes[0].name == "common-memory"
+        assert routes[0].name == "docs-suite"
 
     def test_route_resolution_matches_portable_workspace_globs(self):
         config = {
             "bank_routing": {
                 "rules": [
-                    {"name": "workspace", "workspace_glob": "rigplane-*", "bank_id": "workspace-bank"},
-                    {"name": "repo", "repo_name_glob": "rigplane-*", "bank_id": "repo-bank"},
+                    {"name": "workspace", "workspace_glob": "project-*", "bank_id": "workspace-bank"},
+                    {"name": "repo", "repo_name_glob": "project-*", "bank_id": "repo-bank"},
                     {
                         "name": "path",
-                        "workspace_path_glob": "/work/*/rigplane-*",
+                        "workspace_path_glob": "/work/*/project-*",
                         "bank_id": "path-bank",
                     },
                 ],
@@ -1937,8 +1937,8 @@ class TestBankRouting:
             fallback_bank_id="global-user",
             bank_id_template="",
             profile="default",
-            workspace="rigplane-desktop",
-            workspace_path="/work/alice/rigplane-pro",
+            workspace="project-alpha-desktop",
+            workspace_path="/work/alice/project-alpha",
             platform="cli",
             user="",
             session="s1",
@@ -1951,9 +1951,9 @@ class TestBankRouting:
             "bank_routing": {
                 "rules": [
                     {
-                        "name": "rigplane-git",
-                        "git_remote_glob": "*github.com*rigplane/rigplane-*",
-                        "bank_id": "rigplane-bank",
+                        "name": "project-alpha-git",
+                        "git_remote_glob": "*github.com*acme/project-*",
+                        "bank_id": "project-alpha-bank",
                     }
                 ]
             }
@@ -1965,32 +1965,32 @@ class TestBankRouting:
             bank_id_template="",
             profile="default",
             workspace="hermes",
-            workspace_path="/some/host/path/rigplane-pro",
+            workspace_path="/some/host/path/project-alpha",
             platform="cli",
             user="",
             session="s1",
-            git_remote="git@github.com:rigplane/rigplane-pro.git",
+            git_remote="git@github.com:acme/project-alpha.git",
         )
 
-        assert [route.bank_id for route in routes] == ["rigplane-bank"]
+        assert [route.bank_id for route in routes] == ["project-alpha-bank"]
 
     def test_route_resolution_matches_normalized_git_repo_glob(self):
         config = {
             "bank_routing": {
                 "rules": [
                     {
-                        "name": "rigplane-repo",
-                        "git_repo_glob": "rigplane/rigplane-*",
-                        "bank_id": "rigplane-bank",
+                        "name": "project-alpha-repo",
+                        "git_repo_glob": "acme/project-*",
+                        "bank_id": "project-alpha-bank",
                     }
                 ]
             }
         }
 
         for remote in (
-            "git@github.com:rigplane/rigplane-pro.git",
-            "https://github.com/rigplane/rigplane-pro.git",
-            "ssh://git@github.com/rigplane/rigplane-pro.git",
+            "git@github.com:acme/project-alpha.git",
+            "https://github.com/acme/project-alpha.git",
+            "ssh://git@github.com/acme/project-alpha.git",
         ):
             routes = _resolve_hindsight_routes(
                 config,
@@ -1998,14 +1998,14 @@ class TestBankRouting:
                 bank_id_template="",
                 profile="default",
                 workspace="hermes",
-                workspace_path="/some/host/path/rigplane-pro",
+                workspace_path="/some/host/path/project-alpha",
                 platform="cli",
                 user="",
                 session="s1",
                 git_remote=remote,
             )
 
-            assert [route.bank_id for route in routes] == ["rigplane-bank"]
+            assert [route.bank_id for route in routes] == ["project-alpha-bank"]
 
     def test_provider_initialize_stores_resolved_routes(self, tmp_path, monkeypatch):
         config = {
@@ -2018,10 +2018,10 @@ class TestBankRouting:
                 "recall": {"include_global": True, "global_bank_id": "global-user"},
                 "rules": [
                     {
-                        "name": "rigplane",
-                        "workspace_path_prefix": "/Users/moroz/Projects/rigplane-pro",
+                        "name": "project-alpha",
+                        "workspace_path_prefix": "/work/acme/project-alpha",
                         "bank_id": "infra",
-                        "retain_tags": ["project:rigplane"],
+                        "retain_tags": ["project:alpha"],
                     }
                 ],
             },
@@ -2037,13 +2037,13 @@ class TestBankRouting:
             hermes_home=str(tmp_path),
             platform="cli",
             agent_identity="default",
-            agent_workspace="rigplane-pro",
-            agent_workspace_path="/Users/moroz/Projects/rigplane-pro",
+            agent_workspace="project-alpha",
+            agent_workspace_path="/work/acme/project-alpha",
         )
 
         assert [route.bank_id for route in p._hindsight_routes] == ["infra", "global-user"]
-        assert p._hindsight_routes[0].name == "rigplane"
-        assert p._hindsight_routes[0].retain_tags == ["source:hermes", "project:rigplane"]
+        assert p._hindsight_routes[0].name == "project-alpha"
+        assert p._hindsight_routes[0].retain_tags == ["source:hermes", "project:alpha"]
         assert p._hindsight_routes[1].retain is False
         assert p._bank_id == "infra"
 
@@ -2200,35 +2200,35 @@ class TestBankRouting:
         assert routes == []
 
     def test_extract_routing_context_caches_git_identity(self, tmp_path):
-        workspace = tmp_path / "rigplane-pro"
+        workspace = tmp_path / "project-alpha"
         workspace.mkdir()
-        (workspace / "AGENTS.md").write_text("# proprietary project\n")
+        (workspace / "AGENTS.md").write_text("# project marker\n")
         os.system(f"git -C {workspace} init -q")
-        os.system(f"git -C {workspace} remote add origin git@github.com:rigplane/rigplane-pro.git")
+        os.system(f"git -C {workspace} remote add origin git@github.com:acme/project-alpha.git")
         os.system(f"git -C {workspace} checkout -b feature/test >/dev/null 2>&1")
 
         cache_root = tmp_path / "profile" / "cache"
         first = _extract_hindsight_routing_context(
-            workspace="rigplane-pro",
+            workspace="project-alpha",
             workspace_path=str(workspace),
-            profile="frontdesk",
+            profile="support",
             platform="cli",
             user="",
             session="s1",
             cache_root=cache_root,
             registry_version="v1",
         )
-        assert first.repo_name == "rigplane-pro"
-        assert first.git_remote == "git@github.com:rigplane/rigplane-pro.git"
-        assert first.git_repo == "rigplane/rigplane-pro"
+        assert first.repo_name == "project-alpha"
+        assert first.git_remote == "git@github.com:acme/project-alpha.git"
+        assert first.git_repo == "acme/project-alpha"
         assert first.git_branch == "feature/test"
         assert first.cache_hit is False
 
         os.system(f"git -C {workspace} checkout -b feature/changed >/dev/null 2>&1")
         second = _extract_hindsight_routing_context(
-            workspace="rigplane-pro",
+            workspace="project-alpha",
             workspace_path=str(workspace),
-            profile="frontdesk",
+            profile="support",
             platform="cli",
             user="",
             session="s1",
@@ -2243,9 +2243,9 @@ class TestBankRouting:
         # are unavailable.
         os.system(f"rm -rf {workspace / '.git'}")
         third = _extract_hindsight_routing_context(
-            workspace="rigplane-pro",
+            workspace="project-alpha",
             workspace_path=str(workspace),
-            profile="frontdesk",
+            profile="support",
             platform="cli",
             user="",
             session="s1",
@@ -2253,13 +2253,13 @@ class TestBankRouting:
             registry_version="v1",
         )
         assert third.cache_hit is True
-        assert third.git_repo == "rigplane/rigplane-pro"
+        assert third.git_repo == "acme/project-alpha"
 
         (workspace / "AGENTS.md").write_text("# changed marker\n")
         fourth = _extract_hindsight_routing_context(
-            workspace="rigplane-pro",
+            workspace="project-alpha",
             workspace_path=str(workspace),
-            profile="frontdesk",
+            profile="support",
             platform="cli",
             user="",
             session="s1",
@@ -2277,7 +2277,7 @@ class TestBankRouting:
         context = _extract_hindsight_routing_context(
             workspace="private",
             workspace_path=str(workspace),
-            profile="frontdesk",
+            profile="support",
             platform="cli",
             user="",
             session="s1",
@@ -2313,13 +2313,13 @@ class TestBankRouting:
 
     def test_bank_registry_generates_deterministic_candidates(self):
         context = _extract_hindsight_routing_context(
-            workspace="rigplane-pro",
-            workspace_path="/work/rigplane-pro",
-            profile="frontdesk",
+            workspace="project-alpha",
+            workspace_path="/work/project-alpha",
+            profile="support",
             platform="cli",
             user="",
             session="s1",
-            git_remote="git@github.com:rigplane/rigplane-pro.git",
+            git_remote="git@github.com:acme/project-alpha.git",
             registry_version="v1",
         )
         candidates = _generate_hindsight_bank_candidates(
@@ -2329,19 +2329,19 @@ class TestBankRouting:
                     "display_name": "Global user",
                     "recall_policy": {"enabled": True, "tags": ["scope:global"]},
                     "retain_policy": {"enabled": False},
-                    "match": {"profile": "frontdesk"},
+                    "match": {"profile": "support"},
                 },
                 {
-                    "id": "hindsight-product-rigplane",
-                    "display_name": "RigPlane product",
+                    "id": "team-product-memory",
+                    "display_name": "Team product",
                     "recall_policy": {
                         "enabled": True,
-                        "tags": ["project:rigplane"],
+                        "tags": ["project:alpha"],
                         "tags_match": "all_strict",
                     },
-                    "retain_policy": {"enabled": True, "tags": ["project:rigplane"]},
-                    "match": {"git_repo_glob": "rigplane/rigplane-*", "repo_name_glob": "rigplane-*"},
-                    "allowed_profiles": ["frontdesk"],
+                    "retain_policy": {"enabled": True, "tags": ["project:alpha"]},
+                    "match": {"git_repo_glob": "acme/project-*", "repo_name_glob": "project-*"},
+                    "allowed_profiles": ["support"],
                     "allowed_platforms": ["cli"],
                 },
                 {
@@ -2354,11 +2354,11 @@ class TestBankRouting:
         )
 
         assert [candidate.bank_id for candidate in candidates] == [
-            "hindsight-product-rigplane",
+            "team-product-memory",
             "global-user",
         ]
         assert candidates[0].retain is True
-        assert candidates[0].recall_tags == ["project:rigplane"]
+        assert candidates[0].recall_tags == ["project:alpha"]
         assert candidates[0].recall_tags_match == "all_strict"
         assert candidates[1].recall is True
         assert candidates[1].retain is False
@@ -2369,11 +2369,11 @@ class TestBankRouting:
             "bank_registry_version": "v1",
             "bank_registry": [
                 {
-                    "id": "hindsight-product-rigplane",
-                    "display_name": "RigPlane product",
+                    "id": "team-product-memory",
+                    "display_name": "Team product",
                     "recall_policy": {"enabled": True, "types": ["observation"]},
-                    "retain_policy": {"enabled": True, "tags": ["project:rigplane"]},
-                    "match": {"git_repo_glob": "rigplane/rigplane-*"},
+                    "retain_policy": {"enabled": True, "tags": ["project:alpha"]},
+                    "match": {"git_repo_glob": "acme/project-*"},
                 }
             ],
         }
@@ -2382,17 +2382,17 @@ class TestBankRouting:
             config,
             fallback_bank_id="global-user",
             bank_id_template="",
-            profile="frontdesk",
-            workspace="rigplane-pro",
-            workspace_path="/work/rigplane-pro",
+            profile="support",
+            workspace="project-alpha",
+            workspace_path="/work/project-alpha",
             platform="cli",
             user="",
             session="s1",
-            git_remote="https://github.com/rigplane/rigplane-pro.git",
+            git_remote="https://github.com/acme/project-alpha.git",
         )
 
-        assert [route.bank_id for route in routes] == ["hindsight-product-rigplane"]
-        assert routes[0].retain_tags == ["project:rigplane"]
+        assert [route.bank_id for route in routes] == ["team-product-memory"]
+        assert routes[0].retain_tags == ["project:alpha"]
         assert routes[0].recall_types == ["observation"]
 
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1972,6 +1972,39 @@ class TestBankRouting:
 
         assert [route.bank_id for route in routes] == ["rigplane-bank"]
 
+    def test_route_resolution_matches_normalized_git_repo_glob(self):
+        config = {
+            "bank_routing": {
+                "rules": [
+                    {
+                        "name": "rigplane-repo",
+                        "git_repo_glob": "rigplane/rigplane-*",
+                        "bank_id": "rigplane-bank",
+                    }
+                ]
+            }
+        }
+
+        for remote in (
+            "git@github.com:rigplane/rigplane-pro.git",
+            "https://github.com/rigplane/rigplane-pro.git",
+            "ssh://git@github.com/rigplane/rigplane-pro.git",
+        ):
+            routes = _resolve_hindsight_routes(
+                config,
+                fallback_bank_id="global-user",
+                bank_id_template="",
+                profile="default",
+                workspace="hermes",
+                workspace_path="/some/host/path/rigplane-pro",
+                platform="cli",
+                user="",
+                session="s1",
+                git_remote=remote,
+            )
+
+            assert [route.bank_id for route in routes] == ["rigplane-bank"]
+
     def test_provider_initialize_stores_resolved_routes(self, tmp_path, monkeypatch):
         config = {
             "mode": "cloud",

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1921,6 +1921,73 @@ class TestBankRouting:
         assert routes[0].recall_tags_match == "all_strict"
         assert routes[0].recall_types == ["observation"]
 
+    def test_route_resolution_normalizes_route_string_recall_types_and_bool_strings(self):
+        config = {
+            "recall_types": "observation",
+            "bank_routing": {
+                "rules": [
+                    {
+                        "name": "project",
+                        "bank_id": "project-bank",
+                        "recall": "false",
+                        "retain": "false",
+                        "recall_types": "world, experience",
+                    }
+                ]
+            },
+        }
+
+        routes = _resolve_hindsight_routes(
+            config,
+            fallback_bank_id="global-user",
+            bank_id_template="",
+            profile="default",
+            workspace="hermes",
+            workspace_path="/repo/project",
+            platform="cli",
+            user="",
+            session="s1",
+        )
+
+        assert routes[0].recall is False
+        assert routes[0].retain is False
+        assert routes[0].recall_types == ["world", "experience"]
+
+    def test_route_resolution_supports_global_recall_tags_and_bool_strings(self):
+        config = {
+            "recall_types": "observation",
+            "bank_routing": {
+                "recall": {
+                    "include_global": True,
+                    "global_bank_id": "global-user",
+                    "global_retain": "false",
+                    "global_tags": "scope:global,source:hermes",
+                    "global_tags_match": "all_strict",
+                    "global_types": "observation,world",
+                },
+                "rules": [{"name": "project", "bank_id": "project-bank"}],
+            },
+        }
+
+        routes = _resolve_hindsight_routes(
+            config,
+            fallback_bank_id="fallback-bank",
+            bank_id_template="",
+            profile="default",
+            workspace="hermes",
+            workspace_path="/repo/project",
+            platform="cli",
+            user="",
+            session="s1",
+        )
+
+        global_route = routes[1]
+        assert global_route.bank_id == "global-user"
+        assert global_route.retain is False
+        assert global_route.recall_tags == ["scope:global", "source:hermes"]
+        assert global_route.recall_tags_match == "all_strict"
+        assert global_route.recall_types == ["observation", "world"]
+
 
 # ---------------------------------------------------------------------------
 # Availability tests

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -21,6 +21,8 @@ from plugins.memory.hindsight import (
     RECALL_SCHEMA,
     REFLECT_SCHEMA,
     RETAIN_SCHEMA,
+    _extract_hindsight_routing_context,
+    _generate_hindsight_bank_candidates,
     _load_config,
     _build_embedded_profile_env,
     _normalize_observation_scopes,
@@ -2196,6 +2198,160 @@ class TestBankRouting:
         )
 
         assert routes == []
+
+    def test_extract_routing_context_caches_git_identity(self, tmp_path):
+        workspace = tmp_path / "rigplane-pro"
+        workspace.mkdir()
+        (workspace / "AGENTS.md").write_text("# proprietary project\n")
+        os.system(f"git -C {workspace} init -q")
+        os.system(f"git -C {workspace} remote add origin git@github.com:rigplane/rigplane-pro.git")
+        os.system(f"git -C {workspace} checkout -b feature/test >/dev/null 2>&1")
+
+        cache_root = tmp_path / "profile" / "cache"
+        first = _extract_hindsight_routing_context(
+            workspace="rigplane-pro",
+            workspace_path=str(workspace),
+            profile="frontdesk",
+            platform="cli",
+            user="",
+            session="s1",
+            cache_root=cache_root,
+            registry_version="v1",
+        )
+        assert first.repo_name == "rigplane-pro"
+        assert first.git_remote == "git@github.com:rigplane/rigplane-pro.git"
+        assert first.git_repo == "rigplane/rigplane-pro"
+        assert first.git_branch == "feature/test"
+        assert first.cache_hit is False
+
+        os.system(f"git -C {workspace} checkout -b feature/changed >/dev/null 2>&1")
+        second = _extract_hindsight_routing_context(
+            workspace="rigplane-pro",
+            workspace_path=str(workspace),
+            profile="frontdesk",
+            platform="cli",
+            user="",
+            session="s1",
+            cache_root=cache_root,
+            registry_version="v1",
+        )
+        assert second.cache_hit is False
+        assert second.git_branch == "feature/changed"
+
+        # Removing .git proves the third call is served from the profile cache
+        # when the safe invalidation fields still match and live git signals
+        # are unavailable.
+        os.system(f"rm -rf {workspace / '.git'}")
+        third = _extract_hindsight_routing_context(
+            workspace="rigplane-pro",
+            workspace_path=str(workspace),
+            profile="frontdesk",
+            platform="cli",
+            user="",
+            session="s1",
+            cache_root=cache_root,
+            registry_version="v1",
+        )
+        assert third.cache_hit is True
+        assert third.git_repo == "rigplane/rigplane-pro"
+
+        (workspace / "AGENTS.md").write_text("# changed marker\n")
+        fourth = _extract_hindsight_routing_context(
+            workspace="rigplane-pro",
+            workspace_path=str(workspace),
+            profile="frontdesk",
+            platform="cli",
+            user="",
+            session="s1",
+            cache_root=cache_root,
+            registry_version="v1",
+        )
+        assert fourth.cache_hit is False
+        assert fourth.git_repo == ""
+
+    def test_bank_registry_generates_deterministic_candidates(self):
+        context = _extract_hindsight_routing_context(
+            workspace="rigplane-pro",
+            workspace_path="/work/rigplane-pro",
+            profile="frontdesk",
+            platform="cli",
+            user="",
+            session="s1",
+            git_remote="git@github.com:rigplane/rigplane-pro.git",
+            registry_version="v1",
+        )
+        candidates = _generate_hindsight_bank_candidates(
+            [
+                {
+                    "id": "global-user",
+                    "display_name": "Global user",
+                    "recall_policy": {"enabled": True, "tags": ["scope:global"]},
+                    "retain_policy": {"enabled": False},
+                    "match": {"profile": "frontdesk"},
+                },
+                {
+                    "id": "hindsight-product-rigplane",
+                    "display_name": "RigPlane product",
+                    "recall_policy": {
+                        "enabled": True,
+                        "tags": ["project:rigplane"],
+                        "tags_match": "all_strict",
+                    },
+                    "retain_policy": {"enabled": True, "tags": ["project:rigplane"]},
+                    "match": {"git_repo_glob": "rigplane/rigplane-*", "repo_name_glob": "rigplane-*"},
+                    "allowed_profiles": ["frontdesk"],
+                    "allowed_platforms": ["cli"],
+                },
+                {
+                    "id": "scratch",
+                    "match": {"git_repo_glob": "other/*"},
+                    "retain_policy": {"enabled": True},
+                },
+            ],
+            context,
+        )
+
+        assert [candidate.bank_id for candidate in candidates] == [
+            "hindsight-product-rigplane",
+            "global-user",
+        ]
+        assert candidates[0].retain is True
+        assert candidates[0].recall_tags == ["project:rigplane"]
+        assert candidates[0].recall_tags_match == "all_strict"
+        assert candidates[1].recall is True
+        assert candidates[1].retain is False
+        assert any("git_repo_glob" in reason for reason in candidates[0].reasons)
+
+    def test_bank_registry_routes_apply_when_no_bank_routing_configured(self):
+        config = {
+            "bank_registry_version": "v1",
+            "bank_registry": [
+                {
+                    "id": "hindsight-product-rigplane",
+                    "display_name": "RigPlane product",
+                    "recall_policy": {"enabled": True, "types": ["observation"]},
+                    "retain_policy": {"enabled": True, "tags": ["project:rigplane"]},
+                    "match": {"git_repo_glob": "rigplane/rigplane-*"},
+                }
+            ],
+        }
+
+        routes = _resolve_hindsight_routes(
+            config,
+            fallback_bank_id="global-user",
+            bank_id_template="",
+            profile="frontdesk",
+            workspace="rigplane-pro",
+            workspace_path="/work/rigplane-pro",
+            platform="cli",
+            user="",
+            session="s1",
+            git_remote="https://github.com/rigplane/rigplane-pro.git",
+        )
+
+        assert [route.bank_id for route in routes] == ["hindsight-product-rigplane"]
+        assert routes[0].retain_tags == ["project:rigplane"]
+        assert routes[0].recall_types == ["observation"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -2269,6 +2269,48 @@ class TestBankRouting:
         assert fourth.cache_hit is False
         assert fourth.git_repo == ""
 
+    def test_extract_routing_context_strips_credentials_from_git_remote_cache(self, tmp_path):
+        workspace = tmp_path / "private"
+        workspace.mkdir()
+        cache_root = tmp_path / "profile" / "cache"
+
+        context = _extract_hindsight_routing_context(
+            workspace="private",
+            workspace_path=str(workspace),
+            profile="frontdesk",
+            platform="cli",
+            user="",
+            session="s1",
+            git_remote="https://credential-user:ghp_secret123@github.com/acme/private.git",
+            cache_root=cache_root,
+            registry_version="v1",
+        )
+
+        assert context.git_remote == "https://github.com/acme/private.git"
+        assert context.git_repo == "acme/private"
+
+        cache_files = list((cache_root / "hindsight" / "project-context").glob("*.json"))
+        assert len(cache_files) == 1
+        cached = json.loads(cache_files[0].read_text(encoding="utf-8"))
+        cached_text = json.dumps(cached)
+        assert cached["git_remote"] == "https://github.com/acme/private.git"
+        assert cached["git_repo"] == "acme/private"
+        assert "credential-user" not in cached_text
+        assert "ghp_secret123" not in cached_text
+
+        candidates = _generate_hindsight_bank_candidates(
+            [
+                {
+                    "id": "private-bank",
+                    "match": {"git_repo_glob": "acme/*"},
+                    "retain_policy": {"enabled": True},
+                }
+            ],
+            context,
+        )
+
+        assert [candidate.bank_id for candidate in candidates] == ["private-bank"]
+
     def test_bank_registry_generates_deterministic_candidates(self):
         context = _extract_hindsight_routing_context(
             workspace="rigplane-pro",

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -913,6 +913,37 @@ class TestPrefetch:
         assert "- infra memory" in p._prefetch_result
         assert "- global-user memory" in p._prefetch_result
 
+    def test_queue_prefetch_skips_when_routing_resolves_no_recall_routes(self, provider_with_config):
+        p = provider_with_config(
+            bank_id="global-user",
+            bank_routing={
+                "include_fallback": False,
+                "rules": [
+                    {
+                        "name": "other-project",
+                        "workspace_path_prefix": "/repo/other",
+                        "bank_id": "other-bank",
+                    }
+                ],
+            },
+        )
+        p.initialize(
+            session_id="test-session",
+            hermes_home="unused",
+            platform="cli",
+            agent_workspace="project",
+            agent_workspace_path="/repo/project",
+        )
+        p._client = _make_mock_client()
+
+        assert p._hindsight_routes == []
+
+        p.queue_prefetch("project context")
+
+        assert p._prefetch_thread is None
+        p._client.arecall.assert_not_called()
+        assert p.prefetch("project context") == ""
+
 
 # ---------------------------------------------------------------------------
 # sync_turn tests
@@ -1053,8 +1084,8 @@ class TestSyncTurn:
     def test_sync_turn_appends_only_delta_when_append_supported(self, provider_with_config, monkeypatch):
         """On append-capable APIs each retain ships only the new turns, not the whole session."""
         monkeypatch.setattr(
-            "plugins.memory.hindsight._fetch_hindsight_api_version",
-            lambda *a, **kw: "0.5.6",
+            "plugins.memory.hindsight._fetch_hindsight_version_info",
+            lambda *a, **kw: {"version": "0.5.6"},
         )
         from plugins.memory.hindsight import _append_capability_cache, _append_capability_lock
         # Clear before AND after: the capability cache is module-global and keyed
@@ -1404,6 +1435,40 @@ class TestSessionSwitchBufferFlush:
         provider._client.aretain_batch.assert_not_called()
         assert provider._session_id == "new-sid"
 
+    def test_switch_flush_skips_when_routing_resolves_no_retain_routes(self, provider_with_config):
+        p = provider_with_config(
+            retain_every_n_turns=3,
+            bank_routing={
+                "include_fallback": False,
+                "rules": [
+                    {
+                        "name": "other-project",
+                        "workspace_path_prefix": "/repo/other",
+                        "bank_id": "other-bank",
+                    }
+                ],
+            },
+        )
+        p.initialize(
+            session_id="old-sid",
+            hermes_home="unused",
+            platform="cli",
+            agent_workspace="project",
+            agent_workspace_path="/repo/project",
+        )
+        p._client = _make_mock_client()
+
+        assert p._hindsight_routes == []
+        p.sync_turn("buffered user", "buffered assistant")
+        p._client.aretain_batch.assert_not_called()
+
+        p.on_session_switch("new-sid")
+        p._retain_queue.join()
+
+        p._client.aretain_batch.assert_not_called()
+        assert p._session_id == "new-sid"
+        assert p._session_turns == []
+
     def test_prefetch_result_cleared_on_switch(self, provider):
         """Stale recall text from the old session must not leak into the
         next session's first prefetch read."""
@@ -1511,7 +1576,7 @@ class TestUpdateModeAppendCapability:
         per-process unique doc_id and NOT pass update_mode."""
         self._clear_capability_cache()
         monkeypatch.setattr(
-            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            "plugins.memory.hindsight._fetch_hindsight_version_info",
             lambda *a, **kw: None,
         )
         old_doc = provider._document_id
@@ -1528,8 +1593,8 @@ class TestUpdateModeAppendCapability:
         """API on >=0.5.0 — retain uses stable session_id and sets update_mode='append'."""
         self._clear_capability_cache()
         monkeypatch.setattr(
-            "plugins.memory.hindsight._fetch_hindsight_api_version",
-            lambda *a, **kw: "0.5.6",
+            "plugins.memory.hindsight._fetch_hindsight_version_info",
+            lambda *a, **kw: {"version": "0.5.6"},
         )
         provider.sync_turn("hello", "hi")
         provider._retain_queue.join()
@@ -1547,10 +1612,10 @@ class TestUpdateModeAppendCapability:
 
         def _spy(*a, **kw):
             calls["n"] += 1
-            return "0.5.6"
+            return {"version": "0.5.6"}
 
         monkeypatch.setattr(
-            "plugins.memory.hindsight._fetch_hindsight_api_version", _spy
+            "plugins.memory.hindsight._fetch_hindsight_version_info", _spy
         )
         provider.sync_turn("a", "b")
         provider._retain_queue.join()
@@ -1563,8 +1628,8 @@ class TestUpdateModeAppendCapability:
         import logging
         self._clear_capability_cache()
         monkeypatch.setattr(
-            "plugins.memory.hindsight._fetch_hindsight_api_version",
-            lambda *a, **kw: "0.4.22",
+            "plugins.memory.hindsight._fetch_hindsight_version_info",
+            lambda *a, **kw: {"version": "0.4.22"},
         )
         with caplog.at_level(logging.WARNING, logger="plugins.memory.hindsight"):
             provider.sync_turn("a", "b")
@@ -1584,8 +1649,8 @@ class TestUpdateModeAppendCapability:
         in the OLD session's stable document, not a per-process id."""
         self._clear_capability_cache()
         monkeypatch.setattr(
-            "plugins.memory.hindsight._fetch_hindsight_api_version",
-            lambda *a, **kw: "0.5.6",
+            "plugins.memory.hindsight._fetch_hindsight_version_info",
+            lambda *a, **kw: {"version": "0.5.6"},
         )
         p = provider_with_config(retain_every_n_turns=3, retain_async=False)
         p.sync_turn("turn1-user", "turn1-asst")
@@ -1987,6 +2052,59 @@ class TestBankRouting:
         assert global_route.recall_tags == ["scope:global", "source:hermes"]
         assert global_route.recall_tags_match == "all_strict"
         assert global_route.recall_types == ["observation", "world"]
+
+    def test_route_resolution_treats_include_global_false_string_as_false(self):
+        config = {
+            "bank_routing": {
+                "recall": {
+                    "include_global": "false",
+                    "global_bank_id": "global-user",
+                },
+                "rules": [{"name": "project", "bank_id": "project-bank"}],
+            },
+        }
+
+        routes = _resolve_hindsight_routes(
+            config,
+            fallback_bank_id="fallback-bank",
+            bank_id_template="",
+            profile="default",
+            workspace="hermes",
+            workspace_path="/repo/project",
+            platform="cli",
+            user="",
+            session="s1",
+        )
+
+        assert [route.bank_id for route in routes] == ["project-bank"]
+
+    def test_route_resolution_treats_include_fallback_false_string_as_false(self):
+        config = {
+            "bank_routing": {
+                "include_fallback": "false",
+                "rules": [
+                    {
+                        "name": "other-project",
+                        "workspace_path_prefix": "/repo/other",
+                        "bank_id": "other-bank",
+                    }
+                ],
+            },
+        }
+
+        routes = _resolve_hindsight_routes(
+            config,
+            fallback_bank_id="fallback-bank",
+            bank_id_template="",
+            profile="default",
+            workspace="hermes",
+            workspace_path="/repo/project",
+            platform="cli",
+            user="",
+            session="s1",
+        )
+
+        assert routes == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -26,6 +26,7 @@ from plugins.memory.hindsight import (
     _normalize_observation_scopes,
     _normalize_retain_tags,
     _resolve_bank_id_template,
+    _resolve_hindsight_routes,
     _sanitize_bank_segment,
 )
 
@@ -855,6 +856,63 @@ class TestPrefetch:
         assert call_kwargs["tags_match"] == "all"
         assert call_kwargs["types"] == ["world"]
 
+    def test_queue_prefetch_fans_out_to_routed_recall_banks(self, provider_with_config):
+        p = provider_with_config(
+            bank_id="global-user",
+            recall_max_tokens=1024,
+            bank_routing={
+                "recall": {
+                    "include_global": True,
+                    "global_bank_id": "global-user",
+                    "global_types": ["observation"],
+                },
+                "rules": [
+                    {
+                        "name": "infra",
+                        "workspace_path_prefix": "/Users/moroz/Projects/rigplane-pro",
+                        "bank_id": "infra",
+                        "retain": True,
+                        "recall": True,
+                        "recall_tags": ["project:rigplane", "domain:infra"],
+                        "recall_tags_match": "all_strict",
+                        "recall_types": ["observation"],
+                    }
+                ],
+            },
+        )
+        p.initialize(
+            session_id="test-session",
+            hermes_home="unused",
+            platform="cli",
+            agent_workspace="rigplane-pro",
+            agent_workspace_path="/Users/moroz/Projects/rigplane-pro",
+        )
+        p._client = _make_mock_client()
+
+        async def _arecall(**kwargs):
+            bank_id = kwargs["bank_id"]
+            return SimpleNamespace(results=[SimpleNamespace(text=f"{bank_id} memory")])
+
+        p._client.arecall = AsyncMock(side_effect=_arecall)
+
+        p.queue_prefetch("deployment context")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        calls = [call.kwargs for call in p._client.arecall.call_args_list]
+        assert [call["bank_id"] for call in calls] == ["infra", "global-user"]
+        assert calls[0]["tags"] == ["project:rigplane", "domain:infra"]
+        assert calls[0]["tags_match"] == "all_strict"
+        assert calls[0]["types"] == ["observation"]
+        assert calls[1]["types"] == ["observation"]
+        assert "tags" not in calls[1]
+        assert all(call["budget"] == "mid" for call in calls)
+        assert all(call["max_tokens"] == 1024 for call in calls)
+        assert "## Hindsight Memory: infra (infra)" in p._prefetch_result
+        assert "## Hindsight Memory: global (global-user)" in p._prefetch_result
+        assert "- infra memory" in p._prefetch_result
+        assert "- global-user memory" in p._prefetch_result
+
 
 # ---------------------------------------------------------------------------
 # sync_turn tests
@@ -1121,6 +1179,111 @@ class TestSyncTurn:
         assert "こんにちは" in raw_json
         assert "你好" in raw_json
         assert "👨‍👩‍👧‍👦" in raw_json
+
+    def test_sync_turn_retains_to_each_routed_retain_bank(self, provider_with_config):
+        p = provider_with_config(
+            bank_id="global-user",
+            retain_tags=["source:hermes"],
+            bank_routing={
+                "recall": {"include_global": True, "global_bank_id": "global-user"},
+                "rules": [
+                    {
+                        "name": "infra",
+                        "workspace_path_prefix": "/Users/moroz/Projects/rigplane-pro",
+                        "bank_id": "infra",
+                        "retain": True,
+                        "recall": True,
+                        "retain_tags": ["project:rigplane", "domain:infra"],
+                    },
+                    {
+                        "name": "skip-retain",
+                        "workspace": "rigplane-pro",
+                        "bank_id": "scratch",
+                        "retain": False,
+                        "recall": True,
+                    },
+                ],
+                "strategy": "all_matches",
+            },
+        )
+        p.initialize(
+            session_id="session-1",
+            hermes_home="unused",
+            platform="cli",
+            agent_workspace="rigplane-pro",
+            agent_workspace_path="/Users/moroz/Projects/rigplane-pro",
+            parent_session_id="parent-1",
+        )
+        p._client = _make_mock_client()
+
+        p.sync_turn("hello", "hi")
+        p._retain_queue.join()
+
+        calls = [call.kwargs for call in p._client.aretain_batch.call_args_list]
+        assert [call["bank_id"] for call in calls] == ["infra"]
+        assert calls[0]["document_id"] == p._document_id
+        assert calls[0]["retain_async"] is True
+        item = calls[0]["items"][0]
+        assert item["tags"] == [
+            "source:hermes",
+            "project:rigplane",
+            "domain:infra",
+            "session:session-1",
+            "parent:parent-1",
+        ]
+        content = json.loads(item["content"])
+        assert content[0][0]["content"] == "User: hello"
+        assert content[0][1]["content"] == "Assistant: hi"
+
+    def test_sync_turn_continues_when_one_routed_retain_bank_fails(self, provider_with_config):
+        p = provider_with_config(
+            bank_routing={
+                "rules": [
+                    {"name": "infra", "bank_id": "infra"},
+                    {"name": "docs", "bank_id": "docs"},
+                ],
+                "strategy": "all_matches",
+            },
+        )
+        p._client = _make_mock_client()
+
+        async def _aretain_batch(**kwargs):
+            if kwargs["bank_id"] == "infra":
+                raise RuntimeError("infra unavailable")
+            return SimpleNamespace(ok=True)
+
+        p._client.aretain_batch = AsyncMock(side_effect=_aretain_batch)
+
+        p.sync_turn("hello", "hi")
+        p._retain_queue.join()
+
+        calls = [call.kwargs for call in p._client.aretain_batch.call_args_list]
+        assert [call["bank_id"] for call in calls] == ["infra", "docs"]
+
+    def test_multibank_on_session_switch_flushes_old_session_for_all_retain_routes(self, provider_with_config):
+        p = provider_with_config(
+            retain_every_n_turns=3,
+            bank_routing={
+                "rules": [
+                    {"name": "infra", "bank_id": "infra"},
+                    {"name": "docs", "bank_id": "docs"},
+                ],
+                "strategy": "all_matches",
+            },
+        )
+        p._client = _make_mock_client()
+
+        p.sync_turn("old user", "old assistant")
+        p.on_session_switch("new-session", parent_session_id="old-session")
+        p._retain_queue.join()
+
+        calls = [call.kwargs for call in p._client.aretain_batch.call_args_list]
+        assert [call["bank_id"] for call in calls] == ["infra", "docs"]
+        assert all(call["document_id"].startswith("test-session-") for call in calls)
+        for call in calls:
+            item = call["items"][0]
+            assert "old user" in item["content"]
+            assert "session:test-session" in item["tags"]
 
 
 # ---------------------------------------------------------------------------
@@ -1627,6 +1790,136 @@ class TestBankIdTemplate:
         # No agent_identity passed — template renders to "hermes-" which collapses to "hermes"
         p.initialize(session_id="s1", hermes_home=str(tmp_path), platform="cli")
         assert p._bank_id == "hermes"
+
+
+# ---------------------------------------------------------------------------
+# bank_routing tests
+# ---------------------------------------------------------------------------
+
+
+class TestBankRouting:
+    def test_route_resolution_falls_back_to_static_bank_without_routing(self):
+        routes = _resolve_hindsight_routes(
+            {},
+            fallback_bank_id="global-user",
+            bank_id_template="",
+            profile="default",
+            workspace="hermes",
+            workspace_path="/Users/moroz/Projects/unknown",
+            platform="cli",
+            user="",
+            session="s1",
+        )
+
+        assert [route.bank_id for route in routes] == ["global-user"]
+        assert routes[0].name == "fallback"
+        assert routes[0].recall is True
+        assert routes[0].retain is True
+
+    def test_route_resolution_matches_longest_workspace_path_prefix(self):
+        config = {
+            "bank_routing": {
+                "rules": [
+                    {
+                        "name": "projects",
+                        "workspace_path_prefix": "/Users/moroz/Projects",
+                        "bank_id": "all-projects",
+                    },
+                    {
+                        "name": "common-memory",
+                        "workspace_path_prefix": "/Users/moroz/Projects/common-memory",
+                        "bank_id": "infra",
+                    },
+                ]
+            }
+        }
+
+        routes = _resolve_hindsight_routes(
+            config,
+            fallback_bank_id="global-user",
+            bank_id_template="",
+            profile="default",
+            workspace="hermes",
+            workspace_path="/Users/moroz/Projects/common-memory/server",
+            platform="cli",
+            user="",
+            session="s1",
+        )
+
+        assert [route.bank_id for route in routes] == ["infra"]
+        assert routes[0].name == "common-memory"
+
+    def test_provider_initialize_stores_resolved_routes(self, tmp_path, monkeypatch):
+        config = {
+            "mode": "cloud",
+            "apiKey": "k",
+            "api_url": "http://x",
+            "bank_id": "global-user",
+            "retain_tags": ["source:hermes"],
+            "bank_routing": {
+                "recall": {"include_global": True, "global_bank_id": "global-user"},
+                "rules": [
+                    {
+                        "name": "rigplane",
+                        "workspace_path_prefix": "/Users/moroz/Projects/rigplane-pro",
+                        "bank_id": "infra",
+                        "retain_tags": ["project:rigplane"],
+                    }
+                ],
+            },
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+
+        p = HindsightMemoryProvider()
+        p.initialize(
+            session_id="s1",
+            hermes_home=str(tmp_path),
+            platform="cli",
+            agent_identity="default",
+            agent_workspace="rigplane-pro",
+            agent_workspace_path="/Users/moroz/Projects/rigplane-pro",
+        )
+
+        assert [route.bank_id for route in p._hindsight_routes] == ["infra", "global-user"]
+        assert p._hindsight_routes[0].name == "rigplane"
+        assert p._hindsight_routes[0].retain_tags == ["source:hermes", "project:rigplane"]
+        assert p._hindsight_routes[1].retain is False
+        assert p._bank_id == "infra"
+
+    def test_route_resolution_uses_top_level_recall_defaults_for_routes(self):
+        config = {
+            "recall_tags": ["source:hermes"],
+            "recall_tags_match": "all_strict",
+            "recall_types": ["observation"],
+            "bank_routing": {
+                "rules": [
+                    {
+                        "name": "project",
+                        "workspace_path_prefix": "/repo/project",
+                        "bank_id": "project-bank",
+                    }
+                ]
+            },
+        }
+
+        routes = _resolve_hindsight_routes(
+            config,
+            fallback_bank_id="global-user",
+            bank_id_template="",
+            profile="default",
+            workspace="hermes",
+            workspace_path="/repo/project",
+            platform="cli",
+            user="",
+            session="s1",
+        )
+
+        assert routes[0].recall_tags == ["source:hermes"]
+        assert routes[0].recall_tags_match == "all_strict"
+        assert routes[0].recall_types == ["observation"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add portable deterministic route predicates (`workspace_path_glob`, `workspace_glob`, `repo_name_glob`, `git_remote_glob`) so multi-machine/product-family routing does not require host-local absolute paths
- add `bank_routing` support to the Hindsight memory provider for multi-bank automatic recall/retain
- resolve routes from stable runtime context (`workspace_path_prefix`, workspace, profile, platform, user) while preserving single-bank fallback behavior
- fan out auto-recall to recall-enabled routes with bank-labeled context sections
- fan out auto-retain of the full JSON turn payload to retain-enabled routes with deterministic tag merging and per-bank failure isolation
- propagate `agent_workspace_path` into memory provider initialization and document the new routing config

## Design notes
- Portable predicates are still deterministic policy config, not LLM autonomy; they are a Phase 1 step toward a richer bank registry/router while preserving strict retain guardrails.
- Hindsight banks remain hard isolation boundaries; Hermes only orchestrates per-bank calls client-side.
- Explicit tools keep the existing schema and target the primary resolved bank, avoiding tool-schema bloat.
- Resolved routes are not injected into the system prompt; dynamic bank labels only appear in prefetch context, preserving prompt-cache safety.
- Global recall is recall-only by default so project transcripts are not retained into global/personal memory unless explicitly configured.

## Verification
```bash
uv run --with pytest --with pyyaml --with pytest-asyncio python -m pytest \
  tests/agent/test_memory_provider.py \
  tests/agent/test_memory_async_sync.py \
  tests/agent/test_memory_session_switch.py \
  tests/run_agent/test_memory_provider_init.py \
  tests/plugins/memory/test_hindsight_provider.py \
  -q -o 'addopts='
```

Result:

```text
246 passed in 8.82s
```

Also checked:

```bash
git diff --check
```

No whitespace errors.

Refs #31776

