### PR TITLE
fix(cron): hoist profile scoping above no_agent short-circuit in run_job

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1987,6 +1987,15 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     #   - wakeAgent=false gate    → treated like empty stdout (silent), since
     #                               the whole point of no_agent is that there
     #                               is no agent to wake
+    try:
+        from dotenv import load_dotenv
+        try:
+            load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="utf-8")
+        except UnicodeDecodeError:
+            load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="latin-1")
+    except Exception:
+        pass
+
     if job.get("no_agent"):
         script_path = job.get("script")
         if not script_path:
@@ -2215,14 +2224,6 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
 
     try:
-        # Re-read .env and config.yaml fresh every run so provider/key
-        # changes take effect without a gateway restart.
-        from dotenv import load_dotenv
-        try:
-            load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="utf-8")
-        except UnicodeDecodeError:
-            load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="latin-1")
-
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:
             _VAR_MAP["HERMES_CRON_AUTO_DELIVER_PLATFORM"].set(delivery_target["platform"])


### PR DESCRIPTION
## What changed

In `cron/scheduler.py`, the `load_dotenv` call that reloads `.env` from the correct `HERMES_HOME` (matching a job's `profile` field) was placed inside the LLM agent path  **after** the `no_agent` short-circuit returned early.

This hoists that block to immediately before the `if job.get('no_agent')` check, so **both** the `no_agent` and LLM paths run under the job's configured profile's environment. The redundant copy inside the LLM path is removed.

## Why

In a multi-gateway multi-profile setup, `no_agent` cron jobs always ran with the ticking gateway's `HERMES_HOME` instead of the job's profile. This caused scripts to resolve against the wrong environment, and the failures were non-deterministic (race condition on which gateway won the tick).

## How to test

1. Configure two Hermes profiles: `dev` and `prod`, each with different `HERMES_HOME`
2. Create a `no_agent` cron job with `profile: dev` that echoes `$HERMES_HOME`
3. Before fix: the script runs under whichever gateway happened to tick it
4. After fix: the script always runs under the `dev` profile's `HERMES_HOME`

## Scope

- `cron/scheduler.py`  1 file, +9/−8
- Cron component only

Closes #53077