### PR TITLE
test(acp): use socketpair transport so ping-suppression e2e runs on Windows

### DIFF
--- a/tests/acp/test_ping_suppression.py
+++ b/tests/acp/test_ping_suppression.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
+import socket
 from io import StringIO
 
 import pytest
@@ -121,49 +121,35 @@ async def test_bare_ping_request_produces_proper_response_and_no_stderr_noise(
     # Also suppress propagation of caplog's default handler interfering with
     # our stream (caplog still captures via its own propagation hook).
     try:
-        loop = asyncio.get_running_loop()
+        # Full-duplex in-memory transport. ``socket.socketpair()`` +
+        # ``asyncio.open_connection(sock=...)`` works on the Windows
+        # ProactorEventLoop, whereas anonymous ``os.pipe()`` FDs cannot be
+        # registered with the IOCP -- ``connect_read_pipe``/``connect_write_pipe``
+        # raise ``OSError: [WinError 6] The handle is invalid`` there. Both are
+        # plain byte streams, so the JSON-RPC framing under test is unchanged.
+        client_sock, agent_sock = socket.socketpair()
 
-        # Pipe client -> agent
-        client_to_agent_r, client_to_agent_w = os.pipe()
-        # Pipe agent -> client
-        agent_to_client_r, agent_to_client_w = os.pipe()
-
-        in_read_file = os.fdopen(client_to_agent_r, "rb", buffering=0)
-        in_write_file = os.fdopen(client_to_agent_w, "wb", buffering=0)
-        out_read_file = os.fdopen(agent_to_client_r, "rb", buffering=0)
-        out_write_file = os.fdopen(agent_to_client_w, "wb", buffering=0)
-
-        # Agent reads its input from this StreamReader:
-        agent_input = asyncio.StreamReader(limit=1024 * 1024, loop=loop)
-        agent_input_proto = asyncio.StreamReaderProtocol(agent_input, loop=loop)
-        await loop.connect_read_pipe(lambda: agent_input_proto, in_read_file)
-
-        # Agent writes its output via this StreamWriter:
-        out_transport, out_protocol = await loop.connect_write_pipe(
-            asyncio.streams.FlowControlMixin, out_write_file
-        )
-        agent_output = asyncio.StreamWriter(out_transport, out_protocol, None, loop)
-
-        # Test harness reads agent output via this StreamReader:
-        client_input = asyncio.StreamReader(limit=1024 * 1024, loop=loop)
-        client_input_proto = asyncio.StreamReaderProtocol(client_input, loop=loop)
-        await loop.connect_read_pipe(lambda: client_input_proto, out_read_file)
+        # Agent side: reads requests from ``agent_reader``, writes responses to
+        # ``agent_writer``.
+        agent_reader, agent_writer = await asyncio.open_connection(sock=agent_sock)
+        # Test-harness side: writes the request, reads the response.
+        client_reader, client_writer = await asyncio.open_connection(sock=client_sock)
 
         agent_task = asyncio.create_task(
             acp.run_agent(
                 _FakeAgent(),
-                input_stream=agent_output,
-                output_stream=agent_input,
+                input_stream=agent_writer,
+                output_stream=agent_reader,
                 use_unstable_protocol=True,
             )
         )
 
         # Send a bare `ping`
         request = {"jsonrpc": "2.0", "id": 1, "method": "ping", "params": {}}
-        in_write_file.write((json.dumps(request) + "\n").encode())
-        in_write_file.flush()
+        client_writer.write((json.dumps(request) + "\n").encode())
+        await client_writer.drain()
 
-        response_line = await asyncio.wait_for(client_input.readline(), timeout=5.0)
+        response_line = await asyncio.wait_for(client_reader.readline(), timeout=5.0)
         # Give the supervisor task a tick to fire (filter should eat it)
         await asyncio.sleep(0.2)
 
@@ -176,8 +162,8 @@ async def test_bare_ping_request_produces_proper_response_and_no_stderr_noise(
             f"ping noise leaked to stderr:\n{logs}"
         )
 
-        # Clean shutdown
-        in_write_file.close()
+        # Clean shutdown: closing the client side signals EOF to the agent.
+        client_writer.close()
         try:
             await asyncio.wait_for(agent_task, timeout=2.0)
         except (asyncio.TimeoutError, Exception):


### PR DESCRIPTION
## What

Replace this ACP test's anonymous `os.pipe()` transport with `socket.socketpair()` plus `asyncio.open_connection(sock=...)`.

## Why

On native Windows, `ProactorEventLoop` cannot register anonymous pipe file descriptors with IOCP. The test therefore fails during its own transport setup with:

```text
_overlapped.CreateIoCompletionPort(...)
OSError: [WinError 6] The handle is invalid
```

That happens before `acp.run_agent` runs, so the production ping handler and `_BenignProbeMethodFilter` are never exercised. This is the ACP test baseline failure tracked in #48986.

Sockets are supported by the Proactor loop and preserve the test's byte-stream JSON-RPC behavior. The existing `-32601` response and no-`Background task failed` assertions remain unchanged. There is no platform branch.

## Current-main A/B proof

Fresh native-Windows verification on CPython 3.12.11 using `ProactorEventLoop`, after rebasing onto `main` at `9f384783e`:

- Current `main`: `1 failed, 8 passed`; the E2E test fails at `CreateIoCompletionPort` with `WinError 6`.
- This branch (`862e2b53b`): `9 passed`.
- Per-file parallel runner on this branch: `9 passed, 0 failed`.
- `git diff --check upstream/main...HEAD`: clean.

The canonical wrapper also reports `9 passed` when its Windows interpreter is forced to UTF-8. The wrapper's separate UTF-8/bootstrap fix is already covered by #67387; this PR changes only the ACP test transport.

## Scope

One test file, `+21/-35`. No production behavior, dependency, or lockfile changes.

Part of #48986.