### PR TITLE
fix(agent): clear stale file mutation warnings after external writes

### DIFF
--- a/agent/file_mutation_verifier.py
+++ b/agent/file_mutation_verifier.py
@@ -1,0 +1,572 @@
+"""Generation-aware recovery for failed file mutations.
+
+The turn-end verifier normally keeps failed ``write_file``/``patch`` calls
+visible.  A later foreground ``terminal`` or ``execute_code`` call may be a
+legitimate fallback, but it only clears a failure when content on the exact
+backend target changes during that successful call's execution window.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import ntpath
+import os
+import threading
+import time
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Sequence
+
+from agent.tool_dispatch_helpers import (
+    _extract_error_preview,
+    _extract_file_mutation_targets,
+    _extract_landed_file_mutation_paths,
+)
+from agent.tool_result_classification import file_mutation_result_landed
+
+logger = logging.getLogger(__name__)
+
+_FILE_MUTATING_TOOLS = frozenset({"write_file", "patch"})
+_EXTERNAL_FILE_CAPABLE_TOOLS = frozenset({"terminal", "execute_code"})
+
+
+@dataclass(frozen=True)
+class FileContentFingerprint:
+    """A reliable existence/content token; metadata is intentionally absent."""
+
+    kind: str
+    sha256: str | None = None
+
+
+@dataclass(frozen=True)
+class MutationTargetIdentity:
+    """The target identity captured by the mutation tool's own resolver."""
+
+    raw_path: str
+    resolved_path: str | None
+    task_id: str
+    defer_fingerprint: bool = False
+
+
+@dataclass(frozen=True)
+class _FallbackProbe:
+    state_key: str
+    resolved_path: str
+    task_id: str
+    generation: int
+    before: FileContentFingerprint
+
+
+@dataclass(frozen=True)
+class _VerifierCallContext:
+    """Exact per-turn state and revocation token captured before a tool call."""
+
+    epoch: object
+    state: dict[str, dict[str, Any]] | None
+    lock: threading.Lock
+    changed_paths: set[str] | None
+    active_event: threading.Event
+    deadline: float | None
+    cancel_check: Callable[[], bool] | None
+
+
+_mutation_targets: ContextVar[tuple[MutationTargetIdentity, ...]] = ContextVar(
+    "file_mutation_verifier_targets",
+    default=(),
+)
+_fallback_probes: ContextVar[tuple[_FallbackProbe, ...]] = ContextVar(
+    "file_mutation_verifier_fallback_probes",
+    default=(),
+)
+_call_context: ContextVar[_VerifierCallContext | None] = ContextVar(
+    "file_mutation_verifier_call_context",
+    default=None,
+)
+_pending_probe_activation: ContextVar[Callable[[], None] | None] = ContextVar(
+    "file_mutation_verifier_pending_probe_activation",
+    default=None,
+)
+_lock_creation_lock = threading.Lock()
+
+
+def activate_pending_file_mutation_verifier_call() -> None:
+    """Arm deferred fallback probes after the tool's execution gate approves."""
+
+    activation = _pending_probe_activation.get()
+    _pending_probe_activation.set(None)
+    if activation is not None:
+        activation()
+
+
+def publish_mutation_target_identities(
+    targets: Sequence[MutationTargetIdentity],
+) -> None:
+    """Publish identities from a file tool for same-thread result recording."""
+
+    _mutation_targets.set(tuple(targets))
+
+
+def _consume_mutation_target_identities() -> tuple[MutationTargetIdentity, ...]:
+    targets = _mutation_targets.get()
+    _mutation_targets.set(())
+    return targets
+
+
+def _consume_fallback_probes() -> tuple[_FallbackProbe, ...]:
+    probes = _fallback_probes.get()
+    _fallback_probes.set(())
+    return probes
+
+
+def _consume_call_context() -> _VerifierCallContext | None:
+    context = _call_context.get()
+    _call_context.set(None)
+    return context
+
+
+def _turn_epoch(agent: Any) -> object:
+    epoch = getattr(agent, "_turn_file_mutation_epoch", None)
+    if epoch is not None:
+        return epoch
+    with _lock_creation_lock:
+        epoch = getattr(agent, "_turn_file_mutation_epoch", None)
+        if epoch is None:
+            epoch = object()
+            agent._turn_file_mutation_epoch = epoch
+    return epoch
+
+
+def _call_context_is_current(
+    agent: Any,
+    context: _VerifierCallContext | None,
+) -> bool:
+    if context is None or not context.active_event.is_set():
+        return False
+    if context.deadline is not None and time.monotonic() >= context.deadline:
+        return False
+    if context.cancel_check is not None:
+        try:
+            if context.cancel_check():
+                return False
+        except Exception:
+            # A broken cancellation predicate must never make stale evidence
+            # eligible to clear an actionable mutation failure.
+            return False
+    return bool(
+        getattr(agent, "_turn_file_mutation_epoch", None) is context.epoch
+        and getattr(agent, "_turn_failed_file_mutations", None) is context.state
+        and getattr(agent, "_turn_file_mutation_lock", None) is context.lock
+        and getattr(agent, "_turn_file_mutation_paths", None) is context.changed_paths
+    )
+
+
+def _state_lock(agent: Any) -> threading.Lock:
+    lock = getattr(agent, "_turn_file_mutation_lock", None)
+    if lock is not None:
+        return lock
+    # Tool dispatch outside a normal conversation turn is unusual but valid in
+    # tests/plugins.  Avoid racing two lazy lock creations in that path.
+    with _lock_creation_lock:
+        lock = getattr(agent, "_turn_file_mutation_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            agent._turn_file_mutation_lock = lock
+    return lock
+
+
+def _fingerprint(
+    resolved_path: str,
+    task_id: str,
+) -> FileContentFingerprint | None:
+    """Read a content token through the same backend selected by file tools."""
+
+    try:
+        from tools.file_tools import _fingerprint_resolved_file_content
+
+        return _fingerprint_resolved_file_content(resolved_path, task_id)
+    except Exception as exc:
+        logger.debug(
+            "file-mutation verifier fingerprint failed for %r: %s",
+            resolved_path,
+            exc,
+        )
+        return None
+
+
+def _is_external_fallback(tool_name: str, args: Mapping[str, Any]) -> bool:
+    if tool_name not in _EXTERNAL_FILE_CAPABLE_TOOLS:
+        return False
+    # A successful background terminal result proves only that a process was
+    # launched, not that the process completed its mutation. Treat any truthy
+    # value conservatively because direct callers are not guaranteed to enforce
+    # the JSON-schema boolean type before dispatch.
+    return tool_name != "terminal" or not bool(args.get("background", False))
+
+
+def prepare_file_mutation_verifier_call(
+    agent: Any,
+    tool_name: str,
+    args: Mapping[str, Any],
+    effective_task_id: str,
+    *,
+    active_event: threading.Event | None = None,
+    deadline: float | None = None,
+    cancel_check: Callable[[], bool] | None = None,
+    defer_probe_activation: bool = False,
+) -> threading.Event:
+    """Reset call-local evidence and snapshot eligible fallback baselines."""
+
+    _mutation_targets.set(())
+    _fallback_probes.set(())
+    _pending_probe_activation.set(None)
+    if active_event is None:
+        active_event = threading.Event()
+        active_event.set()
+    lock = _state_lock(agent)
+    state = getattr(agent, "_turn_failed_file_mutations", None)
+    context = _VerifierCallContext(
+        epoch=_turn_epoch(agent),
+        state=state,
+        lock=lock,
+        changed_paths=getattr(agent, "_turn_file_mutation_paths", None),
+        active_event=active_event,
+        deadline=deadline,
+        cancel_check=cancel_check,
+    )
+    _call_context.set(context)
+
+    if not _call_context_is_current(agent, context):
+        return active_event
+    if not _is_external_fallback(tool_name, args) or not state:
+        return active_event
+
+    with lock:
+        if not _call_context_is_current(agent, context):
+            return active_event
+        candidates = []
+        for key, info in state.items():
+            resolved_path = info.get("resolved_path")
+            baseline = info.get("fingerprint")
+            generation = info.get("generation")
+            task_id = info.get("task_id")
+            deferred = info.get("fingerprint_deferred") is True
+            if (
+                isinstance(resolved_path, str)
+                and resolved_path
+                and isinstance(generation, int)
+                and task_id == effective_task_id
+                and (
+                    isinstance(baseline, FileContentFingerprint)
+                    or (baseline is None and deferred)
+                )
+            ):
+                candidates.append(
+                    (key, resolved_path, task_id, generation, baseline, deferred)
+                )
+
+    def activate_probes() -> None:
+        probes: list[_FallbackProbe] = []
+        for key, resolved_path, task_id, generation, baseline, deferred in candidates:
+            if not _call_context_is_current(agent, context):
+                return
+            before = _fingerprint(resolved_path, task_id)
+            if before is None:
+                continue
+            if baseline is not None and before != baseline:
+                # Content changed before this fallback began.  It may have been
+                # an unrelated watcher; do not attribute that change to this call.
+                continue
+            with lock:
+                if not _call_context_is_current(agent, context):
+                    return
+                current = state.get(key)
+                if not current or current.get("generation") != generation:
+                    continue
+                current_baseline = current.get("fingerprint")
+                if deferred:
+                    if current_baseline is not None or not current.get(
+                        "fingerprint_deferred"
+                    ):
+                        continue
+                    # The native policy gate captured exact identity without
+                    # reading content. Establish the baseline only after the
+                    # fallback's own execution gate has approved it.
+                    current["fingerprint"] = before
+                    current["fingerprint_deferred"] = False
+                elif current_baseline != baseline:
+                    continue
+            probes.append(
+                _FallbackProbe(
+                    state_key=key,
+                    resolved_path=resolved_path,
+                    task_id=task_id,
+                    generation=generation,
+                    before=before,
+                )
+            )
+
+        if _call_context_is_current(agent, context):
+            _fallback_probes.set(tuple(probes))
+
+    if defer_probe_activation:
+        _pending_probe_activation.set(activate_probes)
+    else:
+        activate_probes()
+    return active_event
+
+
+def _canonical_reported_path(path: str) -> bool:
+    """Return whether a tool-reported path is already backend-absolute."""
+
+    return os.path.isabs(path) or ntpath.isabs(path)
+
+
+def _state_key(identity: str, task_id: str) -> str:
+    """Keep identical path strings isolated across backend task contexts."""
+
+    if not task_id or task_id == "default":
+        return identity
+    return f"{task_id}\0{identity}"
+
+
+def _record_failed_mutation(
+    agent: Any,
+    tool_name: str,
+    args: Mapping[str, Any],
+    result: Any,
+    captured: Sequence[MutationTargetIdentity],
+    context: _VerifierCallContext,
+) -> None:
+    state = context.state
+    lock = context.lock
+    if state is None or not _call_context_is_current(agent, context):
+        return
+    raw_targets = _extract_file_mutation_targets(tool_name, dict(args))
+    captured_by_raw: dict[str, list[MutationTargetIdentity]] = {}
+    for target in captured:
+        captured_by_raw.setdefault(target.raw_path, []).append(target)
+
+    targets: list[MutationTargetIdentity] = []
+    for raw_path in raw_targets:
+        matches = captured_by_raw.get(raw_path)
+        if matches:
+            targets.append(matches.pop(0))
+        else:
+            # Never re-resolve here: the mutation tool did not provide a
+            # trustworthy identity, so this generation is intentionally
+            # unverifiable and its warning cannot be externally suppressed.
+            targets.append(MutationTargetIdentity(raw_path, None, ""))
+
+    if not targets:
+        return
+
+    preview = _extract_error_preview(result)
+    with lock:
+        if not _call_context_is_current(agent, context):
+            return
+        generation = getattr(agent, "_turn_file_mutation_generation", 0) + 1
+        agent._turn_file_mutation_generation = generation
+        for target in targets:
+            identity = target.resolved_path or target.raw_path
+            key = _state_key(identity, target.task_id)
+            previous = state.get(key)
+            if previous is None and target.resolved_path:
+                unresolved_key = _state_key(target.raw_path, target.task_id)
+                previous = state.pop(unresolved_key, None)
+            state[key] = {
+                "tool": (previous or {}).get("tool") or tool_name,
+                "error_preview": (previous or {}).get("error_preview") or preview,
+                "display_path": target.resolved_path or target.raw_path,
+                "resolved_path": target.resolved_path,
+                "task_id": target.task_id,
+                "generation": generation,
+                "fingerprint": None,
+                "fingerprint_deferred": target.defer_fingerprint,
+            }
+
+    # Fingerprints may require a backend round-trip.  Do it without holding
+    # the state lock, then publish only if this generation is still current.
+    for target in targets:
+        if not target.resolved_path or target.defer_fingerprint:
+            continue
+        fingerprint = _fingerprint(target.resolved_path, target.task_id)
+        key = _state_key(target.resolved_path, target.task_id)
+        with lock:
+            if not _call_context_is_current(agent, context):
+                return
+            current = state.get(key)
+            if current and current.get("generation") == generation:
+                current["fingerprint"] = fingerprint
+
+
+def _clear_native_success(
+    agent: Any,
+    tool_name: str,
+    args: Mapping[str, Any],
+    result: Any,
+    captured: Sequence[MutationTargetIdentity],
+    landed: bool,
+    context: _VerifierCallContext,
+) -> None:
+    state = context.state
+    lock = context.lock
+    if state is None or not _call_context_is_current(agent, context):
+        return
+    raw_targets = _extract_file_mutation_targets(tool_name, dict(args))
+    landed_paths = (
+        _extract_landed_file_mutation_paths(tool_name, dict(args), result)
+        if landed
+        else []
+    )
+
+    keys: set[str] = set()
+    task_ids: set[str] = set()
+    if captured:
+        for target in captured:
+            task_ids.add(target.task_id)
+            keys.add(_state_key(target.raw_path, target.task_id))
+            if target.resolved_path:
+                keys.add(_state_key(target.resolved_path, target.task_id))
+    else:
+        # Backward-compatible direct/test calls have no resolver evidence and
+        # therefore can only address the historical default-task keys.
+        keys.update(raw_targets)
+
+    canonical_paths: set[str] = set()
+    for path in landed_paths:
+        if task_ids:
+            keys.update(_state_key(path, task_id) for task_id in task_ids)
+        else:
+            keys.add(path)
+        if _canonical_reported_path(path):
+            canonical_paths.add(path)
+
+    with lock:
+        if not _call_context_is_current(agent, context):
+            return
+        for key in keys:
+            state.pop(key, None)
+        if context.changed_paths is not None:
+            context.changed_paths.update(canonical_paths)
+
+
+def _external_fallback_result_succeeded(
+    tool_name: str,
+    result: Any,
+    is_error: bool,
+) -> bool:
+    """Require each external tool's structured success contract."""
+
+    if is_error or not isinstance(result, str):
+        return False
+    try:
+        payload = json.loads(result)
+    except (TypeError, ValueError):
+        return False
+    if not isinstance(payload, dict) or payload.get("error"):
+        return False
+    if tool_name == "terminal":
+        exit_code = payload.get("exit_code")
+        return type(exit_code) is int and exit_code == 0
+    if tool_name == "execute_code":
+        return payload.get("status") == "success"
+    return False
+
+
+def _finish_external_fallback(
+    agent: Any,
+    tool_name: str,
+    result: Any,
+    is_error: bool,
+    context: _VerifierCallContext | None,
+) -> None:
+    probes = _consume_fallback_probes()
+    if (
+        not probes
+        or not _external_fallback_result_succeeded(tool_name, result, is_error)
+        or not _call_context_is_current(agent, context)
+        or context is None
+        or context.state is None
+    ):
+        return
+    state = context.state
+    lock = context.lock
+
+    for probe in probes:
+        if not _call_context_is_current(agent, context):
+            return
+        after = _fingerprint(probe.resolved_path, probe.task_id)
+        if after is None or after == probe.before:
+            continue
+        with lock:
+            if not _call_context_is_current(agent, context):
+                return
+            current = state.get(probe.state_key)
+            if not current or current.get("generation") != probe.generation:
+                continue
+            if current.get("task_id") != probe.task_id:
+                continue
+            if current.get("fingerprint") != probe.before:
+                continue
+            state.pop(probe.state_key, None)
+            if context.changed_paths is not None:
+                context.changed_paths.add(probe.resolved_path)
+
+
+def record_file_mutation_verifier_result(
+    agent: Any,
+    tool_name: str,
+    args: Mapping[str, Any],
+    result: Any,
+    is_error: bool,
+) -> None:
+    """Record completion evidence for native mutations or external fallbacks."""
+
+    context = _consume_call_context()
+    if tool_name in _FILE_MUTATING_TOOLS:
+        captured = _consume_mutation_target_identities()
+        _fallback_probes.set(())
+        if (
+            context is None
+            or context.state is None
+            or not _call_context_is_current(agent, context)
+        ):
+            return
+        landed = file_mutation_result_landed(tool_name, result)
+        if landed:
+            _clear_native_success(
+                agent,
+                tool_name,
+                args,
+                result,
+                captured,
+                landed=True,
+                context=context,
+            )
+        else:
+            # Dispatcher error classification is advisory; only the tool's
+            # landed-result contract proves that a native mutation succeeded.
+            # A malformed/ambiguous result must retain (or create) the warning
+            # rather than silently clearing an earlier actionable failure.
+            _record_failed_mutation(
+                agent,
+                tool_name,
+                args,
+                result,
+                captured,
+                context,
+            )
+        return
+
+    _mutation_targets.set(())
+    if tool_name in _EXTERNAL_FILE_CAPABLE_TOOLS:
+        _finish_external_fallback(
+            agent,
+            tool_name,
+            result,
+            is_error,
+            context,
+        )
+    else:
+        _fallback_probes.set(())

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -260,7 +260,7 @@ def _extract_file_mutation_targets(tool_name: str, args: Dict[str, Any]) -> List
             return []
         paths: List[str] = []
         for _m in re.finditer(
-            r'^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+)$',
+            r'^\*\*\*\s*(?:Update|Add|Delete)\s+File:\s*(.+)$',
             body,
             re.MULTILINE,
         ):
@@ -268,7 +268,7 @@ def _extract_file_mutation_targets(tool_name: str, args: Dict[str, Any]) -> List
             if p:
                 paths.append(p)
         for _m in re.finditer(
-            r'^\*\*\*\s+Move\s+File:\s*(.+?)\s*->\s*(.+)$',
+            r'^\*\*\*\s*Move\s+File:\s*(.+?)\s*->\s*(.+)$',
             body,
             re.MULTILINE,
         ):

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -555,16 +555,28 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     # ── Concurrent execution ─────────────────────────────────────────
     # Each slot holds (function_name, function_args, function_result, duration, error_flag, blocked_flag, middleware_trace)
     results = [None] * num_tools
+    verifier_active_events: list[threading.Event | None] = [None] * num_tools
     for i, (tc, name, args, middleware_trace, block_result, blocked_by_guardrail) in enumerate(parsed_calls):
         if block_result is not None:
             results[i] = (name, args, block_result, 0.0, True, True, middleware_trace)
+        else:
+            active_event = threading.Event()
+            active_event.set()
+            verifier_active_events[i] = active_event
 
     # Touch activity before launching workers so the gateway knows
     # we're executing tools (not stuck).
     agent._current_tool = tool_names_str
     agent._touch_activity(f"executing {num_tools} tools concurrently: {tool_names_str}")
 
-    def _run_tool(index, tool_call, function_name, function_args, middleware_trace):
+    def _run_tool(
+        index,
+        tool_call,
+        function_name,
+        function_args,
+        middleware_trace,
+        verifier_active_event,
+    ):
         """Worker function executed in a thread."""
         # Register this worker tid so the agent can fan out an interrupt
         # to it — see AIAgent.interrupt().  Must happen first thing, and
@@ -596,6 +608,21 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         start = time.time()
         try:
             try:
+                try:
+                    agent._prepare_file_mutation_verifier_call(
+                        function_name,
+                        function_args,
+                        effective_task_id,
+                        active_event=verifier_active_event,
+                        deadline=deadline,
+                        cancel_check=lambda: bool(agent._interrupt_requested),
+                        defer_probe_activation=True,
+                    )
+                except Exception as verifier_error:
+                    logger.debug(
+                        "file-mutation verifier pre-call failed: %s",
+                        verifier_error,
+                    )
                 result = agent._invoke_tool(
                     function_name,
                     function_args,
@@ -629,11 +656,34 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
             duration = time.time() - start
             is_error, _ = _detect_tool_failure(function_name, result)
+            # Publish the real tool result before verifier bookkeeping. If the
+            # deadline expires during a slow backend fingerprint, post-processing
+            # can still prefer this completed result while revoking late evidence.
+            results[index] = (
+                function_name,
+                function_args,
+                result,
+                duration,
+                is_error,
+                False,
+                middleware_trace,
+            )
+            try:
+                agent._record_file_mutation_result(
+                    function_name,
+                    function_args,
+                    result,
+                    is_error,
+                )
+            except Exception as verifier_error:
+                logger.debug(
+                    "file-mutation verifier completion record failed: %s",
+                    verifier_error,
+                )
             if is_error:
                 logger.info("tool %s failed (%.2fs): %s", function_name, duration, result[:200])
             else:
                 logger.info("tool %s completed (%.2fs, %d chars)", function_name, duration, len(result))
-            results[index] = (function_name, function_args, result, duration, is_error, False, middleware_trace)
         finally:
             # Tear down worker-tid tracking.  Clear any interrupt bit we may
             # have set so the next task scheduled onto this recycled tid
@@ -647,6 +697,23 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 _ra()._set_interrupt(False, _worker_tid)
             except Exception:
                 pass
+
+    def _revoke_verifier_evidence(indices: set[int]) -> None:
+        """Atomically prevent unfinished workers from publishing late evidence."""
+
+        lock = getattr(agent, "_turn_file_mutation_lock", None)
+
+        def revoke() -> None:
+            for index in indices:
+                active_event = verifier_active_events[index]
+                if active_event is not None:
+                    active_event.clear()
+
+        if lock is None:
+            revoke()
+        else:
+            with lock:
+                revoke()
 
     # Start spinner for CLI mode (skip when TUI handles tool progress)
     spinner = None
@@ -683,7 +750,13 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     # callbacks into the worker thread; clears callbacks on exit.
                     try:
                         f = executor.submit(
-                            propagate_context_to_thread(_run_tool), i, tc, name, args, parsed_calls[i][3]
+                            propagate_context_to_thread(_run_tool),
+                            i,
+                            tc,
+                            name,
+                            args,
+                            parsed_calls[i][3],
+                            verifier_active_events[i],
                         )
                     except RuntimeError as submit_error:
                         if not _is_interpreter_shutdown_submit_error(submit_error):
@@ -748,6 +821,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                             for f in not_done
                             if f in future_to_index
                         }
+                        _revoke_verifier_evidence(timed_out_indices)
                         _still_running = [
                             parsed_calls[i][1]
                             for i in timed_out_indices
@@ -784,6 +858,13 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                                 f"{len(not_done)} pending concurrent tool(s)",
                                 force=True,
                             )
+                        _revoke_verifier_evidence(
+                            {
+                                future_to_index[f]
+                                for f in not_done
+                                if f in future_to_index
+                            }
+                        )
                         for f in not_done:
                             f.cancel()
                         # Give already-running tools a moment to notice the
@@ -894,17 +975,6 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 _err_text = _multimodal_text_summary(function_result)
                 result_preview = _err_text[:200] if len(_err_text) > 200 else _err_text
                 logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
-
-            # Track file-mutation outcome for the turn-end verifier.
-            # `blocked` calls never actually ran — don't let a guardrail
-            # block count as either a failure or a success.
-            if not blocked:
-                try:
-                    agent._record_file_mutation_result(
-                        function_name, function_args, function_result, is_error,
-                    )
-                except Exception as _ver_err:
-                    logging.debug("file-mutation verifier record failed: %s", _ver_err)
 
             if not blocked and agent.tool_progress_callback:
                 try:
@@ -1197,6 +1267,21 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     )
             except Exception:
                 pass  # never block tool execution
+
+        if not _execution_blocked:
+            try:
+                agent._prepare_file_mutation_verifier_call(
+                    function_name,
+                    function_args,
+                    effective_task_id,
+                    cancel_check=lambda: bool(agent._interrupt_requested),
+                    defer_probe_activation=True,
+                )
+            except Exception as verifier_error:
+                logger.debug(
+                    "file-mutation verifier pre-call failed: %s",
+                    verifier_error,
+                )
 
         tool_start_time = time.time()
 
@@ -1560,6 +1645,21 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Log tool errors to the persistent error log so [error] tags
         # in the UI always have a corresponding detailed entry on disk.
         _is_error_result, _ = _detect_tool_failure(function_name, function_result)
+        # Record the original structured result before guardrail observations or
+        # persistence wrappers can decorate it and invalidate success contracts.
+        if not _execution_blocked:
+            try:
+                agent._record_file_mutation_result(
+                    function_name,
+                    function_args,
+                    function_result,
+                    _is_error_result,
+                )
+            except Exception as verifier_error:
+                logging.debug(
+                    "file-mutation verifier record failed: %s",
+                    verifier_error,
+                )
         # The agent-runtime tools above (todo, session_search, memory,
         # context-engine, memory-manager, clarify, delegate_task) are
         # dispatched inline — they never reach handle_function_call, so the
@@ -1596,18 +1696,6 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
         else:
             logger.info("tool %s completed (%.2fs, %d chars)", function_name, tool_duration, _result_len)
-
-        # Track file-mutation outcome for the turn-end verifier.  See
-        # the concurrent path for the rationale; both paths must feed
-        # the same state so the footer reflects every tool call in the
-        # turn, not just the parallel ones.
-        if not _execution_blocked:
-            try:
-                agent._record_file_mutation_result(
-                    function_name, function_args, function_result, _is_error_result,
-                )
-            except Exception as _ver_err:
-                logging.debug("file-mutation verifier record failed: %s", _ver_err)
 
         if not _execution_blocked and agent.tool_progress_callback:
             try:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -531,6 +531,9 @@ def build_turn_context(
     # Per-turn file-mutation verifier state.
     agent._turn_failed_file_mutations = {}
     agent._turn_file_mutation_paths = set()
+    agent._turn_file_mutation_lock = threading.Lock()
+    agent._turn_file_mutation_generation = 0
+    agent._turn_file_mutation_epoch = object()
     agent._verification_stop_nudges = 0
     agent._pre_verify_nudges = 0
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -44,6 +44,7 @@ import sys
 import tempfile
 import time
 import threading
+import unicodedata
 import uuid
 from typing import List, Dict, Any, Optional, Callable
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
@@ -190,8 +191,11 @@ from agent.tool_guardrails import (
     toolguard_synthetic_result,
 )
 from agent.tool_result_classification import (
-    FILE_MUTATING_TOOL_NAMES as _FILE_MUTATING_TOOLS,
-    file_mutation_result_landed,
+    FILE_MUTATING_TOOL_NAMES as _FILE_MUTATING_TOOLS,  # noqa: F401  # re-exported for verifier tests
+)
+from agent.file_mutation_verifier import (
+    prepare_file_mutation_verifier_call as _prepare_file_mutation_verifier_call,
+    record_file_mutation_verifier_result as _record_file_mutation_verifier_result,
 )
 from agent.trajectory import (
     convert_scratchpad_to_think,
@@ -205,9 +209,9 @@ from agent.tool_dispatch_helpers import (
     _is_multimodal_tool_result,
     _multimodal_text_summary,
     _append_subdir_hint_to_multimodal,  # noqa: F401  # re-exported for tests that `from run_agent import _append_subdir_hint_to_multimodal`
-    _extract_file_mutation_targets,
-    _extract_landed_file_mutation_paths,
-    _extract_error_preview,
+    _extract_file_mutation_targets,  # noqa: F401  # re-exported for verifier tests
+    _extract_landed_file_mutation_paths,  # noqa: F401  # re-exported for verifier tests
+    _extract_error_preview,  # noqa: F401  # re-exported for verifier tests
     _trajectory_normalize_msg,  # noqa: F401  # re-exported for tests that `from run_agent import _trajectory_normalize_msg`
 )
 from utils import atomic_json_write, base_url_host_matches, base_url_hostname, env_float, is_truthy_value, model_forces_max_completion_tokens
@@ -2818,41 +2822,39 @@ class AIAgent:
         result: Any,
         is_error: bool,
     ) -> None:
-        """Record a ``write_file`` / ``patch`` outcome for the turn-end verifier.
+        """Record mutation/fallback completion for the turn-end verifier."""
 
-        On failure, store ``{path: {error_preview, tool}}`` entries.  On
-        success, remove any prior failure entries for the same paths (the
-        model recovered within the turn).  Silently no-ops if the per-turn
-        state dict hasn't been initialised yet (e.g. a tool dispatched
-        outside ``run_conversation``).
-        """
-        if tool_name not in _FILE_MUTATING_TOOLS:
-            return
-        state = getattr(self, "_turn_failed_file_mutations", None)
-        if state is None:
-            return
-        targets = _extract_file_mutation_targets(tool_name, args)
-        if not targets:
-            return
-        landed = file_mutation_result_landed(tool_name, result)
-        if landed:
-            changed = getattr(self, "_turn_file_mutation_paths", None)
-            if changed is not None:
-                changed.update(_extract_landed_file_mutation_paths(tool_name, args, result))
-        if is_error and not landed:
-            preview = _extract_error_preview(result)
-            for path in targets:
-                # Keep the FIRST error we saw for a given path unless we
-                # later see success.  A repeated failure with a different
-                # message shouldn't silently overwrite the original.
-                if path not in state:
-                    state[path] = {
-                        "tool": tool_name,
-                        "error_preview": preview,
-                    }
-        else:
-            for path in targets:
-                state.pop(path, None)
+        _record_file_mutation_verifier_result(
+            self,
+            tool_name,
+            args,
+            result,
+            is_error,
+        )
+
+    def _prepare_file_mutation_verifier_call(
+        self,
+        tool_name: str,
+        args: Dict[str, Any],
+        effective_task_id: str,
+        *,
+        active_event: threading.Event | None = None,
+        deadline: float | None = None,
+        cancel_check: Callable[[], bool] | None = None,
+        defer_probe_activation: bool = False,
+    ) -> threading.Event:
+        """Capture exact pre-call evidence for mutation/fallback verification."""
+
+        return _prepare_file_mutation_verifier_call(
+            self,
+            tool_name,
+            args,
+            effective_task_id,
+            active_event=active_event,
+            deadline=deadline,
+            cancel_check=cancel_check,
+            defer_probe_activation=defer_probe_activation,
+        )
 
     def _file_mutation_verifier_enabled(self) -> bool:
         """Check whether the per-turn file-mutation verifier footer is on.
@@ -2910,6 +2912,33 @@ class AIAgent:
             return text
         return cls._FOOTER_PATH_RE.sub(lambda m: f"`{m.group(0)}`", text)
 
+    @staticmethod
+    def _sanitize_footer_fragment(value: Any) -> str:
+        """Render untrusted path/error text as a single safe Markdown line."""
+
+        text = str(value)
+        escaped: List[str] = []
+        for char in text:
+            if char == "`":
+                escaped.append("ˋ")
+            elif char == "\n":
+                escaped.append("\\n")
+            elif char == "\r":
+                escaped.append("\\r")
+            elif char == "\t":
+                escaped.append("\\t")
+            elif unicodedata.category(char) in {"Cc", "Zl", "Zp"}:
+                codepoint = ord(char)
+                if codepoint <= 0xFF:
+                    escaped.append(f"\\x{codepoint:02x}")
+                elif codepoint <= 0xFFFF:
+                    escaped.append(f"\\u{codepoint:04x}")
+                else:
+                    escaped.append(f"\\U{codepoint:08x}")
+            else:
+                escaped.append(char)
+        return "".join(escaped)
+
     @classmethod
     def _format_file_mutation_failure_footer(cls, failed: Dict[str, Dict[str, Any]]) -> str:
         """Render the per-turn failed-mutation dict as a user-facing footer.
@@ -2936,12 +2965,17 @@ class AIAgent:
         for path, info in failed.items():
             if shown >= 10:
                 break
-            preview = (info.get("error_preview") or "").strip()
-            tool = info.get("tool") or "patch"
+            display_path = cls._sanitize_footer_fragment(
+                info.get("display_path") or path
+            )
+            preview = cls._sanitize_footer_fragment(
+                (info.get("error_preview") or "").strip()
+            )
+            tool = cls._sanitize_footer_fragment(info.get("tool") or "patch")
             if preview:
-                lines.append(f"  • `{path}` — [{tool}] {preview}")
+                lines.append(f"  • `{display_path}` — [{tool}] {preview}")
             else:
-                lines.append(f"  • `{path}` — [{tool}] failed")
+                lines.append(f"  • `{display_path}` — [{tool}] failed")
             shown += 1
         remaining = len(failed) - shown
         if remaining > 0:

--- a/tests/run_agent/test_file_mutation_fallback_recovery.py
+++ b/tests/run_agent/test_file_mutation_fallback_recovery.py
@@ -1,0 +1,1597 @@
+"""Regression matrix for stale file-mutation failure recovery.
+
+A failed native mutation remains actionable unless a later successful foreground
+terminal/execute_code call changes that exact backend target during its own
+execution window.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+import time
+from pathlib import Path, PurePosixPath
+from types import SimpleNamespace
+
+import pytest
+
+from agent.turn_finalizer import finalize_turn
+from run_agent import AIAgent
+from tools.file_operations import ExecuteResult, PatchResult, WriteResult
+import tools.code_execution_tool as code_execution_tool
+import tools.file_operations as file_operations
+import tools.file_tools as file_tools
+
+
+class _FailingPatchOps:
+    def patch_replace(self, path, old_string, new_string, replace_all=False):
+        return PatchResult(error=f"Could not find {old_string!r} in {path}")
+
+
+class _RemoteFailingPatchOps(_FailingPatchOps):
+    def __init__(self, files: dict[str, bytes], target: str):
+        self.files = files
+        self.target = target
+        self.patch_targets: list[str] = []
+        self.fingerprint_commands: list[str] = []
+        self.raise_on_fingerprint = False
+
+    def patch_replace(self, path, old_string, new_string, replace_all=False):
+        self.patch_targets.append(path)
+        return super().patch_replace(path, old_string, new_string, replace_all)
+
+    def _exec(self, command, cwd=None, timeout=None, stdin_data=None):
+        self.fingerprint_commands.append(command)
+        if self.raise_on_fingerprint:
+            raise RuntimeError("backend fingerprint failed")
+        content = self.files.get(self.target)
+        if content is None:
+            marker = "__HERMES_FILE_CONTENT_MISSING__"
+        else:
+            digest = hashlib.sha256(content).hexdigest()
+            marker = f"__HERMES_FILE_CONTENT_SHA256__={digest}"
+        return ExecuteResult(stdout=marker + "\n", exit_code=0)
+
+
+class _FailingWriteOps(_FailingPatchOps):
+    def write_file(self, path, content):
+        return WriteResult(error=f"write denied for {path}")
+
+
+class _RecordingWriteOps:
+    def __init__(self):
+        self.targets: list[str] = []
+        self.env: object | None = None
+
+    def write_file(self, path, content):
+        self.targets.append(path)
+        return WriteResult(bytes_written=len(content))
+
+
+class _FailingV4AOps(_FailingPatchOps):
+    def __init__(self):
+        self.resolved_paths = None
+
+    def patch_v4a(self, patch_content):
+        return self.patch_v4a_resolved(patch_content, resolved_paths=None)
+
+    def patch_v4a_resolved(self, patch_content, resolved_paths):
+        self.resolved_paths = resolved_paths
+        return PatchResult(error="Patch validation failed")
+
+
+class _InheritedFailingV4AOps(_FailingV4AOps):
+    """Resolved-path support inherited rather than defined on the leaf class."""
+
+
+class _RecordingV4AOps(_FailingPatchOps):
+    def __init__(self):
+        self.resolved_paths = None
+        self.calls = 0
+
+    def patch_v4a_resolved(self, patch_content, resolved_paths):
+        self.calls += 1
+        self.resolved_paths = resolved_paths
+        return PatchResult(success=True)
+
+
+class _DynamicCapabilityMeta(type):
+    def __getattr__(cls, name):
+        if name != "patch_v4a_resolved":
+            raise AttributeError(name)
+
+        def fabricated(instance, patch_content, resolved_paths):
+            instance.fabricated_calls += 1
+            return PatchResult(error="fabricated capability used")
+
+        return fabricated
+
+
+class _DynamicCapabilityOps(_FailingPatchOps, metaclass=_DynamicCapabilityMeta):
+    def __init__(self):
+        self.fabricated_calls = 0
+        self.legacy_calls = 0
+
+    def patch_v4a(self, patch_content):
+        self.legacy_calls += 1
+        return PatchResult(error="legacy V4A validation failed")
+
+
+class _LegacyV4AOps(_FailingPatchOps):
+    """Backend/plugin implementation that predates resolved-path plumbing."""
+
+    def __init__(self):
+        self.calls = 0
+        self.patch_content = None
+
+    def patch_v4a(self, patch_content):
+        self.calls += 1
+        self.patch_content = patch_content
+        return PatchResult(error="legacy V4A validation failed")
+
+
+class _FinalizeAgent(AIAgent):
+    def __init__(self):
+        # Deliberately skip AIAgent.__init__; this fixture exercises only the
+        # mutation-verifier and finalizer seams.
+        self._turn_failed_file_mutations = {}
+        self._turn_file_mutation_paths = set()
+        self._turn_file_mutation_lock = threading.Lock()
+        self._turn_file_mutation_generation = 0
+        self._turn_file_mutation_epoch = object()
+        self.max_iterations = 90
+        self.iteration_budget = SimpleNamespace(remaining=10, used=1, max_total=90)
+        self.quiet_mode = True
+        self.model = "test-model"
+        self.provider = "test-provider"
+        self.base_url = ""
+        self.session_id = "sess-test"
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+        self.session_input_tokens = 0
+        self.session_output_tokens = 0
+        self.session_cache_read_tokens = 0
+        self.session_cache_write_tokens = 0
+        self.session_reasoning_tokens = 0
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_total_tokens = 0
+        self.session_estimated_cost_usd = 0
+        self.session_cost_status = "unknown"
+        self.session_cost_source = "test"
+        self._tool_guardrail_halt_decision = None
+        self._interrupt_message = None
+        self._response_was_previewed = False
+        self._skill_nudge_interval = 0
+        self._iters_since_skill = 0
+        self.valid_tool_names = []
+
+    def _handle_max_iterations(self, *_args):
+        raise AssertionError("not expected")
+
+    def _emit_status(self, *_args, **_kwargs):
+        pass
+
+    def _safe_print(self, *_args, **_kwargs):
+        pass
+
+    def _save_trajectory(self, *_args, **_kwargs):
+        pass
+
+    def _cleanup_task_resources(self, *_args, **_kwargs):
+        pass
+
+    def _drop_trailing_empty_response_scaffolding(self, *_args, **_kwargs):
+        pass
+
+    def _persist_session(self, *_args, **_kwargs):
+        pass
+
+    def _file_mutation_verifier_enabled(self):
+        return True
+
+    def _turn_completion_explainer_enabled(self):
+        return False
+
+    def _drain_pending_steer(self):
+        return None
+
+    def clear_interrupt(self):
+        pass
+
+    def _sync_external_memory_for_turn(self, **_kwargs):
+        pass
+
+
+@pytest.fixture
+def agent() -> _FinalizeAgent:
+    return _FinalizeAgent()
+
+
+def _reset_verifier_turn(agent: _FinalizeAgent) -> None:
+    """Mirror the production per-turn verifier reset with a fresh identity."""
+
+    agent._turn_failed_file_mutations = {}
+    agent._turn_file_mutation_paths = set()
+    agent._turn_file_mutation_lock = threading.Lock()
+    agent._turn_file_mutation_generation = 0
+    agent._turn_file_mutation_epoch = object()
+
+
+@pytest.fixture
+def failing_patch_ops(monkeypatch):
+    ops = _FailingPatchOps()
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda _task_id="default": ops)
+    monkeypatch.setattr(file_tools, "_check_file_staleness", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(file_tools, "_path_resolution_warning", lambda *_args, **_kwargs: None)
+    return ops
+
+
+def _prepare(agent: AIAgent, tool_name: str, args: dict, task_id: str) -> None:
+    """Use the new pre-call seam when present; current main has no such seam."""
+    prepare = getattr(agent, "_prepare_file_mutation_verifier_call", None)
+    if prepare is not None:
+        prepare(tool_name, args, task_id)
+
+
+def _prepare_with_active_event(
+    agent: AIAgent,
+    tool_name: str,
+    args: dict,
+    task_id: str,
+    active_event: threading.Event,
+) -> None:
+    """Backward-compatible probe for revocable concurrent-call evidence."""
+
+    prepare = getattr(agent, "_prepare_file_mutation_verifier_call", None)
+    if prepare is None:
+        return
+    try:
+        prepare(tool_name, args, task_id, active_event=active_event)
+    except TypeError:
+        # Baseline/candidate before the cancellation contract existed.
+        prepare(tool_name, args, task_id)
+
+
+def _prepare_with_execution_bounds(
+    agent: AIAgent,
+    tool_name: str,
+    args: dict,
+    task_id: str,
+    *,
+    deadline: float | None = None,
+    cancel_check=None,
+) -> None:
+    """Prepare verifier evidence with worker-local execution boundaries."""
+
+    active_event = threading.Event()
+    active_event.set()
+    agent._prepare_file_mutation_verifier_call(
+        tool_name,
+        args,
+        task_id,
+        active_event=active_event,
+        deadline=deadline,
+        cancel_check=cancel_check,
+    )
+
+
+def _record_failed_patch(
+    agent: AIAgent,
+    path: str,
+    *,
+    task_id: str = "default",
+    error_old_string: str = "missing",
+) -> tuple[dict, str]:
+    args = {
+        "mode": "replace",
+        "path": path,
+        "old_string": error_old_string,
+        "new_string": "replacement",
+    }
+    _prepare(agent, "patch", args, task_id)
+    result = file_tools.patch_tool(
+        mode="replace",
+        path=path,
+        old_string=error_old_string,
+        new_string="replacement",
+        task_id=task_id,
+    )
+    assert json.loads(result).get("error"), result
+    agent._record_file_mutation_result("patch", args, result, is_error=True)
+    return args, result
+
+
+def _record_successful_external(
+    agent: AIAgent,
+    mutate,
+    *,
+    task_id: str = "default",
+    tool_name: str = "terminal",
+    args: dict | None = None,
+) -> None:
+    if args is None:
+        args = {"command": "external fallback"}
+    _prepare(agent, tool_name, args, task_id)
+    mutate()
+    if tool_name == "execute_code":
+        result = json.dumps({"status": "success", "output": "ok"})
+    else:
+        result = json.dumps({"output": "ok", "exit_code": 0})
+    agent._record_file_mutation_result(tool_name, args, result, is_error=False)
+
+
+def _finalize(agent: _FinalizeAgent, monkeypatch) -> str:
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    result = finalize_turn(
+        agent,
+        final_response="Done.",
+        api_call_count=2,
+        interrupted=False,
+        failed=False,
+        messages=[{"role": "user", "content": "edit it"}],
+        conversation_history=[],
+        effective_task_id="default",
+        turn_id="turn",
+        user_message="edit it",
+        original_user_message="edit it",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+    return result["final_response"]
+
+
+def test_absolute_existing_file_external_rewrite_suppresses_failure(
+    agent, failing_patch_ops, tmp_path
+):
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+
+    _record_failed_patch(agent, str(target))
+    _record_successful_external(agent, lambda: target.write_text("after!\n"))
+
+    assert agent._turn_failed_file_mutations == {}
+    assert agent._turn_file_mutation_paths == {str(target.resolve())}
+
+
+def test_write_file_failure_external_rewrite_suppresses(
+    agent, tmp_path, monkeypatch
+):
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+    ops = _FailingWriteOps()
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda *_args: ops)
+    args = {"path": str(target), "content": "intended\n"}
+
+    _prepare(agent, "write_file", args, "default")
+    result = file_tools.write_file_tool(
+        path=str(target),
+        content="intended\n",
+        task_id="default",
+    )
+    assert json.loads(result).get("error")
+    agent._record_file_mutation_result(
+        "write_file",
+        args,
+        result,
+        is_error=True,
+    )
+    _record_successful_external(agent, lambda: target.write_text("intended\n"))
+
+    assert agent._turn_failed_file_mutations == {}
+    assert agent._turn_file_mutation_paths == {str(target.resolve())}
+
+
+def test_policy_blocked_write_does_not_fingerprint_denied_target(
+    agent, tmp_path, monkeypatch
+):
+    target = tmp_path / "sensitive.txt"
+    target.write_text("secret\n")
+    args = {"path": str(target), "content": "replacement\n"}
+    fingerprinted = []
+
+    _prepare(agent, "write_file", args, "default")
+    monkeypatch.setattr(
+        file_tools,
+        "_check_sensitive_path",
+        lambda *_args, **_kwargs: "blocked sensitive path",
+    )
+    monkeypatch.setattr(
+        file_tools,
+        "_fingerprint_resolved_file_content",
+        lambda path, task_id="default": fingerprinted.append((path, task_id)),
+        raising=False,
+    )
+    result = file_tools.write_file_tool(
+        path=str(target),
+        content="replacement\n",
+        task_id="default",
+    )
+    assert json.loads(result).get("error")
+    agent._record_file_mutation_result(
+        "write_file",
+        args,
+        result,
+        is_error=True,
+    )
+
+    assert fingerprinted == []
+    assert str(target) in agent._turn_failed_file_mutations
+    assert agent._turn_failed_file_mutations[str(target)].get("fingerprint") is None
+
+
+def test_policy_blocked_write_defers_fingerprint_until_external_fallback(
+    agent, tmp_path, monkeypatch
+):
+    target = tmp_path / "sensitive.txt"
+    target.write_text("before\n")
+    args = {"path": str(target), "content": "replacement\n"}
+
+    _prepare(agent, "write_file", args, "default")
+    monkeypatch.setattr(
+        file_tools,
+        "_check_sensitive_path",
+        lambda *_args, **_kwargs: "blocked sensitive path",
+    )
+    result = file_tools.write_file_tool(
+        path=str(target),
+        content="replacement\n",
+        task_id="default",
+    )
+    assert json.loads(result).get("error")
+    agent._record_file_mutation_result(
+        "write_file",
+        args,
+        result,
+        is_error=True,
+    )
+
+    state = agent._turn_failed_file_mutations[str(target.resolve())]
+    assert state.get("fingerprint") is None
+    _record_successful_external(agent, lambda: target.write_text("replacement\n"))
+
+    assert agent._turn_failed_file_mutations == {}
+    assert agent._turn_file_mutation_paths == {str(target.resolve())}
+
+
+@pytest.mark.parametrize("tool_kind", ["write", "v4a"])
+def test_policy_checks_the_exact_captured_mutation_identity(
+    agent, tmp_path, monkeypatch, tool_kind
+):
+    protected = str((tmp_path / "protected-config.yaml").resolve())
+    safe = str((tmp_path / "safe.yaml").resolve())
+    resolver_calls = 0
+
+    def changing_resolver(_raw, _task_id="default"):
+        nonlocal resolver_calls
+        resolver_calls += 1
+        return Path(protected if resolver_calls == 1 else safe)
+
+    monkeypatch.setattr(file_tools, "_resolve_path_for_task", changing_resolver)
+    monkeypatch.setattr(file_tools, "_get_hermes_config_resolved", lambda: protected)
+    monkeypatch.setattr(file_tools, "_check_cross_profile_path", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        file_tools,
+        "_fingerprint_resolved_file_content",
+        lambda *_args, **_kwargs: None,
+    )
+
+    if tool_kind == "write":
+        ops = _RecordingWriteOps()
+        monkeypatch.setattr(file_tools, "_get_file_ops", lambda *_args: ops)
+        result = json.loads(
+            file_tools.write_file_tool(
+                path="relative-config.yaml",
+                content="replacement\n",
+                task_id="default",
+            )
+        )
+        calls = len(ops.targets)
+    else:
+        ops = _RecordingV4AOps()
+        monkeypatch.setattr(file_tools, "_get_file_ops", lambda *_args: ops)
+        stars = "***"
+        body = (
+            f"{stars}Begin Patch\n"
+            f"{stars}Update File: relative-config.yaml\n"
+            "@@\n"
+            "-before\n"
+            "+after\n"
+            f"{stars}End Patch\n"
+        )
+        result = json.loads(
+            file_tools.patch_tool(mode="patch", patch=body, task_id="default")
+        )
+        calls = ops.calls
+
+    assert "error" in result
+    assert "Hermes config" in result["error"]
+    assert calls == 0
+
+
+def test_cross_profile_policy_uses_the_exact_captured_mutation_identity(
+    tmp_path, monkeypatch
+):
+    from agent import file_safety
+
+    protected = str((tmp_path / "profiles" / "other" / "skills" / "x.md").resolve())
+    safe = str((tmp_path / "safe.md").resolve())
+    resolver_calls = 0
+
+    def changing_resolver(_raw, _task_id="default"):
+        nonlocal resolver_calls
+        resolver_calls += 1
+        return Path(protected if resolver_calls == 1 else safe)
+
+    ops = _RecordingWriteOps()
+    monkeypatch.setattr(file_tools, "_resolve_path_for_task", changing_resolver)
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda *_args: ops)
+    monkeypatch.setattr(file_tools, "_get_hermes_config_resolved", lambda: None)
+    monkeypatch.setattr(
+        file_tools,
+        "_fingerprint_resolved_file_content",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        file_safety,
+        "get_cross_profile_warning",
+        lambda resolved: "cross-profile identity blocked" if resolved == protected else None,
+    )
+    monkeypatch.setattr(file_safety, "get_sandbox_mirror_warning", lambda _resolved: None)
+    monkeypatch.setattr(
+        file_safety,
+        "get_container_mirror_warning",
+        lambda _resolved, mirror_prefix=None: None,
+    )
+
+    result = json.loads(
+        file_tools.write_file_tool(
+            path="relative.md",
+            content="replacement\n",
+            task_id="default",
+        )
+    )
+
+    assert result.get("error") == "cross-profile identity blocked"
+    assert resolver_calls == 1
+    assert ops.targets == []
+
+
+@pytest.mark.skipif(
+    not code_execution_tool.SANDBOX_AVAILABLE,
+    reason="execute_code sandbox unavailable",
+)
+def test_real_local_execute_code_rewrite_suppresses(
+    agent, failing_patch_ops, tmp_path, monkeypatch
+):
+    """The real local sandbox shares absolute target identity with file tools."""
+
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+    _record_failed_patch(agent, str(target))
+
+    code = (
+        "from pathlib import Path\n"
+        f"Path({str(target)!r}).write_text('sandbox-after\\n', encoding='utf-8')\n"
+        "print('done')\n"
+    )
+    args = {"code": code}
+    agent._prepare_file_mutation_verifier_call(
+        "execute_code",
+        args,
+        "default",
+        defer_probe_activation=True,
+    )
+    monkeypatch.setattr(
+        "tools.terminal_tool._get_env_config",
+        lambda: {"env_type": "local"},
+    )
+    monkeypatch.setattr(
+        "tools.terminal_tool._docker_has_host_access",
+        lambda _config: False,
+    )
+    monkeypatch.setattr(
+        "tools.approval.check_execute_code_guard",
+        lambda *_args, **_kwargs: {"approved": True},
+    )
+    monkeypatch.setattr(
+        code_execution_tool,
+        "_load_config",
+        lambda: {"timeout": 15, "max_tool_calls": 1},
+    )
+    monkeypatch.setattr(code_execution_tool, "_get_execution_mode", lambda: "strict")
+
+    result = code_execution_tool.execute_code(
+        code=code,
+        task_id="default",
+        enabled_tools=[],
+    )
+    payload = json.loads(result)
+    assert payload.get("status") == "success", payload
+    agent._record_file_mutation_result(
+        "execute_code",
+        args,
+        result,
+        is_error=False,
+    )
+
+    assert target.read_text() == "sandbox-after\n"
+    assert agent._turn_failed_file_mutations == {}
+    assert agent._turn_file_mutation_paths == {str(target.resolve())}
+
+
+@pytest.mark.parametrize("fallback_tool", ["terminal", "execute_code"])
+def test_denied_real_fallback_gate_does_not_activate_deferred_fingerprint(
+    agent, tmp_path, monkeypatch, fallback_tool
+):
+    target = tmp_path / "sensitive.txt"
+    target.write_text("secret\n")
+    write_args = {"path": str(target), "content": "replacement\n"}
+    _prepare(agent, "write_file", write_args, "default")
+    monkeypatch.setattr(
+        file_tools,
+        "_check_sensitive_path",
+        lambda *_args, **_kwargs: "blocked sensitive path",
+    )
+    write_result = file_tools.write_file_tool(
+        path=str(target),
+        content="replacement\n",
+        task_id="default",
+    )
+    agent._record_file_mutation_result(
+        "write_file",
+        write_args,
+        write_result,
+        is_error=True,
+    )
+    state = agent._turn_failed_file_mutations[str(target.resolve())]
+    assert state.get("fingerprint_deferred") is True
+
+    fingerprinted: list[str] = []
+    monkeypatch.setattr(
+        file_tools,
+        "_fingerprint_resolved_file_content",
+        lambda path, _task_id="default": fingerprinted.append(path),
+    )
+
+    if fallback_tool == "execute_code":
+        fallback_args = {"code": "print('denied')"}
+        agent._prepare_file_mutation_verifier_call(
+            fallback_tool,
+            fallback_args,
+            "default",
+            defer_probe_activation=True,
+        )
+        monkeypatch.setattr(
+            "tools.terminal_tool._get_env_config",
+            lambda: {"env_type": "local"},
+        )
+        monkeypatch.setattr(
+            "tools.terminal_tool._docker_has_host_access",
+            lambda _config: False,
+        )
+        monkeypatch.setattr(
+            "tools.approval.check_execute_code_guard",
+            lambda *_args, **_kwargs: {
+                "approved": False,
+                "message": "denied by execute_code guard",
+            },
+        )
+        fallback_result = code_execution_tool.execute_code(
+            code=fallback_args["code"],
+            task_id="default",
+            enabled_tools=[],
+        )
+    else:
+        import tools.terminal_tool as terminal_tool
+
+        fallback_args = {"command": "denied fallback"}
+        agent._prepare_file_mutation_verifier_call(
+            fallback_tool,
+            fallback_args,
+            "default",
+            defer_probe_activation=True,
+        )
+        monkeypatch.setattr(
+            terminal_tool,
+            "_get_env_config",
+            lambda: {"env_type": "local", "cwd": str(tmp_path), "timeout": 30},
+        )
+        monkeypatch.setattr(terminal_tool, "resolve_task_overrides", lambda *_args: {})
+        monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda *_args: "default")
+        monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+        monkeypatch.setitem(
+            terminal_tool._active_environments,
+            "default",
+            SimpleNamespace(cwd=str(tmp_path)),
+        )
+        monkeypatch.setattr(
+            terminal_tool,
+            "_check_all_guards",
+            lambda *_args, **_kwargs: {
+                "approved": False,
+                "status": "blocked",
+                "message": "denied by terminal guard",
+            },
+        )
+        fallback_result = terminal_tool.terminal_tool(
+            command=fallback_args["command"],
+            task_id="default",
+        )
+
+    assert json.loads(fallback_result).get("error")
+    assert fingerprinted == []
+    assert state.get("fingerprint") is None
+    assert state.get("fingerprint_deferred") is True
+    agent._prepare_file_mutation_verifier_call("read_file", {}, "default")
+
+
+def test_absolute_unchanged_file_retains_failure(agent, failing_patch_ops, tmp_path):
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+
+    _record_failed_patch(agent, str(target))
+    _record_successful_external(agent, lambda: None)
+
+    assert str(target.resolve()) in agent._turn_failed_file_mutations
+
+
+def test_unlanded_native_result_cannot_clear_prior_failure(
+    agent, failing_patch_ops, tmp_path
+):
+    """A malformed success classification is not proof that a patch landed."""
+
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+    args, _ = _record_failed_patch(agent, str(target))
+
+    _prepare(agent, "patch", args, "default")
+    agent._record_file_mutation_result(
+        "patch",
+        args,
+        json.dumps({"success": False}),
+        is_error=False,
+    )
+
+    assert str(target.resolve()) in agent._turn_failed_file_mutations
+    assert agent._turn_file_mutation_paths == set()
+
+
+@pytest.mark.parametrize("source", ["live_cwd", "workspace_override"])
+def test_relative_target_uses_effective_task_workspace_not_process_cwd(
+    agent, failing_patch_ops, tmp_path, monkeypatch, source
+):
+    workspace = tmp_path / "workspace"
+    process_cwd = tmp_path / "process-cwd"
+    workspace.mkdir()
+    process_cwd.mkdir()
+    intended = workspace / "app.txt"
+    decoy = process_cwd / "app.txt"
+    intended.write_text("workspace-before\n")
+    decoy.write_text("decoy-before\n")
+    monkeypatch.chdir(process_cwd)
+    task_id = "session-worktree"
+
+    if source == "live_cwd":
+        monkeypatch.setattr(
+            file_tools,
+            "_get_live_tracking_cwd",
+            lambda incoming="default": str(workspace) if incoming == task_id else None,
+        )
+        monkeypatch.setattr(file_tools, "_registered_task_cwd_override", lambda *_args: None)
+    else:
+        monkeypatch.setattr(file_tools, "_get_live_tracking_cwd", lambda *_args: None)
+        monkeypatch.setattr(
+            file_tools,
+            "_registered_task_cwd_override",
+            lambda incoming="default": str(workspace) if incoming == task_id else None,
+        )
+
+    _record_failed_patch(agent, "app.txt", task_id=task_id)
+    _record_successful_external(
+        agent,
+        lambda: intended.write_text("workspace-after!\n"),
+        task_id=task_id,
+    )
+
+    assert agent._turn_failed_file_mutations == {}
+    assert agent._turn_file_mutation_paths == {str(intended.resolve())}
+    assert decoy.read_text() == "decoy-before\n"
+
+
+def test_v4a_uses_captured_resolved_identity_for_backend_calls_and_recovery(
+    agent, tmp_path, monkeypatch
+):
+    workspace = tmp_path / "workspace"
+    process_cwd = tmp_path / "process-cwd"
+    workspace.mkdir()
+    process_cwd.mkdir()
+    target = workspace / "app.txt"
+    target.write_text("before\n")
+    monkeypatch.chdir(process_cwd)
+    task_id = "v4a-worktree"
+    monkeypatch.setattr(
+        file_tools,
+        "_get_live_tracking_cwd",
+        lambda incoming="default": str(workspace) if incoming == task_id else None,
+    )
+    monkeypatch.setattr(file_tools, "_registered_task_cwd_override", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_check_file_staleness", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_path_resolution_warning", lambda *_args: None)
+    ops = _InheritedFailingV4AOps()
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda *_args: ops)
+    stars = "***"
+    body = (
+        f"{stars}Begin Patch\n"
+        f"{stars}Update File: app.txt\n"
+        "@@\n"
+        "-missing\n"
+        "+replacement\n"
+        f"{stars}End Patch\n"
+    )
+    args = {"mode": "patch", "patch": body}
+
+    _prepare(agent, "patch", args, task_id)
+    result = file_tools.patch_tool(
+        mode="patch",
+        patch=body,
+        task_id=task_id,
+    )
+    assert json.loads(result).get("error")
+    agent._record_file_mutation_result("patch", args, result, is_error=True)
+
+    expected = str(target.resolve())
+    assert ops.resolved_paths == {"app.txt": expected}
+    assert any(
+        info["display_path"] == expected
+        for info in agent._turn_failed_file_mutations.values()
+    )
+
+    _record_successful_external(
+        agent,
+        lambda: target.write_text("after!\n"),
+        task_id=task_id,
+    )
+    assert agent._turn_failed_file_mutations == {}
+
+
+def test_v4a_captures_resolved_identities_for_add_delete_move_and_update(
+    tmp_path, monkeypatch
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ops = _RecordingV4AOps()
+
+    def resolve_in_workspace(raw: str, task_id: str = "default"):
+        candidate = Path(raw)
+        return candidate if candidate.is_absolute() else workspace / candidate
+
+    monkeypatch.setattr(file_tools, "_resolve_path_for_task", resolve_in_workspace)
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda *_args: ops)
+    monkeypatch.setattr(file_tools, "_check_sensitive_path", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_check_cross_profile_path", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_check_file_staleness", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_path_resolution_warning", lambda *_args: None)
+    monkeypatch.setattr(
+        file_tools,
+        "_fingerprint_resolved_file_content",
+        lambda *_args, **_kwargs: None,
+    )
+    stars = "***"
+    body = (
+        f"{stars}Begin Patch\n"
+        f"{stars}Update File: update.txt\n"
+        "@@\n-old\n+new\n"
+        f"{stars}Add File: add.txt\n"
+        "+new file\n"
+        f"{stars}Delete File: delete.txt\n"
+        f"{stars}Move File: source.txt -> moved.txt\n"
+        f"{stars}End Patch\n"
+    )
+
+    payload = json.loads(file_tools.patch_tool(mode="patch", patch=body))
+
+    assert payload.get("success") is True
+    assert ops.resolved_paths == {
+        name: str(workspace / name)
+        for name in (
+            "update.txt",
+            "add.txt",
+            "delete.txt",
+            "source.txt",
+            "moved.txt",
+        )
+    }
+
+
+def test_v4a_legacy_backend_signature_remains_compatible(
+    agent, tmp_path, monkeypatch
+):
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+    ops = _LegacyV4AOps()
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda *_args: ops)
+    monkeypatch.setattr(file_tools, "_check_file_staleness", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_path_resolution_warning", lambda *_args: None)
+    stars = "***"
+    body = (
+        f"{stars}Begin Patch\n"
+        f"{stars}Update File: {target}\n"
+        "@@\n"
+        "-missing\n"
+        "+replacement\n"
+        f"{stars}End Patch\n"
+    )
+
+    args = {"mode": "patch", "patch": body}
+    _prepare(agent, "patch", args, "default")
+    result = file_tools.patch_tool(
+        mode="patch",
+        patch=body,
+        task_id="default",
+    )
+    payload = json.loads(result)
+
+    assert payload.get("error") == "legacy V4A validation failed"
+    assert ops.calls == 1
+
+    # A legacy backend does not expose the capability needed to prove that it
+    # used the tool layer's resolved identity. Preserve compatibility, but keep
+    # recovery fail-closed instead of clearing a warning for a possibly
+    # different target.
+    agent._record_file_mutation_result("patch", args, result, is_error=True)
+    _record_successful_external(agent, lambda: target.write_text("after!\n"))
+    assert agent._turn_failed_file_mutations
+    assert agent._turn_file_mutation_paths == set()
+
+
+def test_legacy_v4a_rewrites_relative_header_to_captured_identity(
+    tmp_path, monkeypatch
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "app.txt"
+    target.write_text("before\n")
+    task_id = "legacy-worktree"
+    ops = _LegacyV4AOps()
+    monkeypatch.setattr(
+        file_tools,
+        "_resolve_path_for_task",
+        lambda raw, _task_id="default": workspace / raw,
+    )
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda *_args: ops)
+    monkeypatch.setattr(file_tools, "_check_sensitive_path", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_check_cross_profile_path", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_check_file_staleness", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_path_resolution_warning", lambda *_args: None)
+    stars = "***"
+    body = (
+        f"{stars}Begin Patch\n"
+        f"{stars}Update File: app.txt\n"
+        "@@\n"
+        "-before\n"
+        "+after\n"
+        f"{stars}Add File: add.txt\n"
+        "+new\n"
+        f"{stars}Delete File: delete.txt\n"
+        f"{stars}Move File: source.txt -> moved.txt\n"
+        f"{stars}End Patch\n"
+    )
+
+    payload = json.loads(
+        file_tools.patch_tool(
+            mode="patch",
+            patch=body,
+            task_id=task_id,
+        )
+    )
+
+    assert payload.get("error") == "legacy V4A validation failed"
+    assert ops.patch_content is not None
+    expected_headers = (
+        f"{stars}Update File: {workspace / 'app.txt'}",
+        f"{stars}Add File: {workspace / 'add.txt'}",
+        f"{stars}Delete File: {workspace / 'delete.txt'}",
+        (
+            f"{stars}Move File: {workspace / 'source.txt'} -> "
+            f"{workspace / 'moved.txt'}"
+        ),
+    )
+    assert all(header in ops.patch_content for header in expected_headers)
+    assert f"{stars}Update File: app.txt\n" not in ops.patch_content
+
+
+def test_resolved_v4a_adapter_rejects_missing_identity_mapping():
+    delegate = object.__new__(file_operations.ShellFileOperations)
+    adapter = file_operations._ResolvedPathFileOperations(
+        delegate,
+        {"captured.txt": "/workspace/captured.txt"},
+    )
+
+    with pytest.raises(ValueError, match="No captured resolved identity"):
+        adapter.read_file_raw("uncaptured.txt")
+
+
+def test_v4a_capability_detection_ignores_dynamic_metaclass_attributes(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+    ops = _DynamicCapabilityOps()
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda *_args: ops)
+    monkeypatch.setattr(file_tools, "_check_sensitive_path", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(file_tools, "_check_cross_profile_path", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(file_tools, "_check_file_staleness", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_path_resolution_warning", lambda *_args: None)
+    stars = "***"
+    body = (
+        f"{stars}Begin Patch\n"
+        f"{stars}Update File: {target}\n"
+        "@@\n"
+        "-before\n"
+        "+after\n"
+        f"{stars}End Patch\n"
+    )
+
+    payload = json.loads(file_tools.patch_tool(mode="patch", patch=body))
+
+    assert payload.get("error") == "legacy V4A validation failed"
+    assert ops.legacy_calls == 1
+    assert ops.fabricated_calls == 0
+
+
+def test_ssh_resolution_uses_remote_home_and_never_dereferences_host_symlinks(
+    tmp_path, monkeypatch
+):
+    task_id = "ssh-task"
+    env = SimpleNamespace(
+        _remote_home="/home/remote-user",
+        cwd="/worktree",
+        cwd_owner=task_id,
+    )
+    monkeypatch.setattr(file_tools, "_terminal_env_type_for_task", lambda *_args: "ssh")
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda *_args: SimpleNamespace(env=env))
+    monkeypatch.setattr(file_tools, "_get_live_tracking_cwd", lambda *_args: "/worktree")
+
+    assert file_tools._resolve_path_for_task("~/notes.txt", task_id) == PurePosixPath(
+        "/home/remote-user/notes.txt"
+    )
+
+    host_target = tmp_path / "host-target.txt"
+    host_target.write_text("host\n")
+    host_link = tmp_path / "remote-link.txt"
+    host_link.symlink_to(host_target)
+    assert file_tools._resolve_path_for_task(str(host_link), task_id) == PurePosixPath(
+        str(host_link)
+    )
+
+
+def test_ssh_tilde_sensitive_policy_uses_captured_remote_identity(
+    monkeypatch,
+):
+    task_id = "ssh-sensitive"
+    env = SimpleNamespace(
+        _remote_home="/home/remote-user",
+        cwd="/worktree",
+        cwd_owner=task_id,
+    )
+    ops = _RecordingWriteOps()
+    ops.env = env
+    monkeypatch.setattr(file_tools, "_terminal_env_type_for_task", lambda *_args: "ssh")
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda *_args: ops)
+    monkeypatch.setattr(file_tools, "_get_live_tracking_cwd", lambda *_args: "/worktree")
+    monkeypatch.setattr(
+        file_tools,
+        "_get_hermes_config_resolved",
+        lambda: "/root/.hermes/config.yaml",
+    )
+    monkeypatch.setattr(file_tools, "_check_cross_profile_path", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_check_file_staleness", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_path_resolution_warning", lambda *_args: None)
+    monkeypatch.setattr(
+        file_tools,
+        "_fingerprint_resolved_file_content",
+        lambda *_args, **_kwargs: None,
+    )
+
+    payload = json.loads(
+        file_tools.write_file_tool(
+            path="~/.hermes/config.yaml",
+            content="remote-only\n",
+            task_id=task_id,
+        )
+    )
+
+    expected = "/home/remote-user/.hermes/config.yaml"
+    assert payload.get("error") is None
+    assert payload.get("resolved_path") == expected
+    assert ops.targets == [expected]
+
+
+def test_first_docker_mutation_resolves_after_backend_cwd_is_initialized(
+    monkeypatch,
+):
+    task_id = "docker-first-call"
+    live = False
+    ops = _RecordingWriteOps()
+
+    def get_ops(*_args):
+        nonlocal live
+        live = True
+        return ops
+
+    monkeypatch.setattr(file_tools, "_terminal_env_type_for_task", lambda *_args: "docker")
+    monkeypatch.setattr(
+        file_tools,
+        "_get_live_tracking_cwd",
+        lambda *_args: "/workspace" if live else None,
+    )
+    monkeypatch.setattr(
+        file_tools,
+        "_registered_task_cwd_override",
+        lambda *_args: "/host/users/josh/project",
+    )
+    monkeypatch.setattr(file_tools, "_last_known_cwd_for", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_configured_terminal_cwd", lambda: None)
+    monkeypatch.setattr(file_tools, "_get_file_ops", get_ops)
+    monkeypatch.setattr(file_tools, "_check_sensitive_path", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(file_tools, "_check_cross_profile_path", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(file_tools, "_check_file_staleness", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_path_resolution_warning", lambda *_args: None)
+    monkeypatch.setattr(
+        file_tools,
+        "_fingerprint_resolved_file_content",
+        lambda *_args, **_kwargs: None,
+    )
+
+    payload = json.loads(
+        file_tools.write_file_tool(
+            path="app.txt",
+            content="content\n",
+            task_id=task_id,
+        )
+    )
+
+    assert payload.get("resolved_path") == "/workspace/app.txt"
+    assert ops.targets == ["/workspace/app.txt"]
+
+
+@pytest.mark.parametrize("backend", ["docker", "ssh"])
+def test_nonlocal_target_is_fingerprinted_through_backend_not_host(
+    agent, monkeypatch, backend
+):
+    target = "/workspace/app.txt"
+    remote_files = {target: b"before\n"}
+    ops = _RemoteFailingPatchOps(remote_files, target)
+
+    def resolve_remote(raw: str, task_id: str = "default"):
+        candidate = PurePosixPath(raw)
+        return candidate if candidate.is_absolute() else PurePosixPath("/workspace") / candidate
+
+    monkeypatch.setattr(file_tools, "_terminal_env_type_for_task", lambda *_args: backend)
+    monkeypatch.setattr(file_tools, "_resolve_path_for_task", resolve_remote)
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda *_args: ops)
+    monkeypatch.setattr(file_tools, "_check_sensitive_path", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_check_cross_profile_path", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_check_file_staleness", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_path_resolution_warning", lambda *_args: None)
+
+    _record_failed_patch(agent, "app.txt", task_id="remote-task")
+    _record_successful_external(
+        agent,
+        lambda: remote_files.__setitem__(target, b"after!\n"),
+        task_id="remote-task",
+    )
+
+    assert agent._turn_failed_file_mutations == {}
+    assert agent._turn_file_mutation_paths == {target}
+    assert ops.patch_targets == [target]
+    assert ops.fingerprint_commands
+    assert all(target in command for command in ops.fingerprint_commands)
+
+
+def test_same_resolved_path_in_different_tasks_keeps_independent_failures(
+    agent, monkeypatch
+):
+    target = "/workspace/app.txt"
+    ops_by_task = {
+        "task-a": _RemoteFailingPatchOps({target: b"before-a\n"}, target),
+        "task-b": _RemoteFailingPatchOps({target: b"before-b\n"}, target),
+    }
+
+    monkeypatch.setattr(file_tools, "_terminal_env_type_for_task", lambda *_args: "docker")
+    monkeypatch.setattr(
+        file_tools,
+        "_resolve_path_for_task",
+        lambda _raw, task_id="default": PurePosixPath(target),
+    )
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda task_id="default": ops_by_task[task_id])
+    monkeypatch.setattr(file_tools, "_check_sensitive_path", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_check_cross_profile_path", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_check_file_staleness", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_path_resolution_warning", lambda *_args: None)
+
+    _record_failed_patch(agent, "app.txt", task_id="task-a")
+    _record_failed_patch(agent, "app.txt", task_id="task-b")
+
+    assert len(agent._turn_failed_file_mutations) == 2
+    assert {info["task_id"] for info in agent._turn_failed_file_mutations.values()} == {
+        "task-a",
+        "task-b",
+    }
+
+    _record_successful_external(
+        agent,
+        lambda: ops_by_task["task-a"].files.__setitem__(target, b"after-a\n"),
+        task_id="task-a",
+    )
+
+    assert len(agent._turn_failed_file_mutations) == 1
+    remaining = next(iter(agent._turn_failed_file_mutations.values()))
+    assert remaining["task_id"] == "task-b"
+
+
+def test_metadata_only_touch_and_chmod_do_not_suppress(
+    agent, failing_patch_ops, tmp_path
+):
+    target = tmp_path / "app.txt"
+    target.write_text("same content\n")
+    original_mode = target.stat().st_mode & 0o777
+
+    _record_failed_patch(agent, str(target))
+
+    def metadata_only():
+        os.utime(target, None)
+        target.chmod(original_mode ^ 0o100)
+
+    _record_successful_external(agent, metadata_only)
+
+    assert str(target.resolve()) in agent._turn_failed_file_mutations
+
+
+def test_same_size_rewrite_with_preserved_metadata_suppresses(
+    agent, failing_patch_ops, tmp_path
+):
+    target = tmp_path / "app.txt"
+    target.write_bytes(b"AAAA\n")
+    before = target.stat()
+
+    _record_failed_patch(agent, str(target))
+
+    def rewrite_preserving_metadata():
+        target.write_bytes(b"BBBB\n")
+        target.chmod(before.st_mode & 0o777)
+        os.utime(target, ns=(before.st_atime_ns, before.st_mtime_ns))
+
+    _record_successful_external(agent, rewrite_preserving_metadata)
+
+    assert agent._turn_failed_file_mutations == {}
+
+
+def test_failure_fallback_then_later_failure_is_new_actionable_generation(
+    agent, failing_patch_ops, tmp_path
+):
+    target = tmp_path / "app.txt"
+    target.write_text("first\n")
+
+    _record_failed_patch(agent, str(target), error_old_string="missing-first")
+    _record_successful_external(agent, lambda: target.write_text("fallback\n"))
+    assert agent._turn_failed_file_mutations == {}
+
+    _record_failed_patch(agent, str(target), error_old_string="missing-second")
+
+    info = agent._turn_failed_file_mutations[str(target.resolve())]
+    assert info["generation"] >= 2
+    assert "missing-second" in info["error_preview"]
+
+
+def test_successful_external_tool_before_failure_does_not_suppress(
+    agent, failing_patch_ops, tmp_path
+):
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+
+    _record_successful_external(agent, lambda: target.write_text("earlier\n"))
+    _record_failed_patch(agent, str(target))
+
+    assert str(target.resolve()) in agent._turn_failed_file_mutations
+
+
+@pytest.mark.parametrize("background", [True, 1, "true"])
+def test_background_terminal_launch_does_not_suppress_later_watcher_change(
+    agent, failing_patch_ops, tmp_path, background
+):
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+    _record_failed_patch(agent, str(target))
+
+    _record_successful_external(
+        agent,
+        lambda: target.write_text("watcher-change\n"),
+        args={"command": "watcher", "background": background},
+    )
+
+    assert str(target.resolve()) in agent._turn_failed_file_mutations
+
+
+def test_unresolvable_path_retains_warning(agent):
+    malformed = "bad\x00path.txt"
+    args = {
+        "mode": "replace",
+        "path": malformed,
+        "old_string": "x",
+        "new_string": "y",
+    }
+    _prepare(agent, "patch", args, "default")
+    agent._record_file_mutation_result(
+        "patch",
+        args,
+        json.dumps({"error": "malformed path"}),
+        is_error=True,
+    )
+    _record_successful_external(agent, lambda: None)
+
+    assert agent._turn_failed_file_mutations
+    assert agent._turn_file_mutation_paths == set()
+
+
+def test_backend_fingerprint_exception_retains_warning(agent, monkeypatch):
+    target = "/workspace/app.txt"
+    remote_files = {target: b"before\n"}
+    ops = _RemoteFailingPatchOps(remote_files, target)
+    ops.raise_on_fingerprint = True
+
+    monkeypatch.setattr(file_tools, "_terminal_env_type_for_task", lambda *_args: "docker")
+    monkeypatch.setattr(
+        file_tools,
+        "_resolve_path_for_task",
+        lambda raw, task_id="default": PurePosixPath(target),
+    )
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda *_args: ops)
+    monkeypatch.setattr(file_tools, "_check_sensitive_path", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_check_cross_profile_path", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_check_file_staleness", lambda *_args: None)
+    monkeypatch.setattr(file_tools, "_path_resolution_warning", lambda *_args: None)
+
+    _record_failed_patch(agent, "app.txt", task_id="remote-task")
+    _record_successful_external(
+        agent,
+        lambda: remote_files.__setitem__(target, b"after!\n"),
+        task_id="remote-task",
+    )
+
+    assert any(
+        info["display_path"] == target
+        for info in agent._turn_failed_file_mutations.values()
+    )
+    assert agent._turn_file_mutation_paths == set()
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "args", "result"),
+    [
+        ("terminal", {"command": "fallback"}, json.dumps({"output": "ok"})),
+        (
+            "execute_code",
+            {"code": "print('fallback')"},
+            json.dumps({"status": "unknown", "output": "ok"}),
+        ),
+    ],
+)
+def test_malformed_external_success_result_cannot_suppress(
+    agent, failing_patch_ops, tmp_path, tool_name, args, result
+):
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+    _record_failed_patch(agent, str(target))
+
+    _prepare(agent, tool_name, args, "default")
+    target.write_text("after!\n")
+    agent._record_file_mutation_result(
+        tool_name,
+        args,
+        result,
+        is_error=False,
+    )
+
+    assert str(target.resolve()) in agent._turn_failed_file_mutations
+    assert agent._turn_file_mutation_paths == set()
+
+
+def test_revoked_concurrent_fallback_evidence_cannot_suppress(
+    agent, failing_patch_ops, tmp_path
+):
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+    _record_failed_patch(agent, str(target))
+    args = {"command": "late concurrent fallback"}
+    active_event = threading.Event()
+    active_event.set()
+
+    _prepare_with_active_event(agent, "terminal", args, "default", active_event)
+    active_event.clear()  # dispatcher synthesized timeout/cancellation
+    target.write_text("late-change\n")
+    agent._record_file_mutation_result(
+        "terminal",
+        args,
+        json.dumps({"output": "ok", "exit_code": 0}),
+        is_error=False,
+    )
+
+    assert str(target.resolve()) in agent._turn_failed_file_mutations
+    assert agent._turn_file_mutation_paths == set()
+
+
+@pytest.mark.parametrize("boundary", ["deadline", "interrupt"])
+def test_expired_or_interrupted_fallback_context_cannot_suppress(
+    agent, failing_patch_ops, tmp_path, boundary
+):
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+    _record_failed_patch(agent, str(target))
+    args = {"command": "bounded fallback"}
+    interrupted = threading.Event()
+    deadline = time.monotonic() + 0.2 if boundary == "deadline" else None
+
+    _prepare_with_execution_bounds(
+        agent,
+        "terminal",
+        args,
+        "default",
+        deadline=deadline,
+        cancel_check=interrupted.is_set,
+    )
+    if boundary == "deadline":
+        time.sleep(0.25)
+    else:
+        interrupted.set()
+    target.write_text("late-change\n")
+    agent._record_file_mutation_result(
+        "terminal",
+        args,
+        json.dumps({"output": "ok", "exit_code": 0}),
+        is_error=False,
+    )
+
+    assert str(target.resolve()) in agent._turn_failed_file_mutations
+    assert agent._turn_file_mutation_paths == set()
+
+
+def test_detached_fallback_from_old_turn_cannot_clear_replacement_turn(
+    agent, failing_patch_ops, tmp_path
+):
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+    _record_failed_patch(agent, str(target), error_old_string="old-turn")
+    args = {"command": "detached old-turn fallback"}
+    _prepare(agent, "terminal", args, "default")
+
+    _reset_verifier_turn(agent)
+    errors = []
+
+    def record_new_turn_failure():
+        try:
+            _record_failed_patch(agent, str(target), error_old_string="new-turn")
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            errors.append(exc)
+
+    thread = threading.Thread(target=record_new_turn_failure)
+    thread.start()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert errors == []
+
+    target.write_text("late-old-turn-change\n")
+    agent._record_file_mutation_result(
+        "terminal",
+        args,
+        json.dumps({"output": "ok", "exit_code": 0}),
+        is_error=False,
+    )
+
+    info = agent._turn_failed_file_mutations[str(target.resolve())]
+    assert "new-turn" in info["error_preview"]
+    assert agent._turn_file_mutation_paths == set()
+
+
+def test_detached_native_success_from_old_turn_cannot_clear_replacement_turn(
+    agent, failing_patch_ops, tmp_path
+):
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+    old_args = {"path": str(target), "content": "old-turn-content\n"}
+    _prepare(agent, "write_file", old_args, "default")
+    file_tools._capture_mutation_target_identities([str(target)], "default")
+    old_result = json.dumps(
+        {
+            "bytes_written": len(old_args["content"]),
+            "resolved_path": str(target.resolve()),
+            "files_modified": [str(target.resolve())],
+        }
+    )
+
+    _reset_verifier_turn(agent)
+    errors = []
+
+    def record_new_turn_failure():
+        try:
+            _record_failed_patch(agent, str(target), error_old_string="new-turn")
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            errors.append(exc)
+
+    thread = threading.Thread(target=record_new_turn_failure)
+    thread.start()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert errors == []
+
+    agent._record_file_mutation_result(
+        "write_file",
+        old_args,
+        old_result,
+        is_error=False,
+    )
+
+    info = agent._turn_failed_file_mutations[str(target.resolve())]
+    assert "new-turn" in info["error_preview"]
+    assert agent._turn_file_mutation_paths == set()
+
+
+def test_concurrent_fallback_started_before_failure_cannot_suppress(
+    agent, failing_patch_ops, tmp_path
+):
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+    fallback_started = threading.Event()
+    finish_fallback = threading.Event()
+
+    def fallback_worker():
+        args = {"command": "concurrent fallback"}
+        _prepare(agent, "terminal", args, "default")
+        fallback_started.set()
+        assert finish_fallback.wait(timeout=5)
+        target.write_text("after!\n")
+        agent._record_file_mutation_result(
+            "terminal",
+            args,
+            json.dumps({"output": "ok", "exit_code": 0}),
+            is_error=False,
+        )
+
+    thread = threading.Thread(target=fallback_worker)
+    thread.start()
+    assert fallback_started.wait(timeout=5)
+    _record_failed_patch(agent, str(target))
+    finish_fallback.set()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+
+    assert str(target.resolve()) in agent._turn_failed_file_mutations
+
+
+def test_finalize_turn_omits_footer_after_ordered_content_change(
+    agent, failing_patch_ops, tmp_path, monkeypatch
+):
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+    _record_failed_patch(agent, str(target))
+    _record_successful_external(agent, lambda: target.write_text("after!\n"))
+
+    response = _finalize(agent, monkeypatch)
+
+    assert "File-mutation verifier" not in response
+
+
+def test_finalize_turn_retains_footer_when_target_unchanged(
+    agent, failing_patch_ops, tmp_path, monkeypatch
+):
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+    _record_failed_patch(agent, str(target))
+    _record_successful_external(agent, lambda: None)
+
+    response = _finalize(agent, monkeypatch)
+
+    assert "File-mutation verifier" in response
+    assert str(target.resolve()) in response

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -20,6 +20,7 @@ list of files that did NOT change.
 from __future__ import annotations
 
 import json
+import threading
 
 import pytest
 
@@ -118,6 +119,25 @@ class TestExtractErrorPreview:
 # ---------------------------------------------------------------------------
 
 
+class _BareAgent(AIAgent):
+    """Test shell that mirrors the dispatcher's required pre-call seam."""
+
+    def _record_file_mutation_result(
+        self,
+        tool_name,
+        args,
+        result,
+        is_error,
+    ):
+        self._prepare_file_mutation_verifier_call(tool_name, args, "default")
+        return super()._record_file_mutation_result(
+            tool_name,
+            args,
+            result,
+            is_error,
+        )
+
+
 def _bare_agent() -> AIAgent:
     """Skip __init__ and only attach the per-turn state dict.
 
@@ -127,9 +147,12 @@ def _bare_agent() -> AIAgent:
     Using ``object.__new__`` mirrors the gateway-test pattern documented in
     the agent pitfalls list.
     """
-    agent = object.__new__(AIAgent)
+    agent = object.__new__(_BareAgent)
     agent._turn_failed_file_mutations = {}
     agent._turn_file_mutation_paths = set()
+    agent._turn_file_mutation_lock = threading.Lock()
+    agent._turn_file_mutation_generation = 0
+    agent._turn_file_mutation_epoch = object()
     return agent
 
 
@@ -313,6 +336,38 @@ class TestFormatFooter:
         assert "/tmp/a.md" in out
         assert "Could not find old_string" in out
         assert "git status" in out  # user-actionable hint
+
+    def test_internal_task_scoped_key_uses_display_path(self):
+        out = AIAgent._format_file_mutation_failure_footer(
+            {
+                "task-a\0/workspace/a.md": {
+                    "tool": "patch",
+                    "error_preview": "not found",
+                    "display_path": "/workspace/a.md",
+                }
+            }
+        )
+
+        assert "/workspace/a.md" in out
+        assert "task-a" not in out
+
+    def test_footer_neutralizes_control_characters_and_embedded_backticks(self):
+        display_path = "/tmp/report.md`\n\x85\u2028\u2029  • forged-path"
+        preview = "failed`\r\n\x85\u2028\u2029  • forged-preview"
+        out = AIAgent._format_file_mutation_failure_footer(
+            {
+                "internal": {
+                    "tool": "patch",
+                    "error_preview": preview,
+                    "display_path": display_path,
+                }
+            }
+        )
+
+        assert "/tmp/report.mdˋ\\n\\x85\\u2028\\u2029  • forged-path" in out
+        assert "failedˋ\\r\\n\\x85\\u2028\\u2029  • forged-preview" in out
+        bullet_lines = [line for line in out.splitlines() if line.lstrip().startswith("•")]
+        assert len(bullet_lines) == 1
 
     def test_truncation_at_10_entries(self):
         failed = {

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5169,7 +5169,10 @@ class TestRunConversation:
             content="", finish_reason="stop", tool_calls=[good_tc],
         )
         with (
-            patch("run_agent.handle_function_call", return_value='{"success":true}') as mock_hfc,
+            patch(
+                "run_agent.handle_function_call",
+                return_value='{"bytes_written":12,"resolved_path":"report.md"}',
+            ) as mock_hfc,
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
@@ -5214,7 +5217,10 @@ class TestRunConversation:
         final_resp = _mock_response(content="Done!", finish_reason="stop")
 
         with (
-            patch("run_agent.handle_function_call", return_value='{"success":true}') as mock_hfc,
+            patch(
+                "run_agent.handle_function_call",
+                return_value='{"bytes_written":12,"resolved_path":"report.md"}',
+            ) as mock_hfc,
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -22,11 +22,18 @@ read snapshots captured at flush time, so removing any production flush call
 makes the corresponding assertion fail.
 """
 
+import concurrent.futures
 import copy
+import hashlib
+import json
+import time
 from types import SimpleNamespace
 from pathlib import Path
 import tempfile
+import threading
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from agent.tool_dispatch_helpers import make_tool_result_message
 from run_agent import AIAgent
@@ -250,3 +257,533 @@ def test_execute_tool_calls_concurrent_flushes_each_tool_result_in_order():
     # production flush call breaks one of these assertions.
     assert flushed_tool_ids == ["c1", "c2"]
     assert flush_lengths == [1, 2]
+
+
+@pytest.mark.parametrize(
+    ("replacement_label", "expected_label"),
+    [(None, "old-turn"), ("replacement-turn", "replacement-turn")],
+)
+def test_concurrent_timeout_revokes_detached_mutation_evidence(
+    tmp_path,
+    replacement_label,
+    expected_label,
+):
+    """A timed-out worker cannot publish late evidence in any turn state."""
+
+    from agent.file_mutation_verifier import FileContentFingerprint
+
+    agent = _make_agent()
+    getattr(agent, "valid_tool_names").add("terminal")
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+    target_key = str(target.resolve())
+
+    def fingerprint() -> FileContentFingerprint:
+        return FileContentFingerprint(
+            kind="file",
+            sha256=hashlib.sha256(target.read_bytes()).hexdigest(),
+        )
+
+    def reset_with_failure(label: str) -> None:
+        agent._turn_failed_file_mutations = {
+            target_key: {
+                "tool": "patch",
+                "error_preview": label,
+                "display_path": target_key,
+                "resolved_path": target_key,
+                "task_id": "task-1",
+                "generation": 1,
+                "fingerprint": fingerprint(),
+                "fingerprint_deferred": False,
+            }
+        }
+        agent._turn_file_mutation_paths = set()
+        agent._turn_file_mutation_lock = threading.Lock()
+        agent._turn_file_mutation_generation = 1
+        agent._turn_file_mutation_epoch = object()
+
+    reset_with_failure("old-turn")
+    release = threading.Event()
+    recorded = threading.Event()
+    messages: list = []
+    tool_call = _mock_tool_call(
+        name="terminal",
+        arguments=json.dumps({"command": "late fallback"}),
+        call_id="c-timeout",
+    )
+    assistant_message = SimpleNamespace(content="", tool_calls=[tool_call])
+
+    def late_invoke(*_args, **_kwargs):
+        assert release.wait(timeout=5)
+        target.write_text("late-old-turn-change\n")
+        return json.dumps({"output": "ok", "exit_code": 0})
+
+    real_record = agent._record_file_mutation_result
+
+    def recording_wrapper(*args, **kwargs):
+        try:
+            return real_record(*args, **kwargs)
+        finally:
+            recorded.set()
+
+    agent._flush_messages_to_session_db = MagicMock()
+    try:
+        with (
+            patch.object(agent, "_invoke_tool", side_effect=late_invoke),
+            patch.object(
+                agent,
+                "_record_file_mutation_result",
+                side_effect=recording_wrapper,
+            ),
+            patch(
+                "agent.tool_executor._resolve_concurrent_tool_timeout",
+                return_value=0.05,
+            ),
+            patch(
+                "agent.tool_executor.maybe_persist_tool_result",
+                side_effect=lambda **kwargs: kwargs["content"],
+            ),
+        ):
+            agent._execute_tool_calls_concurrent(
+                assistant_message,
+                messages,
+                "task-1",
+            )
+            assert "timed out" in messages[0]["content"]
+
+            if replacement_label is not None:
+                # Simulate build_turn_context replacing state before the
+                # detached old worker completes. Both generations intentionally
+                # equal one so only call identity can distinguish them.
+                reset_with_failure(replacement_label)
+            release.set()
+            assert recorded.wait(timeout=5)
+    finally:
+        release.set()
+
+    assert agent._turn_failed_file_mutations[target_key]["error_preview"] == (
+        expected_label
+    )
+    assert agent._turn_file_mutation_paths == set()
+
+
+def test_concurrent_timeout_keeps_real_result_while_verifier_record_is_unfinished():
+    agent = _make_agent()
+    getattr(agent, "valid_tool_names").add("terminal")
+    tool_call = _mock_tool_call(
+        name="terminal",
+        arguments=json.dumps({"command": "completed fallback"}),
+        call_id="c-result-before-verifier",
+    )
+    assistant_message = SimpleNamespace(content="", tool_calls=[tool_call])
+    messages: list = []
+    record_entered = threading.Event()
+    release_record = threading.Event()
+    record_finished = threading.Event()
+
+    def blocked_record(*_args, **_kwargs):
+        record_entered.set()
+        try:
+            assert release_record.wait(timeout=5)
+        finally:
+            record_finished.set()
+
+    try:
+        with (
+            patch.object(
+                agent,
+                "_invoke_tool",
+                return_value=json.dumps({"output": "real-result", "exit_code": 0}),
+            ),
+            patch.object(
+                agent,
+                "_record_file_mutation_result",
+                side_effect=blocked_record,
+            ),
+            patch(
+                "agent.tool_executor._resolve_concurrent_tool_timeout",
+                return_value=0.05,
+            ),
+            patch(
+                "agent.tool_executor.maybe_persist_tool_result",
+                side_effect=lambda **kwargs: kwargs["content"],
+            ),
+        ):
+            agent._execute_tool_calls_concurrent(
+                assistant_message,
+                messages,
+                "task-1",
+            )
+        assert record_entered.is_set()
+        assert len(messages) == 1
+        assert "real-result" in messages[0]["content"]
+        assert "timed out" not in messages[0]["content"]
+    finally:
+        release_record.set()
+        assert record_finished.wait(timeout=5)
+
+
+def test_concurrent_dispatch_propagates_verifier_execution_bounds():
+    """Workers receive both the batch deadline and live interrupt predicate."""
+
+    agent = _make_agent()
+    getattr(agent, "valid_tool_names").add("terminal")
+    tool_call = _mock_tool_call(
+        name="terminal",
+        arguments=json.dumps({"command": "bounded fallback"}),
+        call_id="c-bounds",
+    )
+    assistant_message = SimpleNamespace(content="", tool_calls=[tool_call])
+    messages: list = []
+    captured: list[dict] = []
+
+    def capture_prepare(*_args, **kwargs):
+        captured.append(kwargs)
+
+    with (
+        patch.object(agent, "_prepare_file_mutation_verifier_call", side_effect=capture_prepare),
+        patch.object(
+            agent,
+            "_invoke_tool",
+            return_value=json.dumps({"output": "ok", "exit_code": 0}),
+        ),
+        patch(
+            "agent.tool_executor._resolve_concurrent_tool_timeout",
+            return_value=5.0,
+        ),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        agent._execute_tool_calls_concurrent(
+            assistant_message,
+            messages,
+            "task-1",
+        )
+
+    assert len(captured) == 1
+    assert isinstance(captured[0].get("deadline"), float)
+    cancel_check = captured[0].get("cancel_check")
+    assert callable(cancel_check)
+    assert cancel_check() is False
+    agent._interrupt_requested = True
+    assert cancel_check() is True
+
+
+def test_sequential_dispatch_propagates_live_interrupt_and_defers_probe_activation():
+    agent = _make_agent()
+    getattr(agent, "valid_tool_names").add("terminal")
+    tool_call = _mock_tool_call(
+        name="terminal",
+        arguments=json.dumps({"command": "bounded fallback"}),
+        call_id="s-bounds",
+    )
+    assistant_message = SimpleNamespace(content="", tool_calls=[tool_call])
+    messages: list = []
+    captured: list[dict] = []
+
+    def capture_prepare(*_args, **kwargs):
+        captured.append(kwargs)
+
+    with (
+        patch.object(
+            agent,
+            "_prepare_file_mutation_verifier_call",
+            side_effect=capture_prepare,
+        ),
+        patch(
+            "run_agent.handle_function_call",
+            return_value=json.dumps({"output": "ok", "exit_code": 0}),
+        ),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        agent._execute_tool_calls_sequential(
+            assistant_message,
+            messages,
+            "task-1",
+        )
+
+    assert len(captured) == 1
+    assert captured[0].get("defer_probe_activation") is True
+    cancel_check = captured[0].get("cancel_check")
+    assert callable(cancel_check)
+    assert cancel_check() is False
+    agent._interrupt_requested = True
+    assert cancel_check() is True
+
+
+@pytest.mark.parametrize("tool_name", ["terminal", "execute_code"])
+def test_sequential_denied_fallback_does_not_read_deferred_target(
+    tmp_path,
+    tool_name,
+):
+    from agent.file_mutation_verifier import FileContentFingerprint
+
+    agent = _make_agent()
+    getattr(agent, "valid_tool_names").add(tool_name)
+    target = tmp_path / "sensitive.txt"
+    target.write_text("secret\n")
+    target_key = str(target.resolve())
+    setattr(
+        agent,
+        "_turn_failed_file_mutations",
+        {
+            target_key: {
+                "tool": "write_file",
+                "error_preview": "policy denied",
+                "display_path": target_key,
+                "resolved_path": target_key,
+                "task_id": "task-1",
+                "generation": 1,
+                "fingerprint": None,
+                "fingerprint_deferred": True,
+            }
+        },
+    )
+    setattr(agent, "_turn_file_mutation_paths", set())
+    setattr(agent, "_turn_file_mutation_lock", threading.Lock())
+    setattr(agent, "_turn_file_mutation_generation", 1)
+    setattr(agent, "_turn_file_mutation_epoch", object())
+    fingerprinted: list[str] = []
+
+    def fingerprint_spy(path, _task_id="default"):
+        fingerprinted.append(path)
+        return FileContentFingerprint("sha256", "a" * 64)
+
+    if tool_name == "terminal":
+        arguments = {"command": "denied fallback"}
+        denied = json.dumps(
+            {"output": "", "exit_code": -1, "status": "blocked", "error": "denied"}
+        )
+    else:
+        arguments = {"code": "print('denied fallback')"}
+        denied = json.dumps(
+            {"status": "error", "error": "denied", "tool_calls_made": 0}
+        )
+    tool_call = _mock_tool_call(
+        name=tool_name,
+        arguments=json.dumps(arguments),
+        call_id=f"denied-{tool_name}",
+    )
+    assistant_message = SimpleNamespace(content="", tool_calls=[tool_call])
+    messages: list = []
+
+    with (
+        patch(
+            "tools.file_tools._fingerprint_resolved_file_content",
+            side_effect=fingerprint_spy,
+        ),
+        patch("run_agent.handle_function_call", return_value=denied),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        agent._execute_tool_calls_sequential(
+            assistant_message,
+            messages,
+            "task-1",
+        )
+
+    assert fingerprinted == []
+    assert getattr(agent, "_turn_failed_file_mutations")[target_key][
+        "fingerprint_deferred"
+    ] is True
+    assert getattr(agent, "_turn_file_mutation_paths") == set()
+
+
+def test_sequential_interrupt_after_probe_activation_cannot_clear_failure(tmp_path):
+    from agent.file_mutation_verifier import (
+        FileContentFingerprint,
+        activate_pending_file_mutation_verifier_call,
+    )
+
+    agent = _make_agent()
+    getattr(agent, "valid_tool_names").add("terminal")
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+    target_key = str(target.resolve())
+
+    def fingerprint() -> FileContentFingerprint:
+        return FileContentFingerprint(
+            kind="sha256",
+            sha256=hashlib.sha256(target.read_bytes()).hexdigest(),
+        )
+
+    setattr(
+        agent,
+        "_turn_failed_file_mutations",
+        {
+            target_key: {
+                "tool": "patch",
+                "error_preview": "must remain",
+                "display_path": target_key,
+                "resolved_path": target_key,
+                "task_id": "task-1",
+                "generation": 1,
+                "fingerprint": fingerprint(),
+                "fingerprint_deferred": False,
+            }
+        },
+    )
+    setattr(agent, "_turn_file_mutation_paths", set())
+    setattr(agent, "_turn_file_mutation_lock", threading.Lock())
+    setattr(agent, "_turn_file_mutation_generation", 1)
+    setattr(agent, "_turn_file_mutation_epoch", object())
+    tool_call = _mock_tool_call(
+        name="terminal",
+        arguments=json.dumps({"command": "interrupted fallback"}),
+        call_id="s-interrupt",
+    )
+    assistant_message = SimpleNamespace(content="", tool_calls=[tool_call])
+    messages: list = []
+
+    def interrupted_dispatch(*_args, **_kwargs):
+        activate_pending_file_mutation_verifier_call()
+        target.write_text("after-interrupt\n")
+        agent._interrupt_requested = True
+        return json.dumps({"output": "ok", "exit_code": 0})
+
+    with (
+        patch("run_agent.handle_function_call", side_effect=interrupted_dispatch),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        agent._execute_tool_calls_sequential(
+            assistant_message,
+            messages,
+            "task-1",
+        )
+
+    assert getattr(agent, "_turn_failed_file_mutations")[target_key][
+        "error_preview"
+    ] == "must remain"
+    assert getattr(agent, "_turn_file_mutation_paths") == set()
+
+
+@pytest.mark.parametrize("boundary", ["deadline", "interrupt"])
+def test_worker_cannot_publish_between_execution_boundary_and_main_revocation(
+    tmp_path,
+    boundary,
+):
+    """Verifier checks the boundary itself, not only main-thread revocation."""
+
+    from agent.file_mutation_verifier import FileContentFingerprint
+
+    agent = _make_agent()
+    getattr(agent, "valid_tool_names").add("terminal")
+    target = tmp_path / "app.txt"
+    target.write_text("before\n")
+    target_key = str(target.resolve())
+
+    def fingerprint() -> FileContentFingerprint:
+        return FileContentFingerprint(
+            kind="file",
+            sha256=hashlib.sha256(target.read_bytes()).hexdigest(),
+        )
+
+    setattr(
+        agent,
+        "_turn_failed_file_mutations",
+        {
+            target_key: {
+                "tool": "patch",
+                "error_preview": "must remain",
+                "display_path": target_key,
+                "resolved_path": target_key,
+                "task_id": "task-1",
+                "generation": 1,
+                "fingerprint": fingerprint(),
+                "fingerprint_deferred": False,
+            }
+        },
+    )
+    setattr(agent, "_turn_file_mutation_paths", set())
+    setattr(agent, "_turn_file_mutation_lock", threading.Lock())
+    setattr(agent, "_turn_file_mutation_generation", 1)
+    setattr(agent, "_turn_file_mutation_epoch", object())
+
+    invoked = threading.Event()
+    release = threading.Event()
+    recorded = threading.Event()
+    messages: list = []
+    tool_call = _mock_tool_call(
+        name="terminal",
+        arguments=json.dumps({"command": "boundary race"}),
+        call_id=f"c-{boundary}",
+    )
+    assistant_message = SimpleNamespace(content="", tool_calls=[tool_call])
+
+    def late_invoke(*_args, **_kwargs):
+        invoked.set()
+        assert release.wait(timeout=5)
+        target.write_text(f"after-{boundary}\n")
+        return json.dumps({"output": "ok", "exit_code": 0})
+
+    real_record = agent._record_file_mutation_result
+
+    def recording_wrapper(*args, **kwargs):
+        try:
+            return real_record(*args, **kwargs)
+        finally:
+            recorded.set()
+
+    real_wait = concurrent.futures.wait
+    wait_calls = 0
+
+    def boundary_losing_wait(futures, timeout=None):
+        nonlocal wait_calls
+        wait_calls += 1
+        if wait_calls == 1:
+            assert invoked.wait(timeout=5)
+            if boundary == "deadline":
+                time.sleep(0.08)
+            else:
+                agent._interrupt_requested = True
+            release.set()
+            assert recorded.wait(timeout=5)
+            # Deliberately let the worker publish before the main executor gets
+            # a chance to revoke its active_event.
+            return set(), set(futures)
+        return real_wait(futures, timeout=timeout)
+
+    agent._flush_messages_to_session_db = MagicMock()
+    try:
+        with (
+            patch.object(agent, "_invoke_tool", side_effect=late_invoke),
+            patch.object(
+                agent,
+                "_record_file_mutation_result",
+                side_effect=recording_wrapper,
+            ),
+            patch(
+                "agent.tool_executor._resolve_concurrent_tool_timeout",
+                return_value=0.05 if boundary == "deadline" else 5.0,
+            ),
+            patch(
+                "agent.tool_executor.concurrent.futures.wait",
+                side_effect=boundary_losing_wait,
+            ),
+            patch(
+                "agent.tool_executor.maybe_persist_tool_result",
+                side_effect=lambda **kwargs: kwargs["content"],
+            ),
+        ):
+            agent._execute_tool_calls_concurrent(
+                assistant_message,
+                messages,
+                "task-1",
+            )
+    finally:
+        release.set()
+
+    assert getattr(agent, "_turn_failed_file_mutations")[target_key][
+        "error_preview"
+    ] == "must remain"
+    assert getattr(agent, "_turn_file_mutation_paths") == set()

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -221,6 +221,7 @@ class TestPatchHandler:
         result = json.loads(patch_tool(mode="patch", patch="*** Begin Patch\n..."))
         assert result["status"] == "ok"
         mock_ops.patch_v4a.assert_called_once()
+        mock_ops.patch_v4a_resolved.assert_not_called()
 
     @patch("tools.file_tools._get_file_ops")
     def test_patch_mode_missing_content_errors(self, mock_get):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1176,6 +1176,20 @@ def execute_code(
         from tools.interrupt import clear_current_thread_interrupt
         clear_current_thread_interrupt()
 
+    # Approval succeeded. Deferred verifier probes may now read their captured
+    # targets immediately before this foreground script begins.
+    try:
+        from agent.file_mutation_verifier import (
+            activate_pending_file_mutation_verifier_call,
+        )
+
+        activate_pending_file_mutation_verifier_call()
+    except Exception as verifier_error:
+        logger.debug(
+            "file-mutation verifier activation failed: %s",
+            verifier_error,
+        )
+
     if env_type != "local":
         return _execute_remote(code, task_id, enabled_tools)
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -461,7 +461,12 @@ class FileOperations(ABC):
 
     @abstractmethod
     def patch_v4a(self, patch_content: str) -> PatchResult:
-        """Apply a V4A format patch."""
+        """Apply a V4A format patch.
+
+        Keep this historical signature stable for third-party backends. A
+        backend that can consume tool-layer-resolved identities may additionally
+        implement ``patch_v4a_resolved(patch_content, resolved_paths)``.
+        """
         ...
 
     @abstractmethod
@@ -787,6 +792,37 @@ def _maybe_warn_line_oriented_newline_pattern(result: SearchResult, pattern: str
         "lines, or escape as `\\\\n` when searching for a literal backslash+n."
     )
     return result
+
+
+class _ResolvedPathFileOperations:
+    """Translate V4A operation paths while preserving raw paths in its diff."""
+
+    def __init__(self, delegate: "ShellFileOperations", resolved_paths: Dict[str, str]):
+        self._delegate = delegate
+        self._resolved_paths = resolved_paths
+
+    def _path(self, path: str) -> str:
+        try:
+            return self._resolved_paths[path]
+        except KeyError as exc:
+            raise ValueError(
+                f"No captured resolved identity for V4A path: {path}"
+            ) from exc
+
+    def read_file_raw(self, path: str):
+        return self._delegate.read_file_raw(self._path(path))
+
+    def write_file(self, path: str, content: str):
+        return self._delegate.write_file(self._path(path), content)
+
+    def delete_file(self, path: str):
+        return self._delegate.delete_file(self._path(path))
+
+    def move_file(self, src: str, dst: str):
+        return self._delegate.move_file(self._path(src), self._path(dst))
+
+    def _check_lint(self, path: str, content: Optional[str] = None):
+        return self._delegate._check_lint(self._path(path), content)
 
 
 class ShellFileOperations(FileOperations):
@@ -1660,8 +1696,17 @@ class ShellFileOperations(FileOperations):
         )
     
     def patch_v4a(self, patch_content: str) -> PatchResult:
+        """Apply V4A using the historical backend interface."""
+
+        return self.patch_v4a_resolved(patch_content, resolved_paths=None)
+
+    def patch_v4a_resolved(
+        self,
+        patch_content: str,
+        resolved_paths: Optional[Dict[str, str]],
+    ) -> PatchResult:
         """
-        Apply a V4A format patch.
+        Apply a V4A format patch, optionally using tool-resolved identities.
         
         V4A format:
             *** Begin Patch
@@ -1685,8 +1730,15 @@ class ShellFileOperations(FileOperations):
         if parse_error:
             return PatchResult(error=f"Failed to parse patch: {parse_error}")
         
-        # Apply operations
-        result = apply_v4a_operations(operations, self)
+        # Apply through the identities resolved by file_tools when provided.
+        # The proxy translates only backend calls, so user-facing diffs retain
+        # the original V4A path spelling.
+        file_ops = (
+            _ResolvedPathFileOperations(self, resolved_paths)
+            if resolved_paths is not None
+            else self
+        )
+        result = apply_v4a_operations(operations, file_ops)
         return result
     
     def _check_lint(self, path: str, content: Optional[str] = None) -> LintResult:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2,14 +2,25 @@
 """File Tools Module - LLM agent file manipulation tools."""
 
 import errno
+import hashlib
+import inspect
 import json
 import logging
 import os
 import posixpath
+import re
+import shlex
+import stat
 import sys
 import threading
 from pathlib import Path, PurePosixPath
+from typing import Any
 
+from agent.file_mutation_verifier import (
+    FileContentFingerprint,
+    MutationTargetIdentity,
+    publish_mutation_target_identities,
+)
 from agent.file_safety import get_read_block_error
 from tools.binary_extensions import has_binary_extension
 from tools.file_operations import (
@@ -204,12 +215,33 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
 
 
 def _uses_container_paths(task_id: str = "default") -> bool:
+    """Return whether backend paths require POSIX handling without host dereference."""
     try:
         from tools.terminal_tool import _CONTAINER_BACKENDS
         container_backends = _CONTAINER_BACKENDS
     except Exception:
         container_backends = _CONTAINER_PATH_BACKENDS_FALLBACK
-    return _terminal_env_type_for_task(task_id) in container_backends
+    env_type = _terminal_env_type_for_task(task_id)
+    return env_type == "ssh" or env_type in container_backends
+
+
+def _expand_tilde_for_backend(path: str, task_id: str = "default") -> str:
+    """Expand SSH tildes against the remote home, never the Hermes host home."""
+    if _terminal_env_type_for_task(task_id) != "ssh":
+        return _expand_tilde(path)
+    if not path or not path.startswith("~"):
+        return path
+    if path != "~" and not path.startswith("~/"):
+        raise ValueError("SSH file paths using another user's '~name' home are unsupported")
+
+    file_ops = _get_file_ops(task_id)
+    env = getattr(file_ops, "env", None)
+    remote_home = str(getattr(env, "_remote_home", "") or "")
+    if not posixpath.isabs(remote_home):
+        raise ValueError("Unable to determine the SSH user's absolute remote home")
+    if path == "~":
+        return remote_home
+    return posixpath.join(remote_home, path[2:])
 
 
 def _normalize_without_host_deref(path: str | Path | PurePosixPath) -> PurePosixPath:
@@ -400,7 +432,7 @@ def _resolve_base_dir(
     if container_paths is None:
         container_paths = _uses_container_paths(task_id)
     if root:
-        base_text = _expand_tilde(root)
+        base_text = _expand_tilde_for_backend(root, task_id)
     else:
         base_text = os.getcwd()
     if container_paths:
@@ -437,9 +469,14 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
     translated to ``C:\\Users\\...`` before resolution so file tools don't
     treat them as relative ``\\c\\Users\\...`` under the process cwd.
     """
+    backend_type = _terminal_env_type_for_task(task_id)
+    if backend_type == "ssh" and not posixpath.isabs(filepath):
+        # Relative SSH identities depend on the live remote cwd/home. Ensure the
+        # environment has initialized those values before resolving once.
+        _get_file_ops(task_id)
     container_paths = _uses_container_paths(task_id)
     if container_paths:
-        expanded = _expand_tilde(filepath)
+        expanded = _expand_tilde_for_backend(filepath, task_id)
         if posixpath.isabs(expanded):
             return _normalize_without_host_deref(expanded)
         resolved = _resolve_base_dir(task_id, container_paths=True) / expanded
@@ -462,6 +499,173 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
         return p.resolve()
     resolved = _resolve_base_dir(task_id, container_paths=False) / p
     return resolved.resolve()
+
+
+def _publish_captured_mutation_target_identities(
+    raw_paths: list[str],
+    resolved: dict[str, str],
+    task_id: str,
+    *,
+    defer_fingerprint: bool,
+) -> None:
+    """Publish already-resolved identities without another path lookup."""
+
+    publish_mutation_target_identities(
+        [
+            MutationTargetIdentity(
+                raw_path=raw_path,
+                resolved_path=resolved.get(raw_path),
+                task_id=task_id,
+                defer_fingerprint=defer_fingerprint,
+            )
+            for raw_path in raw_paths
+        ]
+    )
+
+
+def _initialize_mutation_backend_if_needed(
+    raw_paths: list[str],
+    task_id: str,
+) -> Any | None:
+    """Initialize non-local cwd/home state before capturing relative identities."""
+    if _terminal_env_type_for_task(task_id) == "local":
+        return None
+    if any(raw_path and not posixpath.isabs(raw_path) for raw_path in raw_paths):
+        return _get_file_ops(task_id)
+    return None
+
+
+def _capture_mutation_target_identities(
+    raw_paths: list[str],
+    task_id: str,
+    *,
+    defer_fingerprint: bool = False,
+) -> dict[str, str]:
+    """Resolve mutation targets once and publish those exact identities.
+
+    The returned mapping is also used by the mutation itself, preventing the
+    verifier from observing a different task cwd if another concurrent tool
+    changes the live terminal cwd after resolution.
+    """
+
+    resolved: dict[str, str] = {}
+    for raw_path in raw_paths:
+        try:
+            target = str(_resolve_path_for_task(raw_path, task_id))
+        except Exception as exc:
+            target = None
+            logger.debug("file mutation target resolution failed for %r: %s", raw_path, exc)
+        else:
+            resolved[raw_path] = target
+    _publish_captured_mutation_target_identities(
+        raw_paths,
+        resolved,
+        task_id,
+        defer_fingerprint=defer_fingerprint,
+    )
+    return resolved
+
+
+def _stable_stat_token(value: os.stat_result) -> tuple[int, ...]:
+    return (
+        value.st_dev,
+        value.st_ino,
+        value.st_size,
+        getattr(value, "st_mtime_ns", int(value.st_mtime * 1_000_000_000)),
+        getattr(value, "st_ctime_ns", int(value.st_ctime * 1_000_000_000)),
+    )
+
+
+def _fingerprint_local_file_content(path: str) -> FileContentFingerprint | None:
+    """Hash a stable local regular-file snapshot without metadata evidence."""
+
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+    try:
+        fd = os.open(path, flags)
+    except FileNotFoundError:
+        return FileContentFingerprint("missing")
+    except (OSError, ValueError):
+        return None
+
+    try:
+        before = os.fstat(fd)
+        if not stat.S_ISREG(before.st_mode):
+            return None
+        digest = hashlib.sha256()
+        while True:
+            chunk = os.read(fd, 1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+        after = os.fstat(fd)
+        if _stable_stat_token(before) != _stable_stat_token(after):
+            return None
+        return FileContentFingerprint("sha256", digest.hexdigest())
+    except OSError:
+        return None
+    finally:
+        os.close(fd)
+
+
+def _fingerprint_resolved_file_content(
+    resolved_path: str,
+    task_id: str = "default",
+) -> FileContentFingerprint | None:
+    """Return a reliable content token for an already-resolved backend path.
+
+    Local targets are read through a stable file descriptor. Container, SSH,
+    and other non-local targets are hashed inside their selected terminal
+    environment; the host filesystem is never consulted for those paths.
+    """
+
+    if _terminal_env_type_for_task(task_id) == "local":
+        return _fingerprint_local_file_content(resolved_path)
+
+    marker_missing = "__HERMES_FILE_CONTENT_MISSING__"
+    marker_digest = "__HERMES_FILE_CONTENT_SHA256__="
+    quoted_path = shlex.quote(resolved_path)
+    command = f"""
+p={quoted_path}
+if [ ! -e "$p" ] && [ ! -L "$p" ]; then
+    printf '%s\\n' '{marker_missing}'
+    exit 0
+fi
+if [ ! -f "$p" ]; then
+    exit 65
+fi
+hermes_content_hash() {{
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum -- "$p" | awk '{{print $1}}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 -- "$p" | awk '{{print $1}}'
+    elif command -v openssl >/dev/null 2>&1; then
+        openssl dgst -sha256 "$p" | awk '{{print $NF}}'
+    else
+        return 127
+    fi
+}}
+first=$(hermes_content_hash) || exit $?
+second=$(hermes_content_hash) || exit $?
+[ "$first" = "$second" ] || exit 75
+[ "${{#first}}" -eq 64 ] || exit 65
+case "$first" in *[!0-9A-Fa-f]*) exit 65 ;; esac
+printf '%s%s\\n' '{marker_digest}' "$first"
+""".strip()
+    try:
+        result = _get_file_ops(task_id)._exec(command, cwd="/", timeout=120)
+    except Exception:
+        return None
+    if result.exit_code != 0:
+        return None
+    for line in result.stdout.splitlines():
+        token = line.strip()
+        if token == marker_missing:
+            return FileContentFingerprint("missing")
+        if token.startswith(marker_digest):
+            digest = token[len(marker_digest) :].lower()
+            if len(digest) == 64 and all(c in "0123456789abcdef" for c in digest):
+                return FileContentFingerprint("sha256", digest)
+    return None
 
 
 def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "default") -> str | None:
@@ -659,13 +863,23 @@ def _get_hermes_config_resolved() -> str | None:
     return _hermes_config_resolved
 
 
-def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
-    """Return an error message if the path targets a sensitive system location."""
-    try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
-    except (OSError, ValueError):
-        resolved = filepath
-    normalized = os.path.normpath(_expand_tilde(filepath))
+def _check_sensitive_path(
+    filepath: str,
+    task_id: str = "default",
+    resolved_path: str | None = None,
+) -> str | None:
+    """Return an error message if the captured target is a sensitive location."""
+    if resolved_path is not None:
+        # Policy must consume the same backend identity that the mutation will
+        # use. In particular, never expand an SSH ``~`` against the host home.
+        resolved = str(resolved_path)
+        normalized = os.path.normpath(resolved)
+    else:
+        try:
+            resolved = str(_resolve_path_for_task(filepath, task_id))
+        except (OSError, ValueError):
+            resolved = filepath
+        normalized = os.path.normpath(_expand_tilde(filepath))
     _err = (
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
@@ -723,7 +937,11 @@ def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | Non
     return None
 
 
-def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | None:
+def _check_cross_profile_path(
+    filepath: str,
+    task_id: str = "default",
+    resolved_path: str | None = None,
+) -> str | None:
     """Return a soft-guard warning when ``filepath`` lands in another Hermes
     profile's scoped area, a host-side sandbox-mirror of authoritative profile
     state, or the Docker container's sandbox mirror of Hermes state.
@@ -761,13 +979,15 @@ def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | 
         # plus the write_denied list still apply.
         return None
 
-    # Resolve via the task's cwd so a relative ``skills/foo/SKILL.md``
-    # in a session that cd'd into ``~/.hermes/profiles/other/`` is
-    # classified against the right base.
-    try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
-    except (OSError, ValueError):
-        resolved = filepath
+    # Use the same captured identity that the mutation will consume. Callers
+    # without a capture retain the historical task-cwd resolution behavior.
+    if resolved_path is not None:
+        resolved = str(resolved_path)
+    else:
+        try:
+            resolved = str(_resolve_path_for_task(filepath, task_id))
+        except (OSError, ValueError):
+            resolved = filepath
 
     warning = get_cross_profile_warning(resolved)
     if warning is not None:
@@ -1675,11 +1895,22 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
     Pass ``True`` after explicit user direction — same shape as ``force``
     on the terminal tool.
     """
-    sensitive_err = _check_sensitive_path(path, task_id)
+    if not path:
+        return tool_error("path required")
+    _initialized_file_ops = _initialize_mutation_backend_if_needed([path], task_id)
+    _resolved_by_path = _capture_mutation_target_identities(
+        [path],
+        task_id,
+        defer_fingerprint=True,
+    )
+    _resolved = _resolved_by_path.get(path)
+    if _resolved is None:
+        return tool_error(f"Unable to resolve write target: {path}")
+    sensitive_err = _check_sensitive_path(path, task_id, _resolved)
     if sensitive_err:
         return tool_error(sensitive_err)
     if not cross_profile:
-        cross_warning = _check_cross_profile_path(path, task_id)
+        cross_warning = _check_cross_profile_path(path, task_id, _resolved)
         if cross_warning:
             return tool_error(cross_warning)
     if _is_internal_file_tool_content(content):
@@ -1688,27 +1919,13 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             "Strip read_file line-number prefixes or reconstruct the intended "
             "file contents before writing."
         )
+    _publish_captured_mutation_target_identities(
+        [path],
+        _resolved_by_path,
+        task_id,
+        defer_fingerprint=False,
+    )
     try:
-        # Resolve once for the registry lock + stale check.  Failures here
-        # fall back to the legacy path — write proceeds, per-task staleness
-        # check below still runs.
-        try:
-            _resolved = str(_resolve_path_for_task(path, task_id))
-        except Exception:
-            _resolved = None
-
-        if _resolved is None:
-            stale_warning = _check_file_staleness(path, task_id)
-            file_ops = _get_file_ops(task_id)
-            result = file_ops.write_file(path, content)
-            result_dict = result.to_dict()
-            if stale_warning:
-                result_dict["_warning"] = stale_warning
-            if not result_dict.get("error"):
-                _mark_verification_stale(task_id, [path], session_id=session_id)
-            _update_read_timestamp(path, task_id)
-            return json.dumps(result_dict, ensure_ascii=False)
-
         # Serialize the read→modify→write region per-path so concurrent
         # subagents can't interleave on the same file.  Different paths
         # remain fully parallel.
@@ -1720,7 +1937,7 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             # Workspace-divergence warning: relative path resolving outside the
             # terminal's cwd (the worktree-cwd bug). Lowest priority of the three.
             cwd_warning = _path_resolution_warning(path, Path(_resolved), task_id)
-            file_ops = _get_file_ops(task_id)
+            file_ops = _initialized_file_ops or _get_file_ops(task_id)
             result = file_ops.write_file(_resolved, content)
             result_dict = result.to_dict()
             effective_warning = cross_warning or stale_warning or cwd_warning
@@ -1745,6 +1962,58 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         else:
             logger.error("write_file error: %s: %s", type(e).__name__, e, exc_info=True)
         return tool_error(str(e))
+
+
+_V4A_FILE_HEADER_RE = re.compile(
+    r"^(?P<prefix>\*{3}[ \t]*(?:Update|Add|Delete)[ \t]+File:[ \t]*)"
+    r"(?P<path>[^\r\n]+?)[ \t]*(?P<cr>\r?)$",
+    re.MULTILINE,
+)
+_V4A_MOVE_HEADER_RE = re.compile(
+    r"^(?P<prefix>\*{3}[ \t]*Move[ \t]+File:[ \t]*)"
+    r"(?P<src>[^\r\n]+?)[ \t]+->[ \t]+"
+    r"(?P<dst>[^\r\n]+?)[ \t]*(?P<cr>\r?)$",
+    re.MULTILINE,
+)
+
+
+def _rewrite_v4a_patch_with_resolved_paths(
+    patch_content: str,
+    resolved_paths: dict[str, str],
+) -> str:
+    """Rewrite legacy V4A headers to the identities authorized by policy."""
+
+    seen: set[str] = set()
+
+    def resolved(raw: str) -> str:
+        key = raw.strip()
+        target = resolved_paths.get(key)
+        if not isinstance(target, str) or not target:
+            raise ValueError(f"No captured resolved identity for V4A path: {key}")
+        seen.add(key)
+        return target
+
+    def rewrite_file(match: re.Match[str]) -> str:
+        return (
+            f"{match.group('prefix')}{resolved(match.group('path'))}"
+            f"{match.group('cr')}"
+        )
+
+    def rewrite_move(match: re.Match[str]) -> str:
+        return (
+            f"{match.group('prefix')}{resolved(match.group('src'))} -> "
+            f"{resolved(match.group('dst'))}{match.group('cr')}"
+        )
+
+    rewritten = _V4A_FILE_HEADER_RE.sub(rewrite_file, patch_content)
+    rewritten = _V4A_MOVE_HEADER_RE.sub(rewrite_move, rewritten)
+    missing = set(resolved_paths).difference(seen)
+    if missing:
+        missing_path = sorted(missing)[0]
+        raise ValueError(
+            f"Captured V4A identity was not present in parsed headers: {missing_path}"
+        )
+    return rewritten
 
 
 def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
@@ -1802,29 +2071,42 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 if _err:
                     return _err
                 _paths_to_check.append(v4a_path)
+    _initialized_file_ops = _initialize_mutation_backend_if_needed(
+        _paths_to_check,
+        task_id,
+    )
+    _path_to_resolved = _capture_mutation_target_identities(
+        _paths_to_check,
+        task_id,
+        defer_fingerprint=True,
+    )
+    _unresolved_paths = [
+        _p for _p in _paths_to_check if _path_to_resolved.get(_p) is None
+    ]
+    if _unresolved_paths:
+        return tool_error(
+            f"Unable to resolve patch target: {_unresolved_paths[0]}"
+        )
     for _p in _paths_to_check:
-        sensitive_err = _check_sensitive_path(_p, task_id)
+        _resolved = _path_to_resolved[_p]
+        sensitive_err = _check_sensitive_path(_p, task_id, _resolved)
         if sensitive_err:
             return tool_error(sensitive_err)
         if not cross_profile:
-            cross_warning = _check_cross_profile_path(_p, task_id)
+            cross_warning = _check_cross_profile_path(_p, task_id, _resolved)
             if cross_warning:
                 return tool_error(cross_warning)
+    _publish_captured_mutation_target_identities(
+        _paths_to_check,
+        _path_to_resolved,
+        task_id,
+        defer_fingerprint=False,
+    )
     try:
         # Resolve paths for locking.  Ordered + deduplicated so concurrent
         # callers lock in the same order — prevents deadlock on overlapping
         # multi-file V4A patches.
-        _resolved_paths: list[str] = []
-        _seen: set[str] = set()
-        for _p in _paths_to_check:
-            try:
-                _r = str(_resolve_path_for_task(_p, task_id))
-            except Exception:
-                _r = None
-            if _r and _r not in _seen:
-                _resolved_paths.append(_r)
-                _seen.add(_r)
-        _resolved_paths.sort()
+        _resolved_paths = sorted(set(_path_to_resolved.values()))
 
         # Acquire per-path locks in sorted order via ExitStack.  On single
         # path this degenerates to one lock; on empty list (unresolvable)
@@ -1837,13 +2119,8 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             # Collect warnings — cross-agent registry first (names sibling),
             # then per-task tracker as a fallback.
             stale_warnings: list[str] = []
-            _path_to_resolved: dict[str, str] = {}
             for _p in _paths_to_check:
-                try:
-                    _r = str(_resolve_path_for_task(_p, task_id))
-                except Exception:
-                    _r = None
-                _path_to_resolved[_p] = _r
+                _r = _path_to_resolved.get(_p)
                 _cross = file_state.check_stale(task_id, _r) if _r else None
                 _sw = _cross or _check_file_staleness(_p, task_id)
                 if not _sw and _r:
@@ -1853,7 +2130,8 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 if _sw:
                     stale_warnings.append(_sw)
 
-            file_ops = _get_file_ops(task_id)
+            file_ops = _initialized_file_ops or _get_file_ops(task_id)
+            result: Any
 
             if mode == "replace":
                 if not path:
@@ -1870,7 +2148,48 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             elif mode == "patch":
                 if not patch:
                     return tool_error("patch content required")
-                result = file_ops.patch_v4a(patch)
+                # Inspect the class statically across its MRO. This rejects
+                # instance proxies and metaclass __getattr__ fabrication while
+                # preserving inherited methods as an explicit capability.
+                try:
+                    patch_v4a_descriptor = inspect.getattr_static(
+                        type(file_ops),
+                        "patch_v4a_resolved",
+                    )
+                except AttributeError:
+                    patch_v4a_descriptor = None
+                has_resolved_capability = callable(patch_v4a_descriptor) or isinstance(
+                    patch_v4a_descriptor,
+                    (staticmethod, classmethod),
+                )
+                patch_v4a_resolved = (
+                    getattr(file_ops, "patch_v4a_resolved", None)
+                    if has_resolved_capability
+                    else None
+                )
+                if callable(patch_v4a_resolved):
+                    result = patch_v4a_resolved(
+                        patch,
+                        resolved_paths=_path_to_resolved,
+                    )
+                else:
+                    # Preserve the historical one-argument plugin interface,
+                    # but rewrite every V4A header to the exact identity already
+                    # authorized above. A relative raw patch must never be
+                    # re-resolved under a backend cwd that changes mid-call.
+                    legacy_patch = _rewrite_v4a_patch_with_resolved_paths(
+                        patch,
+                        _path_to_resolved,
+                    )
+                    # Legacy results do not attest which identity was consumed;
+                    # keep external-fallback warning recovery conservative.
+                    _publish_captured_mutation_target_identities(
+                        _paths_to_check,
+                        {},
+                        task_id,
+                        defer_fingerprint=False,
+                    )
+                    result = file_ops.patch_v4a(legacy_patch)
             else:
                 return tool_error(f"Unknown mode: {mode}")
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2330,6 +2330,21 @@ def terminal_tool(
                     "status": "blocked"
                 }, ensure_ascii=False)
 
+        # The command has passed its own approval and workdir gates. Only now
+        # may a deferred file-mutation verifier read policy-denied target content
+        # to establish a causal baseline for this foreground fallback.
+        try:
+            from agent.file_mutation_verifier import (
+                activate_pending_file_mutation_verifier_call,
+            )
+
+            activate_pending_file_mutation_verifier_call()
+        except Exception as verifier_error:
+            logger.debug(
+                "file-mutation verifier activation failed: %s",
+                verifier_error,
+            )
+
         # Prepare command for execution
         pty_disabled_reason = None
         effective_pty = pty


### PR DESCRIPTION
## Summary

This refresh replaces the original three-file heuristic with an identity-, generation-, task-, and execution-window-aware recovery path for the turn-end file-mutation verifier.

- capture each `write_file` / `patch` target through the file tool's own resolver and use that exact identity for policy checks, mutation, and verification
- resolve SSH targets with remote POSIX/home semantics and initialize non-local backend cwd state before capturing first-call relative mutations
- retain failed-mutation warnings unless a later successful foreground `terminal` / `execute_code` call changes that exact backend target during its own execution window
- isolate concurrent tasks and turn generations, and revoke evidence from timed-out or interrupted detached workers
- preserve the historical `patch_v4a(patch_content)` backend interface while allowing class-defined backends to opt into resolved V4A paths
- keep policy-denied, malformed-result, legacy-backend, fingerprint-error, and unresolved-target paths fail-closed

## Why

The original PR addressed a real false warning: a native file mutation can be denied or fail, then the agent can legitimately recover through a foreground terminal or `execute_code` call. The turn-end verifier should clear the stale warning only when there is causal evidence that the fallback changed the same file.

A path-only stat comparison was not sufficient because paths can resolve differently across task workspaces/backends, metadata can change without content changing, concurrent calls can reorder, and timed-out workers can finish after a new turn has replaced verifier state.

## Safety model

A failed warning is suppressed only when all of these hold:

1. the file tool published its own resolved target identity; when its native policy gate denied content access, fingerprinting remains deferred until the fallback's own execution gate approves;
2. the fallback is foreground `terminal` or `execute_code` in the same task/backend context;
3. the fallback result satisfies that tool's structured success contract;
4. the same verifier turn epoch, state object, lock, task, and failure generation are still current;
5. the verifier independently confirms the per-call event is active, the shared batch deadline has not expired, and the live interrupt predicate is false; and
6. SHA-256 content changed between the fallback's pre-call and post-call fingerprints.

Malformed results, background terminal launches, backend fingerprint failures, unresolved identities, dynamic/proxy-only V4A capabilities, and stale or detached workers retain the warning.

## Implementation notes

- Local content fingerprints use a stable open file descriptor and SHA-256; metadata-only changes do not count.
- Docker/SSH/non-local paths are hashed through the selected backend rather than the host filesystem.
- Internal state keys include non-default task identity so identical path strings in different remote task contexts do not collide. The user-facing footer renders only `display_path`.
- `FileOperations.patch_v4a(patch_content)` remains unchanged for third-party implementations. `ShellFileOperations` additionally provides `patch_v4a_resolved(...)`; capability detection uses static MRO inspection so inherited methods work while dynamic instance/metaclass fabrication does not.
- Legacy one-argument V4A backends receive a header-rewritten patch containing the exact captured absolute identities; the resolved-path adapter rejects any parser/header path absent from the captured mapping.
- Sensitive-path checks consume only the captured mutation identity when one is available, so an SSH `~` target is evaluated against the remote home rather than accidentally expanded against the Hermes host home.
- Concurrent timeout/interrupt handling clears a per-call active event under the verifier state lock before abandoning workers. The verifier also checks the shared monotonic deadline and live interrupt predicate itself, closing the scheduler window before main-thread revocation; per-turn epoch/state identity independently prevents old completions from touching replacement-turn state.
- Sequential calls carry the same live interrupt predicate. External-fallback probes are armed through a call-local `ContextVar` only after the real terminal/`execute_code` approval gate succeeds, so a denied fallback never reads or hashes a policy-denied target.
- Footer fragments escape C0/C1 controls plus Unicode line/paragraph separators, preventing forged bullets or multiline Markdown from untrusted path/error text.

## Strict RED evidence

Before the corresponding fixes:

```text
stale-turn / timeout-revocation / malformed external-result matrix:
5 failed

same resolved path in two task contexts:
1 failed

worker deadline / interrupt enforcement, dispatcher propagation,
and footer control-character neutralization:
4 failed as expected (the inherited V4A capability regression already passed)

captured policy identity, SSH remote resolution, first-call Docker cwd,
and static V4A capability detection:
5 failed

deferred fallback approval ordering, sequential interrupt propagation,
and C1/Unicode footer line-separator neutralization:
4 failed

SSH remote-home policy identity, relative legacy V4A identity,
and missing resolved-path adapter mapping:
3 failed
```

All six RED logs are preserved in the candidate evidence packet.

## Verification

```text
Focused verifier and dispatcher matrix:
97 passed

Entire tests/run_agent suite:
2024 passed, 6 skipped

File operations, file tools, cwd/tilde resolution, SSH, and
code-execution/terminal backend/V4A matrix:
509 passed, 14 skipped

Isolated changed-module agent support suites
(`test_tool_dispatch_helpers`, `test_turn_context`, turn finalizer /
interrupted-sequence / verification-stop):
113 passed

Ruff (all changed Python paths):
All checks passed

py_compile (all changed Python paths):
passed

git diff --check:
passed
```

## Review reproducibility

Frozen candidate manifest SHA-256:

```text
2580f5483bd69893aa405a4233882c4a84a67a87a212b63d17d88cf18e9100ac
```

The local evidence packet includes the 14-path manifest, tracked binary diff, untracked source archive, RED logs, refs/status, pre-publication PR state, and verified `SHA256SUMS`.

Independent concurrency, backend/V4A, and security/spec reviews passed against this frozen candidate before publication.
