### PR TITLE
fix(windows): suppress git-probe console flash + cp950 crash in dashboard

### DIFF
--- a/tests/tui_gateway/test_git_probe.py
+++ b/tests/tui_gateway/test_git_probe.py
@@ -1,0 +1,53 @@
+"""Spawn-hygiene invariants for the gateway git probe (tui_gateway.git_probe).
+
+These guard the Windows-specific failure modes of ``run_git``: the dashboard
+runs windowless (``pythonw``) and probes git once per project directory, so a
+bare spawn would flash a console window per repo, and locale-codepage decoding
+would crash the reader thread on non-ASCII repo paths. We assert the call wiring
+(creationflags + utf-8) rather than spawning real ``git`` so the test is
+deterministic on every platform.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest import mock
+
+from hermes_cli._subprocess_compat import windows_hide_flags
+from tui_gateway import git_probe
+
+
+def _run_with_captured_kwargs(returncode=0, stdout="out\n"):
+    captured = {}
+
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(args[0], returncode, stdout=stdout, stderr="")
+
+    with mock.patch("subprocess.run", side_effect=fake_run):
+        result = git_probe.run_git("/some/repo", "rev-parse", "--show-toplevel")
+    return result, captured
+
+
+def test_run_git_passes_no_window_and_utf8():
+    result, captured = _run_with_captured_kwargs()
+    assert result == "out"
+    kwargs = captured["kwargs"]
+    # No console window flash on Windows; no-op (0) elsewhere.
+    assert kwargs.get("creationflags") == windows_hide_flags()
+    # Explicit codec so non-ASCII repo paths don't crash the reader thread on
+    # locale-ANSI (e.g. cp950) Windows.
+    assert kwargs.get("encoding") == "utf-8"
+    assert kwargs.get("errors") == "replace"
+
+
+def test_run_git_returns_empty_on_nonzero_exit():
+    result, _ = _run_with_captured_kwargs(returncode=128, stdout="")
+    assert result == ""
+
+
+def test_run_git_empty_cwd_does_not_spawn():
+    with mock.patch("subprocess.run") as run:
+        assert git_probe.run_git("", "status") == ""
+    run.assert_not_called()

--- a/tui_gateway/git_probe.py
+++ b/tui_gateway/git_probe.py
@@ -31,6 +31,8 @@ import time
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 _GIT_TIMEOUT = 1.5
 _WARM_WORKERS = 8
 
@@ -50,9 +52,20 @@ def run_git(cwd: str, *args: str) -> str:
             ["git", "-C", cwd, *args],
             capture_output=True,
             text=True,
+            # git emits UTF-8 (paths, branch names) on Windows too; without an
+            # explicit codec the reader thread decodes with the locale ANSI page
+            # (e.g. cp950 on zh-Hant Windows) and raises UnicodeDecodeError on a
+            # non-ASCII repo path, spamming gateway-crash _readerthread logs.
+            encoding="utf-8",
+            errors="replace",
             timeout=_GIT_TIMEOUT,
             check=False,
             stdin=subprocess.DEVNULL,
+            # CREATE_NO_WINDOW on Windows: the gateway/dashboard runs windowless
+            # (pythonw), so each bare git spawn would otherwise allocate a fresh
+            # console window. The Projects-tree scan runs several git commands
+            # per repo, flashing dozens of console/Windows Terminal windows.
+            creationflags=windows_hide_flags(),
         )
         return result.stdout.strip() if result.returncode == 0 else ""
     except Exception:


### PR DESCRIPTION
## What does this PR do?

On Windows, `tui_gateway/git_probe.py::run_git` spawned `git` with **no `creationflags`** and **no explicit `encoding`**. Two consequences:

1. **Console-window flash per repo.** The gateway/dashboard runs windowless (`pythonw.exe`), so each bare `git.exe` allocates a fresh console (`conhost.exe`, and with Windows Terminal as default terminal an `OpenConsole.exe` window). The Projects-tree scanner calls `run_git` several times **per project directory**, so launching the desktop app flashes dozens of console/terminal windows for users with many repos. (Measured on one affected machine: ~118 process spawns in 60s at startup, almost all `git -C <dir> rev-parse ...`, each spawning a conhost.)
2. **`UnicodeDecodeError` on non-ASCII repo paths.** With `text=True` and no codec, the reader thread decodes git's UTF-8 output with the locale ANSI codepage (`cp950` on Traditional-Chinese Windows) and crashes on any repo whose path/branch contains non-ASCII (e.g. CJK) characters, spamming `gateway-crash` / `_readerthread` logs.

Fix at the single `run_git` choke point: add `encoding="utf-8"` / `errors="replace"` and `creationflags=windows_hide_flags()` (the existing `hermes_cli/_subprocess_compat.py` helper — `CREATE_NO_WINDOW` on Windows, `0` elsewhere, so it's a no-op on macOS/Linux).

## Related Issue

Fixes #53178

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/git_probe.py`: `run_git` now passes `encoding="utf-8", errors="replace"` and `creationflags=windows_hide_flags()`; import the helper from `hermes_cli._subprocess_compat`.
- `tests/tui_gateway/test_git_probe.py` (new): asserts the call wiring (no-window flag + utf-8/replace), empty result on non-zero exit, and no spawn for empty `cwd`. Cross-platform (mocks `subprocess.run`).

## How to Test

1. **Repro (before):** On Windows (default terminal = Windows Terminal) with ~15–20 git project dirs (a couple with CJK paths), launch the desktop app and watch `git.exe → conhost.exe → OpenConsole.exe` windows flash; logs show `_readerthread` `UnicodeDecodeError: 'cp950'...` for the non-ASCII repos.
2. **After:** 8 `run_git`/`branch` probes (incl. a CJK-path repo) from a `pythonw` parent → **0** new console/OpenConsole windows and no decode crash (returned correct UTF-8 toplevel + branch).
3. `tests/tui_gateway/test_git_probe.py` → 3 passed. `scripts/check-windows-footguns.py` → clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(windows): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: **Windows 11 (cp950 locale)**. The change is a no-op on macOS/Linux (`windows_hide_flags()` returns `0`; explicit utf-8 is safe everywhere).

> Note: I ran the new test file (`pytest tests/tui_gateway/test_git_probe.py` → 3 passed) and `scripts/check-windows-footguns.py` (clean), not the entire suite locally — CI will run the full suite.

### Documentation & Housekeeping

- [x] Documentation — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact considered (no-op on non-Windows)
