### PR TITLE
test(cron): cover session_search wiring through run_job

### DIFF
--- a/tests/cron/test_scheduler_session_search.py
+++ b/tests/cron/test_scheduler_session_search.py
@@ -1,0 +1,82 @@
+"""Behavior-contract test: cron run_job wires session_search to the job's
+session DB (issue #6581).
+
+When a cron job's agent calls the ``session_search`` tool, the query must reach
+the SessionDB that ``run_job`` provisioned for that run — with the cron-default
+filters (tool output excluded, no role filter) — rather than a detached or
+missing store. This asserts the wiring contract end-to-end through ``run_job``,
+not a snapshot of any particular result.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from cron.scheduler import run_job
+
+
+def test_cron_session_search_uses_passed_session_db(tmp_path):
+    job = {
+        "id": "session-search-job",
+        "name": "session search test",
+        "prompt": "hello",
+    }
+    fake_db = MagicMock()
+
+    class FakeAgent:
+        def __init__(self, *args, **kwargs):
+            self._session_db = kwargs["session_db"]
+            self.session_id = kwargs["session_id"]
+
+        def run_conversation(self, *args, **kwargs):
+            result = self._invoke_tool(
+                "session_search", {"query": "cron jobs"}, effective_task_id="cron"
+            )
+            return {"final_response": result}
+
+        def _invoke_tool(
+            self, function_name, function_args, effective_task_id=None, tool_call_id=None
+        ):
+            if function_name == "session_search":
+                from tools.session_search_tool import session_search as _session_search
+
+                return _session_search(
+                    query=function_args.get("query", ""),
+                    role_filter=function_args.get("role_filter"),
+                    limit=function_args.get("limit", 3),
+                    db=self._session_db,
+                    current_session_id=self.session_id,
+                )
+            raise AssertionError(f"Unexpected tool: {function_name}")
+
+    with patch("cron.scheduler._hermes_home", tmp_path), \
+         patch("cron.scheduler._resolve_origin", return_value=None), \
+         patch("dotenv.load_dotenv"), \
+         patch("hermes_state.SessionDB", return_value=fake_db), \
+         patch(
+             "hermes_cli.runtime_provider.resolve_runtime_provider",
+             return_value={
+                 "api_key": "***",
+                 "base_url": "https://example.invalid/v1",
+                 "provider": "openrouter",
+                 "api_mode": "chat_completions",
+             },
+         ), \
+         patch("run_agent.AIAgent", FakeAgent):
+        fake_db.search_messages.return_value = []
+        success, output, final_response, error = run_job(job)
+
+    assert success is True
+    assert error is None
+    payload = json.loads(final_response)
+    assert payload["success"] is True
+    assert payload["count"] == 0
+    # The query must reach the job's own SessionDB (the wiring contract).
+    # We assert the load-bearing arguments rather than freezing every default,
+    # so this doesn't become a change-detector when tool defaults evolve.
+    fake_db.search_messages.assert_called_once()
+    call = fake_db.search_messages.call_args
+    assert call.kwargs["query"] == "cron jobs"
+    # Cron search excludes tool output by default so noise doesn't crowd recall.
+    assert "tool" in call.kwargs["exclude_sources"]


### PR DESCRIPTION
## Summary

Adds a behavior-contract test (issue #6581) that a cron job's `session_search` tool call reaches the `SessionDB` that `run_job` provisioned for that run, using the cron defaults (tool output excluded from recall).

## Why

Cron runs construct their own session DB. If the `session_search` wiring through `run_job` regresses (detached store, wrong db, dropped filters), a job's recall silently breaks. This pins the wiring end-to-end through `run_job` rather than unit-mocking the tool in isolation.

## Test design

Asserts the **load-bearing invariants** — the query reaches the job's own db, and tool output is excluded — rather than freezing every default argument. This keeps it from becoming a change-detector when `session_search` defaults evolve (per AGENTS.md "behavior contracts over snapshots").

```
1 passed in 4.11s
```

## Note

Rebased reimplementation of #6581 onto current `main`. The original branch patched two symbols that no longer exist (`tools.session_search_tool._summarize_session`, `model_tools._discover_tools`) and asserted an exact arg set that has since changed; this version drops the stale patches and relaxes the assertion to the invariant. #6581 will be closed in favor of this one.