### PR TITLE
feat(cronjob): add `get` action to read a job's full prompt

### DIFF
--- a/tests/cron/test_cron_get_action.py
+++ b/tests/cron/test_cron_get_action.py
@@ -1,0 +1,74 @@
+"""Tests for the cronjob ``get`` action — full-prompt retrieval (issue #18374).
+
+``list`` returns only ``prompt_preview`` (first 100 chars); ``get`` must return
+the complete prompt so sandboxed agents can audit/edit a job's prompt without
+direct jobs.json access.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+LONG_PROMPT = "Monitor solar health and alert on anomalies. " + "detail " * 40  # >100 chars
+
+
+@pytest.fixture
+def cron_env(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "cron").mkdir()
+    (hermes_home / "cron" / "output").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import cron.jobs as jobs_mod
+    monkeypatch.setattr(jobs_mod, "HERMES_DIR", hermes_home)
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", hermes_home / "cron")
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", hermes_home / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", hermes_home / "cron" / "output")
+    return hermes_home
+
+
+def test_get_returns_full_prompt(cron_env):
+    from cron.jobs import create_job
+    from tools.cronjob_tools import cronjob
+
+    job = create_job(prompt=LONG_PROMPT, schedule="every 1h")
+    result = json.loads(cronjob(action="get", job_id=job["id"]))
+
+    assert result["success"] is True
+    assert result["job"]["prompt"] == LONG_PROMPT
+    assert "prompt_preview" not in result["job"]
+    assert len(LONG_PROMPT) > 100  # guard: prompt is long enough to be truncated by list
+
+
+def test_list_only_returns_truncated_preview(cron_env):
+    """Regression guard: list stays a 100-char preview (the asymmetry get fixes)."""
+    from cron.jobs import create_job
+    from tools.cronjob_tools import cronjob
+
+    create_job(prompt=LONG_PROMPT, schedule="every 1h")
+    job = json.loads(cronjob(action="list"))["jobs"][0]
+
+    assert job["prompt_preview"].endswith("...")
+    assert len(job["prompt_preview"]) < len(LONG_PROMPT)
+    assert "prompt" not in job
+
+
+def test_get_unknown_job_returns_error(cron_env):
+    from tools.cronjob_tools import cronjob
+
+    result = json.loads(cronjob(action="get", job_id="does-not-exist"))
+    assert result["success"] is False
+
+
+def test_schema_action_description_lists_get():
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    desc = CRONJOB_SCHEMA["parameters"]["properties"]["action"]["description"]
+    assert "get" in desc

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -711,6 +711,23 @@ def cronjob(
         # Resolve to canonical ID (supports name-based lookup)
         job_id = job["id"]
 
+        if normalized == "get":
+            full = _format_job(job)
+            full.pop("prompt_preview", None)
+            full["prompt"] = str(job.get("prompt") or "")
+            return json.dumps(
+                {
+                    "success": True,
+                    "job": full,
+                    "edit_hint": (
+                        "To change this job, call cronjob(action='update', "
+                        "job_id='%s', prompt=<full new prompt text>). "
+                        "Do NOT edit jobs.json with file/patch tools." % job_id
+                    ),
+                },
+                indent=2,
+            )
+
         if normalized == "remove":
             removed = remove_job(job_id)
             if not removed:
@@ -857,7 +874,9 @@ CRONJOB_SCHEMA = {
     "description": """Manage scheduled cron jobs with a single compressed tool.
 
 Use action='create' to schedule a new job from a prompt or one or more skills.
-Use action='list' to inspect jobs.
+Use action='list' to inspect jobs (shows only a 100-char prompt preview).
+Use action='get' with a job_id to read a job's FULL prompt and config.
+To EDIT a job's prompt: action='get' to read the full prompt, modify that text, then action='update' with the complete new prompt. Always 'get' first; never reconstruct a prompt from the preview or by editing jobs.json directly.
 Use action='update', 'pause', 'resume', 'remove', or 'run' to manage an existing job.
 
 To stop a job the user no longer wants: first action='list' to find the job_id, then action='remove' with that job_id. Never guess job IDs — always list first.
@@ -876,11 +895,11 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
         "properties": {
             "action": {
                 "type": "string",
-                "description": "One of: create, list, update, pause, resume, remove, run. When action=create, the 'schedule' and 'prompt' fields are REQUIRED."
+                "description": "One of: create, list, get, update, pause, resume, remove, run. When action=create, the 'schedule' and 'prompt' fields are REQUIRED."
             },
             "job_id": {
                 "type": "string",
-                "description": "Required for update/pause/resume/remove/run"
+                "description": "Required for get/update/pause/resume/remove/run"
             },
             "prompt": {
                 "type": "string",


### PR DESCRIPTION
## What does this PR do?

Adds a `get` action to the `cronjob` tool so an agent can read a cron job's **full prompt** and config.

Today the tool exposes `create/list/update/pause/resume/remove/run`, but no action returns a job's full prompt — `action='list'` only returns `prompt_preview` (first 100 chars, via `_format_job`), and there's no `get`/`show` action or `include_prompt` option. This creates an asymmetry: a sandboxed agent (no direct `jobs.json` access) can create/update/remove/run jobs but **cannot audit or safely edit the exact prompt it is about to change**. In practice it falls back to grepping `jobs.json` on disk and either fails or — because active and paused copies can share an identical prompt — makes an ambiguous edit. `action='get'` gives the agent a clean read-modify-write path through the tool itself.

## Related Issue

Closes #18374

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/cronjob_tools.py`: add `action='get'` (after job_id resolution) returning `_format_job(job)` with the full `prompt` field (preview removed) plus an `edit_hint` describing the `get → modify → update` flow.
- `tools/cronjob_tools.py`: update the tool description to read the full prompt before `update` and never hand-edit `jobs.json`; add `get` to the `action` enum description and the `job_id` "required for" list.
- `tests/cron/test_cron_get_action.py`: new tests for the action.

## How to Test

1. `pytest tests/cron/test_cron_get_action.py -q` → 4 passed.
2. Manual: create a job with a >100-char prompt; `cronjob(action="get", job_id=...)` returns the full `prompt`, while `cronjob(action="list")` still returns only the 100-char `prompt_preview`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(cronjob): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — `tests/cron/` is 565 passed / 9 failed, where all 9 failures are pre-existing **Windows-only** issues (unix file-mode `0600/0700` asserts, a Codex-auth test, a `~`-expansion test) unrelated to this change; new + existing cronjob tests pass.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated tool descriptions/schemas (the `cronjob` description + `action`/`job_id` schema text) — or N/A
- [x] I've updated relevant documentation — N/A (additive; no behavior change to existing actions)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've considered cross-platform impact — N/A (pure stdlib, no platform-specific code)