### PR TITLE
fix(delegate): inherit subagent endpoint from parent active client

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -32,6 +32,7 @@ from tools.delegate_tool import (
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
+    _inherit_parent_base_url,
 )
 
 
@@ -1371,6 +1372,47 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             self.assertEqual(kwargs["model"], parent.model)
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["base_url"], parent.base_url)
+
+    def test_inherit_parent_base_url_prefers_client_kwargs(self):
+        parent = _make_mock_parent(depth=0)
+        parent.base_url = "https://openrouter.ai/api/v1"
+        parent._client_kwargs = {
+            "api_key": "no-key-required",
+            "base_url": "http://localhost:11434/v1",
+        }
+        self.assertEqual(
+            _inherit_parent_base_url(parent, parent.base_url),
+            "http://localhost:11434/v1",
+        )
+
+    def test_build_child_agent_inherits_active_client_endpoint(self):
+        """Regression: stale parent.base_url must not route subagents to OpenRouter."""
+        parent = _make_mock_parent(depth=0)
+        parent.provider = "ollama"
+        parent.base_url = "https://openrouter.ai/api/v1"
+        parent.api_key = "ollama"
+        parent._client_kwargs = {
+            "api_key": "no-key-required",
+            "base_url": "http://localhost:11434/v1",
+        }
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+            _build_child_agent(
+                task_index=0,
+                goal="Use local Ollama",
+                context=None,
+                toolsets=["terminal"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["base_url"], "http://localhost:11434/v1")
+            self.assertEqual(kwargs["api_key"], "ollama")
 
     @patch("tools.delegate_tool._load_config")
     @patch("tools.delegate_tool._resolve_delegation_credentials")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -988,6 +988,44 @@ def _build_child_progress_callback(
     return _callback
 
 
+def _normalized_runtime_url(value: Any) -> str:
+    return str(value or "").strip().rstrip("/")
+
+
+def _inherit_parent_base_url(parent_agent, fallback_base_url: Optional[str]) -> Optional[str]:
+    """Return the base URL the parent is actually calling, not a stale attribute.
+
+    ``parent_agent.base_url`` can still carry a leftover OpenRouter URL from an
+    old config while the live OpenAI client in ``_client_kwargs`` already points
+    at local Ollama. Subagents must inherit the active endpoint or they 401
+    against OpenRouter with a dummy/local key.
+    """
+    surface_url = _normalized_runtime_url(fallback_base_url)
+    client_kwargs = getattr(parent_agent, "_client_kwargs", None)
+    if isinstance(client_kwargs, dict):
+        kwargs_url = _normalized_runtime_url(client_kwargs.get("base_url"))
+        if (
+            kwargs_url
+            and kwargs_url != surface_url
+            and kwargs_url.startswith(("http://", "https://"))
+        ):
+            return kwargs_url
+
+    client = getattr(parent_agent, "client", None)
+    if client is not None:
+        live_raw = getattr(client, "base_url", "")
+        if isinstance(live_raw, str):
+            live_url = _normalized_runtime_url(live_raw)
+            if (
+                live_url
+                and live_url != surface_url
+                and live_url.startswith(("http://", "https://"))
+            ):
+                return live_url
+
+    return fallback_base_url or None
+
+
 def _build_child_agent(
     task_index: int,
     goal: str,
@@ -1144,6 +1182,8 @@ def _build_child_agent(
     effective_model = model or parent_agent.model
     effective_provider = override_provider or getattr(parent_agent, "provider", None)
     effective_base_url = override_base_url or parent_agent.base_url
+    if not override_base_url:
+        effective_base_url = _inherit_parent_base_url(parent_agent, effective_base_url)
     effective_api_key = override_api_key or parent_api_key
     # Bug #20558 / PR #20563: api_mode must NOT be inherited when the child uses a
     # different provider than the parent — each provider has its own API surface

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1013,15 +1013,15 @@ def _inherit_parent_base_url(parent_agent, fallback_base_url: Optional[str]) -> 
 
     client = getattr(parent_agent, "client", None)
     if client is not None:
-        live_raw = getattr(client, "base_url", "")
-        if isinstance(live_raw, str):
-            live_url = _normalized_runtime_url(live_raw)
-            if (
-                live_url
-                and live_url != surface_url
-                and live_url.startswith(("http://", "https://"))
-            ):
-                return live_url
+        # OpenAI SDK exposes ``base_url`` as an ``httpx.URL``, not ``str`` —
+        # coerce so the comparison works regardless of the client's type.
+        live_url = _normalized_runtime_url(getattr(client, "base_url", ""))
+        if (
+            live_url
+            and live_url != surface_url
+            and live_url.startswith(("http://", "https://"))
+        ):
+            return live_url
 
     return fallback_base_url or None
 


### PR DESCRIPTION
## Summary
Subagents (`delegate_task`) now inherit the parent's active API endpoint from `_client_kwargs` / the mounted OpenAI client when it disagrees with `parent_agent.base_url`, fixing HTTP 401 on subagent tool calls when the parent runs on local Ollama but a stale OpenRouter `base_url` is still stored on the agent object.

## Root cause
Parent chat can work against `http://localhost:11434/v1` while `agent.base_url` still says `https://openrouter.ai/api/v1` (leftover config). Subagents only copied the stale attribute and sent dummy/local keys to OpenRouter → `Missing Authentication header`.

## Changes
- `tools/delegate_tool.py`: new `_inherit_parent_base_url()` helper that prefers `_client_kwargs["base_url"]` (the live client config), then `agent.client.base_url`, falling back to `parent_agent.base_url`. Called from `_build_child_agent` when no override is set.
- `tests/tools/test_delegate.py`: 2 new tests covering the stale-base-url inheritance and the regression case.

Salvage of #53059 by @xxxigm, cherry-picked onto current main with authorship preserved. Closes #53059.
