### PR TITLE
feat(goal): add agent-callable standing goal tool

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13335,6 +13335,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
+            session_id=context.session_id,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             async_delivery=_async_delivery,
         )

--- a/tests/tools/test_goal_tool.py
+++ b/tests/tools/test_goal_tool.py
@@ -1,0 +1,72 @@
+import json
+
+from hermes_cli import goals
+
+
+def test_set_goal_tool_sets_goal_and_subgoals_for_task_session(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    goals._DB_CACHE.clear()
+
+    from tools.goal_tool import set_goal
+
+    try:
+        raw = set_goal(
+            goal="Ship the goal bridge",
+            subgoals=["Expose an agent-callable tool", "Persist subgoals"],
+            task_id="sid-tool-goal",
+        )
+        result = json.loads(raw)
+
+        assert result["success"] is True
+        assert result["goal"] == "Ship the goal bridge"
+        assert result["subgoals"] == ["Expose an agent-callable tool", "Persist subgoals"]
+        state = goals.GoalManager("sid-tool-goal").state
+        assert state is not None
+        assert state.status == "active"
+        assert state.goal == "Ship the goal bridge"
+        assert state.subgoals == ["Expose an agent-callable tool", "Persist subgoals"]
+    finally:
+        goals._DB_CACHE.clear()
+
+
+def test_set_goal_tool_uses_session_context_when_task_id_missing(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    goals._DB_CACHE.clear()
+
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from tools.goal_tool import set_goal
+
+    tokens = set_session_vars(session_id="sid-context-goal")
+    try:
+        raw = set_goal(goal="Use context session", task_id=None)
+        result = json.loads(raw)
+
+        assert result["success"] is True
+        state = goals.GoalManager("sid-context-goal").state
+        assert state is not None
+        assert state.goal == "Use context session"
+    finally:
+        clear_session_vars(tokens)
+        goals._DB_CACHE.clear()
+
+
+def test_set_goal_tool_requires_session_id(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    goals._DB_CACHE.clear()
+
+    from tools.goal_tool import set_goal
+
+    try:
+        raw = set_goal(goal="No session", task_id=None)
+        result = json.loads(raw)
+
+        assert result["success"] is False
+        assert "session" in result["error"].lower()
+    finally:
+        goals._DB_CACHE.clear()

--- a/tools/goal_tool.py
+++ b/tools/goal_tool.py
@@ -1,0 +1,126 @@
+"""Agent-callable bridge for Hermes standing goals.
+
+The `/goal` slash command is handled before normal agent turns, so a skill
+cannot invoke it directly.  This tool gives the agent a first-class, session-
+scoped way to activate the same GoalManager state after it has drafted a goal
+and the user approves running it.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from tools.registry import registry, tool_error, tool_result
+
+
+def _current_session_id(task_id: Optional[str] = None) -> str:
+    """Resolve the session id for the current tool call.
+
+    `run_conversation(..., task_id=...)` passes the active session id to tool
+    handlers in both CLI and gateway paths.  Gateway sessions also expose a
+    contextvar-backed `HERMES_SESSION_ID` for tools that need to recover it
+    without relying on handler kwargs.
+    """
+    if task_id:
+        return str(task_id).strip()
+    try:
+        from gateway.session_context import get_session_env
+
+        return (get_session_env("HERMES_SESSION_ID", "") or "").strip()
+    except Exception:
+        return ""
+
+
+def set_goal(
+    goal: str,
+    subgoals: Optional[List[str]] = None,
+    max_turns: Optional[int] = None,
+    task_id: Optional[str] = None,
+) -> str:
+    """Set a standing goal for the active Hermes session.
+
+    Returns JSON.  This intentionally mirrors `/goal <text>` + optional
+    `/subgoal <text>` state mutation, but does not enqueue a separate kickoff
+    message.  The current turn's normal post-turn goal hook will evaluate and
+    continue the loop if the newly-set goal is not already satisfied.
+    """
+    sid = _current_session_id(task_id)
+    if not sid:
+        return tool_error(
+            "Cannot set a standing goal because no active Hermes session id was available.",
+            success=False,
+        )
+
+    try:
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id=sid)
+        state = mgr.set(goal, max_turns=max_turns)
+        added_subgoals: List[str] = []
+        for raw in subgoals or []:
+            text = str(raw or "").strip()
+            if text:
+                added_subgoals.append(mgr.add_subgoal(text))
+        state = mgr.state or state
+        return tool_result(
+            success=True,
+            session_id=sid,
+            goal=state.goal,
+            status=state.status,
+            max_turns=state.max_turns,
+            subgoals=list(state.subgoals),
+            message=(
+                "Standing goal activated. The session goal loop will continue "
+                "after this turn if the goal is not already satisfied."
+            ),
+        )
+    except ValueError as exc:
+        return tool_error(str(exc), success=False)
+    except Exception as exc:
+        return tool_error(f"Failed to set standing goal: {exc}", success=False)
+
+
+_GOAL_SCHEMA = {
+    "name": "set_goal",
+    "description": (
+        "Activate or replace the standing /goal for the current Hermes session. "
+        "Use after drafting a high-quality goal and the user approves running it. "
+        "Optional subgoals become /subgoal criteria. Does not require the user to paste a slash command."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "goal": {
+                "type": "string",
+                "description": "The polished standing goal text to activate for this session.",
+            },
+            "subgoals": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional additional success criteria, equivalent to /subgoal entries.",
+            },
+            "max_turns": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Optional turn budget override for this goal. Defaults to configured goals.max_turns.",
+            },
+        },
+        "required": ["goal"],
+    },
+}
+
+
+registry.register(
+    name="set_goal",
+    toolset="goal",
+    schema=_GOAL_SCHEMA,
+    handler=lambda args, **kw: set_goal(
+        goal=args.get("goal", ""),
+        subgoals=args.get("subgoals"),
+        max_turns=args.get("max_turns"),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=lambda: True,
+    description="Activate the current session's standing /goal from agent-generated text.",
+    emoji="⊙",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -50,7 +50,7 @@ _HERMES_CORE_TOOLS = [
     # Text-to-speech
     "text_to_speech",
     # Planning & memory
-    "todo", "memory",
+    "todo", "set_goal", "memory",
     # NOTE: the desktop Project tools (project_list/create/switch) are
     # deliberately NOT here. They only make sense where a GUI can follow the
     # move, so they live in the `project` toolset and are enabled solely by the
@@ -200,7 +200,13 @@ TOOLSETS = {
     
     "todo": {
         "description": "Task planning and tracking for multi-step work",
-        "tools": ["todo"],
+        "tools": ["todo", "set_goal"],
+        "includes": []
+    },
+
+    "goal": {
+        "description": "Activate or replace the current session's standing /goal from agent-generated text",
+        "tools": ["set_goal"],
         "includes": []
     },
     


### PR DESCRIPTION
## Summary
- Add a session-scoped `set_goal` tool that lets the agent activate the same standing goal state as `/goal` after drafting a goal and receiving user approval.
- Carry the gateway session id into session context so the tool can resolve the active session.
- Register the tool in the existing planning/goal tool surface.

I recognise this touches the core model-tool surface, so this PR is intentionally isolated for maintainer judgement. If this is considered too much waist expansion, Petra can drop the local patch rather than keep a fork.

## Test plan
- `python -m pytest tests/tools/test_goal_tool.py -q -o 'addopts='`