### PR TITLE
fix(tools): use start_new_session instead of preexec_fn to prevent SIGSEGV in multi-threaded processes

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -599,7 +599,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 ],
                 stdout=bridge_log_fh,
                 stderr=bridge_log_fh,
-                preexec_fn=None if _IS_WINDOWS else os.setsid,
+                start_new_session=True,
                 env=bridge_env,
             )
             _write_bridge_pidfile(self._session_path, self._bridge_process.pid)

--- a/tests/tools/test_windows_compat.py
+++ b/tests/tools/test_windows_compat.py
@@ -46,6 +46,25 @@ class TestNoUnconditionalSetsid:
             )
 
 
+class TestStartNewSession:
+    """All guarded files must use start_new_session=True instead of preexec_fn."""
+
+    @pytest.mark.parametrize("relpath", GUARDED_FILES)
+    def test_uses_start_new_session(self, relpath):
+        """Each guarded file must use start_new_session=True for process isolation."""
+        filepath = PROJECT_ROOT / relpath
+        if not filepath.exists():
+            pytest.skip(f"{relpath} not found")
+        source = filepath.read_text(encoding="utf-8")
+        # Files should use start_new_session=True, not preexec_fn
+        assert "preexec_fn" not in source, (
+            f"{relpath} still uses preexec_fn; use start_new_session=True instead"
+        )
+        assert "start_new_session=True" in source, (
+            f"{relpath} missing start_new_session=True in Popen call"
+        )
+
+
 class TestIsWindowsConstant:
     """Each guarded file must define _IS_WINDOWS."""
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1290,7 +1290,7 @@ def execute_code(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
-            preexec_fn=None if _IS_WINDOWS else os.setsid,
+            start_new_session=True,
             creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
         )
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -731,7 +731,7 @@ class LocalEnvironment(BaseEnvironment):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
-            preexec_fn=None if _IS_WINDOWS else os.setsid,
+            start_new_session=True,
             cwd=_popen_cwd,
             **_popen_kwargs,
         )

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -750,7 +750,7 @@ class ProcessRegistry:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             stdin=subprocess.DEVNULL,
-            preexec_fn=None if _IS_WINDOWS else os.setsid,
+            start_new_session=True,
             **_popen_kwargs,
         )
 


### PR DESCRIPTION
## Summary
Desktop app no longer segfaults (exit code -11) when executing terminal commands, code, or file reads on macOS — `preexec_fn=os.setsid` replaced with `start_new_session=True` in all Popen call sites.

## Root cause (#46789)
When the Desktop GUI app loads native multi-threaded libraries (onnxruntime, BLAS, provider SDKs), `preexec_fn=os.setsid` in subprocess.Popen calls can trigger SIGSEGV. This is a known Python issue: `preexec_fn` runs in a forked child where multi-threaded C extensions are in an undefined state. `start_new_session=True` is the safe equivalent that Python handles internally without calling user code in the forked child.

## Changes
- `tools/code_execution_tool.py`: `preexec_fn` → `start_new_session=True`
- `tools/environments/local.py`: same
- `tools/process_registry.py`: same
- `plugins/platforms/whatsapp/adapter.py`: same (WhatsApp moved to plugin since original PR)
- `tests/tools/test_windows_compat.py`: new `TestStartNewSession` class asserting no `preexec_fn` remains in guarded files

## Validation
- `scripts/run_tests.sh tests/tools/test_windows_compat.py tests/tools/test_process_registry.py tests/tools/test_code_execution.py` — 84 passed, 1 pre-existing failure (unrelated, `test_close_stdin_allows_eof_driven_process_to_finish` fails on main too)
- Verified zero `preexec_fn` usages remain in tools/ or plugins/

Salvaged from #46868 by @liuhao1024. The cherry-pick auto-merged the WhatsApp plugin path (moved from `gateway/platforms/whatsapp.py` to `plugins/platforms/whatsapp/adapter.py` since the original PR).

Closes #46789
