### PR TITLE
fix(update): reinstall active memory provider deps after update (#53272)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7438,6 +7438,50 @@ def _refresh_active_lazy_features() -> None:
         print("  `hermes update` once the upstream issue is resolved.")
 
 
+def _refresh_active_memory_provider() -> None:
+    """Reinstall pip dependencies for the active memory provider after an update.
+
+    Mirrors :func:`_refresh_active_lazy_features` for memory-provider plugins.
+    ``hermes update`` rebuilds the venv (``uv pip install -e .[all]``), which
+    removes plugin dependencies declared in ``plugin.yaml`` (e.g. ``mem0ai``
+    for the Mem0 OSS provider) that ``hermes memory setup`` installed but that
+    are not part of the core ``.[all]`` extra. Without this step the active
+    provider's backend fails to import on the next gateway start
+    (``No module named 'mem0'``) even though ``hermes memory status`` still
+    reports it as installed.
+
+    ``memory_setup._install_dependencies`` is idempotent — it only installs
+    packages that fail to import — so re-running it on every update is a safe
+    no-op when the provider's deps are already present.
+
+    Never raises. A failure here must not block the rest of the update.
+    """
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.memory_setup import _install_dependencies
+    except Exception as exc:
+        logger.debug("Memory provider refresh skipped (import failed): %s", exc)
+        return
+
+    try:
+        provider = (load_config().get("memory", {}) or {}).get("provider", "")
+    except Exception as exc:
+        logger.debug("Memory provider refresh skipped (config read failed): %s", exc)
+        return
+
+    if not provider:
+        return
+
+    print()
+    print(f"→ Refreshing active memory provider '{provider}' dependencies...")
+    try:
+        _install_dependencies(provider)
+    except Exception as exc:
+        # _install_dependencies swallows its own install errors, but defend
+        # the update flow against unexpected provider/config failures.
+        print(f"  ⚠ Memory provider refresh failed unexpectedly: {exc}")
+
+
 def _install_python_dependencies_with_optional_fallback(
     install_cmd_prefix: list[str],
     *,
@@ -9326,6 +9370,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         _clear_update_incomplete_marker()
 
         _refresh_active_lazy_features()
+        _refresh_active_memory_provider()
 
         _update_node_dependencies()
         _build_web_ui(PROJECT_ROOT / "web")

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -394,6 +394,7 @@ def _setup_update_mocks(monkeypatch, tmp_path):
     monkeypatch.setattr(hermes_config, "check_config_version", lambda: (5, 5))
     monkeypatch.setattr(hermes_config, "migrate_config", lambda **kw: {"env_added": [], "config_added": []})
     monkeypatch.setattr(hermes_main, "_refresh_active_lazy_features", lambda: None)
+    monkeypatch.setattr(hermes_main, "_refresh_active_memory_provider", lambda: None)
 
 
 def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypatch, tmp_path, capsys):

--- a/tests/hermes_cli/test_update_refresh_memory_provider.py
+++ b/tests/hermes_cli/test_update_refresh_memory_provider.py
@@ -1,0 +1,100 @@
+"""Regression tests for active memory-provider dependency refresh during ``hermes update``.
+
+Issue #53272: ``hermes update`` rebuilds the venv and drops memory-provider
+plugin ``pip_dependencies`` (e.g. ``mem0ai``) installed by ``hermes memory
+setup``, but never reinstalls them — so the active provider's backend fails to
+import after an update.
+
+These tests cover ``_refresh_active_memory_provider``: the function the update
+flow calls (alongside ``_refresh_active_lazy_features``) to reinstall the
+*active* memory provider's missing deps. The config read and the install
+subprocess are mocked; the routing logic under test is real.
+"""
+
+from hermes_cli import main as hermes_main
+
+
+def test_refresh_calls_install_dependencies_when_provider_set(monkeypatch):
+    """A configured ``memory.provider`` must trigger a reinstall of its deps."""
+    calls = []
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": {"provider": "mem0"}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.memory_setup._install_dependencies",
+        lambda name: calls.append(name),
+    )
+
+    hermes_main._refresh_active_memory_provider()
+
+    assert calls == ["mem0"]
+
+
+def test_refresh_skips_when_no_provider_configured(monkeypatch):
+    """An empty provider string must not trigger any install."""
+    calls = []
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": {"provider": ""}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.memory_setup._install_dependencies",
+        lambda name: calls.append(name),
+    )
+
+    hermes_main._refresh_active_memory_provider()
+
+    assert calls == []
+
+
+def test_refresh_skips_when_memory_section_absent(monkeypatch):
+    """A config without a ``memory`` section must not trigger any install."""
+    calls = []
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.memory_setup._install_dependencies",
+        lambda name: calls.append(name),
+    )
+
+    hermes_main._refresh_active_memory_provider()
+
+    assert calls == []
+
+
+def test_refresh_never_raises_on_install_failure(monkeypatch):
+    """An exception from the installer must not escape into the update flow."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": {"provider": "mem0"}},
+    )
+
+    def boom(name):
+        raise RuntimeError("install exploded")
+
+    monkeypatch.setattr("hermes_cli.memory_setup._install_dependencies", boom)
+
+    # Must not raise — update must complete even if the provider refresh fails.
+    hermes_main._refresh_active_memory_provider()
+
+
+def test_refresh_never_raises_on_config_read_failure(monkeypatch):
+    """A broken config read must not escape into the update flow."""
+    calls = []
+
+    def bad_load_config():
+        raise OSError("config file vanished")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", bad_load_config)
+    monkeypatch.setattr(
+        "hermes_cli.memory_setup._install_dependencies",
+        lambda name: calls.append(name),
+    )
+
+    # Must not raise.
+    hermes_main._refresh_active_memory_provider()
+
+    assert calls == []


### PR DESCRIPTION
## What

After `hermes update` rebuilds the venv (`uv pip install -e .[all]`), memory-provider plugin dependencies declared in `plugin.yaml` (e.g. `mem0ai` for the Mem0 OSS provider) — installed by `hermes memory setup` but not part of the core `.[all]` extra — are lost. On the next gateway start the active provider's backend fails:

```
ERROR plugins.memory.mem0: Mem0 backend failed to initialize (oss mode): No module named 'mem0'
```

## Fix

Add `_refresh_active_memory_provider()` to the update flow, mirroring the existing `_refresh_active_lazy_features()` for lazy backends. It reads `memory.provider` from config and calls the idempotent `memory_setup._install_dependencies(provider)` — which only installs packages that fail to `__import__`, so it is a safe no-op when deps are already present. Called immediately after `_refresh_active_lazy_features()` in `_cmd_update_impl`. Never raises.

## Why this approach

The update flow already has an analogous step for lazy backends (`_refresh_active_lazy_features`). Memory-provider plugin deps are the same class of problem — deps installed post-setup that survive until the next venv rebuild — and get the same treatment.

## Verification

- **RED (upstream/main):** 5 regression tests fail with `AttributeError: module 'hermes_cli.main' has no attribute '_refresh_active_memory_provider'`.
- **GREEN (this branch):** all 5 pass.
- **Regression sweep:** `test_update_autostash.py` (33 tests, full update flow) — all pass.

```
tests/hermes_cli/test_update_refresh_memory_provider.py .....                      [100%]  5 passed
tests/hermes_cli/test_update_autostash.py .................................        [100%] 33 passed
```

Test cases cover: provider set → install called; empty provider → skip; no `memory` section → skip; install failure → no raise; config read failure → no raise.

## Scope

Root-cause fix (Layer 1). The issue also mentions `hermes memory status` showing "available ✓" when broken and `hermes doctor` warning about `MEM0_API_KEY` in OSS mode — both framed as an "OR" alternative mitigation and belonging in separate branches.

Fixes #53272.

---
*Auto-published by Moonsong via Path B automated pipeline.*
