### PR TITLE
fix(matrix): make message length limit configurable via MATRIX_MAX_MESSAGE_LENGTH

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -337,8 +337,13 @@ class _MatrixModelPickerPrompt:
 
 
 # Matrix message size limit (4000 chars practical, spec has no hard limit
-# but clients render poorly above this).
-MAX_MESSAGE_LENGTH = 4000
+# but clients render poorly above this). Overridable via MATRIX_MAX_MESSAGE_LENGTH
+# for homeservers/clients that handle larger events (e.g. to keep wide Markdown
+# tables in a single message).
+try:
+    MAX_MESSAGE_LENGTH = int(os.getenv("MATRIX_MAX_MESSAGE_LENGTH", "4000"))
+except ValueError:
+    MAX_MESSAGE_LENGTH = 4000
 
 # Store directory for E2EE keys and sync state.
 # Uses get_hermes_home() so each profile gets its own Matrix store.
@@ -4391,7 +4396,7 @@ def register(ctx) -> None:
         allow_all_env="MATRIX_ALLOW_ALL_USERS",
         cron_deliver_env_var="MATRIX_HOME_ROOM",
         standalone_sender_fn=_standalone_send,
-        max_message_length=4000,
+        max_message_length=MAX_MESSAGE_LENGTH,
         emoji="🔐",
         allow_update_command=True,
     )

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -251,6 +251,36 @@ def _make_fake_mautrix():
 # Platform & Config
 # ---------------------------------------------------------------------------
 
+class TestMatrixMaxMessageLength:
+    """MAX_MESSAGE_LENGTH is configurable via MATRIX_MAX_MESSAGE_LENGTH."""
+
+    def _reload_adapter(self):
+        import importlib
+        import plugins.platforms.matrix.adapter as adapter
+        return importlib.reload(adapter)
+
+    def test_default_is_4000(self, monkeypatch):
+        monkeypatch.delenv("MATRIX_MAX_MESSAGE_LENGTH", raising=False)
+        adapter = self._reload_adapter()
+        assert adapter.MAX_MESSAGE_LENGTH == 4000
+
+    def test_env_override_applied(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_MAX_MESSAGE_LENGTH", "16000")
+        adapter = self._reload_adapter()
+        assert adapter.MAX_MESSAGE_LENGTH == 16000
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_MAX_MESSAGE_LENGTH", "not-a-number")
+        adapter = self._reload_adapter()
+        assert adapter.MAX_MESSAGE_LENGTH == 4000
+
+    def teardown_method(self):
+        # Restore the module to its unconfigured default for later tests.
+        import importlib
+        import plugins.platforms.matrix.adapter as adapter
+        importlib.reload(adapter)
+
+
 class TestMatrixConfigLoading:
     def test_apply_env_overrides_with_access_token(self, monkeypatch):
         monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_abc123")

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -434,6 +434,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `MATRIX_APPROVAL_TIMEOUT_SECONDS` | Timeout for Matrix reaction approval/model-picker prompts (default: `300`) |
 | `MATRIX_ALLOW_PUBLIC_ROOMS` | Allow Matrix room-creation tools to create public rooms (default: `false`) |
 | `MATRIX_MAX_MEDIA_BYTES` | Maximum Matrix media upload/download size in bytes (default: `104857600`) |
+| `MATRIX_MAX_MESSAGE_LENGTH` | Character limit before outbound Matrix messages are split into continuation chunks (default: `4000`). Raise it to keep wide Markdown tables in a single message. |
 | `MATRIX_RECOVERY_KEY` | Recovery key for cross-signing verification after device key rotation. Recommended for E2EE setups with cross-signing enabled. |
 | `MATRIX_RECOVERY_KEY_OUTPUT_FILE` | Optional one-time path for a generated Matrix recovery key. Created with mode `0600` and never overwritten. |
 | `HASS_TOKEN` | Home Assistant Long-Lived Access Token (enables HA platform + tools) |


### PR DESCRIPTION
## What does this PR do?

The Matrix adapter hardcoded `MAX_MESSAGE_LENGTH = 4000` in two places (`plugins/platforms/matrix/adapter.py`), so long responses such as wide Markdown tables were split into continuation chunks mid-table, breaking their formatting, with no way to raise the threshold.

This makes the limit configurable via a new `MATRIX_MAX_MESSAGE_LENGTH` env var, following the file's existing `os.getenv("MATRIX_*", default)` convention (cf. `MATRIX_MAX_MEDIA_BYTES`). The default stays `4000`, so behavior is unchanged unless the var is set. The reporter noted the config-var approach alone is sufficient, so the shared `truncate_message()` splitter is intentionally left untouched.

## Related Issue

Fixes #53026

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/matrix/adapter.py`: read `MAX_MESSAGE_LENGTH` from `MATRIX_MAX_MESSAGE_LENGTH` (default `4000`, falls back to `4000` on a non-integer value); use the constant in `register()` instead of a second `4000` literal.
- `tests/gateway/test_matrix.py`: new `TestMatrixMaxMessageLength` covering default, env override, and invalid-value fallback.
- `website/docs/reference/environment-variables.md`: document `MATRIX_MAX_MESSAGE_LENGTH`.

## How to Test

1. `python3 -c 'import plugins.platforms.matrix.adapter as a; print(a.MAX_MESSAGE_LENGTH)'` → `4000`.
2. `MATRIX_MAX_MESSAGE_LENGTH=16000 python3 -c 'import plugins.platforms.matrix.adapter as a; print(a.MAX_MESSAGE_LENGTH)'` → `16000`.
3. `pytest tests/gateway/test_matrix.py -k MaxMessageLength -q` → 3 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] I've updated relevant documentation (environment-variables reference)