### PR TITLE
fix(cli): warn and fallback when resumed session's original provider is missing

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2467,6 +2467,21 @@ def _cprint(text: str):
             pass
 
 
+def _get_session_provider(session_meta: dict | None) -> str | None:
+    """Extract the original provider from session metadata model_config."""
+    if not session_meta:
+        return None
+    raw = session_meta.get("model_config")
+    if not raw:
+        return None
+    try:
+        import json
+        config = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return config.get("provider")
+
+
 def _prepend_note_to_message(message, note: str):
     """Prepend a one-shot system-style note to a user message.
 

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -483,6 +483,24 @@ class CLIAgentSetupMixin:
             if resolved_meta:
                 session_meta = resolved_meta
 
+        from cli import _get_session_provider
+        stored_provider = _get_session_provider(session_meta)
+        if stored_provider and stored_provider != self.provider:
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+            try:
+                runtime = resolve_runtime_provider(requested=stored_provider)
+                if runtime:
+                    self.provider = stored_provider
+                    self.model = session_meta.get("model", self.model)
+                    from cli import _accent_hex
+                    self._console_print(
+                        f"[{_accent_hex()}]↻ Switched provider to [bold]{stored_provider}[/bold] (matching session's original configuration)[/]"
+                    )
+            except Exception:
+                self._console_print(
+                    f"[yellow]⚠ Stored provider '{stored_provider}' is no longer configured. Continuing with current provider '{self.provider}'.[/]"
+                )
+
         restored = self._session_db.get_messages_as_conversation(self.session_id)
         if restored:
             restored = [m for m in restored if m.get("role") != "session_meta"]

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -707,6 +707,24 @@ class CLICommandsMixin:
             if resolved_meta:
                 session_meta = resolved_meta
 
+        from cli import _get_session_provider
+        stored_provider = _get_session_provider(session_meta)
+        if stored_provider and stored_provider != self.provider:
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+            try:
+                runtime = resolve_runtime_provider(requested=stored_provider)
+                if runtime:
+                    self.provider = stored_provider
+                    self.model = session_meta.get("model", self.model)
+                    from cli import _cprint
+                    _cprint(
+                        f"  ↔ Switched provider to [bold]{stored_provider}[/bold] (matching session's original configuration)"
+                    )
+            except Exception:
+                _cprint(
+                    f"  ⚠ Stored provider '{stored_provider}' is no longer configured. Continuing with current provider '{self.provider}'."
+                )
+
         if target_id == self.session_id:
             _cprint("  Already on that session.")
             return


### PR DESCRIPTION
## What changed

When a session created with provider X is resumed after X is removed from config.yaml, the code now:

1. **Detects the mismatch**: Extracts the stored provider from the session's `model_config` field in SQLite via a new `_get_session_provider()` helper
2. **Tries to switch back**: Resolves the stored provider via `resolve_runtime_provider()` if still configured, it restores the original provider and model
3. **Warns on failure**: If the stored provider is no longer configured, prints a clear warning: \"Session was created with provider 'X' which is no longer configured. Continuing with current provider 'Y'.\"

Previously, the session silently resumed with whatever provider was currently configured, with no indication to the user.

## Why

The session's `model_config` was loadable from the DB but never consulted during resume. This caused confusing behavior  sessions that worked before would silently switch providers or trigger API 400 errors from model/provider mismatch.

## How to test

1. Create a session with a non-default provider: `hermes --provider openai`
2. Note the session ID
3. Remove that provider from config.yaml / `.env`
4. Resume: `.resume <session_id>`
5. Expected: warning message about provider mismatch, session continues with current default
6. Re-add the provider, repeat step 4
7. Expected: message confirming switch back to original provider

## Platforms tested

- Linux (Pop!_OS 22.04)
- CLI only (no gateway/API path changes)

Closes #52943