### PR TITLE
docs(moa): clarify MoA presets are selectable on every surface

### DIFF
--- a/website/docs/user-guide/features/mixture-of-agents.md
+++ b/website/docs/user-guide/features/mixture-of-agents.md
@@ -21,7 +21,13 @@ You can select a preset through the normal model picker surfaces:
 /model review --provider moa
 ```
 
-The Dashboard, TUI, and Desktop model pickers also show a `Mixture of Agents` provider row. Its models are your configured preset names.
+MoA presets are selectable on **every Hermes surface**, because MoA is a normal provider in the model system:
+
+- **CLI / gateway / TUI `/model`** — `/model <preset> --provider moa`, or `/model --provider moa` for the default preset. A bare `/model <preset>` also works when the name exactly matches a configured preset.
+- **`hermes model`** and the **Dashboard model picker** — a `Mixture of Agents` provider row appears with your preset names as its models.
+- **Desktop GUI app** — the model dropdown shows an `MoA presets` section; selecting one (`MoA: <preset>`) switches the active model to that preset. The Desktop settings panel also creates and edits presets.
+
+Configured presets therefore show up wherever you would pick any other model.
 
 ## Slash command shortcut
 


### PR DESCRIPTION
## Summary
Clarifies in the MoA docs that preset models are selectable on every Hermes surface, not just "the pickers" — verified against the code on current main.

## Changes
- `website/docs/user-guide/features/mixture-of-agents.md`: expand the "Select a MoA preset" section into an explicit per-surface list (CLI/gateway/TUI `/model`, `hermes model`, Dashboard picker, Desktop GUI dropdown + settings).

## Surface verification (against current main)
| Surface | Where | Mechanism |
|---|---|---|
| `/model` (CLI/gateway/TUI) | `hermes_cli/model_switch.py` | exact preset name → `provider=moa, model=<preset>` |
| `hermes model` / picker payload | `hermes_cli/inventory.py` `_moa_provider_row()` | injects `Mixture of Agents` provider row |
| Dashboard | `hermes_cli/web_server.py` → `build_models_payload()` | same inventory row in `/api/models` |
| Desktop GUI | `apps/desktop/src/app/shell/model-menu-panel.tsx` | `MoA presets` dropdown section, selectable per preset |

## Infographic

![moa-hermesbench-results](https://v3b.fal.media/files/b/0a9fdf9c/KGmVE0kc8PsvcdyqZuKLG_0f3TgtRi.png)
