### PR TITLE
fix(skills-hub): apply provider filter before the per-source limit truncates the catalog in unified_search

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1757,6 +1757,44 @@ class TestProviderFilter:
         results = unified_search("cuda", [src], source_filter="nvidia", limit=25)
         assert [r.identifier for r in results] == ["NVIDIA/skills/cuda"]
 
+    def test_unified_search_provider_filter_survives_per_source_limit(self):
+        # Real HermesIndexSource (not a MagicMock that returns a fixed list
+        # regardless of `limit`): the provider's matching skills sit past the
+        # default top-50, so a search path that lets the index truncate to 50
+        # before applying the provider filter returns nothing. 55 non-NVIDIA
+        # matches first, then 5 NVIDIA matches at index positions 55-59 — all
+        # match "cuda" only in their description (same relevance score), so the
+        # stable index-order tiebreaker keeps the NVIDIA entries outside the
+        # first 50 ranked rows.
+        from tools.skills_hub import HermesIndexSource
+
+        skills = [
+            {"name": f"thing-{i}", "description": "mentions cuda toolkit",
+             "source": "clawhub", "identifier": f"clawhub/thing-{i}", "tags": []}
+            for i in range(55)
+        ]
+        for i in range(5):
+            skills.append({
+                "name": f"gpu-helper-{i}",
+                "description": "mentions cuda toolkit",
+                "source": "github",
+                "identifier": f"NVIDIA/skills/skills/gpu-helper-{i}",
+                "tags": [],
+                "extra": {"provider": "NVIDIA"},
+            })
+
+        src = HermesIndexSource(auth=GitHubAuth())
+        src._index = {"skills": skills}
+        src._loaded = True
+
+        with patch.object(HermesIndexSource, "is_available",
+                          property(lambda self: True)):
+            results = unified_search("cuda", [src], source_filter="nvidia",
+                                     limit=25)
+
+        ids = {r.identifier for r in results}
+        assert ids == {f"NVIDIA/skills/skills/gpu-helper-{i}" for i in range(5)}
+
 
 # ---------------------------------------------------------------------------
 # append_audit_log

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3964,17 +3964,26 @@ def parallel_search_sources(
 def unified_search(query: str, sources: List[SkillSource],
                    source_filter: str = "all", limit: int = 10) -> List[SkillMeta]:
     """Search all sources (in parallel) and merge results."""
+    # A provider filter (nvidia/openai/...) narrows the merged set AFTER the
+    # search, so the index must hand back its full candidate pool — not just its
+    # default top-50 — or matching provider skills ranked below position 50 are
+    # truncated away before the filter ever sees them. Mirror ``do_browse``,
+    # which already passes a generous ``hermes-index`` limit for exactly this
+    # reason. The final ``deduped[:limit]`` still bounds user-visible rows.
+    _is_provider = source_filter.strip().lower() in _PROVIDER_FILTER_VALUES
+    per_source_limits = {"hermes-index": 1_000_000} if _is_provider else None
     all_results, _, _ = parallel_search_sources(
         sources,
         query=query,
         source_filter=source_filter,
+        per_source_limits=per_source_limits,
         overall_timeout=30,
     )
 
     # A provider filter (nvidia/openai/...) is applied here, on the merged set,
     # because it targets the per-tap ``extra.provider`` label rather than a real
     # source id (the runtime index stores every GitHub tap as source="github").
-    if source_filter.strip().lower() in _PROVIDER_FILTER_VALUES:
+    if _is_provider:
         all_results = _filter_results_by_provider(all_results, source_filter)
 
     # Deduplicate by identifier, preferring higher trust levels.


### PR DESCRIPTION
## What does this PR do?

Runtime-mirror follow-up to the just-landed per-tap provider search (`3d735fe15`, #53191).

**Problem:** `hermes skills search <query> --source <provider>` (and `--json`) returns empty/under-filled whenever the provider's matching skills don't rank in the global top-50 — the common case for a niche provider against an ~86k-entry catalog, and the exact headline use case #53191 added. It works in `browse`, broken in `search`.

**Root cause:** `unified_search` called `parallel_search_sources` without `per_source_limits`, so the `hermes-index` source used its default `lim = per_source_limits.get(src.source_id(), 50)` and returned only its global top-50 ranked rows. `_filter_results_by_provider` then narrowed *that pre-truncated 50-row slice*, so provider skills ranked below position 50 were dropped before the filter ever saw them. The browse path (`do_browse`) already passes a generous `{"hermes-index": ...}` per-source limit precisely to avoid this; the search path was never given the same treatment.

**Fix:** when a provider filter is active, pass a generous `hermes-index` per-source limit so the filter sees the full candidate pool (mirrors `do_browse`). The final `deduped[:limit]` still bounds user-visible rows, so this only widens the pre-filter pool, not the output.

## Related Issue

Runtime-mirror follow-up to `3d735fe15` (#53191); no separate issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_hub.py` — `unified_search` now passes `{"hermes-index": 1_000_000}` as `per_source_limits` when a provider filter is active, so the provider filter narrows the full candidate pool instead of a default 50-row slice.
- `tests/tools/test_skills_hub.py` — new regression `test_unified_search_provider_filter_survives_per_source_limit`.

## How to Test

1. Real `HermesIndexSource` pre-loaded with 55 non-NVIDIA + 5 NVIDIA-provider skills all matching `"cuda"`, the NVIDIA ones at index positions 55-59 (outside the global top-50).
2. Before this fix: `unified_search("cuda", [src], source_filter="nvidia", limit=25)` returns `[]` (index truncated to 50 before the provider filter).
3. After this fix: it returns all 5 NVIDIA identifiers (generous index limit lets all 60 reach the filter).
4. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/tools/test_skills_hub.py tests/hermes_cli/test_skills_hub.py -q` — all pass. The new test FAILS before the prod change and PASSES after. Note: the existing sibling test mocks `search` to return a fixed 2-item list regardless of `limit`, which masks this bug — the new test uses a real index to exercise the truncation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A