### PR TITLE
fix(whatsapp): pass Baileys quoted reply text to the agent

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1229,14 +1229,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if data.get("isGroup"):
                 body = self._clean_bot_mention_text(body, data)
 
-            # If this is a reply, include the quoted message text so the agent
-            # knows exactly what the user is responding to (fixes "approve" context issue)
+            # If this is a reply, preserve the quoted text on MessageEvent so
+            # gateway/run.py can inject a standard, platform-agnostic
+            # "[Replying to: ...]" disambiguation prefix.  Do not splice it
+            # into body here: doing that bypasses reply_to_is_own_message and
+            # can duplicate the core injection path.
             quoted_text = str(data.get("quotedText") or "").strip()
-            if quoted_text and data.get("hasQuotedMessage"):
-                # Truncate long quoted text to keep prompts reasonable
-                if len(quoted_text) > 300:
-                    quoted_text = quoted_text[:297] + "..."
-                body = f"[Replying to: \"{quoted_text}\"]\n{body}"
+            quoted_message_id = str(data.get("quotedMessageId") or "").strip() or None
+            quoted_is_own = self._message_is_reply_to_bot(data)
             MAX_TEXT_INJECT_BYTES = 100 * 1024
             if msg_type == MessageType.DOCUMENT and cached_urls:
                 for doc_path in cached_urls:
@@ -1270,6 +1270,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 source=source,
                 raw_message=data,
                 message_id=data.get("messageId"),
+                reply_to_message_id=quoted_message_id,
+                reply_to_text=quoted_text or None,
+                reply_to_is_own_message=quoted_is_own,
                 media_urls=cached_urls,
                 media_types=media_types,
             )

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -166,6 +166,22 @@ function getContextInfo(messageContent) {
   return {};
 }
 
+function extractTextFromMessageContent(messageContent) {
+  const content = getMessageContent({ message: messageContent });
+  if (!content || typeof content !== 'object') return '';
+
+  if (content.conversation) return String(content.conversation);
+  if (content.extendedTextMessage?.text) return String(content.extendedTextMessage.text);
+  if (content.imageMessage?.caption) return String(content.imageMessage.caption);
+  if (content.videoMessage?.caption) return String(content.videoMessage.caption);
+  if (content.documentMessage?.caption) return String(content.documentMessage.caption);
+  if (content.buttonsResponseMessage?.selectedDisplayText) return String(content.buttonsResponseMessage.selectedDisplayText);
+  if (content.listResponseMessage?.title) return String(content.listResponseMessage.title);
+  if (content.templateButtonReplyMessage?.selectedDisplayText) return String(content.templateButtonReplyMessage.selectedDisplayText);
+
+  return '';
+}
+
 mkdirSync(SESSION_DIR, { recursive: true });
 
 // Build LID → phone reverse map from session files (lid-mapping-{phone}.json)
@@ -341,6 +357,7 @@ async function startSocket() {
       const quotedParticipant = normalizeWhatsAppId(contextInfo?.participant || '') || null;
       const quotedRemoteJid = normalizeWhatsAppId(contextInfo?.remoteJid || '') || null;
       const hasQuotedMessage = !!contextInfo?.quotedMessage;
+      const quotedText = extractTextFromMessageContent(contextInfo?.quotedMessage || null);
 
       // Extract message body
       let body = '';
@@ -456,6 +473,7 @@ async function startSocket() {
         quotedParticipant,
         quotedRemoteJid,
         hasQuotedMessage,
+        quotedText,
         botIds,
         timestamp: msg.messageTimestamp,
       };

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -322,15 +322,47 @@ class TestBridgeEventMetadata:
             "quotedParticipant": "99999999999@s.whatsapp.net",
             "quotedRemoteJid": "15551234567@s.whatsapp.net",
             "hasQuotedMessage": True,
+            "quotedText": "please approve invoice 123",
+            "botIds": ["99999999999@s.whatsapp.net"],
         }
 
         event = await adapter._build_message_event(data)
 
         assert event is not None
+        assert event.text == "approved"
+        assert event.reply_to_message_id == "outbound-msg"
+        assert event.reply_to_text == "please approve invoice 123"
+        assert event.reply_to_is_own_message is True
         assert event.raw_message["quotedMessageId"] == "outbound-msg"
         assert event.raw_message["quotedParticipant"] == "99999999999@s.whatsapp.net"
         assert event.raw_message["quotedRemoteJid"] == "15551234567@s.whatsapp.net"
         assert event.raw_message["hasQuotedMessage"] is True
+
+    @pytest.mark.asyncio
+    async def test_quoted_reply_without_text_preserves_id_only(self):
+        adapter = _make_adapter()
+        data = {
+            "messageId": "incoming-msg",
+            "chatId": "15551234567@s.whatsapp.net",
+            "senderId": "15551234567@s.whatsapp.net",
+            "senderName": "Tester",
+            "chatName": "Tester",
+            "isGroup": False,
+            "body": "what about this?",
+            "hasMedia": False,
+            "mediaUrls": [],
+            "quotedMessageId": "old-msg",
+            "quotedParticipant": "15551234567@s.whatsapp.net",
+            "hasQuotedMessage": True,
+        }
+
+        event = await adapter._build_message_event(data)
+
+        assert event is not None
+        assert event.text == "what about this?"
+        assert event.reply_to_message_id == "old-msg"
+        assert event.reply_to_text is None
+        assert event.reply_to_is_own_message is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The Baileys WhatsApp bridge already forwards reply metadata such as `quotedMessageId`, `quotedParticipant`, and `hasQuotedMessage`, and the Python adapter has logic that looks for a `quotedText` field.

However, `scripts/whatsapp-bridge/bridge.js` never populated `quotedText` from Baileys' `contextInfo.quotedMessage`. As a result, replies such as "approve", "ok", or "what about this?" reached the agent without the actual text of the quoted WhatsApp message. The model could see that the incoming message was a reply, but not what it was replying to.

This is the same user-visible class of issue addressed for WhatsApp Cloud in #52957, but on the Baileys/Web bridge path.

## Root cause

Baileys exposes the quoted payload under `contextInfo.quotedMessage`, but the bridge event only serialized:

- `quotedMessageId`
- `quotedParticipant`
- `quotedRemoteJid`
- `hasQuotedMessage`

The downstream adapter therefore had no text to pass into the platform-neutral reply context fields.

## Fix

This PR updates the Baileys bridge and adapter path to preserve quoted reply text using the existing `MessageEvent` reply-context mechanism:

- `scripts/whatsapp-bridge/bridge.js`
  - adds `extractTextFromMessageContent(...)` for quoted Baileys payloads
  - extracts text/captions from common quoted message shapes: conversation, extended text, image/video/document captions, and button/list replies
  - includes `quotedText` in the bridge event

- `plugins/platforms/whatsapp/adapter.py`
  - stops splicing `[Replying to: ...]` directly into `body`
  - populates `MessageEvent.reply_to_message_id`
  - populates `MessageEvent.reply_to_text`
  - populates `MessageEvent.reply_to_is_own_message`

This leaves `gateway/run.py` responsible for the standard reply-context injection path, which keeps the behavior aligned with other platform adapters and avoids duplicating reply-context formatting inside the WhatsApp adapter.

## Tests

Added/extended coverage in `tests/gateway/test_whatsapp_formatting.py` for:

- preserving quoted text in `reply_to_text`
- preserving the quoted message id in `reply_to_message_id`
- preserving the user's actual message body without mutating it
- marking replies to the bot's own messages via `reply_to_is_own_message`
- preserving only the quoted id when Baileys does not provide quoted text

Validation run on a clean worktree rebased on current `origin/main`:

```bash
PYTHONPATH=. /home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_whatsapp_formatting.py tests/gateway/test_whatsapp_group_gating.py -q
```

Result:

```text
54 passed, 2 warnings in 5.14s
```

Additional checks:

```bash
node --check scripts/whatsapp-bridge/bridge.js
git diff --check origin/main..HEAD
```

Both passed.

## Notes / limitations

If Baileys does not include `contextInfo.quotedMessage` for older messages or unsupported message types, Hermes will still preserve the quoted message id, but `reply_to_text` will remain unset. The extractor covers the common text/caption/button/list reply shapes and can be extended for additional WhatsApp message types later.
