### PR TITLE
docs: add local-ollama-setup guide to the sidebar

### DIFF
--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -682,6 +682,7 @@ const sidebars: SidebarsConfig = {
         'guides/run-hermes-with-nous-portal',
         'guides/tips',
         'guides/local-llm-on-mac',
+        'guides/local-ollama-setup',
         'guides/daily-briefing-bot',
         'guides/team-telegram-assistant',
         'guides/python-library',


### PR DESCRIPTION
`guides/local-ollama-setup.md` ships as a published guide, but `sidebars.ts` doesn't list it, so the nav can't reach it. this adds it next to `local-llm-on-mac` in the guides section.

fixes #36985.
