### PR TITLE
fix(tools_config): guard against None in known_plugin_toolsets config

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1458,8 +1458,8 @@ def _get_platform_tools(
     # has been saved for that platform (tracked via known_plugin_toolsets).
     # Unknown plugins default to enabled; known-but-absent = disabled.
     if plugin_ts_keys:
-        known_map = config.get("known_plugin_toolsets", {})
-        known_for_platform = set(known_map.get(platform, []))
+        known_map = config.get("known_plugin_toolsets", {}) or {}
+        known_for_platform = set(known_map.get(platform, []) or [])
         for pts in plugin_ts_keys:
             if pts in toolset_names:
                 # Explicitly listed in config — enabled


### PR DESCRIPTION
## Problem

When `config.yaml` has `known_plugin_toolsets: null` (or any value mapped to `None` by the YAML loader), `config.get("known_plugin_toolsets", {})` returns `None` — because Python's `dict.get` only falls back to the default when the key is **absent**, not when its value is `None`.

The subsequent `set(known_map.get(platform, []))` then crashes with `TypeError: 'NoneType' object is not iterable`, causing the gateway to fail to start and Hermes Desktop to show "Hermes couldn't start".

## Fix

- `or {}` to guard against `known_map` being `None`
- `or []` to guard against `known_map.get(platform, [])` returning `None`

## How to reproduce

1. Set `known_plugin_toolsets: null` or `known_plugin_toolsets:` (empty) in `~/.hermes/config.yaml`
2. Restart any process that calls `_get_platform_tools` (gateway, desktop, CLI)
3. Observe `TypeError: 'NoneType' object is not iterable`

## Testing

- Verified that `config.get("known_plugin_toolsets", {}) or {}` returns `{}` when the value is `None`
- Verified that `set(known_map.get("windows", []) or [])` returns `set()` when the key doesn't exist in the config

