### PR TITLE
fix(kanban): scope GitHub CLI auth forwarding to workers

### DIFF
--- a/tests/hermes_cli/test_kanban_worker_github_env.py
+++ b/tests/hermes_cli/test_kanban_worker_github_env.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+
+FAKE_TOKEN = "fake-token-for-test"
+
+
+def test_normal_terminal_env_still_strips_github_tokens(monkeypatch):
+    from tools.environments.local import _make_run_env
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    run_env = _make_run_env({"GH_TOKEN": FAKE_TOKEN, "GITHUB_TOKEN": FAKE_TOKEN})
+
+    assert "GH_TOKEN" not in run_env
+    assert "GITHUB_TOKEN" not in run_env
+
+
+def test_force_prefix_can_forward_github_token_to_subprocess(monkeypatch):
+    from tools.environments.local import _make_run_env
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    run_env = _make_run_env({"_HERMES_FORCE_GITHUB_TOKEN": FAKE_TOKEN})
+
+    assert run_env["GITHUB_TOKEN"] == FAKE_TOKEN
+    assert "_HERMES_FORCE_GITHUB_TOKEN" not in run_env
+
+
+def test_force_prefix_can_forward_gh_token_to_subprocess(monkeypatch):
+    from tools.environments.local import _make_run_env
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    run_env = _make_run_env({"_HERMES_FORCE_GH_TOKEN": FAKE_TOKEN})
+
+    assert run_env["GH_TOKEN"] == FAKE_TOKEN
+    assert "_HERMES_FORCE_GH_TOKEN" not in run_env
+
+
+def test_kanban_worker_forced_github_env_only_in_worker_context(monkeypatch):
+    from tools import terminal_tool
+
+    monkeypatch.setenv("GH_TOKEN", FAKE_TOKEN)
+    monkeypatch.setenv("GITHUB_TOKEN", FAKE_TOKEN)
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", FAKE_TOKEN)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    assert terminal_tool._kanban_worker_forced_github_env() == {}
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_auth_probe")
+    forced = terminal_tool._kanban_worker_forced_github_env()
+
+    assert forced["_HERMES_FORCE_GH_TOKEN"] == FAKE_TOKEN
+    assert forced["_HERMES_FORCE_GITHUB_TOKEN"] == FAKE_TOKEN
+    assert "_HERMES_FORCE_COPILOT_GITHUB_TOKEN" not in forced
+    assert "GH_TOKEN" not in forced
+    assert "GITHUB_TOKEN" not in forced
+    assert "COPILOT_GITHUB_TOKEN" not in forced
+
+
+def test_kanban_worker_does_not_forward_copilot_provider_token(monkeypatch):
+    from tools import terminal_tool
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_auth_probe")
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", FAKE_TOKEN)
+    forced = terminal_tool._kanban_worker_forced_github_env()
+
+    assert forced == {}
+
+
+def test_kanban_worker_force_env_keeps_copilot_out_of_subprocess(monkeypatch):
+    from tools import terminal_tool
+    from tools.environments.local import _make_run_env
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_auth_probe")
+    monkeypatch.setenv("GH_TOKEN", FAKE_TOKEN)
+    monkeypatch.setenv("GITHUB_TOKEN", FAKE_TOKEN)
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", FAKE_TOKEN)
+
+    run_env = _make_run_env(terminal_tool._kanban_worker_forced_github_env())
+
+    assert run_env["GH_TOKEN"] == FAKE_TOKEN
+    assert run_env["GITHUB_TOKEN"] == FAKE_TOKEN
+    assert "COPILOT_GITHUB_TOKEN" not in run_env
+    assert "_HERMES_FORCE_GH_TOKEN" not in run_env
+    assert "_HERMES_FORCE_GITHUB_TOKEN" not in run_env
+    assert "_HERMES_FORCE_COPILOT_GITHUB_TOKEN" not in run_env
+
+
+def test_local_environment_receives_kanban_force_env(monkeypatch):
+    from tools import terminal_tool
+
+    captured = {}
+
+    class FakeLocalEnvironment:
+        def __init__(self, *, cwd, timeout, env):
+            captured["cwd"] = cwd
+            captured["timeout"] = timeout
+            captured["env"] = env
+
+    monkeypatch.setattr(terminal_tool, "_LocalEnvironment", FakeLocalEnvironment)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_auth_probe")
+    monkeypatch.setenv("GITHUB_TOKEN", FAKE_TOKEN)
+
+    env = terminal_tool._create_environment(
+        env_type="local",
+        image="",
+        cwd="/tmp",
+        timeout=60,
+        local_config={"force_env": terminal_tool._kanban_worker_forced_github_env()},
+    )
+
+    assert isinstance(env, FakeLocalEnvironment)
+    assert captured["env"] == {"_HERMES_FORCE_GITHUB_TOKEN": FAKE_TOKEN}

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -49,6 +49,8 @@ from utils import env_var_enabled
 
 logger = logging.getLogger(__name__)
 
+_HERMES_PROVIDER_ENV_FORCE_PREFIX = "_HERMES_FORCE_"
+
 
 # ---------------------------------------------------------------------------
 # Global interrupt event: set by the agent when a user interrupt arrives.
@@ -1338,6 +1340,30 @@ def _get_env_config() -> Dict[str, Any]:
     }
 
 
+def _kanban_worker_forced_github_env() -> Dict[str, str]:
+    """Return trusted GitHub CLI credential overrides for Kanban workers only.
+
+    Terminal subprocesses intentionally strip Hermes-managed provider/tool
+    credentials by default, including GitHub tokens. Dispatched Kanban workers
+    still need private-repo ``gh issue`` / ``gh pr`` reconciliation. The worker
+    process has already loaded its profile ``.env``; this narrowly forwards
+    only standard ``gh`` CLI token variables, and only while
+    ``HERMES_KANBAN_TASK`` indicates the process is a task-scoped worker. Provider
+    tokens such as ``COPILOT_GITHUB_TOKEN`` stay blocked unless a separate
+    capability explicitly proves that wider boundary. Values go through the
+    existing internal ``_HERMES_FORCE_`` escape hatch, so ordinary sessions keep
+    the default terminal sandbox stripping behavior.
+    """
+    if not os.environ.get("HERMES_KANBAN_TASK"):
+        return {}
+    forced: Dict[str, str] = {}
+    for name in ("GH_TOKEN", "GITHUB_TOKEN"):
+        value = os.environ.get(name)
+        if value:
+            forced[f"{_HERMES_PROVIDER_ENV_FORCE_PREFIX}{name}"] = value
+    return forced
+
+
 def _get_modal_backend_state(modal_mode: object | None) -> Dict[str, Any]:
     """Resolve direct vs managed Modal backend selection."""
     return resolve_modal_backend_state(
@@ -1380,7 +1406,13 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     docker_extra_args = cc.get("docker_extra_args", [])
 
     if env_type == "local":
-        return _LocalEnvironment(cwd=cwd, timeout=timeout)
+        lc = local_config or {}
+        force_env = lc.get("force_env")
+        return _LocalEnvironment(
+            cwd=cwd,
+            timeout=timeout,
+            env=force_env if isinstance(force_env, dict) else {},
+        )
     
     elif env_type == "docker":
         # One-shot orphan reaper: clean up labeled containers left behind by
@@ -2177,6 +2209,7 @@ def terminal_tool(
                         if env_type == "local":
                             local_config = {
                                 "persistent": config.get("local_persistent", False),
+                                "force_env": _kanban_worker_forced_github_env(),
                             }
 
                         new_env = _create_environment(


### PR DESCRIPTION
## Summary
- Forward standard GitHub CLI token variables into terminal subprocesses only for task-scoped Kanban workers.
- Preserve normal terminal provider-secret stripping for ordinary sessions.
- Keep provider/model credentials such as `COPILOT_GITHUB_TOKEN` blocked unless a separate capability proves that wider boundary.
- Add focused regression coverage for normal stripping, `_HERMES_FORCE_`, Kanban worker gating, final local subprocess env creation, and Copilot-token exclusion.

## Scope
- `tools/terminal_tool.py`
- `tests/hermes_cli/test_kanban_worker_github_env.py`

## Risk
Low. The forwarding path is gated by `HERMES_KANBAN_TASK` and only maps standard `gh` CLI token variables (`GH_TOKEN`, `GITHUB_TOKEN`) through the existing internal `_HERMES_FORCE_` mechanism. Ordinary terminal subprocesses continue to strip provider/tool credentials, and `COPILOT_GITHUB_TOKEN` remains blocked.

## Rollback
Revert this PR with:

```bash
git revert <merge-sha>
```

## Validation
- `/Users/tom/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/hermes_cli/test_kanban_worker_github_env.py tests/tools/test_local_env_blocklist.py tests/tools/test_env_passthrough.py`
  - Result: `59 passed in 1.45s`
- `/Users/tom/.hermes/hermes-agent/venv/bin/python -m py_compile tools/terminal_tool.py tests/hermes_cli/test_kanban_worker_github_env.py`
  - Result: pass
- `git diff --check fork/fix/kanban-worker-github-cli-auth...HEAD`
  - Result: pass

## Evidence
Local evidence bundle:

```text
evidence/2026-06-26/kanban-worker-github-auth-propagation-fix/
```

Runtime proof:
- Sacrificial Kanban worker: `t_ab027c21`
- Run: `229`
- Command: `gh issue view 6189 --repo AgilityHackers/agentic-platform --json number,title --jq .number`
- Observed output: `6189`
- Outcome: completed and archived

Review reconciliation update:

```yaml
review:
  security_reviewer: APPROVE
  architecture_reviewer: APPROVE
  test_adequacy_reviewer: REQUEST_CHANGES_RESOLVED
new_head_sha: 342ebd46e1468c8060144d9b876984f729e4a2bd
```

Additional focused coverage added:

```yaml
coverage:
  - _HERMES_FORCE_GH_TOKEN round-trips into actual subprocess env as GH_TOKEN
  - Kanban worker forced env plus _make_run_env keeps COPILOT_GITHUB_TOKEN absent
  - _HERMES_FORCE_* keys do not leak into final subprocess env
```

## Proven
- Normal terminal subprocesses still strip GitHub token variables.
- The existing internal `_HERMES_FORCE_` path can forward selected GitHub CLI token variables.
- GitHub CLI token forwarding is gated by `HERMES_KANBAN_TASK`.
- Kanban worker forwarding is limited to `GH_TOKEN` and `GITHUB_TOKEN`.
- `COPILOT_GITHUB_TOKEN` remains absent from both the forced Kanban env and the final local subprocess env.
- A sacrificial spawned Kanban worker completed a private GitHub CLI read without printing tokens.
- No generic Kanban dispatch was used for the proof.
- No original blocked backlog auth card was rerun.

## Not Proven
- Every gateway launch mode loads GitHub tokens into the worker process environment.
- launchd/systemd environment generation includes GitHub tokens.
- All existing GitHub-auth-blocked Kanban cards are safe to rerun.
- Non-default worker profiles are fully health-certified.
- Broad autonomous backlog execution.
- production_ready.
- VERTICAL_COMPLETE.
- Scratch workspace post-completion cwd cleanup traceback resolved.
