### PR TITLE
fix(security): extend gateway-lifecycle guard to launchctl and pidof kills

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1121,6 +1121,61 @@ class TestPgrepKillExpansion:
         dangerous, _, _ = detect_dangerous_command(cmd)
         assert dangerous is False
 
+    def test_kill_dollar_pidof_detected(self):
+        """`kill $(pidof hermes)` is the BSD/Linux equivalent of the
+        pgrep expansion and bypasses the pkill/killall name pattern
+        in the same way. See issue #33071."""
+        cmd = "kill -TERM $(pidof hermes_cli.main)"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "pidof" in desc.lower() or "pgrep" in desc.lower()
+
+    def test_kill_backtick_pidof_detected(self):
+        cmd = "kill -9 `pidof hermes`"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+
+class TestLaunchctlGatewayLifecycle:
+    """launchctl stop/kickstart/bootout/unload against the Hermes service
+    label achieves the same effect as `hermes gateway stop|restart` and
+    must require the same approval. See issue #33071.
+    """
+
+    def test_launchctl_stop_hermes_detected(self):
+        cmd = "launchctl stop ai.hermes.gateway"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "launchd" in desc.lower() or "hermes" in desc.lower()
+
+    def test_launchctl_kickstart_hermes_detected(self):
+        cmd = "launchctl kickstart -k system/ai.hermes.gateway"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_launchctl_bootout_hermes_detected(self):
+        cmd = "launchctl bootout system/ai.hermes.gateway"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_launchctl_unload_hermes_detected(self):
+        cmd = "launchctl unload ~/Library/LaunchAgents/ai.hermes.gateway.plist"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_launchctl_print_unrelated_not_flagged(self):
+        """Read-only inspection of an unrelated launchd label must stay safe."""
+        cmd = "launchctl print system/com.apple.WindowServer"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    def test_launchctl_stop_unrelated_not_flagged(self):
+        """`launchctl stop` on a non-Hermes label is out of scope for the
+        gateway-lifecycle guard."""
+        cmd = "launchctl stop com.example.unrelated"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is False
+
 
 class TestGitDestructiveOps:
     """git reset --hard, push --force, clean -f, branch -D can destroy

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -443,8 +443,15 @@ DANGEROUS_PATTERNS = [
     # The name-based pattern above catches `pkill hermes` but not
     # `kill -9 $(pgrep -f hermes)` because the substitution is opaque
     # to regex at detection time. Catch the structural pattern instead.
-    (r'\bkill\b.*\$\(\s*pgrep\b', "kill process via pgrep expansion (self-termination)"),
-    (r'\bkill\b.*`\s*pgrep\b', "kill process via backtick pgrep expansion (self-termination)"),
+    # `pidof` is the BSD/Linux alternative to `pgrep` and is equally
+    # opaque, so include it in the same alternation.
+    (r'\bkill\b.*\$\(\s*(pgrep|pidof)\b', "kill process via pgrep/pidof expansion (self-termination)"),
+    (r'\bkill\b.*`\s*(pgrep|pidof)\b', "kill process via backtick pgrep/pidof expansion (self-termination)"),
+    # launchctl-driven gateway stop/restart on macOS. The agent can bypass
+    # the `hermes gateway stop|restart` pattern above by driving launchd
+    # directly against the service label (commonly `ai.hermes.gateway`).
+    # Catch the operations that stop, restart, or unload it.
+    (r'\blaunchctl\s+(stop|kickstart|bootout|unload|kill|disable|remove)\b.*\b(hermes|ai\.hermes)\b', "stop/restart hermes launchd service (kills running agents)"),
     # File copy/move/edit into sensitive system paths (/etc/ and macOS
     # /private/etc/ mirror).
     (rf'\b(cp|mv|install)\b.*\s{_SYSTEM_CONFIG_PATH}', "copy/move file into system config path"),


### PR DESCRIPTION
## Summary
Closes two gateway-lifecycle approval bypasses on #33071. The dangerous-command guard already blocks `hermes gateway stop|restart`, `pkill/killall hermes`, `kill $(pgrep …)`, and `systemctl stop|restart`, but an agent could still stop/restart the gateway via `launchctl` against the service label or by swapping `pidof` for `pgrep` in the kill-expansion form.

## Changes
- `tools/approval.py`: widen the gateway-lifecycle block —
  - `kill … $(pgrep …)` / backtick form extended to `(pgrep|pidof)` (pidof is the BSD/Linux equivalent, equally opaque to the name pattern).
  - new `launchctl (stop|kickstart|bootout|unload|kill|disable|remove) … (hermes|ai.hermes)` pattern. Read-only `launchctl print`/`list` and operations on unrelated labels stay unflagged.
- `tests/tools/test_approval.py`: +55 lines covering the pidof expansion, the launchctl vectors, and negative cases (unrelated labels, read-only inspection).

## Validation
Real `detect_dangerous_command(...)`:

| Command | Result |
|---|---|
| `kill -TERM $(pidof hermes_cli.main)` | BLOCK |
| `launchctl stop ai.hermes.gateway` | BLOCK |
| `launchctl kickstart -k system/ai.hermes.gateway` | BLOCK |
| `kill -9 $(pgrep -f hermes)` (existing) | BLOCK |
| `kill 12345` (literal PID) | allow (intentional) |
| `launchctl print …` / `launchctl stop com.example.unrelated` | allow |
| `pidof hermes` (read-only) | allow |

`scripts/run_tests.sh tests/tools/test_approval.py` → 238/238 passing.

**Out of scope (by design):** plain `kill -TERM <numeric_pid>` with a PID resolved out-of-band. Catching that needs runtime gateway-PID state and would break the `test_safe_kill_pid_not_flagged` contract (a literal-PID `kill 12345` must stay safe). The guard is command-pattern based, not PID based — and a determined agent has many equivalents (`os.kill`, scripts), so the real protection remains the supervised gateway auto-restarting. This PR closes the catchable string-level vectors.

Cherry-picked from #33084 by @briandevans (authorship preserved); the contributor already documented the numeric-PID exclusion and its rationale in the commit message.

Fixes #33071

## Infographic

![gateway-lifecycle-guard](https://v3b.fal.media/files/b/0a9fe060/0gQwan_AZ__L81DlrZaqJ_R3NmWLGq.png)