### PR TITLE
fix(cli): sort session browse by latest activity

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3126,7 +3126,11 @@ class GatewaySlashCommandsMixin:
 
         def _list_titled_sessions() -> list[dict]:
             user_source = source.platform.value if source.platform else None
-            sessions = self._session_db.list_sessions_rich(source=user_source, limit=10)
+            sessions = self._session_db.list_sessions_rich(
+                source=user_source,
+                limit=10,
+                order_by_last_active=True,
+            )
             return [s for s in sessions if s.get("title")][:10]
 
         if not name:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3128,7 +3128,7 @@ class GatewaySlashCommandsMixin:
             user_source = source.platform.value if source.platform else None
             sessions = self._session_db.list_sessions_rich(
                 source=user_source,
-                limit=10,
+                limit=40,
                 order_by_last_active=True,
             )
             return [s for s in sessions if s.get("title")][:10]

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12902,7 +12902,10 @@ def main():
 
         if action == "list":
             sessions = db.list_sessions_rich(
-                source=args.source, exclude_sources=_exclude, limit=args.limit
+                source=args.source,
+                exclude_sources=_exclude,
+                limit=args.limit,
+                order_by_last_active=True,
             )
             if not sessions:
                 print("No sessions found.")
@@ -13010,7 +13013,10 @@ def main():
             source = getattr(args, "source", None)
             _browse_exclude = None if source else ["tool"]
             sessions = db.list_sessions_rich(
-                source=source, exclude_sources=_browse_exclude, limit=limit
+                source=source,
+                exclude_sources=_browse_exclude,
+                limit=limit,
+                order_by_last_active=True,
             )
             db.close()
             if not sessions:

--- a/hermes_cli/session_listing.py
+++ b/hermes_cli/session_listing.py
@@ -55,6 +55,7 @@ def query_session_listing(
         source=query_source,
         exclude_sources=exclude_sources,
         limit=fetch_limit,
+        order_by_last_active=True,
     )
     result: list[dict[str, Any]] = []
     for row in rows:

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -97,6 +97,35 @@ class TestHandleResumeCommand:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_list_named_sessions_requests_last_active_order(self):
+        """Gateway /resume should list numbered sessions by latest activity."""
+        captured = {}
+
+        class FakeDB:
+            def list_sessions_rich(self, **kwargs):
+                captured["kwargs"] = kwargs
+                return [
+                    {
+                        "id": "sess_001",
+                        "source": "telegram",
+                        "title": "Research",
+                        "preview": "latest work",
+                    }
+                ]
+
+        event = _make_event(text="/resume")
+        runner = _make_runner(session_db=FakeDB(), event=event)
+
+        result = await runner._handle_resume_command(event)
+
+        assert captured["kwargs"] == {
+            "source": "telegram",
+            "limit": 10,
+            "order_by_last_active": True,
+        }
+        assert "Research" in result
+
+    @pytest.mark.asyncio
     async def test_list_shows_usage_when_no_titled(self, tmp_path):
         """With no arg and no titled sessions, shows instructions."""
         from hermes_state import SessionDB

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -120,10 +120,45 @@ class TestHandleResumeCommand:
 
         assert captured["kwargs"] == {
             "source": "telegram",
-            "limit": 10,
+            "limit": 40,
             "order_by_last_active": True,
         }
         assert "Research" in result
+
+    @pytest.mark.asyncio
+    async def test_list_named_sessions_overfetches_before_title_filter(self):
+        """Recent unnamed sessions should not hide older named sessions."""
+        captured = {}
+
+        class FakeDB:
+            def list_sessions_rich(self, **kwargs):
+                captured["kwargs"] = kwargs
+                unnamed = [
+                    {
+                        "id": f"unnamed_{idx}",
+                        "source": "telegram",
+                        "title": "",
+                        "preview": f"recent unnamed {idx}",
+                    }
+                    for idx in range(10)
+                ]
+                return unnamed + [
+                    {
+                        "id": "named_older",
+                        "source": "telegram",
+                        "title": "Research",
+                        "preview": "older titled work",
+                    }
+                ]
+
+        event = _make_event(text="/resume")
+        runner = _make_runner(session_db=FakeDB(), event=event)
+
+        result = await runner._handle_resume_command(event)
+
+        assert captured["kwargs"]["limit"] == 40
+        assert "Research" in result
+        assert "No named sessions" not in result
 
     @pytest.mark.asyncio
     async def test_list_shows_usage_when_no_titled(self, tmp_path):

--- a/tests/hermes_cli/test_session_browse.py
+++ b/tests/hermes_cli/test_session_browse.py
@@ -6,6 +6,7 @@ Covers:
 - Argument parser registration
 """
 
+import sys
 import time
 from unittest.mock import MagicMock, patch
 
@@ -441,6 +442,70 @@ class TestCmdSessionsBrowse:
                 result = _session_browse_picker(sessions)
 
         assert result == "s1"
+
+    def test_cli_browse_requests_last_active_order(self, monkeypatch, capsys):
+        """The real sessions browse command should sort by latest activity."""
+        import hermes_cli.main as main_mod
+        import hermes_state
+
+        captured = {}
+
+        class FakeDB:
+            def list_sessions_rich(self, **kwargs):
+                captured["kwargs"] = kwargs
+                return []
+
+            def close(self):
+                captured["closed"] = True
+
+        monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["hermes", "sessions", "browse", "--source", "tui", "--limit", "42"],
+        )
+
+        main_mod.main()
+
+        assert captured["kwargs"] == {
+            "source": "tui",
+            "exclude_sources": None,
+            "limit": 42,
+            "order_by_last_active": True,
+        }
+        assert "No sessions found." in capsys.readouterr().out
+
+    def test_cli_list_requests_last_active_order(self, monkeypatch, capsys):
+        """The real sessions list command should sort by latest activity."""
+        import hermes_cli.main as main_mod
+        import hermes_state
+
+        captured = {}
+
+        class FakeDB:
+            def list_sessions_rich(self, **kwargs):
+                captured["kwargs"] = kwargs
+                return []
+
+            def close(self):
+                captured["closed"] = True
+
+        monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["hermes", "sessions", "list", "--source", "tui", "--limit", "42"],
+        )
+
+        main_mod.main()
+
+        assert captured["kwargs"] == {
+            "source": "tui",
+            "exclude_sources": None,
+            "limit": 42,
+            "order_by_last_active": True,
+        }
+        assert "No sessions found." in capsys.readouterr().out
 
 
 # ─── Edge cases ──────────────────────────────────────────────────────────────

--- a/tests/hermes_cli/test_session_listing.py
+++ b/tests/hermes_cli/test_session_listing.py
@@ -1,0 +1,65 @@
+from hermes_cli.session_listing import query_session_listing
+
+
+class _StubSessionDB:
+    def __init__(self, rows):
+        self.rows = rows
+        self.calls = []
+
+    def list_sessions_rich(self, **kwargs):
+        self.calls.append(kwargs)
+        return list(self.rows)
+
+
+def test_query_session_listing_requests_last_active_order():
+    db = _StubSessionDB([
+        {
+            "id": "old_active",
+            "source": "cli",
+            "title": "Old but active",
+        }
+    ])
+
+    rows = query_session_listing(
+        db,
+        source="cli",
+        current_session_id="current",
+        include_all_sources=False,
+        include_unnamed=False,
+        limit=10,
+        exclude_sources=["tool"],
+    )
+
+    assert [row["id"] for row in rows] == ["old_active"]
+    assert db.calls == [
+        {
+            "source": "cli",
+            "exclude_sources": ["tool"],
+            "limit": 40,
+            "order_by_last_active": True,
+        }
+    ]
+
+
+def test_query_session_listing_keeps_all_source_mode_ordered_by_last_active():
+    db = _StubSessionDB([
+        {
+            "id": "telegram_active",
+            "source": "telegram",
+            "title": "Telegram",
+        }
+    ])
+
+    rows = query_session_listing(
+        db,
+        source="cli",
+        include_all_sources=True,
+        include_unnamed=False,
+        limit=5,
+        exclude_sources=["tool"],
+    )
+
+    assert [row["id"] for row in rows] == ["telegram_active"]
+    assert db.calls[0]["source"] is None
+    assert db.calls[0]["limit"] == 20
+    assert db.calls[0]["order_by_last_active"] is True


### PR DESCRIPTION
## What does this PR do?

Sorts user-facing session picker/list rows by latest real activity instead of root session creation time for the CLI session switching surfaces.

The root cause was that `hermes sessions browse` / `hermes sessions list` and related recent-session helpers called `SessionDB.list_sessions_rich(...)` without `order_by_last_active=True`, even though the TUI gateway session list already used that mode. As a result, a recently resumed older TUI conversation could appear below newer but inactive root sessions.

This PR uses the existing `order_by_last_active=True` code path rather than adding new session-store behavior.

## Related Issue

Fixes #52857

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/main.py` so `hermes sessions list` and `hermes sessions browse` request `order_by_last_active=True`.
- Updated `hermes_cli/session_listing.py` so classic CLI `/resume` and `/sessions` recent-session lists use latest-activity ordering.
- Updated `gateway/slash_commands.py` so gateway `/resume` no-arg titled-session listing uses latest-activity ordering and over-fetches before filtering untitled sessions.
- Added regression coverage in `tests/hermes_cli/test_session_browse.py`, `tests/hermes_cli/test_session_listing.py`, and `tests/gateway/test_resume_command.py`.

## How to Test

1. Create or resume an older TUI session and add recent activity.
2. Run `hermes sessions browse --source tui`.
3. Confirm the recently active older session appears before newer inactive root sessions.
4. Run targeted tests:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_session_browse.py tests/hermes_cli/test_session_listing.py tests/gateway/test_resume_command.py -- -q
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS with targeted repository test wrapper

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation passed:

```text
scripts/run_tests.sh tests/hermes_cli/test_session_browse.py tests/hermes_cli/test_session_listing.py tests/gateway/test_resume_command.py -- -q

=== Summary: 3 files, 56 tests passed, 0 failed (0% complete) in 0.9s (20 workers) ===
```
