### PR TITLE
fix(desktop): restore right sidebar folder picker + cwd fallback chain

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -448,7 +448,7 @@ export function DesktopController() {
     [activeSessionIdRef, updateSessionState]
   )
 
-  const { refreshProjectBranch } = useCwdActions({
+  const { changeSessionCwd, refreshProjectBranch } = useCwdActions({
     activeSessionId,
     activeSessionIdRef,
     onSessionRuntimeInfo: updateActiveSessionRuntimeInfo,
@@ -1219,6 +1219,7 @@ export function DesktopController() {
         key={currentCwd || 'no-cwd'}
         onActivateFile={path => composer.insertContextPathInlineRef(path)}
         onActivateFolder={path => composer.insertContextPathInlineRef(path, true)}
+        onChangeCwd={changeSessionCwd}
       />
     </Pane>
   )

--- a/apps/desktop/src/app/right-sidebar/index.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.test.tsx
@@ -31,10 +31,10 @@ describe('RightSidebarPane', () => {
     delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
   })
 
-  it('renders the tree whenever the session has a working dir (repo or not) — no picker', async () => {
+  it('renders the tree and an "Open folder" button when the session has a working dir', async () => {
     setCurrentCwd('/repo')
 
-    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} onChangeCwd={vi.fn()} />)
 
     const refresh = await screen.findByRole('button', { name: 'Refresh tree' })
 
@@ -42,16 +42,19 @@ describe('RightSidebarPane', () => {
     fireEvent.click(refresh)
     await waitFor(() => expect(readDir).toHaveBeenCalledWith('/repo'))
 
-    // The freeform folder picker is retired.
-    expect(screen.queryByRole('button', { name: 'Open folder' })).toBeNull()
+    // The folder picker is available so the user can change the working dir.
+    expect(screen.getByRole('button', { name: 'Open folder' })).toBeDefined()
   })
 
-  it('shows no tree for a detached chat (no working dir)', async () => {
+  it('shows the folder picker (not a dead "No project open") for a detached chat', async () => {
     setCurrentCwd('')
 
-    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} onChangeCwd={vi.fn()} />)
 
-    await waitFor(() => expect(screen.queryByRole('button', { name: 'Refresh tree' })).toBeNull())
+    // No tree to refresh (no cwd yet), but the "Open folder" button is present
+    // so the user can pick a folder to start working in.
+    expect(screen.queryByRole('button', { name: 'Refresh tree' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Open folder' })).toBeDefined()
     expect(readDir).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { useDelayedTrue } from '@/hooks/use-delayed-true'
 import { useI18n } from '@/i18n'
+import { selectDesktopPaths } from '@/lib/desktop-fs'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { cn } from '@/lib/utils'
 import { $panesFlipped } from '@/store/layout'
@@ -22,19 +23,15 @@ import { useProjectTree } from './files/use-project-tree'
 interface RightSidebarPaneProps {
   onActivateFile: (path: string) => void
   onActivateFolder: (path: string) => void
+  onChangeCwd: (path: string) => Promise<void> | void
 }
 
-export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSidebarPaneProps) {
+export function RightSidebarPane({ onActivateFile, onActivateFolder, onChangeCwd }: RightSidebarPaneProps) {
   const { t } = useI18n()
   const r = t.rightSidebar
   const panesFlipped = useStore($panesFlipped)
   const currentCwd = useStore($currentCwd).trim()
-
-  // The file tree is simply "browse the session's working directory". If the
-  // session has a cwd — a repo, a sibling worktree, or any folder — show it. A
-  // bare/detached chat (resolveNewSessionCwd → '') has none, so it shows the
-  // empty hint instead of whatever dir Hermes happens to run from.
-  const hasWorkspace = Boolean(currentCwd)
+  const hasCwd = currentCwd.length > 0
 
   const {
     collapseAll,
@@ -47,15 +44,29 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
     rootError,
     rootLoading,
     setNodeOpen
-  } = useProjectTree(hasWorkspace ? currentCwd : '')
+  } = useProjectTree(hasCwd ? currentCwd : '')
 
-  const cwdName =
-    effectiveCwd
-      .split(/[\\/]+/)
-      .filter(Boolean)
-      .pop() ?? effectiveCwd
+  const cwdName = hasCwd
+    ? (effectiveCwd
+        .split(/[\\/]+/)
+        .filter(Boolean)
+        .pop() ?? effectiveCwd)
+    : r.noFolderSelected
 
   const canCollapse = Object.values(openState).some(Boolean)
+
+  const chooseFolder = async () => {
+    const selected = await selectDesktopPaths({
+      defaultPath: hasCwd ? effectiveCwd : undefined,
+      directories: true,
+      multiple: false,
+      title: r.changeCwdTitle
+    })
+
+    if (selected?.[0]) {
+      await onChangeCwd(selected[0])
+    }
+  }
 
   const previewFile = async (path: string) => {
     try {
@@ -88,10 +99,11 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
         cwdName={cwdName}
         data={data}
         error={rootError}
-        hasWorkspace={hasWorkspace}
+        hasCwd={hasCwd}
         loading={rootLoading}
         onActivateFile={onActivateFile}
         onActivateFolder={onActivateFolder}
+        onChangeFolder={chooseFolder}
         onCollapseAll={collapseAll}
         onLoadChildren={loadChildren}
         onNodeOpenChange={setNodeOpen}
@@ -106,7 +118,8 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
 interface FilesystemTabProps extends FileTreeBodyProps {
   canCollapse: boolean
   cwdName: string
-  hasWorkspace: boolean
+  hasCwd: boolean
+  onChangeFolder: () => Promise<void> | void
   onCollapseAll: () => void
   onRefresh: () => void
 }
@@ -125,10 +138,11 @@ function FilesystemTab({
   cwdName,
   data,
   error,
-  hasWorkspace,
+  hasCwd,
   loading,
   onActivateFile,
   onActivateFolder,
+  onChangeFolder,
   onCollapseAll,
   onLoadChildren,
   onNodeOpenChange,
@@ -139,17 +153,50 @@ function FilesystemTab({
   const { t } = useI18n()
   const r = t.rightSidebar
 
-  // No working directory (a bare/detached chat) → no tree, just a terse hint.
-  // Switching workspace is a project/worktree action, never a raw folder picker.
-  if (!hasWorkspace) {
-    return <PaneEmptyState label={r.noProjectOpen} />
+  // No working directory yet (a bare/detached chat) → show a picker button
+  // so the user can choose a folder to start working in — no project
+  // registration required. This restores the pre-#49037 behavior.
+  if (!hasCwd) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col">
+        <RightSidebarSectionHeader>
+          <div className="flex min-w-0 flex-1">
+            <button
+              className="flex w-full min-w-0 items-center rounded-md text-left hover:text-(--ui-text-secondary)"
+              onClick={() => void onChangeFolder()}
+              type="button"
+            >
+              <SidebarPanelLabel>{cwdName}</SidebarPanelLabel>
+            </button>
+          </div>
+          <Button
+            aria-label={r.openFolder}
+            className={HEADER_ACTION_CLASS}
+            onClick={() => void onChangeFolder()}
+            size="icon-xs"
+            title={r.openFolder}
+            variant="ghost"
+          >
+            <Codicon name="folder-opened" size="0.8125rem" />
+          </Button>
+        </RightSidebarSectionHeader>
+        <PaneEmptyState label={r.noFolderSelected} />
+      </div>
+    )
   }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <RightSidebarSectionHeader>
         <div className="flex min-w-0 flex-1">
-          <SidebarPanelLabel>{cwdName}</SidebarPanelLabel>
+          <button
+            className="flex w-full min-w-0 items-center rounded-md text-left hover:text-(--ui-text-secondary)"
+            onClick={() => void onChangeFolder()}
+            title={hasCwd ? r.folderTip(cwd) : r.openFolder}
+            type="button"
+          >
+            <SidebarPanelLabel>{cwdName}</SidebarPanelLabel>
+          </button>
         </div>
         <Button
           aria-label={r.refreshTree}
@@ -161,6 +208,16 @@ function FilesystemTab({
           variant="ghost"
         >
           <Codicon name="refresh" size="0.8125rem" spinning={loading} />
+        </Button>
+        <Button
+          aria-label={r.openFolder}
+          className={HEADER_ACTION_CLASS}
+          onClick={() => void onChangeFolder()}
+          size="icon-xs"
+          title={r.openFolder}
+          variant="ghost"
+        >
+          <Codicon name="folder-opened" size="0.8125rem" />
         </Button>
         <Button
           aria-label={r.collapseAll}
@@ -236,10 +293,6 @@ function FileTreeBody({
   // Stay blank for a beat, then skeleton — so a fast project switch doesn't
   // flash a jarring loading state.
   const showSkeleton = useDelayedTrue(loading && data.length === 0)
-
-  if (!cwd) {
-    return <EmptyState body={r.noProjectBody} title={r.noProjectTitle} />
-  }
 
   if (error) {
     return (

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -31,7 +31,9 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder, onChangeCwd
   const r = t.rightSidebar
   const panesFlipped = useStore($panesFlipped)
   const currentCwd = useStore($currentCwd).trim()
-  const hasCwd = currentCwd.length > 0
+  // The file tree is simply "browse the session's working directory". If the
+  // session has a cwd — a repo, a sibling worktree, or any folder — show it.
+  const hasCwd = Boolean(currentCwd)
 
   const {
     collapseAll,

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -198,14 +198,21 @@ describe('workspaceCwdForNewSession', () => {
     expect(workspaceCwdForNewSession()).toBe('/home/user/configured')
   })
 
-  it('starts detached (no inherited cwd) when no default project dir is configured', () => {
-    // A bare new chat must NOT inherit the sticky/remembered or live workspace —
-    // that's the "why is my new session already on a branch" bug. Only an
-    // explicit configured default pre-attaches.
+  it('inherits the remembered workspace cwd when no default project dir is configured', () => {
+    // Both remembered and live cwd are set, so this also pins the order:
+    // remembered wins over live.
     window.localStorage.setItem('hermes.desktop.workspace-cwd', '/home/user/sticky')
     $currentCwd.set('/home/user/live')
 
-    expect(workspaceCwdForNewSession()).toBe('')
+    expect(workspaceCwdForNewSession()).toBe('/home/user/sticky')
+  })
+
+  it('inherits the live cwd when nothing is configured or remembered', () => {
+    // Last link of the chain: with no default and no remembered workspace, a new
+    // chat still roots at wherever you currently are.
+    $currentCwd.set('/home/user/live')
+
+    expect(workspaceCwdForNewSession()).toBe('/home/user/live')
   })
 
   it('does not rewrite the live cwd while a session is active', () => {
@@ -233,9 +240,21 @@ describe('workspaceCwdForNewSession', () => {
     setCurrentCwd('/backend/project-b')
     expect(workspaceCwdForNewSession()).toBe('/backend/project-b')
 
-    // Back on local with no configured default: a bare new chat is detached and
-    // never reads the remote keys (nor inherits the sticky local workspace).
+    // Back on local: returns the local sticky, not the remote '/backend/project-b',
+    // so local and remote workspace memory stay isolated.
     $connection.set(null)
+    expect(workspaceCwdForNewSession()).toBe('/local/project')
+  })
+
+  it('never inherits a local cwd in remote mode — the gateway stays detached', () => {
+    // Remote = a gateway on another machine; the local picker can't point there, so
+    // none of the local sources (default, remembered, live) may leak into a new
+    // remote chat. It stays detached until the user sets a cwd for that remote.
+    applyConfiguredDefaultProjectDir('/home/user/configured')
+    window.localStorage.setItem('hermes.desktop.workspace-cwd', '/home/user/sticky')
+    $currentCwd.set('/home/user/live')
+    $connection.set({ baseUrl: 'http://backend-a', mode: 'remote' } as never)
+
     expect(workspaceCwdForNewSession()).toBe('')
   })
 })

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -343,13 +343,9 @@ export const workspaceCwdForNewSession = (): string => {
     return getRememberedWorkspaceCwd()
   }
 
-  // Restore the pre-#49037 fallback chain: configured default → remembered
-  // workspace cwd → current $currentCwd. A bare new chat inherits the last
-  // folder the user worked in, so the right sidebar tree and coding rail
-  // have a root instead of showing "No project open". Entering a project or
-  // worktree still attaches its cwd directly (startSessionInWorkspace),
-  // so the projects paradigm is unaffected — this only fills the gap for
-  // global/detached sessions that had no cwd. See issue #53004.
+  // Desktop renderer only: gateway/TUI/CLI resolve their cwd server-side and never
+  // call this, so reviving last-folder inheritance here can't affect them. Safe to
+  // inherit in the desktop because the right-sidebar picker can re-point the folder.
   return getConfiguredDefaultProjectDir() || getRememberedWorkspaceCwd() || $currentCwd.get().trim()
 }
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -343,13 +343,14 @@ export const workspaceCwdForNewSession = (): string => {
     return getRememberedWorkspaceCwd()
   }
 
-  // A bare new chat starts DETACHED — no inherited cwd, so the composer's coding
-  // rail (which keys off $currentCwd) shows no branch and the first message runs
-  // in the gateway's default rather than silently in the last repo you touched.
-  // Only an explicit default-project-dir setting pre-attaches. Entering a
-  // project/worktree attaches its cwd directly (startSessionInWorkspace), so the
-  // "remember where I was when I'm in a project" case is unaffected.
-  return getConfiguredDefaultProjectDir()
+  // Restore the pre-#49037 fallback chain: configured default → remembered
+  // workspace cwd → current $currentCwd. A bare new chat inherits the last
+  // folder the user worked in, so the right sidebar tree and coding rail
+  // have a root instead of showing "No project open". Entering a project or
+  // worktree still attaches its cwd directly (startSessionInWorkspace),
+  // so the projects paradigm is unaffected — this only fills the gap for
+  // global/detached sessions that had no cwd. See issue #53004.
+  return getConfiguredDefaultProjectDir() || getRememberedWorkspaceCwd() || $currentCwd.get().trim()
 }
 
 export const setCurrentBranch = (next: Updater<string>) => updateAtom($currentBranch, next)


### PR DESCRIPTION
## What does this PR do?

Restores two behaviors that PR #49037 (projects paradigm) removed from the right sidebar, without touching the projects paradigm on the left sidebar.

### 1. Right sidebar folder picker (restored)

PR #49037 removed the onChangeCwd prop and "Open Folder" button from RightSidebarPane, leaving global sessions with a dead "No project open" panel and no way to change the working directory. This restores:
- onChangeCwd prop wired to changeSessionCwd (the hook already existed in use-cwd-actions.ts, just wasnt destructured)
- The "Open folder" button + clickable folder name in the header
- For detached sessions (no cwd): "No folder selected" with the picker button instead of dead "No project open"

### 2. Cwd fallback chain for new global sessions (restored)

PR #49037 deliberately removed the fallback chain in workspaceCwdForNewSession(), making new global sessions start detached (no cwd) unless a default-project-dir was explicitly configured. The old fallback chain is restored:

configured default -> remembered workspace cwd -> current currentCwd

This means a new global session inherits the last folder the user worked in, so the right sidebar tree and coding rail have a root. Entering a project/worktree still attaches its cwd directly via startSessionInWorkspace, so the projects paradigm is unaffected.

## Related Issue

Fixes #53004

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- apps/desktop/src/app/right-sidebar/index.tsx -- restored onChangeCwd prop, chooseFolder(), "Open folder" button, clickable folder name. Detached sessions show picker instead of dead "No project open".
- apps/desktop/src/app/desktop-controller.tsx -- destructured changeSessionCwd from useCwdActions, wired to RightSidebarPane.onChangeCwd.
- apps/desktop/src/store/session.ts -- restored workspaceCwdForNewSession() fallback chain.
- apps/desktop/src/app/right-sidebar/index.test.tsx -- updated tests for restored behavior.

## How to Test

1. Start a new global session (Cmd+N) -> right sidebar shows your last folder (not "No project open") -- cwd fallback chain works
2. Click "Open folder" button -> native picker -> pick a different folder -> tree reroots
3. Enter a project from the left sidebar -> start a session -> cwd is the project root (projects paradigm still works)

## Checklist

- [x] Ive read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isnt a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] Ive added tests for my changes
- [x] Ive tested on my platform: macOS 26.5.1
- [x] N/A -- no config keys, no architecture changes, no tool behavior changes