### PR TITLE
fix(terminal): suppress Windows desktop terminal console flashes

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -183,7 +183,7 @@ def windows_detach_flags_without_breakaway() -> int:
     return _CREATE_NEW_PROCESS_GROUP | _DETACHED_PROCESS | _CREATE_NO_WINDOW
 
 
-def windows_hide_flags() -> int:
+def windows_hide_flags(*, breakaway_from_job: bool = False) -> int:
     """Return Win32 creationflags that merely hide the child's console
     window without detaching the child.  0 on non-Windows.
 
@@ -195,10 +195,19 @@ def windows_hide_flags() -> int:
     ``DETACHED_PROCESS`` — the child still inherits stdio handles so
     ``capture_output=True`` works.  ``DETACHED_PROCESS`` would sever
     stdio and break stdout capture.
+
+    ``breakaway_from_job=True`` adds ``CREATE_BREAKAWAY_FROM_JOB`` for
+    callers running under a Desktop/Electron job object where
+    ``CREATE_NO_WINDOW`` alone still allows a visible console flash.
+    Some job objects reject breakaway with ``OSError``; those callers
+    should retry once without the bit.
     """
     if not IS_WINDOWS:
         return 0
-    return _CREATE_NO_WINDOW
+    flags = _CREATE_NO_WINDOW
+    if breakaway_from_job:
+        flags |= _CREATE_BREAKAWAY_FROM_JOB
+    return flags
 
 
 def windows_detach_popen_kwargs() -> dict:

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -624,6 +624,52 @@ class TestSubprocessCompatHelpers:
         assert fallback & 0x00000008, "fallback missing DETACHED_PROCESS"
         assert fallback & 0x08000000, "fallback missing CREATE_NO_WINDOW"
 
+    def test_windows_hide_flags_can_opt_into_breakaway(self, monkeypatch):
+        from hermes_cli import _subprocess_compat as sc
+
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+
+        assert sc.windows_hide_flags() == 0x08000000
+        assert sc.windows_hide_flags(breakaway_from_job=True) == (
+            0x08000000 | 0x01000000
+        )
+
+    def test_local_environment_run_bash_retries_without_breakaway(self, monkeypatch):
+        import tools.environments.local as local_mod
+
+        calls: list[int] = []
+
+        def fake_popen(args, **kwargs):
+            calls.append(kwargs.get("creationflags", 0))
+            if len(calls) == 1:
+                raise OSError(5, "Access is denied")
+            proc = MagicMock()
+            proc.pid = 12345
+            proc.stdin = None
+            return proc
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(local_mod, "_find_bash", lambda: "bash")
+        monkeypatch.setattr(local_mod, "_make_run_env", lambda env: {})
+        monkeypatch.setattr(local_mod, "_resolve_safe_cwd", lambda cwd: cwd)
+        monkeypatch.setattr(local_mod.subprocess, "Popen", fake_popen)
+
+        with mock.patch.object(
+            local_mod.LocalEnvironment,
+            "init_session",
+            autospec=True,
+            return_value=None,
+        ):
+            env = local_mod.LocalEnvironment(cwd="/tmp", timeout=10, env={})
+
+        proc = env._run_bash("echo hi")
+
+        assert proc.pid == 12345
+        assert calls == [
+            local_mod.windows_hide_flags(breakaway_from_job=True),
+            local_mod.windows_hide_flags(),
+        ]
+
 
 # ---------------------------------------------------------------------------
 # tui_gateway/entry.py signal installation survives absent POSIX signals

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -720,21 +720,29 @@ class LocalEnvironment(BaseEnvironment):
 
         _popen_cwd = self.cwd
 
-        _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
+        popen_kwargs = {
+            "text": True,
+            "env": run_env,
+            "encoding": "utf-8",
+            "errors": "replace",
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.STDOUT,
+            "stdin": subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
+            "start_new_session": True,
+            "cwd": _popen_cwd,
+        }
 
-        proc = subprocess.Popen(
-            args,
-            text=True,
-            env=run_env,
-            encoding="utf-8",
-            errors="replace",
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
-            start_new_session=True,
-            cwd=_popen_cwd,
-            **_popen_kwargs,
-        )
+        if _IS_WINDOWS:
+            popen_kwargs["creationflags"] = windows_hide_flags(
+                breakaway_from_job=True
+            )
+            try:
+                proc = subprocess.Popen(args, **popen_kwargs)
+            except OSError:
+                popen_kwargs["creationflags"] = windows_hide_flags()
+                proc = subprocess.Popen(args, **popen_kwargs)
+        else:
+            proc = subprocess.Popen(args, **popen_kwargs)
         if not _IS_WINDOWS:
             try:
                 proc._hermes_pgid = os.getpgid(proc.pid)


### PR DESCRIPTION
## Summary
- opt `windows_hide_flags()` into `CREATE_BREAKAWAY_FROM_JOB` for Desktop/Electron terminal launches
- retry hidden local bash spawns once without breakaway when Windows denies that flag
- add regression tests for the hide-flag bundle and the LocalEnvironment retry path

## Verification
- `uv run python --version`
- `uv run --with pytest python -m pytest tests/tools/test_windows_native_support.py -k 'SubprocessCompatHelpers or LocalEnvironment'`\n- `uv run --extra dev python -m ruff check hermes_cli/_subprocess_compat.py tools/environments/local.py tests/tools/test_windows_native_support.py`\n- `git diff --check`\n\nFixes #53273