### PR TITLE
fix(dashboard): allow declared public websocket origins

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -444,6 +444,51 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     return host_only == bound_lc
 
 
+def _canonical_web_origin(parsed: urllib.parse.ParseResult) -> Optional[Tuple[str, str, int]]:
+    """Return a normalised (scheme, host, port) tuple for http(s) origins."""
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in {"http", "https"}:
+        return None
+    host = parsed.hostname
+    if not host:
+        return None
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
+    if port is None:
+        port = 443 if scheme == "https" else 80
+    return scheme, host.lower(), port
+
+
+def _origin_matches_declared_public_url(parsed_origin: urllib.parse.ParseResult) -> bool:
+    """True when the WS Origin matches dashboard.public_url.
+
+    Loopback dashboards may still be intentionally exposed through a trusted
+    reverse proxy/tunnel. In that topology the proxy sends ``Host: 127.0.0.1``
+    to the local origin so the Host guard passes, while the browser correctly
+    sends ``Origin: https://public-dashboard.example``. The operator-declared
+    ``dashboard.public_url`` / ``HERMES_DASHBOARD_PUBLIC_URL`` is the explicit
+    allowlist for that public browser origin.
+    """
+    origin = _canonical_web_origin(parsed_origin)
+    if origin is None:
+        return False
+    try:
+        from hermes_cli.dashboard_auth.prefix import resolve_public_url
+
+        public_url = resolve_public_url()
+    except Exception:
+        return False
+    if not public_url:
+        return False
+    try:
+        parsed_public = urllib.parse.urlparse(public_url)
+    except ValueError:
+        return False
+    return origin == _canonical_web_origin(parsed_public)
+
+
 @app.middleware("http")
 async def host_header_middleware(request: Request, call_next):
     """Reject requests whose Host header doesn't match the bound interface.
@@ -11428,6 +11473,9 @@ def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
 
     if not parsed.netloc:
         return f"origin_mismatch origin={origin} bound={bound_host}"
+
+    if _origin_matches_declared_public_url(parsed):
+        return None
 
     if not _is_accepted_host(parsed.netloc, bound_host):
         return f"origin_mismatch origin={origin} bound={bound_host}"

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -197,6 +197,55 @@ class TestWebSocketHostOriginGuard:
 
         assert exc.value.code == 4403
 
+    def test_loopback_proxy_websocket_origin_declared_public_url_is_accepted(self, monkeypatch):
+        """A loopback-bound dashboard behind a trusted reverse proxy can
+        receive Host: 127.0.0.1 from the proxy while the browser Origin is the
+        declared public dashboard URL. That is the intended Cloudflare/SSH
+        tunnel deployment, not DNS rebinding noise.
+        """
+        from fastapi.testclient import TestClient
+
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws.app.state, "bound_host", "127.0.0.1", raising=False)
+        monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+        monkeypatch.setenv("HERMES_DASHBOARD_PUBLIC_URL", "https://dashboard.example")
+
+        client = TestClient(ws.app)
+        url = f"/api/events?token={ws._SESSION_TOKEN}&channel=security-test"
+        with client.websocket_connect(
+            url,
+            headers={
+                "Host": "127.0.0.1:9119",
+                "Origin": "https://dashboard.example",
+            },
+        ):
+            pass
+
+    def test_public_url_does_not_allow_other_websocket_origins(self, monkeypatch):
+        from fastapi.testclient import TestClient
+        from starlette.websockets import WebSocketDisconnect
+
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws.app.state, "bound_host", "127.0.0.1", raising=False)
+        monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+        monkeypatch.setenv("HERMES_DASHBOARD_PUBLIC_URL", "https://dashboard.example")
+
+        client = TestClient(ws.app)
+        url = f"/api/events?token={ws._SESSION_TOKEN}&channel=security-test"
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with client.websocket_connect(
+                url,
+                headers={
+                    "Host": "127.0.0.1:9119",
+                    "Origin": "https://evil.example",
+                },
+            ):
+                pass
+
+        assert exc.value.code == 4403
+
     def test_loopback_websocket_host_and_origin_are_accepted(self, monkeypatch):
         from fastapi.testclient import TestClient
 


### PR DESCRIPTION
## Summary
- allow dashboard WebSocket Origin checks to accept the operator-declared `dashboard.public_url` / `HERMES_DASHBOARD_PUBLIC_URL`
- preserve DNS-rebinding protection by still requiring the local Host header to match the bound interface and rejecting unrelated Origins
- add regression coverage for Cloudflare-style loopback Host + public Origin, plus hostile Origin rejection with `public_url` configured

## Test Plan
- `python -m pytest tests/hermes_cli/test_web_server_host_header.py tests/hermes_cli/test_dashboard_auth_prefix.py -q -o 'addopts='`

## Context
A loopback-bound dashboard behind Cloudflare Tunnel can receive `Host: 127.0.0.1:<port>` from the tunnel while the browser sends `Origin: https://dashboard.example.com` on WebSocket upgrades. Without the declared public URL as an Origin allowlist, the dashboard chat/event WebSockets are refused with `origin_mismatch ... bound=127.0.0.1`, causing noisy reconnect logs.
