### PR TITLE
docs(moa): add HermesBench results to Mixture of Agents page

### DIFF
--- a/website/docs/user-guide/features/mixture-of-agents.md
+++ b/website/docs/user-guide/features/mixture-of-agents.md
@@ -106,6 +106,18 @@ hermes moa configure review       # create or update a named preset
 hermes moa delete review
 ```
 
+## Benchmarks
+
+On HermesBench, a two-model MoA preset — `claude-opus-4.8` aggregating over a `gpt-5.5` reference — outscores either model run on its own:
+
+| Model | HermesBench score |
+|---|---|
+| **Opus aggregator (opus-4.8 + gpt-5.5 reference) — MoA** | **0.8202** |
+| `anthropic/claude-opus-4.8` | 0.7607 |
+| `openai/gpt-5.5` | 0.7412 |
+
+The MoA configuration beats its strongest component (opus-4.8) by ~6 points, confirming that aggregating a second perspective lifts quality on hard tasks rather than just averaging the two.
+
 ## Notes
 
 - MoA is no longer listed under `hermes tools`; there is no `moa` toolset to enable.


### PR DESCRIPTION
## Summary
Adds a Benchmarks section to the Mixture of Agents docs page with HermesBench results showing a two-model MoA preset beating either of its component models run solo.

## Changes
- `website/docs/user-guide/features/mixture-of-agents.md`: new `## Benchmarks` section with a HermesBench score table.

## Results
| Model | HermesBench score |
|---|---|
| **Opus aggregator (opus-4.8 + gpt-5.5 reference) — MoA** | **0.8202** |
| `anthropic/claude-opus-4.8` | 0.7607 |
| `openai/gpt-5.5` | 0.7412 |

MoA beats its strongest component (opus-4.8) by ~6 points.

## Notes
- HermesBench is referenced by name only (not linked) — the eval repos are private, so a public docs link would 404.
- Follow-up to the merged MoA virtual-provider work in #46081.

## Infographic

![moa-hermesbench-results](https://v3b.fal.media/files/b/0a9fdf9c/KGmVE0kc8PsvcdyqZuKLG_0f3TgtRi.png)
