### PR TITLE
fix(desktop): enable titleBarOverlay on Linux for Electron 40+

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -534,11 +534,8 @@ function getTitleBarOverlayOptions() {
     return { height: TITLEBAR_HEIGHT }
   }
 
-  // Windows + WSLg paint WCO natively; plain Linux disables it (frameless hidden
-  // titlebar still applies).
-  if (!IS_WINDOWS && !IS_WSL) {
-    return false
-  }
+  // Linux (KDE Plasma / GNOME) gets the same native overlay as Windows/WSLg.
+  // Electron 40+ supports titleBarOverlay natively on all platforms.
 
   return {
     color: TITLEBAR_OVERLAY_COLOR,
@@ -3788,7 +3785,9 @@ function getWindowButtonPosition() {
 }
 
 function getNativeOverlayWidth() {
-  return computeNativeOverlayWidth({ isWindows: IS_WINDOWS, isWsl: IS_WSL })
+  // Linux has the same titleBarOverlay as Windows since Electron 28+.
+  const isLinux = !IS_MAC && !IS_WINDOWS && !IS_WSL
+  return computeNativeOverlayWidth({ isWindows: IS_WINDOWS || isLinux, isWsl: IS_WSL })
 }
 
 function getWindowState() {


### PR DESCRIPTION
## What does this PR do?

Enables the native window control overlay (minimize, maximize, close) on Linux. Electron 40+ now properly respects `titleBarStyle: "hidden"` on Linux, so the old guard that returned `false` for `titleBarOverlay` leaves users with no window buttons at all.

Closes #53514. Related to #53690.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `apps/desktop/electron/main.cjs` — removed the Linux `return false` in `getTitleBarOverlayOptions()`, letting it fall through to the same overlay config as Windows
- Same file — updated `getNativeOverlayWidth()` to return the 144px fallback for Linux so the renderer reserves space for the buttons

## How to Test

1. Run Hermes Desktop on Linux (KDE/GNOME)
2. Before: no min/max/close buttons on the window — frameless titlebar with nothing in the top-right corner
3. After: native overlay buttons render in the top-right via Electron's titleBarOverlay

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant tests: `node --test electron/titlebar-overlay-width.test.cjs electron/bootstrap-platform.test.cjs electron/window-state.test.cjs electron/update-relaunch.test.cjs` (49/49 pass)
- [x] I've tested on my platform: Linux (Arch, KDE Plasma Wayland)