### PR TITLE
fix(update): resume Windows gateways without console wrappers

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -809,6 +809,50 @@ def _build_gateway_argv() -> tuple[list[str], str, dict[str, str]]:
     return argv, working_dir, env_overlay
 
 
+def _visible_profile_args(argv: list[str]) -> list[str]:
+    """Return an explicit ``--profile``/``-p`` selector from a captured argv."""
+    for index, token in enumerate(argv):
+        lowered = token.lower()
+        if lowered in ("--profile", "-p"):
+            if index + 1 < len(argv):
+                return [token, argv[index + 1]]
+            return []
+        if lowered.startswith("--profile=") or lowered.startswith("-p="):
+            return [token]
+    return []
+
+
+def _looks_like_python_executable(value: str) -> bool:
+    name = Path(value).name.lower()
+    return name in {"python", "python.exe", "pythonw", "pythonw.exe", "python3", "python3.exe"}
+
+
+def _canonical_gateway_restart_from_wrapper(
+    run_argv: list[str],
+) -> tuple[list[str], str, dict[str, str]] | None:
+    """Return a direct windowless gateway argv for captured launcher commands."""
+    try:
+        from gateway.status import looks_like_gateway_command_line
+
+        command_line = subprocess.list2cmdline(run_argv)
+        if not looks_like_gateway_command_line(command_line):
+            return None
+        new_argv, working_dir, env_overlay = _build_gateway_argv()
+        profile_args = _visible_profile_args(run_argv)
+        if profile_args:
+            new_argv = [
+                new_argv[0],
+                "-m",
+                "hermes_cli.main",
+                *profile_args,
+                "gateway",
+                "run",
+            ]
+        return new_argv, working_dir, env_overlay
+    except Exception:
+        return None
+
+
 def windowless_gateway_restart_spec(
     run_argv: list[str],
 ) -> tuple[list[str], str, dict[str, str]]:
@@ -829,11 +873,12 @@ def windowless_gateway_restart_spec(
     (VIRTUAL_ENV, PYTHONPATH) the base interpreter needs to resolve the
     ``hermes_cli`` package without the venv launcher's site config.
 
-    Returns ``(new_argv, working_dir, env_overlay)``.  ``new_argv``
-    preserves every argument after the interpreter (``-m hermes_cli.main
-    [--profile X] gateway run [--replace]``) verbatim.  On non-Windows, or
-    if ``run_argv`` doesn't start with a resolvable python, the argv is
-    returned unchanged with an empty overlay.
+    Returns ``(new_argv, working_dir, env_overlay)``.  Python-led argv preserve
+    every argument after the interpreter (``-m hermes_cli.main [--profile X]
+    gateway run [--replace]``) verbatim.  Captured Windows wrapper argv such as
+    ``hermes.exe gateway run`` are normalized to the same direct ``pythonw``
+    command used by a fresh gateway start, so post-update resume does not
+    relaunch a terminal/console wrapper.
     """
     if not run_argv:
         return run_argv, "", {}
@@ -849,12 +894,22 @@ def windowless_gateway_restart_spec(
     # Only rewrite when the leading token actually looks like a python
     # interpreter we can find a windowless sibling for.  If a caller passed
     # something else (a captured argv whose argv[0] is already pythonw, or a
-    # non-python launcher), leave it alone.
+    # non-python launcher), canonicalize real gateway launchers to the direct
+    # windowless form instead of replaying the launcher.
+    if not _looks_like_python_executable(python_exe):
+        wrapper_spec = _canonical_gateway_restart_from_wrapper(run_argv)
+        if wrapper_spec is not None:
+            return wrapper_spec
+        return run_argv, "", {}
+
     try:
         windowless_python, venv_dir, extra_pythonpath = _resolve_detached_python(
             python_exe
         )
     except Exception:
+        wrapper_spec = _canonical_gateway_restart_from_wrapper(run_argv)
+        if wrapper_spec is not None:
+            return wrapper_spec
         return run_argv, "", {}
 
     new_argv = [windowless_python, *rest]

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8422,18 +8422,27 @@ def _write_update_planned_stop_marker(profile_path: Path, pid: int) -> bool:
 
 
 def _wait_for_windows_update_gateway_exit(
-    pids: list[int], *, timeout: float
+    pids: list[int], *, timeout: float, pid_paths: dict[int, Path] | None = None
 ) -> set[int]:
     """Wait for the given gateway PIDs to exit, returning survivors."""
     if not pids:
         return set()
 
-    from gateway.status import _pid_exists
+    from gateway.status import _pid_exists, get_running_pid
 
+    pid_paths = pid_paths or {}
     remaining = set(pids)
     deadline = _time.monotonic() + max(timeout, 0.0)
     while remaining and _time.monotonic() < deadline:
         for pid in list(remaining):
+            pid_path = pid_paths.get(pid)
+            if pid_path is not None:
+                try:
+                    if get_running_pid(pid_path, cleanup_stale=False) != pid:
+                        remaining.discard(pid)
+                        continue
+                except Exception:
+                    pass
             try:
                 if not _pid_exists(pid):
                     remaining.discard(pid)
@@ -8444,6 +8453,13 @@ def _wait_for_windows_update_gateway_exit(
 
     survivors: set[int] = set()
     for pid in remaining:
+        pid_path = pid_paths.get(pid)
+        if pid_path is not None:
+            try:
+                if get_running_pid(pid_path, cleanup_stale=False) != pid:
+                    continue
+            except Exception:
+                pass
         try:
             if _pid_exists(pid):
                 survivors.add(pid)
@@ -8518,12 +8534,14 @@ def _pause_windows_gateways_for_update() -> dict | None:
 
     profiles: dict[str, int] = {}
     mapped_pids = []
+    mapped_pid_paths: dict[int, Path] = {}
     for pid in running_pids:
         proc = profile_processes.get(pid)
         if proc is None:
             continue
         profiles[str(proc.profile)] = int(pid)
         mapped_pids.append(int(pid))
+        mapped_pid_paths[int(pid)] = Path(proc.path) / "gateway.pid"
         _write_update_planned_stop_marker(Path(proc.path), int(pid))
 
     print("→ Stopping Windows gateway process(es) before updating Hermes...")
@@ -8534,6 +8552,7 @@ def _pause_windows_gateways_for_update() -> dict | None:
     survivors = _wait_for_windows_update_gateway_exit(
         mapped_pids,
         timeout=drain_timeout,
+        pid_paths=mapped_pid_paths,
     )
     unmapped_pids = [pid for pid in running_pids if pid not in profile_processes]
 

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -475,8 +475,9 @@ def test_pause_windows_gateways_for_update_stops_profile_and_unmapped_pids(
     monkeypatch.setattr(gateway_mod, "_get_restart_drain_timeout", lambda: 0.1)
     waited_for = []
 
-    def fake_wait(pids, *, timeout):
+    def fake_wait(pids, *, timeout, pid_paths=None):
         waited_for.extend(pids)
+        assert pid_paths == {101: profile_home / "gateway.pid"}
         return set()
 
     monkeypatch.setattr(cli_main, "_wait_for_windows_update_gateway_exit", fake_wait)
@@ -521,6 +522,30 @@ def test_pause_windows_gateways_for_update_stops_profile_and_unmapped_pids(
     # An unmapped PID whose argv we captured is respawnable, so we must NOT
     # tell the user to restart it manually.
     assert "Restart manually after update" not in captured
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_wait_for_windows_update_gateway_exit_treats_cleared_pid_file_as_stopped(
+    _winp,
+    monkeypatch,
+    tmp_path,
+):
+    """Mapped Windows gateways can clear their runtime files before the
+    pythonw process vanishes.  Once the profile pid file no longer resolves to
+    the old PID, update can resume instead of waiting the full drain timeout."""
+    import gateway.status as status_mod
+
+    pid_path = tmp_path / "gateway.pid"
+    monkeypatch.setattr(status_mod, "_pid_exists", lambda pid: True)
+    monkeypatch.setattr(status_mod, "get_running_pid", lambda *_a, **_k: None)
+
+    survivors = cli_main._wait_for_windows_update_gateway_exit(
+        [101],
+        timeout=30.0,
+        pid_paths={101: pid_path},
+    )
+
+    assert survivors == set()
 
 
 @patch.object(cli_main, "_is_windows", return_value=True)

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -1122,3 +1122,45 @@ class TestWindowlessGatewayRestartSpec:
         assert env["VIRTUAL_ENV"] == str(Path("C:/venv"))
         assert "PYTHONPATH" in env
         assert "site-packages" in env["PYTHONPATH"]
+
+    def test_windows_normalizes_non_python_gateway_launcher(self):
+        """Captured wrapper argv must not be replayed after update.
+
+        Regression guard for the post-update Windows resume path: if an
+        unmapped gateway was captured as ``hermes.exe gateway run``, replaying
+        that launcher can leave a terminal window open.  Normalize it to the
+        same direct windowless argv used by a clean gateway start.
+        """
+        import hermes_cli.gateway_windows as gw
+
+        argv = [
+            "C:/Users/me/AppData/Local/hermes/hermes-agent/venv/Scripts/hermes.exe",
+            "--profile",
+            "work",
+            "gateway",
+            "run",
+        ]
+        canonical = (
+            ["C:/base/pythonw.exe", "-m", "hermes_cli.main", "gateway", "run"],
+            "C:/hermes",
+            {"VIRTUAL_ENV": "C:/venv", "PYTHONPATH": "C:/hermes"},
+        )
+
+        with mock.patch.object(gw.sys, "platform", "win32"), mock.patch.object(
+            gw,
+            "_resolve_detached_python",
+            side_effect=AssertionError("hermes.exe is a launcher, not Python"),
+        ), mock.patch.object(gw, "_build_gateway_argv", return_value=canonical):
+            new_argv, cwd, env = gw.windowless_gateway_restart_spec(list(argv))
+
+        assert new_argv == [
+            "C:/base/pythonw.exe",
+            "-m",
+            "hermes_cli.main",
+            "--profile",
+            "work",
+            "gateway",
+            "run",
+        ]
+        assert cwd == "C:/hermes"
+        assert env == {"VIRTUAL_ENV": "C:/venv", "PYTHONPATH": "C:/hermes"}


### PR DESCRIPTION
## What does this PR do?

Fixes the Windows `hermes update` gateway resume path so a cleanly-stopped gateway does not make update wait for the full drain timeout, and so captured gateway launcher commands are not replayed as terminal/console wrappers.

Root cause found in live testing on Windows: the update pause helper wrote the planned-stop marker and the gateway exited cleanly, clearing `gateway.pid` and `gateway.lock`, but the old `pythonw.exe` process object could linger. The update helper waited only on raw PID existence, so with `agent.restart_drain_timeout: 180` it looked hung even though the gateway had already stopped. Separately, unmapped Windows gateway resume replayed captured argv; if that argv was a launcher such as `hermes.exe gateway run`, the watcher could preserve a wrapper-shaped launch instead of normalizing to direct windowless Python.

This PR makes mapped profile waits treat a cleared/replaced profile pid file as stopped, and normalizes captured non-Python gateway launcher argv to the same direct `pythonw.exe -m hermes_cli.main ... gateway run` shape used by clean gateway starts.

## Related Issue

N/A. Related prior PR discovered during duplicate search: #49025 covers an older pythonw-only approach in `hermes_cli/gateway.py`; this PR targets the current update pause/resume path on main and the mapped-profile wait hang reproduced locally.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: pass mapped profile pid-file paths into the Windows update gateway wait helper, and treat the old gateway as stopped once its profile pid file no longer resolves to the old PID.
- `hermes_cli/gateway_windows.py`: normalize captured non-Python gateway launcher argv, such as `hermes.exe --profile work gateway run`, to direct windowless `pythonw.exe -m hermes_cli.main --profile work gateway run` before the restart watcher respawns it.
- `tests/hermes_cli/test_update_concurrent_quarantine.py`: add coverage for the mapped Windows gateway case where the pid file is cleared while the old process still exists.
- `tests/tools/test_windows_native_support.py`: add coverage that captured `hermes.exe ... gateway run` is not replayed and is not treated as a Python interpreter.

## How to Test

1. Run the focused update pause/resume tests:
   `python scripts/run_tests_parallel.py -j 4 tests/hermes_cli/test_update_concurrent_quarantine.py -- -k "windows_update_gateway_exit or pause_windows_gateways_for_update_stops_profile"`
2. Run the focused Windows restart-spec tests:
   `python scripts/run_tests_parallel.py -j 4 tests/tools/test_windows_native_support.py -- -k TestWindowlessGatewayRestartSpec`
3. On Windows, with a running gateway and `agent.restart_drain_timeout: 180`, run the update-style pause/resume helpers. Verified locally that the helper returned in 9.23s instead of timing out, restarted the gateway, and the final gateway process was `pythonw.exe -m hermes_cli.main gateway run --replace` with pid/lock/runtime status passing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / AppData Hermes install

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused checks passed:

- `python -m py_compile hermes_cli\main.py hermes_cli\gateway_windows.py`
- `python scripts\run_tests_parallel.py -j 4 tests/hermes_cli/test_update_concurrent_quarantine.py -- -k "windows_update_gateway_exit or pause_windows_gateways_for_update_stops_profile"` — 2 passed
- `python scripts\run_tests_parallel.py -j 4 tests/tools/test_windows_native_support.py -- -k TestWindowlessGatewayRestartSpec` — 4 passed
- `git diff --check -- hermes_cli/main.py hermes_cli/gateway_windows.py tests/hermes_cli/test_update_concurrent_quarantine.py tests/tools/test_windows_native_support.py`

The local test runner printed a post-summary cp1252 progress callback traceback when rendering a checkmark, but both focused test invocations exited 0 and reported 100% pass.

