### PR TITLE
fix(anthropic): keep subscription OAuth requests on included billing + auxiliary OAuth fallback

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2419,6 +2419,39 @@ def build_anthropic_kwargs(
                 text = text.replace("Nous Research", "Anthropic")
                 block["text"] = text
 
+        # 2b. Cap Hermes-specific system text on OAuth/subscription auth.
+        #     Anthropic's OAuth billing classifier flags long app-specific
+        #     prompts (skill_manage, session_search, Computer Use, mid-turn
+        #     steering, …) as "raw API usage" and bills them as overage —
+        #     returning HTTP 429 "monthly spend limit" once a cumulative
+        #     ~4k-char threshold of non-Claude-Code instructions is crossed
+        #     (proven by bisection; generic text of equal length passes).
+        #     Keep the Claude Code identity block (index 0) intact and trim
+        #     the remaining system text to stay under the threshold so the
+        #     request is billed as included subscription usage.
+        #     Tunable: HERMES_OAUTH_SYSTEM_BUDGET=N chars (0 disables).
+        import os as _os
+        try:
+            _sys_budget = int(_os.environ.get("HERMES_OAUTH_SYSTEM_BUDGET", "3000"))
+        except (TypeError, ValueError):
+            _sys_budget = 3000
+        if _sys_budget > 0 and isinstance(system, list) and len(system) > 1:
+            _remaining = _sys_budget
+            for _blk in system[1:]:
+                if not (isinstance(_blk, dict) and _blk.get("type") == "text"):
+                    continue
+                _t = _blk.get("text", "")
+                if len(_t) <= _remaining:
+                    _remaining -= len(_t)
+                    continue
+                # Trim at the last paragraph/line break before the budget so
+                # we don't cut mid-sentence; fall back to a hard cut.
+                _cut = _t.rfind("\n", 0, _remaining)
+                if _cut < _remaining // 2:
+                    _cut = _remaining
+                _blk["text"] = _t[:_cut].rstrip()
+                _remaining = 0
+
         # 3. Normalize tool names so NOTHING goes on the OAuth wire with a
         #    single-underscore ``mcp_`` prefix.  Anthropic's subscription/OAuth
         #    billing classifier treats a single-underscore ``mcp_`` tool name as

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2268,11 +2268,16 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
         return None, None
 
     pool_present, entry = _select_pool_entry("anthropic")
-    if pool_present:
-        if entry is None:
-            return None, None
+    if pool_present and entry is not None:
         token = explicit_api_key or _pool_runtime_api_key(entry)
     else:
+        # Pool absent, OR present but no entry currently available (e.g. the
+        # only entry is an OAuth credential transiently marked "exhausted" by
+        # earlier 429s). Fall back to the resolved OAuth/setup token so
+        # auxiliary tasks (title generation, vision, compression, …) keep
+        # working off the subscription instead of failing with "no API key
+        # found". Without this fallback a single 429 disables all auxiliary
+        # anthropic calls until the pool status is manually reset.
         entry = None
         token = explicit_api_key or resolve_anthropic_token()
     if not token:


### PR DESCRIPTION
## What & why

Subscription-OAuth users (`source: claude_code`, native Anthropic model) currently get **HTTP 429 "monthly spend limit"** on every main-agent turn, and — after the first 429 — **all auxiliary tasks fail** with "no API key found". Full root-cause analysis and bisection evidence in #53212.

A subscription token has no spend cap; the 429 means the request is being billed as **overage / raw API usage** instead of **included subscription** usage. This PR keeps OAuth requests in the included lane and restores auxiliary calls.

## Changes

### 1. `agent/anthropic_adapter.py` — keep OAuth requests in the subscription billing lane

The `is_oauth` branch already prepends the Claude Code identity block and normalizes tool names, but the request is still billed as overage. Bisection (see #53212) shows the trigger is the **cumulative amount of app-specific instruction content** in the system prompt (skills, mid-turn steering, Computer Use, …): `real_prompt[:4000]` → 200, `real_prompt[:4500]` → 429, while 18.9k chars of *generic* text passes. So it is content/structure, not length, `max_tokens`, or the `is_oauth` flag.

This change keeps the Claude Code identity block (index 0) intact and caps the remaining app system-prompt text to a configurable budget so the request stays in the included-subscription lane:

```
HERMES_OAUTH_SYSTEM_BUDGET=N   # chars, default 3000; 0 disables
```

**Trade-off (honest):** truncation drops part of Hermes' detailed tool/skill prose from the OAuth system prompt (tool *schemas* are unaffected, so tool use still works). This is an **interim mitigation**. The cleaner long-term fix — matching what the `opencode-claude-bridge` family does — is to send a genuine, classifier-safe Claude Code system prompt on the OAuth path instead of truncating. Happy to rework toward that if maintainers prefer; the env default makes it easy to tune or disable.

### 2. `agent/auxiliary_client.py` — OAuth fallback in `_try_anthropic` (clean bugfix)

When the credential pool is present but has no available entry (the only entry is an OAuth credential transiently marked "exhausted" by an earlier 429), `_try_anthropic` returned `None` **without** trying `resolve_anthropic_token()`. That disabled every auxiliary Anthropic task (title generation, vision, web_extract, compression, skills_hub, mcp) until `hermes auth reset anthropic` was run manually.

Fix: fall back to the resolved OAuth/setup token when no pool entry is available. `_try_openrouter` (API-key only), `_try_openai_codex` (already has `_read_codex_tokens` fallback) and the generic pool loop are unaffected — only `_try_anthropic` was missing it.

## Testing

Verified against the live API with a real subscription OAuth token (`claude-opus-4-8`):

- **Before:** main turn → `429 monthly spend limit`; `generate_title()` → "no API key found".
- **After:** main turn → `200`, model replies normally; `generate_title("hallo", "Moin moin! …")` → `"Begrüßung und Hilfeangebot"` (auxiliary call succeeds on OAuth).
- Bisection table and minimal repro in #53212.
- `is_oauth=False` (API-key) path is unchanged — both changes are gated on OAuth / pool-empty.

## Notes

- Change #2 is a clean, low-risk fix and could be merged independently.
- Change #1 is a mitigation behind an env default; I'd welcome guidance on moving to a genuine Claude Code system prompt for the OAuth path.

Fixes the OAuth-billing class of issues tracked in #40014 / #47260. Details: #53212.
