### PR TITLE
feat: support session toolset overrides

### DIFF
--- a/agent/session_toolsets.py
+++ b/agent/session_toolsets.py
@@ -1,0 +1,131 @@
+"""Helpers for parsing session-boundary command arguments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import shlex
+from typing import Iterable
+
+_DEFAULT_TOOLSET_ALIASES = {"all", "*"}
+
+
+@dataclass(frozen=True)
+class NewSessionArgs:
+    title: str | None
+    toolsets: list[str] | None
+    explicit_toolset: bool
+    invalid_toolsets: list[str]
+    parse_error: str | None = None
+
+
+def parse_new_session_args(raw_args: str, *, valid_toolsets: Iterable[str]) -> NewSessionArgs:
+    """Parse `/new` command args into an optional title and toolset override.
+
+    The parser intentionally only treats --toolset/--toolsets as special.
+    Other option-looking tokens are preserved as title text for backwards
+    compatibility with existing `/new [title]` behavior.
+    """
+
+    raw_args = raw_args or ""
+    try:
+        tokens = shlex.split(raw_args)
+    except ValueError as exc:
+        return NewSessionArgs(
+            title=None,
+            toolsets=None,
+            explicit_toolset=False,
+            invalid_toolsets=[],
+            parse_error=str(exc),
+        )
+
+    valid = {str(toolset) for toolset in valid_toolsets}
+    title_parts: list[str] = []
+    requested_toolsets: list[str] = []
+    explicit_toolset = False
+    parse_error: str | None = None
+
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+
+        if token in {"--toolset", "--toolsets"}:
+            explicit_toolset = True
+            if index + 1 >= len(tokens):
+                parse_error = f"{token} requires a value"
+                break
+            value = tokens[index + 1]
+            parsed_values = _split_toolset_value(value)
+            if not parsed_values:
+                parse_error = f"{token} requires at least one toolset"
+            requested_toolsets.extend(parsed_values)
+            index += 2
+            continue
+
+        if token.startswith("--toolset=") or token.startswith("--toolsets="):
+            explicit_toolset = True
+            option, value = token.split("=", 1)
+            parsed_values = _split_toolset_value(value)
+            if not parsed_values:
+                parse_error = f"{option} requires at least one toolset"
+            requested_toolsets.extend(parsed_values)
+            index += 1
+            continue
+
+        title_parts.append(token)
+        index += 1
+
+    title = " ".join(title_parts).strip() or None
+    deduped_toolsets = _dedupe_preserving_order(requested_toolsets)
+    default_aliases = [name for name in deduped_toolsets if name in _DEFAULT_TOOLSET_ALIASES]
+    concrete_toolsets = [name for name in deduped_toolsets if name not in _DEFAULT_TOOLSET_ALIASES]
+
+    if default_aliases and concrete_toolsets:
+        parse_error = "--toolset all cannot be combined with other toolsets"
+
+    invalid_toolsets = [name for name in concrete_toolsets if name not in valid]
+
+    if parse_error:
+        return NewSessionArgs(
+            title=title,
+            toolsets=None,
+            explicit_toolset=explicit_toolset,
+            invalid_toolsets=invalid_toolsets,
+            parse_error=parse_error,
+        )
+
+    toolsets: list[str] | None
+    if default_aliases or not explicit_toolset:
+        toolsets = None
+    else:
+        toolsets = concrete_toolsets
+        if not toolsets:
+            return NewSessionArgs(
+                title=title,
+                toolsets=None,
+                explicit_toolset=explicit_toolset,
+                invalid_toolsets=invalid_toolsets,
+                parse_error="--toolset requires at least one toolset",
+            )
+
+    return NewSessionArgs(
+        title=title,
+        toolsets=toolsets,
+        explicit_toolset=explicit_toolset,
+        invalid_toolsets=invalid_toolsets,
+        parse_error=None,
+    )
+
+
+def _split_toolset_value(value: str) -> list[str]:
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def _dedupe_preserving_order(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped

--- a/cli.py
+++ b/cli.py
@@ -861,6 +861,9 @@ def validate_toolset(*args, **kwargs):
     return _validate_toolset(*args, **kwargs)
 
 
+_NEW_SESSION_TOOLSETS_UNSET = object()
+
+
 def _sync_process_session_id(session_id: str) -> None:
     """Keep process-local session-id consumers aligned after CLI switches."""
     from gateway.session_context import set_current_session_id
@@ -3558,6 +3561,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         
         # Parse and validate toolsets
         self.enabled_toolsets = toolsets
+        self._default_enabled_toolsets = list(toolsets) if toolsets else None
+        self._session_toolset_override = None
         self.disabled_toolsets = CLI_CONFIG["agent"].get("disabled_toolsets") or []
 
         if toolsets and "all" not in toolsets and "*" not in toolsets:
@@ -6555,7 +6560,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             from hermes_cli.plugins import invoke_hook as _invoke_hook
             _invoke_hook(
                 event_type,
-                session_id=self.agent.session_id if self.agent else None,
+                session_id=self.agent.session_id if self.agent else self.session_id,
                 platform=getattr(self, "platform", None) or "cli",
                 reason="new_session" if event_type == "on_session_reset" else "session_boundary",
             )
@@ -6591,7 +6596,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             )
             return False
 
-    def new_session(self, silent=False, title=None):
+    def _parse_new_session_command_args(self, raw_args: str):
+        from agent.session_toolsets import parse_new_session_args
+
+        valid = set(get_all_toolsets().keys())
+        valid.update(str(name) for name in (CLI_CONFIG.get("mcp_servers") or {}).keys())
+        return parse_new_session_args(raw_args, valid_toolsets=valid)
+
+    @staticmethod
+    def _normalize_enabled_toolsets_for_session(toolsets):
+        if not toolsets or "all" in toolsets or "*" in toolsets:
+            return None
+        return tuple(sorted(str(toolset) for toolset in toolsets))
+
+    def new_session(self, silent=False, title=None, enabled_toolsets_override=_NEW_SESSION_TOOLSETS_UNSET):
         """Start a fresh session with a new session ID and cleared agent state."""
         if self.agent and self.conversation_history:
             # Trigger memory extraction on the old session before session_id rotates.
@@ -6623,6 +6641,25 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # /resume and `hermes sessions list` (gemini-cli#27770 port).
             self._discard_session_if_empty(old_session_id)
 
+        old_effective_toolsets = self._normalize_enabled_toolsets_for_session(self.enabled_toolsets)
+        explicit_toolset_request = enabled_toolsets_override is not _NEW_SESSION_TOOLSETS_UNSET
+        if explicit_toolset_request:
+            if enabled_toolsets_override is None:
+                restored = self._default_enabled_toolsets
+                self.enabled_toolsets = list(restored) if restored else None
+                self._session_toolset_override = None
+            else:
+                self.enabled_toolsets = list(enabled_toolsets_override)
+                self._session_toolset_override = list(enabled_toolsets_override)
+        new_effective_toolsets = self._normalize_enabled_toolsets_for_session(self.enabled_toolsets)
+        rebuild_agent = self.agent is not None and old_effective_toolsets != new_effective_toolsets
+        if rebuild_agent:
+            try:
+                self.agent.close()
+            except Exception:
+                logger.debug("Could not close old agent before toolset rebuild", exc_info=True)
+            self.agent = None
+
         self.session_start = datetime.now()
         timestamp_str = self.session_start.strftime("%Y%m%d_%H%M%S")
         short_uuid = uuid.uuid4().hex[:6]
@@ -6647,43 +6684,47 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if hasattr(self.agent, "_invalidate_system_prompt"):
                 self.agent._invalidate_system_prompt()
 
-            if self._session_db:
-                try:
+        if self._session_db:
+            try:
+                if self.agent:
                     self.agent._session_db_created = False
-                    self._session_db.create_session(
-                        session_id=self.session_id,
-                        source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
-                        model=self.model,
-                        model_config={
-                            "max_iterations": self.max_turns,
-                            "reasoning_config": self.reasoning_config,
-                        },
-                    )
+                self._session_db.create_session(
+                    session_id=self.session_id,
+                    source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                    model=self.model,
+                    model_config={
+                        "max_iterations": self.max_turns,
+                        "reasoning_config": self.reasoning_config,
+                    },
+                )
+                if self.agent:
                     self.agent._session_db_created = True
-                except Exception:
-                    pass
-                if title and self._session_db:
-                    from hermes_state import SessionDB
+            except Exception:
+                pass
+            if title and self._session_db:
+                from hermes_state import SessionDB
+                try:
+                    sanitized = SessionDB.sanitize_title(title)
+                except ValueError as e:
+                    _cprint(f"  Title rejected: {e}")
+                    sanitized = None
+                    title = None
+                if sanitized:
                     try:
-                        sanitized = SessionDB.sanitize_title(title)
+                        self._session_db.set_session_title(self.session_id, sanitized)
+                        self._pending_title = None
+                        title = sanitized
                     except ValueError as e:
-                        _cprint(f"  Title rejected: {e}")
-                        sanitized = None
+                        _cprint(f"  {e} — session started untitled.")
                         title = None
-                    if sanitized:
-                        try:
-                            self._session_db.set_session_title(self.session_id, sanitized)
-                            self._pending_title = None
-                            title = sanitized
-                        except ValueError as e:
-                            _cprint(f"  {e} — session started untitled.")
-                            title = None
-                        except Exception:
-                            title = None
-                    elif title is not None:
-                        # sanitize_title returned empty (whitespace-only / unprintable)
-                        _cprint("  Title is empty after cleanup — session started untitled.")
+                    except Exception:
                         title = None
+                elif title is not None:
+                    # sanitize_title returned empty (whitespace-only / unprintable)
+                    _cprint("  Title is empty after cleanup — session started untitled.")
+                    title = None
+
+        if self.agent:
             # Notify memory providers that session_id rotated to a fresh
             # conversation. reset=True signals providers to flush accumulated
             # per-session state (_session_turns, _turn_counter, _document_id).
@@ -6700,13 +6741,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     )
             except Exception:
                 pass
-            self._notify_session_boundary("on_session_reset")
+        self._notify_session_boundary("on_session_reset")
 
         if not silent:
             if title:
                 print(f"(^_^)v New session started: {title}")
             else:
                 print("(^_^)v New session started!")
+            if explicit_toolset_request:
+                if self.enabled_toolsets:
+                    print(f"Toolsets: {', '.join(self.enabled_toolsets)}")
+                else:
+                    print("Toolsets: default")
 
 
 
@@ -8045,7 +8091,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 cmd_original=cmd_original,
             ) is None:
                 return True  # confirmation cancelled — command handled, keep REPL alive
-            self.new_session(silent=True)
+            self.new_session(silent=True, enabled_toolsets_override=None)
             _clear_output_history()
             # Clear terminal screen.  Inside the TUI, Rich's console.clear()
             # goes through patch_stdout's StdoutProxy which swallows the
@@ -8171,7 +8217,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # so "/new now My Session" yields title="My Session" instead of
             # title="now My Session". See _split_destructive_skip.
             _new_args, _ = self._split_destructive_skip(cmd_original)
-            title = _new_args.strip() or None
+            parsed = self._parse_new_session_command_args(_new_args)
+            if parsed.parse_error or parsed.invalid_toolsets or (parsed.explicit_toolset and parsed.toolsets == []):
+                if parsed.parse_error:
+                    _cprint(f"  Invalid /new arguments: {parsed.parse_error}")
+                if parsed.invalid_toolsets:
+                    _cprint(f"  Unknown toolset(s): {', '.join(parsed.invalid_toolsets)}")
+                return True
+            title = parsed.title
             if self._confirm_destructive_slash(
                 "new",
                 "This starts a fresh session.\n"
@@ -8179,7 +8232,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 cmd_original=cmd_original,
             ) is None:
                 return True  # confirmation cancelled — command handled, keep REPL alive
-            self.new_session(title=title)
+            override = parsed.toolsets if parsed.explicit_toolset else None
+            self.new_session(title=title, enabled_toolsets_override=override)
         elif canonical == "resume":
             self._handle_resume_command(cmd_original)
         elif canonical == "sessions":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2615,6 +2615,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
+        self._session_toolset_overrides: Dict[str, Optional[List[str]]] = {}
         # Startup restore gate: while restart-interrupted sessions are being
         # auto-resumed, real inbound messages are queued instead of competing
         # with the synthetic resume turns for the same session.  The queued
@@ -4121,6 +4122,59 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._session_reasoning_overrides.pop(session_key, None)
         else:
             self._session_reasoning_overrides[session_key] = dict(reasoning_config)
+
+    def _valid_session_toolsets(self) -> set[str]:
+        from toolsets import get_all_toolsets
+
+        valid = set(get_all_toolsets().keys())
+        try:
+            cfg = _load_gateway_config()
+        except Exception:
+            cfg = {}
+        valid.update(str(name) for name in (cfg.get("mcp_servers") or {}).keys())
+        return valid
+
+    def _set_session_toolset_override(
+        self,
+        session_key: str,
+        toolsets: Optional[List[str]],
+        *,
+        explicit: bool,
+    ) -> None:
+        if not session_key or not explicit:
+            return
+        if not hasattr(self, "_session_toolset_overrides"):
+            self._session_toolset_overrides = {}
+        if toolsets:
+            self._session_toolset_overrides[session_key] = list(toolsets)
+        else:
+            self._session_toolset_overrides.pop(session_key, None)
+
+    def _clear_session_boundary_overrides(self, session_key: str) -> None:
+        """Clear transient state that must not cross a true session boundary."""
+        if not session_key:
+            return
+        self._session_model_overrides.pop(session_key, None)
+        self._set_session_reasoning_override(session_key, None)
+        pending_notes = getattr(self, "_pending_model_notes", None)
+        if isinstance(pending_notes, dict):
+            pending_notes.pop(session_key, None)
+        if hasattr(self, "_session_toolset_overrides"):
+            self._session_toolset_overrides.pop(session_key, None)
+
+    def _resolve_enabled_toolsets_for_session(
+        self,
+        user_config: dict,
+        platform_key: str,
+        session_key: str,
+    ) -> List[str]:
+        overrides = getattr(self, "_session_toolset_overrides", {}) or {}
+        override = overrides.get(session_key)
+        if override:
+            return sorted(override)
+
+        from hermes_cli.tools_config import _get_platform_tools
+        return sorted(_get_platform_tools(user_config, platform_key))
 
     @staticmethod
     def _load_service_tier() -> str | None:
@@ -6458,10 +6512,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # session is still alive and a resumed turn rebuilds
                         # its agent from these overrides. Only true session
                         # finalization, /new, and /reset clear them.)
-                        self._session_model_overrides.pop(key, None)
-                        self._set_session_reasoning_override(key, None)
-                        if hasattr(self, "_pending_model_notes"):
-                            self._pending_model_notes.pop(key, None)
+                        self._clear_session_boundary_overrides(key)
                         _pending_approvals = getattr(self, "_pending_approvals", None)
                         if isinstance(_pending_approvals, dict):
                             _pending_approvals.pop(key, None)
@@ -9255,10 +9306,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # session-scoped transient state so the fresh session does not
             # inherit the previous conversation's model/reasoning overrides
             # or a queued "/model switched" note.
-            self._session_model_overrides.pop(session_key, None)
-            self._set_session_reasoning_override(session_key, None)
-            if hasattr(self, "_pending_model_notes"):
-                self._pending_model_notes.pop(session_key, None)
+            self._clear_session_boundary_overrides(session_key)
             session_entry.was_auto_reset = False
         
         # Emit session:start for new or auto-reset sessions
@@ -10214,10 +10262,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 new_entry = self.session_store.reset_session(session_key)
                 self._evict_cached_agent(session_key)
-                self._session_model_overrides.pop(session_key, None)
-                self._set_session_reasoning_override(session_key, None)
-                if hasattr(self, "_pending_model_notes"):
-                    self._pending_model_notes.pop(session_key, None)
+                self._clear_session_boundary_overrides(session_key)
                 if new_entry is not None:
                     # Drop the stale reference to the bloated compressed child and
                     # re-point the Telegram topic binding at the fresh session.
@@ -14840,8 +14885,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         user_config = _load_gateway_config()
         platform_key = _platform_config_key(source.platform)
 
-        from hermes_cli.tools_config import _get_platform_tools
-        enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+        enabled_toolsets = self._resolve_enabled_toolsets_for_session(
+            user_config,
+            platform_key,
+            session_key,
+        )
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -102,6 +102,20 @@ class GatewaySlashCommandsMixin:
         
         # Get existing session key
         session_key = self._session_key_for_source(source)
+        had_toolset_override = session_key in (getattr(self, "_session_toolset_overrides", {}) or {})
+        raw_args = event.get_command_args().strip()
+        from agent.session_toolsets import parse_new_session_args
+        parsed_args = parse_new_session_args(
+            raw_args,
+            valid_toolsets=getattr(self, "_valid_session_toolsets")(),
+        )
+        if parsed_args.parse_error or parsed_args.invalid_toolsets or (parsed_args.explicit_toolset and parsed_args.toolsets == []):
+            parts = []
+            if parsed_args.parse_error:
+                parts.append(f"Invalid /new arguments: {parsed_args.parse_error}")
+            if parsed_args.invalid_toolsets:
+                parts.append(f"Unknown toolset(s): {', '.join(parsed_args.invalid_toolsets)}")
+            return EphemeralReply("\n".join(parts))
         self._invalidate_session_run_generation(session_key, reason="session_reset")
         # Evict the running-agent slot now that the generation is bumped. The
         # in-flight run's own guarded release (run_generation=old) will return
@@ -179,12 +193,9 @@ class GatewaySlashCommandsMixin:
         # Reset the session
         new_entry = self.session_store.reset_session(session_key)
 
-        # Clear any session-scoped model/reasoning overrides so the next agent
-        # picks up configured defaults instead of previous session switches.
-        self._session_model_overrides.pop(session_key, None)
-        self._set_session_reasoning_override(session_key, None)
-        if hasattr(self, "_pending_model_notes"):
-            self._pending_model_notes.pop(session_key, None)
+        # Clear session-scoped overrides so the next agent picks up the fresh
+        # session's defaults/toolset request instead of previous-session state.
+        getattr(self, "_clear_session_boundary_overrides")(session_key)
 
         # Clear session-scoped dangerous-command approvals and /yolo state.
         # /new is a conversation-boundary operation — approval state from the
@@ -235,7 +246,7 @@ class GatewaySlashCommandsMixin:
             header = self._telegram_topic_new_header(source) or t("gateway.reset.header_new")
 
         # Set session title if provided with /new <title>
-        _title_arg = event.get_command_args().strip()
+        _title_arg = parsed_args.title or ""
         _title_note = ""
         if _title_arg and self._session_db and new_entry:
             from hermes_state import SessionDB
@@ -256,6 +267,31 @@ class GatewaySlashCommandsMixin:
                 # sanitize_title returned empty (whitespace-only / unprintable)
                 _title_note = t("gateway.reset.title_empty_untitled")
         header = header + _title_note
+
+        toolset_note = ""
+        getattr(self, "_set_session_toolset_override")(
+            session_key,
+            parsed_args.toolsets,
+            explicit=True,
+        )
+        if parsed_args.explicit_toolset or had_toolset_override:
+            if parsed_args.toolsets:
+                try:
+                    from gateway.run import _load_gateway_config
+                    agent_cfg = (_load_gateway_config().get("agent") or {})
+                except Exception:
+                    agent_cfg = {}
+                disabled = set(agent_cfg.get("disabled_toolsets") or [])
+                active = [name for name in parsed_args.toolsets if name not in disabled]
+                skipped = [name for name in parsed_args.toolsets if name in disabled]
+                if active:
+                    toolset_note += "\nToolsets: " + ", ".join(active)
+                else:
+                    toolset_note += "\nToolsets: none active"
+                if skipped:
+                    toolset_note += "\nDisabled by config: " + ", ".join(skipped)
+            else:
+                toolset_note += "\nToolsets: default"
 
         # When /new runs inside a Telegram DM topic lane, rewrite the
         # (chat_id, thread_id) → session_id binding so the next message
@@ -291,8 +327,8 @@ class GatewaySlashCommandsMixin:
             _tip_line = ""
 
         if session_info:
-            return EphemeralReply(f"{header}\n\n{session_info}{_tip_line}")
-        return EphemeralReply(f"{header}{_tip_line}")
+            return EphemeralReply(f"{header}{toolset_note}\n\n{session_info}{_tip_line}")
+        return EphemeralReply(f"{header}{toolset_note}{_tip_line}")
 
     async def _handle_profile_command(self, event: MessageEvent) -> str:
         """Handle /profile — show active profile name and home directory."""
@@ -3225,6 +3261,7 @@ class GatewaySlashCommandsMixin:
         if not new_entry:
             return t("gateway.resume.switch_failed")
         self._clear_session_boundary_security_state(session_key)
+        getattr(self, "_clear_session_boundary_overrides")(session_key)
 
         # Evict any cached agent for this session so the next message
         # rebuilds with the correct session_id end-to-end — mirrors
@@ -3389,6 +3426,7 @@ class GatewaySlashCommandsMixin:
         if not new_entry:
             return t("gateway.branch.switch_failed")
         self._clear_session_boundary_security_state(session_key)
+        getattr(self, "_clear_session_boundary_overrides")(session_key)
 
         # Evict any cached agent for this session
         self._evict_cached_agent(session_key)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -66,7 +66,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("start", "Acknowledge platform start pings without a reply", "Session",
                gateway_only=True),
     CommandDef("new", "Start a new session (fresh session ID + history)", "Session",
-               aliases=("reset",), args_hint="[name]"),
+               aliases=("reset",), args_hint="[--toolset name[,name]] [name]"),
     CommandDef("topic", "Enable or inspect Telegram DM topic sessions", "Session",
                gateway_only=True, args_hint="[off|help|session-id]"),
     CommandDef("clear", "Clear screen and start a new session", "Session",

--- a/tests/agent/test_session_toolsets.py
+++ b/tests/agent/test_session_toolsets.py
@@ -1,0 +1,133 @@
+from agent.session_toolsets import parse_new_session_args
+
+
+def test_parse_title_only():
+    result = parse_new_session_args("Debug auth", valid_toolsets={"terminal", "file"})
+
+    assert result.title == "Debug auth"
+    assert result.toolsets is None
+    assert result.explicit_toolset is False
+    assert result.invalid_toolsets == []
+    assert result.parse_error is None
+
+
+def test_parse_comma_toolsets_and_title():
+    result = parse_new_session_args(
+        "--toolset terminal,file Debug auth",
+        valid_toolsets={"terminal", "file"},
+    )
+
+    assert result.toolsets == ["terminal", "file"]
+    assert result.title == "Debug auth"
+    assert result.explicit_toolset is True
+
+
+def test_parse_repeated_toolset_flags():
+    result = parse_new_session_args(
+        "--toolset terminal --toolset file",
+        valid_toolsets={"terminal", "file"},
+    )
+
+    assert result.toolsets == ["terminal", "file"]
+
+
+def test_parse_equals_form():
+    result = parse_new_session_args(
+        "--toolsets=terminal,file Focus",
+        valid_toolsets={"terminal", "file"},
+    )
+
+    assert result.toolsets == ["terminal", "file"]
+    assert result.title == "Focus"
+
+
+def test_parse_all_normalizes_to_default():
+    result = parse_new_session_args(
+        "--toolset all General",
+        valid_toolsets={"terminal", "file"},
+    )
+
+    assert result.toolsets is None
+    assert result.explicit_toolset is True
+    assert result.title == "General"
+
+
+def test_parse_star_normalizes_to_default():
+    result = parse_new_session_args(
+        "--toolset '*' General",
+        valid_toolsets={"terminal", "file"},
+    )
+
+    assert result.toolsets is None
+    assert result.explicit_toolset is True
+    assert result.title == "General"
+
+
+def test_invalid_toolset_reported_without_losing_title():
+    result = parse_new_session_args("--toolset nope Debug", valid_toolsets={"terminal"})
+
+    assert result.invalid_toolsets == ["nope"]
+    assert result.title == "Debug"
+
+
+def test_missing_toolset_value_returns_parse_error():
+    result = parse_new_session_args("--toolset", valid_toolsets={"terminal"})
+
+    assert result.parse_error
+    assert result.toolsets is None
+
+
+def test_empty_toolset_value_returns_parse_error():
+    result = parse_new_session_args("--toolset ,,, Focus", valid_toolsets={"terminal"})
+
+    assert result.parse_error
+    assert result.title == "Focus"
+    assert result.toolsets is None
+
+
+def test_all_cannot_be_combined_with_specific_toolsets():
+    result = parse_new_session_args("--toolset all,file Focus", valid_toolsets={"file"})
+
+    assert result.parse_error
+    assert result.toolsets is None
+
+
+def test_configured_mcp_name_is_accepted_when_caller_supplies_it():
+    result = parse_new_session_args(
+        "--toolset local-mcp Focus",
+        valid_toolsets={"terminal", "local-mcp"},
+    )
+
+    assert result.toolsets == ["local-mcp"]
+    assert result.title == "Focus"
+
+
+def test_parse_quoted_title_with_toolsets():
+    result = parse_new_session_args('--toolset file "Bug bash"', valid_toolsets={"file"})
+
+    assert result.toolsets == ["file"]
+    assert result.title == "Bug bash"
+
+
+def test_unknown_flags_stay_in_title_text():
+    result = parse_new_session_args("--weird flag Title", valid_toolsets={"terminal"})
+
+    assert result.toolsets is None
+    assert result.title == "--weird flag Title"
+
+
+def test_deduplicates_toolsets_preserving_order():
+    result = parse_new_session_args(
+        "--toolset terminal,file --toolset terminal Focus",
+        valid_toolsets={"terminal", "file"},
+    )
+
+    assert result.toolsets == ["terminal", "file"]
+    assert result.title == "Focus"
+
+
+def test_shlex_error_returns_parse_error():
+    result = parse_new_session_args('--toolset file "Bug bash', valid_toolsets={"file"})
+
+    assert result.parse_error
+    assert result.toolsets is None

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -37,6 +37,7 @@ class _FakeAgent:
         )
         self.commit_memory_session = MagicMock()
         self._invalidate_system_prompt = MagicMock()
+        self.close = MagicMock()
 
         # Token counters (non-zero to verify reset)
         self.session_total_tokens = 1000

--- a/tests/cli/test_destructive_slash_inline_skip_e2e.py
+++ b/tests/cli/test_destructive_slash_inline_skip_e2e.py
@@ -24,8 +24,8 @@ def _make_cli_stub():
 
     new_session_calls = []
 
-    def _capture_new_session(self_, title=None, silent=False):
-        new_session_calls.append({"title": title, "silent": silent})
+    def _capture_new_session(self_, title=None, silent=False, **kwargs):
+        new_session_calls.append({"title": title, "silent": silent, **kwargs})
 
     self_ = SimpleNamespace(
         _app=None,
@@ -44,6 +44,9 @@ def _make_cli_stub():
     )
     # Bind the methods we need under test.
     self_._split_destructive_skip = HermesCLI._split_destructive_skip
+    self_._parse_new_session_command_args = HermesCLI._parse_new_session_command_args.__get__(
+        self_, type(self_)
+    )
     self_._confirm_destructive_slash = HermesCLI._confirm_destructive_slash.__get__(
         self_, type(self_)
     )
@@ -90,8 +93,8 @@ def test_new_without_skip_token_still_consults_modal():
     new_session_calls = []
     modal_calls = []
 
-    def _capture_new_session(self_, title=None, silent=False):
-        new_session_calls.append({"title": title, "silent": silent})
+    def _capture_new_session(self_, title=None, silent=False, **kwargs):
+        new_session_calls.append({"title": title, "silent": silent, **kwargs})
 
     def _record_modal(**kw):
         modal_calls.append(kw)
@@ -111,6 +114,9 @@ def test_new_without_skip_token_still_consults_modal():
         _session_db=None,
     )
     self_._split_destructive_skip = HermesCLI._split_destructive_skip
+    self_._parse_new_session_command_args = HermesCLI._parse_new_session_command_args.__get__(
+        self_, type(self_)
+    )
     self_._normalize_slash_confirm_choice = HermesCLI._normalize_slash_confirm_choice.__get__(
         self_, type(self_)
     )

--- a/tests/cli/test_new_session_toolsets.py
+++ b/tests/cli/test_new_session_toolsets.py
@@ -1,0 +1,156 @@
+"""Tests for CLI /new --toolset session overrides."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from hermes_state import SessionDB
+from tests.cli.test_cli_new_session import _FakeAgent, _make_cli
+
+
+def test_new_command_parses_toolsets_and_title():
+    cli = _make_cli()
+    cli._confirm_destructive_slash = lambda *_a, **_kw: "once"
+    cli.new_session = MagicMock()
+
+    cli.process_command("/new --toolset terminal,file Focus")
+
+    cli.new_session.assert_called_once_with(
+        title="Focus",
+        enabled_toolsets_override=["terminal", "file"],
+    )
+
+
+def test_new_command_parse_error_does_not_reset():
+    cli = _make_cli()
+    cli._confirm_destructive_slash = MagicMock(return_value="once")
+    cli.new_session = MagicMock()
+    warnings: list[str] = []
+    method_globals = cli.process_command.__globals__
+    original = method_globals["_cprint"]
+    method_globals["_cprint"] = lambda msg: warnings.append(msg)
+    try:
+        cli.process_command("/new --toolset")
+    finally:
+        method_globals["_cprint"] = original
+
+    cli._confirm_destructive_slash.assert_not_called()
+    cli.new_session.assert_not_called()
+    assert any("Invalid /new arguments" in warning for warning in warnings)
+
+
+def test_new_command_invalid_toolset_does_not_reset():
+    cli = _make_cli()
+    cli._confirm_destructive_slash = MagicMock(return_value="once")
+    cli.new_session = MagicMock()
+    warnings: list[str] = []
+    method_globals = cli.process_command.__globals__
+    original = method_globals["_cprint"]
+    method_globals["_cprint"] = lambda msg: warnings.append(msg)
+    try:
+        cli.process_command("/new --toolset nope Focus")
+    finally:
+        method_globals["_cprint"] = original
+
+    cli._confirm_destructive_slash.assert_not_called()
+    cli.new_session.assert_not_called()
+    assert any("Unknown toolset(s): nope" in warning for warning in warnings)
+
+
+def test_new_session_toolset_override_rebuilds_live_agent_and_keeps_title(tmp_path):
+    cli = _make_cli(toolsets=["terminal"])
+    cli._session_db = SessionDB(db_path=tmp_path / "state.db")
+    cli._session_db.create_session(session_id=cli.session_id, source="cli", model=cli.model)
+    old_agent = _FakeAgent(cli.session_id, cli.session_start)
+    cli.agent = old_agent
+    cli.conversation_history = []
+    old_session_id = cli.session_id
+
+    cli.new_session(title="Focused", enabled_toolsets_override=["file"])
+
+    old_agent.close.assert_called_once()
+    assert cli.agent is None
+    assert cli.enabled_toolsets == ["file"]
+    assert cli._session_toolset_override == ["file"]
+    assert cli.session_id != old_session_id
+    new_session = cli._session_db.get_session(cli.session_id)
+    assert new_session is not None
+    assert new_session["title"] == "Focused"
+
+
+def test_new_session_same_toolset_uses_existing_agent_reset_path(tmp_path):
+    cli = _make_cli(toolsets=["file"])
+    cli._session_db = SessionDB(db_path=tmp_path / "state.db")
+    cli._session_db.create_session(session_id=cli.session_id, source="cli", model=cli.model)
+    agent = _FakeAgent(cli.session_id, cli.session_start)
+    cli.agent = agent
+    cli.conversation_history = []
+
+    cli.new_session(enabled_toolsets_override=["file"])
+
+    agent.close.assert_not_called()
+    assert cli.agent is agent
+    assert agent.session_id == cli.session_id
+    assert agent._last_flushed_db_idx == 0
+
+
+def test_new_session_default_override_restores_constructor_toolsets():
+    cli = _make_cli(toolsets=["terminal", "file"])
+    cli.agent = _FakeAgent("old_session_id", datetime.now())
+    cli.enabled_toolsets = ["web"]
+    cli._session_toolset_override = ["web"]
+
+    cli.new_session(enabled_toolsets_override=None)
+
+    assert cli.enabled_toolsets == ["terminal", "file"]
+    assert cli._session_toolset_override is None
+
+
+def test_new_command_without_toolset_clears_previous_override():
+    cli = _make_cli(toolsets=["terminal", "file"])
+    cli._confirm_destructive_slash = lambda *_a, **_kw: "once"
+    cli.new_session = MagicMock()
+
+    cli.process_command("/new Normal")
+
+    cli.new_session.assert_called_once_with(
+        title="Normal",
+        enabled_toolsets_override=None,
+    )
+
+
+def test_clear_command_restores_default_toolsets(tmp_path):
+    cli = _make_cli(toolsets=["terminal", "file"])
+    cli._session_db = SessionDB(db_path=tmp_path / "state.db")
+    cli._session_db.create_session(session_id=cli.session_id, source="cli", model=cli.model)
+    cli.agent = _FakeAgent(cli.session_id, cli.session_start)
+    cli.conversation_history = []
+    cli.enabled_toolsets = ["web"]
+    cli._session_toolset_override = ["web"]
+    cli._confirm_destructive_slash = lambda *_a, **_kw: "once"
+    cli.console = MagicMock()
+    cli.show_banner = MagicMock()
+
+    cli.process_command("/clear")
+
+    assert cli.enabled_toolsets == ["terminal", "file"]
+    assert cli._session_toolset_override is None
+
+
+@patch("hermes_cli.plugins.invoke_hook")
+def test_new_session_toolset_rebuild_still_emits_reset_hook(mock_invoke_hook, tmp_path):
+    cli = _make_cli(toolsets=["terminal"])
+    cli._session_db = SessionDB(db_path=tmp_path / "state.db")
+    cli._session_db.create_session(session_id=cli.session_id, source="cli", model=cli.model)
+    cli.agent = _FakeAgent(cli.session_id, cli.session_start)
+    cli.conversation_history = []
+
+    cli.new_session(silent=True, enabled_toolsets_override=["file"])
+
+    assert cli.agent is None
+    assert any(
+        call.args == ("on_session_reset",)
+        and call.kwargs["session_id"] == cli.session_id
+        for call in mock_invoke_hook.call_args_list
+    )

--- a/tests/gateway/test_new_session_toolsets.py
+++ b/tests/gateway/test_new_session_toolsets.py
@@ -1,0 +1,125 @@
+"""Gateway /new --toolset tests."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.session import build_session_key
+from tests.gateway.test_session_model_reset import _make_event, _make_runner, _make_source
+
+
+@pytest.mark.asyncio
+async def test_new_command_stores_toolset_override_and_uses_parsed_title():
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    runner._session_db = MagicMock()
+
+    reply = await runner._handle_reset_command(
+        _make_event("/new --toolset terminal,file Focus")
+    )
+
+    runner.session_store.reset_session.assert_called_once_with(session_key)
+    assert runner._session_toolset_overrides[session_key] == ["terminal", "file"]
+    runner._session_db.set_session_title.assert_called_once()
+    assert runner._session_db.set_session_title.call_args.args[1] == "Focus"
+    assert "Toolsets: terminal, file" in str(reply)
+
+
+@pytest.mark.asyncio
+async def test_new_command_without_toolset_clears_existing_override():
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    runner._session_toolset_overrides[session_key] = ["file"]
+
+    reply = await runner._handle_reset_command(_make_event("/new Normal"))
+
+    assert session_key not in runner._session_toolset_overrides
+    assert "Toolsets: default" in str(reply)
+
+
+@pytest.mark.asyncio
+async def test_invalid_toolset_does_not_reset_or_mutate_override():
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    runner._session_toolset_overrides[session_key] = ["file"]
+    runner._invalidate_session_run_generation = MagicMock()
+    runner._release_running_agent_state = MagicMock()
+    runner._evict_cached_agent = MagicMock()
+
+    reply = await runner._handle_reset_command(_make_event("/new --toolset nope Focus"))
+
+    runner.session_store.reset_session.assert_not_called()
+    runner._invalidate_session_run_generation.assert_not_called()
+    runner._release_running_agent_state.assert_not_called()
+    runner._evict_cached_agent.assert_not_called()
+    assert runner._session_toolset_overrides[session_key] == ["file"]
+    assert "Unknown toolset(s): nope" in str(reply)
+
+
+@pytest.mark.asyncio
+async def test_parse_error_does_not_reset_or_mutate_override():
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    runner._session_toolset_overrides[session_key] = ["file"]
+    runner._invalidate_session_run_generation = MagicMock()
+
+    reply = await runner._handle_reset_command(_make_event("/new --toolset"))
+
+    runner.session_store.reset_session.assert_not_called()
+    runner._invalidate_session_run_generation.assert_not_called()
+    assert runner._session_toolset_overrides[session_key] == ["file"]
+    assert "Invalid /new arguments" in str(reply)
+
+
+def test_resolve_enabled_toolsets_prefers_session_override():
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    runner._session_toolset_overrides[session_key] = ["terminal", "file"]
+    user_config = {
+        "platforms": {Platform.TELEGRAM.value: {"tools": ["web"]}},
+        "tools": ["web"],
+    }
+
+    result = runner._resolve_enabled_toolsets_for_session(
+        user_config,
+        Platform.TELEGRAM.value,
+        session_key,
+    )
+
+    assert result == ["file", "terminal"]
+
+
+def test_clear_session_boundary_overrides_clears_toolset_with_model_state():
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    runner._session_model_overrides[session_key] = {"model": "gpt-4o"}
+    runner._session_reasoning_overrides[session_key] = {"enabled": True}
+    runner._session_toolset_overrides[session_key] = ["file"]
+    runner._pending_model_notes[session_key] = "note"
+
+    runner._clear_session_boundary_overrides(session_key)
+
+    assert session_key not in runner._session_model_overrides
+    assert session_key not in runner._session_reasoning_overrides
+    assert session_key not in runner._session_toolset_overrides
+    assert session_key not in runner._pending_model_notes
+
+
+@pytest.mark.asyncio
+async def test_resume_clears_session_toolset_override():
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    runner._session_toolset_overrides[session_key] = ["file"]
+    runner._session_db = MagicMock()
+    runner._session_db.find_session_by_name.return_value = "target-session"
+    runner._session_db.resolve_resume_session_id.return_value = "target-session"
+    runner._session_db.get_session_title.return_value = "Target"
+    runner.session_store.switch_session.return_value = runner.session_store.reset_session.return_value
+    runner.session_store.load_transcript.return_value = []
+
+    await runner._handle_resume_command(_make_event("/resume Target"))
+
+    assert session_key not in runner._session_toolset_overrides

--- a/tests/gateway/test_session_model_reset.py
+++ b/tests/gateway/test_session_model_reset.py
@@ -38,6 +38,7 @@ def _make_runner():
     runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
     runner._session_model_overrides = {}
     runner._session_reasoning_overrides = {}
+    runner._session_toolset_overrides = {}
     runner._pending_model_notes = {}
     runner._background_tasks = set()
 

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -36,7 +36,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 
 | Command | Description |
 |---------|-------------|
-| `/new [name]` (alias: `/reset`) | Start a new session (fresh session ID + history). Optional `[name]` sets the initial session title — e.g. `/new my-experiment` opens a fresh session already titled `my-experiment` so it's easy to find later with `/resume` or `/sessions`. Append `now`, `--yes`, or `-y` to skip the confirmation modal — e.g. `/reset now`, `/new --yes my-experiment`. |
+| `/new [--toolset name[,name]] [name]` (alias: `/reset`) | Start a new session (fresh session ID + history). Optional `[name]` sets the initial session title — e.g. `/new my-experiment` opens a fresh session already titled `my-experiment` so it's easy to find later with `/resume` or `/sessions`. Add `--toolset terminal,file` to start the fresh session with an explicit, session-scoped toolset allowlist; use repeated flags (`--toolset terminal --toolset file`), `--toolsets`, or `--toolset all`/plain `/new` to return to configured defaults. Explicit allowlists do not persist to `config.yaml`, still respect `agent.disabled_toolsets`, and include configured MCP server toolsets only when named. Append `now`, `--yes`, or `-y` to skip the confirmation modal — e.g. `/reset now`, `/new --yes --toolset terminal,file my-experiment`. |
 | `/clear` | Clear screen and start a new session |
 | `/history` | Show conversation history |
 | `/save` | Save the current conversation |
@@ -200,8 +200,8 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | Command | Description |
 |---------|-------------|
 | `/start` | Platform-protocol command. Many chat platforms (Telegram, Discord, …) send `/start` automatically the first time a user opens a bot conversation. Hermes acknowledges the ping silently — no agent reply, no session burn — so first-contact handshakes don't waste a turn. You can also send it explicitly to confirm the gateway is reachable. |
-| `/new` | Start a new conversation. |
-| `/reset` | Reset conversation history. |
+| `/new [--toolset name[,name]] [name]` | Start a new conversation. Optional title text names the new session. Add `--toolset terminal,file` (or repeated `--toolset` flags / `--toolsets`) to use an explicit session-scoped toolset allowlist for subsequent messages in the new session. `/new` without `--toolset`, or `/new --toolset all`, returns to configured platform defaults. The override is not persisted to config, still respects `agent.disabled_toolsets`, and configured MCP server toolsets are included only when explicitly named. |
+| `/reset [--toolset name[,name]] [name]` | Alias for `/new`; resets conversation history and supports the same session-scoped toolset override syntax. |
 | `/status` | Show session info, followed by a local **Session recap** block (recent turn counts, top tools used, files touched, latest prompt + reply). |
 | `/stop` | Kill all running background processes and interrupt the running agent. |
 | `/model [provider:model]` | Show or change the model. Supports provider switches (`/model zai:glm-5`), custom endpoints (`/model custom:model`), named custom providers (`/model custom:local:qwen`), auto-detect (`/model custom`), and user-defined aliases (`/model fav`, `/model grok` — see [Custom model aliases](#custom-model-aliases)). Use `--global` to persist the change to config.yaml. **Note:** `/model` can only switch between already-configured providers. To add a new provider or set up API keys, use `hermes model` from your terminal (outside the chat session). |


### PR DESCRIPTION
## Summary
- add a shared parser for /new and /reset toolset override arguments
- support session-scoped toolset overrides in CLI and gateway flows without persisting config changes
- clear boundary overrides on reset/resume/branch and document the new syntax

## Validation
- scripts/run_tests.sh tests/agent/test_session_toolsets.py tests/cli/test_new_session_toolsets.py tests/gateway/test_new_session_toolsets.py tests/test_empty_session_hygiene.py tests/gateway/test_agent_cache.py tests/cli/test_destructive_slash_inline_skip_e2e.py tests/cli/test_cli_new_session.py tests/cli/test_session_boundary_hooks.py tests/gateway/test_session_model_reset.py tests/hermes_cli/test_commands.py
- git diff --check

## Risks / follow-ups
- Requires users to start a fresh session for the selected toolset allowlist to take effect, preserving prompt-cache behavior.