### PR TITLE
fix(desktop): dedupe same-turn completion fallback

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -6,6 +6,7 @@ import { translateNow } from '@/i18n'
 import {
   appendAssistantTextPart,
   appendReasoningPart,
+  assistantCompletionLooksEquivalent,
   assistantTextPart,
   type ChatMessage,
   type ChatMessagePart,
@@ -620,7 +621,11 @@ export function useMessageStream({
             const existing = prev[index]
             const existingText = chatMessageText(existing).trim()
 
-            if (existing.pending || (finalText && existingText === finalText)) {
+            const sameAssistantTurn =
+              Boolean(state.sawAssistantPayload) &&
+              assistantCompletionLooksEquivalent(existingText, finalText)
+
+            if (existing.pending || (finalText && existingText === finalText) || sameAssistantTurn) {
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -4,6 +4,7 @@ import type { ChatMessage, ChatMessagePart } from './chat-messages'
 import {
   appendAssistantTextPart,
   appendReasoningPart,
+  assistantCompletionLooksEquivalent,
   chatMessageText,
   preserveLocalAssistantErrors,
   renderMediaTags,
@@ -173,6 +174,20 @@ describe('renderMediaTags', () => {
     const text = chatMessageText({ id: 'a', role: 'assistant', parts })
 
     expect(text).toBe('ok\n[Audio: voice.mp3](#media:%2Ftmp%2Fvoice.mp3)')
+  })
+})
+
+describe('assistantCompletionLooksEquivalent', () => {
+  it('treats markdown and whitespace-only drift as the same completion', () => {
+    expect(assistantCompletionLooksEquivalent('Here is**one**answer', 'Here is **one** answer')).toBe(true)
+  })
+
+  it('treats a streamed prefix as the same completion tail', () => {
+    expect(assistantCompletionLooksEquivalent('Sure,hereisthere', 'Sure, here is the rest of the answer')).toBe(true)
+  })
+
+  it('does not collapse unrelated assistant turns', () => {
+    expect(assistantCompletionLooksEquivalent('first answer', 'completely different reply')).toBe(false)
   })
 })
 

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -121,6 +121,25 @@ export function chatMessageText(message: ChatMessage): string {
     .join('')
 }
 
+function normalizeAssistantCompletionText(text: string): string {
+  return text
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1')
+    .replace(/[*_`~]/g, '')
+    .replace(/\s+/g, '')
+    .toLowerCase()
+}
+
+export function assistantCompletionLooksEquivalent(existingText: string, finalText: string): boolean {
+  const existing = normalizeAssistantCompletionText(existingText)
+  const final = normalizeAssistantCompletionText(finalText)
+
+  if (!existing || !final) {
+    return false
+  }
+
+  return existing === final || existing.startsWith(final) || final.startsWith(existing)
+}
+
 const ATTACHED_CONTEXT_MARKER_RE = /(?:^|\n)--- Attached Context ---\s*\n/
 const CONTEXT_WARNINGS_MARKER_RE = /(?:^|\n)--- Context Warnings ---[\s\S]*$/
 const CONTEXT_REF_RE = /@(file|folder|url|image|tool|terminal):(?:"[^"\n]+"|'[^'\n]+'|`[^`\n]+`|\S+)/g


### PR DESCRIPTION
## Summary
- dedupe same-turn desktop assistant completion fallback when the streamed raw text and the final completion text are the same answer with only markdown or whitespace drift
- replace the last assistant bubble instead of appending a second one when the turn already emitted assistant payloads but lost the live stream id/pending marker before final completion
- cover the new equivalence rule with targeted desktop message tests

## Testing
- npm run test:ui -- src/lib/chat-messages.test.ts
- npx eslint src/lib/chat-messages.ts src/lib/chat-messages.test.ts src/app/session/hooks/use-message-stream.ts
- git diff --check

Closes #53179.
