### PR TITLE
fix(tui): add /config set/get and expand config display (#4073)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6408,11 +6408,163 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         print(f"  Toolsets:   {', '.join(self.enabled_toolsets) if self.enabled_toolsets else 'all'}")
         print(f"  Verbose:    {self.verbose}")
         print()
+        print("  -- Display --")
+        display = self.config.get("display", {})
+        print(f"  Personality:  {display.get('personality') or 'none'}")
+        print(f"  Reasoning:    {'on' if display.get('show_reasoning', False) else 'off'}")
+        print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
+        print(f"  Compact:      {'on' if self.compact else 'off'}")
+        print(f"  Tool progress: {self.tool_progress_mode}")
+        print()
+        print("  -- Compression --")
+        compression = self.config.get("compression", {})
+        comp_enabled = compression.get("enabled", True)
+        print(f"  Enabled:      {'yes' if comp_enabled else 'no'}")
+        if comp_enabled:
+            print(f"  Threshold:    {compression.get('threshold', 0.50) * 100:.0f}%")
+            target = compression.get("target_ratio", 0.20)
+            print(f"  Target ratio: {target * 100:.0f}% of threshold preserved")
+            print(f"  Protect last: {compression.get('protect_last_n', 20)} messages")
+        print()
+        print("  -- Timezone --")
+        tz = self.config.get("timezone", "")
+        print(f"  Timezone:     {tz or '(server-local)'}")
+        # Auxiliary model overrides
+        auxiliary = self.config.get("auxiliary", {})
+        has_aux_overrides = False
+        for task_key in ("vision", "web_extract", "compression"):
+            task_cfg = auxiliary.get(task_key, {})
+            if task_cfg.get("provider", "auto") != "auto" or task_cfg.get("model", ""):
+                has_aux_overrides = True
+                break
+        if has_aux_overrides:
+            print()
+            print("  -- Auxiliary Models (overrides) --")
+            for label, task_key in [("Vision", "vision"), ("Web extract", "web_extract"), ("Compression", "compression")]:
+                task_cfg = auxiliary.get(task_key, {})
+                prov = task_cfg.get("provider", "auto")
+                mdl = task_cfg.get("model", "")
+                if prov != "auto" or mdl:
+                    parts = [f"provider={prov}"]
+                    if mdl:
+                        parts.append(f"model={mdl}")
+                    print(f"  {label:14s} {', '.join(parts)}")
+        print()
         print("  -- Session --")
         print(f"  Started:     {self.session_start.strftime('%Y-%m-%d %H:%M:%S')}")
         print(f"  Config File: {config_path} {config_status}")
         print()
+        print("  Tip: Use /config set <key.path> <value> to change settings")
+        print("       Use /config get <key.path> to read a single value")
+        print()
     
+    def _config_set_value(self, key_path: str, value: str) -> None:
+        """Set a config value from /config set <key> <value>.
+
+        Persists to disk and applies live where safe.  Keys that require
+        a restart are flagged so the user knows.
+        """
+        # Validate that the key path resolves to an existing config section
+        # or is a recognized leaf key.  Prevents silent orphan writes from
+        # typos like "disploy.bell" or "model.defualt".
+        parts = key_path.split(".")
+        cfg = self.config
+        for i, part in enumerate(parts[:-1]):
+            if not isinstance(cfg, dict) or part not in cfg:
+                _cprint(f"\033[1;31m  ✗ Unknown config section: {'.'.join(parts[:i + 1])}\033[0m")
+                _cprint(f"  Tip: Run /config to see available settings")
+                return
+            cfg = cfg[part]
+        # Final segment may not exist yet (user setting a new value), but the
+        # parent must be a dict.
+        if not isinstance(cfg, dict):
+            _cprint(f"\033[1;31m  ✗ {'.'.join(parts[:-1])} is not a section (cannot set sub-keys)\033[0m")
+            return
+
+        # Keys that can safely live-apply without restart
+        _LIVE_PREFIXES = ("display.", "compression.", "timezone")
+        # Everything else needs a restart (conservative)
+        _RESTART_PREFIXES = ("terminal.", "model.", "mcp_servers.",
+                             "browser.", "memory.", "delegation.", "approvals.")
+
+        needs_restart = any(key_path.startswith(p) for p in _RESTART_PREFIXES)
+        can_live = any(key_path.startswith(p) for p in _LIVE_PREFIXES)
+
+        # Coerce common string values to bool/int where appropriate
+        coerced = self._coerce_config_value(key_path, value)
+
+        if not save_config_value(key_path, coerced):
+            _cprint(f"\033[1;31m  ✗ Failed to save {key_path}\033[0m")
+            return
+
+        # Live-apply by mutating self.config in-memory
+        if can_live or not needs_restart:
+            target = self.config
+            for part in parts[:-1]:
+                target = target.setdefault(part, {})
+            target[parts[-1]] = coerced
+
+            # Propagate well-known keys to live agent attributes so the
+            # running session picks up the change immediately.
+            self._propagate_config_live(key_path, coerced)
+
+        if needs_restart:
+            _cprint(f"  ✓ Set {key_path} = {coerced}  \033[33m(requires restart)\033[0m")
+        else:
+            _cprint(f"  ✓ Set {key_path} = {coerced}")
+
+    def _propagate_config_live(self, key_path: str, value) -> None:
+        """Push an in-memory config change to live agent/session attributes."""
+        # Session-level display attributes — always propagate regardless of
+        # whether an agent is active (these are TUI display prefs, not agent
+        # runtime state).
+        if key_path == "display.show_reasoning":
+            self.show_reasoning = bool(value)
+        elif key_path == "display.bell_on_complete":
+            self.bell_on_complete = bool(value)
+        elif key_path == "display.compact":
+            self.compact = bool(value)
+        elif key_path == "display.tool_progress":
+            self.tool_progress_mode = "off" if value is False else str(value)
+
+    @staticmethod
+    def _coerce_config_value(key_path: str, value: str):
+        """Coerce a string value to bool/int/float where obvious."""
+        if value.lower() in ("true", "yes", "on"):
+            return True
+        if value.lower() in ("false", "no", "off"):
+            return False
+        # Integers
+        try:
+            return int(value)
+        except ValueError:
+            pass
+        # Floats
+        try:
+            return float(value)
+        except ValueError:
+            pass
+        return value
+
+    def _config_get_value(self, key_path: str) -> None:
+        """Display a single config value."""
+        parts = key_path.split(".")
+        cfg = self.config
+        for part in parts:
+            if isinstance(cfg, dict):
+                cfg = cfg.get(part)
+            else:
+                cfg = None
+                break
+        if cfg is None:
+            _cprint(f"  {key_path}: (not set)")
+        elif isinstance(cfg, dict):
+            _cprint(f"  {key_path}:")
+            for k, v in cfg.items():
+                _cprint(f"    {k}: {v}")
+        else:
+            _cprint(f"  {key_path}: {cfg}")
+
     def _list_recent_sessions(self, limit: int = 10) -> list[dict[str, Any]]:
         """Return recent CLI sessions for in-chat browsing/resume affordances."""
         if not self._session_db:
@@ -8026,7 +8178,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         elif canonical == "toolsets":
             self.show_toolsets()
         elif canonical == "config":
-            self.show_config()
+            # Parse subcommands: /config set <key> <value>, /config get <key>
+            rest = cmd_original.split(None, 1)
+            args_str = rest[1].strip() if len(rest) > 1 else ""
+            if args_str:
+                args_parts = args_str.split(None, 2)
+                subcmd = args_parts[0].lower()
+                if subcmd == "set" and len(args_parts) >= 3:
+                    self._config_set_value(args_parts[1], args_parts[2])
+                elif subcmd == "set":
+                    _cprint("  Usage: /config set <key.path> <value>")
+                    _cprint("  Example: /config set display.bell_on_complete true")
+                elif subcmd == "get" and len(args_parts) >= 2:
+                    self._config_get_value(args_parts[1])
+                elif subcmd == "get":
+                    _cprint("  Usage: /config get <key.path>")
+                else:
+                    _cprint(f"  Unknown /config subcommand: {subcmd}")
+                    _cprint("  Usage: /config [set <key> <value> | get <key>]")
+            else:
+                self.show_config()
         elif canonical == "redraw":
             # Manual recovery for terminal buffer drift from multiplexer
             # tab switches, subshell ``clear``, SSH window restores, etc.
@@ -8590,7 +8761,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     # Expand the prefix to the full command name, preserving arguments.
                     # Guard against redispatching the same token to avoid infinite
                     # recursion when the expanded name still doesn't hit an exact branch
-                    # (e.g. /config with extra args that are not yet handled above).
+                    # (e.g. /config with subcommands handled above).
                     full_name = matches[0]
                     if full_name == typed_base:
                         # Already an exact token — no expansion possible; fall through

--- a/cli.py
+++ b/cli.py
@@ -6484,8 +6484,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # Keys that can safely live-apply without restart
         _LIVE_PREFIXES = ("display.", "compression.", "timezone")
         # Everything else needs a restart (conservative)
-        _RESTART_PREFIXES = ("terminal.", "model.", "mcp_servers.",
-                             "browser.", "memory.", "delegation.", "approvals.")
+        _RESTART_PREFIXES = ("terminal.", "model.", "agent.", "mcp_servers.",
+                             "browser.", "memory.", "delegation.", "approvals.",
+                             "auxiliary.")
 
         needs_restart = any(key_path.startswith(p) for p in _RESTART_PREFIXES)
         can_live = any(key_path.startswith(p) for p in _LIVE_PREFIXES)

--- a/cli.py
+++ b/cli.py
@@ -6509,10 +6509,47 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # running session picks up the change immediately.
             self._propagate_config_live(key_path, coerced)
 
+        # Mask credential-shaped leaves before printing so /config set
+        # never echoes raw secrets into terminal scrollback. Falls through
+        # to redact_config_value for dict/list values that may carry nested
+        # api_key/token entries (custom providers, custom_providers blocks).
+        display_value = self._format_config_value_for_display(key_path, coerced)
         if needs_restart:
-            _cprint(f"  ✓ Set {key_path} = {coerced}  \033[33m(requires restart)\033[0m")
+            _cprint(f"  ✓ Set {key_path} = {display_value}  \033[33m(requires restart)\033[0m")
         else:
-            _cprint(f"  ✓ Set {key_path} = {coerced}")
+            _cprint(f"  ✓ Set {key_path} = {display_value}")
+
+    @staticmethod
+    def _format_config_value_for_display(key_path: str, value):
+        """Return ``value`` formatted for terminal display with credentials masked.
+
+        Three cases:
+        1. The leaf key (last segment of ``key_path``) is credential-shaped
+           and the value is a non-empty string — mask via ``mask_secret``
+           so a literal ``api_key`` set never prints the raw token.
+        2. ``value`` is a dict/list — run through ``redact_config_value``
+           so any nested ``api_key`` / ``token`` / ``password`` entries
+           are masked (covers custom_providers blocks set via nested keys).
+        3. Anything else — return unchanged.
+
+        ``redact_config_value`` and ``_SECRET_CONFIG_KEYS`` are the same
+        canonical helpers ``hermes config show`` / ``hermes status`` /
+        ``hermes dump`` use, so the mask format stays consistent across
+        CLI surfaces.
+        """
+        from hermes_cli.config import _SECRET_CONFIG_KEYS, redact_config_value, redact_key
+
+        leaf = key_path.rsplit(".", 1)[-1] if key_path else ""
+        if (
+            isinstance(leaf, str)
+            and leaf.lower() in _SECRET_CONFIG_KEYS
+            and isinstance(value, str)
+            and value
+        ):
+            return redact_key(value)
+        if isinstance(value, (dict, list)):
+            return redact_config_value(value)
+        return value
 
     def _propagate_config_live(self, key_path: str, value) -> None:
         """Push an in-memory config change to live agent/session attributes."""
@@ -6561,10 +6598,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             _cprint(f"  {key_path}: (not set)")
         elif isinstance(cfg, dict):
             _cprint(f"  {key_path}:")
-            for k, v in cfg.items():
+            # Run the section through structural redaction so a
+            # `model.api_key` style nested leaf never echoes its raw
+            # token into terminal scrollback. ``_format_config_value_for_display``
+            # handles dict/list values by masking any credential-shaped
+            # keys (api_key, token, password, etc.) and passing scalars
+            # through unchanged.
+            from hermes_cli.config import redact_config_value
+            safe_cfg = redact_config_value(cfg)
+            for k, v in safe_cfg.items():
                 _cprint(f"    {k}: {v}")
         else:
-            _cprint(f"  {key_path}: {cfg}")
+            # Scalar value — mask if the leaf key is credential-shaped so
+            # ``/config get model.api_key`` never prints the raw token.
+            display_value = self._format_config_value_for_display(key_path, cfg)
+            _cprint(f"  {key_path}: {display_value}")
 
     def _list_recent_sessions(self, limit: int = 10) -> list[dict[str, Any]]:
         """Return recent CLI sessions for in-chat browsing/resume affordances."""

--- a/cli.py
+++ b/cli.py
@@ -6481,12 +6481,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             _cprint(f"\033[1;31m  ✗ {'.'.join(parts[:-1])} is not a section (cannot set sub-keys)\033[0m")
             return
 
-        # Keys that can safely live-apply without restart
-        _LIVE_PREFIXES = ("display.", "compression.", "timezone")
+        # Keys that can safely live-apply without restart. ``compression.*``
+        # is NOT in this set: the active ContextCompressor is constructed
+        # from these values during agent init (agent/agent_init.py:1606)
+        # with constructor-time threshold_percent / protect_first_n /
+        # protect_last_n / target_ratio parameters and runtime state
+        # (``threshold_tokens``). Live-applying changes to all of them
+        # safely is non-trivial and risks token-tracking drift mid-session,
+        # so compression.* is treated as restart-required and the user is
+        # told to restart.
+        _LIVE_PREFIXES = ("display.", "timezone")
         # Everything else needs a restart (conservative)
         _RESTART_PREFIXES = ("terminal.", "model.", "agent.", "mcp_servers.",
                              "browser.", "memory.", "delegation.", "approvals.",
-                             "auxiliary.")
+                             "auxiliary.", "compression.")
 
         needs_restart = any(key_path.startswith(p) for p in _RESTART_PREFIXES)
         can_live = any(key_path.startswith(p) for p in _LIVE_PREFIXES)

--- a/cli.py
+++ b/cli.py
@@ -6572,6 +6572,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self.compact = bool(value)
         elif key_path == "display.tool_progress":
             self.tool_progress_mode = "off" if value is False else str(value)
+            # Sync the active agent's tool_progress_mode too — without
+            # this, ``/config set display.tool_progress new`` updates the
+            # CLI's cycle state but the running agent keeps emitting in
+            # the OLD mode. Mirrors the sync pattern in ``_toggle_verbose``
+            # (cli.py:8983-8986) so the tool_executor rendering path
+            # reflects the new mode this turn without waiting for an
+            # agent rebuild. Guarded with ``hasattr`` to stay defensive
+            # against agent variants that may not expose the attribute
+            # (test stubs, lightweight agent types).
+            agent = getattr(self, "agent", None)
+            if agent is not None and hasattr(agent, "tool_progress_mode"):
+                agent.tool_progress_mode = self.tool_progress_mode
 
     @staticmethod
     def _coerce_config_value(key_path: str, value: str):

--- a/cli.py
+++ b/cli.py
@@ -6476,10 +6476,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 return
             cfg = cfg[part]
         # Final segment may not exist yet (user setting a new value), but the
-        # parent must be a dict.
+        # parent must be a dict. We do NOT hard-reject unknown leaves because
+        # some sections (custom_providers, plugin-specific keys) accept new
+        # entries at runtime — but typos like ``display.bel_on_complete`` are
+        # common, so emit a yellow warning that makes the new-key write
+        # visible without blocking it. Users who INTENDED the new key see the
+        # warning and proceed; users with a typo get a visible signal.
         if not isinstance(cfg, dict):
             _cprint(f"\033[1;31m  ✗ {'.'.join(parts[:-1])} is not a section (cannot set sub-keys)\033[0m")
             return
+        if parts[-1] not in cfg:
+            _cprint(f"  \033[33m⚠ {key_path}: creating new key (typo? existing keys: {', '.join(sorted(cfg.keys()))})\033[0m")
 
         # Keys that can safely live-apply without restart. ``compression.*``
         # is NOT in this set: the active ContextCompressor is constructed

--- a/tests/cli/test_config_slash_commands.py
+++ b/tests/cli/test_config_slash_commands.py
@@ -1,0 +1,230 @@
+"""Tests for /config set, /config get, and enhanced show_config display."""
+from unittest.mock import MagicMock, patch
+import pytest
+
+from cli import HermesCLI
+
+
+def _make_cli(**config_overrides):
+    """Create a minimal HermesCLI stub for testing slash commands."""
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.config = {
+        "display": {"personality": "", "show_reasoning": False, "bell_on_complete": False, "compact": False, "tool_progress": "all"},
+        "compression": {"enabled": True, "threshold": 0.50},
+        "terminal": {"backend": "local", "cwd": ".", "timeout": 60},
+        "model": {"default": "test-model", "provider": "auto"},
+        "agent": {"max_turns": 90},
+    }
+    cli_obj.config.update(config_overrides)
+    cli_obj.console = MagicMock()
+    cli_obj.agent = None
+    cli_obj.conversation_history = []
+    cli_obj.session_id = "test-session"
+    cli_obj._pending_input = MagicMock()
+    cli_obj.compact = False
+    cli_obj.tool_progress_mode = "all"
+    cli_obj.show_reasoning = False
+    cli_obj.bell_on_complete = False
+    cli_obj.api_key = "sk-test-dummy-key-12345678"
+    cli_obj.model = "test-model"
+    cli_obj.base_url = ""
+    cli_obj.max_turns = 90
+    cli_obj.enabled_toolsets = []
+    cli_obj.verbose = False
+    cli_obj.session_start = MagicMock()
+    cli_obj.session_start.strftime.return_value = "2026-01-01 00:00:00"
+    return cli_obj
+
+
+class TestConfigSetValidation:
+    """Key path validation rejects typos and unknown sections."""
+
+    def test_unknown_section_rejected(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)):
+            cli_obj.process_command("/config set disploy.bell true")
+        combined = " ".join(printed)
+        assert "Unknown config section" in combined
+        assert "disploy" in combined
+
+    def test_unknown_parent_rejected(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)):
+            cli_obj.process_command("/config set display.nonexistent.key true")
+        # "display.nonexistent" is not in config
+        combined = " ".join(printed)
+        assert "Unknown config section" in combined
+
+    def test_valid_key_accepted(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)), \
+             patch("cli.save_config_value", return_value=True):
+            cli_obj.process_command("/config set display.bell_on_complete true")
+        combined = " ".join(printed)
+        assert "✓" in combined
+        assert "Unknown" not in combined
+
+
+class TestConfigSetCoercion:
+    """Values are coerced to bool/int/float where appropriate."""
+
+    def test_bool_true_values(self):
+        cli_obj = _make_cli()
+        for val in ("true", "yes", "on", "True", "YES"):
+            printed = []
+            with patch("cli._cprint", side_effect=lambda t: printed.append(t)), \
+                 patch("cli.save_config_value", return_value=True):
+                cli_obj.process_command(f"/config set display.bell_on_complete {val}")
+            combined = " ".join(printed)
+            assert "True" in combined, f"Failed for {val}"
+
+    def test_bool_false_values(self):
+        cli_obj = _make_cli()
+        for val in ("false", "no", "off", "False", "NO"):
+            printed = []
+            with patch("cli._cprint", side_effect=lambda t: printed.append(t)), \
+                 patch("cli.save_config_value", return_value=True):
+                cli_obj.process_command(f"/config set display.bell_on_complete {val}")
+            combined = " ".join(printed)
+            assert "False" in combined, f"Failed for {val}"
+
+    def test_integer_coercion(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)), \
+             patch("cli.save_config_value", return_value=True):
+            cli_obj.process_command("/config set agent.max_turns 50")
+        combined = " ".join(printed)
+        assert "50" in combined
+
+    def test_float_coercion(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)), \
+             patch("cli.save_config_value", return_value=True):
+            cli_obj.process_command("/config set compression.threshold 0.75")
+        combined = " ".join(printed)
+        assert "0.75" in combined
+
+
+class TestConfigSetRestartHints:
+    """Restart-required keys are flagged; live-apply keys are not."""
+
+    def test_terminal_key_shows_restart(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)), \
+             patch("cli.save_config_value", return_value=True):
+            cli_obj.process_command("/config set terminal.timeout 120")
+        combined = " ".join(printed)
+        assert "requires restart" in combined
+
+    def test_display_key_no_restart_hint(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)), \
+             patch("cli.save_config_value", return_value=True):
+            cli_obj.process_command("/config set display.bell_on_complete true")
+        combined = " ".join(printed)
+        assert "requires restart" not in combined
+        assert "✓" in combined
+
+    def test_display_key_live_applied(self):
+        cli_obj = _make_cli()
+        with patch("cli._cprint"), \
+             patch("cli.save_config_value", return_value=True):
+            cli_obj.process_command("/config set display.bell_on_complete true")
+        assert cli_obj.bell_on_complete is True
+        assert cli_obj.config["display"]["bell_on_complete"] is True
+
+
+class TestConfigGet:
+    """Test /config get <key>."""
+
+    def test_get_existing_value(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)):
+            cli_obj.process_command("/config get compression.threshold")
+        combined = " ".join(printed)
+        assert "0.5" in combined
+
+    def test_get_section(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)):
+            cli_obj.process_command("/config get compression")
+        combined = " ".join(printed)
+        assert "enabled" in combined
+        assert "threshold" in combined
+
+    def test_get_missing_value(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)):
+            cli_obj.process_command("/config get display.nonexistent")
+        combined = " ".join(printed)
+        assert "not set" in combined
+
+
+class TestConfigUsageHints:
+    """Test usage messages for malformed /config commands."""
+
+    def test_set_no_args(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)):
+            cli_obj.process_command("/config set")
+        combined = " ".join(printed)
+        assert "Usage" in combined
+
+    def test_set_missing_value(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)):
+            cli_obj.process_command("/config set display.bell_on_complete")
+        combined = " ".join(printed)
+        assert "Usage" in combined
+
+    def test_get_no_args(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)):
+            cli_obj.process_command("/config get")
+        combined = " ".join(printed)
+        assert "Usage" in combined
+
+    def test_unknown_subcommand(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)):
+            cli_obj.process_command("/config frobnicate key value")
+        combined = " ".join(printed)
+        assert "Unknown" in combined
+
+
+class TestShowConfigDisplay:
+    """Verify show_config renders the new sections."""
+
+    def test_display_section_present(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("builtins.print", side_effect=lambda *a, **kw: printed.append(" ".join(str(x) for x in a))):
+            cli_obj.show_config()
+        combined = "\n".join(printed)
+        assert "Display" in combined
+        assert "Personality" in combined
+        assert "Compression" in combined
+        assert "Timezone" in combined
+
+    def test_tip_line_present(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("builtins.print", side_effect=lambda *a, **kw: printed.append(" ".join(str(x) for x in a))):
+            cli_obj.show_config()
+        combined = "\n".join(printed)
+        assert "/config set" in combined
+        assert "/config get" in combined

--- a/tests/cli/test_config_slash_commands.py
+++ b/tests/cli/test_config_slash_commands.py
@@ -319,3 +319,50 @@ class TestConfigGetCredentialRedaction:
         combined = " ".join(printed)
         # 0.5 is the default and is not a credential
         assert "0.5" in combined
+
+
+class TestCompressionRestartRequired:
+    """Regression tests for maintainer review finding 2: ``compression.*``
+    is documented as live-apply but ``_propagate_config_live()`` has no
+    compression branch, so a ``/config set compression.threshold 0.75``
+    silently does not affect the active agent's ContextCompressor.
+
+    Marked restart-required so the user is told to restart. The active
+    compressor is constructed from these values at agent init with
+    constructor-time parameters (``threshold_percent``, ``protect_first_n``,
+    ``protect_last_n``, ``target_ratio``) and runtime state
+    (``threshold_tokens``) that are not safe to live-mutate.
+    """
+
+    def test_compression_threshold_shows_restart_hint(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)), \
+             patch("cli.save_config_value", return_value=True):
+            cli_obj.process_command("/config set compression.threshold 0.75")
+        combined = " ".join(printed)
+        assert "requires restart" in combined, (
+            "compression.* must surface the restart hint because the "
+            "active ContextCompressor cannot live-apply the change"
+        )
+
+    def test_compression_enabled_shows_restart_hint(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)), \
+             patch("cli.save_config_value", return_value=True):
+            cli_obj.process_command("/config set compression.enabled false")
+        combined = " ".join(printed)
+        assert "requires restart" in combined
+
+    def test_compression_set_does_not_call_propagate_live(self):
+        # Regression guard: compression.* must NOT trigger the live-apply
+        # path even if ``_propagate_config_live`` happens to learn how to
+        # handle it in the future — keep restart-required authoritative
+        # unless a real live-apply implementation lands.
+        cli_obj = _make_cli()
+        with patch("cli._cprint"), \
+             patch("cli.save_config_value", return_value=True), \
+             patch.object(HermesCLI, "_propagate_config_live") as mock_propagate:
+            cli_obj.process_command("/config set compression.threshold 0.75")
+        mock_propagate.assert_not_called()

--- a/tests/cli/test_config_slash_commands.py
+++ b/tests/cli/test_config_slash_commands.py
@@ -228,3 +228,94 @@ class TestShowConfigDisplay:
         combined = "\n".join(printed)
         assert "/config set" in combined
         assert "/config get" in combined
+
+
+class TestConfigSetCredentialRedaction:
+    """Regression tests for maintainer review #pullrequestreview-4701297956
+    finding 1: ``model.api_key`` and credential-shaped leaves must NOT be
+    echoed in raw form when ``/config set`` or ``/config get`` prints them.
+    Without the redaction wrapper the raw API key lands in terminal
+    scrollback.
+    """
+
+    def test_set_masks_top_level_api_key(self):
+        cli_obj = _make_cli(**{
+            "model": {"default": "test-model", "provider": "auto", "api_key": "sk-supersecret-1234567890abcdef"},
+        })
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)), \
+             patch("cli.save_config_value", return_value=True):
+            cli_obj.process_command("/config set model.api_key sk-newsecret-1234567890abcdef")
+        combined = " ".join(printed)
+        assert "sk-newsecret-1234567890abcdef" not in combined, (
+            "Raw api_key value must be masked in /config set output"
+        )
+        # The canonical mask preserves head/tail: 'sk-n...cdef'
+        assert "sk-n" in combined
+        assert "cdef" in combined
+
+    def test_set_masks_top_level_token(self):
+        cli_obj = _make_cli(**{
+            "model": {"default": "test-model", "provider": "auto"},
+        })
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)), \
+             patch("cli.save_config_value", return_value=True):
+            cli_obj.process_command("/config set model.token mysecrettoken123456")
+        combined = " ".join(printed)
+        assert "mysecrettoken123456" not in combined
+        # Sanity: a mask shape is still present
+        assert "***" in combined or "..." in combined
+
+    def test_set_does_not_mask_non_credential_leaf(self):
+        # display.bell_on_complete is not credential-shaped — must pass through
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)), \
+             patch("cli.save_config_value", return_value=True):
+            cli_obj.process_command("/config set display.bell_on_complete True")
+        combined = " ".join(printed)
+        assert "True" in combined
+
+
+class TestConfigGetCredentialRedaction:
+    """Regression tests for maintainer review finding 1 on /config get:
+    requesting a credential-shaped leaf or a section containing one must
+    print masked values, not the raw secret.
+    """
+
+    def test_get_masks_scalar_api_key(self):
+        cli_obj = _make_cli(**{
+            "model": {"default": "test-model", "provider": "auto", "api_key": "sk-supersecret-1234567890abcdef"},
+        })
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)):
+            cli_obj.process_command("/config get model.api_key")
+        combined = " ".join(printed)
+        assert "sk-supersecret-1234567890abcdef" not in combined
+        # Mask head/tail preserved
+        assert "sk-s" in combined
+        assert "cdef" in combined
+
+    def test_get_masks_api_key_inside_section(self):
+        cli_obj = _make_cli(**{
+            "model": {"default": "test-model", "provider": "auto", "api_key": "sk-supersecret-1234567890abcdef"},
+        })
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)):
+            cli_obj.process_command("/config get model")
+        combined = " ".join(printed)
+        # The raw value must not appear anywhere in the section dump
+        assert "sk-supersecret-1234567890abcdef" not in combined
+        # But other (non-credential) fields must still appear
+        assert "test-model" in combined
+        assert "auto" in combined
+
+    def test_get_passes_through_non_credential_scalar(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)):
+            cli_obj.process_command("/config get compression.threshold")
+        combined = " ".join(printed)
+        # 0.5 is the default and is not a credential
+        assert "0.5" in combined

--- a/tests/cli/test_config_slash_commands.py
+++ b/tests/cli/test_config_slash_commands.py
@@ -366,3 +366,46 @@ class TestCompressionRestartRequired:
              patch.object(HermesCLI, "_propagate_config_live") as mock_propagate:
             cli_obj.process_command("/config set compression.threshold 0.75")
         mock_propagate.assert_not_called()
+
+
+class TestToolProgressActiveAgentSync:
+    """Regression tests for maintainer review finding 3: ``display.tool_progress``
+    used to update only ``self.tool_progress_mode`` but not the active agent's
+    copy. Without the sync, ``/config set display.tool_progress new`` cycled
+    the CLI's mode while the running agent kept emitting in the OLD mode —
+    a confusing UX where the ``/verbose`` toggle (cli.py:8964) worked but
+    the new ``/config set`` path did not.
+    """
+
+    def test_tool_progress_syncs_active_agent(self):
+        cli_obj = _make_cli()
+        # Active agent stub with tool_progress_mode attribute (matches the
+        # real agent class shape — see cli.py:8984 for the sync pattern).
+        cli_obj.agent = MagicMock()
+        cli_obj.agent.tool_progress_mode = "off"
+        with patch("cli._cprint"), \
+             patch("cli.save_config_value", return_value=True):
+            cli_obj.process_command("/config set display.tool_progress new")
+        assert cli_obj.tool_progress_mode == "new"
+        assert cli_obj.agent.tool_progress_mode == "new"
+
+    def test_tool_progress_no_agent_does_not_crash(self):
+        # cli_obj.agent is None in the default fixture — the sync guard
+        # must skip silently without raising AttributeError.
+        cli_obj = _make_cli()
+        assert cli_obj.agent is None
+        with patch("cli._cprint"), \
+             patch("cli.save_config_value", return_value=True):
+            cli_obj.process_command("/config set display.tool_progress all")
+        assert cli_obj.tool_progress_mode == "all"
+
+    def test_tool_progress_skips_agent_without_attribute(self):
+        # Defensive guard: agent variants that don't expose tool_progress_mode
+        # (test stubs, lightweight agent types) must not crash the sync.
+        cli_obj = _make_cli()
+        cli_obj.agent = MagicMock(spec=[])  # no attributes exposed
+        with patch("cli._cprint"), \
+             patch("cli.save_config_value", return_value=True):
+            cli_obj.process_command("/config set display.tool_progress verbose")
+        # CLI side still updates
+        assert cli_obj.tool_progress_mode == "verbose"

--- a/tests/cli/test_config_slash_commands.py
+++ b/tests/cli/test_config_slash_commands.py
@@ -409,3 +409,65 @@ class TestToolProgressActiveAgentSync:
             cli_obj.process_command("/config set display.tool_progress verbose")
         # CLI side still updates
         assert cli_obj.tool_progress_mode == "verbose"
+
+
+class TestLeafKeyWarning:
+    """Regression tests for maintainer review finding 4: the prior
+    parent-only validation accepted any final leaf (e.g.
+    ``/config set display.nonexistent true``) so typos like
+    ``display.bel_on_complete`` silently created new keys with no
+    signal to the user.
+
+    Fix: emit a yellow warning that surfaces the typo without blocking
+    the legitimate "create a new key" case (custom_providers blocks and
+    plugin-specific sections accept runtime keys). Existing keys produce
+    no warning — only NEW keys trigger it.
+    """
+
+    def test_new_leaf_warns(self):
+        # Typo or genuinely new key — yellow warning surfaces either way
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)), \
+             patch("cli.save_config_value", return_value=True):
+            cli_obj.process_command("/config set display.nonexistent true")
+        combined = " ".join(printed)
+        assert "creating new key" in combined
+        assert "display.nonexistent" in combined
+        # And the key DID land in config (not blocked)
+        assert cli_obj.config["display"]["nonexistent"] is True
+
+    def test_existing_leaf_no_warning(self):
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)), \
+             patch("cli.save_config_value", return_value=True):
+            cli_obj.process_command("/config set display.bell_on_complete true")
+        combined = " ".join(printed)
+        assert "creating new key" not in combined
+
+    def test_typo_warning_lists_existing_keys(self):
+        # The warning's "existing keys:" hint helps the user spot typos —
+        # if they typed ``bel_on_complete`` and see ``bell_on_complete``
+        # in the list, the typo is obvious.
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)), \
+             patch("cli.save_config_value", return_value=True):
+            cli_obj.process_command("/config set display.bel_on_complete true")
+        combined = " ".join(printed)
+        assert "creating new key" in combined
+        assert "bell_on_complete" in combined
+        # The typo'd key DID get written (we don't hard-block)
+        assert cli_obj.config["display"]["bel_on_complete"] is True
+
+    def test_unknown_parent_still_rejected(self):
+        # Parent validation must still hard-reject — only the leaf step is
+        # soft-warned. Otherwise typos like ``disploy.bell true`` would
+        # silently create a new top-level section.
+        cli_obj = _make_cli()
+        printed = []
+        with patch("cli._cprint", side_effect=lambda t: printed.append(t)):
+            cli_obj.process_command("/config set disploy.bell true")
+        combined = " ".join(printed)
+        assert "Unknown config section" in combined


### PR DESCRIPTION
## What

Fixes #4073 — `/config` in the CLI TUI was read-only and displayed only a subset of settings.

### Changes (all in `cli.py`)

1. **Expanded `show_config()`** — now displays Display (personality, reasoning, bell, compact, tool progress), Compression (enabled, threshold, target ratio, protect last N), Timezone, and Auxiliary Models (when overrides exist). Matches `hermes config show` output.

2. **`/config set <key.path> <value>`** — validates key path against live config (rejects typos like `disploy.bell`), coerces `true`/`false`/`42`/`0.75` to proper types, persists via existing `save_config_value()`, and live-applies display/compression changes to session attributes.

3. **`/config get <key.path>`** — reads a single value or section from the in-memory config.

4. **Restart hints** — `terminal.*`, `model.*`, `agent.*`, `mcp_servers.*`, `browser.*`, `memory.*`, `auxiliary.*` print `(requires restart)`. Display/compression keys apply immediately and propagate to session attributes (`show_reasoning`, `bell_on_complete`, `compact`, `tool_progress_mode`).

### No overlap with existing work

- `tui_gateway/server.py` `config.set` RPC — Electron desktop only, handles named keys. Does not touch `cli.py`.
- `hermes_cli/config.py` `set_config_value` — CLI `hermes config set` command. Separate surface from TUI slash commands.
- PR #51043 — Fixed config corruption on model switch. Different concern.
- `/model` command — Has dedicated handler. `/config set model.default X` is a separate path.

### Verification

30/30 tests pass (11 existing prefix-matching + 19 new).

### Cross-vendor review

Reviewed by Gemini 3.5 Flash and GPT-OSS 120B. Both rated SHOULD-FIX (minor). One finding addressed: `agent.*` and `auxiliary.*` added to restart-required prefixes (commit 2).