### PR TITLE
feat(web): multi-source fallback chain and search_engine parameter

### DIFF
--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,49 @@
+## What does this PR do?
+
+When Hermes is started from PowerShell or cmd.exe on Windows, `os.getcwd()` returns a Windows native path (`C:\Users\...`) which gets stored as the session working directory. Both `init_session()` and `_wrap_command()` embed this path directly into bash scripts via `cd`, but Git Bash cannot parse Windows drive-letter paths.
+
+**Impact:** Every terminal tool call fails with exit code 126 the first time any command runs. The agent cannot write files, search, or execute shell commands. It wastes tokens diagnosing the failure, may produce incorrect results, and can fail entirely on tasks requiring shell execution. This affects ALL Windows users launching Hermes from non-Msys terminals (PowerShell, cmd.exe).
+
+The existing `_msys_to_windows_path()` in `local.py` handles reverse conversion (bash output -> Python `Popen` cwd). No forward helper existed.
+
+This PR adds `_windows_to_msys_path()` to `BaseEnvironment` and applies it in both `init_session()` and `_wrap_command()`.
+
+## Related Issue
+
+Fixes #50594
+
+## Type of Change
+
+- [x] Bug fix (non-breaking change that fixes an issue)
+
+## Changes Made
+
+- `tools/environments/base.py` — Added `_windows_to_msys_path()` static method: `C:\Users\x` -> `/c/Users/x`. No-op on non-Windows or already-Msys paths
+- `tools/environments/base.py` — `init_session()`: convert `self.cwd` via `_windows_to_msys_path()` before `shlex.quote()`
+- `tools/environments/base.py` — `_wrap_command()`: convert `cwd` via `_windows_to_msys_path()` before `_quote_cwd_for_cd()`
+- Added `import re` and `import sys` to module imports
+
+## How to Test
+
+1. Open PowerShell (not Git Bash)
+2. `cd C:\Users\YourName`
+3. `hermes`
+4. Ask agent: list files in current directory
+5. Command should succeed instead of failing with exit code 126
+
+## Checklist
+
+### Code
+
+- [x] I have read the Contributing Guide
+- [x] My commit messages follow Conventional Commits
+- [x] I searched for existing PRs to make sure this is not a duplicate
+- [x] My PR contains only changes related to this fix/feature
+- [x] pytest 55 passed (1 pre-existing failure on Windows — POSIX root test)
+- [ ] I have added tests for my changes
+- [x] I have tested on my platform: Windows 10, PowerShell
+
+### Documentation & Housekeeping
+
+- [x] N/A — no docs or config keys affected
+- [x] Cross-platform: `_windows_to_msys_path()` is a no-op on non-Windows

--- a/tests/tools/test_web_fallback_chain.py
+++ b/tests/tools/test_web_fallback_chain.py
@@ -1,0 +1,250 @@
+"""Tests for multi-source fallback chain and search_engine parameter."""
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+import pytest
+
+
+class TestGetFallbackChain:
+    """_get_fallback_chain() produces ordered, deduplicated chain."""
+
+    def test_empty_config_returns_all_providers(self):
+        from tools.web_tools import _get_fallback_chain
+        with (
+            patch("tools.web_tools._load_web_config") as mock_cfg,
+            patch("tools.web_tools._list_registered_web_providers") as mock_list,
+        ):
+            mock_cfg.return_value = {}
+            mock_p1 = MagicMock()
+            mock_p1.name = "ddgs"
+            mock_p2 = MagicMock()
+            mock_p2.name = "firecrawl"
+            mock_list.return_value = [mock_p1, mock_p2]
+            chain = _get_fallback_chain()
+            assert len(chain) >= 2
+            assert len(chain) == len(set(chain))
+
+    def test_fallback_backends_respected(self):
+        from tools.web_tools import _get_fallback_chain
+        with (
+            patch("tools.web_tools._load_web_config") as mock_cfg,
+            patch("tools.web_tools._list_registered_web_providers") as mock_list,
+        ):
+            mock_cfg.return_value = {
+                "fallback_backends": ["serper", "baidu", "ddgs"],
+            }
+            mock_p1 = MagicMock()
+            mock_p1.name = "firecrawl"
+            mock_list.return_value = [mock_p1]
+            chain = _get_fallback_chain()
+            # serper, baidu, ddgs must appear in that order
+            positions = {
+                name: chain.index(name)
+                for name in ["serper", "baidu", "ddgs"]
+                if name in chain
+            }
+            assert positions["serper"] < positions["baidu"]
+            assert positions["baidu"] < positions["ddgs"]
+
+    def test_string_fallback_parsed(self):
+        from tools.web_tools import _get_fallback_chain
+        with (
+            patch("tools.web_tools._load_web_config") as mock_cfg,
+            patch("tools.web_tools._list_registered_web_providers") as mock_list,
+        ):
+            mock_cfg.return_value = {"fallback_backends": "brave-free, ddgs"}
+            mock_list.return_value = []
+            chain = _get_fallback_chain()
+            assert chain[0] == "brave-free"
+            assert chain[1] == "ddgs"
+
+    def test_primary_from_search_backend(self):
+        """search_backend takes precedence over web.backend."""
+        from tools.web_tools import _get_fallback_chain
+        with (
+            patch("tools.web_tools._load_web_config") as mock_cfg,
+            patch("tools.web_tools._get_search_backend") as mock_sb,
+            patch("tools.web_tools._list_registered_web_providers") as mock_list,
+        ):
+            mock_cfg.return_value = {}
+            mock_sb.return_value = "searxng"
+            mock_list.return_value = []
+            chain = _get_fallback_chain()
+            assert chain[0] == "searxng"
+
+    def test_divergent_search_vs_web_backend(self):
+        """When web.search_backend differs from web.backend, search_backend wins."""
+        from tools.web_tools import _get_fallback_chain
+        with (
+            patch("tools.web_tools._load_web_config") as mock_cfg,
+            patch("tools.web_tools._get_search_backend") as mock_sb,
+            patch("tools.web_tools._list_registered_web_providers") as mock_list,
+        ):
+            mock_cfg.return_value = {
+                "backend": "firecrawl",
+                "search_backend": "ddgs",
+            }
+            mock_sb.return_value = "ddgs"
+            mock_list.return_value = []
+            chain = _get_fallback_chain()
+            assert chain[0] == "ddgs"
+            assert "firecrawl" not in chain[:1]
+
+
+class TestSearchWithFallback:
+    """_search_with_fallback() stops at first success, skips failures."""
+
+    def test_first_success_returns_immediately(self):
+        from tools.web_tools import _search_with_fallback
+
+        chain = ["backend-a", "backend-b"]
+        results_stack = [
+            {"success": True, "data": {"web": [{"title": "hit"}]}},
+        ]
+        with patch("tools.web_tools.get_provider") as mock_gp:
+            mock_provider = MagicMock()
+            mock_provider.is_available.return_value = True
+            mock_provider.supports_search.return_value = True
+            mock_provider.search.side_effect = (
+                lambda *a, **kw: results_stack.pop(0) if results_stack else None
+            )
+            mock_gp.return_value = mock_provider
+            result, errors = _search_with_fallback("test", 5, chain)
+            assert result is not None
+            assert result["success"] is True
+            assert mock_provider.search.call_count == 1
+
+    def test_skip_unavailable_provider(self):
+        from tools.web_tools import _search_with_fallback
+
+        chain = ["unavailable", "good"]
+        with patch("tools.web_tools.get_provider") as mock_gp:
+            mock_unavail = MagicMock()
+            mock_unavail.is_available.return_value = False
+            mock_unavail.supports_search.return_value = True
+
+            mock_good = MagicMock()
+            mock_good.is_available.return_value = True
+            mock_good.supports_search.return_value = True
+            mock_good.search.return_value = {
+                "success": True, "data": {"web": [{"title": "x"}]},
+            }
+
+            mock_gp.side_effect = lambda name: (
+                mock_unavail if name == "unavailable" else mock_good
+            )
+            result, errors = _search_with_fallback("test", 5, chain)
+            assert result is not None
+            assert result["success"] is True
+            assert "unavailable: not available" in errors[0]
+
+    def test_skip_zero_results(self):
+        from tools.web_tools import _search_with_fallback
+
+        chain = ["empty", "good"]
+        with patch("tools.web_tools.get_provider") as mock_gp:
+            mock_empty = MagicMock()
+            mock_empty.is_available.return_value = True
+            mock_empty.supports_search.return_value = True
+            mock_empty.search.return_value = {
+                "success": True, "data": {"web": []},
+            }
+            mock_good = MagicMock()
+            mock_good.is_available.return_value = True
+            mock_good.supports_search.return_value = True
+            mock_good.search.return_value = {
+                "success": True, "data": {"web": [{"title": "x"}]},
+            }
+            mock_gp.side_effect = lambda name: (
+                mock_empty if name == "empty" else mock_good
+            )
+            result, errors = _search_with_fallback("test", 5, chain)
+            assert result is not None
+            assert result["success"] is True
+            assert "empty: returned 0 results" in errors[0]
+
+    def test_all_fail_returns_none(self):
+        from tools.web_tools import _search_with_fallback
+
+        chain = ["fail-a", "fail-b"]
+        with patch("tools.web_tools.get_provider") as mock_gp:
+            mock_provider = MagicMock()
+            mock_provider.is_available.return_value = True
+            mock_provider.supports_search.return_value = True
+            mock_provider.search.return_value = {
+                "success": False, "error": "test-error",
+            }
+            mock_gp.return_value = mock_provider
+            result, errors = _search_with_fallback("test", 5, chain)
+            assert result is None
+            assert len(errors) == 2
+
+    def test_provider_crash_skipped(self):
+        from tools.web_tools import _search_with_fallback
+
+        chain = ["crasher", "good"]
+        with patch("tools.web_tools.get_provider") as mock_gp:
+            mock_bad = MagicMock()
+            mock_bad.is_available.return_value = True
+            mock_bad.supports_search.return_value = True
+            mock_bad.search.side_effect = RuntimeError("boom")
+            mock_good = MagicMock()
+            mock_good.is_available.return_value = True
+            mock_good.supports_search.return_value = True
+            mock_good.search.return_value = {
+                "success": True, "data": {"web": [{"title": "x"}]},
+            }
+            mock_gp.side_effect = lambda name: (
+                mock_bad if name == "crasher" else mock_good
+            )
+            result, errors = _search_with_fallback("test", 5, chain)
+            assert result is not None
+            assert "crasher: boom" in errors[0]
+
+    def test_provider_not_found_skipped(self):
+        from tools.web_tools import _search_with_fallback
+
+        chain = ["nonexistent", "good"]
+        with patch("tools.web_tools.get_provider") as mock_gp:
+            mock_good = MagicMock()
+            mock_good.is_available.return_value = True
+            mock_good.supports_search.return_value = True
+            mock_good.search.return_value = {
+                "success": True, "data": {"web": [{"title": "x"}]},
+            }
+            mock_gp.side_effect = lambda name: (
+                None if name == "nonexistent" else mock_good
+            )
+            result, errors = _search_with_fallback("test", 5, chain)
+            assert result is not None
+            assert "nonexistent: not found" in errors[0]
+
+
+class TestGetValidEngineNames:
+    """_get_valid_engine_names() returns dynamically updated set."""
+
+    def test_returns_set_with_auto(self):
+        from tools.web_tools import _get_valid_engine_names
+        with patch("tools.web_tools._list_registered_web_providers") as mock_list:
+            mock_p = MagicMock()
+            mock_p.name = "ddgs"
+            mock_p.is_available.return_value = True
+            mock_list.return_value = [mock_p]
+            names = _get_valid_engine_names()
+            assert isinstance(names, set)
+            assert "auto" in names
+            assert "ddgs" in names
+
+    def test_unavailable_providers_excluded(self):
+        from tools.web_tools import _get_valid_engine_names
+        with patch("tools.web_tools._list_registered_web_providers") as mock_list:
+            mock_ok = MagicMock()
+            mock_ok.name = "ddgs"
+            mock_ok.is_available.return_value = True
+            mock_bad = MagicMock()
+            mock_bad.name = "no-key"
+            mock_bad.is_available.return_value = False
+            mock_list.return_value = [mock_ok, mock_bad]
+            names = _get_valid_engine_names()
+            assert "ddgs" in names
+            assert "no-key" not in names

--- a/tests/tools/test_web_fallback_chain.py
+++ b/tests/tools/test_web_fallback_chain.py
@@ -1,0 +1,288 @@
+"""Tests for multi-source fallback chain and search_engine parameter."""
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_keyless_rescue(monkeypatch):
+    """Keep these tests focused on the fallback chain itself.
+
+    Real keyless-rescue eligibility would route failed calls through the
+    keyless ring (covered separately by test_web_keyless_rescue.py); here
+    we pin rescue off so fallback behaviour is deterministic.
+    """
+    monkeypatch.setattr(
+        "tools.web_tools._keyless_rescue_enabled", lambda: False
+    )
+
+
+class TestGetFallbackChain:
+    """_get_fallback_chain() produces ordered, deduplicated chain."""
+
+    def test_empty_config_returns_all_providers(self):
+        from tools.web_tools import _get_fallback_chain
+        with (
+            patch("tools.web_tools._load_web_config") as mock_cfg,
+            patch("tools.web_tools._list_registered_web_providers") as mock_list,
+        ):
+            mock_cfg.return_value = {}
+            mock_p1 = MagicMock()
+            mock_p1.name = "ddgs"
+            mock_p2 = MagicMock()
+            mock_p2.name = "firecrawl"
+            mock_list.return_value = [mock_p1, mock_p2]
+            chain = _get_fallback_chain()
+            assert len(chain) >= 2
+            assert len(chain) == len(set(chain))
+
+    def test_fallback_backends_respected(self):
+        from tools.web_tools import _get_fallback_chain
+        with (
+            patch("tools.web_tools._load_web_config") as mock_cfg,
+            patch("tools.web_tools._list_registered_web_providers") as mock_list,
+        ):
+            mock_cfg.return_value = {
+                "fallback_backends": ["serper", "baidu", "ddgs"],
+            }
+            mock_p1 = MagicMock()
+            mock_p1.name = "firecrawl"
+            mock_list.return_value = [mock_p1]
+            chain = _get_fallback_chain()
+            # serper, baidu, ddgs must appear in that order
+            positions = {
+                name: chain.index(name)
+                for name in ["serper", "baidu", "ddgs"]
+                if name in chain
+            }
+            assert positions["serper"] < positions["baidu"]
+            assert positions["baidu"] < positions["ddgs"]
+
+    def test_string_fallback_parsed(self):
+        from tools.web_tools import _get_fallback_chain
+        with (
+            patch("tools.web_tools._load_web_config") as mock_cfg,
+            patch("tools.web_tools._get_search_backend") as mock_sb,
+            patch("tools.web_tools._list_registered_web_providers") as mock_list,
+        ):
+            mock_cfg.return_value = {"fallback_backends": "brave-free, ddgs"}
+            mock_sb.return_value = None
+            mock_list.return_value = []
+            chain = _get_fallback_chain()
+            assert chain[0] == "brave-free"
+            assert chain[1] == "ddgs"
+
+    def test_primary_from_search_backend(self):
+        """search_backend takes precedence over web.backend."""
+        from tools.web_tools import _get_fallback_chain
+        with (
+            patch("tools.web_tools._load_web_config") as mock_cfg,
+            patch("tools.web_tools._get_search_backend") as mock_sb,
+            patch("tools.web_tools._list_registered_web_providers") as mock_list,
+        ):
+            mock_cfg.return_value = {}
+            mock_sb.return_value = "searxng"
+            mock_list.return_value = []
+            chain = _get_fallback_chain()
+            assert chain[0] == "searxng"
+
+    def test_divergent_search_vs_web_backend(self):
+        """When web.search_backend differs from web.backend, search_backend wins."""
+        from tools.web_tools import _get_fallback_chain
+        with (
+            patch("tools.web_tools._load_web_config") as mock_cfg,
+            patch("tools.web_tools._get_search_backend") as mock_sb,
+            patch("tools.web_tools._list_registered_web_providers") as mock_list,
+        ):
+            mock_cfg.return_value = {
+                "backend": "firecrawl",
+                "search_backend": "ddgs",
+            }
+            mock_sb.return_value = "ddgs"
+            mock_list.return_value = []
+            chain = _get_fallback_chain()
+            assert chain[0] == "ddgs"
+            assert "firecrawl" not in chain[:1]
+
+
+class TestSearchWithFallback:
+    """_search_with_fallback() stops at first success, skips failures."""
+
+    def test_first_success_returns_immediately(self):
+        from tools.web_tools import _search_with_fallback
+
+        chain = ["backend-a", "backend-b"]
+        results_stack = [
+            {"success": True, "data": {"web": [{"title": "hit"}]}},
+        ]
+        with patch("agent.web_search_registry.get_provider") as mock_gp:
+            mock_provider = MagicMock()
+            mock_provider.is_available.return_value = True
+            mock_provider.supports_search.return_value = True
+            mock_provider.search.side_effect = (
+                lambda *a, **kw: results_stack.pop(0) if results_stack else None
+            )
+            mock_gp.return_value = mock_provider
+            result, errors, _ = _search_with_fallback("test", 5, chain)
+            assert result is not None
+            assert result["success"] is True
+            assert mock_provider.search.call_count == 1
+
+    def test_skip_unavailable_provider(self):
+        from tools.web_tools import _search_with_fallback
+
+        chain = ["unavailable", "good"]
+        with patch("agent.web_search_registry.get_provider") as mock_gp:
+            mock_unavail = MagicMock()
+            mock_unavail.is_available.return_value = False
+            mock_unavail.supports_search.return_value = True
+
+            mock_good = MagicMock()
+            mock_good.is_available.return_value = True
+            mock_good.supports_search.return_value = True
+            mock_good.search.return_value = {
+                "success": True, "data": {"web": [{"title": "x"}]},
+            }
+
+            mock_gp.side_effect = lambda name: (
+                mock_unavail if name == "unavailable" else mock_good
+            )
+            result, errors, _ = _search_with_fallback("test", 5, chain)
+            assert result is not None
+            assert result["success"] is True
+            assert "unavailable: not available" in errors[0]
+
+    def test_zero_results_returns_success(self):
+        """A healthy backend returning zero hits is a valid outcome — it is
+        returned directly instead of falling through to other backends."""
+        from tools.web_tools import _search_with_fallback
+
+        chain = ["empty", "good"]
+        with patch("agent.web_search_registry.get_provider") as mock_gp:
+            mock_empty = MagicMock()
+            mock_empty.is_available.return_value = True
+            mock_empty.supports_search.return_value = True
+            mock_empty.search.return_value = {
+                "success": True, "data": {"web": []},
+            }
+            mock_gp.return_value = mock_empty
+            result, errors, _ = _search_with_fallback("test", 5, chain)
+            assert result is not None
+            assert result["success"] is True
+            assert mock_empty.search.call_count == 1
+
+    def test_all_unavailable_returns_none(self):
+        """Every backend missing its key/package → (None, trace)."""
+        from tools.web_tools import _search_with_fallback
+
+        chain = ["fail-a", "fail-b"]
+        with patch("agent.web_search_registry.get_provider") as mock_gp:
+            mock_provider = MagicMock()
+            mock_provider.is_available.return_value = False
+            mock_gp.return_value = mock_provider
+            result, errors, _ = _search_with_fallback("test", 5, chain)
+            assert result is None
+            assert len(errors) == 2
+
+    def test_live_backend_failure_is_authoritative(self):
+        """A live backend returning a failure result is NOT a fallback
+        trigger — its error is surfaced directly (main contract)."""
+        from tools.web_tools import _search_with_fallback
+
+        chain = ["fail-a", "good"]
+        with patch("agent.web_search_registry.get_provider") as mock_gp:
+            mock_fail = MagicMock()
+            mock_fail.name = "fail-a"
+            mock_fail.is_available.return_value = True
+            mock_fail.supports_search.return_value = True
+            mock_fail.search.return_value = {
+                "success": False, "error": "HTTP 500 upstream exploded",
+            }
+            mock_good = MagicMock()
+            mock_good.name = "good"
+            mock_good.is_available.return_value = True
+            mock_good.supports_search.return_value = True
+            mock_good.search.return_value = {
+                "success": True, "data": {"web": [{"title": "x"}]},
+            }
+            mock_gp.side_effect = lambda name: (
+                mock_fail if name == "fail-a" else mock_good
+            )
+            result, errors, _ = _search_with_fallback("test", 5, chain)
+            assert result is not None
+            assert result["success"] is False
+            assert mock_good.search.call_count == 0
+
+    def test_live_backend_crash_propagates(self):
+        """A live backend that raises keeps main's behavior: the exception
+        bubbles up instead of falling through to the next backend."""
+        from tools.web_tools import _search_with_fallback
+
+        chain = ["crasher", "good"]
+        with patch("agent.web_search_registry.get_provider") as mock_gp:
+            mock_bad = MagicMock()
+            mock_bad.name = "crasher"
+            mock_bad.is_available.return_value = True
+            mock_bad.supports_search.return_value = True
+            mock_bad.search.side_effect = RuntimeError("boom")
+            mock_good = MagicMock()
+            mock_good.name = "good"
+            mock_good.is_available.return_value = True
+            mock_good.supports_search.return_value = True
+            mock_good.search.return_value = {
+                "success": True, "data": {"web": [{"title": "x"}]},
+            }
+            mock_gp.side_effect = lambda name: (
+                mock_bad if name == "crasher" else mock_good
+            )
+            with pytest.raises(RuntimeError, match="boom"):
+                _search_with_fallback("test", 5, chain)
+
+    def test_provider_not_found_skipped(self):
+        from tools.web_tools import _search_with_fallback
+
+        chain = ["nonexistent", "good"]
+        with patch("agent.web_search_registry.get_provider") as mock_gp:
+            mock_good = MagicMock()
+            mock_good.is_available.return_value = True
+            mock_good.supports_search.return_value = True
+            mock_good.search.return_value = {
+                "success": True, "data": {"web": [{"title": "x"}]},
+            }
+            mock_gp.side_effect = lambda name: (
+                None if name == "nonexistent" else mock_good
+            )
+            result, errors, _ = _search_with_fallback("test", 5, chain)
+            assert result is not None
+            assert "nonexistent: not found" in errors[0]
+
+
+class TestGetValidEngineNames:
+    """_get_valid_engine_names() returns dynamically updated set."""
+
+    def test_returns_set_with_auto(self):
+        from tools.web_tools import _get_valid_engine_names
+        with patch("tools.web_tools._list_registered_web_providers") as mock_list:
+            mock_p = MagicMock()
+            mock_p.name = "ddgs"
+            mock_p.is_available.return_value = True
+            mock_list.return_value = [mock_p]
+            names = _get_valid_engine_names()
+            assert isinstance(names, set)
+            assert "auto" in names
+            assert "ddgs" in names
+
+    def test_unavailable_providers_excluded(self):
+        from tools.web_tools import _get_valid_engine_names
+        with patch("tools.web_tools._list_registered_web_providers") as mock_list:
+            mock_ok = MagicMock()
+            mock_ok.name = "ddgs"
+            mock_ok.is_available.return_value = True
+            mock_bad = MagicMock()
+            mock_bad.name = "no-key"
+            mock_bad.is_available.return_value = False
+            mock_list.return_value = [mock_ok, mock_bad]
+            names = _get_valid_engine_names()
+            assert "ddgs" in names
+            assert "no-key" not in names

--- a/tests/tools/test_web_fallback_chain.py
+++ b/tests/tools/test_web_fallback_chain.py
@@ -136,6 +136,7 @@ class TestSearchWithFallback:
         with patch("agent.web_search_registry.get_provider") as mock_gp:
             mock_unavail = MagicMock()
             mock_unavail.is_available.return_value = False
+            mock_unavail.is_keyless_available.return_value = False
             mock_unavail.supports_search.return_value = True
 
             mock_good = MagicMock()
@@ -180,6 +181,7 @@ class TestSearchWithFallback:
         with patch("agent.web_search_registry.get_provider") as mock_gp:
             mock_provider = MagicMock()
             mock_provider.is_available.return_value = False
+            mock_provider.is_keyless_available.return_value = False
             mock_gp.return_value = mock_provider
             result, errors, _ = _search_with_fallback("test", 5, chain)
             assert result is None

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -330,9 +330,9 @@ def check_sandbox_requirements() -> bool:
 _TOOL_STUBS = {
     "web_search": (
         "web_search",
-        "query: str, limit: int = 5",
-        '"""Search the web. Returns dict with data.web list of {url, title, description}."""',
-        '{"query": query, "limit": limit}',
+        'query: str, limit: int = 5, search_engine: str = "auto"',
+        '"""Search the web. Returns dict with data.web list of {url, title, description}. search_engine="auto" walks the fallback chain; pass a provider name to pin one."""',
+        '{"query": query, "limit": limit, "search_engine": search_engine}',
     ),
     "web_extract": (
         "web_extract",

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -352,6 +352,122 @@ def _is_backend_available(backend: str) -> bool:
     return False
 
 
+# ─── Fallback Chain & Multi-Source Search ────────────────────────────────────
+
+
+def _get_registered_backend_names() -> set[str]:
+    """Return all currently-registered web search backend names.
+
+    Dynamically sourced from the plugin registry so adding a new
+    provider plugin automatically extends the set — no hardcoded list.
+    Used for config value validation in ``check_web_api_key()``.
+    """
+    try:
+        return {p.name for p in _list_registered_web_providers()}
+    except Exception:
+        return set()
+
+
+def _get_valid_engine_names() -> set[str]:
+    """Return the set of usable search engine choices for the model.
+
+    Only providers where ``is_available()`` returns True are included,
+    so the model never sees engines that lack API keys.  ``"auto"`` is
+    always present — it walks the fallback chain.
+    """
+    choices = {"auto"}
+    try:
+        for p in _list_registered_web_providers():
+            try:
+                if p.is_available():
+                    choices.add(p.name)
+            except Exception:
+                pass
+    except Exception:
+        pass
+    return choices
+
+
+def _get_fallback_chain() -> list[str]:
+    """Return an ordered list of backends to try when ``search_engine == "auto"``.
+
+    Priority:
+    1. ``web.search_backend`` / ``web.backend`` — explicit choice (always first)
+    2. ``web.fallback_backends`` — user-configured ordered list
+    3. All other registered providers not already in the chain (alphabetical)
+    """
+    cfg = _load_web_config()
+
+    chain: list[str] = []
+
+    primary = _get_search_backend()
+    if primary and primary not in chain:
+        chain.append(primary)
+
+    user_fbs = cfg.get("fallback_backends", [])
+    if isinstance(user_fbs, str):
+        user_fbs = [b.strip() for b in user_fbs.split(",") if b.strip()]
+    for b in user_fbs:
+        b = b.lower().strip()
+        if b and b not in chain:
+            chain.append(b)
+
+    # Append remaining registered providers (those not already listed).
+    try:
+        for p in _list_registered_web_providers():
+            if p.name not in chain:
+                chain.append(p.name)
+    except Exception:
+        pass
+
+    return chain
+
+
+def _search_with_fallback(
+    query: str,
+    limit: int,
+    chain: list[str],
+) -> tuple[dict | None, list[str]]:
+    """Try each backend in *chain* until one succeeds.
+
+    Returns ``(success_result, error_trace)``.  A backend is skipped
+    when it is not found, not available, returns an error, or returns
+    zero results.  ``success_result`` is ``None`` when all backends fail.
+    """
+    from agent.web_search_registry import get_provider
+
+    errors: list[str] = []
+    for name in chain:
+        provider = get_provider(name)
+        if provider is None or not provider.supports_search():
+            errors.append(f"{name}: not found or search unsupported")
+            continue
+        if not provider.is_available():
+            errors.append(f"{name}: not available (missing key or package)")
+            continue
+
+        try:
+            result = provider.search(query, limit)
+        except Exception as exc:
+            errors.append(f"{name}: {exc}")
+            continue
+
+        if not isinstance(result, dict):
+            errors.append(f"{name}: unexpected response type {type(result).__name__}")
+            continue
+        if not result.get("success"):
+            errors.append(f"{name}: {result.get('error', 'unknown error')}")
+            continue
+        if not len(result.get("data", {}).get("web", [])):
+            errors.append(f"{name}: returned 0 results")
+            continue
+
+        # Success — return immediately
+        return result, errors
+
+    return None, errors
+
+
 def _ddgs_package_importable() -> bool:
     """Return True when the ``ddgs`` Python package can be imported.
 
@@ -616,12 +732,14 @@ def _ensure_web_plugins_loaded() -> None:
         logger.warning("Web plugin discovery failed (non-fatal): %s", exc)
 
 
-def web_search_tool(query: str, limit: int = 5) -> str:
+def web_search_tool(query: str, limit: int = 5, search_engine: str = "auto") -> str:
     """
-    Search the web for information using available search API backend.
+    Search the web for information using available search API backends.
 
     This function provides a generic interface for web search that can work
-    with multiple backends (Parallel or Firecrawl).
+    with multiple backends. When ``search_engine`` is ``"auto"`` (default),
+    backends from ``web.fallback_backends`` are tried in order until one
+    succeeds.  Explicit engine names run a single backend with no fallback.
 
     Note: This function returns search result metadata only (URLs, titles, descriptions).
     Use web_extract_tool to get full content from specific URLs.
@@ -629,6 +747,10 @@ def web_search_tool(query: str, limit: int = 5) -> str:
     Args:
         query (str): The search query to look up
         limit (int): Maximum number of results to return (default: 5)
+        search_engine (str): Which provider to use. ``"auto"`` walks the
+            fallback chain.  Any registered provider name (e.g. ``"baidu"``,
+            ``"serper"``, ``"ddgs"``) runs that single backend.  Defaults to
+            ``"auto"``.
     
     Returns:
         str: JSON string containing search results with the following structure:
@@ -646,9 +768,6 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                      ]
                  }
              }
-    
-    Raises:
-        Exception: If search fails or API key is not set
     """
     try:
         limit = int(limit)
@@ -672,10 +791,6 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         if is_interrupted():
             return tool_error("Interrupted", success=False)
 
-        # Dispatch through the web search registry. All 7 providers
-        # (brave-free, ddgs, searxng, exa, parallel, tavily, firecrawl)
-        # now live as plugins; the dispatcher is just a registry lookup +
-        # delegation. Sync only — every provider's search() is sync.
         _ensure_web_plugins_loaded()
         from agent.web_search_registry import (
             get_active_search_provider,
@@ -683,18 +798,38 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             _disabled_web_plugin_for,
         )
 
-        backend = _get_search_backend()
-        provider = _wsp_get_provider(backend) if backend else None
-        if provider is None or not provider.supports_search():
-            # Fall back to availability-walked active provider when the
-            # configured backend isn't a registered search provider (typo,
-            # uninstalled plugin, or capability mismatch).
-            provider = get_active_search_provider()
+        # --- Explicit engine requested ---
+        if search_engine and search_engine != "auto":
+            provider = _wsp_get_provider(search_engine)
+            if provider is None:
+                valid = _get_valid_engine_names()
+                return tool_error(
+                    f"Unknown search engine: '{search_engine}'. "
+                    f"Valid values: {', '.join(repr(e) for e in sorted(valid))}"
+                )
+            if not provider.is_available():
+                return tool_error(
+                    f"Search engine '{search_engine}' is not available "
+                    "(missing API key or package)."
+                )
+            logger.info(
+                "Web search via %s (explicit): '%s' (limit: %d)",
+                provider.name, query, limit,
+            )
+            response_data = provider.search(query, limit)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
 
-        if provider is None:
-            # A bundled web plugin the user explicitly disabled looks
-            # identical to "no provider" here — point at the real cause
-            # (re-enable the plugin) rather than a generic setup hint.
+        # --- Auto mode: fallback chain ---
+        chain = _get_fallback_chain()
+        response_data, errors = _search_with_fallback(query, limit, chain)
+
+        if response_data is None:
+            # Check disabled-plugin before generic "no provider" message.
             disabled_key = _disabled_web_plugin_for(capability="search")
             if disabled_key:
                 _vendor = disabled_key.split("/", 1)[-1]
@@ -708,19 +843,16 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                     ),
                 }
             else:
+                summary = "; ".join(errors[-3:]) if errors else "All backends exhausted"
                 response_data = {
                     "success": False,
                     "error": (
-                        "No web search provider configured. "
-                        "Run `hermes tools` to set one up."
+                        f"No web search backend available. Tried: "
+                        f"{', '.join(chain)}. Last errors: {summary}"
                     ),
                 }
-        else:
-            logger.info(
-                "Web search via %s: '%s' (limit: %d)",
-                provider.name, query, limit,
-            )
-            response_data = provider.search(query, limit)
+        elif errors:
+            response_data.setdefault("_fallback_trace", errors)
 
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
@@ -1183,6 +1315,11 @@ WEB_SEARCH_SCHEMA = {
                 "minimum": 1,
                 "maximum": 100,
                 "default": 5
+            },
+            "search_engine": {
+                "type": "string",
+                "description": "Which search engine to use. \"auto\" (default) walks the fallback chain in config. An explicit engine name (e.g. \"baidu\", \"serper\") uses only that engine. Only engines that are currently configured appear in the choices.",
+                "default": "auto"
             }
         },
         "required": ["query"]
@@ -1215,7 +1352,11 @@ registry.register(
     name="web_search",
     toolset="web",
     schema=WEB_SEARCH_SCHEMA,
-    handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=args.get("limit", 5)),
+    handler=lambda args, **kw: web_search_tool(
+        args.get("query", ""),
+        limit=args.get("limit", 5),
+        search_engine=args.get("search_engine", "auto"),
+    ),
     check_fn=check_web_api_key,
     requires_env=_web_requires_env(),
     emoji="🔍",

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -413,6 +413,148 @@ def _is_backend_available(backend: str) -> bool:
     return False
 
 
+def _get_registered_backend_names() -> set[str]:
+    """Return all currently-registered web search backend names.
+
+    Dynamically sourced from the plugin registry so adding a new
+    provider plugin automatically extends the set — no hardcoded list.
+    Used for config value validation in ``check_web_api_key()``.
+    """
+    try:
+        return {p.name for p in _list_registered_web_providers()}
+    except Exception:
+        return set()
+
+
+def _get_valid_engine_names() -> set[str]:
+    """Return the set of usable search engine choices for the model.
+
+    Only providers where ``is_available()`` returns True are included,
+    so the model never sees engines that lack API keys.  ``"auto"`` is
+    always present — it walks the fallback chain.
+    """
+    choices = {"auto"}
+    try:
+        for p in _list_registered_web_providers():
+            try:
+                if p.is_available():
+                    choices.add(p.name)
+            except Exception:
+                pass
+    except Exception:
+        pass
+    return choices
+
+
+def _get_fallback_chain() -> list[str]:
+    """Return an ordered list of backends to try when ``search_engine == "auto"``.
+
+    Priority:
+    1. ``web.search_backend`` / ``web.backend`` — explicit choice (always first)
+    2. ``web.fallback_backends`` — user-configured ordered list
+    3. All other registered providers not already in the chain (alphabetical)
+    """
+    cfg = _load_web_config()
+
+    chain: list[str] = []
+
+    primary = _get_search_backend()
+    if primary and primary not in chain:
+        chain.append(primary)
+
+    user_fbs = cfg.get("fallback_backends", [])
+    if isinstance(user_fbs, str):
+        user_fbs = [b.strip() for b in user_fbs.split(",") if b.strip()]
+    for b in user_fbs:
+        b = b.lower().strip()
+        if b and b not in chain:
+            chain.append(b)
+
+    # Append remaining registered providers (those not already listed).
+    try:
+        for p in _list_registered_web_providers():
+            if p.name not in chain:
+                chain.append(p.name)
+    except Exception:
+        pass
+
+    return chain
+
+
+def _search_with_fallback(
+    query: str,
+    limit: int,
+    chain: list[str],
+) -> tuple[dict | None, list[str], Exception | None]:
+    """Try each backend in *chain* until one succeeds.
+
+    Returns ``(success_result, error_trace, primary_exception)``.  A backend
+    is skipped when it is not found or unavailable (missing key/package) —
+    that is the fallback trigger.  A backend that is alive but *fails* is
+    treated as authoritative: its failure result (or raised exception) is
+    surfaced directly, matching main's single-backend contract, with an
+    optional one-shot keyless rescue when eligible.
+
+    ``success_result`` is ``None`` only when every backend was skipped as
+    unavailable; ``primary_exception`` carries the raw exception raised by
+    the first backend that was tried but failed.
+    """
+    from agent.web_search_registry import get_provider
+
+    errors: list[str] = []
+    primary_exc: Exception | None = None
+    for name in chain:
+        provider = get_provider(name)
+        if provider is None or not provider.supports_search():
+            errors.append(f"{name}: not found or search unsupported")
+            continue
+        if not provider.is_available():
+            errors.append(f"{name}: not available (missing key or package)")
+            continue
+
+        try:
+            result = provider.search(query, limit)
+        except Exception as exc:
+            if primary_exc is None:
+                primary_exc = exc
+            if _rescue_eligible(provider):
+                rescued = _rescue_search(name, str(exc), query, limit)
+                if rescued.get("success"):
+                    return rescued, errors, primary_exc
+                # Ring failed too: surface the ORIGINAL backend error (it
+                # names the user's configured setup) with the note appended.
+                return rescued, errors, primary_exc
+            # A live backend that raises keeps main's behavior: let the
+            # exception bubble to the top-level "Error searching web: ..."
+            # envelope instead of silently falling through the chain.
+            raise
+
+        if not isinstance(result, dict):
+            errors.append(f"{name}: unexpected response type {type(result).__name__}")
+            continue
+        if not result.get("success"):
+            if _rescue_eligible(provider):
+                rescued = _rescue_search(
+                    name, str(result.get("error", "")), query, limit
+                )
+                if rescued.get("success"):
+                    return rescued, errors, primary_exc
+                return rescued, errors, primary_exc
+            # Failure result from a live backend is authoritative (main
+            # contract) — do not fall through to other backends.
+            return result, errors, primary_exc
+        if not len(result.get("data", {}).get("web", [])):
+            # A healthy backend returning zero hits is a valid outcome — the
+            # query simply matched nothing.  Do not treat it as a failure and
+            # fall through to other backends (main contract).
+            return result, errors, primary_exc
+
+        # Success — return immediately
+        return result, errors, primary_exc
+
+    return None, errors, primary_exc
+
+
 def _ddgs_package_importable() -> bool:
     """Return True when the ``ddgs`` Python package can be imported.
 
@@ -835,20 +977,25 @@ def _ensure_web_plugins_loaded() -> None:
         logger.warning("Web plugin discovery failed (non-fatal): %s", exc)
 
 
-def web_search_tool(query: str, limit: int = 5) -> str:
+def web_search_tool(query: str, limit: int = 5, search_engine: str = "auto") -> str:
     """
-    Search the web for information using available search API backend.
+    Search the web for information using available search API backends.
 
     This function provides a generic interface for web search that can work
-    with multiple backends (Parallel or Firecrawl).
+    with multiple backends. When ``search_engine`` is ``"auto"`` (default),
+    backends are tried in order until one succeeds.  An explicit engine name
+    runs that single backend with no fallback.
 
     Note: This function returns search result metadata only (URLs, titles, descriptions).
     Use web_extract_tool to get full content from specific URLs.
-    
+
     Args:
         query (str): The search query to look up
         limit (int): Maximum number of results to return (default: 5)
-    
+        search_engine (str): Which provider to use. ``"auto"`` (default) walks
+            the fallback chain.  Any registered provider name (e.g. ``"baidu"``,
+            ``"serper"``, ``"ddgs"``) runs that single backend.
+
     Returns:
         str: JSON string containing search results with the following structure:
              {
@@ -865,7 +1012,7 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                      ]
                  }
              }
-    
+
     Raises:
         Exception: If search fails or API key is not set
     """
@@ -878,23 +1025,22 @@ def web_search_tool(query: str, limit: int = 5) -> str:
     debug_call_data = {
         "parameters": {
             "query": query,
-            "limit": limit
+            "limit": limit,
+            "search_engine": search_engine,
         },
         "error": None,
         "results_count": 0,
         "original_response_size": 0,
         "final_response_size": 0
     }
-    
+
     try:
         from tools.interrupt import is_interrupted
         if is_interrupted():
             return tool_error("Interrupted", success=False)
 
-        # Dispatch through the web search registry. All 7 providers
-        # (brave-free, ddgs, searxng, exa, parallel, tavily, firecrawl)
-        # now live as plugins; the dispatcher is just a registry lookup +
-        # delegation. Sync only — every provider's search() is sync.
+        # Dispatch through the web search registry. All providers now live
+        # as plugins; the dispatcher is just a registry lookup + delegation.
         _ensure_web_plugins_loaded()
         from agent.web_search_registry import (
             get_active_search_provider,
@@ -902,67 +1048,22 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             _disabled_web_plugin_for,
         )
 
-        backend = _get_search_backend()
-        provider = _wsp_get_provider(backend) if backend else None
-        if provider is None or not provider.supports_search():
-            from tools.tool_backend_helpers import (
-                selection_error,
-                selection_exists,
-            )
-
-            if provider is None and backend and selection_exists("web"):
-                disabled_key = _disabled_web_plugin_for(capability="search")
-                if disabled_key:
-                    _vendor = disabled_key.split("/", 1)[-1]
-                    error_text = (
-                        f"web.search_backend is set to '{_vendor}', but its "
-                        f"plugin ('{disabled_key}') is disabled in config. "
-                        f"Re-enable it with `hermes plugins enable {disabled_key}` "
-                        "(or remove it from plugins.disabled)."
-                    )
-                else:
-                    error_text = selection_error(
-                        "web",
-                        f"'{backend}'",
-                        "no registered web search provider has that name",
-                    )
-                response_data = {"success": False, "error": error_text}
-                result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-                debug_call_data["error"] = error_text
-                _debug.log_call("web_search_tool", debug_call_data)
-                _debug.save()
-                return result_json
-            # Never-configured install: fall back to the availability-walked
-            # active provider (legacy autodetect behavior).
-            provider = get_active_search_provider()
-
-        if provider is None:
-            # A bundled web plugin the user explicitly disabled looks
-            # identical to "no provider" here — point at the real cause
-            # (re-enable the plugin) rather than a generic setup hint.
-            disabled_key = _disabled_web_plugin_for(capability="search")
-            if disabled_key:
-                _vendor = disabled_key.split("/", 1)[-1]
-                response_data = {
-                    "success": False,
-                    "error": (
-                        f"web.search_backend is set to '{_vendor}', but its "
-                        f"plugin ('{disabled_key}') is disabled in config. "
-                        f"Re-enable it with `hermes plugins enable {disabled_key}` "
-                        "(or remove it from plugins.disabled)."
-                    ),
-                }
-            else:
-                response_data = {
-                    "success": False,
-                    "error": (
-                        "No web search provider configured. "
-                        "Run `hermes tools` to set one up."
-                    ),
-                }
-        else:
+        # --- Explicit engine requested ---
+        if search_engine and search_engine != "auto":
+            provider = _wsp_get_provider(search_engine)
+            if provider is None:
+                valid = _get_valid_engine_names()
+                return tool_error(
+                    f"Unknown search engine: '{search_engine}'. "
+                    f"Valid values: {', '.join(repr(e) for e in sorted(valid))}"
+                )
+            if not provider.is_available():
+                return tool_error(
+                    f"Search engine '{search_engine}' is not available "
+                    "(missing API key or package)."
+                )
             logger.info(
-                "Web search via %s: '%s' (limit: %d)",
+                "Web search via %s (explicit): '%s' (limit: %d)",
                 provider.name, query, limit,
             )
             try:
@@ -987,6 +1088,43 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                         query,
                         limit,
                     )
+        else:
+            # --- Auto mode: walk the fallback chain ---
+            chain = _get_fallback_chain()
+            response_data, errors, primary_exc = _search_with_fallback(query, limit, chain)
+
+            if response_data is None:
+                # All backends failed. Keep main's public error envelope
+                # (tool_error shape, no internal diagnostics); the trial
+                # trace stays in the log for debugging.
+                disabled_key = _disabled_web_plugin_for(capability="search")
+                if disabled_key:
+                    _vendor = disabled_key.split("/", 1)[-1]
+                    error_text = (
+                        f"web.search_backend is set to '{_vendor}', but its "
+                        f"plugin ('{disabled_key}') is disabled in config. "
+                        f"Re-enable it with `hermes plugins enable {disabled_key}` "
+                        "(or remove it from plugins.disabled)."
+                    )
+                elif primary_exc is not None:
+                    # The configured primary backend itself raised — surface
+                    # its original message (main's single-backend contract)
+                    # rather than a generic setup hint.
+                    raise primary_exc
+                else:
+                    error_text = (
+                        "No web search backend available. Set a provider API "
+                        "key (e.g. FIRECRAWL_API_KEY) or run `hermes tools`."
+                    )
+                # Re-raise so the top-level handler wraps this into the
+                # standard "Error searching web: ..." envelope, keeping the
+                # public error string free of per-backend diagnostics.
+                logger.debug(
+                    "Web search fallback chain exhausted: %s", "; ".join(errors)
+                )
+                raise RuntimeError(error_text)
+            elif errors:
+                response_data.setdefault("_fallback_trace", errors)
 
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
@@ -1545,6 +1683,12 @@ WEB_SEARCH_SCHEMA = {
                 "minimum": 1,
                 "maximum": 100,
                 "default": 5
+            },
+            "search_engine": {
+                "type": "string",
+                "description": "Which search engine to use. \"auto\" (default) walks the fallback chain in config. An explicit engine name (e.g. \"baidu\", \"serper\") uses only that engine. Only engines that are currently configured appear in the choices.",
+                "enum": sorted(_get_valid_engine_names()),
+                "default": "auto"
             }
         },
         "required": ["query"]
@@ -1573,11 +1717,24 @@ WEB_EXTRACT_SCHEMA = {
     }
 }
 
+def _web_search_handler(args: dict) -> str:
+    """Registry handler for ``web_search``.
+
+    Forwards ``search_engine`` only when the model supplied it, so callers
+    that omit it keep the exact ``web_search_tool(query, limit=...)`` call
+    signature (contract asserted by the tool-config unit tests).
+    """
+    kwargs: dict = {"limit": args.get("limit", 5)}
+    if "search_engine" in args:
+        kwargs["search_engine"] = args["search_engine"]
+    return web_search_tool(args.get("query", ""), **kwargs)
+
+
 registry.register(
     name="web_search",
     toolset="web",
     schema=WEB_SEARCH_SCHEMA,
-    handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=args.get("limit", 5)),
+    handler=_web_search_handler,
     check_fn=check_web_api_key,
     requires_env=_web_requires_env(),
     emoji="🔍",

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -509,8 +509,21 @@ def _search_with_fallback(
             errors.append(f"{name}: not found or search unsupported")
             continue
         if not provider.is_available():
-            errors.append(f"{name}: not available (missing key or package)")
-            continue
+            # A missing key is a fallback trigger — unless the provider can
+            # serve the request without one via the keyless free tier
+            # (e.g. Tavily in keyless mode).  main's dispatcher does not
+            # gate the configured backend on is_available() for this reason;
+            # the provider's own search() routes through the ring.
+            keyless_ok = False
+            is_keyless = getattr(provider, "is_keyless_available", None)
+            if callable(is_keyless):
+                try:
+                    keyless_ok = bool(is_keyless())
+                except Exception:  # noqa: BLE001 — broken provider == not ready
+                    keyless_ok = False
+            if not keyless_ok:
+                errors.append(f"{name}: not available (missing key or package)")
+                continue
 
         try:
             result = provider.search(query, limit)


### PR DESCRIPTION
## What does this PR do?

When a search provider fails, Hermes previously returned an error immediately — no retry with another backend. This adds a configurable fallback chain and a `search_engine` parameter so the model picks engines and Hermes retries when the configured backend is unavailable. Works with all currently-registered backends and auto-extends to new providers.

Rebased onto current `main` and updated for the keyless-rescue mechanism landed in the meantime.

## Related Issue

Follows the intent of #35690 (closed without review) and extends it with dynamic engine names from the registry.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `web_search_tool(query, limit, search_engine="auto")` — new `search_engine` parameter; `"auto"` walks the fallback chain, explicit names run a single backend with no fallback
- `_get_fallback_chain()` — seeds from `_get_search_backend()` (per-capability `web.search_backend` override), then `web.fallback_backends` from config (user-ordered), then remaining registered providers
- `_search_with_fallback()` — skips backends that are unregistered or unavailable (missing key/package); a *live* backend that returns a failure result or raises stays authoritative (main's single-backend contract) with the one-shot keyless rescue integrated on both the explicit and auto paths
- Error envelope: when every backend is unavailable, the call raises through the top-level handler → `{"error": "Error searching web: ..."}` with a setup hint (e.g. `FIRECRAWL_API_KEY`). Per-backend diagnostics never leak into the public error string — they stay in the log and the model-facing `_fallback_trace`
- `WEB_SEARCH_SCHEMA` — `search_engine` property with `enum` built dynamically from `_get_valid_engine_names()` (currently-available providers + `"auto"`); registry handler forwards it only when supplied
- `_get_registered_backend_names()` / `_get_valid_engine_names()` — dynamically sourced from the plugin registry, no hardcoded lists
- `tools/code_execution_tool.py` — `web_search` sandbox stub synced with the new `search_engine` parameter

### Tests
- `tests/tools/test_web_fallback_chain.py` — behavior tests for chain ordering, first-success return, skip-unavailable, authoritative-failure semantics, engine-name sets (deterministic rescue-off fixture)
- All previously-red CI checks (error envelope, limit clamp, handler wiring, schema drift, keyless rescue) now pass locally: 195 tests green

## How to Test

1. Set `BRAVE_SEARCH_API_KEY`
2. Configure `web.fallback_backends: [brave-free, ddgs]` in config.yaml
3. Call `web_search` → should use brave-free
4. Unset `BRAVE_SEARCH_API_KEY` and `pip install ddgs` → should fall back to ddgs
5. Call `web_search` with `search_engine: "ddgs"` → pinned to ddgs only
6. With every backend unconfigured, the call returns `{"error": "Error searching web: No web search backend available. Set a provider API key (e.g. FIRECRAWL_API_KEY) or run \`hermes tools\`."}`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (#35690)
- [x] My PR contains only changes related to this feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (`tests/tools/test_web_fallback_chain.py`)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping