### PR TITLE
fix(desktop): keep assistant text streamed before an inline tool call

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -12,6 +12,7 @@ import {
   chatMessageText,
   type GatewayEventPayload,
   reasoningPart,
+  reconcileCompletedTextParts,
   renderMediaTags,
   textPart,
   upsertToolPart
@@ -19,11 +20,7 @@ import {
 import { coerceGatewayText, coerceThinkingText, normalizePersonalityValue } from '@/lib/chat-runtime'
 import { playCompletionSound } from '@/lib/completion-sound'
 import { gatewayEventRequiresSessionId } from '@/lib/gateway-events'
-import {
-  dedupeGeneratedImageEchoesInParts,
-  generatedImageEchoSources,
-  stripGeneratedImageEchoes
-} from '@/lib/generated-images'
+import { dedupeGeneratedImageEchoesInParts } from '@/lib/generated-images'
 import { triggerHaptic } from '@/lib/haptics'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import { parseTodos } from '@/lib/todos'
@@ -560,28 +557,6 @@ export function useMessageStream({
         const streamId = state.streamId
         const finalText = renderMediaTags(text).trim()
         const completionError = completionErrorText(finalText)
-        const normalize = (value: string) => value.replace(/\s+/g, ' ').trim()
-
-        const replaceTextPart = (parts: ChatMessagePart[]) => {
-          const visibleFinalText = stripGeneratedImageEchoes(finalText, generatedImageEchoSources(parts)).trim()
-          const dedupeReference = normalize(visibleFinalText)
-
-          const kept = parts.filter(part => {
-            if (part.type === 'text') {
-              return false
-            }
-
-            if (part.type !== 'reasoning' || !dedupeReference) {
-              return true
-            }
-
-            const r = normalize(part.text)
-
-            return !(r && (dedupeReference.startsWith(r) || r.startsWith(dedupeReference)))
-          })
-
-          return visibleFinalText ? [...kept, assistantTextPart(visibleFinalText)] : kept
-        }
 
         const completeMessage = (message: ChatMessage): ChatMessage =>
           completionError
@@ -593,7 +568,7 @@ export function useMessageStream({
               }
             : {
                 ...message,
-                parts: replaceTextPart(message.parts),
+                parts: reconcileCompletedTextParts(message.parts, finalText),
                 pending: false
               }
 

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -6,7 +6,10 @@ import {
   appendReasoningPart,
   chatMessageText,
   preserveLocalAssistantErrors,
+  reasoningPart,
+  reconcileCompletedTextParts,
   renderMediaTags,
+  textPart,
   toChatMessages,
   upsertToolPart
 } from './chat-messages'
@@ -783,5 +786,71 @@ describe('upsertToolPart', () => {
       data: { web: [{ title: 'Suva forecast' }] },
       summary: 'Did 1 search in 0.5s'
     })
+  })
+})
+
+describe('reconcileCompletedTextParts', () => {
+  const toolCallPart = (name: string, id: string): ChatMessagePart => {
+    const [part] = upsertToolPart([], { name, tool_id: id }, 'complete')
+
+    return part
+  }
+
+  it('keeps assistant text streamed before an inline tool call (issue #53204)', () => {
+    const streamed: ChatMessagePart[] = [
+      textPart("Good, I've saved the new AP info to Honcho."),
+      toolCallPart('honcho_conclude', 'tc-1'),
+      textPart('All set.')
+    ]
+
+    // The gateway's completion text is just the trailing block after the tool.
+    const completed = reconcileCompletedTextParts(streamed, 'All set.')
+
+    expect(completed.map(part => part.type)).toEqual(['text', 'tool-call', 'text'])
+    expect((completed[0] as Extract<ChatMessagePart, { type: 'text' }>).text).toBe(
+      "Good, I've saved the new AP info to Honcho."
+    )
+    expect((completed[2] as Extract<ChatMessagePart, { type: 'text' }>).text).toBe('All set.')
+  })
+
+  it('keeps identical pre-tool narration even when it matches the trailing completion text', () => {
+    const streamed: ChatMessagePart[] = [textPart('Okay.'), toolCallPart('terminal', 'tc-dup'), textPart('Okay.')]
+
+    const completed = reconcileCompletedTextParts(streamed, 'Okay.')
+
+    expect(completed.map(part => part.type)).toEqual(['text', 'tool-call', 'text'])
+    expect((completed[0] as Extract<ChatMessagePart, { type: 'text' }>).text).toBe('Okay.')
+    expect((completed[2] as Extract<ChatMessagePart, { type: 'text' }>).text).toBe('Okay.')
+  })
+
+  it('does not duplicate text when the completion repeats the only streamed block', () => {
+    const streamed: ChatMessagePart[] = [textPart('Hello world')]
+
+    const completed = reconcileCompletedTextParts(streamed, 'Hello world')
+
+    expect(completed.map(part => part.type)).toEqual(['text'])
+    expect((completed[0] as Extract<ChatMessagePart, { type: 'text' }>).text).toBe('Hello world')
+  })
+
+  it('replaces the trailing streamed text with the final completion text', () => {
+    const streamed: ChatMessagePart[] = [
+      textPart('Before the tool.'),
+      toolCallPart('terminal', 'tc-2'),
+      textPart('After the to')
+    ]
+
+    const completed = reconcileCompletedTextParts(streamed, 'After the tool ran fine.')
+
+    expect(completed.map(part => part.type)).toEqual(['text', 'tool-call', 'text'])
+    expect((completed[0] as Extract<ChatMessagePart, { type: 'text' }>).text).toBe('Before the tool.')
+    expect((completed[2] as Extract<ChatMessagePart, { type: 'text' }>).text).toBe('After the tool ran fine.')
+  })
+
+  it('drops a reasoning part the completion text duplicates', () => {
+    const streamed: ChatMessagePart[] = [reasoningPart('The answer is 42.')]
+
+    const completed = reconcileCompletedTextParts(streamed, 'The answer is 42.')
+
+    expect(completed.map(part => part.type)).toEqual(['text'])
   })
 })

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -1,6 +1,10 @@
 import type { ThreadMessageLike } from '@assistant-ui/react'
 
-import { dedupeGeneratedImageEchoesInParts } from '@/lib/generated-images'
+import {
+  dedupeGeneratedImageEchoesInParts,
+  generatedImageEchoSources,
+  stripGeneratedImageEchoes
+} from '@/lib/generated-images'
 import { mediaDisplayLabel, mediaMarkdownHref } from '@/lib/media'
 import { parseTodos } from '@/lib/todos'
 import type { SessionMessage, UsageStats } from '@/types/hermes'
@@ -119,6 +123,51 @@ export function chatMessageText(message: ChatMessage): string {
     .filter((part): part is Extract<ChatMessagePart, { type: 'text' }> => part.type === 'text')
     .map(part => part.text)
     .join('')
+}
+
+// Reconcile the streamed parts of an assistant turn with the gateway's
+// completion text. `finalText` is the completion payload after renderMediaTags +
+// trim; it is the *trailing* assistant text of the turn (everything after the
+// last inline tool call), not the whole response. Earlier parts — narration
+// emitted before an inline tool call — are preserved verbatim, so text streamed
+// before a tool call is never lost (even when it happens to equal the trailing
+// completion text). Only the trailing run of text/reasoning parts (after the
+// last non-streamed part, e.g. a tool call) is reconciled: a part there is
+// dropped when the completion text fully duplicates it (prefix/suffix overlap,
+// after whitespace normalization), then the freshly media-rendered completion
+// text is appended. Turns without a tool call have a single trailing text part
+// that overlaps `finalText`, so they collapse to just that text — unchanged.
+// See issue #53204.
+export function reconcileCompletedTextParts(parts: ChatMessagePart[], finalText: string): ChatMessagePart[] {
+  const normalize = (value: string) => value.replace(/\s+/g, ' ').trim()
+  const visibleFinalText = stripGeneratedImageEchoes(finalText, generatedImageEchoSources(parts)).trim()
+  const dedupeReference = normalize(visibleFinalText)
+
+  let boundary = parts.length
+
+  while (boundary > 0) {
+    const part = parts[boundary - 1]
+
+    if (part.type !== 'text' && part.type !== 'reasoning') {
+      break
+    }
+
+    boundary--
+  }
+
+  const head = parts.slice(0, boundary)
+
+  const keptTrailing = dedupeReference
+    ? parts.slice(boundary).filter(part => {
+        const streamed = normalize((part as Extract<ChatMessagePart, { type: 'text' | 'reasoning' }>).text)
+
+        return !(streamed && (dedupeReference.startsWith(streamed) || streamed.startsWith(dedupeReference)))
+      })
+    : parts.slice(boundary)
+
+  const kept = [...head, ...keptTrailing]
+
+  return visibleFinalText ? [...kept, assistantTextPart(visibleFinalText)] : kept
 }
 
 const ATTACHED_CONTEXT_MARKER_RE = /(?:^|\n)--- Attached Context ---\s*\n/


### PR DESCRIPTION
## What does this PR do?

In the Desktop app, when the assistant streams a text block, calls a tool inline, then emits a short trailing text in the same turn, the earlier text disappeared once the tool finished (issue #53204).

On `message.complete`, `completeAssistantMessage` rebuilt the bubble by dropping **all** existing text parts and re-appending only the gateway's completion text. That completion text is just the trailing block after the last inline tool call, so the preceding narration (e.g. "Good, I've saved the new info.") was lost.

The fix reconciles only the trailing run of text/reasoning parts against the completion text and preserves earlier narration verbatim, so `[text, tool-call, text]` stays intact. Turns without a tool call still collapse to a single text part with no duplication.

## Related Issue

Fixes #53204

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/chat-messages.ts`: added a pure, exported helper `reconcileCompletedTextParts(parts, finalText)` that keeps every part up to and including the last tool call, dedupes only the trailing text/reasoning run against the completion text, then appends the rendered completion text.
- `apps/desktop/src/app/session/hooks/use-message-stream.ts`: `completeAssistantMessage` now calls that helper instead of the inline closure that stripped all text parts.
- `apps/desktop/src/lib/chat-messages.test.ts`: added unit tests (pre-tool text survives, identical text before/after a tool is kept, no duplication without a tool, trailing partial text replaced by the final text, reasoning dedupe).

## How to Test

1. `cd apps/desktop`
2. `npx vitest run --environment jsdom src/lib/chat-messages.test.ts` — 34 passing.
3. `npx tsc -p . --noEmit` and `npx eslint src/lib/chat-messages.ts src/lib/chat-messages.test.ts src/app/session/hooks/use-message-stream.ts` — both clean.

Manually: have the assistant write a substantive reply, call a tool inline, then a short confirmation; the first text block remains visible after the tool completes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(desktop):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (TypeScript-only change; ran the desktop Vitest suite instead)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure rendering logic, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A