### PR TITLE
fix(auth): surface Codex quota exhaustion in CLI and dashboard auth status

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3833,6 +3833,17 @@ def _codex_pool_rate_limit_status() -> Optional[Dict[str, Any]]:
                 return None
         return None
 
+    def _fallback_exhausted_reset_at(entry: Dict[str, Any], code: Any) -> Optional[float]:
+        status_at = _parse_reset_at(entry.get("last_status_at"))
+        if status_at is None:
+            return None
+        try:
+            code_int = int(code)
+        except (TypeError, ValueError):
+            code_int = None
+        ttl = 5 * 60 if code_int == 401 else 60 * 60
+        return status_at + ttl
+
     try:
         with _auth_store_lock():
             auth_store = _load_auth_store()
@@ -3862,10 +3873,18 @@ def _codex_pool_rate_limit_status() -> Optional[Dict[str, Any]]:
                 or "rate limit" in message
                 or "usage limit" in message
                 or "quota" in message
+                # Older Codex pool entries can be marked exhausted without
+                # provider error metadata. The credential pool still freezes
+                # them for a default cooldown using last_status_at, and
+                # `hermes auth list` reports that cooldown. Keep status
+                # surfaces consistent with the pool in that legacy shape.
+                or (code is None and not reason and not message)
             )
             if not is_rate_limited:
                 continue
             reset_at = _parse_reset_at(entry.get("last_error_reset_at"))
+            if reset_at is None:
+                reset_at = _fallback_exhausted_reset_at(entry, code)
             if reset_at is not None and reset_at <= now:
                 continue
             return {

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5939,6 +5939,49 @@ def _compute_nous_auth_status() -> Dict[str, Any]:
     return _snapshot_nous_pool_status()
 
 
+def _format_quota_reset_at(reset_at: Any) -> str:
+    """Format an epoch reset time as local wall-clock, or '' if unknown.
+
+    Accepts seconds or milliseconds since the epoch (mirroring the upstream
+    normalisation in ``_codex_pool_rate_limit_status._parse_reset_at``) so any
+    surface can pass a raw provider timestamp without losing the retry hint.
+    """
+    try:
+        ts = float(reset_at)
+    except (TypeError, ValueError):
+        return ""
+    if ts <= 0:
+        return ""
+    if ts > 1_000_000_000_000:  # milliseconds → seconds
+        ts /= 1000.0
+    try:
+        # rstrip(): some platforms/locales render an empty %Z, leaving a
+        # trailing space that would otherwise show as "... 14:30 )".
+        return datetime.fromtimestamp(ts).astimezone().strftime("%Y-%m-%d %H:%M %Z").rstrip()
+    except (ValueError, OverflowError, OSError):
+        return ""
+
+
+def format_quota_status(status: Optional[Dict[str, Any]]) -> str:
+    """Human-readable quota-exhaustion suffix for an auth-status dict.
+
+    Returns ``""`` when the provider is usable.  When a provider reports
+    ``rate_limited`` (currently codex via ``get_codex_auth_status``, where every
+    credential is frozen in a quota cooldown), this turns the ``rate_limited`` +
+    ``reset_at`` fields into a short summary like
+    ``"quota exhausted (retry after 2026-06-26 14:30 KST)"`` so that every status
+    surface (``hermes status``, ``hermes auth status``) shows the same exhaustion
+    state that ``hermes auth list`` already does.  Provider-agnostic: any status
+    dict that grows a ``rate_limited`` flag renders consistently.
+    """
+    if not isinstance(status, dict) or not status.get("rate_limited"):
+        return ""
+    when = _format_quota_reset_at(status.get("reset_at"))
+    if when:
+        return f"quota exhausted (retry after {when})"
+    return "quota exhausted"
+
+
 def get_codex_auth_status() -> Dict[str, Any]:
     """Status snapshot for Codex auth.
     

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -497,7 +497,16 @@ def auth_status_command(args) -> None:
             print(f"{provider}: logged out")
         return
 
-    print(f"{provider}: logged in")
+    quota = auth_mod.format_quota_status(status)
+    if quota:
+        # Logged in, but the provider reports a quota cooldown (codex: every
+        # credential frozen).  Surface it so `auth status` agrees with `auth list`.
+        print(f"{provider}: logged in — {quota}")
+        error = status.get("error")
+        if error:
+            print(f"  error: {error}")
+    else:
+        print(f"{provider}: logged in")
     for key in ("auth_type", "client_id", "redirect_uri", "scope", "expires_at", "api_base_url"):
         value = status.get(key)
         if value:

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
-from hermes_cli.auth import AuthError, resolve_provider
+from hermes_cli.auth import AuthError, format_quota_status, resolve_provider
 from hermes_cli.colors import Colors, color
 from hermes_cli.config import get_env_path, get_env_value, get_hermes_home, load_config
 from hermes_cli.models import provider_label
@@ -250,17 +250,27 @@ def show_status(args):
         print(f"    Error:      {nous_error}")
 
     codex_logged_in = bool(codex_status.get("logged_in"))
-    print(
-        f"  {'OpenAI Codex':<12}  {check_mark(codex_logged_in)} "
-        f"{'logged in' if codex_logged_in else 'not logged in (run: hermes model)'}"
-    )
+    codex_quota = format_quota_status(codex_status)
+    if codex_quota:
+        # Logged in but every codex credential is frozen in a quota cooldown.
+        # Surface it as a warning so `hermes status` agrees with `hermes auth list`
+        # instead of showing a clean "logged in".
+        print(
+            f"  {'OpenAI Codex':<12}  {color('⚠', Colors.YELLOW)} "
+            f"logged in — {codex_quota}"
+        )
+    else:
+        print(
+            f"  {'OpenAI Codex':<12}  {check_mark(codex_logged_in)} "
+            f"{'logged in' if codex_logged_in else 'not logged in (run: hermes model)'}"
+        )
     codex_auth_file = codex_status.get("auth_store")
     if codex_auth_file:
         print(f"    Auth file:  {codex_auth_file}")
     codex_last_refresh = _format_iso_timestamp(codex_status.get("last_refresh"))
     if codex_status.get("last_refresh"):
         print(f"    Refreshed:  {codex_last_refresh}")
-    if codex_status.get("error") and not codex_logged_in:
+    if codex_status.get("error") and (not codex_logged_in or codex_quota):
         print(f"    Error:      {codex_status.get('error')}")
 
     qwen_logged_in = bool(qwen_status.get("logged_in"))

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5905,6 +5905,12 @@ def _resolve_provider_status(provider_id: str, status_fn) -> Dict[str, Any]:
                 "expires_at": None,
                 "has_refresh_token": False,
                 "last_refresh": raw.get("last_refresh"),
+                # Surface quota exhaustion so the dashboard agrees with
+                # `hermes auth list` / `hermes status` instead of showing a
+                # clean "connected" while every codex credential is frozen.
+                "rate_limited": bool(raw.get("rate_limited")),
+                "reset_at": raw.get("reset_at"),
+                "error": raw.get("error"),
             }
         if provider_id == "qwen-oauth":
             raw = hauth.get_qwen_auth_status()

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -498,6 +498,32 @@ def test_codex_auth_status_reports_pool_only_rate_limit(tmp_path, monkeypatch):
     assert status["error_code"] == "codex_rate_limited"
 
 
+def test_codex_auth_status_reports_legacy_exhausted_pool_cooldown(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _codex_pool_only_store()
+    entry = payload["credential_pool"]["openai-codex"][0]
+    entry.update(
+        {
+            "last_status": "exhausted",
+            "last_status_at": time.time(),
+            "last_error_code": None,
+            "last_error_reason": None,
+            "last_error_message": None,
+            "last_error_reset_at": None,
+        }
+    )
+    _write_auth_store(tmp_path, payload)
+
+    from hermes_cli.auth import get_codex_auth_status
+
+    status = get_codex_auth_status()
+
+    assert status["logged_in"] is True
+    assert status["rate_limited"] is True
+    assert status["error_code"] == "codex_rate_limited"
+    assert status["reset_at"] > time.time()
+
+
 def test_format_quota_status_not_rate_limited_returns_empty():
     from hermes_cli.auth import format_quota_status
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -6,10 +6,13 @@ import base64
 import json
 import time
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 import yaml
+
+import hermes_cli.auth as auth_mod
 
 
 def _write_auth_store(tmp_path, payload: dict) -> None:
@@ -493,6 +496,92 @@ def test_codex_auth_status_reports_pool_only_rate_limit(tmp_path, monkeypatch):
     assert status["logged_in"] is True
     assert status["rate_limited"] is True
     assert status["error_code"] == "codex_rate_limited"
+
+
+def test_format_quota_status_not_rate_limited_returns_empty():
+    from hermes_cli.auth import format_quota_status
+
+    assert format_quota_status({"logged_in": True}) == ""
+    assert format_quota_status({"rate_limited": False}) == ""
+    assert format_quota_status(None) == ""
+
+
+def test_format_quota_status_without_reset_omits_retry_hint():
+    from hermes_cli.auth import format_quota_status
+
+    assert format_quota_status({"rate_limited": True, "reset_at": None}) == "quota exhausted"
+    # Non-positive / non-numeric reset times degrade to the bare summary.
+    assert format_quota_status({"rate_limited": True, "reset_at": 0}) == "quota exhausted"
+    assert format_quota_status({"rate_limited": True, "reset_at": "nope"}) == "quota exhausted"
+
+
+def test_format_quota_status_accepts_seconds_and_milliseconds():
+    from hermes_cli.auth import format_quota_status
+
+    future_s = time.time() + 3600
+    sec = format_quota_status({"rate_limited": True, "reset_at": future_s})
+    ms = format_quota_status({"rate_limited": True, "reset_at": future_s * 1000.0})
+    assert sec.startswith("quota exhausted (retry after ")
+    # Milliseconds must be normalised to seconds (mirrors _parse_reset_at),
+    # not silently dropped to the bare summary.
+    assert ms.startswith("quota exhausted (retry after ")
+
+
+def test_auth_status_reports_codex_quota_exhausted(tmp_path, monkeypatch, capsys):
+    """`hermes auth status openai-codex` must surface quota exhaustion.
+
+    Regression: it printed a bare ``logged in`` even when every codex
+    credential was frozen in a quota cooldown, contradicting
+    ``hermes auth list`` (the only truthful surface).
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _codex_pool_only_store(exhausted=True))
+
+    from hermes_cli.auth_commands import auth_status_command
+
+    auth_status_command(SimpleNamespace(provider="openai-codex"))
+
+    out = capsys.readouterr().out
+    assert "logged in" in out
+    assert "quota exhausted" in out
+    # last_error_reset_at is now + 3600 → retry hint expected.
+    assert "retry after" in out
+    # The provider error must be surfaced alongside the quota line.
+    assert "usage limit" in out.lower()
+
+
+def test_auth_status_non_codex_provider_has_no_quota_warning(monkeypatch, capsys):
+    """A non-codex provider whose status lacks ``rate_limited`` must not show
+    a spurious codex-style ``quota exhausted`` line (format_quota_status is
+    applied to every provider in auth_status_command)."""
+    monkeypatch.setattr(
+        auth_mod,
+        "get_auth_status",
+        lambda provider=None: {"logged_in": True, "auth_type": "oauth"},
+        raising=False,
+    )
+
+    from hermes_cli.auth_commands import auth_status_command
+
+    auth_status_command(SimpleNamespace(provider="spotify"))
+
+    out = capsys.readouterr().out
+    assert "spotify: logged in" in out
+    assert "quota exhausted" not in out
+
+
+def test_auth_status_healthy_codex_has_no_quota_warning(tmp_path, monkeypatch, capsys):
+    """A usable codex credential must NOT show a spurious exhaustion warning."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _codex_pool_only_store(exhausted=False))
+
+    from hermes_cli.auth_commands import auth_status_command
+
+    auth_status_command(SimpleNamespace(provider="openai-codex"))
+
+    out = capsys.readouterr().out
+    assert "logged in" in out
+    assert "quota exhausted" not in out
 
 
 def test_codex_runtime_pool_only_rate_limit_is_not_missing_auth(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -351,3 +351,85 @@ class TestShowStatusXaiOAuth:
 
         assert "xAI OAuth" in out
         assert "not logged in (run: hermes auth add xai-oauth)" in out
+
+
+class TestShowStatusCodexQuota:
+    """Codex row must surface pool exhaustion, not just 'logged in'.
+
+    Regression: ``get_codex_auth_status`` already returns ``rate_limited`` +
+    ``reset_at`` when every codex credential is frozen in a quota cooldown,
+    but ``status.py`` only read ``logged_in`` and printed a clean
+    ``✓ logged in`` — hiding the exhaustion that ``hermes auth list`` shows.
+    """
+
+    def test_rate_limited_codex_shows_quota_exhausted_with_reset(
+        self, monkeypatch, capsys, tmp_path
+    ):
+        import time
+
+        import hermes_cli.auth as auth_mod
+
+        status_mod = _base_xai_mocks(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            auth_mod,
+            "get_xai_oauth_auth_status",
+            lambda: {},
+            raising=False,
+        )
+        monkeypatch.setattr(
+            auth_mod,
+            "get_codex_auth_status",
+            lambda: {
+                "logged_in": True,
+                "rate_limited": True,
+                "error_code": "codex_rate_limited",
+                "error": "The usage limit has been reached",
+                "reset_at": time.time() + 3600,
+                "auth_store": str(tmp_path / "auth.json"),
+                "source": "pool:codex@example.com",
+            },
+            raising=False,
+        )
+
+        status_mod.show_status(SimpleNamespace(all=False, deep=False))
+        out = capsys.readouterr().out
+
+        assert "OpenAI Codex" in out
+        # The exhaustion must be surfaced, not hidden behind a clean check.
+        assert "quota exhausted" in out
+        # reset_at present → a retry hint must be shown.
+        assert "retry after" in out
+
+    def test_rate_limited_without_reset_still_shows_exhausted(
+        self, monkeypatch, capsys, tmp_path
+    ):
+        import hermes_cli.auth as auth_mod
+
+        status_mod = _base_xai_mocks(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            auth_mod,
+            "get_xai_oauth_auth_status",
+            lambda: {},
+            raising=False,
+        )
+        monkeypatch.setattr(
+            auth_mod,
+            "get_codex_auth_status",
+            lambda: {
+                "logged_in": True,
+                "rate_limited": True,
+                "error_code": "codex_rate_limited",
+                "error": "Codex provider quota exhausted",
+                "reset_at": None,
+                "source": "pool:codex@example.com",
+            },
+            raising=False,
+        )
+
+        status_mod.show_status(SimpleNamespace(all=False, deep=False))
+        out = capsys.readouterr().out
+
+        assert "OpenAI Codex" in out
+        assert "quota exhausted" in out
+        # No reset_at → no retry hint should be fabricated.
+        assert "retry after" not in out

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -889,3 +889,48 @@ def test_status_unknown_provider_degrades_to_logged_out():
     with patch("hermes_cli.auth.get_auth_status", return_value={"logged_in": False}):
         out = ws._resolve_provider_status("totally-unknown", None)
     assert out["logged_in"] is False
+
+
+def test_status_codex_surfaces_quota_exhaustion():
+    """Dashboard provider status must surface codex quota exhaustion.
+
+    Regression: the openai-codex branch kept ``logged_in`` but dropped the
+    ``rate_limited``/``reset_at``/``error`` that ``get_codex_auth_status``
+    returns when every credential is frozen — so the dashboard showed a clean
+    "connected" while ``hermes auth list`` showed exhausted.
+    """
+    import hermes_cli.web_server as ws
+
+    codex_status = {
+        "logged_in": True,
+        "rate_limited": True,
+        "error_code": "codex_rate_limited",
+        "error": "The usage limit has been reached",
+        "reset_at": time.time() + 3600,
+        "source": "pool:codex@example.com",
+        "auth_mode": "chatgpt",
+    }
+    with patch("hermes_cli.auth.get_codex_auth_status", return_value=codex_status):
+        out = ws._resolve_provider_status("openai-codex", None)
+
+    assert out["logged_in"] is True
+    assert out["rate_limited"] is True
+    assert out.get("reset_at")
+    assert "usage limit" in (out.get("error") or "").lower()
+
+
+def test_status_codex_healthy_has_no_rate_limit_flag():
+    """A usable codex credential must not report a spurious rate-limit."""
+    import hermes_cli.web_server as ws
+
+    codex_status = {
+        "logged_in": True,
+        "source": "pool:codex@example.com",
+        "auth_mode": "chatgpt",
+        "api_key": "sk-test",
+    }
+    with patch("hermes_cli.auth.get_codex_auth_status", return_value=codex_status):
+        out = ws._resolve_provider_status("openai-codex", None)
+
+    assert out["logged_in"] is True
+    assert out.get("rate_limited") is False


### PR DESCRIPTION
## Summary

Codex auth status surfaces showed a clean "logged in" / "connected" even when every
codex credential was frozen in a quota cooldown, while `hermes auth list` correctly
showed it as exhausted. `get_codex_auth_status()` already returns
`rate_limited` / `reset_at` / `error` in that state — the display surfaces just
dropped those fields. This wires them through.

## Changes (scoped)

- `hermes auth status openai-codex` now shows the logged-in-but-quota-exhausted state
  with a retry hint instead of a bare `logged in`.
- `hermes status` (`--all`) now surfaces Codex quota exhaustion and the retry-after time.
- dashboard `/api/providers/oauth` now preserves `openai-codex`
  `rate_limited` / `reset_at` / `error` instead of discarding them (API truth;
  web-UI rendering of these fields is a separate front-end concern).
- New shared formatter `format_quota_status()` keeps all surfaces consistent and
  normalises seconds/milliseconds reset timestamps.

## Out of scope (intentionally not changed)

- `gateway /status` and the TUI do **not** currently expose Codex auth state at all,
  so there is nothing untruthful to fix there — adding Codex auth/quota display to
  those surfaces would be a separate display feature.

## Tests

- New tests for all three surfaces + the formatter (seconds/ms reset, missing reset,
  non-codex providers must not show a spurious quota warning).
- `tests/hermes_cli/test_status.py`, `test_auth_commands.py`, `test_web_oauth_dispatch.py`: 104 passed.
