### PR TITLE
fix(desktop/windows): stop the uv-launched gateway before recreating the venv

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1635,6 +1635,38 @@ function Install-Venv {
             } catch {
                 Write-Warn "Could not enumerate venv processes: $($_.Exception.Message)"
             }
+            # The path-prefix sweep above misses the gateway on a uv-managed venv.
+            # `uv venv` installs TRAMPOLINE launchers in venv\Scripts\: running
+            # venv\Scripts\pythonw.exe re-execs into the uv base interpreter under
+            # %APPDATA%\uv\python\..., so the LIVE gateway process's ExecutablePath
+            # is that base interpreter, NOT under this venv -- and its image name is
+            # python/pythonw, so the hermes.exe taskkill misses it too. Result: the
+            # venv-holding gateway survives and Remove-Item still hits a locked .pyd
+            # ("Access to the path '...pywintypes311.dll' is denied"). Catch it two
+            # more ways: (1) the pid the gateway recorded in gateway_state.json, and
+            # (2) any python/pythonw whose command line runs our gateway module.
+            # Both require the gateway to be in the installer's session, so an
+            # autostart task should register with LogonType=Interactive, not S4U.
+            $stateFile = Join-Path $HermesHome "gateway_state.json"
+            if (Test-Path $stateFile) {
+                try {
+                    $gwPid = (Get-Content $stateFile -Raw | ConvertFrom-Json).pid
+                    if ($gwPid -and $gwPid -ne $myPid) {
+                        Write-Info "  stopping gateway PID $gwPid (recorded in gateway_state.json)"
+                        & taskkill /PID $gwPid /T /F 2>$null | Out-Null
+                    }
+                } catch {}
+            }
+            try {
+                Get-CimInstance Win32_Process -Filter "name='python.exe' OR name='pythonw.exe'" -ErrorAction Stop |
+                    Where-Object { $_.ProcessId -ne $myPid -and $_.CommandLine -and $_.CommandLine -match 'hermes_cli(\.main)?\b' -and $_.CommandLine -match '\bgateway\b' } |
+                    ForEach-Object {
+                        Write-Info "  stopping PID $($_.ProcessId) ($($_.Name)) running the hermes gateway"
+                        & taskkill /PID $_.ProcessId /T /F 2>$null | Out-Null
+                    }
+            } catch {
+                Write-Warn "Could not enumerate gateway processes by command line: $($_.Exception.Message)"
+            }
             Start-Sleep -Milliseconds 800
         }
         Remove-Item -Recurse -Force "venv" -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Problem
On Windows, `install.ps1` aborts at the venv stage with a locked-file error when a Hermes **gateway** is running:

```
Cannot remove item ...\venv\Lib\site-packages\pywin32_system32\pywintypes311.dll: Access to the path '...' is denied
```

The venv-recreate guard already tries to stop running processes first, but it only matches:
- `taskkill /IM hermes.exe` — the gateway runs as `python`/`pythonw`, not `hermes.exe`; and
- processes whose `ExecutablePath` starts with `venv\Scripts\`.

`uv venv` installs **trampoline** launchers: running `venv\Scripts\pythonw.exe` re-execs into the uv-managed base interpreter under `%APPDATA%\uv\python\…`, so the live gateway's `ExecutablePath` is that base interpreter — **not** under the venv. Both filters miss it, the gateway keeps the venv's `.pyd`/`.dll` files mapped, and the venv delete fails → the whole install/update aborts (and, when triggered from the desktop bootstrap, manifests as a recurring "INSTALL DIDN'T FINISH" loop).

## Fix
Before deleting the venv, also stop the gateway two robust ways:
1. the pid it records in `gateway_state.json`, and
2. any `python`/`pythonw` whose command line runs the gateway module (`hermes_cli[.main] … gateway`), tree-killed.

Both require the gateway to share the installer's session, so this pairs naturally with autostart tasks registered `LogonType=Interactive` rather than S4U/Session-0 (a Session-0 gateway is invisible to an un-elevated installer's `Get-CimInstance` command-line read).

## Verification
- Reproduced: with the gateway up, the existing sweep leaves it running and the venv delete fails on a locked `pywintypes311.dll`.
- With the patch, the command-line filter matches the live gateway — both the `venv\Scripts\pythonw.exe` trampoline **parent** and the uv-base-`python.exe` **child** (each carrying `-m hermes_cli.main gateway run`); the `gateway_state.json` pid matches the child. Tree-killing both releases the venv and the recreate succeeds.
- `scripts/install.ps1` parses clean under the Windows PowerShell 5.1 AST parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
