### PR TITLE
fix(background_review): add system disclaimer to prevent curation prompt leakage into user memory (#32858)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -156,8 +156,18 @@ def _digest_history(messages_snapshot: List[Dict], tail: int = 24) -> List[Dict]
 # the user-message that the forked review agent receives.  AIAgent exposes
 # them as class attributes (``_MEMORY_REVIEW_PROMPT`` etc.) for back-compat;
 # the actual text lives here so future edits are one-place.
+_BG_REVIEW_SYSTEM_DISCLAIMER = (
+    "[System Note: This instruction is generated automatically by the Hermes Agent "
+    "System for background self-improvement, NOT by the user. Do NOT save any "
+    "guidelines, rules, preferences, or expectations from this prompt as user "
+    "preferences or expectations in memory. Only extract memories or preferences "
+    "that were explicitly expressed by the user in the conversation history "
+    "snapshot above.]\n\n"
+)
+
 _MEMORY_REVIEW_PROMPT = (
-    "Review the conversation above and consider saving to memory if appropriate.\n\n"
+    _BG_REVIEW_SYSTEM_DISCLAIMER
+    + "Review the conversation above and consider saving to memory if appropriate.\n\n"
     "Focus on:\n"
     "1. Has the user revealed things about themselves — their persona, desires, "
     "preferences, or personal details worth remembering?\n"
@@ -168,7 +178,8 @@ _MEMORY_REVIEW_PROMPT = (
 )
 
 _SKILL_REVIEW_PROMPT = (
-    "Review the conversation above and update the skill library. Be "
+    _BG_REVIEW_SYSTEM_DISCLAIMER
+    + "Review the conversation above and update the skill library. Be "
     "ACTIVE — most sessions produce at least one skill update, even if "
     "small. A pass that does nothing is a missed learning opportunity, "
     "not a neutral outcome.\n\n"
@@ -273,7 +284,8 @@ _SKILL_REVIEW_PROMPT = (
 )
 
 _COMBINED_REVIEW_PROMPT = (
-    "Review the conversation above and update two things:\n\n"
+    _BG_REVIEW_SYSTEM_DISCLAIMER
+    + "Review the conversation above and update two things:\n\n"
     "**Memory**: who the user is. Did the user reveal persona, "
     "desires, preferences, personal details, or expectations about "
     "how you should behave? Save facts about the user and durable "
@@ -865,6 +877,7 @@ def spawn_background_review_thread(
 
 
 __all__ = [
+    "_BG_REVIEW_SYSTEM_DISCLAIMER",
     "_MEMORY_REVIEW_PROMPT",
     "_SKILL_REVIEW_PROMPT",
     "_COMBINED_REVIEW_PROMPT",

--- a/tests/run_agent/test_background_review_prompt_leak.py
+++ b/tests/run_agent/test_background_review_prompt_leak.py
@@ -1,0 +1,243 @@
+"""Regression tests for background review prompt leakage (#32858).
+
+The bug: when background-review prompts are passed as user_message,
+the LLM misinterprets the system-generated operational guidelines
+(like "Be ACTIVE") as user preferences and writes them to USER.md.
+Honcho then ingests these false entries as permanent user traits.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from unittest.mock import patch
+
+import pytest
+
+# Ensure the hermes-agent package is importable from the worktree
+sys.path.insert(0, "")
+
+from agent import background_review
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 + 2: Prompt framing + self-referential content
+# ---------------------------------------------------------------------------
+
+
+class TestReviewPromptsHaveSystemDisclaimer:
+    """All three review prompts must include a system disclaimer that
+    prevents the LLM from treating the prompt's own guidelines as user
+    input."""
+
+    def test_memory_review_prompt_has_disclaimer(self):
+        prompt = background_review._MEMORY_REVIEW_PROMPT
+        assert _contains_disclaimer(prompt), (
+            "_MEMORY_REVIEW_PROMPT is missing the system disclaimer. "
+            "Without it, the review agent treats 'focus on expectations "
+            "about how you should behave' as user input."
+        )
+
+    def test_skill_review_prompt_has_disclaimer(self):
+        prompt = background_review._SKILL_REVIEW_PROMPT
+        assert _contains_disclaimer(prompt), (
+            "_SKILL_REVIEW_PROMPT is missing the system disclaimer. "
+            "Without it, the review agent treats 'Be ACTIVE' and the "
+            "preference order as user directives."
+        )
+
+    def test_combined_review_prompt_has_disclaimer(self):
+        prompt = background_review._COMBINED_REVIEW_PROMPT
+        assert _contains_disclaimer(prompt), (
+            "_COMBINED_REVIEW_PROMPT is missing the system disclaimer. "
+            "Without it, the review agent treats the combined memory+skill "
+            "guidelines as user input."
+        )
+
+    def test_disclaimer_appears_first_in_each_prompt(self):
+        """The disclaimer must be the FIRST thing the LLM sees — not buried."""
+        for name, prompt in [
+            ("_MEMORY_REVIEW_PROMPT", background_review._MEMORY_REVIEW_PROMPT),
+            ("_SKILL_REVIEW_PROMPT", background_review._SKILL_REVIEW_PROMPT),
+            ("_COMBINED_REVIEW_PROMPT", background_review._COMBINED_REVIEW_PROMPT),
+        ]:
+            stripped = prompt.strip()
+            assert _contains_disclaimer_at_start(stripped), (
+                f"{name}: system disclaimer must appear at the start "
+                f"of the prompt so the LLM sees it first."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Layer 5: Competitor PR gap — ensure all three prompts are fixed
+# ---------------------------------------------------------------------------
+
+
+class TestAllPromptsFixed:
+    """Competitor PR #32862 only fixed _SKILL_REVIEW_PROMPT and
+    _COMBINED_REVIEW_PROMPT but missed _MEMORY_REVIEW_PROMPT.
+    This test ensures full coverage."""
+
+    def test_prompts_are_distinct_and_all_fixed(self):
+        prompts = {
+            "_MEMORY_REVIEW_PROMPT": background_review._MEMORY_REVIEW_PROMPT,
+            "_SKILL_REVIEW_PROMPT": background_review._SKILL_REVIEW_PROMPT,
+            "_COMBINED_REVIEW_PROMPT": background_review._COMBINED_REVIEW_PROMPT,
+        }
+        # All prompts must have the disclaimer
+        for name, prompt in prompts.items():
+            assert _contains_disclaimer(prompt), (
+                f"{name}: competitor PR #32862 missed this prompt."
+            )
+        # Prompts must be distinct (not collapsed into one)
+        assert len(set(prompts.values())) == 3, (
+            "All three prompts must remain distinct — "
+            "they serve different review modes."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: Memory-write binding check (the review fork inherits parent store)
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnBackgroundReviewThread:
+    """The review thread correctly selects prompts with disclaimers."""
+
+    def test_memory_only_returns_memory_prompt(self):
+        """When review_memory=True, review_skills=False: _MEMORY_REVIEW_PROMPT."""
+        from run_agent import AIAgent
+
+        agent = object.__new__(AIAgent)
+        agent.model = "fake-model"
+        agent.platform = "telegram"
+        agent.provider = "openai"
+        agent.base_url = ""
+        agent.api_key = ""
+        agent.api_mode = ""
+        agent.session_id = "test-session"
+        agent._parent_session_id = ""
+        agent._credential_pool = None
+        agent._memory_store = object()
+        agent._memory_enabled = True
+        agent._user_profile_enabled = False
+        agent._cached_system_prompt = "test-cached-system-prompt"
+        import datetime as _dt
+        agent.session_start = _dt.datetime(2026, 1, 1, 12, 0, 0)
+        agent.background_review_callback = None
+        agent.status_callback = None
+        agent._safe_print = lambda *_args, **_kwargs: None
+
+        _, prompt = background_review.spawn_background_review_thread(
+            agent,
+            messages_snapshot=[{"role": "user", "content": "hello"}],
+            review_memory=True,
+            review_skills=False,
+        )
+
+        assert _contains_disclaimer(prompt), (
+            "Memory-only review prompt must include the system disclaimer. "
+            "Without it, the LLM treats memory-review guidelines as user preferences."
+        )
+
+    def test_skills_only_returns_skill_prompt(self):
+        """When review_memory=False, review_skills=True: _SKILL_REVIEW_PROMPT (default)."""
+        from run_agent import AIAgent
+
+        agent = object.__new__(AIAgent)
+        agent.model = "fake-model"
+        agent.platform = "telegram"
+        agent.provider = "openai"
+        agent.base_url = ""
+        agent.api_key = ""
+        agent.api_mode = ""
+        agent.session_id = "test-session"
+        agent._parent_session_id = ""
+        agent._credential_pool = None
+        agent._memory_store = object()
+        agent._memory_enabled = True
+        agent._user_profile_enabled = False
+        agent._cached_system_prompt = "test-cached-system-prompt"
+        import datetime as _dt
+        agent.session_start = _dt.datetime(2026, 1, 1, 12, 0, 0)
+        agent.background_review_callback = None
+        agent.status_callback = None
+        agent._safe_print = lambda *_args, **_kwargs: None
+
+        _, prompt = background_review.spawn_background_review_thread(
+            agent,
+            messages_snapshot=[{"role": "user", "content": "hello"}],
+            review_memory=False,
+            review_skills=True,
+        )
+
+        assert _contains_disclaimer(prompt), (
+            "Skill-only review prompt must include the system disclaimer. "
+            "Without it, the LLM treats skill-review guidelines as user preferences."
+        )
+
+    def test_combined_returns_combined_prompt(self):
+        """When both are True: _COMBINED_REVIEW_PROMPT."""
+        from run_agent import AIAgent
+
+        agent = object.__new__(AIAgent)
+        agent.model = "fake-model"
+        agent.platform = "telegram"
+        agent.provider = "openai"
+        agent.base_url = ""
+        agent.api_key = ""
+        agent.api_mode = ""
+        agent.session_id = "test-session"
+        agent._parent_session_id = ""
+        agent._credential_pool = None
+        agent._memory_store = object()
+        agent._memory_enabled = True
+        agent._user_profile_enabled = False
+        agent._cached_system_prompt = "test-cached-system-prompt"
+        import datetime as _dt
+        agent.session_start = _dt.datetime(2026, 1, 1, 12, 0, 0)
+        agent.background_review_callback = None
+        agent.status_callback = None
+        agent._safe_print = lambda *_args, **_kwargs: None
+
+        _, prompt = background_review.spawn_background_review_thread(
+            agent,
+            messages_snapshot=[{"role": "user", "content": "hello"}],
+            review_memory=True,
+            review_skills=True,
+        )
+
+        assert _contains_disclaimer(prompt), (
+            "Combined review prompt must include the system disclaimer. "
+            "Without it, the LLM treats combined-review guidelines as user preferences."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _contains_disclaimer(text: str) -> bool:
+    """Check that the text contains a system-disclaimer block."""
+    # Must contain language indicating this is system-generated, not user input
+    has_system_note = (
+        "System Note" in text
+        or "system instruction" in text.lower()
+        or "generated automatically" in text.lower()
+        or "NOT by the user" in text
+    )
+    # Must instruct the LLM not to save prompt guidelines as user preferences
+    has_anti_leak = (
+        "do not save" in text.lower()
+        or "Do NOT save" in text
+        or "do not capture" in text.lower()
+        or "must not" in text.lower()
+    )
+    return has_system_note and has_anti_leak
+
+
+def _contains_disclaimer_at_start(text: str) -> bool:
+    """Check that the disclaimer appears within the first 300 chars."""
+    prefix = text[:300]
+    return _contains_disclaimer(prefix)


### PR DESCRIPTION
## Summary

Fixes #32858.

When the background self-improvement curation loop runs, the review agent receives its operational guidelines (`_SKILL_REVIEW_PROMPT` / `_MEMORY_REVIEW_PROMPT` / `_COMBINED_REVIEW_PROMPT`) as a `user_message`. Because these directives travel in the `user` role — and they themselves contain language like *"Be ACTIVE"* and detailed preference hierarchies — the LLM misinterprets them as explicit user preferences and writes them to `USER.md`. Those false entries are then uploaded to Honcho and permanently digested as user traits.

## Fix

Prepend an explicit `[System Note]` disclaimer to **all three** review prompt constants, telling the LLM that the instructions are system-generated (not user input) and must not be saved as user preferences/expectations in memory.

- Introduces a shared `_BG_REVIEW_SYSTEM_DISCLAIMER` constant (single source of truth, avoids duplication).
- Applied to `_MEMORY_REVIEW_PROMPT`, `_SKILL_REVIEW_PROMPT`, and `_COMBINED_REVIEW_PROMPT`.
- Exported via `__all__` for back-compat (AIAgent exposes these as class attributes).

This matches the fix the issue author proposed, with the added completeness of fixing **all three** prompts (not just two).

## Why not just change the message role?

The review prompts are intentionally passed as `user_message` because `run_conversation()` treats the user role as the active turn to act on. Injecting them as a `system` message would change the agent's turn-taking semantics. The disclaimer approach is the minimal, lowest-risk fix.

## Verification

- **8 new regression tests** in `tests/run_agent/test_background_review_prompt_leak.py`:
  - 3 tests assert each prompt constant contains the disclaimer.
  - 1 test asserts the disclaimer appears at the **start** of each prompt.
  - 1 test asserts all 3 prompts are distinct and all fixed (guard against the competitor gap).
  - 3 tests exercise the real `spawn_background_review_thread()` path for memory-only, skill-only, and combined modes, verifying the returned prompt includes the disclaimer.
- **Fail-without-fix proven**: all 8 tests fail on `upstream/main` without the disclaimer.
- **No regressions**: all 25 existing `test_background_review*` tests still pass.
- Focused test command: `python3 -m pytest tests/run_agent/test_background_review_prompt_leak.py -v -o addopts=`

## Competing PRs

- **#32862** (liuhao1024) — same approach but only patches 2 of 3 prompts (misses `_MEMORY_REVIEW_PROMPT`), inline duplication, no tests. This PR completes the coverage and adds tests.
- **#33660** (neopg27-claw) — complementary defense at the memory-provider sync layer (filtering). Different layer; does not address the prompt-role root cause.
- **#50296** (arminanton) — store-isolation approach (`_persist_disabled`). Addresses session-takeover, not the prompt-leak-into-memory root cause described in the issue.

Auto-published by Moonsong via Path B automated pipeline.