### PR TITLE
fix(gemini): disable httpx keep-alive to prevent stale connection hangs

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -860,7 +860,11 @@ class GeminiNativeClient:
         self.chat = _GeminiChatNamespace(self)
         self.is_closed = False
         self._http = http_client or httpx.Client(
-            timeout=timeout or httpx.Timeout(connect=15.0, read=600.0, write=30.0, pool=30.0)
+            timeout=timeout or httpx.Timeout(connect=15.0, read=600.0, write=30.0, pool=30.0),
+            # Disable keep-alive to avoid stale connections in long-lived cached clients.
+            # Without this, Google API closes idle connections but httpx keeps them in the
+            # pool → new requests reuse dead sockets and hang on read timeout (600s).
+            limits=httpx.Limits(max_connections=100, max_keepalive_connections=0),
         )
 
     def close(self) -> None:


### PR DESCRIPTION
## Bug Description

Compression hangs indefinitely after `Auxiliary compression: using gemini` log entry. GCP Console shows the Gemini API call completed successfully, but Hermes never receives the response — no error logs, no completion logs. Gateway threads stuck in `futex_do_wait` (waiting on locks, not network I/O).

## Root Cause

`GeminiNativeClient` is cached as a singleton (`_client_cache`) and reused across sessions. The default `httpx.Client` keeps TCP connections alive (`max_keepalive_connections=20`). Google API closes idle connections server-side, but httpx does not detect this — it reuses the dead socket from its pool. The request sends at the TCP level (so GCP sees it), but reading the response blocks until read timeout (600s).

## Fix

Set `max_keepalive_connections=0` in `GeminiNativeClient.__init__` so each request establishes a fresh connection, eliminating stale socket reuse.

## How to Verify

1. Trigger context compression with Gemini as summary model
2. Observe that `using gemini` is followed by completion within ~5s (not 600s timeout)
3. Gateway threads no longer stuck in `futex_do_wait`

## Test Plan

- [x] Manual verification: patched client returns in 1.4s with correct response content
- [x] Confirmed `max_keepalive_connections=0` is applied at runtime

## Risk Assessment

Low — only affects `GeminiNativeClient`. Disabling keep-alive adds minimal overhead (TLS handshake ~50ms) but eliminates the hang entirely. No API surface or behavior change for callers.

## Backward Compatibility

- [x] No breaking changes