### PR TITLE
fix(tui): Route skill slash commands through dispatch

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -264,6 +264,118 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
     expect(renderedText).toContain('⊙ Goal set. Starting now.')
     expect(renderedText).not.toContain('/goal: no output')
   })
+
+  it('submits skill directives returned directly by slash.exec', async () => {
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const states: Record<string, unknown>[] = []
+    const skillMessage = 'Use this skill to investigate the bug.'
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'slash.exec') {
+        return {
+          type: 'skill',
+          name: 'hermes-agent-dev',
+          message: skillMessage
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => states.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/hermes-agent-dev investigate this bug')
+
+    expect(calls.map(c => c.method)).toEqual(['slash.exec', 'prompt.submit'])
+    expect(calls[0]?.params).toEqual({
+      command: 'hermes-agent-dev investigate this bug',
+      session_id: RUNTIME_SESSION_ID
+    })
+    expect(calls[1]?.params).toEqual({
+      session_id: RUNTIME_SESSION_ID,
+      text: skillMessage
+    })
+    expect(requestGateway).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
+
+    const renderedText = states
+      .flatMap(state => {
+        const messages = Array.isArray(state.messages)
+          ? (state.messages as Array<{ parts?: Array<{ text?: string }> }>)
+          : []
+
+        return messages.flatMap(message => (message.parts ?? []).map(part => part.text ?? ''))
+      })
+      .join('\n')
+
+    expect(renderedText).toContain('⚡ loading skill: hermes-agent-dev')
+  })
+
+  it('falls back to command.dispatch for skill directives from older slash.exec backends', async () => {
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const states: Record<string, unknown>[] = []
+    const skillMessage = 'Use this legacy skill payload.'
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'slash.exec') {
+        throw new Error('skill command: use command.dispatch')
+      }
+
+      if (method === 'command.dispatch') {
+        return {
+          type: 'skill',
+          name: 'hermes-agent-dev',
+          message: skillMessage
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => states.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/hermes-agent-dev investigate this bug')
+
+    expect(calls.map(c => c.method)).toEqual(['slash.exec', 'command.dispatch', 'prompt.submit'])
+    expect(calls[1]?.params).toEqual({
+      arg: 'investigate this bug',
+      name: 'hermes-agent-dev',
+      session_id: RUNTIME_SESSION_ID
+    })
+    expect(calls[2]?.params).toEqual({
+      session_id: RUNTIME_SESSION_ID,
+      text: skillMessage
+    })
+
+    const renderedText = states
+      .flatMap(state => {
+        const messages = Array.isArray(state.messages)
+          ? (state.messages as Array<{ parts?: Array<{ text?: string }> }>)
+          : []
+
+        return messages.flatMap(message => (message.parts ?? []).map(part => part.text ?? ''))
+      })
+      .join('\n')
+
+    expect(renderedText).toContain('⚡ loading skill: hermes-agent-dev')
+  })
 })
 
 describe('usePromptActions desktop slash pickers', () => {

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1099,26 +1099,35 @@ def test_cli_exec_allowed(server, argv):
 # ── slash.exec skill command interception ────────────────────────────
 
 
-def test_slash_exec_rejects_skill_commands(server):
-    """slash.exec must reject skill commands so the TUI falls through to command.dispatch."""
+def test_slash_exec_routes_skill_commands_to_dispatch(server):
+    """slash.exec routes skill commands through command.dispatch directly."""
     # Register a mock session
     sid = "test-session"
     server._sessions[sid] = {"session_key": sid, "agent": None}
 
     # Mock scan_skill_commands to return a known skill
     fake_skills = {"/hermes-agent-dev": {"name": "hermes-agent-dev", "description": "Dev workflow"}}
+    fake_msg = "Loaded skill content here"
 
-    with patch("agent.skill_commands.get_skill_commands", return_value=fake_skills):
+    with patch("agent.skill_commands.get_skill_commands", return_value=fake_skills), \
+         patch("agent.skill_commands.scan_skill_commands", return_value=fake_skills), \
+         patch("agent.skill_commands.build_skill_invocation_message", return_value=fake_msg) as build_msg:
         resp = server.handle_request({
             "id": "r1",
             "method": "slash.exec",
-            "params": {"command": "hermes-agent-dev", "session_id": sid},
+            "params": {"command": "hermes-agent-dev investigate this bug", "session_id": sid},
         })
 
-    # Should return an error so the TUI's .catch() fires command.dispatch
-    assert "error" in resp
-    assert resp["error"]["code"] == 4018
-    assert "skill command" in resp["error"]["message"]
+    assert "error" not in resp
+    result = resp["result"]
+    assert result["type"] == "skill"
+    assert result["name"] == "hermes-agent-dev"
+    assert result["message"] == fake_msg
+    build_msg.assert_called_once_with(
+        "/hermes-agent-dev",
+        "investigate this bug",
+        task_id=sid,
+    )
 
 
 def test_slash_exec_handles_plugin_commands_in_live_gateway(server):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9366,7 +9366,7 @@ def _(rid, params: dict) -> dict:
 
         skill_count = 0
         try:
-            from agent.skill_commands import scan_skill_commands
+            from agent.skill_commands import get_skill_commands
 
             for k, info in sorted(scan_skill_commands().items()):
                 d = str(info.get("description", "Skill"))
@@ -10616,17 +10616,6 @@ def _(rid, params: dict) -> dict:
                 "snapshot restore mutates live config/state; use command.dispatch for /snapshot restore",
             )
 
-    try:
-        from agent.skill_commands import get_skill_commands
-
-        _cmd_key = f"/{_cmd_base}"
-        if _cmd_key in get_skill_commands():
-            return _err(
-                rid, 4018, f"skill command: use command.dispatch for {_cmd_key}"
-            )
-    except Exception:
-        pass
-
     plugin_handler = None
     resolve_plugin_command_result = None
     if _cmd_base:
@@ -10648,6 +10637,21 @@ def _(rid, params: dict) -> dict:
         except Exception as e:
             return _ok(rid, {"output": f"Plugin command error: {e}"})
 
+    try:
+        from agent.skill_commands import get_skill_commands
+
+        _cmd_key = f"/{_cmd_base}"
+        if _cmd_key in get_skill_commands():
+            return _methods["command.dispatch"](
+                rid,
+                {
+                    "name": _cmd_base,
+                    "arg": _cmd_arg,
+                    "session_id": params.get("session_id", ""),
+                },
+            )
+    except Exception:
+        pass
     worker = session.get("slash_worker")
     if not worker:
         try:

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -745,6 +745,40 @@ describe('createSlashHandler', () => {
     expect(ctx.transcript.send).toHaveBeenCalledWith(skillMessage)
   })
 
+  it('handles skill payloads returned directly by slash.exec', async () => {
+    patchUiState({ sid: 'sid-abc' })
+    const skillMessage = 'Use this skill to do X.\n\n## Steps\n1. First step'
+
+    const ctx = buildCtx({
+      gateway: {
+        gw: {
+          getLogTail: vi.fn(() => ''),
+          request: vi.fn((method: string) => {
+            if (method === 'slash.exec') {
+              return Promise.resolve({ type: 'skill', message: skillMessage, name: 'hermes-agent-dev' })
+            }
+
+            return Promise.resolve({})
+          })
+        },
+        rpc: vi.fn(() => Promise.resolve({}))
+      }
+    })
+
+    const h = createSlashHandler(ctx)
+    expect(h('/hermes-agent-dev investigate this bug')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.transcript.sys).toHaveBeenCalledWith('⚡ loading skill: hermes-agent-dev')
+    })
+    expect(ctx.transcript.send).toHaveBeenCalledWith(skillMessage)
+    expect(ctx.gateway.gw.request).toHaveBeenCalledWith('slash.exec', {
+      command: 'hermes-agent-dev investigate this bug',
+      session_id: 'sid-abc'
+    })
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
+  })
+
   it('handles command.dispatch payloads returned directly by slash.exec', async () => {
     patchUiState({ sid: 'sid-abc' })
 


### PR DESCRIPTION
Route TUI slash skill invocations through command.dispatch instead of returning the 4018 fallback error. This lets current TUI and desktop clients receive the same structured skill payload from slash.exec that command.dispatch already returns, while keeping client fallback coverage for older gateways.

The backend now detects skill commands after plugin handling and delegates to command.dispatch using the existing skill payload builder. TUI and desktop tests cover both the direct slash.exec skill payload path and the legacy command.dispatch fallback path.

Verified locally:
- py -m pytest tests/tui_gateway/test_protocol.py::test_slash_exec_routes_skill_commands_to_dispatch tests/tui_gateway/test_protocol.py::test_command_dispatch_returns_skill_payload tests/tui_gateway/test_protocol.py::test_slash_exec_routes_pending_input_commands_to_dispatch tests/tui_gateway/test_goal_command.py::test_slash_exec_routes_goal_to_command_dispatch -q
- git diff --check