### PR TITLE
fix(doctor): detect agent-browser in the Hermes-managed node bin (#53192)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1525,10 +1525,22 @@ def run_doctor(args):
         agent_browser_path = PROJECT_ROOT / "node_modules" / "agent-browser"
         agent_browser_ok = False
         _which_ab = shutil.which("agent-browser")
+        # `hermes acp --setup-browser` installs agent-browser into the
+        # Hermes-managed node prefix, which isn't necessarily on PATH. Mirror
+        # dep_ensure._has_hermes_agent_browser() so doctor and dep_ensure agree
+        # on what "installed" means; otherwise doctor false-negatives (#53192).
+        _managed_ab = HERMES_HOME / "node" / "bin" / "agent-browser"
+        _legacy_ab = HERMES_HOME / "node_modules" / ".bin" / "agent-browser"
         if agent_browser_path.exists():
             check_ok("agent-browser (Node.js)", "(browser automation)")
             agent_browser_ok = True
         elif _which_ab and agent_browser_runnable(_which_ab):
+            check_ok("agent-browser", "(browser automation)")
+            agent_browser_ok = True
+        elif _managed_ab.is_file() and agent_browser_runnable(str(_managed_ab)):
+            check_ok("agent-browser", "(browser automation)")
+            agent_browser_ok = True
+        elif _legacy_ab.is_file() and agent_browser_runnable(str(_legacy_ab)):
             check_ok("agent-browser", "(browser automation)")
             agent_browser_ok = True
         elif _which_ab:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -673,6 +673,73 @@ def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser
     assert "npm install -g agent-browser && agent-browser install" in out
 
 
+def _run_doctor_with_managed_agent_browser(monkeypatch, tmp_path, runnable):
+    """Set up run_doctor with node present, agent-browser only in the
+    Hermes-managed node bin (~/.hermes/node/bin), not on PATH or in
+    PROJECT_ROOT/node_modules. Returns the captured stdout."""
+    home = tmp_path / ".hermes"
+    (home / "node" / "bin").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    managed_ab = home / "node" / "bin" / "agent-browser"
+    managed_ab.write_text("#!/bin/sh\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)  # no node_modules/agent-browser here
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.delenv("PREFIX", raising=False)
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    # node on PATH, agent-browser is NOT on PATH (only in the managed bin)
+    monkeypatch.setattr(
+        doctor_mod.shutil,
+        "which",
+        lambda cmd: "/usr/bin/node" if cmd in {"node", "npm"} else None,
+    )
+    # agent_browser_runnable is imported into doctor's namespace
+    monkeypatch.setattr(
+        doctor_mod,
+        "agent_browser_runnable",
+        lambda path: runnable and str(path) == str(managed_ab),
+    )
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    return buf.getvalue()
+
+
+def test_run_doctor_detects_agent_browser_in_managed_node_bin(monkeypatch, tmp_path):
+    # Regression for #53192: `hermes acp --setup-browser` installs into
+    # ~/.hermes/node/bin/agent-browser, which isn't on PATH; doctor must still
+    # report it installed instead of "agent-browser not installed".
+    out = _run_doctor_with_managed_agent_browser(monkeypatch, tmp_path, runnable=True)
+    assert "agent-browser not installed" not in out
+    assert "agent-browser found but not runnable" not in out
+    assert "✓ agent-browser" in out
+
+
+def test_run_doctor_managed_agent_browser_not_runnable_still_warns(monkeypatch, tmp_path):
+    # A present-but-unrunnable managed binary must fall through to the existing
+    # warning, not be reported as OK.
+    out = _run_doctor_with_managed_agent_browser(monkeypatch, tmp_path, runnable=False)
+    assert "agent-browser not installed" in out
+
+
 def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What does this PR do?

`hermes acp --setup-browser --yes` installs `agent-browser` into the Hermes-managed
node prefix at `~/.hermes/node/bin/agent-browser`, which isn't necessarily on `PATH`.
`hermes doctor` only checked `PROJECT_ROOT/node_modules` and `PATH` (`shutil.which`),
so it reported `agent-browser not installed (run: npm install)` even though the binary
was present and runnable — a discovery false negative, not an install failure (#53192).

This mirrors the detection `hermes_cli/dep_ensure.py::_has_hermes_agent_browser()`
already does, so doctor and dep_ensure agree on what "installed" means.

## Related Issue

Fixes #53192

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/doctor.py`: in the Node.js + agent-browser check, look for the binary in
  `HERMES_HOME/node/bin/agent-browser` and the legacy `HERMES_HOME/node_modules/.bin/agent-browser`
  before warning, each gated by `agent_browser_runnable()` (the same dangling-symlink guard
  the existing PATH branch uses). PATH, `node_modules`, and Termux behavior are unchanged.
- `tests/hermes_cli/test_doctor.py`: added a positive case (managed bin present and runnable →
  detected, no warning) and a negative case (present but not runnable → still warns).

## How to Test

1. With node installed and `agent-browser` only at `~/.hermes/node/bin/agent-browser` (not on PATH,
   no `node_modules/agent-browser`), run `hermes doctor` — it now reports agent-browser OK instead of
   "not installed".
2. `pytest tests/hermes_cli/test_doctor.py -q` → all green (66 passed).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/hermes_cli/test_doctor.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior-only fix)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the new paths match the non-Windows branch of
  `dep_ensure._has_hermes_agent_browser()`; the existing Windows `.cmd` handling there is unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A