### PR TITLE
Send long Telegram responses as text files

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -418,6 +418,9 @@ class TelegramAdapter(BasePlatformAdapter):
     # Bot API 10.1 Rich Messages cap the raw markdown/html text at 32,768
     # UTF-8 characters. Content above this is sent via the legacy chunking path.
     RICH_MESSAGE_MAX_CHARS = 32768
+    # Avoid Telegram flood-wait stalls for long final replies by sending the
+    # full answer as one .txt document instead of several 4096-char messages.
+    LONG_TEXT_DOCUMENT_THRESHOLD = 6000
     # Backwards-compatible alias for tests/external callers that referenced the
     # initial implementation name. The API limit is character-based, not bytes.
     RICH_MESSAGE_MAX_BYTES = RICH_MESSAGE_MAX_CHARS
@@ -1042,6 +1045,75 @@ class TelegramAdapter(BasePlatformAdapter):
                 return False
             return default
         return bool(value)
+
+    def _long_text_document_threshold(self) -> int:
+        raw = None
+        if getattr(self.config, "extra", None):
+            raw = self.config.extra.get("long_text_document_threshold")
+        try:
+            value = int(raw) if raw is not None else self.LONG_TEXT_DOCUMENT_THRESHOLD
+        except (TypeError, ValueError):
+            value = self.LONG_TEXT_DOCUMENT_THRESHOLD
+        # Keep this above Telegram's single-message limit; smaller values would
+        # surprise users by converting ordinary short answers into files.
+        return max(self.MAX_MESSAGE_LENGTH + 1, value)
+
+    def _should_send_long_text_as_document(
+        self,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Return True when a final long answer should be delivered as .txt.
+
+        Large chunked Telegram sends often trigger Bot API flood waits of several
+        minutes.  Default to document delivery for final long answers, while
+        allowing operators to opt out with
+        ``platforms.telegram.extra.long_text_as_document: false``.
+        """
+        if not content or not content.strip():
+            return False
+        if not self._coerce_bool_extra("long_text_as_document", True):
+            return False
+        # Draft/progress/status traffic should stay text. Final gateway replies
+        # carry notify=True; direct tool sends may omit metadata, so still apply
+        # the threshold there.
+        if metadata and metadata.get("status_key"):
+            return False
+        return utf16_len(content) >= self._long_text_document_threshold()
+
+    async def _send_long_text_document(
+        self,
+        chat_id: str,
+        content: str,
+        *,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        caption: Optional[str] = None,
+    ) -> SendResult:
+        """Send long text as a temporary UTF-8 .txt document."""
+        fd, tmp_path = tempfile.mkstemp(
+            prefix="hermes-response-",
+            suffix=".txt",
+            text=True,
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(content)
+            timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+            file_name = f"hermes-response-{timestamp}.txt"
+            return await self.send_document(
+                chat_id=chat_id,
+                file_path=tmp_path,
+                caption=caption or "Ответ слишком длинный для Telegram — отправляю полным текстом в файле.",
+                file_name=file_name,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
     def _link_preview_kwargs(self) -> Dict[str, Any]:
         if not getattr(self, "_disable_link_previews", False):
@@ -2602,7 +2674,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
-        
+
         try:
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
             # sendRichMessage so tables/task lists/etc. render natively. Falls
@@ -2625,6 +2697,14 @@ class TelegramAdapter(BasePlatformAdapter):
                             except Exception:
                                 pass  # Typing failures are non-fatal
                     return rich_result
+
+            if self._should_send_long_text_as_document(content, metadata):
+                return await self._send_long_text_document(
+                    chat_id,
+                    content,
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
 
             # Format and split message if needed
             formatted = self.format_message(content)
@@ -2958,6 +3038,29 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+
+        if finalize and self._should_send_long_text_as_document(content, metadata):
+            notice = "Ответ слишком длинный для Telegram — отправляю полным текстом в файле."
+            try:
+                await self._bot.edit_message_text(
+                    chat_id=int(chat_id),
+                    message_id=int(message_id),
+                    text=notice,
+                )
+            except Exception as e:
+                if "not modified" not in str(e).lower():
+                    logger.debug(
+                        "[%s] Long-text document notice edit failed: %s",
+                        self.name,
+                        e,
+                    )
+            return await self._send_long_text_document(
+                chat_id,
+                content,
+                reply_to=message_id,
+                metadata=metadata,
+                caption=notice,
+            )
 
         # Rich finalize (Bot API 10.1): when the completed content has
         # constructs the legacy MarkdownV2 edit degrades (tables → bullet

--- a/tests/gateway/test_telegram_overflow_partial.py
+++ b/tests/gateway/test_telegram_overflow_partial.py
@@ -138,3 +138,95 @@ async def test_stream_consumer_fallback_sends_tail_after_partial_overflow():
     adapter.delete_message.assert_not_awaited()
     assert consumer.final_response_sent is True
     assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_send_long_text_delivers_txt_document_instead_of_chunks(telegram_adapter):
+    """Long final sends use one document upload, avoiding Telegram flood waits."""
+    telegram_adapter.config.extra["long_text_document_threshold"] = 200
+    content = "word " * 80
+    captured = {}
+
+    async def fake_send_document(chat_id, file_path, caption=None, file_name=None, reply_to=None, metadata=None, **_kwargs):
+        with open(file_path, "r", encoding="utf-8") as handle:
+            captured["body"] = handle.read()
+        captured.update(
+            chat_id=chat_id,
+            caption=caption,
+            file_name=file_name,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+        return SendResult(success=True, message_id="doc-1")
+
+    telegram_adapter.send_document = AsyncMock(side_effect=fake_send_document)
+    telegram_adapter._bot.send_message = AsyncMock(return_value=_message(202))
+
+    result = await telegram_adapter.send(
+        "12345",
+        content,
+        reply_to="99",
+        metadata={"thread_id": "77", "notify": True},
+    )
+
+    assert result.success is True
+    assert result.message_id == "doc-1"
+    telegram_adapter._bot.send_message.assert_not_awaited()
+    telegram_adapter.send_document.assert_awaited_once()
+    assert captured["body"] == content
+    assert captured["file_name"].startswith("hermes-response-")
+    assert captured["file_name"].endswith(".txt")
+    assert captured["reply_to"] == "99"
+    assert captured["metadata"] == {"thread_id": "77", "notify": True}
+
+
+@pytest.mark.asyncio
+async def test_edit_finalize_long_text_replaces_preview_and_sends_txt_document(telegram_adapter):
+    """Finalizing a long streamed reply avoids continuation chunk storms."""
+    telegram_adapter.config.extra["long_text_document_threshold"] = 200
+    content = "word " * 80
+    captured = {}
+
+    async def fake_send_document(chat_id, file_path, caption=None, file_name=None, reply_to=None, metadata=None, **_kwargs):
+        with open(file_path, "r", encoding="utf-8") as handle:
+            captured["body"] = handle.read()
+        captured.update(caption=caption, reply_to=reply_to, metadata=metadata)
+        return SendResult(success=True, message_id="doc-2")
+
+    telegram_adapter._bot.edit_message_text = AsyncMock(return_value=True)
+    telegram_adapter._bot.send_message = AsyncMock(return_value=_message(202))
+    telegram_adapter.send_document = AsyncMock(side_effect=fake_send_document)
+
+    result = await telegram_adapter.edit_message(
+        "12345",
+        "201",
+        content,
+        finalize=True,
+        metadata={"thread_id": "77", "notify": True},
+    )
+
+    assert result.success is True
+    assert result.message_id == "doc-2"
+    telegram_adapter._bot.edit_message_text.assert_awaited_once()
+    telegram_adapter._bot.send_message.assert_not_awaited()
+    assert captured["body"] == content
+    assert captured["reply_to"] == "201"
+    assert captured["metadata"] == {"thread_id": "77", "notify": True}
+
+
+@pytest.mark.asyncio
+async def test_long_text_document_can_be_disabled(telegram_adapter):
+    """Operators can opt out and keep the legacy chunked text behavior."""
+    telegram_adapter.config.extra["long_text_as_document"] = False
+    telegram_adapter.config.extra["long_text_document_threshold"] = 200
+    content = "word " * 80
+    telegram_adapter._bot.send_message = AsyncMock(
+        side_effect=[_message(202), _message(203), _message(204)]
+    )
+    telegram_adapter.send_document = AsyncMock(return_value=SendResult(success=True, message_id="doc"))
+
+    result = await telegram_adapter.send("12345", content, metadata={"notify": True})
+
+    assert result.success is True
+    telegram_adapter.send_document.assert_not_awaited()
+    assert telegram_adapter._bot.send_message.await_count > 1

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -62,6 +62,7 @@ def _make_adapter(extra=None):
     bot.do_api_request = AsyncMock(return_value=SimpleNamespace(message_id=123))
     bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
     bot.send_chat_action = AsyncMock()  # keeps the post-send typing re-trigger quiet
+    bot.send_document = AsyncMock(return_value=MagicMock(message_id=2))
     bot.send_message_draft = AsyncMock(return_value=True)  # legacy draft fallback
     bot.edit_message_text = AsyncMock(return_value=MagicMock(message_id=1))  # legacy edit path
     bot.delete_message = AsyncMock(return_value=True)
@@ -310,18 +311,21 @@ async def test_expect_edits_metadata_keeps_preview_on_legacy_path():
 
 
 @pytest.mark.asyncio
-async def test_oversized_content_skips_rich_and_chunks():
+async def test_oversized_content_skips_rich_and_sends_document():
     adapter = _make_adapter()
-    # > 32,768 characters -> rich pre-check fails, legacy chunking takes over.
+    # > 32,768 characters -> rich pre-check fails, long-text document delivery
+    # takes over to avoid Bot API flood waits from many continuation messages.
     oversized = "a" * 40000
     assert len(oversized) > TelegramAdapter.RICH_MESSAGE_MAX_CHARS
 
     result = await adapter.send("12345", oversized)
 
     assert result.success is True
-    adapter._bot.do_api_request.assert_not_called()
-    # Oversized content is split into multiple legacy chunks.
-    assert adapter._bot.send_message.await_count > 1
+    bot = adapter._bot
+    assert bot is not None
+    bot.do_api_request.assert_not_called()
+    bot.send_message.assert_not_awaited()
+    bot.send_document.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- send long Telegram replies as a single UTF-8 `.txt` document to avoid Bot API flood-wait stalls from many continuation messages
- apply the same document fallback when finalizing an oversized streamed preview, replacing the preview with a short notice
- keep rich-message delivery ahead of the fallback and add opt-out/configurable threshold coverage

## Tests
- `venv/bin/python -m pytest tests/gateway/test_telegram_overflow_partial.py tests/gateway/test_telegram_send_path_health.py tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_documents.py -q`
- `venv/bin/python -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_overflow_partial.py tests/gateway/test_telegram_rich_messages.py`
- `venv/bin/python -m ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_overflow_partial.py tests/gateway/test_telegram_rich_messages.py`
