### PR TITLE
fix(hermes): heal managed Node when a sibling tool (npm/npx) is missing, not only broken

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -438,17 +438,28 @@ def find_hermes_node_executable(command: str) -> str | None:
     """Return a Hermes-managed Node/npm executable path, healing broken trees."""
     names = _candidate_node_command_names(command)
     broken_present = False
+    found_present = False
     for directory in iter_hermes_node_dirs():
         for name in names:
             candidate = directory / name
             if candidate.is_file() and (
                 sys.platform == "win32" or os.access(candidate, os.X_OK)
             ):
+                found_present = True
                 resolved = str(candidate)
                 if node_tool_runnable(resolved):
                     return resolved
                 broken_present = True
-    if broken_present and heal_hermes_managed_node():
+    # Heal when the requested tool is present-but-broken, OR entirely missing
+    # while the managed tree is otherwise present (a sibling tool such as
+    # ``node`` survives). A self-update clobber (``npm i -g npm``), partial
+    # symlink cleanup, or interrupted zip extraction can delete ``npm``/``npx``
+    # while leaving ``node`` behind — both are partial-tree states that
+    # heal_hermes_managed_node() repairs by redownloading the full tarball.
+    needs_heal = broken_present or (
+        not found_present and hermes_managed_node_tree_present()
+    )
+    if needs_heal and heal_hermes_managed_node():
         for directory in iter_hermes_node_dirs():
             for name in names:
                 candidate = directory / name

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -259,6 +259,38 @@ class TestNodeToolRunnable:
         assert resolved == str(broken_npm)
         assert resolved != str(system_bin / "npm")
 
+    def test_missing_managed_npm_heals_when_node_still_runs(self, tmp_path, monkeypatch):
+        """npm can be entirely absent (self-update clobber / partial extract)
+        while a sibling managed node survives — heal must still fire."""
+        profile_home = tmp_path / "profiles" / "assistant"
+        managed_bin = profile_home / "node" / "bin"
+        managed_bin.mkdir(parents=True)
+        # Healthy managed node, but NO managed npm file at all.
+        self._stub(managed_bin, "node", "#!/bin/sh\necho '22.0.0'\nexit 0\n")
+        healed_npm = managed_bin / "npm"
+        heal_called = {"value": False}
+
+        system_bin = tmp_path / "system-bin"
+        system_bin.mkdir()
+        self._stub(system_bin, "npm", "#!/bin/sh\necho '11.10.0'\nexit 0\n")
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setenv("PATH", str(system_bin))
+        monkeypatch.setattr(hermes_constants, "_managed_node_heal_attempted", False)
+
+        def _heal():
+            heal_called["value"] = True
+            healed_npm.write_text("#!/bin/sh\necho '22.0.0'\nexit 0\n")
+            healed_npm.chmod(0o755)
+            return True
+
+        monkeypatch.setattr(hermes_constants, "heal_hermes_managed_node", _heal)
+
+        resolved = find_node_executable("npm")
+        assert heal_called["value"] is True
+        assert resolved == str(healed_npm)
+        assert resolved != str(system_bin / "npm")
+
     def test_broken_managed_npm_heals_instead_of_path_fallback(self, tmp_path, monkeypatch):
         profile_home = tmp_path / "profiles" / "assistant"
         managed_bin = profile_home / "node" / "bin"


### PR DESCRIPTION
## What does this PR do?

Direct sibling follow-up to the just-landed managed-Node healing commits (`65be0061e`, `9274f73e4`, `3c5bcd3ee`).

**Problem:** When managed `npm`/`npx` goes missing while managed `node` survives — a self-update clobber (`npm i -g npm`), partial symlink cleanup, or an interrupted Windows zip extraction — `find_node_executable("npm")` returns `None` and every caller (WhatsApp bridge deps, web-UI build, `hermes update` Node refresh) hard-fails with the misleading `✗ npm not found on PATH — install Node.js first`, despite a healthy system npm on PATH and with no auto-recovery.

**Root cause:** `find_hermes_node_executable` only set `broken_present=True` inside the `candidate.is_file()` branch — i.e. heal fired *only* when the requested tool's file was present-but-broken. When the file was entirely absent, `broken_present` stayed `False`, heal never ran, and the function returned `None`. `find_node_executable` then suppressed the PATH fallback because `hermes_managed_node_tree_present()` was still `True` (managed `node` exists).

**Fix:** track whether any runnable candidate file was located and trigger heal when the managed tree is present but no runnable candidate for the requested tool was found — both broken-present and missing-while-sibling-present are partial-tree states that `heal_hermes_managed_node()` repairs by redownloading the full tarball. The existing once-per-process `_managed_node_heal_attempted` guard prevents repeated downloads.

## Related Issue

Sibling follow-up to `65be0061e` / `9274f73e4` / `3c5bcd3ee` (no separate issue).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_constants.py` — `find_hermes_node_executable` now heals when the managed tree is present but no runnable candidate for the requested tool exists (missing-while-sibling-present), not only when the file is present-but-broken.
- `tests/test_hermes_constants.py` — new regression `test_missing_managed_npm_heals_when_node_still_runs`.

## How to Test

1. Managed `node` healthy under `$HERMES_HOME/node/bin`, no managed `npm` file, a healthy system `npm` on PATH.
2. Before this fix: `find_node_executable("npm")` returns `None`, heal is never invoked.
3. After this fix: heal fires, materializes a runnable managed npm, and `find_node_executable("npm")` returns the managed npm.
4. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/test_hermes_constants.py -q` — 66 passed. The new test FAILS before the prod change (heal not called) and PASSES after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A