### PR TITLE
fix(install): derive Python versions from pyproject.toml requires-python

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -143,7 +143,13 @@ $PythonVersion = "3.11"
 # available, in preference order.  uv discovers both uv-managed and system
 # interpreters, so this list also matches a pre-existing system Python.  Single
 # source of truth shared by Test-Python's fallback and Resolve-AvailablePythonVersion.
-$PythonFallbackVersions = @("3.12", "3.13", "3.10")
+#
+# After the repository is cloned, these defaults are overridden by
+# Update-PythonVersionsFromPyproject which reads the actual requires-python
+# from pyproject.toml.  The values here are only used for the pre-clone
+# ``python`` stage, where they must be compatible with the project's
+# published constraint (currently >=3.11,<3.14).
+$PythonFallbackVersions = @("3.12", "3.13")
 $NodeVersion = "22"
 
 # Stage-protocol version.  Bumped only for genuinely breaking changes to the
@@ -572,6 +578,72 @@ function Resolve-AvailablePythonVersion {
         } catch { }
     }
     return $null
+}
+
+function Update-PythonVersionsFromPyproject {
+    <#
+    .SYNOPSIS
+    Read requires-python from the cloned repo's pyproject.toml and update
+    $script:PythonVersion + $script:PythonFallbackVersions to match the
+    project's constraint.  This keeps the installer in sync with upstream's
+    Python version requirement without manual bumps.
+
+    Called from Install-Repository (after clone/update) and Install-Venv
+    (as a safety net for cross-process stage-driver mode).  Idempotent and
+    best-effort: if pyproject.toml doesn't exist or can't be parsed, the
+    hardcoded defaults (which are compatible with the published constraint)
+    are preserved.
+    #>
+    $pyproject = Join-Path $InstallDir "pyproject.toml"
+    if (-not (Test-Path $pyproject)) { return }
+
+    try {
+        $content = Get-Content $pyproject -Raw -ErrorAction SilentlyContinue
+        if (-not $content) { return }
+
+        $m = [regex]::Match($content, 'requires-python\s*=\s*"([^"]+)"')
+        if (-not $m.Success) { return }
+        $spec = $m.Groups[1].Value
+
+        # Parse minimum version (e.g., >=3.11 → 3.11)
+        $minMatch = [regex]::Match($spec, '>=(\d+\.\d+)')
+        if (-not $minMatch.Success) { return }
+        $minVer = $minMatch.Groups[1].Value
+
+        # Parse maximum version (e.g., <3.14 → 3.14) — optional
+        $maxMatch = [regex]::Match($spec, '<(\d+\.\d+)')
+        $maxVer = if ($maxMatch.Success) { $maxMatch.Groups[1].Value } else { $null }
+
+        if ($script:PythonVersion -ne $minVer) {
+            Write-Info "Project requires Python $spec; configuring installer for Python $minVer"
+            $script:PythonVersion = $minVer
+        }
+
+        $parts = $minVer.Split('.')
+        $maj = $parts[0]
+        $min = [int]$parts[1]
+
+        # Upper bound, if present, as a comparable numeric
+        $maxMin = [int]999
+        if ($maxVer) {
+            $maxParts = $maxVer.Split('.')
+            $maxMin = [int]$maxParts[1]
+        }
+
+        # Build fallback list: next 3 minor versions within the constraint
+        $fb = @()
+        $c = $min + 1
+        while ($fb.Count -lt 3 -and $c -lt $maxMin) {
+            $fb += "$maj.$c"
+            $c++
+        }
+        $script:PythonFallbackVersions = $fb
+
+    } catch {
+        # Best-effort; keep hardcoded defaults if parsing fails.
+        # The installer continues with the pre-clone defaults, which
+        # are already compatible with the published constraint.
+    }
 }
 
 function Test-Python {
@@ -1570,6 +1642,10 @@ function Install-Repository {
         }
     }
 
+    # Derive Python versions from the cloned project's requires-python,
+    # so a future pyproject.toml bump doesn't silently break the installer.
+    Update-PythonVersionsFromPyproject
+
     Write-Success "Repository ready"
 }
 
@@ -1578,6 +1654,12 @@ function Install-Venv {
         Write-Info "Skipping virtual environment (-NoVenv)"
         return
     }
+
+    # Ensure Python version config reflects the cloned project's constraint,
+    # even when Install-Repository ran in a previous process (stage-driver
+    # / Hermes-Setup.exe mode) and its Update-PythonVersionsFromPyproject
+    # call didn't survive into this one.
+    Update-PythonVersionsFromPyproject
 
     # Re-resolve the interpreter before creating the venv.  Under Hermes-Setup.exe
     # each stage runs in its own powershell.exe, so the fallback the `python`
@@ -1680,6 +1762,10 @@ function Install-Venv {
 }
 
 function Install-Dependencies {
+    # Ensure Python version config is up to date (safety net for
+    # cross-process stage-driver mode).
+    Update-PythonVersionsFromPyproject
+
     Write-Info "Installing dependencies..."
     
     Push-Location $InstallDir


### PR DESCRIPTION
Fixes #53338

## Description

The Windows installer (`scripts/install.ps1`) hardcoded `$PythonVersion = "3.11"` and `$PythonFallbackVersions = @("3.12", "3.13", "3.10")`, which can fall out of sync with the project's `requires-python` in `pyproject.toml`. If the constraint changes (e.g. to `>=3.14`), the installer silently fails with an incompatibility error at the `python` stage.

This PR makes three changes:

1. **Add `Update-PythonVersionsFromPyproject`** — a new helper that reads `requires-python` from the cloned repo's `pyproject.toml` and derives the correct `$PythonVersion` (primary) and `$PythonFallbackVersions` (fallback candidates within the constraint). Idempotent, best-effort, degrades gracefully to hardcoded defaults if the file doesn't exist or can't be parsed.

2. **Call it from `Install-Repository`** — after a successful clone/update, so the venv and dependency stages use the project's actual constraint. Also called defensively from `Install-Venv` and `Install-Dependencies` for cross-process stage-driver mode (Hermes-Setup.exe).

3. **Remove `3.10` from the hardcoded fallback list** — `3.10` does not satisfy `requires-python >=3.11`, so including it could cause a false success in the `python` stage followed by a failure in the `venv` stage when uv validates against the cloned project's constraint.

## Verification

- All 11 existing installer tests pass (`test_install_ps1_python_fallback_venv`, `test_install_ps1_uv_powershell_host`, `test_install_ps1_native_stderr_eap`)
- Only `scripts/install.ps1` modified (F1: focused)
- No secrets, no personal refs, no unrelated changes