### PR TITLE
fix(discord): suppress exact heartbeat bot loops

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -328,6 +328,11 @@ def _looks_like_nonconversational_history_message(content: str) -> bool:
     return any(pattern.match(text) for pattern in _DISCORD_NONCONVERSATIONAL_HISTORY_MESSAGE_PATTERNS)
 
 
+def _is_exact_heartbeat_message(content: str) -> bool:
+    """Return whether a live inbound bot message is exactly HEARTBEAT_OK."""
+    return (content or "").strip() == "HEARTBEAT_OK"
+
+
 def _clean_discord_id(entry: str) -> str:
     """Strip common prefixes from a Discord user ID or username entry.
 
@@ -1402,6 +1407,15 @@ class DiscordAdapter(BasePlatformAdapter):
                 await asyncio.wait_for(self._ready_event.wait(), timeout=30.0)
             except asyncio.TimeoutError:
                 pass
+        if (
+            getattr(message.author, "bot", False)
+            and _is_exact_heartbeat_message(
+                getattr(message, "clean_content", None)
+                or getattr(message, "content", "")
+            )
+        ):
+            self._nonconversational_messages.mark_many([str(message.id)])
+            return False
         admitted, role_authorized = self._discord_message_admission(
             message, claim=True,
         )

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -3,7 +3,9 @@
 import os
 import re
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from plugins.platforms.discord.adapter import DiscordAdapter, _is_exact_heartbeat_message
 
 
 def _make_author(*, bot: bool = False, is_self: bool = False):
@@ -21,6 +23,7 @@ def _make_message(*, author=None, content="hello", mentions=None, is_dm=False):
     msg = MagicMock()
     msg.author = author or _make_author()
     msg.content = content
+    msg.clean_content = content
     msg.attachments = []
     msg.mentions = mentions or []
     if is_dm:
@@ -38,7 +41,7 @@ def _make_message(*, author=None, content="hello", mentions=None, is_dm=False):
     return msg
 
 
-class TestDiscordBotFilter(unittest.TestCase):
+class TestDiscordBotFilter(unittest.IsolatedAsyncioTestCase):
     """Test the DISCORD_ALLOW_BOTS filtering logic."""
 
     @staticmethod
@@ -76,6 +79,10 @@ class TestDiscordBotFilter(unittest.TestCase):
         # Replicate the exact filter logic from discord.py on_message
         if message.author == client_user:
             return False  # own messages always ignored
+
+        content = getattr(message, "clean_content", message.content) or ""
+        if getattr(message.author, "bot", False) and _is_exact_heartbeat_message(content):
+            return False
 
         if getattr(message.author, "bot", False):
             allow = allow_bots.lower().strip()
@@ -115,6 +122,97 @@ class TestDiscordBotFilter(unittest.TestCase):
         msg = _make_message(author=bot, mentions=[])
         self.assertFalse(self._run_filter(msg, "mentions", our_user))
 
+    def test_allow_bots_mentions_accepts_with_mention(self):
+        """With allow_bots=mentions, bot messages with @mention are accepted."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, mentions=[our_user])
+        self.assertTrue(self._run_filter(msg, "mentions", our_user))
+
+    def test_allow_bots_mentions_accepts_with_raw_content_mention(self):
+        """Raw <@!ID> mention counts even when message.mentions is empty."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, content=f"<@!{our_user.id}> relay", mentions=[])
+        self.assertTrue(self._run_filter(msg, "mentions", our_user))
+
+    def test_heartbeat_ok_bot_message_is_nonconversational(self):
+        """Exact bot HEARTBEAT_OK pings must not trigger another bot."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, content="HEARTBEAT_OK", mentions=[our_user])
+        self.assertTrue(_is_exact_heartbeat_message("HEARTBEAT_OK"))
+        self.assertFalse(self._run_filter(msg, "mentions", our_user))
+
+    def test_operational_bot_handoff_still_passes_with_mention(self):
+        """Non-heartbeat Molly/Petra handoffs still pass the bot mention path."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(
+            author=bot,
+            content="Owner: Molly\nAsk: Petra validate project access\nEvidence: project visible",
+            mentions=[our_user],
+        )
+        self.assertFalse(_is_exact_heartbeat_message(msg.content))
+        self.assertTrue(self._run_filter(msg, "mentions", our_user))
+
+    async def test_real_dispatch_drops_and_persists_exact_heartbeat(self):
+        adapter = object.__new__(DiscordAdapter)
+        adapter._ready_event = MagicMock()
+        adapter._ready_event.is_set.return_value = True
+        adapter._nonconversational_messages = MagicMock()
+        adapter._discord_message_admission = MagicMock(return_value=(True, False))
+        adapter._handle_message = AsyncMock(return_value=True)
+        msg = _make_message(author=_make_author(bot=True), content="HEARTBEAT_OK")
+        msg.id = 4242
+
+        assert await adapter._dispatch_discord_message(msg) is False
+        adapter._nonconversational_messages.mark_many.assert_called_once_with(["4242"])
+        adapter._discord_message_admission.assert_not_called()
+        adapter._handle_message.assert_not_awaited()
+
+    async def test_real_dispatch_hands_off_nonheartbeat_bot_message(self):
+        adapter = object.__new__(DiscordAdapter)
+        adapter._ready_event = MagicMock()
+        adapter._ready_event.is_set.return_value = True
+        adapter._nonconversational_messages = MagicMock()
+        adapter._discord_message_admission = MagicMock(return_value=(True, False))
+        adapter._handle_message = AsyncMock(return_value=True)
+        msg = _make_message(author=_make_author(bot=True), content="Petra validate access")
+
+        assert await adapter._dispatch_discord_message(msg) is True
+        adapter._discord_message_admission.assert_called_once_with(msg, claim=True)
+        adapter._handle_message.assert_awaited_once_with(msg, role_authorized=False)
+
+    def test_inline_mention_requirement_off_preserves_reply_ping_behavior(self):
+        """Default behavior: resolved reply-ping mentions still admit bot messages."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, content="reply-ping only", mentions=[our_user])
+
+        self.assertTrue(
+            self._run_filter(
+                msg,
+                "all",
+                our_user,
+                bots_require_inline_mention=False,
+            )
+        )
+
+    def test_inline_mention_requirement_rejects_reply_ping_only(self):
+        """Opt-in guard rejects bot messages where only Discord's reply-ping mentions us."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, content="reply-ping only", mentions=[our_user])
+
+        self.assertFalse(
+            self._run_filter(
+                msg,
+                "all",
+                our_user,
+                bots_require_inline_mention=True,
+            )
+        )
 
     def test_inline_mention_requirement_accepts_body_mention(self):
         """Opt-in guard still admits intentional inline cross-bot mentions."""
@@ -138,8 +236,9 @@ class TestDiscordBotFilter(unittest.TestCase):
 
     def test_default_is_none(self):
         """Default behavior (no env var) should be 'none'."""
-        default = os.getenv("DISCORD_ALLOW_BOTS", "none")
-        self.assertEqual(default, "none")
+        with patch.dict(os.environ, {}, clear=True):
+            default = os.getenv("DISCORD_ALLOW_BOTS", "none")
+            self.assertEqual(default, "none")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Treat exact bot `HEARTBEAT_OK` messages as non-conversational before bot-admission filtering.
- Mark dropped heartbeat messages as non-conversational so they do not wake peer bots or partition history.
- Preserve normal bot handoff messages that mention Hermes.

## Audit / duplication check
- No matching open PR found for exact `HEARTBEAT_OK` Discord bot-loop suppression.
- This deliberately excludes local/private protocol documentation from the upstream PR.

## Test Plan
- `scripts/run_tests.sh tests/gateway/test_discord_bot_filter.py -q`
