### PR TITLE
fix(desktop): lazy-require simple-git so module loads when dep is missing

### DIFF
--- a/apps/desktop/electron/git-review-ops.cjs
+++ b/apps/desktop/electron/git-review-ops.cjs
@@ -10,7 +10,20 @@ const { execFile } = require('node:child_process')
 const fs = require('node:fs/promises')
 const path = require('node:path')
 
-const simpleGit = require('simple-git')
+// Lazy require so the module loads even when simple-git is unavailable
+// (e.g. bundling failed, or the packaged asar doesn't include it).
+// All callers already handle null/empty returns gracefully.
+let _simpleGit = null
+function loadSimpleGit() {
+  if (_simpleGit === null) {
+    try {
+      _simpleGit = require('simple-git')
+    } catch {
+      _simpleGit = false
+    }
+  }
+  return _simpleGit || false
+}
 
 const { resolveRequestedPathForIpc } = require('./hardening.cjs')
 
@@ -45,7 +58,11 @@ function runGh(args, cwd, ghBin) {
 }
 
 function gitFor(cwd, gitBin) {
-  return simpleGit({ baseDir: cwd, binary: gitBin || 'git', maxConcurrentProcesses: 4, trimmed: false })
+  const sg = loadSimpleGit()
+  if (!sg) {
+    return null
+  }
+  return sg({ baseDir: cwd, binary: gitBin || 'git', maxConcurrentProcesses: 4, trimmed: false })
 }
 
 // simple-git reports renames as `old => new` (and `dir/{old => new}/f`); resolve


### PR DESCRIPTION
Fixes #53069

## Description

The desktop app crashes at startup with `Error: Cannot find module 'simple-git'` when the dependency is unavailable in the packaged asar (e.g. bundling was skipped, failed, or the user runs a version before the bundling step was added).

The root cause: `git-review-ops.cjs` does a top-level `require('simple-git')` at module load time. If simple-git isn't available, the entire Electron main process crashes before any IPC handler can catch the error.

The fix:
- Replace the eager top-level `require('simple-git')` with a lazy loader that catches the missing-module error and returns `false`
- `gitFor()` returns `null` when simple-git is unavailable
- All callers already have try-catch blocks that return empty/null results, so they degrade gracefully without any changes to the IPC handlers

## Verification
- `node --check` confirms valid JS syntax
- Module loads successfully even when `require('simple-git')` is mocked to throw
- All existing exports are preserved
- No secrets, personal refs, or unrelated changes