### PR TITLE
fix(cron): forward model/provider overrides on cron create CLI

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -310,6 +310,9 @@ def cron_create(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", False) or None,
+        model=getattr(args, "model", None),
+        provider=getattr(args, "provider", None),
+        base_url=getattr(args, "base_url", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -38,6 +38,21 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         "--deliver",
         help="Delivery target: origin, local, telegram, discord, signal, or platform:chat_id",
     )
+    cron_create.add_argument(
+        "--model",
+        help="Pin the job to a specific model (e.g. 'claude-sonnet-4-5'). "
+        "Omit to use the global default at run time.",
+    )
+    cron_create.add_argument(
+        "--provider",
+        help="Pin the job to a specific provider (e.g. 'anthropic', 'openrouter'). "
+        "Use with --model.",
+    )
+    cron_create.add_argument(
+        "--base-url",
+        dest="base_url",
+        help="Optional custom API base URL for the pinned model/provider.",
+    )
     cron_create.add_argument("--repeat", type=int, help="Optional repeat count")
     cron_create.add_argument(
         "--skill",

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -51,6 +51,8 @@ def test_cron_create_options():
         "--name", "daily", "--deliver", "origin", "--repeat", "3",
         "--skill", "a", "--skill", "b", "--no-agent",
         "--workdir", "/tmp/x",
+        "--model", "claude-sonnet-4-5", "--provider", "anthropic",
+        "--base-url", "https://api.example.com",
     ])
     assert ns.schedule == "0 9 * * *"
     assert ns.prompt == "daily task prompt"
@@ -60,6 +62,21 @@ def test_cron_create_options():
     assert ns.skills == ["a", "b"]
     assert ns.no_agent is True
     assert ns.workdir == "/tmp/x"
+    # Model-pinning flags forwarded to the cronjob backend (#6758).
+    assert ns.model == "claude-sonnet-4-5"
+    assert ns.provider == "anthropic"
+    assert ns.base_url == "https://api.example.com"
+
+
+def test_cron_create_model_flags_default_none():
+    """Omitting the pinning flags must leave them None so the job falls back to
+    the global default model at run time, not an empty-string pin (#6758).
+    """
+    parser = _build()
+    ns = parser.parse_args(["cron", "create", "30m", "do a thing"])
+    assert ns.model is None
+    assert ns.provider is None
+    assert ns.base_url is None
 
 
 def test_cron_edit_no_agent_tristate():


### PR DESCRIPTION
## Summary

`hermes cron create` couldn't pin a job to a specific model. The cronjob backend (`tools/cronjob_tools.py::cronjob`) already accepts `model` / `provider` / `base_url`, but the CLI never exposed or forwarded them — so a job created from the shell always fell back to the global default model at run time.

## Fix

- Add `--model` / `--provider` / `--base-url` to the `cron create` subparser (`hermes_cli/subcommands/cron.py`).
- Forward them through `cron_create()` into `_cron_api` (`hermes_cli/cron.py`).
- Omitting them leaves the values `None`, preserving the existing default-model fallback (no empty-string pin).

## Tests

Extended `tests/hermes_cli/test_cron_parser_builder.py`:
- `test_cron_create_options` now asserts the three new flags parse.
- `test_cron_create_model_flags_default_none` pins the default-None fallback contract.

```
7 passed in 0.34s
```

## Note

This is a rebased reimplementation of #6758 onto current `main`, after the cron CLI was extracted from the `main()` god-file into `hermes_cli/subcommands/cron.py`. The original branch no longer rebases cleanly against that refactor, so this opens a clean replacement; #6758 will be closed in its favor. Related: #8239 (same feature area).