### PR TITLE
fix(desktop/windows): self-heal missing @esbuild platform binary in bundle-electron-main

### DIFF
--- a/apps/desktop/scripts/bundle-electron-main.mjs
+++ b/apps/desktop/scripts/bundle-electron-main.mjs
@@ -9,14 +9,15 @@
 import { build } from 'esbuild'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { renameSync } from 'node:fs'
+import { renameSync, existsSync } from 'node:fs'
+import { createRequire } from 'node:module'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const root = resolve(here, '..')
 const entry = resolve(root, 'electron/main.cjs')
 const tmp = resolve(root, 'electron/main.bundled.cjs')
 
-await build({
+const options = {
   entryPoints: [entry],
   bundle: true,
   platform: 'node',
@@ -24,8 +25,56 @@ await build({
   target: 'node20',
   outfile: tmp,
   external: ['electron', 'node-pty'],
-  logLevel: 'info'
-})
+  logLevel: 'info',
+}
+
+// esbuild's native binary ships as a platform-specific OPTIONAL dependency
+// (`@esbuild/<os>-<arch>`). esbuild is only a transitive dependency here, and
+// on some lockfile / `npm ci` combinations npm never lays the optional package
+// down — leaving `node_modules/@esbuild` empty, so esbuild throws
+//   Error: The package "@esbuild/win32-x64" could not be found ...
+// at build time and the desktop build fails (observed on Windows). Self-heal:
+// install the matching platform binary at esbuild's own resolved version, then
+// retry. A no-op once the binary is present.
+async function bundleMain() {
+  try {
+    await build(options)
+  } catch (err) {
+    const message = String((err && err.message) || err)
+    const missing = message.match(/The package "(@esbuild\/[^"]+)" could not be found/)
+    if (!missing) throw err
+
+    const require = createRequire(import.meta.url)
+    const esbuildPkgJson = require.resolve('esbuild/package.json')
+    const version = require(esbuildPkgJson).version
+    const installRoot = resolve(dirname(esbuildPkgJson), '..', '..')
+    const pkg = `${missing[1]}@${version}`
+    console.warn(`[bundle-electron-main] ${missing[1]} is missing — installing ${pkg} and retrying…`)
+
+    // Invoke npm via the current Node + npm-cli.js: no shell, array args
+    // (nothing is interpolated/escaped), and it sidesteps Node 20+'s refusal to
+    // execFile a .cmd directly (EINVAL on Windows). npm_execpath is set when
+    // this runs under `npm run`; otherwise resolve npm-cli.js next to Node.
+    const { execFileSync } = await import('node:child_process')
+    const nodeDir = dirname(process.execPath)
+    const npmCli = [
+      process.env.npm_execpath,
+      resolve(nodeDir, 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+      resolve(nodeDir, '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    ].find((p) => p && /\.[cm]?js$/i.test(p) && existsSync(p))
+    if (!npmCli) {
+      throw new Error(`could not locate npm-cli.js to install ${pkg}; run \`npm install --no-save ${pkg}\` and rebuild`)
+    }
+    execFileSync(
+      process.execPath,
+      [npmCli, 'install', '--no-save', '--no-audit', '--no-fund', '--prefix', installRoot, pkg],
+      { stdio: 'inherit' },
+    )
+    await build(options)
+  }
+}
+
+await bundleMain()
 
 // Overwrite the original with the bundled version.
 renameSync(tmp, entry)


### PR DESCRIPTION
## Problem
`apps/desktop` builds fail in the `bundle-electron-main.mjs` step with:

```
Error: The package "@esbuild/win32-x64" could not be found, and is needed by esbuild.
```

esbuild is a **transitive-only** dependency of `apps/desktop` (it is `import`ed by `scripts/bundle-electron-main.mjs` but not declared in `apps/desktop/package.json`), and esbuild ships its native binary as a platform-specific **optional** dependency (`@esbuild/<os>-<arch>`). On some lockfile / `npm ci` combinations npm never installs that optional package: `node_modules/@esbuild` ends up empty and `package-lock.json` carries no `@esbuild/*` package entries, so `npm run pack` dies on whatever platform is building. Reproduced on Windows / Node 24 (a clean reinstall left `node_modules/@esbuild` empty).

## Fix
`bundle-electron-main.mjs` now catches that specific esbuild error and installs the matching `@esbuild` platform package **at esbuild's own resolved version**, then retries the build — a no-op once the binary is present. npm is invoked via the current Node + `npm-cli.js` (no shell, array args) to avoid Node 20+'s `EINVAL` when exec'ing `npm.cmd` directly on Windows.

## Verification
- Reproduced: removed `node_modules/@esbuild`, ran the bundler → failed with the exact error above.
- With the patch: detects the missing pkg, installs `@esbuild/win32-x64@0.28.1`, rebuilds successfully — verified on Windows / Node 24, both with `npm_execpath` set (under `npm run pack`) and resolving `npm-cli.js` next to Node.
- `node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
