### PR TITLE
fix: add per-job allow_silent flag for recurring briefing/report jobs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -789,6 +789,7 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    allow_silent: bool = True,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -833,6 +834,11 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        allow_silent: When True (default), the job may suppress delivery by
+                responding with ``[SILENT]``.  When False, the SILENT instruction
+                is omitted from the prompt and any SILENT response is delivered
+                anyway — use for briefing/report jobs that must always produce
+                output.
 
     Returns:
         The created job dict
@@ -967,6 +973,7 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        "allow_silent": bool(allow_silent),
     }
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1786,16 +1786,28 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
 
     # Always prepend cron execution guidance so the agent knows how
     # delivery works and can suppress delivery when appropriate.
+    # When allow_silent=False (briefing/report jobs), omit the SILENT
+    # instruction so the agent always delivers output (#53248).
+    allow_silent = job.get("allow_silent", True)
+    if allow_silent:
+        silence_guidance = (
+            "SILENT: If there is genuinely nothing new to report, respond "
+            "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
+            "Never combine [SILENT] with content — either report your "
+            "findings normally, or say [SILENT] and nothing more."
+        )
+    else:
+        silence_guidance = (
+            "DELIVERY: This job must always deliver output. "
+            "Do not use [SILENT] — always produce a report."
+        )
     cron_hint = (
         "[IMPORTANT: You are running as a scheduled cron job. "
         "DELIVERY: Your final response will be automatically delivered "
         "to the user — do NOT use send_message or try to deliver "
         "the output yourself. Just produce your report/output as your "
         "final response and the system handles the rest. "
-        "SILENT: If there is genuinely nothing new to report, respond "
-        "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
-        "Never combine [SILENT] with content — either report your "
-        "findings normally, or say [SILENT] and nothing more.]\n\n"
+        f"{silence_guidance}]\n\n"
     )
     prompt = cron_hint + prompt
     if skills is None:
@@ -2781,9 +2793,18 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # a real report that merely quoted "[SILENT]" mid-sentence (#51438,
         # #46917).  Keeps the intentional bracketed-prefix / trailing-line
         # tolerance the cron contract relies on.
+        # When allow_silent=False (briefing/report jobs), deliver the response
+        # even if it looks like a silence marker (#53248).
         if should_deliver and success and _is_cron_silence_response(deliver_content):
-            logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
-            should_deliver = False
+            allow_silent = job.get("allow_silent", True)
+            if allow_silent:
+                logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+                should_deliver = False
+            else:
+                logger.info(
+                    "Job '%s': agent returned %s but allow_silent=False — delivering anyway",
+                    job["id"], SILENT_MARKER,
+                )
 
         delivery_error = None
         if should_deliver:

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -518,6 +518,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if "allow_silent" in job:
+        result["allow_silent"] = bool(job["allow_silent"])
     return result
 
 
@@ -587,6 +589,7 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    allow_silent: Optional[bool] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -654,6 +657,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                allow_silent=allow_silent if allow_silent is not None else True,
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -826,6 +830,8 @@ def cronjob(
                             success=False,
                         )
                 updates["no_agent"] = target_no_agent
+            if allow_silent is not None:
+                updates["allow_silent"] = bool(allow_silent)
             if repeat is not None:
                 # Normalize: treat 0 or negative as None (infinite)
                 normalized_repeat = None if repeat <= 0 else repeat
@@ -970,6 +976,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "allow_silent": {
+                "type": "boolean",
+                "description": "When True (default), the job may suppress delivery by responding with [SILENT] when there's nothing new to report. When False, the SILENT instruction is omitted from the prompt and any SILENT response is delivered anyway — use for recurring briefing/report jobs that must always produce output. On update, pass a boolean to change."
+            },
         },
         "required": ["action"]
     }
@@ -1025,6 +1035,8 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        attach_to_session=args.get("attach_to_session"),
+        allow_silent=args.get("allow_silent"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,


### PR DESCRIPTION
Fixes #53248

## Description

Adds a per-job `allow_silent` flag (default `True` for backward compatibility) that lets recurring briefing/report jobs opt out of the generic `[SILENT]` suppression behavior.

When `allow_silent=False`:
- The `[SILENT]` suppression instruction is **omitted** from the cron prompt — replaced with guidance that the job must always deliver
- Any `[SILENT]` response from the agent is **delivered anyway** instead of being suppressed

## Changes

- **`cron/jobs.py`**: `create_job()` accepts and stores `allow_silent`
- **`cron/scheduler.py`**: `_build_job_prompt()` conditionally includes the SILENT instruction based on `allow_silent`. `run_one_job()` skips silence detection when `allow_silent=False`.
- **`tools/cronjob_tools.py`**: `cronjob()` tool accepts `allow_silent` on create/update, exposes it in `_format_job()`, and documents it in the schema.

## Verification

- All three modified files compile cleanly
- No secrets or personal refs leaked
- Only the 3 intended files changed (46 insertions, 6 deletions)
- Backward compatible: existing jobs without `allow_silent` default to `True` (same behavior as before)