### PR TITLE
fix(desktop): re-enable titleBarOverlay on plain Linux

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -533,9 +533,10 @@ function getTitleBarOverlayOptions() {
     return { height: TITLEBAR_HEIGHT }
   }
 
-  // Windows + WSLg paint WCO natively; plain Linux disables it (frameless hidden
-  // titlebar still applies).
-  if (!IS_WINDOWS && !IS_WSL) {
+  // WSLg paints WCO via the RDP host's own min/max/close, so requesting
+  // an Electron overlay there just leaves a dead gap. Plain Linux (KDE,
+  // GNOME) can use the native overlay — let it through.
+  if (!IS_WINDOWS && IS_WSL) {
     return false
   }
 


### PR DESCRIPTION
Commit da5484b61 disabled the Window Controls Overlay on all Linux (non-Windows, non-WSL) with the note that WCO is a Windows/macOS-only Electron feature. However, several Linux compositors (KDE/KWin, GNOME/Mutter) do support it — plain Electron titleBarOverlay paints native min/max/close buttons that were working before that change.

Narrow the exclusion to only WSLg, where the RDP host draws its own window controls and an Electron overlay would leave a dead gap.

Fixes: da5484b61 ("fix(desktop): WSL2 clipboard image paste + Linux titlebar overlay")

## What does this PR do?

Re-enables the Electron Window Controls Overlay on plain Linux (non-WSL) so native minimize/maximize/close buttons appear in the top-right titlebar area. Commit da5484b61 unconditionally disabled the overlay for all Linux desktops based on the assumption that WCO is Windows/macOS-only, but it works on KDE Plasma, GNOME, and other compositors — users on those desktops lost their window control buttons. This PR narrows the exclusion to WSLg only, where the RDP host already draws its own window controls.

## Related Issue

N/A — no existing issue. This was a regression from da5484b61.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/main.cjs` — Changed the `getTitleBarOverlayOptions()` guard from `if (!IS_WINDOWS && !IS_WSL)` to `if (!IS_WINDOWS && IS_WSL)`, so plain Linux gets the overlay while WSLg (where the RDP host provides its own window controls) remains excluded.

## How to Test

1. Run the Hermes Desktop app on Linux (non-WSL) — KDE Plasma, GNOME, or any compositor
2. Observe native minimize/maximize/close buttons in the top-right corner of the titlebar
3. Verify the buttons work (click minimize, maximize, close)
4. Confirm existing Windows and macOS behavior is unaffected

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: EndeavourOS (Arch Linux) / KDE Plasma 6

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- delete this section -->

## Screenshots / Logs

Before: top-right of the Hermes window on Linux has no window control buttons after da5484b61.
After: native minimize/maximize/close buttons are restored in the titlebar overlay.

<img width="523" height="425" alt="Screenshot_20260626_114851" src="https://github.com/user-attachments/assets/446d75f2-1c06-4a21-b11a-f0b8c8ed826b" />
