### PR TITLE
fix(skills): background review fork respects pinned skills

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -912,6 +912,67 @@ class TestExternalSkillMutations:
         assert "OLD_MARKER" in (skill_dir / "SKILL.md").read_text()
         assert "NEW_MARKER" not in (skill_dir / "SKILL.md").read_text()
 
+    def test_background_review_refuses_to_patch_pinned_skill(self, tmp_path):
+        """#25839: the autonomous review fork respects pin like the curator
+        does — a pinned skill is off-limits to background maintenance, even
+        for patch/edit (which a foreground user-directed call is allowed to
+        perform). Without a user in the loop there is no one to consent."""
+        from tools.skill_provenance import (
+            BACKGROUND_REVIEW,
+            reset_current_write_origin,
+            set_current_write_origin,
+        )
+
+        def _fake_get_record(skill_name):
+            return {"pinned": True} if skill_name == "my-skill" else {"pinned": False}
+
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            token = set_current_write_origin(BACKGROUND_REVIEW)
+            try:
+                with patch("tools.skill_usage.get_record", side_effect=_fake_get_record):
+                    raw = skill_manage(
+                        action="patch",
+                        name="my-skill",
+                        old_string="Do the thing.",
+                        new_string="Do the new thing.",
+                    )
+            finally:
+                reset_current_write_origin(token)
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "pinned" in result["error"].lower()
+
+    def test_background_review_unpinned_skill_not_blocked_by_pin_guard(self, tmp_path):
+        """The pin guard must not over-block: an unpinned agent-owned skill is
+        still writable by the review fork."""
+        from tools.skill_provenance import (
+            BACKGROUND_REVIEW,
+            reset_current_write_origin,
+            set_current_write_origin,
+        )
+
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            token = set_current_write_origin(BACKGROUND_REVIEW)
+            try:
+                with patch(
+                    "tools.skill_usage.get_record",
+                    side_effect=lambda n: {"pinned": False},
+                ):
+                    raw = skill_manage(
+                        action="patch",
+                        name="my-skill",
+                        old_string="Do the thing.",
+                        new_string="Do the new thing.",
+                    )
+            finally:
+                reset_current_write_origin(token)
+
+        result = json.loads(raw)
+        assert result["success"] is True
+
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -254,6 +254,27 @@ def _background_review_write_guard(
     except Exception:
         return None
 
+    # Pin must be respected by autonomous maintenance. The curator already
+    # skips pinned skills from every auto-transition; the background review
+    # fork is the same kind of autonomous, no-user-present actor, so it must
+    # not write to a pinned skill either (issue #25839). This is stricter than
+    # the foreground ``_pinned_guard`` (which only blocks deletion) precisely
+    # because there is no user in the loop to consent to an edit here.
+    try:
+        from tools import skill_usage
+        if skill_usage.get_record(name).get("pinned"):
+            return {
+                "success": False,
+                "error": (
+                    f"Refusing background curator {action} for pinned skill "
+                    f"'{name}': pinned skills are off-limits to autonomous "
+                    "maintenance. Ask the user to run "
+                    f"`hermes curator unpin {name}` if they want it changed."
+                ),
+            }
+    except Exception:
+        logger.debug("pinned skill guard lookup failed for %s", name, exc_info=True)
+
     try:
         from agent.skill_utils import is_external_skill_path
         if is_external_skill_path(skill_dir):


### PR DESCRIPTION
## Summary
The background self-improvement review fork now respects pinned skills, matching the curator. Previously a user-pinned skill could still be edited by the autonomous review fork — the guard only blocked external / bundled / hub-installed / protected-builtin skills, not pinned agent-owned ones.

Root cause: `_background_review_write_guard` in `tools/skill_manager_tool.py` checked ownership classes but never the pin flag. The curator skips pinned skills from every auto-transition; the review fork is the same kind of no-user-present actor and should too. This was the second concrete ask in #25839 (the first — stop forging `role: "user"` for review prompts — was already addressed: the review prompt is the fork's own user turn, gated by a memory/skills-only tool whitelist plus write-origin provenance).

## Changes
- `tools/skill_manager_tool.py`: add a pin check to `_background_review_write_guard`, so background-origin `edit`/`patch`/`delete`/`write_file`/`remove_file` on a pinned skill are refused. Deliberately stricter than the foreground `_pinned_guard` (which only blocks delete) — with no user in the loop there is no one to consent to an edit.
- `tests/tools/test_skill_manager_tool.py`: background-review patch on a pinned skill is refused; an unpinned skill is NOT over-blocked.

## Validation
| Origin | Skill | Action | Result |
|---|---|---|---|
| background_review | pinned | patch/edit | **refused** |
| background_review | unpinned | patch | allowed |
| foreground | pinned | patch/edit | allowed (unchanged) |
| foreground | pinned | delete | refused (unchanged) |

`scripts/run_tests.sh tests/tools/test_skill_manager_tool.py tests/tools/test_skill_provenance.py` → 103/103 passing.

Scope note: this addresses the pin-respect gap. The broader "gate all background-review skill writes behind approval" lever already exists as opt-in (`skills.write_approval`, default off) — left as-is since flipping that default is a separate product decision.

Reported by @xlionjuan (via their agent Kuri) in #25839.

Fixes #25839

## Infographic

![review-fork-pin](https://v3b.fal.media/files/b/0a9fe13c/GGiMZNy35Z9flFcxE3Pey_cNFLV9dn.png)