### PR TITLE
Keep OpenAI Codex and OpenAI API as separate model-picker choices

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1090,7 +1090,6 @@ PROVIDER_GROUPS: dict[str, tuple[str, str, list[str]]] = {
     "minimax":  ("MiniMax",         "Global, OAuth Coding Plan & China endpoints",     ["minimax", "minimax-oauth", "minimax-cn"]),
     "xai":      ("xAI Grok",        "Direct API or SuperGrok / Premium+ OAuth",        ["xai", "xai-oauth"]),
     "google":   ("Google Gemini",   "Google AI Studio (API key)",                     ["gemini"]),
-    "openai":   ("OpenAI",          "Codex CLI or direct OpenAI API",                  ["openai-codex", "openai-api"]),
     "opencode": ("OpenCode",        "Zen pay-as-you-go or Go subscription",            ["opencode-zen", "opencode-go"]),
     "copilot":  ("GitHub Copilot",  "GitHub token API or copilot --acp process",       ["copilot", "copilot-acp"]),
 }

--- a/tests/hermes_cli/test_provider_groups.py
+++ b/tests/hermes_cli/test_provider_groups.py
@@ -60,6 +60,15 @@ def test_ungrouped_providers_pass_through_in_order():
     assert [r["slug"] for r in rows] == ["nous", "openrouter", "deepseek"]
 
 
+def test_openai_providers_remain_separate_top_level_rows():
+    """OpenAI Codex and OpenAI API must stay as separate first-step choices."""
+    rows = group_providers(["openai-codex", "openai-api"])
+    assert all(r["kind"] == "single" for r in rows)
+    assert [r["slug"] for r in rows] == ["openai-codex", "openai-api"]
+    assert provider_group_for_slug("openai-codex") == ""
+    assert provider_group_for_slug("openai-api") == ""
+
+
 def test_multi_member_group_folds_to_one_row():
     rows = group_providers(["minimax", "minimax-oauth", "minimax-cn"])
     assert len(rows) == 1


### PR DESCRIPTION
## What
Removes the `openai` entry from `PROVIDER_GROUPS` so **OpenAI Codex** (`openai-codex`) and **OpenAI API** (`openai-api`) appear as two separate top-level rows in the model picker, instead of being folded under a single "OpenAI" group that requires an extra drill-in step.

## Why
Unlike the other grouped providers (e.g. `minimax`, `xai`) whose members are variants of the *same* credential/path, `openai-codex` and `openai-api` are genuinely **different setups**: a Codex CLI subscription vs. a direct OpenAI API key. Folding them behind one "OpenAI" row adds a navigation step and conflates two unrelated auth flows. Surfacing them as first-class choices matches how other distinct-auth providers are listed and shortens the common "I just want the API key" path by one step.

## Change
- `hermes_cli/models.py`: drop the single `"openai"` `PROVIDER_GROUPS` line (one deletion).
- `tests/hermes_cli/test_provider_groups.py`: add a test pinning the two slugs as separate, ungrouped top-level rows.

No behavior change for any other provider. `pytest tests/hermes_cli/test_provider_groups.py` → 12 passed.