### PR TITLE
fix(bluebubbles): resolve reply-to text so the agent sees reply context

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -32,6 +32,7 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
 )
 from gateway.platforms.helpers import strip_markdown
+from gateway import rich_sent_store
 
 logger = logging.getLogger(__name__)
 
@@ -151,6 +152,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        self._sent_guids: OrderedDict[str, None] = OrderedDict()
 
     # ------------------------------------------------------------------
     # API helpers
@@ -546,6 +548,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 last = SendResult(
                     success=True, message_id=str(msg_id), raw_response=res
                 )
+                if msg_id and msg_id != "ok":
+                    rich_sent_store.record(chat_id, msg_id, chunk)
+                    self._sent_guids[msg_id] = None
+                    if len(self._sent_guids) > 500:
+                        self._sent_guids.popitem(last=False)
             except Exception as exc:
                 return SendResult(success=False, error=str(exc))
         return last
@@ -1011,20 +1018,31 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             user_name=sender,
             chat_id_alt=chat_identifier,
         )
+        message_id = self._value(
+            record.get("guid"),
+            record.get("messageGuid"),
+            record.get("id"),
+        )
+        reply_to_id = self._value(
+            record.get("threadOriginatorGuid"),
+            record.get("associatedMessageGuid"),
+        )
+        reply_to_text = None
+        reply_to_is_own = False
+        if reply_to_id:
+            reply_to_text = rich_sent_store.lookup(session_chat_id, reply_to_id)
+            reply_to_is_own = reply_to_id in self._sent_guids
+        if text and message_id:
+            rich_sent_store.record(session_chat_id, message_id, text)
         event = MessageEvent(
             text=text,
             message_type=msg_type,
             source=source,
             raw_message=payload,
-            message_id=self._value(
-                record.get("guid"),
-                record.get("messageGuid"),
-                record.get("id"),
-            ),
-            reply_to_message_id=self._value(
-                record.get("threadOriginatorGuid"),
-                record.get("associatedMessageGuid"),
-            ),
+            message_id=message_id,
+            reply_to_message_id=reply_to_id,
+            reply_to_text=reply_to_text,
+            reply_to_is_own_message=reply_to_is_own,
             media_urls=media_urls,
             media_types=media_types,
         )

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+from gateway import rich_sent_store
 from gateway.config import Platform, PlatformConfig
 
 
@@ -830,3 +831,144 @@ class TestBlueBubblesWebhookRegistration:
             adapter._unregister_webhook()
         )
         assert ok is False
+
+
+class TestReplyContextResolution:
+    """BlueBubbles webhook carries threadOriginatorGuid but never the quoted
+    text.  rich_sent_store resolves it so run.py can inject the disambiguation
+    prefix."""
+
+    @pytest.mark.asyncio
+    async def test_reply_to_own_earlier_message_resolves_text(self, monkeypatch):
+        """User replies to their own earlier message — text was indexed on the
+        earlier inbound, so the reply resolves it."""
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        monkeypatch.setattr(adapter, "handle_message", lambda e: handled.append(e) or asyncio.sleep(0))
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-prior",
+                "text": "remind me to buy milk",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "chats": [{"guid": "iMessage;-;+15551234567"}],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-reply",
+                "text": "did you?",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "threadOriginatorGuid": "msg-prior",
+                "chats": [{"guid": "iMessage;-;+15551234567"}],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        reply_event = handled[-1]
+        assert reply_event.reply_to_message_id == "msg-prior"
+        assert reply_event.reply_to_text == "remind me to buy milk"
+        assert reply_event.reply_to_is_own_message is False
+
+    @pytest.mark.asyncio
+    async def test_reply_to_bot_message_marks_own(self, monkeypatch):
+        """User replies to one of the bot's messages — the guid was tracked in
+        _sent_guids on outbound, so reply_to_is_own_message is True."""
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        monkeypatch.setattr(adapter, "handle_message", lambda e: handled.append(e) or asyncio.sleep(0))
+
+        rich_sent_store.record("iMessage;-;+15551234567", "msg-bot", "Sure, milk added.")
+        adapter._sent_guids["msg-bot"] = None
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-reply",
+                "text": "thanks",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "threadOriginatorGuid": "msg-bot",
+                "chats": [{"guid": "iMessage;-;+15551234567"}],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        reply_event = handled[-1]
+        assert reply_event.reply_to_message_id == "msg-bot"
+        assert reply_event.reply_to_text == "Sure, milk added."
+        assert reply_event.reply_to_is_own_message is True
+
+    @pytest.mark.asyncio
+    async def test_reply_to_unknown_message_id_no_text(self, monkeypatch):
+        """Quoted message we never indexed — id is surfaced, text is None."""
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        monkeypatch.setattr(adapter, "handle_message", lambda e: handled.append(e) or asyncio.sleep(0))
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-reply",
+                "text": "what about this",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "threadOriginatorGuid": "msg-gone",
+                "chats": [{"guid": "iMessage;-;+15551234567"}],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        reply_event = handled[-1]
+        assert reply_event.reply_to_message_id == "msg-gone"
+        assert reply_event.reply_to_text is None
+        assert reply_event.reply_to_is_own_message is False
+
+    @pytest.mark.asyncio
+    async def test_non_reply_message_has_no_reply_context(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        monkeypatch.setattr(adapter, "handle_message", lambda e: handled.append(e) or asyncio.sleep(0))
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-plain",
+                "text": "hello",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "chats": [{"guid": "iMessage;-;+15551234567"}],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        event = handled[-1]
+        assert event.reply_to_message_id is None
+        assert event.reply_to_text is None
+        assert event.reply_to_is_own_message is False
+
+    @pytest.mark.asyncio
+    async def test_send_records_outbound_text(self, monkeypatch):
+        """send() must index its guid -> text so replies to the bot resolve."""
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_resolve(chat_id):
+            return "iMessage;-;user@example.com"
+
+        async def fake_api_post(path, payload):
+            return {"data": {"guid": "msg-out-1"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter.send("iMessage;-;user@example.com", "here is your answer")
+        assert result.success
+        assert result.message_id == "msg-out-1"
+        assert rich_sent_store.lookup("iMessage;-;user@example.com", "msg-out-1") == "here is your answer"
+        assert "msg-out-1" in adapter._sent_guids


### PR DESCRIPTION
## Summary

- BlueBubbles replies arrived with `reply_to_message_id` set (from `threadOriginatorGuid`) but `reply_to_text=None`, so `run.py` never injected the `[Replying to: "..."]` disambiguation prefix — the agent was blind to what the user replied to
- Index `(chat_id, message_guid) → text` in `rich_sent_store` on every inbound webhook message and every outbound `send()`, then look up the quoted text when processing replies — the same pattern already used by WhatsApp Cloud (#52957), Signal, and Yuanbao
- Derive `reply_to_is_own_message` from a bounded in-memory set of outbound GUIDs tracked by the adapter

## Test plan

- [x] Reply to user's own earlier message resolves quoted text
- [x] Reply to bot's message resolves text and marks `reply_to_is_own_message=True`
- [x] Reply to unknown/pre-boot message surfaces the id with `reply_to_text=None` (no crash)
- [x] Non-reply messages have no reply context fields set
- [x] `send()` records outbound text by GUID for future reply lookups
- [x] All 60 existing BlueBubbles tests still pass