### PR TITLE
fix(tui): preserve filtered model provider selection

### DIFF
--- a/ui-tui/src/__tests__/modelPicker.test.ts
+++ b/ui-tui/src/__tests__/modelPicker.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { providerIndexAfterClearingFilter } from '../components/modelPicker.js'
+import type { ModelOptionProvider } from '../gatewayTypes.js'
+
+const provider = (slug: string, name = slug): ModelOptionProvider => ({ name, slug })
+
+describe('ModelPicker provider filtering', () => {
+  it('keeps the selected provider when clearing the provider filter', () => {
+    const nous = provider('nous', 'Nous Portal')
+    const ollama = provider('ollama-cloud', 'Ollama Cloud')
+
+    const rows = [
+      { name: nous.name, provider: nous },
+      { name: ollama.name, provider: ollama }
+    ]
+
+    // With a provider-stage filter like "ollama", the selected row is index 0
+    // in the filtered list, but index 1 in the full list after setFilter('').
+    expect(providerIndexAfterClearingFilter(rows, ollama)).toBe(1)
+  })
+})

--- a/ui-tui/src/__tests__/modelPicker.test.ts
+++ b/ui-tui/src/__tests__/modelPicker.test.ts
@@ -19,4 +19,36 @@ describe('ModelPicker provider filtering', () => {
     // in the filtered list, but index 1 in the full list after setFilter('').
     expect(providerIndexAfterClearingFilter(rows, ollama)).toBe(1)
   })
+
+  it('returns -1 when provider is undefined', () => {
+    const rows = [
+      { name: 'A', provider: provider('a') }
+    ]
+
+    expect(providerIndexAfterClearingFilter(rows, undefined)).toBe(-1)
+  })
+
+  it('returns -1 when provider slug is not in rows', () => {
+    const rows = [
+      { name: 'A', provider: provider('a') },
+      { name: 'B', provider: provider('b') }
+    ]
+
+    expect(providerIndexAfterClearingFilter(rows, provider('missing'))).toBe(-1)
+  })
+
+  it('returns -1 for empty rows', () => {
+    expect(providerIndexAfterClearingFilter([], provider('a'))).toBe(-1)
+  })
+
+  it('finds the first match when multiple rows share a slug', () => {
+    const p = provider('dup')
+
+    const rows = [
+      { name: 'First', provider: p },
+      { name: 'Second', provider: p }
+    ]
+
+    expect(providerIndexAfterClearingFilter(rows, p)).toBe(0)
+  })
 })

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -134,8 +134,17 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
   const back = () => {
     // Esc first clears an active filter on the list stages, before navigating.
     if ((stage === 'provider' || stage === 'model') && filter.trim()) {
+      // Preserve the selected provider across filter clear (same fix as
+      // Enter→key/model and Ctrl+D transitions above).
+      const fullProviderIdx = providerIndexAfterClearingFilter(providerRows, provider)
+
+      if (fullProviderIdx >= 0) {
+        setProviderIdx(fullProviderIdx)
+      } else if (stage === 'provider') {
+        setProviderIdx(0)
+      }
+
       setFilter('')
-      setProviderIdx(stage === 'provider' ? 0 : providerIdx)
       setModelIdx(0)
 
       return

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -17,6 +17,16 @@ const MAX_WIDTH = 90
 
 type Stage = 'provider' | 'key' | 'model' | 'disconnect'
 
+type ProviderRow = { name: string; provider: ModelOptionProvider }
+
+export function providerIndexAfterClearingFilter(providerRows: ProviderRow[], provider: ModelOptionProvider | undefined) {
+  if (!provider) {
+    return -1
+  }
+
+  return providerRows.findIndex(row => row.provider.slug === provider.slug)
+}
+
 export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect, sessionId, t }: ModelPickerProps) {
   const [providers, setProviders] = useState<ModelOptionProvider[]>([])
   const [currentModel, setCurrentModel] = useState('')
@@ -307,6 +317,12 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
         if (provider.authenticated === false) {
           // api_key providers: prompt for key inline
           if (provider.auth_type === 'api_key' && provider.key_env) {
+            const fullProviderIdx = providerIndexAfterClearingFilter(providerRows, provider)
+
+            if (fullProviderIdx >= 0) {
+              setProviderIdx(fullProviderIdx)
+            }
+
             setStage('key')
             setKeyInput('')
             setKeyError('')
@@ -315,6 +331,12 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
 
           // Other auth types: no-op (warning shown tells them to run hermes model)
           return
+        }
+
+        const fullProviderIdx = providerIndexAfterClearingFilter(providerRows, provider)
+
+        if (fullProviderIdx >= 0) {
+          setProviderIdx(fullProviderIdx)
         }
 
         setStage('model')
@@ -365,7 +387,14 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
 
     // Disconnect (Ctrl+D): only in provider stage, only for authenticated providers.
     if (key.ctrl && ch === 'd' && stage === 'provider' && provider?.authenticated !== false) {
+      const fullProviderIdx = providerIndexAfterClearingFilter(providerRows, provider)
+
+      if (fullProviderIdx >= 0) {
+        setProviderIdx(fullProviderIdx)
+      }
+
       setStage('disconnect')
+      setFilter('')
 
       return
     }


### PR DESCRIPTION
## Summary
Fixes the TUI `/model` picker losing the selected provider when transitioning stages after filtering — selecting "Ollama Cloud" from a filtered list no longer becomes "Nous Portal" on the key-entry screen.

Salvage of #53287 (@donovan-yohan). Fixes #53286.

## Root cause
`providerIdx` indexes `filteredProviderRows`, but the filter only applies when `stage === 'provider'`. On stage transitions (key entry, model selection, disconnect), `setFilter('')` is called, making `filteredProviderRows` return the full unfiltered list — but `providerIdx` stays at its filtered position, pointing to a different provider.

## Changes
- `ui-tui/src/components/modelPicker.tsx`: Added `providerIndexAfterClearingFilter()` helper that finds the provider's index in the full (unfiltered) list by slug. Called before all 3 stage transitions that clear the filter (key entry, model selection, disconnect confirmation).
- `ui-tui/src/__tests__/modelPicker.test.ts`: Test verifying the helper correctly maps a filtered index back to the full-list index.

## Validation
| | Before | After |
|---|---|---|
| Filtered provider selection | Wrong provider on next screen | Correct provider preserved |
| Typecheck | — | Pass |
| ESLint | — | Pass |
| Tests | 0 | 1 test pass |

@donovan-yohan's authorship preserved via cherry-pick.
