### PR TITLE
feat(prompt): announce the selected [Workflow] up front for Level 1+ tasks

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1279,6 +1279,14 @@ def init_agent(
     # single turn; the runtime already executes such batches concurrently.
     agent._parallel_tool_call_guidance = bool(_agent_section.get("parallel_tool_call_guidance", True))
 
+    # Up-front [Workflow] announcement toggle.  Default True.  Sibling of the
+    # other prompt-guidance toggles (task_completion / parallel_tool_call) and
+    # kept under ``agent.*`` for the same reason: it injects a static guidance
+    # block into the system prompt.  Deliberately NOT tied to the enforcement
+    # namespace (``workflow_guardrails.enabled`` / final_gate_mode), so display
+    # and the later hard-enforcement phase can be toggled independently.
+    agent._workflow_display_guidance = bool(_agent_section.get("workflow_display_guidance", True))
+
     # Local Python toolchain probe toggle.  Default True.  When False,
     # the probe is skipped entirely (no subprocess calls, no system-prompt
     # line).  Useful for users on exotic setups where the probe heuristics

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -363,6 +363,31 @@ PARALLEL_TOOL_CALL_GUIDANCE = (
     "in doubt and the calls are independent, batch them."
 )
 
+# Up-front workflow announcement. The user wants to see which workflow was
+# chosen before the work starts. This instruction used to live only in the
+# on-demand `user-workflow-routing` skill body, which never entered the active
+# context — so the block was emitted ~0 times. Promoting it to the always-on
+# system prompt is the display path (enforcement is a separate, later step).
+WORKFLOW_DISPLAY_GUIDANCE = (
+    "# Announce the workflow up front\n"
+    "For any Level 1+ task (anything that edits files, runs tests, calls "
+    "agents/tools, makes external calls, or changes state), emit a compact "
+    "`[Workflow]` block as the FIRST line of your response, before doing the "
+    "work. Skip it for Level 0 conversational/explanatory answers, when the "
+    "user explicitly asked for a quick/raw answer, and when the response must "
+    "follow a strict machine-readable contract (JSON-only, a required schema, "
+    "or a structured tool/parser format) — there, omit the block entirely so "
+    "the output stays parseable.\n"
+    "Format (2-5 lines, plain text):\n"
+    "[Workflow: <short type label, e.g. standard feature impl> · Risk L<0-4>]\n"
+    "- <Stage> (<model/agent>): <purpose>\n"
+    "- Gates: <plan/approval/reviewer/tests, or \"none\">\n"
+    "Reflect the ACTUAL plan you will run; if routing changes mid-task, update "
+    "the block. Never list the same model as both implementer and adversarial "
+    "reviewer for quality-sensitive work. Keep it an honest, compact routing "
+    "summary — the full plan and evidence still belong later in the response."
+)
+
 # OpenAI GPT/Codex-specific execution guidance.  Addresses known failure modes
 # where GPT models abandon work on partial results, skip prerequisite lookups,
 # hallucinate instead of using tools, and declare "done" without verification.

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -41,6 +41,7 @@ from agent.prompt_builder import (
     TASK_COMPLETION_GUIDANCE,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
+    WORKFLOW_DISPLAY_GUIDANCE,
     drain_truncation_warnings,
 )
 from agent.runtime_cwd import resolve_context_cwd
@@ -183,6 +184,15 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # (default True) and only injected when tools are actually loaded.
     if getattr(agent, "_parallel_tool_call_guidance", True) and agent.valid_tool_names:
         stable_parts.append(PARALLEL_TOOL_CALL_GUIDANCE)
+
+    # Up-front [Workflow] announcement. Lives here (always-on system prompt)
+    # rather than in the on-demand user-workflow-routing skill, which never
+    # entered active context. Gated by config.yaml ``workflow_guardrails.enabled``
+    # (default True) — previously an inert flag. Only injected when tools are
+    # loaded, since a no-tool (conversational) turn is Level 0 with nothing to
+    # announce.
+    if getattr(agent, "_workflow_display_guidance", True) and agent.valid_tool_names:
+        stable_parts.append(WORKFLOW_DISPLAY_GUIDANCE)
 
     # Tool-aware behavioral guidance: only inject when the tools are loaded
     tool_guidance = []

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -954,6 +954,14 @@ DEFAULT_CONFIG = {
         # compounds over a long conversation.  Costs ~70 tokens in the cached
         # system prompt.  Set False to disable globally.
         "parallel_tool_call_guidance": True,
+        # Up-front [Workflow] announcement guidance — short prompt block telling
+        # the model to emit a compact `[Workflow: ... · Risk L<0-4>]` block as
+        # the first line of any Level 1+ response (file edits, tests, tool/agent
+        # calls, state changes), naming each stage's model and purpose.  Skipped
+        # for Level 0 conversational answers.  This is the display path only;
+        # hard enforcement is a separate concern under ``workflow_guardrails``.
+        # Costs ~120 tokens in the cached system prompt.  Set False to disable.
+        "workflow_display_guidance": True,
         # Local-environment toolchain probe — surfaces Python/pip/uv/PEP-668
         # state in the system prompt when something non-default is detected
         # (e.g. python3 has no pip module, pip→python version mismatch, PEP

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -96,3 +96,44 @@ class TestCodingContextBlock:
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         agent = _make_agent(valid_tool_names=[], platform="cli")
         assert "coding agent" not in _stable_prompt(agent)
+
+
+class TestWorkflowDisplayGuidance:
+    """The [Workflow] announce instruction must live in the always-on system
+    prompt, not only in the on-demand user-workflow-routing skill (which never
+    entered active context, so the block was emitted 0 times)."""
+
+    def test_injected_when_enabled(self):
+        agent = _make_agent(
+            valid_tool_names=["read_file"],
+            _workflow_display_guidance=True,
+        )
+        stable = _stable_prompt(agent)
+        assert "[Workflow:" in stable
+        # Must carve out strict machine-readable contracts so JSON/schema
+        # responses are not corrupted by a prepended workflow block.
+        assert "machine-readable" in stable
+
+    def test_absent_when_disabled(self):
+        agent = _make_agent(
+            valid_tool_names=["read_file"],
+            _workflow_display_guidance=False,
+        )
+        assert "[Workflow:" not in _stable_prompt(agent)
+
+    def test_absent_without_tools(self):
+        # No tools → conversational (Level 0) → nothing to announce.
+        agent = _make_agent(
+            valid_tool_names=[],
+            _workflow_display_guidance=True,
+        )
+        assert "[Workflow:" not in _stable_prompt(agent)
+
+    def test_default_on_when_flag_absent(self):
+        # getattr(..., True): an agent built without the attribute (older code
+        # path / partial init) must still get the guidance — default-on.
+        agent = _make_agent(valid_tool_names=["read_file"])
+        delattr(agent, "_workflow_display_guidance") if hasattr(
+            agent, "_workflow_display_guidance"
+        ) else None
+        assert "[Workflow:" in _stable_prompt(agent)


### PR DESCRIPTION
## Summary

The "announce the chosen workflow up front" instruction lived only in the
on-demand `user-workflow-routing` skill body, which never entered the active
context — so the `[Workflow]` block was effectively never emitted. This promotes
it to the always-on system prompt so the model reliably announces the workflow
for Level 1+ tasks.

**Scope: display path only.** Hard enforcement (post-response verification /
gating) is intentionally out of scope and left for a later change.

## Changes

- `agent/prompt_builder.py`: new `WORKFLOW_DISPLAY_GUIDANCE` constant — emit a
  compact `[Workflow: <type> · Risk L<0-4>]` block as the first line of any
  Level 1+ response (stage = model/agent + purpose, plus Gates). Carve-outs:
  Level 0 conversational answers, explicit quick/raw requests, and strict
  machine-readable contracts (JSON-only / schema / parser format).
- `agent/system_prompt.py`: inject it into `stable_parts` (byte-stable, so it
  doesn't churn the cache prefix per turn), gated like the sibling guidance
  toggles and only when tools are loaded (a no-tool turn is Level 0).
- `agent/agent_init.py` + `hermes_cli/config.py`: new `agent.workflow_display_guidance`
  toggle (default True, documented in DEFAULT_CONFIG). Kept under `agent.*`
  alongside the other prompt-guidance toggles and deliberately decoupled from
  the enforcement namespace (`workflow_guardrails.*`) so display and a future
  enforcement phase can be toggled independently.

## Tests

- `tests/agent/test_system_prompt.py`: injected-when-enabled (+ strict-format
  carve-out present), absent-when-disabled, absent-without-tools, default-on
  when the flag attribute is missing. `tests/agent/test_system_prompt.py`: 9 passed;
  `tests/hermes_cli/test_config.py`: 106 passed.
