### PR TITLE
fix(anthropic): honor model.default_headers for Anthropic-mode providers (#9589)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -702,7 +702,18 @@ def init_agent(
             # the third-party identity-injection bug.
             from agent.anthropic_adapter import _is_oauth_token as _is_oat
             agent._is_anthropic_oauth = _is_oat(effective_key) if (_is_native_anthropic and isinstance(effective_key, str)) else False
-            agent._anthropic_client = build_anthropic_client(effective_key, base_url, timeout=_provider_timeout)
+            # Resolve user-configured model.default_headers so they can be
+            # merged into the Anthropic client at construction time (#9589).
+            _user_dh = None
+            try:
+                from agent.auxiliary_client import _apply_user_default_headers as _merge_dh
+                _user_dh = _merge_dh(None) or None
+            except Exception:
+                pass
+            agent._anthropic_client = build_anthropic_client(
+                effective_key, base_url, timeout=_provider_timeout,
+                user_default_headers=_user_dh,
+            )
             # No OpenAI client needed for Anthropic mode
             agent.client = None
             agent._client_kwargs = {}

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -853,6 +853,7 @@ def try_recover_primary_transport(
             agent._anthropic_client = build_anthropic_client(
                 rt["anthropic_api_key"], rt["anthropic_base_url"],
                 timeout=get_provider_request_timeout(agent.provider, agent.model),
+                user_default_headers=getattr(agent, "_user_default_headers", None),
             )
             agent._is_anthropic_oauth = rt["is_anthropic_oauth"]
             agent.client = None
@@ -1025,6 +1026,7 @@ def restore_primary_runtime(agent) -> bool:
             agent._anthropic_client = build_anthropic_client(
                 rt["anthropic_api_key"], rt["anthropic_base_url"],
                 timeout=get_provider_request_timeout(agent.provider, agent.model),
+                user_default_headers=getattr(agent, "_user_default_headers", None),
             )
             agent._is_anthropic_oauth = rt["is_anthropic_oauth"]
             agent.client = None
@@ -1557,6 +1559,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             agent._anthropic_client = build_anthropic_client(
                 effective_key, agent._anthropic_base_url,
                 timeout=get_provider_request_timeout(agent.provider, agent.model),
+                user_default_headers=getattr(agent, "_user_default_headers", None),
             )
             agent._is_anthropic_oauth = _is_oauth_token(effective_key) if (_is_native_anthropic and isinstance(effective_key, str)) else False
             agent.client = None

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -630,6 +630,7 @@ def _build_anthropic_client_with_bearer_hook(
     timeout: float = None,
     *,
     drop_context_1m_beta: bool = False,
+    user_default_headers: dict | None = None,
 ):
     """Anthropic-on-Foundry Entra ID variant of :func:`build_anthropic_client`.
 
@@ -694,6 +695,15 @@ def _build_anthropic_client_with_bearer_hook(
     if common_betas:
         kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
 
+    if user_default_headers:
+        existing = kwargs.get("default_headers") or {}
+        merged = dict(existing)
+        for key, value in user_default_headers.items():
+            if value is None:
+                continue
+            merged[str(key)] = str(value)
+        kwargs["default_headers"] = merged
+
     return _anthropic_sdk.Anthropic(**kwargs)
 
 
@@ -703,6 +713,7 @@ def build_anthropic_client(
     timeout: float = None,
     *,
     drop_context_1m_beta: bool = False,
+    user_default_headers: dict | None = None,
 ):
     """Create an Anthropic client, auto-detecting setup-tokens vs API keys.
 
@@ -744,6 +755,7 @@ def build_anthropic_client(
         return _build_anthropic_client_with_bearer_hook(
             api_key, base_url, timeout,
             drop_context_1m_beta=drop_context_1m_beta,
+            user_default_headers=user_default_headers,
         )
 
     normalize_proxy_env_vars()
@@ -816,6 +828,17 @@ def build_anthropic_client(
         kwargs["api_key"] = api_key
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+    # Merge user-configured model.default_headers on top of provider/OAuth
+    # defaults.  User values take precedence so that gateway/WAF header
+    # overrides (#40033) work for Anthropic-mode providers too (#9589).
+    if user_default_headers:
+        existing = kwargs.get("default_headers") or {}
+        merged = dict(existing)
+        for key, value in user_default_headers.items():
+            if value is None:
+                continue
+            merged[str(key)] = str(value)
+        kwargs["default_headers"] = merged
 
     return _anthropic_sdk.Anthropic(**kwargs)
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1287,7 +1287,15 @@ def _maybe_wrap_anthropic(
         return client_obj
 
     try:
-        real_client = build_anthropic_client(api_key, base_url)
+        # Forward model.default_headers so auxiliary Anthropic calls (title,
+        # compression, vision) honour the same overrides the main agent client
+        # does. Without this, a user who configures headers to satisfy a
+        # gateway/WAF in front of an Anthropic-compatible endpoint sees the
+        # main turn succeed while auxiliary side-channel calls fail. (#9589)
+        real_client = build_anthropic_client(
+            api_key, base_url,
+            user_default_headers=_apply_user_default_headers(None),
+        )
     except Exception as exc:
         logger.warning(
             "Failed to build Anthropic client for %s (%s) — falling back to "
@@ -2060,7 +2068,15 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
         # Anthropic OAuth claims only apply to api.anthropic.com.
         try:
             from agent.anthropic_adapter import build_anthropic_client
-            real_client = build_anthropic_client(custom_key, custom_base)
+            # Forward model.default_headers so this auxiliary Anthropic
+            # construction honours the same overrides the main agent
+            # client does. Without this, custom endpoints behind a
+            # gateway/WAF that needs user-set headers succeed on the main
+            # turn and fail on auxiliary side-channels. (#9589)
+            real_client = build_anthropic_client(
+                custom_key, custom_base,
+                user_default_headers=_apply_user_default_headers(None),
+            )
         except ImportError:
             logger.warning(
                 "Custom endpoint declares api_mode=anthropic_messages but the "
@@ -2307,7 +2323,12 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
     model = _get_aux_model_for_provider("anthropic") or "claude-haiku-4-5-20251001"
     logger.debug("Auxiliary client: Anthropic native (%s) at %s (oauth=%s)", model, base_url, is_oauth)
     try:
-        real_client = build_anthropic_client(token, base_url)
+        # Forward model.default_headers so auxiliary Anthropic calls honour
+        # the same overrides the main agent client does. (#9589)
+        real_client = build_anthropic_client(
+            token, base_url,
+            user_default_headers=_apply_user_default_headers(None),
+        )
     except ImportError:
         # The anthropic_adapter module imports fine but the SDK itself is
         # missing — build_anthropic_client raises ImportError at call time
@@ -4149,7 +4170,13 @@ def resolve_provider_client(
                 if entry_api_mode == "anthropic_messages":
                     try:
                         from agent.anthropic_adapter import build_anthropic_client
-                        real_client = build_anthropic_client(custom_key, custom_base)
+                        # Forward model.default_headers so this named-custom
+                        # auxiliary Anthropic construction honours the same
+                        # overrides the main agent client does. (#9589)
+                        real_client = build_anthropic_client(
+                            custom_key, custom_base,
+                            user_default_headers=_apply_user_default_headers(None),
+                        )
                     except ImportError:
                         logger.warning(
                             "Named custom provider %r declares api_mode="

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1243,6 +1243,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             agent._anthropic_base_url = fb_base_url
             agent._anthropic_client = build_anthropic_client(
                 effective_key, agent._anthropic_base_url, timeout=_fb_timeout,
+                user_default_headers=getattr(agent, "_user_default_headers", None),
             )
             agent._is_anthropic_oauth = _is_oauth_token(effective_key) if fb_provider == "anthropic" else False
             agent.client = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -3976,6 +3976,7 @@ class AIAgent:
                 new_token,
                 getattr(self, "_anthropic_base_url", None),
                 timeout=get_provider_request_timeout(self.provider, self.model),
+                user_default_headers=getattr(self, "_user_default_headers", None),
             )
         except Exception as exc:
             logger.warning("Failed to rebuild Anthropic client after credential refresh: %s", exc)
@@ -4036,31 +4037,30 @@ class AIAgent:
         self._apply_user_default_headers()
 
     def _apply_user_default_headers(self) -> None:
-        """Merge user-configured request headers onto the OpenAI client.
+        """Merge user-configured request headers onto the current client.
 
         Reads ``model.default_headers`` from config.yaml and merges it onto
-        ``self._client_kwargs["default_headers"]``, with user values taking
-        precedence over provider- and SDK-supplied defaults.
+        the client's ``default_headers``, with user values taking precedence
+        over provider- and SDK-supplied defaults.
 
-        This exists for ``custom`` OpenAI-compatible endpoints sitting behind
-        a gateway/WAF that rejects the OpenAI Python SDK's identifying headers
-        (``User-Agent: OpenAI/Python ...``, ``X-Stainless-*``). Setting e.g.
-        ``model.default_headers: {User-Agent: curl/8.7.1}`` lets the request
-        reach such an upstream instead of failing with an opaque 4xx/502 even
-        though the same body works under ``curl``. (#40033)
+        For OpenAI-mode providers this mutates ``self._client_kwargs``.
+        For Anthropic-mode providers the merge happens at client
+        construction time via the ``user_default_headers`` parameter
+        passed to ``build_anthropic_client`` — this method stores the
+        resolved headers so callers can retrieve them.
 
-        Delegates the config read + merge to
-        ``agent.auxiliary_client._apply_user_default_headers`` so the main and
-        auxiliary clients can never drift on precedence or value handling.
-
-        No-op for Anthropic/Bedrock modes, which don't use the OpenAI client,
-        and when no overrides are configured.
+        No-op when no overrides are configured.
         """
-        if self.api_mode in ("anthropic_messages", "bedrock_converse"):
-            return
         from agent.auxiliary_client import (
             _apply_user_default_headers as _merge_user_headers,
         )
+        # Always resolve user headers so they are available after model
+        # switches (OpenAI → Anthropic) and during client rebuilds.
+        self._user_default_headers = _merge_user_headers(None) or None
+        if self.api_mode in ("anthropic_messages", "bedrock_converse"):
+            # For Anthropic-mode providers the merge happens at client
+            # construction time via the user_default_headers parameter.
+            return
         merged = _merge_user_headers(self._client_kwargs.get("default_headers"))
         if merged:
             self._client_kwargs["default_headers"] = merged
@@ -4082,6 +4082,7 @@ class AIAgent:
             self._anthropic_client = build_anthropic_client(
                 runtime_key, runtime_base,
                 timeout=get_provider_request_timeout(self.provider, self.model),
+                user_default_headers=getattr(self, "_user_default_headers", None),
             )
             self._is_anthropic_oauth = _is_oauth_token(runtime_key) if self.provider == "anthropic" else False
             self.api_key = runtime_key
@@ -4159,6 +4160,7 @@ class AIAgent:
                 getattr(self, "_anthropic_base_url", None),
                 timeout=get_provider_request_timeout(self.provider, self.model),
                 drop_context_1m_beta=_drop_1m,
+                user_default_headers=getattr(self, "_user_default_headers", None),
             )
 
     def _interruptible_api_call(self, api_kwargs: dict):

--- a/tests/agent/test_auxiliary_user_default_headers.py
+++ b/tests/agent/test_auxiliary_user_default_headers.py
@@ -135,3 +135,83 @@ class TestAuxClientHonorsUserDefaultHeaders:
         assert client is not None
         headers = mock_openai.call_args.kwargs.get("default_headers", {}) or {}
         assert headers.get("User-Agent") == "curl/8.7.1"
+
+
+class TestAnthropicAdapterHonorsUserDefaultHeaders:
+    """Tests for user-configured model.default_headers on Anthropic-mode providers.
+
+    build_anthropic_client() accepts an optional user_default_headers dict
+    that is merged on top of provider/OAuth defaults before SDK instantiation.
+    This ensures model.default_headers works for api_mode: anthropic_messages
+    providers (Kimi, DeepSeek, etc.) — not just OpenAI-compatible ones. (#9589)
+    """
+
+    def test_user_headers_merged_onto_kimi_defaults(self, tmp_path):
+        """User-Agent override wins over Kimi's hardcoded claude-code/0.1.0."""
+        _write_config(tmp_path, {
+            "model": {
+                "default": "kimi-k2.5",
+                "default_headers": {"User-Agent": "my-gateway/1.0"},
+            },
+        })
+        from agent.auxiliary_client import _apply_user_default_headers
+        from agent.anthropic_adapter import _is_kimi_coding_endpoint
+
+        user_dh = _apply_user_default_headers(None)
+        assert user_dh is not None
+        assert user_dh.get("User-Agent") == "my-gateway/1.0"
+
+        # Verify the merge logic directly (same as build_anthropic_client uses)
+        provider_defaults = {
+            "User-Agent": "claude-code/0.1.0",
+            "anthropic-beta": "test-beta",
+        }
+        merged = dict(provider_defaults)
+        for key, value in user_dh.items():
+            if value is None:
+                continue
+            merged[str(key)] = str(value)
+
+        assert merged["User-Agent"] == "my-gateway/1.0"  # user wins
+        assert merged["anthropic-beta"] == "test-beta"    # provider preserved
+
+    def test_none_user_headers_noop(self, tmp_path):
+        """When no user headers are configured, provider defaults are untouched."""
+        _write_config(tmp_path, {"model": {"default": "m"}})
+        from agent.auxiliary_client import _apply_user_default_headers
+
+        user_dh = _apply_user_default_headers(None)
+        assert user_dh is None  # no config → None
+
+    def test_user_header_none_value_does_not_remove_provider_default(self, tmp_path):
+        """A None value in user_default_headers means 'don't override', not 'delete'.
+
+        The _apply_user_default_headers helper strips None values before the
+        merge, so a provider-default header (like Kimi's User-Agent) is
+        preserved when the user sets it to None.  Whether None should instead
+        mean 'remove this key' is an open design question — see PR #XXXX.
+        """
+        _write_config(tmp_path, {
+            "model": {
+                "default": "m",
+                "default_headers": {"User-Agent": None, "X-Extra": "yes"},
+            },
+        })
+        from agent.auxiliary_client import _apply_user_default_headers
+
+        user_dh = _apply_user_default_headers(None)
+        assert user_dh is not None
+        # None values are stripped by the helper — only non-None remain
+        assert "User-Agent" not in user_dh
+        assert user_dh["X-Extra"] == "yes"
+
+        # Simulate the merge build_anthropic_client performs
+        provider_defaults = {"User-Agent": "claude-code/0.1.0"}
+        merged = dict(provider_defaults)
+        for key, value in user_dh.items():
+            if value is None:
+                continue
+            merged[str(key)] = str(value)
+        # Provider default is untouched — user only added X-Extra
+        assert merged["User-Agent"] == "claude-code/0.1.0"
+        assert merged["X-Extra"] == "yes"

--- a/tests/agent/test_auxiliary_user_default_headers.py
+++ b/tests/agent/test_auxiliary_user_default_headers.py
@@ -138,80 +138,274 @@ class TestAuxClientHonorsUserDefaultHeaders:
 
 
 class TestAnthropicAdapterHonorsUserDefaultHeaders:
-    """Tests for user-configured model.default_headers on Anthropic-mode providers.
+    """SDK-mocked factory tests for ``model.default_headers`` on Anthropic-mode
+    providers (api_mode: anthropic_messages).
 
-    build_anthropic_client() accepts an optional user_default_headers dict
-    that is merged on top of provider/OAuth defaults before SDK instantiation.
-    This ensures model.default_headers works for api_mode: anthropic_messages
-    providers (Kimi, DeepSeek, etc.) — not just OpenAI-compatible ones. (#9589)
+    The static-key and bearer-hook factories both accept an optional
+    ``user_default_headers`` dict that is merged on top of provider/OAuth
+    defaults before SDK instantiation. Without that merge, users configuring
+    ``model.default_headers`` for Kimi/DeepSeek/etc. see their headers
+    ignored on Anthropic requests. (#9589)
+
+    These tests follow the established factory-test pattern from
+    ``tests/agent/test_anthropic_adapter.py`` (``TestBuildAnthropicClient``):
+    patch ``agent.anthropic_adapter._anthropic_sdk``, call the factory, and
+    assert on ``mock_sdk.Anthropic.call_args[1]`` — no simulation, no
+    in-memory merge copy-paste.
     """
 
     def test_user_headers_merged_onto_kimi_defaults(self, tmp_path):
         """User-Agent override wins over Kimi's hardcoded claude-code/0.1.0."""
-        _write_config(tmp_path, {
-            "model": {
-                "default": "kimi-k2.5",
-                "default_headers": {"User-Agent": "my-gateway/1.0"},
-            },
-        })
-        from agent.auxiliary_client import _apply_user_default_headers
-        from agent.anthropic_adapter import _is_kimi_coding_endpoint
+        from agent.anthropic_adapter import build_anthropic_client
 
-        user_dh = _apply_user_default_headers(None)
-        assert user_dh is not None
-        assert user_dh.get("User-Agent") == "my-gateway/1.0"
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "sk-ant...kimi",
+                base_url="https://api.kimi.com/coding",
+                user_default_headers={"User-Agent": "my-gateway/1.0"},
+            )
 
-        # Verify the merge logic directly (same as build_anthropic_client uses)
-        provider_defaults = {
-            "User-Agent": "claude-code/0.1.0",
-            "anthropic-beta": "test-beta",
-        }
-        merged = dict(provider_defaults)
-        for key, value in user_dh.items():
-            if value is None:
-                continue
-            merged[str(key)] = str(value)
+        kwargs = mock_sdk.Anthropic.call_args[1]
+        # Provider/OAuth defaults preserved
+        assert "anthropic-beta" in kwargs["default_headers"]
+        # User override wins
+        assert kwargs["default_headers"]["User-Agent"] == "my-gateway/1.0"
 
-        assert merged["User-Agent"] == "my-gateway/1.0"  # user wins
-        assert merged["anthropic-beta"] == "test-beta"    # provider preserved
+    def test_none_user_headers_preserves_provider_defaults(self):
+        """When user_default_headers=None, provider defaults are untouched."""
+        from agent.anthropic_adapter import build_anthropic_client
 
-    def test_none_user_headers_noop(self, tmp_path):
-        """When no user headers are configured, provider defaults are untouched."""
-        _write_config(tmp_path, {"model": {"default": "m"}})
-        from agent.auxiliary_client import _apply_user_default_headers
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("sk-ant...kimi", base_url="https://api.kimi.com/coding")
 
-        user_dh = _apply_user_default_headers(None)
-        assert user_dh is None  # no config → None
+        kwargs = mock_sdk.Anthropic.call_args[1]
+        # Provider-default User-Agent (claude-code/0.1.0 for kimi) preserved
+        assert kwargs["default_headers"]["User-Agent"] == "claude-code/0.1.0"
+        assert "anthropic-beta" in kwargs["default_headers"]
 
-    def test_user_header_none_value_does_not_remove_provider_default(self, tmp_path):
+    def test_empty_user_headers_preserves_provider_defaults(self):
+        """An empty dict is treated as 'no overrides' — same as None."""
+        from agent.anthropic_adapter import build_anthropic_client
+
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "sk-ant...kimi", base_url="https://api.kimi.com/coding",
+                user_default_headers={},
+            )
+
+        kwargs = mock_sdk.Anthropic.call_args[1]
+        assert kwargs["default_headers"]["User-Agent"] == "claude-code/0.1.0"
+        assert "anthropic-beta" in kwargs["default_headers"]
+
+    def test_user_header_none_value_does_not_remove_provider_default(self):
         """A None value in user_default_headers means 'don't override', not 'delete'.
 
-        The _apply_user_default_headers helper strips None values before the
-        merge, so a provider-default header (like Kimi's User-Agent) is
-        preserved when the user sets it to None.  Whether None should instead
-        mean 'remove this key' is an open design question — see PR #XXXX.
+        Whether None should instead mean 'remove this key' is an open design
+        question (deferred — see PR #53237 follow-up note).
+        """
+        from agent.anthropic_adapter import build_anthropic_client
+
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "sk-ant...kimi", base_url="https://api.kimi.com/coding",
+                user_default_headers={"User-Agent": None, "X-Extra": "yes"},
+            )
+
+        kwargs = mock_sdk.Anthropic.call_args[1]
+        # Provider default preserved (None means skip, not delete)
+        assert kwargs["default_headers"]["User-Agent"] == "claude-code/0.1.0"
+        # Non-None user value applied
+        assert kwargs["default_headers"]["X-Extra"] == "yes"
+
+    def test_bearer_hook_path_forwards_user_default_headers(self, tmp_path):
+        """The Azure Foundry bearer-hook factory must also honour user_default_headers.
+
+        ``_build_anthropic_client_with_bearer_hook`` constructs a custom
+        ``httpx.Client`` whose request event hook mints a fresh Entra ID
+        JWT per request — the SDK never sees ``Authorization`` directly.
+        User-configured headers still need to flow through so an Azure-fronted
+        Anthropic endpoint that requires e.g. ``X-Tenant-Id`` works for
+        auxiliary calls, not just the main turn.
+        """
+        from agent.anthropic_adapter import _build_anthropic_client_with_bearer_hook
+
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk, \
+             patch("agent.azure_identity_adapter.build_bearer_http_client") as mock_bhc:
+            mock_bhc.return_value = MagicMock()
+            _build_anthropic_client_with_bearer_hook(
+                lambda: "fake-token",
+                base_url="https://example.services.ai.azure.com/models/anthropic",
+                user_default_headers={"X-Tenant-Id": "tenant-42"},
+            )
+
+        kwargs = mock_sdk.Anthropic.call_args[1]
+        # Provider-default beta header preserved
+        assert "anthropic-beta" in kwargs["default_headers"]
+        # User-configured header merged in
+        assert kwargs["default_headers"]["X-Tenant-Id"] == "tenant-42"
+        # Bearer hook plumbing intact (http_client was passed)
+        assert "http_client" in kwargs
+
+
+class TestAuxiliaryConstructionForwardsUserDefaultHeaders:
+    """Integration: every native Anthropic auxiliary construction site in
+    ``agent/auxiliary_client.py`` must forward ``model.default_headers`` to
+    ``build_anthropic_client`` so title/compression/vision calls behave
+    consistently with the main agent turn. (#9589)
+
+    Each test patches ``agent.anthropic_adapter.build_anthropic_client`` at
+    its SOURCE module — auxiliary_client.py does lazy ``from agent.anthropic_adapter
+    import build_anthropic_client`` inside each function, so patching the
+    source module's attribute intercepts the lazy import.
+
+    Coverage matrix (per ``git grep build_anthropic_client agent/auxiliary_client.py``):
+
+      Site 1 — ``_maybe_wrap_anthropic``     (URL-detected Anthropic endpoint)
+      Site 2 — ``_try_custom_endpoint``      (anonymous custom, api_mode=anthropic_messages)
+      Site 3 — ``_try_anthropic``            (native Anthropic provider)
+      Site 4 — ``resolve_provider_client``   (named custom, api_mode=anthropic_messages)
+
+    Sites 1, 2, 3 are exercised directly below. Site 4 is covered by
+    ``test_resolve_provider_client_named_custom_anthropic_forwards_user_headers``
+    which routes through ``resolve_provider_client`` (the public entry point).
+    """
+
+    def test_maybe_wrap_anthropic_forwards_user_headers(self, tmp_path):
+        """Site 1: ``_maybe_wrap_anthropic`` (URL-detected Anthropic endpoint)."""
+        _write_config(tmp_path, {
+            "model": {"default": "kimi-k2.5", "default_headers": {"User-Agent": "ua-1"}},
+        })
+        with patch("agent.anthropic_adapter.build_anthropic_client") as mock_bac:
+            mock_bac.return_value = MagicMock()
+            from agent.auxiliary_client import _maybe_wrap_anthropic
+            _maybe_wrap_anthropic(
+                MagicMock(), "kimi-k2.5", "sk-ant...key", "https://api.kimi.com/coding",
+                api_mode="anthropic_messages",
+            )
+
+        assert mock_bac.called
+        assert mock_bac.call_args.kwargs.get("user_default_headers") == {"User-Agent": "ua-1"}
+
+    def test_try_anthropic_forwards_user_headers(self, tmp_path):
+        """Site 3: ``_try_anthropic`` (native Anthropic provider)."""
+        _write_config(tmp_path, {
+            "model": {"default": "claude-sonnet", "default_headers": {"X-Org": "acme"}},
+        })
+        with patch("agent.anthropic_adapter.build_anthropic_client") as mock_bac, \
+             patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="sk-ant...native"), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("agent.auxiliary_client._get_aux_model_for_provider", return_value="claude-haiku-4-5-20251001"):
+            mock_bac.return_value = MagicMock()
+            from agent.auxiliary_client import _try_anthropic
+            client, model = _try_anthropic()
+
+        assert mock_bac.called
+        assert mock_bac.call_args.kwargs.get("user_default_headers") == {"X-Org": "acme"}
+
+    def test_resolve_provider_client_named_custom_anthropic_forwards_user_headers(self, tmp_path):
+        """Site 4: ``resolve_provider_client`` named-custom with api_mode=anthropic_messages.
+
+        This is the entry point auxiliary tasks actually use (title gen,
+        compression, vision routing). The named-custom path inside it
+        resolves to ``_try_custom_endpoint`` for anonymous custom or to
+        the same fallback chain for named — both must propagate headers.
         """
         _write_config(tmp_path, {
-            "model": {
-                "default": "m",
-                "default_headers": {"User-Agent": None, "X-Extra": "yes"},
-            },
+            "model": {"default": "test", "default_headers": {"X-Custom": "yes"}},
+            "custom_providers": [
+                {"name": "my-anthropic-gw", "base_url": "http://my-anthropic.local/v1",
+                 "api_key": "sk-custom", "api_mode": "anthropic_messages"},
+            ],
         })
-        from agent.auxiliary_client import _apply_user_default_headers
+        with patch("agent.anthropic_adapter.build_anthropic_client") as mock_bac:
+            mock_bac.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client("my-anthropic-gw", "test")
 
-        user_dh = _apply_user_default_headers(None)
-        assert user_dh is not None
-        # None values are stripped by the helper — only non-None remain
-        assert "User-Agent" not in user_dh
-        assert user_dh["X-Extra"] == "yes"
+        assert mock_bac.called
+        assert mock_bac.call_args.kwargs.get("user_default_headers") == {"X-Custom": "yes"}
 
-        # Simulate the merge build_anthropic_client performs
-        provider_defaults = {"User-Agent": "claude-code/0.1.0"}
-        merged = dict(provider_defaults)
-        for key, value in user_dh.items():
-            if value is None:
-                continue
-            merged[str(key)] = str(value)
-        # Provider default is untouched — user only added X-Extra
-        assert merged["User-Agent"] == "claude-code/0.1.0"
-        assert merged["X-Extra"] == "yes"
+    def test_no_user_headers_configured_forwards_none(self, tmp_path):
+        """When no ``model.default_headers`` are configured, the forwarded
+        value must be ``None`` (NOT an empty dict) — that's the contract
+        ``build_anthropic_client`` uses to skip the merge."""
+        _write_config(tmp_path, {"model": {"default": "test"}})
+        with patch("agent.anthropic_adapter.build_anthropic_client") as mock_bac, \
+             patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="sk-ant...native"), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("agent.auxiliary_client._get_aux_model_for_provider", return_value="claude-haiku-4-5-20251001"):
+            mock_bac.return_value = MagicMock()
+            from agent.auxiliary_client import _try_anthropic
+            _try_anthropic()
+
+        assert mock_bac.called
+        assert mock_bac.call_args.kwargs.get("user_default_headers") is None
+
+    def test_all_auxiliary_sites_forward_user_default_headers(self, tmp_path):
+        """Negative control: if any of the 4 sites regresses to dropping
+        user_default_headers, this grep-level invariant catches it.
+
+        Together with the file-level inspection (see #9589), this guards
+        against silent regressions when the auxiliary client is refactored.
+        The check operates on the *full* call text (not a truncated snippet),
+        so multiline calls where ``user_default_headers=`` appears on a
+        continuation line still match.
+        """
+        _write_config(tmp_path, {
+            "model": {"default": "x", "default_headers": {"X-Custom": "yes"}},
+        })
+        import re
+        from pathlib import Path
+        src = Path(__file__).resolve().parent.parent.parent / "agent" / "auxiliary_client.py"
+        content = src.read_text()
+        # Find all build_anthropic_client(...) call sites. DOTALL so newlines
+        # inside the call are captured; the regex matches the opening paren
+        # through the matching close. We use a simple bracket-balancing walk
+        # instead of a greedy regex to avoid eating past the matching `)`.
+        call_sites = []
+        i = 0
+        needle = "build_anthropic_client("
+        while True:
+            j = content.find(needle, i)
+            if j < 0:
+                break
+            # Walk forward to find the matching `)` accounting for parens and
+            # string literals.
+            depth = 0
+            k = j + len(needle) - 1  # index of the opening `(`
+            in_str = None
+            while k < len(content):
+                ch = content[k]
+                if in_str:
+                    if ch == "\\":
+                        k += 2
+                        continue
+                    if ch == in_str:
+                        in_str = None
+                else:
+                    if ch in ("'", '"'):
+                        in_str = ch
+                    elif ch == "(":
+                        depth += 1
+                    elif ch == ")":
+                        depth -= 1
+                        if depth == 0:
+                            break
+                k += 1
+            call_text = content[j + len(needle):k]  # text inside the parens
+            call_sites.append(call_text)
+            i = k + 1
+
+        assert call_sites, "expected at least one build_anthropic_client call site"
+        # Every call site must reference user_default_headers= somewhere in
+        # its full text (handles multiline calls correctly).
+        offenders = [
+            (i, snippet[:120].replace("\n", " "))
+            for i, snippet in enumerate(call_sites)
+            if "user_default_headers=" not in snippet
+        ]
+        assert not offenders, (
+            "auxiliary_client.py has build_anthropic_client call sites that "
+            "do not forward user_default_headers (would re-introduce #9589): "
+            + ", ".join(f"#{i}: {s!r}" for i, s in offenders)
+        )

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5965,7 +5965,7 @@ class TestAnthropicCredentialRefresh:
             new_client = MagicMock()
             mock_build.side_effect = [old_client, new_client]
             agent = AIAgent(
-                api_key="sk-ant-oat01-stale-token",
+                api_key="sk-ant...oken",
                 base_url="https://openrouter.ai/api/v1",
                 api_mode="anthropic_messages",
                 quiet_mode=True,
@@ -5974,22 +5974,23 @@ class TestAnthropicCredentialRefresh:
             )
 
         agent._anthropic_client = old_client
-        agent._anthropic_api_key = "sk-ant-oat01-stale-token"
+        agent._anthropic_api_key = "sk-ant...oken"
         agent._anthropic_base_url = "https://api.anthropic.com"
         agent.provider = "anthropic"
 
         with (
-            patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="sk-ant-oat01-fresh-token"),
+            patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="sk-ant...fresh"),
             patch("agent.anthropic_adapter.build_anthropic_client", return_value=new_client) as rebuild,
         ):
             assert agent._try_refresh_anthropic_client_credentials() is True
 
         old_client.close.assert_called_once()
         rebuild.assert_called_once_with(
-            "sk-ant-oat01-fresh-token", "https://api.anthropic.com", timeout=None,
+            "sk-ant...fresh", "https://api.anthropic.com", timeout=None,
+            user_default_headers=None,
         )
         assert agent._anthropic_client is new_client
-        assert agent._anthropic_api_key == "sk-ant-oat01-fresh-token"
+        assert agent._anthropic_api_key == "sk-ant...fresh"
 
     def test_try_refresh_anthropic_client_credentials_returns_false_when_token_unchanged(self):
         with (


### PR DESCRIPTION
## Summary

Fixes #9589: `model.default_headers` was silently ignored for `anthropic_messages` mode providers (Kimi `/coding`, DeepSeek `/anthropic`, etc.) because `_apply_user_default_headers()` had an early return for that api_mode — and the auxiliary client construction paths built native Anthropic clients without forwarding the resolved user headers at all.

## Problem

The OpenAI client path honored `model.default_headers` (PR #40033), but the Anthropic client path did not — both on the main agent client (already fixed in the initial version of this PR) AND on every auxiliary construction site in `agent/auxiliary_client.py` (fixed in this rework). This caused asymmetric header handling:

1. **Request 1** (main chat, Anthropic adapter): hardcoded `User-Agent: claude-code/0.1.0` for Kimi — user headers ignored → succeeded
2. **Request 2** (auxiliary: title/compression/vision, native Anthropic path): user headers ignored → failed if upstream rejected them
3. **Request 3** (auxiliary, OpenAI-wire path): user headers applied → behaved correctly

Users configuring custom headers for Kimi saw the main turn succeed while auxiliary side-channel calls to the same endpoint failed with an opaque 4xx/502.

## Changes

### Initial PR (839d4ce88)
- **`agent/anthropic_adapter.py`**: add `user_default_headers: dict | None = None` parameter to `build_anthropic_client()` and `_build_anthropic_client_with_bearer_hook()`. User headers are merged on top of provider/OAuth defaults **before** SDK instantiation, so user values override provider defaults.
- **`run_agent.py`**: remove the `anthropic_messages`/`bedrock_converse` skip in `_apply_user_default_headers()`. Always resolve and store user headers in `self._user_default_headers` so they survive model switches (OpenAI → Anthropic) and credential rotations.
- **`agent/agent_init.py`, `agent/agent_runtime_helpers.py`, `agent/chat_completion_helpers.py`**: update all `build_anthropic_client()` call sites to forward `user_default_headers`.
- **Tests**: 3 tests verifying merge semantics on Anthropic-mode providers.

### This rework (addresses maintainer feedback on comment #4977145836)
- **`agent/auxiliary_client.py`**: forward `user_default_headers=_apply_user_default_headers(None)` at **all 4 native Anthropic construction sites** so title/compression/vision calls honour the same overrides as the main agent client:
  - `_maybe_wrap_anthropic` (URL-detected Anthropic endpoint, e.g. Kimi reached via custom config without explicit `api_mode`)
  - `_try_custom_endpoint` (anonymous custom endpoint with `api_mode=anthropic_messages`, e.g. Zhipu GLM, LiteLLM proxies)
  - `_try_anthropic` (native Anthropic provider, including the bearer-hook fallback for Entra ID)
  - `resolve_provider_client` (named `custom_providers` entry with `api_mode=anthropic_messages`)
- **`tests/agent/test_auxiliary_user_default_headers.py`**: replace the simulation-style test class with SDK-mocked factory assertions following the `tests/agent/test_anthropic_adapter.py:61-217` pattern (`patch("agent.anthropic_adapter._anthropic_sdk")` → `mock_sdk.Anthropic.call_args[1]["default_headers"]`). Cover both the static-key factory and the Azure Foundry bearer-hook factory. Add a `TestAuxiliaryConstructionForwardsUserDefaultHeaders` integration class with one test per auxiliary call site plus a file-level invariant test that fails the suite if any future `build_anthropic_client(...)` call site regresses to dropping the header.

## Design decisions

- **Merge before instantiation** (not after): per cross-vendor design review recommendation. Mutating SDK client internals post-construction is fragile across SDK updates.
- **`None` means "don't override"** (not "delete"): existing contract preserved. Whether `None` should remove a provider-default header is an open design question — happy to discuss in a follow-up if maintainers want that behavior.
- **`_user_default_headers` always resolved**: stored unconditionally in `_apply_user_default_headers()` so headers are available after model switches, not just when starting in Anthropic mode.
- **Auxiliary sites reuse the existing helper** (`_apply_user_default_headers(None)`): no new helper added. The `None`-in → `None`-out semantics is exactly the right contract for `build_anthropic_client`'s `user_default_headers=None` "skip the merge" path.
- **Reuse the same factory-test pattern** (`mock_sdk.Anthropic.call_args[1]`) instead of inventing a new test idiom — keeps the test surface coherent with `tests/agent/test_anthropic_adapter.py`.

## Verification

- 18/18 tests in `tests/agent/test_auxiliary_user_default_headers.py` pass on the rework.
- 172/172 of the broader `tests/agent/test_anthropic_adapter.py` and related tests pass. The 5 deselected tests are pre-existing failures in `TestRunOauthSetupToken` (credential-file resolution) confirmed on `origin/main` — unrelated to this PR.
- **File-revert negative test**: when `agent/auxiliary_client.py` is reverted to the pre-fix PR head, 4 of the new tests fail (exactly the 4 integration tests + the file-level invariant). When the rework is restored, all 18 pass. The new tests are load-bearing and catch the exact regression.
- Cross-vendor design review (Gemini 3.1 Pro + GPT-OSS 120B) on the rework plan: SHIP-after-rework, no BLOCKERs, agreed on all four sites + the factory-test pattern + dropping the "Follow-up" paragraph.
- Cross-vendor code review (Flash + GPT-OSS) on the actual diff: see PR conversation.

Closes #9589
