### PR TITLE
fix(agent): auto-retry streaming without stream_options on 400/422 rejection

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -52,6 +52,13 @@ _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
 # narrower non-rate-limit case.  See issue #24996.
 _FALLBACK_EXHAUSTED_COOLDOWN_S = 5.0
 
+# Base URLs known to reject ``stream_options: {"include_usage": True}``
+# (e.g. Azure AI Foundry MaaS endpoints with strict Pydantic validation).
+# Populated at runtime when a 422 ``extra_forbidden`` error targets
+# ``stream_options``.  Keyed by the host portion of the base URL so that
+# different deployments on the same host share the cache entry.
+_STREAM_OPTIONS_INCOMPATIBLE: set = set()
+
 
 def _ra():
     """Lazy ``run_agent`` reference.
@@ -2283,13 +2290,21 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 pool=_conn_cap,
             ),
         }
-        # OpenAI's `stream_options={"include_usage": True}` drives usage
+# OpenAI's `stream_options={"include_usage": True}` drives usage
         # accounting on OpenAI-compatible endpoints (incl. the Gemini OpenAI
         # compat shim and aggregators like OpenRouter).  Google's *native*
         # Gemini REST endpoint rejects the keyword outright
         # (`Completions.create() got an unexpected keyword argument
-        # 'stream_options'`), so omit it only for that endpoint.
-        if not is_native_gemini_base_url(agent.base_url):
+        # 'stream_options'`), so omit it only for that endpoint.  Endpoints
+        # that have previously rejected ``stream_options`` with a 400/422
+        # (e.g. Azure AI Foundry MaaS) are tracked in
+        # ``_STREAM_OPTIONS_INCOMPATIBLE`` so we skip the field on the
+        # first attempt instead of paying for a failed round-trip.
+        _host = base_url_hostname(agent.base_url or "")
+        if (
+            not is_native_gemini_base_url(agent.base_url)
+            and _host not in _STREAM_OPTIONS_INCOMPATIBLE
+        ):
             stream_kwargs["stream_options"] = {"include_usage": True}
         request_client = _set_request_client(
             agent._create_request_openai_client(
@@ -3061,6 +3076,36 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         agent._buffer_status(_exhausted_msg)
                     else:
                         _err_lower = str(e).lower()
+                        # Azure AI Foundry MaaS (and similar strict
+                        # Pydantic-validated endpoints) reject
+                        # ``stream_options: {"include_usage": True}``
+                        # with HTTP 400/422.  Cache the incompatibility
+                        # and retry once without it.
+                        _is_stream_options_rejected = False
+                        _status = getattr(e, "status_code", None)
+                        if _status in (400, 422):
+                            _err_body = str(getattr(e, "body", "") or "").lower()
+                            if "stream_options" in _err_body and (
+                                "extra" in _err_body
+                                or "not supported" in _err_body
+                                or "unrecognized" in _err_body
+                                or "unexpected" in _err_body
+                            ):
+                                _is_stream_options_rejected = True
+                        if _is_stream_options_rejected:
+                            _host = base_url_hostname(agent.base_url or "")
+                            if _host and _host not in _STREAM_OPTIONS_INCOMPATIBLE:
+                                _STREAM_OPTIONS_INCOMPATIBLE.add(_host)
+                                logger.info(
+                                    "Endpoint %s rejected stream_options "
+                                    "(HTTP %s) — caching incompatibility "
+                                    "and retrying without it.",
+                                    _host, _status,
+                                )
+                                _close_request_client_once(
+                                    "stream_options_422_retry_cleanup"
+                                )
+                                continue
                         _is_stream_unsupported = (
                             "stream" in _err_lower
                             and "not supported" in _err_lower

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3094,18 +3094,36 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                                 _is_stream_options_rejected = True
                         if _is_stream_options_rejected:
                             _host = base_url_hostname(agent.base_url or "")
-                            if _host and _host not in _STREAM_OPTIONS_INCOMPATIBLE:
+                            if _host:
+                                # Idempotent insert — ``set.add`` is atomic under
+                                # the GIL, so two concurrent rejections for the
+                                # same host both populate the cache without
+                                # racing on the read-then-write.  Track first
+                                # sighting so the user-visible INFO log fires
+                                # only once per host instead of once per
+                                # concurrent retry.
+                                _first_time = (
+                                    _host not in _STREAM_OPTIONS_INCOMPATIBLE
+                                )
                                 _STREAM_OPTIONS_INCOMPATIBLE.add(_host)
-                                logger.info(
-                                    "Endpoint %s rejected stream_options "
-                                    "(HTTP %s) — caching incompatibility "
-                                    "and retrying without it.",
-                                    _host, _status,
-                                )
-                                _close_request_client_once(
-                                    "stream_options_422_retry_cleanup"
-                                )
-                                continue
+                                if _first_time:
+                                    logger.info(
+                                        "Endpoint %s rejected stream_options "
+                                        "(HTTP %s) — caching incompatibility "
+                                        "and retrying without it.",
+                                        _host, _status,
+                                    )
+                            # Always clean up the failed request's client and
+                            # retry, regardless of whether the host was already
+                            # cached.  A concurrent request that lost the race
+                            # to populate the cache still needs to drop
+                            # ``stream_options`` for its own retry — otherwise
+                            # it falls through with the 422 even though the
+                            # host is now known incompatible.
+                            _close_request_client_once(
+                                "stream_options_422_retry_cleanup"
+                            )
+                            continue
                         _is_stream_unsupported = (
                             "stream" in _err_lower
                             and "not supported" in _err_lower

--- a/tests/agent/test_stream_options_incompatible.py
+++ b/tests/agent/test_stream_options_incompatible.py
@@ -1,0 +1,147 @@
+"""Tests for stream_options incompatibility caching (issue #9705).
+
+Azure AI Foundry MaaS endpoints reject ``stream_options:
+{"include_usage": True}`` with HTTP 422 ``extra_forbidden``.  The fix
+caches the incompatibility by hostname so subsequent requests skip the
+field.
+"""
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+from agent.chat_completion_helpers import (
+    _STREAM_OPTIONS_INCOMPATIBLE,
+)
+from utils import base_url_hostname
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    """Ensure the module-level cache is clean for every test."""
+    _STREAM_OPTIONS_INCOMPATIBLE.clear()
+    yield
+    _STREAM_OPTIONS_INCOMPATIBLE.clear()
+
+
+class TestStreamOptionsIncompatibleCache:
+    """Verify the cache set behaves as expected."""
+
+    def test_cache_is_empty_by_default(self):
+        assert len(_STREAM_OPTIONS_INCOMPATIBLE) == 0
+
+    def test_add_host_to_cache(self):
+        _STREAM_OPTIONS_INCOMPATIBLE.add("my-hub.services.ai.azure.com")
+        assert "my-hub.services.ai.azure.com" in _STREAM_OPTIONS_INCOMPATIBLE
+
+    def test_cache_isolation_between_tests(self):
+        """Cache from prior test should not leak (autouse fixture)."""
+        assert len(_STREAM_OPTIONS_INCOMPATIBLE) == 0
+
+
+class TestStreamOptionsDetection:
+    """Verify 422 error detection logic."""
+
+    def _make_422_error(self, body: str) -> SimpleNamespace:
+        """Create a mock error mimicking OpenAI SDK APIStatusError."""
+        return SimpleNamespace(
+            status_code=422,
+            body=body,
+            message="Unprocessable Entity",
+        )
+
+    def test_detects_stream_options_422(self):
+        e = self._make_422_error(
+            '{"detail": [{"type": "extra_forbidden", '
+            '"loc": ["body", "stream_options", "include_usage"], '
+            '"msg": "Extra inputs are not permitted"}]}'
+        )
+        assert getattr(e, "status_code", None) == 422
+        _err_body = str(getattr(e, "body", "") or "").lower()
+        assert "stream_options" in _err_body
+        assert "extra" in _err_body
+
+    def test_ignores_unrelated_422(self):
+        e = self._make_422_error(
+            '{"detail": [{"type": "missing", "loc": ["body", "messages"]}]}'
+        )
+        _err_body = str(getattr(e, "body", "") or "").lower()
+        assert "stream_options" not in _err_body
+
+    def test_ignores_non_422(self):
+        e = SimpleNamespace(status_code=500, body="server error")
+        assert getattr(e, "status_code", None) not in (400, 422)
+
+    def test_detects_stream_options_400(self):
+        """Some proxies return 400 instead of 422 for unsupported params."""
+        e = SimpleNamespace(
+            status_code=400,
+            body='{"error": {"message": "Unrecognized request argument: stream_options"}}',
+        )
+        _status = getattr(e, "status_code", None)
+        _err_body = str(getattr(e, "body", "") or "").lower()
+        assert _status in (400, 422)
+        assert "stream_options" in _err_body
+        assert "unrecognized" in _err_body
+
+    def test_detects_stream_options_not_supported(self):
+        e = SimpleNamespace(
+            status_code=422,
+            body='{"error": "stream_options is not supported"}',
+        )
+        _status = getattr(e, "status_code", None)
+        _err_body = str(getattr(e, "body", "") or "").lower()
+        assert _status in (400, 422)
+        assert "stream_options" in _err_body
+        assert "not supported" in _err_body
+
+    def test_detects_stream_options_unexpected(self):
+        e = SimpleNamespace(
+            status_code=400,
+            body='{"error": "unexpected stream_options field"}',
+        )
+        _status = getattr(e, "status_code", None)
+        _err_body = str(getattr(e, "body", "") or "").lower()
+        assert _status in (400, 422)
+        assert "stream_options" in _err_body
+        assert "unexpected" in _err_body
+
+    def test_ignores_error_without_status_code(self):
+        e = SimpleNamespace(body="some error")
+        assert getattr(e, "status_code", None) is None
+
+
+class TestStreamOptionsKwargsBuilding:
+    """Verify stream_kwargs includes/excludes stream_options based on cache."""
+
+    def test_stream_options_included_when_cache_empty(self):
+        """Default behaviour: stream_options is present."""
+        host = "hub.services.ai.azure.com"
+        assert host not in _STREAM_OPTIONS_INCOMPATIBLE
+        # Simulate the conditional logic from _call_chat_completions
+        stream_kwargs = {"stream": True}
+        _host = host
+        if _host not in _STREAM_OPTIONS_INCOMPATIBLE:
+            stream_kwargs["stream_options"] = {"include_usage": True}
+        assert "stream_options" in stream_kwargs
+        assert stream_kwargs["stream_options"] == {"include_usage": True}
+
+    def test_stream_options_excluded_when_host_cached(self):
+        """After 422, stream_options is omitted."""
+        host = "hub.services.ai.azure.com"
+        _STREAM_OPTIONS_INCOMPATIBLE.add(host)
+        stream_kwargs = {"stream": True}
+        _host = host
+        if _host not in _STREAM_OPTIONS_INCOMPATIBLE:
+            stream_kwargs["stream_options"] = {"include_usage": True}
+        assert "stream_options" not in stream_kwargs
+
+    def test_different_host_not_affected(self):
+        """Cache is host-scoped — other hosts are unaffected."""
+        _STREAM_OPTIONS_INCOMPATIBLE.add("hub-a.services.ai.azure.com")
+        host_b = "hub-b.services.ai.azure.com"
+        stream_kwargs = {"stream": True}
+        _host = host_b
+        if _host not in _STREAM_OPTIONS_INCOMPATIBLE:
+            stream_kwargs["stream_options"] = {"include_usage": True}
+        assert "stream_options" in stream_kwargs

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -363,6 +363,152 @@ class TestStreamingAccumulator:
         assert len(response.choices[0].message.tool_calls) == 1
 
 
+# ── Test: stream_options 422 retry ───────────────────────────────────────
+
+
+class TestStreamOptions422Retry:
+    """Integration coverage for the Azure-MaaS ``stream_options`` 422 retry.
+
+    Existing tests in ``tests/agent/test_stream_options_incompatible.py``
+    cover the cache and predicate in isolation.  This class exercises the
+    real retry path inside ``_interruptible_streaming_api_call``: first
+    request raises an HTTP 422 mentioning ``stream_options`` + ``extra``,
+    second request succeeds, and the second request's kwargs must NOT
+    include ``stream_options``.
+
+    See issue #9705 and PR #53271.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clean_cache(self):
+        """Per-test isolation for the module-level incompatibility cache."""
+        from agent.chat_completion_helpers import _STREAM_OPTIONS_INCOMPATIBLE
+        _STREAM_OPTIONS_INCOMPATIBLE.clear()
+        yield
+        _STREAM_OPTIONS_INCOMPATIBLE.clear()
+
+    @staticmethod
+    def _azure_422_error():
+        """Build an ``openai.APIStatusError`` matching the Azure MaaS shape."""
+        import httpx
+        from openai import APIStatusError
+
+        body = (
+            '{"detail": [{"type": "extra_forbidden", '
+            '"loc": ["body", "stream_options", "include_usage"], '
+            '"msg": "Extra inputs are not permitted"}]}'
+        )
+        response = httpx.Response(
+            422,
+            request=httpx.Request(
+                "POST", "https://hub.services.ai.azure.com/openai/v1/chat/completions"
+            ),
+            content=body.encode(),
+        )
+        return APIStatusError(
+            "Extra inputs are not permitted",
+            response=response,
+            body=body,
+        )
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_retry_omits_stream_options_after_422(self, mock_close, mock_create):
+        """First call 422 → second call succeeds without stream_options."""
+        from run_agent import AIAgent
+        from agent.chat_completion_helpers import _STREAM_OPTIONS_INCOMPATIBLE
+        from utils import base_url_hostname
+
+        azure_422 = self._azure_422_error()
+        chunks = [
+            _make_stream_chunk(content="hi", finish_reason="stop", model="test/model"),
+            _make_empty_chunk(usage=SimpleNamespace(prompt_tokens=2, completion_tokens=1)),
+        ]
+        # First call raises 422, second returns the successful stream.
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = [azure_422, iter(chunks)]
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://hub.services.ai.azure.com/openai/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        # Retry succeeded.
+        assert response.choices[0].message.content == "hi"
+        # Two attempts: one 422, one success.
+        assert mock_client.chat.completions.create.call_count == 2
+        # First attempt included stream_options (cache was empty pre-population).
+        first_kwargs = mock_client.chat.completions.create.call_args_list[0].kwargs
+        assert first_kwargs.get("stream_options") == {"include_usage": True}
+        # Second attempt omitted it — the retry dropped the field.
+        second_kwargs = mock_client.chat.completions.create.call_args_list[1].kwargs
+        assert "stream_options" not in second_kwargs
+        # The host is now cached so subsequent requests skip the field
+        # without the extra round-trip.
+        host = base_url_hostname(agent.base_url)
+        assert host in _STREAM_OPTIONS_INCOMPATIBLE
+        # Cleanup fired for the failed first attempt.
+        assert mock_close.call_count >= 1
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_concurrent_loser_still_retries(self, mock_close, mock_create):
+        """A second request that loses the race to populate the cache
+        still retries — not blocked behind ``host in cache``.
+
+        Regression guard for the race the maintainer flagged on PR #53271:
+        if request A populates the cache between request B's read and write,
+        the OLD code gated retry on ``host not in cache`` and request B
+        would fall through with the 422.  With idempotent insert +
+        unconditional continue, B's matching rejection still retries
+        without stream_options.
+        """
+        from run_agent import AIAgent
+        from agent.chat_completion_helpers import _STREAM_OPTIONS_INCOMPATIBLE
+        from utils import base_url_hostname
+
+        azure_422 = self._azure_422_error()
+        chunks = [
+            _make_stream_chunk(content="ok", finish_reason="stop", model="test/model"),
+        ]
+
+        # Pre-populate the cache (simulating request A having already
+        # cached the host) before request B runs.  B should still retry.
+        host = "hub.services.ai.azure.com"
+        _STREAM_OPTIONS_INCOMPATIBLE.add(host)
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = [azure_422, iter(chunks)]
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url=f"https://{host}/openai/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.choices[0].message.content == "ok"
+        assert mock_client.chat.completions.create.call_count == 2
+        second_kwargs = mock_client.chat.completions.create.call_args_list[1].kwargs
+        assert "stream_options" not in second_kwargs
+
+
 # ── Test: Streaming Callbacks ────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Auto-retry streaming without `stream_options` when the endpoint rejects it with HTTP 400/422.

Azure AI Foundry MaaS endpoints (and similar strict Pydantic-validated endpoints) reject `stream_options: {"include_usage": True}` because the field is not in their schema. This causes a hard failure on 100% of streaming requests for affected endpoints.

**Fix:** Detect the rejection (HTTP 400/422 with body mentioning `stream_options` + `extra`/`not supported`/`unrecognized`/`unexpected`), cache the incompatibility by hostname, and retry once without the field. The cache is module-level so subsequent requests skip `stream_options` immediately without the extra round-trip.

## Changes

- `agent/chat_completion_helpers.py`: 
  - Module-level `_STREAM_OPTIONS_INCOMPATIBLE` set caches hostnames that rejected `stream_options`
  - `_call_chat_completions()` checks the cache before adding `stream_options` to `stream_kwargs`
  - `_call()` exception handler detects 400/422 rejection, caches the hostname, and retries
- `tests/agent/test_stream_options_incompatible.py`: 13 new tests covering cache behavior, error detection (422, 400, various body patterns), and kwargs building

## Notes

- The retry consumes one attempt from `_max_stream_retries` (default 2). This is acceptable because the second attempt succeeds (host is cached), so at most one normal retry is consumed. If `_max_stream_retries=1`, the 422 retry uses the only attempt, but the second attempt (without `stream_options`) succeeds.
- Host-level cache scoping is correct for most endpoints. Mixed gateways (same host, different backends with different validation rules) would incorrectly suppress `stream_options` for the compliant backend — but missing `stream_options` only loses token usage stats, which is an acceptable tradeoff.
- This fix also covers the Gemini case from the unmerged PR #14392 (same root cause, different provider).

Closes #9705
