### PR TITLE
feat: add memory sidecar context retrieval and runtime fixes

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -145,6 +145,78 @@ def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str
     )
 
 
+def _ollama_false_length_context_error(agent: Any, response: Any, assistant_message: Any) -> Optional[tuple[str, str]]:
+    """Detect Ollama's false ``finish_reason='length'`` on tiny local completions.
+
+    Some Ollama chat-completions routes report ``finish_reason='length'`` after
+    emitting only 1-2 visible tokens when the request silently hit the default
+    4K runtime context ceiling. Hermes previously treated that as a genuine
+    output truncation and injected continuation prompts, which produced junk like
+    ``כןII`` / ``Please`` instead of surfacing the real context problem.
+
+    Returns ``(final_response, error)`` when the turn should stop immediately,
+    else ``None``.
+    """
+    base_url = str(
+        getattr(agent, "base_url", None)
+        or getattr(agent, "_base_url_lower", None)
+        or ""
+    ).lower()
+    if not (
+        "localhost:11434" in base_url
+        or "127.0.0.1:11434" in base_url
+        or "ollama" in base_url
+        or ":11434" in base_url
+    ):
+        return None
+
+    if getattr(assistant_message, "tool_calls", None):
+        return None
+
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return None
+
+    prompt_tokens = getattr(usage, "prompt_tokens", None)
+    completion_tokens = getattr(usage, "completion_tokens", None)
+    total_tokens = getattr(usage, "total_tokens", None)
+    if not isinstance(prompt_tokens, int):
+        return None
+    if not isinstance(completion_tokens, int):
+        return None
+    if not isinstance(total_tokens, int):
+        return None
+
+    if prompt_tokens < 4094 or total_tokens != 4096 or completion_tokens > 2:
+        return None
+
+    visible = (getattr(assistant_message, "content", None) or "").strip()
+    model = getattr(agent, "model", "") or "the selected model"
+    configured_ctx = getattr(agent, "_ollama_num_ctx", None)
+    configured_ctx_note = (
+        f" Hermes is configured for ollama_num_ctx={configured_ctx:,}, so the live Ollama runtime likely ignored or failed to apply that setting."
+        if isinstance(configured_ctx, int) and configured_ctx > 4096
+        else ""
+    )
+    response_text = (
+        "⚠️ **Ollama Runtime Context Too Small**\n\n"
+        f"Hermes sent a large system prompt to `{model}`, but the Ollama "
+        "chat-completions runtime responded as if it still had only a 4,096-token "
+        "context window (`prompt_tokens≈4095`, `completion_tokens≤2`, `finish_reason=length`).\n\n"
+        "This is not a real output truncation, so Hermes stopped instead of "
+        "sending misleading continuation prompts."
+        f"{configured_ctx_note}\n\n"
+        "Try reloading the Ollama model with a larger runtime context (for example 65,536 tokens) and then retry."
+    )
+    error_text = (
+        "Ollama chat-completions route hit a 4096-token runtime context ceiling; "
+        f"provider returned finish_reason='length' after only {completion_tokens} completion token(s)."
+    )
+    if visible:
+        response_text += f"\n\nPartial visible output before stop: `{visible}`"
+    return response_text, error_text
+
+
 def _ra():
     """Lazy reference to ``run_agent`` so callers can patch
     ``run_agent.handle_function_call`` / ``run_agent._set_interrupt`` /
@@ -1688,6 +1760,22 @@ def run_conversation(
                             "completed": False,
                             "partial": True,
                             "error": _exhaust_error,
+                        }
+
+                    _ollama_false_length = _ollama_false_length_context_error(
+                        agent, response, _trunc_msg
+                    )
+                    if _ollama_false_length:
+                        _ollama_response, _ollama_error = _ollama_false_length
+                        agent._cleanup_task_resources(effective_task_id)
+                        agent._persist_session(messages, conversation_history)
+                        return {
+                            "final_response": _ollama_response,
+                            "messages": messages,
+                            "api_calls": api_call_count,
+                            "completed": False,
+                            "partial": True,
+                            "error": _ollama_error,
                         }
 
                     if agent.api_mode in {"chat_completions", "bedrock_converse", "anthropic_messages"}:

--- a/agent/memory_sidecar/__init__.py
+++ b/agent/memory_sidecar/__init__.py
@@ -1,0 +1,36 @@
+"""Hermes memory sidecar primitives.
+
+MVP surface for structured transcript observations backed by a dedicated
+SQLite/FTS5 sidecar database.
+"""
+
+from .models import (
+    OBSERVATION_TYPES,
+    PRIVACY_STATES,
+    ContextQuery,
+    ContextResult,
+    IngestSource,
+    Observation,
+    ObservationFile,
+    SessionFact,
+    validate_observation_type,
+    validate_privacy_status,
+)
+from .retrieval import format_context_result, merge_context_results
+from .store import MemorySidecarStore
+
+__all__ = [
+    "OBSERVATION_TYPES",
+    "PRIVACY_STATES",
+    "ContextQuery",
+    "ContextResult",
+    "IngestSource",
+    "MemorySidecarStore",
+    "Observation",
+    "format_context_result",
+    "merge_context_results",
+    "ObservationFile",
+    "SessionFact",
+    "validate_observation_type",
+    "validate_privacy_status",
+]

--- a/agent/memory_sidecar/models.py
+++ b/agent/memory_sidecar/models.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+OBSERVATION_TYPES: tuple[str, ...] = (
+    "decision",
+    "change",
+    "bug",
+    "how_it_works",
+    "next_step",
+)
+
+PRIVACY_STATES: tuple[str, ...] = (
+    "public",
+    "redacted",
+    "skipped",
+)
+
+
+def validate_observation_type(value: str) -> str:
+    cleaned = str(value or "").strip()
+    if cleaned not in OBSERVATION_TYPES:
+        allowed = ", ".join(OBSERVATION_TYPES)
+        raise ValueError(f"unknown observation_type '{cleaned}' (allowed: {allowed})")
+    return cleaned
+
+
+def validate_privacy_status(value: str) -> str:
+    cleaned = str(value or "").strip()
+    if cleaned not in PRIVACY_STATES:
+        allowed = ", ".join(PRIVACY_STATES)
+        raise ValueError(f"unknown privacy_status '{cleaned}' (allowed: {allowed})")
+    return cleaned
+
+
+@dataclass(frozen=True)
+class IngestSource:
+    source_id: str
+    path: str
+    last_offset: int = 0
+    partial_line: str = ""
+    last_event_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not str(self.source_id).strip():
+            raise ValueError("source_id must not be empty")
+        if not str(self.path).strip():
+            raise ValueError("path must not be empty")
+        if int(self.last_offset) < 0:
+            raise ValueError("last_offset must be >= 0")
+
+
+@dataclass(frozen=True)
+class ObservationFile:
+    file_path: str
+    change_kind: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not str(self.file_path).strip():
+            raise ValueError("file_path must not be empty")
+
+
+@dataclass(frozen=True)
+class Observation:
+    session_id: str
+    event_ts: str
+    observation_type: str
+    title: str
+    summary: str
+    detail: str
+    concepts: tuple[str, ...] = ()
+    files: tuple[ObservationFile, ...] = ()
+    privacy_status: str = "public"
+    confidence: float = 0.5
+    role: Optional[str] = None
+    message_id: Optional[str] = None
+    created_at: Optional[str] = None
+    id: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if not str(self.session_id).strip():
+            raise ValueError("session_id must not be empty")
+        if not str(self.event_ts).strip():
+            raise ValueError("event_ts must not be empty")
+        if not str(self.title).strip():
+            raise ValueError("title must not be empty")
+        if not str(self.summary).strip():
+            raise ValueError("summary must not be empty")
+        if not str(self.detail).strip():
+            raise ValueError("detail must not be empty")
+        validate_observation_type(self.observation_type)
+        validate_privacy_status(self.privacy_status)
+        if not 0.0 <= float(self.confidence) <= 1.0:
+            raise ValueError("confidence must be between 0.0 and 1.0")
+
+
+@dataclass(frozen=True)
+class SessionFact:
+    session_id: str
+    last_seen_at: str
+    user_goal: Optional[str] = None
+    latest_summary: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not str(self.session_id).strip():
+            raise ValueError("session_id must not be empty")
+        if not str(self.last_seen_at).strip():
+            raise ValueError("last_seen_at must not be empty")
+
+
+@dataclass(frozen=True)
+class ContextQuery:
+    query: Optional[str] = None
+    session_id: Optional[str] = None
+    types: tuple[str, ...] = ()
+    concepts: tuple[str, ...] = ()
+    file_path: Optional[str] = None
+    limit: int = 8
+    time_bias: str = "recent"
+
+    def __post_init__(self) -> None:
+        if self.limit < 1:
+            raise ValueError("limit must be >= 1")
+        if self.time_bias not in {"recent", "relevant"}:
+            raise ValueError("time_bias must be 'recent' or 'relevant'")
+        for kind in self.types:
+            validate_observation_type(kind)
+
+
+@dataclass(frozen=True)
+class ContextResult:
+    observations: tuple[Observation, ...] = ()
+    decisions: tuple[Observation, ...] = ()
+    changed_files: tuple[str, ...] = ()
+    session_fact: Optional[SessionFact] = None
+    suggested_follow_ups: tuple[str, ...] = field(default_factory=tuple)

--- a/agent/memory_sidecar/retrieval.py
+++ b/agent/memory_sidecar/retrieval.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from .models import ContextResult, Observation
+
+
+def _bullet_list(title: str, items: list[str]) -> list[str]:
+    if not items:
+        return []
+    return [f"{title}:", *[f"- {item}" for item in items]]
+
+
+def _observation_line(observation: Observation) -> str:
+    title = observation.title.strip()
+    if observation.files:
+        file_list = ", ".join(file.file_path for file in observation.files[:3])
+        return f"[{observation.observation_type}] {title} (files: {file_list})"
+    return f"[{observation.observation_type}] {title}"
+
+
+def merge_context_results(primary: ContextResult, fallback: ContextResult, *, limit: int) -> ContextResult:
+    """Merge targeted and fallback retrieval results, preserving primary order."""
+    merged: list[Observation] = []
+    seen: set[tuple[object, str, str]] = set()
+    for source in (primary.observations, fallback.observations):
+        for obs in source:
+            key = (obs.id, obs.session_id, obs.title)
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append(obs)
+            if len(merged) >= limit:
+                break
+        if len(merged) >= limit:
+            break
+
+    changed_files: list[str] = []
+    for path in (*primary.changed_files, *fallback.changed_files):
+        if path not in changed_files:
+            changed_files.append(path)
+
+    follow_ups: list[str] = []
+    for item in (*primary.suggested_follow_ups, *fallback.suggested_follow_ups):
+        if item not in follow_ups:
+            follow_ups.append(item)
+
+    observations = tuple(merged)
+    return ContextResult(
+        observations=observations,
+        decisions=tuple(obs for obs in observations if obs.observation_type == "decision"),
+        changed_files=tuple(changed_files),
+        session_fact=primary.session_fact or fallback.session_fact,
+        suggested_follow_ups=tuple(follow_ups),
+    )
+
+
+def format_context_result(result: ContextResult, *, max_observations: int = 4) -> str:
+    """Format sidecar retrieval into a compact prompt-ready text block."""
+    lines: list[str] = ["Memory sidecar context:"]
+
+    fact = result.session_fact
+    if fact and fact.user_goal:
+        lines.append(f"User goal: {fact.user_goal}")
+    if fact and fact.latest_summary:
+        lines.append(f"Latest summary: {fact.latest_summary}")
+
+    decisions = [obs.title.strip() for obs in result.decisions[:max_observations]]
+    lines.extend(_bullet_list("Recent decisions", decisions))
+
+    next_steps = [
+        obs.title.strip()
+        for obs in result.observations
+        if obs.observation_type == "next_step"
+    ][:max_observations]
+    lines.extend(_bullet_list("Next steps", next_steps))
+
+    relevant_observations = [
+        _observation_line(obs)
+        for obs in result.observations
+        if obs.observation_type not in {"decision", "next_step"}
+    ][:max_observations]
+    lines.extend(_bullet_list("Relevant observations", relevant_observations))
+
+    if result.changed_files:
+        lines.append(f"Changed files: {', '.join(result.changed_files[:8])}")
+    if result.suggested_follow_ups:
+        lines.extend(_bullet_list("Useful follow-ups", list(result.suggested_follow_ups[:3])))
+
+    if len(lines) == 1:
+        return ""
+    return "\n".join(lines)

--- a/agent/memory_sidecar/runtime.py
+++ b/agent/memory_sidecar/runtime.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Optional
+
+from .models import Observation, ObservationFile, SessionFact
+from .store import MemorySidecarStore
+
+logger = logging.getLogger(__name__)
+
+_EXPLICIT_OBSERVATION_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("decision:", "decision"),
+    ("verdict:", "decision"),
+    ("recommendation:", "decision"),
+    ("next step:", "next_step"),
+    ("next steps:", "next_step"),
+    ("todo:", "next_step"),
+    ("issue:", "bug"),
+    ("bug:", "bug"),
+    ("problem:", "bug"),
+    ("changed:", "change"),
+    ("updated:", "change"),
+    ("implemented:", "change"),
+    ("added:", "change"),
+    ("removed:", "change"),
+    ("patched:", "change"),
+    ("how it works:", "how_it_works"),
+)
+_PATH_RE = re.compile(r"(?:~?/)?[A-Za-z0-9_./-]+\.(?:py|md|json|yaml|yml|toml|js|ts|tsx|jsx|sql|sh)")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _truncate(text: str, limit: int) -> str:
+    cleaned = " ".join(str(text or "").split())
+    if len(cleaned) <= limit:
+        return cleaned
+    return cleaned[: limit - 1].rstrip() + "…"
+
+
+def _normalize_title(text: str) -> str:
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+    return _truncate(first_line or text.strip(), 120)
+
+
+def _extract_files(text: str) -> tuple[ObservationFile, ...]:
+    seen: set[str] = set()
+    files: list[ObservationFile] = []
+    for match in _PATH_RE.findall(text):
+        path = match.rstrip(".,:;)\"]'")
+        if path in seen:
+            continue
+        seen.add(path)
+        files.append(ObservationFile(file_path=path))
+        if len(files) >= 8:
+            break
+    return tuple(files)
+
+
+def _classify_observation(text: str) -> Optional[tuple[str, float]]:
+    first_line = next((line.strip().lower() for line in text.splitlines() if line.strip()), "")
+    for prefix, kind in _EXPLICIT_OBSERVATION_PATTERNS:
+        if first_line.startswith(prefix):
+            return kind, 0.9
+    return None
+
+
+def ingest_message(
+    store: MemorySidecarStore,
+    *,
+    session_id: str,
+    message_id: int,
+    role: str,
+    content: object,
+) -> None:
+    if not isinstance(content, str):
+        return
+    text = content.strip()
+    if not text:
+        return
+
+    now_iso = _now_iso()
+    current_fact = store.get_session_fact(session_id)
+    user_goal = current_fact.user_goal if current_fact else None
+    latest_summary = current_fact.latest_summary if current_fact else None
+
+    if role == "user" and not user_goal and len(text) >= 12:
+        user_goal = _truncate(text, 280)
+    if role == "assistant":
+        latest_summary = _truncate(text, 280)
+
+    if user_goal or latest_summary or current_fact:
+        store.upsert_session_fact(
+            SessionFact(
+                session_id=session_id,
+                user_goal=user_goal,
+                latest_summary=latest_summary,
+                last_seen_at=now_iso,
+            )
+        )
+
+    classified = _classify_observation(text)
+    if not classified:
+        return
+    observation_type, confidence = classified
+    store.insert_observation(
+        Observation(
+            session_id=session_id,
+            message_id=str(message_id),
+            role=role,
+            event_ts=now_iso,
+            observation_type=observation_type,
+            title=_normalize_title(text),
+            summary=_truncate(text, 240),
+            detail=text[:4000],
+            concepts=(observation_type, role),
+            files=_extract_files(text),
+            privacy_status="public",
+            confidence=confidence,
+        )
+    )

--- a/agent/memory_sidecar/store.py
+++ b/agent/memory_sidecar/store.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Iterable, Optional
+
+from hermes_constants import get_hermes_home
+from hermes_state import apply_wal_with_fallback
+
+from .models import ContextQuery, ContextResult, IngestSource, Observation, ObservationFile, SessionFact
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS ingest_sources (
+    source_id TEXT PRIMARY KEY,
+    path TEXT NOT NULL UNIQUE,
+    last_offset INTEGER NOT NULL DEFAULT 0,
+    partial_line TEXT NOT NULL DEFAULT '',
+    last_event_at TEXT,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS observations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    message_id TEXT,
+    role TEXT,
+    event_ts TEXT NOT NULL,
+    observation_type TEXT NOT NULL,
+    title TEXT NOT NULL,
+    summary TEXT NOT NULL,
+    detail TEXT NOT NULL,
+    privacy_status TEXT NOT NULL,
+    confidence REAL NOT NULL DEFAULT 0.5,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS observation_concepts (
+    observation_id INTEGER NOT NULL REFERENCES observations(id) ON DELETE CASCADE,
+    concept TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS observation_files (
+    observation_id INTEGER NOT NULL REFERENCES observations(id) ON DELETE CASCADE,
+    file_path TEXT NOT NULL,
+    change_kind TEXT
+);
+
+CREATE TABLE IF NOT EXISTS session_facts (
+    session_id TEXT PRIMARY KEY,
+    user_goal TEXT,
+    latest_summary TEXT,
+    last_seen_at TEXT NOT NULL
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS observations_fts USING fts5(
+    title,
+    summary,
+    detail,
+    concepts,
+    file_paths,
+    tokenize='unicode61'
+);
+
+CREATE INDEX IF NOT EXISTS idx_observations_session_id ON observations(session_id);
+CREATE INDEX IF NOT EXISTS idx_observations_type ON observations(observation_type);
+CREATE INDEX IF NOT EXISTS idx_observations_event_ts ON observations(event_ts);
+CREATE INDEX IF NOT EXISTS idx_observation_files_path ON observation_files(file_path);
+CREATE INDEX IF NOT EXISTS idx_observation_concepts_concept ON observation_concepts(concept);
+"""
+
+
+class MemorySidecarStore:
+    """SQLite-backed store for normalized transcript observations."""
+
+    def __init__(self, db_path: str | Path | None = None) -> None:
+        if db_path is None:
+            db_path = get_hermes_home() / "memory_sidecar.db"
+        self.db_path = Path(db_path).expanduser()
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self.db_path), check_same_thread=False, timeout=10.0)
+        self._conn.row_factory = sqlite3.Row
+        self._lock = threading.RLock()
+        self._init_db()
+
+    def _init_db(self) -> None:
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        apply_wal_with_fallback(self._conn, db_label="memory_sidecar.db")
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    def get_checkpoint(self, source_id: str) -> Optional[IngestSource]:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT source_id, path, last_offset, partial_line, last_event_at, updated_at FROM ingest_sources WHERE source_id = ?",
+                (source_id,),
+            ).fetchone()
+        return self._row_to_ingest_source(row) if row else None
+
+    def upsert_checkpoint(self, checkpoint: IngestSource) -> IngestSource:
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO ingest_sources (source_id, path, last_offset, partial_line, last_event_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(source_id) DO UPDATE SET
+                    path = excluded.path,
+                    last_offset = excluded.last_offset,
+                    partial_line = excluded.partial_line,
+                    last_event_at = excluded.last_event_at,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    checkpoint.source_id,
+                    checkpoint.path,
+                    checkpoint.last_offset,
+                    checkpoint.partial_line,
+                    checkpoint.last_event_at,
+                    checkpoint.updated_at or checkpoint.last_event_at or "",
+                ),
+            )
+            self._conn.commit()
+        return self.get_checkpoint(checkpoint.source_id) or checkpoint
+
+    def insert_observation(self, observation: Observation) -> Observation:
+        with self._lock:
+            cur = self._conn.execute(
+                """
+                INSERT INTO observations (
+                    session_id, message_id, role, event_ts, observation_type,
+                    title, summary, detail, privacy_status, confidence, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    observation.session_id,
+                    observation.message_id,
+                    observation.role,
+                    observation.event_ts,
+                    observation.observation_type,
+                    observation.title,
+                    observation.summary,
+                    observation.detail,
+                    observation.privacy_status,
+                    observation.confidence,
+                    observation.created_at or observation.event_ts,
+                ),
+            )
+            lastrowid = cur.lastrowid
+            if lastrowid is None:
+                raise RuntimeError("insert_observation() did not return a row id")
+            observation_id = int(lastrowid)
+            self._replace_concepts(observation_id, observation.concepts)
+            self._replace_files(observation_id, observation.files)
+            self._upsert_fts(observation_id, observation)
+            self._conn.commit()
+        return Observation(
+            id=observation_id,
+            session_id=observation.session_id,
+            message_id=observation.message_id,
+            role=observation.role,
+            event_ts=observation.event_ts,
+            observation_type=observation.observation_type,
+            title=observation.title,
+            summary=observation.summary,
+            detail=observation.detail,
+            concepts=observation.concepts,
+            files=observation.files,
+            privacy_status=observation.privacy_status,
+            confidence=observation.confidence,
+            created_at=observation.created_at or observation.event_ts,
+        )
+
+    def upsert_session_fact(self, fact: SessionFact) -> SessionFact:
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO session_facts (session_id, user_goal, latest_summary, last_seen_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(session_id) DO UPDATE SET
+                    user_goal = excluded.user_goal,
+                    latest_summary = excluded.latest_summary,
+                    last_seen_at = excluded.last_seen_at
+                """,
+                (fact.session_id, fact.user_goal, fact.latest_summary, fact.last_seen_at),
+            )
+            self._conn.commit()
+        return self.get_session_fact(fact.session_id) or fact
+
+    def get_session_fact(self, session_id: str) -> Optional[SessionFact]:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT session_id, user_goal, latest_summary, last_seen_at FROM session_facts WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+        if not row:
+            return None
+        return SessionFact(
+            session_id=row["session_id"],
+            user_goal=row["user_goal"],
+            latest_summary=row["latest_summary"],
+            last_seen_at=row["last_seen_at"],
+        )
+
+    def query_context(self, query: ContextQuery) -> ContextResult:
+        where: list[str] = []
+        params: list[object] = []
+        joins: list[str] = []
+        order_clause = "o.event_ts DESC, o.id DESC"
+
+        if query.query:
+            joins.append("JOIN observations_fts fts ON fts.rowid = o.id")
+            where.append("observations_fts MATCH ?")
+            params.append(query.query)
+            if query.time_bias == "relevant":
+                order_clause = "bm25(observations_fts), o.event_ts DESC, o.id DESC"
+
+        if query.session_id:
+            where.append("o.session_id = ?")
+            params.append(query.session_id)
+
+        if query.types:
+            placeholders = ",".join("?" * len(query.types))
+            where.append(f"o.observation_type IN ({placeholders})")
+            params.extend(query.types)
+
+        if query.concepts:
+            joins.append("JOIN observation_concepts oc ON oc.observation_id = o.id")
+            placeholders = ",".join("?" * len(query.concepts))
+            where.append(f"oc.concept IN ({placeholders})")
+            params.extend(query.concepts)
+
+        if query.file_path:
+            joins.append("JOIN observation_files ofi ON ofi.observation_id = o.id")
+            where.append("ofi.file_path = ?")
+            params.append(query.file_path)
+
+        sql = f"""
+            SELECT DISTINCT o.id, o.session_id, o.message_id, o.role, o.event_ts,
+                   o.observation_type, o.title, o.summary, o.detail,
+                   o.privacy_status, o.confidence, o.created_at
+            FROM observations o
+            {' '.join(joins)}
+            {'WHERE ' + ' AND '.join(where) if where else ''}
+            ORDER BY {order_clause}
+            LIMIT ?
+        """
+        params.append(query.limit)
+
+        with self._lock:
+            rows = self._conn.execute(sql, params).fetchall()
+            observations = tuple(self._hydrate_observation(row) for row in rows)
+            decisions = tuple(obs for obs in observations if obs.observation_type == "decision")
+            changed_files = tuple(self._collect_changed_files(query, observations))
+            session_fact = self.get_session_fact(query.session_id) if query.session_id else None
+
+        return ContextResult(
+            observations=observations,
+            decisions=decisions,
+            changed_files=changed_files,
+            session_fact=session_fact,
+            suggested_follow_ups=self._suggest_follow_ups(observations),
+        )
+
+    def _collect_changed_files(self, query: ContextQuery, observations: tuple[Observation, ...]) -> list[str]:
+        if not observations:
+            return []
+        ids = [obs.id for obs in observations if obs.id is not None]
+        if not ids:
+            return []
+        placeholders = ",".join("?" * len(ids))
+        sql = f"SELECT DISTINCT file_path FROM observation_files WHERE observation_id IN ({placeholders}) ORDER BY file_path"
+        rows = self._conn.execute(sql, ids).fetchall()
+        files = [str(r["file_path"]) for r in rows]
+        if query.file_path and query.file_path not in files:
+            files.insert(0, query.file_path)
+        return files
+
+    def _replace_concepts(self, observation_id: int, concepts: Iterable[str]) -> None:
+        self._conn.execute("DELETE FROM observation_concepts WHERE observation_id = ?", (observation_id,))
+        values = [(observation_id, str(concept).strip()) for concept in concepts if str(concept).strip()]
+        if values:
+            self._conn.executemany(
+                "INSERT INTO observation_concepts (observation_id, concept) VALUES (?, ?)",
+                values,
+            )
+
+    def _replace_files(self, observation_id: int, files: Iterable[ObservationFile]) -> None:
+        self._conn.execute("DELETE FROM observation_files WHERE observation_id = ?", (observation_id,))
+        values = [
+            (observation_id, entry.file_path, entry.change_kind)
+            for entry in files
+            if str(entry.file_path).strip()
+        ]
+        if values:
+            self._conn.executemany(
+                "INSERT INTO observation_files (observation_id, file_path, change_kind) VALUES (?, ?, ?)",
+                values,
+            )
+
+    def _upsert_fts(self, observation_id: int, observation: Observation) -> None:
+        self._conn.execute("DELETE FROM observations_fts WHERE rowid = ?", (observation_id,))
+        self._conn.execute(
+            "INSERT INTO observations_fts(rowid, title, summary, detail, concepts, file_paths) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                observation_id,
+                observation.title,
+                observation.summary,
+                observation.detail,
+                " ".join(observation.concepts),
+                " ".join(file.file_path for file in observation.files),
+            ),
+        )
+
+    def _hydrate_observation(self, row: sqlite3.Row) -> Observation:
+        observation_id = int(row["id"])
+        concepts = tuple(
+            entry["concept"]
+            for entry in self._conn.execute(
+                "SELECT concept FROM observation_concepts WHERE observation_id = ? ORDER BY concept",
+                (observation_id,),
+            ).fetchall()
+        )
+        files = tuple(
+            ObservationFile(file_path=entry["file_path"], change_kind=entry["change_kind"])
+            for entry in self._conn.execute(
+                "SELECT file_path, change_kind FROM observation_files WHERE observation_id = ? ORDER BY file_path",
+                (observation_id,),
+            ).fetchall()
+        )
+        return Observation(
+            id=observation_id,
+            session_id=row["session_id"],
+            message_id=row["message_id"],
+            role=row["role"],
+            event_ts=row["event_ts"],
+            observation_type=row["observation_type"],
+            title=row["title"],
+            summary=row["summary"],
+            detail=row["detail"],
+            concepts=concepts,
+            files=files,
+            privacy_status=row["privacy_status"],
+            confidence=float(row["confidence"]),
+            created_at=row["created_at"],
+        )
+
+    @staticmethod
+    def _row_to_ingest_source(row: sqlite3.Row) -> IngestSource:
+        return IngestSource(
+            source_id=row["source_id"],
+            path=row["path"],
+            last_offset=int(row["last_offset"]),
+            partial_line=row["partial_line"] or "",
+            last_event_at=row["last_event_at"],
+            updated_at=row["updated_at"],
+        )
+
+    @staticmethod
+    def _suggest_follow_ups(observations: tuple[Observation, ...]) -> tuple[str, ...]:
+        suggestions: list[str] = []
+        if any(obs.observation_type == "next_step" for obs in observations):
+            suggestions.append("What is the next concrete step from the latest session?")
+        if any(obs.observation_type == "decision" for obs in observations):
+            suggestions.append("Which prior decisions still constrain the current work?")
+        if any(obs.files for obs in observations):
+            suggestions.append("Which changed files should be opened first?")
+        return tuple(suggestions)

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -462,14 +462,40 @@ def build_turn_context(
         except Exception:
             pass
 
-    # External memory provider: prefetch once before the tool loop.
-    ext_prefetch_cache = ""
+    # External memory provider + local memory sidecar: prefetch once before the tool loop.
+    ext_prefetch_cache_parts: list[str] = []
     if agent._memory_manager:
         try:
             _query = original_user_message if isinstance(original_user_message, str) else ""
-            ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""
+            _provider_prefetch = agent._memory_manager.prefetch_all(_query) or ""
+            if _provider_prefetch:
+                ext_prefetch_cache_parts.append(str(_provider_prefetch))
         except Exception:
             pass
+
+    try:
+        _query = original_user_message if isinstance(original_user_message, str) else ""
+        _get_session_db = getattr(agent, "_get_session_db_for_recall", None)
+        if _query and callable(_get_session_db):
+            _session_db = _get_session_db()
+            _build_sidecar_context = getattr(
+                _session_db, "build_memory_sidecar_context_block", None
+            )
+            if callable(_build_sidecar_context):
+                _sidecar_context = _build_sidecar_context(
+                    session_id=agent.session_id,
+                    query=_query,
+                    limit=3,
+                    max_observations=3,
+                )
+                if _sidecar_context:
+                    ext_prefetch_cache_parts.append(str(_sidecar_context))
+    except Exception:
+        pass
+
+    ext_prefetch_cache = "\n\n".join(
+        part.strip() for part in ext_prefetch_cache_parts if isinstance(part, str) and part.strip()
+    )
 
     return TurnContext(
         user_message=user_message,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -776,6 +776,8 @@ class SessionDB:
         self._fts_enabled = False
         self._trigram_available = False
         self._fts_unavailable_warned = False
+        self._memory_sidecar_store = None
+        self._memory_sidecar_disabled = False
         self._conn = None
         try:
             if read_only:
@@ -1095,6 +1097,12 @@ class SessionDB:
         help shrink the WAL file.
         """
         with self._lock:
+            if self._memory_sidecar_store is not None:
+                try:
+                    self._memory_sidecar_store.close()
+                except Exception:
+                    pass
+                self._memory_sidecar_store = None
             if self._conn:
                 try:
                     self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
@@ -1102,6 +1110,147 @@ class SessionDB:
                     pass
                 self._conn.close()
                 self._conn = None
+
+    def _get_memory_sidecar_store(self, *, for_write: bool = False):
+        if self._memory_sidecar_disabled:
+            return None
+        if for_write and self.read_only:
+            return None
+        if self._memory_sidecar_store is not None:
+            return self._memory_sidecar_store
+        try:
+            from agent.memory_sidecar import MemorySidecarStore
+
+            self._memory_sidecar_store = MemorySidecarStore()
+            return self._memory_sidecar_store
+        except Exception as exc:
+            self._memory_sidecar_disabled = True
+            logger.warning("Memory sidecar disabled for %s: %s", self.db_path, exc)
+            return None
+
+    def _maybe_ingest_sidecar_message(
+        self,
+        *,
+        session_id: str,
+        message_id: int,
+        role: str,
+        content: Any,
+    ) -> None:
+        store = self._get_memory_sidecar_store(for_write=True)
+        if store is None:
+            return
+        try:
+            from agent.memory_sidecar.runtime import ingest_message
+
+            ingest_message(
+                store,
+                session_id=session_id,
+                message_id=message_id,
+                role=role,
+                content=content,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Memory sidecar ingest failed for session %s message %s: %s",
+                session_id,
+                message_id,
+                exc,
+            )
+
+    @staticmethod
+    def _normalize_memory_sidecar_query(query: str | None) -> str | None:
+        if not query:
+            return query
+        tokens = []
+        for raw_token in str(query).split():
+            token = raw_token.strip()
+            if not token:
+                continue
+            if re.search(r"[^\w]", token):
+                token = '"' + token.replace('"', '""') + '"'
+            tokens.append(token)
+        normalized = " ".join(tokens).strip()
+        return normalized or None
+
+    def query_memory_sidecar_context(
+        self,
+        *,
+        session_id: str,
+        query: str | None = None,
+        types: tuple[str, ...] = (),
+        concepts: tuple[str, ...] = (),
+        file_path: str | None = None,
+        limit: int = 8,
+        time_bias: str = "recent",
+    ):
+        """Query structured sidecar context for a session.
+
+        This is the low-level retrieval surface for live conversation use.
+        It is read-safe even when the SessionDB itself was opened read-only.
+        Returns ``None`` if the sidecar is unavailable/disabled.
+        """
+        store = self._get_memory_sidecar_store()
+        if store is None:
+            return None
+        from agent.memory_sidecar import ContextQuery
+
+        normalized_query = self._normalize_memory_sidecar_query(query)
+        return store.query_context(
+            ContextQuery(
+                query=normalized_query,
+                session_id=session_id,
+                types=types,
+                concepts=concepts,
+                file_path=file_path,
+                limit=limit,
+                time_bias=time_bias,
+            )
+        )
+
+    def build_memory_sidecar_context_block(
+        self,
+        *,
+        session_id: str,
+        query: str | None = None,
+        types: tuple[str, ...] = (),
+        concepts: tuple[str, ...] = (),
+        file_path: str | None = None,
+        limit: int = 8,
+        time_bias: str = "recent",
+        max_observations: int = 4,
+    ) -> str:
+        """Return a concise prompt-ready context block from the sidecar."""
+        result = self.query_memory_sidecar_context(
+            session_id=session_id,
+            query=query,
+            types=types,
+            concepts=concepts,
+            file_path=file_path,
+            limit=limit,
+            time_bias=time_bias,
+        )
+        if result is None:
+            return ""
+        if query:
+            fallback = self.query_memory_sidecar_context(
+                session_id=session_id,
+                types=types,
+                concepts=concepts,
+                file_path=file_path,
+                limit=limit,
+                time_bias="recent",
+            )
+            if fallback is not None:
+                from agent.memory_sidecar.retrieval import (
+                    format_context_result,
+                    merge_context_results,
+                )
+
+                result = merge_context_results(result, fallback, limit=limit)
+                return format_context_result(result, max_observations=max_observations)
+        from agent.memory_sidecar.retrieval import format_context_result
+
+        return format_context_result(result, max_observations=max_observations)
 
     @staticmethod
     def _parse_schema_columns(schema_sql: str) -> Dict[str, Dict[str, str]]:
@@ -2812,7 +2961,14 @@ class SessionDB:
                 )
             return msg_id
 
-        return self._execute_write(_do)
+        msg_id = self._execute_write(_do)
+        self._maybe_ingest_sidecar_message(
+            session_id=session_id,
+            message_id=msg_id,
+            role=role,
+            content=content,
+        )
+        return msg_id
 
     def _insert_message_rows(self, conn, session_id: str, messages: List[Dict[str, Any]]) -> tuple[int, int]:
         """Insert *messages* as fresh active rows for *session_id*.

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -65,12 +65,32 @@ def register_provider(profile: ProviderProfile) -> None:
 def get_provider_profile(name: str) -> ProviderProfile | None:
     """Look up a provider profile by name or alias.
 
+    Composite runtime provider IDs such as ``custom:local`` should resolve to
+    the canonical profile for their provider family (``custom`` here), while
+    still preferring an exact registry hit if one exists.
+
     Returns None if the provider has no profile (falls back to generic).
     """
     if not _discovered:
         _discover_providers()
-    canonical = _ALIASES.get(name, name)
-    return _REGISTRY.get(canonical)
+
+    raw_name = str(name or "").strip()
+    if not raw_name:
+        return None
+
+    canonical = _ALIASES.get(raw_name, raw_name)
+    profile = _REGISTRY.get(canonical)
+    if profile is not None:
+        return profile
+
+    if ":" in raw_name:
+        family, _suffix = raw_name.split(":", 1)
+        family = family.strip()
+        if family:
+            canonical = _ALIASES.get(family, family)
+            return _REGISTRY.get(canonical)
+
+    return None
 
 
 def list_providers() -> list[ProviderProfile]:

--- a/tests/agent/test_memory_sidecar_models.py
+++ b/tests/agent/test_memory_sidecar_models.py
@@ -1,0 +1,58 @@
+import pytest
+
+from agent.memory_sidecar.models import (
+    ContextQuery,
+    Observation,
+    ObservationFile,
+    validate_observation_type,
+    validate_privacy_status,
+)
+
+
+def test_validate_observation_type_rejects_unknown_value():
+    with pytest.raises(ValueError, match="unknown observation_type"):
+        validate_observation_type("mystery")
+
+
+def test_validate_privacy_status_rejects_unknown_value():
+    with pytest.raises(ValueError, match="unknown privacy_status"):
+        validate_privacy_status("secret")
+
+
+def test_observation_requires_mvp_type_and_confidence_range():
+    with pytest.raises(ValueError, match="unknown observation_type"):
+        Observation(
+            session_id="s1",
+            event_ts="2026-06-26T18:11:10Z",
+            observation_type="mystery",
+            title="Bad",
+            summary="Bad",
+            detail="Bad",
+        )
+
+    with pytest.raises(ValueError, match="confidence"):
+        Observation(
+            session_id="s1",
+            event_ts="2026-06-26T18:11:10Z",
+            observation_type="decision",
+            title="Bad",
+            summary="Bad",
+            detail="Bad",
+            confidence=1.5,
+        )
+
+
+def test_context_query_validates_limit_time_bias_and_types():
+    with pytest.raises(ValueError, match="limit"):
+        ContextQuery(limit=0)
+
+    with pytest.raises(ValueError, match="time_bias"):
+        ContextQuery(time_bias="fresh")
+
+    with pytest.raises(ValueError, match="unknown observation_type"):
+        ContextQuery(types=("weird",))
+
+
+def test_observation_file_requires_path():
+    with pytest.raises(ValueError, match="file_path"):
+        ObservationFile(file_path="")

--- a/tests/agent/test_memory_sidecar_store.py
+++ b/tests/agent/test_memory_sidecar_store.py
@@ -1,0 +1,71 @@
+from agent.memory_sidecar.models import ContextQuery, IngestSource, Observation, ObservationFile, SessionFact
+from agent.memory_sidecar.store import MemorySidecarStore
+
+
+def test_store_round_trip_query_and_checkpoint(tmp_path):
+    store = MemorySidecarStore(tmp_path / "memory_sidecar.db")
+
+    checkpoint = store.upsert_checkpoint(
+        IngestSource(
+            source_id="src-1",
+            path="/tmp/session.jsonl",
+            last_offset=128,
+            partial_line="{\"partial\": true",
+            last_event_at="2026-06-26T18:11:10Z",
+            updated_at="2026-06-26T18:12:00Z",
+        )
+    )
+    assert checkpoint.last_offset == 128
+
+    stored = store.insert_observation(
+        Observation(
+            session_id="session-1",
+            message_id="msg-7",
+            role="assistant",
+            event_ts="2026-06-26T18:11:10Z",
+            observation_type="decision",
+            title="Adopt sidecar DB",
+            summary="Use a Hermes-native SQLite sidecar for compact context retrieval.",
+            detail="Decision: keep the memory sidecar inside Hermes with no HTTP worker.",
+            concepts=("memory", "privacy"),
+            files=(ObservationFile(file_path="agent/memory_sidecar/store.py", change_kind="created"),),
+            privacy_status="public",
+            confidence=0.91,
+        )
+    )
+    assert stored.id is not None
+
+    store.upsert_session_fact(
+        SessionFact(
+            session_id="session-1",
+            user_goal="Build a safe Hermes-native memory sidecar",
+            latest_summary="Models and store landed for the MVP.",
+            last_seen_at="2026-06-26T18:13:00Z",
+        )
+    )
+
+    result = store.query_context(
+        ContextQuery(
+            query="Hermes sidecar",
+            session_id="session-1",
+            types=("decision",),
+            concepts=("memory",),
+            file_path="agent/memory_sidecar/store.py",
+            limit=5,
+            time_bias="relevant",
+        )
+    )
+
+    assert len(result.observations) == 1
+    assert result.observations[0].title == "Adopt sidecar DB"
+    assert result.decisions[0].observation_type == "decision"
+    assert result.changed_files == ("agent/memory_sidecar/store.py",)
+    assert result.session_fact is not None
+    assert result.session_fact.user_goal == "Build a safe Hermes-native memory sidecar"
+    assert any("decisions" in line.lower() or "changed files" in line.lower() for line in result.suggested_follow_ups)
+
+    loaded_checkpoint = store.get_checkpoint("src-1")
+    assert loaded_checkpoint is not None
+    assert loaded_checkpoint.partial_line == "{\"partial\": true"
+
+    store.close()

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -9,6 +9,7 @@ confirm the prologue produces the right ``TurnContext`` and applies the
 from __future__ import annotations
 
 import types
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -30,6 +31,21 @@ class _FakeGuardrails:
 
     def reset_for_turn(self):
         self.reset_called = True
+
+
+class _FakeSessionDB:
+    def __init__(self, block: str = ""):
+        self.block = block
+        self.calls = []
+
+    def build_memory_sidecar_context_block(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.block
+
+
+class _ExplodingSessionDB:
+    def build_memory_sidecar_context_block(self, **_kwargs):
+        raise RuntimeError("sidecar unavailable")
 
 
 class _FakeAgent:
@@ -56,7 +72,7 @@ class _FakeAgent:
         )
         self._cached_system_prompt = "SYSTEM"
         self._memory_store = None
-        self._memory_manager = None
+        self._memory_manager: Any = None
         self._memory_nudge_interval = 0
         self._turns_since_memory = 0
         self._user_turn_count = 0
@@ -67,6 +83,7 @@ class _FakeAgent:
         self._memory_write_origin = "assistant_tool"
         self._stream_context_scrubber = None
         self._stream_think_scrubber = None
+        self._session_db: Any = None
         # Attributes the prologue assigns; recorded for assertions.
         self._invalid_tool_retries = -1
         self._vision_supported = None
@@ -99,6 +116,9 @@ class _FakeAgent:
 
     def _persist_session(self, *_a, **_k):
         self._persist_calls += 1
+
+    def _get_session_db_for_recall(self):
+        return self._session_db
 
 
 @pytest.fixture(autouse=True)
@@ -216,6 +236,44 @@ def test_ensure_db_session_runs_after_system_prompt_restore():
     assert agent._cached_system_prompt == "REBUILT-SYSTEM"
 
 
+def test_sidecar_context_is_prefetched_into_ext_cache():
+    agent = _FakeAgent()
+    agent._session_db = _FakeSessionDB(block="Memory sidecar context:\n- prior deploy fix")
+
+    ctx = _build(agent, user_message="deploy smoke failing")
+
+    assert "Memory sidecar context:" in ctx.ext_prefetch_cache
+    assert "prior deploy fix" in ctx.ext_prefetch_cache
+    assert agent._session_db.calls == [{
+        "session_id": "sess-1",
+        "query": "deploy smoke failing",
+        "limit": 3,
+        "max_observations": 3,
+    }]
+
+
+def test_sidecar_context_appends_after_memory_manager_prefetch():
+    agent = _FakeAgent()
+    agent._memory_manager = types.SimpleNamespace(prefetch_all=lambda _q: "provider memory")
+    agent._session_db = _FakeSessionDB(block="Memory sidecar context:\n- deploy note")
+
+    ctx = _build(agent, user_message="deploy smoke failing")
+
+    assert ctx.ext_prefetch_cache == (
+        "provider memory\n\nMemory sidecar context:\n- deploy note"
+    )
+
+
+def test_sidecar_failure_is_fail_open_and_preserves_provider_prefetch():
+    agent = _FakeAgent()
+    agent._memory_manager = types.SimpleNamespace(prefetch_all=lambda _q: "provider memory")
+    agent._session_db = _ExplodingSessionDB()
+
+    ctx = _build(agent, user_message="deploy smoke failing")
+
+    assert ctx.ext_prefetch_cache == "provider memory"
+
+
 # ── Between-turns MCP refresh (cache-safe late-binding) ──────────────────────
 #
 # A slow MCP server that connects after the agent's build-time tool snapshot
@@ -278,10 +336,9 @@ def test_between_turns_refresh_no_churn_when_unchanged():
     import model_tools
     with patch("tools.mcp_tool.has_registered_mcp_tools", return_value=True), \
          patch.object(
-             model_tools, "get_tool_definitions",
-             return_value=[{"type": "function", "function": {"name": "a", "description": "", "parameters": {}}}],
-         ):
+            model_tools, "get_tool_definitions",
+            return_value=[{"type": "function", "function": {"name": "a", "description": "", "parameters": {}}}],
+        ):
         _build(agent)
 
     assert agent.tools is same  # not replaced → no churn
-

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -19,6 +19,18 @@ class TestRegistry:
         assert get_provider_profile("qwen").name == "qwen-oauth"
         assert get_provider_profile("qwen-portal").name == "qwen-oauth"
 
+    def test_composite_provider_id_resolves_family_profile(self):
+        local = get_provider_profile("custom:local")
+        named = get_provider_profile("custom:my-proxy")
+        ollama = get_provider_profile("ollama:lab")
+
+        assert local is not None
+        assert named is not None
+        assert ollama is not None
+        assert local.name == "custom"
+        assert named.name == "custom"
+        assert ollama.name == "custom"
+
     def test_unknown_provider_returns_none(self):
         assert get_provider_profile("nonexistent-provider") is None
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4603,6 +4603,36 @@ class TestRunConversation:
         assert result["api_calls"] == 3
         assert result["completed"] is False
 
+    def test_ollama_false_length_context_error_skips_continuation(self, agent):
+        """Tiny Ollama completions at the 4096-token ceiling should stop with
+        a context diagnostic instead of injecting bogus continuation prompts."""
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "gemma4:e2b"
+        agent._ollama_num_ctx = 131072
+
+        resp = _mock_response(content="כן", finish_reason="length")
+        resp.usage = SimpleNamespace(
+            prompt_tokens=4095,
+            completion_tokens=1,
+            total_tokens=4096,
+        )
+        agent.client.chat.completions.create.return_value = resp
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["api_calls"] == 1
+        assert result["completed"] is False
+        assert "runtime context too small" in result["final_response"].lower()
+        assert "4,096-token" in result["final_response"]
+        assert "finish_reason='length'" in result["error"]
+
     def test_length_with_tool_calls_returns_partial_without_executing_tools(self, agent):
         self._setup_agent(agent)
         bad_tc = _mock_tool_call(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3588,6 +3588,38 @@ class TestRunConversation:
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
 
+    def test_sidecar_context_is_injected_into_current_user_message(self, agent):
+        self._setup_agent(agent)
+        agent.session_id = "sess-123"
+        session_db = MagicMock()
+        session_db.build_memory_sidecar_context_block.return_value = (
+            "Memory sidecar context:\n- prior deploy fix"
+        )
+        agent._get_session_db_for_recall = MagicMock(return_value=session_db)
+        resp = _mock_response(content="Final answer", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = resp
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("deploy smoke failing")
+
+        assert result["final_response"] == "Final answer"
+        assert result["completed"] is True
+        sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        user_message = next(msg for msg in sent_messages if msg.get("role") == "user")
+        assert "deploy smoke failing" in user_message["content"]
+        assert "Memory sidecar context:" in user_message["content"]
+        assert "prior deploy fix" in user_message["content"]
+        session_db.build_memory_sidecar_context_block.assert_called_once_with(
+            session_id="sess-123",
+            query="deploy smoke failing",
+            limit=3,
+            max_observations=3,
+        )
+
     def test_ollama_small_runtime_context_fails_before_api_call(self, agent, caplog):
         self._setup_agent(agent)
         agent.model = "qwen3.5:9b"

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4539,3 +4539,118 @@ class TestListCronJobRuns:
         detail = " ".join(row[-1] for row in plan)
         assert "USING INDEX" in detail or "USING COVERING INDEX" in detail, detail
         assert "idx_sessions_source" in detail, detail
+
+
+class TestMemorySidecarRuntime:
+    def test_append_message_updates_session_fact(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            from agent.memory_sidecar import MemorySidecarStore
+
+            db.create_session(session_id="s1", source="cli")
+            db.append_message("s1", role="user", content="Investigate why deploys fail in production")
+            db.append_message("s1", role="assistant", content="Working summary: traced failure to missing env var")
+
+            store = MemorySidecarStore()
+            try:
+                fact = store.get_session_fact("s1")
+                assert fact is not None
+                assert "deploys fail in production" in (fact.user_goal or "")
+                assert "missing env var" in (fact.latest_summary or "")
+            finally:
+                store.close()
+        finally:
+            db.close()
+
+    def test_append_message_creates_explicit_observation(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            from agent.memory_sidecar import ContextQuery, MemorySidecarStore
+
+            db.create_session(session_id="s1", source="cli")
+            db.append_message(
+                "s1",
+                role="assistant",
+                content="Decision: patch hermes_state.py before wiring dashboard queries",
+            )
+
+            store = MemorySidecarStore()
+            try:
+                result = store.query_context(ContextQuery(session_id="s1", types=("decision",)))
+                assert len(result.observations) == 1
+                obs = result.observations[0]
+                assert obs.observation_type == "decision"
+                assert obs.message_id is not None
+                assert any(f.file_path == "hermes_state.py" for f in obs.files)
+            finally:
+                store.close()
+        finally:
+            db.close()
+
+    def test_query_memory_sidecar_context_returns_structured_hits(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session(session_id="s1", source="cli")
+            db.append_message("s1", role="user", content="Goal: stabilize deploys before launch")
+            db.append_message(
+                "s1",
+                role="assistant",
+                content="Decision: patch deploy.py before touching the dashboard.",
+            )
+            db.append_message(
+                "s1",
+                role="assistant",
+                content="Next step: rerun the deploy smoke test after patching deploy.py.",
+            )
+
+            result = db.query_memory_sidecar_context(
+                session_id="s1",
+                query="deploy.py",
+                limit=5,
+            )
+
+            assert result is not None
+            assert result.session_fact is not None
+            assert "stabilize deploys" in (result.session_fact.user_goal or "")
+            assert any(obs.observation_type == "decision" for obs in result.observations)
+            assert any(obs.observation_type == "next_step" for obs in result.observations)
+        finally:
+            db.close()
+
+    def test_build_memory_sidecar_context_block_is_prompt_ready(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        writer = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            writer.create_session(session_id="s1", source="cli")
+            writer.append_message("s1", role="user", content="Investigate flaky deploy smoke failures")
+            writer.append_message(
+                "s1",
+                role="assistant",
+                content="Decision: update deploy.py before changing alerts.",
+            )
+            writer.append_message(
+                "s1",
+                role="assistant",
+                content="Next step: rerun the deploy smoke test and inspect deploy.py logs.",
+            )
+        finally:
+            writer.close()
+
+        reader = SessionDB(db_path=tmp_path / "state.db", read_only=True)
+        try:
+            block = reader.build_memory_sidecar_context_block(
+                session_id="s1",
+                query="deploy smoke",
+                limit=5,
+            )
+
+            assert "Memory sidecar context:" in block
+            assert "User goal:" in block
+            assert "Recent decisions:" in block
+            assert "Next steps:" in block
+            assert "deploy.py" in block
+        finally:
+            reader.close()


### PR DESCRIPTION
## Summary
- add Hermes-native memory sidecar retrieval and inject it into turn context as ext prefetch data
- guard against false Ollama `finish_reason="length"` at the runtime context ceiling
- resolve provider profile lookup for composite runtime IDs

## Validation
- `pytest tests/agent/test_turn_context.py tests/test_hermes_state.py tests/providers/test_provider_profiles.py -q`
- `pytest tests/run_agent/test_run_agent.py -q -k 'memory_context or sanitize_context or user_message_is_not_mutated_by_run_conversation or sidecar_context_is_injected_into_current_user_message'`
- previously on the source branch: full `pytest tests/run_agent/test_run_agent.py -q` passed

## Notes
- cherry-picked onto a clean branch from `origin/main` so the PR contains only the intended 3 commits
- one existing unrelated warning remains from `discord/player.py` deprecation (`audioop`)
