### PR TITLE
fix(config): normalize scalar agent.disabled_toolsets so a single value actually disables the toolset

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -135,6 +135,11 @@ def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     # the scalar form behaves identically to the list form.
     if isinstance(user_disabled, str):
         user_disabled = [user_disabled]
+    elif not isinstance(user_disabled, (list, tuple, set)):
+        # A non-iterable scalar hand-edit (e.g. ``disabled_toolsets: 5``) would
+        # crash ``for name in user_disabled`` with a TypeError and take the
+        # scheduler down — it can't name a toolset, so drop it defensively.
+        user_disabled = []
     for name in user_disabled:
         name = str(name).strip()
         if name and name not in disabled:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -128,6 +128,13 @@ def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     disabled = ["cronjob", "messaging", "clarify"]
     agent_cfg = (cfg or {}).get("agent") or {}
     user_disabled = agent_cfg.get("disabled_toolsets") or []
+    # The job-spawn loader reads config.yaml directly (yaml.safe_load) and does
+    # NOT route through load_config()'s normalizer, so a scalar hand-edit
+    # ``disabled_toolsets: memory`` arrives here as a bare string. Iterating it
+    # would walk characters and silently disable nothing — coerce to a list so
+    # the scalar form behaves identically to the list form.
+    if isinstance(user_disabled, str):
+        user_disabled = [user_disabled]
     for name in user_disabled:
         name = str(name).strip()
         if name and name not in disabled:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5723,7 +5723,12 @@ def _normalize_disabled_toolsets(config: Dict[str, Any]) -> Dict[str, Any]:
 
     A value that is already a list/tuple/set is preserved (non-string members
     are dropped, mirroring the ``{str(ts) for ts in ...}`` coercion consumers
-    already do). ``None``/empty values are left untouched.
+    already do). Each member is stripped and empty members are dropped so a
+    value like ``" memory "`` matches the consumers' exact-string key equality
+    (``_get_platform_tools`` compares without its own ``.strip()``). A
+    non-iterable scalar (``int``/``bool``) can't name a toolset and would make
+    those consumers raise ``TypeError`` when they iterate it, so it is dropped
+    to an empty list to fail safe. ``None`` is left untouched.
     """
     agent_in = config.get("agent")
     if not isinstance(agent_in, dict):
@@ -5733,12 +5738,16 @@ def _normalize_disabled_toolsets(config: Dict[str, Any]) -> Dict[str, Any]:
         return config
 
     if isinstance(raw, str):
-        normalized_value: list[str] = [raw] if raw.strip() else []
+        stripped = raw.strip()
+        normalized_value: list[str] = [stripped] if stripped else []
     elif isinstance(raw, (list, tuple, set)):
-        normalized_value = [ts for ts in raw if isinstance(ts, str)]
+        normalized_value = [
+            ts.strip() for ts in raw if isinstance(ts, str) and ts.strip()
+        ]
     else:
-        # A non-iterable scalar (int/bool) can't name a toolset — drop it.
-        return config
+        # A non-iterable scalar (int/bool) can't name a toolset and would make
+        # consumers (``{str(ts) for ts in ...}``) raise TypeError — drop it.
+        normalized_value = []
 
     if normalized_value == raw:
         return config

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5709,6 +5709,47 @@ def _normalize_max_turns_config(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
+def _normalize_disabled_toolsets(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Coerce a scalar ``agent.disabled_toolsets`` into a list.
+
+    The natural YAML hand-edit is the scalar form
+    ``agent.disabled_toolsets: memory`` rather than the list ``[memory]``.
+    Consumers (``_get_platform_tools``, the cron resolver) iterate the value to
+    build a disable set, so a bare string is iterated character-by-character
+    (``{'m','e','o','r','y'}``) and silently disables nothing — the toolset
+    stays enabled with no error or warning. Normalizing a scalar to a
+    single-element list at load time makes the scalar form behave identically
+    to the list form for every consumer of ``load_config()``.
+
+    A value that is already a list/tuple/set is preserved (non-string members
+    are dropped, mirroring the ``{str(ts) for ts in ...}`` coercion consumers
+    already do). ``None``/empty values are left untouched.
+    """
+    agent_in = config.get("agent")
+    if not isinstance(agent_in, dict):
+        return config
+    raw = agent_in.get("disabled_toolsets")
+    if raw is None:
+        return config
+
+    if isinstance(raw, str):
+        normalized_value: list[str] = [raw] if raw.strip() else []
+    elif isinstance(raw, (list, tuple, set)):
+        normalized_value = [ts for ts in raw if isinstance(ts, str)]
+    else:
+        # A non-iterable scalar (int/bool) can't name a toolset — drop it.
+        return config
+
+    if normalized_value == raw:
+        return config
+
+    config = dict(config)
+    agent_config = dict(agent_in)
+    agent_config["disabled_toolsets"] = normalized_value
+    config["agent"] = agent_config
+    return config
+
+
 def cfg_get(cfg: Optional[Dict[str, Any]], *keys: str, default: Any = None) -> Any:
     """Traverse nested dict keys safely, returning ``default`` on any miss.
 
@@ -6011,7 +6052,9 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             except Exception as e:
                 _warn_config_parse_failure(config_path, e)
 
-        normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
+        normalized = _normalize_disabled_toolsets(
+            _normalize_root_model_keys(_normalize_max_turns_config(config))
+        )
         expanded = _expand_env_vars(normalized)
         # Managed scope wins at the leaf. Applied AFTER user expansion so a user
         # ${VAR} cannot shadow a managed literal: managed values are expanded only

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -59,6 +59,64 @@ def test_agent_disabled_toolsets_with_explicit_platform_config():
     assert "terminal" in enabled
 
 
+def test_scalar_agent_disabled_toolsets_disables_after_normalization():
+    """A scalar ``disabled_toolsets: memory`` (the natural YAML hand-edit form)
+    must actually disable the toolset once routed through the load-time
+    normalizer. Without normalization the bare string is iterated
+    character-by-character and silently disables nothing."""
+    from hermes_cli.config import _normalize_disabled_toolsets
+
+    raw_config = {
+        "agent": {"disabled_toolsets": "memory"},
+        "platform_toolsets": {"cli": ["web", "terminal", "memory"]},
+    }
+    normalized = _normalize_disabled_toolsets(raw_config)
+
+    assert normalized["agent"]["disabled_toolsets"] == ["memory"]
+
+    enabled = _get_platform_tools(normalized, "cli")
+    assert "memory" not in enabled
+    assert "web" in enabled
+    assert "terminal" in enabled
+
+
+def test_normalize_disabled_toolsets_preserves_list_and_ignores_junk():
+    """List form is preserved; a non-string/non-iterable scalar is dropped and
+    an empty/whitespace scalar normalizes to an empty list (no-op)."""
+    from hermes_cli.config import _normalize_disabled_toolsets
+
+    # Already a list → unchanged.
+    cfg_list = {"agent": {"disabled_toolsets": ["memory", "web"]}}
+    assert _normalize_disabled_toolsets(cfg_list)["agent"]["disabled_toolsets"] == [
+        "memory",
+        "web",
+    ]
+    # Non-string scalar can't name a toolset → left untouched (consumers ignore).
+    cfg_int = {"agent": {"disabled_toolsets": 5}}
+    assert _normalize_disabled_toolsets(cfg_int)["agent"]["disabled_toolsets"] == 5
+    # Empty/whitespace scalar → empty list, not a 1-element [" "].
+    cfg_blank = {"agent": {"disabled_toolsets": "   "}}
+    assert _normalize_disabled_toolsets(cfg_blank)["agent"]["disabled_toolsets"] == []
+
+
+def test_cron_resolver_coerces_scalar_disabled_toolsets():
+    """The cron job-spawn loader reads config.yaml directly (bypassing the
+    load-time normalizer), so ``_resolve_cron_disabled_toolsets`` must defend
+    against a scalar value itself — otherwise it walks characters and never
+    appends the intended toolset to the cron denylist."""
+    from cron.scheduler import _resolve_cron_disabled_toolsets
+
+    scalar_cfg = {"agent": {"disabled_toolsets": "memory"}}
+    resolved = _resolve_cron_disabled_toolsets(scalar_cfg)
+
+    assert "memory" in resolved
+    # No stray single characters from char-iterating the scalar.
+    assert "m" not in resolved
+    assert "e" not in resolved
+    # The always-on cron-protected toolsets remain.
+    assert {"cronjob", "messaging", "clarify"}.issubset(set(resolved))
+
+
 def test_all_invalid_platform_toolsets_logs_runtime_warning(caplog):
     """#38798: an explicit platform config whose toolset names are all invalid
     (e.g. 'hermes' instead of 'hermes-cli') must warn at resolve time so an

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -80,9 +80,10 @@ def test_scalar_agent_disabled_toolsets_disables_after_normalization():
     assert "terminal" in enabled
 
 
-def test_normalize_disabled_toolsets_preserves_list_and_ignores_junk():
-    """List form is preserved; a non-string/non-iterable scalar is dropped and
-    an empty/whitespace scalar normalizes to an empty list (no-op)."""
+def test_normalize_disabled_toolsets_preserves_list_and_drops_junk():
+    """List form is preserved; a non-string/non-iterable scalar is dropped to
+    an empty list (fail-safe, not preserved) and an empty/whitespace scalar
+    normalizes to an empty list (no-op)."""
     from hermes_cli.config import _normalize_disabled_toolsets
 
     # Already a list → unchanged.
@@ -91,12 +92,23 @@ def test_normalize_disabled_toolsets_preserves_list_and_ignores_junk():
         "memory",
         "web",
     ]
-    # Non-string scalar can't name a toolset → left untouched (consumers ignore).
+    # Non-string scalar can't name a toolset and would make consumers
+    # ``{str(ts) for ts in ...}`` raise TypeError → drop to [] to fail safe.
     cfg_int = {"agent": {"disabled_toolsets": 5}}
-    assert _normalize_disabled_toolsets(cfg_int)["agent"]["disabled_toolsets"] == 5
+    assert _normalize_disabled_toolsets(cfg_int)["agent"]["disabled_toolsets"] == []
+    # After normalization, _get_platform_tools must not raise (un-normalized,
+    # the int would make ``{str(ts) for ts in 5}`` raise TypeError).
+    enabled = _get_platform_tools(_normalize_disabled_toolsets(cfg_int), "cli")
+    assert isinstance(enabled, set)
     # Empty/whitespace scalar → empty list, not a 1-element [" "].
     cfg_blank = {"agent": {"disabled_toolsets": "   "}}
     assert _normalize_disabled_toolsets(cfg_blank)["agent"]["disabled_toolsets"] == []
+    # Whitespace-padded members are stripped so they match exact-string keys.
+    cfg_padded = {"agent": {"disabled_toolsets": [" memory ", "", "web"]}}
+    assert _normalize_disabled_toolsets(cfg_padded)["agent"]["disabled_toolsets"] == [
+        "memory",
+        "web",
+    ]
 
 
 def test_cron_resolver_coerces_scalar_disabled_toolsets():
@@ -114,6 +126,20 @@ def test_cron_resolver_coerces_scalar_disabled_toolsets():
     assert "m" not in resolved
     assert "e" not in resolved
     # The always-on cron-protected toolsets remain.
+    assert {"cronjob", "messaging", "clarify"}.issubset(set(resolved))
+
+
+def test_cron_resolver_coerces_non_iterable_scalar_disabled_toolsets():
+    """A non-string scalar hand-edit (``disabled_toolsets: 5``) reaches the cron
+    resolver un-normalized; it must be coerced to ``[]`` rather than crashing
+    ``for name in user_disabled`` with ``TypeError: 'int' object is not
+    iterable`` and taking the scheduler down."""
+    from cron.scheduler import _resolve_cron_disabled_toolsets
+
+    scalar_cfg = {"agent": {"disabled_toolsets": 5}}
+    resolved = _resolve_cron_disabled_toolsets(scalar_cfg)
+
+    # No crash; the always-on cron-protected toolsets are still present.
     assert {"cronjob", "messaging", "clarify"}.issubset(set(resolved))
 
 


### PR DESCRIPTION
## What does this PR do?

`agent.disabled_toolsets` is consumed by iterating the raw value with **no type-normalization** anywhere. When a user hand-edits `config.yaml` with the natural YAML **scalar** form:

```yaml
agent:
  disabled_toolsets: memory   # instead of the list [memory]
```

the value is the string `"memory"`, which gets iterated character-by-character:

- `hermes_cli/tools_config.py` (`_get_platform_tools`): `{str(ts) for ts in "memory"}` → `{'m','e','o','r','y'}`, so `enabled_toolsets -= disabled_set` is a silent no-op — the toolset stays **enabled**.
- `cron/scheduler.py` (`_resolve_cron_disabled_toolsets`): `for name in "memory"` appends junk single chars to the cron denylist and never disables the intended toolset.

There is no error or warning. A user who believes they disabled `terminal` / `execute_code` / `memory` silently keeps it live across CLI, gateway, and cron — the same silently-dropped-config class as #38798.

This adds a `_normalize_disabled_toolsets` helper to the config load/normalize chain (alongside `_normalize_root_model_keys` / `_normalize_max_turns_config`), so every consumer of `load_config()` receives a list. The cron **job-spawn** loader reads `config.yaml` directly (`yaml.safe_load`) and bypasses that load-time normalizer, so a scalar is also coerced defensively inside `_resolve_cron_disabled_toolsets`. A hand-edited scalar now behaves identically to the list form.

## Related Issue

<!-- No filed issue; reproduced config-correctness bug in the silently-dropped-config family (cf. #38798). -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: new `_normalize_disabled_toolsets(config)` helper (scalar/str → single-element list, non-string members dropped, empty/whitespace scalar → `[]`, list/tuple/set preserved); chained into the normalize composition in `_load_config_impl`.
- `cron/scheduler.py`: defensive `isinstance(user_disabled, str)` coercion in `_resolve_cron_disabled_toolsets` (the job-spawn loader bypasses `load_config()`).
- `tests/hermes_cli/test_tools_config.py`: scalar regression test through the normalizer + `_get_platform_tools`, a helper unit test (list preserved / junk dropped / blank → `[]`), and a cron-resolver scalar test.

## How to Test

1. `config.yaml` with `agent: { disabled_toolsets: memory }` (scalar). Before: `memory` is still enabled (`hermes tools` / cron agents). After: `memory` is disabled, identical to the list form `[memory]`.
2. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_tools_config.py -k "scalar or normalize_disabled or cron_resolver" -v` — all three new tests pass; fail-before/pass-after verified (without the prod hunks the cron resolver returns `[..., 'm','e','o','r','y']` and the scalar test leaves `memory` enabled).
3. Full `tests/hermes_cli/test_tools_config.py` (104), `tests/hermes_cli/test_config.py` + `tests/cron/test_scheduler.py` (297) green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched-area tests and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new keys; existing key now also accepts the scalar form)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-agnostic config normalization
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A