### PR TITLE
fix(tui): preserve filtered model provider selection

### DIFF
--- a/ui-tui/src/__tests__/modelPicker.test.ts
+++ b/ui-tui/src/__tests__/modelPicker.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { providerIndexAfterClearingFilter } from '../components/modelPicker.js'
+import type { ModelOptionProvider } from '../gatewayTypes.js'
+
+const provider = (slug: string, name = slug): ModelOptionProvider => ({ name, slug })
+
+describe('ModelPicker provider filtering', () => {
+  it('keeps the selected provider when clearing the provider filter', () => {
+    const nous = provider('nous', 'Nous Portal')
+    const ollama = provider('ollama-cloud', 'Ollama Cloud')
+
+    const rows = [
+      { name: nous.name, provider: nous },
+      { name: ollama.name, provider: ollama }
+    ]
+
+    // With a provider-stage filter like "ollama", the selected row is index 0
+    // in the filtered list, but index 1 in the full list after setFilter('').
+    expect(providerIndexAfterClearingFilter(rows, ollama)).toBe(1)
+  })
+})

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -17,6 +17,16 @@ const MAX_WIDTH = 90
 
 type Stage = 'provider' | 'key' | 'model' | 'disconnect'
 
+type ProviderRow = { name: string; provider: ModelOptionProvider }
+
+export function providerIndexAfterClearingFilter(providerRows: ProviderRow[], provider: ModelOptionProvider | undefined) {
+  if (!provider) {
+    return -1
+  }
+
+  return providerRows.findIndex(row => row.provider.slug === provider.slug)
+}
+
 export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect, sessionId, t }: ModelPickerProps) {
   const [providers, setProviders] = useState<ModelOptionProvider[]>([])
   const [currentModel, setCurrentModel] = useState('')
@@ -307,6 +317,12 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
         if (provider.authenticated === false) {
           // api_key providers: prompt for key inline
           if (provider.auth_type === 'api_key' && provider.key_env) {
+            const fullProviderIdx = providerIndexAfterClearingFilter(providerRows, provider)
+
+            if (fullProviderIdx >= 0) {
+              setProviderIdx(fullProviderIdx)
+            }
+
             setStage('key')
             setKeyInput('')
             setKeyError('')
@@ -315,6 +331,12 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
 
           // Other auth types: no-op (warning shown tells them to run hermes model)
           return
+        }
+
+        const fullProviderIdx = providerIndexAfterClearingFilter(providerRows, provider)
+
+        if (fullProviderIdx >= 0) {
+          setProviderIdx(fullProviderIdx)
         }
 
         setStage('model')
@@ -365,7 +387,14 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
 
     // Disconnect (Ctrl+D): only in provider stage, only for authenticated providers.
     if (key.ctrl && ch === 'd' && stage === 'provider' && provider?.authenticated !== false) {
+      const fullProviderIdx = providerIndexAfterClearingFilter(providerRows, provider)
+
+      if (fullProviderIdx >= 0) {
+        setProviderIdx(fullProviderIdx)
+      }
+
       setStage('disconnect')
+      setFilter('')
 
       return
     }


### PR DESCRIPTION
## Summary

Fixes #53286.

The TUI `/model` picker used `providerIdx` from the filtered provider list after clearing the filter. Selecting `Ollama Cloud` from a filtered list could become `Nous Portal` on the next screen, so saving an Ollama key failed with a Nous OAuth error.

This PR preserves the selected provider by slug before provider-stage transitions that clear or stop applying the filter: key entry, model selection, and disconnect confirmation.

## Reproduction fixed

1. Open TUI `/model`.
2. Type `ollama` in the provider list.
3. Select `Ollama Cloud`.
4. Before: key screen could show `Configure Nous Portal`, and saving showed `Nous Portal uses oauth_device_code auth`.
5. After: key screen remains on `Ollama Cloud`.

## Adversarial review

- Finding: same filtered-index drift affected `Ctrl+D` disconnect confirmation.
- Action: fixed by preserving provider identity before entering `disconnect`.
- Follow-up review: no blocking findings. Residual risk is helper-level coverage rather than full interactive TUI coverage.

## Verification

- `npm --workspace ui-tui exec -- eslint src/components/modelPicker.tsx src/__tests__/modelPicker.test.ts`
- `npm --workspace ui-tui test -- modelPicker`
- `npm --workspace ui-tui run typecheck`
- `git diff --check`
