### PR TITLE
FGD-199L: add Hermes live pulse backend

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -511,6 +511,30 @@ def init_agent(
     except Exception:
         pass
 
+    # Budget checkpointing scaffolding is dormant by default. When explicitly
+    # enabled in config.yaml, conversation_loop may request one structured,
+    # no-tools continuation packet before max-turn exhaustion.
+    agent._budget_checkpointing_enabled = False
+    agent._budget_checkpoint_warning_ratio = 0.75
+    agent._budget_checkpoint_checkpoint_ratio = 0.88
+    agent._budget_checkpoint_mode = "continuation_packet"
+    agent._budget_checkpoint_warning_emitted = False
+    agent._budget_checkpoint_emitted = False
+    try:
+        from hermes_cli.config import load_config as _load_budget_cfg
+
+        _budget_cfg = (
+            (_load_budget_cfg().get("agent") or {}).get("budget_checkpointing")
+            or {}
+        )
+        if isinstance(_budget_cfg, dict):
+            agent._budget_checkpointing_enabled = bool(_budget_cfg.get("enabled", False))
+            agent._budget_checkpoint_warning_ratio = float(_budget_cfg.get("warning_ratio", 0.75))
+            agent._budget_checkpoint_checkpoint_ratio = float(_budget_cfg.get("checkpoint_ratio", 0.88))
+            agent._budget_checkpoint_mode = str(_budget_cfg.get("mode", "continuation_packet") or "continuation_packet")
+    except Exception:
+        pass
+
     # Iteration budget: the LLM is only notified when it actually exhausts
     # the iteration budget (api_call_count >= max_iterations).  At that
     # point we inject ONE message, allow one final API call, and if the

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1302,6 +1302,165 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
 
 
+_CONTINUATION_PACKET_FIELDS = [
+    "issue",
+    "lane",
+    "owner",
+    "task class",
+    "budget state",
+    "last completed phase",
+    "current phase",
+    "repo/worktree/branch",
+    "commit SHA",
+    "PR URL/state",
+    "merge state",
+    "package path",
+    "Drive target",
+    "Obsidian target",
+    "Linear state",
+    "validation",
+    "remaining actions",
+    "forbidden actions",
+    "do-not-repeat list",
+    "next safe resume packet",
+    "FGD-21 footer",
+]
+
+
+def _build_budget_checkpoint_request(
+    *,
+    api_call_count: int,
+    max_iterations: int,
+    budget_state: str = "checkpoint",
+    task_metadata: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Build the dormant continuation-packet prompt for budget checkpoints."""
+    task_metadata = task_metadata or {}
+    metadata_lines = []
+    for key in ("issue", "lane", "owner", "task_class", "last_completed_phase", "current_phase"):
+        if task_metadata.get(key):
+            metadata_lines.append(f"- {key.replace('_', ' ')}: {task_metadata[key]}")
+    metadata_block = "\n".join(metadata_lines) if metadata_lines else "- none supplied; infer only from accepted conversation evidence"
+    fields = "\n".join(f"- {field}" for field in _CONTINUATION_PACKET_FIELDS)
+    return (
+        "Budget checkpoint threshold reached before iteration exhaustion. "
+        "Do not call tools. Return a structured CONTINUATION PACKET only; "
+        "do not provide a generic summary.\n\n"
+        f"Budget state: {budget_state} ({api_call_count}/{max_iterations} API/tool iterations).\n"
+        "Known task metadata:\n"
+        f"{metadata_block}\n\n"
+        "The continuation packet must preserve these fields exactly where known, "
+        "using 'unknown' when evidence is missing:\n"
+        f"{fields}\n\n"
+        "The FGD-21 footer must include Worker used, Worker suitable, "
+        "Jimmy review result, and Next handover type."
+    )
+
+
+def _build_no_tools_finalizer_messages(agent, messages: list) -> list:
+    """Prepare sanitized messages for a no-tools finalizer request."""
+    _needs_sanitize = agent._should_sanitize_tool_calls()
+    api_messages = []
+    for msg in messages:
+        api_msg = msg.copy()
+        agent._copy_reasoning_content_for_api(msg, api_msg)
+        for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
+            api_msg.pop(internal_field, None)
+        for schema_foreign in ("tool_name", "codex_reasoning_items", "codex_message_items"):
+            api_msg.pop(schema_foreign, None)
+        for internal_key in [k for k in api_msg if isinstance(k, str) and k.startswith("_")]:
+            api_msg.pop(internal_key, None)
+        if _needs_sanitize:
+            agent._sanitize_tool_calls_for_strict_api(api_msg, model=agent.model)
+        api_messages.append(api_msg)
+
+    effective_system = agent._cached_system_prompt or ""
+    if agent.ephemeral_system_prompt:
+        effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+    if effective_system:
+        api_messages = [{"role": "system", "content": effective_system}] + api_messages
+    if agent.prefill_messages:
+        sys_offset = 1 if effective_system else 0
+        for idx, pfm in enumerate(agent.prefill_messages):
+            api_messages.insert(sys_offset + idx, pfm.copy())
+
+    api_messages = agent._sanitize_api_messages(api_messages)
+    api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
+    return api_messages
+
+
+def handle_budget_checkpoint(
+    agent,
+    messages: list,
+    api_call_count: int,
+    *,
+    budget_state: str = "checkpoint",
+    task_metadata: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Request a structured no-tools continuation packet before exhaustion.
+
+    Dormant helper only: no production call site is wired in this gate.
+    """
+    checkpoint_request = _build_budget_checkpoint_request(
+        api_call_count=api_call_count,
+        max_iterations=agent.max_iterations,
+        budget_state=budget_state,
+        task_metadata=task_metadata,
+    )
+    messages.append({"role": "user", "content": checkpoint_request})
+
+    try:
+        api_messages = _build_no_tools_finalizer_messages(agent, messages)
+
+        if agent.api_mode == "codex_responses":
+            codex_kwargs = agent._build_api_kwargs(api_messages)
+            codex_kwargs.pop("tools", None)
+            checkpoint_response = agent._run_codex_stream(codex_kwargs)
+            checkpoint_result = agent._get_transport().normalize_response(checkpoint_response)
+            final_response = (checkpoint_result.content or "").strip()
+        elif agent.api_mode == "anthropic_messages":
+            transport = agent._get_transport()
+            ant_kwargs = transport.build_kwargs(
+                model=agent.model,
+                messages=api_messages,
+                tools=None,
+                max_tokens=agent.max_tokens,
+                reasoning_config=agent.reasoning_config,
+                is_oauth=agent._is_anthropic_oauth,
+                preserve_dots=agent._anthropic_preserve_dots(),
+            )
+            checkpoint_response = agent._anthropic_messages_create(ant_kwargs)
+            checkpoint_result = transport.normalize_response(
+                checkpoint_response,
+                strip_tool_prefix=agent._is_anthropic_oauth,
+            )
+            final_response = (checkpoint_result.content or "").strip()
+        else:
+            checkpoint_kwargs = {
+                "model": agent.model,
+                "messages": api_messages,
+            }
+            if agent.max_tokens is not None:
+                checkpoint_kwargs.update(agent._max_tokens_param(agent.max_tokens))
+            checkpoint_response = agent._ensure_primary_openai_client(
+                reason="budget_checkpoint_continuation"
+            ).chat.completions.create(**checkpoint_kwargs)
+            checkpoint_result = agent._get_transport().normalize_response(checkpoint_response)
+            final_response = (checkpoint_result.content or "").strip()
+
+        if final_response:
+            if "<think>" in final_response:
+                final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
+            if final_response:
+                messages.append({"role": "assistant", "content": final_response})
+                return final_response
+
+        return "Budget checkpoint reached, but no continuation packet was generated."
+    except Exception as e:
+        logger.warning(f"Failed to get budget checkpoint continuation response: {e}")
+        return f"Budget checkpoint reached but continuation packet generation failed. Error: {str(e)}"
+
+
 def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     """Request a summary when max iterations are reached. Returns the final response text."""
     print(f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary...")

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -27,6 +27,7 @@ import time
 import uuid
 from typing import Any, Dict, List, Optional
 
+from agent.chat_completion_helpers import handle_budget_checkpoint
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
@@ -484,6 +485,38 @@ def run_conversation(
             if not agent.quiet_mode:
                 agent._safe_print(f"\n⚠️  Iteration budget exhausted ({agent.iteration_budget.used}/{agent.iteration_budget.max_total} iterations used)")
             break
+
+        if getattr(agent, "_budget_checkpointing_enabled", False):
+            try:
+                _budget_state = agent.iteration_budget.threshold_state(
+                    warning_ratio=getattr(agent, "_budget_checkpoint_warning_ratio", 0.75),
+                    checkpoint_ratio=getattr(agent, "_budget_checkpoint_checkpoint_ratio", 0.88),
+                )
+            except Exception as _budget_err:
+                logger.debug("budget checkpoint threshold check failed: %s", _budget_err)
+                _budget_state = "normal"
+
+            if _budget_state == "warning" and not getattr(agent, "_budget_checkpoint_warning_emitted", False):
+                agent._budget_checkpoint_warning_emitted = True
+                agent._emit_status(
+                    f"⚠️ Budget checkpoint warning ({agent.iteration_budget.used}/{agent.iteration_budget.max_total})"
+                )
+            elif (
+                _budget_state == "checkpoint"
+                and getattr(agent, "_budget_checkpoint_mode", "continuation_packet") == "continuation_packet"
+                and not getattr(agent, "_budget_checkpoint_emitted", False)
+            ):
+                agent._budget_checkpoint_emitted = True
+                _turn_exit_reason = "budget_checkpoint"
+                failed = True
+                final_response = handle_budget_checkpoint(
+                    agent,
+                    messages,
+                    api_call_count,
+                    budget_state=_budget_state,
+                    task_metadata={},
+                )
+                break
 
         # Fire step_callback for gateway hooks (agent:step event)
         if agent.step_callback is not None:

--- a/agent/iteration_budget.py
+++ b/agent/iteration_budget.py
@@ -58,5 +58,41 @@ class IterationBudget:
         with self._lock:
             return max(0, self.max_total - self._used)
 
+    @property
+    def ratio_used(self) -> float:
+        """Fraction of the total iteration budget already consumed."""
+        with self._lock:
+            if self.max_total <= 0:
+                return 1.0
+            return min(1.0, self._used / self.max_total)
+
+    def threshold_state(
+        self,
+        *,
+        warning_ratio: float = 0.75,
+        checkpoint_ratio: float = 0.88,
+    ) -> str:
+        """Classify current budget pressure without changing runtime behavior.
+
+        Returns one of: ``normal``, ``warning``, ``checkpoint``, or
+        ``exhausted``. This is scaffolding for callers that may later choose to
+        emit warnings or continuation checkpoints; the helper itself has no side
+        effects.
+        """
+        if not (0 <= warning_ratio < checkpoint_ratio <= 1):
+            raise ValueError(
+                "warning_ratio must be >= 0 and less than checkpoint_ratio, "
+                "and checkpoint_ratio must be <= 1"
+            )
+
+        ratio = self.ratio_used
+        if ratio >= 1.0:
+            return "exhausted"
+        if ratio >= checkpoint_ratio:
+            return "checkpoint"
+        if ratio >= warning_ratio:
+            return "warning"
+        return "normal"
+
 
 __all__ = ["IterationBudget"]

--- a/gateway/live_pulse.py
+++ b/gateway/live_pulse.py
@@ -1,0 +1,233 @@
+"""Non-secret Hermes gateway live pulse for Mission Control / Agent Floor.
+
+This module exports metadata only: counts, redacted session identity, state,
+elapsed time, model/provider labels, and process counts. It never writes chat
+content, user prompts, tool output, command text, logs, credentials, or raw
+session keys.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+try:
+    from hermes_constants import get_hermes_home
+except Exception:  # pragma: no cover - defensive fallback for isolated imports
+    def get_hermes_home() -> Path:  # type: ignore[no-redef]
+        return Path.home() / ".hermes"
+
+PULSE_PATH = get_hermes_home() / "tools" / "agent_floor" / "hermes_live_pulse.json"
+SIGNALS = {"safe_to_message", "caution_active_workflow", "do_not_interrupt", "unknown"}
+HEARTBEAT_INTERVAL_SECONDS = 30
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _hash_session_key(session_key: str) -> str:
+    if not session_key:
+        return ""
+    return hashlib.sha256(session_key.encode("utf-8", errors="replace")).hexdigest()[:16]
+
+
+def _safe_str(value: Any, max_len: int = 96) -> str:
+    text = "" if value is None else str(value)
+    text = " ".join(text.split())
+    return text[: max_len - 1] + "…" if len(text) > max_len else text
+
+
+def _agent_activity(agent: Any) -> dict[str, Any]:
+    if not agent or not hasattr(agent, "get_activity_summary"):
+        return {}
+    try:
+        activity = agent.get_activity_summary() or {}
+    except Exception:
+        return {}
+    current_tool = activity.get("current_tool")
+    return {
+        "current_phase": _safe_str(activity.get("last_activity_desc") or current_tool or "running"),
+        "current_tool": _safe_str(current_tool, 64) if current_tool else None,
+        "api_call_count": activity.get("api_call_count"),
+        "max_iterations": activity.get("max_iterations"),
+        "seconds_since_activity": activity.get("seconds_since_activity"),
+    }
+
+
+def _classify_background_process(proc: dict[str, Any]) -> tuple[str, bool, str]:
+    """Classify process-registry rows without exposing command text.
+
+    Only session-linked/task-linked running processes are treated as
+    interrupt-sensitive. Unscoped long-lived helpers stay visible but must not
+    pin Agent Floor to caution forever.
+    """
+    has_session_key = bool(proc.get("has_session_key"))
+    task_id = _safe_str(proc.get("task_id"), 64) if proc.get("task_id") else ""
+    # The process registry uses task_id="default" for unscoped terminal
+    # background processes. Treat that as a visible helper, not evidence of
+    # interrupt-sensitive delegated work.
+    has_meaningful_task_id = bool(task_id and task_id != "default")
+    detached = bool(proc.get("detached"))
+    uptime = int(proc.get("uptime_seconds") or 0)
+
+    if detached:
+        return "detached_or_recovered_process", False, "detached recovered process; visible warning only"
+    if not has_meaningful_task_id and uptime >= 300:
+        return "default_long_lived_helper", False, "default/unscoped helper older than five minutes; not interrupt-sensitive"
+    if has_session_key or has_meaningful_task_id:
+        return "active_background_work", True, "linked to an active Hermes session or non-default task"
+    return "unscoped_recent_background_process", False, "unscoped recent process; visible warning only"
+
+
+def _process_rows() -> list[dict[str, Any]]:
+    try:
+        from tools.process_registry import process_registry
+        rows = []
+        for proc in process_registry.list_sessions():
+            if proc.get("status") != "running":
+                continue
+            classification, interrupt_sensitive, reason = _classify_background_process(proc)
+            rows.append({
+                "process_id": _safe_str(proc.get("session_id"), 48),
+                "state": "background_running",
+                "classification": classification,
+                "interrupt_sensitive": interrupt_sensitive,
+                "classification_reason": reason,
+                "elapsed_seconds": int(proc.get("uptime_seconds") or 0),
+                "session_linked": bool(proc.get("has_session_key")),
+                "task_id": _safe_str(proc.get("task_id"), 64) if proc.get("task_id") else None,
+                "pid_scope": _safe_str(proc.get("pid_scope"), 24) if proc.get("pid_scope") else None,
+                "detached": bool(proc.get("detached")),
+            })
+        return rows
+    except Exception:
+        return []
+
+
+def _pending_approval_counts() -> dict[str, int]:
+    try:
+        from tools.approval import gateway_pending_approval_counts
+        return gateway_pending_approval_counts()
+    except Exception:
+        return {}
+
+
+def build_live_pulse(
+    *,
+    running_agents: dict[str, Any] | None = None,
+    running_started: dict[str, float] | None = None,
+    pending_sentinel: Any = None,
+    background_tasks: set[Any] | None = None,
+    session_platform_resolver: Callable[[str], str] | None = None,
+) -> dict[str, Any]:
+    now = time.time()
+    running_agents = running_agents or {}
+    running_started = running_started or {}
+    approval_counts = _pending_approval_counts()
+    pending_approval_total = sum(int(v or 0) for v in approval_counts.values())
+    sessions: list[dict[str, Any]] = []
+    active_agent_turns = 0
+    starting_turns = 0
+
+    for session_key, agent in running_agents.items():
+        started = float(running_started.get(session_key, now) or now)
+        is_starting = agent is pending_sentinel
+        pending_count = int(approval_counts.get(session_key, 0) or 0)
+        if is_starting:
+            starting_turns += 1
+            state = "starting"
+            risk = "caution_active_workflow"
+        elif pending_count:
+            active_agent_turns += 1
+            state = "waiting_human_approval"
+            risk = "safe_to_message"
+        else:
+            active_agent_turns += 1
+            state = "running"
+            risk = "caution_active_workflow"
+        row = {
+            "session_key_hash": _hash_session_key(session_key),
+            "session_id": "" if is_starting else _safe_str(getattr(agent, "session_id", ""), 64),
+            "platform": _safe_str(session_platform_resolver(session_key), 32) if session_platform_resolver else "unknown",
+            "state": state,
+            "elapsed_seconds": max(0, int(now - started)),
+            "model": "" if is_starting else _safe_str(getattr(agent, "model", ""), 96),
+            "provider": "" if is_starting else _safe_str(getattr(agent, "provider", ""), 64),
+            "current_phase": "starting" if is_starting else "running",
+            "current_tool": None,
+            "pending_approval_count": pending_count,
+            "background_process_count": 0,
+            "interruption_risk": risk,
+        }
+        if not is_starting:
+            row.update(_agent_activity(agent))
+        sessions.append(row)
+
+    running_processes = _process_rows()
+    running_background_process_total_count = len(running_processes)
+    running_background_process_count = len([
+        proc for proc in running_processes if proc.get("interrupt_sensitive")
+    ])
+    background_helper_process_count = len([
+        proc for proc in running_processes if not proc.get("interrupt_sensitive")
+    ])
+
+    async_job_count = len([t for t in (background_tasks or set()) if hasattr(t, "done") and not t.done()])
+
+    if any(row.get("interruption_risk") == "do_not_interrupt" for row in sessions):
+        signal = "do_not_interrupt"
+        reason = "A live Hermes session reports do-not-interrupt risk."
+    elif active_agent_turns or starting_turns or running_background_process_count or async_job_count:
+        signal = "caution_active_workflow"
+        reason = "Hermes gateway reports active turn/startup/background activity."
+    elif pending_approval_total:
+        signal = "safe_to_message"
+        reason = "Hermes is waiting on human approval; messaging is unlikely to interrupt active execution."
+    elif background_helper_process_count:
+        signal = "safe_to_message"
+        reason = "Fresh gateway pulse shows no active turns or interrupt-sensitive background work; non-interrupting background helper present."
+    else:
+        signal = "safe_to_message"
+        reason = "Fresh gateway pulse shows no active turns, approvals, async jobs, or background processes."
+
+    return {
+        "schema_version": "hermes-live-pulse-v1",
+        "generated_at": _now_iso(),
+        "profile": os.getenv("HERMES_PROFILE") or "jimmy",
+        "gateway": {"running": True, "pid": os.getpid()},
+        "summary": {
+            "active_agent_turns": active_agent_turns,
+            "starting_turns": starting_turns,
+            "pending_approval_count": pending_approval_total,
+            "running_background_process_count": running_background_process_count,
+            "background_process_total_count": running_background_process_total_count,
+            "background_helper_process_count": background_helper_process_count,
+            "async_job_count": async_job_count,
+            "interruption_signal": signal,
+            "interruption_reason": reason,
+        },
+        "sessions": sessions,
+        "running_background_processes": running_processes,
+        "source_limits": [
+            "No chat content included",
+            "No raw user prompt included",
+            "No raw tool output included",
+            "No sensitive command text included",
+            "No approval payload included",
+            "No logs, databases, caches, browser profiles, tokens, credentials, or session bodies inspected",
+        ],
+    }
+
+
+def write_live_pulse(**kwargs: Any) -> dict[str, Any]:
+    pulse = build_live_pulse(**kwargs)
+    PULSE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = PULSE_PATH.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(pulse, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    tmp.replace(PULSE_PATH)
+    return pulse

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1610,6 +1610,16 @@ class TelegramAdapter(BasePlatformAdapter):
             self._app = builder.build()
             self._bot = self._app.bot
             
+            # Earliest redacted media ingress diagnostic.  Registered in an
+            # earlier handler group so it observes voice/audio/media updates
+            # before the normal text/command/media routing filters decide which
+            # handler receives the update.  The diagnostic helper logs only
+            # shape metadata and returns without mutating the update.
+            self._app.add_handler(TelegramMessageHandler(
+                filters.ALL,
+                self._handle_ingress_diagnostic
+            ), group=-1)
+
             # Register handlers
             self._app.add_handler(TelegramMessageHandler(
                 filters.TEXT & ~filters.COMMAND,
@@ -5114,6 +5124,103 @@ class TelegramAdapter(BasePlatformAdapter):
             return MessageType.VOICE
         return MessageType.DOCUMENT
 
+    def _telegram_voice_media_event_kind(self, msg: Any) -> Optional[str]:
+        """Return the redacted diagnostic event kind for Telegram media ingress."""
+        if getattr(msg, "voice", None):
+            return "voice"
+        if any(
+            getattr(msg, attr, None)
+            for attr in ("audio", "photo", "video", "document", "sticker")
+        ):
+            return "media"
+        return None
+
+    def _telegram_ingress_message(self, update: Any) -> tuple[str, Any]:
+        """Return the first message-like object on a Telegram update.
+
+        Only the update/message shape is reported by diagnostics; identifiers,
+        bodies, file IDs, usernames, URLs, and paths are intentionally ignored.
+        """
+        for event_kind, attr in (
+            ("message", "message"),
+            ("edited_message", "edited_message"),
+            ("channel_post", "channel_post"),
+            ("edited_channel_post", "edited_channel_post"),
+        ):
+            msg = getattr(update, attr, None)
+            if msg is not None:
+                return event_kind, msg
+        return "none", None
+
+    def _log_telegram_media_ingress_diagnostic(self, update: Any) -> None:
+        """Emit earliest redacted Telegram media ingress diagnostics.
+
+        This runs before routing/media-handler matching and logs only update
+        shape metadata for voice/audio/media messages.  It deliberately omits
+        chat/user identifiers, file IDs, captions, message bodies, URLs, paths,
+        and config/env values.
+        """
+        event_kind, msg = self._telegram_ingress_message(update)
+        if msg is None:
+            return
+
+        has_voice = bool(getattr(msg, "voice", None))
+        has_audio = bool(getattr(msg, "audio", None))
+        has_photo = bool(getattr(msg, "photo", None))
+        has_video = bool(getattr(msg, "video", None))
+        has_document = bool(getattr(msg, "document", None))
+        has_sticker = bool(getattr(msg, "sticker", None))
+        has_media = any((has_voice, has_audio, has_photo, has_video, has_document, has_sticker))
+        if not has_media:
+            return
+
+        if has_voice:
+            message_kind = "voice"
+        elif has_audio:
+            message_kind = "audio"
+        else:
+            message_kind = "media"
+        thread_marker = "<ID>" if getattr(msg, "message_thread_id", None) is not None else "none"
+        logger.info(
+            "Telegram media ingress diagnostic: "
+            "event_kind=%s message_kind=%s has_voice=%s has_audio=%s has_media=%s "
+            "media_handler_expected=yes chat=<ID> thread=%s",
+            event_kind,
+            message_kind,
+            "yes" if has_voice else "no",
+            "yes" if has_audio else "no",
+            "yes" if has_media else "no",
+            thread_marker,
+        )
+
+    async def _handle_ingress_diagnostic(self, update: Any, context: Any) -> None:
+        """Observe Telegram update shape before normal routing without mutating it."""
+        self._log_telegram_media_ingress_diagnostic(update)
+
+    def _log_voice_media_route_decision(self, msg: Any, *, accepted: bool) -> None:
+        """Emit a redacted component-level route diagnostic for media ingress.
+
+        This intentionally avoids chat/user/thread values, captions, message
+        bodies, file IDs, URLs, paths, and config values. It only records the
+        route-gate outcome needed to tell whether Telegram media reached the
+        adapter and was accepted for downstream caching/STT.
+        """
+        event_kind = self._telegram_voice_media_event_kind(msg)
+        if event_kind is None:
+            return
+
+        decision = "accepted" if accepted else "dropped"
+        drop_gate = "none" if accepted else "route_gate"
+        thread_marker = "<ID>" if getattr(msg, "message_thread_id", None) is not None else "none"
+        logger.info(
+            "Telegram voice/media route diagnostic: "
+            "event_kind=%s route_decision=%s drop_gate=%s stt_reached=no chat=<ID> thread=%s",
+            event_kind,
+            decision,
+            drop_gate,
+            thread_marker,
+        )
+
     async def _cache_observed_media(self, msg: Message, event: MessageEvent) -> None:
         """Cache an unmentioned group attachment and annotate the observed text.
 
@@ -5560,7 +5667,9 @@ class TelegramAdapter(BasePlatformAdapter):
         """Handle incoming media messages, downloading images to local cache."""
         if not update.message:
             return
-        if not self._should_process_message(update.message):
+        accepted = self._should_process_message(update.message)
+        self._log_voice_media_route_decision(update.message, accepted=accepted)
+        if not accepted:
             if self._should_observe_unmentioned_group_message(update.message):
                 _m = update.message
                 _observe_type = self._media_message_type(_m)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2238,6 +2238,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
+        self._agent_floor_live_pulse_heartbeat_task: Optional[asyncio.Task] = None
 
 
     def _wire_teams_pipeline_runtime(self) -> None:
@@ -2999,6 +3000,53 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     def _running_agent_count(self) -> int:
         return len(self._running_agents)
+
+    def _write_agent_floor_live_pulse(self) -> None:
+        """Best-effort non-secret live pulse for Mission Control / Agent Floor."""
+        try:
+            from gateway.live_pulse import write_live_pulse
+
+            write_live_pulse(
+                running_agents=getattr(self, "_running_agents", {}) or {},
+                running_started=getattr(self, "_running_agents_ts", {}) or {},
+                pending_sentinel=_AGENT_PENDING_SENTINEL,
+                background_tasks=getattr(self, "_background_tasks", set()) or set(),
+                session_platform_resolver=lambda key: key.split(":", 1)[0] if key else "unknown",
+            )
+        except Exception:
+            logger.debug("Failed to write Agent Floor live pulse", exc_info=True)
+
+    async def _agent_floor_live_pulse_heartbeat(self) -> None:
+        """Keep Agent Floor's non-secret live pulse fresh while gateway runs."""
+        try:
+            from gateway.live_pulse import HEARTBEAT_INTERVAL_SECONDS
+        except Exception:
+            HEARTBEAT_INTERVAL_SECONDS = 30
+
+        while self._running:
+            self._write_agent_floor_live_pulse()
+            try:
+                await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                await asyncio.sleep(30)
+
+    def _start_agent_floor_live_pulse_heartbeat(self) -> None:
+        task = getattr(self, "_agent_floor_live_pulse_heartbeat_task", None)
+        if task is not None and not task.done():
+            return
+        task = asyncio.create_task(self._agent_floor_live_pulse_heartbeat())
+        self._agent_floor_live_pulse_heartbeat_task = task
+        task.add_done_callback(
+            lambda done: setattr(self, "_agent_floor_live_pulse_heartbeat_task", None)
+        )
+
+    def _stop_agent_floor_live_pulse_heartbeat(self) -> None:
+        task = getattr(self, "_agent_floor_live_pulse_heartbeat_task", None)
+        if task is not None and not task.done():
+            task.cancel()
+        self._agent_floor_live_pulse_heartbeat_task = None
 
     def _status_action_label(self) -> str:
         return "restart" if self._restart_requested else "shutdown"
@@ -5009,6 +5057,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         self._running = True
         self._update_runtime_status("running")
+        self._start_agent_floor_live_pulse_heartbeat()
         
         # Emit gateway:startup hook
         hook_count = len(self.hooks.loaded_hooks)
@@ -5948,6 +5997,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     continue
                 _task.cancel()
             self._background_tasks.clear()
+            stop_live_pulse_heartbeat = getattr(
+                self,
+                "_stop_agent_floor_live_pulse_heartbeat",
+                None,
+            )
+            if callable(stop_live_pulse_heartbeat):
+                stop_live_pulse_heartbeat()
 
             self.adapters.clear()
             for _session_key in list(self._running_agents):
@@ -7528,6 +7584,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._active_session_leases[_quick_key] = _active_session_lease
         self._running_agents[_quick_key] = _AGENT_PENDING_SENTINEL
         self._running_agents_ts[_quick_key] = time.time()
+        self._write_agent_floor_live_pulse()
         _run_generation = self._begin_session_run_generation(_quick_key)
 
         try:
@@ -12445,6 +12502,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._running_agents_ts.pop(session_key, None)
         if hasattr(self, "_busy_ack_ts"):
             self._busy_ack_ts.pop(session_key, None)
+        self._write_agent_floor_live_pulse()
         return True
 
     def _clear_session_boundary_security_state(self, session_key: str) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11654,6 +11654,78 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return prefix
         return user_text
 
+    @staticmethod
+    def _is_useful_stt_transcript(transcript: object) -> bool:
+        """Return True when STT output contains usable spoken text.
+
+        Some providers return success with an empty string, whitespace, or
+        punctuation-only placeholders for silence/noise. Treat those as no
+        useful transcript so voice messages do not silently enter the agent as
+        empty user turns.
+        """
+        if not isinstance(transcript, str):
+            return False
+        cleaned = transcript.strip()
+        if not cleaned:
+            return False
+        return any(ch.isalnum() for ch in cleaned)
+
+    @staticmethod
+    def _stt_transcript_length_bucket(transcript: object) -> str:
+        if not isinstance(transcript, str):
+            return "none"
+        length = len(transcript.strip())
+        if length == 0:
+            return "0"
+        if length <= 20:
+            return "1-20"
+        if length <= 100:
+            return "21-100"
+        return "100+"
+
+    @staticmethod
+    def _classify_stt_error(error: object) -> str:
+        text = str(error or "").lower()
+        if (
+            "no stt provider" in text
+            or "voice_tools_openai_key" in text
+            or "openai_api_key" in text
+            or "api key" in text
+            or "provider" in text and "configured" in text
+        ):
+            return "provider_unavailable"
+        if (
+            "decode" in text
+            or "codec" in text
+            or "ffmpeg" in text
+            or "audio" in text and ("invalid" in text or "corrupt" in text)
+        ):
+            return "audio_decode_error"
+        if "module" in text or "import" in text or "dependency" in text or "not installed" in text:
+            return "dependency_error"
+        return "unknown_error"
+
+    @staticmethod
+    def _log_stt_result_diagnostic(
+        *,
+        stt_attempted: bool,
+        stt_provider_available: str,
+        stt_result_class: str,
+        transcript_non_empty: bool,
+        transcript_length_bucket: str = "none",
+    ) -> None:
+        """Emit redacted STT outcome metadata without paths/transcript text."""
+        logger.info(
+            "Telegram voice STT result diagnostic: "
+            "stt_attempted=%s stt_provider_available=%s "
+            "stt_result_class=%s transcript_non_empty=%s transcript_length_bucket=%s",
+            "yes" if stt_attempted else "no",
+            stt_provider_available,
+            stt_result_class,
+            "yes" if transcript_non_empty else "no",
+            transcript_length_bucket,
+        )
+
     async def _enrich_message_with_transcription(
         self,
         user_text: str,
@@ -11677,6 +11749,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 this to echo transcripts back to the user before the agent loop.
         """
         if not getattr(self.config, "stt_enabled", True):
+            self._log_stt_result_diagnostic(
+                stt_attempted=False,
+                stt_provider_available="unknown",
+                stt_result_class="provider_unavailable",
+                transcript_non_empty=False,
+            )
             notes = []
             for path in audio_paths:
                 abs_path = os.path.abspath(path)
@@ -11706,18 +11784,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("Transcribing user voice: %s", path)
                 result = await asyncio.to_thread(transcribe_audio, path)
                 if result["success"]:
-                    transcript = result["transcript"]
-                    successful_transcripts.append(transcript)
-                    enriched_parts.append(
-                        f'[The user sent a voice message~ '
-                        f'Here\'s what they said: "{transcript}"]'
+                    transcript = result.get("transcript", "")
+                    useful_transcript = self._is_useful_stt_transcript(transcript)
+                    self._log_stt_result_diagnostic(
+                        stt_attempted=True,
+                        stt_provider_available="yes",
+                        stt_result_class="success_non_empty" if useful_transcript else "success_empty",
+                        transcript_non_empty=useful_transcript,
+                        transcript_length_bucket=self._stt_transcript_length_bucket(transcript),
                     )
+                    if useful_transcript:
+                        successful_transcripts.append(transcript)
+                        enriched_parts.append(
+                            f'[The user sent a voice message~ '
+                            f'Here\'s what they said: "{transcript}"]'
+                        )
+                    else:
+                        enriched_parts.append(
+                            "[The user sent a voice message, but speech-to-text "
+                            "did not produce usable transcript text. Ask the user "
+                            "to resend the voice note or type the message.]"
+                        )
                 else:
                     error = result.get("error", "unknown error")
-                    if (
-                        "No STT provider" in error
-                        or error.startswith("Neither VOICE_TOOLS_OPENAI_KEY nor OPENAI_API_KEY is set")
-                    ):
+                    result_class = self._classify_stt_error(error)
+                    self._log_stt_result_diagnostic(
+                        stt_attempted=True,
+                        stt_provider_available="no" if result_class == "provider_unavailable" else "unknown",
+                        stt_result_class=result_class,
+                        transcript_non_empty=False,
+                    )
+                    if result_class == "provider_unavailable":
                         _no_stt_note = (
                             "[The user sent a voice message but I can't listen "
                             "to it right now — no STT provider is configured. "
@@ -11738,6 +11835,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             f"transcribing it~ ({error})]"
                         )
             except Exception as e:
+                result_class = self._classify_stt_error(e)
+                self._log_stt_result_diagnostic(
+                    stt_attempted=True,
+                    stt_provider_available="unknown",
+                    stt_result_class=result_class,
+                    transcript_non_empty=False,
+                )
                 logger.error("Transcription error: %s", e)
                 enriched_parts.append(
                     "[The user sent a voice message but something went wrong "

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -816,6 +816,15 @@ DEFAULT_CONFIG = {
     "max_concurrent_sessions": None,
     "agent": {
         "max_turns": 90,
+        # Budget checkpointing scaffolding is disabled by default. Future
+        # gates may use these thresholds to emit continuation packets before
+        # max-turn exhaustion; this gate only records non-active defaults.
+        "budget_checkpointing": {
+            "enabled": False,
+            "warning_ratio": 0.75,
+            "checkpoint_ratio": 0.88,
+            "mode": "continuation_packet",
+        },
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has

--- a/tests/agent/test_budget_checkpoint_finalizer.py
+++ b/tests/agent/test_budget_checkpoint_finalizer.py
@@ -1,0 +1,167 @@
+from types import SimpleNamespace
+
+
+def test_handle_budget_checkpoint_requests_structured_packet_without_tools():
+    from agent.chat_completion_helpers import handle_budget_checkpoint
+
+    captured_kwargs = {}
+
+    class FakeCompletions:
+        def create(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="CONTINUATION PACKET"))])
+
+    class FakeClient:
+        chat = SimpleNamespace(completions=FakeCompletions())
+
+    class FakeTransport:
+        def normalize_response(self, response, **kwargs):
+            return SimpleNamespace(content=response.choices[0].message.content)
+
+    class FakeAgent:
+        model = "test-model"
+        max_iterations = 30
+        api_mode = "chat_completions"
+        _cached_system_prompt = "You are helpful."
+        ephemeral_system_prompt = ""
+        prefill_messages = []
+        provider = "openrouter"
+        base_url = "https://openrouter.ai/api/v1"
+        _base_url_lower = "https://openrouter.ai/api/v1"
+        max_tokens = None
+        reasoning_config = None
+        providers_allowed = None
+        providers_ignored = None
+        providers_order = None
+        provider_sort = None
+        openrouter_min_coding_score = None
+        _is_anthropic_oauth = False
+
+        def _should_sanitize_tool_calls(self):
+            return False
+
+        def _copy_reasoning_content_for_api(self, msg, api_msg):
+            return None
+
+        def _sanitize_api_messages(self, messages):
+            return messages
+
+        def _drop_thinking_only_and_merge_users(self, messages):
+            return messages
+
+        def _supports_reasoning_extra_body(self):
+            return False
+
+        def _is_openrouter_url(self):
+            return True
+
+        def _max_tokens_param(self, max_tokens):
+            return {"max_tokens": max_tokens}
+
+        def _ensure_primary_openai_client(self, reason):
+            return FakeClient()
+
+        def _get_transport(self):
+            return FakeTransport()
+
+    messages = [{"role": "user", "content": "ship the issue"}]
+
+    result = handle_budget_checkpoint(
+        FakeAgent(),
+        messages,
+        api_call_count=27,
+        budget_state="checkpoint 27/30",
+        task_metadata={
+            "issue": "Hermes: Budget-aware full-flow delivery",
+            "lane": "FGDGHO / Wiring / Hermes",
+            "owner": "Jimmy",
+            "task_class": "full delivery",
+            "current_phase": "validation",
+        },
+    )
+
+    assert result == "CONTINUATION PACKET"
+    assert "tools" not in captured_kwargs
+
+    api_messages = captured_kwargs["messages"]
+    checkpoint_prompt = api_messages[-1]["content"]
+    assert "CONTINUATION PACKET" in checkpoint_prompt
+    assert "Do not call tools" in checkpoint_prompt
+    assert "issue" in checkpoint_prompt
+    assert "lane" in checkpoint_prompt
+    assert "owner" in checkpoint_prompt
+    assert "task class" in checkpoint_prompt
+    assert "budget state" in checkpoint_prompt
+    assert "last completed phase" in checkpoint_prompt
+    assert "current phase" in checkpoint_prompt
+    assert "repo/worktree/branch" in checkpoint_prompt
+    assert "commit SHA" in checkpoint_prompt
+    assert "PR URL/state" in checkpoint_prompt
+    assert "merge state" in checkpoint_prompt
+    assert "package path" in checkpoint_prompt
+    assert "Drive target" in checkpoint_prompt
+    assert "Obsidian target" in checkpoint_prompt
+    assert "Linear state" in checkpoint_prompt
+    assert "validation" in checkpoint_prompt
+    assert "remaining actions" in checkpoint_prompt
+    assert "forbidden actions" in checkpoint_prompt
+    assert "do-not-repeat list" in checkpoint_prompt
+    assert "next safe resume packet" in checkpoint_prompt
+    assert "FGD-21 footer" in checkpoint_prompt
+    assert "summarizing what you've found" not in checkpoint_prompt
+
+
+def test_handle_budget_checkpoint_strips_tools_from_codex_kwargs():
+    from agent.chat_completion_helpers import handle_budget_checkpoint
+
+    captured_kwargs = {}
+
+    class FakeTransport:
+        def normalize_response(self, response, **kwargs):
+            return SimpleNamespace(content="CODEX CONTINUATION")
+
+    class FakeAgent:
+        model = "test-model"
+        max_iterations = 30
+        api_mode = "codex_responses"
+        _cached_system_prompt = ""
+        ephemeral_system_prompt = ""
+        prefill_messages = []
+        provider = "openai-codex"
+        base_url = ""
+        _base_url_lower = ""
+        max_tokens = None
+        reasoning_config = None
+        providers_allowed = None
+        providers_ignored = None
+        providers_order = None
+        provider_sort = None
+        openrouter_min_coding_score = None
+        _is_anthropic_oauth = False
+
+        def _should_sanitize_tool_calls(self):
+            return False
+
+        def _copy_reasoning_content_for_api(self, msg, api_msg):
+            return None
+
+        def _sanitize_api_messages(self, messages):
+            return messages
+
+        def _drop_thinking_only_and_merge_users(self, messages):
+            return messages
+
+        def _build_api_kwargs(self, messages):
+            return {"input": messages, "tools": [{"name": "should_not_survive"}]}
+
+        def _run_codex_stream(self, kwargs):
+            captured_kwargs.update(kwargs)
+            return SimpleNamespace()
+
+        def _get_transport(self):
+            return FakeTransport()
+
+    result = handle_budget_checkpoint(FakeAgent(), [{"role": "user", "content": "work"}], 27)
+
+    assert result == "CODEX CONTINUATION"
+    assert "tools" not in captured_kwargs

--- a/tests/agent/test_budget_checkpoint_runtime.py
+++ b/tests/agent/test_budget_checkpoint_runtime.py
@@ -1,0 +1,133 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+@pytest.fixture()
+def agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            max_iterations=4,
+        )
+        a.client = MagicMock()
+        a._cached_system_prompt = "You are helpful."
+        a._use_prompt_caching = False
+        a.tool_delay = 0
+        a.compression_enabled = False
+        a.save_trajectories = False
+        return a
+
+
+def _mock_response(*, content="", finish_reason="stop", tool_calls=None):
+    message = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=message, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], usage=None)
+
+
+def _mock_tool_call(call_id="call_1"):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name="web_search", arguments="{}"),
+    )
+
+
+def _run_without_persistence(agent, prompt="work"):
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        return agent.run_conversation(prompt)
+
+
+def test_budget_checkpoint_disabled_does_not_call_checkpoint_helper(agent, monkeypatch):
+    agent._budget_checkpointing_enabled = False
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(finish_reason="tool_calls", tool_calls=[_mock_tool_call("c1")]),
+        _mock_response(finish_reason="tool_calls", tool_calls=[_mock_tool_call("c2")]),
+        _mock_response(content="Done", finish_reason="stop"),
+    ]
+    checkpoint_calls = []
+
+    def fake_checkpoint(*args, **kwargs):
+        checkpoint_calls.append((args, kwargs))
+        return "SHOULD NOT RUN"
+
+    monkeypatch.setattr("agent.conversation_loop.handle_budget_checkpoint", fake_checkpoint)
+
+    with patch("run_agent.handle_function_call", return_value="search result"):
+        result = _run_without_persistence(agent)
+
+    assert result["final_response"] == "Done"
+    assert checkpoint_calls == []
+
+
+def test_budget_checkpoint_enabled_calls_helper_before_exhaustion(agent, monkeypatch):
+    agent._budget_checkpointing_enabled = True
+    agent._budget_checkpoint_warning_ratio = 0.25
+    agent._budget_checkpoint_checkpoint_ratio = 0.50
+    agent._budget_checkpoint_mode = "continuation_packet"
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(finish_reason="tool_calls", tool_calls=[_mock_tool_call("c1")]),
+        _mock_response(content="SHOULD NOT REACH SECOND API CALL", finish_reason="stop"),
+    ]
+    checkpoint_calls = []
+
+    def fake_checkpoint(agent_arg, messages, api_call_count, **kwargs):
+        checkpoint_calls.append((api_call_count, kwargs))
+        return "CONTINUATION PACKET"
+
+    monkeypatch.setattr("agent.conversation_loop.handle_budget_checkpoint", fake_checkpoint)
+
+    with patch("run_agent.handle_function_call", return_value="search result"):
+        result = _run_without_persistence(agent)
+
+    assert result["final_response"] == "CONTINUATION PACKET"
+    assert result["completed"] is False
+    assert result["turn_exit_reason"] == "budget_checkpoint"
+    assert checkpoint_calls == [(2, {"budget_state": "checkpoint", "task_metadata": {}})]
+    assert agent.client.chat.completions.create.call_count == 1
+
+
+def test_budget_checkpoint_disabled_preserves_max_iteration_summary(agent):
+    agent.max_iterations = 1
+    agent.iteration_budget.max_total = 1
+    agent._budget_checkpointing_enabled = False
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(finish_reason="tool_calls", tool_calls=[_mock_tool_call("c1")]),
+        _mock_response(content="Could not finish — budget exhausted.", finish_reason="stop"),
+    ]
+
+    with patch("run_agent.handle_function_call", return_value="search result"):
+        result = _run_without_persistence(agent)
+
+    assert result["completed"] is False
+    assert result["turn_exit_reason"].startswith("max_iterations_reached")
+    assert result["final_response"] == "Could not finish — budget exhausted."

--- a/tests/gateway/test_live_pulse.py
+++ b/tests/gateway/test_live_pulse.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import importlib
+import json
+import time
+from pathlib import Path
+
+
+class DummyAgent:
+    session_id = "session-visible-id"
+    model = "test-model"
+    provider = "test-provider"
+
+    def get_activity_summary(self) -> dict[str, object]:
+        return {
+            "current_tool": "terminal",
+            "last_activity_desc": "running validation",
+            "api_call_count": 2,
+            "max_iterations": 90,
+            "seconds_since_activity": 1,
+        }
+
+
+def reload_live_pulse(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import gateway.live_pulse as live_pulse
+
+    return importlib.reload(live_pulse)
+
+
+def test_build_live_pulse_reports_non_secret_active_agent_metadata(monkeypatch, tmp_path):
+    live_pulse = reload_live_pulse(monkeypatch, tmp_path)
+    monkeypatch.setattr(live_pulse, "_pending_approval_counts", lambda: {})
+    monkeypatch.setattr(live_pulse, "_process_rows", lambda: [])
+
+    pulse = live_pulse.build_live_pulse(
+        running_agents={"telegram:chat:thread": DummyAgent()},
+        running_started={"telegram:chat:thread": time.time() - 5},
+        session_platform_resolver=lambda key: key.split(":", 1)[0],
+    )
+
+    assert pulse["schema_version"] == "hermes-live-pulse-v1"
+    assert pulse["summary"]["active_agent_turns"] == 1
+    assert pulse["summary"]["starting_turns"] == 0
+    assert pulse["summary"]["pending_approval_count"] == 0
+    assert pulse["summary"]["interruption_signal"] == "caution_active_workflow"
+    assert pulse["sessions"][0]["session_key_hash"]
+    assert "telegram:chat:thread" not in json.dumps(pulse)
+    assert pulse["sessions"][0]["platform"] == "telegram"
+    assert pulse["sessions"][0]["current_tool"] == "terminal"
+    assert pulse["sessions"][0]["current_phase"] == "running validation"
+
+
+def test_pending_sentinel_counts_as_starting_without_session_body(monkeypatch, tmp_path):
+    live_pulse = reload_live_pulse(monkeypatch, tmp_path)
+    sentinel = object()
+    monkeypatch.setattr(live_pulse, "_pending_approval_counts", lambda: {})
+    monkeypatch.setattr(live_pulse, "_process_rows", lambda: [])
+
+    pulse = live_pulse.build_live_pulse(
+        running_agents={"telegram:chat:thread": sentinel},
+        running_started={"telegram:chat:thread": time.time() - 2},
+        pending_sentinel=sentinel,
+    )
+
+    assert pulse["summary"]["active_agent_turns"] == 0
+    assert pulse["summary"]["starting_turns"] == 1
+    assert pulse["sessions"][0]["state"] == "starting"
+    assert pulse["sessions"][0]["session_id"] == ""
+    assert pulse["sessions"][0]["model"] == ""
+    assert pulse["sessions"][0]["provider"] == ""
+
+
+def test_pending_approval_counts_expose_counts_only(monkeypatch, tmp_path):
+    live_pulse = reload_live_pulse(monkeypatch, tmp_path)
+    monkeypatch.setattr(live_pulse, "_pending_approval_counts", lambda: {"telegram:chat:thread": 3})
+    monkeypatch.setattr(live_pulse, "_process_rows", lambda: [])
+
+    pulse = live_pulse.build_live_pulse(
+        running_agents={"telegram:chat:thread": DummyAgent()},
+        running_started={"telegram:chat:thread": time.time() - 5},
+    )
+
+    assert pulse["summary"]["pending_approval_count"] == 3
+    assert pulse["sessions"][0]["state"] == "waiting_human_approval"
+    assert pulse["sessions"][0]["pending_approval_count"] == 3
+    serialized = json.dumps(pulse)
+    assert "pattern_keys" not in serialized
+    assert "rm -rf" not in serialized
+    assert "No approval payload included" in serialized
+
+
+def test_background_helpers_do_not_force_caution(monkeypatch, tmp_path):
+    live_pulse = reload_live_pulse(monkeypatch, tmp_path)
+    monkeypatch.setattr(live_pulse, "_pending_approval_counts", lambda: {})
+    monkeypatch.setattr(
+        live_pulse,
+        "_process_rows",
+        lambda: [
+            {
+                "process_id": "helper",
+                "state": "background_running",
+                "classification": "default_long_lived_helper",
+                "interrupt_sensitive": False,
+            }
+        ],
+    )
+
+    pulse = live_pulse.build_live_pulse()
+
+    assert pulse["summary"]["running_background_process_count"] == 0
+    assert pulse["summary"]["background_helper_process_count"] == 1
+    assert pulse["summary"]["background_process_total_count"] == 1
+    assert pulse["summary"]["interruption_signal"] == "safe_to_message"
+
+
+def test_interrupt_sensitive_background_work_forces_caution(monkeypatch, tmp_path):
+    live_pulse = reload_live_pulse(monkeypatch, tmp_path)
+    monkeypatch.setattr(live_pulse, "_pending_approval_counts", lambda: {})
+    monkeypatch.setattr(
+        live_pulse,
+        "_process_rows",
+        lambda: [
+            {
+                "process_id": "task-linked",
+                "state": "background_running",
+                "classification": "active_background_work",
+                "interrupt_sensitive": True,
+            }
+        ],
+    )
+
+    pulse = live_pulse.build_live_pulse()
+
+    assert pulse["summary"]["running_background_process_count"] == 1
+    assert pulse["summary"]["background_helper_process_count"] == 0
+    assert pulse["summary"]["interruption_signal"] == "caution_active_workflow"
+
+
+def test_write_live_pulse_uses_hermes_home_profile_safe_path(monkeypatch, tmp_path):
+    live_pulse = reload_live_pulse(monkeypatch, tmp_path)
+    monkeypatch.setattr(live_pulse, "_pending_approval_counts", lambda: {})
+    monkeypatch.setattr(live_pulse, "_process_rows", lambda: [])
+
+    pulse = live_pulse.write_live_pulse()
+    expected = tmp_path / "tools" / "agent_floor" / "hermes_live_pulse.json"
+
+    assert expected.exists()
+    written = json.loads(expected.read_text())
+    assert written["schema_version"] == "hermes-live-pulse-v1"
+    assert written["generated_at"] == pulse["generated_at"]
+    source_limits = "\n".join(written["source_limits"])
+    assert "No chat content included" in source_limits
+    assert "No raw user prompt included" in source_limits
+    assert "No raw tool output included" in source_limits
+    assert "No sensitive command text included" in source_limits
+    assert "No approval payload included" in source_limits
+    assert "tokens" in source_limits
+    assert "credentials" in source_limits
+    assert "session bodies" in source_limits

--- a/tests/gateway/test_telegram_voice_route_diagnostic.py
+++ b/tests/gateway/test_telegram_voice_route_diagnostic.py
@@ -1,0 +1,228 @@
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+
+
+PRIVATE_CHAT_ID = "SHOULD_NOT_LEAK_CHAT_ID"
+PRIVATE_THREAD_ID = "424242"
+PRIVATE_USERNAME = "SHOULD_NOT_LEAK_USERNAME"
+PRIVATE_BODY = "SHOULD_NOT_LEAK_MESSAGE_BODY"
+PRIVATE_FILE_ID = "SHOULD_NOT_LEAK_FILE_ID"
+PRIVATE_URL = "SHOULD_NOT_LEAK_URL"
+PRIVATE_PATH = "SHOULD_NOT_LEAK_PRIVATE_PATH"
+PRIVATE_CONFIG_VALUE = "SHOULD_NOT_LEAK_PRIVATE_CONFIG_VALUE"
+
+
+def _make_adapter(require_mention=True):
+    from gateway.platforms.telegram import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={
+            "require_mention": require_mention,
+            "allowed_topics": [],
+            "allowed_chats": [],
+            "group_allowed_chats": [],
+        },
+    )
+    adapter._bot = SimpleNamespace(id=999, username="hermes_bot")
+    adapter._mention_patterns = []
+    adapter._dm_topics_config = []
+    adapter._dm_topic_chat_ids = set()
+    adapter._is_callback_user_authorized = lambda user_id, **_kw: True
+    return adapter
+
+
+def _voice_message(*, text=PRIVATE_BODY, caption=PRIVATE_BODY, reply_to_bot=False):
+    reply_to_message = None
+    if reply_to_bot:
+        reply_to_message = SimpleNamespace(
+            from_user=SimpleNamespace(id=999),
+            message_id=10,
+            text="previous bot reply",
+            caption=None,
+        )
+    return SimpleNamespace(
+        message_id=42,
+        text=text,
+        caption=caption,
+        entities=[],
+        caption_entities=[],
+        message_thread_id=PRIVATE_THREAD_ID,
+        is_topic_message=True,
+        chat=SimpleNamespace(id=PRIVATE_CHAT_ID, type="group", title="Private Group", is_forum=True),
+        from_user=SimpleNamespace(id=111, full_name=PRIVATE_USERNAME, first_name="Test"),
+        reply_to_message=reply_to_message,
+        voice=SimpleNamespace(file_id=PRIVATE_FILE_ID, file_unique_id="unique", file_size=1234),
+        audio=None,
+        photo=None,
+        video=None,
+        document=None,
+        sticker=None,
+        file_path=PRIVATE_PATH,
+        url=PRIVATE_URL,
+        private_config=PRIVATE_CONFIG_VALUE,
+        date=None,
+    )
+
+
+def test_voice_route_diagnostic_logs_redacted_drop_without_sensitive_values(caplog):
+    adapter = _make_adapter(require_mention=True)
+    message = _voice_message(reply_to_bot=False)
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.telegram"):
+        accepted = adapter._should_process_message(message)
+        adapter._log_voice_media_route_decision(message, accepted=accepted)
+
+    assert accepted is False
+    output = caplog.text
+    assert "Telegram voice/media route diagnostic" in output
+    assert "event_kind=voice" in output
+    assert "route_decision=dropped" in output
+    assert "drop_gate=route_gate" in output
+    assert "stt_reached=no" in output
+    assert "chat=<ID>" in output
+    assert "thread=<ID>" in output
+
+    for secret in (
+        PRIVATE_CHAT_ID,
+        PRIVATE_THREAD_ID,
+        PRIVATE_USERNAME,
+        PRIVATE_BODY,
+        PRIVATE_FILE_ID,
+        PRIVATE_URL,
+        PRIVATE_PATH,
+        PRIVATE_CONFIG_VALUE,
+    ):
+        assert secret not in output
+
+
+def test_voice_route_diagnostic_logs_redacted_accept_without_sensitive_values(caplog):
+    adapter = _make_adapter(require_mention=True)
+    message = _voice_message(reply_to_bot=True)
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.telegram"):
+        accepted = adapter._should_process_message(message)
+        adapter._log_voice_media_route_decision(message, accepted=accepted)
+
+    assert accepted is True
+    output = caplog.text
+    assert "event_kind=voice" in output
+    assert "route_decision=accepted" in output
+    assert "drop_gate=none" in output
+    assert "stt_reached=no" in output
+
+    for secret in (
+        PRIVATE_CHAT_ID,
+        PRIVATE_THREAD_ID,
+        PRIVATE_USERNAME,
+        PRIVATE_BODY,
+        PRIVATE_FILE_ID,
+        PRIVATE_URL,
+        PRIVATE_PATH,
+        PRIVATE_CONFIG_VALUE,
+    ):
+        assert secret not in output
+
+
+@pytest.mark.asyncio
+async def test_media_handler_emits_redacted_drop_diagnostic_before_cache_or_stt(caplog):
+    adapter = _make_adapter(require_mention=True)
+
+    def _do_not_observe(message):
+        return False
+
+    adapter._should_observe_unmentioned_group_message = _do_not_observe
+    message = _voice_message(reply_to_bot=False)
+    update = SimpleNamespace(message=message, update_id=100)
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.telegram"):
+        await adapter._handle_media_message(update, SimpleNamespace())
+
+    output = caplog.text
+    assert "Telegram voice/media route diagnostic" in output
+    assert "event_kind=voice" in output
+    assert "route_decision=dropped" in output
+    assert "drop_gate=route_gate" in output
+    assert "stt_reached=no" in output
+    assert "Cached user voice" not in output
+
+    for secret in (
+        PRIVATE_CHAT_ID,
+        PRIVATE_THREAD_ID,
+        PRIVATE_USERNAME,
+        PRIVATE_BODY,
+        PRIVATE_FILE_ID,
+        PRIVATE_URL,
+        PRIVATE_PATH,
+        PRIVATE_CONFIG_VALUE,
+    ):
+        assert secret not in output
+
+
+def test_ingress_diagnostic_logs_voice_before_media_handler_matching(caplog):
+    adapter = _make_adapter(require_mention=True)
+    message = _voice_message(reply_to_bot=True)
+    update = SimpleNamespace(message=message, edited_message=None, channel_post=None, update_id=100)
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.telegram"):
+        adapter._log_telegram_media_ingress_diagnostic(update)
+
+    output = caplog.text
+    assert "Telegram media ingress diagnostic" in output
+    assert "event_kind=message" in output
+    assert "message_kind=voice" in output
+    assert "has_voice=yes" in output
+    assert "has_audio=no" in output
+    assert "has_media=yes" in output
+    assert "media_handler_expected=yes" in output
+    assert "chat=<ID>" in output
+    assert "thread=<ID>" in output
+
+    for secret in (
+        PRIVATE_CHAT_ID,
+        PRIVATE_THREAD_ID,
+        PRIVATE_USERNAME,
+        PRIVATE_BODY,
+        PRIVATE_FILE_ID,
+        PRIVATE_URL,
+        PRIVATE_PATH,
+        PRIVATE_CONFIG_VALUE,
+    ):
+        assert secret not in output
+
+
+def test_ingress_diagnostic_ignores_plain_text_to_avoid_unrelated_log_noise(caplog):
+    adapter = _make_adapter(require_mention=True)
+    text_message = SimpleNamespace(
+        message_id=43,
+        text="plain group chatter",
+        caption=None,
+        entities=[],
+        caption_entities=[],
+        message_thread_id=None,
+        chat=SimpleNamespace(id=PRIVATE_CHAT_ID, type="group", title="Private Group", is_forum=False),
+        from_user=SimpleNamespace(id=111, full_name=PRIVATE_USERNAME, first_name="Test"),
+        reply_to_message=None,
+        voice=None,
+        audio=None,
+        photo=None,
+        video=None,
+        document=None,
+        sticker=None,
+        date=None,
+    )
+    update = SimpleNamespace(message=text_message, edited_message=None, channel_post=None, update_id=101)
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.telegram"):
+        adapter._log_telegram_media_ingress_diagnostic(update)
+        assert adapter._should_process_message(text_message) is False
+
+    assert "Telegram media ingress diagnostic" not in caplog.text
+    assert "Telegram voice/media route diagnostic" not in caplog.text

--- a/tests/gateway/test_voice_stt_result_diagnostic.py
+++ b/tests/gateway/test_voice_stt_result_diagnostic.py
@@ -1,0 +1,120 @@
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gateway.run import GatewayRunner
+
+
+PRIVATE_AUDIO_PATH = "/private/cache/SHOULD_NOT_LEAK_AUDIO.ogg"
+PRIVATE_TRANSCRIPT = "SHOULD_NOT_LEAK_TRANSCRIPT_BODY"
+
+
+def _runner(*, stt_enabled=True):
+    runner = object.__new__(GatewayRunner)
+    setattr(runner, "config", SimpleNamespace(stt_enabled=stt_enabled))
+    setattr(runner, "_has_setup_skill", lambda: False)
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_stt_success_empty_logs_redacted_diagnostic_and_no_useful_transcript(caplog):
+    runner = _runner()
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "   "},
+    ):
+        with caplog.at_level(logging.INFO, logger="gateway.run"):
+            enriched, transcripts = await runner._enrich_message_with_transcription(
+                "",
+                [PRIVATE_AUDIO_PATH],
+            )
+
+    assert transcripts == []
+    assert "speech-to-text did not produce usable transcript text" in enriched
+    output = caplog.text
+    assert "Telegram voice STT result diagnostic" in output
+    assert "stt_attempted=yes" in output
+    assert "stt_provider_available=yes" in output
+    assert "stt_result_class=success_empty" in output
+    assert "transcript_non_empty=no" in output
+    assert "transcript_length_bucket=0" in output
+    assert PRIVATE_AUDIO_PATH not in output
+    assert PRIVATE_TRANSCRIPT not in output
+
+
+@pytest.mark.asyncio
+async def test_stt_success_punctuation_placeholder_treated_as_empty(caplog):
+    runner = _runner()
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "... ... ..."},
+    ):
+        with caplog.at_level(logging.INFO, logger="gateway.run"):
+            enriched, transcripts = await runner._enrich_message_with_transcription(
+                "",
+                [PRIVATE_AUDIO_PATH],
+            )
+
+    assert transcripts == []
+    assert "Here's what they said" not in enriched
+    assert "speech-to-text did not produce usable transcript text" in enriched
+    output = caplog.text
+    assert "stt_result_class=success_empty" in output
+    assert "transcript_non_empty=no" in output
+    assert PRIVATE_AUDIO_PATH not in output
+
+
+@pytest.mark.asyncio
+async def test_stt_success_non_empty_logs_redacted_diagnostic(caplog):
+    runner = _runner()
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": PRIVATE_TRANSCRIPT},
+    ):
+        with caplog.at_level(logging.INFO, logger="gateway.run"):
+            enriched, transcripts = await runner._enrich_message_with_transcription(
+                "",
+                [PRIVATE_AUDIO_PATH],
+            )
+
+    assert transcripts == [PRIVATE_TRANSCRIPT]
+    assert PRIVATE_TRANSCRIPT in enriched
+    output = caplog.text
+    assert "Telegram voice STT result diagnostic" in output
+    assert "stt_result_class=success_non_empty" in output
+    assert "transcript_non_empty=yes" in output
+    assert "transcript_length_bucket=21-100" in output
+    assert PRIVATE_AUDIO_PATH not in output
+    # The transcript may appear in enriched text, but must never be logged.
+    assert PRIVATE_TRANSCRIPT not in output
+
+
+@pytest.mark.asyncio
+async def test_stt_provider_unavailable_logs_redacted_class(caplog):
+    runner = _runner()
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": False, "error": "No STT provider configured"},
+    ):
+        with caplog.at_level(logging.INFO, logger="gateway.run"):
+            enriched, transcripts = await runner._enrich_message_with_transcription(
+                "",
+                [PRIVATE_AUDIO_PATH],
+            )
+
+    assert transcripts == []
+    assert "no STT provider is configured" in enriched
+    output = caplog.text
+    assert "Telegram voice STT result diagnostic" in output
+    assert "stt_attempted=yes" in output
+    assert "stt_provider_available=no" in output
+    assert "stt_result_class=provider_unavailable" in output
+    assert "transcript_non_empty=no" in output
+    assert PRIVATE_AUDIO_PATH not in output
+    assert "No STT provider configured" not in output

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -73,6 +73,19 @@ class TestLoadConfigDefaults:
             assert config["terminal"]["backend"] == "local"
             assert config["display"]["interim_assistant_messages"] is True
 
+    def test_budget_checkpointing_defaults_are_disabled(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+            budget_cfg = config["agent"]["budget_checkpointing"]
+
+            assert budget_cfg == {
+                "enabled": False,
+                "warning_ratio": 0.75,
+                "checkpoint_ratio": 0.88,
+                "mode": "continuation_packet",
+            }
+            assert DEFAULT_CONFIG["agent"]["budget_checkpointing"] == budget_cfg
+
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
             config_path = tmp_path / "config.yaml"

--- a/tests/run_agent/test_iteration_budget_race.py
+++ b/tests/run_agent/test_iteration_budget_race.py
@@ -104,3 +104,50 @@ def test_iteration_budget_remaining():
     assert budget.remaining == 2
     budget.refund()
     assert budget.remaining == 3
+
+
+def test_iteration_budget_ratio_used_tracks_consumed_fraction():
+    """ratio_used must report used/max_total without mutating budget state."""
+    from run_agent import IterationBudget
+
+    budget = IterationBudget(max_total=4)
+
+    assert budget.ratio_used == 0.0
+    budget.consume()
+    assert budget.ratio_used == 0.25
+    budget.consume()
+    budget.consume()
+    assert budget.ratio_used == 0.75
+    assert budget.used == 3
+
+
+def test_iteration_budget_threshold_state_reports_lifecycle_states():
+    """threshold_state must classify normal/warning/checkpoint/exhausted bands."""
+    from run_agent import IterationBudget
+
+    budget = IterationBudget(max_total=10)
+    assert budget.threshold_state(warning_ratio=0.75, checkpoint_ratio=0.9) == "normal"
+
+    for _ in range(7):
+        budget.consume()
+    assert budget.threshold_state(warning_ratio=0.75, checkpoint_ratio=0.9) == "normal"
+
+    budget.consume()
+    assert budget.threshold_state(warning_ratio=0.75, checkpoint_ratio=0.9) == "warning"
+
+    budget.consume()
+    assert budget.threshold_state(warning_ratio=0.75, checkpoint_ratio=0.9) == "checkpoint"
+
+    budget.consume()
+    assert budget.threshold_state(warning_ratio=0.75, checkpoint_ratio=0.9) == "exhausted"
+
+
+def test_iteration_budget_threshold_state_validates_ratios():
+    """threshold_state must reject invalid threshold ordering."""
+    from run_agent import IterationBudget
+
+    budget = IterationBudget(max_total=10)
+
+    import pytest
+    with pytest.raises(ValueError, match="warning_ratio"):
+        budget.threshold_state(warning_ratio=0.95, checkpoint_ratio=0.9)

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -146,6 +146,88 @@ class TestApproveAndCheckSession:
         assert is_approved(key, "rm") is True
 
 
+class TestGitPushForceDetection:
+    """FGD-215: detect force-push risk from the git-push command segment only."""
+
+    def test_plain_branch_push_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command('git push origin "$BRANCH"')
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_plain_push_followed_by_grep_dash_f_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command(
+            'git push origin "$BRANCH"\n'
+            'git diff --name-only main...HEAD | grep -F "plugin/file.php"'
+        )
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_plain_push_followed_by_curl_dash_f_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command(
+            'git push origin "$BRANCH"\n'
+            'curl -f https://example.invalid/status'
+        )
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_plain_push_followed_by_force_prose_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command(
+            'git push origin "$BRANCH"\n'
+            'python3 create_issue.py --body '
+            "'Force push was forbidden; --force was not used'"
+        )
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_force_short_flag_is_dangerous(self):
+        dangerous, key, desc = detect_dangerous_command("git push -f origin branch")
+        assert dangerous is True
+        assert key is not None
+        assert "force" in desc.lower()
+
+    def test_force_long_flag_is_dangerous(self):
+        dangerous, key, desc = detect_dangerous_command("git push --force origin branch")
+        assert dangerous is True
+        assert key is not None
+        assert "force" in desc.lower()
+
+    def test_force_with_lease_is_dangerous(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "git push --force-with-lease origin branch"
+        )
+        assert dangerous is True
+        assert key is not None
+        assert "force" in desc.lower()
+
+    def test_mirror_push_is_dangerous(self):
+        dangerous, key, desc = detect_dangerous_command("git push --mirror origin")
+        assert dangerous is True
+        assert key is not None
+        assert "mirror" in desc.lower() or "history" in desc.lower()
+
+    def test_all_push_is_dangerous(self):
+        dangerous, key, desc = detect_dangerous_command("git push --all origin")
+        assert dangerous is True
+        assert key is not None
+        assert "all" in desc.lower() or "history" in desc.lower()
+
+    def test_tags_push_is_dangerous(self):
+        dangerous, key, desc = detect_dangerous_command("git push --tags origin")
+        assert dangerous is True
+        assert key is not None
+        assert "tags" in desc.lower() or "history" in desc.lower()
+
+    def test_delete_refspec_is_dangerous(self):
+        dangerous, key, desc = detect_dangerous_command("git push origin :branch")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower() or "history" in desc.lower()
+
+
 class TestSessionKeyContext:
     def test_context_session_key_overrides_process_env(self):
         token = approval_module.set_current_session_key("alice")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -793,6 +793,16 @@ def has_blocking_approval(session_key: str) -> bool:
         return bool(_gateway_queues.get(session_key))
 
 
+def gateway_pending_approval_counts() -> dict[str, int]:
+    """Return non-secret pending gateway approval counts by session key."""
+    with _lock:
+        return {
+            session_key: len(entries)
+            for session_key, entries in _gateway_queues.items()
+            if entries
+        }
+
+
 def submit_pending(session_key: str, approval: dict):
     """Store a pending approval request for a session."""
     with _lock:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -12,6 +12,7 @@ import contextvars
 import logging
 import os
 import re
+import shlex
 import sys
 import threading
 import time
@@ -462,10 +463,10 @@ DANGEROUS_PATTERNS = [
     # `python3 << 'EOF'` feeds arbitrary code via stdin without -c/-e flags.
     (r'\b(python[23]?|perl|ruby|node)\s+<<', "script execution via heredoc"),
     # Git destructive operations that can lose uncommitted work or rewrite
-    # shared history. Not captured by rm/chmod/etc patterns.
+    # shared history. Not captured by rm/chmod/etc patterns. Git-push history
+    # rewrite detection is command-segment aware in _detect_dangerous_git_push()
+    # so unrelated later shell text/flags do not contaminate a plain push.
     (r'\bgit\s+reset\s+--hard\b', "git reset --hard (destroys uncommitted changes)"),
-    (r'\bgit\s+push\b.*--force\b', "git force push (rewrites remote history)"),
-    (r'\bgit\s+push\b.*-f\b', "git force push short flag (rewrites remote history)"),
     (r'\bgit\s+clean\s+-[^\s]*f', "git clean with force (deletes untracked files)"),
     (r'\bgit\s+branch\s+-D\b', "git branch force delete"),
     # Script execution after chmod +x — catches the two-step pattern where
@@ -591,6 +592,97 @@ def _rewrite_resolved_hermes_home(command: str) -> str:
     return command
 
 
+_GIT_PUSH_FORCE_DESC = "git force push (rewrites remote history)"
+_GIT_PUSH_FORCE_SHORT_DESC = "git force push short flag (rewrites remote history)"
+_GIT_PUSH_MIRROR_DESC = "git mirror push (rewrites remote history)"
+_GIT_PUSH_ALL_DESC = "git push --all (updates multiple remote refs)"
+_GIT_PUSH_TAGS_DESC = "git push --tags (updates remote tags)"
+_GIT_PUSH_DELETE_REFSPEC_DESC = "git push delete refspec (deletes remote branch/tag)"
+
+
+def _shell_command_segments(command: str) -> list[str]:
+    """Split a shell-ish command into command segments outside quotes.
+
+    This intentionally recognizes only separators needed by the approval
+    detector: newline, semicolon, pipe, and ampersand outside quotes. It does
+    not execute or expand shell syntax; it only prevents broad regex matching
+    from letting an unrelated later segment contaminate an earlier command.
+    """
+    segments: list[str] = []
+    current: list[str] = []
+    quote: str | None = None
+    escaped = False
+    for ch in command:
+        if escaped:
+            current.append(ch)
+            escaped = False
+            continue
+        if ch == "\\" and quote != "'":
+            current.append(ch)
+            escaped = True
+            continue
+        if quote:
+            current.append(ch)
+            if ch == quote:
+                quote = None
+            continue
+        if ch in {"'", '"'}:
+            current.append(ch)
+            quote = ch
+            continue
+        if ch in "\n;|&":
+            segment = "".join(current).strip()
+            if segment:
+                segments.append(segment)
+            current = []
+            continue
+        current.append(ch)
+    segment = "".join(current).strip()
+    if segment:
+        segments.append(segment)
+    return segments
+
+
+def _detect_dangerous_git_push(command: str) -> tuple[bool, Optional[str], Optional[str]]:
+    """Detect dangerous git-push args within the actual git-push segment.
+
+    The old regex used ``git push.*-f`` across the whole script, so a safe push
+    followed by unrelated ``grep -F``, ``curl -f``, or body text mentioning
+    ``--force`` was treated as a force push. Tokenizing each command segment
+    with shlex keeps force/history checks scoped to the push invocation.
+    """
+    for segment in _shell_command_segments(command):
+        try:
+            tokens = shlex.split(segment, posix=True)
+        except ValueError:
+            # Fall back to whitespace splitting if a partial shell fragment is
+            # malformed; this keeps detection conservative without executing it.
+            tokens = segment.split()
+        for git_index, token in enumerate(tokens):
+            if token != "git":
+                continue
+            try:
+                push_index = tokens.index("push", git_index + 1)
+            except ValueError:
+                continue
+            push_args = tokens[push_index + 1:]
+            for arg in push_args:
+                if arg == "-f":
+                    return True, _GIT_PUSH_FORCE_SHORT_DESC, _GIT_PUSH_FORCE_SHORT_DESC
+                if arg == "--force" or arg.startswith("--force=") or arg == "--force-with-lease" or arg.startswith("--force-with-lease="):
+                    return True, _GIT_PUSH_FORCE_DESC, _GIT_PUSH_FORCE_DESC
+                if arg == "--mirror":
+                    return True, _GIT_PUSH_MIRROR_DESC, _GIT_PUSH_MIRROR_DESC
+                if arg == "--all":
+                    return True, _GIT_PUSH_ALL_DESC, _GIT_PUSH_ALL_DESC
+                if arg == "--tags":
+                    return True, _GIT_PUSH_TAGS_DESC, _GIT_PUSH_TAGS_DESC
+                if re.match(r"^:[^\s:]+$", arg):
+                    return True, _GIT_PUSH_DELETE_REFSPEC_DESC, _GIT_PUSH_DELETE_REFSPEC_DESC
+            break
+    return False, None, None
+
+
 def detect_dangerous_command(command: str) -> tuple:
     """Check if a command matches any dangerous patterns.
 
@@ -602,6 +694,9 @@ def detect_dangerous_command(command: str) -> tuple:
         if pattern_re.search(command_lower):
             pattern_key = description
             return (True, pattern_key, description)
+    git_push = _detect_dangerous_git_push(command_lower)
+    if git_push[0]:
+        return git_push
     return (False, None, None)
 
 


### PR DESCRIPTION
Adds non-secret Hermes gateway live pulse writer and heartbeat backend.

Writes hermes-live-pulse-v1 to the Agent Floor profile-safe pulse path.

Adds heartbeat/runtime integration in gateway/run.py.

Adds pending approval counts only in tools/approval.py, with no payload exposure.

Adds focused live pulse tests.

Does not restart the gateway.
Does not activate runtime.
Does not touch the dirty active Hermes worktree.
Does not alter final-sentinel work.
Does not mutate Mission Control/local registry, Kanban, Linear, Obsidian, Drive, Sheets, DB, or source registry.

Gate D is required after merge/acceptance to activate/restart gateway and prove fresh pulse readback.