### PR TITLE
fix(agent): don't mislabel a proxy/WAF 403 block as an API-key rejection

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -191,6 +191,68 @@ def _is_nous_inference_route(provider: str, base_url: str) -> bool:
     )
 
 
+# Substrings that mark a 401/403 body as a genuine credential/permission
+# rejection rather than a proxy/WAF block. Kept deliberately broad: if any of
+# these show up we keep the existing "your API key was rejected" guidance.
+_AUTH_ERROR_MARKERS = (
+    "api key",
+    "api_key",
+    "apikey",
+    "authentication",
+    "authenticate",
+    "unauthorized",
+    "unauthenticated",
+    "permission",
+    "forbidden",
+    "not authorized",
+    "no access",
+    "have access",
+    "invalid token",
+    "expired",
+    "credential",
+    "x-api-key",
+    "bearer",
+)
+
+
+def _summarize_403_proxy_block(api_error: Any, status_code: Any) -> Optional[str]:
+    """Detect a non-standard HTTP 403 that is a proxy/WAF block rather than an
+    API-key/permission rejection, and return a short one-line snippet of its
+    body.
+
+    Some custom OpenAI-compatible relays sit behind a WAF that blocks the OpenAI
+    SDK's default ``User-Agent`` and answers with a short plain-text body such as
+    ``Your request was blocked.`` — no auth-shaped JSON. Reporting that as "your
+    API key was rejected" sends users down the wrong debugging path (see #53099).
+
+    Returns the cleaned snippet only when the response is confidently a non-auth
+    403; otherwise ``None`` so callers keep the existing key-rejection guidance.
+    We default to ``None`` whenever there's any doubt.
+    """
+    if status_code != 403:
+        return None
+    # A structured JSON error body is the standard auth/permission shape; leave
+    # those to the existing guidance.
+    body = getattr(api_error, "body", None)
+    if isinstance(body, (dict, list)):
+        return None
+    text = body if isinstance(body, str) else str(api_error)
+    if not text or not text.strip():
+        return None
+    lowered = text.lower()
+    # Anything that smells like a credential/permission failure → not our case.
+    if any(marker in lowered for marker in _AUTH_ERROR_MARKERS):
+        return None
+    # A JSON ``error`` envelope is auth-shaped too — only treat clearly
+    # plain-text bodies as proxy/WAF blocks.
+    if '"error"' in lowered or "'error'" in lowered:
+        return None
+    snippet = " ".join(text.split())
+    if len(snippet) > 200:
+        snippet = snippet[:200] + "…"
+    return snippet
+
+
 def _billing_or_entitlement_message(
     *,
     capability: str,
@@ -3398,6 +3460,19 @@ def run_conversation(
                                     agent._vprint(f"{agent.log_prefix}      ⚠️  Note: `{_model}` looks like an OpenRouter slug (`:free` suffix).", force=True)
                                     agent._vprint(f"{agent.log_prefix}         Nous Portal won't recognize that model name. Either switch to a", force=True)
                                     agent._vprint(f"{agent.log_prefix}         Nous catalog model, or run `/model openrouter:{_model}` to use OpenRouter.", force=True)
+                        elif _summarize_403_proxy_block(api_error, status_code) is not None:
+                            # Non-standard 403 whose body isn't auth-shaped — a
+                            # custom relay/WAF blocking the request (often the
+                            # OpenAI SDK User-Agent), not a key rejection (#53099).
+                            _block_body = _summarize_403_proxy_block(api_error, status_code)
+                            agent._vprint(f"{agent.log_prefix}   💡 The endpoint returned a non-standard HTTP 403 that doesn't look like an", force=True)
+                            agent._vprint(f"{agent.log_prefix}      API-key rejection — likely a proxy/WAF block: \"{_block_body}\"", force=True)
+                            agent._vprint(f"{agent.log_prefix}      Your key and model access may be fine. For a custom endpoint, try:", force=True)
+                            agent._vprint(f"{agent.log_prefix}      • Check the endpoint's proxy/WAF rules (some block the OpenAI SDK User-Agent).", force=True)
+                            agent._vprint(f"{agent.log_prefix}      • Override the request User-Agent via model.default_headers, e.g.:", force=True)
+                            agent._vprint(f"{agent.log_prefix}            model:", force=True)
+                            agent._vprint(f"{agent.log_prefix}              default_headers:", force=True)
+                            agent._vprint(f"{agent.log_prefix}                User-Agent: curl/8.7.1", force=True)
                         else:
                             agent._vprint(f"{agent.log_prefix}   💡 Your API key was rejected by the provider. Check:", force=True)
                             agent._vprint(f"{agent.log_prefix}      • Is the key valid? Run: hermes setup", force=True)

--- a/tests/agent/test_waf_403_block_guidance.py
+++ b/tests/agent/test_waf_403_block_guidance.py
@@ -1,0 +1,104 @@
+"""Tests for the non-auth HTTP 403 (proxy/WAF block) guidance branch in
+``agent.conversation_loop``.
+
+Regression context (#53099): a custom OpenAI-compatible relay sitting behind a
+WAF blocked the OpenAI SDK's default ``User-Agent`` and answered with a short
+plain-text 403 body (``Your request was blocked.``). Hermes classified that as
+auth and printed "Your API key was rejected by the provider", sending the user
+down the wrong debugging path even though the key, model, and endpoint were all
+valid.
+
+The fix adds a conservative branch — ``_summarize_403_proxy_block`` — that fires
+only when a 403 body is clearly *not* auth-shaped, and prints proxy/WAF +
+``model.default_headers`` guidance instead of the key-rejection message.
+"""
+from __future__ import annotations
+
+import inspect
+
+from agent import conversation_loop
+from agent.conversation_loop import _summarize_403_proxy_block
+
+
+class _FakeAPIError(Exception):
+    """Stand-in for an OpenAI SDK status error: carries ``status_code`` and an
+    optional structured ``body`` like the real exceptions do."""
+
+    def __init__(self, message: str, status_code: int, body=None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body
+
+
+def test_plain_text_403_block_is_detected():
+    """A plain-text 'Your request was blocked.' 403 is recognized as a
+    proxy/WAF block and its body is echoed back as a short snippet."""
+    err = _FakeAPIError("Your request was blocked.", status_code=403, body=None)
+    snippet = _summarize_403_proxy_block(err, 403)
+    assert snippet is not None
+    assert "blocked" in snippet.lower()
+
+
+def test_string_body_403_block_is_detected():
+    """A 403 whose ``body`` is the plain-text block string is detected too."""
+    err = _FakeAPIError(
+        "Error code: 403 - Your request was blocked.",
+        status_code=403,
+        body="Your request was blocked.",
+    )
+    snippet = _summarize_403_proxy_block(err, 403)
+    assert snippet == "Your request was blocked."
+
+
+def test_auth_shaped_json_403_is_not_a_block():
+    """A standard auth-shaped JSON 403 body must NOT be treated as a WAF block —
+    callers keep the existing key-rejection guidance."""
+    err = _FakeAPIError(
+        "permission denied",
+        status_code=403,
+        body={"error": {"message": "You do not have access to model gpt-5.5",
+                        "type": "invalid_request_error"}},
+    )
+    assert _summarize_403_proxy_block(err, 403) is None
+
+
+def test_auth_shaped_plain_text_403_is_not_a_block():
+    """Even a plain-text 403 that mentions an API-key/permission failure must
+    fall back to the key-rejection guidance (markers win)."""
+    err = _FakeAPIError("Incorrect API key provided.", status_code=403, body=None)
+    assert _summarize_403_proxy_block(err, 403) is None
+
+    err2 = _FakeAPIError("You do not have access to this model.", status_code=403, body=None)
+    assert _summarize_403_proxy_block(err2, 403) is None
+
+
+def test_401_is_never_a_block():
+    """The heuristic only applies to 403 — a 401 is left to the OAuth/key
+    guidance regardless of body shape."""
+    err = _FakeAPIError("Your request was blocked.", status_code=401, body=None)
+    assert _summarize_403_proxy_block(err, 401) is None
+
+
+def test_block_snippet_is_truncated():
+    """A long plain-text block body is collapsed to a single short line."""
+    long_body = "Your request was blocked. " * 50
+    err = _FakeAPIError(long_body, status_code=403, body=long_body)
+    snippet = _summarize_403_proxy_block(err, 403)
+    assert snippet is not None
+    assert len(snippet) <= 201
+    assert "\n" not in snippet
+
+
+def test_waf_guidance_strings_present_in_source():
+    """The user-facing proxy/WAF guidance — including the ``default_headers``
+    workaround — must exist in the run_conversation body so a future refactor
+    can't silently drop it."""
+    source = inspect.getsource(conversation_loop.run_conversation)
+
+    assert "_summarize_403_proxy_block" in source
+    assert "proxy/WAF block" in source
+    assert "default_headers" in source
+    assert "User-Agent: curl/8.7.1" in source
+    # And the existing key-rejection guidance must still be present for the
+    # genuinely auth-shaped case.
+    assert "Your API key was rejected by the provider" in source


### PR DESCRIPTION
## What does this PR do?

A custom OpenAI-compatible endpoint that sits behind a proxy/WAF can return an HTTP 403 with a short plain-text body like `Your request was blocked.` (commonly because the relay blocks the OpenAI SDK's default `User-Agent`). Hermes classifies any non-billing 403 as auth and prints:

```
Your API key was rejected by the provider. Check:
  • Is the key valid? Run: hermes setup
  • Does your account have access to gpt-5.5?
```

That guidance is misleading — the key, model, and endpoint are valid — and sends users down the wrong debugging path.

This adds a small, conservative branch in the existing non-retryable auth-guidance block: when a 403 body is clearly **not** auth-shaped (plain text, no auth markers like `api key`/`authentication`/`permission`, no JSON `error` envelope), Hermes reports it as a likely proxy/WAF block, echoes the short body, and suggests checking the endpoint's WAF/proxy rules or overriding the request `User-Agent` via `model.default_headers`. Genuinely auth-shaped 401/403 responses still get the existing key-rejection message, and the heuristic defaults to the old behavior whenever it's unsure (it does not touch the error classifier).

## Related Issue

Fixes #53099

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_loop.py`: add `_summarize_403_proxy_block()` helper + `_AUTH_ERROR_MARKERS`, and a guidance branch before the generic "API key was rejected" message.
- `tests/agent/test_waf_403_block_guidance.py`: cover the new branch (plain-text block detected; auth-shaped JSON/plain-text 403 and 401 still fall back to key-rejection; snippet truncation; guidance strings present in source).

## How to Test

1. Point Hermes at an OpenAI-compatible endpoint behind a WAF that blocks the OpenAI SDK `User-Agent` and returns `403 Your request was blocked.`
2. Before this change: Hermes prints "Your API key was rejected by the provider."
3. After this change: Hermes reports a likely proxy/WAF block, echoes the body, and suggests the `model.default_headers` / `User-Agent: curl/8.7.1` workaround.
4. `pytest tests/agent/test_waf_403_block_guidance.py tests/agent/test_nous_oauth_401_guidance.py -q` — all green.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(agent):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (error-message-only change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (no platform-specific code)
- [x] I've updated tool descriptions/schemas — N/A
