### PR TITLE
FGD-199L: add Hermes live pulse backend

### DIFF
--- a/gateway/live_pulse.py
+++ b/gateway/live_pulse.py
@@ -1,0 +1,233 @@
+"""Non-secret Hermes gateway live pulse for Mission Control / Agent Floor.
+
+This module exports metadata only: counts, redacted session identity, state,
+elapsed time, model/provider labels, and process counts. It never writes chat
+content, user prompts, tool output, command text, logs, credentials, or raw
+session keys.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+try:
+    from hermes_constants import get_hermes_home
+except Exception:  # pragma: no cover - defensive fallback for isolated imports
+    def get_hermes_home() -> Path:  # type: ignore[no-redef]
+        return Path.home() / ".hermes"
+
+PULSE_PATH = get_hermes_home() / "tools" / "agent_floor" / "hermes_live_pulse.json"
+SIGNALS = {"safe_to_message", "caution_active_workflow", "do_not_interrupt", "unknown"}
+HEARTBEAT_INTERVAL_SECONDS = 30
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _hash_session_key(session_key: str) -> str:
+    if not session_key:
+        return ""
+    return hashlib.sha256(session_key.encode("utf-8", errors="replace")).hexdigest()[:16]
+
+
+def _safe_str(value: Any, max_len: int = 96) -> str:
+    text = "" if value is None else str(value)
+    text = " ".join(text.split())
+    return text[: max_len - 1] + "…" if len(text) > max_len else text
+
+
+def _agent_activity(agent: Any) -> dict[str, Any]:
+    if not agent or not hasattr(agent, "get_activity_summary"):
+        return {}
+    try:
+        activity = agent.get_activity_summary() or {}
+    except Exception:
+        return {}
+    current_tool = activity.get("current_tool")
+    return {
+        "current_phase": _safe_str(activity.get("last_activity_desc") or current_tool or "running"),
+        "current_tool": _safe_str(current_tool, 64) if current_tool else None,
+        "api_call_count": activity.get("api_call_count"),
+        "max_iterations": activity.get("max_iterations"),
+        "seconds_since_activity": activity.get("seconds_since_activity"),
+    }
+
+
+def _classify_background_process(proc: dict[str, Any]) -> tuple[str, bool, str]:
+    """Classify process-registry rows without exposing command text.
+
+    Only session-linked/task-linked running processes are treated as
+    interrupt-sensitive. Unscoped long-lived helpers stay visible but must not
+    pin Agent Floor to caution forever.
+    """
+    has_session_key = bool(proc.get("has_session_key"))
+    task_id = _safe_str(proc.get("task_id"), 64) if proc.get("task_id") else ""
+    # The process registry uses task_id="default" for unscoped terminal
+    # background processes. Treat that as a visible helper, not evidence of
+    # interrupt-sensitive delegated work.
+    has_meaningful_task_id = bool(task_id and task_id != "default")
+    detached = bool(proc.get("detached"))
+    uptime = int(proc.get("uptime_seconds") or 0)
+
+    if detached:
+        return "detached_or_recovered_process", False, "detached recovered process; visible warning only"
+    if not has_meaningful_task_id and uptime >= 300:
+        return "default_long_lived_helper", False, "default/unscoped helper older than five minutes; not interrupt-sensitive"
+    if has_session_key or has_meaningful_task_id:
+        return "active_background_work", True, "linked to an active Hermes session or non-default task"
+    return "unscoped_recent_background_process", False, "unscoped recent process; visible warning only"
+
+
+def _process_rows() -> list[dict[str, Any]]:
+    try:
+        from tools.process_registry import process_registry
+        rows = []
+        for proc in process_registry.list_sessions():
+            if proc.get("status") != "running":
+                continue
+            classification, interrupt_sensitive, reason = _classify_background_process(proc)
+            rows.append({
+                "process_id": _safe_str(proc.get("session_id"), 48),
+                "state": "background_running",
+                "classification": classification,
+                "interrupt_sensitive": interrupt_sensitive,
+                "classification_reason": reason,
+                "elapsed_seconds": int(proc.get("uptime_seconds") or 0),
+                "session_linked": bool(proc.get("has_session_key")),
+                "task_id": _safe_str(proc.get("task_id"), 64) if proc.get("task_id") else None,
+                "pid_scope": _safe_str(proc.get("pid_scope"), 24) if proc.get("pid_scope") else None,
+                "detached": bool(proc.get("detached")),
+            })
+        return rows
+    except Exception:
+        return []
+
+
+def _pending_approval_counts() -> dict[str, int]:
+    try:
+        from tools.approval import gateway_pending_approval_counts
+        return gateway_pending_approval_counts()
+    except Exception:
+        return {}
+
+
+def build_live_pulse(
+    *,
+    running_agents: dict[str, Any] | None = None,
+    running_started: dict[str, float] | None = None,
+    pending_sentinel: Any = None,
+    background_tasks: set[Any] | None = None,
+    session_platform_resolver: Callable[[str], str] | None = None,
+) -> dict[str, Any]:
+    now = time.time()
+    running_agents = running_agents or {}
+    running_started = running_started or {}
+    approval_counts = _pending_approval_counts()
+    pending_approval_total = sum(int(v or 0) for v in approval_counts.values())
+    sessions: list[dict[str, Any]] = []
+    active_agent_turns = 0
+    starting_turns = 0
+
+    for session_key, agent in running_agents.items():
+        started = float(running_started.get(session_key, now) or now)
+        is_starting = agent is pending_sentinel
+        pending_count = int(approval_counts.get(session_key, 0) or 0)
+        if is_starting:
+            starting_turns += 1
+            state = "starting"
+            risk = "caution_active_workflow"
+        elif pending_count:
+            active_agent_turns += 1
+            state = "waiting_human_approval"
+            risk = "safe_to_message"
+        else:
+            active_agent_turns += 1
+            state = "running"
+            risk = "caution_active_workflow"
+        row = {
+            "session_key_hash": _hash_session_key(session_key),
+            "session_id": "" if is_starting else _safe_str(getattr(agent, "session_id", ""), 64),
+            "platform": _safe_str(session_platform_resolver(session_key), 32) if session_platform_resolver else "unknown",
+            "state": state,
+            "elapsed_seconds": max(0, int(now - started)),
+            "model": "" if is_starting else _safe_str(getattr(agent, "model", ""), 96),
+            "provider": "" if is_starting else _safe_str(getattr(agent, "provider", ""), 64),
+            "current_phase": "starting" if is_starting else "running",
+            "current_tool": None,
+            "pending_approval_count": pending_count,
+            "background_process_count": 0,
+            "interruption_risk": risk,
+        }
+        if not is_starting:
+            row.update(_agent_activity(agent))
+        sessions.append(row)
+
+    running_processes = _process_rows()
+    running_background_process_total_count = len(running_processes)
+    running_background_process_count = len([
+        proc for proc in running_processes if proc.get("interrupt_sensitive")
+    ])
+    background_helper_process_count = len([
+        proc for proc in running_processes if not proc.get("interrupt_sensitive")
+    ])
+
+    async_job_count = len([t for t in (background_tasks or set()) if hasattr(t, "done") and not t.done()])
+
+    if any(row.get("interruption_risk") == "do_not_interrupt" for row in sessions):
+        signal = "do_not_interrupt"
+        reason = "A live Hermes session reports do-not-interrupt risk."
+    elif active_agent_turns or starting_turns or running_background_process_count or async_job_count:
+        signal = "caution_active_workflow"
+        reason = "Hermes gateway reports active turn/startup/background activity."
+    elif pending_approval_total:
+        signal = "safe_to_message"
+        reason = "Hermes is waiting on human approval; messaging is unlikely to interrupt active execution."
+    elif background_helper_process_count:
+        signal = "safe_to_message"
+        reason = "Fresh gateway pulse shows no active turns or interrupt-sensitive background work; non-interrupting background helper present."
+    else:
+        signal = "safe_to_message"
+        reason = "Fresh gateway pulse shows no active turns, approvals, async jobs, or background processes."
+
+    return {
+        "schema_version": "hermes-live-pulse-v1",
+        "generated_at": _now_iso(),
+        "profile": os.getenv("HERMES_PROFILE") or "jimmy",
+        "gateway": {"running": True, "pid": os.getpid()},
+        "summary": {
+            "active_agent_turns": active_agent_turns,
+            "starting_turns": starting_turns,
+            "pending_approval_count": pending_approval_total,
+            "running_background_process_count": running_background_process_count,
+            "background_process_total_count": running_background_process_total_count,
+            "background_helper_process_count": background_helper_process_count,
+            "async_job_count": async_job_count,
+            "interruption_signal": signal,
+            "interruption_reason": reason,
+        },
+        "sessions": sessions,
+        "running_background_processes": running_processes,
+        "source_limits": [
+            "No chat content included",
+            "No raw user prompt included",
+            "No raw tool output included",
+            "No sensitive command text included",
+            "No approval payload included",
+            "No logs, databases, caches, browser profiles, tokens, credentials, or session bodies inspected",
+        ],
+    }
+
+
+def write_live_pulse(**kwargs: Any) -> dict[str, Any]:
+    pulse = build_live_pulse(**kwargs)
+    PULSE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = PULSE_PATH.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(pulse, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    tmp.replace(PULSE_PATH)
+    return pulse

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2815,6 +2815,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
+        self._agent_floor_live_pulse_heartbeat_task: Optional[asyncio.Task] = None
 
         # scale-to-zero (Phase 0, F13): gateway-scoped "last inbound seen" clock.
         # There is no such clock today (only a per-agent _last_activity_ts), so the
@@ -3844,6 +3845,52 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 raise
             except Exception:  # noqa: BLE001 - the watcher must never crash the gateway
                 logger.debug("scale-to-zero watcher iteration error", exc_info=True)
+    def _write_agent_floor_live_pulse(self) -> None:
+        """Best-effort non-secret live pulse for Mission Control / Agent Floor."""
+        try:
+            from gateway.live_pulse import write_live_pulse
+
+            write_live_pulse(
+                running_agents=getattr(self, "_running_agents", {}) or {},
+                running_started=getattr(self, "_running_agents_ts", {}) or {},
+                pending_sentinel=_AGENT_PENDING_SENTINEL,
+                background_tasks=getattr(self, "_background_tasks", set()) or set(),
+                session_platform_resolver=lambda key: key.split(":", 1)[0] if key else "unknown",
+            )
+        except Exception:
+            logger.debug("Failed to write Agent Floor live pulse", exc_info=True)
+
+    async def _agent_floor_live_pulse_heartbeat(self) -> None:
+        """Keep Agent Floor's non-secret live pulse fresh while gateway runs."""
+        try:
+            from gateway.live_pulse import HEARTBEAT_INTERVAL_SECONDS
+        except Exception:
+            HEARTBEAT_INTERVAL_SECONDS = 30
+
+        while self._running:
+            self._write_agent_floor_live_pulse()
+            try:
+                await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                await asyncio.sleep(30)
+
+    def _start_agent_floor_live_pulse_heartbeat(self) -> None:
+        task = getattr(self, "_agent_floor_live_pulse_heartbeat_task", None)
+        if task is not None and not task.done():
+            return
+        task = asyncio.create_task(self._agent_floor_live_pulse_heartbeat())
+        self._agent_floor_live_pulse_heartbeat_task = task
+        task.add_done_callback(
+            lambda done: setattr(self, "_agent_floor_live_pulse_heartbeat_task", None)
+        )
+
+    def _stop_agent_floor_live_pulse_heartbeat(self) -> None:
+        task = getattr(self, "_agent_floor_live_pulse_heartbeat_task", None)
+        if task is not None and not task.done():
+            task.cancel()
+        self._agent_floor_live_pulse_heartbeat_task = None
 
     def _status_action_label(self) -> str:
         return "restart" if self._restart_requested else "shutdown"
@@ -6205,6 +6252,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         self._running = True
         self._update_runtime_status("running")
+        self._start_agent_floor_live_pulse_heartbeat()
         
         # Emit gateway:startup hook
         hook_count = len(self.hooks.loaded_hooks)
@@ -7213,6 +7261,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     continue
                 _task.cancel()
             self._background_tasks.clear()
+            stop_live_pulse_heartbeat = getattr(
+                self,
+                "_stop_agent_floor_live_pulse_heartbeat",
+                None,
+            )
+            if callable(stop_live_pulse_heartbeat):
+                stop_live_pulse_heartbeat()
 
             self.adapters.clear()
             for _session_key in list(self._running_agents):
@@ -9006,6 +9061,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._running_agents[_quick_key] = _AGENT_PENDING_SENTINEL
         self._running_agents_ts[_quick_key] = time.time()
         self._persist_active_agents()
+        self._write_agent_floor_live_pulse()
         _run_generation = self._begin_session_run_generation(_quick_key)
 
         try:
@@ -14217,6 +14273,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # between lifecycle transitions.  Preserves gateway_state (see
         # _persist_active_agents).
         self._persist_active_agents()
+        self._write_agent_floor_live_pulse()
         return True
 
     def _clear_session_boundary_security_state(self, session_key: str) -> None:

--- a/tests/gateway/test_live_pulse.py
+++ b/tests/gateway/test_live_pulse.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import importlib
+import json
+import time
+from pathlib import Path
+
+
+class DummyAgent:
+    session_id = "session-visible-id"
+    model = "test-model"
+    provider = "test-provider"
+
+    def get_activity_summary(self) -> dict[str, object]:
+        return {
+            "current_tool": "terminal",
+            "last_activity_desc": "running validation",
+            "api_call_count": 2,
+            "max_iterations": 90,
+            "seconds_since_activity": 1,
+        }
+
+
+def reload_live_pulse(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import gateway.live_pulse as live_pulse
+
+    return importlib.reload(live_pulse)
+
+
+def test_build_live_pulse_reports_non_secret_active_agent_metadata(monkeypatch, tmp_path):
+    live_pulse = reload_live_pulse(monkeypatch, tmp_path)
+    monkeypatch.setattr(live_pulse, "_pending_approval_counts", lambda: {})
+    monkeypatch.setattr(live_pulse, "_process_rows", lambda: [])
+
+    pulse = live_pulse.build_live_pulse(
+        running_agents={"telegram:chat:thread": DummyAgent()},
+        running_started={"telegram:chat:thread": time.time() - 5},
+        session_platform_resolver=lambda key: key.split(":", 1)[0],
+    )
+
+    assert pulse["schema_version"] == "hermes-live-pulse-v1"
+    assert pulse["summary"]["active_agent_turns"] == 1
+    assert pulse["summary"]["starting_turns"] == 0
+    assert pulse["summary"]["pending_approval_count"] == 0
+    assert pulse["summary"]["interruption_signal"] == "caution_active_workflow"
+    assert pulse["sessions"][0]["session_key_hash"]
+    assert "telegram:chat:thread" not in json.dumps(pulse)
+    assert pulse["sessions"][0]["platform"] == "telegram"
+    assert pulse["sessions"][0]["current_tool"] == "terminal"
+    assert pulse["sessions"][0]["current_phase"] == "running validation"
+
+
+def test_pending_sentinel_counts_as_starting_without_session_body(monkeypatch, tmp_path):
+    live_pulse = reload_live_pulse(monkeypatch, tmp_path)
+    sentinel = object()
+    monkeypatch.setattr(live_pulse, "_pending_approval_counts", lambda: {})
+    monkeypatch.setattr(live_pulse, "_process_rows", lambda: [])
+
+    pulse = live_pulse.build_live_pulse(
+        running_agents={"telegram:chat:thread": sentinel},
+        running_started={"telegram:chat:thread": time.time() - 2},
+        pending_sentinel=sentinel,
+    )
+
+    assert pulse["summary"]["active_agent_turns"] == 0
+    assert pulse["summary"]["starting_turns"] == 1
+    assert pulse["sessions"][0]["state"] == "starting"
+    assert pulse["sessions"][0]["session_id"] == ""
+    assert pulse["sessions"][0]["model"] == ""
+    assert pulse["sessions"][0]["provider"] == ""
+
+
+def test_pending_approval_counts_expose_counts_only(monkeypatch, tmp_path):
+    live_pulse = reload_live_pulse(monkeypatch, tmp_path)
+    monkeypatch.setattr(live_pulse, "_pending_approval_counts", lambda: {"telegram:chat:thread": 3})
+    monkeypatch.setattr(live_pulse, "_process_rows", lambda: [])
+
+    pulse = live_pulse.build_live_pulse(
+        running_agents={"telegram:chat:thread": DummyAgent()},
+        running_started={"telegram:chat:thread": time.time() - 5},
+    )
+
+    assert pulse["summary"]["pending_approval_count"] == 3
+    assert pulse["sessions"][0]["state"] == "waiting_human_approval"
+    assert pulse["sessions"][0]["pending_approval_count"] == 3
+    serialized = json.dumps(pulse)
+    assert "pattern_keys" not in serialized
+    assert "rm -rf" not in serialized
+    assert "No approval payload included" in serialized
+
+
+def test_background_helpers_do_not_force_caution(monkeypatch, tmp_path):
+    live_pulse = reload_live_pulse(monkeypatch, tmp_path)
+    monkeypatch.setattr(live_pulse, "_pending_approval_counts", lambda: {})
+    monkeypatch.setattr(
+        live_pulse,
+        "_process_rows",
+        lambda: [
+            {
+                "process_id": "helper",
+                "state": "background_running",
+                "classification": "default_long_lived_helper",
+                "interrupt_sensitive": False,
+            }
+        ],
+    )
+
+    pulse = live_pulse.build_live_pulse()
+
+    assert pulse["summary"]["running_background_process_count"] == 0
+    assert pulse["summary"]["background_helper_process_count"] == 1
+    assert pulse["summary"]["background_process_total_count"] == 1
+    assert pulse["summary"]["interruption_signal"] == "safe_to_message"
+
+
+def test_interrupt_sensitive_background_work_forces_caution(monkeypatch, tmp_path):
+    live_pulse = reload_live_pulse(monkeypatch, tmp_path)
+    monkeypatch.setattr(live_pulse, "_pending_approval_counts", lambda: {})
+    monkeypatch.setattr(
+        live_pulse,
+        "_process_rows",
+        lambda: [
+            {
+                "process_id": "task-linked",
+                "state": "background_running",
+                "classification": "active_background_work",
+                "interrupt_sensitive": True,
+            }
+        ],
+    )
+
+    pulse = live_pulse.build_live_pulse()
+
+    assert pulse["summary"]["running_background_process_count"] == 1
+    assert pulse["summary"]["background_helper_process_count"] == 0
+    assert pulse["summary"]["interruption_signal"] == "caution_active_workflow"
+
+
+def test_write_live_pulse_uses_hermes_home_profile_safe_path(monkeypatch, tmp_path):
+    live_pulse = reload_live_pulse(monkeypatch, tmp_path)
+    monkeypatch.setattr(live_pulse, "_pending_approval_counts", lambda: {})
+    monkeypatch.setattr(live_pulse, "_process_rows", lambda: [])
+
+    pulse = live_pulse.write_live_pulse()
+    expected = tmp_path / "tools" / "agent_floor" / "hermes_live_pulse.json"
+
+    assert expected.exists()
+    written = json.loads(expected.read_text())
+    assert written["schema_version"] == "hermes-live-pulse-v1"
+    assert written["generated_at"] == pulse["generated_at"]
+    source_limits = "\n".join(written["source_limits"])
+    assert "No chat content included" in source_limits
+    assert "No raw user prompt included" in source_limits
+    assert "No raw tool output included" in source_limits
+    assert "No sensitive command text included" in source_limits
+    assert "No approval payload included" in source_limits
+    assert "tokens" in source_limits
+    assert "credentials" in source_limits
+    assert "session bodies" in source_limits

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -818,6 +818,16 @@ def has_blocking_approval(session_key: str) -> bool:
         return bool(_gateway_queues.get(session_key))
 
 
+def gateway_pending_approval_counts() -> dict[str, int]:
+    """Return non-secret pending gateway approval counts by session key."""
+    with _lock:
+        return {
+            session_key: len(entries)
+            for session_key, entries in _gateway_queues.items()
+            if entries
+        }
+
+
 def submit_pending(session_key: str, approval: dict):
     """Store a pending approval request for a session."""
     with _lock:


### PR DESCRIPTION
Clean replacement for contaminated PR #53238.

Adds non-secret Hermes gateway live pulse writer and heartbeat backend.

Writes hermes-live-pulse-v1 to the Agent Floor profile-safe pulse path.

Adds heartbeat/runtime integration in gateway/run.py.

Adds pending approval counts only in tools/approval.py, with no payload exposure.

Adds focused live pulse tests.

Does not restart the gateway.
Does not activate runtime.
Does not touch the dirty active Hermes worktree.
Does not alter final-sentinel work.
Does not mutate Mission Control/local registry, Kanban, Linear, Obsidian, Drive, Sheets, DB, or source registry.

Gate D is required after merge/acceptance to activate/restart gateway and prove fresh pulse readback.