### PR TITLE
fix(tui): update dashboard reconnect breadcrumb on /branch

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1173,6 +1173,11 @@ def test_session_branch_persists_branched_from_marker(server, monkeypatch):
     assert kwargs["parent_session_id"] == parent_key
     # The marker — without it the branch is invisible in /resume and /sessions.
     assert kwargs["model_config"] == {"_branched_from": parent_key}
+    # session_key must be in the response so the TUI can update the dashboard
+    # reconnect breadcrumb — without it, a WebSocket drop after /branch
+    # resumes the stale parent session instead of the branch.
+    result = resp.get("result", {})
+    assert result.get("session_key") == "20260101_000001_child0"
 
 
 def test_make_agent_accepts_list_system_prompt(server, monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7681,7 +7681,7 @@ def _(rid, params: dict) -> dict:
         if lease is not None:
             lease.release()
         return _err(rid, 5000, f"agent init failed on branch: {e}")
-    return _ok(rid, {"session_id": new_sid, "title": title, "parent": old_key})
+    return _ok(rid, {"session_id": new_sid, "session_key": new_key, "title": title, "parent": old_key})
 
 
 @method("session.interrupt")

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -22,11 +22,21 @@ vi.mock('../config/env.js', async importActual => {
   }
 })
 
+const mockWriteActiveSessionFile = vi.fn()
+vi.mock('../app/useSessionLifecycle.js', async importActual => {
+  const actual = await importActual<Record<string, unknown>>()
+  return {
+    ...actual,
+    writeActiveSessionFile: (...args: unknown[]) => mockWriteActiveSessionFile(...args),
+  }
+})
+
 describe('createSlashHandler', () => {
   beforeEach(() => {
     resetOverlayState()
     resetUiState()
     envState.dashboardTuiMode = false
+    mockWriteActiveSessionFile.mockReset()
   })
 
   it('opens the unified sessions overlay for /resume', () => {
@@ -360,7 +370,7 @@ describe('createSlashHandler', () => {
 
   it('keeps visible scrollback when branching a TUI session', async () => {
     patchUiState({ sid: 'sid-parent' })
-    const rpc = vi.fn(() => Promise.resolve({ session_id: 'sid-branch', title: 'branch title' }))
+    const rpc = vi.fn(() => Promise.resolve({ session_id: 'sid-branch', session_key: 'key-branch', title: 'branch title' }))
     const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
 
     expect(createSlashHandler(ctx)('/branch branch title')).toBe(true)
@@ -371,6 +381,7 @@ describe('createSlashHandler', () => {
       expect(ctx.transcript.sys).toHaveBeenCalledWith('branched → branch title')
     })
     expect(ctx.transcript.setHistoryItems).not.toHaveBeenCalled()
+    expect(mockWriteActiveSessionFile).toHaveBeenCalledWith('key-branch')
   })
 
   it('reloads skills in the live gateway and refreshes the catalog', async () => {

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -1,4 +1,5 @@
 import { attachedImageNotice, introMsg, toTranscriptMessages } from '../../../domain/messages.js'
+import { writeActiveSessionFile } from '../../useSessionLifecycle.js'
 import { TUI_SESSION_MODEL_FLAG } from '../../../domain/slash.js'
 import type {
   BackgroundStartResponse,
@@ -250,6 +251,7 @@ export const sessionCommands: SlashCommand[] = [
           }
 
           void ctx.session.closeSession(prevSid)
+          writeActiveSessionFile(r.session_key ?? r.session_id)
           patchUiState({ sid: r.session_id })
           ctx.session.setSessionStartedAt(Date.now())
           ctx.transcript.sys(`branched → ${r.title ?? ''}`)

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -355,6 +355,7 @@ export interface SessionCompressResponse {
 
 export interface SessionBranchResponse {
   session_id?: string
+  session_key?: string
   title?: string
 }
 


### PR DESCRIPTION
## Summary

The dashboard PTY reconnect feature (41f812614 "Reconnect dashboard PTY chat after socket drops") writes a per-channel breadcrumb file so an unclean WebSocket drop auto-resumes the correct session. Three session-switch paths already call `writeActiveSessionFile`:

- `startNewSession` (useSessionLifecycle.ts:223)
- `activateLiveSession` (useSessionLifecycle.ts:312)
- `resumeById` (useSessionLifecycle.ts:366)

But `/branch` (`/fork`) switches the active session without updating the breadcrumb.

After `/branch` the breadcrumb still points at the parent session (which is immediately closed via `closeSession(prevSid)`). A WebSocket drop then resumes the stale parent — silently losing the branched conversation.

## Changes

| File | Change |
|------|--------|
| `tui_gateway/server.py` | Return `session_key` in `session.branch` RPC response |
| `ui-tui/src/app/slash/commands/session.ts` | Call `writeActiveSessionFile(r.session_key ?? r.session_id)` after branch |
| `ui-tui/src/gatewayTypes.ts` | Add `session_key` to `SessionBranchResponse` |

## Test plan

- [x] Existing branch test updated to verify `writeActiveSessionFile` is called with the persistent session key
- [x] Server-side test asserts `session_key` is present in the branch RPC response
- [x] `npx vitest run ui-tui/src/__tests__/createSlashHandler.test.ts` — 66 passed
- [x] `pytest tests/tui_gateway/test_protocol.py::test_session_branch_persists_branched_from_marker` — 1 passed