### PR TITLE
fix(file-tools): resolve local V4A patch paths before apply

### DIFF
--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -325,6 +325,43 @@ def test_patch_reports_resolved_absolute_path(_isolated_cwd, monkeypatch):
 # env's live cwd only when the resolving session owns it.)
 
 
+def test_v4a_patch_applies_to_resolved_workspace_not_backend_cwd(_isolated_cwd, monkeypatch):
+    """V4A patch headers must resolve to the same absolute path the tool reports."""
+    workspace, decoy = _isolated_cwd
+    task_id = "sess-v4a"
+
+    monkeypatch.setattr(ft, "_get_live_tracking_cwd", lambda task_id="default": None)
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    terminal_tool.register_task_env_overrides(task_id, {"cwd": str(workspace)})
+
+    from tools.environments.local import LocalEnvironment
+    from tools.file_operations import ShellFileOperations
+
+    env = LocalEnvironment(cwd=str(decoy))
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ShellFileOperations(env))
+
+    import json
+    out = json.loads(ft.patch_tool(
+        mode="patch",
+        patch=(
+            "*** Begin Patch\n"
+            "*** Update File: target.py\n"
+            "@@\n"
+            "-WORKSPACE_ORIGINAL\n"
+            "+WORKSPACE_PATCHED\n"
+            "*** End Patch\n"
+        ),
+        task_id=task_id,
+    ))
+
+    expected = str((workspace / "target.py").resolve())
+    assert not out.get("error"), out
+    assert out.get("resolved_path") == expected
+    assert out.get("files_modified") == [expected]
+    assert (workspace / "target.py").read_text() == "WORKSPACE_PATCHED\n"
+    assert (decoy / "target.py").read_text() == "DECOY_ORIGINAL\n"
+
+
 class _FakeOwnedEnv:
     def __init__(self, cwd: str, cwd_owner: str):
         self.cwd = cwd

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -5,6 +5,7 @@ import errno
 import json
 import logging
 import os
+import re
 import threading
 from pathlib import Path
 
@@ -330,6 +331,43 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
             )
     except Exception:
         return None
+
+
+_V4A_FILE_HEADER_RE = re.compile(
+    r"^(\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*)(.+)$",
+    re.MULTILINE,
+)
+
+
+def _file_ops_uses_host_paths(file_ops) -> bool:
+    """Return True when file_ops targets the same host filesystem as Hermes."""
+    env = getattr(file_ops, "env", None)
+    if env is None:
+        return True
+    try:
+        from tools.environments.local import LocalEnvironment
+    except ImportError:
+        return True
+    return isinstance(env, LocalEnvironment)
+
+
+def _rewrite_v4a_patch_paths_for_host(
+    patch: str,
+    path_to_resolved: dict[str, str | None],
+    file_ops,
+) -> str:
+    """Rewrite local V4A headers to the exact resolved host paths."""
+    if not _file_ops_uses_host_paths(file_ops):
+        return patch
+
+    def _replace(match: re.Match) -> str:
+        original = match.group(2).strip()
+        resolved = path_to_resolved.get(original)
+        if not resolved:
+            return match.group(0)
+        return f"{match.group(1)}{resolved}"
+
+    return _V4A_FILE_HEADER_RE.sub(_replace, patch)
 
 
 def _is_blocked_device_path(path: str) -> bool:
@@ -1511,7 +1549,12 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             elif mode == "patch":
                 if not patch:
                     return tool_error("patch content required")
-                result = file_ops.patch_v4a(patch)
+                patch_for_ops = _rewrite_v4a_patch_paths_for_host(
+                    patch,
+                    _path_to_resolved,
+                    file_ops,
+                )
+                result = file_ops.patch_v4a(patch_for_ops)
             else:
                 return tool_error(f"Unknown mode: {mode}")
 


### PR DESCRIPTION
## Summary

This makes local/host-backed V4A `patch` operations apply to the same resolved absolute path that `patch_tool` validates, locks, and reports.

Before this change, `patch_tool(mode="patch")` collected and resolved V4A file headers for sensitive-path checks, stale-file checks, locking, and `files_modified` reporting, but then passed the original raw patch text to `file_ops.patch_v4a()`. If the backend `LocalEnvironment.cwd` differed from the session/task workspace override, the tool could report that it patched the workspace file while the parser actually read and wrote the same relative path under the backend cwd.

## Why

This is the V4A sibling of the existing write/replace path-resolution hardening: the control plane and the execution plane must agree on the target file. A successful patch response that names one workspace while modifying another makes wrong-workspace edits hard to notice and recover from.

## Reproduction

A minimal isolated repro on current `main`:

```text
workspace dir: ...\.bughunt-tmp\v4a-cwd\workspace
decoy dir: ...\.bughunt-tmp\v4a-cwd\decoy
resolved upper: ...\.bughunt-tmp\v4a-cwd\workspace\target.txt
result.files_modified: [...\.bughunt-tmp\v4a-cwd\workspace\target.txt]
workspace: WORKSPACE_ORIGINAL
decoy: DECOY_PATCHED
```

The tool reports the workspace path but changes the decoy/backend-cwd file.

After this fix:

```text
resolved upper: ...\.bughunt-tmp\v4a-cwd-fixed\workspace\target.txt
result.files_modified: [...\.bughunt-tmp\v4a-cwd-fixed\workspace\target.txt]
workspace: WORKSPACE_PATCHED
decoy: DECOY_ORIGINAL
```

## Changes

- Add a local/host-backed V4A header rewrite that replaces `*** Update/Add/Delete File:` paths with the already-resolved absolute paths.
- Keep non-local backend behavior unchanged so remote path semantics are not host-canonicalized by this narrow fix.
- Add a regression test where the session workspace and local backend cwd intentionally differ.

## Tests

```text
python -m pytest tests/tools/test_file_tools_cwd_resolution.py -k "v4a_patch_applies_to_resolved_workspace_not_backend_cwd or patch_reports_resolved_absolute_path or write_file_reports_resolved_absolute_path" -q --timeout-method=thread
3 passed, 25 deselected

python -m py_compile tools/file_tools.py
```

Note: Running the entire `test_file_tools_cwd_resolution.py` file on this Windows sandbox currently hits two pre-existing Windows string assertion failures where warning text contains escaped backslashes, unrelated to this change.
