### PR TITLE
fix(model-picker): rank NVIDIA NIM models for agentic use

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -282,12 +282,15 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "nvidia/nemotron-3-super-120b-a12b",
         "nvidia/nemotron-3-nano-30b-a3b",
         "nvidia/llama-3.3-nemotron-super-49b-v1.5",
-        # Third-party agentic models hosted on build.nvidia.com
-        # (map to OpenRouter defaults — users get familiar picks on NIM)
+        # Third-party agentic models hosted on build.nvidia.com.
+        # Keep current build.nvidia.com free endpoints here so the picker shows
+        # them near the top instead of burying live-only entries beyond the
+        # Telegram row limit.
+        "minimaxai/minimax-m3",
+        "minimaxai/minimax-m2.7",
         "qwen/qwen3.5-397b-a17b",
         "deepseek-ai/deepseek-v3.2",
         "moonshotai/kimi-k2.6",
-        "minimaxai/minimax-m2.5",
         "z-ai/glm5",
         "openai/gpt-oss-120b",
     ],
@@ -508,6 +511,83 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "qwen/qwen3-235b-a22b-fp8",
     ],
 }
+
+
+# NVIDIA NIM's ``/v1/models`` catalog is a flat list with very little metadata
+# (no pricing, no tool-call capability flags, no model quality hints). For the
+# picker this means utility/safety/embedding models can easily crowd out the
+# public trial models people actually want to drive Hermes with. Keep a short,
+# provider-specific priority list for the strongest agentic/coding picks, push
+# clearly non-chat utility models to the bottom, and preserve the provider's
+# original order within each tier so newly-added neutral models still surface
+# without requiring a Hermes release.
+_NVIDIA_PICKER_PRIORITY_SUBSTRINGS: tuple[str, ...] = (
+    "minimaxai/minimax-m3",
+    "deepseek-ai/deepseek-v4-pro",
+    "deepseek-ai/deepseek-v4-flash",
+    "nvidia/nemotron-3-ultra-550b",
+    "nvidia/nemotron-3-super-120b",
+    "minimaxai/minimax-m2.7",
+    "moonshotai/kimi-k2.6",
+    "z-ai/glm-5.1",
+    "z-ai/glm5",
+    "qwen/qwen3.5-397b-a17b",
+    "qwen/qwen3-next-80b",
+    "meta/llama-4-maverick",
+    "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+    "openai/gpt-oss-120b",
+)
+
+_NVIDIA_PICKER_UTILITY_SUBSTRINGS: tuple[str, ...] = (
+    "embed",
+    "retriever",
+    "rerank",
+    "guard",
+    "safety",
+    "topic-control",
+    "content-safety",
+    "parse",
+    "asr",
+    "tts",
+    "transcrib",
+)
+
+
+def _rank_nvidia_model_ids(model_ids: list[str]) -> list[str]:
+    """Return a picker-friendly ordering for NVIDIA NIM model IDs.
+
+    Tier 0: short provider-specific priority list for the strongest public
+    agentic/coding models.
+    Tier 1: everything else, preserving the provider's original order.
+    Tier 2: obvious utility/non-chat models (embeddings, safety, parser, ASR,
+    TTS, retrievers).
+    """
+    unique: list[str] = []
+    seen: set[str] = set()
+    for raw in model_ids:
+        mid = str(raw or "").strip()
+        if not mid:
+            continue
+        key = mid.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(mid)
+
+    def _bucket(model_id: str) -> tuple[int, int]:
+        lower = model_id.lower()
+        for idx, needle in enumerate(_NVIDIA_PICKER_PRIORITY_SUBSTRINGS):
+            if needle in lower:
+                return (0, idx)
+        if any(needle in lower for needle in _NVIDIA_PICKER_UTILITY_SUBSTRINGS):
+            return (2, 0)
+        return (1, 0)
+
+    ranked = sorted(
+        enumerate(unique),
+        key=lambda item: (_bucket(item[1])[0], _bucket(item[1])[1], item[0]),
+    )
+    return [model_id for _idx, model_id in ranked]
 
 # ---------------------------------------------------------------------------
 # Nous Portal free-model helper
@@ -2432,17 +2512,26 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                             if m.lower() not in merged_lower:
                                 merged.append(m)
                                 merged_lower.add(m.lower())
+                        if normalized == "nvidia":
+                            return _rank_nvidia_model_ids(merged)
                         return merged
+                    if normalized == "nvidia":
+                        return _rank_nvidia_model_ids(live)
                     return live
             # Use profile's fallback_models if defined
             if _p.fallback_models:
-                return list(_p.fallback_models)
+                fallback = list(_p.fallback_models)
+                if normalized == "nvidia":
+                    return _rank_nvidia_model_ids(fallback)
+                return fallback
     except Exception:
         pass
 
     curated_static = list(_PROVIDER_MODELS.get(normalized, []))
     if normalized in _MODELS_DEV_PREFERRED:
         return _merge_with_models_dev(normalized, curated_static)
+    if normalized == "nvidia":
+        return _rank_nvidia_model_ids(curated_static)
     return curated_static
 
 

--- a/plugins/model-providers/nvidia/__init__.py
+++ b/plugins/model-providers/nvidia/__init__.py
@@ -11,6 +11,9 @@ nvidia = ProviderProfile(
     description="NVIDIA NIM — accelerated inference",
     signup_url="https://build.nvidia.com/",
     fallback_models=(
+        "nvidia/nemotron-3-super-120b-a12b",
+        "minimaxai/minimax-m3",
+        "minimaxai/minimax-m2.7",
         "nvidia/llama-3.1-nemotron-70b-instruct",
         "nvidia/llama-3.3-70b-instruct",
     ),

--- a/tests/hermes_cli/test_nvidia_picker_models.py
+++ b/tests/hermes_cli/test_nvidia_picker_models.py
@@ -1,0 +1,50 @@
+from hermes_cli.models import _rank_nvidia_model_ids, provider_model_ids
+
+
+def test_nvidia_ranker_promotes_agentic_models_and_demotes_utility():
+    ranked = _rank_nvidia_model_ids([
+        "google/gemma-4-31b-it",
+        "nvidia/llama-nemotron-embed-1b-v2",
+        "minimaxai/minimax-m3",
+        "deepseek-ai/deepseek-v4-pro",
+        "moonshotai/kimi-k2.6",
+        "nvidia/nemotron-parse",
+    ])
+
+    assert ranked.index("minimaxai/minimax-m3") < ranked.index("google/gemma-4-31b-it")
+    assert ranked.index("deepseek-ai/deepseek-v4-pro") < ranked.index("google/gemma-4-31b-it")
+    assert ranked.index("moonshotai/kimi-k2.6") < ranked.index("google/gemma-4-31b-it")
+    assert ranked.index("nvidia/llama-nemotron-embed-1b-v2") > ranked.index("google/gemma-4-31b-it")
+    assert ranked.index("nvidia/nemotron-parse") > ranked.index("google/gemma-4-31b-it")
+
+
+def test_nvidia_provider_model_ids_ranks_live_catalog(monkeypatch):
+    live_catalog = [
+        "google/gemma-4-31b-it",
+        "nvidia/llama-nemotron-embed-1b-v2",
+        "deepseek-ai/deepseek-v4-pro",
+        "minimaxai/minimax-m3",
+        "moonshotai/kimi-k2.6",
+    ]
+
+    def fake_fetch_models(self, api_key: str, base_url: str | None = None):
+        return list(live_catalog)
+
+    monkeypatch.setattr(
+        "providers.base.ProviderProfile.fetch_models",
+        fake_fetch_models,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_api_key_provider_credentials",
+        lambda provider: {
+            "api_key": "nvapi-test",
+            "base_url": "https://integrate.api.nvidia.com/v1",
+        },
+    )
+
+    models = provider_model_ids("nvidia")
+
+    assert models.index("minimaxai/minimax-m3") < models.index("google/gemma-4-31b-it")
+    assert models.index("deepseek-ai/deepseek-v4-pro") < models.index("google/gemma-4-31b-it")
+    assert models.index("moonshotai/kimi-k2.6") < models.index("google/gemma-4-31b-it")
+    assert models.index("nvidia/llama-nemotron-embed-1b-v2") > models.index("google/gemma-4-31b-it")


### PR DESCRIPTION
## Summary

NVIDIA NIM's `/v1/models` catalog is a flat list with almost no picker-friendly metadata:
no pricing, no tool-call capability flags, and no quality hints. In practice this
lets utility/safety/embedding models crowd out the public trial models people actually
want to drive Hermes with in `/model`.

This change keeps scope deliberately narrow to the `nvidia` provider and adds a
tiered picker ordering that:

- promotes a short provider-specific set of strong agentic/coding models,
- preserves NVIDIA's original catalog order for the rest,
- pushes obvious utility/non-chat models (embeddings, safety, parser, ASR, TTS,
  retrievers/rerankers) to the bottom.

That means models like `minimaxai/minimax-m3`, `deepseek-ai/deepseek-v4-pro`,
`deepseek-ai/deepseek-v4-flash`, `nvidia/nemotron-3-ultra-550b-a55b`,
`moonshotai/kimi-k2.6`, and `z-ai/glm-5.1` surface near the top of the picker
instead of being buried behind Gemma, guards, embeddings, and utility rows.

## Why only NVIDIA?

The underlying problem is real today on NVIDIA NIM, and NIM's `/v1/models`
response does not currently expose enough metadata to solve it generically from
live data alone. Keeping the change provider-scoped makes it useful immediately
without changing ordering for other providers.

## Tests

Added invariant tests in `tests/hermes_cli/test_nvidia_picker_models.py` that check:

- strong agentic models rank ahead of neutral Gemma rows,
- utility models rank below those neutral rows,
- the live provider path also applies the same ordering.

## Local verification

- `pytest -q tests/hermes_cli/test_nvidia_picker_models.py`
- live NVIDIA NIM catalog smoke: ranked picker now shows
  `minimaxai/minimax-m3`, `deepseek-ai/deepseek-v4-pro`,
  `deepseek-ai/deepseek-v4-flash`, `nvidia/nemotron-3-ultra-550b-a55b`,
  `nvidia/nemotron-3-super-120b-a12b`, `minimaxai/minimax-m2.7`,
  `moonshotai/kimi-k2.6`, `z-ai/glm-5.1`, `z-ai/glm5`,
  `qwen/qwen3.5-397b-a17b` at the top of the picker.
