### PR TITLE
fix(gateway): accept .stl and .3mf document uploads

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1275,6 +1275,8 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".ini": "text/plain",
     ".cfg": "text/plain",
     ".zip": "application/zip",
+    ".stl": "model/stl",
+    ".3mf": "model/3mf",
     ".doc": "application/msword",
     ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     ".xls": "application/vnd.ms-excel",

--- a/tests/gateway/test_document_cache.py
+++ b/tests/gateway/test_document_cache.py
@@ -156,6 +156,8 @@ class TestSupportedDocumentTypes:
             ".md",
             ".txt",
             ".zip",
+            ".stl",
+            ".3mf",
             ".doc",
             ".docx",
             ".xls",

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -261,6 +261,18 @@ class TestDocumentDownloadBlock:
         assert event.media_types == ["application/zip"]
 
     @pytest.mark.asyncio
+    async def test_stl_document_cached(self, adapter):
+        """A .stl upload should survive the document allowlist and cache flow."""
+        doc = _make_document(file_name="part.stl", mime_type="model/stl", file_size=100)
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.media_urls and event.media_urls[0].endswith("part.stl")
+        assert event.media_types == ["model/stl"]
+
+    @pytest.mark.asyncio
     async def test_png_document_is_routed_as_image(self, adapter):
         """Telegram documents that are really PNGs should use the image path."""
         file_obj = _make_file_obj(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)


### PR DESCRIPTION
## What does this PR do?

Accept `.stl` and `.3mf` files as supported document attachments so Telegram gateway users can send common 3D-printing model files through the normal document cache path instead of receiving an unsupported-type text fallback.

## Related Issue

Fixes #53249

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `.stl` -> `model/stl` and `.3mf` -> `model/3mf` to [`gateway/platforms/base.py`](/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/her-308-53249-stl-3mf/gateway/platforms/base.py)
- Added a Telegram regression test proving `.stl` uploads are cached instead of rejected in [`tests/gateway/test_telegram_documents.py`](/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/her-308-53249-stl-3mf/tests/gateway/test_telegram_documents.py)
- Extended the shared document allowlist assertions in [`tests/gateway/test_document_cache.py`](/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/her-308-53249-stl-3mf/tests/gateway/test_document_cache.py)

## How to Test

1. `uv run --with pytest python -m pytest tests/gateway/test_telegram_documents.py tests/gateway/test_document_cache.py`
2. `uv run --extra dev python -m ruff check gateway/platforms/base.py tests/gateway/test_telegram_documents.py tests/gateway/test_document_cache.py`
3. Upload a `.stl` or `.3mf` file through the Telegram gateway path and confirm Hermes caches the document instead of emitting an unsupported-type fallback message.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 via targeted gateway tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

- `uv run python --version` -> `Python 3.11.14`
- `uv run --with pytest python -m pytest tests/gateway/test_telegram_documents.py tests/gateway/test_document_cache.py` -> `77 passed`
- `uv run --extra dev python -m ruff check gateway/platforms/base.py tests/gateway/test_telegram_documents.py tests/gateway/test_document_cache.py` -> `All checks passed!`
