### PR TITLE
[codex] Preserve background review provenance on skill approval

### DIFF
--- a/hermes_cli/write_approval_commands.py
+++ b/hermes_cli/write_approval_commands.py
@@ -149,7 +149,7 @@ def _apply_one(subsystem: str, rec, memory_store):
             return bool(result.get("success")), result.get("error", "")
         else:
             from tools.skill_manager_tool import apply_skill_pending
-            result = json.loads(apply_skill_pending(payload))
+            result = json.loads(apply_skill_pending(payload, origin=rec.get("origin")))
             return bool(result.get("success")), result.get("error", "")
     except Exception as e:
         return False, str(e)

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -170,6 +170,88 @@ def test_handle_approve_all(hermes_home):
     assert len(store.user_entries) == 2
 
 
+def test_handle_approve_background_skill_marks_agent_created(hermes_home):
+    # A staged background-review skill write must remain curator-managed after
+    # a foreground /skills approve replay.
+    import importlib
+    import tools.skill_manager_tool as smt
+    importlib.reload(smt)
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    from tools.skill_provenance import (
+        BACKGROUND_REVIEW,
+        reset_current_write_origin,
+        set_current_write_origin,
+    )
+    from tools.skill_usage import load_usage
+
+    _set_approval("skills", True)
+    content = _SKILL.replace("name: test-skill", "name: review-approved-skill")
+
+    token = set_current_write_origin(BACKGROUND_REVIEW)
+    try:
+        staged = json.loads(smt.skill_manage(
+            "create",
+            "review-approved-skill",
+            content=content,
+        ))
+    finally:
+        reset_current_write_origin(token)
+
+    assert staged.get("staged") is True
+    rec = wa.get_pending(wa.SKILLS, staged["pending_id"])
+    assert rec["origin"] == "background_review"
+    assert " [auto]" in handle_pending_subcommand(wa.SKILLS, ["pending"])
+
+    out = handle_pending_subcommand(wa.SKILLS, ["approve", rec["id"]])
+    assert "Approved 1 skills write(s)." in out
+    assert load_usage()["review-approved-skill"]["created_by"] == "agent"
+
+
+def test_handle_approve_background_skill_patch_uses_approval_context(hermes_home):
+    import importlib
+    import tools.skill_manager_tool as smt
+    importlib.reload(smt)
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    from tools.skill_provenance import (
+        BACKGROUND_REVIEW,
+        reset_current_write_origin,
+        set_current_write_origin,
+    )
+
+    token = set_current_write_origin(BACKGROUND_REVIEW)
+    try:
+        created = json.loads(
+            smt.skill_manage("create", "review-patched-skill", content=_SKILL)
+        )
+    finally:
+        reset_current_write_origin(token)
+    assert created["success"] is True
+    _set_approval("skills", True)
+
+    token = set_current_write_origin(BACKGROUND_REVIEW)
+    try:
+        staged = json.loads(smt.skill_manage(
+            "patch",
+            "review-patched-skill",
+            old_string="# Test\nbody",
+            new_string="# Test\nupdated body",
+        ))
+    finally:
+        reset_current_write_origin(token)
+
+    assert staged.get("staged") is True
+    rec = wa.get_pending(wa.SKILLS, staged["pending_id"])
+    assert rec["origin"] == BACKGROUND_REVIEW
+
+    smt._reset_background_review_read_marks()
+    out = handle_pending_subcommand(wa.SKILLS, ["approve", rec["id"]])
+    assert "Approved 1 skills write(s)." in out
+    skill_md = smt._find_skill("review-patched-skill")["path"] / "SKILL.md"
+    assert "updated body" in skill_md.read_text(encoding="utf-8")
+
+
 def test_handle_approval_on(hermes_home):
     from hermes_cli.write_approval_commands import handle_pending_subcommand
     from tools import write_approval as wa

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1438,15 +1438,20 @@ def _apply_skill_write_gate(action, name, **payload_kwargs):
     )
 
 
-def apply_skill_pending(payload: Dict[str, Any]) -> str:
-    """Replay a staged skill write, bypassing the gate. Returns the tool result
-    JSON string. Called by the /skills approve handler.
+def apply_skill_pending(payload: Dict[str, Any], *, origin: str = None) -> str:
+    """Replay a staged skill write, bypassing the gate.
+
+    ``origin`` is approval metadata, not a live execution context. Rebinding the
+    background-review ContextVar here would also re-enable autonomous write
+    guards whose per-review state is not stored with the pending record.
     """
-    token = _skill_gate_bypass.set(True)
+    gate_token = _skill_gate_bypass.set(True)
     try:
-        return skill_manage(
-            action=payload.get("action", ""),
-            name=payload.get("name", ""),
+        action = payload.get("action", "")
+        name = payload.get("name", "")
+        result_json = skill_manage(
+            action=action,
+            name=name,
             content=payload.get("content"),
             category=payload.get("category"),
             file_path=payload.get("file_path"),
@@ -1456,8 +1461,18 @@ def apply_skill_pending(payload: Dict[str, Any]) -> str:
             replace_all=payload.get("replace_all", False),
             absorbed_into=payload.get("absorbed_into"),
         )
+
+        if action == "create":
+            try:
+                from tools.skill_provenance import BACKGROUND_REVIEW
+                from tools.skill_usage import mark_agent_created
+                if origin == BACKGROUND_REVIEW and json.loads(result_json).get("success"):
+                    mark_agent_created(name)
+            except Exception:
+                pass
+        return result_json
     finally:
-        _skill_gate_bypass.reset(token)
+        _skill_gate_bypass.reset(gate_token)
 
 
 # Debounce state for the sync push hook. A burst of skill_manage writes


### PR DESCRIPTION
## What does this PR do?

Fixes a provenance gap in the `skills.write_approval` approval path.

Background-review skill writes were already staged with `origin: background_review`, which is why `/skills pending` displayed `[auto]`. But `/skills approve` replayed only the stored `skill_manage` payload, so a successful approved create never received the curator provenance marker and `.usage.json` kept `created_by: null`.

This PR passes the pending record origin into skill replay as approval metadata. After a successful background-origin `create`, replay calls `mark_agent_created()`. It deliberately does not restore the live background-review ContextVar: doing so would also activate autonomous edit, patch, file, and delete guards whose per-review state is not stored with the pending record.

Impact surface: narrow. The change is limited to skill write-approval replay. Foreground-created skills remain user-owned, non-create approvals retain their existing foreground approval semantics, and old pending payloads keep their current shape.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/write_approval_commands.py`: pass pending skill record `origin` into `apply_skill_pending(...)` during `/skills approve`.
- `tools/skill_manager_tool.py`: treat origin as approval metadata and mark only successful approved background-origin creates as agent-created.
- `tests/tools/test_write_approval.py`: cover both approved background creates and approved background patches, proving patch replay does not re-enter autonomous-review guards.

## How to Test

1. Enable `skills.write_approval`.
2. Stage a `skill_manage(create)` while the write origin is `background_review`; `/skills pending` should show `[auto]`.
3. Approve it with `/skills approve <id>` and confirm the skill's `.usage.json` record has `created_by: "agent"`.
4. Stage and approve a background-origin `patch`; confirm the patch succeeds without a background-review read marker in the approval context.

Validation run locally on macOS:

```bash
scripts/run_tests.sh tests/tools/test_write_approval.py tests/tools/test_skill_manager_tool.py tests/tools/test_skill_provenance.py
/Users/bytedance/.hermes/hermes-agent/venv/bin/python -m ruff check hermes_cli/write_approval_commands.py tools/skill_manager_tool.py tests/tools/test_write_approval.py
/Users/bytedance/.hermes/hermes-agent/venv/bin/python scripts/check-windows-footguns.py hermes_cli/write_approval_commands.py tools/skill_manager_tool.py tests/tools/test_write_approval.py
git diff --check -- hermes_cli/write_approval_commands.py tools/skill_manager_tool.py tests/tools/test_write_approval.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing open and closed PRs/issues for duplicate `skill approve background_review created_by write_approval` reports
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass; not run, targeted tests above were run
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A
- [x] Cross-platform impact considered; no platform-specific code added, Windows footgun scan passed for changed files
- [x] Tool descriptions/schemas update N/A

## Screenshots / Logs

Targeted tests passed on current `main`: 65 passed, 0 failed.