### PR TITLE
fix(tui-gateway): reject oversized websocket messages

### DIFF
--- a/tests/tui_gateway/test_ws.py
+++ b/tests/tui_gateway/test_ws.py
@@ -1,0 +1,105 @@
+"""Tests for tui_gateway.ws message-size guards."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class _FakeDisconnect(Exception):
+    def __init__(self, code: int = 1000, reason: str = "bye") -> None:
+        super().__init__(reason)
+        self.code = code
+        self.reason = reason
+
+
+class _FakeWebSocket:
+    def __init__(self, incoming: list[object]) -> None:
+        self._incoming = list(incoming)
+        self.client = SimpleNamespace(host="127.0.0.1", port=43124)
+        self.accepted = False
+        self.sent_text: list[str] = []
+        self.closed_calls: list[dict[str, object | None]] = []
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def send_text(self, text: str) -> None:
+        self.sent_text.append(text)
+
+    async def receive_text(self) -> str:
+        if not self._incoming:
+            raise _FakeDisconnect()
+        item = self._incoming.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return str(item)
+
+    async def close(self, code: int | None = None, reason: str | None = None) -> None:
+        self.closed_calls.append({"code": code, "reason": reason})
+
+
+@pytest.fixture()
+def ws_mod():
+    sys.modules.pop("tui_gateway.ws", None)
+    sys.modules.pop("tui_gateway.server", None)
+    with patch.dict("sys.modules", {
+        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
+        "hermes_cli.env_loader": MagicMock(),
+        "hermes_cli.banner": MagicMock(),
+        "hermes_state": MagicMock(),
+    }):
+        mod = importlib.import_module("tui_gateway.ws")
+        yield mod
+
+
+@pytest.mark.asyncio
+async def test_oversized_message_closes_with_1009(ws_mod, monkeypatch, caplog):
+    oversized = "x" * 9
+    ws = _FakeWebSocket([oversized])
+
+    monkeypatch.setattr(ws_mod, "_MAX_WS_MESSAGE_BYTES", 8)
+    monkeypatch.setattr(ws_mod, "_WebSocketDisconnect", _FakeDisconnect)
+    monkeypatch.setattr(ws_mod, "_disable_nagle", lambda _ws: None)
+    monkeypatch.setattr(ws_mod.server, "resolve_skin", lambda: "test-skin")
+    monkeypatch.setattr(ws_mod.server, "dispatch", lambda req, transport: {"unexpected": True})
+    monkeypatch.setattr(ws_mod.server, "_close_sessions_for_transport", lambda transport, end_reason: (0, 0))
+
+    with caplog.at_level("WARNING"):
+        await ws_mod.handle_ws(ws)
+
+    assert ws.accepted is True
+    assert any(close["code"] == 1009 and close["reason"] == "Message too large" for close in ws.closed_calls)
+    assert "ws oversized message rejected" in caplog.text
+    assert len(ws.sent_text) == 1
+    assert json.loads(ws.sent_text[0])["params"]["type"] == "gateway.ready"
+
+
+@pytest.mark.asyncio
+async def test_boundary_message_dispatches(ws_mod, monkeypatch):
+    request = {"jsonrpc": "2.0", "id": "r1", "method": "ping"}
+    raw = json.dumps(request)
+    responses: list[dict[str, object]] = []
+    ws = _FakeWebSocket([raw, _FakeDisconnect()])
+
+    monkeypatch.setattr(ws_mod, "_MAX_WS_MESSAGE_BYTES", len(raw.encode("utf-8")))
+    monkeypatch.setattr(ws_mod, "_WebSocketDisconnect", _FakeDisconnect)
+    monkeypatch.setattr(ws_mod, "_disable_nagle", lambda _ws: None)
+    monkeypatch.setattr(ws_mod.server, "resolve_skin", lambda: "test-skin")
+    monkeypatch.setattr(
+        ws_mod.server,
+        "dispatch",
+        lambda req, transport: responses.append(req) or {"jsonrpc": "2.0", "id": req["id"], "result": {"ok": True}},
+    )
+    monkeypatch.setattr(ws_mod.server, "_close_sessions_for_transport", lambda transport, end_reason: (0, 0))
+
+    await ws_mod.handle_ws(ws)
+
+    assert responses == [request]
+    assert any(json.loads(text).get("result") == {"ok": True} for text in ws.sent_text)
+    assert not any(close["code"] == 1009 for close in ws.closed_calls)

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -38,6 +38,7 @@ _log = logging.getLogger(__name__)
 # to flush a WS frame before we mark the transport dead. Protects handler
 # threads from a wedged socket.
 _WS_WRITE_TIMEOUT_S = 10.0
+_MAX_WS_MESSAGE_BYTES = 1 * 1024 * 1024
 _WS_LOG_PAYLOAD_PREVIEW = 240
 
 # Keep starlette optional at import time; handle_ws uses the real class when
@@ -219,6 +220,22 @@ async def handle_ws(ws: Any) -> None:
             except Exception:
                 disconnect_reason = "receive_failed"
                 _log.exception("ws receive failed peer=%s", peer)
+                break
+
+            raw_bytes = len(raw.encode("utf-8"))
+            if raw_bytes > _MAX_WS_MESSAGE_BYTES:
+                disconnect_reason = "oversized_message"
+                _log.warning(
+                    "ws oversized message rejected peer=%s size=%d limit=%d payload=%r",
+                    peer,
+                    raw_bytes,
+                    _MAX_WS_MESSAGE_BYTES,
+                    raw[:_WS_LOG_PAYLOAD_PREVIEW],
+                )
+                try:
+                    await ws.close(code=1009, reason="Message too large")
+                except Exception as exc:
+                    _log.debug("ws oversized close failed peer=%s error=%s", peer, exc)
                 break
 
             line = raw.strip()


### PR DESCRIPTION
## Summary

- reject inbound WebSocket frames larger than 1 MiB before JSON parsing and close the connection with code `1009`
- log the peer, measured payload size, limit, and a bounded preview so operators can diagnose oversized-client behavior without OOMing the gateway
- add focused async regression coverage for both the oversized-close path and the exact-boundary accepted path

Closes #53142.

## Verification

- `uv run python --version`
- `uv run --with pytest python -m pytest tests/tui_gateway/test_ws.py`
- `uv run --extra dev python -m ruff check tui_gateway/ws.py tests/tui_gateway/test_ws.py`
- `git diff --check`
