### PR TITLE
fix(cli): inherit terminal foreground for response text

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1832,8 +1832,45 @@ def _hex_to_ansi(hex_color: str, *, bold: bool = False) -> str:
         return _ACCENT_ANSI_DEFAULT if bold else "\033[38;2;184;134;11m"
 
 
+def _response_body_raw_color() -> str:
+    """Return the authored skin color for assistant response body text.
+
+    This deliberately bypasses SkinConfig.get_color() because cli.py installs a
+    light-mode remap hook there. That hook is correct for transparent chrome on
+    a light terminal, but response prose should not get pinned to the cached
+    remapped near-black value after a light -> dark terminal/cmux switch.
+    """
+    try:
+        from hermes_cli.skin_engine import get_active_skin
+        skin = get_active_skin()
+        return skin.colors.get("banner_text", "#FFF8DC")
+    except Exception:
+        return "#FFF8DC"
+
+
+def _raw_hex_to_ansi(hex_color: str) -> str:
+    """Convert a raw hex color to ANSI without light-mode remapping."""
+    try:
+        r = int(hex_color[1:3], 16)
+        g = int(hex_color[3:5], 16)
+        b = int(hex_color[5:7], 16)
+        return f"\033[38;2;{r};{g};{b}m"
+    except (ValueError, IndexError):
+        return "\033[38;2;255;248;220m"
+
+
+def _response_body_style() -> str:
+    """Return the Rich style for assistant response body text."""
+    return _response_body_raw_color()
+
+
+def _response_body_ansi() -> str:
+    """Return the ANSI prefix for streamed assistant response body text."""
+    return _raw_hex_to_ansi(_response_body_raw_color())
+
+
 # ────────────────────────────────────────────────────────────────────────
-# Light/dark terminal mode detection.
+
 #
 # Mirrors ui-tui/src/theme.ts detectLightMode().  Used to decide whether
 # to remap "near-white" skin colors (e.g. #FFF8DC banner_text, #B8860B
@@ -5177,19 +5214,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 from hermes_cli.skin_engine import get_active_skin
                 _skin = get_active_skin()
                 label = _skin.get_branding("response_label", "⚕ Hermes")
-                _text_hex = _skin.get_color("banner_text", "#FFF8DC")
             except Exception:
                 label = "⚕ Hermes"
-                _text_hex = "#FFF8DC"
-            # Build a true-color ANSI escape for the response text color
-            # so streamed content matches the Rich Panel appearance.
-            try:
-                _r = int(_text_hex[1:3], 16)
-                _g = int(_text_hex[3:5], 16)
-                _b = int(_text_hex[5:7], 16)
-                self._stream_text_ansi = f"\033[38;2;{_r};{_g};{_b}m"
-            except (ValueError, IndexError):
-                self._stream_text_ansi = ""
+            self._stream_text_ansi = _response_body_ansi()
             if self.show_timestamps:
                 label = f"{label} {datetime.now().strftime('%H:%M')}"
             w = self._scrollback_box_width()
@@ -11669,11 +11696,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     _skin = get_active_skin()
                     label = _skin.get_branding("response_label", "⚕ Hermes")
                     _resp_color = _maybe_remap_for_light_mode(_skin.get_color("response_border", "#CD7F32"))
-                    _resp_text = _maybe_remap_for_light_mode(_skin.get_color("banner_text", "#FFF8DC"))
                 except Exception:
                     label = "⚕ Hermes"
                     _resp_color = _maybe_remap_for_light_mode("#CD7F32")
-                    _resp_text = _maybe_remap_for_light_mode("#FFF8DC")
+                _resp_text = _response_body_style()
 
                 is_error_response = result and (result.get("failed") or result.get("partial"))
                 already_streamed = self._stream_started and self._stream_box_opened and not is_error_response

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -854,6 +854,16 @@ def get_prompt_toolkit_style_overrides() -> Dict[str, str]:
     except Exception:
         return {}
 
+    def _raw_color(key: str, fallback: str = "") -> str:
+        """Read a skin color without the CLI light-mode remap hook.
+
+        Some prompt_toolkit styles paint an explicit background (status bar,
+        completion menu, voice bar). Those foreground/background pairs are
+        authored together; remapping only the foreground for a terminal-level
+        light background can make text invisible on the style's own background.
+        """
+        return skin.colors.get(key, fallback)
+
     # Input/prompt: leave unset by default so the typed text inherits
     # the terminal's foreground color (readable in both light and dark
     # color schemes).  Skins can opt into a colored prompt by setting
@@ -866,19 +876,34 @@ def get_prompt_toolkit_style_overrides() -> Dict[str, str]:
     label = skin.get_color("ui_label", title)
     warn = skin.get_color("ui_warn", "#FF8C00")
     error = skin.get_color("ui_error", "#FF6B6B")
-    status_bg = skin.get_color("status_bar_bg", "#1a1a2e")
-    status_text = skin.get_color("status_bar_text", text)
-    status_strong = skin.get_color("status_bar_strong", title)
-    status_dim = skin.get_color("status_bar_dim", dim)
-    status_good = skin.get_color("status_bar_good", skin.get_color("ui_ok", "#8FBC8F"))
-    status_warn = skin.get_color("status_bar_warn", warn)
-    status_bad = skin.get_color("status_bar_bad", skin.get_color("banner_accent", warn))
-    status_critical = skin.get_color("status_bar_critical", error)
-    voice_bg = skin.get_color("voice_status_bg", status_bg)
-    menu_bg = skin.get_color("completion_menu_bg", "#1a1a2e")
-    menu_current_bg = skin.get_color("completion_menu_current_bg", "#333355")
-    menu_meta_bg = skin.get_color("completion_menu_meta_bg", menu_bg)
-    menu_meta_current_bg = skin.get_color("completion_menu_meta_current_bg", menu_current_bg)
+
+    # Explicit-background prompt_toolkit chrome must use raw authored color
+    # pairs. SkinConfig.get_color may be monkey-patched by cli.py to remap
+    # near-white foregrounds to dark values for light terminal backgrounds;
+    # that is correct for transparent terminal text but wrong for widgets that
+    # draw their own dark/light background.
+    raw_title = _raw_color("banner_title", "#FFD700")
+    raw_text = _raw_color("banner_text", "#FFF8DC")
+    raw_dim = _raw_color("banner_dim", "#555555")
+    raw_label = _raw_color("ui_label", raw_title)
+    raw_warn = _raw_color("ui_warn", "#FF8C00")
+    raw_error = _raw_color("ui_error", "#FF6B6B")
+    raw_ok = _raw_color("ui_ok", "#8FBC8F")
+    raw_accent = _raw_color("banner_accent", raw_warn)
+
+    status_bg = _raw_color("status_bar_bg", "#1a1a2e")
+    status_text = _raw_color("status_bar_text", raw_text)
+    status_strong = _raw_color("status_bar_strong", raw_title)
+    status_dim = _raw_color("status_bar_dim", raw_dim)
+    status_good = _raw_color("status_bar_good", raw_ok)
+    status_warn = _raw_color("status_bar_warn", raw_warn)
+    status_bad = _raw_color("status_bar_bad", raw_accent)
+    status_critical = _raw_color("status_bar_critical", raw_error)
+    voice_bg = _raw_color("voice_status_bg", status_bg)
+    menu_bg = _raw_color("completion_menu_bg", "#1a1a2e")
+    menu_current_bg = _raw_color("completion_menu_current_bg", "#333355")
+    menu_meta_bg = _raw_color("completion_menu_meta_bg", menu_bg)
+    menu_meta_current_bg = _raw_color("completion_menu_meta_current_bg", menu_current_bg)
 
     return {
         # Typed input always uses terminal default fg/bg so it's
@@ -899,11 +924,11 @@ def get_prompt_toolkit_style_overrides() -> Dict[str, str]:
         "status-bar-critical": f"bg:{status_bg} {status_critical} bold",
         "input-rule": input_rule,
         "image-badge": f"{label} bold",
-        "completion-menu": f"bg:{menu_bg} {text}",
-        "completion-menu.completion": f"bg:{menu_bg} {text}",
-        "completion-menu.completion.current": f"bg:{menu_current_bg} {title}",
-        "completion-menu.meta.completion": f"bg:{menu_meta_bg} {dim}",
-        "completion-menu.meta.completion.current": f"bg:{menu_meta_current_bg} {label}",
+        "completion-menu": f"bg:{menu_bg} {raw_text}",
+        "completion-menu.completion": f"bg:{menu_bg} {raw_text}",
+        "completion-menu.completion.current": f"bg:{menu_current_bg} {raw_title}",
+        "completion-menu.meta.completion": f"bg:{menu_meta_bg} {raw_dim}",
+        "completion-menu.meta.completion.current": f"bg:{menu_meta_current_bg} {raw_label}",
         "clarify-border": input_rule,
         "clarify-title": f"{title} bold",
         "clarify-question": f"{text} bold",
@@ -921,6 +946,6 @@ def get_prompt_toolkit_style_overrides() -> Dict[str, str]:
         "approval-cmd": f"{dim} italic",
         "approval-choice": dim,
         "approval-selected": f"{title} bold",
-        "voice-status": f"bg:{voice_bg} {label}",
-        "voice-status-recording": f"bg:{voice_bg} {error} bold",
+        "voice-status": f"bg:{voice_bg} {raw_label}",
+        "voice-status-recording": f"bg:{voice_bg} {raw_error} bold",
     }

--- a/tests/cli/test_cli_light_mode.py
+++ b/tests/cli/test_cli_light_mode.py
@@ -174,3 +174,45 @@ class TestSkinConfigHook:
         cli_mod._LIGHT_MODE_CACHE = False
         skin = SkinConfig(name="test", colors={"banner_text": "#FFF8DC"})
         assert skin.get_color("banner_text") == "#FFF8DC"
+
+
+class TestResponseBodyUsesRawSkinText:
+    def test_response_body_helpers_do_not_pin_light_mode_remap(self, cli_mod):
+        """Response prose should use raw skin text, not cached remapped black.
+
+        The light-mode cache can remap banner_text to black. If response body
+        text reuses that remapped skin color, an already-running Hermes process
+        can become unreadable after the terminal/cmux flips to a dark theme.
+        """
+        from hermes_cli.skin_engine import set_active_skin
+
+        set_active_skin("default")
+        cli_mod._LIGHT_MODE_CACHE = True
+        assert cli_mod._maybe_remap_for_light_mode("#FFF8DC") == "#1A1A1A"
+        assert cli_mod._response_body_style() == "#FFF8DC"
+        assert cli_mod._response_body_ansi() == "\033[38;2;255;248;220m"
+
+    def test_streaming_response_body_uses_raw_skin_text(self, cli_mod, monkeypatch):
+        from hermes_cli.skin_engine import set_active_skin
+
+        set_active_skin("default")
+        cli_mod._LIGHT_MODE_CACHE = True
+        printed = []
+        monkeypatch.setattr(cli_mod, "_cprint", printed.append)
+
+        cli = cli_mod.HermesCLI.__new__(cli_mod.HermesCLI)
+        cli.show_reasoning = False
+        cli.show_timestamps = False
+        cli.final_response_markdown = "strip"
+        cli._reasoning_box_opened = False
+        cli._stream_box_opened = False
+        cli._stream_buf = ""
+        cli._stream_table_buf = []
+        cli._in_stream_table = False
+        cli._close_reasoning_box = lambda: None
+        cli._scrollback_box_width = lambda: 80
+
+        cli._emit_stream_text("hello\n")
+
+        assert cli._stream_text_ansi == "\033[38;2;255;248;220m"
+        assert "    \033[38;2;255;248;220mhello\033[0m" in printed

--- a/tests/cli/test_cli_skin_integration.py
+++ b/tests/cli/test_cli_skin_integration.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from cli import HermesCLI, _rich_text_from_ansi
+from cli import HermesCLI, _rich_text_from_ansi, _maybe_remap_for_light_mode
 from hermes_cli.skin_engine import get_active_skin, set_active_skin
 
 
@@ -86,6 +86,27 @@ class TestCliSkinPromptIntegration:
         assert style_dict["input-rule"] == skin.get_color("input_rule")
         assert style_dict["prompt-working"] == f"{skin.get_color('banner_dim')} italic"
         assert style_dict["approval-title"] == f"{skin.get_color('ui_warn')} bold"
+
+    def test_explicit_background_tui_styles_use_raw_skin_pairs_when_light_remapped(self):
+        cli = _make_cli_stub()
+        cli._tui_style_base.update({
+            "completion-menu": "bg:#1a1a2e #FFF8DC",
+            "completion-menu.completion": "bg:#1a1a2e #FFF8DC",
+            "completion-menu.completion.current": "bg:#333355 #FFD700",
+            "completion-menu.meta.completion": "bg:#1a1a2e #888888",
+            "completion-menu.meta.completion.current": "bg:#333355 #FFBF00",
+            "status-bar": "bg:#1a1a2e #C0C0C0",
+        })
+
+        set_active_skin("default")
+        with patch("cli._LIGHT_MODE_CACHE", True):
+            assert _maybe_remap_for_light_mode("#FFF8DC") == "#1A1A1A"
+            style_dict = cli._build_tui_style_dict()
+
+        assert style_dict["completion-menu"] == "bg:#1a1a2e #FFF8DC"
+        assert style_dict["completion-menu.completion"] == "bg:#1a1a2e #FFF8DC"
+        assert style_dict["completion-menu.completion.current"] == "bg:#333355 #FFD700"
+        assert style_dict["status-bar"] == "bg:#1a1a2e #FFF8DC"
 
     def test_apply_tui_skin_style_updates_running_app(self):
         cli = _make_cli_stub()


### PR DESCRIPTION
## Summary
- Keep assistant response prose on the terminal default foreground instead of pinning it to the skin banner_text color
- Apply the same behavior to streamed response text and final Rich panels
- Fix prompt_toolkit chrome with explicit backgrounds (slash completion menu, status/voice bars) so foreground/background color pairs use raw authored skin colors instead of stale light-mode remaps
- Add regression coverage for response body text and explicit-background TUI styles

## Test Plan
- [x] uv run --extra dev python -m pytest tests/cli/test_cli_light_mode.py -q
- [x] uv run --extra dev python -m pytest tests/cli/test_cli_markdown_rendering.py -q
- [x] uv run --extra dev python -m pytest tests/cli/test_cli_skin_integration.py tests/cli/test_cli_light_mode.py tests/cli/test_cli_markdown_rendering.py -q
- [x] python -m py_compile cli.py hermes_cli/skin_engine.py tests/cli/test_cli_light_mode.py tests/cli/test_cli_skin_integration.py
- [x] git diff --check -- cli.py hermes_cli/skin_engine.py tests/cli/test_cli_light_mode.py tests/cli/test_cli_skin_integration.py
- [x] Manual cmux smoke: start Hermes with HERMES_LIGHT=1, switch cmux to Builtin Dark while running, type / and verify slash command names/descriptions are readable

Draft until Patron confirms local/manual terminal theme testing.
