### PR TITLE
fix(tui): inject COLORTERM=truecolor for 256-color terminals on TUI launch (#53301)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1971,6 +1971,18 @@ def _resolve_tui_heap_mb(default_mb: int = 8192) -> int:
     return max(1536, sized) if limit_mb > 2048 else sized
 
 
+def _apply_tui_truecolor_env(env: dict[str, str]) -> None:
+    """#53301: Some capable terminals (Windows Terminal under WSL2) support
+    truecolor but don't set COLORTERM. When TERM indicates >=256-color
+    capability and no truecolor/24bit COLORTERM is set, advertise truecolor so
+    the TUI's chalk 5.x renderer uses its full color gamut for pet sprites.
+    """
+    if (env.get("COLORTERM") or "").lower() in {"truecolor", "24bit"}:
+        return
+    if (env.get("TERM") or "").lower().endswith("256color"):
+        env["COLORTERM"] = "truecolor"
+
+
 def _launch_tui(
     resume_session_id: Optional[str] = None,
     tui_dev: bool = False,
@@ -2010,6 +2022,9 @@ def _launch_tui(
     env.setdefault("HERMES_PYTHON", sys.executable)
     env.setdefault("HERMES_CWD", os.getcwd())
     env.setdefault("NODE_ENV", "development" if tui_dev else "production")
+
+    # #53301: Advertise truecolor for capable terminals that don't set COLORTERM
+    _apply_tui_truecolor_env(env)
 
     wt_info = None
     if worktree:

--- a/tests/hermes_cli/test_tui_colorterm.py
+++ b/tests/hermes_cli/test_tui_colorterm.py
@@ -1,0 +1,65 @@
+"""Regression tests for #53301: TUI COLORTERM injection for truecolor terminals.
+
+Tests the _apply_tui_truecolor_env() helper extracted from _launch_tui().
+"""
+
+from __future__ import annotations
+
+import hermes_cli.main
+
+
+def test_injects_colorterm_when_term_is_256color():
+    """When TERM ends in 256color and COLORTERM is unset, inject truecolor."""
+    env: dict[str, str] = {"TERM": "xterm-256color"}
+    hermes_cli.main._apply_tui_truecolor_env(env)
+    assert env.get("COLORTERM") == "truecolor"
+
+
+def test_injects_for_screen_256color():
+    """'screen-256color' is also a >=256-color TERM."""
+    env: dict[str, str] = {"TERM": "screen-256color"}
+    hermes_cli.main._apply_tui_truecolor_env(env)
+    assert env.get("COLORTERM") == "truecolor"
+
+
+def test_injects_for_tmux_256color():
+    """'tmux-256color' is a >=256-color TERM."""
+    env: dict[str, str] = {"TERM": "tmux-256color"}
+    hermes_cli.main._apply_tui_truecolor_env(env)
+    assert env.get("COLORTERM") == "truecolor"
+
+
+def test_noop_when_colorterm_already_truecolor():
+    """If COLORTERM is already 'truecolor', do nothing."""
+    env: dict[str, str] = {"TERM": "xterm-256color", "COLORTERM": "truecolor"}
+    hermes_cli.main._apply_tui_truecolor_env(env)
+    assert env.get("COLORTERM") == "truecolor"
+    assert "FORCE_COLOR" not in env
+
+
+def test_noop_when_colorterm_is_24bit():
+    """'24bit' is also a valid truecolor COLORTERM value."""
+    env: dict[str, str] = {"TERM": "xterm-256color", "COLORTERM": "24bit"}
+    hermes_cli.main._apply_tui_truecolor_env(env)
+    assert env.get("COLORTERM") == "24bit"
+
+
+def test_noop_when_term_is_not_256color():
+    """'xterm' without -256color does NOT trigger injection."""
+    env: dict[str, str] = {"TERM": "xterm"}
+    hermes_cli.main._apply_tui_truecolor_env(env)
+    assert "COLORTERM" not in env
+
+
+def test_noop_when_term_is_empty():
+    """Missing TERM: no injection."""
+    env: dict[str, str] = {}
+    hermes_cli.main._apply_tui_truecolor_env(env)
+    assert "COLORTERM" not in env
+
+
+def test_colorterm_case_insensitive():
+    """COLORTERM=TrueColor (mixed case) is recognized and not overwritten."""
+    env: dict[str, str] = {"TERM": "xterm-256color", "COLORTERM": "TrueColor"}
+    hermes_cli.main._apply_tui_truecolor_env(env)
+    assert env.get("COLORTERM") == "TrueColor"  # preserved as-is


### PR DESCRIPTION
## Summary

Fixes #53301: When running `hermes --tui` on Windows Terminal via WSL2, pet sprite colors appear significantly washed out and desaturated because chalk 5.x falls back to 256-color mode when `COLORTERM` is not set.

## Root Cause

Windows Terminal (under WSL2) supports truecolor but does not set the `COLORTERM` environment variable. Hermes launches the TUI subprocess without injecting `COLORTERM`, so chalk 5.x uses level 2 (256-color) instead of level 3 (truecolor).

## Fix

Extracted a helper `_apply_tui_truecolor_env()` that injects `COLORTERM=truecolor` when:
- TERM ends in `256color` (indicating >=256-color capability)
- COLORTERM is not already set to `truecolor` or `24bit`

The helper is called from `_launch_tui()` before the TUI subprocess is spawned.

## Verification

- **8/8 unit tests pass** covering all branches:
  - ✅ Injects for `xterm-256color`, `screen-256color`, `tmux-256color`
  - ✅ No-op when COLORTERM already `truecolor` / `24bit`
  - ✅ No-op when TERM is not a 256color variant
  - ✅ Case-insensitive COLORTERM recognition
- RED→GREEN proven: all 8 tests fail on upstream/main (helper doesn't exist)
- Single production function added (+12 lines), called from existing code path

## Test Results

```
tests/hermes_cli/test_tui_colorterm.py::test_injects_colorterm_when_term_is_256color PASSED
tests/hermes_cli/test_tui_colorterm.py::test_injects_for_screen_256color PASSED
tests/hermes_cli/test_tui_colorterm.py::test_injects_for_tmux_256color PASSED
tests/hermes_cli/test_tui_colorterm.py::test_noop_when_colorterm_already_truecolor PASSED
tests/hermes_cli/test_tui_colorterm.py::test_noop_when_colorterm_is_24bit PASSED
tests/hermes_cli/test_tui_colorterm.py::test_noop_when_term_is_not_256color PASSED
tests/hermes_cli/test_tui_colorterm.py::test_noop_when_term_is_empty PASSED
tests/hermes_cli/test_tui_colorterm.py::test_colorterm_case_insensitive PASSED
============================== 8 passed in 0.17s ==============================
```

**Reviewer revision notes:** The builder's original inline fix also set `FORCE_COLOR=3` (unnecessary — chalk respects COLORTERM). This final version drops FORCE_COLOR and extracts a testable helper with comprehensive unit tests, replacing the builder's broken subprocess-based E2E test approach.

---

Auto-published by Moonsong via Path B automated pipeline.