### PR TITLE
fix(terminal): prefer $SHELL over bash for background process spawning (#42203)

### DIFF
--- a/tests/tools/test_find_shell.py
+++ b/tests/tools/test_find_shell.py
@@ -1,0 +1,77 @@
+"""Tests for _find_shell — user-login-shell preference on POSIX.
+
+Regression tests for #42203: on macOS, ``_find_shell`` used to return
+``/bin/bash`` (bash 3.2) which silently swallowed background commands
+when ``~/.bash_profile`` contained ``exec /bin/zsh -l``.
+"""
+
+import os
+import platform
+from unittest.mock import patch
+
+import pytest
+
+from tools.environments.local import _find_bash, _find_shell
+
+
+class TestFindShellPrefersUserShell:
+    """_find_shell should prefer $SHELL over bash on POSIX."""
+
+    def test_returns_shell_env_when_set_and_exists(self, tmp_path):
+        """When $SHELL points to an existing binary, _find_shell returns it."""
+        fake_zsh = tmp_path / "zsh"
+        fake_zsh.touch()
+        with patch.dict(os.environ, {"SHELL": str(fake_zsh)}):
+            assert _find_shell() == str(fake_zsh)
+
+    def test_falls_back_to_find_bash_when_shell_unset(self):
+        """When $SHELL is unset, _find_shell delegates to _find_bash."""
+        env = {k: v for k, v in os.environ.items() if k != "SHELL"}
+        with patch.dict(os.environ, env, clear=True):
+            assert _find_shell() == _find_bash()
+
+    def test_falls_back_to_find_bash_when_shell_not_a_file(self, tmp_path):
+        """When $SHELL points to a non-existent path, _find_shell delegates."""
+        fake_path = str(tmp_path / "nonexistent_shell")
+        with patch.dict(os.environ, {"SHELL": fake_path}):
+            assert _find_shell() == _find_bash()
+
+    def test_falls_back_to_find_bash_when_shell_empty(self):
+        """When $SHELL is empty string, _find_shell delegates."""
+        with patch.dict(os.environ, {"SHELL": ""}):
+            assert _find_shell() == _find_bash()
+
+
+class TestFindShellWindowsBehavior:
+    """On Windows, _find_shell always delegates to _find_bash."""
+
+    def test_windows_ignores_shell_env(self):
+        """On Windows, $SHELL is ignored — _find_shell delegates to _find_bash."""
+        with patch("tools.environments.local._IS_WINDOWS", True):
+            # Even if SHELL is set, it should be ignored on Windows
+            with patch.dict(os.environ, {"SHELL": "/usr/bin/zsh"}):
+                result = _find_shell()
+                assert result == _find_bash()
+
+
+class TestFindShellReturnsString:
+    """_find_shell must return a string, never None."""
+
+    def test_returns_string(self):
+        """_find_shell always returns a non-empty string on any platform."""
+        result = _find_shell()
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+
+class TestFindBashUnchanged:
+    """_find_bash should be unaffected by the _find_shell change."""
+
+    def test_find_bash_still_prefers_bash(self):
+        """_find_bash still returns bash (not $SHELL) on POSIX."""
+        result = _find_bash()
+        # On any system, _find_bash should return something containing "bash"
+        # or fall back to $SHELL or /bin/sh — but it should NOT prefer $SHELL
+        # over bash the way _find_shell does.
+        assert isinstance(result, str)
+        assert len(result) > 0

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -288,8 +288,33 @@ def _find_bash() -> str:
     )
 
 
-# Backward compat — process_registry.py imports this name
-_find_shell = _find_bash
+def _find_shell() -> str:
+    """Find the user's login shell for background process spawning.
+
+    Unlike ``_find_bash`` (which always returns a bash binary for callers
+    that explicitly need bash), this function prefers the user's configured
+    ``$SHELL`` on POSIX so that ``spawn_local`` uses the shell the user
+    actually logs in with.
+
+    On macOS Catalina+ the default login shell is zsh, but
+    ``shutil.which("bash")`` still finds the system ``/bin/bash`` (GNU bash
+    3.2).  When bash 3.2 is invoked with ``-l`` (login) and stdin is
+    ``/dev/null``, it sources ``~/.bash_profile`` which on many macOS setups
+    contains ``exec /bin/zsh -l``.  That ``exec`` replaces bash with zsh but
+    drops the ``-c`` argument, so the background command never runs — the
+    subprocess exits 0 with no output and no side effects.
+
+    Preferring ``$SHELL`` avoids this entirely because zsh handles ``-lic``
+    correctly even with redirected stdin.
+
+    On Windows, ``$SHELL`` is typically bash (Git Bash), so behaviour is
+    unchanged — we fall through to ``_find_bash``.
+    """
+    if not _IS_WINDOWS:
+        user_shell = os.environ.get("SHELL")
+        if user_shell and os.path.isfile(user_shell):
+            return user_shell
+    return _find_bash()
 
 
 # Standard PATH entries for environments with minimal PATH.


### PR DESCRIPTION
## Summary

Salvage of #42219 by @liuhao1024 (rebased onto current main, 506 commits ahead — cherry-pick applied cleanly, no conflicts).

On macOS, `terminal(background=true)` silently fails to execute commands. `_find_shell()` returned `/bin/bash` (bash 3.2) instead of the user's `$SHELL` (typically `/bin/zsh`). When bash 3.2 runs as a login shell (`-l`) with `stdin=/dev/null` and `~/.bash_profile` contains `exec /bin/zsh -l`, bash execs into zsh and loses the `-c` argument — the command never runs, exit code 0, no output.

## Fix

Replace `_find_shell = _find_bash` alias with a proper function that prefers `$SHELL` on POSIX systems, falling back to `_find_bash` when `$SHELL` is unset, empty, or points to a non-existent file. Windows behavior is unchanged.

## Testing

- `pytest tests/tools/test_find_shell.py` -> 7 passed
- `pytest tests/tools/test_process_registry.py -k spawn_local` -> 1 passed (no regression)
- `ruff check tools/environments/local.py tests/tools/test_find_shell.py` -> passed
- Mutation test: reverting to `_find_bash()` causes `test_returns_shell_env_when_set_and_exists` to FAIL — confirmed non-vacuous

Closes #42203
Closes #42219
Closes #42290

Co-authored-by: liuhao1024 <sunsky.lau@gmail.com>