### PR TITLE
fix(codex): support scoped access-token automation

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1999,6 +1999,14 @@ def _read_codex_access_token() -> Optional[str]:
     fallback-to-Codex working when the pool state is stale but the stored OAuth
     token is still valid.
     """
+    try:
+        from hermes_cli.auth import _read_codex_access_token_env
+        env_token = _read_codex_access_token_env()
+        if env_token:
+            return env_token
+    except Exception:
+        pass
+
     pool_present, entry = _select_pool_entry("openai-codex")
     if pool_present:
         token = _pool_runtime_api_key(entry)

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -26,10 +26,13 @@ from dataclasses import dataclass, field
 from typing import Any, Optional
 
 from tools.environments.local import hermes_subprocess_env
+from agent.secret_sources.onepassword import fetch_onepassword_secrets
 
 # Default minimum codex version we test against. The PR sets this from the
 # `codex --version` parsed at install time; bumping is a one-line change here.
 MIN_CODEX_VERSION = (0, 125, 0)
+CODEX_ACCESS_TOKEN_OP_REF_ENV = "CODEX_ACCESS_TOKEN_OP_REF"
+HERMES_CODEX_ACCESS_TOKEN_OP_REF_ENV = "HERMES_CODEX_ACCESS_TOKEN_OP_REF"
 
 
 @dataclass
@@ -49,6 +52,35 @@ class _Pending:
     queue: queue.Queue
     method: str
     sent_at: float = field(default_factory=time.time)
+
+
+def _resolve_codex_access_token_from_1password(env: dict[str, str]) -> Optional[str]:
+    """Resolve CODEX_ACCESS_TOKEN from a 1Password secret reference.
+
+    This is intentionally scoped to the app-server transport. Tokens with
+    ``aud=codex-app-server`` are valid for official Codex CLI automation but
+    not for Hermes' direct ``chatgpt.com/backend-api/codex`` client. Resolving
+    the secret here lets deployments avoid writing the token into ``.env`` and
+    avoids shadowing OAuth credentials used by the default Hermes runtime.
+    """
+    if (env.get("CODEX_ACCESS_TOKEN") or "").strip():
+        return None
+    ref = (
+        env.get(HERMES_CODEX_ACCESS_TOKEN_OP_REF_ENV)
+        or env.get(CODEX_ACCESS_TOKEN_OP_REF_ENV)
+        or ""
+    ).strip()
+    if not ref.startswith("op://"):
+        return None
+    try:
+        secrets, warnings = fetch_onepassword_secrets(
+            references={"CODEX_ACCESS_TOKEN": ref}, use_cache=False,
+        )
+    except RuntimeError:
+        return None
+    if warnings:
+        return None
+    return (secrets.get("CODEX_ACCESS_TOKEN") or "").strip() or None
 
 
 class CodexAppServerClient:
@@ -92,6 +124,9 @@ class CodexAppServerClient:
             spawn_env.update(env)
         if codex_home:
             spawn_env["CODEX_HOME"] = codex_home
+        resolved_codex_token = _resolve_codex_access_token_from_1password(spawn_env)
+        if resolved_codex_token:
+            spawn_env["CODEX_ACCESS_TOKEN"] = resolved_codex_token
 
         app_server_args = list(extra_args or [])
         # Kanban workers must be able to write their handoff/status back to

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3848,23 +3848,80 @@ def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
         return None
 
 
+def _codex_access_token_env_backend_compatible(token: str) -> bool:
+    """Return True when CODEX_ACCESS_TOKEN is usable on backend-api/codex.
+
+    OpenAI's Business/Enterprise Codex access tokens for `codex app-server`
+    currently carry audience `codex-app-server`; those are accepted by the
+    official Codex CLI/app-server path, but chatgpt.com/backend-api/codex rejects
+    them as unparsable/unauthorized.  Do not let such a token shadow a working
+    Hermes OAuth credential for the backend-api provider.
+    """
+    if not token or "." not in token:
+        return False
+    try:
+        payload_b64 = token.split(".")[1]
+        payload_b64 += "=" * (-len(payload_b64) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload_b64.encode("ascii")).decode("utf-8"))
+    except Exception:
+        return False
+    aud = claims.get("aud")
+    if isinstance(aud, str):
+        audiences = {aud}
+    elif isinstance(aud, list):
+        audiences = {str(item) for item in aud}
+    else:
+        audiences = set()
+    exp = claims.get("exp")
+    if not isinstance(exp, (int, float)) or exp <= time.time():
+        return False
+    return "https://api.openai.com/v1" in audiences
+
+
+def _read_codex_access_token_env() -> str:
+    """Return an explicit backend-api compatible Codex token from env, if set.
+
+    This is intentionally separate from OPENAI_API_KEY: these tokens authenticate
+    against chatgpt.com/backend-api/codex and should not be routed to the metered
+    Platform API.  Codex app-server access tokens are ignored here because they
+    require the app-server runtime, not the backend-api provider.
+    """
+    token = (os.getenv("CODEX_ACCESS_TOKEN") or "").strip()
+    if token and _codex_access_token_env_backend_compatible(token):
+        return token
+    return ""
+
+
 def resolve_codex_runtime_credentials(
     *,
     force_refresh: bool = False,
     refresh_if_expiring: bool = True,
     refresh_skew_seconds: int = CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
 ) -> Dict[str, Any]:
-    """Resolve runtime credentials from Hermes's own Codex token store.
+    """Resolve runtime credentials for the ChatGPT Codex backend.
 
-    Falls back to the credential pool when the singleton (``providers.openai-codex.tokens``)
-    has no usable access_token but the pool (``credential_pool.openai-codex``) does. This
-    closes the divergence between the chat path (singleton-only via this function) and
-    the auxiliary path (pool-first via ``_read_codex_access_token``). Without this
-    fallback, a user whose tokens live only in the pool — for example after a manual
-    pool seed, a partial re-auth, or pool-only restoration from a backup — gets a bare
-    HTTP 401 ``Missing Authentication header`` from the wire instead of a usable
-    credential. See issue #32992.
+    Prefer an explicit backend-compatible ``CODEX_ACCESS_TOKEN`` for automation
+    (ChatGPT Business / Enterprise access-token flow). Fall back to
+    Hermes-managed OAuth refresh tokens for interactive/local use, and then to
+    the openai-codex credential pool when the singleton auth-store entry is
+    missing but a usable pool entry exists. The pool fallback closes the
+    singleton-vs-pool divergence tracked in issue #32992.
     """
+    access_token_env = _read_codex_access_token_env()
+    if access_token_env:
+        base_url = (
+            os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+            or DEFAULT_CODEX_BASE_URL
+        )
+        return {
+            "provider": "openai-codex",
+            "base_url": base_url,
+            "api_key": access_token_env,
+            "source": "codex-access-token-env",
+            "last_refresh": None,
+            "auth_mode": "access_token",
+        }
+
     read_error: Optional[AuthError] = None
     try:
         data = _read_codex_tokens()

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -110,6 +110,46 @@ class TestCodexAppServerModule:
         assert "boom" in str(err)
         assert "-32600" in str(err)
 
+    def test_1password_secret_ref_resolves_only_when_token_missing(self, monkeypatch) -> None:
+        from agent.transports import codex_app_server as cas
+
+        calls = []
+
+        class Result:
+            returncode = 0
+            stdout = "secret-token\n"
+            stderr = ""
+
+        def fake_fetch(**kwargs):
+            calls.append(kwargs)
+            return ({"CODEX_ACCESS_TOKEN": "secret-token"}, [])
+
+        monkeypatch.setattr(cas, "fetch_onepassword_secrets", fake_fetch)
+
+        env = {"HERMES_CODEX_ACCESS_TOKEN_OP_REF": "op://Petra/Codex/credential"}
+        assert cas._resolve_codex_access_token_from_1password(env) == "secret-token"
+        assert calls[0]["references"] == {
+            "CODEX_ACCESS_TOKEN": "op://Petra/Codex/credential"
+        }
+        assert calls[0]["use_cache"] is False
+
+        env_with_token = {
+            "CODEX_ACCESS_TOKEN": "already-present",
+            "HERMES_CODEX_ACCESS_TOKEN_OP_REF": "op://Petra/Codex/credential",
+        }
+        assert cas._resolve_codex_access_token_from_1password(env_with_token) is None
+        assert len(calls) == 1
+
+    def test_1password_secret_ref_ignores_non_op_refs(self, monkeypatch) -> None:
+        from agent.transports import codex_app_server as cas
+
+        def fake_fetch(*args, **kwargs):  # pragma: no cover - should not execute
+            raise AssertionError("op should not be called for non-op refs")
+
+        monkeypatch.setattr(cas, "fetch_onepassword_secrets", fake_fetch)
+        env = {"HERMES_CODEX_ACCESS_TOKEN_OP_REF": "plain-secret"}
+        assert cas._resolve_codex_access_token_from_1password(env) is None
+
 
 class TestSpawnEnvIsolation:
     """The codex spawn must NOT rewrite HOME — codex's shell tool spawns

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -50,8 +50,83 @@ def _jwt_with_exp(exp_epoch: int) -> str:
     return f"h.{encoded}.s"
 
 
+def _codex_backend_jwt(exp_epoch: int | None = None) -> str:
+    if exp_epoch is None:
+        exp_epoch = int(time.time()) + 3600
+    payload = {"exp": exp_epoch, "aud": ["https://api.openai.com/v1"]}
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).rstrip(b"=").decode("utf-8")
+    return f"h.{encoded}.s"
 
 
+def test_read_codex_tokens_success(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    _setup_hermes_auth(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    data = _read_codex_tokens()
+    assert data["tokens"]["access_token"] == "access"
+    assert data["tokens"]["refresh_token"] == "refresh"
+
+
+
+
+def test_resolve_codex_runtime_credentials_uses_codex_access_token_env_without_auth_store(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    token = _codex_backend_jwt()
+    monkeypatch.setenv("CODEX_ACCESS_TOKEN", token)
+
+    resolved = resolve_codex_runtime_credentials(force_refresh=True)
+
+    assert resolved["api_key"] == token
+    assert resolved["source"] == "codex-access-token-env"
+    assert resolved["auth_mode"] == "access_token"
+    assert resolved["base_url"] == DEFAULT_CODEX_BASE_URL
+
+
+def test_resolve_codex_runtime_credentials_prefers_codex_access_token_env_over_oauth_refresh(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    _setup_hermes_auth(hermes_home, access_token=_jwt_with_exp(int(time.time()) - 10), refresh_token="refresh-old")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    token = _codex_backend_jwt()
+    monkeypatch.setenv("CODEX_ACCESS_TOKEN", token)
+
+    def _should_not_refresh(tokens, timeout_seconds):
+        raise AssertionError("access-token mode must not use OAuth refresh tokens")
+
+    monkeypatch.setattr("hermes_cli.auth._refresh_codex_auth_tokens", _should_not_refresh)
+
+    resolved = resolve_codex_runtime_credentials(force_refresh=True)
+
+    assert resolved["api_key"] == token
+    assert resolved["source"] == "codex-access-token-env"
+
+
+def test_resolve_codex_runtime_credentials_ignores_app_server_access_token_for_backend(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    _setup_hermes_auth(hermes_home, access_token="oauth-access", refresh_token="oauth-refresh")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    payload = {"exp": int(time.time()) + 3600, "aud": "codex-app-server"}
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).rstrip(b"=").decode("utf-8")
+    monkeypatch.setenv("CODEX_ACCESS_TOKEN", f"h.{encoded}.s")
+
+    resolved = resolve_codex_runtime_credentials(force_refresh=False, refresh_if_expiring=False)
+
+    assert resolved["api_key"] == "oauth-access"
+    assert resolved["source"] == "hermes-auth-store"
+
+
+def test_resolve_codex_runtime_credentials_ignores_expired_backend_token(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    _setup_hermes_auth(hermes_home, access_token="oauth-access", refresh_token="oauth-refresh")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_ACCESS_TOKEN", _codex_backend_jwt(int(time.time()) - 1))
+
+    resolved = resolve_codex_runtime_credentials(force_refresh=False, refresh_if_expiring=False)
+
+    assert resolved["api_key"] == "oauth-access"
+    assert resolved["source"] == "hermes-auth-store"
 
 
 def test_resolve_codex_runtime_credentials_missing_access_token(tmp_path, monkeypatch):
@@ -59,6 +134,7 @@ def test_resolve_codex_runtime_credentials_missing_access_token(tmp_path, monkey
     _setup_hermes_auth(hermes_home, access_token="")
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex"))
+    monkeypatch.delenv("CODEX_ACCESS_TOKEN", raising=False)
 
     with pytest.raises(AuthError) as exc:
         resolve_codex_runtime_credentials()

--- a/website/docs/user-guide/features/codex-app-server-runtime.md
+++ b/website/docs/user-guide/features/codex-app-server-runtime.md
@@ -154,11 +154,18 @@ uses:
    npm i -g @openai/codex
    codex --version   # 0.130.0 or newer
    ```
-2. **Codex OAuth login.** The codex subprocess reads `~/.codex/auth.json`. Two ways to populate it:
+2. **Codex authentication.** The subprocess can use `~/.codex/auth.json` or a non-interactive access token:
    ```bash
    codex login                  # writes tokens to ~/.codex/auth.json
+   export CODEX_ACCESS_TOKEN=... # Business/Enterprise automation path
    ```
-   Hermes' own `hermes auth add openai-codex` writes to `~/.hermes/auth.json` — that's a separate session. **Run `codex login` separately** if you haven't.
+   Hermes' own `hermes auth add openai-codex` writes to `~/.hermes/auth.json` — that's a separate session. **Run `codex login` separately** if you rely on OAuth.
+
+   For headless deployments, store the token in 1Password and resolve it only for this runtime:
+   ```bash
+   HERMES_CODEX_ACCESS_TOKEN_OP_REF="op://Vault/Item/credential"
+   ```
+   The resolved token is passed only to `codex app-server`; it does not shadow Hermes' direct Codex OAuth fallback.
 
 3. **(Optional) Install the Codex plugins you want.** When you enable the runtime, Hermes auto-migrates whichever curated plugins you've already installed via Codex CLI:
    ```bash


### PR DESCRIPTION
## Summary
- Accept explicit backend-compatible Codex access tokens without letting app-server-scoped tokens shadow Hermes OAuth credentials.
- Resolve optional Codex app-server access-token references from 1Password at spawn time without writing secrets to disk.
- Document the scoped token behavior for the Codex app-server runtime.

## Audit / duplication check
- No matching open PR found for app-server scoped token references or 1Password-backed resolution. Other Codex auth PRs address refresh-token/self-healing or unrelated provider display issues.

## Test Plan
- `python -m pytest tests/agent/transports/test_codex_app_server_runtime.py tests/hermes_cli/test_auth_codex_provider.py -q -o 'addopts='`
