### PR TITLE
fix(desktop): call checkUpdates() in startUpdatePoller so version pill auto-populates

### DIFF
--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -51,7 +51,10 @@ const {
   applyUpdates,
   $updateApply,
   $updateOverlayOpen,
-  resetUpdateApplyState
+  resetUpdateApplyState,
+  startUpdatePoller,
+  stopUpdatePoller,
+  $updateStatus
 } = await import('./updates')
 
 const { setConnection } = await import('./session')
@@ -432,5 +435,74 @@ describe('applyBackendUpdate recovery', () => {
 
     expect(result.ok).toBe(false)
     expect($backendUpdateApply.get().stage).toBe('error')
+  })
+})
+
+describe('startUpdatePoller', () => {
+  const checkMock = vi.fn()
+  const onProgressMock = vi.fn()
+  const listeners: Record<string, Function> = {}
+
+  beforeEach(() => {
+    storage.clear()
+    checkMock.mockReset()
+    onProgressMock.mockReset()
+    Object.keys(listeners).forEach(k => delete listeners[k])
+    checkMock.mockResolvedValue({
+      supported: true,
+      behind: 5,
+      targetSha: 'sha-abc',
+      fetchedAt: 0
+    })
+    $updateStatus.set(null)
+    ;(globalThis as unknown as { window: unknown }).window = {
+      hermesDesktop: { updates: { check: checkMock, onProgress: onProgressMock } },
+      addEventListener: vi.fn((event: string, handler: Function) => {
+        listeners[event] = handler
+      }),
+      removeEventListener: vi.fn()
+    }
+    vi.useFakeTimers()
+    stopUpdatePoller()
+  })
+
+  afterEach(() => {
+    stopUpdatePoller()
+    delete (globalThis as unknown as { window?: unknown }).window
+    vi.useRealTimers()
+  })
+
+  it('calls checkUpdates() on startup so the version pill populates immediately', async () => {
+    startUpdatePoller()
+
+    // checkUpdates() is async — flush microtasks without advancing the 30-min interval.
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(checkMock).toHaveBeenCalled()
+    expect($updateStatus.get()?.behind).toBe(5)
+  })
+
+  it('calls checkUpdates() on each interval tick', async () => {
+    startUpdatePoller()
+    await vi.advanceTimersByTimeAsync(0)
+    checkMock.mockClear()
+
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000)
+
+    expect(checkMock).toHaveBeenCalled()
+  })
+
+  it('calls checkUpdates() when the window regains focus', async () => {
+    startUpdatePoller()
+    await vi.advanceTimersByTimeAsync(0)
+    checkMock.mockClear()
+
+    // Invoke the registered focus handler directly (the mock window doesn't
+    // propagate DOM events, so call the stored listener).
+    listeners['focus']?.()
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(checkMock).toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -610,6 +610,7 @@ export function startUpdatePoller(): void {
   }
 
   pollerStarted = true
+  void checkUpdates()
   void checkBackendUpdates()
   void refreshDesktopVersion()
   bridge.onProgress(ingestProgress)
@@ -632,6 +633,7 @@ export function startUpdatePoller(): void {
   window.addEventListener('focus', onFocus)
   backgroundTimer = setInterval(
     () => {
+      void checkUpdates()
       void checkBackendUpdates()
     },
     30 * 60 * 1000
@@ -659,6 +661,7 @@ function onFocus() {
   }
 
   lastFocusAt = now
+  void checkUpdates()
   void checkBackendUpdates()
   void refreshDesktopVersion()
 }


### PR DESCRIPTION
## Bug Description

The Desktop statusbar version pill shows the commit-behind count (e.g. `v0.17.0 (+28)`) but after a restart it only shows the version number with no counter. The counter only appears after the user manually clicks the version pill to open the updates overlay.

Fixes #53079

## Root Cause

`startUpdatePoller()` in `src/store/updates.ts` only calls `checkBackendUpdates()` — it never calls `checkUpdates()` (the client/local update check). The statusbar `clientVersionItem` reads `$updateStatus` (set by `checkUpdates()`), not `$backendUpdateStatus`. Since `checkUpdates()` is never auto-triggered, `$updateStatus` stays `null` → `behind` defaults to 0 → no counter shown.

For local-mode Desktop (gateway runs on same machine), `checkBackendUpdates()` early-returns because `isRemoteMode() === false`, so even the background timer does nothing.

## Fix

Added `void checkUpdates()` in three places alongside the existing `checkBackendUpdates()` calls:

- **Startup** in `startUpdatePoller()` — immediate check on mount
- **30-minute `setInterval`** callback — periodic background poll
- **`onFocus` handler** — check when user returns to the app

`checkUpdates()` uses the Electron IPC bridge (local git check), not the gateway, so no mode gating is needed. The existing `$updateChecking` atom guard prevents double-fire when focus/interval overlap.

## How to Verify

1. Launch the Desktop app with a local backend
2. Wait a few seconds — the version pill should automatically show `vX.Y.Z (+N)` without clicking
3. Switch to another window and back — the counter should refresh
4. Existing update overlay (clicking the pill) still works as before

## Test Plan

- [x] Added 3 regression tests for `startUpdatePoller` (startup, interval, focus)
- [x] Existing 21 tests still pass (24/24 total)
- [ ] Manual verification of the fix

## Risk Assessment

Low — adds a single async fire-and-forget call alongside an existing identical pattern. The `$updateChecking` guard inside `checkUpdates()` prevents concurrent runs. No new dependencies, no config changes, no API surface changes.
