### PR TITLE
fix(terminal): don't hardcode 'Linux environment' in tool description (#7672)

### DIFF
--- a/tests/tools/test_terminal_tool_description.py
+++ b/tests/tools/test_terminal_tool_description.py
@@ -1,0 +1,28 @@
+"""Regression test for the terminal tool description wording (issue #7672).
+
+The description used to claim "Execute shell commands on a Linux environment",
+which is misleading for users running locally on Windows/macOS or in a non-Linux
+configured backend. Pin the invariant: the description must describe the
+environment as *configured* rather than hardcoding Linux.
+"""
+
+from __future__ import annotations
+
+from tools.terminal_tool import TERMINAL_TOOL_DESCRIPTION
+
+
+def test_terminal_description_does_not_hardcode_linux():
+    # The core of issue #7672: don't assert every user is on Linux.
+    assert "Linux environment" not in TERMINAL_TOOL_DESCRIPTION
+
+
+def test_terminal_description_mentions_configured_environment():
+    # It should frame the environment as setup-dependent, naming the real options.
+    assert "configured execution environment" in TERMINAL_TOOL_DESCRIPTION
+    assert "local machine" in TERMINAL_TOOL_DESCRIPTION
+    assert "Docker container" in TERMINAL_TOOL_DESCRIPTION
+
+
+def test_terminal_description_keeps_persistence_contract():
+    # The persistence guidance the rest of the prompt relies on must survive.
+    assert "persist between calls" in TERMINAL_TOOL_DESCRIPTION

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -932,7 +932,7 @@ import sys
 
 
 # Tool description for LLM
-TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on a Linux environment. Filesystem, current working directory, and exported environment variables persist between calls.
+TERMINAL_TOOL_DESCRIPTION = """Execute shell commands in the configured execution environment (local machine, Docker container, or cloud sandbox depending on setup — not necessarily Linux). Filesystem, current working directory, and exported environment variables persist between calls.
 
 Do NOT use cat/head/tail to read files — use read_file instead.
 Do NOT use grep/rg/find to search — use search_files instead.


### PR DESCRIPTION
## Summary

Fixes #7672. The `terminal` tool description opened with **"Execute shell commands on a Linux environment"**, which is misleading for users running locally on Windows/macOS or against a non-Linux configured backend.

## Fix

Reword the first sentence to frame the environment as *configured* — local machine, Docker container, or cloud sandbox depending on setup — without hardcoding Linux. Minimal one-line change to the description string; the rest of the prompt (read_file/search_files/patch guidance, the persistence contract) is untouched.

```
-Execute shell commands on a Linux environment. Filesystem, current working directory, ...
+Execute shell commands in the configured execution environment (local machine, Docker container, or cloud sandbox depending on setup — not necessarily Linux). Filesystem, current working directory, ...
```

## Tests

Adds `tests/tools/test_terminal_tool_description.py` with invariant-style assertions (not a snapshot freeze):
- description no longer contains "Linux environment"
- it names the real configured options (local machine / Docker container)
- the "persist between calls" persistence contract survives

```
3 passed in 1.09s
```

## Note

Rebased reimplementation of #23242 onto current `main` (the base description string had since changed, so the old branch no longer applied cleanly). #23242 will be closed in favor of this one.