### PR TITLE
Add stt.echo config to suppress voice transcript echo

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -568,6 +568,7 @@ export const SECTIONS: DesktopConfigSection[] = [
     keys: [
       'tts.provider',
       'stt.enabled',
+      'stt.echo',
       'stt.provider',
       'voice.auto_tts',
       'tts.edge.voice',

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -603,6 +603,7 @@ class GatewayConfig:
 
     # STT settings
     stt_enabled: bool = True  # Whether to auto-transcribe inbound voice messages
+    stt_echo: bool = True  # Whether to post raw STT transcripts back to the chat
 
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
@@ -726,6 +727,7 @@ class GatewayConfig:
             "always_log_local": self.always_log_local,
             "filter_silence_narration": self.filter_silence_narration,
             "stt_enabled": self.stt_enabled,
+            "stt_echo": self.stt_echo,
             "group_sessions_per_user": self.group_sessions_per_user,
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "max_concurrent_sessions": self.max_concurrent_sessions,
@@ -769,9 +771,13 @@ class GatewayConfig:
         if not isinstance(quick_commands, dict):
             quick_commands = {}
 
+        stt_cfg = data.get("stt") if isinstance(data.get("stt"), dict) else {}
         stt_enabled = data.get("stt_enabled")
         if stt_enabled is None:
-            stt_enabled = data.get("stt", {}).get("enabled") if isinstance(data.get("stt"), dict) else None
+            stt_enabled = stt_cfg.get("enabled")
+        stt_echo = data.get("stt_echo")
+        if stt_echo is None:
+            stt_echo = stt_cfg.get("echo")
 
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
@@ -815,6 +821,7 @@ class GatewayConfig:
                 data.get("filter_silence_narration"), True
             ),
             stt_enabled=_coerce_bool(stt_enabled, True),
+            stt_echo=_coerce_bool(stt_echo, True),
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10125,18 +10125,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _successful_transcripts:
                     _echo_adapter = self.adapters.get(source.platform)
                     _echo_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
-                    if _echo_adapter:
-                        for _tx in _successful_transcripts:
-                            try:
-                                await _echo_adapter.send(
-                                    source.chat_id,
-                                    f'🎙️ "{_tx}"',
-                                    metadata=_echo_meta,
-                                )
-                            except Exception as _echo_exc:
-                                logger.debug(
-                                    "Transcript echo failed (non-fatal): %s", _echo_exc,
-                                )
+                    await self._echo_successful_transcripts(
+                        adapter=_echo_adapter,
+                        chat_id=source.chat_id,
+                        transcripts=_successful_transcripts,
+                        metadata=_echo_meta,
+                    )
                 # NOTE: Previously, when transcription failed (e.g. no STT
                 # provider configured), the gateway also emitted a hardcoded
                 # English notice via `_stt_adapter.send()`. That bypassed the
@@ -14572,6 +14566,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return prefix
         return user_text
 
+    async def _echo_successful_transcripts(
+        self,
+        *,
+        adapter: Any,
+        chat_id: str,
+        transcripts: List[str],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Post raw STT transcripts back to the chat when ``stt.echo`` is enabled."""
+        if not getattr(self.config, "stt_echo", True):
+            return
+        if not adapter or not transcripts:
+            return
+        for tx in transcripts:
+            try:
+                await adapter.send(
+                    chat_id,
+                    f'🎙️ "{tx}"',
+                    metadata=metadata,
+                )
+            except Exception as exc:
+                logger.debug("Transcript echo failed (non-fatal): %s", exc)
+
     async def _enrich_message_with_transcription(
         self,
         user_text: str,
@@ -14708,18 +14725,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if successful_transcripts:
                 echo_adapter = self.adapters.get(source.platform)
                 echo_meta = {"thread_id": source.thread_id} if source.thread_id else None
-                if echo_adapter:
-                    for tx in successful_transcripts:
-                        try:
-                            await echo_adapter.send(
-                                source.chat_id,
-                                f'🎙️ "{tx}"',
-                                metadata=echo_meta,
-                            )
-                        except Exception as echo_exc:
-                            logger.debug(
-                                "Transcript echo failed (non-fatal): %s", echo_exc,
-                            )
+                await self._echo_successful_transcripts(
+                    adapter=echo_adapter,
+                    chat_id=source.chat_id,
+                    transcripts=successful_transcripts,
+                    metadata=echo_meta,
+                )
             return enriched_text or None
 
         # Non-audio fallback: preserve original _dequeue_pending_text semantics.
@@ -18589,18 +18600,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                         pending_text = _enriched
                                         if _transcripts:
                                             _echo_meta = {"thread_id": source.thread_id} if source.thread_id else None
-                                            for _tx in _transcripts:
-                                                try:
-                                                    await _adapter.send(
-                                                        source.chat_id,
-                                                        f'🎙️ "{_tx}"',
-                                                        metadata=_echo_meta,
-                                                    )
-                                                except Exception as _echo_exc:
-                                                    logger.debug(
-                                                        "Voice-interrupt echo failed (non-fatal): %s",
-                                                        _echo_exc,
-                                                    )
+                                            await self._echo_successful_transcripts(
+                                                adapter=_adapter,
+                                                chat_id=source.chat_id,
+                                                transcripts=_transcripts,
+                                                metadata=_echo_meta,
+                                            )
                                     except Exception as _trans_exc:
                                         logger.warning(
                                             "Voice-interrupt transcription failed: %s", _trans_exc,
@@ -19009,17 +19014,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             pending = _enriched or None
                             if _transcripts:
                                 _echo_meta = {"thread_id": source.thread_id} if source.thread_id else None
-                                for _tx in _transcripts:
-                                    try:
-                                        await adapter.send(
-                                            source.chat_id,
-                                            f'🎙️ "{_tx}"',
-                                            metadata=_echo_meta,
-                                        )
-                                    except Exception as _echo_exc:
-                                        logger.debug(
-                                            "Voice-drain echo failed (non-fatal): %s", _echo_exc,
-                                        )
+                                await self._echo_successful_transcripts(
+                                    adapter=adapter,
+                                    chat_id=source.chat_id,
+                                    transcripts=_transcripts,
+                                    metadata=_echo_meta,
+                                )
                         except Exception as _trans_exc:
                             logger.warning(
                                 "Voice-drain transcription failed: %s", _trans_exc,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2017,6 +2017,7 @@ DEFAULT_CONFIG = {
     
     "stt": {
         "enabled": True,
+        "echo": True,  # Post raw STT transcripts back to the chat (🎙️ "...")
         "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe)
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -16,6 +16,27 @@ def test_gateway_config_stt_disabled_from_dict_nested():
     assert config.stt_enabled is False
 
 
+def test_gateway_config_stt_echo_disabled_from_dict_nested():
+    config = GatewayConfig.from_dict({"stt": {"echo": False}})
+    assert config.stt_echo is False
+
+
+def test_load_gateway_config_bridges_stt_echo_from_config_yaml(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.dump({"stt": {"echo": False}}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    config = load_gateway_config()
+
+    assert config.stt_echo is False
+
+
 def test_load_gateway_config_bridges_stt_enabled_from_config_yaml(tmp_path, monkeypatch):
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()
@@ -185,3 +206,87 @@ async def test_prepare_inbound_message_text_transcribes_queued_voice_event():
     # Success path: the transcript passes through as a plain quoted line, with
     # no "voice message" meta-commentary that the LLM would echo back.
     assert "queued voice transcript" in result
+
+
+@pytest.mark.asyncio
+async def test_echo_successful_transcripts_skipped_when_stt_echo_disabled():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_echo=False)
+    adapter = AsyncMock()
+
+    await runner._echo_successful_transcripts(
+        adapter=adapter,
+        chat_id="123",
+        transcripts=["hello from voice"],
+        metadata={"thread_id": "456"},
+    )
+
+    adapter.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_echo_successful_transcripts_posts_when_enabled():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_echo=True)
+    adapter = AsyncMock()
+
+    await runner._echo_successful_transcripts(
+        adapter=adapter,
+        chat_id="123",
+        transcripts=["hello from voice"],
+        metadata={"thread_id": "456"},
+    )
+
+    adapter.send.assert_awaited_once_with(
+        "123",
+        '🎙️ "hello from voice"',
+        metadata={"thread_id": "456"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_text_skips_transcript_echo_when_disabled():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True, stt_echo=False)
+    runner._model = "test-model"
+    runner._base_url = ""
+    runner._has_setup_skill = lambda: False
+    echo_adapter = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: echo_adapter}
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+    )
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=["/tmp/queued-voice.ogg"],
+        media_types=["audio/ogg"],
+    )
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={
+            "success": True,
+            "transcript": "queued voice transcript",
+            "provider": "local_command",
+        },
+    ):
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert result is not None
+    assert "queued voice transcript" in result
+    echo_adapter.send.assert_not_called()

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -135,6 +135,14 @@ def is_stt_enabled(stt_config: Optional[dict] = None) -> bool:
     return is_truthy_value(enabled, default=True)
 
 
+def is_stt_echo_enabled(stt_config: Optional[dict] = None) -> bool:
+    """Return whether raw STT transcripts should be echoed back to the chat."""
+    if stt_config is None:
+        stt_config = _load_stt_config()
+    echo = stt_config.get("echo", True)
+    return is_truthy_value(echo, default=True)
+
+
 def _has_openai_audio_backend() -> bool:
     """Return True when OpenAI audio can use config credentials, env credentials, or the managed gateway."""
     try:

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -135,14 +135,6 @@ def is_stt_enabled(stt_config: Optional[dict] = None) -> bool:
     return is_truthy_value(enabled, default=True)
 
 
-def is_stt_echo_enabled(stt_config: Optional[dict] = None) -> bool:
-    """Return whether raw STT transcripts should be echoed back to the chat."""
-    if stt_config is None:
-        stt_config = _load_stt_config()
-    echo = stt_config.get("echo", True)
-    return is_truthy_value(echo, default=True)
-
-
 def _has_openai_audio_backend() -> bool:
     """Return True when OpenAI audio can use config credentials, env credentials, or the managed gateway."""
     try:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1543,6 +1543,8 @@ Hashes are deterministic — the same user always maps to the same hash, so the 
 
 ```yaml
 stt:
+  enabled: true                # Auto-transcribe inbound voice messages (default: true)
+  echo: true                   # Post raw transcripts back to the chat as 🎙️ "..." (default: true)
   provider: "local"            # "local" | "groq" | "openai" | "mistral"
   local:
     model: "base"              # tiny, base, small, medium, large-v3
@@ -1550,6 +1552,8 @@ stt:
     model: "whisper-1"         # whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe
   # model: "whisper-1"         # Legacy fallback key still respected
 ```
+
+Set `stt.echo: false` when the gateway should transcribe voice notes for the agent but must not post the raw transcript back to the chat (for example, customer-facing WhatsApp bots).
 
 Provider behavior:
 


### PR DESCRIPTION
## Summary
Gateway voice-note handling always posted raw STT output back to the chat (`🎙️ "..."`) with no config toggle. Customer-facing bots need transcription for the agent without exposing the verbatim transcript to end users.

## Changes
- Add `stt.echo` (default `true`) to `GatewayConfig`, loaded from `config.yaml` under `stt.echo`
- Centralize transcript echo in `_echo_successful_transcripts()` and gate all four call sites (fresh inbound, queued dequeue, voice interrupt, voice drain)
- Document the setting and expose it in desktop settings
- Add regression tests for config bridging and echo suppression

## Tests
- [x] `python -m pytest tests/gateway/test_stt_config.py -q` (12 passed)