### PR TITLE
fix(cron): let briefing jobs require delivery

### DIFF
--- a/cron/blueprint_catalog.py
+++ b/cron/blueprint_catalog.py
@@ -95,6 +95,7 @@ class AutomationBlueprint:
     prompt_template: str
     slots: List[BlueprintSlot] = field(default_factory=list)
     deliver_default: str = "origin"
+    allow_silent: Optional[bool] = None
     skills: tuple = ()        # skills the job loads before running
     tags: tuple = ()
 
@@ -132,6 +133,7 @@ CATALOG: List[AutomationBlueprint] = [
             "good-morning with the date and offer to connect calendar/email."
         ),
         slots=[_TIME("08:00"), _DELIVER],
+        allow_silent=False,
         tags=("daily", "briefing"),
     ),
     AutomationBlueprint(
@@ -185,6 +187,7 @@ CATALOG: List[AutomationBlueprint] = [
             ),
             _DELIVER,
         ],
+        allow_silent=False,
         tags=("weekly", "review"),
     ),
     AutomationBlueprint(
@@ -199,6 +202,7 @@ CATALOG: List[AutomationBlueprint] = [
             "recent context and any task tools. Encouraging, short, one message."
         ),
         slots=[_TIME("09:00"), _DELIVER],
+        allow_silent=False,
         tags=("daily", "focus"),
     ),
     AutomationBlueprint(
@@ -708,6 +712,8 @@ def fill_blueprint(
     }
     if blueprint.skills:
         spec["skills"] = list(blueprint.skills)
+    if blueprint.allow_silent is not None:
+        spec["allow_silent"] = blueprint.allow_silent
     if origin is not None:
         spec["origin"] = origin
     return spec

--- a/cron/blueprint_catalog.py
+++ b/cron/blueprint_catalog.py
@@ -95,6 +95,7 @@ class AutomationBlueprint:
     prompt_template: str
     slots: List[BlueprintSlot] = field(default_factory=list)
     deliver_default: str = "origin"
+    allow_silent: Optional[bool] = None
     skills: tuple = ()        # skills the job loads before running
     tags: tuple = ()
 
@@ -136,6 +137,7 @@ CATALOG: List[AutomationBlueprint] = [
         ),
         slots=[_TIME("08:00"), _DELIVER],
         skills=("google-workspace",),
+        allow_silent=False,
         tags=("daily", "briefing"),
     ),
     AutomationBlueprint(
@@ -194,6 +196,7 @@ CATALOG: List[AutomationBlueprint] = [
             _DELIVER,
         ],
         skills=("weekly-review-planning",),
+        allow_silent=False,
         tags=("weekly", "review"),
     ),
     AutomationBlueprint(
@@ -208,6 +211,7 @@ CATALOG: List[AutomationBlueprint] = [
             "recent context and any task tools. Encouraging, short, one message."
         ),
         slots=[_TIME("09:00"), _DELIVER],
+        allow_silent=False,
         tags=("daily", "focus"),
     ),
     AutomationBlueprint(
@@ -794,6 +798,8 @@ def fill_blueprint(
     }
     if blueprint.skills:
         spec["skills"] = list(blueprint.skills)
+    if blueprint.allow_silent is not None:
+        spec["allow_silent"] = blueprint.allow_silent
     if origin is not None:
         spec["origin"] = origin
     return spec

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1639,6 +1639,15 @@ def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
     return str(resolved)
 
 
+def _normalize_allow_silent(value: Optional[bool]) -> Optional[bool]:
+    """Normalize and validate a cron job's silence-suppression contract."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    raise ValueError("allow_silent must be a boolean")
+
+
 def _resolve_default_model_snapshot() -> Optional[str]:
     """Resolve the global default model the same way the cron ticker does.
 
@@ -1797,6 +1806,7 @@ def create_job(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    allow_silent: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1854,6 +1864,10 @@ def create_job(
         monitor_url: Optional http(s) URL used as the monitor source instead
                 of a script — fetched with a bounded GET each tick. Same
                 hash-suppression semantics as ``monitor_script``.
+        allow_silent: When False, this job is always-deliver: the scheduler does
+                not tell the agent to use the cron silence marker, and a final
+                marker response is delivered instead of suppressed. Defaults to
+                True for backwards compatibility.
 
     Returns:
         The created job dict
@@ -1893,6 +1907,8 @@ def create_job(
 
     # Monitor-mode validation: exactly one source, and monitor mode only
     # makes sense when there IS an agent to suppress/wake.
+    normalized_allow_silent = _normalize_allow_silent(allow_silent)
+
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface these as clear ValueErrors at create time so bad configs never
     # reach the scheduler (shared with update_job, see
@@ -1995,6 +2011,10 @@ def create_job(
     # global cron.mirror_delivery config, default off).
     if normalized_attach is not None:
         job["attach_to_session"] = normalized_attach
+    # Only persist allow_silent when explicitly set. Missing means the legacy
+    # behavior: cron jobs may suppress delivery with the silence marker.
+    if normalized_allow_silent is not None:
+        job["allow_silent"] = normalized_allow_silent
 
     with _jobs_lock():
         jobs = load_jobs()
@@ -2102,6 +2122,9 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates[_mon_field] = _mv or None
 
             previous_inference_axes = _normalized_inference_axes(job)
+            if "allow_silent" in updates:
+                updates["allow_silent"] = _normalize_allow_silent(updates["allow_silent"])
+
             updated = _apply_skill_fields({**job, **updates})
 
             # Re-check execution-mode invariants on the MERGED record when

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1385,6 +1385,15 @@ def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
     return str(resolved)
 
 
+def _normalize_allow_silent(value: Optional[bool]) -> Optional[bool]:
+    """Normalize and validate a cron job's silence-suppression contract."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    raise ValueError("allow_silent must be a boolean")
+
+
 def _resolve_default_model_snapshot() -> Optional[str]:
     """Resolve the global default model the same way the cron ticker does.
 
@@ -1513,6 +1522,7 @@ def create_job(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    allow_silent: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1570,6 +1580,10 @@ def create_job(
         monitor_url: Optional http(s) URL used as the monitor source instead
                 of a script — fetched with a bounded GET each tick. Same
                 hash-suppression semantics as ``monitor_script``.
+        allow_silent: When False, this job is always-deliver: the scheduler does
+                not tell the agent to use the cron silence marker, and a final
+                marker response is delivered instead of suppressed. Defaults to
+                True for backwards compatibility.
 
     Returns:
         The created job dict
@@ -1620,6 +1634,7 @@ def create_job(
             "the whole point of a monitor job is to suppress or wake the AGENT "
             "based on source changes. Use a plain no_agent script job instead."
         )
+    normalized_allow_silent = _normalize_allow_silent(allow_silent)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -1720,6 +1735,10 @@ def create_job(
     # global cron.mirror_delivery config, default off).
     if normalized_attach is not None:
         job["attach_to_session"] = normalized_attach
+    # Only persist allow_silent when explicitly set. Missing means the legacy
+    # behavior: cron jobs may suppress delivery with the silence marker.
+    if normalized_allow_silent is not None:
+        job["allow_silent"] = normalized_allow_silent
 
     with _jobs_lock():
         jobs = load_jobs()
@@ -1819,6 +1838,9 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = _normalize_workdir(_wd)
 
             previous_inference_axes = _normalized_inference_axes(job)
+            if "allow_silent" in updates:
+                updates["allow_silent"] = _normalize_allow_silent(updates["allow_silent"])
+
             updated = _apply_skill_fields({**job, **updates})
             schedule_changed = "schedule" in updates
             inference_fields_changed = bool(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1549,6 +1549,24 @@ def _cron_mirror_delivery_enabled(job: dict, cfg: Optional[dict] = None) -> bool
         return False
 
 
+def _cron_silence_allowed(job: dict) -> bool:
+    """Whether this cron job may suppress delivery with the silence marker.
+
+    Default ON preserves the historical monitor/watchdog behavior. Jobs that
+    must always produce a user-visible report, like daily briefings, opt out
+    with ``allow_silent=False``.
+    """
+    return job.get("allow_silent") is not False
+
+
+def _is_scheduler_internal_silence(output: str, final_response: str) -> bool:
+    """True for scheduler-generated silence, not an agent-authored marker."""
+    return (
+        str(final_response or "").strip().upper() == SILENT_MARKER
+        and "**Status:** silent" in str(output or "")
+    )
+
+
 def _target_matches_origin(origin: dict, platform_name: str, chat_id: str,
                            thread_id: Optional[str]) -> bool:
     """True when a delivery target is the job's own origin conversation.
@@ -3905,18 +3923,29 @@ def _build_job_prompt(
         prompt = f"{notepad_section}{prompt}"
         has_injected_data = True
 
-    # Always prepend cron execution guidance so the agent knows how
-    # delivery works and can suppress delivery when appropriate.
+    # Always prepend cron execution guidance so the agent knows how delivery
+    # works. Silence suppression is per-job: monitors keep the historical
+    # marker contract, while always-deliver jobs get an all-clear instruction
+    # instead of a conflicting suppression rule.
+    if _cron_silence_allowed(job):
+        silence_guidance = (
+            "SILENT: If there is genuinely nothing new to report, respond "
+            "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
+            "Never combine [SILENT] with content — either report your "
+            "findings normally, or say [SILENT] and nothing more."
+        )
+    else:
+        silence_guidance = (
+            "DELIVERY REQUIRED: Always produce a concise final response for "
+            "this job. If everything is normal or there is nothing new, send "
+            "a short all-clear rather than suppressing delivery."
+        )
     cron_hint = (
         "[IMPORTANT: You are running as a scheduled cron job. "
         "DELIVERY: Your final response will be automatically delivered "
         "to the user — do NOT use send_message or try to deliver "
         "the output yourself. Just produce your report/output as your "
-        "final response and the system handles the rest. "
-        "SILENT: If there is genuinely nothing new to report, respond "
-        "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
-        "Never combine [SILENT] with content — either report your "
-        "findings normally, or say [SILENT] and nothing more.]\n\n"
+        f"final response and the system handles the rest. {silence_guidance}]\n\n"
     )
     prompt = cron_hint + prompt
     if skills is None:
@@ -6446,7 +6475,10 @@ def _run_one_job_body(
             # a real report that merely quoted "[SILENT]" mid-sentence (#51438,
             # #46917).  Keeps the intentional bracketed-prefix / trailing-line
             # tolerance the cron contract relies on.
-            if should_deliver and success and _is_cron_silence_response(deliver_content):
+            if should_deliver and success and _is_cron_silence_response(deliver_content) and (
+                _cron_silence_allowed(job)
+                or _is_scheduler_internal_silence(output, final_response)
+            ):
                 logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                 should_deliver = False
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -757,6 +757,24 @@ def _cron_mirror_delivery_enabled(job: dict, cfg: Optional[dict] = None) -> bool
         return False
 
 
+def _cron_silence_allowed(job: dict) -> bool:
+    """Whether this cron job may suppress delivery with the silence marker.
+
+    Default ON preserves the historical monitor/watchdog behavior. Jobs that
+    must always produce a user-visible report, like daily briefings, opt out
+    with ``allow_silent=False``.
+    """
+    return job.get("allow_silent") is not False
+
+
+def _is_scheduler_internal_silence(output: str, final_response: str) -> bool:
+    """True for scheduler-generated silence, not an agent-authored marker."""
+    return (
+        str(final_response or "").strip().upper() == SILENT_MARKER
+        and "**Status:** silent" in str(output or "")
+    )
+
+
 def _target_matches_origin(origin: dict, platform_name: str, chat_id: str,
                            thread_id: Optional[str]) -> bool:
     """True when a delivery target is the job's own origin conversation.
@@ -2683,18 +2701,29 @@ def _build_job_prompt(
         prompt = f"{notepad_section}{prompt}"
         has_injected_data = True
 
-    # Always prepend cron execution guidance so the agent knows how
-    # delivery works and can suppress delivery when appropriate.
+    # Always prepend cron execution guidance so the agent knows how delivery
+    # works. Silence suppression is per-job: monitors keep the historical
+    # marker contract, while always-deliver jobs get an all-clear instruction
+    # instead of a conflicting suppression rule.
+    if _cron_silence_allowed(job):
+        silence_guidance = (
+            "SILENT: If there is genuinely nothing new to report, respond "
+            "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
+            "Never combine [SILENT] with content — either report your "
+            "findings normally, or say [SILENT] and nothing more."
+        )
+    else:
+        silence_guidance = (
+            "DELIVERY REQUIRED: Always produce a concise final response for "
+            "this job. If everything is normal or there is nothing new, send "
+            "a short all-clear rather than suppressing delivery."
+        )
     cron_hint = (
         "[IMPORTANT: You are running as a scheduled cron job. "
         "DELIVERY: Your final response will be automatically delivered "
         "to the user — do NOT use send_message or try to deliver "
         "the output yourself. Just produce your report/output as your "
-        "final response and the system handles the rest. "
-        "SILENT: If there is genuinely nothing new to report, respond "
-        "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
-        "Never combine [SILENT] with content — either report your "
-        "findings normally, or say [SILENT] and nothing more.]\n\n"
+        f"final response and the system handles the rest. {silence_guidance}]\n\n"
     )
     prompt = cron_hint + prompt
     if skills is None:
@@ -4568,7 +4597,10 @@ def run_one_job(
             # a real report that merely quoted "[SILENT]" mid-sentence (#51438,
             # #46917).  Keeps the intentional bracketed-prefix / trailing-line
             # tolerance the cron contract relies on.
-            if should_deliver and success and _is_cron_silence_response(deliver_content):
+            if should_deliver and success and _is_cron_silence_response(deliver_content) and (
+                _cron_silence_allowed(job)
+                or _is_scheduler_internal_silence(output, final_response)
+            ):
                 logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                 should_deliver = False
 

--- a/cron/suggestion_catalog.py
+++ b/cron/suggestion_catalog.py
@@ -58,6 +58,7 @@ CATALOG: List[CatalogEntry] = [
             "schedule": "0 8 * * *",
             "name": "Daily briefing",
             "deliver": "origin",
+            "allow_silent": False,
         },
     ),
     CatalogEntry(
@@ -99,6 +100,7 @@ CATALOG: List[CatalogEntry] = [
             "schedule": "0 18 * * 0",
             "name": "Weekly review",
             "deliver": "origin",
+            "allow_silent": False,
         },
     ),
     CatalogEntry(
@@ -116,6 +118,7 @@ CATALOG: List[CatalogEntry] = [
             "schedule": "0 9 * * 1-5",
             "name": "Workday start reminder",
             "deliver": "origin",
+            "allow_silent": False,
         },
     ),
 ]

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5684,7 +5684,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
     _JOB_ID_RE = __import__("re").compile(r"[a-f0-9]{12}")
     # Allowed fields for update — prevents clients injecting arbitrary keys
-    _UPDATE_ALLOWED_FIELDS = {"name", "schedule", "prompt", "deliver", "skills", "skill", "repeat", "enabled"}
+    _UPDATE_ALLOWED_FIELDS = {
+        "name", "schedule", "prompt", "deliver", "skills", "skill",
+        "repeat", "enabled", "allow_silent",
+    }
     _MAX_NAME_LENGTH = 200
     _MAX_PROMPT_LENGTH = 5000
 
@@ -5742,6 +5745,7 @@ class APIServerAdapter(BasePlatformAdapter):
             deliver = body.get("deliver", "local")
             skills = body.get("skills")
             repeat = body.get("repeat")
+            allow_silent = body.get("allow_silent")
 
             if not name:
                 return web.json_response({"error": "Name is required"}, status=400)
@@ -5761,6 +5765,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     return web.json_response({"error": scan_error}, status=400)
             if repeat is not None and (not isinstance(repeat, int) or repeat < 1):
                 return web.json_response({"error": "Repeat must be a positive integer"}, status=400)
+            if allow_silent is not None and not isinstance(allow_silent, bool):
+                return web.json_response({"error": "allow_silent must be a boolean"}, status=400)
 
             kwargs = {
                 "prompt": prompt,
@@ -5773,6 +5779,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 kwargs["skills"] = skills
             if repeat is not None:
                 kwargs["repeat"] = repeat
+            if allow_silent is not None:
+                kwargs["allow_silent"] = allow_silent
 
             job = _cron_create(**kwargs)
             return web.json_response({"job": job})
@@ -5830,6 +5838,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 scan_error = _scan_cron_prompt(sanitized["prompt"])
                 if scan_error:
                     return web.json_response({"error": scan_error}, status=400)
+            if "allow_silent" in sanitized and not isinstance(sanitized["allow_silent"], bool):
+                return web.json_response({"error": "allow_silent must be a boolean"}, status=400)
             job = _cron_update(job_id, sanitized)
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5488,7 +5488,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
     _JOB_ID_RE = __import__("re").compile(r"[a-f0-9]{12}")
     # Allowed fields for update — prevents clients injecting arbitrary keys
-    _UPDATE_ALLOWED_FIELDS = {"name", "schedule", "prompt", "deliver", "skills", "skill", "repeat", "enabled"}
+    _UPDATE_ALLOWED_FIELDS = {
+        "name", "schedule", "prompt", "deliver", "skills", "skill",
+        "repeat", "enabled", "allow_silent",
+    }
     _MAX_NAME_LENGTH = 200
     _MAX_PROMPT_LENGTH = 5000
 
@@ -5546,6 +5549,7 @@ class APIServerAdapter(BasePlatformAdapter):
             deliver = body.get("deliver", "local")
             skills = body.get("skills")
             repeat = body.get("repeat")
+            allow_silent = body.get("allow_silent")
 
             if not name:
                 return web.json_response({"error": "Name is required"}, status=400)
@@ -5565,6 +5569,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     return web.json_response({"error": scan_error}, status=400)
             if repeat is not None and (not isinstance(repeat, int) or repeat < 1):
                 return web.json_response({"error": "Repeat must be a positive integer"}, status=400)
+            if allow_silent is not None and not isinstance(allow_silent, bool):
+                return web.json_response({"error": "allow_silent must be a boolean"}, status=400)
 
             kwargs = {
                 "prompt": prompt,
@@ -5577,6 +5583,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 kwargs["skills"] = skills
             if repeat is not None:
                 kwargs["repeat"] = repeat
+            if allow_silent is not None:
+                kwargs["allow_silent"] = allow_silent
 
             job = _cron_create(**kwargs)
             return web.json_response({"job": job})
@@ -5634,6 +5642,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 scan_error = _scan_cron_prompt(sanitized["prompt"])
                 if scan_error:
                     return web.json_response({"error": scan_error}, status=400)
+            if "allow_silent" in sanitized and not isinstance(sanitized["allow_silent"], bool):
+                return web.json_response({"error": "allow_silent must be a boolean"}, status=400)
             job = _cron_update(job_id, sanitized)
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -396,6 +396,7 @@ def cron_create(args):
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
+        allow_silent=getattr(args, "allow_silent", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -470,6 +471,7 @@ def cron_edit(args):
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
+        allow_silent=getattr(args, "allow_silent", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -360,6 +360,7 @@ def cron_create(args):
         no_agent=getattr(args, "no_agent", False) or None,
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
+        allow_silent=getattr(args, "allow_silent", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -431,6 +432,7 @@ def cron_edit(args):
         no_agent=getattr(args, "no_agent", None),
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
+        allow_silent=getattr(args, "allow_silent", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -66,6 +66,20 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
             "pattern (memory alerts, disk alerts, CI pings)."
         ),
     )
+    create_silence = cron_create.add_mutually_exclusive_group()
+    create_silence.add_argument(
+        "--always-deliver",
+        dest="allow_silent",
+        action="store_false",
+        default=None,
+        help="Do not inject the cron [SILENT] suppression rule; send an all-clear instead.",
+    )
+    create_silence.add_argument(
+        "--allow-silent",
+        dest="allow_silent",
+        action="store_true",
+        help="Allow this job to suppress delivery with [SILENT] when there is nothing new.",
+    )
     cron_create.add_argument(
         "--monitor-script",
         dest="monitor_script",
@@ -177,6 +191,20 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         action="store_const",
         const=False,
         help="Disable no-agent mode on this job (reverts to LLM-driven execution).",
+    )
+    edit_silence = cron_edit.add_mutually_exclusive_group()
+    edit_silence.add_argument(
+        "--always-deliver",
+        dest="allow_silent",
+        action="store_false",
+        default=None,
+        help="Do not inject the cron [SILENT] suppression rule; send an all-clear instead.",
+    )
+    edit_silence.add_argument(
+        "--allow-silent",
+        dest="allow_silent",
+        action="store_true",
+        help="Allow this job to suppress delivery with [SILENT] when there is nothing new.",
     )
     cron_edit.add_argument(
         "--continuity",

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -66,6 +66,20 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
             "pattern (memory alerts, disk alerts, CI pings)."
         ),
     )
+    create_silence = cron_create.add_mutually_exclusive_group()
+    create_silence.add_argument(
+        "--always-deliver",
+        dest="allow_silent",
+        action="store_false",
+        default=None,
+        help="Do not inject the cron [SILENT] suppression rule; send an all-clear instead.",
+    )
+    create_silence.add_argument(
+        "--allow-silent",
+        dest="allow_silent",
+        action="store_true",
+        help="Allow this job to suppress delivery with [SILENT] when there is nothing new.",
+    )
     cron_create.add_argument(
         "--monitor-script",
         dest="monitor_script",
@@ -164,6 +178,20 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         action="store_const",
         const=False,
         help="Disable no-agent mode on this job (reverts to LLM-driven execution).",
+    )
+    edit_silence = cron_edit.add_mutually_exclusive_group()
+    edit_silence.add_argument(
+        "--always-deliver",
+        dest="allow_silent",
+        action="store_false",
+        default=None,
+        help="Do not inject the cron [SILENT] suppression rule; send an all-clear instead.",
+    )
+    edit_silence.add_argument(
+        "--allow-silent",
+        dest="allow_silent",
+        action="store_true",
+        help="Allow this job to suppress delivery with [SILENT] when there is nothing new.",
     )
     cron_edit.add_argument(
         "--monitor-script",

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -388,6 +388,7 @@ class CronJobCreate(BaseModel):
     enabled_toolsets: Optional[List[str]] = None
     workdir: Optional[str] = None
     no_agent: bool = False
+    allow_silent: Optional[Any] = None
 
 
 class CronJobUpdate(BaseModel):

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -372,6 +372,7 @@ class CronJobCreate(BaseModel):
     enabled_toolsets: Optional[List[str]] = None
     workdir: Optional[str] = None
     no_agent: bool = False
+    allow_silent: Optional[Any] = None
 
 
 class CronJobUpdate(BaseModel):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12710,6 +12710,8 @@ def _list_cron_job_runs_sync(job_id: str, profile: Optional[str] = None, limit: 
 
 
 def _create_cron_job_sync(body: CronJobCreate, profile: Optional[str] = None):
+    if body.allow_silent is not None and not isinstance(body.allow_silent, bool):
+        raise HTTPException(status_code=400, detail="allow_silent must be a boolean")
     try:
         profile_name, profile_home = _cron_profile_home(profile)
         script = _normalize_dashboard_cron_script(body.script, profile_home)
@@ -12739,6 +12741,7 @@ def _create_cron_job_sync(body: CronJobCreate, profile: Optional[str] = None):
             enabled_toolsets=_cron_string_list(body.enabled_toolsets),
             workdir=_cron_optional_text(body.workdir),
             no_agent=no_agent,
+            allow_silent=body.allow_silent,
         )
     except HTTPException:
         raise
@@ -12756,6 +12759,8 @@ def _update_cron_job_sync(job_id: str, body: CronJobUpdate, profile: Optional[st
     selected = profile or _find_cron_job_profile(job_id)
     if not selected:
         raise HTTPException(status_code=404, detail="Job not found")
+    if "allow_silent" in body.updates and not isinstance(body.updates["allow_silent"], bool):
+        raise HTTPException(status_code=400, detail="allow_silent must be a boolean")
     try:
         profile_name, profile_home = _cron_profile_home(selected)
         existing = _call_cron_for_profile(profile_name, "get_job", job_id)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11893,6 +11893,8 @@ def _list_cron_job_runs_sync(job_id: str, profile: Optional[str] = None, limit: 
 
 
 def _create_cron_job_sync(body: CronJobCreate, profile: Optional[str] = None):
+    if body.allow_silent is not None and not isinstance(body.allow_silent, bool):
+        raise HTTPException(status_code=400, detail="allow_silent must be a boolean")
     try:
         profile_name, profile_home = _cron_profile_home(profile)
         script = _normalize_dashboard_cron_script(body.script, profile_home)
@@ -11922,6 +11924,7 @@ def _create_cron_job_sync(body: CronJobCreate, profile: Optional[str] = None):
             enabled_toolsets=_cron_string_list(body.enabled_toolsets),
             workdir=_cron_optional_text(body.workdir),
             no_agent=no_agent,
+            allow_silent=body.allow_silent,
         )
     except HTTPException:
         raise
@@ -11939,6 +11942,8 @@ def _update_cron_job_sync(job_id: str, body: CronJobUpdate, profile: Optional[st
     selected = profile or _find_cron_job_profile(job_id)
     if not selected:
         raise HTTPException(status_code=404, detail="Job not found")
+    if "allow_silent" in body.updates and not isinstance(body.updates["allow_silent"], bool):
+        raise HTTPException(status_code=400, detail="allow_silent must be a boolean")
     try:
         profile_name, profile_home = _cron_profile_home(selected)
         existing = _call_cron_for_profile(profile_name, "get_job", job_id)

--- a/tests/cron/test_blueprint_catalog.py
+++ b/tests/cron/test_blueprint_catalog.py
@@ -72,6 +72,15 @@ class TestScheduleResolution:
         spec = fill_blueprint(get_blueprint("morning-brief"), {})
         assert spec["schedule"] == "0 8 * * *"
 
+    def test_morning_briefing_is_always_deliver(self):
+        spec = fill_blueprint(get_blueprint("morning-brief"), {})
+        assert spec["allow_silent"] is False
+
+    def test_report_blueprints_are_always_deliver(self):
+        for key in ("morning-brief", "weekly-review", "workday-start"):
+            spec = fill_blueprint(get_blueprint(key), {})
+            assert spec["allow_silent"] is False
+
 
 class TestValidation:
     def test_invalid_time_rejected(self):

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -260,6 +260,19 @@ class TestJobCRUD:
         )
         assert job["deliver"] == "origin"
 
+    def test_default_delivery_local_no_origin(self, tmp_cron_dir):
+        job = create_job(prompt="Test", schedule="30m")
+        assert job["deliver"] == "local"
+
+    def test_allow_silent_false_is_persisted(self, tmp_cron_dir):
+        job = create_job(prompt="Daily briefing", schedule="every 1h", allow_silent=False)
+        assert job["allow_silent"] is False
+        assert get_job(job["id"])["allow_silent"] is False
+
+    def test_allow_silent_rejects_non_bool_on_create(self, tmp_cron_dir):
+        with pytest.raises(ValueError, match="allow_silent"):
+            create_job(prompt="Daily briefing", schedule="every 1h", allow_silent="false")
+
 
 class TestUpdateJob:
     def test_update_name(self, tmp_cron_dir):
@@ -276,6 +289,85 @@ class TestUpdateJob:
         # Verify persisted to disk
         fetched = get_job(job["id"])
         assert fetched["name"] == "New Name"
+
+    def test_update_schedule(self, tmp_cron_dir):
+        job = create_job(prompt="Daily report", schedule="every 1h")
+        assert job["schedule"]["kind"] == "interval"
+        assert job["schedule"]["minutes"] == 60
+        old_next_run = job["next_run_at"]
+        new_schedule = parse_schedule("every 2h")
+        updated = update_job(job["id"], {"schedule": new_schedule, "schedule_display": new_schedule["display"]})
+        assert updated is not None
+        assert updated["schedule"]["kind"] == "interval"
+        assert updated["schedule"]["minutes"] == 120
+        assert updated["schedule_display"] == "every 120m"
+        assert updated["next_run_at"] != old_next_run
+        # Verify persisted to disk
+        fetched = get_job(job["id"])
+        assert fetched["schedule"]["minutes"] == 120
+        assert fetched["schedule_display"] == "every 120m"
+
+    def test_update_to_past_oneshot_rejected(self, tmp_cron_dir, monkeypatch):
+        """Updating a job's schedule to a one-shot >ONESHOT_GRACE_SECONDS in the
+        past must raise ValueError — otherwise the ghost-job bug (#59395) re-enters
+        through the update door (next_run_at=None stored with state='scheduled').
+        The original job must be left unchanged on disk."""
+        now = datetime(2026, 7, 6, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = create_job(prompt="Recurring", schedule="every 1h", deliver="local")
+        past = parse_schedule((now - timedelta(minutes=10)).isoformat())
+        with pytest.raises(ValueError, match="past and cannot be scheduled"):
+            update_job(job["id"], {"schedule": past})
+        # Original job unchanged — still the recurring interval, still scheduled.
+        fetched = get_job(job["id"])
+        assert fetched["schedule"]["kind"] == "interval"
+        assert fetched["next_run_at"] is not None
+
+    def test_update_to_future_oneshot_accepted(self, tmp_cron_dir, monkeypatch):
+        """Updating to a FUTURE one-shot still works — only past ones are rejected."""
+        now = datetime(2026, 7, 6, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = create_job(prompt="Recurring", schedule="every 1h", deliver="local")
+        future = parse_schedule((now + timedelta(hours=2)).isoformat())
+        updated = update_job(job["id"], {"schedule": future})
+        assert updated is not None
+        assert updated["schedule"]["kind"] == "once"
+        assert updated["next_run_at"] is not None
+
+    def test_update_enable_disable(self, tmp_cron_dir):
+        job = create_job(prompt="Toggle me", schedule="every 1h")
+        assert job["enabled"] is True
+        updated = update_job(job["id"], {"enabled": False})
+        assert updated["enabled"] is False
+        fetched = get_job(job["id"])
+        assert fetched["enabled"] is False
+
+    def test_update_allow_silent(self, tmp_cron_dir):
+        job = create_job(prompt="Report", schedule="every 1h")
+        updated = update_job(job["id"], {"allow_silent": False})
+        assert updated["allow_silent"] is False
+        assert get_job(job["id"])["allow_silent"] is False
+
+    def test_update_allow_silent_rejects_non_bool(self, tmp_cron_dir):
+        job = create_job(prompt="Report", schedule="every 1h")
+        with pytest.raises(ValueError, match="allow_silent"):
+            update_job(job["id"], {"allow_silent": "false"})
+        assert "allow_silent" not in get_job(job["id"])
+
+    def test_update_nonexistent_returns_none(self, tmp_cron_dir):
+        result = update_job("nonexistent_id", {"name": "X"})
+        assert result is None
+
+    def test_update_rejects_id_change(self, tmp_cron_dir):
+        """Job IDs are filesystem path components — must be immutable."""
+        job = create_job(prompt="Original", schedule="every 1h")
+
+        with pytest.raises(ValueError, match="id"):
+            update_job(job["id"], {"id": "../escape"})
+
+        # Original job still resolvable, no rename happened.
+        assert get_job(job["id"]) is not None
+        assert get_job("../escape") is None
 
 
 class TestPauseResumeJob:

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -234,6 +234,19 @@ class TestJobCRUD:
         )
         assert job["deliver"] == "origin"
 
+    def test_default_delivery_local_no_origin(self, tmp_cron_dir):
+        job = create_job(prompt="Test", schedule="30m")
+        assert job["deliver"] == "local"
+
+    def test_allow_silent_false_is_persisted(self, tmp_cron_dir):
+        job = create_job(prompt="Daily briefing", schedule="every 1h", allow_silent=False)
+        assert job["allow_silent"] is False
+        assert get_job(job["id"])["allow_silent"] is False
+
+    def test_allow_silent_rejects_non_bool_on_create(self, tmp_cron_dir):
+        with pytest.raises(ValueError, match="allow_silent"):
+            create_job(prompt="Daily briefing", schedule="every 1h", allow_silent="false")
+
 
 class TestUpdateJob:
     def test_update_name(self, tmp_cron_dir):
@@ -250,6 +263,85 @@ class TestUpdateJob:
         # Verify persisted to disk
         fetched = get_job(job["id"])
         assert fetched["name"] == "New Name"
+
+    def test_update_schedule(self, tmp_cron_dir):
+        job = create_job(prompt="Daily report", schedule="every 1h")
+        assert job["schedule"]["kind"] == "interval"
+        assert job["schedule"]["minutes"] == 60
+        old_next_run = job["next_run_at"]
+        new_schedule = parse_schedule("every 2h")
+        updated = update_job(job["id"], {"schedule": new_schedule, "schedule_display": new_schedule["display"]})
+        assert updated is not None
+        assert updated["schedule"]["kind"] == "interval"
+        assert updated["schedule"]["minutes"] == 120
+        assert updated["schedule_display"] == "every 120m"
+        assert updated["next_run_at"] != old_next_run
+        # Verify persisted to disk
+        fetched = get_job(job["id"])
+        assert fetched["schedule"]["minutes"] == 120
+        assert fetched["schedule_display"] == "every 120m"
+
+    def test_update_to_past_oneshot_rejected(self, tmp_cron_dir, monkeypatch):
+        """Updating a job's schedule to a one-shot >ONESHOT_GRACE_SECONDS in the
+        past must raise ValueError — otherwise the ghost-job bug (#59395) re-enters
+        through the update door (next_run_at=None stored with state='scheduled').
+        The original job must be left unchanged on disk."""
+        now = datetime(2026, 7, 6, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = create_job(prompt="Recurring", schedule="every 1h", deliver="local")
+        past = parse_schedule((now - timedelta(minutes=10)).isoformat())
+        with pytest.raises(ValueError, match="past and cannot be scheduled"):
+            update_job(job["id"], {"schedule": past})
+        # Original job unchanged — still the recurring interval, still scheduled.
+        fetched = get_job(job["id"])
+        assert fetched["schedule"]["kind"] == "interval"
+        assert fetched["next_run_at"] is not None
+
+    def test_update_to_future_oneshot_accepted(self, tmp_cron_dir, monkeypatch):
+        """Updating to a FUTURE one-shot still works — only past ones are rejected."""
+        now = datetime(2026, 7, 6, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = create_job(prompt="Recurring", schedule="every 1h", deliver="local")
+        future = parse_schedule((now + timedelta(hours=2)).isoformat())
+        updated = update_job(job["id"], {"schedule": future})
+        assert updated is not None
+        assert updated["schedule"]["kind"] == "once"
+        assert updated["next_run_at"] is not None
+
+    def test_update_enable_disable(self, tmp_cron_dir):
+        job = create_job(prompt="Toggle me", schedule="every 1h")
+        assert job["enabled"] is True
+        updated = update_job(job["id"], {"enabled": False})
+        assert updated["enabled"] is False
+        fetched = get_job(job["id"])
+        assert fetched["enabled"] is False
+
+    def test_update_allow_silent(self, tmp_cron_dir):
+        job = create_job(prompt="Report", schedule="every 1h")
+        updated = update_job(job["id"], {"allow_silent": False})
+        assert updated["allow_silent"] is False
+        assert get_job(job["id"])["allow_silent"] is False
+
+    def test_update_allow_silent_rejects_non_bool(self, tmp_cron_dir):
+        job = create_job(prompt="Report", schedule="every 1h")
+        with pytest.raises(ValueError, match="allow_silent"):
+            update_job(job["id"], {"allow_silent": "false"})
+        assert "allow_silent" not in get_job(job["id"])
+
+    def test_update_nonexistent_returns_none(self, tmp_cron_dir):
+        result = update_job("nonexistent_id", {"name": "X"})
+        assert result is None
+
+    def test_update_rejects_id_change(self, tmp_cron_dir):
+        """Job IDs are filesystem path components — must be immutable."""
+        job = create_job(prompt="Original", schedule="every 1h")
+
+        with pytest.raises(ValueError, match="id"):
+            update_job(job["id"], {"id": "../escape"})
+
+        # Original job still resolvable, no rename happened.
+        assert get_job(job["id"]) is not None
+        assert get_job("../escape") is None
 
 
 class TestPauseResumeJob:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1414,13 +1414,15 @@ class TestRunJobSkillBacked:
 class TestSilentDelivery:
     """Verify that [SILENT] responses suppress delivery while still saving output."""
 
-    def _make_job(self):
-        return {
+    def _make_job(self, **overrides):
+        job = {
             "id": "monitor-job",
             "name": "monitor",
             "deliver": "origin",
             "origin": {"platform": "telegram", "chat_id": "123"},
         }
+        job.update(overrides)
+        return job
 
     def test_silent_response_suppresses_delivery(self, caplog):
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
@@ -1524,6 +1526,31 @@ class TestSilentDelivery:
         save_mock.assert_called_once_with("monitor-job", "# full output")
         deliver_mock.assert_not_called()
 
+    def test_allow_silent_false_delivers_marker_response(self):
+        """Always-deliver jobs must not be silently dropped by the marker gate."""
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job(allow_silent=False)]), \
+             patch("cron.scheduler.claim_job_for_fire", return_value=True), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT]", None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_called_once()
+
+    def test_allow_silent_false_still_suppresses_scheduler_internal_silence(self):
+        """Scheduler-generated no-output signals must not leak the marker."""
+        output = "# Cron Job Output\n\n**Job:** monitor\n**Status:** silent (empty output)\n"
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job(allow_silent=False)]), \
+             patch("cron.scheduler.claim_job_for_fire", return_value=True), \
+             patch("cron.scheduler.run_job", return_value=(True, output, "[SILENT]", None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_not_called()
+
     def test_whitespace_only_response_is_marked_failed_not_delivered(self):
         """Whitespace-only final responses should behave like empty responses."""
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
@@ -1587,13 +1614,45 @@ class TestOneShotDispatchClaim:
 
 
 class TestBuildJobPromptSilentHint:
-    """Verify _build_job_prompt always injects [SILENT] guidance."""
+    """Verify _build_job_prompt injects the right delivery guidance."""
 
     def test_hint_always_present(self):
         job = {"prompt": "Check for updates"}
         result = _build_job_prompt(job)
         assert "[SILENT]" in result
         assert "Check for updates" in result
+
+    def test_hint_present_even_without_prompt(self):
+        job = {"prompt": ""}
+        result = _build_job_prompt(job)
+        assert "[SILENT]" in result
+
+    def test_hint_present_when_legacy_prompt_is_null(self):
+        job = {"id": "abc123deadbe", "name": None, "prompt": None}
+        result = _build_job_prompt(job)
+        assert "[SILENT]" in result
+
+    def test_silent_hint_omitted_for_always_deliver_jobs(self):
+        job = {"prompt": "Daily briefing", "allow_silent": False}
+        result = _build_job_prompt(job)
+        assert "[SILENT]" not in result
+        assert "Always produce a concise final response" in result
+        assert "Daily briefing" in result
+
+    def test_delivery_guidance_present(self):
+        """Cron hint tells agents their final response is auto-delivered."""
+        job = {"prompt": "Generate a report"}
+        result = _build_job_prompt(job)
+        assert "do NOT use send_message" in result
+        assert "automatically delivered" in result
+
+    def test_delivery_guidance_precedes_user_prompt(self):
+        """System guidance appears before the user's prompt text."""
+        job = {"prompt": "My custom prompt"}
+        result = _build_job_prompt(job)
+        system_pos = result.index("do NOT use send_message")
+        prompt_pos = result.index("My custom prompt")
+        assert system_pos < prompt_pos
 
 
 class TestParseWakeGate:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -944,13 +944,15 @@ class TestRunJobSkillBacked:
 class TestSilentDelivery:
     """Verify that [SILENT] responses suppress delivery while still saving output."""
 
-    def _make_job(self):
-        return {
+    def _make_job(self, **overrides):
+        job = {
             "id": "monitor-job",
             "name": "monitor",
             "deliver": "origin",
             "origin": {"platform": "telegram", "chat_id": "123"},
         }
+        job.update(overrides)
+        return job
 
     def test_silent_response_suppresses_delivery(self, caplog):
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
@@ -990,6 +992,29 @@ class TestSilentDelivery:
             tick(verbose=False)
         deliver_mock.assert_called_once()
 
+
+    def test_allow_silent_false_delivers_marker_response(self):
+        """Always-deliver jobs must not be silently dropped by the marker gate."""
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job(allow_silent=False)]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT]", None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_called_once()
+
+    def test_allow_silent_false_still_suppresses_scheduler_internal_silence(self):
+        """Scheduler-generated no-output signals must not leak the marker."""
+        output = "# Cron Job Output\n\n**Job:** monitor\n**Status:** silent (empty output)\n"
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job(allow_silent=False)]), \
+             patch("cron.scheduler.run_job", return_value=(True, output, "[SILENT]", None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_not_called()
 
     def test_whitespace_only_response_is_marked_failed_not_delivered(self):
         """Whitespace-only final responses should behave like empty responses."""
@@ -1038,13 +1063,45 @@ class TestOneShotDispatchClaim:
 
 
 class TestBuildJobPromptSilentHint:
-    """Verify _build_job_prompt always injects [SILENT] guidance."""
+    """Verify _build_job_prompt injects the right delivery guidance."""
 
     def test_hint_always_present(self):
         job = {"prompt": "Check for updates"}
         result = _build_job_prompt(job)
         assert "[SILENT]" in result
         assert "Check for updates" in result
+
+    def test_hint_present_even_without_prompt(self):
+        job = {"prompt": ""}
+        result = _build_job_prompt(job)
+        assert "[SILENT]" in result
+
+    def test_hint_present_when_legacy_prompt_is_null(self):
+        job = {"id": "abc123deadbe", "name": None, "prompt": None}
+        result = _build_job_prompt(job)
+        assert "[SILENT]" in result
+
+    def test_silent_hint_omitted_for_always_deliver_jobs(self):
+        job = {"prompt": "Daily briefing", "allow_silent": False}
+        result = _build_job_prompt(job)
+        assert "[SILENT]" not in result
+        assert "Always produce a concise final response" in result
+        assert "Daily briefing" in result
+
+    def test_delivery_guidance_present(self):
+        """Cron hint tells agents their final response is auto-delivered."""
+        job = {"prompt": "Generate a report"}
+        result = _build_job_prompt(job)
+        assert "do NOT use send_message" in result
+        assert "automatically delivered" in result
+
+    def test_delivery_guidance_precedes_user_prompt(self):
+        """System guidance appears before the user's prompt text."""
+        job = {"prompt": "My custom prompt"}
+        result = _build_job_prompt(job)
+        system_pos = result.index("do NOT use send_message")
+        prompt_pos = result.index("My custom prompt")
+        assert system_pos < prompt_pos
 
 
 class TestParseWakeGate:

--- a/tests/cron/test_suggestions.py
+++ b/tests/cron/test_suggestions.py
@@ -162,6 +162,24 @@ class TestCatalog:
         assert classify_items_script_path() not in monitor.job_spec["prompt"]
         assert Path(classify_items_script_path()).name == "classify_items.py"
 
+    def test_daily_briefing_catalog_is_always_deliver(self):
+        from cron.suggestion_catalog import CATALOG
+
+        daily = next(e for e in CATALOG if e.key == "catalog:daily-briefing")
+        assert daily.job_spec["allow_silent"] is False
+
+    def test_report_catalog_entries_are_always_deliver(self):
+        from cron.suggestion_catalog import CATALOG
+
+        always_deliver = {
+            "catalog:daily-briefing",
+            "catalog:weekly-review",
+            "catalog:standup-reminder",
+        }
+        by_key = {entry.key: entry for entry in CATALOG}
+        for key in always_deliver:
+            assert by_key[key].job_spec["allow_silent"] is False
+
 
 class TestBlueprintBridge:
     def test_blueprint_registers_suggestion(self, store):

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -139,6 +139,68 @@ class TestCreateJob:
                 assert call_kwargs["origin"]["forwarded_for"] == "203.0.113.11"
                 assert call_kwargs["origin"]["user_agent"] == "cron-client"
 
+    @pytest.mark.asyncio
+    async def test_create_job_allow_silent_false(self, adapter):
+        """POST /api/jobs forwards allow_silent when explicitly set."""
+        app = _create_app(adapter)
+        mock_create = MagicMock(return_value={**SAMPLE_JOB, "allow_silent": False})
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                f"{_MOD}._CRON_AVAILABLE", True
+            ), patch(
+                f"{_MOD}._cron_create", mock_create
+            ):
+                resp = await cli.post("/api/jobs", json={
+                    "name": "daily-briefing",
+                    "schedule": "0 8 * * *",
+                    "prompt": "Daily briefing",
+                    "allow_silent": False,
+                })
+                assert resp.status == 200
+                assert mock_create.call_args[1]["allow_silent"] is False
+
+    @pytest.mark.asyncio
+    async def test_create_job_rejects_non_bool_allow_silent(self, adapter):
+        """POST /api/jobs requires allow_silent to be a JSON boolean."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True):
+                resp = await cli.post("/api/jobs", json={
+                    "name": "daily-briefing",
+                    "schedule": "0 8 * * *",
+                    "allow_silent": "false",
+                })
+                assert resp.status == 400
+                data = await resp.json()
+                assert "allow_silent" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_job_missing_name(self, adapter):
+        """POST /api/jobs without name returns 400."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True):
+                resp = await cli.post("/api/jobs", json={
+                    "schedule": "*/5 * * * *",
+                    "prompt": "do something",
+                })
+                assert resp.status == 400
+                data = await resp.json()
+                assert "name" in data["error"].lower() or "Name" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_job_name_too_long(self, adapter):
+        """POST /api/jobs with name > 200 chars returns 400."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True):
+                resp = await cli.post("/api/jobs", json={
+                    "name": "x" * 201,
+                    "schedule": "*/5 * * * *",
+                })
+                assert resp.status == 400
+                data = await resp.json()
+                assert "200" in data["error"] or "Name" in data["error"]
 
     @pytest.mark.asyncio
     async def test_create_job_reports_saved_but_unregistered(self, adapter):
@@ -213,6 +275,40 @@ class TestGetJob:
 # ---------------------------------------------------------------------------
 
 class TestUpdateJob:
+
+    @pytest.mark.asyncio
+    async def test_update_job_allow_silent(self, adapter):
+        """PATCH /api/jobs/{id} allows boolean allow_silent updates."""
+        app = _create_app(adapter)
+        updated_job = {**SAMPLE_JOB, "allow_silent": False}
+        mock_update = MagicMock(return_value=updated_job)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                f"{_MOD}._CRON_AVAILABLE", True
+            ), patch(
+                f"{_MOD}._cron_update", mock_update
+            ):
+                resp = await cli.patch(
+                    f"/api/jobs/{VALID_JOB_ID}",
+                    json={"allow_silent": False},
+                )
+                assert resp.status == 200
+                sanitized = mock_update.call_args[0][1]
+                assert sanitized["allow_silent"] is False
+
+    @pytest.mark.asyncio
+    async def test_update_job_rejects_non_bool_allow_silent(self, adapter):
+        """PATCH /api/jobs/{id} rejects non-boolean allow_silent."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True):
+                resp = await cli.patch(
+                    f"/api/jobs/{VALID_JOB_ID}",
+                    json={"allow_silent": "false"},
+                )
+                assert resp.status == 400
+                data = await resp.json()
+                assert "allow_silent" in data["error"]
 
     @pytest.mark.asyncio
     async def test_update_job_rejects_unknown_fields(self, adapter):

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -33,12 +33,70 @@ def test_cron_subactions_present():
         assert ns.cron_command == action
 
 
+def test_cron_aliases():
+    parser = _build()
+    # create has alias "add"
+    ns = parser.parse_args(["cron", "add", "30m"])
+    assert ns.cron_command == "add"
+    # remove has aliases rm / delete
+    for alias in ("rm", "delete"):
+        ns = parser.parse_args(["cron", alias, "jid"])
+        assert ns.cron_command == alias
+    ns = parser.parse_args(["cron", "history", "jid", "--limit", "7"])
+    assert ns.cron_command == "history"
+    assert ns.job_id == "jid"
+    assert ns.limit == 7
+
+
+def test_cron_create_options():
+    parser = _build()
+    ns = parser.parse_args([
+        "cron", "create", "0 9 * * *", "daily task prompt",
+        "--name", "daily", "--deliver", "origin", "--repeat", "3",
+        "--skill", "a", "--skill", "b", "--no-agent",
+        "--always-deliver", "--workdir", "/tmp/x",
+    ])
+    assert ns.schedule == "0 9 * * *"
+    assert ns.prompt == "daily task prompt"
+    assert ns.name == "daily"
+    assert ns.deliver == "origin"
+    assert ns.repeat == 3
+    assert ns.skills == ["a", "b"]
+    assert ns.no_agent is True
+    assert ns.allow_silent is False
+    assert ns.workdir == "/tmp/x"
+
+
 def test_cron_edit_no_agent_tristate():
     parser = _build()
     # --no-agent -> True, --agent -> False, neither -> None
     assert parser.parse_args(["cron", "edit", "j", "--no-agent"]).no_agent is True
     assert parser.parse_args(["cron", "edit", "j", "--agent"]).no_agent is False
     assert parser.parse_args(["cron", "edit", "j"]).no_agent is None
+
+
+def test_cron_allow_silent_flags():
+    parser = _build()
+    assert parser.parse_args(
+        ["cron", "create", "30m", "Brief", "--always-deliver"]
+    ).allow_silent is False
+    assert parser.parse_args(
+        ["cron", "create", "30m", "Brief", "--allow-silent"]
+    ).allow_silent is True
+    assert parser.parse_args(["cron", "create", "30m", "Brief"]).allow_silent is None
+    assert parser.parse_args(
+        ["cron", "edit", "jobid", "--always-deliver"]
+    ).allow_silent is False
+    assert parser.parse_args(
+        ["cron", "edit", "jobid", "--allow-silent"]
+    ).allow_silent is True
+    assert parser.parse_args(["cron", "edit", "jobid"]).allow_silent is None
+
+
+def test_cron_dispatch_func_is_injected_handler():
+    parser = _build()
+    ns = parser.parse_args(["cron", "list"])
+    assert ns.func is _sentinel_handler
 
 
 def test_cron_accept_hooks_flag_on_run_and_tick():

--- a/tests/hermes_cli/test_web_server_skill_editor.py
+++ b/tests/hermes_cli/test_web_server_skill_editor.py
@@ -206,3 +206,29 @@ class TestCronJobSkills:
         )
         assert resp.status_code == 200
         assert resp.json()["skills"] == []
+
+    def test_create_job_allow_silent_must_be_bool(self, client, isolated_profiles):
+        resp = client.post(
+            "/api/cron/jobs",
+            json={
+                "prompt": "do work",
+                "schedule": "every 1h",
+                "allow_silent": "false",
+            },
+        )
+        assert resp.status_code == 400
+        assert "allow_silent" in resp.json()["detail"]
+
+    def test_update_job_allow_silent_must_be_bool(self, client, isolated_profiles):
+        job = client.post(
+            "/api/cron/jobs",
+            json={"prompt": "do work", "schedule": "every 1h"},
+        ).json()
+
+        resp = client.put(
+            f"/api/cron/jobs/{job['id']}",
+            json={"updates": {"allow_silent": "false"}},
+            params={"profile": "default"},
+        )
+        assert resp.status_code == 400
+        assert "allow_silent" in resp.json()["detail"]

--- a/tests/tools/test_blueprints.py
+++ b/tests/tools/test_blueprints.py
@@ -31,6 +31,7 @@ metadata:
     blueprint:
       schedule: "0 8 * * *"
       deliver: telegram
+      allow_silent: false
       prompt: "Summarize my unread email and today's calendar."
 ---
 
@@ -70,6 +71,7 @@ class TestParseBlueprint:
         assert spec.skill_name == "morning-brief"
         assert spec.schedule == "0 8 * * *"
         assert spec.deliver == "telegram"
+        assert spec.allow_silent is False
         assert spec.prompt is not None and spec.prompt.startswith("Summarize")
 
 
@@ -121,6 +123,7 @@ class TestCreateBlueprintJob:
         assert captured["schedule"] == "0 8 * * *"
         assert captured["skills"] == ["morning-brief"]
         assert captured["deliver"] == "telegram"
+        assert captured["allow_silent"] is False
         assert captured["prompt"].startswith("Summarize")
         assert job["id"] == "abc123"
 
@@ -133,6 +136,7 @@ class TestExportBlueprint:
             "skills": ["morning-brief"],
             "deliver": "telegram",
             "prompt": "Summarize my unread email.",
+            "allow_silent": False,
         }
         md = export_blueprint(job, "# Morning Brief\n\nDoes the morning digest.")
         # The exported SKILL.md must itself parse back as a blueprint.
@@ -140,6 +144,7 @@ class TestExportBlueprint:
         assert spec is not None
         assert spec.schedule == "0 8 * * *"
         assert spec.deliver == "telegram"
+        assert spec.allow_silent is False
         # Name is sanitized to a valid skill identifier.
         assert spec.skill_name == "my-morning-brief"
 

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -246,6 +246,51 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_create_and_update_allow_silent(self):
+        from cron.jobs import get_job
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Daily briefing",
+                schedule="every 1h",
+                allow_silent=False,
+            )
+        )
+        assert created["success"] is True
+        assert created["job"]["allow_silent"] is False
+        assert get_job(created["job_id"])["allow_silent"] is False
+
+        updated = json.loads(
+            cronjob(action="update", job_id=created["job_id"], allow_silent=True)
+        )
+        assert updated["success"] is True
+        assert updated["job"]["allow_silent"] is True
+        assert get_job(created["job_id"])["allow_silent"] is True
+
+    def test_allow_silent_string_is_rejected(self):
+        created = json.loads(cronjob(action="create", prompt="Report", schedule="every 1h"))
+        result = json.loads(
+            cronjob(action="update", job_id=created["job_id"], allow_silent="false")
+        )
+        assert result["success"] is False
+        assert "allow_silent" in result["error"]
+
+    def test_attach_to_session_round_trips(self):
+        from cron.jobs import get_job
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Daily briefing",
+                schedule="every 1h",
+                attach_to_session=True,
+            )
+        )
+        assert created["success"] is True
+        assert created["job"]["attach_to_session"] is True
+        assert get_job(created["job_id"])["attach_to_session"] is True
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 

--- a/tools/blueprints.py
+++ b/tools/blueprints.py
@@ -11,6 +11,7 @@ frontmatter:
           deliver: origin            # optional (default "origin")
           prompt: "..."              # optional task instruction for the run
           no_agent: false            # optional
+          allow_silent: true          # optional, default cron silence behavior
 
 Because a blueprint is just a skill, it flows through the ENTIRE existing
 skills-hub pipeline for free — search, inspect, quarantine, security scan,
@@ -63,6 +64,7 @@ class BlueprintSpec:
     deliver: str = "origin"
     prompt: Optional[str] = None
     no_agent: bool = False
+    allow_silent: Optional[bool] = None
     model: Optional[str] = None
     provider: Optional[str] = None
     enabled_toolsets: Optional[List[str]] = None
@@ -122,6 +124,9 @@ def parse_blueprint(skill_md_text: str) -> Optional[BlueprintSpec]:
     if prompt is not None:
         prompt = str(prompt)
     no_agent = bool(blueprint.get("no_agent", False))
+    allow_silent = blueprint.get("allow_silent")
+    if allow_silent is not None and not isinstance(allow_silent, bool):
+        raise BlueprintError("blueprint.allow_silent must be a boolean when present")
     model = blueprint.get("model")
     provider = blueprint.get("provider")
     toolsets = blueprint.get("enabled_toolsets")
@@ -134,6 +139,7 @@ def parse_blueprint(skill_md_text: str) -> Optional[BlueprintSpec]:
         deliver=deliver,
         prompt=prompt,
         no_agent=no_agent,
+        allow_silent=allow_silent,
         model=str(model).strip() if model else None,
         provider=str(provider).strip() if provider else None,
         enabled_toolsets=[str(t) for t in toolsets] if toolsets else None,
@@ -191,6 +197,7 @@ def blueprint_to_job_spec(
         "provider": spec.provider,
         "enabled_toolsets": spec.enabled_toolsets,
         "no_agent": spec.no_agent,
+        "allow_silent": spec.allow_silent,
     }
 
 
@@ -268,6 +275,8 @@ def export_blueprint(job: Dict[str, Any], body: str, *, blueprint_name: Optional
         blueprint_block["prompt"] = job["prompt"]
     if job.get("no_agent"):
         blueprint_block["no_agent"] = True
+    if isinstance(job.get("allow_silent"), bool):
+        blueprint_block["allow_silent"] = job["allow_silent"]
     if job.get("model"):
         blueprint_block["model"] = job["model"]
     if job.get("provider"):

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -430,6 +430,14 @@ def _normalize_optional_job_value(value: Optional[Any], *, strip_trailing_slash:
     return text or None
 
 
+def _validate_optional_bool(value: Optional[Any], name: str) -> Optional[bool]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    raise ValueError(f"{name} must be a boolean")
+
+
 def _normalize_deliver_param(value: Any) -> Optional[str]:
     """Normalize a user-supplied ``deliver`` value to the canonical string form.
 
@@ -670,6 +678,10 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     ]
     if external_refs:
         result["context_from"] = external_refs
+    if isinstance(job.get("allow_silent"), bool):
+        result["allow_silent"] = job["allow_silent"]
+    if isinstance(job.get("attach_to_session"), bool):
+        result["attach_to_session"] = job["attach_to_session"]
     return result
 
 
@@ -1201,6 +1213,7 @@ def cronjob(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    allow_silent: Optional[bool] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1211,6 +1224,10 @@ def cronjob(
         normalized = (action or "").strip().lower()
 
         if normalized == "create":
+            try:
+                _allow_silent = _validate_optional_bool(allow_silent, "allow_silent")
+            except ValueError as exc:
+                return tool_error(str(exc), success=False)
             if not schedule:
                 return tool_error("schedule is required for create", success=False)
             canonical_skills = _canonical_skills(skill, skills)
@@ -1301,6 +1318,7 @@ def cronjob(
                     attach_to_session=attach_to_session,
                     monitor_script=_normalize_optional_job_value(monitor_script),
                     monitor_url=_normalize_optional_job_value(monitor_url),
+                    allow_silent=_allow_silent,
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
@@ -1462,6 +1480,10 @@ def cronjob(
 
         if normalized == "update":
             updates: Dict[str, Any] = {}
+            try:
+                _allow_silent = _validate_optional_bool(allow_silent, "allow_silent")
+            except ValueError as exc:
+                return tool_error(str(exc), success=False)
             if prompt is not None:
                 scan_error = _scan_cron_prompt(prompt)
                 if scan_error:
@@ -1567,6 +1589,8 @@ def cronjob(
                 updates["enabled_toolsets"] = enabled_toolsets or None
             if attach_to_session is not None:
                 updates["attach_to_session"] = bool(attach_to_session)
+            if _allow_silent is not None:
+                updates["allow_silent"] = _allow_silent
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
@@ -1737,6 +1761,11 @@ Scheduling from cron-run sessions is disabled by default and enabled via cron.al
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "allow_silent": {
+                "type": "boolean",
+                "default": True,
+                "description": "Default True preserves monitor/watchdog behavior: the cron run may respond with [SILENT] to suppress delivery when there is nothing new. Set False for always-deliver recurring briefings or reports where an all-clear should still be sent; the scheduler omits the silent-suppression prompt and will not drop a [SILENT] final response for that job."
+            },
         },
         "required": ["action"]
     }
@@ -1797,6 +1826,8 @@ registry.register(
         no_agent=args.get("no_agent"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),
+        attach_to_session=args.get("attach_to_session"),
+        allow_silent=args.get("allow_silent"),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id"),
     ),

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -411,6 +411,14 @@ def _normalize_optional_job_value(value: Optional[Any], *, strip_trailing_slash:
     return text or None
 
 
+def _validate_optional_bool(value: Optional[Any], name: str) -> Optional[bool]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    raise ValueError(f"{name} must be a boolean")
+
+
 def _normalize_deliver_param(value: Any) -> Optional[str]:
     """Normalize a user-supplied ``deliver`` value to the canonical string form.
 
@@ -591,6 +599,10 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if isinstance(job.get("allow_silent"), bool):
+        result["allow_silent"] = job["allow_silent"]
+    if isinstance(job.get("attach_to_session"), bool):
+        result["attach_to_session"] = job["attach_to_session"]
     return result
 
 
@@ -1049,6 +1061,7 @@ def cronjob(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    allow_silent: Optional[bool] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1059,6 +1072,10 @@ def cronjob(
         normalized = (action or "").strip().lower()
 
         if normalized == "create":
+            try:
+                _allow_silent = _validate_optional_bool(allow_silent, "allow_silent")
+            except ValueError as exc:
+                return tool_error(str(exc), success=False)
             if not schedule:
                 return tool_error("schedule is required for create", success=False)
             canonical_skills = _canonical_skills(skill, skills)
@@ -1137,6 +1154,7 @@ def cronjob(
                     attach_to_session=attach_to_session,
                     monitor_script=_normalize_optional_job_value(monitor_script),
                     monitor_url=_normalize_optional_job_value(monitor_url),
+                    allow_silent=_allow_silent,
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
@@ -1298,6 +1316,10 @@ def cronjob(
 
         if normalized == "update":
             updates: Dict[str, Any] = {}
+            try:
+                _allow_silent = _validate_optional_bool(allow_silent, "allow_silent")
+            except ValueError as exc:
+                return tool_error(str(exc), success=False)
             if prompt is not None:
                 scan_error = _scan_cron_prompt(prompt)
                 if scan_error:
@@ -1392,6 +1414,8 @@ def cronjob(
                 updates["enabled_toolsets"] = enabled_toolsets or None
             if attach_to_session is not None:
                 updates["attach_to_session"] = bool(attach_to_session)
+            if _allow_silent is not None:
+                updates["allow_silent"] = _allow_silent
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
@@ -1549,6 +1573,11 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "allow_silent": {
+                "type": "boolean",
+                "default": True,
+                "description": "Default True preserves monitor/watchdog behavior: the cron run may respond with [SILENT] to suppress delivery when there is nothing new. Set False for always-deliver recurring briefings or reports where an all-clear should still be sent; the scheduler omits the silent-suppression prompt and will not drop a [SILENT] final response for that job."
+            },
         },
         "required": ["action"]
     }
@@ -1608,6 +1637,8 @@ registry.register(
         no_agent=args.get("no_agent"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),
+        attach_to_session=args.get("attach_to_session"),
+        allow_silent=args.get("allow_silent"),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id"),
     ),


### PR DESCRIPTION
## What does this PR do?

Fixes cron jobs that are supposed to always deliver a report, such as daily briefings, inheriting the generic `[SILENT]` suppression instruction.

This adds an explicit per-job `allow_silent` flag. Existing jobs keep the current behavior by default. Jobs with `allow_silent=False` get an always-deliver prompt hint instead of the silent-suppression rule, and the delivery gate will not drop a final `[SILENT]` response for that job.

## Related Issue

Fixes #53230

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Added strict `allow_silent` storage/update support for cron jobs.
- Made cron prompt construction and delivery suppression respect `allow_silent=False`.
- Exposed the flag through the cronjob tool, CLI create/edit, skill-backed blueprints, dashboard cron API, and API-server cron jobs API.
- Marked built-in daily/morning briefing, weekly review, and workday-start catalog paths as always-deliver.
- Added regression coverage for scheduler behavior, job persistence, tool/API round trips, and blueprint/suggestion catalog paths.

## How to Test

1. `scripts/run_tests.sh tests/cron/test_scheduler.py tests/cron/test_jobs.py tests/tools/test_cronjob_tools.py tests/cron/test_blueprint_catalog.py tests/cron/test_suggestions.py tests/tools/test_blueprints.py tests/gateway/test_api_server_jobs.py tests/hermes_cli/test_cron_parser_builder.py tests/hermes_cli/test_web_server_skill_editor.py`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the repo test wrapper and all focused tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — no platform-specific primitives added
- [x] I've updated tool descriptions/schemas if I changed tool behavior

## Screenshots / Logs

Duplicate-work checks performed before implementation:

- Exact issue PR search: `gh pr list --repo NousResearch/hermes-agent --state all --search "53230"` returned no PRs.
- Broader keyword PR search for cron silent/all-clear/briefing/report returned no PRs.
- Related issues reviewed: #5023 and #51438 cover intentional silent-marker suppression; #23118 covers broader durable delivery semantics and does not supersede this fix.

Proof:

```text
=== Summary: 9 files, 504 tests passed, 0 failed (100% complete) in 11.2s (16 workers) ===
```

Private pre-push review note: the normal push hook launched the configured background review. The Claude/Grogu side failed local auth (`401 Invalid authentication credentials`), but the Codex/Mario report completed and flagged strict boolean/API/CLI/catalog/internal-silence gaps; the latest commit addresses those findings.

## 2026-07-13 shepherding refresh

The issue premise still holds on current `main`: `cron/scheduler.py::_build_job_prompt()` still injects the generic `[SILENT]` instruction for every agent-driven cron job, and the delivery path still suppresses a recognized silence response without a per-job opt-out.

The open implementation cluster is now:

- #53248 — the minimal three-file `allow_silent` lane covering job storage, scheduler prompt/delivery behavior, and the model-facing cron tool. It is cleanly mergeable with current CI green.
- #53270 — a second minimal three-file `allow_silent` implementation of the same core surface. Its historical checks are green, but the branch is now conflicting.
- #53365 — the competing `delivery_policy="always"` API with scheduler tests. Its branch also contains unrelated CLI/gateway/tool/ComfyUI/TUI changes, is conflicting, and has no check rollup.
- #53917 — a newer four-file `allow_silent` lane covering the same core/tool contract plus a dedicated 12-test regression file. Its description reports 79 adjacent cron-tool tests passing, but the branch is currently conflicting and has no GitHub check rollup.
- This PR (#53252) — the broader end-to-end `allow_silent` lane: it covers the same core contract plus strict boolean validation and creation/edit round trips across blueprints, built-in briefing catalogs, CLI, dashboard, and API-server surfaces. Its focused proof remains 504 passing tests; it is cleanly mergeable and its current GitHub check rollup is fully green.

This comparison is review context rather than a claim that later-opening alternatives should be closed automatically. A maintainer still needs to choose the intended API shape and whether to land the minimal core surface or the end-to-end wiring.

