### PR TITLE
fix(desktop): prevent infinite download loop on Windows when clicking file artifacts

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1290,12 +1290,36 @@ function loadWindowUrl(win, url, label) {
   win.loadURL(url).catch(error => rememberLog(`${label} failed to load: ${describeCrashReason(error)}`))
 }
 
+// Archive/compressed file extensions that Windows/Electron mishandles
+// when passed to shell.openPath(), triggering an infinite download loop
+// that writes .tmp files to ~/Downloads/ until the system freezes.
+// These should be revealed in folder instead of opened.
+const ARCHIVE_EXTENSIONS = new Set([
+  '.gz', '.tar', '.tgz', '.zip', '.bz2', '.xz', '.7z', '.rar',
+  '.zst', '.lz', '.lzma'
+])
+
+// Debounce tracker for openExternal to prevent rapid re-triggering
+// (e.g. when a failed openPath triggers a Chromium download that
+// re-fires the IPC call in a loop).
+let openExternalLastCall = 0
+const OPEN_EXTERNAL_DEBOUNCE_MS = 1000
+
 function openExternalUrl(rawUrl) {
   const raw = String(rawUrl || '').trim()
 
   if (!raw) {
     return false
   }
+
+  // Debounce: ignore calls within 1s of the last one. This prevents
+  // rapid re-triggering loops (e.g. Chromium re-downloading a file
+  // that shell.openPath mishandled on Windows).
+  const now = Date.now()
+  if (now - openExternalLastCall < OPEN_EXTERNAL_DEBOUNCE_MS) {
+    return true
+  }
+  openExternalLastCall = now
 
   let parsed
 
@@ -1317,6 +1341,19 @@ function openExternalUrl(rawUrl) {
       localPath = resolveRequestedPathForIpc(parsed.toString(), { purpose: 'Open external file' })
     } catch {
       return false
+    }
+
+    // Archive/compressed files (npm tarballs, etc.) trigger an infinite
+    // download loop on Windows when passed to shell.openPath(). Skip
+    // openPath entirely and reveal in folder instead.
+    const ext = path.extname(localPath).toLowerCase()
+    if (ARCHIVE_EXTENSIONS.has(ext)) {
+      try {
+        shell.showItemInFolder(localPath)
+      } catch (revealError) {
+        rememberLog(`[file] showItemInFolder failed for archive: ${revealError.message}`)
+      }
+      return true
     }
 
     void shell


### PR DESCRIPTION
Fixes #53170

## Description

On Windows, clicking a **file-type** artifact in the Desktop Artifacts view triggers an infinite download loop that writes `.tmp` files (npm tar.gz packages) to \~/Downloads/ until the system freezes.

**Root cause:** `shell.openPath()` returns an empty string (no error) even when Windows/Electron mishandles the file association for archive/compressed files, causing Chromium to re-download the file repeatedly. Each iteration creates a new UUID-named `.tmp` file.

**Fix (two parts):**

1. **Archive extension blocklist** — for `.gz`, `.tar`, `.tgz`, `.zip`, `.bz2`, `.xz`, `.7z`, `.rar`, `.zst`, `.lz`, `.lzma` files, skip `shell.openPath()` entirely and go directly to `shell.showItemInFolder()` (reveal in Explorer). These file types are the ones that trigger the download loop.

2. **Debounce** — a 1-second debounce on `openExternalUrl()` prevents rapid re-triggering if a failed open attempt causes Chromium to re-fire the IPC call.

## Verification

- `node -c apps/desktop/electron/main.cjs` — syntax check passes
- Only one file changed (37 insertions)
- No secrets, personal refs, or unrelated changes