### PR TITLE
fix(delegation): resolve custom:* provider base_url from config instead of falling through to parent (Fixes #53064)

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2787,6 +2787,41 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "api_mode": None,
         }
 
+    # For custom:* providers, resolve directly from config to avoid
+    # issues with the runtime provider system falling through to the
+    # parent agent's base_url instead of the custom provider's configured
+    # base_url. Fixes #53064.
+    if configured_provider.startswith("custom:"):
+        from hermes_cli.runtime_provider import _get_named_custom_provider, _detect_api_mode_for_url, _getenv
+
+        custom_conf = _get_named_custom_provider(configured_provider)
+        if custom_conf:
+            base_url = (custom_conf.get("base_url") or "").rstrip("/")
+            if base_url:
+                # Resolve API key: inline key > key_env > env var > none
+                api_key = str(custom_conf.get("api_key", "") or "").strip()
+                if not api_key:
+                    key_env = str(custom_conf.get("key_env", "") or "").strip()
+                    if key_env:
+                        api_key = _getenv(key_env, "").strip()
+                if not api_key:
+                    # If the parent has a key for a matching host, inherit it
+                    # rather than forcing a hard error — matches the pattern
+                    # used by the base_url branch above.
+                    api_key = None  # Will be inherited from parent in _build_child_agent
+
+                api_mode = custom_conf.get("api_mode") if isinstance(custom_conf.get("api_mode"), str) else None
+                if not api_mode:
+                    api_mode = _detect_api_mode_for_url(base_url) or "chat_completions"
+
+                return {
+                    "model": configured_model or custom_conf.get("model") or None,
+                    "provider": configured_provider,
+                    "base_url": base_url,
+                    "api_key": api_key,
+                    "api_mode": api_mode,
+                }
+
     # Provider is configured — resolve full credentials
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider


### PR DESCRIPTION
## What changed and why

When `delegation.provider` is set to a `custom:*` provider (e.g. `custom:or-api`),
subagents received the provider name but `resolve_runtime_provider()` returned the
parent agent's base_url instead of the custom provider's configured base_url. This
caused API calls to hit the wrong endpoint, fail with 503, and trigger the fallback
chain — silently routing all subsequent subagents away from the intended provider.

For `custom:*` providers, credentials are now resolved directly from the
providers/custom_providers config via `_get_named_custom_provider()`, bypassing the
generic runtime provider path that lacks the necessary custom_providers context in the
delegation code path.

## How to reproduce the bug (before this fix)

1. Configure a custom provider in config.yaml:
   ```yaml
   custom_providers:
   - name: or-api
     base_url: https://openrouter.ai/api/v1
     api_mode: chat_completions
     key_env: OR_API_KEY
     model: anthropic/claude-opus-4.8
   ```
2. Set delegation config:
   ```yaml
   delegation:
     provider: custom:or-api
     model: anthropic/claude-haiku-4-5
   ```
3. Run any `delegate_task` without explicit model/provider parameters.

**Actual (buggy):** Subagent gets `provider=custom:or-api` BUT `base_url=https://www.micuapi.ai`
(parent's default URL). API call fails. Fallback chain activates → subagent ends up on wrong provider.

## How to verify the fix

1. Set up the config as above
2. Inspect the resolved credentials from `_resolve_delegation_credentials` — `base_url` should now be `https://openrouter.ai/api/v1`
3. Run delegation — no 503 errors, no fallback activation

## Platforms tested

- [x] Ubuntu / Debian
- [ ] macOS
- [ ] Windows (or WSL)

## Related

Fixes #53064