### PR TITLE
fix(gateway): suppress operational status/error noise on all chat gateways (#39293)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -87,6 +87,22 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 
+# Surfaces that consume gateway text programmatically (CLI/TUI "local"
+# diagnostics, API JSON, webhook payloads) and therefore must keep RAW
+# status/error text. EVERY other platform is a human-facing chat surface
+# where operational lifecycle/provider-error noise (and any secrets in it)
+# must be suppressed or sanitized. Widens #28533's Telegram-only filter to
+# all chat gateways (#39293). Fail-closed: unknown/empty platform -> chat.
+_GATEWAY_RAW_TEXT_PLATFORMS = frozenset(
+    {"local", "api_server", "webhook", "msgraph_webhook"}
+)
+
+
+def _gateway_surface_passes_raw_text(platform: Any) -> bool:
+    """True only for programmatic/local surfaces that must keep raw text."""
+    return _gateway_platform_value(platform) in _GATEWAY_RAW_TEXT_PLATFORMS
+
+
 _GATEWAY_PROVIDER_ERROR_RE = re.compile(
     r"("  # infrastructure/provider error preambles, not ordinary assistant prose
     r"api\s+(?:call\s+)?failed"
@@ -370,15 +386,18 @@ def _looks_like_gateway_provider_error(text: str) -> bool:
 
 
 def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
-    """Sanitize final gateway replies before sending them to high-noise chats.
+    """Sanitize final gateway replies before sending them to chat surfaces.
 
-    Telegram is Bob's mobile inbox, so it should receive concise, safe provider
-    failure categories instead of raw HTTP bodies, request IDs, or policy text.
-    Other platforms keep the existing behaviour for now.
+    Every human-facing chat surface (Telegram, WhatsApp, Discord, Slack,
+    Signal, Matrix, plugin platforms, etc.) should receive concise, safe
+    provider failure categories with secrets redacted instead of raw HTTP
+    bodies, request IDs, leaked credentials, or policy text. Only programmatic
+    surfaces in ``_GATEWAY_RAW_TEXT_PLATFORMS`` (CLI/TUI ``local`` diagnostics,
+    API JSON, webhook payloads) keep the raw text unchanged.
     """
     if not text:
         return text
-    if _gateway_platform_value(platform) != "telegram":
+    if _gateway_surface_passes_raw_text(platform):
         return text
 
     redacted = _redact_gateway_user_facing_secrets(str(text))
@@ -392,7 +411,7 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     text = str(message or "").strip()
     if not text:
         return None
-    if _gateway_platform_value(platform) != "telegram":
+    if _gateway_surface_passes_raw_text(platform):
         return text
 
     text = _redact_gateway_user_facing_secrets(text)

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -1,10 +1,40 @@
-"""Telegram-specific gateway filtering for noisy status/error output."""
+"""Gateway noise/secret filtering across chat surfaces (Telegram + siblings)."""
+
+import pytest
 
 from gateway.config import Platform
 from gateway.run import (
     _prepare_gateway_status_message,
     _sanitize_gateway_final_response,
 )
+
+# Every human-facing chat surface that must receive noise-filtered,
+# secret-redacted, provider-error-sanitized output (not just Telegram).
+CHAT_PLATFORMS = [
+    "telegram",
+    "whatsapp",
+    "discord",
+    "slack",
+    "signal",
+    "matrix",
+    "mattermost",
+    "dingtalk",
+    "feishu",
+    "wecom",
+    "weixin",
+    "bluebubbles",
+    "qqbot",
+    "homeassistant",
+    "sms",
+]
+
+NOISY_STATUS_MESSAGES = [
+    "🗜️ Preflight compression check before sending...",
+    "🗜️ Compacting context — summarizing earlier conversation so I can continue...",
+    "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",
+    "⏱️ Rate limited. Waiting 30.0s (attempt 2/3)...",
+    "⏳ Retrying in 4.2s (attempt 1/3)...",
+]
 
 
 def test_telegram_status_suppresses_auxiliary_and_retry_noise():
@@ -23,12 +53,62 @@ def test_telegram_status_suppresses_auxiliary_and_retry_noise():
         assert _prepare_gateway_status_message(Platform.TELEGRAM, "warn", message) is None
 
 
-def test_non_telegram_status_is_unchanged():
-    """The Telegram quieting policy must not hide CLI/Discord diagnostics."""
+def test_programmatic_surfaces_keep_raw_status():
+    """Programmatic surfaces (local/api/webhook) must keep raw diagnostics.
+
+    Negative case for the invariant: the chat-noise filter must not touch
+    CLI/TUI diagnostics, API JSON, or webhook payloads.
+    """
     message = "⏳ Retrying in 4.2s (attempt 1/3)..."
 
-    assert _prepare_gateway_status_message(Platform.DISCORD, "lifecycle", message) == message
-    assert _prepare_gateway_status_message("local", "lifecycle", message) == message
+    for platform in ("local", "api_server", "webhook", "msgraph_webhook"):
+        assert (
+            _prepare_gateway_status_message(platform, "lifecycle", message) == message
+        )
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+@pytest.mark.parametrize("message", NOISY_STATUS_MESSAGES)
+def test_all_chat_gateways_suppress_noise(platform, message):
+    """Operational lifecycle/retry noise must be suppressed on every chat surface."""
+    assert _prepare_gateway_status_message(platform, "warn", message) is None
+
+
+@pytest.mark.parametrize("platform", ["whatsapp", "slack", "signal", "matrix"])
+def test_chat_gateways_redact_secret_in_provider_error(platform):
+    """Provider-error bodies carrying secrets must never reach chat users.
+
+    THE security invariant being widened from Telegram (#28533) to all chat
+    surfaces (#39293): a leaked bearer token in a provider error body must be
+    redacted/replaced before delivery on any chat platform.
+    """
+    raw = (
+        "API call failed after 3 retries: HTTP 401 Unauthorized — "
+        "Authorization: Bearer sk-ABCDEF0123456789abcdef0123"
+    )
+
+    sanitized = _sanitize_gateway_final_response(platform, raw)
+
+    assert "sk-ABCDEF0123456789abcdef0123" not in sanitized
+    assert "sk-ABCDEF" not in sanitized
+    assert "HTTP 401" not in sanitized
+    # The user gets the safe provider-error category instead of the raw body.
+    assert "provider" in sanitized.lower()
+
+
+def test_plugin_platform_string_suppresses_noise():
+    """Unknown/plugin chat platforms fail closed to the chat-filter path."""
+    message = "⏳ Retrying in 4.2s (attempt 1/3)..."
+
+    assert _prepare_gateway_status_message("irc", "warn", message) is None
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_chat_gateways_keep_normal_answers(platform):
+    """Normal assistant content must pass through unchanged on chat surfaces."""
+    answer = "Here is the clean summary you asked for."
+
+    assert _sanitize_gateway_final_response(platform, answer) == answer
 
 
 def test_telegram_status_sanitizes_raw_provider_security_errors():

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -96,6 +96,35 @@ def test_chat_gateways_redact_secret_in_provider_error(platform):
     assert "provider" in sanitized.lower()
 
 
+@pytest.mark.parametrize("platform", ["whatsapp", "slack", "signal", "matrix"])
+def test_chat_gateways_redact_secret_in_non_error_body(platform):
+    """Secrets must be redacted even when no provider-error rewrite fires.
+
+    The provider-error case above is rewritten wholesale to a generic
+    category string, so it cannot, on its own, prove the secret-redaction
+    layer works — the rewrite would strip the body regardless. This case
+    feeds ordinary assistant prose that merely *echoes* a bearer token (not
+    a provider-error envelope), so `_redact_gateway_user_facing_secrets` is
+    the only thing standing between the token and the user. Removing the
+    redaction patterns makes this fail (genuine regression guard); the
+    surrounding prose must survive intact.
+    """
+    raw = (
+        "Sure — here is the example request you asked for: "
+        "curl -H 'Authorization: Bearer sk-ABCDEF0123456789abcdef0123' "
+        "https://api.example.com/v1/models"
+    )
+
+    sanitized = _sanitize_gateway_final_response(platform, raw)
+
+    assert "sk-ABCDEF0123456789abcdef0123" not in sanitized
+    assert "sk-ABCDEF" not in sanitized
+    assert "[REDACTED]" in sanitized
+    # Non-secret prose is preserved — redaction is surgical, not a wholesale
+    # rewrite, on bodies that are not provider-error envelopes.
+    assert "here is the example request you asked for" in sanitized
+
+
 def test_plugin_platform_string_suppresses_noise():
     """Unknown/plugin chat platforms fail closed to the chat-filter path."""
     message = "⏳ Retrying in 4.2s (attempt 1/3)..."


### PR DESCRIPTION
## Summary
Operational status/error noise (compression chatter, retry backoff, auxiliary failures) is now suppressed on ALL chat gateways, not just Telegram. Raw diagnostics are kept for programmatic surfaces (CLI/local, API server, webhooks).

## Root cause
The existing noise filter was Telegram-only (`_gateway_platform_value(platform) != "telegram"`). On Discord, Slack, and other chat channels, internal compression lifecycle messages appeared as chat messages and leaked raw provider error bodies (e.g. OpenRouter 402 credit errors during compression).

## Changes
- `gateway/run.py`: introduces `_GATEWAY_RAW_TEXT_PLATFORMS` frozenset + `_gateway_surface_passes_raw_text()` — fail-closed (unknown platform = chat = filtered). Widens both `_sanitize_gateway_final_response` and `_prepare_gateway_status_message` from Telegram-only to all chat surfaces.
- `tests/gateway/test_telegram_noise_filter.py`: parametrized tests across 15 chat platforms, secret-redaction regression tests (bearer token leak in provider error body must be redacted on Slack/Discord, not just Telegram), plugin/unknown platform fail-closed test.

Salvage of #39323 by @briandevans, cherry-picked onto current main with authorship preserved. Also closes #50825, #51423, #41277 (duplicate approaches — #39323 is the most thorough: widens both sanitize paths, has security regression tests, and properly abstracts the platform check).
