### PR TITLE
fix(gateway): drop exact-duplicate rapid re-sends when coalescing queued messages

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1948,8 +1948,23 @@ def merge_pending_message_event(
             and getattr(existing, "message_type", None) == MessageType.TEXT
             and event.message_type == MessageType.TEXT
         ):
-            if event.text:
-                existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+            incoming = event.text or ""
+            if incoming:
+                existing_text = existing.text or ""
+                if not existing_text:
+                    existing.text = incoming
+                else:
+                    # Drop exact rapid-fire duplicates (a user mashing the same
+                    # message while a turn is busy): skip when the incoming
+                    # fragment is identical to the whole pending text or to its
+                    # trailing fragment.  Only EXACT matches are dropped, so
+                    # genuine new or near-duplicate content is never lost.
+                    incoming_stripped = incoming.strip()
+                    existing_stripped = existing_text.strip()
+                    last_fragment = existing_stripped.rsplit("\n", 1)[-1].strip()
+                    if incoming_stripped and incoming_stripped in (existing_stripped, last_fragment):
+                        return
+                    existing.text = f"{existing_text}\n{incoming}"
             return
 
     pending_messages[session_key] = event

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -259,6 +259,40 @@ def test_merge_pending_message_event_promotes_document_followups_over_text():
     assert merged.media_types == ["application/pdf"]
 
 
+def test_merge_pending_message_event_drops_exact_text_duplicates():
+    """A user mashing the same message while a turn is busy must not stack
+    that text repeatedly; exact duplicates are dropped, near-duplicates and
+    genuinely new content are preserved."""
+    pending = {}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="u1",
+    )
+    session_key = build_session_key(source)
+
+    def text_event(t):
+        return MessageEvent(text=t, message_type=MessageType.TEXT, source=source)
+
+    merge_pending_message_event(pending, session_key, text_event("status please"), merge_text=True)
+    # exact duplicates — dropped
+    merge_pending_message_event(pending, session_key, text_event("status please"), merge_text=True)
+    merge_pending_message_event(pending, session_key, text_event("status please"), merge_text=True)
+    assert pending[session_key].text == "status please"
+
+    # near-duplicate — preserved (no data loss)
+    merge_pending_message_event(pending, session_key, text_event("Status please"), merge_text=True)
+    assert pending[session_key].text == "status please\nStatus please"
+
+    # new content then a trailing exact duplicate of it — duplicate dropped
+    merge_pending_message_event(pending, session_key, text_event("one more thing"), merge_text=True)
+    merge_pending_message_event(pending, session_key, text_event("one more thing"), merge_text=True)
+    assert pending[session_key].text == (
+        "status please\nStatus please\none more thing"
+    )
+
+
 @pytest.mark.asyncio
 async def test_recent_telegram_text_followup_is_queued_without_interrupt():
     runner = _make_runner()

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -293,6 +293,35 @@ def test_merge_pending_message_event_drops_exact_text_duplicates():
     )
 
 
+def test_merge_pending_message_event_drops_whitespace_only_variants():
+    """A rapid re-send that differs from the pending text only by surrounding
+    whitespace is treated as a duplicate and dropped — mobile clients often
+    append a trailing space or newline on those re-sends, so the comparison is
+    whitespace-insensitive by design. Genuine content differences are still
+    appended, so nothing meaningful is lost."""
+    pending = {}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="u1",
+    )
+    session_key = build_session_key(source)
+
+    def text_event(t):
+        return MessageEvent(text=t, message_type=MessageType.TEXT, source=source)
+
+    merge_pending_message_event(pending, session_key, text_event("weiter"), merge_text=True)
+    # whitespace-only variants (trailing newline, surrounding spaces) — dropped
+    merge_pending_message_event(pending, session_key, text_event("weiter\n"), merge_text=True)
+    merge_pending_message_event(pending, session_key, text_event("  weiter  "), merge_text=True)
+    assert pending[session_key].text == "weiter"
+
+    # a real content difference is still appended (guards against over-dropping)
+    merge_pending_message_event(pending, session_key, text_event("weiter bitte"), merge_text=True)
+    assert pending[session_key].text == "weiter\nweiter bitte"
+
+
 @pytest.mark.asyncio
 async def test_recent_telegram_text_followup_is_queued_without_interrupt():
     runner = _make_runner()


### PR DESCRIPTION
## What does this PR do?

When a user sends the **same text several times in quick succession** while an
agent turn is busy, `merge_pending_message_event` appended each copy to the
pending turn. The agent then saw the same line stacked repeatedly once the turn
picked up the coalesced message (e.g. `weiter\nweiter\nweiter`), which wastes
context and can skew the model's reading of intent.

This coalesces duplicate rapid re-sends in the pending-message queue: an incoming
`TEXT` fragment is skipped when, ignoring surrounding whitespace, it is identical
to the whole pending text or to its trailing line. The match is
whitespace-insensitive by design — mobile clients often append a trailing space
or newline on rapid re-sends, so a byte-exact check would let those slip past and
stack anyway. Content and casing differences (`"Status"` after `"status"`) are
still treated as distinct, so near-duplicates and genuinely new content are never
lost.

This is intentionally narrow and operates purely on the in-memory pending queue.
It is distinct from transcript-level dedup on transient provider failure (which
keys on `platform_message_id` to avoid persisting the *same* message twice on
retry) — here we collapse *rapid identical re-sends* the user actually typed.

## Related Issue

Fixes #52991

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py` — in `merge_pending_message_event`, drop an incoming
  `TEXT` fragment when (whitespace-normalized) it equals the whole pending text or
  its trailing line; otherwise append as before. Behavior for non-text merges is
  unchanged.
- `tests/gateway/test_session_race_guard.py` — add
  `test_merge_pending_message_event_drops_exact_text_duplicates` covering exact
  duplicates dropped, near-duplicates preserved, and a trailing exact-dup of new
  content dropped; and
  `test_merge_pending_message_event_drops_whitespace_only_variants` pinning the
  whitespace-insensitive behavior (a re-send differing only by surrounding
  whitespace is dropped, a genuine content difference is still appended).

## How to Test

1. `pytest tests/gateway/test_session_race_guard.py -q` — all pass (incl. the new test).
2. Manual: while an agent turn is processing on Telegram, send the same short
   message 3× rapidly. Before: the queued turn shows the line stacked 3×. After:
   it appears once. Sending a near-duplicate (different casing/extra word) still
   appends, so nothing is lost.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant suite (`pytest tests/gateway/test_session_race_guard.py -q`) and it passes; CI runs the full suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Fedora-family, Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure-Python string logic, no platform deps
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
