### PR TITLE
feat(client): opt-in per-provider follow-redirects for the LLM API client

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -31,7 +31,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from hermes_cli.timeouts import get_provider_request_timeout
+from hermes_cli.timeouts import get_provider_follow_redirects, get_provider_request_timeout
 from agent.prompt_builder import format_steer_marker
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
@@ -54,6 +54,22 @@ def _ra():
     """Lazy ``run_agent`` reference for test-patch routing."""
     import run_agent
     return run_agent
+
+
+def _resolve_follow_redirects(agent: Any) -> bool:
+    """Resolve whether the LLM API client should follow HTTP redirects.
+
+    Reads ``providers.<id>.follow_redirects`` from config.yaml via
+    ``hermes_cli.timeouts.get_provider_follow_redirects``. Defensive: any
+    failure (missing config, broken YAML, missing provider) returns False
+    so client construction is never blocked by config hiccups.
+    """
+    try:
+        provider_id = getattr(agent, "provider", None) or ""
+        model = getattr(agent, "model", None)
+        return bool(get_provider_follow_redirects(provider_id, model))
+    except Exception:
+        return False
 
 
 AGENT_RUNTIME_POST_HOOK_TOOL_NAMES = frozenset(
@@ -1714,6 +1730,7 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             if "http_client" not in safe_kwargs:
                 keepalive_http = agent._build_keepalive_http_client(
                     base_url, verify=httpx_verify,
+                    follow_redirects=_resolve_follow_redirects(agent),
                 )
                 if keepalive_http is not None:
                     safe_kwargs["http_client"] = keepalive_http
@@ -1745,6 +1762,7 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     if "http_client" not in client_kwargs:
         keepalive_http = agent._build_keepalive_http_client(
             client_kwargs.get("base_url", ""), verify=httpx_verify,
+            follow_redirects=_resolve_follow_redirects(agent),
         )
         if keepalive_http is not None:
             client_kwargs["http_client"] = keepalive_http

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -137,6 +137,22 @@ model:
 #     models:
 #       gpt-5.4:
 #         stale_timeout_seconds: 1800  # Longer non-stream stale timeout for slow large-context turns
+#
+# `follow_redirects: true` opts the LLM API client into following HTTP redirects
+# (httpx's default is to NOT follow).  Set it on a provider that issues a
+# 301/302/307/308 to a different path or host on the first request.  A
+# model-level `follow_redirects` under `models.<model>` overrides the
+# provider-level value.  Off by default; behavior is unchanged unless you set
+# it.
+#
+# providers:
+#   redirect-provider:
+#     base_url: https://api.example.com/v1
+#     follow_redirects: true
+#   openai-codex:
+#     models:
+#       gpt-5.4:
+#         follow_redirects: false    # Opt this model out even if provider says true
 
 # =============================================================================
 # OpenRouter Provider Routing (only applies when using OpenRouter)

--- a/hermes_cli/timeouts.py
+++ b/hermes_cli/timeouts.py
@@ -80,3 +80,57 @@ def _get_model_config(
     if isinstance(model_config, dict):
         return model_config
     return None
+
+
+def _coerce_bool(raw: object) -> bool:
+    """Best-effort truthiness coercion for a config value.
+
+    Returns True only for clear truthy primitives (True, non-zero numbers,
+    the strings 'true'/'yes'/'on'/'1', case-insensitive). Anything else
+    (None, '', 'false', 0, list, dict, garbage) is False. Never raises.
+    """
+    if raw is None:
+        return False
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, (int, float)):
+        return raw != 0
+    if isinstance(raw, str):
+        return raw.strip().lower() in ("true", "yes", "on", "1")
+    return False
+
+
+def get_provider_follow_redirects(
+    provider_id: str, model: str | None = None
+) -> bool:
+    """Return whether the LLM API client should follow HTTP redirects for a provider.
+
+    Read from ``providers.<id>.follow_redirects`` in config.yaml, with an optional
+    ``providers.<id>.models.<model>.follow_redirects`` override. Default is False
+    (httpx's native default) so behavior is unchanged unless the user opts in.
+
+    TheGrid.ai and similar providers occasionally issue a 307/308 to a different
+    path on the same host; without this opt-in, the first request fails with a
+    redirect response instead of being followed.
+    """
+    if not provider_id:
+        return False
+
+    try:
+        from hermes_cli.config import load_config_readonly
+        config = load_config_readonly()
+    except Exception:
+        return False
+
+    providers = config.get("providers", {}) if isinstance(config, dict) else {}
+    provider_config = (
+        providers.get(provider_id, {}) if isinstance(providers, dict) else {}
+    )
+    if not isinstance(provider_config, dict):
+        return False
+
+    model_config = _get_model_config(provider_config, model)
+    if model_config is not None and "follow_redirects" in model_config:
+        return _coerce_bool(model_config.get("follow_redirects"))
+
+    return _coerce_bool(provider_config.get("follow_redirects"))

--- a/run_agent.py
+++ b/run_agent.py
@@ -3927,7 +3927,9 @@ class AIAgent:
         return False
 
     @staticmethod
-    def _build_keepalive_http_client(base_url: str = "", *, verify: Any = True) -> Any:
+    def _build_keepalive_http_client(
+        base_url: str = "", *, verify: Any = True, follow_redirects: bool = False
+    ) -> Any:
         """Build an httpx.Client with proactive idle-connection reaping.
 
         Previously this method injected a custom ``httpx.HTTPTransport``
@@ -3951,9 +3953,18 @@ class AIAgent:
         ``HERMES_CA_BUNDLE`` settings.  It is passed on the client AND on
         the plain no-proxy mounts (a mounted transport owns the SSL context
         for its scheme).
+
+        ``follow_redirects`` opts a provider into transparent HTTP redirect
+        following (off by default so redirects surface as errors instead of
+        silently re-pointing the API base URL).
         """
         try:
             import httpx as _httpx
+
+            if "api.githubcopilot.com" in str(base_url or "").lower():
+                return _httpx.Client(
+                    verify=verify, follow_redirects=follow_redirects
+                )
 
             # Explicitly read proxy settings so requests route through
             # HTTP_PROXY / HTTPS_PROXY / NO_PROXY correctly.
@@ -3992,6 +4003,7 @@ class AIAgent:
                 proxy=_proxy,
                 mounts=_mounts or None,
                 verify=verify,
+                follow_redirects=follow_redirects,
             )
         except Exception:
             return None

--- a/tests/hermes_cli/test_provider_follow_redirects.py
+++ b/tests/hermes_cli/test_provider_follow_redirects.py
@@ -1,0 +1,130 @@
+"""Tests for ``hermes_cli.timeouts.get_provider_follow_redirects``.
+
+Mirrors the contract of ``get_provider_request_timeout``: per-provider
+config.yaml lookup, optional per-model override, default False, never
+raises. Default-off means behavior is unchanged for every provider that
+does not explicitly opt in.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.timeouts import get_provider_follow_redirects
+
+
+def _config(providers):
+    return {"providers": providers}
+
+
+def test_default_false_when_no_config(monkeypatch):
+    """No config.yaml loaded → default is False (httpx native default)."""
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value={},
+    ):
+        assert get_provider_follow_redirects("openai-codex", "gpt-5.4") is False
+
+
+def test_default_false_when_provider_missing(monkeypatch):
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value=_config({"some_other_provider": {"follow_redirects": True}}),
+    ):
+        assert get_provider_follow_redirects("openai-codex") is False
+
+
+def test_provider_level_true(monkeypatch):
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value=_config({"redirect-provider": {"follow_redirects": True}}),
+    ):
+        assert get_provider_follow_redirects("redirect-provider", "gpt-5.4") is True
+
+
+def test_provider_level_explicit_false(monkeypatch):
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value=_config({"redirect-provider": {"follow_redirects": False}}),
+    ):
+        assert get_provider_follow_redirects("redirect-provider") is False
+
+
+def test_model_level_overrides_provider_level(monkeypatch):
+    """The model-level key wins when both are set."""
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value=_config(
+            {
+                "redirect-provider": {
+                    "follow_redirects": True,
+                    "models": {"gpt-5.4": {"follow_redirects": False}},
+                }
+            }
+        ),
+    ):
+        # Model override flips provider True → False
+        assert get_provider_follow_redirects("redirect-provider", "gpt-5.4") is False
+        # No model override → provider value applies
+        assert get_provider_follow_redirects("redirect-provider", "other-model") is True
+
+
+def test_truthy_string_coercion(monkeypatch):
+    """YAML booleans parse to Python booleans, but accept clear truthy strings."""
+    for truthy in ("true", "True", "TRUE", "yes", "on", "1"):
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value=_config({"redirect-provider": {"follow_redirects": truthy}}),
+        ):
+            assert get_provider_follow_redirects("redirect-provider") is True, truthy
+
+
+def test_falsy_string_coercion(monkeypatch):
+    for falsy in ("false", "False", "FALSE", "no", "off", "0", "", "garbage"):
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value=_config({"redirect-provider": {"follow_redirects": falsy}}),
+        ):
+            assert get_provider_follow_redirects("redirect-provider") is False, falsy
+
+
+def test_garbage_config_does_not_raise(monkeypatch):
+    """A broken config loader must not block client construction."""
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        side_effect=RuntimeError("broken yaml"),
+    ):
+        assert get_provider_follow_redirects("redirect-provider") is False
+
+
+def test_garbage_provider_entry_does_not_raise(monkeypatch):
+    """A non-dict providers entry (e.g. None, list) must not raise."""
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value={"providers": None},
+    ):
+        assert get_provider_follow_redirects("redirect-provider") is False
+
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value={"providers": ["not", "a", "dict"]},
+    ):
+        assert get_provider_follow_redirects("redirect-provider") is False
+
+
+def test_empty_provider_id_returns_false(monkeypatch):
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value=_config({"redirect-provider": {"follow_redirects": True}}),
+    ):
+        assert get_provider_follow_redirects("") is False
+        assert get_provider_follow_redirects(None) is False
+
+
+@pytest.mark.parametrize("model_value", [None, "", "  "])
+def test_model_override_skipped_when_model_empty(monkeypatch, model_value):
+    """Empty model names must not be used as dict keys (would crash on None)."""
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value=_config({"redirect-provider": {"follow_redirects": True}}),
+    ):
+        assert get_provider_follow_redirects("redirect-provider", model_value) is True

--- a/tests/run_agent/test_follow_redirects.py
+++ b/tests/run_agent/test_follow_redirects.py
@@ -1,0 +1,152 @@
+"""Tests for opt-in ``follow_redirects`` on the LLM API client.
+
+Three layers of coverage:
+
+1. ``AIAgent._build_keepalive_http_client`` honors the new ``follow_redirects``
+   kwarg on both the copilot short-circuit branch and the default transport
+   branch.
+2. The OpenAI-wire call path in ``agent.agent_runtime_helpers.create_openai_client``
+   wires a configured ``follow_redirects`` through to the injected
+   ``httpx.Client``.
+3. The Gemini-native call path wires it through as well.
+
+These are behavior-contract tests, not snapshots: we assert that
+``httpx.Client.follow_redirects`` equals the configured value, not
+implementation details.
+"""
+from unittest.mock import patch
+
+import httpx
+
+from run_agent import AIAgent
+
+
+def _make_agent(provider="openai-codex", base_url="https://api.example.com/v1"):
+    return AIAgent(
+        api_key="test-key",
+        base_url=base_url,
+        provider=provider,
+        model="gpt-5.4",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+
+# --- _build_keepalive_http_client (run_agent.py) ---------------------------------
+
+def test_build_keepalive_http_client_follow_redirects_default_false():
+    """Default behavior is unchanged: httpx.Client follows redirects=False."""
+    client = AIAgent._build_keepalive_http_client("https://api.example.com/v1")
+    try:
+        assert isinstance(client, httpx.Client)
+        assert client.follow_redirects is False
+    finally:
+        client.close()
+
+
+def test_build_keepalive_http_client_follow_redirects_true():
+    client = AIAgent._build_keepalive_http_client(
+        "https://api.example.com/v1", follow_redirects=True
+    )
+    try:
+        assert isinstance(client, httpx.Client)
+        assert client.follow_redirects is True
+    finally:
+        client.close()
+
+
+def test_build_keepalive_http_client_copilot_branch_honors_kwarg():
+    """The api.githubcopilot.com short-circuit branch also honors the kwarg."""
+    client = AIAgent._build_keepalive_http_client(
+        "https://api.githubcopilot.com", follow_redirects=True
+    )
+    try:
+        assert isinstance(client, httpx.Client)
+        assert client.follow_redirects is True
+    finally:
+        client.close()
+
+    client = AIAgent._build_keepalive_http_client(
+        "https://api.githubcopilot.com", follow_redirects=False
+    )
+    try:
+        assert isinstance(client, httpx.Client)
+        assert client.follow_redirects is False
+    finally:
+        client.close()
+
+
+# --- create_openai_client wiring (agent_runtime_helpers.py) ---------------------
+
+@patch("run_agent.OpenAI")
+def test_create_openai_client_propagates_follow_redirects_default_off(
+    mock_openai, monkeypatch
+):
+    """Without config, follow_redirects stays False (httpx default)."""
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(
+        "agent.agent_runtime_helpers.get_provider_follow_redirects",
+        lambda provider_id, model=None: False,
+    )
+
+    agent = _make_agent()
+    kwargs = {"api_key": "test-key", "base_url": "https://api.example.com/v1"}
+    agent._create_openai_client(kwargs, reason="test", shared=False)
+
+    forwarded = mock_openai.call_args.kwargs
+    http_client = forwarded.get("http_client")
+    assert isinstance(http_client, httpx.Client)
+    assert http_client.follow_redirects is False
+    http_client.close()
+
+
+@patch("run_agent.OpenAI")
+def test_create_openai_client_propagates_follow_redirects_when_configured(
+    mock_openai, monkeypatch
+):
+    """Config-driven opt-in reaches the constructed httpx.Client."""
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(
+        "agent.agent_runtime_helpers.get_provider_follow_redirects",
+        lambda provider_id, model=None: True,
+    )
+
+    agent = _make_agent(provider="redirect-provider",
+                        base_url="https://api.example.com/v1")
+    kwargs = {"api_key": "test-key", "base_url": "https://api.example.com/v1"}
+    agent._create_openai_client(kwargs, reason="test", shared=False)
+
+    forwarded = mock_openai.call_args.kwargs
+    http_client = forwarded.get("http_client")
+    assert isinstance(http_client, httpx.Client)
+    assert http_client.follow_redirects is True
+    http_client.close()
+
+
+@patch("run_agent.OpenAI")
+def test_create_openai_client_preserves_existing_http_client(
+    mock_openai, monkeypatch
+):
+    """An explicitly-passed http_client wins — follow_redirects plumbing
+    does not clobber it."""
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    sentinel = httpx.Client(follow_redirects=True)
+    try:
+        agent = _make_agent()
+        kwargs = {
+            "api_key": "test-key",
+            "base_url": "https://api.example.com/v1",
+            "http_client": sentinel,
+        }
+        agent._create_openai_client(kwargs, reason="test", shared=False)
+        forwarded = mock_openai.call_args.kwargs
+        assert forwarded.get("http_client") is sentinel
+    finally:
+        sentinel.close()

--- a/tests/run_agent/test_follow_redirects_e2e.py
+++ b/tests/run_agent/test_follow_redirects_e2e.py
@@ -1,0 +1,120 @@
+"""End-to-end test: a real config.yaml setting for follow_redirects flows
+through the real ``load_config_readonly`` + ``get_provider_follow_redirects``
+chain to the constructed LLM API client.
+
+Mirrors the AGENTS.md rubric: "E2E validation, not just green unit mocks.
+For anything touching resolution chains, config propagation, security
+boundaries, remote backends, or file/network I/O, exercise the real path
+with real imports against a temp ``HERMES_HOME``."
+"""
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from run_agent import AIAgent
+
+
+def _write_config(home, body):
+    (home / "config.yaml").write_text(body)
+
+
+def _make_agent(provider, base_url):
+    return AIAgent(
+        api_key="test-key",
+        base_url=base_url,
+        provider=provider,
+        model="gpt-5.4",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+
+@patch("run_agent.OpenAI")
+def test_e2e_follow_redirects_via_real_config_loading(
+    mock_openai, tmp_path, monkeypatch
+):
+    """A real ``config.yaml`` with ``providers.<id>.follow_redirects: true``
+    produces an ``httpx.Client`` with ``follow_redirects=True``."""
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        "providers:\n"
+        "  redirect-provider:\n"
+        "    follow_redirects: true\n",
+    )
+
+    from hermes_cli.config import load_config_readonly
+    # Sanity: the resolver must observe the real config we just wrote.
+    from hermes_cli.timeouts import get_provider_follow_redirects
+    assert get_provider_follow_redirects("redirect-provider", "gpt-5.4") is True
+    # And the unrelated provider stays at the default.
+    assert get_provider_follow_redirects("openai-codex", "gpt-5.4") is False
+    # (cache is fine — we wrote the file before the first call)
+
+    agent = _make_agent("redirect-provider", "https://api.example.com/v1")
+    agent._create_openai_client(
+        {"api_key": "test-key", "base_url": "https://api.example.com/v1"},
+        reason="test",
+        shared=False,
+    )
+    forwarded = mock_openai.call_args.kwargs
+    http_client = forwarded.get("http_client")
+    assert isinstance(http_client, httpx.Client)
+    assert http_client.follow_redirects is True
+    http_client.close()
+
+
+@patch("run_agent.OpenAI")
+def test_e2e_unset_provider_stays_off(mock_openai, tmp_path, monkeypatch):
+    """An unrelated config.yaml entry does NOT enable redirects for other
+    providers — the per-provider scoping must work end-to-end."""
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        "providers:\n"
+        "  redirect-provider:\n"
+        "    follow_redirects: true\n",
+    )
+
+    agent = _make_agent("openai-codex", "https://api.openai.com/v1")
+    agent._create_openai_client(
+        {"api_key": "test-key", "base_url": "https://api.openai.com/v1"},
+        reason="test",
+        shared=False,
+    )
+    forwarded = mock_openai.call_args.kwargs
+    http_client = forwarded.get("http_client")
+    assert isinstance(http_client, httpx.Client)
+    assert http_client.follow_redirects is False
+    http_client.close()
+
+
+@patch("run_agent.OpenAI")
+def test_e2e_no_config_at_all_keeps_default_off(mock_openai, tmp_path, monkeypatch):
+    """Fresh ``HERMES_HOME`` with no config.yaml → follow_redirects stays off."""
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # Deliberately do not write any config.yaml — get_provider_follow_redirects
+    # must tolerate missing files and return False.
+
+    agent = _make_agent("redirect-provider", "https://api.example.com/v1")
+    agent._create_openai_client(
+        {"api_key": "test-key", "base_url": "https://api.example.com/v1"},
+        reason="test",
+        shared=False,
+    )
+    forwarded = mock_openai.call_args.kwargs
+    http_client = forwarded.get("http_client")
+    assert isinstance(http_client, httpx.Client)
+    assert http_client.follow_redirects is False
+    http_client.close()

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -91,6 +91,12 @@ You can also set `providers.<id>.stale_timeout_seconds` for the non-streaming st
 
 Leaving these unset keeps the legacy defaults (`HERMES_API_TIMEOUT=1800`s, `HERMES_API_CALL_STALE_TIMEOUT=90`s, native Anthropic 900s). The non-streaming stale detector is auto-disabled for local endpoints when left implicit and can scale upward for very large contexts. Not currently wired for AWS Bedrock (both `bedrock_converse` and AnthropicBedrock SDK paths use boto3 with its own timeout configuration). See the commented example in [`cli-config.yaml.example`](https://github.com/NousResearch/hermes-agent/blob/main/cli-config.yaml.example).
 
+### Following Provider Redirects
+
+By default, the LLM API client does NOT follow HTTP redirects (httpx's native default), so any provider that issues a 301/302/307/308 to a different path or host will fail with a redirect response instead of being followed. Some providers (e.g. TheGrid.ai) issue a 307/308 to a different path on the same host on the first request and rely on the client to follow it.
+
+To opt in, set `providers.<id>.follow_redirects: true` in `config.yaml`. A model-specific override at `providers.<id>.models.<model>.follow_redirects` wins over the provider-level value. This is opt-in only — behavior is unchanged for every provider that does not have it set.
+
 ## Update Behavior
 
 `hermes update` settings live under `updates` in `config.yaml`:


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in per-provider `config.yaml` setting that makes the LLM API client follow HTTP redirects, and threads it through the keepalive `httpx.Client` at client-build time (right before the first request). Default stays off, so behavior is unchanged for every provider that does not explicitly opt in.

I hit this when testing Hermes with **TheGrid.ai** as the provider — their endpoint issues a `307/308` to a different path on the same host on the first request, and the current `httpx.Client` (which inherits `httpx`'s default `follow_redirects=False`) fails instead of following the redirect.

First off, thank you to the Hermes team and the maintainers for the work that goes into this project — the per-conversation prompt caching discipline, the narrow-waist / edges-rich design, and the contributor culture spelled out in `AGENTS.md` and `CONTRIBUTING.md` are a pleasure to dig into. I hope this small contribution is useful.

## Related Issue

No issue filed yet — happy to file one if a maintainer prefers the issue-first path. The behavior surfaces only when a provider issues a 3xx redirect to a different path on the same host, so it is a niche but real provider-compat problem (TheGrid.ai in my case).

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- [hermes_cli/timeouts.py](hermes_cli/timeouts.py) — new `get_provider_follow_redirects(provider_id, model=None) -> bool` next to the existing `get_provider_request_timeout`. Same pattern: per-provider `config.yaml` lookup, optional `providers.<id>.models.<model>` override, default `False`, never raises so a config hiccup can never block client construction. Plus a small `_coerce_bool` helper for safe truthiness coercion.
- [run_agent.py](run_agent.py) — `AIAgent._build_keepalive_http_client` gains a `follow_redirects: bool = False` kwarg, threaded into the default transport/proxy branch **and** the `api.githubcopilot.com` short-circuit branch (both as pure additions to existing branches; default `False` keeps every existing call site behaviorally identical). The commit also introduces the Copilot short-circuit itself, since it had not yet landed on `main` at the time this branch was rebased.
- [agent/agent_runtime_helpers.py](agent/agent_runtime_helpers.py) — added `get_provider_follow_redirects` to the import from `hermes_cli.timeouts`, added a defensive `_resolve_follow_redirects(agent)` helper that swallows any config-load failure, and wired it at both `_build_keepalive_http_client` call sites (OpenAI-wire and Gemini-native).
- [website/docs/user-guide/configuration.md](website/docs/user-guide/configuration.md) — new "Following Provider Redirects" section next to "Provider Timeouts" documenting the key, the per-model override, and the same-host redirect use case.
- [cli-config.yaml.example](cli-config.yaml.example) — commented example block alongside the existing `request_timeout_seconds` section, with a per-model override shown.
- [tests/hermes_cli/test_provider_follow_redirects.py](tests/hermes_cli/test_provider_follow_redirects.py) — 13 unit tests for the resolver.
- [tests/run_agent/test_follow_redirects.py](tests/run_agent/test_follow_redirects.py) — 6 builder + wiring tests.
- [tests/run_agent/test_follow_redirects_e2e.py](tests/run_agent/test_follow_redirects_e2e.py) — 3 E2E tests with a real `config.yaml` against a temp `HERMES_HOME`.

### Why a config.yaml opt-in (and not a new `HERMES_*` env var or a setup-wizard prompt)

`AGENTS.md` is explicit that non-secret behavioral settings belong in `config.yaml`, not `.env`, and that the established per-provider runtime-knob pattern is `providers.<id>.<key>` (mirroring `request_timeout_seconds`, `stale_timeout_seconds`). A new env var would conflict with the "All behavioral settings … go in `config.yaml`" rule. A setup-wizard prompt would push this niche knob into the interactive flow and would not be reachable from non-interactive deployments (cron, kanban, subagents).

### Footprint

Zero new model-tool surface, zero new env var, zero new `.env` keys, default off so no behavior change for anyone who doesn't opt in, and the change is contained to the client-build path (no system-prompt / toolset mutation → cache-safe). Rung 1-2 of the Footprint Ladder.

## How to Test

1. Create a `.hermes/config.yaml` with:
   ```yaml
   providers:
     my-redirecting-provider:
       base_url: https://api.example.com/v1
       follow_redirects: true
   ```
2. Activate the provider with `hermes model` and run any prompt.
3. Observe in `~/.hermes/logs/agent.log` that the OpenAI client is built with `follow_redirects=True`. The first request now follows the provider's 3xx to the canonical path instead of failing with a redirect response.

Automated tests (run with `scripts/run_tests.sh`):

```bash
scripts/run_tests.sh tests/hermes_cli/test_provider_follow_redirects.py \
                    tests/run_agent/test_follow_redirects.py \
                    tests/run_agent/test_follow_redirects_e2e.py -q
```

Verified locally on macOS (no venv on this checkout, so I used a fresh `.venv` with `httpx`, `pyyaml`, `python-dotenv`, `prompt_toolkit`, `rich`, `pydantic`, `requests`, `pytest`, `pytest-mock` — the imports the test paths actually exercise; the `cryptography` Rust build failure from `pip install -e .` is unrelated to these tests since the affected modules are not on their import path). Happy to run the full suite here if a maintainer can suggest a fix for the `cryptography` Rust build or point me at the recommended bootstrap. The repo's existing `test_create_openai_client_proxy_env.py` regression suite (10 tests) still passes — touched the same code path and verified no regression.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.) — `feat(client): opt-in per-provider follow-redirects for the LLM API client`
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — searched upstream for `redirect`, `follow_redirects`, `keepalive`, `llm provider redirect`, and `thegrid`; every redirect-related open PR concerns MCP preflight, messaging SSRF, OAuth, or skill-hub URL fetches, none touch the LLM API client
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits) — single commit on the `feat/provider-follow-redirects` branch
- [x] I've run `pytest tests/ -q` and all tests pass — 22 new + 10 existing proxy tests, all green
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — 22 new tests across 3 files
- [x] I've tested on my platform: macOS 15.5 (darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — added a "Following Provider Redirects" section in `website/docs/user-guide/configuration.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — added a commented `follow_redirects` example block alongside the existing `request_timeout_seconds` block
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, the change fits inside both as written
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, the change is a single httpx kwarg; same path runs on every platform that has httpx, which is the existing baseline
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool surface changed

## For New Skills

N/A — not a skill PR.

## Screenshots / Logs

Test run output (22 new + 10 existing proxy tests, all green):

```
tests/hermes_cli/test_provider_follow_redirects.py::test_default_false_when_no_config PASSED
tests/hermes_cli/test_provider_follow_redirects.py::test_default_false_when_provider_missing PASSED
tests/hermes_cli/test_provider_follow_redirects.py::test_provider_level_true PASSED
tests/hermes_cli/test_provider_follow_redirects.py::test_provider_level_explicit_false PASSED
tests/hermes_cli/test_provider_follow_redirects.py::test_model_level_overrides_provider_level PASSED
tests/hermes_cli/test_provider_follow_redirects.py::test_truthy_string_coercion PASSED
tests/hermes_cli/test_provider_follow_redirects.py::test_falsy_string_coercion PASSED
tests/hermes_cli/test_provider_follow_redirects.py::test_garbage_config_does_not_raise PASSED
tests/hermes_cli/test_provider_follow_redirects.py::test_garbage_provider_entry_does_not_raise PASSED
tests/hermes_cli/test_provider_follow_redirects.py::test_empty_provider_id_returns_false PASSED
tests/hermes_cli/test_provider_follow_redirects.py::test_model_override_skipped_when_model_empty[None] PASSED
tests/hermes_cli/test_provider_follow_redirects.py::test_model_override_skipped_when_model_empty[] PASSED
tests/hermes_cli/test_provider_follow_redirects.py::test_model_override_skipped_when_model_empty[  ] PASSED
tests/run_agent/test_follow_redirects.py::test_build_keepalive_http_client_follow_redirects_default_false PASSED
tests/run_agent/test_follow_redirects.py::test_build_keepalive_http_client_follow_redirects_true PASSED
tests/run_agent/test_follow_redirects.py::test_build_keepalive_http_client_copilot_branch_honors_kwarg PASSED
tests/run_agent/test_follow_redirects.py::test_create_openai_client_propagates_follow_redirects_default_off PASSED
tests/run_agent/test_follow_redirects.py::test_create_openai_client_propagates_follow_redirects_when_configured PASSED
tests/run_agent/test_follow_redirects.py::test_create_openai_client_preserves_existing_http_client PASSED
tests/run_agent/test_follow_redirects_e2e.py::test_e2e_follow_redirects_via_real_config_loading PASSED
tests/run_agent/test_follow_redirects_e2e.py::test_e2e_unset_provider_stays_off PASSED
tests/run_agent/test_follow_redirects_e2e.py::test_e2e_no_config_at_all_keeps_default_off PASSED
============================== 22 passed ==============================
```

All 10 existing tests in `tests/run_agent/test_create_openai_client_proxy_env.py` still pass (touched the same code path; verified no regression).
