### PR TITLE
fix(desktop): persist MoA preset add/delete/set-default immediately

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -772,9 +772,13 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
             </Select>
             <Button
               disabled={applying}
-              onClick={() =>
-                setMoa(prev => prev && { ...prev, default_preset: selectedMoaPreset || prev.default_preset })
-              }
+              onClick={() => {
+                const next: MoaConfigResponse = {
+                  ...moa,
+                  default_preset: selectedMoaPreset || moa.default_preset
+                }
+                void saveMoa(next)
+              }}
               size="sm"
               variant="text"
             >
@@ -783,23 +787,21 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
             <Button
               disabled={Object.keys(moa.presets).length <= 1 || applying}
               onClick={() => {
-                setMoa(prev => {
-                  if (!prev || Object.keys(prev.presets).length <= 1) {
-                    return prev
-                  }
+                if (Object.keys(moa.presets).length <= 1) {
+                  return
+                }
 
-                  const next = { ...prev.presets }
-                  delete next[selectedMoaPreset]
-                  const fallback = Object.keys(next)[0]
-
-                  return {
-                    ...prev,
-                    presets: next,
-                    default_preset: prev.default_preset === selectedMoaPreset ? fallback : prev.default_preset,
-                    active_preset: prev.active_preset === selectedMoaPreset ? '' : prev.active_preset
-                  }
-                })
+                const presets = { ...moa.presets }
+                delete presets[selectedMoaPreset]
+                const fallback = Object.keys(presets)[0]
+                const next: MoaConfigResponse = {
+                  ...moa,
+                  presets,
+                  default_preset: moa.default_preset === selectedMoaPreset ? fallback : moa.default_preset,
+                  active_preset: moa.active_preset === selectedMoaPreset ? '' : moa.active_preset
+                }
                 setSelectedMoaPreset(Object.keys(moa.presets).find(name => name !== selectedMoaPreset) || '')
+                void saveMoa(next)
               }}
               size="sm"
               variant="ghost"
@@ -816,18 +818,16 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
               disabled={!newMoaPresetName.trim() || !!moa.presets[newMoaPresetName.trim()] || applying}
               onClick={() => {
                 const name = newMoaPresetName.trim()
-                setMoa(
-                  prev =>
-                    prev && {
-                      ...prev,
-                      presets: {
-                        ...prev.presets,
-                        [name]: { ...currentMoaPreset, reference_models: [...currentMoaPreset.reference_models] }
-                      }
-                    }
-                )
+                const next: MoaConfigResponse = {
+                  ...moa,
+                  presets: {
+                    ...moa.presets,
+                    [name]: { ...currentMoaPreset, reference_models: [...currentMoaPreset.reference_models] }
+                  }
+                }
                 setSelectedMoaPreset(name)
                 setNewMoaPresetName('')
+                void saveMoa(next)
               }}
               size="sm"
               variant="textStrong"


### PR DESCRIPTION
## Summary
The desktop MoA settings "Add preset", "Set default", and "Delete" buttons mutated local React state only and never called the save endpoint — so a newly constructed preset vanished on refresh. Each now persists immediately.

## Root cause
All three handlers called `setMoa(...)` (local state) but not `saveMoa(...)`. Persistence only happened on a separate "Save" click, which users don't expect after explicitly adding/deleting a preset.

## Fix
- `apps/desktop/src/app/settings/model-settings.tsx`: Add preset / Set default / Delete now build the next `MoaConfigResponse` and call `saveMoa(next)`, which PUTs to `/api/model/moa` and updates state from the server response.

## Verification
| Check | Result |
|---|---|
| `model-settings.tsx` typecheck | no new errors |
| Backend round-trip (E2E) | new preset PUT → reload from disk → preset present, default_preset + max_tokens persisted |
| Root cause | renderer-only; backend `PUT /api/model/moa` already persisted correctly |

## Infographic

![moa-presets-now-save](https://v3b.fal.media/files/b/0a9fe579/a1-sm7b_zZzEg4iuv2s9z_OCqphYyT.png)
