### PR TITLE
test(web): cover provider plugin discovery before search dispatch

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -464,6 +464,26 @@ class TestWebSearchSchema:
         assert result == '{"success": true}'
         mock_search.assert_called_once_with("docs", limit=5)
 
+    def test_web_search_discovers_provider_plugins_before_registry_lookup(self):
+        import tools.web_tools
+
+        fake_search = MagicMock(return_value={"success": True, "data": {"web": []}})
+        fake_provider = MagicMock(supports_search=MagicMock(return_value=True))
+        fake_provider.name = "brave-free"
+        fake_provider.search = fake_search
+
+        with patch("tools.web_tools._get_search_backend", return_value="brave-free"), \
+             patch("hermes_cli.plugins._ensure_plugins_discovered") as mock_discover, \
+             patch("agent.web_search_registry.get_provider", return_value=fake_provider), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("docs", limit=2))
+
+        assert result == {"success": True, "data": {"web": []}}
+        mock_discover.assert_called_once_with()
+        fake_search.assert_called_once_with("docs", 2)
+
     def test_web_search_clamps_limit_before_backend_call(self):
         import tools.web_tools
 


### PR DESCRIPTION
## Summary
- Add regression coverage that web search dispatch triggers plugin discovery before looking up provider-backed search implementations.

## Audit / duplication check
- Current main already contains the production discovery path; this PR is intentionally test-only.
- Open web-provider PRs add new providers, not this dispatch-order regression test.

## Test Plan
- `python -m pytest tests/tools/test_web_tools_config.py::TestWebSearchSchema::test_web_search_discovers_provider_plugins_before_registry_lookup -q -o 'addopts='`
