### PR TITLE
desktop: stage simple-git into packaged app so git-review-ops loads

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,7 +18,7 @@
     "profile:main": "wait-on http://127.0.0.1:5174 && cross-env XCURSOR_SIZE=24 HERMES_DESKTOP_DEV_SERVER=http://127.0.0.1:5174 electron --inspect=9229 .",
     "profile:main:cpu": "wait-on http://127.0.0.1:5174 && cross-env XCURSOR_SIZE=24 NODE_OPTIONS=--cpu-prof HERMES_DESKTOP_DEV_SERVER=http://127.0.0.1:5174 electron .",
     "start": "npm run build && electron .",
-    "build": "node scripts/assert-root-install.cjs && node scripts/write-build-stamp.cjs && node scripts/stage-native-deps.cjs && tsc -b && vite build &&  node scripts/bundle-electron-main.mjs && npm run postbuild",
+    "build": "node scripts/assert-root-install.cjs && node scripts/write-build-stamp.cjs && node scripts/stage-native-deps.cjs && node scripts/stage-git-deps.cjs && tsc -b && vite build &&  node scripts/bundle-electron-main.mjs && npm run postbuild",
     "postbuild": "node scripts/assert-dist-built.cjs",
     "prebuilder": "node scripts/patch-electron-builder-mac-binary.cjs",
     "builder": "cross-env NODE_OPTIONS=--max-old-space-size=16384 node scripts/run-electron-builder.cjs",
@@ -178,6 +178,10 @@
       {
         "from": "build/native-deps",
         "to": "native-deps"
+      },
+      {
+        "from": "build/extra-node-modules",
+        "to": "node_modules"
       },
       {
         "from": "assets/icon.ico",

--- a/apps/desktop/scripts/stage-git-deps.cjs
+++ b/apps/desktop/scripts/stage-git-deps.cjs
@@ -1,0 +1,133 @@
+'use strict'
+
+/**
+ * stage-git-deps.cjs — stage pure-JS runtime node_modules for packaging.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The packaged app ships NO node_modules: main.cjs is meant to be bundled
+ * (scripts/bundle-electron-main.mjs) and the electron-builder `files:` list
+ * deliberately omits node_modules. That works for everything main.cjs pulls
+ * in directly — but `electron/git-review-ops.cjs` is loaded as a SEPARATE,
+ * unbundled sibling file (main.cjs require()s it at runtime), so its
+ * `require('simple-git')` stays a bare runtime require with nothing to
+ * resolve. Result: the app dies on launch with
+ *
+ *   Error: Cannot find module 'simple-git'
+ *   Require stack: .../app.asar/electron/git-review-ops.cjs
+ *
+ * `simple-git` is workspace-hoisted into the repo-root node_modules/, which
+ * electron-builder's file collector cannot reach once `files:` is set.
+ *
+ * THE FIX
+ * -------
+ * Mirror scripts/stage-native-deps.cjs: copy ONLY simple-git and its
+ * production dependency closure into apps/desktop/build/extra-node-modules/,
+ * then ship that subtree via extraResources mapped to `node_modules`. It
+ * lands at <resources>/node_modules/, which is on Node's module-resolution
+ * walk as it exits the app.asar boundary into the real parent directory — so
+ * `require('simple-git')` from inside the asar resolves with NO code change.
+ *
+ * The dependency closure is computed dynamically from each package.json's
+ * `dependencies`, so it stays correct if simple-git's deps change. Modules
+ * are resolved from the repo-root node_modules first (hoisted), falling back
+ * to the app-local node_modules.
+ *
+ * Runs as part of `npm run build`. Idempotent — re-stages on every build.
+ */
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+const APP_ROOT = path.resolve(__dirname, '..')
+const REPO_ROOT = path.resolve(APP_ROOT, '..', '..')
+const STAGE_ROOT = path.join(APP_ROOT, 'build', 'extra-node-modules')
+
+// Entry points whose production closure we want in the packaged app.
+const ROOTS = ['simple-git']
+
+// Where to look for an installed module, in priority order.
+const SEARCH_ROOTS = [
+  path.join(REPO_ROOT, 'node_modules'),
+  path.join(APP_ROOT, 'node_modules')
+]
+
+function rmrf(target) {
+  fs.rmSync(target, { recursive: true, force: true })
+}
+
+function ensureDir(target) {
+  fs.mkdirSync(target, { recursive: true })
+}
+
+function findModuleDir(name) {
+  for (const root of SEARCH_ROOTS) {
+    const candidate = path.join(root, name)
+    if (fs.existsSync(path.join(candidate, 'package.json'))) {
+      return candidate
+    }
+  }
+  return null
+}
+
+// Recursively copy a directory, skipping any nested node_modules (deps are
+// resolved and staged flat at the top level, matching the hoisted layout).
+function copyModule(srcDir, destDir) {
+  ensureDir(destDir)
+  for (const entry of fs.readdirSync(srcDir, { withFileTypes: true })) {
+    if (entry.isDirectory() && entry.name === 'node_modules') continue
+    const src = path.join(srcDir, entry.name)
+    const dest = path.join(destDir, entry.name)
+    if (entry.isDirectory()) {
+      copyModule(src, dest)
+    } else if (entry.isFile() || entry.isSymbolicLink()) {
+      fs.copyFileSync(src, dest)
+    }
+  }
+}
+
+function readDeps(moduleDir) {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(moduleDir, 'package.json'), 'utf8'))
+    return Object.keys(pkg.dependencies || {})
+  } catch {
+    return []
+  }
+}
+
+function main() {
+  rmrf(STAGE_ROOT)
+  ensureDir(STAGE_ROOT)
+
+  const seen = new Set()
+  const queue = [...ROOTS]
+  let staged = 0
+
+  while (queue.length) {
+    const name = queue.shift()
+    if (seen.has(name)) continue
+    seen.add(name)
+
+    const moduleDir = findModuleDir(name)
+    if (!moduleDir) {
+      throw new Error(
+        `stage-git-deps: dependency "${name}" not found in any node_modules ` +
+          `(${SEARCH_ROOTS.join(', ')}). Run \`npm install\` at the workspace root first.`
+      )
+    }
+
+    copyModule(moduleDir, path.join(STAGE_ROOT, name))
+    staged += 1
+
+    for (const dep of readDeps(moduleDir)) {
+      if (!seen.has(dep)) queue.push(dep)
+    }
+  }
+
+  console.log(
+    `[stage-git-deps] ${path.relative(APP_ROOT, STAGE_ROOT)}: staged ${staged} modules ` +
+      `(${[...seen].sort().join(', ')})`
+  )
+}
+
+main()


### PR DESCRIPTION
## What does this PR do?

The packaged desktop app ships no `node_modules`: `main.cjs` is bundled by esbuild and the electron-builder `files:` list omits `node_modules`. But `electron/git-review-ops.cjs` is loaded as a separate, **unbundled** sibling of `main.cjs` (required at runtime), so its `require('simple-git')` stays a bare runtime require with nothing to resolve. The app crashes on launch:

```
Error: Cannot find module 'simple-git'
Require stack: .../app.asar/electron/git-review-ops.cjs
```

`simple-git` is workspace-hoisted to the repo-root `node_modules`, which electron-builder's file collector can't reach once `files:` is explicitly set.

## Fix

Mirror the existing `node-pty` handling (`stage-native-deps.cjs`): a new `scripts/stage-git-deps.cjs` copies `simple-git` + its production dependency closure (computed dynamically from each package.json, so it won't rot) into `apps/desktop/build/extra-node-modules/`, shipped via a new `extraResources` entry mapped to `node_modules`. It lands at `<resources>/node_modules/`, which is on Node's module-resolution walk as it exits the `app.asar` boundary into the real parent dir — so `git-review-ops.cjs` needs no change.

Editing `app.asar` directly isn't viable: `Info.plist` enforces `ElectronAsarIntegrity`, so a modified asar fails its hash and won't launch.

## Type of change

- Bug fix (non-breaking)
## Testing

- `node scripts/stage-git-deps.cjs` stages 7 modules (simple-git, @kwsites/*, @simple-git/*, debug, ms); `require('simple-git')` resolves from the staged tree.
- 