### PR TITLE
fix(projects): use _branch_lane_id for non-git folders to prevent duplicate lanes (#53329)

### DIFF
--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -350,3 +350,35 @@ def test_colliding_repo_basenames_disambiguate_labels():
     labels = sorted(p["label"] for p in tree["projects"])
 
     assert labels == ["x/proj", "y/proj"]
+
+
+def test_non_git_folder_uses_branch_lane_id():
+    """#53329: _place_by_heuristic must use _branch_lane_id for non-git folders.
+
+    Before the fix, non-git folders got a lane key equal to the raw path,
+    while the desktop overlay expected ::branch::main. This caused duplicate
+    lanes (one from backend, one from overlay).
+    """
+    result = pt._place_by_heuristic("/home/user/my-project")
+    assert result is not None
+    assert result["lane_key"] == pt._branch_lane_id(
+        "/home/user/my-project", pt.DEFAULT_BRANCH_LABEL
+    ), (
+        f"Expected lane_key to use _branch_lane_id scheme but got "
+        f"{result['lane_key']!r}"
+    )
+    # The label should still be the folder basename
+    assert result["lane_label"] == "my-project"
+    # Must be marked as main lane
+    assert result["is_main"] is True
+
+
+def test_non_git_folder_lane_matches_overlay_scheme():
+    """#53329: verify the lane key format matches what the overlay expects."""
+    result = pt._place_by_heuristic("/data/work/folder-x")
+    assert result is not None
+    # Overlay expects: <path>::branch::main
+    expected = "/data/work/folder-x::branch::main"
+    assert result["lane_key"] == expected, (
+        f"Expected lane_key={expected!r} but got {result['lane_key']!r}"
+    )

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -126,7 +126,7 @@ def _place_by_heuristic(path: str) -> Optional[dict]:
         repo_path = _with_base_name(path, m.group(1))
         return _placement(repo_path, path, m.group(2), path, False, False)
 
-    return _placement(path, path, base, path, True, False)
+    return _placement(path, _branch_lane_id(path, DEFAULT_BRANCH_LABEL), base, path, True, False)
 
 
 def _place(cwd: str, branch: str, resolve: Optional[Resolve], persisted_root: str) -> Optional[dict]:


### PR DESCRIPTION
## Summary

Fixes #53329: Non-git project folders showed duplicate lanes (one labeled with the folder name, one labeled "main") because the backend used the raw path as the lane key while the frontend overlay expected the `<path>::branch::main` scheme.

## Root Cause

In `tui_gateway/project_tree.py` `_place_by_heuristic()`, the fallback for non-git folders called:

```python
_placement(path, path, base, path, True, False)
```

Using the raw path as the lane key. Elsewhere in the same file, `_place()` uses `_branch_lane_id(path, DEFAULT_BRANCH_LABEL)` producing `<path>::branch::main`. The mismatch meant the frontend overlay couldn't match and created a second lane.

## Fix

Changed the fallback to use the consistent scheme:

```python
_placement(path, _branch_lane_id(path, DEFAULT_BRANCH_LABEL), base, path, True, False)
```

## Verification

- **19/19 tests pass** (2 new regression tests + 17 existing)
- RED→GREEN proven: new tests fail on upstream/main (`lane_key == raw path` vs expected `path::branch::main`)
- Single-file production diff (+1/-1 line in `project_tree.py`)

## Test Results

```
tests/tui_gateway/test_project_tree.py::test_non_git_folder_uses_branch_lane_id PASSED
tests/tui_gateway/test_project_tree.py::test_non_git_folder_lane_matches_overlay_scheme PASSED
...
============================== 19 passed in 0.08s ==============================
```

---

Auto-published by Moonsong via Path B automated pipeline.