### PR TITLE
fix: show both kimi-coding and kimi-coding-cn in /model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -368,8 +368,8 @@ def resolve_persist_behavior(is_global: bool, is_session: bool) -> bool:
     1. ``--session`` explicitly opts out → ``False`` (this session only).
     2. ``--global`` explicitly opts in → ``True``.
     3. Otherwise defer to ``model.persist_switch_by_default`` in
-       ``config.yaml`` (defaults to ``True``, so a plain ``/model <name>``
-       survives across sessions — the behavior users expect).
+       ``config.yaml`` (defaults to ``False`` — plain ``/model <name>``
+       is session-only so different platforms don't cross-contaminate).
 
     The config read is defensive: on a fresh install ``model`` may be a
     flat string rather than a dict, in which case the built-in default
@@ -384,10 +384,10 @@ def resolve_persist_behavior(is_global: bool, is_session: bool) -> bool:
 
         model_cfg = load_config().get("model")
         if isinstance(model_cfg, dict):
-            return bool(model_cfg.get("persist_switch_by_default", True))
+            return bool(model_cfg.get("persist_switch_by_default", False))
     except Exception:
         pass
-    return True
+    return False
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1468,7 +1468,6 @@ def list_authenticated_providers(
 
     results: List[dict] = []
     seen_slugs: set = set()  # lowercase-normalized to catch case variants (#9545)
-    seen_mdev_ids: set = set()  # prevent duplicate entries for aliases (e.g. kimi-coding + kimi-coding-cn)
     # Effective base URLs of every built-in row we emit (normalized lower+rstrip).
     # Section 4 uses this to hide ``custom_providers`` entries that point at the
     # same endpoint as a built-in (e.g. a user-defined "my-dashscope" on
@@ -1603,10 +1602,30 @@ def list_authenticated_providers(
             and _alias_target in _AGG_PROVIDERS
         ):
             continue
-        # Skip aliases that map to the same models.dev provider (e.g.
-        # kimi-coding and kimi-coding-cn both → kimi-for-coding).
-        # The first one with valid credentials wins (#10526).
-        if mdev_id in seen_mdev_ids:
+        # Resolve the canonical provider profile name.  Skip hermes_ids
+        # that are mere aliases resolving to a different canonical profile
+        # (e.g. "kimi" and "moonshot" both → "kimi-coding").  Only process
+        # entries whose hermes_id matches the canonical profile name so
+        # distinct profiles (e.g. kimi-coding, kimi-coding-cn) each get
+        # their own picker row.
+        _canonical = hermes_id
+        try:
+            from providers import get_provider_profile as _gpp
+            _prof = _gpp(hermes_id)
+            if _prof is not None:
+                _canonical = _prof.name
+        except Exception:
+            pass
+        if _canonical != hermes_id:
+            continue
+
+        # Skip duplicates: another entry with the same slug was already
+        # emitted (e.g. two PROVIDER_TO_MODELS_DEV entries routing to the
+        # same hermes_id).  Distinct canonical profiles that share a
+        # models.dev ID (e.g. kimi-coding and kimi-coding-cn → kimi-for-coding)
+        # are both allowed through since they have different slugs.
+        slug = hermes_id
+        if slug.lower() in seen_slugs:
             continue
         pdata = data.get(mdev_id)
         if not isinstance(pdata, dict):
@@ -1652,9 +1671,8 @@ def list_authenticated_providers(
         total = len(model_ids)
         top = model_ids[:max_models] if max_models is not None else model_ids
 
-        slug = hermes_id
         pinfo = _mdev_pinfo(mdev_id)
-        display_name = pinfo.name if pinfo else mdev_id
+        display_name = pconfig.name if pconfig and pconfig.name else (pinfo.name if pinfo else mdev_id)
 
         results.append({
             "slug": slug,
@@ -1666,7 +1684,6 @@ def list_authenticated_providers(
             "source": "built-in",
         })
         seen_slugs.add(slug.lower())
-        seen_mdev_ids.add(mdev_id)
         _record_builtin_endpoint(slug)
 
     # --- 2. Check Hermes-only providers (nous, openai-codex, copilot, opencode-go) ---

--- a/tests/hermes_cli/test_kimi_cn_provider_listing.py
+++ b/tests/hermes_cli/test_kimi_cn_provider_listing.py
@@ -1,0 +1,119 @@
+"""Test that kimi-coding and kimi-coding-cn both appear in the /model picker.
+
+Both providers share the same models.dev ID (kimi-for-coding) but are distinct
+profiles with different API keys, base URLs, and endpoints.  The /model picker
+must show both so users can pick the right endpoint for their key type.
+
+Regression: the original ``seen_mdev_ids`` dedup by mdev_id alone would skip
+kimi-coding-cn after kimi-coding was emitted because both map to
+``kimi-for-coding`` (#10526).  The fix deduplicates by
+``(mdev_id, canonical_profile_name)`` instead, allowing distinct profiles
+through.
+"""
+
+import os
+from unittest.mock import patch
+
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+# -- Only KIMI_CN_API_KEY set ------------------------------------------------
+
+
+@patch.dict(os.environ, {"KIMI_CN_API_KEY": "sk-cn-fake"}, clear=False)
+def test_kimi_cn_appears_when_only_cn_key_set():
+    """kimi-coding-cn should appear when only KIMI_CN_API_KEY is set."""
+    providers = list_authenticated_providers(current_provider="kimi-coding-cn")
+
+    # kimi-coding-cn must be listed (it has credentials)
+    cn = next((p for p in providers if p["slug"] == "kimi-coding-cn"), None)
+    assert cn is not None, (
+        "kimi-coding-cn should appear when KIMI_CN_API_KEY is set"
+    )
+    assert cn["is_current"] is True
+    assert cn["total_models"] > 0
+
+    # kimi-coding must NOT appear (no KIMI_API_KEY)
+    intl = next((p for p in providers if p["slug"] == "kimi-coding"), None)
+    assert intl is None, (
+        "kimi-coding should NOT appear when only KIMI_CN_API_KEY is set"
+    )
+
+
+# -- Only KIMI_API_KEY set ---------------------------------------------------
+
+
+@patch.dict(os.environ, {"KIMI_API_KEY": "sk-intl-fake"}, clear=False)
+def test_kimi_intl_appears_when_only_intl_key_set():
+    """kimi-coding (international) should appear when only KIMI_API_KEY is set."""
+    providers = list_authenticated_providers(current_provider="kimi-coding")
+
+    intl = next((p for p in providers if p["slug"] == "kimi-coding"), None)
+    assert intl is not None, (
+        "kimi-coding should appear when KIMI_API_KEY is set"
+    )
+    assert intl["is_current"] is True
+
+    # kimi-coding-cn must NOT appear (no KIMI_CN_API_KEY)
+    cn = next((p for p in providers if p["slug"] == "kimi-coding-cn"), None)
+    assert cn is None, (
+        "kimi-coding-cn should NOT appear when only KIMI_API_KEY is set"
+    )
+
+
+# -- Both keys set -----------------------------------------------------------
+
+@patch.dict(os.environ, {
+    "KIMI_API_KEY": "sk-intl-fake",
+    "KIMI_CN_API_KEY": "sk-cn-fake",
+}, clear=False)
+def test_both_kimi_providers_appear_when_both_keys_set():
+    """Both kimi-coding and kimi-coding-cn should appear when both keys set.
+
+    They are distinct profiles with different env vars and endpoints.  The
+    existing aliases (kimi, moonshot → kimi-coding; kimi-cn, moonshot-cn →
+    kimi-coding-cn) must NOT create additional rows.
+    """
+    providers = list_authenticated_providers(current_provider="kimi-coding")
+
+    # Both profile slugs must appear
+    intl = next((p for p in providers if p["slug"] == "kimi-coding"), None)
+    assert intl is not None, "kimi-coding should appear when KIMI_API_KEY is set"
+    assert intl["is_current"] is True
+
+    cn = next((p for p in providers if p["slug"] == "kimi-coding-cn"), None)
+    assert cn is not None, (
+        "kimi-coding-cn should appear when KIMI_CN_API_KEY is set"
+    )
+    assert cn["is_current"] is False  # `current_provider` is kimi-coding
+
+    # Exactly 2 Kimi entries — no duplicates for aliases (kimi, moonshot,
+    # moonshot-cn, kimi-cn)
+    kimi_slugs = [p["slug"] for p in providers if "kimi" in p["slug"] or "moonshot" in p["slug"]]
+    assert len(kimi_slugs) == 2, (
+        f"Expected exactly 2 Kimi entries (kimi-coding, kimi-coding-cn), "
+        f"got {kimi_slugs}"
+    )
+
+
+# -- Both aliases deduped correctly ------------------------------------------
+
+@patch.dict(os.environ, {
+    "KIMI_API_KEY": "sk-intl-fake",
+    "KIMI_CN_API_KEY": "sk-cn-fake",
+}, clear=False)
+def test_kimi_aliases_not_listed_separately():
+    """Alias hermes_ids (kimi, moonshot) must NOT create phantom picker rows.
+
+    They resolve to the same canonical profile (kimi-coding) and should be
+    deduped.  Only the canonical slug (kimi-coding) should appear.
+    """
+    providers = list_authenticated_providers(current_provider="kimi-coding-cn")
+
+    slugs = {p["slug"] for p in providers}
+    # These alias slugs must NOT appear
+    for bad_slug in ("kimi", "moonshot", "moonshot-cn", "kimi-cn"):
+        assert bad_slug not in slugs, (
+            f"Alias slug '{bad_slug}' must not appear in picker (resolved to "
+            f"canonical profile)"
+        )


### PR DESCRIPTION
## Problem 1: Only one Kimi entry in /model picker

Both `kimi-coding` (international) and `kimi-coding-cn` (China) share the same models.dev ID `kimi-for-coding`. The /model picker was deduplicating by mdev_id alone, so only the first Kimi entry with credentials appeared — typically international, even when the user only has KIMI_CN_API_KEY set.

Users with China API keys could not see or select the CN variant, causing:
```
RuntimeError: Provider 'kimi-coding' is set in config.yaml but no API key was found.
```

### Fix

**Filter non-canonical aliases:** Resolve canonical profile name via `get_provider_profile()`. Skip alias hermes_ids (kimi, moonshot → kimi-coding).

**Deduplicate by slug instead of mdev_id:** After filtering, dedup by slug so distinct canonical profiles (kimi-coding, kimi-coding-cn) each get their own picker row.

**Display name:** Prefer `PROVIDER_REGISTRY[name]` so CN variant shows "Kimi / Moonshot (China)" instead of sharing the generic models.dev label.

## Problem 2: /model switches cross-contaminate across platforms

`model.persist_switch_by_default` was `True`, so every `/model <name>` on any platform (Feishu, Telegram, Desktop TUI) wrote the provider/model to the global `config.yaml`. The next platform to read config.yaml would silently adopt the other platform's model.

### Fix

Change the default to `False`. Plain `/model <name>` is now session-only. Use `--global` to persist. Pre-existing config values are respected; only the implicit default changes.

## Test coverage

4 new tests in `tests/hermes_cli/test_kimi_cn_provider_listing.py`:
- Only KIMI_CN_API_KEY set → only kimi-coding-cn appears
- Only KIMI_API_KEY set → only kimi-coding appears
- Both keys set → both providers appear, no aliases duplicated
- Alias slugs never appear as picker rows

All existing tests pass.