### PR TITLE
fix(vision): reject corrupt PNGs before native vision embed

### DIFF
--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -15,8 +15,14 @@ from unittest.mock import patch
 import pytest
 
 
-PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+# Minimal valid 1x1 PNG bytes. Resolver validation requires a decodable fixture.
+PNG = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+)
 JPEG = b"\xff\xd8\xff" + b"\x00" * 64
+CORRUPT_PNG = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAFElEQVR4nGP8z8Dwn4EIwESJ5gAAVQ4CH1evYJQAAAAASUVORK5CYII="
+)
 
 
 def _reload(monkeypatch, hermes_home: Path):
@@ -56,6 +62,16 @@ class TestDataUrl:
         with pytest.raises(isrc.NotAnImage):
             await isrc.resolve_image_source(
                 f"data:text/plain;base64,{b64}", isrc.ResolveContext())
+
+    @pytest.mark.asyncio
+    async def test_corrupt_png_rejected_at_resolver_boundary(self, tmp_path, monkeypatch):
+        """A PNG-shaped but undecodable payload never becomes a resolved image."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        img = tmp_path / "corrupt.png"
+        img.write_bytes(CORRUPT_PNG)
+        with pytest.raises(isrc.NotAnImage):
+            await isrc.resolve_image_source(str(img), isrc.ResolveContext())
 
 
 class TestLocalBackend:

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -27,6 +27,11 @@ _TINY_PNG = base64.b64decode(
     b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
 )
 
+# PNG header only — IDAT does not zlib-decompress (LLM-hallucinated test fixture).
+_CORRUPT_PNG = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAFElEQVR4nGP8z8Dwn4EIwESJ5gAAVQ4CH1evYJQAAAAASUVORK5CYII="
+)
+
 
 # ─── _supports_media_in_tool_results ─────────────────────────────────────────
 
@@ -138,6 +143,18 @@ class TestVisionAnalyzeNative:
         )
         assert isinstance(result, dict)
         assert result.get("_multimodal") is True
+
+    def test_corrupt_png_rejected_before_native_embed(self, tmp_path):
+        """Header-only PNG bytes must not enter conversation history."""
+        img = tmp_path / "bad.png"
+        img.write_bytes(_CORRUPT_PNG)
+        result = asyncio.get_event_loop().run_until_complete(
+            _vision_analyze_native(str(img), "what is this?")
+        )
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert parsed.get("success") is False
+        assert "Only real image files" in parsed.get("error", "")
 
     def test_oversized_image_resized_under_embed_cap(self, tmp_path):
         """Regression for the wedged-session incident (May 2026).

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -27,6 +27,11 @@ _TINY_PNG = base64.b64decode(
     b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
 )
 
+# PNG-shaped but undecodable; resolver/native fast path must reject it.
+_CORRUPT_PNG = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAFElEQVR4nGP8z8Dwn4EIwESJ5gAAVQ4CH1evYJQAAAAASUVORK5CYII="
+)
+
 
 # ─── _supports_media_in_tool_results ─────────────────────────────────────────
 
@@ -103,6 +108,19 @@ class TestVisionAnalyzeNative:
         )
         assert isinstance(result, dict)
         assert result.get("_multimodal") is True
+
+    def test_corrupt_png_rejected_before_native_embed(self, tmp_path):
+        """Header-only PNG bytes must not enter conversation history."""
+        img = tmp_path / "bad.png"
+        img.write_bytes(_CORRUPT_PNG)
+        result = asyncio.get_event_loop().run_until_complete(
+            _vision_analyze_native(str(img), "what is this?")
+        )
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert parsed.get("success") is False
+        assert "multimodal" not in parsed
+        assert "recognized image" in parsed.get("error", "")
 
     def test_oversized_image_resized_under_embed_cap(self, tmp_path):
         """Regression for the wedged-session incident (May 2026).

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -33,6 +33,7 @@ import json
 import logging
 import os
 import uuid
+import zlib
 from pathlib import Path
 from typing import Any, Awaitable, Dict, Optional
 from urllib.parse import urlparse
@@ -106,13 +107,43 @@ async def _validate_image_url_async(url: str) -> bool:
     return await async_is_safe_url(url)
 
 
+def _png_zlib_payload_is_valid(image_path: Path) -> bool:
+    """Return True when a PNG file's concatenated IDAT stream decompresses."""
+    try:
+        data = image_path.read_bytes()
+    except OSError:
+        return False
+    if not data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return False
+
+    idat_parts: list[bytes] = []
+    offset = 8
+    while offset + 8 <= len(data):
+        length = int.from_bytes(data[offset : offset + 4], "big")
+        chunk_type = data[offset + 4 : offset + 8]
+        chunk_end = offset + 8 + length + 4
+        if chunk_end > len(data):
+            return False
+        if chunk_type == b"IDAT":
+            idat_parts.append(data[offset + 8 : offset + 8 + length])
+        offset = chunk_end
+
+    if not idat_parts:
+        return False
+    try:
+        zlib.decompress(b"".join(idat_parts))
+    except zlib.error:
+        return False
+    return True
+
+
 def _detect_image_mime_type(image_path: Path) -> Optional[str]:
     """Return a MIME type when the file looks like a supported image."""
     with image_path.open("rb") as f:
         header = f.read(64)
 
     if header.startswith(b"\x89PNG\r\n\x1a\n"):
-        return "image/png"
+        return "image/png" if _png_zlib_payload_is_valid(image_path) else None
     if header.startswith(b"\xff\xd8\xff"):
         return "image/jpeg"
     if header.startswith((b"GIF87a", b"GIF89a")):

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -33,6 +33,7 @@ import contextlib
 import asyncio
 import json
 from concurrent.futures import ThreadPoolExecutor
+from io import BytesIO
 import logging
 import os
 import uuid
@@ -251,6 +252,15 @@ def _detect_image_mime_type_from_bytes(data: bytes) -> Optional[str]:
     """
     header = data[:64]
     if header.startswith(b"\x89PNG\r\n\x1a\n"):
+        # Magic bytes alone are insufficient: native vision history is
+        # immutable, so reject corrupt PNGs before they can be embedded.
+        try:
+            from PIL import Image
+
+            with Image.open(BytesIO(data)) as image:
+                image.verify()
+        except Exception:
+            return None
         return "image/png"
     if header.startswith(b"\xff\xd8\xff"):
         return "image/jpeg"


### PR DESCRIPTION
This fixes a rather annoying state that can occur when you try to use an invalid png as input to vision.

## Summary

- Validate that PNG `IDAT` chunks zlib-decompress before `vision_analyze` treats a file as a real image.
- Prevents header-only / hallucinated PNG bytes from being embedded into conversation history on the native-vision fast path, which can permanently wedge a session when the provider rejects the image on every subsequent turn.

## Reproduce the bug (before this fix)

1. Run Hermes with a vision-capable main model on a provider that accepts native tool-result images (e.g. `openai-codex` + `gpt-5.5`).
2. Write a file that looks like a PNG but has corrupt compressed data — for example the LLM-hallucinated 10×10 red PNG from a tool health check:

```python
import base64, pathlib
png = "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAFElEQVR4nGP8z8Dwn4EIwESJ5gAAVQ4CH1evYJQAAAAASUVORK5CYII="
pathlib.Path("red.png").write_bytes(base64.b64decode(png))
```

3. Call `vision_analyze(image_url="red.png", ...)`.
4. **Before:** Hermes accepts the file (magic bytes match), embeds it via the native fast path, and the next provider call fails with HTTP 400 (`The image data you provided does not represent a valid image`). Because the bad image stays in immutable session history, **every later message in that session fails the same way** — even plain text follow-ups.
5. **After:** `vision_analyze` returns a tool error (`Only real image files are supported for vision analysis.`) and no image is embedded.

## Test plan

- [x] `pytest tests/tools/test_vision_native_fast_path.py::TestVisionAnalyzeNative::test_corrupt_png_rejected_before_native_embed`
- [x] Existing native fast-path tests still pass