### PR TITLE
fix(compression): break infinite loop when aux model context < session size (#53008)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -741,6 +741,7 @@ class ContextCompressor(ContextEngine):
         self._summary_failure_cooldown_until = 0.0  # transient errors must not block a fresh session
         self._last_summary_error = None
         self._last_compress_aborted = False
+        self._aux_context_overflow_warned = False
         self.last_real_prompt_tokens = 0
         self.last_compression_rough_tokens = 0
         self.last_rough_tokens_when_real_prompt_fit = 0
@@ -777,6 +778,7 @@ class ContextCompressor(ContextEngine):
         self._last_compression_made_progress = False
         self._summary_failure_cooldown_until = 0.0
         self._last_compress_aborted = False
+        self._aux_context_overflow_warned = False
         self._context_probed = False
         self._context_probe_persistable = False
         self.last_real_prompt_tokens = 0
@@ -950,6 +952,7 @@ class ContextCompressor(ContextEngine):
         self._ineffective_compression_count = 0
         self._verify_compaction_cleared_threshold = False
         self._last_compression_made_progress = False
+        self._aux_context_overflow_warned = False
 
     # When the MINIMUM_CONTEXT_LENGTH floor meets/exceeds a small context
     # window, compacting at the percentage (50% → 32K of a 64K window) wastes
@@ -1129,6 +1132,9 @@ class ContextCompressor(ContextEngine):
         self.awaiting_real_usage_after_compression = False
 
         self.summary_model = summary_model_override or ""
+        # Call-scoped override used when an oversized compression window must
+        # bypass auxiliary.compression config and use the main runtime.
+        self._force_main_summary_runtime: bool = False
         self._session_db: Any = None
         self._session_id: str = ""
 
@@ -1143,6 +1149,13 @@ class ContextCompressor(ContextEngine):
         # Lets the boundary wrapper distinguish a completed rewrite from a
         # no-op/abort without inferring progress from message-list length.
         self._last_compression_made_progress: bool = False
+        # Aux compression model's context length, set by
+        # check_compression_model_feasibility().  When the compression
+        # window exceeds this, compress() proactively falls back to the
+        # main model instead of sending content the aux model cannot
+        # process.  (#53008)
+        self._aux_compression_context_length: int = 0
+        self._aux_context_overflow_warned: bool = False
         self._summary_failure_cooldown_until: float = 0.0
         self._last_summary_error: Optional[str] = None
         # When summary generation fails and a static fallback is inserted,
@@ -2011,7 +2024,18 @@ This compaction should PRIORITISE preserving all information related to the focu
                 # fall back to the model's native output ceiling.
                 # timeout resolved from auxiliary.compression.timeout config by call_llm
             }
-            if self.summary_model:
+            if getattr(self, "_force_main_summary_runtime", False):
+                # Explicit values must win over auxiliary.compression config.
+                # Merely omitting ``model`` would let call_llm resolve the same
+                # undersized auxiliary model again from config.yaml.
+                call_kwargs.update({
+                    "provider": self.provider or "auto",
+                    "model": self.model,
+                    "base_url": self.base_url or None,
+                    "api_key": self.api_key or None,
+                    "api_mode": self.api_mode or None,
+                })
+            elif self.summary_model:
                 call_kwargs["model"] = self.summary_model
             # Compression is atomic: protect the in-flight summary call from a
             # mid-turn gateway interrupt. Without this, an incoming user message
@@ -2996,7 +3020,56 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         # Phase 3: Generate structured summary
         summary_focus_topic = focus_topic or self._derive_auto_focus_topic(messages)
-        summary = self._generate_summary(turns_to_summarize, focus_topic=summary_focus_topic)
+
+        # Proactive main-model fallback (#53008): if the compression window
+        # (the middle turns sent to the summariser) exceeds the aux model's
+        # context window, the aux model cannot process it — the API call
+        # will either error out (context too long) or be silently truncated
+        # to a near-useless summary.  Fall back to the main model for this
+        # pass instead.  The aux model is restored afterwards so future
+        # passes (on a smaller post-compression session) can use it again.
+        #
+        # We compare the actual window size (turns_to_summarize), NOT the
+        # full session — the tail (protected recent messages) and head
+        # (system prompt + first exchange) are never sent to the summariser,
+        # so a session can be larger than the aux context while the window
+        # still fits.
+        _window_tokens = estimate_messages_tokens_rough(turns_to_summarize)
+        _saved_summary_model = ""
+        _saved_force_main_runtime = getattr(self, "_force_main_summary_runtime", False)
+        _aux_context = getattr(self, "_aux_compression_context_length", 0)
+        if (
+            _aux_context > 0
+            and _window_tokens > _aux_context
+            and self.summary_model
+            and self.summary_model != self.model
+        ):
+            _saved_summary_model = self.summary_model
+            self.summary_model = ""
+            self._force_main_summary_runtime = True
+            if not getattr(self, "_aux_context_overflow_warned", False):
+                self._aux_context_overflow_warned = True
+                if not self.quiet_mode:
+                    logger.warning(
+                        "Compression window (~%d tokens) exceeds the "
+                        "auxiliary compression model's context window "
+                        "(%d tokens) — using the main model for this "
+                        "compression pass. Consider a larger compression "
+                        "model or /new to start a fresh session.",
+                        _window_tokens,
+                        _aux_context,
+                    )
+
+        try:
+            summary = self._generate_summary(turns_to_summarize, focus_topic=summary_focus_topic)
+        finally:
+            # Restore the aux summary model for future passes — after
+            # compression the session may be small enough for the aux model
+            # again.  Use finally so the model is restored even if
+            # _generate_summary raises an unexpected exception. (#53008)
+            if _saved_summary_model:
+                self.summary_model = _saved_summary_model
+            self._force_main_summary_runtime = _saved_force_main_runtime
 
         # If summary generation failed, behavior splits on
         # ``abort_on_summary_failure`` (config: compression.abort_on_summary_failure):

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -245,6 +245,11 @@ def check_compression_model_feasibility(agent: Any) -> None:
             custom_providers=agent._custom_providers,
         )
 
+        # Store the aux model's context length so compress() can proactively
+        # fall back to the main model when the compression window exceeds it.
+        # (#53008)
+        agent.context_compressor._aux_compression_context_length = aux_context or 0
+
         # Hard floor: the auxiliary compression model must have at least
         # MINIMUM_CONTEXT_LENGTH (64K) tokens of context.  The main model
         # is already required to meet this floor (checked earlier in
@@ -264,18 +269,26 @@ def check_compression_model_feasibility(agent: Any) -> None:
             )
 
         threshold = agent.context_compressor.threshold_tokens
-        if aux_context < threshold:
+        if aux_context and aux_context < threshold:
             # Auto-correct: lower the live session threshold so
             # compression actually works this session.  The hard floor
             # above guarantees aux_context >= MINIMUM_CONTEXT_LENGTH,
             # so the new threshold is always >= 64K.
             #
-            # The compression summariser sends a single user-role
-            # prompt (no system prompt, no tools) to the aux model, so
-            # new_threshold == aux_context is safe: the request is
-            # the raw messages plus a small summarisation instruction.
+            # Use an 80% safety margin instead of the full aux_context.
+            # The summariser prompt itself (window + instruction) fits
+            # within aux_context even at 100% — the original author's
+            # reasoning was correct on that.  But the POST-compression
+            # session (summary + protected head + protected tail) must
+            # also fall below the threshold to avoid re-triggering.
+            # With threshold = 100% of aux_context, a large protected
+            # tail (e.g. huge tool output) leaves no room: the post-
+            # compression session can't drop below 100%.  80% gives 20%
+            # headroom for the tail, making it far more likely that
+            # compression actually brings the session below the threshold.
+            # (#53008)
             old_threshold = threshold
-            new_threshold = aux_context
+            new_threshold = max(MINIMUM_CONTEXT_LENGTH, int(aux_context * 0.8))
             agent.context_compressor.threshold_tokens = new_threshold
             # Keep threshold_percent in sync so future main-model
             # context_length changes (update_model) re-derive from a
@@ -285,7 +298,7 @@ def check_compression_model_feasibility(agent: Any) -> None:
                 agent.context_compressor.threshold_percent = (
                     new_threshold / main_ctx
                 )
-            safe_pct = int((aux_context / main_ctx) * 100) if main_ctx else 50
+            safe_pct = int((new_threshold / main_ctx) * 100) if main_ctx else 50
             # Build human-readable "model (provider)" labels for both
             # the main model and the compression model so users can
             # tell at a glance which provider each side is actually
@@ -312,13 +325,19 @@ def check_compression_model_feasibility(agent: Any) -> None:
                 else _main_model
             )
             _aux_label = f"{aux_model} ({_aux_provider_label})"
+            _margin_pct = int((new_threshold / aux_context) * 100) if aux_context else 80
             msg = (
                 f"⚠ Compression model {_aux_label} context is "
                 f"{aux_context:,} tokens, but the main model "
                 f"{_main_label}'s compression threshold was "
                 f"{old_threshold:,} tokens. "
                 f"Auto-lowered this session's threshold to "
-                f"{new_threshold:,} tokens so compression can run.\n"
+                f"{new_threshold:,} tokens ({_margin_pct}% of the aux "
+                f"model's context, with a safety margin) so compression "
+                f"can run.\n"
+                f"  If the compression window grows beyond {aux_context:,} "
+                f"tokens, Hermes will automatically use the main model "
+                f"for that compression pass instead.\n"
                 f"  To make this permanent, edit config.yaml — either:\n"
                 f"  1. Use a larger compression model:\n"
                 f"       auxiliary:\n"

--- a/tests/agent/test_compression_53008.py
+++ b/tests/agent/test_compression_53008.py
@@ -1,0 +1,236 @@
+"""Regression tests for issue #53008 auxiliary-model compression loops.
+
+Two issue-specific safeguards remain necessary on top of the provider-token
+anti-thrash verification already present on current main:
+
+1. The auto-lowered threshold uses 80% of the auxiliary model context so the
+   summary and protected tail have headroom.
+2. If the actual compression window exceeds the auxiliary model context,
+   compression temporarily uses the main model and always restores the
+   configured auxiliary model afterwards.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+from agent.context_compressor import ContextCompressor, estimate_messages_tokens_rough
+
+Message = dict[str, Any]
+
+
+def _make_compressor(
+    *,
+    model: str = "test-model",
+    threshold_percent: float = 0.50,
+    protect_first_n: int = 2,
+    protect_last_n: int = 3,
+    quiet_mode: bool = True,
+    abort_on_summary_failure: bool = False,
+) -> ContextCompressor:
+    with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+        return ContextCompressor(
+            model=model,
+            threshold_percent=threshold_percent,
+            protect_first_n=protect_first_n,
+            protect_last_n=protect_last_n,
+            quiet_mode=quiet_mode,
+            abort_on_summary_failure=abort_on_summary_failure,
+        )
+
+
+def _build_session(n_turns: int, chars_per_msg: int = 200) -> list[Message]:
+    """Build a multi-turn conversation with controllable size."""
+    base = " ".join(["x"] * chars_per_msg)
+    messages: list[Message] = [{"role": "system", "content": "You are helpful."}]
+    for i in range(n_turns):
+        messages.append({"role": "user", "content": f"{base} turn {i}"})
+        messages.append({"role": "assistant", "content": f"{base} reply {i}"})
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: safety margin (tested via conversation_compression integration)
+# The 80% margin is applied in check_compression_model_feasibility, which
+# requires a full agent mock.  The unit test for the margin is in
+# test_compression_feasibility.py.  Here we test the compressor-side fixes.
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: proactive main-model fallback in compress()
+# ---------------------------------------------------------------------------
+
+
+class TestProactiveMainModelFallback:
+    """compress() falls back to the main model when the compression window
+    (middle turns sent to the summariser) exceeds the aux model's context."""
+
+    def test_falls_back_when_window_exceeds_aux_context(self):
+        comp = _make_compressor()
+        comp.summary_model = "aux-small-model"
+        comp._aux_compression_context_length = 500
+
+        messages = _build_session(30, chars_per_msg=200)
+
+        captured = []
+
+        def _capture(*args, **kwargs):
+            captured.append(comp.summary_model)
+            return "Summary."
+
+        with patch.object(comp, "_generate_summary", side_effect=_capture):
+            comp.compress(messages, current_tokens=50_000)
+
+        assert captured == [""], (
+            f"summary_model should be empty (main model) when window > aux_context, got {captured}"
+        )
+
+    def test_restores_aux_model_after_fallback(self):
+        comp = _make_compressor()
+        comp.summary_model = "aux-small-model"
+        comp._aux_compression_context_length = 500
+
+        messages = _build_session(30, chars_per_msg=200)
+
+        with patch.object(comp, "_generate_summary", return_value="Summary."):
+            comp.compress(messages, current_tokens=50_000)
+
+        assert comp.summary_model == "aux-small-model"
+
+    def test_fallback_explicitly_bypasses_auxiliary_task_config(self):
+        """The real call boundary must receive the main runtime explicitly."""
+        comp = _make_compressor()
+        comp.provider = "test"
+        comp.base_url = "http://test"
+        comp.api_key = "test-key"
+        comp.summary_model = "aux-small-model"
+        comp._aux_compression_context_length = 500
+        messages = _build_session(30, chars_per_msg=200)
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="Summary."))]
+        )
+
+        with patch("agent.context_compressor.call_llm", return_value=response) as call:
+            comp.compress(messages, current_tokens=50_000)
+
+        kwargs = call.call_args.kwargs
+        assert kwargs["provider"] == "test"
+        assert kwargs["model"] == "test-model"
+        assert kwargs["base_url"] == "http://test"
+        assert kwargs["api_key"] == "test-key"
+        assert "aux-small-model" not in kwargs.values()
+
+    def test_no_fallback_when_window_within_aux_context(self):
+        comp = _make_compressor()
+        comp.summary_model = "aux-small-model"
+        comp._aux_compression_context_length = 10_000_000
+
+        messages = _build_session(30, chars_per_msg=200)
+
+        captured = []
+
+        def _capture(*args, **kwargs):
+            captured.append(comp.summary_model)
+            return "Summary."
+
+        with patch.object(comp, "_generate_summary", side_effect=_capture):
+            comp.compress(messages, current_tokens=50_000)
+
+        assert captured == ["aux-small-model"]
+
+    def test_no_fallback_when_no_aux_model(self):
+        comp = _make_compressor()
+        comp.summary_model = ""
+        comp._aux_compression_context_length = 500
+
+        messages = _build_session(30, chars_per_msg=200)
+
+        with patch.object(comp, "_generate_summary", return_value="Summary."):
+            comp.compress(messages, current_tokens=50_000)
+
+        assert comp.summary_model == ""
+
+    def test_no_fallback_when_aux_context_not_set(self):
+        comp = _make_compressor()
+        comp.summary_model = "aux-model"
+        comp._aux_compression_context_length = 0
+
+        messages = _build_session(30, chars_per_msg=200)
+
+        with patch.object(comp, "_generate_summary", return_value="Summary."):
+            comp.compress(messages, current_tokens=50_000)
+
+        assert comp.summary_model == "aux-model"
+
+    def test_no_fallback_when_session_large_but_window_small(self):
+        """The comparison is against the compression window, NOT the full
+        session.  A session can be much larger than the aux context while
+        the window (middle turns) still fits — in that case the aux model
+        is used, not the main model."""
+        comp = _make_compressor()
+        comp.summary_model = "aux-small-model"
+        comp._aux_compression_context_length = 50_000
+
+        messages = _build_session(30, chars_per_msg=200)
+
+        captured = []
+
+        def _capture(*args, **kwargs):
+            captured.append(comp.summary_model)
+            return "Summary."
+
+        with patch.object(comp, "_generate_summary", side_effect=_capture):
+            comp.compress(messages, current_tokens=200_000)
+
+        assert captured == ["aux-small-model"], (
+            "aux model should be used — the window fits even though the "
+            f"full session (200K) exceeds the aux context (50K). Got {captured}"
+        )
+
+    def test_aux_model_restored_even_when_summary_raises(self):
+        """If _generate_summary raises an unexpected exception, the aux
+        model is still restored via the finally block."""
+        comp = _make_compressor()
+        comp.summary_model = "aux-small-model"
+        comp._aux_compression_context_length = 500
+
+        messages = _build_session(30, chars_per_msg=200)
+
+        with patch.object(comp, "_generate_summary", side_effect=RuntimeError("boom")):
+            try:
+                comp.compress(messages, current_tokens=50_000)
+            except RuntimeError:
+                pass
+
+        assert comp.summary_model == "aux-small-model", (
+            f"summary_model should be restored even after an exception, got '{comp.summary_model}'"
+        )
+
+    def test_aux_model_restored_when_summary_returns_none(self):
+        """When _generate_summary returns None (summary failure), the aux
+        model is restored before the abort/fallback path runs."""
+        comp = _make_compressor(abort_on_summary_failure=True)
+        comp.summary_model = "aux-small-model"
+        comp._aux_compression_context_length = 500
+
+        messages = _build_session(30, chars_per_msg=200)
+
+        with patch.object(comp, "_generate_summary", return_value=None):
+            comp.compress(messages, current_tokens=50_000)
+
+        assert comp.summary_model == "aux-small-model"
+
+    def test_overflow_warning_emitted_once(self):
+        comp = _make_compressor(quiet_mode=False)
+        comp.summary_model = "aux-small-model"
+        comp._aux_compression_context_length = 500
+
+        messages = _build_session(30, chars_per_msg=200)
+
+        with patch.object(comp, "_generate_summary", return_value="Summary."):
+            comp.compress(messages, current_tokens=50_000)
+            assert comp._aux_context_overflow_warned is True
+            comp.compress(messages, current_tokens=50_000)
+
+        assert comp._aux_context_overflow_warned is True

--- a/tests/agent/test_context_compressor_cross_session_guard.py
+++ b/tests/agent/test_context_compressor_cross_session_guard.py
@@ -21,9 +21,15 @@ from unittest.mock import patch
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 
 # Stub out optional heavy dependencies not installed in the test environment
-sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
-sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
-sys.modules.setdefault("fal_client", types.SimpleNamespace())
+fire_module = types.ModuleType("fire")
+setattr(fire_module, "Fire", lambda *a, **k: None)
+sys.modules.setdefault("fire", fire_module)
+
+firecrawl_module = types.ModuleType("firecrawl")
+setattr(firecrawl_module, "Firecrawl", object)
+sys.modules.setdefault("firecrawl", firecrawl_module)
+
+sys.modules.setdefault("fal_client", types.ModuleType("fal_client"))
 
 from agent.context_compressor import ContextCompressor
 
@@ -55,6 +61,8 @@ def _make_compressor():
     c._context_probed = False
     c._last_compression_savings_pct = 100.0
     c._ineffective_compression_count = 0
+    c._aux_compression_context_length = 0
+    c._aux_context_overflow_warned = False
     c._last_summary_error = None
     c._last_summary_dropped_count = 0
     c._last_summary_fallback_used = False
@@ -143,3 +151,45 @@ def test_no_false_positive_when_previous_summary_already_none():
 
     # Should still be None — guard is no-op
     assert c._previous_summary is None
+
+
+def test_on_session_end_clears_all_per_session_compression_state():
+    """Natural session end must clear the same per-session state as /reset."""
+    c = _make_compressor()
+    c._previous_summary = "stale summary"
+    c._last_summary_error = "stale error"
+    c._last_summary_dropped_count = 3
+    c._last_summary_fallback_used = True
+    c._last_aux_model_failure_error = "aux failed"
+    c._last_aux_model_failure_model = "tiny-aux"
+    c._last_compression_savings_pct = 1.0
+    c._ineffective_compression_count = 2
+    c._summary_failure_cooldown_until = 123.0
+    c._last_compress_aborted = True
+    c._aux_context_overflow_warned = True
+    c._context_probed = True
+    c._context_probe_persistable = True
+    c.last_real_prompt_tokens = 99
+    c.last_compression_rough_tokens = 88
+    c.last_rough_tokens_when_real_prompt_fit = 77
+    c.awaiting_real_usage_after_compression = True
+
+    c.on_session_end("ended-session", [])
+
+    assert c._previous_summary is None
+    assert c._last_summary_error is None
+    assert c._last_summary_dropped_count == 0
+    assert c._last_summary_fallback_used is False
+    assert c._last_aux_model_failure_error is None
+    assert c._last_aux_model_failure_model is None
+    assert c._last_compression_savings_pct == 100.0
+    assert c._ineffective_compression_count == 0
+    assert c._summary_failure_cooldown_until == 0.0
+    assert c._last_compress_aborted is False
+    assert c._aux_context_overflow_warned is False
+    assert c._context_probed is False
+    assert c._context_probe_persistable is False
+    assert c.last_real_prompt_tokens == 0
+    assert c.last_compression_rough_tokens == 0
+    assert c.last_rough_tokens_when_real_prompt_fit == 0
+    assert c.awaiting_real_usage_after_compression is False

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -8,12 +8,21 @@ Two-phase design:
      status_callback (gateway platforms)
 """
 
+from typing import Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from run_agent import AIAgent
 from agent.context_compressor import ContextCompressor
+
+
+def _context_compressor(agent: AIAgent) -> ContextCompressor:
+    return getattr(agent, "context_compressor")
+
+
+def _set_emit_status(agent: AIAgent, callback: Callable[[str], None]) -> None:
+    setattr(agent, "_emit_status", callback)
 
 
 @pytest.fixture(autouse=True)
@@ -94,8 +103,9 @@ def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_clien
     assert "threshold:" in messages[0]
     # Warning stored for gateway replay
     assert agent._compression_warning is not None
-    # Threshold on the live compressor was actually lowered to aux_context.
-    assert agent.context_compressor.threshold_tokens == 80_000
+    # Threshold on the live compressor was lowered to 80% of aux_context
+    # (safety margin, #53008).
+    assert _context_compressor(agent).threshold_tokens == 64_000  # 80% of 80K
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=32_768)
@@ -119,6 +129,29 @@ def test_rejects_aux_below_minimum_context(mock_get_client, mock_ctx_len):
     assert "32,768" in err
     assert "64,000" in err
     assert "below the minimum" in err
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=64_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_threshold_floor_respected_at_minimum_aux_context(mock_get_client, mock_ctx_len):
+    """When aux_context == MINIMUM_CONTEXT_LENGTH (64K), the 80% safety
+    margin would give 51,200 — below the floor.  The threshold must be
+    clamped to MINIMUM_CONTEXT_LENGTH, not below it. (#53008)"""
+    agent = _make_agent(main_context=200_000, threshold_percent=0.50)
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "min-ctx-model")
+
+    _set_emit_status(agent, lambda msg: None)
+    agent._check_compression_model_feasibility()
+
+    from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+    assert _context_compressor(agent).threshold_tokens == MINIMUM_CONTEXT_LENGTH, (
+        f"Threshold should be clamped to MINIMUM_CONTEXT_LENGTH ({MINIMUM_CONTEXT_LENGTH:,}) "
+        f"when 80% of aux_context would go below it, got "
+        f"{_context_compressor(agent).threshold_tokens:,}"
+    )
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=200_000)
@@ -405,7 +438,7 @@ def test_just_below_threshold_auto_corrects(mock_get_client, mock_ctx_len):
     assert len(messages) == 1
     assert "small-model" in messages[0]
     assert "Auto-lowered" in messages[0]
-    assert agent.context_compressor.threshold_tokens == 99_999
+    assert _context_compressor(agent).threshold_tokens == 79_999  # 80% of 99,999
 
 
 # ── Two-phase: __init__ + run_conversation replay ───────────────────


### PR DESCRIPTION
## Summary

Fixes #53008. When Hermes uses an auxiliary compression model with a smaller context window than the main model, compression could repeatedly re-trigger without producing enough headroom.

## Root cause

- Feasibility correction set the compression threshold to 100% of the auxiliary model context, leaving no room for the summary and protected conversation tail.
- Once the actual middle window exceeded the auxiliary context, summary generation still selected the undersized auxiliary runtime.

## Fix

1. Auto-corrected thresholds now use 80% of auxiliary context, clamped to `MINIMUM_CONTEXT_LENGTH`.
2. `compress()` compares the actual middle window with auxiliary context. Oversized windows use the main runtime for that pass, then restore the configured auxiliary model in `finally`.
3. The fallback passes the main provider, model, endpoint, API key, and API mode explicitly, so `call_llm(task="compression")` cannot re-select the auxiliary task configuration.
4. The overflow warning is emitted once per session and reset on both session reset and natural session end.

Current `main` already contains provider-token anti-thrash verification. This rebase deliberately removes the PR's older threshold-escape implementation instead of duplicating that upstream behavior.

## Verification

- `scripts/check.sh --project hermes-agent --worktree worktrees/hermes-agent/53008`: PASS
- Locked dependency sync, `uv lock --check`, and full `ruff check .`: PASS
- Changed tests: 32/32 PASS
- Focused compression integration set: 47/47 PASS
- Exact-base proof on `7b5ba2054721dde998ed47fd4a0f031955278e99`: 6 regression failures on base, all pass on this branch
- `git diff --check origin/main`: PASS

Full-project `ty` remains advisory and hits its existing upstream panic in `tools/checkpoint_manager.py`; the blocking project gates pass.
