### PR TITLE
fix(kanban): activate board in-session on switch, not just on disk (#53180)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1108,7 +1108,7 @@ def _cmd_boards_create(args: argparse.Namespace) -> int:
     print(f"  Display name: {meta.get('name', '')}")
     print(f"  DB path:      {meta['db_path']}")
     if getattr(args, "switch", False):
-        kb.set_current_board(meta["slug"])
+        kb.activate_board(meta["slug"])
         print(f"  Switched to {meta['slug']!r}.")
     else:
         print(f"  Use `hermes kanban boards switch {meta['slug']}` to make it current.")
@@ -1151,7 +1151,7 @@ def _cmd_boards_switch(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
-    kb.set_current_board(normed)
+    kb.activate_board(normed)
     print(f"Active board is now {normed!r}.")
     return 0
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -438,6 +438,25 @@ def set_current_board(slug: str) -> Path:
     return path
 
 
+def activate_board(slug: str) -> None:
+    """Persist *and* immediately activate ``slug`` in the running session.
+
+    Writes ``<root>/kanban/current`` (future sessions), updates the
+    in-process ContextVar override (so ``get_current_board()`` returns the
+    new board right away), and syncs ``HERMES_KANBAN_BOARD`` (so shelled-out
+    ``hermes kanban …`` calls agree).  Without the in-session updates an
+    interactive chat that pinned the board at boot (see
+    ``_pin_kanban_board_for_chat``) keeps seeing the stale board because the
+    env var shadows the file write (#53180).
+    """
+    normed = _normalize_board_slug(slug)
+    if not normed:
+        raise ValueError("board slug is required")
+    set_current_board(normed)
+    _CURRENT_BOARD_OVERRIDE.set(normed)
+    os.environ["HERMES_KANBAN_BOARD"] = normed
+
+
 def clear_current_board() -> None:
     """Remove ``<root>/kanban/current`` so the active board reverts to ``default``."""
     try:

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -61,6 +61,8 @@ def fresh_home(tmp_path, monkeypatch):
         pass
     # Kanban module-level init cache must not leak between tests.
     kb._INITIALIZED_PATHS.clear()
+    # ContextVar must not leak between tests (activate_board sets it).
+    kb._CURRENT_BOARD_OVERRIDE.set(None)
     return home
 
 
@@ -206,6 +208,50 @@ class TestCurrentBoard:
         kb.set_current_board("my-proj")
         expected = fresh_home / "kanban" / "boards" / "my-proj" / "kanban.db"
         assert kb.kanban_db_path() == expected
+
+    def test_boards_switch_takes_effect_with_env_pinned(self, fresh_home, monkeypatch):
+        """Switching boards in-session must override the env var pinned at
+        chat boot (#53180).
+
+        ``_pin_kanban_board_for_chat`` sets ``HERMES_KANBAN_BOARD`` at chat
+        startup so in-process and shelled-out calls agree.  Without an
+        in-session override, ``boards switch`` writes the ``current`` file
+        but the pinned env var shadows it and the running session keeps the
+        old board.
+        """
+        import argparse
+        from hermes_cli import kanban
+
+        kb.create_board("alpha")
+        kb.create_board("beta")
+        # Simulate _pin_kanban_board_for_chat at chat boot.
+        monkeypatch.setenv("HERMES_KANBAN_BOARD", "alpha")
+        assert kb.get_current_board() == "alpha"
+
+        args = argparse.Namespace(slug="beta")
+        rc = kanban._cmd_boards_switch(args)
+        assert rc == 0
+
+        # The switch must take effect in the running session, not just on disk.
+        assert kb.get_current_board() == "beta"
+
+    def test_activate_board_overrides_pinned_env(self, fresh_home, monkeypatch):
+        """``activate_board`` sets the ContextVar so it beats a pinned env var."""
+        kb.create_board("alpha")
+        kb.create_board("beta")
+        monkeypatch.setenv("HERMES_KANBAN_BOARD", "alpha")
+        assert kb.get_current_board() == "alpha"
+
+        kb.activate_board("beta")
+        assert kb.get_current_board() == "beta"
+        # Env var is also synced so shelled-out calls agree.
+        assert os.environ["HERMES_KANBAN_BOARD"] == "beta"
+
+    def test_activate_board_persists_file(self, fresh_home):
+        """``activate_board`` also writes the ``current`` file for future sessions."""
+        kb.create_board("alpha")
+        kb.activate_board("alpha")
+        assert kb.current_board_path().read_text(encoding="utf-8").strip() == "alpha"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`/kanban boards switch <slug>` printed "Active board is now X" but had no effect in the running session — the switch only persisted for *new* shells. A subsequent `/kanban list` still showed the old board.

## Root cause

Interactive chat pins `HERMES_KANBAN_BOARD` into `os.environ` at boot (`_pin_kanban_board_for_chat`). `get_current_board()` resolves in priority order:

1. `_CURRENT_BOARD_OVERRIDE` ContextVar
2. `HERMES_KANBAN_BOARD` env var
3. `current` file on disk

`boards switch` only wrote the file (layer 3), so the pinned env var (layer 2) shadowed it for the rest of the session.

## Fix

Introduce `activate_board(slug)` in `kanban_db.py` that:
- Writes `<root>/kanban/current` (future sessions)
- Sets `_CURRENT_BOARD_OVERRIDE` ContextVar (layer 1, highest precedence — the running session picks it up immediately)
- Syncs `HERMES_KANBAN_BOARD` env var (shelled-out `hermes kanban …` calls agree)

Both `_cmd_boards_switch` and `_cmd_boards_create --switch` now call `activate_board()` instead of `set_current_board()`.

## How verified

- **RED**: 3 new regression tests fail on upstream/main (`d430684d7`) — `test_boards_switch_takes_effect_with_env_pinned` fails with `assert alpha == beta`, confirming the env var shadows the file write.
- **GREEN**: all 59 tests pass after the fix (3 new + 56 existing, 0 regressions).
- Re-tested after rebase onto `2d3071f9d` (upstream/main): 59 passed, 0 failed.

## Test summary

```
59 passed, 0 failed in 3.29s
```

New tests:
- `test_boards_switch_takes_effect_with_env_pinned` — switch overrides a pinned env var in-session
- `test_activate_board_overrides_pinned_env` — ContextVar beats pinned env var + env is synced
- `test_activate_board_persists_file` — file on disk is also written for future sessions

## Competitor note

PR #48385 (nuffin) addresses the same symptom by modifying `set_current_board()` directly to set the env var. This PR takes a more complete approach: (1) sets the ContextVar (layer 1, highest precedence, as the issue suggests), (2) does not mutate the shared `set_current_board()` contract, (3) includes regression tests (#48385 has none).

Closes #53180.

---
Auto-published by Moonsong via Path B automated pipeline.