### PR TITLE
fix(desktop): keep titlebar overlay off session title

### DIFF
--- a/apps/desktop/src/app/shell/app-shell.tsx
+++ b/apps/desktop/src/app/shell/app-shell.tsx
@@ -192,7 +192,7 @@ export function AppShell({
       {nativeOverlayWidth > 0 && (
         <div
           aria-hidden
-          className="pointer-events-none fixed inset-x-0 top-0 z-[4] h-(--titlebar-height) border-b border-(--ui-stroke-tertiary) bg-(--ui-chat-surface-background)"
+          className="pointer-events-none fixed right-0 top-0 z-[4] h-(--titlebar-height) w-(--titlebar-tools-right) border-b border-(--ui-stroke-tertiary) bg-(--ui-chat-surface-background)"
         />
       )}
 


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows Desktop titlebar layering issue where the active session title/menu trigger could be mounted and clickable but visually hidden.

When Electron reports a native titlebar overlay width, `AppShell` renders an opaque fixed titlebar background at `z-[4]`. That background was full-width, while chat content lives under `main z-3`, so the overlay could paint over the session title even though pointer events still passed through. This made the titlebar look blank while clicks opened the session actions menu.

This narrows that native-overlay background to the right-side window-controls area, keeping the intended background behind native controls without masking the session title.

## Related Issue

N/A. Found while testing the Desktop titlebar locally on Windows.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/shell/app-shell.tsx`: constrain the fixed native-overlay titlebar background to `right-0` / `w-(--titlebar-tools-right)` instead of `inset-x-0`.

## How to Test

1. On Windows Desktop, launch Hermes with an active session and native titlebar overlay controls.
2. Confirm the active session title/menu trigger is visible in the titlebar.
3. Confirm clicking the visible title opens the session actions menu, while the titlebar no longer appears to have a blank invisible menu trigger over the session-title area.
4. Confirm the native window-controls area on the right still has the titlebar background.

Local checks run:

- `npm --workspace apps/desktop run typecheck`
- `npm --workspace apps/desktop run pack`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass. Not run; this is a Desktop renderer layout change. Targeted Desktop checks are listed above.
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features). Not added; this is a visual Electron titlebar layering fix.
- [x] I've tested on my platform: Windows 11, via Desktop typecheck and unpacked app build.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Local build output confirmed `typecheck` and `pack` completed successfully. Manual visual confirmation should be done on Windows Desktop before marking ready for review.