### PR TITLE
fix(desktop): clear stale active todos on turn completion

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.test.tsx
@@ -1,0 +1,94 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $todosBySession, clearSessionTodos } from '@/store/todos'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './use-message-stream'
+
+let handleEvent: ((event: RpcEvent) => void) | null = null
+
+function MessageStreamHarness({ onEvent }: { onEvent: (handler: (event: RpcEvent) => void) => void }) {
+  const activeSessionIdRef = useRef<string | null>('session-1')
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    onEvent(stream.handleGatewayEvent)
+  }, [onEvent, stream.handleGatewayEvent])
+
+  return null
+}
+
+describe('useMessageStream todo status cleanup', () => {
+  beforeEach(() => {
+    handleEvent = null
+    clearSessionTodos('session-1')
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearSessionTodos('session-1')
+    vi.restoreAllMocks()
+  })
+
+  it('clears stale active todos when the turn completes', async () => {
+    render(
+      <MessageStreamHarness
+        onEvent={handler => {
+          handleEvent = handler
+        }}
+      />
+    )
+
+    await waitFor(() => expect(handleEvent).not.toBeNull())
+
+    act(() =>
+      handleEvent!({
+        payload: {
+          name: 'todo',
+          todos: [
+            { content: 'done', id: 'done', status: 'completed' },
+            { content: 'last step', id: 'last', status: 'in_progress' }
+          ],
+          tool_id: 'todo-live'
+        },
+        session_id: 'session-1',
+        type: 'tool.progress'
+      })
+    )
+
+    expect($todosBySession.get()['session-1']).toHaveLength(2)
+
+    act(() =>
+      handleEvent!({
+        payload: { text: 'All done.' },
+        session_id: 'session-1',
+        type: 'message.complete'
+      })
+    )
+
+    expect($todosBySession.get()['session-1']).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -2,8 +2,8 @@ import type { QueryClient } from '@tanstack/react-query'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
 import { writeAgentTerminalChunk } from '@/app/right-sidebar/terminal/agent-terminal-stream'
-import { closeAgentTerminalByProc } from '@/app/right-sidebar/terminal/terminals'
 import { readActiveTerminal } from '@/app/right-sidebar/terminal/buffer'
+import { closeAgentTerminalByProc } from '@/app/right-sidebar/terminal/terminals'
 import { translateNow } from '@/i18n'
 import {
   appendAssistantTextPart,
@@ -56,7 +56,7 @@ import {
 } from '@/store/session'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { clearSessionSubagents, pruneDelegateFallbackSubagents, upsertSubagent } from '@/store/subagents'
-import { setSessionTodos } from '@/store/todos'
+import { clearActiveSessionTodos, setSessionTodos } from '@/store/todos'
 import { recordToolDiff } from '@/store/tool-diffs'
 import { notifyWorkspaceChanged, toolMayMutateFiles } from '@/store/workspace-events'
 import type { RpcEvent } from '@/types/hermes'
@@ -939,6 +939,7 @@ export function useMessageStream({
         // prompt, and vice versa.
         clearAllPrompts(sessionId)
         clearClarifyRequest(undefined, sessionId)
+        clearActiveSessionTodos(sessionId)
         setSessionCompacting(sessionId, false)
 
         flushQueuedDeltas(sessionId)
@@ -1219,6 +1220,7 @@ export function useMessageStream({
         if (sessionId) {
           clearAllPrompts(sessionId)
           clearClarifyRequest(undefined, sessionId)
+          clearActiveSessionTodos(sessionId)
           setSessionCompacting(sessionId, false)
           compactedTurnRef.current.delete(sessionId)
         }

--- a/apps/desktop/src/store/todos.test.ts
+++ b/apps/desktop/src/store/todos.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { TodoItem } from '@/lib/todos'
 
-import { $todosBySession, clearSessionTodos, setSessionTodos } from './todos'
+import { $todosBySession, clearActiveSessionTodos, clearSessionTodos, setSessionTodos } from './todos'
 
 const todo = (id: string, status: TodoItem['status']): TodoItem => ({ content: `task ${id}`, id, status })
 
@@ -43,5 +43,23 @@ describe('setSessionTodos finished-list auto-clear', () => {
     vi.advanceTimersByTime(60_000)
 
     expect($todosBySession.get().s1).toHaveLength(2)
+  })
+
+  it('drops an active list when the turn has already ended', () => {
+    setSessionTodos('s1', [todo('a', 'completed'), todo('b', 'in_progress')])
+
+    clearActiveSessionTodos('s1')
+
+    expect($todosBySession.get().s1).toBeUndefined()
+  })
+
+  it('does not bypass the linger for an already finished list', () => {
+    setSessionTodos('s1', [todo('a', 'completed')])
+
+    clearActiveSessionTodos('s1')
+
+    expect($todosBySession.get().s1).toHaveLength(1)
+    vi.advanceTimersByTime(5_000)
+    expect($todosBySession.get().s1).toBeUndefined()
   })
 })

--- a/apps/desktop/src/store/todos.ts
+++ b/apps/desktop/src/store/todos.ts
@@ -62,3 +62,13 @@ export function clearSessionTodos(sid: string) {
   const { [sid]: _drop, ...rest } = map
   $todosBySession.set(rest)
 }
+
+export function clearActiveSessionTodos(sid: string) {
+  const todos = $todosBySession.get()[sid]
+
+  if (!todos || !todoListActive(todos)) {
+    return
+  }
+
+  clearSessionTodos(sid)
+}


### PR DESCRIPTION
## Summary

- clear stale active Desktop todo status rows when a turn reaches `message.complete` or a terminal error event
- preserve the existing short linger for already-finished todo lists so final checkmarks remain visible
- add a `useMessageStream` regression that reproduces `Tasks N/M` staying active after the final response

This avoids a stale `Tasks N/M` composer panel when a turn finishes without a final `todo` tool update, leaving the last item marked `pending` or `in_progress` even though the session is no longer running.

## Tests

```text
npm run test:ui --workspace apps/desktop -- src/store/todos.test.ts src/app/session/hooks/use-message-stream.test.tsx
# 2 files passed, 6 tests passed

npx eslint src/app/session/hooks/use-message-stream.ts src/app/session/hooks/use-message-stream.test.tsx src/store/todos.ts src/store/todos.test.ts
# passed

npm run typecheck --workspace apps/desktop
# passed
```