### PR TITLE
fix(cron): scope thread_id-loss warning to same-conversation delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1149,10 +1149,25 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         chat_id = target["chat_id"]
         thread_id = target.get("thread_id")
 
-        # Diagnostic: log thread_id for topic-aware delivery debugging
+        # Diagnostic: log thread_id for topic-aware delivery debugging.
+        # Losing the origin thread_id is only a routing bug when we are
+        # delivering back to the SAME platform+chat the origin thread belongs to
+        # (e.g. deliver=origin into a topic-scoped chat). For cross-channel /
+        # cross-DM delivery -- a job created in a DM thread but configured
+        # deliver=<platform>:<other-chat>, or any fan-out / home-channel
+        # fallback -- the origin thread ts is meaningless in the target chat, so
+        # dropping it is correct and the warning is a false positive that fires
+        # on every tick. Gate on the same platform+chat as the origin. (We do
+        # NOT reuse _target_matches_origin here: it additionally requires the
+        # thread to match, which is exactly the dropped-thread condition we are
+        # trying to diagnose.)
         origin = _resolve_origin(job) or {}
         origin_thread = origin.get("thread_id")
-        if origin_thread and not thread_id:
+        same_conversation_as_origin = bool(origin) and (
+            str(origin.get("platform", "")).lower() == str(platform_name).lower()
+            and str(origin.get("chat_id", "")) == str(chat_id)
+        )
+        if origin_thread and not thread_id and same_conversation_as_origin:
             logger.warning(
                 "Job '%s': origin has thread_id=%s but delivery target lost it "
                 "(deliver=%s, target=%s)",


### PR DESCRIPTION
## Problem

`_deliver_result` in `cron/scheduler.py` logs a `WARNING` —
`"origin has thread_id=%s but delivery target lost it"` — whenever a job's
origin captured a `thread_id` but the resolved delivery target has none. It
never checks whether the target is the **same conversation** as the origin.

As a result, any cron job created inside a thread but configured to deliver
**elsewhere** logs this warning on *every scheduler tick*, forever.

### Concrete repro
A job created in a Slack DM thread with `deliver=slack:<some-channel>`:
- origin = `{platform: slack, chat_id: D… (the DM), thread_id: <dm-thread-ts>}`
- resolved target = `{platform: slack, chat_id: C… (the channel), thread_id: None}`

The DM's thread ts is meaningless in the target channel, so the resolver
**correctly** drops it. But the diagnostic still fires every tick:

```
WARNING cron.scheduler: Job '…': origin has thread_id=… but delivery target
lost it (deliver=slack:some-channel, target={'platform': 'slack',
'chat_id': 'C…', 'thread_id': None})
```

This is persistent log noise that masks genuine delivery problems.

## Fix

Only warn when delivering back to the **same platform+chat** the origin
thread belongs to (the real `deliver=origin` thread-loss case). Cross-channel
/ cross-DM delivery, fan-out, and home-channel fallback legitimately drop the
thread and stay quiet.

I intentionally did **not** reuse `_target_matches_origin` here: it
additionally requires the `thread_id` to match, which is exactly the
dropped-thread condition this diagnostic is trying to detect — using it would
make the warning unreachable.

Delivery behavior is unchanged; this only scopes a diagnostic log line.