### PR TITLE
fix(agent): route Kimi /coding to anthropic_messages in AIAgent.__init__

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -337,6 +337,19 @@ def init_agent(
         # use a URL convention ending in /anthropic. Auto-detect these so the
         # Anthropic Messages API adapter is used instead of chat completions.
         agent.api_mode = "anthropic_messages"
+    elif (
+        agent._base_url_hostname == "api.kimi.com"
+        and "/coding" in agent._base_url_lower
+    ):
+        # Kimi Code's api.kimi.com/coding endpoint speaks the Anthropic
+        # Messages protocol (it accepts Claude Code's native request shape),
+        # even on URLs like .../coding/v1 that do NOT carry the /anthropic
+        # suffix matched above. Mirror determine_api_mode() so a directly
+        # constructed AIAgent routes to the Anthropic adapter instead of
+        # falling through to chat_completions and sending the wrong wire
+        # protocol. See hermes_cli.providers.determine_api_mode and
+        # hermes_cli.runtime_provider._detect_api_mode_for_url.
+        agent.api_mode = "anthropic_messages"
     elif agent.provider == "bedrock" or (
         agent._base_url_hostname.startswith("bedrock-runtime.")
         and base_url_host_matches(agent._base_url_lower, "amazonaws.com")

--- a/tests/agent/test_agent_init_kimi_coding_api_mode.py
+++ b/tests/agent/test_agent_init_kimi_coding_api_mode.py
@@ -1,0 +1,124 @@
+"""Regression: AIAgent.__init__ must route Kimi /coding to anthropic_messages.
+
+Kimi Code's ``api.kimi.com/coding`` endpoint speaks the **Anthropic Messages**
+protocol (it accepts Claude Code's native request shape), even on URLs like
+``.../coding/v1`` that do NOT carry the ``/anthropic`` suffix.
+
+Three other resolution paths already detect this correctly:
+
+- ``hermes_cli.providers.determine_api_mode`` (the canonical resolver)
+- ``hermes_cli.runtime_provider._detect_api_mode_for_url``
+- ``tools.delegate_tool`` child-runtime resolution
+
+But the hand-rolled api_mode inference inside ``agent.agent_init`` (the block
+that runs in ``AIAgent.__init__``) omitted the rule, so a freshly constructed
+agent pointed at ``api.kimi.com/coding`` fell through to ``chat_completions``.
+That sends OpenAI-shaped requests to an Anthropic-Messages endpoint — the wrong
+wire protocol — which is exactly the routing-drift class this guards against.
+
+The contract asserted here is an *invariant between two resolvers*: whatever
+``determine_api_mode(provider, base_url)`` decides for the Kimi /coding
+endpoint, a real ``AIAgent`` constructed with that same provider/base_url
+(and no explicit ``api_mode``) must agree. This is not a snapshot of a literal
+value — if the canonical mapping ever changes, both sides move together.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _prep_home(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text("", encoding="utf-8")
+
+
+def _make_agent(tmp_path: Path, **overrides):
+    from run_agent import AIAgent
+
+    kwargs = dict(
+        model="kimi-k2.5",
+        api_key="sk-kimi-dummy",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+    )
+    kwargs.update(overrides)
+    return AIAgent(**kwargs)
+
+
+# URLs the Kimi /coding endpoint is reached through. None carry an explicit
+# /anthropic suffix except the last; the bug was that the non-/anthropic forms
+# (the common ones) fell through to chat_completions.
+_KIMI_CODING_URLS = [
+    "https://api.kimi.com/coding",
+    "https://api.kimi.com/coding/v1",
+    "https://api.kimi.com/coding/",
+    "https://api.kimi.com/coding/anthropic",
+]
+
+
+@pytest.mark.parametrize("base_url", _KIMI_CODING_URLS)
+@pytest.mark.parametrize("provider", ["kimi-coding", "custom"])
+def test_kimi_coding_infers_anthropic_messages(monkeypatch, tmp_path, provider, base_url):
+    """A fresh AIAgent on Kimi /coding must use the anthropic_messages mode."""
+    _prep_home(tmp_path, monkeypatch)
+    agent = _make_agent(tmp_path, provider=provider, base_url=base_url)
+    assert agent.api_mode == "anthropic_messages", (
+        f"provider={provider!r} base_url={base_url!r} resolved to "
+        f"{agent.api_mode!r}; Kimi /coding speaks Anthropic Messages."
+    )
+
+
+@pytest.mark.parametrize("base_url", _KIMI_CODING_URLS)
+@pytest.mark.parametrize("provider", ["kimi-coding", "custom"])
+def test_agent_api_mode_matches_canonical_resolver(monkeypatch, tmp_path, provider, base_url):
+    """Behavior contract: AIAgent's inferred api_mode == determine_api_mode().
+
+    The two resolvers must not drift. determine_api_mode is the canonical
+    source of truth used by the model-switch / runtime pipelines; the
+    in-__init__ inference must produce the same wire protocol for the same
+    provider + base_url.
+    """
+    from hermes_cli.providers import determine_api_mode
+
+    _prep_home(tmp_path, monkeypatch)
+    expected = determine_api_mode(provider, base_url)
+    agent = _make_agent(tmp_path, provider=provider, base_url=base_url)
+    assert agent.api_mode == expected, (
+        f"AIAgent inferred {agent.api_mode!r} but determine_api_mode said "
+        f"{expected!r} for provider={provider!r} base_url={base_url!r}."
+    )
+
+
+def test_explicit_api_mode_override_is_respected(monkeypatch, tmp_path):
+    """An explicit api_mode the user passes always wins over inference."""
+    _prep_home(tmp_path, monkeypatch)
+    agent = _make_agent(
+        tmp_path,
+        provider="kimi-coding",
+        base_url="https://api.kimi.com/coding/v1",
+        api_mode="chat_completions",
+    )
+    assert agent.api_mode == "chat_completions"
+
+
+def test_kimi_chat_endpoint_stays_chat_completions(monkeypatch, tmp_path):
+    """Don't over-fire: Kimi's OpenAI-compatible /v1 endpoint is NOT /coding.
+
+    The kimi-coding provider has dual endpoints — sk-kimi-* keys hit
+    api.kimi.com/coding (Anthropic), legacy keys hit api.moonshot.ai/v1
+    (OpenAI chat completions). The fix must key on the /coding path, not the
+    provider name, so the chat endpoint is left untouched.
+    """
+    _prep_home(tmp_path, monkeypatch)
+    agent = _make_agent(
+        tmp_path,
+        provider="kimi-coding",
+        base_url="https://api.moonshot.ai/v1",
+    )
+    assert agent.api_mode == "chat_completions"


### PR DESCRIPTION
## Summary

`AIAgent.__init__` (via `agent/agent_init.py`) infers `api_mode` from
`base_url` using a **hand-rolled resolver that has drifted** from the canonical
`hermes_cli.providers.determine_api_mode()`. The inference block detects the
`/anthropic` suffix, `chatgpt.com/backend-api/codex`, `api.x.ai`,
`api.anthropic.com`, and Bedrock — but it **omits Kimi Code's
`api.kimi.com/coding` endpoint**, which speaks the **Anthropic Messages**
protocol on URLs like `.../coding/v1` that carry no `/anthropic` suffix.

As a result, a directly-constructed `AIAgent` pointed at `api.kimi.com/coding`
falls through to `chat_completions` and sends OpenAI-shaped requests to an
Anthropic-Messages endpoint — the wrong wire protocol.

## The bug, line by line

`agent/agent_init.py` (the `api_mode` inference chain in `AIAgent.__init__`):
the `elif` ladder handles `/anthropic`, codex, xAI, Anthropic and Bedrock, then
falls through to `chat_completions` — with **no branch for the Kimi `/coding`
host**.

Three sibling resolvers already handle this correctly:

- `hermes_cli/providers.py` → `determine_api_mode()` (the canonical resolver):
  `if hostname == "api.kimi.com" and "/coding" in url_lower: return "anthropic_messages"`
- `hermes_cli/runtime_provider.py` → `_detect_api_mode_for_url()`: same rule.
- `tools/delegate_tool.py` (child-runtime resolution): `elif "api.kimi.com/coding" in base_lower: api_mode = "anthropic_messages"`.

Only the in-`__init__` inference was missing it — classic sibling-path drift.

### Reproduction on current `main`

```python
from run_agent import AIAgent
a = AIAgent(model="kimi-k2.5", provider="kimi-coding", api_key="x",
            base_url="https://api.kimi.com/coding/v1",
            quiet_mode=True, skip_context_files=True, skip_memory=True, platform="cli")
print(a.api_mode)          # -> 'chat_completions'  (BUG)

from hermes_cli.providers import determine_api_mode
print(determine_api_mode("kimi-coding", "https://api.kimi.com/coding/v1"))
# -> 'anthropic_messages'  (canonical)
```

## Fix

Add the matching rule to `agent_init`, mirroring `determine_api_mode()`, placed
right after the existing `/anthropic`-suffix branch:

```python
elif (
    agent._base_url_hostname == "api.kimi.com"
    and "/coding" in agent._base_url_lower
):
    agent.api_mode = "anthropic_messages"
```

The whole bug class is now aligned: the in-`__init__` inference agrees with
`determine_api_mode()` for the same `provider` + `base_url`.

- Explicit `api_mode=...` passed by the caller still wins (checked first).
- The OpenAI-compatible `api.moonshot.ai/v1` chat endpoint is **unaffected** —
  the rule keys on the `/coding` path, not the `kimi-coding` provider name
  (the provider has dual endpoints: `sk-kimi-*` → `/coding` Anthropic, legacy
  keys → `/v1` OpenAI chat).

## Tests

`tests/agent/test_agent_init_kimi_coding_api_mode.py` — real `AIAgent`
construction against a temp `HERMES_HOME`, real imports. The core assertion is
a **behavior-contract invariant**, not a snapshot:

> whatever `determine_api_mode(provider, base_url)` decides for the Kimi
> `/coding` endpoint, a real `AIAgent` built with that same provider/base_url
> (and no explicit `api_mode`) must agree.

Plus guards that the explicit-override path and the `api.moonshot.ai/v1` chat
endpoint are left untouched.

- **Before fix:** 12 failed, 6 passed (the `/coding`, `/coding/v1`, `/coding/`
  cases all resolved to `chat_completions`).
- **After fix:** 18 passed.
- `tests/agent/test_kimi_coding_anthropic_thinking.py` and
  `tests/run_agent/test_provider_parity.py`: 110 passed (no regressions).

## Footprint

No new core tools, no new `HERMES_*` env vars, no new hooks. One `elif` branch
mirroring an existing canonical rule; prompt caching / role alternation
untouched.
