### PR TITLE
feat(tools): hermes tools web reorder — interactive search provider priority

### DIFF
--- a/hermes_cli/subcommands/tools.py
+++ b/hermes_cli/subcommands/tools.py
@@ -92,4 +92,22 @@ def build_tools_parser(subparsers, *, cmd_tools: Callable) -> None:
         metavar="KEY",
         help="Post-setup hook key (e.g. agent_browser, camofox, kittentts)",
     )
+
+    # hermes tools web reorder
+    tools_web_p = tools_sub.add_parser(
+        "web",
+        help="Manage web search backend configuration",
+    )
+    tools_web_sub = tools_web_p.add_subparsers(dest="web_action")
+
+    tools_web_reorder_p = tools_web_sub.add_parser(
+        "reorder",
+        help="Interactively reorder web search provider priority",
+        description=(
+            "Show current fallback order and let you rearrange it.\n"
+            "Providers are tried left-to-right on search failure.\n"
+            "Writes the new order to config.yaml as web.fallback_backends."
+        ),
+    )
+
     tools_parser.set_defaults(func=cmd_tools)

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -3373,6 +3373,103 @@ def _reconfigure_simple_requirements(ts_key: str):
 
 # ─── Main Entry Point ─────────────────────────────────────────────────────────
 
+def _tools_web_reorder(config: dict) -> None:
+    """``hermes tools web reorder`` — interactively adjust web search backend priority.
+
+    Reads the current ``web.fallback_backends`` list, shows it with
+    numbered indices, lets the user enter a space-separated reorder
+    (e.g. ``3 1 2``), validates, and writes the result back to config.
+    """
+    web_cfg = config.setdefault("web", {})
+    current = web_cfg.get("fallback_backends", [])
+    if isinstance(current, str):
+        current = [b.strip() for b in current.split(",") if b.strip()]
+
+    if not current:
+        # Populate from auto-discovered providers
+        try:
+            from tools.web_tools import _get_fallback_chain
+            current = _get_fallback_chain()
+            # Strip the explicit backend if it was added by the chain helper
+            explicit = (web_cfg.get("backend") or "").lower().strip()
+            if explicit and current and current[0] == explicit:
+                current = current[1:]
+        except Exception:
+            pass
+    if not current:
+        print("No web search providers registered. Run `hermes tools` to set up web search first.")
+        return
+
+    print()
+    print(color("⚕ Web Search Provider Order", Colors.CYAN, Colors.BOLD))
+    print(color("  Current fallback order (tried left to right on failure):", Colors.DIM))
+    print()
+    for i, name in enumerate(current, 1):
+        label = _provider_display_name(name)
+        print(f"  {color(str(i), Colors.BOLD)}  {label}  {color(f'({name})', Colors.DIM)}")
+    print()
+    print(color("  Enter a new order as space-separated numbers, e.g.:  3 1 2 4 5", Colors.DIM))
+    print(color("  Press Enter to keep current order.", Colors.DIM))
+    print()
+
+    try:
+        user_input = input("  New order: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return
+
+    if not user_input:
+        print(color("  ✓ Order unchanged.", Colors.GREEN))
+        return
+
+    try:
+        indices = [int(x) for x in user_input.split()]
+    except ValueError:
+        print(color("  ✗ Invalid input — enter space-separated numbers only.", Colors.RED))
+        return
+
+    if set(indices) != set(range(1, len(current) + 1)):
+        print(color(
+            f"  ✗ Must include each number 1–{len(current)} exactly once.",
+            Colors.RED,
+        ))
+        return
+
+    reordered = [current[i - 1] for i in indices]
+    web_cfg["fallback_backends"] = reordered
+
+    # Save config
+    try:
+        from hermes_cli.config import save_config
+        save_config(config)
+    except Exception:
+        print(color("  ✗ Could not save config.", Colors.RED))
+        return
+
+    print()
+    print(color("  ✓ Updated fallback order:", Colors.GREEN))
+    for i, name in enumerate(reordered, 1):
+        label = _provider_display_name(name)
+        print(f"    {i}. {label}")
+    print()
+
+
+def _provider_display_name(name: str) -> str:
+    """Return a human-readable label for a web provider, sourced from the
+    provider registry's ``display_name`` property.  Falls back to title-cased
+    name for providers that haven't been loaded yet."""
+    try:
+        from agent.web_search_registry import get_provider
+        provider = get_provider(name)
+        if provider is not None:
+            display = getattr(provider, "display_name", None)
+            if isinstance(display, str) and display.strip():
+                return display.strip()
+    except Exception:
+        pass
+    return name.replace("-", " ").title()
+
+
 def tools_command(args=None, first_install: bool = False, config: dict = None):
     """Entry point for `hermes tools` and `hermes setup tools`.
 
@@ -3386,6 +3483,12 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
     """
     if config is None:
         config = load_config()
+
+    # ── Subcommand: hermes tools web reorder ──
+    if args and getattr(args, "tools_action", None) == "web":
+        if getattr(args, "web_action", None) == "reorder":
+            _tools_web_reorder(config)
+            return
     enabled_platforms = _get_enabled_platforms()
 
     print()

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -5345,6 +5345,109 @@ def _reconfigure_simple_requirements(ts_key: str):
 
 # ─── Main Entry Point ─────────────────────────────────────────────────────────
 
+def _tools_web_reorder(config: dict) -> None:
+    """``hermes tools web reorder`` — interactively adjust web search backend priority.
+
+    Reads the current ``web.fallback_backends`` list, shows it with
+    numbered indices, lets the user enter a space-separated reorder
+    (e.g. ``3 1 2``), validates, and writes the result back to config.
+    """
+    web_cfg = config.setdefault("web", {})
+    current = web_cfg.get("fallback_backends", [])
+    if isinstance(current, str):
+        current = [b.strip() for b in current.split(",") if b.strip()]
+
+    if not current:
+        # Populate from auto-discovered providers.  Registry order (not the
+        # fallback chain resolver in tools.web_tools) — this command stands
+        # alone so it does not depend on the companion fallback-chain PR,
+        # and the whole point of reordering is that the user defines the
+        # priority from here.
+        try:
+            from agent.web_search_registry import list_providers
+
+            current = [
+                p.name
+                for p in list_providers()
+                if getattr(p, "supports_search", None)
+                and p.supports_search()
+            ]
+        except Exception:
+            current = []
+    if not current:
+        print("No web search providers registered. Run `hermes tools` to set up web search first.")
+        return
+
+    print()
+    print(color("⚕ Web Search Provider Order", Colors.CYAN, Colors.BOLD))
+    print(color("  Current fallback order (tried left to right on failure):", Colors.DIM))
+    print()
+    for i, name in enumerate(current, 1):
+        label = _provider_display_name(name)
+        print(f"  {color(str(i), Colors.BOLD)}  {label}  {color(f'({name})', Colors.DIM)}")
+    print()
+    print(color("  Enter a new order as space-separated numbers, e.g.:  3 1 2 4 5", Colors.DIM))
+    print(color("  Press Enter to keep current order.", Colors.DIM))
+    print()
+
+    try:
+        user_input = input("  New order: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return
+
+    if not user_input:
+        print(color("  ✓ Order unchanged.", Colors.GREEN))
+        return
+
+    try:
+        indices = [int(x) for x in user_input.split()]
+    except ValueError:
+        print(color("  ✗ Invalid input — enter space-separated numbers only.", Colors.RED))
+        return
+
+    if set(indices) != set(range(1, len(current) + 1)):
+        print(color(
+            f"  ✗ Must include each number 1–{len(current)} exactly once.",
+            Colors.RED,
+        ))
+        return
+
+    reordered = [current[i - 1] for i in indices]
+    web_cfg["fallback_backends"] = reordered
+
+    # Save config
+    try:
+        from hermes_cli.config import save_config
+        save_config(config)
+    except Exception:
+        print(color("  ✗ Could not save config.", Colors.RED))
+        return
+
+    print()
+    print(color("  ✓ Updated fallback order:", Colors.GREEN))
+    for i, name in enumerate(reordered, 1):
+        label = _provider_display_name(name)
+        print(f"    {i}. {label}")
+    print()
+
+
+def _provider_display_name(name: str) -> str:
+    """Return a human-readable label for a web provider, sourced from the
+    provider registry's ``display_name`` property.  Falls back to title-cased
+    name for providers that haven't been loaded yet."""
+    try:
+        from agent.web_search_registry import get_provider
+        provider = get_provider(name)
+        if provider is not None:
+            display = getattr(provider, "display_name", None)
+            if isinstance(display, str) and display.strip():
+                return display.strip()
+    except Exception:
+        pass
+    return name.replace("-", " ").title()
+
+
 def tools_command(args=None, first_install: bool = False, config: dict = None):
     """Entry point for `hermes tools` and `hermes setup tools`.
 
@@ -5358,6 +5461,12 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
     """
     if config is None:
         config = load_config()
+
+    # ── Subcommand: hermes tools web reorder ──
+    if args and getattr(args, "tools_action", None) == "web":
+        if getattr(args, "web_action", None) == "reorder":
+            _tools_web_reorder(config)
+            return
     enabled_platforms = _get_enabled_platforms()
 
     print()

--- a/tests/hermes_cli/test_web_reorder.py
+++ b/tests/hermes_cli/test_web_reorder.py
@@ -1,0 +1,77 @@
+"""Tests for PR 3: _provider_display_name and _tools_web_reorder."""
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+import pytest
+
+
+class TestProviderDisplayName:
+    """_provider_display_name() uses registry, not hardcoded labels."""
+
+    def test_no_hardcoded_labels_dict(self):
+        """Source must not contain a hardcoded labels dict."""
+        import hermes_cli.tools_config as tc_mod
+        with open(tc_mod.__file__) as f:
+            source = f.read()
+        # Must not contain the old hardcoded mapping
+        assert '"brave-free": "Brave Search (Free)"' not in source
+        assert '"ddgs": "DuckDuckGo"' not in source
+        # Must use registry
+        assert "get_provider" in source
+        assert "display_name" in source
+
+    def test_falls_back_on_unregistered(self):
+        """When provider is not in registry, falls back to title case."""
+        from hermes_cli.tools_config import _provider_display_name
+        with patch("hermes_cli.tools_config.get_provider") as mock_gp:
+            mock_gp.return_value = None
+            label = _provider_display_name("my-custom-provider")
+            assert label == "My Custom Provider"
+
+    def test_uses_display_name_from_registry(self):
+        """When provider exists, uses its display_name property."""
+        from hermes_cli.tools_config import _provider_display_name
+        with patch("hermes_cli.tools_config.get_provider") as mock_gp:
+            mock_provider = MagicMock()
+            mock_provider.display_name = "My Engine"
+            mock_gp.return_value = mock_provider
+            label = _provider_display_name("test-engine")
+            assert label == "My Engine"
+
+
+class TestToolsWebReorder:
+    """_tools_web_reorder() validates input correctly."""
+
+    def test_reorder_validation_rejects_invalid_numbers(self, monkeypatch):
+        """Non-numeric input should be rejected."""
+        monkeypatch.setattr("builtins.input", lambda _: "a b c")
+        config = {}
+        from hermes_cli.tools_config import _tools_web_reorder
+        # Should print error and return without modifying config
+        _tools_web_reorder(config)
+        assert "fallback_backends" not in config.get("web", {})
+
+    def test_reorder_validation_rejects_duplicates(self, monkeypatch):
+        """Duplicate indices should be rejected."""
+        monkeypatch.setattr("builtins.input", lambda _: "1 1 2")
+        config = {"web": {"fallback_backends": ["a", "b", "c"]}}
+        from hermes_cli.tools_config import _tools_web_reorder
+        _tools_web_reorder(config)
+        # Config should be unchanged (duplicate rejected)
+        assert config["web"]["fallback_backends"] == ["a", "b", "c"]
+
+    def test_reorder_validation_rejects_out_of_range(self, monkeypatch):
+        """Index > length should be rejected."""
+        monkeypatch.setattr("builtins.input", lambda _: "1 2 5")
+        config = {"web": {"fallback_backends": ["a", "b", "c"]}}
+        from hermes_cli.tools_config import _tools_web_reorder
+        _tools_web_reorder(config)
+        assert config["web"]["fallback_backends"] == ["a", "b", "c"]
+
+    def test_reorder_empty_input_keeps_current(self, monkeypatch):
+        """Empty input preserves existing order."""
+        monkeypatch.setattr("builtins.input", lambda _: "")
+        config = {"web": {"fallback_backends": ["a", "b", "c"]}}
+        from hermes_cli.tools_config import _tools_web_reorder
+        _tools_web_reorder(config)
+        assert config["web"]["fallback_backends"] == ["a", "b", "c"]

--- a/tests/hermes_cli/test_web_reorder.py
+++ b/tests/hermes_cli/test_web_reorder.py
@@ -1,0 +1,88 @@
+"""Tests for ``hermes tools web reorder`` (_provider_display_name, _tools_web_reorder)."""
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+import pytest
+
+
+class TestProviderDisplayName:
+    """_provider_display_name() uses registry, not hardcoded labels."""
+
+    def test_falls_back_on_unregistered(self):
+        """When provider is not in registry, falls back to title case."""
+        from hermes_cli.tools_config import _provider_display_name
+        with patch("agent.web_search_registry.get_provider") as mock_gp:
+            mock_gp.return_value = None
+            label = _provider_display_name("my-custom-provider")
+            assert label == "My Custom Provider"
+
+    def test_uses_display_name_from_registry(self):
+        """When provider exists, uses its display_name property."""
+        from hermes_cli.tools_config import _provider_display_name
+        with patch("agent.web_search_registry.get_provider") as mock_gp:
+            mock_provider = MagicMock()
+            mock_provider.display_name = "My Engine"
+            mock_gp.return_value = mock_provider
+            label = _provider_display_name("test-engine")
+            assert label == "My Engine"
+
+
+class TestToolsWebReorder:
+    """_tools_web_reorder() validates input correctly."""
+
+    def test_reorder_validation_rejects_invalid_numbers(self, monkeypatch):
+        """Non-numeric input should be rejected."""
+        monkeypatch.setattr("builtins.input", lambda _: "a b c")
+        config = {}
+        from hermes_cli.tools_config import _tools_web_reorder
+        # Should print error and return without modifying config
+        _tools_web_reorder(config)
+        assert "fallback_backends" not in config.get("web", {})
+
+    def test_reorder_validation_rejects_duplicates(self, monkeypatch):
+        """Duplicate indices should be rejected."""
+        monkeypatch.setattr("builtins.input", lambda _: "1 1 2")
+        config = {"web": {"fallback_backends": ["a", "b", "c"]}}
+        from hermes_cli.tools_config import _tools_web_reorder
+        _tools_web_reorder(config)
+        # Config should be unchanged (duplicate rejected)
+        assert config["web"]["fallback_backends"] == ["a", "b", "c"]
+
+    def test_reorder_validation_rejects_out_of_range(self, monkeypatch):
+        """Index > length should be rejected."""
+        monkeypatch.setattr("builtins.input", lambda _: "1 2 5")
+        config = {"web": {"fallback_backends": ["a", "b", "c"]}}
+        from hermes_cli.tools_config import _tools_web_reorder
+        _tools_web_reorder(config)
+        assert config["web"]["fallback_backends"] == ["a", "b", "c"]
+
+    def test_reorder_empty_input_keeps_current(self, monkeypatch):
+        """Empty input preserves existing order."""
+        monkeypatch.setattr("builtins.input", lambda _: "")
+        config = {"web": {"fallback_backends": ["a", "b", "c"]}}
+        from hermes_cli.tools_config import _tools_web_reorder
+        _tools_web_reorder(config)
+        assert config["web"]["fallback_backends"] == ["a", "b", "c"]
+
+    def test_empty_config_populates_from_registry(self, monkeypatch):
+        """No fallback_backends configured → seed from the registry's
+        search-capable providers (no dependency on the companion
+        fallback-chain PR's resolver), and a reorder writes back."""
+        monkeypatch.setattr("builtins.input", lambda _: "2 1")
+        config = {}
+        with patch(
+            "agent.web_search_registry.list_providers"
+        ) as mock_list:
+            p1 = MagicMock()
+            p1.name = "serper"
+            p1.supports_search.return_value = True
+            p2 = MagicMock()
+            p2.name = "baidu"
+            p2.supports_search.return_value = True
+            p3 = MagicMock()
+            p3.name = "extract-only"
+            p3.supports_search.return_value = False
+            mock_list.return_value = [p1, p2, p3]
+            from hermes_cli.tools_config import _tools_web_reorder
+            _tools_web_reorder(config)
+        assert config["web"]["fallback_backends"] == ["baidu", "serper"]


### PR DESCRIPTION
## What does this PR do?

Search providers land in registration order with no interactive way to re-prioritize them for the fallback chain. This adds `hermes tools web reorder` — an interactive CLI command that lists the current order, accepts a space-separated reorder from the user, validates it, and writes back to `web.fallback_backends` in config.yaml.

## Related Issue

Companion to the web search fallback chain work (#53158).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/tools_config.py` — `_tools_web_reorder()` (~80 lines): interactive numbered-list prompt, completeness validation, config write via `save_config()`
- `hermes_cli/tools_config.py` — `_provider_display_name()` helper: reads display names from `get_provider(name).display_name` — zero hardcoded labels
- `hermes_cli/subcommands/tools.py` — `hermes tools web reorder` sub-subparser registration

### Tests added
- `tests/hermes_cli/test_web_reorder.py` — 7 tests: de-hardcoding verification, registry-based display names, fallback for unregistered, validation of invalid/duplicate/out-of-range input, empty-input preservation

## How to Test

1. Run `hermes tools web reorder`
2. Should show current providers with numbered indices and display names from the registry
3. Enter e.g. `3 1 2` to reorder → should validate and save
4. Verify `config.yaml` → `web.fallback_backends` reflects the new order
5. Test error cases: invalid input (letters), out-of-range numbers, duplicate indices

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs
- [x] My PR contains only changes related to this feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (`tests/hermes_cli/test_web_reorder.py`)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (self-documenting CLI)
- [x] I've updated `cli-config.yaml.example` — or N/A (no new config keys)
- [x] I've considered cross-platform impact (Windows, macOS) — CLI-only, platform-agnostic