### PR TITLE
docs(agent): Nemotron vLLM tool flags + classify tool-choice 400

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -59,6 +59,7 @@ class FailoverReason(enum.Enum):
     long_context_tier = "long_context_tier"    # Anthropic "extra usage" tier gate
     oauth_long_context_beta_forbidden = "oauth_long_context_beta_forbidden"  # Anthropic OAuth subscription rejects 1M context beta — disable beta and retry
     llama_cpp_grammar_pattern = "llama_cpp_grammar_pattern"  # llama.cpp json-schema-to-grammar rejects regex escapes in `pattern` / `format` — strip from tools and retry
+    vllm_tool_choice_unconfigured = "vllm_tool_choice_unconfigured"  # vLLM rejected tools because --enable-auto-tool-choice / --tool-call-parser missing on the server
 
     # Catch-all
     unknown = "unknown"                  # Unclassifiable — retry with backoff
@@ -268,6 +269,14 @@ _REQUEST_VALIDATION_PATTERNS = [
     "invalid_request_error",
     "unknown_parameter",
     "unsupported_parameter",
+]
+
+# vLLM OpenAI-compatible server rejected a tools request because
+# --enable-auto-tool-choice / --tool-call-parser were not active on the
+# instance that received the call (common with misconfigured Nemotron serves).
+_VLLM_TOOL_CHOICE_PATTERNS = [
+    '"auto" tool choice requires --enable-auto-tool-choice',
+    "tool choice requires --enable-auto-tool-choice and --tool-call-parser",
 ]
 
 # OpenRouter aggregator policy-block patterns.
@@ -984,6 +993,14 @@ def _classify_400(
             retryable=True,
         )
 
+    # vLLM tool-calling flags missing on the server handling this request.
+    if any(p in error_msg for p in _VLLM_TOOL_CHOICE_PATTERNS):
+        return result_fn(
+            FailoverReason.vllm_tool_choice_unconfigured,
+            retryable=False,
+            should_fallback=False,
+        )
+
     # Invalid encrypted reasoning replay blob (OpenAI Responses API).  Must be
     # checked BEFORE context_overflow because some surfaces emit messages that
     # contain context-like phrasing ("encrypted content … could not be
@@ -1191,6 +1208,13 @@ def _classify_by_message(
         return result_fn(
             FailoverReason.image_too_large,
             retryable=True,
+        )
+
+    if any(p in error_msg for p in _VLLM_TOOL_CHOICE_PATTERNS):
+        return result_fn(
+            FailoverReason.vllm_tool_choice_unconfigured,
+            retryable=False,
+            should_fallback=False,
         )
 
     # Usage-limit patterns need the same disambiguation as 402: some providers

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -63,6 +63,7 @@ class TestFailoverReason:
             "thinking_signature", "long_context_tier",
             "oauth_long_context_beta_forbidden",
             "llama_cpp_grammar_pattern",
+            "vllm_tool_choice_unconfigured",
             "unknown",
         }
         actual = {r.value for r in FailoverReason}
@@ -1129,6 +1130,26 @@ class TestClassifyApiError:
         e = MockAPIError("input is too long for model", status_code=400)
         result = classify_api_error(e)
         assert result.reason == FailoverReason.context_overflow
+
+    def test_vllm_tool_choice_flags_missing(self):
+        """vLLM 400 when --enable-auto-tool-choice / parser not configured."""
+        e = MockAPIError(
+            '"auto" tool choice requires --enable-auto-tool-choice and '
+            "--tool-call-parser to be set",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="custom", model="nemotron")
+        assert result.reason == FailoverReason.vllm_tool_choice_unconfigured
+        assert result.retryable is False
+        assert result.should_fallback is False
+
+    def test_vllm_tool_choice_flags_missing_without_status_code(self):
+        e = MockAPIError(
+            "tool choice requires --enable-auto-tool-choice and "
+            "--tool-call-parser to be set"
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.vllm_tool_choice_unconfigured
 
     def test_ollama_context_length_exceeded(self):
         """Ollama 'context length exceeded' error → context_overflow."""

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -697,14 +697,27 @@ hermes model
 
 **Context length:** vLLM reads the model's `max_position_embeddings` by default. If that exceeds your GPU memory, it errors and asks you to set `--max-model-len` lower. You can also use `--max-model-len auto` to automatically find the maximum that fits. Set `--gpu-memory-utilization 0.95` (default 0.9) to squeeze more context into VRAM.
 
-**Tool calling requires explicit flags:**
+**Tool calling requires explicit server flags** whenever the agent sends `tools` (delegation, subagents, and normal turns all do). Hermes uses the standard chat-completions path and does not inject `tool_choice: "auto"` on custom/vLLM endpoints, but vLLM still requires the flags below on the instance that receives the request:
 
 | Flag | Purpose |
 |------|---------|
-| `--enable-auto-tool-choice` | Required for `tool_choice: "auto"` (the default in Hermes) |
-| `--tool-call-parser <name>` | Parser for the model's tool call format |
+| `--enable-auto-tool-choice` | Lets vLLM accept tool-enabled chat completion requests |
+| `--tool-call-parser <name>` | Parser matching the model family's tool-call format |
 
-Supported parsers: `hermes` (Qwen 2.5, Hermes 2/3), `llama3_json` (Llama 3.x), `mistral`, `deepseek_v3`, `deepseek_v31`, `xlam`, `pythonic`. Without these flags, tool calls won't work — the model will output tool calls as text.
+Supported parsers include `hermes` (Qwen 2.5, Hermes 2/3), `llama3_json` (Llama 3.x), `qwen3_coder` (Nemotron 3, Qwen3 coder), `mistral`, `deepseek_v3`, `deepseek_v31`, `xlam`, `pythonic`. Without the correct parser, tool calls come back as plain text or the server returns HTTP 400.
+
+**NVIDIA Nemotron 3 Super (NVFP4 / FP8 / BF16):** use `qwen3_coder`, not `hermes`. NVIDIA's vLLM recipes also recommend `--reasoning-parser nemotron_v3` (or `super_v3` with the plugin script from the model card) so reasoning tokens stay separate from tool arguments:
+
+```bash
+vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 \
+  --served-model-name nemotron \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser nemotron_v3 \
+  --trust-remote-code
+```
+
+Point `custom_providers.base_url` at the same host/port you verify with `curl /v1/chat/completions` (include a dummy `tools[]` payload). If curl returns the same 400, fix the vLLM launch flags before retrying from Hermes.
 
 **Qwen reasoning parsers:** Hermes preserves structured reasoning metadata such as `reasoning`, `reasoning_content`, and streamed reasoning deltas when OpenAI-compatible servers return them. That metadata is treated as reasoning/thinking trace data, not as a replacement for the assistant's visible answer. For Qwen reasoning models served by vLLM, make sure the final user-visible response still appears in `content`. If `--reasoning-parser qwen3` leaves `content` empty in your deployment, either disable that parser or pass a server-supported request option such as `chat_template_kwargs.enable_thinking: false` through `extra_body`.
 


### PR DESCRIPTION
## Summary

- Classify vLLM's `"auto" tool choice requires --enable-auto-tool-choice…` 400 as non-retryable `vllm_tool_choice_unconfigured` so delegation/subagent loops fail fast instead of hammering a misconfigured server.
- Update `providers.md` vLLM section: clarify Hermes omits `tool_choice` on custom endpoints, document Nemotron 3 Super flags (`qwen3_coder` + `nemotron_v3`), and add a curl verification step.

## Test plan

- [x] `tests/agent/test_error_classifier.py -k vllm_tool_choice`
- [ ] Manual: misconfigured vLLM without `--enable-auto-tool-choice` → classifier reason `vllm_tool_choice_unconfigured`, `retryable=False`

