### PR TITLE
fix(compression): prevent infinite loop when aux model context < session size

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -638,6 +638,8 @@ class ContextCompressor(ContextEngine):
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
         self._summary_failure_cooldown_until = 0.0  # transient errors must not block a fresh session
+        self._post_compression_rough_tokens = 0
+        self._aux_context_overflow_warned = False
         self.last_real_prompt_tokens = 0
         self.last_compression_rough_tokens = 0
         self.last_rough_tokens_when_real_prompt_fit = 0
@@ -713,6 +715,8 @@ class ContextCompressor(ContextEngine):
         self.last_compression_rough_tokens = 0
         self.awaiting_real_usage_after_compression = False
         self._ineffective_compression_count = 0
+        self._post_compression_rough_tokens = 0
+        self._aux_context_overflow_warned = False
 
     # When the MINIMUM_CONTEXT_LENGTH floor meets/exceeds a small context
     # window, compacting at the percentage (50% → 32K of a 64K window) wastes
@@ -869,6 +873,19 @@ class ContextCompressor(ContextEngine):
         # Anti-thrashing: track whether last compression was effective
         self._last_compression_savings_pct: float = 100.0
         self._ineffective_compression_count: int = 0
+        # Aux compression model's context length, set by
+        # check_compression_model_feasibility().  When the session exceeds
+        # this, compress() proactively falls back to the main model instead
+        # of sending content the aux model cannot process.  (#53008)
+        self._aux_compression_context_length: int = 0
+        self._aux_context_overflow_warned: bool = False
+        # Rough token estimate immediately after the last compression pass.
+        # should_compress() uses this to avoid re-triggering when the last
+        # pass left the session at or above the threshold — the compression
+        # model may be too small to reduce the session below the (possibly
+        # auto-lowered) threshold, so re-triggering every turn loops
+        # indefinitely with near-zero effectiveness. (#53008)
+        self._post_compression_rough_tokens: int = 0
         self._summary_failure_cooldown_until: float = 0.0
         self._last_summary_error: Optional[str] = None
         # When summary generation fails and a static fallback is inserted,
@@ -967,6 +984,14 @@ class ContextCompressor(ContextEngine):
         Includes anti-thrashing protection: if the last two compressions
         each saved less than 10%, skip compression to avoid infinite loops
         where each pass removes only 1-2 messages.
+
+        Also includes a post-compression re-trigger guard (#53008): if the
+        last compression pass left the session at or above the threshold,
+        do not re-trigger until enough new content arrives.  This prevents
+        an infinite loop when the compression model's context is smaller
+        than the session — the aux model cannot summarise content larger
+        than its own context, so each pass is near-zero effective but the
+        session remains above the (possibly auto-lowered) threshold.
         """
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
         if tokens < self.threshold_tokens:
@@ -981,6 +1006,27 @@ class ContextCompressor(ContextEngine):
                     self._ineffective_compression_count,
                 )
             return False
+        # Post-compression re-trigger guard (#53008): if the last pass left
+        # the session at or above the threshold, the compression model could
+        # not reduce it enough (e.g. the aux model's context is smaller than
+        # the session).  Re-triggering immediately would loop with near-zero
+        # effectiveness.  Wait until at least 20% of the threshold in new
+        # content arrives before attempting another pass.
+        _post = self._post_compression_rough_tokens
+        if _post > 0 and _post >= self.threshold_tokens:
+            _growth = tokens - _post
+            _growth_floor = max(self.threshold_tokens // 5, 4096)
+            if _growth < _growth_floor:
+                if not self.quiet_mode:
+                    logger.warning(
+                        "Compression skipped — last pass left ~%d tokens "
+                        "(>= threshold %d) with only ~%d new tokens since. "
+                        "The compression model may be too small for this "
+                        "session; consider /new, /compress <topic>, or a "
+                        "larger compression model.",
+                        _post, self.threshold_tokens, _growth,
+                    )
+                return False
         return True
 
     # ------------------------------------------------------------------
@@ -2443,6 +2489,9 @@ This compaction should PRIORITISE preserving all information related to the focu
             # re-triggers a no-op compression loop.  (#40803)
             self._ineffective_compression_count += 1
             self._last_compression_savings_pct = 0.0
+            # Record the post-compression estimate (unchanged) so the
+            # re-trigger guard in should_compress() also fires. (#53008)
+            self._post_compression_rough_tokens = int(display_tokens)
             if not self.quiet_mode:
                 logger.warning(
                     "Compression skipped: compress_start (%d) >= compress_end (%d) "
@@ -2503,7 +2552,49 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         # Phase 3: Generate structured summary
         summary_focus_topic = focus_topic or self._derive_auto_focus_topic(messages)
+
+        # Proactive main-model fallback (#53008): if the compression window
+        # (the middle turns sent to the summariser) exceeds the aux model's
+        # context window, the aux model cannot process it — the API call
+        # will either error out (context too long) or be silently truncated
+        # to a near-useless summary.  Fall back to the main model for this
+        # pass instead.  The aux model is restored afterwards so future
+        # passes (on a smaller post-compression session) can use it again.
+        #
+        # We compare the actual window size (turns_to_summarize), NOT the
+        # full session — the tail (protected recent messages) and head
+        # (system prompt + first exchange) are never sent to the summariser,
+        # so a session can be larger than the aux context while the window
+        # still fits.
+        _window_tokens = estimate_messages_tokens_rough(turns_to_summarize)
+        _saved_summary_model = ""
+        if (
+            self._aux_compression_context_length > 0
+            and _window_tokens > self._aux_compression_context_length
+            and self.summary_model
+        ):
+            _saved_summary_model = self.summary_model
+            self.summary_model = ""
+            if not self._aux_context_overflow_warned:
+                self._aux_context_overflow_warned = True
+                if not self.quiet_mode:
+                    logger.warning(
+                        "Compression window (~%d tokens) exceeds the "
+                        "auxiliary compression model's context window "
+                        "(%d tokens) — using the main model for this "
+                        "compression pass. Consider a larger compression "
+                        "model or /new to start a fresh session.",
+                        _window_tokens,
+                        self._aux_compression_context_length,
+                    )
+
         summary = self._generate_summary(turns_to_summarize, focus_topic=summary_focus_topic)
+
+        # Restore the aux summary model for future passes — after
+        # compression the session may be small enough for the aux model
+        # again. (#53008)
+        if _saved_summary_model:
+            self.summary_model = _saved_summary_model
 
         # If summary generation failed, behavior splits on
         # ``abort_on_summary_failure`` (config: compression.abort_on_summary_failure):
@@ -2536,6 +2627,9 @@ This compaction should PRIORITISE preserving all information related to the focu
             self._last_summary_dropped_count = 0  # nothing actually dropped
             self._last_summary_fallback_used = False
             self._last_compress_aborted = True
+            # Record the post-compression estimate (unchanged — session
+            # was preserved) so the re-trigger guard fires. (#53008)
+            self._post_compression_rough_tokens = int(display_tokens)
             if not self.quiet_mode:
                 if self._last_summary_auth_failure:
                     logger.warning(
@@ -2669,6 +2763,12 @@ This compaction should PRIORITISE preserving all information related to the focu
             self._ineffective_compression_count += 1
         else:
             self._ineffective_compression_count = 0
+
+        # Record the post-compression rough estimate so should_compress()
+        # can avoid re-triggering when this pass left the session at or
+        # above the threshold (the compression model may be too small).
+        # (#53008)
+        self._post_compression_rough_tokens = new_estimate
 
         if not self.quiet_mode:
             logger.info(

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -165,6 +165,12 @@ def check_compression_model_feasibility(agent: Any) -> None:
             custom_providers=agent._custom_providers,
         )
 
+        # Store the aux model's context length so compress() can proactively
+        # fall back to the main model when the session exceeds it — the aux
+        # model cannot summarise content larger than its own context window.
+        # (#53008)
+        agent.context_compressor._aux_compression_context_length = aux_context or 0
+
         # Hard floor: the auxiliary compression model must have at least
         # MINIMUM_CONTEXT_LENGTH (64K) tokens of context.  The main model
         # is already required to meet this floor (checked earlier in
@@ -239,6 +245,10 @@ def check_compression_model_feasibility(agent: Any) -> None:
                 f"{old_threshold:,} tokens. "
                 f"Auto-lowered this session's threshold to "
                 f"{new_threshold:,} tokens so compression can run.\n"
+                f"  If the compression window (middle turns sent to the "
+                f"summariser) grows beyond {aux_context:,} tokens, the "
+                f"compression model cannot process it — Hermes will "
+                f"automatically use the main model for those passes instead.\n"
                 f"  To make this permanent, edit config.yaml — either:\n"
                 f"  1. Use a larger compression model:\n"
                 f"       auxiliary:\n"

--- a/tests/agent/test_compression_retrigger_guard.py
+++ b/tests/agent/test_compression_retrigger_guard.py
@@ -1,0 +1,536 @@
+"""Tests for the compression infinite-loop fix (#53008).
+
+When the auxiliary compression model's context window is smaller than the
+main model's compression threshold, ``check_compression_model_feasibility``
+auto-lowers ``threshold_tokens`` to the aux model's context size.  If the
+compression window (the middle turns sent to the summariser) then grows
+beyond the aux model's context, the aux model cannot process it — the API
+call errors out or is silently truncated, producing a near-useless summary.
+Each pass is near-zero effective but the session remains above the threshold,
+looping indefinitely (the reporter observed 12–16 consecutive compressions).
+
+Two-layer fix:
+
+1. **Proactive main-model fallback** (root fix): ``compress()`` estimates
+   the token count of ``turns_to_summarize`` (the actual content sent to
+   the summariser) and compares it with ``_aux_compression_context_length``.
+   When the window exceeds the aux model's context, the aux model is
+   temporarily swapped out for the main model for that pass.  The main
+   model has enough context to summarise effectively, breaking the loop
+   at the root.  The aux model is restored afterwards so future passes
+   (on a smaller post-compression session) can use it again.
+
+2. **Post-compression re-trigger guard** (safety net): ``should_compress()``
+   records ``_post_compression_rough_tokens`` after every pass.  If the last
+   pass left the session at or above the threshold AND not enough new content
+   has arrived, compression is skipped.  This catches edge cases where even
+   the main model cannot reduce the session below the threshold.
+"""
+
+from unittest.mock import patch
+
+from agent.context_compressor import ContextCompressor, estimate_messages_tokens_rough
+
+
+def _make_compressor(**kwargs) -> ContextCompressor:
+    defaults = dict(
+        model="test-model",
+        threshold_percent=0.50,
+        protect_first_n=2,
+        protect_last_n=3,
+        quiet_mode=True,
+    )
+    defaults.update(kwargs)
+    with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+        return ContextCompressor(**defaults)
+
+
+def _build_session(n_turns: int, chars_per_msg: int = 200) -> list:
+    """Build a multi-turn conversation with controllable size."""
+    base = " ".join(["x"] * chars_per_msg)
+    messages = [{"role": "system", "content": "You are helpful."}]
+    for i in range(n_turns):
+        messages.append({"role": "user", "content": f"{base} turn {i}"})
+        messages.append({"role": "assistant", "content": f"{base} reply {i}"})
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: proactive main-model fallback in compress()
+# ---------------------------------------------------------------------------
+
+
+class TestProactiveMainModelFallback:
+    """compress() falls back to the main model when the compression window
+    (middle turns sent to the summariser) exceeds the aux model's context."""
+
+    def test_falls_back_when_window_exceeds_aux_context(self):
+        """When the compression window > _aux_compression_context_length,
+        compress() temporarily clears summary_model so _generate_summary
+        uses the main model."""
+        comp = _make_compressor()
+        comp.summary_model = "aux-small-model"
+        # Set aux context very low so even a small window exceeds it
+        comp._aux_compression_context_length = 500
+
+        messages = _build_session(30, chars_per_msg=200)
+
+        captured_summary_model = []
+
+        def _capture_summary(*args, **kwargs):
+            captured_summary_model.append(comp.summary_model)
+            return "Summary of conversation."
+
+        with patch.object(comp, "_generate_summary", side_effect=_capture_summary):
+            comp.compress(messages, current_tokens=50_000)
+
+        assert captured_summary_model == [""], (
+            "summary_model should be empty (main model) during _generate_summary "
+            f"when window > aux_context, got {captured_summary_model}"
+        )
+
+    def test_restores_aux_model_after_fallback(self):
+        """After the proactive fallback pass, summary_model is restored so
+        future passes (on a smaller session) can use the aux model again."""
+        comp = _make_compressor()
+        comp.summary_model = "aux-small-model"
+        comp._aux_compression_context_length = 500
+
+        messages = _build_session(30, chars_per_msg=200)
+
+        with patch.object(comp, "_generate_summary", return_value="Summary."):
+            comp.compress(messages, current_tokens=50_000)
+
+        assert comp.summary_model == "aux-small-model", (
+            "summary_model should be restored after the fallback pass"
+        )
+
+    def test_no_fallback_when_window_within_aux_context(self):
+        """When the compression window <= _aux_compression_context_length,
+        the aux model is used as-is (no fallback)."""
+        comp = _make_compressor()
+        comp.summary_model = "aux-small-model"
+        # Set aux context very high so the window fits
+        comp._aux_compression_context_length = 10_000_000
+
+        messages = _build_session(30, chars_per_msg=200)
+
+        captured = []
+
+        def _capture(*args, **kwargs):
+            captured.append(comp.summary_model)
+            return "Summary."
+
+        with patch.object(comp, "_generate_summary", side_effect=_capture):
+            comp.compress(messages, current_tokens=50_000)
+
+        assert captured == ["aux-small-model"], (
+            "aux model should be used when window fits within its context"
+        )
+
+    def test_no_fallback_when_no_aux_model_configured(self):
+        """When summary_model is empty (no aux model), no fallback happens."""
+        comp = _make_compressor()
+        comp.summary_model = ""
+        comp._aux_compression_context_length = 500
+
+        messages = _build_session(30, chars_per_msg=200)
+
+        with patch.object(comp, "_generate_summary", return_value="Summary."):
+            comp.compress(messages, current_tokens=50_000)
+
+        assert comp.summary_model == ""
+
+    def test_no_fallback_when_aux_context_not_set(self):
+        """When _aux_compression_context_length is 0 (feasibility check not
+        run), no fallback happens — preserves existing behavior."""
+        comp = _make_compressor()
+        comp.summary_model = "aux-model"
+        comp._aux_compression_context_length = 0
+
+        messages = _build_session(30, chars_per_msg=200)
+
+        with patch.object(comp, "_generate_summary", return_value="Summary."):
+            comp.compress(messages, current_tokens=50_000)
+
+        assert comp.summary_model == "aux-model"
+
+    def test_no_fallback_when_session_large_but_window_small(self):
+        """The comparison is against the compression window, NOT the full
+        session.  A session can be much larger than the aux context while
+        the window (middle turns) still fits — in that case the aux model
+        is used, not the main model."""
+        comp = _make_compressor()
+        comp.summary_model = "aux-small-model"
+        # Aux context is 50K — larger than the window but smaller than the
+        # full session (which we claim is 200K via current_tokens)
+        comp._aux_compression_context_length = 50_000
+
+        messages = _build_session(30, chars_per_msg=200)
+
+        captured = []
+
+        def _capture(*args, **kwargs):
+            captured.append(comp.summary_model)
+            return "Summary."
+
+        with patch.object(comp, "_generate_summary", side_effect=_capture):
+            # current_tokens=200_000 (full session) but the actual window
+            # is much smaller (only ~30 turns of ~200 chars each)
+            comp.compress(messages, current_tokens=200_000)
+
+        assert captured == ["aux-small-model"], (
+            "aux model should be used — the window fits even though the "
+            f"full session (200K) exceeds the aux context (50K). Got {captured}"
+        )
+
+    def test_overflow_warning_emitted_once(self):
+        """The overflow warning is emitted at most once per session."""
+        comp = _make_compressor(quiet_mode=False)
+        comp.summary_model = "aux-small-model"
+        comp._aux_compression_context_length = 500
+
+        messages = _build_session(30, chars_per_msg=200)
+
+        with patch.object(comp, "_generate_summary", return_value="Summary."):
+            comp.compress(messages, current_tokens=50_000)
+            assert comp._aux_context_overflow_warned is True
+            # Second pass — warning flag already set, no duplicate
+            comp.compress(messages, current_tokens=50_000)
+
+        assert comp._aux_context_overflow_warned is True
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: post-compression re-trigger guard in should_compress()
+# ---------------------------------------------------------------------------
+
+
+class TestPostCompressionRetriggerGuard:
+    """should_compress() blocks re-triggering when the last pass left the
+    session at or above the threshold with insufficient new content."""
+
+    def test_blocks_when_last_pass_left_session_above_threshold(self):
+        comp = _make_compressor()
+        comp._post_compression_rough_tokens = 120_000
+        assert not comp.should_compress(122_000), (
+            "should_compress should return False — last pass left session "
+            "above threshold and only 2K new tokens (< 20K floor)"
+        )
+
+    def test_allows_when_significant_growth_since_last_pass(self):
+        comp = _make_compressor()
+        comp._post_compression_rough_tokens = 120_000
+        assert comp.should_compress(145_000), (
+            "should_compress should return True — 25K new tokens >= 20K floor"
+        )
+
+    def test_allows_when_last_pass_brought_session_below_threshold(self):
+        comp = _make_compressor()
+        comp._post_compression_rough_tokens = 80_000  # below threshold 100,000
+        assert comp.should_compress(120_000)
+
+    def test_allows_when_no_prior_compression(self):
+        comp = _make_compressor()
+        comp._post_compression_rough_tokens = 0
+        assert comp.should_compress(120_000)
+
+    def test_growth_floor_is_twenty_percent_of_threshold(self):
+        """Growth floor = max(threshold // 5, 4096). For 100K threshold → 20K."""
+        comp = _make_compressor()
+        comp._post_compression_rough_tokens = 120_000
+        assert not comp.should_compress(139_999)  # 19,999 growth → blocked
+        assert comp.should_compress(140_000)      # 20,000 growth → allowed
+
+    def test_growth_floor_has_minimum_of_4096(self):
+        """For very small thresholds, growth floor is at least 4096."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=10_000):
+            comp = ContextCompressor(
+                model="tiny-model",
+                threshold_percent=0.50,
+                protect_first_n=2,
+                protect_last_n=3,
+                quiet_mode=True,
+            )
+        threshold = comp.threshold_tokens
+        comp._post_compression_rough_tokens = threshold + 1_000
+        assert not comp.should_compress(threshold + 5_000)    # 4,000 growth → blocked
+        assert comp.should_compress(threshold + 5_096)        # 4,096 growth → allowed
+
+    def test_anti_thrashing_takes_precedence(self):
+        """Anti-thrashing (ineffective_count >= 2) blocks regardless of guard."""
+        comp = _make_compressor()
+        comp._ineffective_compression_count = 2
+        comp._post_compression_rough_tokens = 0
+        assert not comp.should_compress(120_000)
+
+    def test_guard_resets_after_session_reset(self):
+        """on_session_reset clears _post_compression_rough_tokens."""
+        comp = _make_compressor()
+        comp._post_compression_rough_tokens = 120_000
+        comp.on_session_reset()
+        assert comp._post_compression_rough_tokens == 0
+        assert comp.should_compress(120_000)
+
+
+# ---------------------------------------------------------------------------
+# compress(): _post_compression_rough_tokens is set after each pass
+# ---------------------------------------------------------------------------
+
+
+class TestPostCompressionTokensRecorded:
+    """compress() records _post_compression_rough_tokens after every pass."""
+
+    def test_compression_sets_post_compression_tokens(self):
+        comp = _make_compressor()
+        messages = _build_session(30, chars_per_msg=200)
+
+        with patch.object(comp, "_generate_summary", return_value="Summary of conversation."):
+            result = comp.compress(messages, current_tokens=50_000)
+
+        assert comp._post_compression_rough_tokens > 0
+        expected = estimate_messages_tokens_rough(result)
+        assert comp._post_compression_rough_tokens == expected
+
+    def test_noop_compression_sets_post_compression_tokens(self):
+        """When compress_start >= compress_end (no-op), post-compression tokens
+        are set to the pre-compression estimate so the guard fires."""
+        comp = _make_compressor()
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        comp.compress(messages, current_tokens=5_000)
+        # Too few messages → early return before the no-op-window path.
+        assert comp._post_compression_rough_tokens == 0
+
+    def test_abort_sets_post_compression_tokens(self):
+        """When compression is aborted (summary failure), post-compression
+        tokens are set so the guard fires on the next turn."""
+        comp = _make_compressor(abort_on_summary_failure=True)
+        messages = _build_session(30, chars_per_msg=200)
+
+        with patch.object(comp, "_generate_summary", return_value=None):
+            comp.compress(messages, current_tokens=50_000)
+
+        assert comp._post_compression_rough_tokens > 0
+
+
+# ---------------------------------------------------------------------------
+# Integration: the full #53008 scenario — proactive fallback breaks the loop
+# ---------------------------------------------------------------------------
+
+
+class TestInfiniteLoopPrevention:
+    """Simulate the #53008 scenario end-to-end: threshold lowered below
+    session size, proactive fallback uses the main model, compression is
+    effective, no infinite loop."""
+
+    def test_proactive_fallback_breaks_infinite_loop(self):
+        """Simulate: aux context = 131K, threshold lowered to 131K.  Build
+        a session large enough that the compression window exceeds 131K.
+        The proactive fallback swaps to the main model for the summary,
+        which has enough context to compress effectively.  After one pass
+        the session is below threshold and should_compress returns False."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=1_000_000):
+            comp = ContextCompressor(
+                model="big-main-model",
+                threshold_percent=0.131,  # 131K — simulates auto-lowered
+                protect_first_n=2,
+                protect_last_n=3,
+                quiet_mode=True,
+            )
+        comp.summary_model = "aux-small-model"
+        comp._aux_compression_context_length = 131_000
+
+        threshold = comp.threshold_tokens
+        assert 130_000 <= threshold <= 132_000
+
+        # Build a session large enough that the compression window > 131K.
+        # tail_token_budget = 131K * 0.20 = 26K, soft_ceiling = 39K.
+        # So the tail is ~26-39K tokens.  We need the middle window > 131K,
+        # so the total session needs to be > 131K + 39K + head ≈ 175K.
+        # At ~500 tokens per message (2000 chars), we need ~350 messages
+        # in the middle, so ~360 turns total.
+        messages = _build_session(360, chars_per_msg=2000)
+
+        session_tokens = estimate_messages_tokens_rough(messages)
+        assert session_tokens > 175_000, (
+            f"Session must be > 175K for the window to exceed 131K, "
+            f"got {session_tokens:,}"
+        )
+
+        # Verify the compression window actually exceeds the aux context
+        compress_start = comp._protect_head_size(messages)
+        compress_start = comp._align_boundary_forward(messages, compress_start)
+        compress_end = comp._find_tail_cut_by_tokens(messages, compress_start)
+        window = messages[compress_start:compress_end]
+        window_tokens = estimate_messages_tokens_rough(window)
+        assert window_tokens > 131_000, (
+            f"Compression window ({window_tokens:,}) must exceed aux context "
+            f"(131,000) for this test to be meaningful"
+        )
+
+        # First compression should trigger
+        assert comp.should_compress(session_tokens)
+
+        # Track which model was used for the summary
+        used_models = []
+
+        def _track_model(*args, **kwargs):
+            used_models.append(comp.summary_model)
+            return "Effective summary of the conversation. " * 100
+
+        with patch.object(comp, "_generate_summary", side_effect=_track_model):
+            result = comp.compress(messages, current_tokens=session_tokens)
+
+        # The main model was used (proactive fallback), not the aux model
+        assert used_models == [""], (
+            f"Main model should have been used for the summary, got {used_models}"
+        )
+
+        # The aux model is restored after the pass
+        assert comp.summary_model == "aux-small-model"
+
+        # After effective compression, the session should be below threshold
+        new_tokens = estimate_messages_tokens_rough(result)
+        assert new_tokens < threshold, (
+            f"Post-compression session ({new_tokens:,}) should be below "
+            f"threshold ({threshold:,}) — effective compression"
+        )
+        assert not comp.should_compress(new_tokens), (
+            "should_compress should return False — session now below threshold"
+        )
+
+    def test_guard_catches_edge_case_where_main_model_also_fails(self):
+        """Edge case: if even the main model produces an ineffective
+        compression (session stays above threshold), the re-trigger guard
+        prevents the loop."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=1_000_000):
+            comp = ContextCompressor(
+                model="big-main-model",
+                threshold_percent=0.131,
+                protect_first_n=2,
+                protect_last_n=3,
+                quiet_mode=True,
+            )
+        comp.summary_model = "aux-small-model"
+        comp._aux_compression_context_length = 131_000
+
+        # Simulate an ineffective compression: 205K → 204K
+        comp._post_compression_rough_tokens = 204_000
+        comp._ineffective_compression_count = 1
+
+        assert not comp.should_compress(204_000), (
+            "Guard should block — last pass left 204K >= threshold and "
+            "no new content arrived"
+        )
+
+        # After significant growth (30K), compression re-triggers
+        assert comp.should_compress(234_000), (
+            "Guard should allow — 30K growth >= 26K floor"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration: simulate the turn_context.py multi-pass preflight loop
+# (turn_context.py:383-410) — the exact code path that loops infinitely
+# in #53008.  Up to 3 compression passes per turn, breaking when
+# _compression_made_progress returns False or should_compress returns False.
+# ---------------------------------------------------------------------------
+
+
+class TestTurnContextMultiPassLoop:
+    """Simulate the turn_context.py preflight multi-pass loop (up to 3
+    passes per turn) and verify the proactive fallback + guard prevent
+    the infinite loop across multiple turns."""
+
+    def test_multi_pass_loop_terminates_with_proactive_fallback(self):
+        """Simulate 5 turns, each with the preflight multi-pass loop.
+        The proactive fallback ensures the main model is used when the
+        compression window exceeds aux context, producing effective
+        compression.  The loop terminates within 3 passes each turn."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=1_000_000):
+            comp = ContextCompressor(
+                model="big-main-model",
+                threshold_percent=0.131,  # 131K — simulates auto-lowered
+                protect_first_n=2,
+                protect_last_n=3,
+                quiet_mode=True,
+            )
+        comp.summary_model = "aux-small-model"
+        comp._aux_compression_context_length = 131_000
+
+        # Build a session large enough that the window > 131K
+        messages = _build_session(360, chars_per_msg=2000)
+        current_tokens = estimate_messages_tokens_rough(messages)
+
+        summary_calls = []
+
+        def _track_and_summarise(*args, **kwargs):
+            summary_calls.append(comp.summary_model)
+            return "Concise summary of the conversation."
+
+        with patch.object(comp, "_generate_summary", side_effect=_track_and_summarise):
+            for turn in range(5):
+                pass_count = 0
+                while pass_count < 3:
+                    if not comp.should_compress(current_tokens):
+                        break
+                    pass_count += 1
+                    orig_len = len(messages)
+                    orig_tokens = current_tokens
+                    messages = comp.compress(messages, current_tokens=current_tokens)
+                    current_tokens = estimate_messages_tokens_rough(messages)
+                    # Check progress (same logic as turn_context.py)
+                    if orig_len == len(messages) and orig_tokens > 0 and current_tokens >= orig_tokens * 0.95:
+                        break  # No progress
+                    if not comp.should_compress(current_tokens):
+                        break
+
+                assert pass_count <= 3, (
+                    f"Turn {turn}: exceeded 3 passes — infinite loop"
+                )
+
+                # Add new content for the next turn
+                messages.append({"role": "user", "content": " ".join(["x"] * 2000) + f" new turn {turn}"})
+                messages.append({"role": "assistant", "content": " ".join(["x"] * 2000) + f" new reply {turn}"})
+                current_tokens = estimate_messages_tokens_rough(messages)
+
+        # The proactive fallback was used at least once (main model, not aux)
+        assert "" in summary_calls, (
+            f"Main model should have been used at least once, got {summary_calls}"
+        )
+
+        # The aux model was restored after each fallback pass
+        assert comp.summary_model == "aux-small-model"
+
+    def test_guard_prevents_loop_when_compression_always_ineffective(self):
+        """Edge case: if compression is always ineffective, the re-trigger
+        guard ensures the multi-pass loop terminates and does not re-trigger
+        on the next turn."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=1_000_000):
+            comp = ContextCompressor(
+                model="big-main-model",
+                threshold_percent=0.131,
+                protect_first_n=2,
+                protect_last_n=3,
+                quiet_mode=True,
+            )
+        comp.summary_model = "aux-small-model"
+        comp._aux_compression_context_length = 131_000
+
+        comp._post_compression_rough_tokens = 204_000
+        comp._ineffective_compression_count = 1
+
+        assert not comp.should_compress(204_000), (
+            "Guard should block on turn 1 — last pass left session above "
+            "threshold with no growth"
+        )
+        assert not comp.should_compress(204_500), (
+            "Guard should block on turn 2 — only 500 tokens growth < 26K floor"
+        )
+        assert comp.should_compress(235_000), (
+            "Guard should allow on turn 3 — 31K growth >= 26K floor"
+        )

--- a/tests/agent/test_context_compressor_cross_session_guard.py
+++ b/tests/agent/test_context_compressor_cross_session_guard.py
@@ -64,6 +64,9 @@ def _make_compressor():
     c.last_compression_rough_tokens = 0
     c.last_rough_tokens_when_real_prompt_fit = 0
     c.awaiting_real_usage_after_compression = False
+    c._aux_compression_context_length = 0
+    c._aux_context_overflow_warned = False
+    c._post_compression_rough_tokens = 0
     return c
 
 


### PR DESCRIPTION
## What does this PR do?

When the auxiliary compression model's context window is smaller than the main
model's compression threshold, `check_compression_model_feasibility` auto-lowers
`threshold_tokens` to the aux model's context size. If the compression window
(the middle turns sent to the summariser) then grows beyond the aux model's
context, the aux model cannot process it — the API call errors out or is
silently truncated, producing a near-useless summary. Each pass is near-zero
effective but the session remains above the threshold, looping indefinitely (the
reporter observed 12–16 consecutive compressions with no progress).

This PR fixes the root cause with a **two-layer approach**:

1. **Proactive main-model fallback** (root fix): `compress()` estimates the
   token count of `turns_to_summarize` (the actual content sent to the
   summariser) and compares it with `_aux_compression_context_length` (set by
   `check_compression_model_feasibility`). When the window exceeds the aux
   model's context, the aux model is temporarily swapped out for the main model
   for that pass. The main model has enough context to summarise effectively,
   breaking the loop at the root. The aux model is restored afterwards so future
   passes (on a smaller post-compression session) can use it again.

   The comparison is against the **compression window** (middle turns), not the
   full session — the tail (protected recent messages) and head (system prompt +
   first exchange) are never sent to the summariser, so a session can be larger
   than the aux context while the window still fits.

2. **Post-compression re-trigger guard** (safety net): `should_compress()`
   records `_post_compression_rough_tokens` after every pass. If the last pass
   left the session at or above the threshold AND not enough new content (≥20%
   of threshold) has arrived, compression is skipped. This catches edge cases
   where even the main model cannot reduce the session below the threshold.

The feasibility warning is also enhanced to tell the user that Hermes will
automatically use the main model when the compression window outgrows the aux
model's context.

## Related Issue

Fixes #53008

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py`: added `_aux_compression_context_length` and
  `_aux_context_overflow_warned` fields, set by
  `check_compression_model_feasibility`. `compress()` estimates the token count
  of `turns_to_summarize` and, when it exceeds `_aux_compression_context_length`,
  temporarily clears `summary_model` (falling back to the main model), restoring
  it after the pass.
- `agent/context_compressor.py`: added `_post_compression_rough_tokens` field,
  set after every compression pass (success, no-op window, and abort). The
  field is reset on `on_session_reset` and `update_model`.
- `agent/context_compressor.py`: added post-compression re-trigger guard in
  `should_compress()` — blocks re-triggering when the last pass left the session
  at or above the threshold and insufficient new content has arrived.
- `agent/conversation_compression.py`: stores `aux_context` in
  `agent.context_compressor._aux_compression_context_length` during the
  feasibility check; enhanced the auto-lowered-threshold warning to explain the
  main-model fallback behavior.
- `tests/agent/test_compression_retrigger_guard.py`: 22 new tests covering the
  proactive fallback (7 tests, including the critical window-vs-session
  distinction), the re-trigger guard (8 tests), post-compression token recording
  (3 tests), the #53008 infinite-loop simulation with a real 175K+ session (2
  tests), and the `turn_context.py` multi-pass loop integration (2 tests).
- `tests/agent/test_context_compressor_cross_session_guard.py`: added the new
  fields to the `__new__`-based test helper.

## How to Test

1. `pytest tests/agent/test_compression_retrigger_guard.py -v` — 22 tests
   covering the proactive fallback (including the window-vs-session distinction),
   re-trigger guard, reset paths, compress() recording, abort path, the #53008
   infinite-loop simulation with a real 175K+ session, and the
   `turn_context.py` multi-pass loop integration.
2. `pytest tests/agent/test_context_compressor.py tests/run_agent/test_compression_feasibility.py tests/run_agent/test_infinite_compaction_loop.py tests/agent/test_compression_concurrent_fork.py tests/agent/test_context_compressor_cross_session_guard.py tests/agent/test_context_engine.py -q` — 186 existing tests still pass (no regression).
3. Simulate the #53008 scenario: configure a main model with 1M context +
   `compression.threshold: 0.5` (500K threshold) and an aux compression model
   with 131K context. Start a conversation that grows past ~175K tokens. Before
   the fix, the compression window exceeds the aux model's context → the aux
   model cannot summarise it → near-zero effectiveness → infinite loop. After
   the fix, `compress()` detects the window exceeds the aux model's context and
   uses the main model for that pass, producing an effective summary. The aux
   model is restored for future passes on the smaller post-compression session.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```
$ pytest tests/agent/test_compression_retrigger_guard.py -v
22 passed in 0.34s

$ pytest tests/agent/test_context_compressor.py tests/run_agent/test_compression_feasibility.py tests/run_agent/test_infinite_compaction_loop.py tests/agent/test_compression_concurrent_fork.py tests/agent/test_context_compressor_cross_session_guard.py tests/agent/test_context_engine.py -q
186 passed in 16.73s
```
