### PR TITLE
fix(agent): clarify repeated compression warning

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -820,12 +820,6 @@ def compress_context(
         _is_boundary = bool(_old_sid) or in_place
         _boundary_parent = _old_sid or agent.session_id or ""
 
-        # Notify the context engine that a compaction boundary occurred. Plugin
-        # engines (e.g. hermes-lcm) use boundary_reason="compression" to preserve
-        # DAG lineage / checkpoint per-session state across the boundary instead of
-        # re-initializing fresh. See hermes-lcm#68. Built-in ContextCompressor
-        # ignores kwargs. Fires in BOTH modes: rotation passes old→new ids; in-place
-        # passes the SAME id (the boundary is real even though the id didn't move).
         try:
             if _is_boundary and hasattr(agent.context_compressor, "on_session_start"):
                 agent.context_compressor.on_session_start(
@@ -855,7 +849,9 @@ def compress_context(
         except Exception as _me_err:
             logger.debug("memory manager on_session_switch (compression): %s", _me_err)
 
-        # Warn on repeated compressions (quality degrades with each pass).
+        # Warn on repeated compactions without assuming the active context engine is
+        # lossy. LCM-style backends preserve originals durably, so avoid implying
+        # cumulative accuracy loss here (#53000).
         # Route through _emit_status (like the other compression warnings above)
         # so the warning reaches the TUI / Telegram / Discord via status_callback,
         # not just CLI stdout. _emit_status still _vprints for the CLI, and
@@ -864,8 +860,8 @@ def compress_context(
         _cc = agent.context_compressor.compression_count
         if _cc >= 2:
             _cc_msg = (
-                f"{agent.log_prefix}⚠️  Session compressed {_cc} times — "
-                f"accuracy may degrade. Consider /new to start fresh."
+                f"{agent.log_prefix}⚠️  Session compacted {_cc} times. "
+                f"Consider /new to start fresh."
             )
             agent._compression_warning = _cc_msg
             agent._emit_status(_cc_msg)

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -820,6 +820,12 @@ def compress_context(
         _is_boundary = bool(_old_sid) or in_place
         _boundary_parent = _old_sid or agent.session_id or ""
 
+        # Notify the context engine that a compaction boundary occurred. Plugin
+        # engines (e.g. hermes-lcm) use boundary_reason="compression" to preserve
+        # DAG lineage / checkpoint per-session state across the boundary instead of
+        # re-initializing fresh. See hermes-lcm#68. Built-in ContextCompressor
+        # ignores kwargs. Fires in BOTH modes: rotation passes old→new ids; in-place
+        # passes the SAME id (the boundary is real even though the id didn't move).
         try:
             if _is_boundary and hasattr(agent.context_compressor, "on_session_start"):
                 agent.context_compressor.on_session_start(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -79,7 +79,7 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|auto-lowered\s+compression\s+threshold"
     r"|compacting\s+context\s+[—-]\s+summarizing\s+earlier\s+conversation"
     r"|preflight\s+compression"
-    r"|session\s+compressed\s+\d+\s+times"
+    r"|session\s+comp(?:ressed|acted)\s+\d+\s+times"
     r"|rate\s+limited\.\s+waiting\s+\d"
     r"|retrying\s+in\s+\d"
     r"|max\s+retries\s+\(\d+\).*(?:trying\s+fallback|exhausted|invalid\s+responses)"

--- a/tests/agent/test_compression_count_warning_36908.py
+++ b/tests/agent/test_compression_count_warning_36908.py
@@ -1,10 +1,10 @@
 """Regression for #36908: the repeated-compression warning must reach the
 TUI / gateway, not just CLI stdout.
 
-When a session is compressed >= 2 times, ``compress_context`` warns that
-accuracy may degrade. That warning used to go through ``_vprint`` (stdout
-only), so the Ink TUI / Telegram / Discord never saw it — unlike the two
-other compression warnings in the same module, which route through
+When a session is compressed >= 2 times, ``compress_context`` emits a repeated
+compaction warning. That warning used to go through ``_vprint`` (stdout only),
+so the Ink TUI / Telegram / Discord never saw it — unlike the two other
+compression warnings in the same module, which route through
 ``_emit_status`` (and store ``_compression_warning`` for late-bound
 gateway replay). This pins the warning onto the gateway-aware channel.
 """
@@ -54,7 +54,7 @@ def test_repeated_compression_warning_routed_through_emit_status(tmp_path: Path)
     sid = "PARENT_36908"
     db.create_session(sid, source="cli")
 
-    # compression_count == 2 → the "compressed N times" warning should fire.
+    # compression_count == 2 → the repeated-compaction warning should fire.
     agent = _build_agent_with_db(db, sid, compression_count=2)
 
     emitted: list[str] = []
@@ -64,11 +64,16 @@ def test_repeated_compression_warning_routed_through_emit_status(tmp_path: Path)
     agent._compress_context(messages, "sys", approx_tokens=120_000)
 
     # The warning reached the gateway-aware channel...
-    assert any("compressed 2 times" in m.lower() for m in emitted), (
+    assert any("compacted 2 times" in m.lower() for m in emitted), (
         f"repeated-compression warning not emitted via _emit_status: {emitted}"
     )
+    assert all("accuracy may degrade" not in m.lower() for m in emitted)
+    assert any("/new" in m for m in emitted)
     # ...and was stored for late-bound gateway status_callback replay.
-    assert "compressed 2 times" in (getattr(agent, "_compression_warning", "") or "").lower()
+    stored_warning = getattr(agent, "_compression_warning", "") or ""
+    assert "compacted 2 times" in stored_warning.lower()
+    assert "accuracy may degrade" not in stored_warning.lower()
+    assert "/new" in stored_warning
 
 
 def test_no_warning_below_threshold(tmp_path: Path) -> None:
@@ -84,4 +89,4 @@ def test_no_warning_below_threshold(tmp_path: Path) -> None:
     messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
     agent._compress_context(messages, "sys", approx_tokens=120_000)
 
-    assert not any("compressed" in m.lower() and "times" in m.lower() for m in emitted)
+    assert not any("compacted" in m.lower() and "times" in m.lower() for m in emitted)

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -32,6 +32,7 @@ NOISY_STATUS_MESSAGES = [
     "🗜️ Preflight compression check before sending...",
     "🗜️ Compacting context — summarizing earlier conversation so I can continue...",
     "⚠️  Session compressed 12 times — accuracy may degrade. Consider /new to start fresh.",
+    "⚠️  Session compacted 12 times. Consider /new to start fresh.",
     "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",
     "⏱️ Rate limited. Waiting 30.0s (attempt 2/3)...",
     "⏳ Retrying in 4.2s (attempt 1/3)...",


### PR DESCRIPTION
## Summary
- reword the repeated compression warning so it does not claim accuracy may degrade
- keep the existing repeated-compression behavior: warning still emits at compression_count >= 2, stores `_compression_warning`, and routes through `_emit_status`
- update the regression test to require the count and `/new` guidance while rejecting `accuracy may degrade`

Fixes #53000

## Tests
- `uv run --extra dev pytest tests/agent/test_compression_count_warning_36908.py tests/run_agent/test_in_place_compaction.py` — 11 passed in 18.63s
- `git diff --check` — passed (no output)