### PR TITLE
fix(ssh): preflight sync-back size before tar download

### DIFF
--- a/tests/tools/test_ssh_bulk_upload.py
+++ b/tests/tools/test_ssh_bulk_upload.py
@@ -454,6 +454,75 @@ class TestSSHBulkUpload:
         mock_ssh.kill.assert_called_once()
 
 
+class TestSSHBulkDownload:
+    """Unit tests for SSH sync-back tar download preflight."""
+
+    def test_refuses_oversized_remote_before_tar_stream(self, mock_env, tmp_path, monkeypatch):
+        monkeypatch.setattr(ssh_env, "_SYNC_BACK_MAX_BYTES", 100)
+        run_calls = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="101\n", stderr="")
+
+        with patch.object(subprocess, "run", side_effect=fake_run):
+            with pytest.raises(RuntimeError, match="SSH sync-back skipped"):
+                mock_env._ssh_bulk_download(tmp_path / "remote.tar")
+
+        assert len(run_calls) == 1
+        assert "du -sb" in run_calls[0][-1]
+        assert "tar cf -" not in run_calls[0][-1]
+
+    def test_invalid_remote_size_output_fails_before_tar_stream(self, mock_env, tmp_path):
+        run_calls = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="not-a-size\n", stderr="")
+
+        with patch.object(subprocess, "run", side_effect=fake_run):
+            with pytest.raises(RuntimeError, match="invalid output"):
+                mock_env._ssh_bulk_download(tmp_path / "remote.tar")
+
+        assert len(run_calls) == 1
+
+    def test_download_streams_tar_after_size_preflight_passes(self, mock_env, tmp_path, monkeypatch):
+        monkeypatch.setattr(ssh_env, "_SYNC_BACK_MAX_BYTES", 100)
+        run_calls = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            if len(run_calls) == 1:
+                return subprocess.CompletedProcess(cmd, 0, stdout="99\n", stderr="")
+            kwargs["stdout"].write(b"tar-bytes")
+            return subprocess.CompletedProcess(cmd, 0, stderr=b"")
+
+        dest = tmp_path / "remote.tar"
+        with patch.object(subprocess, "run", side_effect=fake_run):
+            mock_env._ssh_bulk_download(dest)
+
+        assert dest.read_bytes() == b"tar-bytes"
+        assert len(run_calls) == 2
+        assert "du -sb" in run_calls[0][-1]
+        assert "du -sk" in run_calls[0][-1]
+        assert "tar cf - -C / home/testuser/.hermes" in run_calls[1][-1]
+
+    def test_size_preflight_failure_raises_clear_error(self, mock_env, tmp_path):
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="du failed")
+
+        with patch.object(subprocess, "run", side_effect=fake_run):
+            with pytest.raises(RuntimeError, match="size check failed: du failed"):
+                mock_env._ssh_bulk_download(tmp_path / "remote.tar")
+
+    def test_remote_size_command_has_bsd_du_fallback(self):
+        cmd = ssh_env._remote_size_bytes_command("/home/test user/.hermes")
+        assert "du -sb" in cmd
+        assert "du -sk" in cmd
+        assert "awk" in cmd
+        assert "'/home/test user/.hermes'" in cmd
+
+
 class TestSSHBulkUploadWiring:
     """Verify bulk_upload_fn is wired into FileSyncManager."""
 

--- a/tests/tools/test_ssh_bulk_upload.py
+++ b/tests/tools/test_ssh_bulk_upload.py
@@ -1,7 +1,9 @@
 """Tests for SSH bulk upload via tar pipe."""
 
+import io
 import os
 import subprocess
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -22,6 +24,23 @@ def _mock_proc(*, returncode=0, poll_return=0, communicate_return=(b"", b""),
     m.stderr = MagicMock()
     m.stderr.read.return_value = stderr_read
     return m
+
+
+def _mock_download_proc(
+    data: bytes = b"fake-tar-data", *, returncode: int | None = 0, stderr: bytes = b""
+):
+    proc = MagicMock()
+    proc.stdout = io.BytesIO(data)
+    proc.stderr = io.BytesIO(stderr)
+    proc.returncode = returncode
+    proc.poll.side_effect = lambda: proc.returncode
+    proc.wait.side_effect = lambda: proc.returncode
+
+    def kill():
+        proc.returncode = -9
+
+    proc.kill.side_effect = kill
+    return proc
 
 
 @pytest.fixture
@@ -492,20 +511,41 @@ class TestSSHBulkDownload:
 
         def fake_run(cmd, **kwargs):
             run_calls.append(cmd)
-            if len(run_calls) == 1:
-                return subprocess.CompletedProcess(cmd, 0, stdout="99\n", stderr="")
-            kwargs["stdout"].write(b"tar-bytes")
-            return subprocess.CompletedProcess(cmd, 0, stderr=b"")
+            return subprocess.CompletedProcess(cmd, 0, stdout="99\n", stderr="")
 
         dest = tmp_path / "remote.tar"
-        with patch.object(subprocess, "run", side_effect=fake_run):
+        proc = _mock_download_proc(b"tar-bytes")
+        with patch.object(subprocess, "run", side_effect=fake_run), \
+             patch.object(subprocess, "Popen", return_value=proc) as mock_popen:
             mock_env._ssh_bulk_download(dest)
 
         assert dest.read_bytes() == b"tar-bytes"
-        assert len(run_calls) == 2
+        assert len(run_calls) == 1
         assert "du -sb" in run_calls[0][-1]
         assert "du -sk" in run_calls[0][-1]
-        assert "tar cf - -C / home/testuser/.hermes" in run_calls[1][-1]
+        assert "tar cf - -C / home/testuser/.hermes" in mock_popen.call_args.args[0][-1]
+
+    def test_actual_tar_stream_over_cap_is_killed_even_when_preflight_passes(
+        self, mock_env, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(ssh_env, "_SYNC_BACK_MAX_BYTES", 100)
+        estimate = subprocess.CompletedProcess([], 0, stdout="99\n", stderr="")
+        monkeypatch.setattr(
+            mock_env,
+            "_build_ssh_command",
+            lambda: [
+                sys.executable,
+                "-c",
+                "import sys; sys.stdout.buffer.write(b'x' * 101)",
+            ],
+        )
+        dest = tmp_path / "remote.tar"
+
+        with patch.object(subprocess, "run", return_value=estimate):
+            with pytest.raises(RuntimeError, match="actual tar stream exceeded cap"):
+                mock_env._ssh_bulk_download(dest)
+
+        assert dest.stat().st_size <= 100
 
     def test_size_preflight_failure_raises_clear_error(self, mock_env, tmp_path):
         def fake_run(cmd, **kwargs):

--- a/tests/tools/test_ssh_bulk_upload.py
+++ b/tests/tools/test_ssh_bulk_upload.py
@@ -195,6 +195,75 @@ class TestSSHBulkUpload:
         mock_ssh.kill.assert_called_once()
 
 
+class TestSSHBulkDownload:
+    """Unit tests for SSH sync-back tar download preflight."""
+
+    def test_refuses_oversized_remote_before_tar_stream(self, mock_env, tmp_path, monkeypatch):
+        monkeypatch.setattr(ssh_env, "_SYNC_BACK_MAX_BYTES", 100)
+        run_calls = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="101\n", stderr="")
+
+        with patch.object(subprocess, "run", side_effect=fake_run):
+            with pytest.raises(RuntimeError, match="SSH sync-back skipped"):
+                mock_env._ssh_bulk_download(tmp_path / "remote.tar")
+
+        assert len(run_calls) == 1
+        assert "du -sb" in run_calls[0][-1]
+        assert "tar cf -" not in run_calls[0][-1]
+
+    def test_invalid_remote_size_output_fails_before_tar_stream(self, mock_env, tmp_path):
+        run_calls = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="not-a-size\n", stderr="")
+
+        with patch.object(subprocess, "run", side_effect=fake_run):
+            with pytest.raises(RuntimeError, match="invalid output"):
+                mock_env._ssh_bulk_download(tmp_path / "remote.tar")
+
+        assert len(run_calls) == 1
+
+    def test_download_streams_tar_after_size_preflight_passes(self, mock_env, tmp_path, monkeypatch):
+        monkeypatch.setattr(ssh_env, "_SYNC_BACK_MAX_BYTES", 100)
+        run_calls = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            if len(run_calls) == 1:
+                return subprocess.CompletedProcess(cmd, 0, stdout="99\n", stderr="")
+            kwargs["stdout"].write(b"tar-bytes")
+            return subprocess.CompletedProcess(cmd, 0, stderr=b"")
+
+        dest = tmp_path / "remote.tar"
+        with patch.object(subprocess, "run", side_effect=fake_run):
+            mock_env._ssh_bulk_download(dest)
+
+        assert dest.read_bytes() == b"tar-bytes"
+        assert len(run_calls) == 2
+        assert "du -sb" in run_calls[0][-1]
+        assert "du -sk" in run_calls[0][-1]
+        assert "tar cf - -C / home/testuser/.hermes" in run_calls[1][-1]
+
+    def test_size_preflight_failure_raises_clear_error(self, mock_env, tmp_path):
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="du failed")
+
+        with patch.object(subprocess, "run", side_effect=fake_run):
+            with pytest.raises(RuntimeError, match="size check failed: du failed"):
+                mock_env._ssh_bulk_download(tmp_path / "remote.tar")
+
+    def test_remote_size_command_has_bsd_du_fallback(self):
+        cmd = ssh_env._remote_size_bytes_command("/home/test user/.hermes")
+        assert "du -sb" in cmd
+        assert "du -sk" in cmd
+        assert "awk" in cmd
+        assert "'/home/test user/.hermes'" in cmd
+
+
 class TestSSHBulkUploadWiring:
     """Verify bulk_upload_fn is wired into FileSyncManager."""
 

--- a/tests/tools/test_ssh_bulk_upload.py
+++ b/tests/tools/test_ssh_bulk_upload.py
@@ -1,7 +1,9 @@
 """Tests for SSH bulk upload via tar pipe."""
 
+import io
 import os
 import subprocess
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -22,6 +24,23 @@ def _mock_proc(*, returncode=0, poll_return=0, communicate_return=(b"", b""),
     m.stderr = MagicMock()
     m.stderr.read.return_value = stderr_read
     return m
+
+
+def _mock_download_proc(
+    data: bytes = b"fake-tar-data", *, returncode: int | None = 0, stderr: bytes = b""
+):
+    proc = MagicMock()
+    proc.stdout = io.BytesIO(data)
+    proc.stderr = io.BytesIO(stderr)
+    proc.returncode = returncode
+    proc.poll.side_effect = lambda: proc.returncode
+    proc.wait.side_effect = lambda: proc.returncode
+
+    def kill():
+        proc.returncode = -9
+
+    proc.kill.side_effect = kill
+    return proc
 
 
 @pytest.fixture
@@ -233,20 +252,41 @@ class TestSSHBulkDownload:
 
         def fake_run(cmd, **kwargs):
             run_calls.append(cmd)
-            if len(run_calls) == 1:
-                return subprocess.CompletedProcess(cmd, 0, stdout="99\n", stderr="")
-            kwargs["stdout"].write(b"tar-bytes")
-            return subprocess.CompletedProcess(cmd, 0, stderr=b"")
+            return subprocess.CompletedProcess(cmd, 0, stdout="99\n", stderr="")
 
         dest = tmp_path / "remote.tar"
-        with patch.object(subprocess, "run", side_effect=fake_run):
+        proc = _mock_download_proc(b"tar-bytes")
+        with patch.object(subprocess, "run", side_effect=fake_run), \
+             patch.object(subprocess, "Popen", return_value=proc) as mock_popen:
             mock_env._ssh_bulk_download(dest)
 
         assert dest.read_bytes() == b"tar-bytes"
-        assert len(run_calls) == 2
+        assert len(run_calls) == 1
         assert "du -sb" in run_calls[0][-1]
         assert "du -sk" in run_calls[0][-1]
-        assert "tar cf - -C / home/testuser/.hermes" in run_calls[1][-1]
+        assert "tar cf - -C / home/testuser/.hermes" in mock_popen.call_args.args[0][-1]
+
+    def test_actual_tar_stream_over_cap_is_killed_even_when_preflight_passes(
+        self, mock_env, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(ssh_env, "_SYNC_BACK_MAX_BYTES", 100)
+        estimate = subprocess.CompletedProcess([], 0, stdout="99\n", stderr="")
+        monkeypatch.setattr(
+            mock_env,
+            "_build_ssh_command",
+            lambda: [
+                sys.executable,
+                "-c",
+                "import sys; sys.stdout.buffer.write(b'x' * 101)",
+            ],
+        )
+        dest = tmp_path / "remote.tar"
+
+        with patch.object(subprocess, "run", return_value=estimate):
+            with pytest.raises(RuntimeError, match="actual tar stream exceeded cap"):
+                mock_env._ssh_bulk_download(dest)
+
+        assert dest.stat().st_size <= 100
 
     def test_size_preflight_failure_raises_clear_error(self, mock_env, tmp_path):
         def fake_run(cmd, **kwargs):

--- a/tests/tools/test_sync_back_backends.py
+++ b/tests/tools/test_sync_back_backends.py
@@ -1,6 +1,7 @@
 """Tests for backend-specific bulk download implementations and cleanup() wiring."""
 
 import asyncio
+import io
 import subprocess
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -11,6 +12,23 @@ from tools.environments import ssh as ssh_env
 from tools.environments import modal as modal_env
 from tools.environments import daytona as daytona_env
 from tools.environments.ssh import SSHEnvironment
+
+
+def _mock_download_proc(
+    data: bytes = b"fake-tar-data", *, returncode: int | None = 0, stderr: bytes = b""
+):
+    proc = MagicMock()
+    proc.stdout = io.BytesIO(data)
+    proc.stderr = io.BytesIO(stderr)
+    proc.returncode = returncode
+    proc.poll.side_effect = lambda: proc.returncode
+    proc.wait.side_effect = lambda: proc.returncode
+
+    def kill():
+        proc.returncode = -9
+
+    proc.kill.side_effect = kill
+    return proc
 
 
 # ── SSH helpers ──────────────────────────────────────────────────────
@@ -104,15 +122,18 @@ class TestSSHBulkDownload:
     """Unit tests for _ssh_bulk_download."""
 
     def test_ssh_bulk_download_runs_tar_over_ssh(self, ssh_mock_env, tmp_path):
-        """subprocess.run command should include tar cf - over SSH."""
+        """The streamed process command should include tar cf - over SSH."""
         dest = tmp_path / "backup.tar"
+        preflight = subprocess.CompletedProcess([], 0, stdout="0\n", stderr="")
+        proc = _mock_download_proc()
 
-        with patch.object(subprocess, "run", return_value=subprocess.CompletedProcess([], 0)) as mock_run:
-            # open() will be called to write stdout; mock it to avoid actual file I/O
+        with patch.object(subprocess, "run", return_value=preflight) as mock_run, \
+             patch.object(subprocess, "Popen", return_value=proc) as mock_popen:
             ssh_mock_env._ssh_bulk_download(dest)
 
         mock_run.assert_called_once()
-        cmd = mock_run.call_args[0][0]
+        mock_popen.assert_called_once()
+        cmd = mock_popen.call_args[0][0]
         cmd_str = " ".join(cmd)
         assert "tar cf -" in cmd_str
         assert "-C /" in cmd_str
@@ -121,39 +142,56 @@ class TestSSHBulkDownload:
         assert "testuser@example.com" in cmd_str
 
     def test_ssh_bulk_download_writes_to_dest(self, ssh_mock_env, tmp_path):
-        """subprocess.run should receive stdout=open(dest, 'wb')."""
+        """The bounded receiver should write process stdout to dest."""
         dest = tmp_path / "backup.tar"
+        preflight = subprocess.CompletedProcess([], 0, stdout="0\n", stderr="")
+        proc = _mock_download_proc(b"archive-bytes")
 
-        with patch.object(subprocess, "run", return_value=subprocess.CompletedProcess([], 0)) as mock_run:
+        with patch.object(subprocess, "run", return_value=preflight), \
+             patch.object(subprocess, "Popen", return_value=proc):
             ssh_mock_env._ssh_bulk_download(dest)
 
-        # The stdout kwarg should be a file object opened for writing
-        call_kwargs = mock_run.call_args
-        # stdout is passed as a keyword arg
-        stdout_val = call_kwargs.kwargs.get("stdout") or call_kwargs[1].get("stdout")
-        # The file was opened via `with open(dest, "wb") as f` and passed as stdout=f.
-        # After the context manager exits, the file is closed, but we can verify
-        # the dest path was used by checking if the file was created.
-        assert dest.exists()
+        assert dest.read_bytes() == b"archive-bytes"
 
     def test_ssh_bulk_download_raises_on_failure(self, ssh_mock_env, tmp_path):
         """Non-zero returncode should raise RuntimeError."""
         dest = tmp_path / "backup.tar"
+        preflight = subprocess.CompletedProcess([], 0, stdout="0\n", stderr="")
+        proc = _mock_download_proc(b"", returncode=1, stderr=b"Permission denied")
 
-        failed = subprocess.CompletedProcess([], 1, stderr=b"Permission denied")
-        with patch.object(subprocess, "run", return_value=failed):
+        with patch.object(subprocess, "run", return_value=preflight), \
+             patch.object(subprocess, "Popen", return_value=proc):
             with pytest.raises(RuntimeError, match="SSH bulk download failed"):
                 ssh_mock_env._ssh_bulk_download(dest)
 
-    def test_ssh_bulk_download_uses_120s_timeout(self, ssh_mock_env, tmp_path):
-        """The subprocess.run call should use a 120s timeout."""
+    def test_ssh_bulk_download_timeout_kills_process(self, ssh_mock_env, tmp_path):
+        """The streamed receive path should enforce its 120s timeout."""
         dest = tmp_path / "backup.tar"
+        preflight = subprocess.CompletedProcess([], 0, stdout="0\n", stderr="")
+        proc = _mock_download_proc(b"", returncode=None)
+        timer_intervals = []
 
-        with patch.object(subprocess, "run", return_value=subprocess.CompletedProcess([], 0)) as mock_run:
-            ssh_mock_env._ssh_bulk_download(dest)
+        class ImmediateTimer:
+            daemon = False
 
-        call_kwargs = mock_run.call_args
-        assert call_kwargs.kwargs.get("timeout") == 120 or call_kwargs[1].get("timeout") == 120
+            def __init__(self, interval, callback):
+                timer_intervals.append(interval)
+                self.callback = callback
+
+            def start(self):
+                self.callback()
+
+            def cancel(self):
+                pass
+
+        with patch.object(subprocess, "run", return_value=preflight), \
+             patch.object(subprocess, "Popen", return_value=proc), \
+             patch.object(ssh_env.threading, "Timer", ImmediateTimer):
+            with pytest.raises(RuntimeError, match="SSH bulk download timed out"):
+                ssh_mock_env._ssh_bulk_download(dest)
+
+        assert timer_intervals == [120]
+        proc.kill.assert_called()
 
 
 class TestSSHCleanup:

--- a/tests/tools/test_sync_back_backends.py
+++ b/tests/tools/test_sync_back_backends.py
@@ -1,6 +1,7 @@
 """Tests for backend-specific bulk download implementations and cleanup() wiring."""
 
 import asyncio
+import io
 import subprocess
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -11,6 +12,23 @@ from tools.environments import ssh as ssh_env
 from tools.environments import modal as modal_env
 from tools.environments import daytona as daytona_env
 from tools.environments.ssh import SSHEnvironment
+
+
+def _mock_download_proc(
+    data: bytes = b"fake-tar-data", *, returncode: int | None = 0, stderr: bytes = b""
+):
+    proc = MagicMock()
+    proc.stdout = io.BytesIO(data)
+    proc.stderr = io.BytesIO(stderr)
+    proc.returncode = returncode
+    proc.poll.side_effect = lambda: proc.returncode
+    proc.wait.side_effect = lambda: proc.returncode
+
+    def kill():
+        proc.returncode = -9
+
+    proc.kill.side_effect = kill
+    return proc
 
 
 # ── SSH helpers ──────────────────────────────────────────────────────
@@ -104,15 +122,18 @@ class TestSSHBulkDownload:
     """Unit tests for _ssh_bulk_download."""
 
     def test_ssh_bulk_download_runs_tar_over_ssh(self, ssh_mock_env, tmp_path):
-        """subprocess.run command should include tar cf - over SSH."""
+        """The streamed process command should include tar cf - over SSH."""
         dest = tmp_path / "backup.tar"
+        preflight = subprocess.CompletedProcess([], 0, stdout="0\n", stderr="")
+        proc = _mock_download_proc()
 
-        with patch.object(subprocess, "run", return_value=subprocess.CompletedProcess([], 0)) as mock_run:
-            # open() will be called to write stdout; mock it to avoid actual file I/O
+        with patch.object(subprocess, "run", return_value=preflight) as mock_run, \
+             patch.object(subprocess, "Popen", return_value=proc) as mock_popen:
             ssh_mock_env._ssh_bulk_download(dest)
 
         mock_run.assert_called_once()
-        cmd = mock_run.call_args[0][0]
+        mock_popen.assert_called_once()
+        cmd = mock_popen.call_args[0][0]
         cmd_str = " ".join(cmd)
         assert "tar cf -" in cmd_str
         assert "-C /" in cmd_str
@@ -120,16 +141,57 @@ class TestSSHBulkDownload:
         assert "ssh" in cmd_str
         assert "testuser@example.com" in cmd_str
 
-
-    def test_ssh_bulk_download_uses_120s_timeout(self, ssh_mock_env, tmp_path):
-        """The subprocess.run call should use a 120s timeout."""
+    def test_ssh_bulk_download_writes_to_dest(self, ssh_mock_env, tmp_path):
+        """The bounded receiver should write process stdout to dest."""
         dest = tmp_path / "backup.tar"
+        preflight = subprocess.CompletedProcess([], 0, stdout="0\n", stderr="")
+        proc = _mock_download_proc(b"archive-bytes")
 
-        with patch.object(subprocess, "run", return_value=subprocess.CompletedProcess([], 0)) as mock_run:
+        with patch.object(subprocess, "run", return_value=preflight), \
+             patch.object(subprocess, "Popen", return_value=proc):
             ssh_mock_env._ssh_bulk_download(dest)
 
-        call_kwargs = mock_run.call_args
-        assert call_kwargs.kwargs.get("timeout") == 120 or call_kwargs[1].get("timeout") == 120
+        assert dest.read_bytes() == b"archive-bytes"
+
+    def test_ssh_bulk_download_raises_on_failure(self, ssh_mock_env, tmp_path):
+        """Non-zero returncode should raise RuntimeError."""
+        dest = tmp_path / "backup.tar"
+        preflight = subprocess.CompletedProcess([], 0, stdout="0\n", stderr="")
+        proc = _mock_download_proc(b"", returncode=1, stderr=b"Permission denied")
+
+        with patch.object(subprocess, "run", return_value=preflight), \
+             patch.object(subprocess, "Popen", return_value=proc):
+            with pytest.raises(ssh_env.EnvironmentConnectionError, match="SSH bulk download failed"):
+                ssh_mock_env._ssh_bulk_download(dest)
+
+    def test_ssh_bulk_download_timeout_kills_process(self, ssh_mock_env, tmp_path):
+        """The streamed receive path should enforce its 120s timeout."""
+        dest = tmp_path / "backup.tar"
+        preflight = subprocess.CompletedProcess([], 0, stdout="0\n", stderr="")
+        proc = _mock_download_proc(b"", returncode=None)
+        timer_intervals = []
+
+        class ImmediateTimer:
+            daemon = False
+
+            def __init__(self, interval, callback):
+                timer_intervals.append(interval)
+                self.callback = callback
+
+            def start(self):
+                self.callback()
+
+            def cancel(self):
+                pass
+
+        with patch.object(subprocess, "run", return_value=preflight), \
+             patch.object(subprocess, "Popen", return_value=proc), \
+             patch.object(ssh_env.threading, "Timer", ImmediateTimer):
+            with pytest.raises(RuntimeError, match="SSH bulk download timed out"):
+                ssh_mock_env._ssh_bulk_download(dest)
+
+        assert timer_intervals == [120]
+        proc.kill.assert_called()
 
 
 class TestSSHCleanup:

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from tools.environments.base import BaseEnvironment, _popen_bash
 from tools.environments.file_sync import (
     FileSyncManager,
+    _SYNC_BACK_MAX_BYTES,
     iter_sync_files,
     quoted_mkdir_command,
     quoted_rm_command,
@@ -19,6 +20,23 @@ from tools.environments.file_sync import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _remote_size_bytes_command(remote_path: str) -> str:
+    """Return a portable-ish shell command that prints a remote path size in bytes.
+
+    GNU ``du -sb`` is preferred. BSD/macOS ``du`` does not support ``-b``,
+    so fall back to KiB blocks and convert to bytes. Both branches exit
+    non-zero when no size can be read, which lets callers fail before
+    starting a potentially huge tar stream.
+    """
+    quoted = shlex.quote(remote_path)
+    return (
+        f"du -sb {quoted} 2>/dev/null | "
+        "awk 'NR==1 {print $1; ok=1} END {exit ok?0:1}' || "
+        f"du -sk {quoted} 2>/dev/null | "
+        "awk 'NR==1 {print $1 * 1024; ok=1} END {exit ok?0:1}'"
+    )
 
 
 def _ensure_ssh_available() -> None:
@@ -302,9 +320,38 @@ class SSHEnvironment(BaseEnvironment):
 
     def _ssh_bulk_download(self, dest: Path) -> None:
         """Download remote .hermes/ as a tar archive."""
+        # Refuse before streaming: FileSyncManager also enforces a 2 GiB
+        # tar cap after download, but checking only after download can still
+        # fill local /tmp with an archive that will never be extracted.
+        remote_hermes = f"{self._remote_home}/.hermes"
+        size_cmd = self._build_ssh_command()
+        size_cmd.append(_remote_size_bytes_command(remote_hermes))
+        size_result = subprocess.run(
+            size_cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            stdin=subprocess.DEVNULL,
+        )
+        if size_result.returncode != 0:
+            raise RuntimeError(
+                f"SSH bulk download size check failed: {size_result.stderr.strip()}"
+            )
+        try:
+            remote_size = int((size_result.stdout or "0").strip().splitlines()[0])
+        except (IndexError, ValueError) as exc:
+            raise RuntimeError(
+                f"SSH bulk download size check returned invalid output: {size_result.stdout!r}"
+            ) from exc
+        if remote_size > _SYNC_BACK_MAX_BYTES:
+            raise RuntimeError(
+                f"SSH sync-back skipped: remote {remote_hermes} is {remote_size} bytes, "
+                f"over cap {_SYNC_BACK_MAX_BYTES}"
+            )
+
         # Tar from / with the full path so archive entries preserve absolute
         # paths (e.g. home/user/.hermes/skills/f.py), matching _pushed_hashes keys.
-        rel_base = f"{self._remote_home}/.hermes".lstrip("/")
+        rel_base = remote_hermes.lstrip("/")
         ssh_cmd = self._build_ssh_command()
         ssh_cmd.append(f"tar cf - -C / {shlex.quote(rel_base)}")
         with open(dest, "wb") as f:

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -7,6 +7,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+import threading
 from pathlib import Path
 
 from tools.environments.base import BaseEnvironment, _popen_bash
@@ -20,6 +21,20 @@ from tools.environments.file_sync import (
 )
 
 logger = logging.getLogger(__name__)
+
+_SYNC_BACK_READ_CHUNK_BYTES = 1024 * 1024
+_SYNC_BACK_STDERR_MAX_BYTES = 64 * 1024
+
+
+def _drain_bounded_stderr(stream, output: bytearray) -> None:
+    """Drain a subprocess stderr pipe without retaining unbounded output."""
+    while True:
+        chunk = stream.read(8192)
+        if not chunk:
+            return
+        output.extend(chunk)
+        if len(output) > _SYNC_BACK_STDERR_MAX_BYTES:
+            del output[:-_SYNC_BACK_STDERR_MAX_BYTES]
 
 
 def _remote_size_bytes_command(remote_path: str) -> str:
@@ -354,16 +369,78 @@ class SSHEnvironment(BaseEnvironment):
         rel_base = remote_hermes.lstrip("/")
         ssh_cmd = self._build_ssh_command()
         ssh_cmd.append(f"tar cf - -C / {shlex.quote(rel_base)}")
-        with open(dest, "wb") as f:
-            result = subprocess.run(
-                ssh_cmd,
-                stdin=subprocess.DEVNULL,
-                stdout=f,
-                stderr=subprocess.PIPE,
-                timeout=120,
+        proc = subprocess.Popen(
+            ssh_cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if proc.stdout is None or proc.stderr is None:
+            proc.kill()
+            proc.wait()
+            raise RuntimeError("SSH bulk download failed to open process pipes")
+        stdout_stream = proc.stdout
+        stderr_stream = proc.stderr
+        stderr_buffer = bytearray()
+        stderr_thread = threading.Thread(
+            target=_drain_bounded_stderr,
+            args=(stderr_stream, stderr_buffer),
+            daemon=True,
+        )
+        stderr_thread.start()
+
+        timed_out = threading.Event()
+
+        def kill_on_timeout() -> None:
+            if proc.poll() is None:
+                timed_out.set()
+                try:
+                    proc.kill()
+                except OSError:
+                    pass
+
+        timer = threading.Timer(120, kill_on_timeout)
+        timer.daemon = True
+        timer.start()
+        received = 0
+        oversized = False
+        try:
+            with open(dest, "wb") as f:
+                while True:
+                    chunk = stdout_stream.read(_SYNC_BACK_READ_CHUNK_BYTES)
+                    if not chunk:
+                        break
+                    if received + len(chunk) > _SYNC_BACK_MAX_BYTES:
+                        oversized = True
+                        try:
+                            proc.kill()
+                        except OSError:
+                            pass
+                        break
+                    f.write(chunk)
+                    received += len(chunk)
+            stdout_stream.close()
+            returncode = proc.wait()
+        finally:
+            timer.cancel()
+            if proc.poll() is None:
+                try:
+                    proc.kill()
+                except OSError:
+                    pass
+                proc.wait()
+            stderr_thread.join(timeout=5)
+
+        stderr_text = bytes(stderr_buffer).decode(errors="replace").strip()
+        if timed_out.is_set():
+            raise RuntimeError("SSH bulk download timed out")
+        if oversized:
+            raise RuntimeError(
+                f"SSH sync-back skipped: actual tar stream exceeded cap "
+                f"{_SYNC_BACK_MAX_BYTES} bytes"
             )
-        if result.returncode != 0:
-            raise RuntimeError(f"SSH bulk download failed: {result.stderr.decode(errors='replace').strip()}")
+        if returncode != 0:
+            raise RuntimeError(f"SSH bulk download failed: {stderr_text}")
 
     def _ssh_delete(self, remote_paths: list[str]) -> None:
         """Batch-delete remote files in one SSH call."""

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -22,6 +22,7 @@ from tools.environments.base import (
 )
 from tools.environments.file_sync import (
     FileSyncManager,
+    _SYNC_BACK_MAX_BYTES,
     iter_sync_files,
     quoted_mkdir_command,
     quoted_rm_command,
@@ -29,6 +30,23 @@ from tools.environments.file_sync import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _remote_size_bytes_command(remote_path: str) -> str:
+    """Return a portable-ish shell command that prints a remote path size in bytes.
+
+    GNU ``du -sb`` is preferred. BSD/macOS ``du`` does not support ``-b``,
+    so fall back to KiB blocks and convert to bytes. Both branches exit
+    non-zero when no size can be read, which lets callers fail before
+    starting a potentially huge tar stream.
+    """
+    quoted = shlex.quote(remote_path)
+    return (
+        f"du -sb {quoted} 2>/dev/null | "
+        "awk 'NR==1 {print $1; ok=1} END {exit ok?0:1}' || "
+        f"du -sk {quoted} 2>/dev/null | "
+        "awk 'NR==1 {print $1 * 1024; ok=1} END {exit ok?0:1}'"
+    )
 
 
 def _ensure_ssh_available() -> None:
@@ -350,9 +368,38 @@ class SSHEnvironment(BaseEnvironment):
 
     def _ssh_bulk_download(self, dest: Path) -> None:
         """Download remote .hermes/ as a tar archive."""
+        # Refuse before streaming: FileSyncManager also enforces a 2 GiB
+        # tar cap after download, but checking only after download can still
+        # fill local /tmp with an archive that will never be extracted.
+        remote_hermes = f"{self._remote_home}/.hermes"
+        size_cmd = self._build_ssh_command()
+        size_cmd.append(_remote_size_bytes_command(remote_hermes))
+        size_result = subprocess.run(
+            size_cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            stdin=subprocess.DEVNULL,
+        )
+        if size_result.returncode != 0:
+            raise RuntimeError(
+                f"SSH bulk download size check failed: {size_result.stderr.strip()}"
+            )
+        try:
+            remote_size = int((size_result.stdout or "0").strip().splitlines()[0])
+        except (IndexError, ValueError) as exc:
+            raise RuntimeError(
+                f"SSH bulk download size check returned invalid output: {size_result.stdout!r}"
+            ) from exc
+        if remote_size > _SYNC_BACK_MAX_BYTES:
+            raise RuntimeError(
+                f"SSH sync-back skipped: remote {remote_hermes} is {remote_size} bytes, "
+                f"over cap {_SYNC_BACK_MAX_BYTES}"
+            )
+
         # Tar from / with the full path so archive entries preserve absolute
         # paths (e.g. home/user/.hermes/skills/f.py), matching _pushed_hashes keys.
-        rel_base = f"{self._remote_home}/.hermes".lstrip("/")
+        rel_base = remote_hermes.lstrip("/")
         ssh_cmd = self._build_ssh_command()
         ssh_cmd.append(f"tar cf - -C / {shlex.quote(rel_base)}")
         with open(dest, "wb") as f:

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -13,6 +13,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+import threading
 from pathlib import Path
 
 from tools.environments.base import (
@@ -30,6 +31,20 @@ from tools.environments.file_sync import (
 )
 
 logger = logging.getLogger(__name__)
+
+_SYNC_BACK_READ_CHUNK_BYTES = 1024 * 1024
+_SYNC_BACK_STDERR_MAX_BYTES = 64 * 1024
+
+
+def _drain_bounded_stderr(stream, output: bytearray) -> None:
+    """Drain a subprocess stderr pipe without retaining unbounded output."""
+    while True:
+        chunk = stream.read(8192)
+        if not chunk:
+            return
+        output.extend(chunk)
+        if len(output) > _SYNC_BACK_STDERR_MAX_BYTES:
+            del output[:-_SYNC_BACK_STDERR_MAX_BYTES]
 
 
 def _remote_size_bytes_command(remote_path: str) -> str:
@@ -402,17 +417,79 @@ class SSHEnvironment(BaseEnvironment):
         rel_base = remote_hermes.lstrip("/")
         ssh_cmd = self._build_ssh_command()
         ssh_cmd.append(f"tar cf - -C / {shlex.quote(rel_base)}")
-        with open(dest, "wb") as f:
-            result = subprocess.run(
-                ssh_cmd,
-                stdin=subprocess.DEVNULL,
-                stdout=f,
-                stderr=subprocess.PIPE,
-                timeout=120,
+        proc = subprocess.Popen(
+            ssh_cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if proc.stdout is None or proc.stderr is None:
+            proc.kill()
+            proc.wait()
+            raise RuntimeError("SSH bulk download failed to open process pipes")
+        stdout_stream = proc.stdout
+        stderr_stream = proc.stderr
+        stderr_buffer = bytearray()
+        stderr_thread = threading.Thread(
+            target=_drain_bounded_stderr,
+            args=(stderr_stream, stderr_buffer),
+            daemon=True,
+        )
+        stderr_thread.start()
+
+        timed_out = threading.Event()
+
+        def kill_on_timeout() -> None:
+            if proc.poll() is None:
+                timed_out.set()
+                try:
+                    proc.kill()
+                except OSError:
+                    pass
+
+        timer = threading.Timer(120, kill_on_timeout)
+        timer.daemon = True
+        timer.start()
+        received = 0
+        oversized = False
+        try:
+            with open(dest, "wb") as f:
+                while True:
+                    chunk = stdout_stream.read(_SYNC_BACK_READ_CHUNK_BYTES)
+                    if not chunk:
+                        break
+                    if received + len(chunk) > _SYNC_BACK_MAX_BYTES:
+                        oversized = True
+                        try:
+                            proc.kill()
+                        except OSError:
+                            pass
+                        break
+                    f.write(chunk)
+                    received += len(chunk)
+            stdout_stream.close()
+            returncode = proc.wait()
+        finally:
+            timer.cancel()
+            if proc.poll() is None:
+                try:
+                    proc.kill()
+                except OSError:
+                    pass
+                proc.wait()
+            stderr_thread.join(timeout=5)
+
+        stderr_text = bytes(stderr_buffer).decode(errors="replace").strip()
+        if timed_out.is_set():
+            raise RuntimeError("SSH bulk download timed out")
+        if oversized:
+            raise RuntimeError(
+                f"SSH sync-back skipped: actual tar stream exceeded cap "
+                f"{_SYNC_BACK_MAX_BYTES} bytes"
             )
-        if result.returncode != 0:
+        if returncode != 0:
             raise EnvironmentConnectionError(
-                f"SSH bulk download failed: {result.stderr.decode(errors='replace').strip()}",
+                f"SSH bulk download failed: {stderr_text}",
                 retry_hint=(
                     f"File sync from {self.host} failed — verify the SSH "
                     "connection is healthy, then retry."


### PR DESCRIPTION
## Summary

- add a remote `.hermes` size preflight before SSH sync-back starts streaming a tarball into local `/tmp`
- prefer GNU `du -sb`, with BSD/macOS `du -sk` fallback converted to bytes
- refuse oversized sync-back before download using the existing `_SYNC_BACK_MAX_BYTES` cap
- add focused unit tests for oversize refusal, invalid size output, preflight failure, successful tar streaming, and BSD fallback command shape

## Why

In a production SSH-backed worker setup, remote `/root/.hermes` grew to several GiB. During worker cleanup Hermes streamed `tar cf - -C / root/.hermes` into local `/tmp/tmp*.tar`; the existing 2 GiB cap only runs after the tar is downloaded, so the Hermes host disk filled before sync-back could be rejected.

Failing before the tar stream protects the host from disk pressure while preserving the existing post-download cap as a second line of defence.

## Test Plan

```bash
python3 -m py_compile tools/environments/ssh.py tests/tools/test_ssh_bulk_upload.py
python3 -m pytest tests/tools/test_ssh_bulk_upload.py -q -o 'addopts='
python3 -m pytest tests/tools/test_file_sync_back.py tests/tools/test_ssh_environment.py tests/tools/test_ssh_bulk_upload.py -q -o 'addopts='
git diff --check
```

Results locally:

```text
26 passed in 0.70s
58 passed, 11 skipped in 1.32s
```
