### PR TITLE
fix(skills/github-auth): correct + harden credential-store setup

### DIFF
--- a/skills/github/github-auth/SKILL.md
+++ b/skills/github/github-auth/SKILL.md
@@ -62,18 +62,36 @@ Tell the user to go to: **https://github.com/settings/tokens**
 
 **Step 2: Configure git to store the token**
 
+Use git's built-in `store` helper. Two things that will silently break this — read before running:
+
+- **`store` ships with git.** It is *not* a separate package. Never `apt install git-credential-store`, and **never create or edit anything under `/usr/lib/git-core/`** — that directory holds git's own binaries; a stray file named `git` or `git-credential-store` there will hang every future git command.
+- **`~/.git-credentials` is one URL-encoded line per host** (`https://user:token@host`), *not* `protocol=`/`host=`/`username=`/`password=` lines. The attribute format is what git passes on stdin to a helper; it is not the on-disk store format, and `store` cannot read it.
+
+*Interactive shell (a human is present to answer the prompt):*
+
 ```bash
-# Set up the credential helper to cache credentials
 # "store" saves to ~/.git-credentials in plaintext (simple, persistent)
 git config --global credential.helper store
 
-# Now do a test operation that triggers auth — git will prompt for credentials
+# Triggers an auth prompt; git writes ~/.git-credentials in the correct format for you.
 # Username: <their-github-username>
 # Password: <paste the personal access token, NOT their GitHub password>
 git ls-remote https://github.com/<their-username>/<any-repo>.git
 ```
 
-After entering credentials once, they're saved and reused for all future operations.
+*Headless / agent context (no TTY — the prompt above would hang, so seed the file directly):*
+
+```bash
+git config --global credential.helper store
+# Single URL line, mode 600. This is the ONLY correct on-disk format.
+printf 'https://%s:%s@github.com\n' '<username>' '<token>' > ~/.git-credentials
+chmod 600 ~/.git-credentials
+
+# Verify with prompts disabled so a misconfig fails fast instead of hanging for 2 min:
+GIT_TERMINAL_PROMPT=0 git ls-remote https://github.com/<username>/<any-repo>.git
+```
+
+After this, credentials are saved and reused for all future operations.
 
 **Alternative: cache helper (credentials expire from memory)**
 
@@ -245,3 +263,7 @@ fi
 | Credentials not persisting | Check `git config --global credential.helper` — must be `store` or `cache` |
 | Multiple GitHub accounts | Use SSH with different keys per host alias in `~/.ssh/config`, or per-repo credential URLs |
 | `gh: command not found` + no sudo | Use git-only Method 1 above — no installation needed |
+| `apt: Unable to locate package git-credential-store` | `store` is built into git — there is no such package. Just run `git config --global credential.helper store`. |
+| `fatal: could not read Username` despite a configured helper | `~/.git-credentials` is in the wrong format. It must be a single `https://user:token@github.com` line, not `protocol=`/`host=` lines. Re-seed it (see Step 2, headless). |
+| `git clone`/`ls-remote` hangs for ~2 min then times out | Something under `/usr/lib/git-core/` was replaced with a script. Verify `file /usr/lib/git-core/git` is an **ELF executable**, not a shell script; if broken, restore with `sudo cp /usr/bin/git /usr/lib/git-core/git` or `sudo apt-get install --reinstall git`. Never write helper scripts into that directory. |
+| Prefer `gh` when available | If `gh` is installed, `echo "<token>" \| gh auth login --with-token && gh auth setup-git` configures both API and git credentials correctly — fewer footguns than hand-editing `~/.git-credentials`. |


### PR DESCRIPTION
The github-auth skill's Step 2 only documented the interactive path (`credential.helper store` then `git ls-remote` to trigger a prompt). In a headless/agent context there is no TTY, so agents improvise — and two failure modes recur:

- writing ~/.git-credentials in the on-stdin attribute format (protocol=/host=/username=/password=) which `store` cannot read; and
- treating `store` as a missing package (`apt install git-credential-store`) and hand-rolling a helper, in one case overwriting /usr/lib/git-core/git and hanging every git command.

This adds a correct non-interactive seeding method (single `https://user:token@host` line, mode 600, GIT_TERMINAL_PROMPT=0 verify), states that `store` is built into git, warns against touching /usr/lib/git-core/, and adds troubleshooting rows for each failure.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

