### PR TITLE
fix(bootstrap): warn on lazy-install activation failure

### DIFF
--- a/hermes_bootstrap.py
+++ b/hermes_bootstrap.py
@@ -49,11 +49,13 @@ against double-reconfigure.
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 
 _IS_WINDOWS = sys.platform == "win32"
 _bootstrap_applied = False
+logger = logging.getLogger(__name__)
 
 
 def apply_windows_utf8_bootstrap() -> bool:
@@ -177,10 +179,13 @@ def activate_durable_lazy_target() -> None:
     try:
         from tools import lazy_deps
         lazy_deps.activate_durable_lazy_target()
-    except Exception:
+    except Exception as exc:
         # Bootstrap must never crash an entry point. If activation fails the
         # backend simply reports itself unavailable, exactly as before.
-        pass
+        logger.warning(
+            "Lazy-install activation failed; optional tools may be unavailable: %s",
+            exc,
+        )
 
 
 # Apply on import — entry points just need ``import hermes_bootstrap``

--- a/tests/test_hermes_bootstrap.py
+++ b/tests/test_hermes_bootstrap.py
@@ -20,10 +20,12 @@ Key invariants covered by these tests:
 from __future__ import annotations
 
 import io
+import logging
 import os
 import subprocess
 import sys
 import textwrap
+import types
 
 import pytest
 
@@ -229,6 +231,32 @@ class TestStdioReconfigureErrorHandling:
         monkeypatch.setattr(sys, "stderr", _BrokenStream())
         # Must not raise.
         hb.apply_windows_utf8_bootstrap()
+
+
+class TestDurableLazyTargetActivation:
+    """Failures in durable lazy-install activation should stay non-fatal
+    but become observable."""
+
+    def test_activation_failure_logs_warning(self, monkeypatch, caplog):
+        hb = _fresh_import()
+        monkeypatch.setenv("HERMES_LAZY_INSTALL_TARGET", "/tmp/hermes-lazy")
+
+        fake_tools = types.ModuleType("tools")
+        fake_lazy_deps = types.ModuleType("tools.lazy_deps")
+
+        def _raise():
+            raise RuntimeError("simulated activation failure")
+
+        fake_lazy_deps.activate_durable_lazy_target = _raise
+        fake_tools.lazy_deps = fake_lazy_deps
+        monkeypatch.setitem(sys.modules, "tools", fake_tools)
+        monkeypatch.setitem(sys.modules, "tools.lazy_deps", fake_lazy_deps)
+
+        with caplog.at_level(logging.WARNING):
+            hb.activate_durable_lazy_target()
+
+        assert "Lazy-install activation failed; optional tools may be unavailable" in caplog.text
+        assert "simulated activation failure" in caplog.text
 
 
 class TestEntryPointsImportBootstrap:


### PR DESCRIPTION
## Summary

- replace the bare `except Exception: pass` around durable lazy-install activation with a warning-level log
- keep bootstrap startup non-fatal while surfacing the activation error to operators in cloud and container deployments
- add a regression test that forces `tools.lazy_deps.activate_durable_lazy_target()` to fail and asserts the warning is emitted

Closes #53144.

## Verification

- `uv run python --version`
- `uv run --with pytest python -m pytest tests/test_hermes_bootstrap.py`
- `uv run --extra dev python -m ruff check hermes_bootstrap.py tests/test_hermes_bootstrap.py`
- `git diff --check`
