### PR TITLE
fix(auxiliary): skip compression timeout retry before fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2628,6 +2628,43 @@ def _is_transient_transport_error(exc: Exception) -> bool:
     return isinstance(status, int) and (status == 408 or 500 <= status < 600)
 
 
+def _is_timeout_transport_error(exc: Exception) -> bool:
+    """Return True when a transport error has already consumed its timeout.
+
+    Timeouts are distinct from short-lived disconnects: retrying the exact
+    same compression provider after the request deadline expires can block a
+    gateway session for another full auxiliary timeout before fallback has a
+    chance to run.
+    """
+    try:
+        from openai import APITimeoutError
+        if isinstance(exc, APITimeoutError):
+            return True
+    except ImportError:
+        pass
+    err_type = type(exc).__name__.lower()
+    err_lower = str(exc).lower()
+    return "timeout" in err_type or "timed out" in err_lower or "timeout" in err_lower
+
+
+def _should_retry_transient_same_provider(task: Optional[str], exc: Exception) -> bool:
+    """Decide whether an auxiliary transient error should get an immediate
+    retry against the same provider before provider/model fallback.
+
+    Context compression runs under interrupt protection so a mid-flight gateway
+    message cannot abort the summary and corrupt the handoff. That protection is
+    correct, but it makes same-provider timeout retries user-visible: the chat
+    appears stuck until the second full timeout elapses. Once a compression
+    provider has exhausted its request timeout, skip the same-target retry and
+    let the existing fallback chain run immediately.
+    """
+    if not _is_transient_transport_error(exc):
+        return False
+    if task == "compression" and _is_timeout_transport_error(exc):
+        return False
+    return True
+
+
 def _is_auth_error(exc: Exception) -> bool:
     """Detect auth failures that should trigger provider-specific refresh."""
     status = getattr(exc, "status_code", None)
@@ -5715,7 +5752,7 @@ def call_llm(
             return _validate_llm_response(
                 client.chat.completions.create(**kwargs), task)
         except Exception as transient_err:
-            if not _is_transient_transport_error(transient_err):
+            if not _should_retry_transient_same_provider(task, transient_err):
                 raise
             logger.info(
                 "Auxiliary %s: transient transport error; retrying once on "
@@ -6229,7 +6266,7 @@ async def async_call_llm(
             return _validate_llm_response(
                 await client.chat.completions.create(**kwargs), task)
         except Exception as transient_err:
-            if not _is_transient_transport_error(transient_err):
+            if not _should_retry_transient_same_provider(task, transient_err):
                 raise
             logger.info(
                 "Auxiliary %s (async): transient transport error; retrying "

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "jvsantos.cunha@gmail.com": "plcunha",  # PR #53171 (auxiliary compression timeout fallback)
     "piyrw9754@gmail.com": "rlaope",  # PR #35075 salvage (align cron invisible-unicode set with install-time scanner; #35075)
     "rebel@rebels-Mac-Studio-2.local": "rebel0789",  # PR #47308 salvage (redact browser_type typed text across display surfaces; #47197)
     "267614622+agt-user@users.noreply.github.com": "agt-user",  # PR #48496 salvage (telegram CLOSE-WAIT polling heartbeat, #48495)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2054,6 +2054,42 @@ class TestAuxiliaryFallbackLayering:
 
         assert main_client.chat.completions.create.called
 
+    def test_compression_timeout_skips_same_provider_retry_and_uses_fallback(self, monkeypatch):
+        """Compression timeouts should fall back immediately, not retry the timed-out provider.
+
+        Compression is interrupt-protected in gateway sessions. If a summary
+        provider consumes the full request timeout, retrying the same provider
+        can make Telegram appear unresponsive for another full timeout before
+        fallback has a chance to run.
+        """
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = TimeoutError("Request timed out")
+
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="from fallback"))
+        ])
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "minimaxai/minimax-m3")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("nvidia", "minimaxai/minimax-m3", None, None, None)), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(fallback_client, "deepseek-v4-flash", "fallback_chain[0](deepseek)")) as mock_chain, \
+             patch("agent.auxiliary_client._try_main_agent_model_fallback") as mock_main:
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+                timeout=1,
+            )
+
+        assert result.choices[0].message.content == "from fallback"
+        assert primary_client.chat.completions.create.call_count == 1
+        mock_chain.assert_called_once_with(
+            "compression", "nvidia", reason="connection error")
+        assert fallback_client.chat.completions.create.called
+        mock_main.assert_not_called()
+
     def test_explicit_provider_rate_limit_triggers_fallback(self, monkeypatch):
         """429 rate-limit on an explicit provider must trigger fallback (not be ignored).
 


### PR DESCRIPTION
## Summary

- Skip the immediate same-provider retry when an auxiliary `compression` call has already failed with a timeout.
- Let the existing auxiliary fallback chain run immediately for compression timeouts.
- Keep same-provider retry behavior for non-timeout transient blips and for other auxiliary tasks.

## Why

In a live Telegram gateway incident, context compression ran under interrupt protection on an explicit auxiliary provider. The provider timed out; `call_llm()` then retried the exact same provider before fallback. Because compression is intentionally interrupt-protected, that second full timeout made the chat look unresponsive even though fallback could have handled the request.

Timeline from the live incident:

- `13:02:18` context compression started for a ~249,920-token session.
- `13:02:18` auxiliary compression selected `nvidia/minimaxai/minimax-m3`.
- `13:11:20` first transport timeout was logged and same-provider retry started.
- `13:20:21` a Telegram interrupt could not stop the protected compression task within 5s.
- `13:20:23` only then did the auxiliary path fall back.

Compression needs interrupt protection to avoid corrupting compaction handoff, but once a provider has consumed its request timeout, retrying the same provider is user-visible latency rather than useful resilience.

## Validation

```bash
python -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py
python -m pytest tests/agent/test_auxiliary_client.py -q
```

Result:

```text
249 passed, 3 warnings in 19.41s
```
