### PR TITLE
fix(gateway): force exit after graceful shutdown

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18508,11 +18508,21 @@ def main():
             data = yaml.safe_load(f) or {}
             config = GatewayConfig.from_dict(data)
     
-    # Run the gateway - exit with code 1 if no platforms connected,
-    # so systemd Restart=on-failure will retry on transient errors (e.g. DNS)
+    # start_gateway() already performs graceful teardown before returning.
+    # Force-exit afterwards so a wedged non-daemon worker thread cannot block
+    # interpreter finalization and strand the gateway half-shut down.
     success = asyncio.run(start_gateway(config))
-    if not success:
-        sys.exit(1)
+    _exit_after_graceful_shutdown(success)
+
+
+def _exit_after_graceful_shutdown(success: bool) -> None:
+    """Flush stdio and terminate immediately after graceful shutdown."""
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.flush()
+        except Exception:
+            pass
+    os._exit(0 if success else 1)
 
 
 if __name__ == "__main__":

--- a/tests/gateway/test_gateway_process_exit.py
+++ b/tests/gateway/test_gateway_process_exit.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+import gateway.run as gateway_run
+
+
+class _ExitCalled(Exception):
+    def __init__(self, code: int):
+        super().__init__(code)
+        self.code = code
+
+
+def _raise_exit(code: int) -> None:
+    raise _ExitCalled(code)
+
+
+def test_main_force_exits_zero_after_clean_shutdown(monkeypatch):
+    async def fake_start_gateway(config=None):
+        return True
+
+    stdout = SimpleNamespace(flush=Mock())
+    stderr = SimpleNamespace(flush=Mock())
+
+    monkeypatch.setattr(gateway_run, "start_gateway", fake_start_gateway)
+    monkeypatch.setattr(gateway_run.os, "_exit", _raise_exit)
+    monkeypatch.setattr(gateway_run.sys, "argv", ["gateway.run"])
+    monkeypatch.setattr(gateway_run.sys, "stdout", stdout)
+    monkeypatch.setattr(gateway_run.sys, "stderr", stderr)
+
+    with pytest.raises(_ExitCalled) as exc_info:
+        gateway_run.main()
+
+    assert exc_info.value.code == 0
+    stdout.flush.assert_called_once_with()
+    stderr.flush.assert_called_once_with()
+
+
+def test_main_force_exits_one_after_failed_shutdown(monkeypatch):
+    async def fake_start_gateway(config=None):
+        return False
+
+    stdout = SimpleNamespace(flush=Mock())
+    stderr = SimpleNamespace(flush=Mock())
+
+    monkeypatch.setattr(gateway_run, "start_gateway", fake_start_gateway)
+    monkeypatch.setattr(gateway_run.os, "_exit", _raise_exit)
+    monkeypatch.setattr(gateway_run.sys, "argv", ["gateway.run"])
+    monkeypatch.setattr(gateway_run.sys, "stdout", stdout)
+    monkeypatch.setattr(gateway_run.sys, "stderr", stderr)
+
+    with pytest.raises(_ExitCalled) as exc_info:
+        gateway_run.main()
+
+    assert exc_info.value.code == 1
+    stdout.flush.assert_called_once_with()
+    stderr.flush.assert_called_once_with()


### PR DESCRIPTION
## What does this PR do?

Closes #53107.

This changes the gateway CLI entrypoint to hard-exit after `start_gateway()` returns, instead of relying on `sys.exit()` and interpreter finalization. The graceful shutdown work already finished inside `start_gateway()`, so a wedged non-daemon worker thread should not be able to keep the process alive with adapters, API server, and cron already stopped.

## Related Issue

Fixes #53107

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill

## Changes Made

- `gateway/run.py`: replace the final `sys.exit(1)` path with `_exit_after_graceful_shutdown(success)`, which flushes stdio and calls `os._exit(0|1)` after teardown completes.
- `tests/gateway/test_gateway_process_exit.py`: add process-exit regression tests covering success and failure exit codes without invoking the real `os._exit`.

## How to Test

1. `uv run --python .venv/bin/python --with pytest --with pytest-asyncio python -m pytest tests/gateway/test_gateway_process_exit.py tests/gateway/test_runner_startup_failures.py -k 'force_exit or startup_failures'`
2. `uv run --python .venv/bin/python --frozen ruff check gateway/run.py tests/gateway/test_gateway_process_exit.py`
3. `git diff --check`

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS
