### PR TITLE
fix(cron): respect job's profile when executing no_agent jobs (#53077)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -31,7 +31,7 @@ except ImportError:  # pragma: no cover - non-Windows
     msvcrt = None
 from datetime import datetime, timedelta
 from pathlib import Path
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root, get_hermes_home
 from typing import Optional, Dict, List, Any, Union
 
 logger = logging.getLogger(__name__)
@@ -248,6 +248,12 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
         state = "scheduled" if normalized.get("enabled", True) else "paused"
     normalized["state"] = state
 
+    # Legacy jobs (created before per-job profile scoping) have no profile
+    # field. Default them to "default" so the scheduler treats them as
+    # root-profile jobs — matching their pre-existing behaviour.
+    prof = normalized.get("profile")
+    normalized["profile"] = (str(prof).strip() if isinstance(prof, str) and prof.strip() else "default")
+
     return normalized
 
 
@@ -266,6 +272,43 @@ def _secure_file(path: Path):
             os.chmod(path, 0o600)
     except (OSError, NotImplementedError):
         pass
+
+
+def current_profile_name() -> str:
+    """Return the active profile name for the process creating a job.
+
+    ``~/.hermes``              -> ``"default"``
+    ``~/.hermes/profiles/X``   -> ``"X"``
+
+    Used at create time to tag a job with the profile whose environment
+    (.env / config.yaml / credentials) it should execute under, so the
+    job runs as its owning profile regardless of which profile's ticker
+    picks it up.
+    """
+    try:
+        from agent.file_safety import _resolve_active_profile_name
+        return _resolve_active_profile_name() or "default"
+    except Exception:
+        return "default"
+
+
+def resolve_profile_home(profile_name: Optional[str]) -> Optional[Path]:
+    """Map a job's ``profile`` name to the HERMES_HOME it should run under.
+
+    ``"default"`` / empty / ``None`` -> the root home (``get_default_hermes_root()``).
+    ``"<name>"``                      -> ``<root>/profiles/<name>``.
+
+    Returns ``None`` when the named profile directory does not exist, so the
+    scheduler can fall back to the ticker's own home and log a warning rather
+    than pointing a job at a missing profile.
+    """
+    name = (profile_name or "").strip()
+    if not name or name == "default":
+        return get_default_hermes_root().resolve()
+    candidate = (get_default_hermes_root() / "profiles" / name).resolve()
+    if candidate.is_dir():
+        return candidate
+    return None
 
 
 def ensure_dirs():
@@ -789,6 +832,7 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    profile: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -868,6 +912,11 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    # Tag the job with the profile whose environment it should execute under.
+    # When the caller does not pass one explicitly, capture the active profile
+    # of the session creating the job so a job created under `hermes -p donna`
+    # runs as donna even if another profile's ticker picks it up.
+    normalized_profile = (str(profile).strip() if isinstance(profile, str) else "") or current_profile_name()
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -967,6 +1016,7 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        "profile": normalized_profile,
     }
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1970,6 +1970,54 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
 
     # ---------------------------------------------------------------
+    # Profile scoping — MUST happen before ANY script/config resolution.
+    # ---------------------------------------------------------------
+    # The shared root store holds every profile's jobs, but a job must run
+    # with the .env / config.yaml / credentials of the profile that created
+    # it — not whichever profile's ticker happened to pick it up. We set
+    # both the in-process ContextVar override (consumed by _get_hermes_home()
+    # for config/.env/script loads) AND os.environ["HERMES_HOME"] (inherited
+    # by child subprocesses). This MUST precede the no_agent short-circuit
+    # so script resolution also runs under the correct profile (#53077).
+    # Restored in the outer finally block.
+    from cron.jobs import resolve_profile_home
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+    _job_profile = (job.get("profile") or "default").strip() or "default"
+    _profile_home = resolve_profile_home(_job_profile)
+    _prior_hermes_home = os.environ.get("HERMES_HOME", "_UNSET_")
+    _hermes_home_token = None
+    if _profile_home is not None and _profile_home != _get_hermes_home().resolve():
+        os.environ["HERMES_HOME"] = str(_profile_home)
+        _hermes_home_token = set_hermes_home_override(str(_profile_home))
+        logger.info("Job '%s': executing under profile %r (HERMES_HOME=%s)",
+                    job_id, _job_profile, _profile_home)
+    elif _profile_home is None and _job_profile != "default":
+        logger.warning(
+            "Job '%s': profile %r no longer exists — running under the "
+            "ticker's profile instead", job_id, _job_profile,
+        )
+
+    try:
+        return _run_job_inner(job, job_id, job_name)
+    finally:
+        # Restore HERMES_HOME to the ticker's value when this job overrode it
+        # for profile-scoped execution. The sequential pool (tick()) guarantees
+        # no overlap between profile-mutating jobs.
+        if _hermes_home_token is not None:
+            try:
+                reset_hermes_home_override(_hermes_home_token)
+            except Exception:
+                pass
+            if _prior_hermes_home == "_UNSET_":
+                os.environ.pop("HERMES_HOME", None)
+            else:
+                os.environ["HERMES_HOME"] = _prior_hermes_home
+
+
+def _run_job_inner(job: dict, job_id: str, job_name: str) -> tuple[bool, str, str, Optional[str]]:
+    """Body of run_job() after profile scoping has been applied."""
+
+    # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.
     # ---------------------------------------------------------------
     # This mirrors the classic "run a bash script on a timer, send its
@@ -2911,12 +2959,26 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
             body."""
             return run_one_job(job, adapters=adapters, loop=loop, verbose=verbose)
 
-        # Partition due jobs: those with a per-job workdir mutate
-        # os.environ["TERMINAL_CWD"] inside run_job, which is process-global —
-        # so they MUST run sequentially to avoid corrupting each other.  Jobs
-        # without a workdir leave env untouched and stay parallel-safe.
-        sequential_jobs = [j for j in due_jobs if (j.get("workdir") or "").strip()]
-        parallel_jobs = [j for j in due_jobs if not (j.get("workdir") or "").strip()]
+        # Partition due jobs into sequential vs. parallel pools.
+        # A job MUST run sequentially when it mutates process-global state:
+        #   • per-job workdir  → changes os.environ["TERMINAL_CWD"]
+        #   • profile mismatch → changes os.environ["HERMES_HOME"] + the
+        #     ContextVar override consumed by _get_hermes_home() (#53077)
+        # Concurrent execution of such jobs would corrupt each other's env,
+        # so they are serialized through a persistent single-thread pool.
+        def _needs_sequential(j: dict) -> bool:
+            if (j.get("workdir") or "").strip():
+                return True
+            prof = (j.get("profile") or "default").strip() or "default"
+            try:
+                from cron.jobs import resolve_profile_home
+                phome = resolve_profile_home(prof)
+            except Exception:
+                phome = None
+            return phome is not None and phome != _get_hermes_home().resolve()
+
+        sequential_jobs = [j for j in due_jobs if _needs_sequential(j)]
+        parallel_jobs = [j for j in due_jobs if not _needs_sequential(j)]
 
         _results: list = []
         _all_futures: list = []

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -144,6 +144,9 @@ def cron_list(show_all: bool = False):
         workdir = job.get("workdir")
         if workdir:
             print(f"    Workdir:   {workdir}")
+        prof = job.get("profile") or "default"
+        if prof != "default":
+            print(f"    Profile:   {prof}")
 
         # Execution history
         last_status = job.get("last_status")
@@ -278,6 +281,7 @@ def cron_create(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", False) or None,
+        profile=getattr(args, "profile", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -294,6 +298,8 @@ def cron_create(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if job_data.get("workdir"):
         print(f"  Workdir: {job_data['workdir']}")
+    if (job_data.get("profile") or "default") != "default":
+        print(f"  Profile: {job_data['profile']}")
     print(f"  Next run: {result['next_run_at']}")
     _warn_if_gateway_not_running()
     return 0
@@ -341,6 +347,7 @@ def cron_edit(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", None),
+        profile=getattr(args, "profile", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -360,6 +367,9 @@ def cron_edit(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if updated.get("workdir"):
         print(f"  Workdir: {updated['workdir']}")
+    prof = updated.get("profile") or "default"
+    if prof != "default":
+        print(f"  Profile: {prof}")
     return 0
 
 

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -70,6 +70,10 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         "--workdir",
         help="Absolute path for the job to run from. Injects AGENTS.md / CLAUDE.md / .cursorrules from that directory and uses it as the cwd for terminal/file/code_exec tools. Omit to preserve old behaviour (no project context files).",
     )
+    cron_create.add_argument(
+        "--profile",
+        help="Profile name this job belongs to. The job will execute under that profile's HERMES_HOME (config, .env, script paths). Defaults to the active profile.",
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -133,6 +137,10 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_edit.add_argument(
         "--workdir",
         help="Absolute path for the job to run from (injects AGENTS.md etc. and sets terminal cwd). Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--profile",
+        help="Change the profile this job belongs to. The job will execute under that profile's HERMES_HOME.",
     )
 
     # lifecycle actions

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -329,3 +329,277 @@ def test_run_job_script_path_traversal_still_blocked(hermes_env):
     ok, output = _run_job_script("/etc/passwd")
     assert ok is False
     assert "Blocked" in output or "outside" in output
+
+
+# ---------------------------------------------------------------------------
+# Profile scoping (#53077)
+# ---------------------------------------------------------------------------
+
+
+def _make_profile_dir(hermes_env, name):
+    """Create a named profile directory under hermes_env/profiles/<name>."""
+    prof_dir = hermes_env / "profiles" / name
+    prof_dir.mkdir(parents=True, exist_ok=True)
+    (prof_dir / "scripts").mkdir(exist_ok=True)
+    (prof_dir / "cron").mkdir(exist_ok=True)
+    return prof_dir
+
+
+def test_create_job_captures_default_profile(hermes_env):
+    """create_job() auto-tags with 'default' when no profile is explicit."""
+    from cron.jobs import create_job
+
+    job = create_job(prompt="hi", schedule="every 5m", deliver="local")
+    assert job.get("profile") == "default"
+
+
+def test_create_job_explicit_profile_stored(hermes_env):
+    """create_job() stores an explicit profile name."""
+    from cron.jobs import create_job
+
+    _make_profile_dir(hermes_env, "donna")
+    job = create_job(
+        prompt="hi", schedule="every 5m", deliver="local", profile="donna",
+    )
+    assert job["profile"] == "donna"
+
+
+def test_create_job_auto_captures_named_profile(hermes_env, monkeypatch):
+    """When HERMES_HOME points at a named profile, create_job() captures it."""
+    from cron.jobs import create_job
+
+    donna_dir = _make_profile_dir(hermes_env, "donna")
+    monkeypatch.setenv("HERMES_HOME", str(donna_dir))
+    import importlib
+    import hermes_constants
+    import cron.jobs
+    importlib.reload(hermes_constants)
+    importlib.reload(cron.jobs)
+
+    job = cron.jobs.create_job(prompt="hi", schedule="every 5m", deliver="local")
+    assert job["profile"] == "donna"
+
+
+def test_normalize_backfills_legacy_profile_to_default(hermes_env):
+    """Legacy jobs without a profile field get 'default' on normalization."""
+    from cron.jobs import _normalize_job_record
+
+    legacy = {
+        "id": "legacy-1",
+        "prompt": "hi",
+        "schedule": "every 5m",
+        "enabled": True,
+    }
+    normalized = _normalize_job_record(legacy)
+    assert normalized["profile"] == "default"
+
+
+def test_resolve_profile_home_default_returns_root(hermes_env):
+    """'default' / empty / None resolves to the root HERMES_HOME."""
+    from cron.jobs import resolve_profile_home
+
+    for name in ("default", "", None):
+        result = resolve_profile_home(name)
+        assert result == hermes_env.resolve()
+
+
+def test_resolve_profile_home_named_returns_profiles_dir(hermes_env):
+    """Named profile resolves to <root>/profiles/<name>."""
+    from cron.jobs import resolve_profile_home
+
+    _make_profile_dir(hermes_env, "donna")
+    result = resolve_profile_home("donna")
+    assert result == (hermes_env / "profiles" / "donna").resolve()
+
+
+def test_resolve_profile_home_missing_returns_none(hermes_env):
+    """Non-existent profile returns None (triggers fallback warning)."""
+    from cron.jobs import resolve_profile_home
+
+    assert resolve_profile_home("ghost") is None
+
+
+def test_current_profile_name_default(hermes_env):
+    """current_profile_name() returns 'default' for root HERMES_HOME."""
+    from cron.jobs import current_profile_name
+
+    assert current_profile_name() == "default"
+
+
+def test_current_profile_name_named(hermes_env, monkeypatch):
+    """current_profile_name() derives profile from HERMES_HOME path."""
+    donna_dir = _make_profile_dir(hermes_env, "donna")
+    monkeypatch.setenv("HERMES_HOME", str(donna_dir))
+    import importlib
+    import hermes_constants
+    import cron.jobs
+    importlib.reload(hermes_constants)
+    importlib.reload(cron.jobs)
+
+    assert cron.jobs.current_profile_name() == "donna"
+
+
+def test_run_job_no_agent_with_profile_sets_hermes_home(hermes_env, monkeypatch):
+    """no_agent job with a named profile runs under that profile's HERMES_HOME.
+
+    Regression for #53077: profile scoping must happen BEFORE the no_agent
+    short-circuit so script resolution uses the correct profile's config.
+    """
+    from cron.scheduler import run_job
+
+    donna_dir = _make_profile_dir(hermes_env, "donna")
+    # Write a script under donna's scripts dir
+    script_path = donna_dir / "scripts" / "whoami.sh"
+    script_path.write_text("#!/bin/bash\necho $HERMES_HOME\n")
+    script_path.chmod(0o755)
+
+    job = {
+        "id": "prof-test-1",
+        "name": "profile no_agent test",
+        "prompt": "",
+        "schedule": "every 5m",
+        "script": "whoami.sh",
+        "no_agent": True,
+        "enabled": True,
+        "profile": "donna",
+        "deliver": "local",
+    }
+
+    captured_env = {}
+
+    original_run_script = None
+
+    def _capture_script(script_path_arg):
+        """Capture HERMES_HOME at the moment the script would run."""
+        import os
+        captured_env["HERMES_HOME"] = os.environ.get("HERMES_HOME")
+        # Return success with empty output
+        return (True, "")
+
+    with patch("cron.scheduler._run_job_script", side_effect=_capture_script):
+        run_job(job)
+
+    # HERMES_HOME must have been set to donna's profile dir during execution
+    assert captured_env.get("HERMES_HOME") == str(donna_dir)
+
+
+def test_run_job_restores_hermes_home_after_profile_scoped(hermes_env):
+    """HERMES_HOME is restored to the ticker's value after a profile-scoped job."""
+    import os
+    from cron.scheduler import run_job
+
+    donna_dir = _make_profile_dir(hermes_env, "donna")
+    original_home = os.environ.get("HERMES_HOME")
+
+    job = {
+        "id": "prof-restore-1",
+        "name": "restore test",
+        "prompt": "",
+        "schedule": "every 5m",
+        "script": "noop.sh",
+        "no_agent": True,
+        "enabled": True,
+        "profile": "donna",
+        "deliver": "local",
+    }
+
+    with patch("cron.scheduler._run_job_script", return_value=(True, "")):
+        run_job(job)
+
+    # HERMES_HOME must be restored to the ticker's original value
+    assert os.environ.get("HERMES_HOME") == original_home
+
+
+def test_run_job_missing_profile_falls_back_with_warning(hermes_env, caplog):
+    """Job referencing a deleted profile runs under ticker's home + warns."""
+    import logging
+    from cron.scheduler import run_job
+
+    job = {
+        "id": "prof-missing-1",
+        "name": "missing profile test",
+        "prompt": "",
+        "schedule": "every 5m",
+        "script": "noop.sh",
+        "no_agent": True,
+        "enabled": True,
+        "profile": "ghost",  # doesn't exist
+        "deliver": "local",
+    }
+
+    with patch("cron.scheduler._run_job_script", return_value=(True, "")) as mock_run:
+        with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+            run_job(job)
+
+    # Script should still run (under the ticker's own HERMES_HOME)
+    mock_run.assert_called_once()
+    # Warning should have been logged
+    assert any("no longer exists" in r.message for r in caplog.records)
+
+
+def test_cronjob_tool_create_stores_profile(hermes_env):
+    """cronjob tool passes profile through to create_job."""
+    from tools.cronjob_tools import cronjob
+
+    _make_profile_dir(hermes_env, "donna")
+    result = json.loads(cronjob(
+        action="create",
+        schedule="every 5m",
+        prompt="hello",
+        profile="donna",
+    ))
+    assert result["success"] is True
+    assert result["job"]["profile"] == "donna"
+
+
+def test_cronjob_tool_update_changes_profile(hermes_env):
+    """cronjob tool update changes the profile field."""
+    from tools.cronjob_tools import cronjob
+
+    _make_profile_dir(hermes_env, "donna")
+    create_result = json.loads(cronjob(
+        action="create",
+        schedule="every 5m",
+        prompt="hello",
+    ))
+    job_id = create_result["job_id"]
+
+    update_result = json.loads(cronjob(
+        action="update",
+        job_id=job_id,
+        profile="donna",
+    ))
+    assert update_result["success"] is True
+    assert update_result["job"]["profile"] == "donna"
+
+
+def test_needs_sequential_routes_profile_mismatch_to_sequential(hermes_env):
+    """Profile-mismatched jobs are identified as needing sequential execution.
+
+    The actual _needs_sequential() helper is defined inside tick(); we verify
+    the same logic here to confirm that a profile-mismatched job would route
+    to the sequential pool (preventing concurrent HERMES_HOME mutation).
+    """
+    from cron.jobs import resolve_profile_home
+    from hermes_constants import get_hermes_home
+
+    _make_profile_dir(hermes_env, "donna")
+
+    # Job whose profile doesn't match the ticker's home
+    job_mismatch = {"profile": "donna", "workdir": ""}
+    prof = (job_mismatch.get("profile") or "default").strip() or "default"
+    phome = resolve_profile_home(prof)
+    needs_seq = phome is not None and phome != get_hermes_home().resolve()
+    assert needs_seq is True  # → sequential pool
+
+    # Job whose profile matches the ticker's home
+    job_match = {"profile": "default", "workdir": ""}
+    prof2 = (job_match.get("profile") or "default").strip() or "default"
+    phome2 = resolve_profile_home(prof2)
+    needs_seq2 = phome2 is not None and phome2 != get_hermes_home().resolve()
+    assert needs_seq2 is False  # → parallel pool
+
+    # Job with workdir always sequential
+    job_workdir = {"profile": "default", "workdir": "/some/dir"}
+    needs_seq3 = bool((job_workdir.get("workdir") or "").strip())
+    assert needs_seq3 is True  # → sequential pool

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -518,6 +518,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if (job.get("profile") or "default") != "default":
+        result["profile"] = job["profile"]
     return result
 
 
@@ -587,6 +589,7 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    profile: Optional[str] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -654,6 +657,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                profile=_normalize_optional_job_value(profile) if profile else None,
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -839,6 +843,8 @@ def cronjob(
                 if job.get("state") != "paused":
                     updates["state"] = "scheduled"
                     updates["enabled"] = True
+            if profile is not None:
+                updates["profile"] = _normalize_optional_job_value(profile) or "default"
             if not updates:
                 return tool_error("No updates provided.", success=False)
             updated = update_job(job_id, updates)
@@ -1026,6 +1032,7 @@ registry.register(
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
         task_id=kw.get("task_id"),
+        profile=args.get("profile"),
     ))(),
     check_fn=check_cronjob_requirements,
     emoji="⏰",


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Closes: #53077 

Fixes a bug where `no_agent` cron jobs ignored the job's configured `profile` field, resolving scripts under the ticking gateway's HERMES_HOME instead of the job's owning profile.                 
   
**Root cause:** The profile→HERMES_HOME override was placed *after* the `no_agent` short-circuit in `run_job()`. Script resolution therefore used the ticker's own profile environment, breaking    
  per-profile isolation for watchdog-style jobs.                                                                                                                                                    
                                                                                                                                                                                                      
**Approach:** Re-add profile scoping at the **top** of `run_job()` — before the `no_agent` short-circuit — so that both agent-driven and no_agent jobs execute under the correct profile's          
  HERMES_HOME. Per-profile storage is preserved (no schema migration). Profile-mismatched jobs route to the sequential pool to prevent concurrent HERMES_HOME mutation.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #53077 

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

  - **`cron/jobs.py`** — Added `current_profile_name()`, `resolve_profile_home()`, and `profile` parameter to `create_job()`. `_normalize_job_record()` backfills legacy jobs to `"default"` for      
  profile field.
  - **`cron/scheduler.py`** — Profile→HERMES_HOME override at the top of `run_job()` (before no_agent short-circuit). Body extracted into `_run_job_inner()`. `try/finally` restores HERMES_HOME after
   each job. `tick()` routes profile-mismatched jobs to the sequential pool via `_needs_sequential()` helper to prevent concurrent HERMES_HOME mutation.                                            
  - **`tools/cronjob_tools.py`** — Thread `profile` param through `cronjob()` tool and registry lambda. `_format_job()` displays non-default profile. Not exposed in model schema (avoids privilege 
  escalation — only CLI sets it).                                                                                                                                                                     
  - **`hermes_cli/subcommands/cron.py`** — Added `--profile` flag to `cron create` and `cron edit` subcommands.
  - **`hermes_cli/cron.py`** — Pass `profile` through create/edit handlers. Display profile in list/create/edit output (omitted when `default`).                                                      
  - **`tests/cron/test_cron_no_agent.py`** — Added 15 new tests (33 total): profile capture, legacy backfill, resolve_profile_home semantics, regression test for no_agent + profile, HERMES_HOME     
  restoration, missing-profile fallback + warning, tool-level create/update, sequential pool routing.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

  1. Create a named profile: `hermes profile create donna`                                                                                                                                            
  2. Create a no_agent job under that profile:                                                                                                                                                      
     hermes cron create --schedule "every 5m" --script watchdog.sh --no-agent --profile donna                                                                                                         
  3. From another profile's gateway, verify the job runs under donna's HERMES_HOME:                                                                                                                   
  - `hermes cron list` shows `Profile: donna`                                                                                                                                                         
  - Logs show `executing under profile 'donna'`                                                                                                                                                       
  4. Run the test suite:                                                                                                                                                                              
     pytest tests/cron/test_cron_no_agent.py -v                                                                                                                                                       
  All 33 tests pass. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform:  macOS 15.2

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

