### PR TITLE
fix: exempt /dashboard-plugins/ from OAuth auth gate (#53066)

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -43,6 +43,7 @@ _GATE_PUBLIC_PREFIXES: tuple[str, ...] = (
     "/login",
     "/api/auth/providers",
     "/assets/",
+    "/dashboard-plugins/",
     "/favicon.ico",
     "/ds-assets/",
     "/fonts/",


### PR DESCRIPTION
Fixes #53066

## Description

Plugin static assets (JS/CSS) are served at `/dashboard-plugins/<name>/<path>` and loaded by the SPA via `<script src>` and `<link href>` tags — neither of which can attach custom auth headers. The OAuth `gated_auth_middleware` was returning 401 for these requests because `/dashboard-plugins/` was missing from `_GATE_PUBLIC_PREFIXES`.

The route handler (`serve_plugin_asset`) already has its own security: path traversal check via `resolve().is_relative_to()` and a browser-asset suffix allowlist (JS/CSS/JSON/HTML/SVG/PNG/JPG/WOFF/etc.). Adding the prefix to the public list simply lets the request reach the handler.

## Verification

- Added `/dashboard-plugins/` to `_GATE_PUBLIC_PREFIXES` in `hermes_cli/dashboard_auth/middleware.py`
- Compile-check passed
- No secrets, personal refs, or unrelated changes