### PR TITLE
vision: official Gemini API as preferred auto-fallback for text-only models

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -362,6 +362,12 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = _API_KEY_PROVIDER_AUX_MODELS_FALL
 _PROVIDER_VISION_MODELS: Dict[str, str] = {
     "xiaomi": "mimo-v2.5",
     "zai": "glm-5v-turbo",
+    # NB: glm-5v-turbo is only reachable on z.ai's standard pay-as-you-go
+    # endpoint (api/paas/v4). A *coding-plan* GLM_API_KEY returns 429
+    # "Insufficient balance" for it, so deployments on a coding-plan key
+    # should pin `auxiliary.vision: {provider: gemini, ...}` in the GLM
+    # profile's config to route image analysis to the official Gemini API
+    # instead of dead-ending here.
 }
 
 # Providers whose endpoint does not accept image input, even though the
@@ -520,6 +526,10 @@ auxiliary_is_nous: bool = False
 # Default auxiliary models per provider
 _OPENROUTER_MODEL = "google/gemini-3-flash-preview"
 _NOUS_MODEL = "google/gemini-3-flash-preview"
+# Official Google Gemini API (native generativelanguage endpoint) used as the
+# preferred vision fallback for text-only main models. Native slug (no
+# "google/" aggregator prefix). Reads GEMINI_API_KEY / GOOGLE_API_KEY.
+_GEMINI_VISION_MODEL = "gemini-3.5-flash"
 _NOUS_DEFAULT_BASE_URL = "https://inference-api.nousresearch.com/v1"
 _ANTHROPIC_DEFAULT_BASE_URL = "https://api.anthropic.com"
 _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
@@ -4485,6 +4495,10 @@ def get_async_text_auxiliary_client(task: str = "", *, main_runtime: Optional[Di
 
 
 _VISION_AUTO_PROVIDER_ORDER = (
+    # Official Google Gemini API first — preferred vision fallback for
+    # text-only main models (DeepSeek V4, GLM-5.2, …). Falls back to the
+    # aggregators only if no Gemini key is configured.
+    "gemini",
     "openrouter",
     "nous",
 )
@@ -4530,6 +4544,14 @@ def _resolve_strict_vision_backend(
     model: Optional[str] = None,
 ) -> Tuple[Optional[Any], Optional[str]]:
     provider = _normalize_vision_provider(provider)
+    if provider == "gemini":
+        # Official Google Gemini API (native generativelanguage endpoint).
+        # Preferred vision fallback for text-only main models; reads
+        # GEMINI_API_KEY / GOOGLE_API_KEY. Returns (None, None) when no key
+        # is configured, so the auto-chain continues to OpenRouter/Nous.
+        return resolve_provider_client(
+            "gemini", model or _GEMINI_VISION_MODEL, is_vision=True
+        )
     if provider == "copilot":
         return resolve_provider_client("copilot", model, is_vision=True)
     if provider == "openrouter":

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3333,6 +3333,11 @@ class TestVisionAutoSkipsKimiCoding:
         )
 
         def fake_strict(provider, model=None):
+            if provider == "gemini":
+                # No Gemini key configured in this scenario → the chain
+                # continues to the next aggregator. (Official Gemini is tried
+                # first as of the Gemini vision-fallback change.)
+                return None, None
             if provider == "openrouter":
                 return fake_or_client, "google/gemini-3-flash-preview"
             if provider == "nous":

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -436,7 +436,8 @@ class TestResolveVisionMainFirst:
         assert "default_headers" not in mock_openai.call_args.kwargs
 
     def test_main_unavailable_vision_falls_through_to_aggregators(self):
-        """Main provider fails → fall back to OpenRouter/Nous strict backends."""
+        """Main provider fails → fall back to a strict vision backend
+        (official Gemini first, then OpenRouter/Nous)."""
         fallback_client = MagicMock()
         with patch(
             "agent.auxiliary_client._read_main_provider", return_value="deepseek",
@@ -457,7 +458,7 @@ class TestResolveVisionMainFirst:
             provider, client, model = resolve_vision_provider_client()
 
         assert client is fallback_client
-        assert provider in {"openrouter", "nous"}
+        assert provider in {"gemini", "openrouter", "nous"}
 
     def test_explicit_provider_override_still_wins(self):
         """Explicit config override bypasses main-first policy."""


### PR DESCRIPTION
## What

Add the official Google Gemini API (native `generativelanguage` endpoint) as the **first** entry in the vision auto-fallback chain, ahead of the OpenRouter and Nous aggregators.

When a text-only main model receives an image, Hermes routes the picture to an auxiliary vision-capable model and feeds the resulting description back to the main model. Today the auto chain only knows two aggregator backends (`openrouter`, `nous`). If a user has a first-party `GEMINI_API_KEY` / `GOOGLE_API_KEY` configured, there is no way to make the auto path use it without an explicit `auxiliary.vision` override — so image analysis silently goes through an aggregator even when a direct Gemini key is available.

## Change

- `_VISION_AUTO_PROVIDER_ORDER`: prepend `"gemini"`.
- `_resolve_strict_vision_backend`: add a `"gemini"` branch (native client, default model `gemini-3.5-flash`). It returns `(None, None)` when no key is configured, so the chain transparently falls through to the existing OpenRouter/Nous backends — **no behavior change for users without a Gemini key**.
- `_GEMINI_VISION_MODEL` constant for the native default slug (no `google/` aggregator prefix).
- `_PROVIDER_VISION_MODELS`: documented that a coding-plan GLM key (which 429s on `glm-5v-turbo`) should pin `auxiliary.vision: {provider: gemini, ...}`.

## Behavior

| Main model | Before | After |
|---|---|---|
| vision-capable (e.g. Gemini, GPT) | native image | native image (unchanged) |
| text-only + Gemini key configured | OpenRouter/Nous | **official Gemini** |
| text-only + no Gemini key | OpenRouter/Nous | OpenRouter/Nous (unchanged) |

## Tests

Updated the two auto-fallback contract tests for the gemini-first order (kimi-coding skip, main-unavailable fall-through). `tests/agent/test_auxiliary_main_first.py`, `test_auxiliary_named_custom_providers.py`, `test_vision_routing_31179.py` pass (59 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
