### PR TITLE
fix(skills-hub): surface per-tap providers in runtime search/filter

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -28,6 +28,20 @@ from agent.skill_utils import is_excluded_skill_path
 _console = Console()
 
 
+def _display_source(r) -> str:
+    """Human-facing source label for a result row.
+
+    GitHub-tap skills are stored under source="github"; surface their per-tap
+    provider label (NVIDIA / OpenAI / ...) when present so the table reflects
+    the real origin instead of the generic "github".
+    """
+    if r.source == "github":
+        provider = (getattr(r, "extra", None) or {}).get("provider")
+        if provider:
+            return provider
+    return r.source
+
+
 # ---------------------------------------------------------------------------
 # Shared do_* functions
 # ---------------------------------------------------------------------------
@@ -303,7 +317,7 @@ def do_search(query: str, source: str = "all", limit: int = 10,
         table.add_row(
             r.name,
             r.description[:60] + ("..." if len(r.description) > 60 else ""),
-            r.source,
+            _display_source(r),
             f"[{trust_style}]{trust_label}[/]",
             r.identifier,
         )
@@ -380,6 +394,16 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
         c.print("[dim]No skills found in the Skills Hub.[/]\n")
         return
 
+    # Provider filter (nvidia/openai/...) narrows GitHub-tap skills by their
+    # per-tap ``extra.provider`` label (the runtime index stores them all under
+    # source="github"). Real source ids were already filtered upstream.
+    from tools.skills_hub import _PROVIDER_FILTER_VALUES, _filter_results_by_provider
+    if source.strip().lower() in _PROVIDER_FILTER_VALUES:
+        all_results = _filter_results_by_provider(all_results, source)
+        if not all_results:
+            c.print(f"[dim]No skills found for provider '{source}'.[/]\n")
+            return
+
     # Deduplicate by identifier, preferring higher trust.
     # identifier is always unique per skill; name is not (browse-sh skills from different
     # sites can share the same task name, e.g. "search-listings" on Airbnb and Booking.com).
@@ -444,7 +468,7 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
             str(i),
             r.name,
             desc,
-            r.source,
+            _display_source(r),
             f"[{trust_style}]{trust_label}[/]",
             r.identifier,
         )
@@ -1797,10 +1821,10 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
 
     elif action == "search":
         if not args:
-            c.print("[bold red]Usage:[/] /skills search <query> [--source skills-sh|well-known|github|official] [--limit N] [--json]\n")
+            c.print("[bold red]Usage:[/] /skills search <query> [--source skills-sh|github|official|nvidia|openai|anthropic|huggingface] [--limit N] [--json]\n")
             return
         source = "all"
-        limit = 10
+        limit = 25
         as_json = False
         query_parts = []
         i = 0

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -39,8 +39,16 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
             "clawhub",
             "lobehub",
             "browse-sh",
+            # Provider filters (GitHub taps stored under source="github"):
+            "nvidia",
+            "openai",
+            "anthropic",
+            "huggingface",
+            "voltagent",
+            "gstack",
+            "minimax",
         ],
-        help="Filter by source (default: all)",
+        help="Filter by source or provider (e.g. nvidia, openai) (default: all)",
     )
 
     skills_search = skills_subparsers.add_parser(
@@ -59,9 +67,18 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
             "clawhub",
             "lobehub",
             "browse-sh",
+            # Provider filters (GitHub taps stored under source="github"):
+            "nvidia",
+            "openai",
+            "anthropic",
+            "huggingface",
+            "voltagent",
+            "gstack",
+            "minimax",
         ],
+        help="Filter by source or provider (e.g. nvidia, openai)",
     )
-    skills_search.add_argument("--limit", type=int, default=10, help="Max results")
+    skills_search.add_argument("--limit", type=int, default=25, help="Max results")
     skills_search.add_argument(
         "--json",
         action="store_true",

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1607,6 +1607,158 @@ class TestUnifiedSearchDedup:
 
 
 # ---------------------------------------------------------------------------
+# GitHub tap provider labeling + index search/filter
+# ---------------------------------------------------------------------------
+
+
+class TestGithubProviderLabeling:
+    def test_provider_for_known_taps_case_insensitive(self):
+        from tools.skills_hub import github_provider_for
+        assert github_provider_for("NVIDIA/skills") == "NVIDIA"
+        assert github_provider_for("nvidia/skills") == "NVIDIA"
+        assert github_provider_for("openai/skills") == "OpenAI"
+        assert github_provider_for("garrytan/gstack") == "gstack"
+
+    def test_provider_for_unknown_repo_is_none(self):
+        from tools.skills_hub import github_provider_for
+        assert github_provider_for("someuser/somerepo") is None
+        assert github_provider_for("") is None
+
+    def test_inspect_stamps_provider_in_extra(self):
+        gs = GitHubSource(auth=GitHubAuth())
+        skill_md = (
+            "---\nname: accelerated-computing-cudf\n"
+            "description: NVIDIA cuDF GPU DataFrames.\n---\n# body\n"
+        )
+        gs._fetch_file_content = lambda repo, path: skill_md
+        meta = gs.inspect("NVIDIA/skills/skills/accelerated-computing-cudf")
+        assert meta is not None
+        # source stays "github" (no churn to dedup/floor/skip logic) ...
+        assert meta.source == "github"
+        # ... but the per-tap provider label rides along in extra
+        assert meta.extra.get("provider") == "NVIDIA"
+
+    def test_inspect_no_provider_for_untapped_repo(self):
+        gs = GitHubSource(auth=GitHubAuth())
+        gs._fetch_file_content = lambda repo, path: (
+            "---\nname: foo\ndescription: bar.\n---\n# b\n"
+        )
+        meta = gs.inspect("someuser/somerepo/skills/foo")
+        assert meta is not None
+        assert "provider" not in meta.extra
+
+
+def _make_index_source(skills):
+    """Build a HermesIndexSource pre-loaded with a fixed skill list."""
+    from tools.skills_hub import HermesIndexSource
+    src = HermesIndexSource(auth=GitHubAuth())
+    src._index = {"skills": skills}
+    src._loaded = True
+    return src
+
+
+class TestHermesIndexSearch:
+    def test_search_matches_identifier_and_provider(self):
+        # NVIDIA skill whose name/description does NOT contain "nvidia" — only
+        # the identifier and the provider label do. The old substring-only
+        # search over name/description/tags would miss it entirely.
+        skills = [
+            {
+                "name": "accelerated-computing-cudf",
+                "description": "GPU DataFrames.",
+                "source": "github",
+                "identifier": "NVIDIA/skills/skills/accelerated-computing-cudf",
+                "tags": [],
+                "extra": {"provider": "NVIDIA"},
+            },
+            {
+                "name": "unrelated",
+                "description": "nothing here",
+                "source": "clawhub",
+                "identifier": "clawhub/unrelated",
+                "tags": [],
+            },
+        ]
+        src = _make_index_source(skills)
+        hits = src.search("nvidia", limit=25)
+        ids = [h.identifier for h in hits]
+        assert "NVIDIA/skills/skills/accelerated-computing-cudf" in ids
+        assert "clawhub/unrelated" not in ids
+
+    def test_search_ranks_exact_name_first(self):
+        skills = [
+            {"name": "z-cuda-helper", "description": "uses cuda", "source": "clawhub",
+             "identifier": "clawhub/z-cuda-helper", "tags": []},
+            {"name": "cuda", "description": "the cuda skill", "source": "github",
+             "identifier": "NVIDIA/skills/skills/cuda", "tags": [],
+             "extra": {"provider": "NVIDIA"}},
+        ]
+        src = _make_index_source(skills)
+        hits = src.search("cuda", limit=25)
+        # exact name match must rank ahead of the substring-in-description match
+        assert hits[0].name == "cuda"
+
+    def test_search_does_not_break_at_limit_arbitrarily(self):
+        # 30 substring matches; with limit=25 we must get the 25 best, and a
+        # higher-relevance name match placed late in index order must survive.
+        skills = [
+            {"name": f"thing-{i}", "description": "mentions cuda", "source": "clawhub",
+             "identifier": f"clawhub/thing-{i}", "tags": []}
+            for i in range(30)
+        ]
+        skills.append(
+            {"name": "cuda", "description": "exact", "source": "github",
+             "identifier": "NVIDIA/skills/skills/cuda", "tags": [],
+             "extra": {"provider": "NVIDIA"}}
+        )
+        src = _make_index_source(skills)
+        hits = src.search("cuda", limit=25)
+        assert len(hits) == 25
+        # The exact-name skill (last in index order) must NOT be dropped.
+        assert any(h.name == "cuda" for h in hits)
+        assert hits[0].name == "cuda"
+
+
+class TestProviderFilter:
+    def test_filter_results_by_provider_narrows_exactly(self):
+        from tools.skills_hub import _filter_results_by_provider
+        results = [
+            SkillMeta(name="a", description="", source="github", identifier="NVIDIA/skills/a",
+                      trust_level="trusted", extra={"provider": "NVIDIA"}),
+            SkillMeta(name="b", description="", source="github", identifier="openai/skills/b",
+                      trust_level="trusted", extra={"provider": "OpenAI"}),
+            SkillMeta(name="c", description="", source="official", identifier="official/c",
+                      trust_level="builtin"),
+        ]
+        nv = _filter_results_by_provider(results, "nvidia")
+        assert [r.identifier for r in nv] == ["NVIDIA/skills/a"]
+        oai = _filter_results_by_provider(results, "openai")
+        assert [r.identifier for r in oai] == ["openai/skills/b"]
+
+    def test_provider_filter_values_match_tap_labels(self):
+        from tools.skills_hub import _PROVIDER_FILTER_VALUES, GITHUB_TAP_PROVIDERS
+        assert _PROVIDER_FILTER_VALUES == frozenset(
+            v.lower() for v in GITHUB_TAP_PROVIDERS.values()
+        )
+
+    def test_unified_search_provider_filter_keeps_index_source(self):
+        # A provider filter must NOT be treated as a real source id (which would
+        # exclude every source and return nothing). It selects sources like
+        # "all", then narrows the merged results by provider.
+        nv = SkillMeta(name="cuda", description="gpu", source="github",
+                       identifier="NVIDIA/skills/cuda", trust_level="trusted",
+                       extra={"provider": "NVIDIA"})
+        other = SkillMeta(name="cuda-clone", description="gpu", source="clawhub",
+                          identifier="clawhub/cuda-clone", trust_level="community")
+        src = MagicMock()
+        src.source_id.return_value = "hermes-index"
+        src.is_available = True
+        src.search.return_value = [nv, other]
+        results = unified_search("cuda", [src], source_filter="nvidia", limit=25)
+        assert [r.identifier for r in results] == ["NVIDIA/skills/cuda"]
+
+
+# ---------------------------------------------------------------------------
 # append_audit_log
 # ---------------------------------------------------------------------------
 

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -390,6 +390,57 @@ class SkillSource(ABC):
 # GitHub source adapter
 # ---------------------------------------------------------------------------
 
+# Map a GitHub tap repo (owner/repo) to the human-facing provider label used
+# in the docs-site catalog (website/scripts/extract-skills.py::GITHUB_TAP_LABELS).
+# The runtime index collapses every GitHub tap into source="github"; stamping
+# this provider label onto each skill's ``extra`` keeps the per-tap identity
+# (NVIDIA / OpenAI / Anthropic / HuggingFace / gstack / ...) searchable and
+# filterable at the CLI without disturbing the source="github" dedup / floor /
+# index-skip logic that keys off the bare source id.
+GITHUB_TAP_PROVIDERS = {
+    "openai/skills": "OpenAI",
+    "anthropics/skills": "Anthropic",
+    "huggingface/skills": "HuggingFace",
+    "nvidia/skills": "NVIDIA",
+    "voltagent/awesome-agent-skills": "VoltAgent",
+    "garrytan/gstack": "gstack",
+    "minimax-ai/cli": "MiniMax",
+}
+
+
+def github_provider_for(repo: str) -> Optional[str]:
+    """Return the provider label for a GitHub tap repo, or None.
+
+    ``repo`` is ``owner/repo``; matched case-insensitively so ``NVIDIA/skills``
+    and ``nvidia/skills`` both resolve to ``"NVIDIA"``.
+    """
+    if not repo:
+        return None
+    return GITHUB_TAP_PROVIDERS.get(repo.strip().lower())
+
+
+# Lowercased set of accepted ``--source`` provider filters. These are not real
+# source ids — they narrow the merged results to GitHub-tap skills carrying the
+# matching ``extra.provider`` label (see ``_filter_results_by_provider``).
+_PROVIDER_FILTER_VALUES = frozenset(v.lower() for v in GITHUB_TAP_PROVIDERS.values())
+
+
+def _filter_results_by_provider(
+    results: List["SkillMeta"], provider: str
+) -> List["SkillMeta"]:
+    """Keep only results whose ``extra.provider`` matches ``provider``.
+
+    An explicit provider filter (e.g. ``--source nvidia``) means "show me that
+    provider's skills" — so it narrows to exactly those, without injecting the
+    official catalog the unfiltered browse/search would lead with.
+    """
+    want = provider.strip().lower()
+    return [
+        r for r in results
+        if str((r.extra or {}).get("provider", "")).lower() == want
+    ]
+
+
 class GitHubSource(SkillSource):
     """Fetch skills from GitHub repos via the Contents API."""
 
@@ -530,6 +581,11 @@ class GitHubSource(SkillSource):
             raw_tags = fm.get("tags", [])
             tags = raw_tags if isinstance(raw_tags, list) else []
 
+        provider = github_provider_for(repo)
+        extra: Dict[str, Any] = {}
+        if provider:
+            extra["provider"] = provider
+
         return SkillMeta(
             name=skill_name,
             description=str(description),
@@ -539,6 +595,7 @@ class GitHubSource(SkillSource):
             repo=repo,
             path=skill_path,
             tags=[str(t) for t in tags],
+            extra=extra,
         )
 
     # -- Internal helpers --
@@ -3625,25 +3682,58 @@ class HermesIndexSource(SkillSource):
         return "community"
 
     def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
-        """Search the cached index.  Zero API calls."""
+        """Search the cached index.  Zero API calls.
+
+        Matches against name, description, tags, identifier, and the per-tap
+        ``extra.provider`` label (so a query like ``nvidia`` surfaces the
+        ``NVIDIA/skills/...`` entries even though their ``source`` is the bare
+        ``github``).  Results are scored and ranked (exact name > name prefix >
+        whole-word > substring) rather than returned in raw index order and
+        truncated at the first ``limit`` hits — that earlier break-at-limit
+        behaviour returned an arbitrary file-order slice and buried the most
+        relevant skills.
+        """
         index = self._ensure_loaded()
         skills = index.get("skills", [])
         if not skills:
             return []
 
         if not query.strip():
-            # No query — return featured/popular
+            # No query — return featured/popular (index order)
             return [self._to_meta(s) for s in skills[:limit]]
 
         query_lower = query.lower()
-        results: List[SkillMeta] = []
-        for s in skills:
-            searchable = f"{s.get('name', '')} {s.get('description', '')} {' '.join(s.get('tags', []))}".lower()
-            if query_lower in searchable:
-                results.append(self._to_meta(s))
-                if len(results) >= limit:
-                    break
-        return results
+        scored: List[Tuple[int, int, dict]] = []
+        for i, s in enumerate(skills):
+            name = str(s.get("name", "")).lower()
+            provider = str((s.get("extra") or {}).get("provider", "")).lower()
+            haystack = " ".join([
+                name,
+                str(s.get("description", "")).lower(),
+                " ".join(str(t).lower() for t in s.get("tags", [])),
+                str(s.get("identifier", "")).lower(),
+                provider,
+            ])
+            if query_lower not in haystack:
+                continue
+            # Lower score sorts first.
+            if name == query_lower:
+                score = 0
+            elif name.startswith(query_lower):
+                score = 1
+            elif provider == query_lower:
+                score = 2
+            elif query_lower in name.split() or query_lower in provider.split():
+                score = 3
+            elif query_lower in name:
+                score = 4
+            else:
+                score = 5
+            # i (original index order) is the stable tiebreaker.
+            scored.append((score, i, s))
+
+        scored.sort(key=lambda x: (x[0], x[1]))
+        return [self._to_meta(s) for _, _, s in scored[:limit]]
 
     def fetch(self, identifier: str) -> Optional[SkillBundle]:
         """Fetch a skill using the resolved path from the index.
@@ -3790,6 +3880,15 @@ def parallel_search_sources(
 
     per_source_limits = per_source_limits or {}
 
+    # A provider filter (e.g. "nvidia", "openai") targets GitHub-tap skills
+    # that the runtime index stores under source="github" with an
+    # ``extra.provider`` label. It is NOT a real source id, so source-level
+    # selection must treat it like "all" (the index / github source carries
+    # the data); the per-provider narrowing happens downstream on the merged
+    # results (see ``_filter_results_by_provider``).
+    _provider_filter = source_filter.strip().lower() in _PROVIDER_FILTER_VALUES
+    _effective_filter = "all" if _provider_filter else source_filter
+
     active: List[SkillSource] = []
     # When the centralized index is available and the user hasn't filtered
     # to a specific source, skip external API sources (github, skills-sh,
@@ -3798,7 +3897,7 @@ def parallel_search_sources(
     _index_available = False
     _api_source_ids = frozenset({"github", "skills-sh", "clawhub",
                                   "claude-marketplace", "lobehub", "well-known"})
-    if source_filter == "all":
+    if _effective_filter == "all":
         for src in sources:
             if (src.source_id() == "hermes-index"
                     and getattr(src, "is_available", False)):
@@ -3807,7 +3906,7 @@ def parallel_search_sources(
 
     for src in sources:
         sid = src.source_id()
-        if source_filter != "all" and sid != source_filter and sid != "official":
+        if _effective_filter != "all" and sid != _effective_filter and sid != "official":
             continue
         # Skip external API sources when the index covers them
         if _index_available and sid in _api_source_ids:
@@ -3871,6 +3970,12 @@ def unified_search(query: str, sources: List[SkillSource],
         source_filter=source_filter,
         overall_timeout=30,
     )
+
+    # A provider filter (nvidia/openai/...) is applied here, on the merged set,
+    # because it targets the per-tap ``extra.provider`` label rather than a real
+    # source id (the runtime index stores every GitHub tap as source="github").
+    if source_filter.strip().lower() in _PROVIDER_FILTER_VALUES:
+        all_results = _filter_results_by_provider(all_results, source_filter)
 
     # Deduplicate by identifier, preferring higher trust levels.
     # identifier is always unique per skill (e.g. "browse-sh/airbnb.com/search-listings-ddgioa").


### PR DESCRIPTION
## Summary
Natural-language skill search now surfaces NVIDIA / OpenAI / Anthropic / HuggingFace skills and lets you filter by provider — previously it returned a short, arbitrary list that buried them.

Root cause (two compounding bugs in the runtime search path):
1. The runtime index collapses every GitHub tap into `source: "github"`, so the per-tap identity (NVIDIA/OpenAI/...) only existed in the docs-site catalog — there was nothing to find or filter by at the CLI.
2. `HermesIndexSource.search()` matched only name/description/tags (not identifier or provider) and **broke at the first `limit` hits in raw index order**, so high-relevance skills were dropped. `search` also defaulted to `--limit 10` against an ~86k-entry catalog.

That's why it only worked when the user explicitly added the NVIDIA registry — that routes through `GitHubSource` directly against `NVIDIA/skills`.

## Changes
- `tools/skills_hub.py`: `GitHubSource` stamps a per-tap `extra.provider` label (`github_provider_for()`); `source` stays `"github"` so dedup / health-floor / index-skip logic is untouched. It flows into the built index.
- `tools/skills_hub.py`: `HermesIndexSource.search()` now matches identifier + provider, and **collect-then-ranks** (exact > prefix > whole-word > substring) instead of break-at-limit.
- `--source nvidia|openai|anthropic|huggingface|voltagent|gstack|minimax` provider filters for `browse`/`search` (narrow the merged results by provider).
- `search --limit` default `10 -> 25`; Source column shows the provider label for github skills.

## Validation
| | Before | After |
|---|---|---|
| `search nvidia` (top 25) | 0 NVIDIA-tap skills | 14 NVIDIA-provider surfaced, ranked |
| `search cuda --source nvidia` | n/a (rejected source) | 9 NVIDIA-only |
| `browse --source nvidia` | n/a | 234 NVIDIA skills |
| `_filter_results_by_provider` nvidia/openai | n/a | 234 / 44, disjoint |

181 unit tests pass (10 new). E2E verified against the live runtime index with an isolated `HERMES_HOME`.

## Infographic

![skills-hub-provider-aware-search](https://v3b.fal.media/files/b/0a9fdf02/C0bC-2YNcq_k7iKvgtqFs_f2pbGDeU.png)
