### PR TITLE
fix(gateway): Windows post-update respawn must mark itself detached (silent gateway death after in-app update)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -752,9 +752,25 @@ def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
         # been spawned inside a job object (Electron/Tauri parent), and
         # without breakaway the respawned gateway would die when that job
         # tears down. See _subprocess_compat.windows_detach_flags().
+        #
+        # Mark the respawn as a detached service launch and sever its stdin.
+        # _windows_gateway_should_absorb_console_controls() keys off
+        # HERMES_GATEWAY_DETACHED (and, failing that, an interactive stdin):
+        # without this marker the respawned gateway inherits the spawning
+        # process's console handle, decides it is "interactive", and SKIPS the
+        # SetConsoleCtrlHandler(NULL, TRUE) guard. It then dies the instant
+        # Windows broadcasts CTRL_CLOSE_EVENT / CTRL_LOGOFF_EVENT when the
+        # parent console (e.g. the post-update desktop shell) goes away —
+        # silently, with no shutdown log. Mirror gateway_windows._spawn_detached:
+        # set HERMES_GATEWAY_DETACHED=1 and redirect stdin to DEVNULL so the
+        # respawn installs the console-control guard and survives. (#21301-followup)
+        _env = dict(os.environ)
+        _env["HERMES_GATEWAY_DETACHED"] = "1"
         _popen_kwargs = {
+            "stdin": subprocess.DEVNULL,
             "stdout": subprocess.DEVNULL,
             "stderr": subprocess.DEVNULL,
+            "env": _env,
         }
         if sys.platform == "win32":
             try:

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -3,6 +3,7 @@
 import argparse
 import signal
 import sys
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -372,6 +373,70 @@ def test_run_gateway_windows_detached_absorbs_console_controls(monkeypatch):
 
     assert calls == [(False, 0)]
     assert (gateway.signal.SIGINT, gateway.signal.SIG_IGN) in signal_calls
+
+
+class TestGatewayRestartWatcher:
+    """Regression tests for the post-update detached respawn watcher.
+
+    The watcher must hand the respawned gateway the same detach context that
+    gateway_windows._spawn_detached gives the autostart path — otherwise the
+    respawn inherits the spawning console, decides it is interactive, skips the
+    SetConsoleCtrlHandler guard, and dies on the next CTRL_CLOSE/LOGOFF event
+    (the silent post-update death this fix addresses).
+    """
+
+    def _watcher_source(self):
+        import ast
+        import re
+        import textwrap
+
+        content = (
+            Path(gateway.__file__).read_text(encoding="utf-8")
+        )
+        start = content.index("watcher = textwrap.dedent(")
+        seg = content[start : start + 3500]
+        m = re.search(
+            r'textwrap\.dedent\(\s*"""(.*?)"""\s*\)\.strip\(\)', seg, re.DOTALL
+        )
+        assert m, "could not locate watcher template literal"
+        inner = textwrap.dedent(m.group(1)).strip()
+        # Must be valid Python — it is executed via `python -c`.
+        ast.parse(inner)
+        return inner
+
+    def test_watcher_marks_respawn_detached_and_severs_stdin(self):
+        src = self._watcher_source()
+        # The respawned gateway must be tagged as a detached service launch so
+        # _windows_gateway_should_absorb_console_controls() returns True.
+        assert 'HERMES_GATEWAY_DETACHED' in src
+        assert '"HERMES_GATEWAY_DETACHED"] = "1"' in src
+        # And its stdin must be severed so the isatty() fallback can't class it
+        # interactive even if the env marker were somehow dropped.
+        assert '"stdin": subprocess.DEVNULL' in src
+        # The env overlay must be passed to Popen, not just constructed.
+        assert '"env": _env' in src
+
+    def test_by_cmdline_spawns_watcher(self, monkeypatch):
+        captured = {}
+
+        def fake_popen(argv, **kwargs):
+            captured["argv"] = argv
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(pid=4321)
+
+        monkeypatch.setattr(gateway.subprocess, "Popen", fake_popen)
+        ok = gateway.launch_detached_gateway_restart_by_cmdline(
+            999999, ["pythonw.exe", "-m", "hermes_cli.main", "gateway", "run"]
+        )
+        assert ok is True
+        # argv = [python, "-c", watcher, old_pid, *run_argv]
+        assert captured["argv"][1] == "-c"
+        assert captured["argv"][3] == "999999"
+        assert captured["argv"][-3:] == ["hermes_cli.main", "gateway", "run"]
+
+    def test_rejects_empty_inputs(self):
+        assert gateway.launch_detached_gateway_restart_by_cmdline(0, ["x"]) is False
+        assert gateway.launch_detached_gateway_restart_by_cmdline(123, []) is False
 
 
 class TestSystemdLingerStatus:


### PR DESCRIPTION
## Summary

On Windows, the post-update gateway respawn watcher launched the new gateway **without** marking it as a detached service, so the respawned gateway would die silently the moment the spawning console went away — leaving the user with no messaging gateway after an in-app update until a manual restart.

## Root cause

`_spawn_gateway_restart_watcher` (in `hermes_cli/gateway.py`) respawns the gateway after the old PID exits. On Windows it set the right detach **creation flags**, but it did **not**:

- set `HERMES_GATEWAY_DETACHED=1` in the child env, nor
- redirect the child's **stdin** to `DEVNULL`.

`_windows_gateway_should_absorb_console_controls()` decides whether the gateway installs the console-control guard (`SetConsoleCtrlHandler(NULL, TRUE)` + `SIGINT`/`SIGBREAK` ignore). It keys off `HERMES_GATEWAY_DETACHED`, falling back to `sys.stdin.isatty()`. Because the respawn carried neither signal, the new gateway **inherited the spawning console**, classed itself interactive, and **skipped the guard**.

It then died the instant Windows broadcast `CTRL_CLOSE_EVENT` / `CTRL_LOGOFF_EVENT` when the parent console (the post-update desktop shell) exited — no shutdown log, no traceback.

The gateway exit diagnostics captured the fingerprint exactly: the dead post-update gateway came up with `stdin_is_tty=true, absorb_windows_console_controls=false`, whereas every healthy detached gateway (autostart `.cmd` / `_spawn_detached`) shows `true`.

## Fix

Mirror the canonical detached launch path (`gateway_windows._spawn_detached`) inside the respawn watcher:

- set `HERMES_GATEWAY_DETACHED=1` in the child env, and
- redirect child **stdin to `DEVNULL`** (belt-and-braces: even if the env marker were ever dropped, the severed stdin keeps the `isatty()` fallback from misclassifying it).

This covers **both** respawn paths, since profile gateways (`launch_detached_profile_gateway_restart`) and unmapped / Scheduled-Task gateways (`launch_detached_gateway_restart_by_cmdline`) share this watcher.

## Tests

Adds `TestGatewayRestartWatcher`:

- `test_watcher_marks_respawn_detached_and_severs_stdin` — asserts the watcher template sets the detached marker, severs stdin, and passes the env overlay to `Popen` (and that the template is valid Python).
- `test_by_cmdline_spawns_watcher` — asserts the by-cmdline entry point spawns the watcher with the expected argv shape.
- `test_rejects_empty_inputs` — guards the early-return validation.

```
pytest tests/hermes_cli/test_gateway.py -k "RestartWatcher or by_cmdline or detached_absorbs"
4 passed
```

No new failures introduced (the pre-existing Linux/Windows-only failures in this file — `signal.SIGKILL`, systemd-linger, Docker-root-guard — are unrelated and fail identically on a clean baseline).
