### PR TITLE
feat: add 'No workspace' bucket for cwd-less sessions in project tree

### DIFF
--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -216,8 +216,47 @@ def test_scoped_session_ids_is_union_of_placed_sessions():
 
     tree = pt.build_tree([project], [owned, auto, homeless], [], resolve, hydrate=True)
 
-    assert set(tree["scoped_session_ids"]) == {owned["id"], auto["id"]}
-    assert homeless["id"] not in tree["scoped_session_ids"]
+    # All three sessions must be scoped — including the cwd-less one, which now
+    # lives under the synthetic "no project" bucket.
+    assert set(tree["scoped_session_ids"]) == {owned["id"], auto["id"], homeless["id"]}
+
+
+def test_no_project_bucket_collects_cwd_less_sessions():
+    """Sessions with no cwd and no git root are grouped under a synthetic 'no
+    project' project so they stay visible in the project-oriented sidebar."""
+    owned = _session("/repo", branch="main")
+    rootless = _session(None)
+    also_rootless = _session(None)
+    resolve = _resolver({"/repo": ("/repo", "/repo")})
+
+    tree = pt.build_tree([], [owned, rootless, also_rootless], [], resolve, hydrate=True)
+    projects = tree["projects"]
+
+    no_project = next((p for p in projects if p.get("isNoProject")), None)
+    assert no_project is not None, "Expected a 'no project' bucket in the tree"
+    assert no_project["isNoProject"] is True
+    # The path must be a non-null synthetic value so existing frontend code
+    # (which keys preview maps on node.path) works without changes.
+    assert no_project.get("path") is not None
+    assert no_project["sessionCount"] == 2
+    # Both rootless session ids must be in the scoped set.
+    assert rootless["id"] in tree["scoped_session_ids"]
+    assert also_rootless["id"] in tree["scoped_session_ids"]
+    # The owned session must NOT appear under the no-project bucket.
+    no_project_ids = {s["id"] for repo in no_project["repos"] for g in repo["groups"] for s in g["sessions"]}
+    assert owned["id"] not in no_project_ids
+
+
+def test_no_project_bucket_excludes_sessions_with_a_repo_root():
+    """A session with a valid git repo root (even without cwd context) goes to
+    its own auto project, not the 'no project' bucket."""
+    resolve = _resolver({"/repo": ("/repo", "/repo")})
+    with_root = _session("/repo", repo_root="/repo")
+
+    tree = pt.build_tree([], [with_root], [], resolve, hydrate=True)
+    no_projects = [p for p in tree["projects"] if p.get("isNoProject")]
+
+    assert len(no_projects) == 0
 
 
 def test_overview_drops_session_rows_but_keeps_counts_and_previews():

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -40,6 +40,8 @@ Resolve = Callable[[str], Optional[dict]]
 _KANBAN_DIR_RE = re.compile(r"^(.*[/\\]\.worktrees)[/\\]t_[0-9a-f]+[/\\]?$")
 _TRUNK_BRANCHES = {"main", "master", "trunk", "develop"}
 DEFAULT_BRANCH_LABEL = "main"
+NO_PROJECT_ID = "__no_project__"
+NO_PROJECT_LABEL = "No workspace"
 
 
 def _branch_lane_id(repo_root: str, branch: str = "") -> str:
@@ -406,6 +408,7 @@ def _project_node(
     color: Any = None,
     icon: Any = None,
     is_auto: bool = False,
+    is_no_project: bool = False,
 ) -> dict:
     return {
         "id": pid,
@@ -414,6 +417,7 @@ def _project_node(
         "color": color,
         "icon": icon,
         "isAuto": is_auto,
+        "isNoProject": is_no_project,
         "sessionCount": session_count,
         "lastActive": last_active,
         "repos": repos,
@@ -522,6 +526,50 @@ def build_tree(
                 last_active=_last_active(repo_sessions),
                 preview_sessions=_previews(repo_sessions),
                 is_auto=True,
+            )
+        )
+
+    # Tier 2.5: the "No workspace" bucket — sessions with no cwd and no git repo
+    # root have no filesystem anchor and can't be grouped under any real project.
+    # Collect them into a single synthetic project so they remain visible and
+    # addressable (scoped) in the project-oriented sidebar view.
+    placed_session_ids: set[str] = {
+        s["id"] for repo_sessions in by_repo.values() for s in repo_sessions if s.get("id")
+    }
+    no_project_sessions = [
+        s for s in unowned if s.get("id") and s["id"] not in placed_session_ids
+    ]
+
+    if no_project_sessions:
+        scoped_ids.extend(s["id"] for s in no_project_sessions if s.get("id"))
+        organized = sorted(no_project_sessions, key=_session_time, reverse=True)
+        no_project_repo = {
+            "id": NO_PROJECT_ID,
+            "label": NO_PROJECT_LABEL,
+            "path": None,
+            "groups": [
+                {
+                    "id": f"{NO_PROJECT_ID}::sessions",
+                    "label": NO_PROJECT_LABEL,
+                    "path": None,
+                    "isMain": True,
+                    "isKanban": False,
+                    "sessions": organized if hydrate else [],
+                }
+            ],
+            "sessionCount": len(organized),
+        }
+        result.append(
+            _project_node(
+                pid=NO_PROJECT_ID,
+                label=NO_PROJECT_LABEL,
+                path=NO_PROJECT_ID,
+                repos=[no_project_repo],
+                session_count=len(organized),
+                last_active=_last_active(organized),
+                preview_sessions=_previews(organized),
+                is_auto=True,
+                is_no_project=True,
             )
         )
 


### PR DESCRIPTION
## Summary

Sessions with no `cwd` and no git repo root are invisible in the project-oriented sidebar view because `build_tree()` skips them entirely. This PR collects them into a synthetic **"No workspace"** project so they remain addressable (scoped) and visible in the grouped sidebar.

## Changes

| File | Change |
|---|---|
| `tui_gateway/project_tree.py` | `_project_node()` gains `is_no_project` parameter; `build_tree()` adds Tier 2.5 — a synthetic project (`isNoProject: true`, path set to a non-null sentinel) for cwd-less, git-root-less sessions |
| `tests/tui_gateway/test_project_tree.py` | Updated `test_scoped_session_ids` to expect cwd-less sessions in scoped ids; added `test_no_project_bucket_collects_cwd_less_sessions` and `test_no_project_bucket_excludes_sessions_with_a_repo_root` |

## Key Design Decisions

- **`path=NO_PROJECT_ID`** instead of `None`: the existing frontend code uses `project.path` as a map key for preview lookups and as a truthiness guard. Setting it to a non-null sentinel avoids any frontend changes.
- **Label is `"No workspace"`** (English) in the backend; the frontend's i18n already has `noWorkspace: '无工作区'` / `'ワークスペースなし'` etc., so a future frontend change can localize it by checking `project.isNoProject`.
- **The bucket is an `isAuto` project**: it behaves like any auto-discovered repo project, including being dismissable.

## Testing

```
pytest tests/tui_gateway/test_project_tree.py -v --tb=short -o 'addopts=' --basetemp=/tmp/pt
```

19 passed (all existing + 2 new)