### PR TITLE
fix(desktop): stage bundled electron main

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,7 +20,7 @@
     "start": "npm run build && electron .",
     "build": "node scripts/assert-root-install.cjs && node scripts/write-build-stamp.cjs && node scripts/stage-native-deps.cjs && tsc -b && vite build &&  node scripts/bundle-electron-main.mjs && npm run postbuild",
     "postbuild": "node scripts/assert-dist-built.cjs",
-    "prebuilder": "node scripts/patch-electron-builder-mac-binary.cjs",
+    "prebuilder": "node scripts/patch-electron-builder-mac-binary.cjs && node scripts/bundle-electron-main.mjs",
     "builder": "cross-env NODE_OPTIONS=--max-old-space-size=16384 node scripts/run-electron-builder.cjs",
     "pack": "npm run build && npm run builder -- --dir",
     "dist": "npm run build && npm run builder",
@@ -37,7 +37,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/backend-ready.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/link-title-window.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/git-worktree-ops.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-count.test.cjs electron/update-rebuild.test.cjs electron/update-marker.test.cjs electron/update-relaunch.test.cjs electron/windows-user-env.test.cjs electron/wsl-clipboard-image.test.cjs electron/titlebar-overlay-width.test.cjs electron/window-state.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/backend-ready.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/link-title-window.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/git-worktree-ops.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-count.test.cjs electron/update-rebuild.test.cjs electron/update-marker.test.cjs electron/update-relaunch.test.cjs electron/windows-user-env.test.cjs electron/wsl-clipboard-image.test.cjs electron/titlebar-overlay-width.test.cjs electron/window-state.test.cjs scripts/packaged-main-validation.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",
@@ -163,7 +163,21 @@
     "files": [
       "dist/**",
       "assets/**",
-      "electron/**",
+      {
+        "from": "electron",
+        "to": "electron",
+        "filter": [
+          "**/*",
+          "!main.cjs"
+        ]
+      },
+      {
+        "from": "build/electron",
+        "to": "electron",
+        "filter": [
+          "main.cjs"
+        ]
+      },
       "public/**",
       "package.json"
     ],

--- a/apps/desktop/scripts/bundle-electron-main.mjs
+++ b/apps/desktop/scripts/bundle-electron-main.mjs
@@ -9,12 +9,14 @@
 import { build } from 'esbuild'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { renameSync } from 'node:fs'
+import { mkdirSync } from 'node:fs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const root = resolve(here, '..')
 const entry = resolve(root, 'electron/main.cjs')
-const tmp = resolve(root, 'electron/main.bundled.cjs')
+const outfile = resolve(root, 'build/electron/main.cjs')
+
+mkdirSync(dirname(outfile), { recursive: true })
 
 await build({
   entryPoints: [entry],
@@ -22,12 +24,9 @@ await build({
   platform: 'node',
   format: 'cjs',
   target: 'node20',
-  outfile: tmp,
+  outfile,
   external: ['electron', 'node-pty'],
   logLevel: 'info'
 })
 
-// Overwrite the original with the bundled version.
-renameSync(tmp, entry)
-
-console.log(`bundled ${entry}`)
+console.log(`bundled ${entry} -> ${outfile}`)

--- a/apps/desktop/scripts/packaged-main-validation.cjs
+++ b/apps/desktop/scripts/packaged-main-validation.cjs
@@ -1,0 +1,24 @@
+'use strict'
+
+const { builtinModules } = require('node:module')
+
+const BUILTIN_MODULES = new Set([...builtinModules, ...builtinModules.map(name => `node:${name}`)])
+const ALLOWED_BARE_REQUIRES = new Set(['electron', 'node-pty'])
+const REQUIRE_SPEC_RE = /require\s*\(\s*['"`]([^'"`]+)['"`]\s*\)/g
+
+function findUnexpectedPackagedMainRequires(source) {
+  const unexpected = new Set()
+  for (const match of source.matchAll(REQUIRE_SPEC_RE)) {
+    const spec = match[1]
+    if (spec.startsWith('.')) {
+      unexpected.add(spec)
+      continue
+    }
+    if (!BUILTIN_MODULES.has(spec) && !ALLOWED_BARE_REQUIRES.has(spec)) {
+      unexpected.add(spec)
+    }
+  }
+  return [...unexpected].sort()
+}
+
+module.exports = { findUnexpectedPackagedMainRequires }

--- a/apps/desktop/scripts/packaged-main-validation.test.cjs
+++ b/apps/desktop/scripts/packaged-main-validation.test.cjs
@@ -1,0 +1,35 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const { findUnexpectedPackagedMainRequires } = require('./packaged-main-validation.cjs')
+
+test('packaged main validator allows bundled externals and builtins', () => {
+  const source = `
+    const fs = require('node:fs')
+    const path = require('path')
+    const electron = require('electron')
+    const nodePty = require('node-pty')
+  `
+
+  assert.deepEqual(findUnexpectedPackagedMainRequires(source), [])
+})
+
+test('packaged main validator rejects relative helper requires', () => {
+  const source = `
+    const helper = require('./backend-probes.cjs')
+    const parent = require("../other.cjs")
+  `
+
+  assert.deepEqual(findUnexpectedPackagedMainRequires(source), ['../other.cjs', './backend-probes.cjs'])
+})
+
+test('packaged main validator rejects unbundled bare package requires', () => {
+  const source = `
+    const simpleGit = require('simple-git')
+    const nested = require("@scope/pkg")
+  `
+
+  assert.deepEqual(findUnexpectedPackagedMainRequires(source), ['@scope/pkg', 'simple-git'])
+})

--- a/apps/desktop/scripts/test-desktop.mjs
+++ b/apps/desktop/scripts/test-desktop.mjs
@@ -2,8 +2,12 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { spawn, spawnSync } from 'node:child_process'
+import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
-import { listPackage } from '@electron/asar'
+import { extractFile, listPackage } from '@electron/asar'
+
+const require = createRequire(import.meta.url)
+const { findUnexpectedPackagedMainRequires } = require('./packaged-main-validation.cjs')
 
 const DESKTOP_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const PACKAGE_JSON = JSON.parse(fs.readFileSync(path.join(DESKTOP_ROOT, 'package.json'), 'utf8'))
@@ -341,10 +345,6 @@ function validateBundle() {
     }
   }
 
-  // Renderer payload check (either unpacked or in the asar)
-  if (exists(APP.unpackedDistIndex)) {
-    return { stamp, nodeBinaries }
-  }
   if (!exists(APP.asarPath)) {
     die(`Missing renderer payload: neither ${APP.unpackedDistIndex} nor ${APP.asarPath} exists`)
   }
@@ -353,6 +353,21 @@ function validateBundle() {
   // backslash-prefixed entries on Windows ('\\dist\\index.html') and
   // forward-slash on Unix.
   const normalized = files.map(f => f.replace(/\\/g, '/').replace(/^\/+/, ''))
+  const packagedMain = 'electron/main.cjs'
+  if (!normalized.includes(packagedMain)) {
+    die(`Missing packaged Electron main in app.asar: ${packagedMain}`)
+  }
+  const packagedMainSource = extractFile(APP.asarPath, packagedMain).toString('utf8')
+  const unexpectedMainRequires = findUnexpectedPackagedMainRequires(packagedMainSource)
+  if (unexpectedMainRequires.length > 0) {
+    die(
+      `Packaged electron/main.cjs has unbundled runtime require() calls: ${unexpectedMainRequires.join(', ')}`
+    )
+  }
+  // Renderer payload check (either unpacked or in the asar)
+  if (exists(APP.unpackedDistIndex)) {
+    return { stamp, nodeBinaries }
+  }
   if (!normalized.includes('dist/index.html')) {
     die(`Missing renderer payload file in app.asar: ${APP.asarPath} (expected dist/index.html)`)
   }

--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -92,9 +92,11 @@ let
         runHook preInstall
         mkdir -p $out
         # vite writes to apps/desktop/dist/ (we cd'd there in buildPhase).
-        # apps/desktop/build was created before the cd.  electron/ is source.
+        # apps/desktop/build was created before the cd.  electron/ is source,
+        # then main.cjs is replaced by the staged self-contained bundle.
         cp -rn apps/desktop/dist $out/
         cp -rn apps/desktop/electron $out/
+        cp -f apps/desktop/build/electron/main.cjs $out/electron/main.cjs
 
         # flatten native-deps and install-stamp.json to the root level, exactly like
         # electron-builder's extraResources does ("from": "build/native-deps", "to": "native-deps")

--- a/tests/test_desktop_electron_bundle_staging.py
+++ b/tests/test_desktop_electron_bundle_staging.py
@@ -1,0 +1,83 @@
+"""Packaging contract for the bundled Electron main process."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DESKTOP_DIR = REPO_ROOT / "apps" / "desktop"
+BUNDLE_SCRIPT = DESKTOP_DIR / "scripts" / "bundle-electron-main.mjs"
+DESKTOP_PKG = DESKTOP_DIR / "package.json"
+PACKAGED_MAIN_VALIDATION = DESKTOP_DIR / "scripts" / "packaged-main-validation.cjs"
+TEST_DESKTOP = DESKTOP_DIR / "scripts" / "test-desktop.mjs"
+NIX_DESKTOP = REPO_ROOT / "nix" / "desktop.nix"
+
+
+def _desktop_pkg() -> dict:
+    assert DESKTOP_PKG.is_file(), f"missing {DESKTOP_PKG}"
+    return json.loads(DESKTOP_PKG.read_text(encoding="utf-8"))
+
+
+def test_bundle_script_stages_main_process_without_overwriting_source():
+    src = BUNDLE_SCRIPT.read_text(encoding="utf-8")
+
+    assert re.search(r"const\s+entry\s*=\s*resolve\(root,\s*['\"]electron/main\.cjs['\"]\)", src)
+    assert re.search(r"const\s+outfile\s*=\s*resolve\(root,\s*['\"]build/electron/main\.cjs['\"]\)", src)
+    assert not re.search(r"outfile\s*[:=]\s*entry\b", src)
+    assert not re.search(r"(renameSync|copyFileSync|writeFileSync|rmSync|unlinkSync)\([^)]*\bentry\b", src)
+
+
+def test_electron_builder_packages_staged_main_process_bundle():
+    pkg = _desktop_pkg()
+    files = pkg.get("build", {}).get("files", [])
+
+    assert "electron/**" not in files
+
+    source_idx = next(
+        (
+            i
+            for i, item in enumerate(files)
+            if isinstance(item, dict) and item.get("from") == "electron" and item.get("to") == "electron"
+        ),
+        None,
+    )
+    staged_idx = next(
+        (
+            i
+            for i, item in enumerate(files)
+            if isinstance(item, dict) and item.get("from") == "build/electron" and item.get("to") == "electron"
+        ),
+        None,
+    )
+
+    assert source_idx is not None, "electron source file set is missing"
+    assert staged_idx is not None, "staged Electron main file set is missing"
+    assert source_idx < staged_idx
+    assert files[source_idx]["filter"] == ["**/*", "!main.cjs"]
+    assert files[staged_idx]["filter"] == ["main.cjs"]
+    assert pkg["main"] == "electron/main.cjs"
+
+
+def test_direct_builder_regenerates_staged_main_process_bundle():
+    prebuilder = _desktop_pkg().get("scripts", {}).get("prebuilder", "")
+
+    assert "bundle-electron-main.mjs" in prebuilder
+
+
+def test_nix_desktop_installs_staged_main_process_bundle():
+    src = NIX_DESKTOP.read_text(encoding="utf-8")
+
+    assert "node scripts/bundle-electron-main.mjs" in src
+    assert "cp -f apps/desktop/build/electron/main.cjs $out/electron/main.cjs" in src
+
+
+def test_packaged_main_validation_rejects_unbundled_requires():
+    helper = PACKAGED_MAIN_VALIDATION.read_text(encoding="utf-8")
+    desktop_test = TEST_DESKTOP.read_text(encoding="utf-8")
+
+    assert "builtinModules" in helper
+    assert "ALLOWED_BARE_REQUIRES" in helper
+    assert "findUnexpectedPackagedMainRequires" in desktop_test


### PR DESCRIPTION
## What does this PR do?

Stops the Desktop build/update path from overwriting the tracked source file `apps/desktop/electron/main.cjs` with generated esbuild output.

The bundler now writes the generated Electron main process to the ignored staging path `apps/desktop/build/electron/main.cjs`. Electron Builder packages that staged file back into `electron/main.cjs`, while the source checkout keeps the editable `electron/main.cjs` unchanged. The Nix desktop path mirrors the same staging behavior.

AI assistance: Codex prepared this implementation and test pass; maintainer review still owns the final merge decision.

## Related Issue

Fixes #53224

Duplicate-work checks before implementation:
- Exact PR search for `53224`: no results.
- Keyword PR searches for `bundle-electron-main main.cjs dirty source checkout desktop updater` and `desktop updater dirty main.cjs bundled`: no results.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/scripts/bundle-electron-main.mjs` now writes the bundled main process to `build/electron/main.cjs` instead of renaming it over `electron/main.cjs`.
- `apps/desktop/package.json` excludes source `electron/main.cjs` from packaged app files, adds the staged bundle at the packaged `electron/main.cjs` path, and regenerates the bundle in `prebuilder` so direct `npm run builder` does not package stale output.
- `nix/desktop.nix` copies source Electron files, then replaces `$out/electron/main.cjs` with the staged bundle.
- `apps/desktop/scripts/test-desktop.mjs` validates packaged `app.asar` contains a bundled main with no relative or unexpected bare runtime `require()` calls.
- Added focused Python and Node regression coverage for the staging/package contract and packaged-main validator.

## How to Test

1. Repro on current main in a temp copy: running `node apps/desktop/scripts/bundle-electron-main.mjs` changes the copied `electron/main.cjs` hash and replaces it with a generated bundle.
2. After this fix: `npm --prefix apps/desktop run prebuilder` regenerates `apps/desktop/build/electron/main.cjs` while the tracked `apps/desktop/electron/main.cjs` hash stays unchanged.
3. Proof commands run locally:

```bash
scripts/run_tests.sh tests/test_desktop_electron_bundle_staging.py tests/test_desktop_electron_pin.py
node --test apps/desktop/scripts/packaged-main-validation.test.cjs
node --check apps/desktop/scripts/test-desktop.mjs
node --check apps/desktop/scripts/bundle-electron-main.mjs
node --check apps/desktop/scripts/packaged-main-validation.cjs
git diff --check
npm --prefix apps/desktop run prebuilder
node - <<'NODE'
const fs = require('node:fs')
const { findUnexpectedPackagedMainRequires } = require('./apps/desktop/scripts/packaged-main-validation.cjs')
const source = fs.readFileSync('apps/desktop/build/electron/main.cjs', 'utf8')
const unexpected = findUnexpectedPackagedMainRequires(source)
console.log(JSON.stringify({ unexpected, hasSimpleGitBundle: source.includes('simple-git') }))
if (unexpected.length) process.exit(1)
NODE
```

Local full `npm --prefix apps/desktop run build` was attempted but this checkout is missing local CodeMirror/Lezer dependencies, so it stops in `tsc -b` before the changed bundling step.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Prebuilder proof:

```text
fd9b14483645d0445b37dd12f7646fa972fe7a42694e86b1c75af69a52263e82  apps/desktop/electron/main.cjs
bundled .../apps/desktop/electron/main.cjs -> .../apps/desktop/build/electron/main.cjs
fd9b14483645d0445b37dd12f7646fa972fe7a42694e86b1c75af69a52263e82  apps/desktop/electron/main.cjs
{"unexpected":[],"hasSimpleGitBundle":true}
```
