### PR TITLE
Add TrustedRouter provider

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -46,7 +46,7 @@ def _resolve_requests_verify() -> bool | str:
 # Only these are stripped — Ollama-style "model:tag" colons (e.g. "qwen3.5:27b")
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
-    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+    "openrouter", "trustedrouter", "nous", "openai-codex", "copilot", "copilot-acp",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "kilocode", "alibaba", "novita",
     "qwen-oauth",
@@ -68,6 +68,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "xai", "x-ai", "x.ai", "grok",
     "nvidia", "nim", "nvidia-nim", "nemotron",
     "qwen-portal", "novita-ai", "novitaai",
+    "tr", "trusted-router", "trustedrouter.com", "quillrouter", "quill-router",
 })
 
 

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -42,11 +42,18 @@ export const PROVIDER_GROUPS: ProviderPrefix[] = [
     priority: 1
   },
   {
+    prefix: 'TRUSTEDROUTER_',
+    name: 'TrustedRouter.com',
+    description: 'OpenAI-compatible attested router',
+    docsUrl: 'https://trustedrouter.com/console/keys',
+    priority: 2
+  },
+  {
     prefix: 'ANTHROPIC_',
     name: 'Anthropic',
     description: 'Claude API access (Sonnet, Opus, Haiku)',
     docsUrl: 'https://console.anthropic.com/settings/keys',
-    priority: 2
+    priority: 3
   },
   {
     prefix: 'XAI_',

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -123,6 +123,7 @@ describe('settings helpers', () => {
       expect(providerGroup('XAI_API_KEY')).toBe('xAI')
       expect(providerGroup('NOUS_API_KEY')).toBe('Nous Portal')
       expect(providerGroup('OPENROUTER_API_KEY')).toBe('OpenRouter')
+      expect(providerGroup('TRUSTEDROUTER_API_KEY')).toBe('TrustedRouter.com')
     })
 
     it('prefers the longest matching prefix so CN/regional buckets win', () => {

--- a/apps/desktop/src/components/onboarding/index.test.tsx
+++ b/apps/desktop/src/components/onboarding/index.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { $desktopOnboarding, type DesktopOnboardingState, type OnboardingContext } from '@/store/onboarding'
 import type { OAuthProvider } from '@/types/hermes'
@@ -32,6 +32,28 @@ function setProviders(providers: OAuthProvider[]) {
 }
 
 const ctx: OnboardingContext = { requestGateway: async () => undefined as never }
+
+function ensureLocalStorage() {
+  if (typeof window.localStorage.getItem === 'function') {
+    return
+  }
+
+  const values = new Map<string, string>()
+
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      clear: () => values.clear(),
+      getItem: (key: string) => values.get(key) ?? null,
+      removeItem: (key: string) => values.delete(key),
+      setItem: (key: string, value: string) => values.set(key, value)
+    }
+  })
+}
+
+beforeEach(() => {
+  ensureLocalStorage()
+})
 
 afterEach(() => {
   cleanup()
@@ -76,6 +98,7 @@ describe('onboarding Picker', () => {
 
     expect(screen.getByText('Anthropic API Key')).toBeTruthy()
     expect(screen.getByText('OpenAI OAuth (ChatGPT)')).toBeTruthy()
+    expect(screen.getByText('API key provider')).toBeTruthy()
     expect(screen.queryByText('Other sign-in options')).toBeNull()
     expect(screen.queryByText('Recommended')).toBeNull()
   })
@@ -98,5 +121,15 @@ describe('onboarding Picker', () => {
     render(<Picker ctx={ctx} />)
 
     expect(screen.queryByRole('button', { name: "I'll choose a provider later" })).toBeNull()
+  })
+
+  it('offers TrustedRouter in the native API-key picker', () => {
+    setProviders([])
+    $desktopOnboarding.set({ ...$desktopOnboarding.get(), mode: 'apikey' })
+    render(<Picker ctx={ctx} />)
+
+    expect(screen.getByText('TrustedRouter.com')).toBeTruthy()
+    expect(screen.getByText('OpenRouter')).toBeTruthy()
+    expect(screen.getByText('OpenAI-compatible routing through TrustedRouter.com.')).toBeTruthy()
   })
 })

--- a/apps/desktop/src/components/onboarding/index.tsx
+++ b/apps/desktop/src/components/onboarding/index.tsx
@@ -50,6 +50,12 @@ export interface ApiKeyOption {
 
 const API_KEY_OPTIONS: ApiKeyOption[] = [
   {
+    id: 'trustedrouter',
+    name: 'TrustedRouter.com',
+    envKey: 'TRUSTEDROUTER_API_KEY',
+    docsUrl: 'https://trustedrouter.com/console/keys'
+  },
+  {
     id: 'openrouter',
     name: 'OpenRouter',
     envKey: 'OPENROUTER_API_KEY',

--- a/apps/desktop/src/components/onboarding/providers.tsx
+++ b/apps/desktop/src/components/onboarding/providers.tsx
@@ -82,8 +82,10 @@ export function KeyProviderRow({ onClick }: { onClick: () => void }) {
   return (
     <RowButton className={PROVIDER_ROW_CLASS} onClick={onClick}>
       <div className="min-w-0">
-        <span className="text-[length:var(--conversation-text-font-size)] font-semibold">OpenRouter</span>
-        <p className="mt-1 text-xs leading-5 text-muted-foreground">{t.onboarding.openRouterPitch}</p>
+        <span className="text-[length:var(--conversation-text-font-size)] font-semibold">
+          {t.onboarding.apiKeyProviderTitle}
+        </span>
+        <p className="mt-1 text-xs leading-5 text-muted-foreground">{t.onboarding.apiKeyProviderPitch}</p>
       </div>
       <ChevronRight className="size-4 text-muted-foreground transition group-hover:text-foreground" />
     </RowButton>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1719,8 +1719,14 @@ export const en: Translations = {
     recommended: 'Recommended',
     connected: 'Connected',
     featuredPitch: 'One subscription, 300+ frontier models — the recommended way to run Hermes',
+    apiKeyProviderTitle: 'API key provider',
+    apiKeyProviderPitch: 'Use TrustedRouter, OpenRouter, or a direct model provider key',
     openRouterPitch: 'One key, hundreds of models — a solid default',
     apiKeyOptions: {
+      trustedrouter: {
+        short: 'attested router',
+        description: 'OpenAI-compatible routing through TrustedRouter.com.'
+      },
       openrouter: {
         short: 'one key, many models',
         description: 'Hosts hundreds of models behind a single key. Good default for new installs.'

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1827,8 +1827,14 @@ export const ja = defineLocale({
     recommended: '推奨',
     connected: '接続済み',
     featuredPitch: '1 つのサブスクリプションで 300 以上の最先端モデル — Hermes を実行するための推奨方法',
+    apiKeyProviderTitle: 'API キープロバイダー',
+    apiKeyProviderPitch: 'TrustedRouter、OpenRouter、または直接プロバイダーのキーを使用',
     openRouterPitch: '1 つのキーで数百のモデル — 堅実なデフォルト',
     apiKeyOptions: {
+      trustedrouter: {
+        short: '検証可能なルーター',
+        description: 'TrustedRouter.com 経由の OpenAI 互換ルーティング。'
+      },
       openrouter: {
         short: '1 つのキーで多くのモデル',
         description: '1 つのキーで数百のモデルをホスト。新規インストールのデフォルトとして最適。'

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1390,6 +1390,8 @@ export interface Translations {
     recommended: string
     connected: string
     featuredPitch: string
+    apiKeyProviderTitle: string
+    apiKeyProviderPitch: string
     openRouterPitch: string
     apiKeyOptions: Record<string, { short: string; description: string }>
     backToSignIn: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1772,8 +1772,11 @@ export const zhHant = defineLocale({
     recommended: '建議',
     connected: '已連線',
     featuredPitch: '一個訂閱，300+ 前沿模型 — 執行 Hermes 的建議方式',
+    apiKeyProviderTitle: 'API 金鑰提供方',
+    apiKeyProviderPitch: '使用 TrustedRouter、OpenRouter 或直接模型提供方金鑰',
     openRouterPitch: '一個金鑰，數百個模型 — 穩定的預設選擇',
     apiKeyOptions: {
+      trustedrouter: { short: '可驗證路由器', description: '透過 TrustedRouter.com 使用 OpenAI 相容路由。' },
       openrouter: { short: '一個金鑰，多個模型', description: '用一個金鑰存取數百個模型。適合新安裝的預設選擇。' },
       openai: { short: 'GPT 等級模型', description: '直接存取 OpenAI 模型。' },
       gemini: { short: 'Gemini 模型', description: '直接存取 Google Gemini 模型。' },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1895,8 +1895,11 @@ export const zh: Translations = {
     recommended: '推荐',
     connected: '已连接',
     featuredPitch: '一个订阅，300+ 前沿模型 — 运行 Hermes 的推荐方式',
+    apiKeyProviderTitle: 'API 密钥提供方',
+    apiKeyProviderPitch: '使用 TrustedRouter、OpenRouter 或直接模型提供方密钥',
     openRouterPitch: '一个密钥，数百个模型 — 稳妥的默认选择',
     apiKeyOptions: {
+      trustedrouter: { short: '可验证路由器', description: '通过 TrustedRouter.com 使用 OpenAI 兼容路由。' },
       openrouter: { short: '一个密钥，多个模型', description: '用一个密钥访问数百个模型。适合新安装的默认选择。' },
       openai: { short: 'GPT 级模型', description: '直接访问 OpenAI 模型。' },
       gemini: { short: 'Gemini 模型', description: '直接访问 Google Gemini 模型。' },

--- a/apps/desktop/src/lib/provider-setup-errors.test.ts
+++ b/apps/desktop/src/lib/provider-setup-errors.test.ts
@@ -10,6 +10,7 @@ describe('isProviderSetupErrorMessage', () => {
     expect(isProviderSetupErrorMessage('No inference provider is configured.')).toBe(true)
     expect(isProviderSetupErrorMessage('No Hermes provider is configured.')).toBe(true)
     expect(isProviderSetupErrorMessage('set an API key (OPENROUTER_API_KEY) in ~/.hermes/.env')).toBe(true)
+    expect(isProviderSetupErrorMessage('set an API key (TRUSTEDROUTER_API_KEY) in ~/.hermes/.env')).toBe(true)
   })
 
   it('does not match non-provider runtime failures', () => {

--- a/apps/desktop/src/lib/provider-setup-errors.ts
+++ b/apps/desktop/src/lib/provider-setup-errors.ts
@@ -1,5 +1,5 @@
 const PROVIDER_SETUP_ERROR_RE =
-  /No (?:inference|Hermes) provider(?: is)? configured|no_provider_configured|OPENROUTER_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|set an API key/i
+  /No (?:inference|Hermes) provider(?: is)? configured|no_provider_configured|TRUSTEDROUTER_API_KEY|OPENROUTER_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|set an API key/i
 
 export function isProviderSetupErrorMessage(message: null | string | undefined): boolean {
   const text = message?.trim()

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1023,6 +1023,7 @@ class ProviderEntry(NamedTuple):
 CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nous",           "Nous Portal",              "Nous Portal (Everything your agent needs, 300+ models with bundled tool use)"),
     ProviderEntry("openrouter",     "OpenRouter",               "OpenRouter (Pay-per-use API aggregator)"),
+    ProviderEntry("trustedrouter",  "TrustedRouter.com",        "TrustedRouter.com (end-to-end encrypted OpenRouter-compatible router)"),
     ProviderEntry("moa",            "Mixture of Agents",        "Mixture of Agents (named presets; aggregator acts after reference models)"),
     ProviderEntry("novita",         "NovitaAI",                 "NovitaAI (Cloud: Model API, Agent Sandbox, GPU Cloud)"),
     ProviderEntry("lmstudio",       "LM Studio",                "LM Studio (Local desktop app with built-in model server)"),
@@ -1187,6 +1188,11 @@ def group_providers(slugs):
 
 
 _PROVIDER_ALIASES = {
+    "tr": "trustedrouter",
+    "trusted-router": "trustedrouter",
+    "trustedrouter.com": "trustedrouter",
+    "quillrouter": "trustedrouter",
+    "quill-router": "trustedrouter",
     "glm": "zai",
     "z-ai": "zai",
     "z.ai": "zai",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -54,6 +54,13 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         is_aggregator=True,
         base_url_env_var="OPENROUTER_BASE_URL",
     ),
+    "trustedrouter": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        extra_env_vars=("TRUSTEDROUTER_API_KEY",),
+        base_url_override="https://api.trustedrouter.com/v1",
+        base_url_env_var="TRUSTEDROUTER_BASE_URL",
+    ),
     "nous": HermesOverlay(
         transport="openai_chat",
         auth_type="oauth_device_code",
@@ -240,6 +247,11 @@ class ProviderDef:
 ALIASES: Dict[str, str] = {
     # openrouter
     "openai": "openrouter",     # bare "openai" → route through aggregator
+    "tr": "trustedrouter",
+    "trusted-router": "trustedrouter",
+    "trustedrouter.com": "trustedrouter",
+    "quillrouter": "trustedrouter",
+    "quill-router": "trustedrouter",
 
     # zai
     "glm": "zai",
@@ -362,6 +374,7 @@ ALIASES: Dict[str, str] = {
 _LABEL_OVERRIDES: Dict[str, str] = {
     "moa": "Mixture of Agents",
     "nous": "Nous Portal",
+    "trustedrouter": "TrustedRouter.com",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
     "stepfun": "StepFun Step Plan",

--- a/plugins/model-providers/trustedrouter/__init__.py
+++ b/plugins/model-providers/trustedrouter/__init__.py
@@ -1,0 +1,70 @@
+"""TrustedRouter.com provider profile."""
+
+import logging
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+logger = logging.getLogger(__name__)
+
+_CACHE: list[str] | None = None
+
+
+class TrustedRouterProfile(ProviderProfile):
+    """TrustedRouter.com - end-to-end encrypted OpenRouter-compatible routing."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Fetch the TrustedRouter model catalog when credentials are available."""
+        global _CACHE  # noqa: PLW0603
+        if _CACHE is not None:
+            return _CACHE
+        try:
+            result = super().fetch_models(api_key=api_key, timeout=timeout)
+            if result is not None:
+                _CACHE = result
+            return result
+        except Exception as exc:
+            logger.debug("fetch_models(trustedrouter): %s", exc)
+            return None
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        supports_reasoning: bool = False,
+        model: str | None = None,
+        session_id: str | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """TrustedRouter accepts OpenRouter/OpenAI-compatible reasoning payloads."""
+        if supports_reasoning:
+            if reasoning_config is not None:
+                return {"reasoning": dict(reasoning_config)}, {}
+            return {"reasoning": {"enabled": True, "effort": "medium"}}, {}
+        return {}, {}
+
+
+trustedrouter = TrustedRouterProfile(
+    name="trustedrouter",
+    aliases=(
+        "tr",
+        "trusted-router",
+        "trustedrouter.com",
+        "quillrouter",
+        "quill-router",
+    ),
+    env_vars=("TRUSTEDROUTER_API_KEY", "TRUSTEDROUTER_BASE_URL"),
+    display_name="TrustedRouter.com",
+    description="TrustedRouter.com - end-to-end encrypted OpenRouter-compatible LLM router",
+    signup_url="https://trustedrouter.com/",
+    base_url="https://api.trustedrouter.com/v1",
+    fallback_models=("trustedrouter/auto",),
+)
+
+register_provider(trustedrouter)

--- a/plugins/model-providers/trustedrouter/plugin.yaml
+++ b/plugins/model-providers/trustedrouter/plugin.yaml
@@ -1,0 +1,5 @@
+name: trustedrouter-provider
+kind: model-provider
+version: 1.0.0
+description: TrustedRouter.com end-to-end encrypted OpenRouter-compatible LLM router
+author: Nous Research

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -41,6 +41,7 @@ class TestProviderRegistry:
         ("minimax-cn", "MiniMax (China)", "api_key"),
         ("kilocode", "Kilo Code", "api_key"),
         ("gmi", "GMI Cloud", "api_key"),
+        ("trustedrouter", "TrustedRouter.com", "api_key"),
     ])
     def test_provider_registered(self, provider_id, name, auth_type):
         assert provider_id in PROVIDER_REGISTRY
@@ -105,6 +106,12 @@ class TestProviderRegistry:
         assert pconfig.api_key_env_vars == ("GMI_API_KEY",)
         assert pconfig.base_url_env_var == "GMI_BASE_URL"
 
+    def test_trustedrouter_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["trustedrouter"]
+        assert pconfig.api_key_env_vars == ("TRUSTEDROUTER_API_KEY",)
+        assert pconfig.base_url_env_var == "TRUSTEDROUTER_BASE_URL"
+        assert pconfig.inference_base_url == "https://api.trustedrouter.com/v1"
+
     def test_huggingface_env_vars(self):
         pconfig = PROVIDER_REGISTRY["huggingface"]
         assert pconfig.api_key_env_vars == ("HF_TOKEN",)
@@ -121,6 +128,7 @@ class TestProviderRegistry:
         assert PROVIDER_REGISTRY["kilocode"].inference_base_url == "https://api.kilo.ai/api/gateway"
         assert PROVIDER_REGISTRY["gmi"].inference_base_url == "https://api.gmi-serving.com/v1"
         assert PROVIDER_REGISTRY["huggingface"].inference_base_url == "https://router.huggingface.co/v1"
+        assert PROVIDER_REGISTRY["trustedrouter"].inference_base_url == "https://api.trustedrouter.com/v1"
 
     def test_oauth_providers_unchanged(self):
         """Ensure we didn't break the existing OAuth providers."""
@@ -142,6 +150,7 @@ PROVIDER_ENV_VARS = (
     "KIMI_API_KEY", "KIMI_BASE_URL", "STEPFUN_API_KEY", "STEPFUN_BASE_URL",
     "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
     "KILOCODE_API_KEY", "KILOCODE_BASE_URL",
+    "TRUSTEDROUTER_API_KEY", "TRUSTEDROUTER_BASE_URL",
     "GMI_API_KEY", "GMI_BASE_URL",
     "DASHSCOPE_API_KEY", "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
     "NOUS_API_KEY", "GITHUB_TOKEN", "GH_TOKEN",
@@ -204,6 +213,14 @@ class TestResolveProvider:
 
     def test_explicit_kilocode(self):
         assert resolve_provider("kilocode") == "kilocode"
+
+    def test_explicit_trustedrouter(self):
+        assert resolve_provider("trustedrouter") == "trustedrouter"
+
+    def test_alias_trusted_router(self):
+        assert resolve_provider("trusted-router") == "trustedrouter"
+        assert resolve_provider("tr") == "trustedrouter"
+        assert resolve_provider("quillrouter") == "trustedrouter"
 
     def test_alias_kilo(self):
         assert resolve_provider("kilo") == "kilocode"
@@ -280,6 +297,10 @@ class TestResolveProvider:
     def test_auto_detects_kilocode_key(self, monkeypatch):
         monkeypatch.setenv("KILOCODE_API_KEY", "test-kilo-key")
         assert resolve_provider("auto") == "kilocode"
+
+    def test_auto_detects_trustedrouter_key(self, monkeypatch):
+        monkeypatch.setenv("TRUSTEDROUTER_API_KEY", "sk-tr-v1-test")
+        assert resolve_provider("auto") == "trustedrouter"
 
     def test_auto_detects_hf_token(self, monkeypatch):
         monkeypatch.setenv("HF_TOKEN", "hf_test_token")

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -69,6 +69,7 @@ def test_all_profiles_register():
     for required in (
         "openrouter", "anthropic", "custom", "bedrock", "openai-codex",
         "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan",
+        "trustedrouter",
     ):
         assert required in names, f"Missing profile: {required}"
 

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -15,6 +15,8 @@ class TestRegistry:
         assert get_provider_profile("moonshot").name == "kimi-coding"
         assert get_provider_profile("kimi-coding-cn").name == "kimi-coding-cn"
         assert get_provider_profile("or").name == "openrouter"
+        assert get_provider_profile("tr").name == "trustedrouter"
+        assert get_provider_profile("trusted-router").name == "trustedrouter"
         assert get_provider_profile("nous-portal").name == "nous"
         assert get_provider_profile("qwen").name == "qwen-oauth"
         assert get_provider_profile("qwen-portal").name == "qwen-oauth"
@@ -405,6 +407,34 @@ class TestOpenRouterProfile:
             model="anthropic/claude-fable-5",
         )
         assert tl == {"verbosity": "high"}
+
+
+class TestTrustedRouterProfile:
+    def test_profile_loads(self):
+        p = get_provider_profile("trustedrouter")
+        assert p is not None
+        assert p.name == "trustedrouter"
+        assert p.display_name == "TrustedRouter.com"
+        assert p.base_url == "https://api.trustedrouter.com/v1"
+        assert p.env_vars == ("TRUSTEDROUTER_API_KEY", "TRUSTEDROUTER_BASE_URL")
+
+    def test_aliases(self):
+        assert get_provider_profile("trusted-router").name == "trustedrouter"
+        assert get_provider_profile("trustedrouter.com").name == "trustedrouter"
+        assert get_provider_profile("quillrouter").name == "trustedrouter"
+
+    def test_fallback_auto_model(self):
+        p = get_provider_profile("trustedrouter")
+        assert p.fallback_models == ("trustedrouter/auto",)
+
+    def test_reasoning_passthrough(self):
+        p = get_provider_profile("trustedrouter")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            supports_reasoning=True,
+        )
+        assert eb["reasoning"] == {"enabled": True, "effort": "high"}
+        assert tl == {}
 
 
 class TestNousProfile:


### PR DESCRIPTION
## What

Adds **TrustedRouter** as a provider, modeled on the existing `openrouter` aggregator overlay.

[TrustedRouter](https://trustedrouter.com) is an OpenAI-compatible aggregator (`https://api.trustedrouter.com/v1`) offering attested, privacy-preserving routing to frontier and open-weight models, with zero-data-retention and end-to-end-encrypted routes.

## Changes

- `plugins/model-providers/trustedrouter/` — bundled provider plugin (`__init__.py` + `plugin.yaml`)
- `hermes_cli/providers.py` — `HermesOverlay` for trustedrouter (`openai_chat` transport, aggregator), aliases (`tr`, `trusted-router`, `quillrouter`, …), label override, `CANONICAL_PROVIDERS` entry
- `hermes_cli/models.py` — provider aliases
- `agent/model_metadata.py` — register `trustedrouter` prefix + aliases for model-name normalization
- `tests/` — provider registration, env var, base URL, alias-resolution, and profile coverage

All changes are additive (new entries in existing provider tables); no existing provider behavior is modified. Verified locally: `pytest tests/hermes_cli/test_api_key_providers.py tests/providers/test_plugin_discovery.py tests/providers/test_provider_profiles.py` → **231 passed**.
