### PR TITLE
fix(cronjob): dont overwrite job provider on model-only update

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -486,7 +486,8 @@ class TestResolveModelOverride:
             cfg_mod, "load_config", lambda: {"model": {"provider": "openai-codex"}}
         )
         provider, model = _resolve_model_override(
-            {"provider": "custom", "model": "gpt-5.4"}
+            {"provider": "custom", "model": "gpt-5.4"},
+            action="create",
         )
         # No matching custom entry → fall back to pinning the main provider.
         assert provider == "openai-codex"
@@ -499,9 +500,26 @@ class TestResolveModelOverride:
         # form is never stripped or pinned.
         monkeypatch.setattr(rp_mod, "has_named_custom_provider", lambda name: False)
         provider, model = _resolve_model_override(
-            {"provider": "custom:cliproxy", "model": "gpt-5.4"}
+            {"provider": "custom:cliproxy", "model": "gpt-5.4"},
         )
         assert provider == "custom:cliproxy"
+        assert model == "gpt-5.4"
+
+    def test_update_does_not_pin_provider(self, monkeypatch):
+        """On update, provider must stay None so the job's existing provider
+        is not overwritten when the user only specifies a model name."""
+        import hermes_cli.config as cfg_mod
+
+        monkeypatch.setattr(
+            cfg_mod, "load_config", lambda: {"model": {"provider": "openai-codex"}}
+        )
+        provider, model = _resolve_model_override(
+            {"model": "gpt-5.4"},
+            action="update",
+        )
+        # Provider should stay None — the current config provider must NOT
+        # overwrite the job's existing provider during an update.
+        assert provider is None
         assert model == "gpt-5.4"
 
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -373,11 +373,13 @@ def _canonical_skills(skill: Optional[str] = None, skills: Optional[Any] = None)
 
 
 
-def _resolve_model_override(model_obj: Optional[Dict[str, Any]]) -> tuple:
+def _resolve_model_override(model_obj: Optional[Dict[str, Any]], *, action: Optional[str] = None) -> tuple:
     """Resolve a model override object into (provider, model) for job storage.
 
-    If provider is omitted, pins the current main provider from config so the
-    job doesn't drift when the user later changes their default via hermes model.
+    If provider is omitted on creation, pins the current main provider from
+    config so the job doesn't drift when the user later changes their default
+    via hermes model. On update, leaves provider unpinned so it doesn't
+    silently overwrite the job's existing provider.
 
     Returns (provider_str_or_none, model_str_or_none).
     """
@@ -403,15 +405,18 @@ def _resolve_model_override(model_obj: Optional[Dict[str, Any]]) -> tuple:
         except Exception:
             provider_name = None
     if model_name and not provider_name:
-        # Pin to the current main provider so the job is stable
-        try:
-            from hermes_cli.config import load_config
-            cfg = load_config()
-            model_cfg = cfg.get("model", {})
-            if isinstance(model_cfg, dict):
-                provider_name = model_cfg.get("provider") or None
-        except Exception:
-            pass  # Best-effort; provider stays None
+        # Only pin the current main provider at creation time so the job
+        # stays stable. During update, leave provider unpinned to preserve
+        # the job's existing provider when the user only specifies a model.
+        if action == "create":
+            try:
+                from hermes_cli.config import load_config
+                cfg = load_config()
+                model_cfg = cfg.get("model", {})
+                if isinstance(model_cfg, dict):
+                    provider_name = model_cfg.get("provider") or None
+            except Exception:
+                pass  # Best-effort; provider stays None
     return (provider_name, model_name)
 
 
@@ -1005,7 +1010,7 @@ registry.register(
     name="cronjob",
     toolset="cronjob",
     schema=CRONJOB_SCHEMA,
-    handler=lambda args, **kw: (lambda _mo=_resolve_model_override(args.get("model")): cronjob(
+    handler=lambda args, **kw: (lambda _mo=_resolve_model_override(args.get("model"), action=args.get("action")): cronjob(
         action=args.get("action", ""),
         job_id=args.get("job_id"),
         prompt=args.get("prompt"),


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where updating a cron job's model without specifying a provider would silently overwrite the job's existing provider with the current main config provider.

**The bug in detail:**

When a user calls `cronjob(action='update', job_id='...', model={"model": "claude-4"})` — intending only to change the model — `_resolve_model_override` pins the current main provider from config (because the `model` dict has no `provider` key), and that resolved provider then gets written into the job's `updates` dict along with the model, overwriting whatever provider the job was originally using.

This is correct and intended behavior at **creation time** (so the job stays stable if the user later changes their default provider), but it is wrong on **update** — the user only asked to change the model.

## Related Issue

No issue filed (found during code analysis).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`tools/cronjob_tools.py`**: Added `action` keyword-only parameter to `_resolve_model_override()`. The provider-from-config pinning logic now only activates when `action="create"`. For update (or any other action, including the default `None`), the provider stays unresolved so the job's existing provider is preserved.
- **`tools/cronjob_tools.py`**: Updated the `cronjob` tool handler to pass `action=args.get("action")` through to `_resolve_model_override`.
- **`tests/tools/test_cronjob_tools.py`**: Updated `test_pins_main_provider_when_bare_custom_unresolvable` to pass `action="create"` (it is a creation-time scenario).
- **`tests/tools/test_cronjob_tools.py`**: Added `test_update_does_not_pin_provider` to verify the fix.

## How to Test

1. `cronjob(action='create', schedule='30m', prompt='test', model={"model": "gpt-4"})` — provider should be pinned at creation → ✅
2. `cronjob(action='update', job_id='<id>', model={"model": "claude-4"})` — provider should NOT be changed → ✅
3. `cronjob(action='update', job_id='<id>', model={"provider": "openai", "model": "gpt-4"})` — explicit provider should still be settable on update → ✅
4. Run: `pytest tests/tools/test_cronjob_tools.py -v -k "TestResolveModelOverride"`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, ...)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A