### PR TITLE
fix(installer): quote uv path invocations

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -554,7 +554,7 @@ install_uv() {
 
     if [ -x "$_managed_uv" ]; then
         UV_CMD="$_managed_uv"
-        UV_VERSION=$($UV_CMD --version 2>/dev/null)
+        UV_VERSION=$("$UV_CMD" --version 2>/dev/null)
         log_success "Managed uv found ($UV_VERSION)"
         return 0
     fi
@@ -590,7 +590,7 @@ install_uv() {
             exit 1
         fi
         rm -f "$_uv_install_log"
-        UV_VERSION=$($UV_CMD --version 2>/dev/null)
+        UV_VERSION=$("$UV_CMD" --version 2>/dev/null)
         log_success "Managed uv installed ($UV_VERSION)"
     else
         log_error "Failed to install uv"
@@ -1315,7 +1315,7 @@ setup_venv() {
     fi
 
     # uv creates the venv and pins the Python version in one step
-    $UV_CMD venv venv --python "$PYTHON_VERSION"
+    "$UV_CMD" venv venv --python "$PYTHON_VERSION"
 
     # Neutralize any inherited UV_PYTHON (e.g. UV_PYTHON=3.14 left in the
     # user's shell env). uv honours UV_PYTHON over an existing venv for the
@@ -1469,7 +1469,7 @@ install_deps() {
         #                  This respects the curation in pyproject.toml.
         # uv's own progress UI handles TTY detection and downgrades
         # gracefully when stdout/stderr aren't terminals.
-        if UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/venv" $UV_CMD sync --extra all --locked; then
+        if UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/venv" "$UV_CMD" sync --extra all --locked; then
             log_success "Main package installed (hash-verified via uv.lock)"
             log_success "All dependencies installed"
             return 0
@@ -1550,7 +1550,7 @@ PY
     install_tier() {
         local name="$1"; local spec="$2"
         log_info "Trying tier: $name ..."
-        if $UV_CMD pip install -e "$spec" 2>"$ALL_INSTALL_LOG"; then
+        if "$UV_CMD" pip install -e "$spec" 2>"$ALL_INSTALL_LOG"; then
             log_success "Main package installed ($name)"
             _installed=true
             _tier_name="$name"

--- a/tests/test_install_sh_uv_cmd_spaces.py
+++ b/tests/test_install_sh_uv_cmd_spaces.py
@@ -1,0 +1,37 @@
+"""Regression for install.sh when the uv binary path contains spaces.
+
+If uv is installed under ``$HOME/.local/bin`` and the user's home directory
+contains a space, every command-position use of ``$UV_CMD`` must stay quoted.
+Otherwise shell word splitting turns the uv path into multiple tokens and the
+installer fails in the ``venv`` and ``python-deps`` stages. See #53086.
+"""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def test_uv_command_invocations_stay_quoted_for_spacey_home_paths() -> None:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+
+    expected_fragments = [
+        'UV_VERSION=$("$UV_CMD" --version 2>/dev/null)',
+        '"$UV_CMD" venv venv --python "$PYTHON_VERSION"',
+        'if UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/venv" "$UV_CMD" sync --extra all --locked; then',
+        'if "$UV_CMD" pip install -e "$spec" 2>"$ALL_INSTALL_LOG"; then',
+    ]
+
+    for fragment in expected_fragments:
+        assert fragment in text, f"Missing quoted uv invocation: {fragment}"
+
+    forbidden_fragments = [
+        'UV_VERSION=$($UV_CMD --version 2>/dev/null)',
+        '$UV_CMD venv venv --python "$PYTHON_VERSION"',
+        'if UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/venv" $UV_CMD sync --extra all --locked; then',
+        'if $UV_CMD pip install -e "$spec" 2>"$ALL_INSTALL_LOG"; then',
+    ]
+
+    for fragment in forbidden_fragments:
+        assert fragment not in text, f"Found unquoted uv invocation: {fragment}"


### PR DESCRIPTION
Fixes #53086

## Summary
- quote command-position uses of `UV_CMD` in `scripts/install.sh`
- cover the managed-uv version probe plus the `venv` and `python-deps` install stages
- add a regression test that locks these uv invocations to quoted form for space-containing home paths

## Verification
- `bash -n scripts/install.sh`
- `scripts/run_tests.sh tests/test_install_sh_uv_cmd_spaces.py tests/test_install_sh_root_fhs_uv_python_path.py tests/test_install_sh_pythonpath_sanitization.py tests/test_install_sh_symlink_stomp.py`
- `uv run --python .venv/bin/python --frozen ruff check tests/test_install_sh_uv_cmd_spaces.py`
- `git diff --check`