### PR TITLE
fix(gateway): detect and migrate custom directives before overwriting systemd unit

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2986,6 +2986,118 @@ WantedBy=default.target
 def _normalize_service_definition(text: str) -> str:
     return "\n".join(line.rstrip() for line in text.strip().splitlines())
 
+# ── Custom directive detection & drop-in migration ────────────────────────
+
+# Keys that generate_systemd_unit() always emits in [Service].  Any
+# Environment= key *value* not in this set, or any other [Service]
+# directive not in this set, is treated as a user customization.
+_GENERATED_ENV_KEYS: frozenset[str] = frozenset({
+    "PATH", "VIRTUAL_ENV", "HERMES_HOME",
+    # System-scope extras (present only when --system is used)
+    "HOME", "USER", "LOGNAME",
+})
+
+_GENERATED_SERVICE_DIRECTIVES: frozenset[str] = frozenset({
+    "Type", "ExecStart", "WorkingDirectory", "Restart", "RestartSec",
+    "RestartForceExitStatus", "KillMode", "KillSignal", "ExecReload",
+    "TimeoutStopSec", "StandardOutput", "StandardError",
+    # System-scope extras
+    "User", "Group",
+})
+
+
+def _parse_env_key(directive: str) -> str | None:
+    """Extract the variable name from ``Environment="KEY=VALUE"``."""
+    import re
+    # Handle both quoted and unquoted forms:
+    #   Environment="KEY=VALUE"
+    #   Environment=KEY=VALUE
+    #   Environment = "KEY=VALUE"
+    m = re.match(r'^Environment\s*=\s*"?([^"=\s]+)=', directive.strip())
+    return m.group(1) if m else None
+
+
+def _detect_custom_directives(existing_unit: str) -> list[str]:
+    """Return [Service] directives in *existing_unit* not in the generated set.
+
+    Scans for:
+    - ``Environment="KEY=VALUE"`` where KEY is not in ``_GENERATED_ENV_KEYS``
+    - Other ``Key=Value`` lines where Key is not in ``_GENERATED_SERVICE_DIRECTIVES``
+
+    Comments and blank lines are ignored.  Only lines inside the [Service]
+    section are considered (the [Unit] and [Install] sections are fully
+    managed by Hermes).
+    """
+    custom: list[str] = []
+    in_service = False
+    for raw_line in existing_unit.splitlines():
+        line = raw_line.strip()
+        if line.startswith("["):
+            in_service = line == "[Service]"
+            continue
+        if not in_service or not line or line.startswith("#"):
+            continue
+        # Normalize: strip whitespace around the directive name for matching
+        eq_pos = line.find("=")
+        if eq_pos < 0:
+            continue
+        directive_name = line[:eq_pos].strip()
+        if directive_name == "Environment":
+            key = _parse_env_key(line)
+            if key and key not in _GENERATED_ENV_KEYS:
+                custom.append(raw_line.strip())
+        elif directive_name not in _GENERATED_SERVICE_DIRECTIVES:
+            custom.append(raw_line.strip())
+    return custom
+
+
+def _drop_in_dir(system: bool = False) -> Path:
+    """Return the drop-in override directory for the gateway service."""
+    unit_path = get_systemd_unit_path(system=system)
+    return unit_path.parent / f"{unit_path.stem}.service.d"
+
+
+def _migrate_custom_to_drop_in(
+    custom_lines: list[str],
+    system: bool = False,
+) -> Path:
+    """Write *custom_lines* into a drop-in override file and return its path.
+
+    Creates the drop-in directory if it does not exist.
+    If ``custom.conf`` already exists, appends only lines not already present.
+    """
+    drop_in = _drop_in_dir(system=system)
+    drop_in.mkdir(parents=True, exist_ok=True)
+    target = drop_in / "custom.conf"
+
+    existing_content = ""
+    existing_lines: set[str] = set()
+    if target.exists():
+        existing_content = target.read_text(encoding="utf-8")
+        existing_lines = {l.strip() for l in existing_content.splitlines() if l.strip()}
+
+    # Filter out lines already present in the existing drop-in
+    new_lines = [l for l in custom_lines if l.strip() not in existing_lines]
+    if not new_lines:
+        return target
+
+    if existing_content:
+        # Append to existing file
+        sep = "\n" if existing_content.endswith("\n") else "\n\n"
+        target.write_text(
+            existing_content + sep + "\n".join(new_lines) + "\n",
+            encoding="utf-8",
+        )
+    else:
+        header = (
+            "# Auto-migrated by `hermes gateway install` — custom directives\n"
+            "# that were previously in the main service file.\n"
+            "# See https://www.freedesktop.org/software/systemd/man/systemd.service.html\n\n"
+            "[Service]\n"
+        )
+        target.write_text(header + "\n".join(new_lines) + "\n", encoding="utf-8")
+
+    return target
 
 # Directives that older systemd versions silently ignore/strip.  Normalize
 # them out of stale-check comparisons so a unit that differs only by these
@@ -3126,6 +3238,59 @@ def _refuse_temp_home_service_write(definition: str, kind: str) -> bool:
     return True
 
 
+def _warn_and_migrate_custom_directives(
+    custom_lines: list[str],
+    system: bool = False,
+) -> None:
+    """Warn about custom directives and offer automatic migration to a drop-in.
+
+    When the existing service file contains [Service] directives that are not
+    part of the generated set (e.g. custom ``Environment=`` variables, custom
+    ``LimitNOFILE=``), the user has edited the main unit file directly.
+    These will be overwritten by the refresh.  This function warns and offers
+    to migrate them to a systemd drop-in override file so they survive future
+    updates.
+    """
+    scope = _service_scope_label(system)
+    print()
+    print("⚠ Custom service directives detected in the main unit file:")
+    for line in custom_lines:
+        print(f"    {line}")
+    print()
+    print(
+        "  Direct edits to the main service file will be overwritten by"
+        " updates."
+    )
+    print("  These directives should be placed in a systemd drop-in override")
+    drop_in = _drop_in_dir(system=system)
+    print(f"  directory instead: {drop_in}/")
+    print()
+
+    if not sys.stdin.isatty():
+        # Non-interactive (CI, piped install): auto-migrate silently.
+        target = _migrate_custom_to_drop_in(custom_lines, system=system)
+        print(f"  → Auto-migrated custom directives to: {target}")
+        print()
+        return
+
+    if prompt_yes_no(
+        "  Migrate these custom directives to a drop-in override now?", True
+    ):
+        target = _migrate_custom_to_drop_in(custom_lines, system=system)
+        print(f"  ✓ Migrated to: {target}")
+        print(
+            "    Run `systemctl --user daemon-reload` after installation"
+            " completes."
+        )
+    else:
+        print(
+            "  Skipped. To migrate manually, create a file at:"
+        )
+        print(f"    {drop_in}/custom.conf")
+        print("  with the directives listed above under a [Service] section.")
+    print()
+
+
 def refresh_systemd_unit_if_needed(system: bool = False) -> bool:
     """Rewrite the installed systemd unit when the generated definition has changed."""
     unit_path = get_systemd_unit_path(system=system)
@@ -3168,6 +3333,18 @@ def refresh_systemd_unit_if_needed(system: bool = False) -> bool:
     # don't carry the pytest markers above but poison the unit identically).
     if _refuse_temp_home_service_write(new_unit, "systemd unit"):
         return False
+
+    # ── Detect and migrate custom directives before overwriting ─────────
+    # Users sometimes add custom Environment= lines or other [Service]
+    # directives directly to the main service file.  Detect these before
+    # overwriting and offer to migrate them to a systemd drop-in override.
+    existing_custom = _detect_custom_directives(
+        unit_path.read_text(encoding="utf-8")
+    )
+    if existing_custom:
+        _warn_and_migrate_custom_directives(
+            existing_custom, system=system,
+        )
 
     unit_path.write_text(new_unit, encoding="utf-8")
     _run_systemctl(["daemon-reload"], system=system, check=True, timeout=30)
@@ -3370,6 +3547,19 @@ def systemd_install(
     new_unit = generate_systemd_unit(system=system, run_as_user=run_as_user)
     if _refuse_temp_home_service_write(new_unit, "systemd unit"):
         return
+
+    # ── Detect and migrate custom directives before overwriting ─────────
+    # On --force or fresh install, also check for customizations if the
+    # unit already exists (e.g. the user ran install --force to update).
+    if unit_path.exists():
+        existing_custom = _detect_custom_directives(
+            unit_path.read_text(encoding="utf-8")
+        )
+        if existing_custom:
+            _warn_and_migrate_custom_directives(
+                existing_custom, system=system,
+            )
+
     print(f"Installing {_service_scope_label(system)} systemd service to: {unit_path}")
     unit_path.write_text(new_unit, encoding="utf-8")
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2035,3 +2035,179 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         assert ok is False
         assert list_calls["n"] >= 1
 
+class TestCustomDirectiveDetection:
+    """Tests for _detect_custom_directives and drop-in migration."""
+
+    def test_detects_custom_environment_variable(self):
+        unit = (
+            '[Service]\n'
+            'Type=simple\n'
+            'Environment="PATH=/usr/bin"\n'
+            'Environment="VIRTUAL_ENV=/home/user/.venv"\n'
+            'Environment="HERMES_HOME=/home/user/.hermes"\n'
+            'Environment="MY_CUSTOM_VAR=hello"\n'
+            'Restart=always\n'
+        )
+        custom = gateway_cli._detect_custom_directives(unit)
+        assert custom == ['Environment="MY_CUSTOM_VAR=hello"']
+
+    def test_ignores_generated_environment_keys(self):
+        unit = (
+            '[Service]\n'
+            'Environment="PATH=/usr/bin"\n'
+            'Environment="VIRTUAL_ENV=/home/user/.venv"\n'
+            'Environment="HERMES_HOME=/home/user/.hermes"\n'
+            'Environment="HOME=/home/user"\n'
+            'Environment="USER=user"\n'
+            'Environment="LOGNAME=user"\n'
+        )
+        custom = gateway_cli._detect_custom_directives(unit)
+        assert custom == []
+
+    def test_detects_custom_service_directives(self):
+        unit = (
+            '[Service]\n'
+            'Type=simple\n'
+            'LimitNOFILE=65536\n'
+            'MemoryMax=2G\n'
+            'Restart=always\n'
+        )
+        custom = gateway_cli._detect_custom_directives(unit)
+        assert "LimitNOFILE=65536" in custom
+        assert "MemoryMax=2G" in custom
+
+    def test_ignores_comments_and_blank_lines(self):
+        unit = (
+            '[Service]\n'
+            '# This is a comment\n'
+            '\n'
+            'Type=simple\n'
+        )
+        custom = gateway_cli._detect_custom_directives(unit)
+        assert custom == []
+
+    def test_ignores_unit_and_install_sections(self):
+        unit = (
+            '[Unit]\n'
+            'Description=Custom thing\n'
+            '\n'
+            '[Service]\n'
+            'Type=simple\n'
+            '\n'
+            '[Install]\n'
+            'WantedBy=custom.target\n'
+        )
+        custom = gateway_cli._detect_custom_directives(unit)
+        assert custom == []
+
+    def test_empty_unit_returns_empty(self):
+        assert gateway_cli._detect_custom_directives("") == []
+
+    def test_multiple_custom_directives(self):
+        unit = (
+            '[Service]\n'
+            'Type=simple\n'
+            'Environment="HTTP_PROXY=http://proxy:8080"\n'
+            'Environment="NO_PROXY=localhost"\n'
+            'LimitNOFILE=4096\n'
+            'Restart=always\n'
+        )
+        custom = gateway_cli._detect_custom_directives(unit)
+        assert len(custom) == 3
+        assert 'Environment="HTTP_PROXY=http://proxy:8080"' in custom
+        assert 'Environment="NO_PROXY=localhost"' in custom
+        assert "LimitNOFILE=4096" in custom
+
+    def test_detects_unquoted_environment_variable(self):
+        """Unquoted Environment=KEY=VALUE is valid systemd syntax."""
+        unit = (
+            '[Service]\n'
+            'Type=simple\n'
+            'Environment=MY_CUSTOM_VAR=hello\n'
+            'Restart=always\n'
+        )
+        custom = gateway_cli._detect_custom_directives(unit)
+        assert custom == ["Environment=MY_CUSTOM_VAR=hello"]
+
+    def test_detects_environment_with_spaces_around_equals(self):
+        unit = (
+            '[Service]\n'
+            'Environment = "MY_VAR=hello"\n'
+            'Restart=always\n'
+        )
+        custom = gateway_cli._detect_custom_directives(unit)
+        assert len(custom) == 1
+        assert "MY_VAR" in custom[0]
+
+    def test_detects_directive_with_space_before_equals(self):
+        unit = (
+            '[Service]\n'
+            'LimitNOFILE = 65536\n'
+            'Restart=always\n'
+        )
+        custom = gateway_cli._detect_custom_directives(unit)
+        assert len(custom) == 1
+        assert "LimitNOFILE" in custom[0]
+
+
+class TestDropInMigration:
+    """Tests for _migrate_custom_to_drop_in."""
+
+    def test_creates_drop_in_file(self, tmp_path, monkeypatch):
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text("[Service]\nType=simple\n", encoding="utf-8")
+        monkeypatch.setattr(
+            gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path
+        )
+
+        custom = ['Environment="MY_VAR=test"', "LimitNOFILE=65536"]
+        target = gateway_cli._migrate_custom_to_drop_in(custom, system=False)
+
+        assert target.exists()
+        assert target.name == "custom.conf"
+        content = target.read_text(encoding="utf-8")
+        assert "[Service]" in content
+        assert 'Environment="MY_VAR=test"' in content
+        assert "LimitNOFILE=65536" in content
+        assert "Auto-migrated" in content
+
+    def test_creates_drop_in_directory(self, tmp_path, monkeypatch):
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text("[Service]\n", encoding="utf-8")
+        monkeypatch.setattr(
+            gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path
+        )
+
+        drop_in_dir = tmp_path / "hermes-gateway.service.d"
+        assert not drop_in_dir.exists()
+
+        gateway_cli._migrate_custom_to_drop_in(["LimitNOFILE=65536"], system=False)
+        assert drop_in_dir.exists()
+        assert (drop_in_dir / "custom.conf").exists()
+
+    def test_overwrites_existing_custom_conf(self, tmp_path, monkeypatch):
+        """When custom.conf exists, new lines are appended, not overwritten."""
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text("[Service]\n", encoding="utf-8")
+        monkeypatch.setattr(
+            gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path
+        )
+
+        drop_in_dir = tmp_path / "hermes-gateway.service.d"
+        drop_in_dir.mkdir()
+        existing = drop_in_dir / "custom.conf"
+        existing.write_text(
+            "# Previous migration\n[Service]\nEnvironment=\"OLD_VAR=old\"\n",
+            encoding="utf-8",
+        )
+
+        target = gateway_cli._migrate_custom_to_drop_in(
+            ['Environment="OLD_VAR=old"', 'Environment="NEW_VAR=new"'],
+            system=False,
+        )
+        content = target.read_text(encoding="utf-8")
+        # Existing content preserved
+        assert "# Previous migration" in content
+        assert 'Environment="OLD_VAR=old"' in content
+        # New line appended (deduped)
+        assert 'Environment="NEW_VAR=new"' in content


### PR DESCRIPTION
## Problem

Closes #7186

Running `hermes gateway install` regenerates the systemd service file from scratch, wiping any custom `Environment=` lines or other modifications the user has added to the service file.

## Root Cause

`refresh_systemd_unit_if_needed()` and `systemd_install()` write the generated unit directly via `unit_path.write_text(new_unit)` without checking for user customizations in the existing file.

## Fix

Before overwriting the systemd unit file, detect custom directives (non-generated `Environment=` keys and non-standard `[Service]` directives), warn the user, and offer to auto-migrate them to a systemd drop-in override file (`custom.conf`).

### Detection

`_detect_custom_directives()` scans the `[Service]` section of the existing unit for:
- `Environment="KEY=VALUE"` where KEY is not in the generated set (PATH, VIRTUAL_ENV, HERMES_HOME, HOME, USER, LOGNAME)
- Other `Key=Value` directives not in the generated set (Type, ExecStart, WorkingDirectory, Restart, etc.)

Handles quoted, unquoted, and whitespace-variant syntax.

### Migration

When custom directives are detected:
- **Interactive mode**: Prompts the user to migrate to a drop-in override file
- **Non-interactive mode** (CI, piped installs): Auto-migrates with a prominent warning

The drop-in file is written to `~/.config/systemd/user/hermes-gateway.service.d/custom.conf` (or the system-scope equivalent). If the file already exists, new lines are appended and duplicates are deduplicated.

### What survives

Drop-in override files in `*.service.d/` are separate files that systemd merges automatically — they survive any overwrite of the main service file. This is the standard systemd approach for customizing vendor-managed units.

## Changes

- `hermes_cli/gateway.py`: Added detection, warning, and migration logic
- `tests/hermes_cli/test_gateway_service.py`: 13 new tests covering edge cases

## Testing

All 13 new tests pass. Existing test `test_systemd_install_repairs_outdated_unit_without_force` continues to pass.