### PR TITLE
fix(macos): preserve active profile in launchd gateway status remediation hints

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4034,6 +4034,13 @@ def launchd_restart():
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
+    # When status probed a named profile, its remediation hints must target the
+    # same profile — bare ``hermes gateway start/stop`` would operate on the
+    # default profile's launchd label. ``_profile_arg()`` returns "" for the
+    # default profile, so default-profile output is unchanged. Mirrors the
+    # scope-aware hints already in ``systemd_status()``.
+    profile_arg = _profile_arg()
+    profile_flag = f" {profile_arg}" if profile_arg else ""
     try:
         result = subprocess.run(
             ["launchctl", "list", label],
@@ -4075,7 +4082,7 @@ def launchd_status(deep: bool = False):
         print("✓ Service definition matches the current Hermes install")
     else:
         print("⚠ Service definition is stale relative to the current Hermes install")
-        print("  Run: hermes gateway start")
+        print(f"  Run: hermes{profile_flag} gateway start")
 
     if service_listed:
         if launchd_pid is not None:
@@ -4088,10 +4095,10 @@ def launchd_status(deep: bool = False):
             print("  launchd cannot manage the gateway on this macOS version.")
             if fallback_pid:
                 print(f"✓ Detached fallback process is running (PID {fallback_pid})")
-                print("  Cron jobs will fire. Stop with: hermes gateway stop")
+                print(f"  Cron jobs will fire. Stop with: hermes{profile_flag} gateway stop")
             else:
                 print("✗ No fallback process is running")
-                print("  Run: hermes gateway start")
+                print(f"  Run: hermes{profile_flag} gateway start")
             print("  ⚠ Auto-start at login and auto-restart on crash are NOT available.")
         else:
             print("✓ Gateway service is registered with launchd")
@@ -4101,7 +4108,7 @@ def launchd_status(deep: bool = False):
     else:
         print("✗ Gateway service is not loaded")
         print("  Service definition exists locally but launchd has not loaded it.")
-        print("  Run: hermes gateway start")
+        print(f"  Run: hermes{profile_flag} gateway start")
         if fallback_pid:
             print(f"  Note: a detached gateway process is running (PID {fallback_pid})")
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -904,6 +904,50 @@ class TestLaunchdServiceRecovery:
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
 
+    def test_launchd_status_hints_preserve_profile_flag(self, tmp_path, monkeypatch, capsys):
+        # When status probed a named profile, the remediation hints must carry
+        # the same ``--profile <name>`` so following them operates on the right
+        # gateway (bare hints target the default profile's launchd label).
+        plist_path = tmp_path / "ai.hermes.gateway-stock.plist"
+        plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_profile_arg", lambda *a, **k: "--profile stock")
+        # returncode != 0 → service not loaded → both the stale-plist hint and
+        # the "not loaded" hint fire.
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=113, stdout="", stderr="Could not find service"),
+        )
+
+        gateway_cli.launchd_status()
+
+        output = capsys.readouterr().out
+        assert "hermes --profile stock gateway start" in output
+        # No bare hint that would target the default profile's gateway.
+        assert "Run: hermes gateway start" not in output
+
+    def test_launchd_status_hints_omit_flag_for_default_profile(self, tmp_path, monkeypatch, capsys):
+        # The default profile yields ``_profile_arg() == ""`` → hints stay bare,
+        # so default-profile output is byte-identical to the pre-fix behavior.
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_profile_arg", lambda *a, **k: "")
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=113, stdout="", stderr="Could not find service"),
+        )
+
+        gateway_cli.launchd_status()
+
+        output = capsys.readouterr().out
+        assert "Run: hermes gateway start" in output
+        assert "--profile" not in output
+
     def test_launchd_domain_uses_user_domain(self, monkeypatch):
         # The user/<uid> domain (not gui/<uid>) is the one reachable from
         # non-Aqua/background sessions on macOS 26+ (issue #23387).


### PR DESCRIPTION
## What does this PR do?

On macOS, `hermes -p <name> gateway status` correctly probes the named profile's launchd label (`get_launchd_label()` → `ai.hermes.gateway-<name>`), but the printed remediation hints say bare `hermes gateway start`/`stop` — which target the **default** profile's label. A multi-profile user who follows the on-screen instructions silently operates on the wrong gateway.

This threads the existing `_profile_arg()` helper into the four `launchd_status()` remediation hints, mirroring the profile/scope-aware hints already in the sibling `systemd_status()` (which interpolates `{scope_flag}` into its `start`/`restart` hints). For the default profile `_profile_arg()` returns `""`, so default-profile output is byte-identical to before.

## Related Issue

<!-- No filed issue; surgical platform-sibling consistency fix. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py`: in `launchd_status()`, compute `profile_flag` once from `_profile_arg()` and interpolate it into all four remediation hints (stale-plist hint, fallback-running stop hint, no-fallback start hint, service-not-loaded start hint).
- `tests/hermes_cli/test_gateway_service.py`: add `test_launchd_status_hints_preserve_profile_flag` (named profile → `hermes --profile stock gateway start`) and `test_launchd_status_hints_omit_flag_for_default_profile` (default → bare hint unchanged).

## How to Test

1. With a named profile gateway not loaded: `hermes -p stock gateway status` → hints now read `Run: hermes --profile stock gateway start` (previously bare `hermes gateway start`).
2. Default profile: `hermes gateway status` → hints stay bare (`hermes gateway start`), byte-identical to before.
3. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_gateway_service.py -k launchd_status_hints -v` — both new tests pass; fail-before/pass-after verified (the profile test fails on clean main without the fix).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched-area tests and all pass (the only failures in the file are pre-existing systemd baselines unrelated to this change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (launchd path)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — macOS-only path; systemd sibling already does this
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A