### PR TITLE
fix(feishu): route markdown tables through post+tag:md instead of force-text

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -154,8 +154,13 @@ _MARKDOWN_HINT_RE = re.compile(
     r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
     re.MULTILINE,
 )
-# Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
+# Detect markdown tables. Feishu post-type 'md' elements now render GFM tables
+# (verified against open.feishu.cn/document/server-docs/im-v1/message-content-description/create_json
+# which lists tables under the `tag: md` example). Older Hermes builds forced
+# table content to plain text because the renderer used to drop it; that
+# workaround now strips formatting from every other element in the same
+# message. We keep the detector so we can still observe table content for
+# logging/metrics, but the outbound payload path uses post + tag:md.
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
@@ -4375,13 +4380,13 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
-        if _MARKDOWN_HINT_RE.search(content):
+        # Feishu post + tag:md renders the full GFM surface (tables, bold,
+        # headings, code blocks, lists, quotes). Route any markdown-shaped
+        # content — including content with tables — through the post payload.
+        # If Feishu ever rejects the post (handled upstream via
+        # _POST_CONTENT_INVALID_RE), the send loop already falls back to
+        # plain text, so we don't need a pre-emptive force-text path here.
+        if _MARKDOWN_TABLE_RE.search(content) or _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2708,6 +2708,59 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_outbound_payload_routes_markdown_tables_to_post_md(self):
+        """Markdown tables must go through post+tag:md, not be force-downgraded to text.
+
+        Regression for the historic ``_MARKDOWN_TABLE_RE`` workaround that
+        force-downgraded the *entire* message to ``msg_type: text`` whenever
+        a GFM table appeared. That side-effect stripped formatting from
+        every other markdown element in the same message (headings, bold,
+        code blocks, lists), making mixed-content replies render as raw
+        markdown source.  Feishu's post + ``tag: md`` element renders GFM
+        tables today, so the table-detector must NOT trigger a text
+        fallback at payload-build time; the call-site already handles
+        post rejection via ``_POST_CONTENT_INVALID_RE``.
+        """
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        content = (
+            "## Heading\n"
+            "Some **bold** prose.\n\n"
+            "| col1 | col2 |\n"
+            "|------|------|\n"
+            "| a    | b    |\n\n"
+            "Trailing text."
+        )
+        msg_type, payload_json = adapter._build_outbound_payload(content)
+
+        self.assertEqual(msg_type, "post")
+        payload = json.loads(payload_json)
+        rows = payload["zh_cn"]["content"]
+        # Whole markdown body (table included) lives inside a single md tag.
+        self.assertEqual(rows, [[{"tag": "md", "text": content}]])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_outbound_payload_keeps_plain_text_for_non_markdown(self):
+        """Plain text without any markdown stays on msg_type: text.
+
+        Guards the second branch of ``_build_outbound_payload`` so that
+        the table-routing change doesn't accidentally widen the post
+        path to messages that have no markdown signal at all (which
+        would cost the receiver a richer-rendering message for nothing).
+        """
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        msg_type, payload_json = adapter._build_outbound_payload("just plain words")
+
+        self.assertEqual(msg_type, "text")
+        self.assertEqual(json.loads(payload_json), {"text": "just plain words"})
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_falls_back_to_text_when_post_payload_is_rejected(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter


### PR DESCRIPTION
## Summary

Feishu's post-type `md` element renders the full GFM surface today, including tables. The historic `_MARKDOWN_TABLE_RE` workaround in `_build_outbound_payload` predates that and force-downgrades the **entire** message to `msg_type: text` whenever a GFM table appears. That side-effect strips formatting from every other markdown element in the same message (headings, bold, code blocks, lists, quotes), so mixed-content replies render as raw markdown source on the client.

This PR routes table-bearing markdown through `post` + `tag: md` like every other markdown shape, removing the force-text branch.

## Repro before this fix

Send any Feishu message that mixes a markdown table with other markdown:

````
## Some heading
Some **bold** prose.

| col1 | col2 |
|------|------|
| a    | b    |

Trailing text with `inline code`.
````

Result on the Feishu client: the whole message arrives as raw text — `##`, `**`, `|`, fences all visible as characters. Same content **without** the table renders correctly as a post.

## Root cause

`plugins/platforms/feishu/adapter.py::FeishuAdapter._build_outbound_payload` (line 4377 on `main`):

```python
def _build_outbound_payload(self, content):
    if _MARKDOWN_TABLE_RE.search(content):
        # Force plain text for anything that looks like a markdown table.
        return "text", json.dumps({"text": content}, ensure_ascii=False)
    if _MARKDOWN_HINT_RE.search(content):
        return "post", _build_markdown_post_payload(content)
    return "text", json.dumps({"text": content}, ensure_ascii=False)
```

The first branch fires whenever the regex matches `^|...|\n|---|...` anywhere in the message and demotes the whole reply to plain text — losing all other markdown for the sake of "rescuing" the table.

The original justification (Feishu's `md` tag didn't render tables) is no longer accurate: the [official `create_json` doc](https://open.feishu.cn/document/server-docs/im-v1/message-content-description/create_json) lists tables under the `tag: md` example, and empirical testing on current Feishu clients (verified in the linked issue #27529) confirms tables render correctly inside post + md.

## Fix

Send tables through `post` + `tag: md` like every other markdown shape:

```python
def _build_outbound_payload(self, content):
    if _MARKDOWN_TABLE_RE.search(content) or _MARKDOWN_HINT_RE.search(content):
        return "post", _build_markdown_post_payload(content)
    return "text", json.dumps({"text": content}, ensure_ascii=False)
```

A pre-emptive text fallback is no longer needed: the send loop already handles a rejected post payload via `_POST_CONTENT_INVALID_RE` and degrades to plain text on both API exception and unsuccessful API response (existing code, `_send_text_message` around line 1801). So if Feishu ever regresses on table rendering inside posts, behaviour reverts to the current safety net automatically — but on success the receiver gets a properly-rendered post for the table **and** all surrounding markdown.

The detector `_MARKDOWN_TABLE_RE` itself is preserved (some metrics / logging paths may want to know a message contained a table). Only the routing changes. The stale comment block above the regex is updated to record the new contract.

## Test Plan

- [x] New: `test_outbound_payload_routes_markdown_tables_to_post_md` pins the regression — a message containing a table plus heading + bold + trailing prose is emitted as a single post+md payload, not downgraded to text.
- [x] New: `test_outbound_payload_keeps_plain_text_for_non_markdown` guards the second branch so the change doesn't accidentally widen the post path to plain-text content (which would cost a richer-rendering payload for nothing).
- [x] Full `tests/gateway/test_feishu.py` suite — **207/207 passed**.
- [x] Existing fallback tests (`test_send_falls_back_to_text_when_post_payload_is_rejected`, `test_send_falls_back_to_text_when_post_response_is_unsuccessful`, `test_edit_message_falls_back_to_text_when_post_update_is_rejected`) still pass — confirms the post-rejection safety net is intact for tables now too.

## References

- #27529 — proposes this exact fix (post + tag:md replaces force-text)
- #9549 — original bug report on table rendering
- #26658 — alternative proposal to remove the detector entirely
- [Feishu API: 发送消息内容结构 — `tag: md`](https://open.feishu.cn/document/server-docs/im-v1/message-content-description/create_json)

Not closing #27529 / #9549 — leaving it to maintainers' judgement whether this PR addresses them in full.
