### PR TITLE
fix(agent): silence verification-stop loop status line

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4694,7 +4694,11 @@ def run_conversation(
                         "_verification_stop_synthetic": True,
                     })
                     agent._session_messages = messages
-                    agent._emit_status("↻ Verification required before finishing")
+                    # Run the verification-stop loop silently — the nudge is an
+                    # internal turn that should not add noise to the user's
+                    # terminal. Keep a debug breadcrumb in agent.log for tracing.
+                    logger.debug("verification stop-loop nudge issued (attempt %d)",
+                                 agent._verification_stop_nudges)
                     continue
 
                 messages.append(final_msg)


### PR DESCRIPTION
## Summary
The verify-on-stop loop no longer prints to your terminal.

PR #52296 added a turn-end guard that, whenever you edit code without fresh passing verification evidence, loops the model once more to nudge it to run tests/lint/build first. It also emitted `↻ Verification required before finishing` to the terminal on every nudge — noise in CLI and gateway sessions. This demotes that emit to a `logger.debug` breadcrumb in `agent.log`. The guard itself is unchanged: it still nudges, still bounded to 2 attempts.

## Changes
- `agent/conversation_loop.py`: replace `_emit_status("↻ Verification required before finishing")` with a silent `logger.debug` in the verification-stop branch.

## Validation
| | Before | After |
|---|---|---|
| Terminal output on nudge | `↻ Verification required before finishing` | (silent; debug line in agent.log) |
| Loop behavior | nudges + continues | unchanged |
| `tests/agent/test_verification_stop.py` + `tests/run_agent/test_file_mutation_verifier.py` | — | 69/69 pass |

## Infographic

![silent-verification-stop](https://v3b.fal.media/files/b/0a9fe0d3/L0te8J0L0dSe0rvghwJSj_ANDcDxnh.png)
