### PR TITLE
fix(agent): call shutdown_memory_provider() in AIAgent.close() + Honcho shutdown chain

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1415,12 +1415,20 @@ class HonchoMemoryProvider(MemoryProvider):
         for t in (self._prefetch_thread, self._sync_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)
-        # Flush any remaining messages
-        if self._manager and not (self._init_thread and self._init_thread.is_alive() and not self._session_initialized):
+        # Shut down the session manager (stops the honcho-async-writer thread
+        # by sending _ASYNC_SHUTDOWN into its queue and joining).  Without
+        # this, the async writer thread survives session teardown and leaks
+        # one thread per session (#46082).
+        if self._manager:
             try:
-                self._manager.flush_all()
+                self._manager.shutdown()
             except Exception:
                 pass
+            if not (self._init_thread and self._init_thread.is_alive() and not self._session_initialized):
+                try:
+                    self._manager.flush_all()
+                except Exception:
+                    pass
 
 
 # ---------------------------------------------------------------------------

--- a/run_agent.py
+++ b/run_agent.py
@@ -3257,7 +3257,29 @@ class AIAgent:
         except Exception:
             pass
 
-        # 6. Free conversation history.  Mirrors _release_evicted_agent_soft's
+        # 6. Shut down the memory provider and context engine.  This releases
+        # per-session background threads (e.g. Honcho's honcho-async-writer
+        # and honcho-prewarm-dialectic) and provider connections that would
+        # otherwise survive session teardown and accumulate as leaks.
+        #
+        # Must run BEFORE clearing _session_messages (step 7) so providers
+        # receive the actual conversation transcript for on_session_end()
+        # extraction, not an empty list.
+        #
+        # The gateway path (gateway/run.py) calls shutdown_memory_provider()
+        # explicitly at session boundaries, but close() is the single terminal
+        # path for CLI, TUI/dashboard, subagent, and cron contexts — all of
+        # which go through close() without calling shutdown_memory_provider().
+        #
+        # See #46082: dashboard process leaked ~2 Honcho threads per session
+        # because agent.close() never triggered the shutdown chain.
+        try:
+            _messages_for_shutdown = list(getattr(self, "_session_messages", []) or [])
+            self.shutdown_memory_provider(_messages_for_shutdown)
+        except Exception:
+            pass
+
+        # 7. Free conversation history.  Mirrors _release_evicted_agent_soft's
         # soft-eviction clear — close() is the hard teardown for true session
         # boundaries (/new, /reset, session expiry), so the message list won't
         # be reused.  Drops the reference proactively rather than waiting for
@@ -3268,7 +3290,7 @@ class AIAgent:
         except Exception:
             pass
 
-        # 7. Finalize the owned SQLite session row unless this agent is only a
+        # 8. Finalize the owned SQLite session row unless this agent is only a
         # temporary helper that deliberately handed session ownership forward
         # (manual compression helpers that rotate to a continuation session_id,
         # or background-review forks that share the live parent's session_id and
@@ -3281,23 +3303,6 @@ class AIAgent:
                 session_id = getattr(self, "session_id", None)
                 if session_db and session_id:
                     session_db.end_session(session_id, "agent_close")
-        except Exception:
-            pass
-
-        # 8. Shut down the memory provider and context engine.  This releases
-        # per-session background threads (e.g. Honcho's honcho-async-writer
-        # and honcho-prewarm-dialectic) and provider connections that would
-        # otherwise survive session teardown and accumulate as leaks.
-        #
-        # The gateway path (gateway/run.py) calls shutdown_memory_provider()
-        # explicitly at session boundaries, but close() is the single terminal
-        # path for CLI, TUI/dashboard, subagent, and cron contexts — all of
-        # which go through close() without calling shutdown_memory_provider().
-        #
-        # See #46082: dashboard process leaked ~2 Honcho threads per session
-        # because agent.close() never triggered the shutdown chain.
-        try:
-            self.shutdown_memory_provider()
         except Exception:
             pass
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3284,6 +3284,23 @@ class AIAgent:
         except Exception:
             pass
 
+        # 8. Shut down the memory provider and context engine.  This releases
+        # per-session background threads (e.g. Honcho's honcho-async-writer
+        # and honcho-prewarm-dialectic) and provider connections that would
+        # otherwise survive session teardown and accumulate as leaks.
+        #
+        # The gateway path (gateway/run.py) calls shutdown_memory_provider()
+        # explicitly at session boundaries, but close() is the single terminal
+        # path for CLI, TUI/dashboard, subagent, and cron contexts — all of
+        # which go through close() without calling shutdown_memory_provider().
+        #
+        # See #46082: dashboard process leaked ~2 Honcho threads per session
+        # because agent.close() never triggered the shutdown chain.
+        try:
+            self.shutdown_memory_provider()
+        except Exception:
+            pass
+
     def _hydrate_todo_store(self, history: List[Dict[str, Any]]) -> None:
         """
         Recover todo state from conversation history.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1254,6 +1254,7 @@ AUTHOR_MAP = {
     "17683456+wanazhar@users.noreply.github.com": "wanazhar",
     "26782336+cixuuz@users.noreply.github.com": "cixuuz",
     "aleksandr.pasevin@openzeppelin.com": "pasevin",
+    "pasevin@gmail.com": "pasevin",
     "ubuntu@localhost.localdomain": "holynn-q",
     "holynn@placeholder.local": "holynn-q",
     "agent@hermes.local": "jacdevos",

--- a/tests/agent/test_close_shutdown_memory.py
+++ b/tests/agent/test_close_shutdown_memory.py
@@ -1,0 +1,102 @@
+"""Tests for AIAgent.close() calling shutdown_memory_provider (#46082)."""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _FakeMemoryManager:
+    """Tracks shutdown_memory_provider calls."""
+
+    def __init__(self):
+        self.on_session_end_called = False
+        self.shutdown_all_called = False
+
+    def on_session_end(self, messages):
+        self.on_session_end_called = True
+
+    def shutdown_all(self):
+        self.shutdown_all_called = True
+
+    def on_session_switch(self, *args, **kwargs):
+        pass
+
+
+class _FakeCompressor:
+    def __init__(self):
+        self.on_session_end_called = False
+
+    def on_session_end(self, sid, messages):
+        self.on_session_end_called = True
+
+
+def test_close_calls_shutdown_memory_provider():
+    """AIAgent.close() must call shutdown_memory_provider() (#46082).
+
+    Prior to the fix, close() cleaned up subprocesses, terminals, browser
+    sessions, child agents, and the httpx client — but never called
+    shutdown_memory_provider(). This left per-session memory provider threads
+    (Honcho's honcho-async-writer, honcho-prewarm-dialectic) alive after
+    session teardown, causing ~2 leaked threads per dashboard session.
+    """
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "test-close-shutdown"
+    agent._session_messages = []
+    agent._active_children = []
+    agent._active_children_lock = threading.Lock()
+    agent.client = None
+    agent._end_session_on_close = False
+    agent.background_review_callback = None
+    agent.memory_notifications = "on"
+
+    mm = _FakeMemoryManager()
+    agent._memory_manager = mm
+    agent.context_compressor = _FakeCompressor()
+
+    # Call close()
+    agent.close()
+
+    # shutdown_memory_provider should have been called,
+    # which calls on_session_end + shutdown_all
+    assert mm.on_session_end_called, (
+        "shutdown_memory_provider() was not called by close() — "
+        "memory manager on_session_end was never triggered"
+    )
+    assert mm.shutdown_all_called, (
+        "shutdown_memory_provider() was not called by close() — "
+        "memory manager shutdown_all was never triggered"
+    )
+
+
+def test_close_is_idempotent_with_memory_provider():
+    """close() can be called multiple times; shutdown is idempotent."""
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "test-idempotent"
+    agent._session_messages = []
+    agent._active_children = []
+    agent._active_children_lock = threading.Lock()
+    agent.client = None
+    agent._end_session_on_close = False
+    agent.background_review_callback = None
+    agent.memory_notifications = "on"
+
+    mm = _FakeMemoryManager()
+    agent._memory_manager = mm
+    agent.context_compressor = _FakeCompressor()
+
+    agent.close()
+    assert mm.shutdown_all_called
+
+    # Second call should not raise
+    mm.shutdown_all_called = False
+    agent.close()
+    # shutdown_all is called again (idempotent in real MemoryManager;
+    # our fake just tracks it)
+    assert mm.shutdown_all_called

--- a/tests/agent/test_close_shutdown_memory.py
+++ b/tests/agent/test_close_shutdown_memory.py
@@ -14,9 +14,11 @@ class _FakeMemoryManager:
     def __init__(self):
         self.on_session_end_called = False
         self.shutdown_all_called = False
+        self.received_messages = None
 
     def on_session_end(self, messages):
         self.on_session_end_called = True
+        self.received_messages = messages
 
     def shutdown_all(self):
         self.shutdown_all_called = True
@@ -28,9 +30,11 @@ class _FakeMemoryManager:
 class _FakeCompressor:
     def __init__(self):
         self.on_session_end_called = False
+        self.received_messages = None
 
     def on_session_end(self, sid, messages):
         self.on_session_end_called = True
+        self.received_messages = messages
 
 
 def test_close_calls_shutdown_memory_provider():
@@ -100,3 +104,52 @@ def test_close_is_idempotent_with_memory_provider():
     # shutdown_all is called again (idempotent in real MemoryManager;
     # our fake just tracks it)
     assert mm.shutdown_all_called
+
+
+def test_close_passes_non_empty_messages_to_providers():
+    """close() must pass _session_messages to shutdown_memory_provider (#46082 review).
+
+    shutdown_memory_provider() runs BEFORE _session_messages is cleared,
+    so providers receive the actual conversation transcript for
+    on_session_end() extraction — not an empty list.
+    """
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "test-msg-ordering"
+    agent._session_messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+    agent._active_children = []
+    agent._active_children_lock = threading.Lock()
+    agent.client = None
+    agent._end_session_on_close = False
+    agent.background_review_callback = None
+    agent.memory_notifications = "on"
+
+    mm = _FakeMemoryManager()
+    agent._memory_manager = mm
+    comp = _FakeCompressor()
+    agent.context_compressor = comp
+
+    agent.close()
+
+    # Providers should have received the actual messages, not []
+    assert mm.received_messages == [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ], (
+        "Memory manager received empty messages — shutdown_memory_provider() "
+        "was called after _session_messages was cleared"
+    )
+    assert comp.received_messages == [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ], (
+        "Context compressor received empty messages — shutdown_memory_provider() "
+        "was called after _session_messages was cleared"
+    )
+
+    # _session_messages should be cleared after close()
+    assert agent._session_messages == []


### PR DESCRIPTION
## Summary

Fixes #46082

The Hermes dashboard process leaks memory progressively because `AIAgent.close()` does not call `shutdown_memory_provider()`. Each dashboard chat session creates memory provider background threads that are never cleaned up, accumulating ~2 leaked threads per session and eventually driving OOM kills.

## Root Cause

**Two gaps in the shutdown chain:**

1. **`AIAgent.close()` (`run_agent.py`)** — cleans up subprocesses, terminals, browser sessions, child agents, and the httpx client, but never calls `shutdown_memory_provider()`. The gateway path (`gateway/run.py:4672`) explicitly calls it at session boundaries, but `close()` is the single terminal path for CLI, TUI/dashboard, subagent, and cron — all of which go through `close()` without triggering the shutdown chain.

2. **`HonchoMemoryProvider.shutdown()` (`plugins/memory/honcho/__init__.py`)** — previously only called `manager.flush_all()`, which flushes pending writes but does NOT stop the `honcho-async-writer` thread. The `HonchoSessionManager.shutdown()` method (which sends `_ASYNC_SHUTDOWN` into the queue and joins the thread) was never called.

## Evidence (py-spy thread dump)

Created 3 dashboard chat sessions via `/api/ws` (real LLM conversations), disconnected each, then dumped thread stacks:

```
Thread 'honcho-async-writer'       — LEAKED (blocked on queue.get in session.py:462)
Thread 'honcho-async-writer'       — LEAKED
Thread 'honcho-prewarm-dialectic'  — LEAKED (blocked on ssl.read in httpx, __init__.py:479)
Thread 'honcho-prewarm-dialectic'  — LEAKED
```

~2 Honcho threads leak per session. Over 120 sessions in 4 hours: ~240 leaked threads + referenced objects (httpx clients, session caches, message queues) → RSS grows from ~250 MB to 1.5+ GB, triggering OOM on low-memory systems.

The gateway does NOT leak because `gateway/run.py:4672` calls `agent.shutdown_memory_provider()` explicitly.

## Changes

### Fix 1: `run_agent.py` — add `shutdown_memory_provider()` to `close()`

```python
# Step 8 in close(), after SQLite session finalize:
try:
    self.shutdown_memory_provider()
except Exception:
    pass
```

### Fix 2: `plugins/memory/honcho/__init__.py` — call `manager.shutdown()`

```python
def shutdown(self) -> None:
    for t in (self._prefetch_thread, self._sync_thread):
        if t and t.is_alive():
            t.join(timeout=5.0)
    if self._manager:
        try:
            self._manager.shutdown()  # stops honcho-async-writer thread
        except Exception:
            pass
        if not (self._init_thread and ...):
            try:
                self._manager.flush_all()
            except Exception:
                pass
```

Both changes are needed: fix 1 triggers the shutdown chain from all `close()` callers, fix 2 ensures the Honcho async writer thread actually stops.

## Testing

```
tests/agent/test_close_shutdown_memory.py::test_close_calls_shutdown_memory_provider PASSED
tests/agent/test_close_shutdown_memory.py::test_close_is_idempotent_with_memory_provider PASSED
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Related Issues

- #46082 — this fix (dashboard memory leak)
- #53303 — separate, smaller leak (_SlashWorker drain threads, PR #53308)
- #48564 — umbrella RFC for dashboard reliability
- #21467, #24775, #32377, #38095 — prior slash_worker leak issues