### PR TITLE
fix(windows): suppress console-window flashes from gh/git probes in desktop gateway

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -27,6 +27,8 @@ import time
 from pathlib import Path
 from typing import Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 # OAuth device code flow constants (same client ID as opencode/Copilot CLI)
@@ -141,6 +143,11 @@ def _try_gh_cli_token() -> Optional[str]:
                 text=True,
                 timeout=5,
                 env=clean_env,
+                # The desktop GUI polls Copilot auth status from the windowless
+                # gateway (pythonw.exe); without CREATE_NO_WINDOW each gh spawn
+                # flashes a console window. windows_hide_flags() is 0 on POSIX.
+                # See #52310.
+                creationflags=windows_hide_flags(),
             )
         except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
             logger.debug("gh CLI token lookup failed (%s): %s", gh_path, exc)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -88,6 +88,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
 
@@ -5213,6 +5214,9 @@ def _git_toplevel(path: Path) -> Optional[Path]:
             text=True,
             timeout=30,
             check=False,
+            # Hide the console window so git probes don't flash on Windows when
+            # the dashboard runs under the windowless desktop gateway (#52310).
+            creationflags=windows_hide_flags(),
         )
     except Exception:
         return None
@@ -5235,6 +5239,7 @@ def _git_branch_exists(repo_root: Path, branch_name: str) -> bool:
             text=True,
             timeout=30,
             check=False,
+            creationflags=windows_hide_flags(),  # no console flash on Windows (#52310)
         )
     except Exception:
         return False
@@ -5249,6 +5254,7 @@ def _git_common_dir(path: Path) -> Optional[Path]:
             text=True,
             timeout=30,
             check=False,
+            creationflags=windows_hide_flags(),  # no console flash on Windows (#52310)
         )
     except Exception:
         return None
@@ -5268,6 +5274,7 @@ def _git_dir(path: Path) -> Optional[Path]:
             text=True,
             timeout=30,
             check=False,
+            creationflags=windows_hide_flags(),  # no console flash on Windows (#52310)
         )
     except Exception:
         return None
@@ -5287,6 +5294,7 @@ def _git_current_branch(path: Path) -> Optional[str]:
             text=True,
             timeout=30,
             check=False,
+            creationflags=windows_hide_flags(),  # no console flash on Windows (#52310)
         )
     except Exception:
         return None
@@ -5344,6 +5352,7 @@ def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> Non
         text=True,
         timeout=60,
         check=False,
+        creationflags=windows_hide_flags(),  # no console flash on Windows (#52310)
     )
     if result.returncode != 0:
         stderr = (result.stderr or result.stdout or "").strip()

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -1122,3 +1122,125 @@ class TestWindowlessGatewayRestartSpec:
         assert env["VIRTUAL_ENV"] == str(Path("C:/venv"))
         assert "PYTHONPATH" in env
         assert "site-packages" in env["PYTHONPATH"]
+
+
+# ---------------------------------------------------------------------------
+# `gh auth token` console-flash suppression (#52310)
+# ---------------------------------------------------------------------------
+
+
+class TestGhAuthTokenNoConsoleFlash:
+    """`gh auth token` probes must pass creationflags=windows_hide_flags().
+
+    The desktop GUI runs the gateway under windowless pythonw.exe and polls
+    GitHub/Copilot auth status, so every un-hidden ``gh`` spawn flashes a
+    console window (#52310). Both probe sites must forward the hide flag;
+    windows_hide_flags() is 0 on POSIX so the call is unchanged off-Windows.
+    """
+
+    def test_skills_hub_gh_cli_passes_hide_flag(self, monkeypatch):
+        from tools import skills_hub
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "ghs_dummy\n"
+            return result
+
+        monkeypatch.setattr(skills_hub.subprocess, "run", fake_run)
+        skills_hub.GitHubAuth()._try_gh_cli()
+
+        assert captured["args"] == ["gh", "auth", "token"]
+        assert "creationflags" in captured["kwargs"], (
+            "skills_hub._try_gh_cli must pass creationflags so the desktop "
+            "gateway doesn't flash a console window on every gh spawn (#52310)"
+        )
+        assert captured["kwargs"]["creationflags"] == windows_hide_flags()
+
+    def test_copilot_auth_gh_cli_passes_hide_flag(self, monkeypatch):
+        from hermes_cli import copilot_auth
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "gho_dummy\n"
+            return result
+
+        monkeypatch.setattr(copilot_auth, "_gh_cli_candidates", lambda: ["gh"])
+        monkeypatch.setattr(copilot_auth.subprocess, "run", fake_run)
+        copilot_auth._try_gh_cli_token()
+
+        assert captured["cmd"][:3] == ["gh", "auth", "token"]
+        assert "creationflags" in captured["kwargs"], (
+            "copilot_auth._try_gh_cli_token must pass creationflags so the "
+            "desktop gateway doesn't flash a console window on every gh spawn (#52310)"
+        )
+        assert captured["kwargs"]["creationflags"] == windows_hide_flags()
+
+
+class TestGitProbeNoConsoleFlash:
+    """`git` probes run from the gateway must pass creationflags=windows_hide_flags().
+
+    During active work the desktop polls git (branch/root) for the UI from the
+    windowless gateway (pythonw); each un-hidden git spawn flashes a console
+    window (#52310). windows_hide_flags() is 0 on POSIX so off-Windows is a no-op.
+    """
+
+    def test_git_probe_run_git_passes_hide_flag(self, monkeypatch):
+        from tui_gateway import git_probe
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "main\n"
+            return result
+
+        monkeypatch.setattr(git_probe.subprocess, "run", fake_run)
+        git_probe.run_git("C:/proj", "branch", "--show-current")
+
+        assert captured["args"][:3] == ["git", "-C", "C:/proj"]
+        assert "creationflags" in captured["kwargs"], (
+            "git_probe.run_git must pass creationflags so the desktop gateway "
+            "doesn't flash a console window on every git probe (#52310)"
+        )
+        assert captured["kwargs"]["creationflags"] == windows_hide_flags()
+
+    def test_kanban_git_current_branch_passes_hide_flag(self, monkeypatch):
+        from pathlib import Path
+        from hermes_cli import kanban_db
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "main\n"
+            return result
+
+        monkeypatch.setattr(kanban_db.subprocess, "run", fake_run)
+        kanban_db._git_current_branch(Path("C:/proj"))
+
+        assert captured["args"][:2] == ["git", "-C"]
+        assert "creationflags" in captured["kwargs"], (
+            "kanban_db git helpers must pass creationflags so the desktop "
+            "gateway doesn't flash a console window on git probes (#52310)"
+        )
+        assert captured["kwargs"]["creationflags"] == windows_hide_flags()

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -33,6 +33,7 @@ from urllib.parse import urljoin, urlparse, urlunparse
 import httpx
 import yaml
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from tools.skills_guard import (
     ScanResult, content_hash, TRUSTED_REPOS,
 )
@@ -302,6 +303,10 @@ class GitHubAuth:
                 ["gh", "auth", "token"],
                 capture_output=True, text=True, timeout=5,
                 stdin=subprocess.DEVNULL,
+                # On Windows this runs from the windowless desktop gateway
+                # (pythonw.exe); without CREATE_NO_WINDOW each spawn flashes a
+                # console window. windows_hide_flags() is 0 on POSIX. See #52310.
+                creationflags=windows_hide_flags(),
             )
             if result.returncode == 0 and result.stdout.strip():
                 return result.stdout.strip()

--- a/tui_gateway/git_probe.py
+++ b/tui_gateway/git_probe.py
@@ -31,6 +31,8 @@ import time
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 _GIT_TIMEOUT = 1.5
 _WARM_WORKERS = 8
 
@@ -53,6 +55,10 @@ def run_git(cwd: str, *args: str) -> str:
             timeout=_GIT_TIMEOUT,
             check=False,
             stdin=subprocess.DEVNULL,
+            # The desktop polls git branch/root for the UI from the windowless
+            # gateway (pythonw); without CREATE_NO_WINDOW each probe flashes a
+            # console window. windows_hide_flags() is 0 on POSIX. See #52310.
+            creationflags=windows_hide_flags(),
         )
         return result.stdout.strip() if result.returncode == 0 else ""
     except Exception:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -23,6 +23,7 @@ from hermes_constants import (
     reset_hermes_home_override,
     set_hermes_home_override,
 )
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.env_loader import load_hermes_dotenv
 from utils import is_truthy_value
 from tui_gateway import git_probe
@@ -11577,6 +11578,7 @@ def _list_repo_files(root: str) -> list[str]:
             timeout=2.0,
             check=False,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),  # no console flash on Windows (#52310)
         )
         if top_result.returncode == 0:
             top = top_result.stdout.decode("utf-8", "replace").strip()
@@ -11595,6 +11597,7 @@ def _list_repo_files(root: str) -> list[str]:
                 timeout=2.0,
                 check=False,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),  # no console flash on Windows (#52310)
             )
             if list_result.returncode == 0:
                 for p in list_result.stdout.decode("utf-8", "replace").split("\0"):


### PR DESCRIPTION
## Problem

On Windows the desktop app runs the gateway under windowless `pythonw.exe`. Several
probes spawn console-subsystem binaries (`gh.exe`, `git.exe`) **without**
`CREATE_NO_WINDOW`, so each spawn briefly flashes a black console window. Reporters
in #42544, #52310 (and the cluster #49851 / #42544) saw two distinct symptoms:

- **Idle flashes** — the GUI polls GitHub / Copilot auth status, which shells out to
  `gh auth token` in `tools/skills_hub.py` and `hermes_cli/copilot_auth.py`.
- **Active-work flashes** — the GUI polls git branch/root for the project view via
  `tui_gateway/git_probe.run_git` (plus the kanban worktree helpers and the Cmd-P
  fuzzy file finder), shelling out to `git`.

> Note: the `bash` terminal path (`tools/environments/local.py::_run_bash`) already
> passes `CREATE_NO_WINDOW` and does **not** flash in my testing — neither the Git
> Bash wrapper (`bin\bash.exe`) nor the real `usr\bin\bash.exe`, even with native
> grandchildren (`rg`, `git`, `cmd`). So the remaining flashes were the `gh`/`git`
> probes above, not the terminal tool.

## Fix

Pass `creationflags=windows_hide_flags()` at every probe site.
`windows_hide_flags()` returns `CREATE_NO_WINDOW` on win32 and `0` on POSIX, so there
is **zero behavioral change off-Windows**.

| File | Probe |
|---|---|
| `tools/skills_hub.py` | `gh auth token` |
| `hermes_cli/copilot_auth.py` | `gh auth token` |
| `tui_gateway/git_probe.py` | `run_git` (branch/root probes) |
| `tui_gateway/server.py` | Cmd-P fuzzy file finder `git` calls |
| `hermes_cli/kanban_db.py` | `git` worktree / branch helpers |

(`hermes_cli/web_server.py`'s `git branch --show-current` already carried the flag.)

## Verification

Windows 11 + Git for Windows 2.51, desktop launched via `hermes desktop`.
Using an `EnumWindows`-based detector (first **validated** by confirming it catches
deliberately-triggered `gh auth token` flashes, 3/3), I captured the gateway's
process+window activity:

- **Before:** `gh auth token` (idle) and `git ... branch --show-current` /
  `rev-parse --show-toplevel` (active work), each owned by the windowless
  `pythonw.exe` gateway, produced a visible `PseudoConsoleWindow`.
- **After:** **0** `ConsoleWindowClass` / `PseudoConsoleWindow` appearances from the
  gateway subtree, both at idle and during active tool use. Confirmed visually by the
  original reporter.

Added regression tests in `tests/tools/test_windows_native_support.py`
(`TestGhAuthTokenNoConsoleFlash`, `TestGitProbeNoConsoleFlash`) asserting each probe
forwards `creationflags=windows_hide_flags()`.

Fixes #52310

### Related issues / PRs

This is the broad fix for the **gh / git probe** flashes — distinct from the bash *terminal*-tool flash (that path already passes `CREATE_NO_WINDOW` and does not flash). It directly addresses:

- `git` probes — #53178 (`git_probe.run_git`), #53424, #53631
- `gh auth token` — #53370

Superset of the narrower copilot_auth-only PRs #53390 / #53397, and of the `git_probe.py`-only PR #53184: this fixes the `gh` (`skills_hub.py`, `copilot_auth.py`) **and** `git` (`git_probe.py`, `server.py`, `kanban_db.py`) sites together, with regression tests. De-facto canonical cluster issue: #42544.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


