### PR TITLE
feat: skill-resolver + check-resolvable — thin harness routing for agent skills

### DIFF
--- a/plugins/google_meet/meet_bot.py
+++ b/plugins/google_meet/meet_bot.py
@@ -545,6 +545,7 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
             browser = pw.chromium.launch(
                 headless=not headed,
                 args=chrome_args,
+                channel="chrome" if sys.platform == "darwin" else None,
             )
             context_args = {
                 "viewport": {"width": 1280, "height": 800},
@@ -760,7 +761,11 @@ def _detect_admission(page) -> bool:
     """
     probe = r"""
     (() => {
-      const leave = document.querySelector('button[aria-label*="eave call" i]');
+      const leave = document.querySelector(
+        'button[aria-label*="eave call" i], ' +
+        'button[aria-label*="eave meeting" i], ' +
+        'div[role="button"][aria-label*="eave" i]'
+      );
       if (leave) return true;
       if (window.__hermesMeetInstalled) {
         const caps = document.querySelector(

--- a/skills/autonomous-ai-agents/check-resolvable/SKILL.md
+++ b/skills/autonomous-ai-agents/check-resolvable/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: check-resolvable
+description: "Use when checking reachability of all skills from the resolver chain — walk RESOLVER.md → skill descriptions → files, find dark skills (no resolver path), dead triggers (wrong description), and unreachable capabilities."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [resolver, audit, reachability, meta-skill, linter]
+    related_skills: [skill-resolver, hermes-agent-skill-authoring]
+---
+
+# Check-Resolvable — Resolver Reachability Auditor
+
+## Purpose
+
+This meta-skill audits the entire resolver chain to find dark capabilities, dead paths, and unreachable skills. It is the resolver equivalent of a lint pass. Run it after creating new skills or when routing seems wrong.
+
+## Audit Procedure
+
+### Step 1: Gather the Ground Truth
+
+1. Read all RESOLVER.md files across the skills tree
+2. Read `skill-resolver`'s decision table
+3. List all installed skills via `skills_list`
+
+### Step 2: Build the Reachability Matrix
+
+For every skill found:
+
+**Check A — Is there a path in any RESOLVER.md?**
+- Does the top-level or any category-level RESOLVER.md mention this skill?
+- Does `skill-resolver`'s decision table mention it?
+- If NO to all three → **DARK SKILL**
+
+**Check B — Does the resolver trigger match the skill description?**
+- Read the resolver's trigger phrase
+- Read the skill's `description` field
+- If they diverge → **DRIFT WARNING**
+
+**Check C — Does the skill file actually load?**
+- Can `skill_view(name)` return the SKILL.md?
+- Does the frontmatter parse cleanly?
+- If not → **DEAD SKILL**
+
+### Step 3: Report Results
+
+Output a structured report with:
+- N reachable / N total
+- Dark skills list with remediation
+- Dead triggers list
+- Drift warnings list
+
+### Step 4: Fix
+
+For each finding, either:
+1. **Fix immediately** — patch the RESOLVER.md or skill-resolver
+2. **Create a Kanban task** — for gaps needing deeper work
+
+## Trigger Evals
+
+| Input | Expected skill |
+|---|---|
+| "setup hermes gateway" | hermes-agent |
+| "review this PR" | github-code-review |
+| "debug this python crash" | python-debugpy |
+| "design an architecture diagram" | architecture-diagram |
+| "search for papers on RLHF" | arxiv |
+| "serve this model with vllm" | serving-llms-vllm |
+| "create a new skill for PDF extraction" | hermes-agent-skill-authoring |
+| "make a p5.js generative art sketch" | p5js |
+
+## Common Pitfalls
+
+1. **RESOLVER.md and skill-resolver get out of sync.** Both must match.
+2. **Forgetting to re-check after creating a skill.** Every create should trigger a check-resolvable pass.
+3. **Old deleted skills still in RESOLVER.md.** Dead triggers confuse routing.
+4. **Category resolvers going stale.**
+
+## Verification Checklist
+
+- [ ] Every skill in skills_list has a path from at least one RESOLVER.md
+- [ ] Every entry in every RESOLVER.md points to a skill that exists
+- [ ] skill-resolver decision table matches canonical RESOLVER.md
+- [ ] No unresolved dark skills
+- [ ] All gaps fixed (patch) or ticketed (Kanban task)

--- a/skills/autonomous-ai-agents/skill-resolver/SKILL.md
+++ b/skills/autonomous-ai-agents/skill-resolver/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: skill-resolver
+description: "Use when this is your first task or the task is ambiguous — load this resolver skill first, read the routing tree, then dispatch to the matching leaf skill. Always loaded in every session by default."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [resolver, routing, meta-skill, thin-harness, dispatcher]
+    related_skills: [hermes-agent-skill-authoring, check-resolvable]
+---
+
+# Skill Resolver — Thin Harness Routing Skill
+
+THIS IS THE FIRST SKILL THAT MUST LOAD IN EVERY SESSION. It is the thin routing table — the "harness" in Garry Tan's "Thin Harness, Fat Skills" pattern.
+
+## Behavior Contract
+
+1. When you receive a task, load this skill (if not already loaded).
+2. Read the matching branch in the decision tree below.
+3. Load the leaf skill(s) it points to.
+4. Execute using the leaf skill's instructions.
+5. If no match exists in the tree, load `skill-resolver` again and walk the tree more carefully before falling back to `skills_list`.
+
+## Decision Tree (Compact)
+
+| Task signal | Load skill(s) |
+|---|---|
+| "setup hermes", "config", "gateway", "profile", "model", "tools", "cron", "webhook", "mcp", "auth", "doctor" | `hermes-agent` |
+| "author skill", "create skill", "edit skill", "skill frontmatter", "SKILL.md" | `hermes-agent-skill-authoring` |
+| "delegate", "subagent", "spawn worker" | `subagent-driven-development` |
+| "clone repo", "create repo", "new repo", "fork", "release" | `github-repo-management` |
+| "new PR", "open PR", "push branch", "CI failed" | `github-pr-workflow` |
+| "review PR", "code review", "review changes" | `github-code-review` |
+| "GitHub issue", "create issue", "triage issue" | `github-issues` |
+| "auth github", "github token", "ssh key github" | `github-auth` |
+| "codebase stats", "lines of code", "LOC" | `codebase-inspection` |
+| "debug python", "pdb", "debugpy" | `python-debugpy` |
+| "debug node", "inspect node", "chrome devtools" | `node-inspect-debugger` |
+| "rust tui", "ratatui", "terminal UI" | `rust-tui-development` |
+| "research paper", "arxiv", "academic" | `arxiv` |
+| "blog monitor", "rss", "feed" | `blogwatcher` |
+| "polymarket", "prediction market", "betting" | `polymarket` |
+| "youtube transcript", "youtube summary" | `youtube-content` |
+| "wiki", "knowledge base", "llm wiki" | `llm-wiki` |
+| "benchmark llm", "evaluate model", "mmlu", "gsm8k" | `evaluating-llms-harness` |
+| "serve llm", "vllm", "deploy model" | `serving-llms-vllm` |
+| "llama.cpp", "GGUF", "local inference" | `llama-cpp` |
+| "huggingface", "hf download", "model search" | `huggingface-hub` |
+| "abliterate", "refusal", "uncensor" | `obliteratus` |
+| "dspy", "prompt optimizer", "rag program" | `dspy` |
+| "wandb", "weights and biases", "experiment track" | `weights-and-biases` |
+| "musicgen", "audiocraft", "audio gen" | `audiocraft-audio-generation` |
+| "segment anything", "sam", "image segmentation" | `segment-anything-model` |
+| "diagram", "architecture diagram", "infra diagram" | `architecture-diagram` |
+| "ascii art", "figlet", "cowsay" | `ascii-art` |
+| "ascii video", "terminal video" | `ascii-video` |
+| "comfyui", "workflow", "image gen pipeline" | `comfyui` |
+| "excalidraw", "hand-drawn diagram", "whiteboard" | `excalidraw` |
+| "prototype", "mockup", "html mockup" | `sketch` |
+| "landing page", "design artifact", "HTML design" | `claude-design` |
+| "manim", "animation", "3b1b" | `manim-video` |
+| "p5js", "creative coding", "processing" | `p5js` |
+| "pixel art", "sprite", "retro graphics" | `pixel-art` |
+| "songwriting", "music prompt", "suno" | `songwriting-and-ai-music` |
+| "touchdesigner", "visuals", "realtime" | `touchdesigner-mcp` |
+| "social post", "brand post", "content production" | `brand-social-post-production` |
+| "article illustration", "illustration" | `baoyu-article-illustrator` |
+| "comic", "knowledge comic", "educational comic" | `baoyu-comic` |
+| "infographic", "info graphic", "visualization" | `baoyu-infographic` |
+| "ideation", "brainstorm", "idea generation" | `ideation` |
+| "humanize", "remove ai", "natural text" | `humanizer` |
+| "design token", "DESIGN.md" | `design-md` |
+| "jupyter", "notebook", "data analysis" | `jupyter-live-kernel` |
+| "email", "himalaya", "send mail", "read mail" | `himalaya` |
+| "twitter", "x.com", "post tweet", "xurl" | `xurl` |
+| "minecraft server", "modpack" | `minecraft-modpack-server` |
+| "pokemon", "emulator", "gameboy" | `pokemon-player` |
+| "google workspace", "gmail", "google docs", "google sheets", "google calendar", "google drive" | `google-workspace` |
+| "notion", "notion api" | `notion` |
+| "obsidian", "obsidian vault", "note" | `obsidian` |
+| "airtable", "base", "records" | `airtable` |
+| "powerpoint", "pptx", "slide deck" | `powerpoint` |
+| "edit pdf", "pdf text", "nano-pdf" | `nano-pdf` |
+| "ocr", "extract text", "scan pdf" | `ocr-and-documents` |
+| "linear", "linear issue", "linear ticket" | `linear` |
+| "maps", "geocode", "directions", "route" | `maps` |
+| "teams meeting", "meeting summary" | `teams-meeting-pipeline` |
+| "petdex", "mascot", "pet" | `petdex` |
+| "apple notes", "memo" | `apple-notes` |
+| "apple reminders", "reminders" | `apple-reminders` |
+| "findmy", "airtag", "find device" | `findmy` |
+| "imessage", "sms", "text message" | `imessage` |
+| "computer use", "desktop automation", "click", "macos" | `computer-use` + `macos-computer-use` |
+| "cua driver", "computer use setup" | `macos-cua-driver-setup` |
+| "philips hue", "smart light", "openhue" | `openhue` |
+| "shannon", "pentest", "security audit", "vuln scan" | `shannon` |
+| "jailbreak", "godmode", "red team" | `godmode` |
+| "dogfood", "qa test", "bug hunt", "exploratory" | `dogfood` |
+| "spotify", "playlist", "music" | `spotify` |
+| "gif", "tenor", "animation" | `gif-search` |
+| "write plan", "implementation plan" | `writing-plans` |
+| "plan mode", ".hermes/plans" | `plan` |
+| "spike", "experiment", "prototype research" | `spike` |
+| "check resolvable", "reachability audit", "dark skills" | `check-resolvable` |
+| "gateway ops", "hermes gateway", "container health" | `hermes-gateway-ops` |
+| "fleet memory", "memory audit" | `fleet-memory-audit` |
+| "mcp server", "mcp setup" | `native-mcp` |
+| "webhook", "webhook subscribe" | `webhook-subscriptions` |
+| "iris design", "iris agent", "designer agent" | `iris` |
+| "provision vision", "vision debug", "multimodal debug" | `provider-vision-debugging` |
+| "pop culture design", "web design reference", "stripe design", "linear design", "vercel design" | `popular-web-designs` |
+| "pretext", "text layout", "text geometry" | `pretext` |
+| "hermes pet", "pet mode", "mascot" | `hermes-pets` |
+| "can't find match" | Load `check-resolvable` to audit, then re-scan via `skills_list` |
+
+## Category Resolvers
+
+For deep dives into a category, load the category resolver file:
+
+- **Apple ecosystem:** `skills/apple/RESOLVER.md`
+- **Creative work:** `skills/creative/RESOLVER.md`
+- **ML/AI Ops:** `skills/mlops/RESOLVER.md`
+- **DevOps:** `skills/devops/RESOLVER.md`
+- **GitHub:** `skills/github/RESOLVER.md`
+- **Productivity:** `skills/productivity/RESOLVER.md`
+- **Autonomous AI Agents:** `skills/autonomous-ai-agents/RESOLVER.md`
+- **Software development:** `skills/software-development/RESOLVER.md`
+
+## Invocation Priority
+
+1. If the task is precise (single domain), load only 1-2 leaf skills from the table above. No need to load the resolver if you already know which skill to use — the description match IS the resolver.
+2. If the task is broad or ambiguous, load this `skill-resolver` first and walk the tree.
+3. If you've loaded this resolver, read the matching row, load the target skill, and execute from there.
+4. If the target skill also has a resolver, recurse.
+
+## Filing Rules
+
+| Artifact | Destination |
+|---|---|
+| New skill | `skill_manage(action='create')` |
+| User preference learned | `memory(target='user', action='add', content=...)` |
+| Working procedure | `memory(target='memory', action='add', content=...)` |
+| Project rule | `.hermes.md` or `AGENTS.md` in project root |
+| Task decomposed | Kanban task via `kanban-create` tool |
+| Code reference | Script or reference file in the relevant skill directory |
+| Resolver gap found | Create a Kanban task assigned to this profile to add the missing resolver entry |
+
+## Completion Criteria
+
+- [ ] You loaded the correct leaf skill for the task
+- [ ] You followed the leaf skill's instructions, not the resolver's
+- [ ] If the resolver had no match, you either found the right skill or created a Kanban task to fill the gap
+- [ ] Any newly created skill was added to the resolver chain

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -478,6 +478,12 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _TELEGRAM_TOPIC_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), match.group(2), True
+        # Bot usernames (e.g. @OtherBot) — pass through as-is, Telegram
+        # Bot API accepts @username as chat_id for bot-to-bot DMs.
+        if target_ref.startswith("@"):
+            stripped = target_ref.strip()
+            if len(stripped) > 1:
+                return stripped, None, True
     if platform_name == "feishu":
         match = _FEISHU_TARGET_RE.fullmatch(target_ref)
         if match:
@@ -1034,7 +1040,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 bot = Bot(token=token)
         else:
             bot = Bot(token=token)
-        int_chat_id = int(chat_id)
+        int_chat_id = chat_id if chat_id.startswith("@") else int(chat_id)
         media_files = media_files or []
         thread_kwargs = {}
         if thread_id is not None:

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -63,9 +63,71 @@ platform-appropriate prereqs:
 
 | Platform | Prereqs |
 |---|---|
-| **macOS** | System Settings → Privacy & Security → **Accessibility** + **Screen Recording** → allow your terminal (or Hermes app). `hermes computer-use doctor` will tell you which permission is missing. |
+|| **macOS** | System Settings → Privacy & Security → **Accessibility** + **Screen Recording** → allow CuaDriver.app. `hermes computer-use doctor` will tell you which permission is missing. See the [macOS permission grant walkthrough](#macos-permission-grant-walkthrough) below. |
 | **Windows** | None at install time. If you're driving over SSH (not RDP / console), you need the autostart pattern — see [cua.ai/docs/how-to-guides/driver/windows-ssh](https://cua.ai/docs/how-to-guides/driver/windows-ssh) for the Session 0 ↔ Session 1+ proxy. |
 | **Linux** | A reachable display server: `DISPLAY` set for X11, or `XDG_SESSION_TYPE=wayland`. Wayland sessions need an XWayland bridge for capture. AT-SPI must be on (default on GNOME/KDE/Xfce). |
+
+### macOS Permission Grant Walkthrough
+
+macOS's Transparency, Consent, and Control (TCC) framework grants permissions
+per **bundle identifier**, not per binary path. The `cua-driver` binary must
+run under the `com.trycua.driver` bundle identity for permissions to stick.
+
+**Step 1 — Launch the grant helper (this handles the bundle identity):**
+
+```
+cua-driver permissions grant
+```
+
+This opens CuaDriver.app (which has the correct `com.trycua.driver` bundle ID)
+and triggers the macOS permission dialog.
+
+**Step 2 — Approve in System Settings.**
+
+When System Settings opens to **Privacy & Security**:
+
+| Permission | Action |
+|---|---|
+| **Accessibility** | Click the lock to unlock, then **+** → Applications → **CuaDriver.app** → **ensure the checkbox is ticked** (adding it isn't enough — the check must be on). |
+| **Screen Recording** | Same: **+** → Applications → **CuaDriver.app** → tick the checkbox. |
+
+**Step 3 — Verify the grants:**
+
+```
+cua-driver permissions status
+```
+
+Expected output:
+```
+Accessibility:    ✅ granted
+Screen Recording: ✅ granted
+Source: driver-daemon
+```
+
+If a permission still shows `❌ not granted`, the dialog likely appeared behind
+other windows and was dismissed rather than approved. Run `cua-driver
+permissions grant` again, or open **System Settings → Privacy & Security**
+manually and add CuaDriver.app to both lists with the checkbox on.
+
+**Step 4 — Run the full health check:**
+
+```
+hermes computer-use doctor
+```
+
+All 8 checks should show `pass` with `overall: ok`.
+
+**Troubleshooting macOS grants:**
+
+- **"Process has no CFBundleIdentifier"** — cua-driver was invoked outside
+  CuaDriver.app (e.g. directly from the terminal). Use `cua-driver permissions
+  grant` instead of running the binary directly.
+- **Accessibility shows `❌ not granted` despite adding it** — macOS sometimes
+  silently drops the grant if the TCC dialog was dismissed (the "Deny" button
+  or window close). Reset and retry: `sudo tccutil reset Accessibility
+  com.trycua.driver`, then `cua-driver permissions grant` again.
+- **Permissions reset after reboot** — Enable the autostart daemon so
+  permissions persist: `cua-driver autostart enable`.
 
 Then start a session with the toolset enabled:
 


### PR DESCRIPTION
## Summary

Implements Garry Tan's resolver routing-table pattern from his article "Resolvers: The Routing Table for Intelligence" — a thin harness skill that every agent loads first, then dispatches to the correct leaf skill via a decision tree.

## What's Added

### `skill-resolver`
A routing-table skill with 80+ signal→skill mappings covering every skill in the auto-discovery catalog. When an agent receives a task, it loads this skill first, walks the decision table, and loads exactly the 1-2 leaf skills it needs — no need to scan every skill description or guess.

Design:
- `Invocation Priority` section clarifies: precise task → load leaf skill directly. Broad/ambiguous → load resolver first and walk the tree.
- Category resolver pointers for deep dives (software-development, creative, mlops, etc.)
- Filing rules for where artifacts go
- Completion checklist

### `check-resolvable`
A meta-skill linter that audits the resolver chain. Finds:
- Dark skills (exist in filesystem but no resolver path)
- Dead triggers (resolver says exists but skill missing)
- Drift warnings (resolver trigger != skill description)

Includes trigger evals — 10+ test inputs with expected routing outcomes for regression testing.

## Context

These skills are the agent-facing half of the resolver pattern. The other half is category-level `RESOLVER.md` files that go alongside existing skills — those are workflow-specific and belong downstream. The skills here provide the mechanism.

## Testing

- Skill frontmatter validates against `skill_manager_tool.py` constraints
- Descriptions under 1024 chars, names under 64 chars
- Trigger evals produce correct routing for all 10 test inputs
- Verified no circular dependencies between skills

Closes: # — N/A