### PR TITLE
fix(auxiliary): disable thinking mode for Qwen3/GLM in auxiliary tasks / 辅助任务禁用 Qwen3/GLM 思考模式

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -237,6 +237,56 @@ def _is_arcee_trinity_thinking(model: Optional[str]) -> bool:
     return bare == "trinity-large-thinking"
 
 
+def _is_qwen3_thinking_model(model: Optional[str]) -> bool:
+    """True for Qwen3 family models with built-in thinking mode (e.g. Qwen3-8B,
+    Qwen3.5-14B, Qwen3.6-27B, Qwen3-Coder-Plus).  On vLLM these models always
+    enter thinking mode unless ``chat_template_kwargs`` is set."""
+    bare = (model or "").strip().lower().rsplit("/", 1)[-1]
+    return bare.startswith("qwen3")
+
+
+def _is_glm_thinking_model(model: Optional[str]) -> bool:
+    """True for GLM-4/4.5 models with built-in thinking mode (e.g. glm-4.5-air,
+    glm4.5-chat).  On vLLM these models always enter thinking mode unless the
+    ``thinking`` flag is set to False."""
+    bare = (model or "").strip().lower().rsplit("/", 1)[-1]
+    return bare.startswith("glm-4") or bare.startswith("glm4")
+
+
+def _get_aux_thinking_disable_kwargs(model: Optional[str], provider: str) -> Optional[Dict[str, Any]]:
+    """Return request kwargs to disable thinking for a model on a custom endpoint.
+
+    Auxiliary tasks (title generation, compression, web extraction, etc.) do not
+    need thinking capability — a reasoning model would waste tokens on internal
+    thought instead of producing actual output, resulting in empty ``content``.
+
+    Only applies to ``custom`` provider endpoints (i.e. self-hosted deployments
+    like vLLM) where Hermes has direct control over request parameters.  For
+    OpenRouter and other aggregator backends, thinking is managed via the
+    ``reasoning_config`` mechanism in the main agent transport.
+
+    Returns a dict of kwargs to merge into ``chat.completions.create()``, or
+    ``None`` when no disable is needed.
+
+    Adding a new model/family:
+      1. Identify the disable parameter against your endpoint (e.g. with curl).
+      2. Add an ``_is_*_thinking_model()`` predicate here.
+      3. Add a branch below that returns the model-specific kwargs.
+    """
+    if provider not in {"custom", "auto"}:
+        return None
+    if not model:
+        return None
+
+    if _is_qwen3_thinking_model(model):
+        # vLLM: top-level chat_template_kwargs for Qwen3
+        return {"chat_template_kwargs": {"enable_thinking": False}}
+    if _is_glm_thinking_model(model):
+        # vLLM: top-level thinking boolean for GLM-4/4.5
+        return {"thinking": False}
+    return None
+
+
 # Context window enforced by ChatGPT's Codex OAuth backend for gpt-5.5.
 # The raw OpenAI API and OpenRouter expose 1.05M for the same slug, but the
 # Codex backend hard-caps at 272K (verified live: a ~330K-token request to
@@ -5421,6 +5471,16 @@ def _build_call_kwargs(
         merged_extra.setdefault("tags", []).extend(_nous_portal_tags())
     if merged_extra:
         kwargs["extra_body"] = merged_extra
+
+    # Disable thinking/reasoning for models that enter thinking mode by
+    # default on self-hosted deployments (vLLM, SGLang, etc.).  Auxiliary
+    # tasks do not need thinking capability — a reasoning model would waste
+    # tokens on internal thought instead of producing actual output, and
+    # may return null content.
+    _thinking_kwargs = _get_aux_thinking_disable_kwargs(model, provider)
+    if _thinking_kwargs:
+        for key, value in _thinking_kwargs.items():
+            kwargs.setdefault(key, value)
 
     return kwargs
 

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -87,7 +87,10 @@ def generate_title(
             timeout=timeout,
             main_runtime=main_runtime,
         )
-        title = (response.choices[0].message.content or "").strip()
+        msg = response.choices[0].message
+        # Prefer content; fall back to reasoning field for models that
+        # output thinking despite disable attempts (e.g. Qwen3 in vLLM).
+        title = (msg.content or getattr(msg, "reasoning", None) or "").strip()
         # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
         title = title.strip('"\'')
         if title.lower().startswith("title:"):


### PR DESCRIPTION
## Summary

Auxiliary tasks (title generation, compression, web extraction) fail silently for reasoning-capable models (Qwen3, GLM-4/4.5) deployed via vLLM. The models enter thinking mode by default, outputting all content to the `reasoning` field with `content: null` — causing empty session titles and wasted tokens.

This adds per-model thinking disable logic to the auxiliary client, gated to `custom`/`auto` provider endpoints only (self-hosted deployments). Aggregator endpoints (OpenRouter) are unaffected.

---

## 问题

辅助任务（标题生成、上下文压缩、网页提取）在 vLLM 部署的推理模型（Qwen3、GLM-4/4.5）上静默失败。模型默认进入思考模式，将所有内容输出到 `reasoning` 字段，`content` 为 null——导致会话标题为空、token 浪费在思考上。

---

## Root cause / 根因

1. Qwen3/GLM-4 系列模型在 vLLM 上默认启用 thinking 模式
2. 辅助请求没有传禁用 thinking 的参数
3. 模型把 token 全花在 `reasoning` 字段上，`content` 返回 null
4. `title_generator.py` 只读 `content`，得到空字符串后静默放弃

---

## Changes / 改动

### 1. Model predicates (auxiliary_client.py)

Follows Hermes existing pattern (`_is_kimi_model`, `_is_arcee_trinity_thinking`):
- `_is_qwen3_thinking_model(model)` — matches `qwen3*` slug prefix
- `_is_glm_thinking_model(model)` — matches `glm-4*` / `glm4*` slug prefix

### 2. `_get_aux_thinking_disable_kwargs(model, provider)`

Returns model-specific disable kwargs:
- Qwen3 (vLLM): `chat_template_kwargs: {enable_thinking: False}`
- GLM-4/4.5 (vLLM): `thinking: False`

**Provider-gated**: only applies when `provider` is `custom` or `auto`. Aggregator endpoints (OpenRouter, Nous) are not affected — they manage thinking via `reasoning_config` in the main transport.

### 3. Auto-inject in `_build_call_kwargs()`

Disable kwargs merged into every auxiliary request for registered models. Non-thinking models pass through unchanged.

### 4. Defensive fallback in `title_generator.py`

If `content` is null, fall back to `reasoning` field. Safety net for models where thinking cannot be fully suppressed.

---

## Design decisions / 设计决策

| Decision | Rationale |
|----------|-----------|
| Function predicates, not registry | Consistent with `_is_kimi_model()`, `_is_arcee_trinity_thinking()` pattern |
| Provider-gated (`custom`/`auto` only) | Only self-hosted deployments need framework-specific params; aggregators handle thinking differently |
| All auxiliary tasks affected | No auxiliary task needs thinking capability; it only wastes tokens and produces null content |
| `chat_template_kwargs` at top level | vLLM reads it from top-level request body, not extra_body |

---

## Adding a new model

1. Identify the disable parameter against your endpoint (e.g. with curl)
2. Add an `_is_*_thinking_model()` predicate
3. Add a branch in `_get_aux_thinking_disable_kwargs()` returning the kwargs

---

## Testing / 验证

```
Before: content=null, reasoning="Here's a thinking process...", finish=length (0.7s)
After:  content="通过公募持仓变化研究股票价值", reasoning=null, finish=stop (0.34s)
```

Verified against local vLLM deployment of Qwen3.6-27B with `chat_template_kwargs={enable_thinking: False}`.

**Provider gating verified**:
- `Qwen3.6-27B` on `custom` → disable kwargs injected ✓
- `Qwen3.6-27B` on `openrouter` → NOT injected ✓
- `Qwen3.6-27B` on `auto` → injected ✓
- `gpt-4o` on `custom` → NOT injected ✓

---

## Files modified / 修改文件

- `agent/auxiliary_client.py` — predicates + injection (50 lines added)
- `agent/title_generator.py` — reasoning fallback (4 lines changed)