### PR TITLE
fix(moa): tolerate non-numeric values in hand-edited MoA preset config

### DIFF
--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -21,6 +21,27 @@ DEFAULT_MOA_AGGREGATOR: dict[str, str] = {
 }
 
 
+def _coerce_float(value: Any, default: float) -> float:
+    if value is None or value == "":
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return default
+
+
 def _clean_slot(slot: Any) -> dict[str, str] | None:
     if not isinstance(slot, dict):
         return None
@@ -57,9 +78,9 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         "enabled": bool(raw.get("enabled", True)),
         "reference_models": refs,
         "aggregator": aggregator,
-        "reference_temperature": float(raw.get("reference_temperature", 0.6) or 0.6),
-        "aggregator_temperature": float(raw.get("aggregator_temperature", 0.4) or 0.4),
-        "max_tokens": int(raw.get("max_tokens", 4096) or 4096),
+        "reference_temperature": _coerce_float(raw.get("reference_temperature"), 0.6),
+        "aggregator_temperature": _coerce_float(raw.get("aggregator_temperature"), 0.4),
+        "max_tokens": _coerce_int(raw.get("max_tokens"), 4096),
     }
 
 

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -55,6 +55,45 @@ def test_legacy_flat_config_becomes_default_preset():
     ]
 
 
+def test_normalize_moa_config_tolerates_non_numeric_values():
+    """Non-numeric strings in hand-edited config.yaml must degrade to defaults
+    instead of crashing normalize_moa_config with ValueError."""
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "broken": {
+                    "max_tokens": "notanumber",
+                    "reference_temperature": "hot",
+                    "aggregator_temperature": "",
+                }
+            }
+        }
+    )
+
+    preset = cfg["presets"]["broken"]
+    assert preset["max_tokens"] == 4096
+    assert preset["reference_temperature"] == 0.6
+    assert preset["aggregator_temperature"] == 0.4
+
+
+def test_normalize_moa_config_coerces_numeric_strings():
+    """Valid numeric strings (e.g. from YAML round-trip) must coerce correctly."""
+    cfg = normalize_moa_config({"max_tokens": "8192", "reference_temperature": "0.9"})
+
+    preset = cfg["presets"][DEFAULT_MOA_PRESET_NAME]
+    assert preset["max_tokens"] == 8192
+    assert preset["reference_temperature"] == 0.9
+
+
+def test_normalize_moa_config_coerces_float_max_tokens():
+    """max_tokens: 4096.0 (float from YAML) must coerce to int."""
+    cfg = normalize_moa_config({"max_tokens": 4096.0})
+    assert cfg["presets"][DEFAULT_MOA_PRESET_NAME]["max_tokens"] == 4096
+
+    cfg2 = normalize_moa_config({"max_tokens": "4096.5"})
+    assert cfg2["presets"][DEFAULT_MOA_PRESET_NAME]["max_tokens"] == 4096
+
+
 def test_exact_preset_matching_is_not_fuzzy():
     config = {"presets": {"coding": {}, "review": {}}}
 


### PR DESCRIPTION
## Summary
A hand-edited `config.yaml` with a non-numeric MoA preset value (e.g. `max_tokens: "notanumber"`) crashes `normalize_moa_config()` with `ValueError`, taking down every code path that reads MoA config. This coerces numeric fields with a safe fallback to defaults.

Salvage of #52758 by @srojk34 (first submitter, includes tests). Duplicate #52774 by @AlexFucuson9 closed.

## Root cause
`_normalize_preset()` did `int(raw.get("max_tokens", 4096) or 4096)` / `float(...)` directly on user-supplied values. A non-numeric string raises `ValueError` instead of degrading to the default.

## Changes
- `hermes_cli/moa_config.py`: `_coerce_float` / `_coerce_int` helpers; `reference_temperature`, `aggregator_temperature`, `max_tokens` now coerce-or-default.
- `tests/hermes_cli/test_moa_config.py`: non-numeric → defaults, and valid numeric strings still coerce.

## Verification
| Check | Result |
|---|---|
| Repro on main | `ValueError: invalid literal for int() ... 'notanumber'` — confirmed |
| After fix | non-numeric → defaults (4096 / 0.6 / 0.4); `"8192"`/`"0.9"` still coerce |
| Sibling path | `moa_loop.py` consumes `resolve_moa_preset()` output, which runs through `normalize_moa_config` first — so the chokepoint fix covers it |
| Tests | `tests/hermes_cli/test_moa_config.py` 10 passed |

## Infographic

![moa-hermesbench-results](https://v3b.fal.media/files/b/0a9fdf9c/KGmVE0kc8PsvcdyqZuKLG_0f3TgtRi.png)
