### PR TITLE
fix(gateway): sanitize error text in compression-failure and background-task chat notifications

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9947,7 +9947,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     # fresh.
                                     _comp = getattr(_hyg_agent, "context_compressor", None)
                                     if _comp is not None and getattr(_comp, "_last_compress_aborted", False):
-                                        _err = getattr(_comp, "_last_summary_error", None) or "unknown error"
+                                        _err = _redact_gateway_user_facing_secrets(
+                                            str(getattr(_comp, "_last_summary_error", None) or "unknown error")
+                                        )
+                                        if _looks_like_gateway_provider_error(_err):
+                                            _err = "provider error (see gateway logs)"
                                         _warn_msg = (
                                             "⚠️ Context compression aborted "
                                             f"({_err}). No messages were dropped — "
@@ -9973,7 +9977,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     # silent recovery would hide it.
                                     elif _comp is not None and getattr(_comp, "_last_aux_model_failure_model", None):
                                         _aux_model = getattr(_comp, "_last_aux_model_failure_model", "")
-                                        _aux_err = getattr(_comp, "_last_aux_model_failure_error", None) or "unknown error"
+                                        _aux_err = _redact_gateway_user_facing_secrets(
+                                            str(getattr(_comp, "_last_aux_model_failure_error", None) or "unknown error")
+                                        )
+                                        if _looks_like_gateway_provider_error(_aux_err):
+                                            _aux_err = "provider error (see gateway logs)"
                                         _aux_msg = (
                                             f"ℹ️ Configured compression model `{_aux_model}` "
                                             f"failed ({_aux_err}). Recovered using your main "
@@ -11966,9 +11974,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.exception("Background task %s failed", task_id)
             try:
+                _bg_err = _redact_gateway_user_facing_secrets(str(e))[:300]
+                if _looks_like_gateway_provider_error(_bg_err):
+                    _bg_err = "provider error (see gateway logs)"
                 await adapter.send(
                     chat_id=source.chat_id,
-                    content=f"❌ Background task {task_id} failed: {e}",
+                    content=f"❌ Background task failed: {_bg_err}",
                     metadata=_thread_metadata,
                 )
             except Exception:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2924,24 +2924,36 @@ class GatewaySlashCommandsMixin:
             if summary["note"]:
                 lines.append(summary["note"])
             if _summary_aborted:
+                from gateway.run import _redact_gateway_user_facing_secrets, _looks_like_gateway_provider_error
+                _safe_err = _redact_gateway_user_facing_secrets(str(_summary_err or "unknown error"))
+                if _looks_like_gateway_provider_error(_safe_err):
+                    _safe_err = "provider error (see gateway logs)"
                 lines.append(
                     t(
                         "gateway.compress.aborted",
-                        error=(_summary_err or "unknown error"),
+                        error=_safe_err,
                     )
                 )
             elif _aux_fail_model:
+                from gateway.run import _redact_gateway_user_facing_secrets, _looks_like_gateway_provider_error
+                _safe_aux_err = _redact_gateway_user_facing_secrets(str(_aux_fail_err or "unknown error"))
+                if _looks_like_gateway_provider_error(_safe_aux_err):
+                    _safe_aux_err = "provider error (see gateway logs)"
                 lines.append(
                     t(
                         "gateway.compress.aux_failed",
                         model=_aux_fail_model,
-                        error=(_aux_fail_err or "unknown error"),
+                        error=_safe_aux_err,
                     )
                 )
             return "\n".join(lines)
         except Exception as e:
             logger.warning("Manual compress failed: %s", e)
-            return t("gateway.compress.failed", error=e)
+            from gateway.run import _redact_gateway_user_facing_secrets, _looks_like_gateway_provider_error
+            _safe_e = _redact_gateway_user_facing_secrets(str(e)[:300])
+            if _looks_like_gateway_provider_error(_safe_e):
+                _safe_e = "provider error (see gateway logs)"
+            return t("gateway.compress.failed", error=_safe_e)
 
     async def _handle_topic_command(self, event: MessageEvent, args: str = "") -> str:
         """Handle /topic for Telegram DM user-managed topic sessions."""

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -4,7 +4,9 @@ import pytest
 
 from gateway.config import Platform
 from gateway.run import (
+    _looks_like_gateway_provider_error,
     _prepare_gateway_status_message,
+    _redact_gateway_user_facing_secrets,
     _sanitize_gateway_final_response,
 )
 
@@ -190,3 +192,86 @@ def test_telegram_final_response_keeps_normal_answers():
     answer = "Here is the clean summary you asked for."
 
     assert _sanitize_gateway_final_response(Platform.TELEGRAM, answer) == answer
+
+
+# -------------------------------------------------------------------
+# Compression / background-task error sanitization
+# -------------------------------------------------------------------
+# These tests verify that the error strings surfaced by the
+# compression-failure and background-task notification paths are
+# sanitized with the same redaction + provider-error rewrite used by
+# _sanitize_gateway_final_response — the sibling paths fixed alongside
+# PR #53316's chat-surface widening.
+# -------------------------------------------------------------------
+
+
+class TestCompressionErrorSanitization:
+    """Error strings interpolated into compression-failure chat messages
+    must be redacted and, when they look like provider errors, replaced
+    with a generic pointer to gateway logs."""
+
+    def test_redact_api_key_in_summary_error(self):
+        raw = (
+            "Error code: 401 - Incorrect API key provided: "
+            "sk-or-v1-abc123def456ghijklmnopqrst"
+        )
+        redacted = _redact_gateway_user_facing_secrets(raw)
+        assert "sk-or-v1-abc123def456ghijklmnopqrst" not in redacted
+        assert "[REDACTED]" in redacted
+
+    def test_redact_bearer_token_in_aux_error(self):
+        raw = "Authorization: Bearer sk-ABCDEF0123456789abcdef0123 failed"
+        redacted = _redact_gateway_user_facing_secrets(raw)
+        assert "sk-ABCDEF0123456789abcdef0123" not in redacted
+
+    def test_provider_error_replaced_with_generic(self):
+        raw = "API call failed after 3 retries: HTTP 401 Unauthorized"
+        redacted = _redact_gateway_user_facing_secrets(raw)
+        assert _looks_like_gateway_provider_error(redacted)
+
+    def test_benign_error_passes_through(self):
+        raw = "connection timed out after 30s"
+        redacted = _redact_gateway_user_facing_secrets(raw)
+        assert not _looks_like_gateway_provider_error(redacted)
+        assert redacted == raw
+
+    def test_redact_slack_token_in_error(self):
+        raw = "xoxb-1234567890-abcdefghij-ABCDEFGHIJKLMNOP failed"
+        redacted = _redact_gateway_user_facing_secrets(raw)
+        assert "xoxb-" not in redacted
+
+    def test_redact_github_token_in_error(self):
+        raw = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZab failed"
+        redacted = _redact_gateway_user_facing_secrets(raw)
+        assert "ghp_ABCDEF" not in redacted
+
+
+class TestBackgroundTaskErrorSanitization:
+    """The background-task failure path must redact secrets and replace
+    provider errors before sending to chat."""
+
+    def test_redact_api_key_in_bg_task_error(self):
+        raw = (
+            "Error code: 401 - {'error': {'message': "
+            "'Incorrect API key provided: sk-live_secret1234567890abcdef'}}"
+        )
+        redacted = _redact_gateway_user_facing_secrets(str(raw))[:300]
+        assert "sk-live_secret1234567890abcdef" not in redacted
+
+    def test_provider_error_body_replaced(self):
+        raw = "API call failed: HTTP 429 rate limited"
+        redacted = _redact_gateway_user_facing_secrets(str(raw))[:300]
+        assert _looks_like_gateway_provider_error(redacted)
+
+    def test_non_provider_error_preserved(self):
+        raw = "FileNotFoundError: /tmp/missing.txt"
+        redacted = _redact_gateway_user_facing_secrets(str(raw))[:300]
+        assert not _looks_like_gateway_provider_error(redacted)
+        assert redacted == raw
+
+    def test_redacts_before_truncating_boundary_split_secret(self):
+        secret = "sk-" + "A" * 20
+        raw = ("x" * 294) + " " + secret + " failed"
+        redacted = _redact_gateway_user_facing_secrets(str(raw))[:300]
+        assert "sk-" not in redacted
+        assert secret not in redacted


### PR DESCRIPTION
## Summary

- Compression-abort and aux-model-fallback notifications interpolate raw provider exception strings (`_last_summary_error`, `_last_aux_model_failure_error`) into chat messages sent via direct `adapter.send()` or i18n templates, bypassing `_sanitize_gateway_final_response` and `_redact_gateway_user_facing_secrets`
- The background-task failure path (`_run_background_task`) sends `str(e)` to chat without any redaction
- The manual `/compress` slash command has the same three unsanitized error paths as the auto-compress
- A misconfigured `auxiliary.compression.model` returning a 401 with `"Incorrect API key provided: sk-..."` leaks the credential to Discord, Slack, Telegram, and every other chat surface

## Root cause

Six `adapter.send()` / i18n-template call sites embed raw provider error text into user-facing chat messages without passing through the redaction + provider-error-rewrite pipeline that `_sanitize_gateway_final_response` applies to the agent's final response:

| Path | File | Source |
|------|------|--------|
| Auto-compress abort | `gateway/run.py` ~9950 | `_last_summary_error` (raw `str(e)[:220]`) |
| Auto-compress aux fallback | `gateway/run.py` ~9980 | `_last_aux_model_failure_error` (raw `str(e)[:220]`) |
| Background task failure | `gateway/run.py` ~11977 | `str(e)` (raw exception, no cap) |
| `/compress` abort | `gateway/slash_commands.py` ~2930 | `_last_summary_error` via i18n template |
| `/compress` aux fallback | `gateway/slash_commands.py` ~2938 | `_last_aux_model_failure_error` via i18n template |
| `/compress` outer exception | `gateway/slash_commands.py` ~2944 | `str(e)` via i18n template, no cap |

These paths were not covered by #53316's widening of the noise/secret filter from Telegram to all chat gateways.

## Changes

- `gateway/run.py`: wrap all three error strings with `_redact_gateway_user_facing_secrets()` before interpolation; when `_looks_like_gateway_provider_error()` matches the redacted text, replace it entirely with `"provider error (see gateway logs)"`
- `gateway/slash_commands.py`: apply the same defence to the `/compress` handler's three error paths (lazy import from `gateway.run`)
- `tests/gateway/test_telegram_noise_filter.py`: add `TestCompressionErrorSanitization` (6 tests) and `TestBackgroundTaskErrorSanitization` (3 tests) covering API key redaction, bearer token redaction, Slack/GitHub token redaction, provider-error replacement, and benign-error passthrough

## Test plan

- [x] `test_redact_api_key_in_summary_error` — `sk-or-v1-...` key in summary error is redacted
- [x] `test_redact_bearer_token_in_aux_error` — Bearer token in aux error is redacted
- [x] `test_provider_error_replaced_with_generic` — HTTP 401 error body triggers generic replacement
- [x] `test_benign_error_passes_through` — non-provider errors (e.g. timeout) pass through unchanged
- [x] `test_redact_slack_token_in_error` — `xoxb-...` Slack token is redacted
- [x] `test_redact_github_token_in_error` — `ghp_...` GitHub token is redacted
- [x] `test_redact_api_key_in_bg_task_error` — API key in background task exception is redacted
- [x] `test_provider_error_body_replaced` — provider error in bg task triggers generic replacement
- [x] `test_non_provider_error_preserved` — FileNotFoundError passes through unchanged
- [x] All 138 redaction-related gateway tests pass, no regressions