### PR TITLE
fix(cron): disable async delegation promises in cron sessions

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2181,6 +2181,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         platform="",
         chat_id="",
         chat_name="",
+        async_delivery=False,
     )
     _cron_delivery_vars = (
         "HERMES_CRON_AUTO_DELIVER_PLATFORM",

--- a/tests/gateway/test_async_delivery_capability.py
+++ b/tests/gateway/test_async_delivery_capability.py
@@ -18,6 +18,7 @@ not snapshots of a current value.
 """
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -141,6 +142,22 @@ class TestAdapterCapabilityFlag:
         finally:
             clear_session_vars(tokens)
 
+    def test_cron_session_binds_no_async_delivery(self):
+        """Cron jobs are detached scheduler runs with no completion-queue
+        re-entry path, so they must opt out of background delivery promises.
+        """
+        tokens = set_session_vars(
+            platform="",
+            chat_id="",
+            chat_name="",
+            async_delivery=False,
+        )
+        try:
+            assert async_delivery_supported() is False
+            assert get_session_env("HERMES_SESSION_PLATFORM") == ""
+        finally:
+            clear_session_vars(tokens)
+
 
 # ---------------------------------------------------------------------------
 # terminal_tool: refuses to register a watcher on unsupported sessions
@@ -209,3 +226,72 @@ class TestTerminalNotifyGate:
         assert not d.get("notify_unsupported")
         # No platform bound -> no gateway watcher, but completion_queue still fires.
         assert len(process_registry.pending_watchers) == 0
+
+
+class TestDelegateTaskBackgroundGate:
+    def test_cron_context_falls_back_to_sync(self, monkeypatch):
+        """Cron jobs must not dispatch detached background subagents because
+        no cron drain re-enters async-delegation completions after the turn.
+        """
+        import tools.delegate_tool as dt
+
+        parent = pytest.importorskip("unittest.mock").MagicMock()
+        parent._delegate_depth = 0
+        parent.session_id = "cron-session"
+        parent._interrupt_requested = False
+        parent._active_children = []
+        parent._active_children_lock = None
+
+        creds = {
+            "model": "m",
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "command": None,
+            "args": None,
+        }
+
+        monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
+        monkeypatch.setattr(
+            dt,
+            "_build_child_agent",
+            lambda **kw: SimpleNamespace(
+                _delegate_saved_tool_names=[],
+                _delegate_role="leaf",
+            ),
+        )
+        monkeypatch.setattr(
+            dt,
+            "_run_single_child",
+            lambda task_index, goal, **kw: {
+                "task_index": task_index,
+                "status": "completed",
+                "summary": f"done: {goal}",
+                "api_calls": 1,
+                "duration_seconds": 0.1,
+                "model": "m",
+                "exit_reason": "completed",
+            },
+        )
+
+        tokens = set_session_vars(
+            platform="",
+            chat_id="",
+            chat_name="",
+            async_delivery=False,
+        )
+        try:
+            out = json.loads(
+                dt.delegate_task(
+                    tasks=[{"goal": "a"}, {"goal": "b"}],
+                    background=True,
+                    parent_agent=parent,
+                )
+            )
+        finally:
+            clear_session_vars(tokens)
+
+        assert out["results"][0]["summary"] == "done: a"
+        assert out["results"][1]["summary"] == "done: b"
+        assert "SYNCHRONOUSLY" in out["note"]


### PR DESCRIPTION
## What does this PR do?

Fixes a cron-session capability mismatch that let `delegate_task(background=true)` promise async completion delivery in cron jobs even though cron has no completion-drain or re-entry path after the scheduler turn exits.

This approach fixes the root cause of the reported bug with the smallest safe change: cron sessions now bind `async_delivery=False`, so background delegation falls back to synchronous execution instead of enqueuing completion events that cron can never route back to the originating run.

## Related Issue

Fixes #53027

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `cron/scheduler.py` so cron session context explicitly sets `async_delivery=False`.
- Added a regression assertion in `tests/gateway/test_async_delivery_capability.py` that cron-style session bindings do not advertise async delivery support.
- Added a targeted `delegate_task(background=True)` regression test proving cron context falls back to synchronous execution instead of promising detached async completion.

## How to Test

1. Run `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/pytest tests/gateway/test_async_delivery_capability.py -q`
2. Confirm the targeted suite passes, including the cron session capability test and the background delegation fallback test.
3. Optionally reproduce the original scenario with a cron job that uses `delegate_task(background=true)` and verify the work completes synchronously instead of losing the batch-complete event after cron exits.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/pytest tests/gateway/test_async_delivery_capability.py -q
14 passed in 1.02s
```
