### PR TITLE
fix(desktop): wait for old Windows GUI before relaunch

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
+++ b/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
@@ -184,6 +184,7 @@ pub async fn launch_hermes_desktop(
     // directly; this matches user double-click/open behavior and avoids cwd /
     // quarantine oddities after a self-update rebuild.
     let mut cmd = desktop_launch_command(&exe_path, &install_root);
+    cmd.env_remove("HERMES_DESKTOP_PID");
     #[cfg(target_os = "windows")]
     {
         use std::os::windows::process::CommandExt;

--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -46,6 +46,7 @@ const UPDATE_EXIT_CONCURRENT: i32 = 2;
 /// install tree before giving up and letting `hermes update`'s own guard decide.
 const DESKTOP_EXIT_WAIT: Duration = Duration::from_secs(20);
 const DESKTOP_EXIT_POLL: Duration = Duration::from_millis(500);
+const DESKTOP_PID_ENV: &str = "HERMES_DESKTOP_PID";
 
 /// Guards against concurrent update runs. The frontend kicks `startUpdate()`
 /// from a mount effect, which can fire more than once (React strict-mode
@@ -198,7 +199,17 @@ async fn run_update(app: AppHandle) -> Result<()> {
     // real progress instead of a frozen first bar.
     let started = Instant::now();
     emit_stage(&app, "handoff", StageState::Running, None, None);
-    wait_for_install_locks_free(&install_root, &app, "handoff").await;
+    if let Err(err) = wait_for_install_locks_free(&install_root, &app, "handoff").await {
+        let message = err.to_string();
+        emit_stage(
+            &app,
+            "handoff",
+            StageState::Failed,
+            Some(started.elapsed().as_millis() as u64),
+            Some(message),
+        );
+        return Err(err);
+    }
     emit_stage(
         &app,
         "handoff",
@@ -481,18 +492,39 @@ async fn run_update(app: AppHandle) -> Result<()> {
 }
 
 /// Poll until the venv shim AND packaged desktop app bundle are no longer locked
-/// (Windows) or a bounded timeout elapses. On non-Windows this is a short fixed
-/// grace since file locking isn't the failure mode there.
-pub(crate) async fn wait_for_install_locks_free(install_root: &Path, app: &AppHandle, stage: &str) {
+/// and the old desktop PID has exited (Windows) or a bounded timeout elapses.
+/// On non-Windows this is a short fixed grace since file locking isn't the
+/// failure mode there.
+pub(crate) async fn wait_for_install_locks_free(
+    install_root: &Path,
+    app: &AppHandle,
+    stage: &str,
+) -> Result<()> {
     let lock_targets = install_lock_probe_paths(install_root);
+    let desktop_pid = desktop_pid_from_env();
     let deadline = Instant::now() + DESKTOP_EXIT_WAIT;
 
-    emit_log(app, Some(stage), LogStream::Stdout, "[handoff] waiting for Hermes to exit…");
+    if let Some(pid) = desktop_pid {
+        emit_log(
+            app,
+            Some(stage),
+            LogStream::Stdout,
+            &format!("[handoff] waiting for Hermes to exit (desktop PID {pid})…"),
+        );
+    } else {
+        emit_log(
+            app,
+            Some(stage),
+            LogStream::Stdout,
+            "[handoff] waiting for Hermes to exit…",
+        );
+    }
 
     loop {
         let locked = locked_paths(&lock_targets);
-        if locked.is_empty() {
-            return;
+        let desktop_alive = desktop_pid.map(desktop_pid_is_alive).unwrap_or(false);
+        if install_handoff_can_proceed(&locked, desktop_alive) {
+            return Ok(());
         }
         if Instant::now() >= deadline {
             // Last resort: a backend hermes.exe (or the desktop Hermes.exe
@@ -507,14 +539,13 @@ pub(crate) async fn wait_for_install_locks_free(install_root: &Path, app: &AppHa
                 app,
                 Some(stage),
                 LogStream::Stdout,
-                &format!(
-                    "[handoff] Hermes still holding install files ({}); force-killing stragglers…",
-                    format_locked_paths(&locked)
-                ),
+                &format_handoff_blockers(&locked, desktop_pid, desktop_alive),
             );
             force_kill_other_hermes();
             tokio::time::sleep(Duration::from_millis(800)).await;
             let locked_after_kill = locked_paths(&lock_targets);
+            let desktop_alive_after_kill = desktop_pid.map(desktop_pid_is_alive).unwrap_or(false);
+            ensure_desktop_exited_after_cleanup(desktop_pid, desktop_alive_after_kill)?;
             if locked_after_kill.is_empty() {
                 emit_log(
                     app,
@@ -533,7 +564,7 @@ pub(crate) async fn wait_for_install_locks_free(install_root: &Path, app: &AppHa
                     ),
                 );
             }
-            return;
+            return Ok(());
         }
         tokio::time::sleep(DESKTOP_EXIT_POLL).await;
     }
@@ -543,6 +574,23 @@ fn install_lock_probe_paths(install_root: &Path) -> Vec<PathBuf> {
     let mut paths = vec![venv_hermes(install_root)];
     paths.extend(desktop_app_payload_paths(install_root));
     paths
+}
+
+fn install_handoff_can_proceed(locked: &[PathBuf], desktop_alive: bool) -> bool {
+    locked.is_empty() && !desktop_alive
+}
+
+fn ensure_desktop_exited_after_cleanup(
+    desktop_pid: Option<u32>,
+    desktop_alive: bool,
+) -> Result<()> {
+    if let Some(pid) = desktop_pid.filter(|_| desktop_alive) {
+        return Err(anyhow!(
+            "Desktop process {pid} is still running after forced cleanup. Close all Hermes windows and retry the update."
+        ));
+    }
+
+    Ok(())
 }
 
 fn desktop_app_payload_paths(install_root: &Path) -> Vec<PathBuf> {
@@ -568,6 +616,69 @@ fn locked_paths(paths: &[PathBuf]) -> Vec<PathBuf> {
 
 fn format_locked_paths(paths: &[PathBuf]) -> String {
     paths.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ")
+}
+
+fn format_handoff_blockers(
+    locked: &[PathBuf],
+    desktop_pid: Option<u32>,
+    desktop_alive: bool,
+) -> String {
+    match (locked.is_empty(), desktop_pid, desktop_alive) {
+        (true, Some(pid), true) => {
+            format!("[handoff] desktop PID {pid} is still alive; force-killing stragglers…")
+        }
+        (false, Some(pid), true) => format!(
+            "[handoff] Hermes still holding install files ({}) and desktop PID {pid} is still alive; force-killing stragglers…",
+            format_locked_paths(locked)
+        ),
+        _ => format!(
+            "[handoff] Hermes still holding install files ({}); force-killing stragglers…",
+            format_locked_paths(locked)
+        ),
+    }
+}
+
+fn desktop_pid_from_env() -> Option<u32> {
+    env::var_os(DESKTOP_PID_ENV)
+        .and_then(|raw| raw.into_string().ok())
+        .and_then(|raw| raw.trim().parse::<u32>().ok())
+        .filter(|pid| *pid > 0)
+}
+
+#[cfg(windows)]
+fn desktop_pid_is_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, GetLastError, ERROR_INVALID_PARAMETER, WAIT_OBJECT_0,
+    };
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, WaitForSingleObject, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE,
+    };
+
+    unsafe {
+        let handle = OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SYNCHRONIZE,
+            0,
+            pid,
+        );
+        if handle.is_null() {
+            let err = GetLastError();
+            // ERROR_INVALID_PARAMETER is Windows' "PID does not exist" signal.
+            // Any other probe failure means we cannot prove the old GUI exited,
+            // so fail closed and let the updater abort recoverably.
+            return err != ERROR_INVALID_PARAMETER;
+        }
+
+        let wait_result = WaitForSingleObject(handle, 0);
+        CloseHandle(handle);
+        // A signaled process handle is the only positive proof that the PID
+        // exited. WAIT_TIMEOUT and probe failures both stay fail-closed.
+        wait_result != WAIT_OBJECT_0
+    }
+}
+
+#[cfg(not(windows))]
+fn desktop_pid_is_alive(_pid: u32) -> bool {
+    false
 }
 
 /// Force-kill any `hermes.exe` other than this process. Windows-only; a no-op
@@ -1093,6 +1204,35 @@ mod tests {
         let probes = install_lock_probe_paths(root);
 
         assert!(locked_paths(&probes).is_empty());
+    }
+
+    #[test]
+    fn install_handoff_waits_for_live_desktop_pid_even_when_files_are_free() {
+        assert!(!install_handoff_can_proceed(&[], true));
+    }
+
+    #[test]
+    fn install_handoff_requires_both_free_files_and_a_dead_desktop_pid() {
+        assert!(install_handoff_can_proceed(&[], false));
+        assert!(!install_handoff_can_proceed(
+            &[PathBuf::from("/x/locked")],
+            false
+        ));
+    }
+
+    #[test]
+    fn post_cleanup_rejects_a_live_desktop_pid() {
+        let error = ensure_desktop_exited_after_cleanup(Some(4242), true).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("Desktop process 4242 is still running"));
+    }
+
+    #[test]
+    fn post_cleanup_accepts_an_exited_or_missing_desktop_pid() {
+        assert!(ensure_desktop_exited_after_cleanup(Some(4242), false).is_ok());
+        assert!(ensure_desktop_exited_after_cleanup(None, false).is_ok());
     }
 
     #[test]

--- a/apps/desktop/electron/updater-process.test.ts
+++ b/apps/desktop/electron/updater-process.test.ts
@@ -19,8 +19,9 @@ test('spawnUpdaterProcess hides the updater console and detaches the child on Wi
   const result = spawnUpdaterProcess(
     'hermes-setup.exe',
     ['--update', '--branch', 'main'],
-    { cwd: 'C:\\Hermes', detached: true, stdio: 'ignore' },
+    { cwd: 'C:\\Hermes', detached: true, env: { HERMES_HOME: 'C:\\Hermes' }, stdio: 'ignore' },
     {
+      desktopPid: 1337,
       isWindows: true,
       spawnProcess: (command, args, options) => {
         calls.push({ args, command, options })
@@ -36,7 +37,13 @@ test('spawnUpdaterProcess hides the updater console and detaches the child on Wi
     {
       args: ['--update', '--branch', 'main'],
       command: 'hermes-setup.exe',
-      options: { cwd: 'C:\\Hermes', detached: true, stdio: 'ignore', windowsHide: true }
+      options: {
+        cwd: 'C:\\Hermes',
+        detached: true,
+        env: { HERMES_DESKTOP_PID: '1337', HERMES_HOME: 'C:\\Hermes' },
+        stdio: 'ignore',
+        windowsHide: true
+      }
     }
   ])
 })
@@ -47,7 +54,7 @@ test('spawnUpdaterProcess preserves updater options off Windows', () => {
   spawnUpdaterProcess(
     'hermes-setup',
     ['--update'],
-    { detached: true, stdio: 'ignore' },
+    { detached: true, env: { HERMES_DESKTOP_PID: 'stale', HERMES_HOME: '/opt/hermes' }, stdio: 'ignore' },
     {
       isWindows: false,
       spawnProcess: (_command, _args, options) => {
@@ -58,5 +65,9 @@ test('spawnUpdaterProcess preserves updater options off Windows', () => {
     }
   )
 
-  assert.deepEqual(capturedOptions, { detached: true, stdio: 'ignore' })
+  assert.deepEqual(capturedOptions, {
+    detached: true,
+    env: { HERMES_DESKTOP_PID: 'stale', HERMES_HOME: '/opt/hermes' },
+    stdio: 'ignore'
+  })
 })

--- a/apps/desktop/electron/updater-process.ts
+++ b/apps/desktop/electron/updater-process.ts
@@ -8,6 +8,7 @@ export interface UpdaterChild {
 }
 
 export interface SpawnUpdaterProcessDeps {
+  desktopPid?: number
   isWindows?: boolean
   spawnProcess?: (command: string, args: string[], options: SpawnOptions) => UpdaterChild
 }
@@ -24,7 +25,20 @@ export function spawnUpdaterProcess(
   deps: SpawnUpdaterProcessDeps = {}
 ): UpdaterChild {
   const isWindows = deps.isWindows ?? process.platform === 'win32'
-  const spawnOptions = hiddenWindowsChildOptions(options, isWindows) as SpawnOptions
+
+  const desktopPid = deps.desktopPid ?? process.pid
+
+  const handoffOptions = isWindows
+    ? {
+        ...options,
+        env: {
+          ...options.env,
+          HERMES_DESKTOP_PID: String(desktopPid)
+        }
+      }
+    : options
+
+  const spawnOptions = hiddenWindowsChildOptions(handoffOptions, isWindows) as SpawnOptions
 
   const child = deps.spawnProcess
     ? deps.spawnProcess(updater, updaterArgs, spawnOptions)


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows desktop update/recovery race where the updater could relaunch a fresh `Hermes.exe` while the old GUI process was still alive.

Previously the Windows updater waited for install-sensitive file locks to clear, but it did not know whether the old desktop GUI PID had actually exited. That leaves a gap where `app.asar` / venv locks can look free while the old `Hermes.exe` process still lingers, allowing the updater to spawn a second desktop instance.

This PR carries the current desktop PID into the Windows updater handoff, waits for both install locks and that desktop PID to clear, and removes the PID sentinel before launching the new desktop. The scope is intentionally limited to the Windows desktop updater/recovery handoff path.

## Related Issue

Fixes #51215

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/main.cjs`: pass `HERMES_DESKTOP_PID=process.pid` to the updater for Windows update and Windows bootstrap recovery handoff.
- `apps/bootstrap-installer/src-tauri/src/update.rs`: read the desktop PID sentinel and wait for both install locks to clear and the old desktop PID to exit before proceeding.
- `apps/bootstrap-installer/src-tauri/src/bootstrap.rs`: clear `HERMES_DESKTOP_PID` before spawning the fresh desktop so it does not inherit stale handoff state.
- `apps/desktop/electron/windows-child-process.test.cjs`: add source-level coverage for the Windows handoff contract and keep existing Windows child-process coverage intact.

## How to Test

1. Source-level repro on `upstream/main d6269da7f`: assert that `applyUpdates()` carries `HERMES_DESKTOP_PID` into the updater handoff. This fails on baseline because the PID sentinel is absent.
2. Apply this PR and run:
   ```bash
   node --test apps/desktop/electron/windows-child-process.test.cjs
   ```
3. Run the broader desktop platform slice:
   ```bash
   npm run test:desktop:platforms -- --test-name-pattern="Windows update handoff|desktop background child processes|intentional or interactive|bootstrap PowerShell"
   ```
4. Run syntax / whitespace checks:
   ```bash
   node --check apps/desktop/electron/main.cjs
   git diff --check
   ```

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local checkout with source-level Windows handoff tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
Baseline source-level repro:
- upstream/main d6269da7f fails the handoff assertion because applyUpdates() does not include HERMES_DESKTOP_PID in the updater env.

Post-fix checks:
- node --test apps/desktop/electron/windows-child-process.test.cjs
  -> 4 tests passed
- npm run test:desktop:platforms -- --test-name-pattern="Windows update handoff|desktop background child processes|intentional or interactive|bootstrap PowerShell"
  -> 251 tests, 250 passed, 1 skipped
- node --check apps/desktop/electron/main.cjs
  -> passed
- git diff --check
  -> passed
```