### PR TITLE
fix(desktop): refresh session list when async delegation completes in background

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -1100,6 +1100,13 @@ export function useMessageStream({
             title: translateNow('notifications.native.inputTitle')
           })
         }
+      } else if (event.type === 'sessions.changed') {
+        // Async delegation (background subagent) completions inject messages
+        // into a session that may not be the active one. The backend emits
+        // this event so the desktop knows to refresh its sidebar session list
+        // and sync across windows. See #desktop-async-delegation-refresh.
+        void refreshSessions().catch(() => undefined)
+        broadcastSessionsChanged()
       } else if (event.type === 'secret.request') {
         // Skill credential capture (tools/skills_tool.py). Blocked on
         // secret.respond {request_id, value}.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8203,6 +8203,12 @@ def _notification_poller_loop(
         try:
             _emit("message.start", sid)
             _run_prompt_submit(rid, sid, session, text)
+            # Async delegation completions inject messages into a session
+            # that the desktop may not be actively viewing. Emit a
+            # sessions.changed event so the desktop knows to refresh its
+            # sidebar session list (see #desktop-async-delegation-refresh).
+            if evt.get("type") == "async_delegation":
+                _emit("sessions.changed", sid, {})
         except Exception as exc:
             print(
                 f"[tui_gateway] notification poller dispatch failed: "
@@ -8246,6 +8252,9 @@ def _notification_poller_loop(
         try:
             _emit("message.start", sid)
             _run_prompt_submit(rid, sid, session, text)
+            # Same sessions.changed signal for the drain path (see above).
+            if evt.get("type") == "async_delegation":
+                _emit("sessions.changed", sid, {})
         except Exception as exc:
             print(
                 f"[tui_gateway] notification poller dispatch failed: "


### PR DESCRIPTION
## Problem

When using `delegate_task(background=true)`, the subagent result is injected into the conversation via the `completion_queue` pipeline. The CLI handles this correctly (same-process drain), but the **desktop app does not refresh its sidebar session list** — the user must close and reopen the app to see the new messages.

Fixes #53186

## Root Cause

`broadcastSessionsChanged()` uses `BroadcastChannel` which only reaches same-app renderer windows. If the subagent result targets a non-active session, the sidebar stays stale. Additionally, `$subagentsBySession` is cleared by `clearSessionSubagents()` at every `message.start`, so completed subagents vanish from the `/agents` panel.

## Changes

### 1. Backend (`tui_gateway/server.py`)
After `_run_prompt_submit` completes for an `async_delegation` event, emit a `sessions.changed` WebSocket event so the desktop knows to refresh its sidebar. Applied in both the main poller loop and the shutdown drain path.

### 2. Desktop (`apps/desktop/src/app/session/hooks/use-message-stream.ts`)
Add a handler for `sessions.changed` that calls `refreshSessions()` + `broadcastSessionsChanged()`.

## Testing

1. Open Hermes Desktop app
2. Ask the agent to delegate a task (e.g., "research topic X using delegate_task")
3. The subagent runs in the background
4. The subagent completes and its result is injected into the conversation
5. **Expected**: The new messages appear in the desktop chat, and the session list updates
6. **Actual (before fix)**: The desktop shows nothing new. User must close and reopen the app

## Related

- #51855 covers stale session list for CLI archive/delete operations (related but distinct)