### PR TITLE
fix(desktop): refresh project tree on first cwd update

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.test.tsx
@@ -1,0 +1,127 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render } from '@testing-library/react'
+import type { MutableRefObject } from 'react'
+import { useEffect } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $currentCwd, setCurrentCwd } from '@/store/session'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './use-message-stream'
+
+const projectStoreMocks = vi.hoisted(() => ({
+  followActiveSessionCwd: vi.fn(async () => undefined),
+  refreshProjectTree: vi.fn(async () => undefined),
+  refreshProjects: vi.fn(async () => undefined)
+}))
+
+vi.mock('@/store/projects', async importOriginal => {
+  const actual = await importOriginal()
+
+  return {
+    ...actual,
+    ...projectStoreMocks
+  }
+})
+
+interface HarnessProps {
+  activeSessionIdRef: MutableRefObject<null | string>
+  onReady: (handleGatewayEvent: (event: RpcEvent) => void) => void
+  sessionStateByRuntimeIdRef: MutableRefObject<Map<string, unknown>>
+}
+
+function MessageStreamHarness({ activeSessionIdRef, onReady, sessionStateByRuntimeIdRef }: HarnessProps) {
+  const { handleGatewayEvent } = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: async () => undefined,
+    queryClient: new QueryClient(),
+    refreshHermesConfig: async () => undefined,
+    refreshSessions: async () => undefined,
+    sessionStateByRuntimeIdRef: sessionStateByRuntimeIdRef as MutableRefObject<Map<string, never>>,
+    updateSessionState: (_sessionId, updater) => updater({ interrupted: false, messages: [] } as never)
+  })
+
+  useEffect(() => {
+    onReady(handleGatewayEvent)
+  }, [handleGatewayEvent, onReady])
+
+  return null
+}
+
+describe('useMessageStream session.info cwd refresh', () => {
+  beforeEach(() => {
+    setCurrentCwd('/old-root')
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    setCurrentCwd('')
+  })
+
+  it('refreshes project caches on the first active-session cwd change without following scope', () => {
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: 'sid-1' }
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, unknown>> = { current: new Map() }
+    let handleGatewayEvent: null | ((event: RpcEvent) => void) = null
+
+    render(
+      <MessageStreamHarness
+        activeSessionIdRef={activeSessionIdRef}
+        onReady={handler => {
+          handleGatewayEvent = handler
+        }}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+
+    act(() => {
+      handleGatewayEvent?.({
+        payload: { cwd: '/new-root' },
+        session_id: 'sid-1',
+        type: 'session.info'
+      } as RpcEvent)
+    })
+
+    expect($currentCwd.get()).toBe('/new-root')
+    expect(projectStoreMocks.refreshProjects).toHaveBeenCalledTimes(1)
+    expect(projectStoreMocks.refreshProjectTree).toHaveBeenCalledTimes(1)
+    expect(projectStoreMocks.followActiveSessionCwd).not.toHaveBeenCalled()
+  })
+
+  it('follows scope on subsequent cwd moves for the same active session', () => {
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: 'sid-1' }
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, unknown>> = { current: new Map() }
+    let handleGatewayEvent: null | ((event: RpcEvent) => void) = null
+
+    render(
+      <MessageStreamHarness
+        activeSessionIdRef={activeSessionIdRef}
+        onReady={handler => {
+          handleGatewayEvent = handler
+        }}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+
+    act(() => {
+      handleGatewayEvent?.({
+        payload: { cwd: '/new-root' },
+        session_id: 'sid-1',
+        type: 'session.info'
+      } as RpcEvent)
+    })
+
+    act(() => {
+      handleGatewayEvent?.({
+        payload: { cwd: '/newer-root' },
+        session_id: 'sid-1',
+        type: 'session.info'
+      } as RpcEvent)
+    })
+
+    expect(projectStoreMocks.refreshProjects).toHaveBeenCalledTimes(1)
+    expect(projectStoreMocks.refreshProjectTree).toHaveBeenCalledTimes(1)
+    expect(projectStoreMocks.followActiveSessionCwd).toHaveBeenCalledTimes(1)
+    expect(projectStoreMocks.followActiveSessionCwd).toHaveBeenCalledWith('/newer-root')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -35,7 +35,7 @@ import { dispatchNativeNotification } from '@/store/native-notifications'
 import { notify } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
 import { flashPetActivity, markPetUnread, setPetActivity } from '@/store/pet'
-import { followActiveSessionCwd } from '@/store/projects'
+import { followActiveSessionCwd, refreshProjects, refreshProjectTree } from '@/store/projects'
 import { clearAllPrompts, setApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
 import {
   $currentCwd,
@@ -757,15 +757,20 @@ export function useMessageStream({
             // via the terminal). When the SAME active session's cwd actually
             // moves, follow it — refresh the project tree + scope so the sidebar
             // tracks the live thread. A fresh selection (different session id)
-            // is a switch, not a move, so it refreshes data without yanking scope.
+            // is a switch, not a move, so it should refresh the project caches
+            // without yanking scope into another project.
             const cwdMoved = payload.cwd !== $currentCwd.get()
             const sameSession = !!sessionId && sessionId === lastCwdInfoSessionRef.current
 
             lastCwdInfoSessionRef.current = sessionId
             setCurrentCwd(payload.cwd)
 
-            if (cwdMoved && sameSession) {
-              void followActiveSessionCwd(payload.cwd)
+            if (cwdMoved) {
+              if (sameSession) {
+                void followActiveSessionCwd(payload.cwd)
+              } else if (sessionId) {
+                void Promise.all([refreshProjects(), refreshProjectTree()])
+              }
             }
           }
 


### PR DESCRIPTION
## Summary
- refresh the project caches when the first `session.info` cwd update arrives for the active desktop session
- keep the existing follow-and-scope behavior for subsequent cwd moves in the same session
- add a regression test covering first-update refresh vs same-session follow

Fixes #53046.

## Testing
- npm run test:ui -- use-message-stream.test.tsx use-project-tree.test.ts
- npx eslint src/app/session/hooks/use-message-stream.ts src/app/session/hooks/use-message-stream.test.tsx
- git diff --check