### PR TITLE
fix(feishu): support OGG format for Feishu TTS voice messages

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2172,12 +2172,12 @@ def text_to_speech_tool(
         text = text[:max_len]
 
     # Detect platform from gateway env var to choose the best output format.
-    # Telegram voice bubbles require Opus (.ogg); OpenAI and ElevenLabs can
-    # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
-    # and needs ffmpeg for conversion.
+    # Feishu and Telegram voice bubbles require Opus (.ogg); OpenAI and
+    # ElevenLabs can produce Opus natively (no ffmpeg needed).  Edge TTS
+    # always outputs MP3 and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
+    want_opus = (platform in {"telegram", "feishu"})
 
     # Determine output path
     if output_path:


### PR DESCRIPTION
## Summary
Feishu voice messages require OGG format to render properly as voice bubbles. This PR adds `feishu` to the `want_opus` platform set in `tts_tool.py`, ensuring Feishu TTS outputs OGG instead of MP3.

## Change
`tools/tts_tool.py` — add `feishu` to the platform check that determines Opus format output.

```python
# Before
want_opus = (platform == "telegram")

# After
want_opus = (platform in {"telegram", "feishu"})
```

## Testing
Manual test confirmed: OGG output, `voice_compatible: true`, renders as voice bubble in Feishu.