### PR TITLE
fix(moa): block the moa virtual provider as a reference or aggregator slot

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -182,6 +182,13 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
 
   const providerOptions = providers.length ? providers : NO_PROVIDERS
 
+  // MoA reference/aggregator slots must never be the moa virtual provider —
+  // that would create a recursive MoA tree (the backend rejects it on save).
+  // Hide it from the slot selectors so it isn't offered as a dead choice.
+  const moaSlotProviderOptions = providerOptions.filter(
+    provider => (provider.slug || '').toLowerCase() !== 'moa'
+  )
+
   const selectedProviderRow = useMemo(
     () => providers.find(provider => provider.slug === selectedProvider),
     [providers, selectedProvider]
@@ -851,7 +858,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                         <SelectValue placeholder={m.provider} />
                       </SelectTrigger>
                       <SelectContent>
-                        {providerOptions.map(provider => (
+                        {moaSlotProviderOptions.map(provider => (
                           <SelectItem key={provider.slug || 'none'} value={provider.slug || 'none'}>
                             {provider.name}
                           </SelectItem>
@@ -930,7 +937,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                       <SelectValue placeholder={m.provider} />
                     </SelectTrigger>
                     <SelectContent>
-                      {providerOptions.map(provider => (
+                      {moaSlotProviderOptions.map(provider => (
                         <SelectItem key={provider.slug || 'none'} value={provider.slug || 'none'}>
                           {provider.name}
                         </SelectItem>

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -28,6 +28,13 @@ def _clean_slot(slot: Any) -> dict[str, str] | None:
     model = str(slot.get("model") or "").strip()
     if not provider or not model:
         return None
+    # MoA is a virtual provider whose presets are themselves MoA runs. Allowing
+    # one as a reference or aggregator slot would create a recursive MoA tree
+    # (the runtime guards in moa_loop.py skip references / raise on aggregators,
+    # but that surfaces only mid-turn). Reject it here so it can never be saved:
+    # an invalid slot is dropped, falling back to the preset's defaults.
+    if provider.lower() == "moa":
+        return None
     return {"provider": provider, "model": model}
 
 

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -95,3 +95,54 @@ def test_build_moa_turn_prompt_encodes_one_shot_default_preset():
     assert decoded_prompt == "write a file then inspect it"
     assert cfg is not None
     assert cfg["reference_models"] == DEFAULT_MOA_REFERENCE_MODELS
+
+
+def test_moa_provider_rejected_as_reference_slot():
+    """A reference slot pointing at the moa virtual provider is dropped, so a
+    preset cannot recursively reference another MoA run."""
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "p": {
+                    "reference_models": [
+                        {"provider": "moa", "model": "default"},
+                        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"},
+                    ],
+                    "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+                }
+            }
+        }
+    )
+
+    refs = cfg["presets"]["p"]["reference_models"]
+    assert {"provider": "moa", "model": "default"} not in refs
+    assert refs == [{"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}]
+
+
+def test_moa_provider_rejected_as_aggregator_slot():
+    """An aggregator slot pointing at the moa virtual provider is dropped and
+    falls back to the default aggregator, never a recursive MoA aggregator."""
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "p": {
+                    "reference_models": [{"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}],
+                    "aggregator": {"provider": "moa", "model": "default"},
+                }
+            }
+        }
+    )
+
+    agg = cfg["presets"]["p"]["aggregator"]
+    assert agg["provider"] != "moa"
+    assert agg == DEFAULT_MOA_AGGREGATOR
+
+
+def test_moa_provider_rejected_case_insensitive():
+    """Case variants like ``MoA`` are also blocked."""
+    cfg = normalize_moa_config(
+        {"presets": {"p": {"aggregator": {"provider": "MoA", "model": "default"}}}}
+    )
+
+    assert cfg["presets"]["p"]["aggregator"]["provider"] != "moa"
+    assert cfg["presets"]["p"]["aggregator"] == DEFAULT_MOA_AGGREGATOR

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -846,6 +846,11 @@ function MoaModelsModal({
           alwaysGlobal
           title="Select MoA Model"
           onApply={async ({ provider, model }) => {
+            if ((provider || "").toLowerCase() === "moa") {
+              setError("MoA presets can't reference or aggregate the Mixture of Agents provider (no recursive MoA).");
+              return;
+            }
+            setError(null);
             updateSelectedPreset((prev) => {
               if (picker.kind === "aggregator") return { ...prev, aggregator: { provider, model } };
               return {


### PR DESCRIPTION
## Summary
A MoA preset can currently be saved with the `moa` virtual provider in a reference or aggregator slot, which creates a recursive MoA tree. The runtime guards in `moa_loop.py` only catch this mid-turn (references silently skipped, aggregator raises `RuntimeError`). This blocks it at the config chokepoint so it can never be saved, and hides it from the slot pickers.

## Changes
- `hermes_cli/moa_config.py`: `_clean_slot()` rejects `provider == "moa"` (case-insensitive). Every save path (CLI `hermes moa configure`, dashboard PUT, desktop settings, hand-edited YAML) routes through this, so a moa reference is dropped (falls back to defaults) and a moa aggregator falls back to the default aggregator. Fail-closed.
- `apps/desktop/src/app/settings/model-settings.tsx`: MoA reference/aggregator provider dropdowns use a filtered list that excludes the moa row.
- `web/src/pages/ModelsPage.tsx`: the MoA model picker rejects a moa pick with an inline error.
- Tests: reference slot, aggregator slot, case-insensitive.

## Verification
| Check | Result |
|---|---|
| moa reference slot | dropped → falls back to default references |
| moa aggregator slot | dropped → falls back to default aggregator |
| `MOA` / `MoA` case variants | blocked |
| `resolve_moa_preset` (moa_loop consumer) | never returns a moa slot |
| Legit configs | preserved untouched |
| `tests/hermes_cli/test_moa_config.py` | 10 passed |

## Infographic

![block-recursive-moa](https://v3b.fal.media/files/b/0a9fe521/IHo8txxYsO5YUBbC1X5vi_oJy2PjMN.png)
