### PR TITLE
fix: normalize lmstudio base urls

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -478,6 +478,16 @@ def _infer_provider_from_url(base_url: str) -> Optional[str]:
     return None
 
 
+def _lmstudio_server_root(base_url: str) -> str:
+    """Return the LM Studio server root for native ``/api/v1`` endpoints."""
+    root = _normalize_base_url(base_url).rstrip("/")
+    for suffix in ("/api/v1", "/api", "/v1"):
+        if root.endswith(suffix):
+            root = root[: -len(suffix)].rstrip("/")
+            break
+    return root
+
+
 def _is_known_provider_base_url(base_url: str) -> bool:
     return _infer_provider_from_url(base_url) is not None
 
@@ -549,6 +559,7 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
     server_url = normalized
     if server_url.endswith("/v1"):
         server_url = server_url[:-3]
+    lmstudio_url = _lmstudio_server_root(base_url)
 
     headers = _auth_headers(api_key)
 
@@ -556,7 +567,7 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
         with httpx.Client(timeout=2.0, headers=headers) as client:
             # LM Studio exposes /api/v1/models — check first (most specific)
             try:
-                r = client.get(f"{server_url}/api/v1/models")
+                r = client.get(f"{lmstudio_url}/api/v1/models")
                 if r.status_code == 200:
                     return "lm-studio"
             except Exception:
@@ -774,7 +785,7 @@ def fetch_endpoint_model_metadata(
     if is_local_endpoint(normalized):
         try:
             if detect_local_server_type(normalized, api_key=api_key) == "lm-studio":
-                server_url = normalized[:-3].rstrip("/") if normalized.endswith("/v1") else normalized
+                server_url = _lmstudio_server_root(normalized)
                 response = requests.get(
                     server_url.rstrip("/") + "/api/v1/models",
                     headers=headers,
@@ -1297,6 +1308,7 @@ def _query_local_context_length(model: str, base_url: str, api_key: str = "") ->
     server_url = base_url.rstrip("/")
     if server_url.endswith("/v1"):
         server_url = server_url[:-3]
+    lmstudio_url = _lmstudio_server_root(base_url)
 
     headers = _auth_headers(api_key)
 
@@ -1340,7 +1352,7 @@ def _query_local_context_length(model: str, base_url: str, api_key: str = "") ->
             # Use _model_id_matches for fuzzy matching: LM Studio stores models as
             # "publisher/slug" but users configure only "slug" after "local:" prefix.
             if server_type == "lm-studio":
-                resp = client.get(f"{server_url}/api/v1/models")
+                resp = client.get(f"{lmstudio_url}/api/v1/models")
                 if resp.status_code == 200:
                     data = resp.json()
                     for m in data.get("models", []):

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -704,6 +704,22 @@ def _resolve_zai_base_url(api_key: str, default_url: str, env_override: str) -> 
     return default_url
 
 
+def _normalize_lmstudio_runtime_base_url(base_url: str) -> str:
+    """Return the OpenAI-compatible LM Studio runtime base URL.
+
+    LM Studio's native management API lives under ``/api/v1`` while its
+    OpenAI-compatible chat endpoint lives under ``/v1``. Users often paste
+    either form into ``LM_BASE_URL`` or ``model.base_url``; normalize before
+    the OpenAI SDK appends ``/chat/completions``.
+    """
+    root = str(base_url or "").strip().rstrip("/")
+    for suffix in ("/api/v1", "/api", "/v1"):
+        if root.endswith(suffix):
+            root = root[: -len(suffix)].rstrip("/")
+            break
+    return (root or "http://127.0.0.1:1234") + "/v1"
+
+
 # =============================================================================
 # Error Types
 # =============================================================================
@@ -6255,6 +6271,9 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
         base_url = env_url.rstrip("/")
     else:
         base_url = pconfig.inference_base_url
+
+    if provider_id == "lmstudio":
+        base_url = _normalize_lmstudio_runtime_base_url(base_url)
 
     return {
         "provider": provider_id,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2871,13 +2871,19 @@ def _is_github_models_base_url(base_url: Optional[str]) -> bool:
 
 
 def _lmstudio_server_root(base_url: Optional[str]) -> Optional[str]:
-    """Strip ``/v1`` suffix from an LM Studio base URL to get the native API root.
+    """Return the LM Studio server root for native ``/api/v1`` endpoints.
 
+    Users commonly copy either the OpenAI-compatible runtime URL
+    (``.../v1``) or the native API prefix (``.../api`` / ``.../api/v1``).
+    Native probes append ``/api/v1/...`` themselves, so normalize all accepted
+    forms back to the bare server root to avoid ``/api/api/v1`` requests.
     Returns ``None`` when the base URL is empty/invalid.
     """
     root = (base_url or "").strip().rstrip("/")
-    if root.endswith("/v1"):
-        root = root[:-3].rstrip("/")
+    for suffix in ("/api/v1", "/api", "/v1"):
+        if root.endswith(suffix):
+            root = root[: -len(suffix)].rstrip("/")
+            break
     return root or None
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -424,6 +424,9 @@ def _resolve_runtime_from_pool_entry(
         provider=provider, api_mode=api_mode, model_cfg=model_cfg
     )
 
+    if provider == "lmstudio":
+        base_url = auth_mod._normalize_lmstudio_runtime_base_url(base_url)
+
     return {
         "provider": provider,
         "api_mode": api_mode,
@@ -1834,6 +1837,8 @@ def resolve_runtime_provider(
         # Strip trailing /v1 for OpenCode Anthropic models (see comment above).
         if api_mode == "anthropic_messages" and provider in {"opencode-zen", "opencode-go"}:
             base_url = re.sub(r"/v1/?$", "", base_url)
+        if provider == "lmstudio":
+            base_url = auth_mod._normalize_lmstudio_runtime_base_url(base_url)
         return {
             "provider": provider,
             "api_mode": api_mode,

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -424,6 +424,31 @@ class TestQueryLocalContextLengthLmStudio:
             "max_context_length (1048576) must not win over loaded_instances."
         )
 
+    def test_lmstudio_native_api_base_url_is_not_doubled(self):
+        from agent.model_metadata import _query_local_context_length
+
+        native_resp = self._make_resp(200, {
+            "models": [
+                {
+                    "key": "publisher/model-a",
+                    "id": "publisher/model-a",
+                    "loaded_instances": [{"config": {"context_length": 32768}}],
+                },
+            ]
+        })
+        client_mock = self._make_client(
+            native_resp,
+            self._make_resp(404, {}),
+            self._make_resp(404, {}),
+        )
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="lm-studio"), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("publisher/model-a", "http://localhost:1234/api/v1")
+
+        assert result == 32768
+        assert client_mock.get.call_args_list[0].args[0] == "http://localhost:1234/api/v1/models"
+
 
 class TestDetectLocalServerTypeAuth:
     def test_passes_bearer_token_to_probe_requests(self):
@@ -444,6 +469,24 @@ class TestDetectLocalServerTypeAuth:
         assert mock_client.call_args.kwargs["headers"] == {
             "Authorization": "Bearer lm-token"
         }
+
+    def test_native_api_base_url_is_not_doubled(self):
+        from agent.model_metadata import detect_local_server_type
+
+        resp = MagicMock()
+        resp.status_code = 200
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.get.return_value = resp
+
+        result = None
+        with patch("httpx.Client", return_value=client_mock):
+            result = detect_local_server_type("http://localhost:1234/api/v1")
+
+        assert result == "lm-studio"
+        assert client_mock.get.call_args_list[0].args[0] == "http://localhost:1234/api/v1/models"
 
 
 class TestFetchEndpointModelMetadataLmStudio:
@@ -488,6 +531,33 @@ class TestFetchEndpointModelMetadataLmStudio:
         }
         assert result["lmstudio-community/Qwen3.5-27B-GGUF/Qwen3.5-27B-Q8_0.gguf"]["context_length"] == 131072
         assert result["Qwen3.5-27B-GGUF/Qwen3.5-27B-Q8_0.gguf"]["context_length"] == 131072
+
+    def test_native_api_base_url_is_not_doubled(self):
+        from agent.model_metadata import fetch_endpoint_model_metadata
+
+        native_resp = self._make_resp(
+            {
+                "models": [
+                    {
+                        "key": "publisher/model-a",
+                        "id": "publisher/model-a",
+                        "loaded_instances": [
+                            {"config": {"context_length": 65536}}
+                        ],
+                    }
+                ]
+            }
+        )
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="lm-studio"), \
+             patch("agent.model_metadata.requests.get", return_value=native_resp) as mock_get:
+            result = fetch_endpoint_model_metadata(
+                "http://localhost:1234/api/v1",
+                force_refresh=True,
+            )
+
+        assert mock_get.call_args[0][0] == "http://localhost:1234/api/v1/models"
+        assert result["publisher/model-a"]["context_length"] == 65536
 
 
 class TestQueryLocalContextLengthNetworkError:

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -427,6 +427,15 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["api_key"] == "lm-token"
         assert creds["base_url"] == "http://lmstudio.remote:4321/v1"
 
+    def test_resolve_lmstudio_normalizes_native_api_base_url_from_env(self, monkeypatch):
+        monkeypatch.setenv("LM_API_KEY", "lm-token")
+        monkeypatch.setenv("LM_BASE_URL", "http://lmstudio.remote:4321/api/v1")
+
+        creds = resolve_api_key_provider_credentials("lmstudio")
+
+        assert creds["provider"] == "lmstudio"
+        assert creds["base_url"] == "http://lmstudio.remote:4321/v1"
+
     def test_resolve_lmstudio_no_api_key_substitutes_placeholder(self, monkeypatch):
         # No-auth LM Studio: when LM_API_KEY isn't set, runtime credentials
         # carry a placeholder so gateway/TUI/cron paths see the local server

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -677,6 +677,19 @@ class TestValidateApiFallback:
 
         assert models == ["publisher/chat-model"]
 
+    def test_fetch_lmstudio_models_normalizes_native_api_base_url(self):
+        mock_resp = MagicMock()
+        mock_resp.__enter__.return_value = mock_resp
+        mock_resp.__exit__.return_value = False
+        mock_resp.read.return_value = b'{"models":[{"key":"publisher/chat-model","type":"llm"}]}'
+
+        with patch("hermes_cli.models.urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+            models = fetch_lmstudio_models(base_url="http://localhost:1234/api/v1")
+
+        request = mock_urlopen.call_args[0][0]
+        assert request.full_url == "http://localhost:1234/api/v1/models"
+        assert models == ["publisher/chat-model"]
+
     def test_validate_lmstudio_rejects_embedding_models(self):
         mock_resp = MagicMock()
         mock_resp.__enter__.return_value = mock_resp

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -354,6 +354,32 @@ def test_resolve_runtime_provider_lmstudio_saved_base_url_wins_over_env(monkeypa
     assert resolved["api_key"] == "dummy-lm-api-key"
 
 
+def test_resolve_runtime_provider_lmstudio_normalizes_native_api_saved_base_url(monkeypatch):
+    monkeypatch.delenv("LM_API_KEY", raising=False)
+    monkeypatch.delenv("LM_BASE_URL", raising=False)
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "lmstudio")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "lmstudio",
+            "base_url": "http://192.168.1.10:1234/api/v1",
+            "default": "qwen/qwen3-coder-30b",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: type("Pool", (), {"has_credentials": lambda self: False})(),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="lmstudio")
+
+    assert resolved["provider"] == "lmstudio"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "http://192.168.1.10:1234/v1"
+
+
 def test_resolve_runtime_provider_openrouter_explicit(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {})


### PR DESCRIPTION
## What does this PR do?

Fixes LM Studio base URL normalization so Hermes uses the correct endpoints when users paste either the OpenAI-compatible runtime URL (`/v1`) or LM Studio native API URLs (`/api`, `/api/v1`).

Previously, native model-management calls could append `/api/v1` to an already-native base URL, producing paths like `/api/api/v1/models`. Runtime resolution could also preserve a native LM Studio base URL, causing the OpenAI SDK to send chat completions to `/api/v1/chat/completions` instead of `/v1/chat/completions`.

This PR normalizes:

- LM Studio model discovery/load/context probes to the server root before appending `/api/v1/*`
- LM Studio runtime base URLs to `/v1` before the OpenAI-compatible client appends chat completion paths

It does not add a UI toggle for disabling tool/function calling; that is a separate behavior change from the URL-construction bug.

## Related Issue

Fixes #53256

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/models.py`: normalize LM Studio native API bases before appending `/api/v1/models` or `/api/v1/models/load`.
- `hermes_cli/auth.py`: normalize LM Studio runtime credentials to the OpenAI-compatible `/v1` endpoint.
- `hermes_cli/runtime_provider.py`: normalize LM Studio runtime URLs after saved config or pool resolution.
- `agent/model_metadata.py`: normalize LM Studio local-server detection and context metadata probes so `/api/v1` input does not become `/api/api/v1`.
- `tests/hermes_cli/test_model_validation.py`: cover native LM Studio model-list URL construction.
- `tests/hermes_cli/test_api_key_providers.py`: cover `LM_BASE_URL=/api/v1` runtime normalization.
- `tests/hermes_cli/test_runtime_provider_resolution.py`: cover saved `model.base_url=/api/v1` runtime normalization.
- `tests/agent/test_model_metadata_local_ctx.py`: cover metadata detection, endpoint metadata, and context probing with native LM Studio base URLs.

## How to Test

1. Configure LM Studio with a base URL such as `http://localhost:1234/api/v1`.
2. Run model discovery or validation; Hermes should request `http://localhost:1234/api/v1/models`, not `http://localhost:1234/api/v1/api/v1/models` or `http://localhost:1234/api/api/v1/models`.
3. Start a chat through the `lmstudio` provider; the runtime base URL should normalize to `http://localhost:1234/v1` so chat completions go to `/v1/chat/completions`.

Test commands run locally:

```bash
uv run --python python3.13 --extra dev scripts/run_tests.sh tests/hermes_cli/test_model_validation.py -- -k lmstudio
uv run --python python3.13 --extra dev scripts/run_tests.sh tests/hermes_cli/test_runtime_provider_resolution.py -- -k lmstudio
uv run --python python3.13 --extra dev scripts/run_tests.sh tests/hermes_cli/test_api_key_providers.py -- -k lmstudio
uv run --python python3.13 --extra dev scripts/run_tests.sh tests/agent/test_model_metadata_local_ctx.py -- -k lmstudio
uv run --python python3.13 --extra dev ruff check hermes_cli/auth.py hermes_cli/models.py hermes_cli/runtime_provider.py agent/model_metadata.py tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_api_key_providers.py tests/agent/test_model_metadata_local_ctx.py
```

All targeted tests and ruff passed.

Also attempted:

```bash
uv run --python python3.13 --extra dev python -m pytest tests/ -q
```

This failed during collection because the local environment is missing the `acp` module, before these LM Studio tests ran.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — URL normalization only, covered by unit tests
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Targeted test summary:

```text
7 passed: tests/hermes_cli/test_model_validation.py -k lmstudio
5 passed: tests/hermes_cli/test_runtime_provider_resolution.py -k lmstudio
3 passed: tests/hermes_cli/test_api_key_providers.py -k lmstudio
8 passed: tests/agent/test_model_metadata_local_ctx.py -k lmstudio
ruff: All checks passed
```
