### PR TITLE
fix(gateway/telegram): reuse live adapter Bot in send_message to prevent polling conflict

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -399,6 +399,18 @@ def _rich_normalize_linebreaks(text: str) -> str:
     return ''.join(out)
 
 
+# Registry of live TelegramAdapter instances keyed by bot token.
+# Allows send_message_tool.py to reuse the gateway's connected Bot
+# instead of creating a competing standalone instance that would
+# conflict with polling (get_updates) on the same token.
+_LIVE_ADAPTERS: Dict[str, 'TelegramAdapter'] = {}
+
+
+def get_telegram_live_adapter(token: str) -> 'Optional[TelegramAdapter]':
+    """Return the live TelegramAdapter for a token, or None if not connected."""
+    return _LIVE_ADAPTERS.get(token)
+
+
 class TelegramAdapter(BasePlatformAdapter):
     """
     Telegram bot adapter.
@@ -2575,6 +2587,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             
             self._mark_connected()
+            _LIVE_ADAPTERS[self.config.token] = self
             mode = "webhook" if self._webhook_mode else "polling"
             logger.info("[%s] Connected to Telegram (%s mode)", self.name, mode)
 
@@ -2646,6 +2659,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         """Stop polling/webhook, cancel pending album flushes, and disconnect."""
+        _LIVE_ADAPTERS.pop(self.config.token, None)
         # Cancel the heartbeat before tearing down the app so the probe task
         # cannot fire get_me() into a half-shutdown bot client.
         if self._polling_heartbeat_task and not self._polling_heartbeat_task.done():

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1010,30 +1010,43 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 formatted = message
             send_parse_mode = ParseMode.MARKDOWN_V2
 
-        # Honour a configured proxy (telegram.proxy_url in config.yaml, exported
-        # as TELEGRAM_PROXY env var by load_gateway_config). Without this, the
-        # standalone send path bypasses the proxy and times out in regions
-        # where api.telegram.org is blocked. The in-gateway adapter does the
-        # same thing in gateway/platforms/telegram.py.
+        # Try to reuse the gateway's live Bot to avoid polling conflicts.
+        # The live adapter already has proxy configured in connect().
+        # Fall back to a standalone Bot when gateway is not running.
         try:
-            from gateway.platforms.base import resolve_proxy_url
-            _tg_proxy = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org"])
-        except Exception:
-            _tg_proxy = None
-        if _tg_proxy:
-            try:
-                from telegram.request import HTTPXRequest
-                logger.info("send_message: standalone Telegram send routed through proxy %s", _tg_proxy)
-                bot = Bot(
-                    token=token,
-                    request=HTTPXRequest(proxy=_tg_proxy),
-                    get_updates_request=HTTPXRequest(proxy=_tg_proxy),
-                )
-            except Exception as _proxy_err:
-                logger.warning("send_message: failed to attach Telegram proxy (%s), falling back to direct connection", _proxy_err)
-                bot = Bot(token=token)
+            from plugins.platforms.telegram.adapter import get_telegram_live_adapter
+            _live = get_telegram_live_adapter(token)
+        except ImportError:
+            _live = None
+
+        if _live is not None and _live._bot is not None:
+            bot = _live._bot
+            logger.debug('Reusing live Telegram adapter Bot for send')
         else:
-            bot = Bot(token=token)
+            # Honour a configured proxy (telegram.proxy_url in config.yaml, exported
+            # as TELEGRAM_PROXY env var by load_gateway_config). Without this, the
+            # standalone send path bypasses the proxy and times out in regions
+            # where api.telegram.org is blocked. The in-gateway adapter does the
+            # same thing in gateway/platforms/telegram.py.
+            try:
+                from gateway.platforms.base import resolve_proxy_url
+                _tg_proxy = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org"])
+            except Exception:
+                _tg_proxy = None
+            if _tg_proxy:
+                try:
+                    from telegram.request import HTTPXRequest
+                    logger.info("send_message: standalone Telegram send routed through proxy %s", _tg_proxy)
+                    bot = Bot(
+                        token=token,
+                        request=HTTPXRequest(proxy=_tg_proxy),
+                        get_updates_request=HTTPXRequest(proxy=_tg_proxy),
+                    )
+                except Exception as _proxy_err:
+                    logger.warning("send_message: failed to attach Telegram proxy (%s), falling back to direct connection", _proxy_err)
+                    bot = Bot(token=token)
+            else:
+                bot = Bot(token=token)
         int_chat_id = int(chat_id)
         media_files = media_files or []
         thread_kwargs = {}


### PR DESCRIPTION
﻿## What

Fixes a timeout issue when sending media via \send_message\ tool while the Telegram gateway is in polling mode.

## Related Issue

When the Telegram gateway uses polling mode, both the polling Bot (in \TelegramAdapter\) and the sending Bot (in \_send_telegram\) call \get_updates()\ simultaneously. This causes send operations to timeout because the polling Bot is consuming updates that the sending Bot needs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added \_LIVE_ADAPTERS\ registry in \plugins/platforms/telegram/adapter.py\ to track active \TelegramAdapter\ Bot instances
- Added \get_telegram_live_adapter(token)\ function to retrieve a live adapter's Bot for reuse
- Register adapter in \connect()\, unregister in \disconnect()\
- Updated \_send_telegram()\ in \	ools/send_message_tool.py\ to use \get_telegram_live_adapter()\ first, falling back to standalone \Bot(token)\ if no live adapter exists

This pattern is identical to the WeChat fix (commit \5ca52bae\): "split poll/send sessions, reuse live adapter for cron & send_message"

## How to Test

1. Start the gateway with Telegram polling enabled (\	elegram.polling=true\)
2. Use \send_message\ to send a photo or media to a Telegram chat
3. **Before fix**: Times out after 60 seconds with \Conflict: Resource not found\ or similar
4. **After fix**: Message sends successfully within seconds using the live polling Bot

## Related Issues

- [#29325](https://github.com/NousResearch/hermes-agent/issues/29325)
- [#40691](https://github.com/NousResearch/hermes-agent/issues/40691)

**Supersedes:** #13003 and #53174 (both had merge conflicts)
