### PR TITLE
fix(cron): reject missing no-agent scripts

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1904,6 +1904,21 @@ def create_job(
         normalized_script,
     )
 
+    # Same invariant, one step further: a no_agent script that is not on disk
+    # can never run, so the job would fail on every fire instead of at create
+    # time. Only no_agent jobs are checked — an agent job may reference a
+    # script it writes later, and the scheduler resolves those at fire time.
+    if normalized_no_agent and normalized_script:
+        _script_path = Path(normalized_script).expanduser()
+        if not _script_path.is_absolute():
+            _script_path = get_hermes_home() / "scripts" / _script_path
+        if not _script_path.is_file():
+            raise ValueError(
+                f"no_agent=True script does not exist: {normalized_script!r}. "
+                f"Write the script under {get_hermes_home() / 'scripts'}/ first, "
+                "then create the job."
+            )
+
     # Normalize context_from: accept str or list of str, store as list or None
     if isinstance(context_from, str):
         context_from = [context_from.strip()] if context_from.strip() else None

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1630,6 +1630,21 @@ def create_job(
             "there is nothing for the job to run."
         )
 
+    # Same invariant, one step further: a no_agent script that is not on disk
+    # can never run, so the job would fail on every fire instead of at create
+    # time. Only no_agent jobs are checked — an agent job may reference a
+    # script it writes later, and the scheduler resolves those at fire time.
+    if normalized_no_agent and normalized_script:
+        _script_path = Path(normalized_script).expanduser()
+        if not _script_path.is_absolute():
+            _script_path = get_hermes_home() / "scripts" / _script_path
+        if not _script_path.is_file():
+            raise ValueError(
+                f"no_agent=True script does not exist: {normalized_script!r}. "
+                f"Write the script under {get_hermes_home() / 'scripts'}/ first, "
+                "then create the job."
+            )
+
     # Normalize context_from: accept str or list of str, store as list or None
     if isinstance(context_from, str):
         context_from = [context_from.strip()] if context_from.strip() else None

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -367,3 +367,21 @@ def test_agent_job_provider_classification_unchanged(error, expected):
 
     job = {"name": "daily-digest", "no_agent": False}
     assert expected in _summarize_cron_failure_for_delivery(job, error)
+
+
+def test_create_job_no_agent_rejects_missing_script(hermes_env):
+    """A no_agent job whose script does not exist can never do anything.
+
+    The script IS the job, so a typo'd or not-yet-written filename must fail at
+    create time rather than scheduling a job that fails on every fire.
+    """
+    from cron.jobs import create_job
+
+    with pytest.raises(ValueError, match="script does not exist"):
+        create_job(
+            prompt=None,
+            schedule="every 5m",
+            script="not-written-yet.sh",
+            no_agent=True,
+            deliver="local",
+        )

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -131,3 +131,21 @@ def test_run_job_script_nul_path_fails_cleanly(hermes_env):
     ok, output = _run_job_script("~user\x00bad.sh")
     assert ok is False
     assert "Blocked" in output
+
+
+def test_create_job_no_agent_rejects_missing_script(hermes_env):
+    """A no_agent job whose script does not exist can never do anything.
+
+    The script IS the job, so a typo'd or not-yet-written filename must fail at
+    create time rather than scheduling a job that fails on every fire.
+    """
+    from cron.jobs import create_job
+
+    with pytest.raises(ValueError, match="script does not exist"):
+        create_job(
+            prompt=None,
+            schedule="every 5m",
+            script="not-written-yet.sh",
+            no_agent=True,
+            deliver="local",
+        )

--- a/tests/cron/test_persisted_error_rearm_legality.py
+++ b/tests/cron/test_persisted_error_rearm_legality.py
@@ -92,6 +92,9 @@ class TestCronRearmRespectsScheduleLegality:
     def test_interval_job_still_rearms_to_now(self, cron_store):
         """Interval jobs (the 2026-08-14 incident class) keep the immediate
         catch-up: re-armed to now, due on this same scan."""
+        scripts_dir = cron_store / "scripts"
+        scripts_dir.mkdir(exist_ok=True)
+        (scripts_dir / "p.py").write_text("print('probe')\n", encoding="utf-8")
         job = J.create_job(prompt="probe", schedule="every 10m", no_agent=True, script="p.py")
         now = datetime(2026, 8, 22, 12, 0, tzinfo=timezone.utc)
         _wedge(

--- a/tests/cron/test_recurring_eagain_redispatch.py
+++ b/tests/cron/test_recurring_eagain_redispatch.py
@@ -54,6 +54,9 @@ def wedge_env(tmp_path, monkeypatch):
     monkeypatch.setattr(jobs_mod, "JOBS_FILE", hermes_home / "cron" / "jobs.json")
     monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", hermes_home / "cron" / "output")
 
+    script = hermes_home / "scripts" / "probe.py"
+    script.write_text("print('ok')\n")
+
     # Create a recurring no_agent interval job.
     job = jobs_mod.create_job(
         prompt="probe",
@@ -64,9 +67,6 @@ def wedge_env(tmp_path, monkeypatch):
     # Force it due now.
     now = datetime.now(timezone.utc)
     jobs_mod.update_job(job["id"], {"next_run_at": (now - timedelta(minutes=1)).isoformat()})
-
-    script = hermes_home / "scripts" / "probe.py"
-    script.write_text("print('ok')\n")
 
     return {"home": hermes_home, "job_id": job["id"]}
 

--- a/tests/cron/test_recurring_persisted_error_recovery.py
+++ b/tests/cron/test_recurring_persisted_error_recovery.py
@@ -55,14 +55,14 @@ def cron_env(tmp_path, monkeypatch):
     monkeypatch.setattr(jobs_mod, "JOBS_FILE", hermes_home / "cron" / "jobs.json")
     monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", hermes_home / "cron" / "output")
 
+    script = hermes_home / "scripts" / "probe.py"
+    script.write_text("print('ok')\n")
     job = jobs_mod.create_job(
         prompt="probe",
         schedule="every 10m",
         no_agent=True,
         script="probe.py",
     )
-    script = hermes_home / "scripts" / "probe.py"
-    script.write_text("print('ok')\n")
     return {"home": hermes_home, "job_id": job["id"]}
 
 

--- a/tests/cron/test_recurring_wedge_selfheal.py
+++ b/tests/cron/test_recurring_wedge_selfheal.py
@@ -54,6 +54,9 @@ def cron_env(tmp_path, monkeypatch):
     monkeypatch.setattr(jobs_mod, "JOBS_FILE", hermes_home / "cron" / "jobs.json")
     monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", hermes_home / "cron" / "output")
 
+    script = hermes_home / "scripts" / "probe.py"
+    script.write_text("print('ok')\n")
+
     job = jobs_mod.create_job(
         prompt="probe",
         schedule="every 10m",
@@ -62,9 +65,6 @@ def cron_env(tmp_path, monkeypatch):
     )
     now = datetime.now(timezone.utc)
     jobs_mod.update_job(job["id"], {"next_run_at": (now - timedelta(minutes=1)).isoformat()})
-
-    script = hermes_home / "scripts" / "probe.py"
-    script.write_text("print('ok')\n")
 
     return {"home": hermes_home, "job_id": job["id"]}
 


### PR DESCRIPTION
## What does this PR do?

**Rewritten and rebased on current `main`.** Most of the original patch has since landed upstream, so this PR is now reduced to the one part that is still missing.

A `no_agent` cron job runs its script instead of an agent, so the script *is* the job. `create_job()` already rejects a missing `script` argument, but a script filename that is not on disk was still accepted — scheduling a job that fails on every fire instead of failing once, loudly, at create time.

What changed since this PR was opened:

- `no_agent=True requires a script` — **already on `main`** (`tools/cronjob_tools.py:662`).
- Script path shape and traversal containment — **already on `main`** (`_validate_cron_script_path`, `tools/cronjob_tools.py:492`), and stricter than this PR's original version: `main` now rejects absolute and `~` paths outright at the API boundary as a prompt-injection guard.
- **Script existence — still missing.** That is all this PR now does.

The original patch also introduced its own path validator that would have *re-allowed* absolute and `~` paths when they resolved inside the scripts directory. Rebasing that as-is would have relaxed a security boundary `main` deliberately tightened, so it is dropped entirely. `main`'s validator stays authoritative.

Existence is enforced for `no_agent` jobs only. An agent job may legitimately reference a script it writes later, and the scheduler resolves those at fire time.

## Related Issue

Fixes #53037

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `cron/jobs.py` — in `create_job()`, next to the existing "no_agent requires a script" invariant, reject a `no_agent` job whose script does not resolve to an existing file. Relative paths resolve under `HERMES_HOME/scripts/`, matching the scheduler.
- `tests/cron/test_cron_no_agent.py` — regression test for the missing-script case.

Production diff is +15 lines; tests +18.

## How to Test

1. Reproduce on `main` — the new test fails with `DID NOT RAISE <class 'ValueError'>`:

```
scripts/run_tests.sh tests/cron/test_cron_no_agent.py
```

2. With the fix, the same file passes:

```
=== Summary: 1 files, 6 tests passed, 0 failed (100% complete) in 1.1s (16 workers) ===
```

3. Real behavior through the `cronjob` tool entry point — a clean structured error, not a traceback:

```
--- missing script, no_agent=True ---
{"error": "no_agent=True script does not exist: 'not-written-yet.sh'. Write the script under
 <HERMES_HOME>/scripts/ first, then create the job.", "success": false}

--- positive control: script exists ---
success: True | job_id: 07243b33ad8d
```

4. Surrounding suites, all green:

```
scripts/run_tests.sh tests/cron/ tests/gateway/test_api_server_jobs.py tests/hermes_cli/test_cron_parser_builder.py
=== Summary: 36 files, 393 tests passed, 0 failed (100% complete) in 25.0s (16 workers) ===

scripts/run_tests.sh tests/tools/test_cronjob_tools.py tests/tools/test_blueprints.py
=== Summary: 2 files, 63 tests passed, 0 failed (100% complete) in 21.2s (16 workers) ===
```

Blast radius: `create_job()` callers are `tools/cronjob_tools.py`, `tools/blueprints.py`, and `hermes_cli/blueprint_cmd.py`. Blueprints never pass `script`, so they are unaffected.

Honest limits: `tests/tools/` and `tests/hermes_cli/` show 19 failures on this machine (voice-mode, wake-word, systemd, file-tools). They are **identical on unmodified `main`** — same 19 tests, set difference empty — so none are introduced here. `ty` reports 6 diagnostics on `cron/jobs.py`, also byte-identical on `main`. ruff is clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cron):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite and all tests pass (pre-existing environment failures noted above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), Python 3.13.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, no user-facing surface change beyond the error message
- [x] I've updated `cli-config.yaml.example` — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — relative paths resolve via `pathlib` under `get_hermes_home()`, no POSIX-only primitives
- [x] I've updated tool descriptions/schemas — N/A, the tool contract is unchanged

## Screenshots / Logs

Included inline under **How to Test** above.
