### PR TITLE
feat(agent): config allowlist to opt read-only terminal commands into parallel batch execution

### DIFF
--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -24,18 +24,73 @@ working unchanged.
 
 from __future__ import annotations
 
+import contextlib
+import contextvars
 import json
 import logging
 import os
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Iterator, Optional
 
 from agent.tool_result_classification import (
     FILE_MUTATING_TOOL_NAMES as _FILE_MUTATING_TOOLS,
 )
 
 logger = logging.getLogger(__name__)
+
+# Set for the duration of a *concurrent* tool batch (the ThreadPoolExecutor
+# path in ``tool_executor.execute_tool_calls_concurrent``).  A batch only
+# reaches that path when ``_should_parallelize_tool_batch`` cleared it, which
+# means every ``terminal`` call in it is allowlisted via
+# ``parallel_safe_prefixes`` — i.e. a declared stateless read-only lookup.
+#
+# Why this exists: concurrent terminal calls share one persistent-shell
+# environment (resolved by task_id) whose ``execute()`` persists session state
+# by read-modify-write of per-session snapshot/cwd files.  Two such calls would
+# race that read-modify-write and corrupt the session PATH (upstream #38249).
+# The terminal tool reads this flag and runs allowlisted parallel-batch calls
+# on the *stateless* ``execute(persist_session=False)`` path, which neither
+# sources nor rewrites the snapshot/cwd files — removing the race by
+# construction.  Off by default; only True inside a concurrent batch.
+_PARALLEL_BATCH_ACTIVE: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "_PARALLEL_BATCH_ACTIVE", default=False
+)
+
+
+def parallel_batch_active() -> bool:
+    """Return True while the current thread runs inside a concurrent tool batch.
+
+    Why: lets the terminal tool select the stateless (non-snapshot-persisting)
+    execution path for calls dispatched concurrently, avoiding the shared
+    session-snapshot read-modify-write race (#38249).
+    What: reads the ``_PARALLEL_BATCH_ACTIVE`` ContextVar (propagated into
+    worker threads via ``contextvars.copy_context``); defaults to False.
+    Test: False outside any batch; True inside ``parallel_batch_scope()``,
+    including in a child thread that copied the context after the scope opened.
+    """
+    return _PARALLEL_BATCH_ACTIVE.get()
+
+
+@contextlib.contextmanager
+def parallel_batch_scope() -> Iterator[None]:
+    """Mark the dynamic extent of a concurrent tool batch.
+
+    Why: the concurrent dispatcher must signal worker threads that terminal
+    calls in this batch are allowlisted stateless lookups eligible for the
+    snapshot-free execution path.  The flag is set on the dispatching thread
+    *before* it copies its context onto workers, so each worker inherits it.
+    What: sets ``_PARALLEL_BATCH_ACTIVE`` True for the ``with`` body and resets
+    it on exit (even on error).
+    Test: ``parallel_batch_active()`` is True inside the ``with`` block and
+    False after it returns or raises.
+    """
+    token = _PARALLEL_BATCH_ACTIVE.set(True)
+    try:
+        yield
+    finally:
+        _PARALLEL_BATCH_ACTIVE.reset(token)
+
 
 # Tools that must never run concurrently (interactive / user-facing).
 # When any of these appear in a batch, we fall back to sequential execution.
@@ -101,6 +156,88 @@ def _is_mcp_tool_parallel_safe(tool_name: str) -> bool:
         return False
 
 
+# Config key (under the ``terminal`` toolset) bridged to this env var as a
+# JSON-encoded list by the CLI config loader, mirroring the other
+# ``terminal.* -> TERMINAL_*`` mappings.
+_TERMINAL_PARALLEL_SAFE_PREFIXES_ENV = "TERMINAL_PARALLEL_SAFE_PREFIXES"
+
+
+def _terminal_parallel_safe_prefixes() -> tuple[str, ...]:
+    """Return the operator-configured read-only ``terminal`` command prefixes.
+
+    Why: lets operators opt specific stateless terminal commands into parallel
+    batch execution without baking any command names into the engine (mirrors
+    the per-server ``supports_parallel_tool_calls`` MCP opt-in).
+    What: parses the ``TERMINAL_PARALLEL_SAFE_PREFIXES`` env var (a JSON list of
+    string prefixes, bridged from ``terminal.parallel_safe_prefixes`` config);
+    returns an empty tuple when unset, empty, or malformed.
+    Test: set the env var to ``'["foo"]'`` -> returns ``("foo",)``; unset or
+    ``'[]'`` or invalid JSON -> returns ``()``.
+    """
+    raw = os.environ.get(_TERMINAL_PARALLEL_SAFE_PREFIXES_ENV)
+    if not raw:
+        return ()
+    try:
+        parsed = json.loads(raw)
+    except Exception:
+        return ()
+    if not isinstance(parsed, list):
+        return ()
+    return tuple(p for p in parsed if isinstance(p, str) and p)
+
+
+# Shell metacharacters that indicate command chaining, redirection, command
+# substitution, or backgrounding.  Any of these in a candidate command means
+# the allowlisted prefix no longer bounds what actually runs (e.g.
+# ``mytool x && rm -rf /``), so the call is rejected from the parallel-safe
+# path and runs serially — the safer default.
+_TERMINAL_PARALLEL_UNSAFE_METACHARS = ("&", ";", "|", "`", "$(", ">", "<", "\n")
+
+
+def _is_terminal_call_parallel_safe(function_args: dict) -> bool:
+    """Decide whether a single ``terminal`` call is safe to run in a batch.
+
+    Why: ``terminal`` is never unconditionally parallel-safe, so a batch
+    containing one is forced serial; this gates the exception on an explicit
+    operator allowlist of read-only command prefixes.  A bare ``startswith``
+    is too lax (``ls`` would match ``lsof``; ``git`` would match the mutating
+    ``git push``), so the prefix must land on a word boundary and the command
+    must be free of shell metacharacters that could smuggle in a second,
+    unvetted command.
+    What: returns True iff an allowlist is configured AND the call's
+    ``command`` is metacharacter-free AND it equals a configured prefix or
+    begins with ``prefix`` followed by whitespace (a word boundary); returns
+    False otherwise (empty/unset allowlist, no command, metacharacters, or a
+    mere substring match like ``lsof`` against prefix ``ls``).
+    Test: with prefixes ``("ls",)`` -> ``{"command": "ls -l"}`` True,
+    ``{"command": "lsof"}`` False; with ``("mytool",)`` ->
+    ``{"command": "mytool sub arg"}`` True,
+    ``{"command": "mytool x && rm -rf /"}`` False (metachar);
+    with no prefixes configured -> always False.
+    """
+    prefixes = _terminal_parallel_safe_prefixes()
+    if not prefixes:
+        return False
+    command = function_args.get("command")
+    if not isinstance(command, str) or not command:
+        return False
+    stripped = command.strip()
+    if not stripped:
+        return False
+    # Reject chaining/redirection/substitution outright — the prefix can only
+    # vouch for the first token, not for anything a metacharacter appends.
+    if any(metachar in stripped for metachar in _TERMINAL_PARALLEL_UNSAFE_METACHARS):
+        return False
+    for prefix in prefixes:
+        if stripped == prefix:
+            return True
+        # Word boundary: the prefix must be followed by whitespace, not an
+        # arbitrary character (so ``ls`` does not match ``lsof``).
+        if stripped.startswith(prefix) and stripped[len(prefix) :][:1].isspace():
+            return True
+    return False
+
+
 def _should_parallelize_tool_batch(tool_calls) -> bool:
     """Return True when a tool-call batch is safe to run concurrently."""
     if len(tool_calls) <= 1:
@@ -137,6 +274,30 @@ def _should_parallelize_tool_batch(tool_calls) -> bool:
             if any(_paths_overlap(scoped_path, existing) for existing in reserved_paths):
                 return False
             reserved_paths.append(scoped_path)
+            continue
+
+        if tool_name == "terminal":
+            # ``terminal`` is gated on the operator allowlist of read-only
+            # command prefixes (see ``_is_terminal_call_parallel_safe``).  A
+            # non-matching command keeps the whole batch sequential.
+            #
+            # Design note (accepted tradeoff): terminal calls are NOT
+            # path-scoped — they reserve no entry in ``reserved_paths`` — so an
+            # allowlisted read-only command that happens to read a file a
+            # batched ``write_file`` is concurrently writing could observe a
+            # torn read.  We accept this by design: terminal commands have no
+            # declarable path footprint, and the operator opts only read-only
+            # lookups into the allowlist.  Operators who need read-after-write
+            # ordering should not allowlist commands that read mutated paths.
+            # (The simpler alternative — forcing any batch with both a terminal
+            # call and a write_file serial — would defeat the feature's main
+            # use case of read-only lookups running alongside file edits.)
+            if not _is_terminal_call_parallel_safe(function_args):
+                logger.debug(
+                    "[parallel-gate] SEQUENTIAL — terminal command not in "
+                    "parallel_safe_prefixes allowlist"
+                )
+                return False
             continue
 
         if tool_name not in _PARALLEL_SAFE_TOOLS:
@@ -434,6 +595,10 @@ __all__ = [
     "_DESTRUCTIVE_PATTERNS",
     "_REDIRECT_OVERWRITE",
     "_is_destructive_command",
+    "_terminal_parallel_safe_prefixes",
+    "_is_terminal_call_parallel_safe",
+    "parallel_batch_active",
+    "parallel_batch_scope",
     "_should_parallelize_tool_batch",
     "_extract_parallel_scope_path",
     "_paths_overlap",

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -36,6 +36,7 @@ from agent.tool_dispatch_helpers import (
     _multimodal_text_summary,
     _append_subdir_hint_to_multimodal,
     make_tool_result_message,
+    parallel_batch_scope,
 )
 from tools.terminal_tool import (
     get_active_env,
@@ -612,7 +613,18 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         futures = []
         if runnable_calls:
             max_workers = min(len(runnable_calls), _MAX_TOOL_WORKERS)
-            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            # Mark the batch as concurrent BEFORE submitting: each worker copies
+            # this thread's context at submit time (propagate_context_to_thread),
+            # so the flag must already be set when copy_context() runs.  This
+            # routes any allowlisted terminal call onto the stateless,
+            # snapshot-free execute() path, avoiding the shared session-snapshot
+            # read-modify-write race (#38249).
+            with (
+                parallel_batch_scope(),
+                concurrent.futures.ThreadPoolExecutor(
+                    max_workers=max_workers
+                ) as executor,
+            ):
                 for submit_index, (i, tc, name, args) in enumerate(runnable_calls):
                     # Propagate the agent turn's ContextVars (e.g.
                     # _approval_session_key) AND thread-local approval/sudo

--- a/cli.py
+++ b/cli.py
@@ -403,6 +403,7 @@ def load_cli_config() -> Dict[str, Any]:
             "daytona_image": "nikolaik/python-nodejs:python3.11-nodejs20",
             "docker_volumes": [],  # host:container volume mounts for Docker backend
             "docker_mount_cwd_to_workspace": False,  # explicit opt-in only; default off for sandbox isolation
+            "parallel_safe_prefixes": [],  # read-only command prefixes the agent may run in parallel batches; empty = all terminal calls serial
         },
         "browser": {
             "inactivity_timeout": 120,  # Auto-cleanup inactive browser sessions after 2 min
@@ -627,6 +628,9 @@ def load_cli_config() -> Dict[str, Any]:
         "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
         "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
         "sandbox_dir": "TERMINAL_SANDBOX_DIR",
+        # Parallel batch execution opt-in (list of read-only command prefixes;
+        # bridged JSON-encoded, parsed by agent.tool_dispatch_helpers).
+        "parallel_safe_prefixes": "TERMINAL_PARALLEL_SAFE_PREFIXES",
         # Persistent shell (non-local backends)
         "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
         # Sudo support (works with all backends)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1508,6 +1508,7 @@ if _config_path.exists():
                 "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
                 "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
                 "sandbox_dir": "TERMINAL_SANDBOX_DIR",
+                "parallel_safe_prefixes": "TERMINAL_PARALLEL_SAFE_PREFIXES",
                 "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
             }
             for _cfg_key, _env_var in _terminal_env_map.items():

--- a/run_agent.py
+++ b/run_agent.py
@@ -199,6 +199,9 @@ from agent.trajectory import (
 )
 from agent.tool_dispatch_helpers import (
     _should_parallelize_tool_batch,
+    _is_terminal_call_parallel_safe,  # noqa: F401  # re-exported for tests that `from run_agent import _is_terminal_call_parallel_safe`
+    parallel_batch_active,  # noqa: F401  # re-exported for tests that `from run_agent import parallel_batch_active`
+    parallel_batch_scope,  # noqa: F401  # re-exported for tests that `from run_agent import parallel_batch_scope`
     _is_destructive_command,  # noqa: F401  # re-exported for tests that access `run_agent._is_destructive_command`
     _extract_parallel_scope_path,  # noqa: F401  # re-exported for tests that `from run_agent import _extract_parallel_scope_path`
     _paths_overlap,  # noqa: F401  # re-exported for tests that `from run_agent import _paths_overlap`

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3347,6 +3347,198 @@ class TestMcpParallelToolBatch:
                 _mcp_tool_server_names.pop("mcp_github_list_repos", None)
 
 
+class TestTerminalPrefixParallelToolBatch:
+    """Integration test: _should_parallelize_tool_batch respects the operator
+    ``terminal.parallel_safe_prefixes`` allowlist.
+
+    Why: terminal calls always hit the not-parallel-safe branch and force the
+    whole batch serial. Operators who run read-only one-shot CLI lookups (e.g.
+    status/query commands) want those batched concurrently. The allowlist is
+    config-driven and bridged to the ``TERMINAL_PARALLEL_SAFE_PREFIXES`` env
+    var (JSON list) — mirroring the per-server ``supports_parallel_tool_calls``
+    MCP opt-in. Empty/unset = current behavior preserved (serial).
+    What: drives the public gate and asserts the boolean it returns.
+    Test: mock the env allowlist, build terminal tool-call batches, assert the
+    gate parallelizes only matching commands and never regresses the default.
+    """
+
+    def test_terminal_batch_parallel_when_prefix_matches(self, monkeypatch):
+        """Two terminal calls whose commands match a configured prefix parallelize."""
+        from run_agent import _should_parallelize_tool_batch
+
+        monkeypatch.setenv("TERMINAL_PARALLEL_SAFE_PREFIXES", '["mytool"]')
+        tc1 = _mock_tool_call(name="terminal", arguments='{"command":"mytool issue 1"}', call_id="c1")
+        tc2 = _mock_tool_call(name="terminal", arguments='{"command":"mytool issue 2"}', call_id="c2")
+        assert _should_parallelize_tool_batch([tc1, tc2])
+
+    def test_terminal_batch_serial_when_prefixes_unset(self, monkeypatch):
+        """Regression: with no allowlist, terminal batches stay sequential."""
+        from run_agent import _should_parallelize_tool_batch
+
+        monkeypatch.delenv("TERMINAL_PARALLEL_SAFE_PREFIXES", raising=False)
+        tc1 = _mock_tool_call(name="terminal", arguments='{"command":"mytool issue 1"}', call_id="c1")
+        tc2 = _mock_tool_call(name="terminal", arguments='{"command":"mytool issue 2"}', call_id="c2")
+        assert not _should_parallelize_tool_batch([tc1, tc2])
+
+    def test_terminal_batch_serial_when_prefixes_empty(self, monkeypatch):
+        """Regression: an explicit empty allowlist behaves like unset (serial)."""
+        from run_agent import _should_parallelize_tool_batch
+
+        monkeypatch.setenv("TERMINAL_PARALLEL_SAFE_PREFIXES", "[]")
+        tc1 = _mock_tool_call(name="terminal", arguments='{"command":"mytool issue 1"}', call_id="c1")
+        tc2 = _mock_tool_call(name="terminal", arguments='{"command":"mytool issue 2"}', call_id="c2")
+        assert not _should_parallelize_tool_batch([tc1, tc2])
+
+    def test_terminal_batch_serial_when_command_not_matching(self, monkeypatch):
+        """A terminal command outside the allowlist forces the batch serial."""
+        from run_agent import _should_parallelize_tool_batch
+
+        monkeypatch.setenv("TERMINAL_PARALLEL_SAFE_PREFIXES", '["mytool"]')
+        tc1 = _mock_tool_call(name="terminal", arguments='{"command":"mytool issue 1"}', call_id="c1")
+        tc2 = _mock_tool_call(name="terminal", arguments='{"command":"rm -rf /"}', call_id="c2")
+        assert not _should_parallelize_tool_batch([tc1, tc2])
+
+    def test_terminal_prefix_requires_word_boundary(self, monkeypatch):
+        """Prefix ``ls`` must NOT match ``lsof`` — the prefix has to land on a
+        word boundary (whitespace or end-of-string), not an arbitrary char."""
+        from run_agent import _should_parallelize_tool_batch
+
+        monkeypatch.setenv("TERMINAL_PARALLEL_SAFE_PREFIXES", '["ls"]')
+        tc1 = _mock_tool_call(name="terminal", arguments='{"command":"lsof -i"}', call_id="c1")
+        tc2 = _mock_tool_call(name="terminal", arguments='{"command":"lsof -nP"}', call_id="c2")
+        assert not _should_parallelize_tool_batch([tc1, tc2])
+
+    def test_terminal_prefix_matches_on_word_boundary(self, monkeypatch):
+        """Prefix ``ls`` matches ``ls -l`` (followed by whitespace) and a bare
+        ``ls`` (end-of-string)."""
+        from run_agent import _should_parallelize_tool_batch
+
+        monkeypatch.setenv("TERMINAL_PARALLEL_SAFE_PREFIXES", '["ls"]')
+        tc1 = _mock_tool_call(name="terminal", arguments='{"command":"ls -l"}', call_id="c1")
+        tc2 = _mock_tool_call(name="terminal", arguments='{"command":"ls"}', call_id="c2")
+        assert _should_parallelize_tool_batch([tc1, tc2])
+
+    def test_terminal_prefix_rejects_command_chaining_metacharacters(self, monkeypatch):
+        """A command whose prefix matches but which chains a second command via
+        ``&&`` is rejected (runs serial) — the prefix only vouches for the first
+        token, not for anything a metacharacter smuggles in."""
+        from run_agent import _should_parallelize_tool_batch
+
+        monkeypatch.setenv("TERMINAL_PARALLEL_SAFE_PREFIXES", '["gh"]')
+        # Sanity: the clean form parallelizes.
+        ok1 = _mock_tool_call(name="terminal", arguments='{"command":"gh issue view 1"}', call_id="a1")
+        ok2 = _mock_tool_call(name="terminal", arguments='{"command":"gh issue view 2"}', call_id="a2")
+        assert _should_parallelize_tool_batch([ok1, ok2])
+
+        # Chaining via && (and each other metachar) forces serial.
+        bad = _mock_tool_call(
+            name="terminal",
+            arguments='{"command":"gh x && rm -rf /"}',
+            call_id="b1",
+        )
+        clean = _mock_tool_call(name="terminal", arguments='{"command":"gh issue view 2"}', call_id="b2")
+        assert not _should_parallelize_tool_batch([bad, clean])
+
+    def test_terminal_prefix_metachar_unit_matrix(self, monkeypatch):
+        """Each chaining/redirection/substitution metachar individually rejects
+        an otherwise-matching command via the underlying predicate."""
+        from run_agent import _is_terminal_call_parallel_safe
+
+        monkeypatch.setenv("TERMINAL_PARALLEL_SAFE_PREFIXES", '["gh"]')
+        for bad in (
+            "gh x && y", "gh x || y", "gh x; y", "gh x | y",
+            "gh `id`", "gh $(id)", "gh > out", "gh < in",
+            "gh x\ny",
+        ):
+            assert not _is_terminal_call_parallel_safe({"command": bad}), bad
+        assert _is_terminal_call_parallel_safe({"command": "gh issue view 1"})
+
+    def test_mixed_terminal_and_write_file_parallel_when_paths_disjoint(
+        self, monkeypatch
+    ):
+        """An allowlisted terminal call batched with a path-scoped write_file to a
+        non-overlapping path parallelizes — closing the gap between the terminal
+        branch and the ``_PATH_SCOPED_TOOLS`` reserved-paths logic."""
+        from run_agent import _should_parallelize_tool_batch
+
+        monkeypatch.setenv("TERMINAL_PARALLEL_SAFE_PREFIXES", '["mytool"]')
+        tc1 = _mock_tool_call(
+            name="terminal", arguments='{"command":"mytool issue 1"}', call_id="c1"
+        )
+        tc2 = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"src/a.py","content":"print(1)"}',
+            call_id="c2",
+        )
+        assert _should_parallelize_tool_batch([tc1, tc2])
+
+    def test_mixed_terminal_and_write_file_serial_when_paths_overlap(
+        self, monkeypatch
+    ):
+        """One allowlisted terminal call plus two write_files targeting the SAME
+        path forces the batch serial via the ``_PATH_SCOPED_TOOLS`` reserved-paths
+        overlap check.
+
+        Note on scope: terminal calls reserve no ``reserved_paths`` entry (they
+        are not path-scoped — see the comment in ``_should_parallelize_tool_batch``'s
+        terminal branch), so this test exercises the write_file/write_file overlap,
+        NOT a terminal-vs-path conflict. The serial result here is driven by the
+        two write_files writing ``src/a.py`` concurrently; the terminal call rides
+        along and does not by itself force serial.
+        """
+        from run_agent import _should_parallelize_tool_batch
+
+        monkeypatch.setenv("TERMINAL_PARALLEL_SAFE_PREFIXES", '["mytool"]')
+        tc1 = _mock_tool_call(
+            name="terminal", arguments='{"command":"mytool issue 1"}', call_id="c1"
+        )
+        tc2 = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"src/a.py","content":"print(1)"}',
+            call_id="c2",
+        )
+        tc3 = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"src/a.py","content":"print(2)"}',
+            call_id="c3",
+        )
+        assert not _should_parallelize_tool_batch([tc1, tc2, tc3])
+
+    def test_mixed_terminal_and_never_parallel_serial(self, monkeypatch):
+        """A matching terminal call mixed with a never-parallel tool stays serial."""
+        from run_agent import _should_parallelize_tool_batch
+
+        monkeypatch.setenv("TERMINAL_PARALLEL_SAFE_PREFIXES", '["mytool"]')
+        tc1 = _mock_tool_call(name="terminal", arguments='{"command":"mytool issue 1"}', call_id="c1")
+        tc2 = _mock_tool_call(name="clarify", arguments='{"question":"which?"}', call_id="c2")
+        assert not _should_parallelize_tool_batch([tc1, tc2])
+
+    def test_single_terminal_call_short_circuits_serial(self, monkeypatch):
+        """A batch of one is always serial regardless of the allowlist."""
+        from run_agent import _should_parallelize_tool_batch
+
+        monkeypatch.setenv("TERMINAL_PARALLEL_SAFE_PREFIXES", '["mytool"]')
+        tc1 = _mock_tool_call(name="terminal", arguments='{"command":"mytool issue 1"}', call_id="c1")
+        assert not _should_parallelize_tool_batch([tc1])
+
+    def test_parallel_batch_scope_flag_propagates_to_worker_thread(self):
+        """Finding 1 wiring: the concurrent dispatcher marks the batch active via
+        ``parallel_batch_scope`` BEFORE submitting work, so a worker thread that
+        copies the context (as ``propagate_context_to_thread`` does) observes the
+        flag and the terminal tool can select the stateless execute path."""
+        import contextvars
+        from run_agent import parallel_batch_active, parallel_batch_scope
+
+        assert parallel_batch_active() is False
+        with parallel_batch_scope():
+            assert parallel_batch_active() is True
+            # A child context copied while the scope is open inherits the flag,
+            # mirroring how worker threads see it.
+            ctx = contextvars.copy_context()
+            assert ctx.run(parallel_batch_active) is True
+        assert parallel_batch_active() is False
+
+
 class TestHandleMaxIterations:
     def test_returns_summary(self, agent):
         resp = _mock_response(content="Here is a summary of what I did.")

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -185,6 +185,98 @@ class TestInitSessionFailure:
         assert calls[0]["login"] is True
 
 
+class TestStatelessExecute:
+    """Finding 1 (#38249): allowlisted concurrent terminal calls must run on a
+    snapshot-free path so two calls sharing one environment cannot race the
+    per-session snapshot/cwd read-modify-write.
+
+    Why: ``BaseEnvironment.execute`` persists session state by read-modify-write
+    of shared snapshot/cwd files; the parallel-prefix feature introduces
+    concurrency, so allowlisted calls must opt out of that shared state.
+    What: ``persist_session=False`` makes ``_wrap_command`` omit the snapshot
+    source/rewrite and the cwd-file write, and makes ``execute`` skip the
+    cwd read-back so ``self.cwd`` is not mutated.
+    Test: assert the wrapped script and the post-execute ``self.cwd`` for both
+    the persisted (default) and stateless paths.
+    """
+
+    def test_wrap_command_stateless_omits_snapshot_and_cwd_file(self):
+        env = _TestableEnv()
+        env._snapshot_ready = True
+
+        persisted = env._wrap_command("echo hi", "/tmp")
+        assert "source" in persisted
+        assert "export -p >" in persisted
+        assert env._snapshot_path in persisted
+        assert env._cwd_file in persisted
+
+        stateless = env._wrap_command("echo hi", "/tmp", persist_session=False)
+        # No snapshot source, no snapshot rewrite, no cwd-file write.
+        assert "source" not in stateless
+        assert "export -p >" not in stateless
+        assert env._snapshot_path not in stateless
+        assert env._cwd_file not in stateless
+        # The command still runs and still cd's into the configured cwd.
+        assert "eval 'echo hi'" in stateless
+        assert "cd -- /tmp" in stateless or "cd -- '/tmp'" in stateless
+
+    def _run_execute(self, env, *, persist_session, new_cwd):
+        """Drive execute() with mocked shell I/O; the fake shell 'reports' a new
+        cwd via the stdout marker the wrapper would emit."""
+        marker = env._cwd_marker
+        output = f"done\n{marker}{new_cwd}{marker}\n"
+
+        env._run_bash = lambda *a, **k: MagicMock()
+        env._wait_for_process = lambda proc, timeout=120: {
+            "output": output,
+            "returncode": 0,
+        }
+        return env.execute("echo hi", persist_session=persist_session)
+
+    def test_execute_persisted_updates_cwd(self):
+        """Sanity: the default (persisted) path DOES propagate cwd from output."""
+        env = _TestableEnv(cwd="/start")
+        env._snapshot_ready = True
+        self._run_execute(env, persist_session=True, new_cwd="/moved")
+        assert env.cwd == "/moved"
+
+    def test_execute_stateless_does_not_mutate_cwd(self):
+        """Stateless path leaves self.cwd untouched — no shared-state write that
+        a concurrent call could race."""
+        env = _TestableEnv(cwd="/start")
+        env._snapshot_ready = True
+        result = self._run_execute(env, persist_session=False, new_cwd="/moved")
+        assert env.cwd == "/start"
+        # The marker is still stripped from user-visible output (parity).
+        assert env._cwd_marker not in result["output"]
+
+    def test_execute_stateless_concurrent_calls_keep_cwd_stable(self):
+        """Two concurrent stateless calls reporting different cwds must not
+        corrupt the shared self.cwd — it stays at its initial value."""
+        import threading
+
+        env = _TestableEnv(cwd="/start")
+        env._snapshot_ready = True
+
+        def worker(target_cwd):
+            marker = env._cwd_marker
+            local = _TestableEnv  # noqa: F841  # readability only
+            env._run_bash = lambda *a, **k: MagicMock()
+            env._wait_for_process = lambda proc, timeout=120, _c=target_cwd: {
+                "output": f"x\n{marker}{_c}{marker}\n",
+                "returncode": 0,
+            }
+            env.execute("echo hi", persist_session=False)
+
+        threads = [threading.Thread(target=worker, args=(f"/c{i}",)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert env.cwd == "/start"
+
+
 class TestCwdMarker:
     def test_marker_contains_session_id(self):
         env = _TestableEnv()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -416,9 +416,26 @@ class BaseEnvironment(ABC):
             return f"$HOME/{shlex.quote(cwd[2:])}"
         return shlex.quote(cwd)
 
-    def _wrap_command(self, command: str, cwd: str) -> str:
+    def _wrap_command(
+        self, command: str, cwd: str, persist_session: bool = True
+    ) -> str:
         """Build the full bash script that sources snapshot, cd's, runs command,
-        re-dumps env vars, and emits CWD markers."""
+        re-dumps env vars, and emits CWD markers.
+
+        Why: when ``persist_session`` is False the call is a stateless,
+        read-only lookup (e.g. an allowlisted command admitted to a concurrent
+        parallel batch).  Such calls must NOT touch the per-session snapshot or
+        cwd files: two concurrent calls sharing this environment would race the
+        snapshot read-modify-write and corrupt the session PATH (#38249).  The
+        stateless script still ``cd``'s into the configured cwd (a read of
+        ``self.cwd``) but neither sources nor rewrites the snapshot, nor writes
+        the cwd file — removing the shared-state race by construction.
+        What: returns the wrapped bash script; ``persist_session=False`` omits
+        the snapshot source, the ``export -p`` re-dump, and the cwd-file write.
+        Test: ``_wrap_command(cmd, cwd, persist_session=False)`` contains no
+        reference to ``self._snapshot_path`` or ``self._cwd_file``; the default
+        (True) still references both.
+        """
         escaped = command.replace("'", "'\\''")
 
         # Quote the snapshot / cwd-file paths so Git Bash on Windows handles
@@ -436,7 +453,7 @@ class BaseEnvironment(ABC):
         # can emit the declarations to stdout, leaking ~60 lines of env
         # vars into every tool response (issue #15459).  Linux bash is
         # silent here, but the redirect is harmless.
-        if self._snapshot_ready:
+        if self._snapshot_ready and persist_session:
             parts.append(
                 f"source {_quoted_snap} >/dev/null 2>&1 || true"
             )
@@ -451,12 +468,19 @@ class BaseEnvironment(ABC):
         parts.append(f"eval '{escaped}'")
         parts.append("__hermes_ec=$?")
 
-        # Re-dump env vars to snapshot (last-writer-wins for concurrent calls)
-        if self._snapshot_ready:
+        # Re-dump env vars to snapshot.  Skipped on the stateless path: a
+        # parallel-batch read-only call must not rewrite the shared snapshot
+        # (that write is the corrupting half of the #38249 race).
+        if self._snapshot_ready and persist_session:
             parts.append(f"export -p > {_quoted_snap} 2>/dev/null || true")
 
-        # Write CWD to file (local reads this) and stdout marker (remote parses this)
-        parts.append(f"pwd -P > {_quoted_cwd_file} 2>/dev/null || true")
+        # Write CWD to file (local reads this) and stdout marker (remote parses
+        # this).  The cwd-file write is shared session state, so it is skipped
+        # on the stateless path; the stdout marker stays (it is per-call output,
+        # not shared state, and ``execute`` skips _update_cwd when not
+        # persisting).
+        if persist_session:
+            parts.append(f"pwd -P > {_quoted_cwd_file} 2>/dev/null || true")
         # Use a distinct line for the marker. The leading \n ensures
         # the marker starts on its own line even if the command doesn't
         # end with a newline (e.g. printf 'exact'). We'll strip this
@@ -836,8 +860,26 @@ class BaseEnvironment(ABC):
         timeout: int | None = None,
         stdin_data: str | None = None,
         rewrite_compound_background: bool = True,
+        persist_session: bool = True,
     ) -> dict:
-        """Execute a command, return {"output": str, "returncode": int}."""
+        """Execute a command, return {"output": str, "returncode": int}.
+
+        Why ``persist_session``: this environment persists session state
+        (env-var snapshot + cwd) by read-modify-write of per-session files
+        shared across all calls bound to the same task_id.  Concurrent calls
+        therefore race those files and can corrupt the session PATH (#38249).
+        Callers that admit a command to a concurrent parallel batch (an
+        allowlisted, declared-stateless read-only lookup) pass
+        ``persist_session=False`` to run on a snapshot-free path that neither
+        sources nor rewrites the snapshot/cwd files — making concurrent calls
+        safe by construction.
+        What: when False, the wrapped script skips snapshot source/rewrite and
+        the cwd-file write, and the result's cwd is NOT propagated back to
+        ``self.cwd`` (no shared-state mutation).
+        Test: two threads calling ``execute(persist_session=False)`` on one
+        environment leave ``self.cwd`` and the snapshot/cwd files unchanged;
+        the default path still updates them.
+        """
         self._before_execute()
 
         exec_command, sudo_stdin = self._prepare_command(command)
@@ -863,7 +905,9 @@ class BaseEnvironment(ABC):
             exec_command = self._embed_stdin_heredoc(exec_command, effective_stdin)
             effective_stdin = None
 
-        wrapped = self._wrap_command(exec_command, effective_cwd)
+        wrapped = self._wrap_command(
+            exec_command, effective_cwd, persist_session=persist_session
+        )
 
         # Use login shell if snapshot failed (so user's profile still loads)
         login = not self._snapshot_ready
@@ -872,7 +916,21 @@ class BaseEnvironment(ABC):
             wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
         )
         result = self._wait_for_process(proc, timeout=effective_timeout)
-        self._update_cwd(result)
+        # Stateless calls must not mutate the shared session cwd; skip the
+        # read-back so concurrent parallel-batch calls cannot clobber self.cwd.
+        if persist_session:
+            self._update_cwd(result)
+        else:
+            # Strip the cwd marker from output for parity with the persisted
+            # path, but restore self.cwd afterwards so this stateless call
+            # leaves no shared-state side effect.  (_extract_cwd_from_output
+            # both strips the marker and assigns self.cwd; we keep the strip,
+            # discard the assignment.)
+            _prev_cwd = self.cwd
+            try:
+                self._extract_cwd_from_output(result)
+            finally:
+                self.cwd = _prev_cwd
 
         return result
 

--- a/tools/environments/modal_utils.py
+++ b/tools/environments/modal_utils.py
@@ -80,11 +80,15 @@ class BaseModalExecutionEnvironment(BaseEnvironment):
         timeout: int | None = None,
         stdin_data: str | None = None,
         rewrite_compound_background: bool = True,
+        persist_session: bool = True,
     ) -> dict:
         # Managed/remote modal transports execute commands via explicit transport
-        # and do not rely on shell background rewriters. Keep parameter for
-        # compatibility with BaseEnvironment callers.
+        # and do not rely on shell background rewriters or the local per-session
+        # snapshot/cwd files. Accept ``persist_session`` for signature parity with
+        # BaseEnvironment callers (the snapshot race it guards against does not
+        # apply to per-call modal transports), but otherwise ignore it.
         _ = rewrite_compound_background
+        _ = persist_session
         self._before_execute()
         prepared = self._prepare_modal_exec(
             command,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2567,6 +2567,19 @@ def terminal_tool(
                         "timeout": effective_timeout,
                         "cwd": command_cwd,
                     }
+                    # Inside a concurrent tool batch every terminal call is an
+                    # allowlisted, declared-stateless read-only lookup (the
+                    # parallel gate forces the batch serial otherwise). Run it on
+                    # the snapshot-free path so concurrent calls sharing this
+                    # task's environment cannot race the session snapshot/cwd
+                    # read-modify-write (#38249).
+                    try:
+                        from agent.tool_dispatch_helpers import parallel_batch_active
+
+                        if parallel_batch_active():
+                            execute_kwargs["persist_session"] = False
+                    except Exception:
+                        pass
                     result = env.execute(command, **execute_kwargs)
                 except Exception as e:
                     error_str = str(e).lower()


### PR DESCRIPTION
# feat(agent): config allowlist to opt read-only terminal commands into parallel batch execution

## Problem

When the model emits a batch of tool calls in a single turn, the agent already
supports executing them concurrently — but any batch containing a `terminal`
call is forced **fully sequential**. `terminal` is deliberately absent from
`_PARALLEL_SAFE_TOOLS`, so even a batch of independent, read-only inspection
commands (status checks, list/read CLIs) runs one-at-a-time.

The response side already produces multi-tool batches; the bottleneck is purely
on the execution side. There is currently no way for an operator to say "these
specific terminal commands are read-only and safe to run in parallel."

## Solution

Add an **opt-in, config-driven allowlist** of command prefixes,
`terminal.parallel_safe_prefixes`, mirroring the existing per-server
`supports_parallel_tool_calls` MCP opt-in introduced in #26825. The mechanism:

- **Off by default.** The default is an empty list — behaviour is unchanged
  unless an operator configures prefixes. With no prefixes set, every terminal
  call still forces the batch serial, exactly as today.
- **Engages only on an explicit match.** A terminal call is eligible for the
  concurrent path only when (a) the allowlist is non-empty AND (b) the call's
  `command` matches a configured prefix on a **word boundary** (the prefix must
  be followed by whitespace or end-of-string — `ls` matches `ls -l` and bare
  `ls`, but never `lsof`).
- **Shell-metacharacter rejection.** A prefix only vouches for the first token.
  Any command containing a chaining / redirection / substitution metacharacter
  (`&`, `;`, `|`, `` ` ``, `$(`, `>`, `<`, newline) is rejected and runs serial,
  so an allowlisted prefix cannot be used to smuggle in a second command
  (`gh ... && rm -rf /` never parallelizes).
- Matching calls dispatch through the **existing** `ThreadPoolExecutor` path
  used for other parallel-safe tools; no new execution machinery.

The config value is bridged to the engine as a JSON-encoded env var
(`TERMINAL_PARALLEL_SAFE_PREFIXES`) and parsed in
`agent.tool_dispatch_helpers`, consistent with the other `terminal.*` config
bridges in `cli.py` / `gateway/run.py`.

## Concurrency safety — persistent-shell snapshot race (#38249)

Allowlisted parallel terminal calls in one batch share a single task-scoped
environment. Its `execute()` persists session state by a read-modify-write of
per-session snapshot/cwd files; under concurrency, two calls interleave that
read-modify-write and corrupt each other's view of session cwd/state — the race
described in #38249.

This PR mitigates the race **by construction** rather than with a lock:

- A new `parallel_batch_scope()` marks the batch as concurrent *before*
  submitting work, so each worker thread copies the flag at submit time.
- Inside a concurrent batch, allowlisted terminal calls run on a **stateless**
  execute path (`persist_session=False`): they do not read or write the
  per-session snapshot/cwd files at all. No shared mutable state ⇒ no race.

A lock was rejected because it would serialize exactly the calls we set out to
parallelize, defeating the feature. Statelessness is the right model here: the
commands are operator-asserted read-only, so they have no session side effects
worth persisting.

Modal / remote transports (`tools/environments/modal_utils.py`) execute each
command via an explicit per-call transport and never touch the local snapshot
files, so the race does not apply to them; they accept `persist_session` for
signature parity with `BaseEnvironment` callers and otherwise ignore it.

## Operator configuration

Root-level, under the `terminal:` block in `$HERMES_HOME/config.yaml` (NOT
under `tools:`):

```yaml
terminal:
  # Read-only command prefixes the agent may run concurrently when the model
  # batches several terminal calls in one turn. Empty (default) = every
  # terminal call forces the batch serial, unchanged from prior behaviour.
  parallel_safe_prefixes:
    - "ls"
    - "cat"
    - "git status"
    - "git log"
```

**The operator owns correctness of this list.** Only genuinely read-only /
side-effect-free command prefixes should be listed — the engine enforces
word-boundary matching and metacharacter rejection, but it cannot know whether
a given CLI mutates state. Prefer narrow, specific prefixes over broad ones to
avoid the prefix-collision class of issue seen in #27060 (a short prefix can
match more commands than intended).

## Test evidence

All gate tests pass on this branch (rebased on `upstream/main`), via the
project venv:

```
tests/run_agent/test_run_agent.py::TestConcurrentToolExecution
tests/run_agent/test_run_agent.py::TestTerminalPrefixParallelToolBatch
tests/run_agent/test_run_agent.py::TestMcpParallelToolBatch
tests/run_agent/test_run_agent.py::TestParallelScopePathNormalization
tests/run_agent/test_run_agent.py::TestPathsOverlap
tests/tools/test_base_environment.py
=> 86 passed
```

Coverage added by this PR:

- **Prefix matching:** unset / empty allowlist ⇒ serial; word-boundary match
  (`ls` ✓ `ls -l`, ✗ `lsof`); metacharacter rejection matrix
  (`&&`, `||`, `;`, `|`, backtick, `$(...)`, `>`, `<`, newline all force serial).
- **Mixed batches:** an allowlisted terminal call batched with a path-scoped
  `write_file` to a disjoint path parallelizes; overlapping paths stay serial.
- **Snapshot race / statelessness** (`test_base_environment.py`): the stateless
  execute path omits the snapshot and cwd files; persisted execute updates cwd
  while stateless execute does not mutate it; concurrent stateless calls keep
  cwd stable.

High-level effect: a batch of allowlisted read-only terminal commands goes from
**serial** to **concurrent**, with no change to any non-allowlisted or
unconfigured behaviour.

## References

- Extends **#26825** — the per-server `supports_parallel_tool_calls` opt-in
  pattern this mirrors.
- Ancestor **#9944** — original parallel tool execution.
- Prefix-collision awareness **#27060** — motivates the operator-owned,
  word-boundary, narrow-prefix guidance.
- Motivation / concurrency race **#38249** — the persistent-shell snapshot race
  this PR avoids via the stateless execute path.

## Scope / safety

- Default-off; zero behaviour change unless `terminal.parallel_safe_prefixes`
  is configured.
- No new dependencies; reuses the existing `ThreadPoolExecutor` dispatch.
- Diff: 10 files, +558 / -14 (8 source + 2 test files).