### PR TITLE
fix: harden Telegram gateway callbacks and flood retries

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1854,6 +1854,49 @@ def classify_send_error(exc: Optional[BaseException], error_text: str = "") -> s
     return "unknown"
 
 
+_RETRY_AFTER_SECONDS_RE = re.compile(
+    r"\bretry\s+(?:after|in)\s+([0-9]+(?:\.[0-9]+)?)\s*(?:seconds?|secs?|s)?\b",
+    re.IGNORECASE,
+)
+
+
+def retry_after_seconds_from_error(error: Any) -> Optional[float]:
+    """Extract a platform rate-limit delay from an exception/result/error text.
+
+    Telegram's PTB ``RetryAfter`` exposes ``retry_after`` as an attribute, but
+    by the time an error crosses adapter layers it may only be a string such as
+    ``"Flood control exceeded. Retry in 24 seconds"``.  Keep the parser in the
+    shared gateway layer so final sends, rich sends and stream fallbacks all
+    honor the provider's wait time instead of retrying too early and surfacing
+    a false delivery failure.
+    """
+    if error is None:
+        return None
+
+    direct = getattr(error, "retry_after", None)
+    if direct is not None:
+        try:
+            return max(0.0, float(direct))
+        except (TypeError, ValueError):
+            pass
+
+    if isinstance(error, dict):
+        for key in ("retry_after", "retryAfter", "retry-after"):
+            if key in error:
+                try:
+                    return max(0.0, float(error[key]))
+                except (TypeError, ValueError):
+                    pass
+
+    match = _RETRY_AFTER_SECONDS_RE.search(str(error))
+    if not match:
+        return None
+    try:
+        return max(0.0, float(match.group(1)))
+    except (TypeError, ValueError):
+        return None
+
+
 class EphemeralReply(str):
     """System-notice reply that auto-deletes after a TTL.
 
@@ -3811,8 +3854,14 @@ class BasePlatformAdapter(ABC):
             # when present — it is authoritative over our backoff schedule.
             server_retry_after = result.retry_after
             for attempt in range(1, max_retries + 1):
-                if server_retry_after is not None:
-                    delay = server_retry_after + random.uniform(0, 1)
+                retry_after = server_retry_after
+                if retry_after is None:
+                    retry_after = retry_after_seconds_from_error(error_str)
+                if retry_after is not None:
+                    # Provider retry-after is authoritative. Add a small jitter
+                    # so concurrent gateway responses do not wake and collide
+                    # on exactly the same second.
+                    delay = float(retry_after) + random.uniform(0.25, 1.0)
                     server_retry_after = None  # only honor once per send
                 else:
                     delay = base_delay * (2 ** (attempt - 1)) + random.uniform(0, 1)

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -26,6 +26,7 @@ from typing import Any, Callable, Optional
 
 from gateway.platforms.base import BasePlatformAdapter as _BasePlatformAdapter
 from gateway.platforms.base import _custom_unit_to_cp
+from gateway.platforms.base import retry_after_seconds_from_error
 from gateway.platforms.base import MEDIA_TAG_CLEANUP_RE
 from gateway.config import (
     DEFAULT_STREAMING_EDIT_INTERVAL as _DEFAULT_STREAMING_EDIT_INTERVAL,
@@ -931,9 +932,11 @@ class GatewayStreamConsumer:
         last_successful_chunk = ""
         sent_any_chunk = False
         for chunk in chunks:
-            # Try sending with one retry on flood-control errors.
+            # Try sending with flood-control-aware retry.  Telegram tells us the
+            # exact wait time ("Retry in N seconds"); honoring it avoids the
+            # partial-overflow path stopping after only the first chunk.
             result = None
-            for attempt in range(2):
+            for attempt in range(3):
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=chunk,
@@ -941,13 +944,20 @@ class GatewayStreamConsumer:
                 )
                 if result.success:
                     break
-                if attempt == 0 and self._is_flood_error(result):
-                    logger.debug(
-                        "Flood control on fallback send, retrying in 3s"
+                if attempt < 2 and self._is_flood_error(result):
+                    wait = (
+                        getattr(result, "retry_after", None)
+                        or retry_after_seconds_from_error(getattr(result, "error", "") or "")
+                        or 3.0
                     )
-                    await asyncio.sleep(3.0)
+                    wait = float(wait) + 0.5
+                    logger.warning(
+                        "Flood control on fallback send, retrying in %.1fs",
+                        wait,
+                    )
+                    await asyncio.sleep(wait)
                 else:
-                    break  # non-flood error or second attempt failed
+                    break  # non-flood error or final attempt failed
 
             if not result or not result.success:
                 if sent_any_chunk:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -72,6 +72,7 @@ from gateway.platforms.base import (
     ProcessingOutcome,
     SendResult,
     classify_send_error,
+    retry_after_seconds_from_error,
     cache_image_from_bytes,
     cache_audio_from_bytes,
     cache_video_from_bytes,
@@ -1413,15 +1414,6 @@ class TelegramAdapter(BasePlatformAdapter):
                 _TimedOut = None
             is_timeout = (_TimedOut and isinstance(exc, _TimedOut)) or "timed out" in err_str
             is_connect_timeout = self._looks_like_connect_timeout(exc)
-            # Extract server-requested retry_after for flood control so the
-            # base retry layer honors Telegram's backoff instead of its own
-            # short exponential schedule.
-            _retry_after = getattr(exc, "retry_after", None)
-            if _retry_after is None:
-                import re as _re
-                _m = _re.search(r"retry\s+(?:in\s+)?(\d+)", err_str, _re.IGNORECASE)
-                if _m:
-                    _retry_after = float(_m.group(1))
             logger.warning(
                 "[%s] sendRichMessage transient failure (no legacy resend): %s",
                 self.name, exc,
@@ -1430,7 +1422,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 success=False,
                 error=str(exc),
                 retryable=(is_connect_timeout or not is_timeout),
-                retry_after=_retry_after,
+                error_kind=classify_send_error(exc),
+                retry_after=retry_after_seconds_from_error(exc),
             )
 
         message_id = None
@@ -1525,6 +1518,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 success=False,
                 error=str(exc),
                 retryable=(is_connect_timeout or not is_timeout),
+                error_kind=classify_send_error(exc),
+                retry_after=retry_after_seconds_from_error(exc),
             )
         # Telegram won't echo rich content for messages that predate the bot's
         # first rich send, so mirror the fresh-send index here too: a streamed
@@ -3034,6 +3029,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 error=str(e),
                 retryable=(is_connect_timeout or is_pool_timeout or not is_timeout),
                 error_kind=error_kind,
+                retry_after=retry_after_seconds_from_error(e),
             )
 
     async def send_or_update_status(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4648,6 +4648,109 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
             return
 
+        # --- Content dashboard callbacks (cd:action) and approval callbacks (ca:decision:content_id) ---
+        if data.startswith(("cd:", "ca:")):
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to manage content.")
+                return
+
+            def _keyboard_from_payload(payload: Dict[str, Any]) -> "InlineKeyboardMarkup":
+                rows = []
+                for row in payload.get("inline_keyboard", []):
+                    rows.append([
+                        InlineKeyboardButton(
+                            str(button.get("text", "—")),
+                            callback_data=str(button.get("callback_data", "")),
+                        )
+                        for button in row
+                    ])
+                return InlineKeyboardMarkup(rows)
+
+            user_display = getattr(query.from_user, "first_name", "User")
+            try:
+                import importlib.util as _importlib_util
+                from hermes_constants import get_hermes_home
+                approval_path = get_hermes_home() / "rollouts" / "telegram_content_factory" / "approval_intake.py"
+                if not approval_path.exists():
+                    await query.answer(text="❌ approval_intake.py missing")
+                    logger.error("[%s] content approval script missing: %s", self.name, approval_path)
+                    return
+                spec = _importlib_util.spec_from_file_location("telegram_content_approval_intake", approval_path)
+                if spec is None or spec.loader is None:
+                    await query.answer(text="❌ approval module load failed")
+                    logger.error("[%s] content approval module spec failed: %s", self.name, approval_path)
+                    return
+                approval_mod = _importlib_util.module_from_spec(spec)
+                spec.loader.exec_module(approval_mod)
+                handled = approval_mod.handle_callback_event(data, user_display=user_display)
+            except Exception as exc:
+                await query.answer(text=f"❌ content callback failed: {str(exc)[:80]}")
+                logger.error("[%s] content dashboard/approval callback failed: %s", self.name, exc, exc_info=True)
+                return
+
+            # Dashboard buttons edit the pinned dashboard message in-place.
+            if handled.get("kind") == "dashboard":
+                try:
+                    await query.edit_message_text(
+                        text=handled["dashboard"]["text"],
+                        reply_markup=_keyboard_from_payload(handled["dashboard"]["keyboard"]),
+                    )
+                    await query.answer(text="Дашборд оновлено")
+                except Exception as exc:
+                    await query.answer(text=f"❌ dashboard update failed: {str(exc)[:80]}")
+                    logger.error("[%s] content dashboard callback edit failed: %s", self.name, exc, exc_info=True)
+                return
+
+            # Approval buttons resolve the original card, refresh the pinned dashboard,
+            # and, on approve, send the approved item to the control topic. Autopost
+            # remains blocked by approval_intake.handle_callback_event().
+            label = approval_mod.callback_label(handled.get("decision") or "")
+            await query.answer(text=label)
+            try:
+                await query.edit_message_text(text=handled["resolved_text"], reply_markup=None)
+            except Exception as exc:
+                logger.warning("[%s] content approval edit failed: %s", self.name, exc)
+                try:
+                    await self._send_message_with_thread_fallback(
+                        chat_id=int(query.message.chat_id),
+                        message_thread_id=query_thread_id,
+                        text=handled["resolved_text"],
+                        **self._link_preview_kwargs(),
+                    )
+                except Exception:
+                    pass
+
+            try:
+                control = approval_mod.get_control_topic()
+                await self._bot.edit_message_text(
+                    chat_id=int(query.message.chat_id),
+                    message_id=int(control["pinned_message_id"]),
+                    text=handled["dashboard"]["text"],
+                    reply_markup=_keyboard_from_payload(handled["dashboard"]["keyboard"]),
+                )
+            except Exception as exc:
+                logger.warning("[%s] content dashboard refresh after approval failed: %s", self.name, exc)
+
+            if handled.get("approved_notification_text"):
+                try:
+                    control = approval_mod.get_control_topic()
+                    await self._send_message_with_thread_fallback(
+                        chat_id=int(query.message.chat_id),
+                        message_thread_id=int(control["thread_id"]),
+                        text=handled["approved_notification_text"],
+                        **self._link_preview_kwargs(),
+                    )
+                except Exception as exc:
+                    logger.warning("[%s] approved content notification send failed: %s", self.name, exc)
+            return
+
         # --- Update prompt callbacks ---
         if not data.startswith("update_prompt:"):
             return

--- a/tests/gateway/test_delivery_retry_after.py
+++ b/tests/gateway/test_delivery_retry_after.py
@@ -1,0 +1,101 @@
+"""Regression tests for flood-control-aware gateway delivery retries."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.config import Platform
+from gateway.platforms import base as base_platform
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.stream_consumer import GatewayStreamConsumer
+
+
+class _RetryAdapter(BasePlatformAdapter):
+    def __init__(self, results):
+        super().__init__(SimpleNamespace(extra={}), Platform.TELEGRAM)
+        self._results = list(results)
+        self.sent = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id: str, content: str, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append((chat_id, content, reply_to, metadata))
+        return self._results.pop(0)
+
+    async def get_chat_info(self, chat_id: str):
+        return {}
+
+
+def test_retry_after_parser_handles_telegram_text_and_attribute():
+    assert base_platform.retry_after_seconds_from_error(
+        "Flood control exceeded. Retry in 24 seconds"
+    ) == 24.0
+    assert base_platform.retry_after_seconds_from_error(
+        "Too Many Requests: retry after 3"
+    ) == 3.0
+    assert base_platform.retry_after_seconds_from_error(
+        SimpleNamespace(retry_after="7")
+    ) == 7.0
+
+
+def test_send_with_retry_waits_for_provider_retry_after(monkeypatch):
+    sleeps = []
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+
+    monkeypatch.setattr(base_platform.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(base_platform.random, "uniform", lambda _a, _b: 0.5)
+
+    adapter = _RetryAdapter([
+        SendResult(
+            success=False,
+            error="Flood control exceeded. Retry in 24 seconds",
+            retryable=True,
+        ),
+        SendResult(success=True, message_id="ok"),
+    ])
+
+    import asyncio
+
+    result = asyncio.run(adapter._send_with_retry("chat", "payload", max_retries=2))
+
+    assert result.success is True
+    assert result.message_id == "ok"
+    assert len(adapter.sent) == 2
+    assert sleeps == [24.5]
+
+
+def test_stream_fallback_final_waits_for_retry_after(monkeypatch):
+    sleeps = []
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+
+    monkeypatch.setattr("gateway.stream_consumer.asyncio.sleep", fake_sleep)
+
+    adapter = MagicMock()
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.message_len_fn = len
+    adapter.send = AsyncMock(side_effect=[
+        SimpleNamespace(
+            success=False,
+            error="Flood control exceeded. Retry in 7 seconds",
+            retry_after=None,
+        ),
+        SimpleNamespace(success=True, message_id="m1"),
+    ])
+
+    consumer = GatewayStreamConsumer(adapter, "chat")
+    import asyncio
+
+    asyncio.run(consumer._send_fallback_final("final answer"))
+
+    assert consumer._final_content_delivered is True
+    assert adapter.send.await_count == 2
+    assert sleeps == [7.5]

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -74,6 +74,23 @@ class _AuthRunner:
         return self.authorized
 
 
+class _FakeLoader:
+    def exec_module(self, module):
+        return None
+
+
+def _fake_approval_import(tmp_path, module):
+    approval_path = tmp_path / "rollouts" / "telegram_content_factory" / "approval_intake.py"
+    approval_path.parent.mkdir(parents=True, exist_ok=True)
+    approval_path.write_text("# fake approval_intake for Telegram callback tests\n", encoding="utf-8")
+    fake_spec = SimpleNamespace(loader=_FakeLoader())
+    return patch.multiple(
+        "importlib.util",
+        spec_from_file_location=MagicMock(return_value=fake_spec),
+        module_from_spec=MagicMock(return_value=module),
+    )
+
+
 # ===========================================================================
 # send_exec_approval — inline keyboard buttons
 # ===========================================================================
@@ -448,6 +465,108 @@ class TestTelegramApprovalCallback:
         # Should still ack with "already resolved" message
         query.answer.assert_called_once()
         assert "already been resolved" in query.answer.call_args[1]["text"]
+
+    @pytest.mark.asyncio
+    async def test_content_dashboard_callback_edits_pinned_dashboard(self, tmp_path):
+        adapter = _make_adapter()
+
+        handled = {
+            "kind": "dashboard",
+            "dashboard": {
+                "text": "✅ Схвалені пости · Майстерня Долі",
+                "keyboard": {
+                    "inline_keyboard": [[{"text": "🔄 Оновити", "callback_data": "cd:refresh"}]],
+                },
+            },
+        }
+        fake_mod = SimpleNamespace(handle_callback_event=MagicMock(return_value=handled))
+
+        query = AsyncMock()
+        query.data = "cd:approved"
+        query.message = MagicMock()
+        query.message.chat_id = -1004448254480
+        query.message.message_thread_id = 17
+        query.message.chat.type = "supergroup"
+        query.from_user = MagicMock()
+        query.from_user.id = 111
+        query.from_user.first_name = "Сергій"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+            with _fake_approval_import(tmp_path, fake_mod):
+                with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+                    await adapter._handle_callback_query(update, context)
+
+        fake_mod.handle_callback_event.assert_called_once_with("cd:approved", user_display="Сергій")
+        query.edit_message_text.assert_called_once()
+        edit_kwargs = query.edit_message_text.call_args[1]
+        assert "Схвалені пости" in edit_kwargs["text"]
+        assert edit_kwargs["reply_markup"] is not None
+        query.answer.assert_called_once()
+        assert "оновлено" in query.answer.call_args[1]["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_content_approval_callback_refreshes_dashboard_and_sends_approved_notification(self, tmp_path):
+        adapter = _make_adapter()
+        adapter._bot.edit_message_text = AsyncMock()
+        adapter._send_message_with_thread_fallback = AsyncMock()
+
+        handled = {
+            "kind": "content_approval",
+            "decision": "approve",
+            "resolved_text": "✅ Рішення записано",
+            "dashboard": {
+                "text": "📌 Пульт Контенту · Майстерня Долі\n✅ Схвалено: 1 / 1",
+                "keyboard": {
+                    "inline_keyboard": [[{"text": "✅ Схвалені", "callback_data": "cd:approved"}]],
+                },
+            },
+            "approved_notification_text": "✅ Схвалено · Instagram",
+        }
+        fake_mod = SimpleNamespace(
+            handle_callback_event=MagicMock(return_value=handled),
+            callback_label=MagicMock(return_value="✅ Затверджено"),
+            get_control_topic=MagicMock(return_value={"thread_id": 17, "pinned_message_id": 18}),
+        )
+
+        query = AsyncMock()
+        query.data = "ca:approve:appr_1"
+        query.message = MagicMock()
+        query.message.chat_id = -1004448254480
+        query.message.message_thread_id = 19
+        query.message.chat.type = "supergroup"
+        query.from_user = MagicMock()
+        query.from_user.id = 111
+        query.from_user.first_name = "Сергій"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+            with _fake_approval_import(tmp_path, fake_mod):
+                with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+                    await adapter._handle_callback_query(update, context)
+
+        fake_mod.handle_callback_event.assert_called_once_with("ca:approve:appr_1", user_display="Сергій")
+        query.answer.assert_called_once()
+        assert "Затверджено" in query.answer.call_args[1]["text"]
+        query.edit_message_text.assert_called_once_with(text="✅ Рішення записано", reply_markup=None)
+        adapter._bot.edit_message_text.assert_called_once()
+        dashboard_kwargs = adapter._bot.edit_message_text.call_args[1]
+        assert dashboard_kwargs["message_id"] == 18
+        assert "Пульт Контенту" in dashboard_kwargs["text"]
+        adapter._send_message_with_thread_fallback.assert_called_once()
+        notification_kwargs = adapter._send_message_with_thread_fallback.call_args[1]
+        assert notification_kwargs["message_thread_id"] == 17
+        assert "Схвалено · Instagram" in notification_kwargs["text"]
 
     @pytest.mark.asyncio
     async def test_model_picker_callback_not_affected(self):


### PR DESCRIPTION
## Summary
- honor Telegram/provider `retry_after` hints when gateway delivery hits flood-control responses
- add regression coverage for retry-after parsing and fallback final delivery retries
- route Telegram content approval/dashboard callback data (`ca:*`, `cd:*`) through the existing gateway callback path with authorization checks
- add regression coverage for approval-card inline keyboards, callback authorization, and dashboard/content callback handling

## Current branch state
- Rebased/rebuilt on latest `origin/main` after upstream moved again
- Head: `2a33d67b1521916acefdd84f8d5a82a0269afa8b`
- Divergence at verification: `0 behind / 2 ahead`

## Tests
- `python3 -m ruff check gateway/platforms/base.py gateway/stream_consumer.py plugins/platforms/telegram/adapter.py tests/gateway/test_delivery_retry_after.py tests/gateway/test_telegram_approval_buttons.py` → `All checks passed!`
- `python3 -m pytest tests/gateway/test_delivery_retry_after.py tests/gateway/test_telegram_approval_buttons.py tests/gateway/test_telegram_callback_auth_fail_closed.py tests/gateway/test_stream_consumer.py tests/gateway/test_stream_consumer_fresh_final.py tests/gateway/test_stream_consumer_thread_routing.py -q` → `164 passed in 36.02s`
- `git diff --check origin/main...HEAD` → passed

## Merge status
- Direct merge attempted after rebase: blocked by base branch policy.
- Auto-merge attempted: contributor account lacks `EnablePullRequestAutoMerge` permission.
- Maintainer merge is required.

## Notes
- GitHub reports no status checks on this branch at the time of verification.
- A broad local `python3 -m pytest tests/gateway` run on this Windows/Python 3.13 environment was not used as a PR blocker because it hit pre-existing/environmental gateway-suite failures outside this PR’s changed files before timing out; the PR-relevant expanded gateway subset above passes.

## Safety / boundaries
- no gateway restart performed
- no cron/webhook/autopost/publication changes
- branch is isolated from fresh `origin/main` and pushed only to fork branch `rainbowrainbowrainbow:plotva/telegram-gateway-hardening-20260626`
