### PR TITLE
fix(providers): gate plugin api_mode by endpoint (#53054)

### DIFF
--- a/contributors/emails/834563048@qq.com
+++ b/contributors/emails/834563048@qq.com
@@ -1,0 +1,2 @@
+david-bowiegxw
+# PR #53055 (providers: plugin ProviderProfile.api_mode)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -466,36 +466,48 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
 # Auto-extend PROVIDER_REGISTRY with any api-key provider registered in
 # providers/ that is not already declared above.  New providers only need a
 # plugins/model-providers/<name>/ plugin — no edits to this file required.
-try:
-    from providers import list_providers as _list_providers_for_registry
-    for _pp in _list_providers_for_registry():
-        if _pp.name in PROVIDER_REGISTRY:
-            continue
-        if _pp.auth_type != "api_key" or not _pp.env_vars:
-            continue
-        # Skip providers that need custom token resolution or are special-cased
-        # in resolve_provider() (copilot/kimi/zai have bespoke token refresh;
-        # openrouter/custom are aggregator/user-supplied and handled outside
-        # the registry — adding them here breaks runtime_provider resolution
-        # that relies on `openrouter not in PROVIDER_REGISTRY`).
-        if _pp.name in {"copilot", "kimi-coding", "kimi-coding-cn", "zai", "openrouter", "custom"}:
-            continue
-        _api_key_vars = tuple(v for v in _pp.env_vars if not v.endswith("_BASE_URL") and not v.endswith("_URL"))
-        _base_url_var = next((v for v in _pp.env_vars if v.endswith("_BASE_URL") or v.endswith("_URL")), None)
-        PROVIDER_REGISTRY[_pp.name] = ProviderConfig(
-            id=_pp.name,
-            name=_pp.display_name or _pp.name,
-            auth_type="api_key",
-            inference_base_url=_pp.base_url,
-            api_key_env_vars=_api_key_vars or _pp.env_vars,
-            base_url_env_var=_base_url_var or "",
-        )
-        # Also register aliases so resolve_provider() resolves them
-        for _alias in _pp.aliases:
-            if _alias not in PROVIDER_REGISTRY:
-                PROVIDER_REGISTRY[_alias] = PROVIDER_REGISTRY[_pp.name]
-except Exception:
-    pass
+def _extend_registry_from_provider_plugins() -> None:
+    """Register every api-key provider plugin into ``PROVIDER_REGISTRY``.
+
+    Runs once at import. Kept as a named, re-runnable function (same body as
+    the former inline block) so tests can drop a plugin under
+    ``$HERMES_HOME/plugins/model-providers/`` and exercise the real
+    discovery → registry → ``resolve_runtime_provider`` chain instead of
+    mirroring this loop by hand.
+    """
+    try:
+        from providers import list_providers as _list_providers_for_registry
+        for _pp in _list_providers_for_registry():
+            if _pp.name in PROVIDER_REGISTRY:
+                continue
+            if _pp.auth_type != "api_key" or not _pp.env_vars:
+                continue
+            # Skip providers that need custom token resolution or are special-cased
+            # in resolve_provider() (copilot/kimi/zai have bespoke token refresh;
+            # openrouter/custom are aggregator/user-supplied and handled outside
+            # the registry — adding them here breaks runtime_provider resolution
+            # that relies on `openrouter not in PROVIDER_REGISTRY`).
+            if _pp.name in {"copilot", "kimi-coding", "kimi-coding-cn", "zai", "openrouter", "custom"}:
+                continue
+            _api_key_vars = tuple(v for v in _pp.env_vars if not v.endswith("_BASE_URL") and not v.endswith("_URL"))
+            _base_url_var = next((v for v in _pp.env_vars if v.endswith("_BASE_URL") or v.endswith("_URL")), None)
+            PROVIDER_REGISTRY[_pp.name] = ProviderConfig(
+                id=_pp.name,
+                name=_pp.display_name or _pp.name,
+                auth_type="api_key",
+                inference_base_url=_pp.base_url,
+                api_key_env_vars=_api_key_vars or _pp.env_vars,
+                base_url_env_var=_base_url_var or "",
+            )
+            # Also register aliases so resolve_provider() resolves them
+            for _alias in _pp.aliases:
+                if _alias not in PROVIDER_REGISTRY:
+                    PROVIDER_REGISTRY[_alias] = PROVIDER_REGISTRY[_pp.name]
+    except Exception:
+        pass
+
+
+_extend_registry_from_provider_plugins()
 
 
 # =============================================================================

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -656,15 +656,63 @@ def nous_api_mode(model: str = "") -> str:
     return "chat_completions"
 
 
+def _plugin_profile_api_mode(provider: str, base_url: str = "") -> str:
+    """Return the api_mode a registered ``ProviderProfile`` declares, or "".
+
+    Plugin providers (``plugins/model-providers/<name>/``, bundled or under
+    ``$HERMES_HOME``) declare their wire protocol on
+    ``ProviderProfile.api_mode``, but the declaration has no reader:
+    ``get_provider()`` resolves against models.dev + ``HERMES_OVERLAYS``
+    only, and the ``ProviderProfile → ProviderConfig`` bridge in
+    ``auth.py`` drops the field. So a plugin speaking Anthropic Messages on
+    an endpoint that is not URL-self-describing resolves to
+    ``chat_completions`` and 404s on every request (#53054).
+
+    ``base_url`` gating: the declaration only applies on the provider's own
+    endpoint — no base_url at all, or one equal to the profile's. A user who
+    overrides base_url to a different endpoint has given the stronger signal
+    (e.g. MiniMax's OpenAI-compatible ``/v1`` route, opting out of the
+    profile's default ``/anthropic``), so we defer rather than force the
+    declared mode. Gating approach adopted from @samfoy's #65956.
+
+    Lazy import: provider discovery imports plugin modules, which may import
+    back into ``hermes_cli`` — importing at module load risks a cycle.
+    """
+    try:
+        from providers import get_provider_profile
+
+        profile = get_provider_profile((provider or "").strip().lower())
+        if profile is None:
+            return ""
+        declared = str(getattr(profile, "api_mode", "") or "").strip()
+        if declared not in TRANSPORT_TO_API_MODE.values():
+            return ""
+        # ``chat_completions`` is ProviderProfile's default *and* this
+        # function's terminal default, so returning it here would only
+        # short-circuit the tiers below (models.dev lookup, bedrock) without
+        # ever changing the answer. Treat it as "nothing declared".
+        if declared == "chat_completions":
+            return ""
+        if base_url:
+            profile_base = str(getattr(profile, "base_url", "") or "").rstrip("/")
+            if base_url.rstrip("/") != profile_base:
+                return ""
+        return declared
+    except Exception:
+        return ""
+
+
 def determine_api_mode(provider: str, base_url: str = "", model: str = "") -> str:
     """Determine the API mode (wire protocol) for a provider/endpoint.
 
     Resolution order:
       1. Host-mandated mode (special endpoints that only accept one protocol).
       2. Nous Portal dual-wire (model-derived; overlay alone is openai_chat).
-      3. Known provider → transport → TRANSPORT_TO_API_MODE.
-      4. Direct provider checks (bedrock).
-      5. Default: 'chat_completions'.
+      3. Hermes overlay transport (the in-tree declaration for that id).
+      4. Plugin ``ProviderProfile.api_mode`` (on the profile's own endpoint).
+      5. models.dev provider → transport → TRANSPORT_TO_API_MODE.
+      6. Direct provider checks (bedrock).
+      7. Default: 'chat_completions'.
 
     *model* is optional but required for dual-wire providers (Nous) whose
     transport depends on the catalog id, not just the provider/host.
@@ -680,6 +728,20 @@ def determine_api_mode(provider: str, base_url: str = "", model: str = "") -> st
     provider_norm = (provider or "").strip().lower()
     if provider_norm in {"nous", "nous-portal", "nousresearch"}:
         return nous_api_mode(model)
+
+    # In-tree declarations win: an overlay is Hermes' own statement about
+    # this provider's transport.
+    if normalize_provider(provider) in HERMES_OVERLAYS:
+        pdef = get_provider(provider)
+        if pdef is not None:
+            return TRANSPORT_TO_API_MODE.get(pdef.transport, "chat_completions")
+
+    # A plugin profile's declaration outranks a models.dev-only hit, whose
+    # transport is the generic ``openai_chat`` default (models.dev carries no
+    # transport data) and would otherwise mask the declaration.
+    declared = _plugin_profile_api_mode(provider, base_url)
+    if declared:
+        return declared
 
     pdef = get_provider(provider)
     if pdef is not None:

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -714,6 +714,7 @@ def determine_api_mode(provider: str, base_url: str = "", model: str = "") -> st
       1. Host-mandated mode (special endpoints that only accept one protocol).
       2. Nous Portal dual-wire (model-derived; overlay alone is openai_chat).
       3. Known provider → transport → TRANSPORT_TO_API_MODE.
+         Plugin-profile transports apply only on their declared endpoint.
       4. Direct provider checks (bedrock).
       5. Default: 'chat_completions'.
 
@@ -734,6 +735,18 @@ def determine_api_mode(provider: str, base_url: str = "", model: str = "") -> st
 
     pdef = get_provider(provider)
     if pdef is not None:
+        # ``get_provider`` bridges ProviderProfile-only plugins into a
+        # ProviderDef. Honor that declaration on the profile's own endpoint,
+        # but do not force it onto a user-supplied override. An override to a
+        # different, non-self-describing endpoint is the stronger signal; for
+        # example, MiniMax's /v1 route opts out of its /anthropic default.
+        # Host-mandated overrides have already returned above.
+        if (
+            pdef.source == "plugin-profile"
+            and base_url
+            and base_url.rstrip("/") != pdef.base_url.rstrip("/")
+        ):
+            return "chat_completions"
         return TRANSPORT_TO_API_MODE.get(pdef.transport, "chat_completions")
 
     # Direct provider checks for providers not in HERMES_OVERLAYS

--- a/providers/README.md
+++ b/providers/README.md
@@ -40,8 +40,9 @@ layer reads from it:
   `auth_type="api_key"` profile.
 - `hermes_cli/config.py` injects every `env_var` into
   `OPTIONAL_ENV_VARS` so the setup wizard knows about it.
-- `hermes_cli/runtime_provider.py` reads `profile.api_mode` as a fallback
-  when URL detection finds nothing.
+- `hermes_cli/providers.py::determine_api_mode` reads `profile.api_mode` as
+  a fallback when host/URL detection finds nothing; every runtime resolver
+  reaches it through `runtime_provider._fallback_api_mode`.
 - `agent/model_metadata.py` maps hostname → provider via
   `profile.get_hostname()`.
 - `agent/auxiliary_client.py` reads `profile.default_aux_model` first

--- a/providers/README.md
+++ b/providers/README.md
@@ -40,8 +40,9 @@ layer reads from it:
   `auth_type="api_key"` profile.
 - `hermes_cli/config.py` injects every `env_var` into
   `OPTIONAL_ENV_VARS` so the setup wizard knows about it.
-- `hermes_cli/runtime_provider.py` reads `profile.api_mode` as a fallback
-  when URL detection finds nothing.
+- `hermes_cli/providers.py::get_provider` exposes `profile.api_mode` as a
+  transport, and `determine_api_mode` applies it when host/URL detection finds
+  nothing; every runtime resolver reaches it through `_fallback_api_mode`.
 - `agent/model_metadata.py` maps hostname → provider via
   `profile.get_hostname()`.
 - `agent/auxiliary_client.py` reads `profile.default_aux_model` first

--- a/tests/hermes_cli/test_plugin_provider_api_mode.py
+++ b/tests/hermes_cli/test_plugin_provider_api_mode.py
@@ -1,0 +1,248 @@
+"""Regression tests for #53054: a plugin ``ProviderProfile``'s declared
+``api_mode`` must be honored by every API-key runtime-resolution path.
+
+``providers/README.md`` documents the declaration as a resolution input, but
+nothing read it: ``get_provider()`` resolves against models.dev +
+``HERMES_OVERLAYS`` only, and the ``ProviderProfile → ProviderConfig`` bridge
+in ``hermes_cli/auth.py`` drops the field. So the runtime derived the mode
+from host/URL detection alone, and any ``anthropic_messages`` plugin whose
+endpoint is not URL-self-describing (no ``/anthropic`` suffix — e.g.
+Volcengine Ark's ``…/api/coding``) silently degraded to ``chat_completions``
+and 404'd on every request.
+
+``_fallback_api_mode`` (33a2f29a63) closed the same latent class for in-tree
+overlays by routing all three resolver paths through
+``providers.determine_api_mode``; plugin profiles are still invisible to it,
+because ``determine_api_mode`` never consulted the plugin registry.
+
+These tests run the REAL chain — plugin file on disk → provider discovery
+import → ``register_provider()`` → ``auth._extend_registry_from_provider_plugins()``
+→ ``resolve_runtime_provider()`` — rather than hand-mirroring the bridge, so
+a regression in any link fails them. All three API-key resolver paths are
+covered: pooled, explicit API-key, and the ordinary no-pool route, plus the
+precedence guards (persisted config, host detection, base_url override) and
+the in-tree overlay lane that must stay untouched.
+
+HERMES_HOME is sandboxed to a per-session tempdir by tests/conftest.py, so
+the plugin below is never written into a real Hermes install.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+PLUGIN_NAME = "testgw"
+PLUGIN_ALIAS = "testgw-alias"
+PLUGIN_ENV_VAR = "TESTGW_API_KEY"
+# Anthropic-Messages endpoint that is NOT URL-self-describing: no /anthropic
+# suffix, host isn't api.kimi.com — same shape as Ark's
+# https://ark.cn-beijing.volces.com/api/coding.
+PLUGIN_BASE_URL = "https://gw.example.com/api/coding"
+
+PLUGIN_INIT = f'''
+from providers import register_provider
+from providers.base import ProviderProfile
+
+register_provider(ProviderProfile(
+    name="{PLUGIN_NAME}",
+    aliases=("{PLUGIN_ALIAS}",),
+    api_mode="anthropic_messages",
+    env_vars=("{PLUGIN_ENV_VAR}",),
+    base_url="{PLUGIN_BASE_URL}",
+    auth_type="api_key",
+))
+'''
+
+PLUGIN_YAML = f"""name: {PLUGIN_NAME}
+kind: model-provider
+version: 0.0.1
+description: Non-self-describing anthropic_messages test provider (#53054)
+"""
+
+
+def _clear_provider_caches() -> None:
+    """Force providers/__init__.py to re-discover on next lookup."""
+    import providers as _pkg
+
+    _pkg._REGISTRY.clear()
+    _pkg._ALIASES.clear()
+    _pkg._discovered = False
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("plugins.model_providers") or mod.startswith(
+            "_hermes_user_provider"
+        ):
+            del sys.modules[mod]
+
+
+@pytest.fixture()
+def registered_plugin_provider():
+    """Install a user model-provider plugin and run the production discovery
+    + auth-registration chain against it.
+
+    Yields the bridged ``ProviderConfig``. Cleans the shared registries
+    afterwards so other tests never see the fake provider.
+    """
+    from hermes_constants import get_hermes_home
+    from hermes_cli import auth as auth_mod
+
+    plugin_dir = get_hermes_home() / "plugins" / "model-providers" / PLUGIN_NAME
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "__init__.py").write_text(PLUGIN_INIT)
+    (plugin_dir / "plugin.yaml").write_text(PLUGIN_YAML)
+
+    _clear_provider_caches()
+    try:
+        # The real registration loop: discovery runs lazily inside
+        # list_providers(), then the profile is bridged into
+        # PROVIDER_REGISTRY exactly as at import time.
+        auth_mod._extend_registry_from_provider_plugins()
+        pconfig = auth_mod.PROVIDER_REGISTRY.get(PLUGIN_NAME)
+        assert pconfig is not None, (
+            "plugin provider was not bridged into PROVIDER_REGISTRY"
+        )
+        yield pconfig
+    finally:
+        auth_mod.PROVIDER_REGISTRY.pop(PLUGIN_NAME, None)
+        auth_mod.PROVIDER_REGISTRY.pop(PLUGIN_ALIAS, None)
+        _clear_provider_caches()
+
+
+def test_declared_api_mode_reaches_determine_api_mode(registered_plugin_provider):
+    """The declaration is visible to the resolver entry point, by name and
+    by alias — ``get_provider()`` alone never sees a plugin profile."""
+    from hermes_cli.providers import determine_api_mode, get_provider
+
+    assert get_provider(PLUGIN_NAME, allow_network=False) is None
+    assert determine_api_mode(PLUGIN_NAME, PLUGIN_BASE_URL) == "anthropic_messages"
+    assert determine_api_mode(PLUGIN_ALIAS, PLUGIN_BASE_URL) == "anthropic_messages"
+
+
+def test_no_pool_route_honors_declared_api_mode(
+    registered_plugin_provider, monkeypatch
+):
+    """Ordinary no-pool API-key route: discovery → registry → resolve."""
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    monkeypatch.setenv(PLUGIN_ENV_VAR, "sk-testgw-0123456789")
+    runtime = resolve_runtime_provider(requested=PLUGIN_NAME)
+
+    assert runtime["provider"] == PLUGIN_NAME
+    assert runtime["api_mode"] == "anthropic_messages"
+    assert runtime["base_url"] == PLUGIN_BASE_URL
+    assert runtime["api_key"] == "sk-testgw-0123456789"
+
+
+def test_explicit_api_key_route_honors_declared_api_mode(
+    registered_plugin_provider,
+):
+    """Explicit API-key route (``_resolve_explicit_runtime``)."""
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    runtime = resolve_runtime_provider(
+        requested=PLUGIN_NAME, explicit_api_key="sk-explicit-0123456789"
+    )
+
+    assert runtime["source"] == "explicit"
+    assert runtime["api_mode"] == "anthropic_messages"
+    assert runtime["base_url"] == PLUGIN_BASE_URL
+
+
+def test_pooled_route_honors_declared_api_mode(registered_plugin_provider):
+    """Pooled-credential route (``_resolve_runtime_from_pool_entry``)."""
+    from hermes_cli.runtime_provider import _resolve_runtime_from_pool_entry
+
+    entry = SimpleNamespace(
+        runtime_base_url=PLUGIN_BASE_URL,
+        base_url=PLUGIN_BASE_URL,
+        runtime_api_key="sk-pooled-0123456789",
+        access_token="sk-pooled-0123456789",
+    )
+    runtime = _resolve_runtime_from_pool_entry(
+        provider=PLUGIN_NAME,
+        entry=entry,
+        requested_provider=PLUGIN_NAME,
+        model_cfg={},
+    )
+
+    assert runtime["api_mode"] == "anthropic_messages"
+
+
+def test_persisted_config_api_mode_still_wins(registered_plugin_provider):
+    """Config precedence is unchanged: an explicit persisted api_mode for the
+    same provider beats the profile-declared fallback."""
+    from hermes_cli.runtime_provider import _resolve_runtime_from_pool_entry
+
+    entry = SimpleNamespace(
+        runtime_base_url=PLUGIN_BASE_URL,
+        base_url=PLUGIN_BASE_URL,
+        runtime_api_key="sk-pooled-0123456789",
+        access_token="sk-pooled-0123456789",
+    )
+    runtime = _resolve_runtime_from_pool_entry(
+        provider=PLUGIN_NAME,
+        entry=entry,
+        requested_provider=PLUGIN_NAME,
+        model_cfg={"provider": PLUGIN_NAME, "api_mode": "chat_completions"},
+    )
+
+    assert runtime["api_mode"] == "chat_completions"
+
+
+def test_host_detection_still_wins_over_declared_profile(
+    registered_plugin_provider,
+):
+    """Host precedence is unchanged: a host that mandates a wire protocol
+    beats the profile-declared fallback."""
+    from hermes_cli.runtime_provider import _fallback_api_mode
+
+    # testgw declares anthropic_messages, but a direct api.openai.com URL
+    # must still resolve to codex_responses.
+    assert (
+        _fallback_api_mode(PLUGIN_NAME, "https://api.openai.com/v1")
+        == "codex_responses"
+    )
+
+
+def test_base_url_override_defers_to_default(registered_plugin_provider):
+    """A base_url pointing somewhere other than the profile's own endpoint is
+    the stronger signal — the declared mode must not be forced onto it."""
+    from hermes_cli.runtime_provider import _fallback_api_mode
+
+    assert (
+        _fallback_api_mode(PLUGIN_NAME, "https://gw.example.com/v1")
+        == "chat_completions"
+    )
+    # Trailing-slash differences are not an override.
+    assert (
+        _fallback_api_mode(PLUGIN_NAME, PLUGIN_BASE_URL + "/")
+        == "anthropic_messages"
+    )
+
+
+def test_in_tree_overlays_are_unaffected(registered_plugin_provider):
+    """The overlay lane keeps precedence and its existing answers."""
+    from hermes_cli.providers import determine_api_mode
+
+    assert determine_api_mode("openai-api", "https://api.openai.com/v1") == (
+        "codex_responses"
+    )
+    assert determine_api_mode("openrouter", "https://openrouter.ai/api/v1") == (
+        "chat_completions"
+    )
+    assert determine_api_mode("nous", "", "anthropic/claude-x") == (
+        "anthropic_messages"
+    )
+
+
+def test_unknown_provider_keeps_chat_completions_default():
+    """Providers with no profile and no overlay keep the existing default."""
+    from hermes_cli.runtime_provider import _fallback_api_mode
+
+    assert (
+        _fallback_api_mode("no-such-provider", "https://gw.example.com/v1")
+        == "chat_completions"
+    )

--- a/tests/hermes_cli/test_plugin_provider_api_mode.py
+++ b/tests/hermes_cli/test_plugin_provider_api_mode.py
@@ -1,0 +1,220 @@
+"""Regression tests for plugin ``ProviderProfile.api_mode`` resolution.
+
+These tests run the real chain: plugin file on disk -> provider discovery ->
+auth registry extension -> runtime resolution. They cover every API-key route
+and the precedence rules that must remain unchanged.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+PLUGIN_NAME = "testgw"
+PLUGIN_ALIAS = "testgw-alias"
+PLUGIN_ENV_VAR = "TESTGW_API_KEY"
+# Anthropic Messages endpoint that is not URL-self-describing, matching the
+# shape of Ark's https://ark.cn-beijing.volces.com/api/coding endpoint.
+PLUGIN_BASE_URL = "https://gw.example.com/api/coding"
+
+PLUGIN_INIT = f'''
+from providers import register_provider
+from providers.base import ProviderProfile
+
+register_provider(ProviderProfile(
+    name="{PLUGIN_NAME}",
+    aliases=("{PLUGIN_ALIAS}",),
+    api_mode="anthropic_messages",
+    env_vars=("{PLUGIN_ENV_VAR}",),
+    base_url="{PLUGIN_BASE_URL}",
+    auth_type="api_key",
+))
+'''
+
+PLUGIN_YAML = f"""name: {PLUGIN_NAME}
+kind: model-provider
+version: 0.0.1
+description: Non-self-describing anthropic_messages test provider (#53054)
+"""
+
+
+def _clear_provider_caches() -> None:
+    """Force the provider package to rediscover plugins on next lookup."""
+    import providers as provider_package
+
+    provider_package._REGISTRY.clear()
+    provider_package._ALIASES.clear()
+    provider_package._PROVIDER_LIST_CACHE = None
+    provider_package._discovered = False
+    for module_name in list(sys.modules):
+        if module_name.startswith("plugins.model_providers") or module_name.startswith(
+            "_hermes_user_provider"
+        ):
+            del sys.modules[module_name]
+
+
+@pytest.fixture(scope="module")
+def registered_plugin_provider():
+    """Install a provider before auth import, then run the production chain."""
+    from hermes_constants import get_hermes_home
+
+    plugin_dir = get_hermes_home() / "plugins" / "model-providers" / PLUGIN_NAME
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "__init__.py").write_text(PLUGIN_INIT, encoding="utf-8")
+    (plugin_dir / "plugin.yaml").write_text(PLUGIN_YAML, encoding="utf-8")
+
+    _clear_provider_caches()
+    auth_module = None
+    try:
+        # The test file runs in its own process. Creating the plugin before
+        # auth's first import exercises its real one-shot registration block,
+        # without mirroring the bridge or adding a test-only production hook.
+        assert "hermes_cli.auth" not in sys.modules
+        from hermes_cli import auth as auth_module
+
+        provider_config = auth_module.PROVIDER_REGISTRY.get(PLUGIN_NAME)
+        assert provider_config is not None, (
+            "plugin provider was not bridged into PROVIDER_REGISTRY"
+        )
+        yield provider_config
+    finally:
+        if auth_module is not None:
+            auth_module.PROVIDER_REGISTRY.pop(PLUGIN_NAME, None)
+            auth_module.PROVIDER_REGISTRY.pop(PLUGIN_ALIAS, None)
+        _clear_provider_caches()
+
+
+def test_declared_api_mode_reaches_determine_api_mode(registered_plugin_provider):
+    """The resolver sees the declaration by canonical name and alias."""
+    from hermes_cli.providers import determine_api_mode, get_provider
+
+    provider = get_provider(PLUGIN_NAME, allow_network=False)
+    assert provider is not None
+    assert provider.source == "plugin-profile"
+    assert provider.transport == "anthropic_messages"
+    assert determine_api_mode(PLUGIN_NAME, PLUGIN_BASE_URL) == "anthropic_messages"
+    assert determine_api_mode(PLUGIN_ALIAS, PLUGIN_BASE_URL) == "anthropic_messages"
+
+
+def test_no_pool_route_honors_declared_api_mode(
+    registered_plugin_provider, monkeypatch
+):
+    """Ordinary no-pool API-key route honors the plugin declaration."""
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    monkeypatch.setenv(PLUGIN_ENV_VAR, "sk-testgw-0123456789")
+    runtime = resolve_runtime_provider(requested=PLUGIN_NAME)
+
+    assert runtime["provider"] == PLUGIN_NAME
+    assert runtime["api_mode"] == "anthropic_messages"
+    assert runtime["base_url"] == PLUGIN_BASE_URL
+    assert runtime["api_key"] == "sk-testgw-0123456789"
+
+
+def test_explicit_api_key_route_honors_declared_api_mode(
+    registered_plugin_provider,
+):
+    """Explicit API-key route honors the plugin declaration."""
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    runtime = resolve_runtime_provider(
+        requested=PLUGIN_NAME, explicit_api_key="sk-explicit-0123456789"
+    )
+
+    assert runtime["source"] == "explicit"
+    assert runtime["api_mode"] == "anthropic_messages"
+    assert runtime["base_url"] == PLUGIN_BASE_URL
+
+
+def test_pooled_route_honors_declared_api_mode(registered_plugin_provider):
+    """Pooled-credential route honors the plugin declaration."""
+    from hermes_cli.runtime_provider import _resolve_runtime_from_pool_entry
+
+    entry = SimpleNamespace(
+        runtime_base_url=PLUGIN_BASE_URL,
+        base_url=PLUGIN_BASE_URL,
+        runtime_api_key="sk-pooled-0123456789",
+        access_token="sk-pooled-0123456789",
+    )
+    runtime = _resolve_runtime_from_pool_entry(
+        provider=PLUGIN_NAME,
+        entry=entry,
+        requested_provider=PLUGIN_NAME,
+        model_cfg={},
+    )
+
+    assert runtime["api_mode"] == "anthropic_messages"
+
+
+def test_persisted_config_api_mode_still_wins(registered_plugin_provider):
+    """An explicit persisted mode for the same provider keeps precedence."""
+    from hermes_cli.runtime_provider import _resolve_runtime_from_pool_entry
+
+    entry = SimpleNamespace(
+        runtime_base_url=PLUGIN_BASE_URL,
+        base_url=PLUGIN_BASE_URL,
+        runtime_api_key="sk-pooled-0123456789",
+        access_token="sk-pooled-0123456789",
+    )
+    runtime = _resolve_runtime_from_pool_entry(
+        provider=PLUGIN_NAME,
+        entry=entry,
+        requested_provider=PLUGIN_NAME,
+        model_cfg={"provider": PLUGIN_NAME, "api_mode": "chat_completions"},
+    )
+
+    assert runtime["api_mode"] == "chat_completions"
+
+
+def test_host_detection_still_wins_over_declared_profile(
+    registered_plugin_provider,
+):
+    """A host-mandated wire protocol beats the profile fallback."""
+    from hermes_cli.runtime_provider import _fallback_api_mode
+
+    assert (
+        _fallback_api_mode(PLUGIN_NAME, "https://api.openai.com/v1")
+        == "codex_responses"
+    )
+
+
+def test_base_url_override_defers_to_default(registered_plugin_provider):
+    """A different base URL must not inherit the profile's declared mode."""
+    from hermes_cli.runtime_provider import _fallback_api_mode
+
+    assert (
+        _fallback_api_mode(PLUGIN_NAME, "https://gw.example.com/v1")
+        == "chat_completions"
+    )
+    assert (
+        _fallback_api_mode(PLUGIN_NAME, PLUGIN_BASE_URL + "/")
+        == "anthropic_messages"
+    )
+
+
+def test_in_tree_overlays_are_unaffected(registered_plugin_provider):
+    """The overlay lane retains precedence and its existing answers."""
+    from hermes_cli.providers import determine_api_mode
+
+    assert determine_api_mode("openai-api", "https://api.openai.com/v1") == (
+        "codex_responses"
+    )
+    assert determine_api_mode("openrouter", "https://openrouter.ai/api/v1") == (
+        "chat_completions"
+    )
+    assert determine_api_mode("nous", "", "anthropic/claude-x") == (
+        "anthropic_messages"
+    )
+
+
+def test_unknown_provider_keeps_chat_completions_default():
+    """Unknown providers retain the conservative existing default."""
+    from hermes_cli.runtime_provider import _fallback_api_mode
+
+    assert (
+        _fallback_api_mode("no-such-provider", "https://gw.example.com/v1")
+        == "chat_completions"
+    )


### PR DESCRIPTION
## What does this PR do?

Completes the `ProviderProfile.api_mode` fix on current `main` without forcing a
plugin's declared transport onto a user-supplied endpoint override.

`main` now bridges profile-only providers through `get_provider()` as a
`ProviderDef(source="plugin-profile")`, so the old head of this PR is obsolete:
the declared transport already reaches `determine_api_mode()` and all three
runtime fallback paths. This head is re-derived from current `main` and retains
only the remaining correctness gap.

## Remaining bug on current main

`determine_api_mode()` currently returns a profile-only provider's transport for
*every* `base_url`, including a different user override. For example, a profile
whose default endpoint is native Anthropic Messages can be redirected to an
OpenAI-compatible `/v1` endpoint and still be forced onto
`anthropic_messages`.

That violates the established precedence rule: a different explicit endpoint is
the stronger signal. Recognized hosts remain handled by the host-mandated tier;
an unknown override should retain the conservative `chat_completions` default.

## Fix

- In `determine_api_mode()`, apply a `source="plugin-profile"` transport only
  when `base_url` is absent or matches the profile's declared endpoint.
- Preserve trailing-slash equivalence.
- Leave host-mandated modes, Hermes overlays, models.dev providers, persisted
  config, Nous dual-wire routing, and unknown-provider defaults unchanged.
- Correct `providers/README.md` to describe the current profile-to-runtime path.

The endpoint-gating design is adopted from @samfoy's #65956.

## Regression coverage

The test installs a real provider plugin beneath the isolated test
`HERMES_HOME` **before the first auth import**, then exercises the production
chain:

plugin on disk → discovery → `ProviderProfile` registration → auth registry
extension → `get_provider()` → `determine_api_mode()` → runtime resolution.

Coverage includes:

- canonical name and alias resolution;
- pooled, explicit-key, and ordinary no-pool API-key routes;
- persisted-config precedence;
- host-mandated precedence;
- different-`base_url` override gating and trailing-slash equivalence;
- unchanged overlay and unknown-provider behavior.

Mutation check: removing the new endpoint gate makes the override regression
test fail (`anthropic_messages` instead of `chat_completions`).

## Verification

```text
tests/hermes_cli/test_plugin_provider_api_mode.py                  9 passed

runtime/provider/model-switch focused selection                168 passed

provider + runtime surrounding suites                          250 passed

ruff (changed Python files)                                      passed
git diff --check                                                 passed
```

## Relationship to the overlapping PRs

- #65956 still contains distinct unknown-provider/OpenRouter fallback behavior;
  that scope should be reviewed separately from this endpoint-gating fix.
- #52549 combines provider identity and runtime work. Current `main` already
  contains the profile-only `get_provider()` bridge this PR now builds on, so
  this focused head does not reintroduce that broader identity change.

Fixes #53054.
