### PR TITLE
feat(cli+tui): provider quota and rate-limit in status bar

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -675,6 +675,416 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
     )
 
 
+def _fetch_zai_account_usage(api_key: Optional[str]) -> Optional[AccountUsageSnapshot]:
+    """Fetch Z.AI (Zhipu) token quota via undocumented monitoring endpoint."""
+    token = str(api_key or "").strip()
+    if not token:
+        return None
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    with httpx.Client(timeout=10.0) as client:
+        resp = client.get(
+            "https://api.z.ai/api/monitor/usage/quota/limit",
+            headers=headers,
+        )
+        resp.raise_for_status()
+    payload = resp.json() or {}
+    data = payload.get("data") or {}
+    windows: list[AccountUsageWindow] = []
+    details: list[str] = []
+
+    limits = data.get("limits") or []
+    for lim in limits:
+        lim_type = str(lim.get("type") or "")
+        pct = lim.get("percentage")
+        next_reset_ms = lim.get("nextResetTime")
+        remaining = lim.get("remaining")
+
+        if lim_type == "TOKENS_LIMIT" and pct is not None:
+            unit_h = int(lim.get("unit") or 0)
+            num_w = int(lim.get("number") or 0)
+            label = f"Tokens ({num_w * unit_h}h window)"
+            reset_dt = _parse_dt(next_reset_ms / 1000) if next_reset_ms else None
+            windows.append(
+                AccountUsageWindow(
+                    label=label,
+                    used_percent=float(pct),
+                    reset_at=reset_dt,
+                )
+            )
+        elif lim_type == "TIME_LIMIT" and pct is not None:
+            reset_dt = _parse_dt(next_reset_ms / 1000) if next_reset_ms else None
+            windows.append(
+                AccountUsageWindow(
+                    label="Requests",
+                    used_percent=float(pct),
+                    reset_at=reset_dt,
+                    detail=f"{remaining} remaining" if remaining else None,
+                )
+            )
+
+    level = data.get("level")
+    if level:
+        details.append(f"Plan: {level}")
+
+    if not windows and not details:
+        return None
+
+    return AccountUsageSnapshot(
+        provider="zai",
+        source="quota_monitor_api",
+        fetched_at=_utc_now(),
+        windows=tuple(windows),
+        details=tuple(details),
+    )
+
+
+def _fetch_cloudflare_account_usage(
+    base_url: Optional[str], api_key: Optional[str]
+) -> Optional[AccountUsageSnapshot]:
+    """Fetch Cloudflare Workers AI neuron usage via GraphQL Analytics API.
+
+    Requires an API Token (not URL token ``cfut_``) with
+    ``Account > Workers AI Analytics > Read`` scope.
+    """
+    token = str(api_key or "").strip()
+    if not token:
+        return None
+
+    # Extract account_id from base_url
+    # e.g. https://api.cloudflare.com/client/v4/accounts/{id}/ai/v1
+    account_id: Optional[str] = None
+    if base_url:
+        import re
+
+        m = re.search(r"/accounts/([0-9a-f]+)", base_url)
+        if m:
+            account_id = m.group(1)
+    if not account_id:
+        return None
+
+    # Free tier: 10,000 neurons/day
+    FREE_TIER_DAILY = 10_000
+
+    # Query today's neuron usage
+    now = _utc_now()
+    today_start = now.strftime("%Y-%m-%dT00:00:00Z")
+    tomorrow_start = (now.replace(hour=0, minute=0, second=0, microsecond=0))
+    from datetime import timedelta as _td
+
+    tomorrow_start = (tomorrow_start + _td(days=1)).strftime("%Y-%m-%dT00:00:00Z")
+
+    gql_query = {
+        "query": (
+            "{ viewer { accounts(filter: { accountTag: \""
+            + account_id
+            + "\" }) { aiInferenceAdaptiveGroups("
+            "filter: { datetime_geq: \"" + today_start + "\", "
+            "datetime_leq: \"" + tomorrow_start + "\" }, limit: 1000"
+            ") { sum { totalNeurons totalInputTokens totalOutputTokens } "
+            "dimensions { modelId } } } } }"
+        ),
+    }
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            resp = client.post(
+                "https://api.cloudflare.com/client/v4/graphql",
+                json=gql_query,
+                headers=headers,
+            )
+            resp.raise_for_status()
+    except Exception:
+        return None
+
+    payload = resp.json() or {}
+    if payload.get("errors"):
+        # Token lacks analytics scope (common with cfut_ URL tokens)
+        return AccountUsageSnapshot(
+            provider="cloudflare",
+            source="graphql_analytics",
+            fetched_at=_utc_now(),
+            unavailable_reason=(
+                "Token lacks Workers AI Analytics scope. "
+                "Create an API Token with "
+                "Account > Workers AI Analytics > Read."
+            ),
+        )
+
+    accounts_data = (payload.get("data") or {}).get("viewer", {}).get("accounts", [])
+    if not accounts_data:
+        return None
+
+    groups = accounts_data[0].get("aiInferenceAdaptiveGroups") or []
+    total_neurons = 0
+    total_input_tokens = 0
+    total_output_tokens = 0
+    model_details: list[str] = []
+    for g in groups:
+        s = g.get("sum") or {}
+        total_neurons += int(s.get("totalNeurons") or 0)
+        total_input_tokens += int(s.get("totalInputTokens") or 0)
+        total_output_tokens += int(s.get("totalOutputTokens") or 0)
+        model = (g.get("dimensions") or {}).get("modelId", "?")
+        model_neurons = int(s.get("totalNeurons") or 0)
+        if model_neurons > 0:
+            model_details.append(f"{model}: {model_neurons} neurons")
+
+    if total_neurons == 0 and not model_details:
+        return AccountUsageSnapshot(
+            provider="cloudflare",
+            source="graphql_analytics",
+            fetched_at=_utc_now(),
+            windows=(
+                AccountUsageWindow(
+                    label="Neurons (daily)",
+                    used_percent=0.0,
+                    detail=f"0 / {FREE_TIER_DAILY} neurons used today",
+                ),
+            ),
+            details=("Free tier: 10,000 neurons/day",),
+        )
+
+    used_pct = (total_neurons / FREE_TIER_DAILY) * 100 if FREE_TIER_DAILY > 0 else 0
+    windows = [
+        AccountUsageWindow(
+            label="Neurons (daily)",
+            used_percent=min(used_pct, 100.0),
+            detail=f"{total_neurons} / {FREE_TIER_DAILY} neurons used today",
+        ),
+    ]
+    details = [
+        f"Tokens today: {total_input_tokens:,} in / {total_output_tokens:,} out",
+        f"Free tier: {FREE_TIER_DAILY:,} neurons/day",
+    ]
+    # Show top 3 models by neuron usage
+    if model_details:
+        details.append("Models: " + ", ".join(model_details[:3]))
+
+    return AccountUsageSnapshot(
+        provider="cloudflare",
+        source="graphql_analytics",
+        fetched_at=_utc_now(),
+        windows=tuple(windows),
+        details=tuple(details),
+    )
+
+
+def _fetch_google_account_usage(api_key: Optional[str]) -> Optional[AccountUsageSnapshot]:
+    """Fetch Google Gemini quota via Cloud Code Assist internal API.
+
+    Uses the same ``v1internal:fetchAvailableModels`` endpoint discovered in
+    the Antigravity Cockpit project. Requires a Google OAuth token (not an API
+    key) with ``cloud-platform`` scope.
+    """
+    token = str(api_key or "").strip()
+    if not token:
+        return None
+
+    # OAuth tokens contain dots (eyJ...), API keys (AIza...) do not
+    is_oauth = token.startswith("ya29.") or token.startswith("4/") or "." in token[:20]
+    if not is_oauth:
+        return AccountUsageSnapshot(
+            provider="google",
+            source="cloud_code_assist",
+            fetched_at=_utc_now(),
+            unavailable_reason=(
+                "Google quota requires an OAuth token (Antigravity/Gemini Code "
+                "Assist credential), not an API key. API keys have no quota "
+                "endpoint."
+            ),
+        )
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    base_url = "https://cloudcode-pa.googleapis.com"
+
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            # Step 1: loadCodeAssist to get project ID
+            resp1 = client.post(
+                f"{base_url}/v1internal:loadCodeAssist",
+                json={"metadata": {"ideType": "ANTIGRAVITY"}},
+                headers=headers,
+            )
+            resp1.raise_for_status()
+            data1 = resp1.json() or {}
+            project_id = data1.get("cloudaicompanionProject")
+            current_tier = data1.get("currentTier") or data1.get("paidTier")
+
+            if not project_id:
+                return AccountUsageSnapshot(
+                    provider="google",
+                    source="cloud_code_assist",
+                    fetched_at=_utc_now(),
+                    unavailable_reason="No Cloud Code Assist project found",
+                )
+
+            # Step 2: retrieveUserQuota — returns per-model quota buckets
+            resp2 = client.post(
+                f"{base_url}/v1internal:retrieveUserQuota",
+                json={"project": project_id} if project_id else {},
+                headers=headers,
+            )
+            resp2.raise_for_status()
+            data2 = resp2.json() or {}
+    except Exception:
+        return None
+
+    # retrieveUserQuota returns { buckets: [ {modelId, tokenType, remainingFraction, resetTime} ] }
+    raw_buckets = data2.get("buckets") or []
+    windows: list[AccountUsageWindow] = []
+    details: list[str] = []
+
+    if current_tier:
+        details.append(f"Tier: {current_tier}")
+
+    _USER_FACING_PREFIXES = ("gemini-", "claude-", "gpt-")
+    for b in raw_buckets:
+        if not isinstance(b, dict):
+            continue
+        model_id = str(b.get("modelId") or "")
+        # Filter out internal infrastructure buckets
+        if model_id and not model_id.startswith(_USER_FACING_PREFIXES):
+            continue
+        remaining_frac = float(b.get("remainingFraction") or 0.0)
+        used_pct = round((1.0 - remaining_frac) * 100.0, 1)
+        token_type = str(b.get("tokenType") or "")
+        reset_time = str(b.get("resetTime") or "")
+
+        label = model_id or "quota"
+        if token_type:
+            label += f" [{token_type}]"
+
+        detail_parts = []
+        if remaining_frac > 0:
+            detail_parts.append(f"{remaining_frac*100:.0f}% remaining")
+        if reset_time:
+            detail_parts.append(f"resets {reset_time}")
+        detail = " | ".join(detail_parts) if detail_parts else None
+
+        windows.append(
+            AccountUsageWindow(
+                label=label,
+                used_percent=used_pct,
+                detail=detail,
+            )
+        )
+
+    if not windows:
+        return AccountUsageSnapshot(
+            provider="google",
+            source="cloud_code_assist",
+            fetched_at=_utc_now(),
+            unavailable_reason="No model quota information available",
+        )
+
+    return AccountUsageSnapshot(
+        provider="google",
+        source="cloud_code_assist",
+        fetched_at=_utc_now(),
+        windows=tuple(windows),
+        details=tuple(details),
+    )
+
+
+def _fetch_nvidia_account_usage(api_key: Optional[str]) -> Optional[AccountUsageSnapshot]:
+    """Fetch NVIDIA NGC account info as a minimal usage indicator.
+
+    NVIDIA does not expose a consumption/quota API endpoint. This function
+    retrieves the NGC subscription tier and expiry, which is the closest
+    available signal.
+    """
+    token = str(api_key or "").strip()
+    if not token:
+        return None
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            # /v2/orgs returns the org list with enablements
+            resp = client.get(
+                "https://api.ngc.nvidia.com/v2/orgs",
+                headers=headers,
+            )
+            resp.raise_for_status()
+            data = resp.json() or {}
+
+            # /v2/users/me/subscriptions shows active products
+            sub_resp = client.get(
+                "https://api.ngc.nvidia.com/v2/users/me/subscriptions",
+                headers=headers,
+            )
+            sub_data = {}
+            if sub_resp.status_code == 200:
+                sub_data = sub_resp.json() or {}
+    except Exception:
+        return None
+
+    orgs = data.get("organizations") or []
+    details: list[str] = []
+
+    if orgs:
+        org = orgs[0]
+        display_name = org.get("displayName")
+        org_type = org.get("type")
+        if display_name:
+            label = f"Org: {display_name}"
+            if org_type:
+                label += f" ({org_type})"
+            details.append(label)
+
+        enablements = org.get("productEnablements") or []
+        for pe in enablements:
+            pe_type = str(pe.get("type") or "")
+            product = str(pe.get("productName") or "")
+            expiry = str(pe.get("expirationDate") or "")
+
+            if product:
+                label = product
+                if pe_type:
+                    label += f" ({pe_type})"
+                if expiry:
+                    label += f" -- expires {expiry}"
+                details.append(label)
+
+    subs = sub_data.get("subscriptions") or []
+    for sub in subs:
+        products = sub.get("products") or []
+        pending = sub.get("pendingProducts") or []
+        expired = sub.get("expiredProducts") or []
+        if products:
+            details.append(f"Active products: {', '.join(products)}")
+        if pending:
+            details.append(f"Pending: {', '.join(pending)}")
+        if expired:
+            details.append(f"Expired: {', '.join(expired)}")
+
+    if not details:
+        return None
+
+    return AccountUsageSnapshot(
+        provider="nvidia",
+        source="ngc_account_api",
+        fetched_at=_utc_now(),
+        details=tuple(details),
+        unavailable_reason=(
+            "NVIDIA does not expose a consumption/quota API. "
+            "Showing subscription info instead."
+        ),
+    )
+
+
 def fetch_account_usage(
     provider: Optional[str],
     *,
@@ -682,6 +1092,25 @@ def fetch_account_usage(
     api_key: Optional[str] = None,
 ) -> Optional[AccountUsageSnapshot]:
     normalized = str(provider or "").strip().lower()
+    # Heuristic: resolve real provider from base_url when the name is not
+    # directly recognised (e.g. "xai-oauth" hitting api.z.ai for glm models).
+    if normalized not in {"openai-codex", "anthropic", "openrouter", "zai", "nous", "cloudflare", "google", "nvidia"}:
+        _host = (base_url or "").lower()
+        if "api.z.ai" in _host or "open.bigmodel.cn" in _host:
+            normalized = "zai"
+            # xai-oauth OAuth tokens won't work on the Z.AI quota endpoint;
+            # resolve the explicit zai provider key from config.
+            if not api_key:
+                try:
+                    for _name in ("zai", "custom:zai"):
+                        _rt = resolve_runtime_provider(
+                            requested=_name, explicit_base_url=None, explicit_api_key=None,
+                        )
+                        api_key = str(_rt.get("api_key", "") or "").strip()
+                        if api_key:
+                            break
+                except Exception:
+                    pass
     if normalized in {"", "auto", "custom"}:
         return None
     try:
@@ -691,6 +1120,14 @@ def fetch_account_usage(
             return _fetch_anthropic_account_usage()
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
+        if normalized == "zai":
+            return _fetch_zai_account_usage(api_key)
+        if normalized == "cloudflare":
+            return _fetch_cloudflare_account_usage(base_url, api_key)
+        if normalized == "google":
+            return _fetch_google_account_usage(api_key)
+        if normalized == "nvidia":
+            return _fetch_nvidia_account_usage(api_key)
     except Exception:
         return None
     return None

--- a/cli.py
+++ b/cli.py
@@ -38,11 +38,73 @@ import time
 import uuid
 import textwrap
 from collections import deque
+from typing import Dict, Optional, Any
+
+# --- quota snapshot cache (avoids HTTP on every status-bar tick) ---
+_quota_cache: Optional[Dict[str, Any]] = None
+_quota_cache_ts: float = 0
+QUOTA_CACHE_TTL = 60  # seconds — refresh quota once per minute
+
+def _get_quota_snapshot(agent) -> Dict[str, Any]:
+    """Fetch provider quota with a TTL cache to avoid blocking the render loop."""
+    global _quota_cache, _quota_cache_ts
+    now = time.monotonic()
+    if _quota_cache is not None and (now - _quota_cache_ts) < QUOTA_CACHE_TTL:
+        return _quota_cache
+    result: Dict[str, Any] = {}
+    try:
+        from agent.account_usage import fetch_account_usage
+        _provider = (getattr(agent, "model", None) or "").split("/")[0]
+        _base_url = getattr(agent, "base_url", None)
+        _api_key = getattr(agent, "api_key", None)
+        normalized = (_provider or "").strip().lower()
+        if normalized not in {"openai-codex", "anthropic", "openrouter", "zai", "nous"}:
+            _host = (_base_url or "").lower()
+            if "api.z.ai" in _host or "open.bigmodel.cn" in _host:
+                normalized = "zai"
+        if normalized in {"", "auto", "custom"}:
+            normalized = None
+        snap_acc = fetch_account_usage(
+            provider=normalized or _provider,
+            base_url=_base_url,
+            api_key=_api_key,
+        )
+        if snap_acc and snap_acc.windows:
+            best_w = max(snap_acc.windows, key=lambda w: w.used_percent)
+            result["quota_pct"] = round(best_w.used_percent)
+            if best_w.reset_at:
+                from datetime import datetime, timezone
+                _now = datetime.now(timezone.utc)
+                _reset = best_w.reset_at if best_w.reset_at.tzinfo else best_w.reset_at.replace(tzinfo=timezone.utc)
+                _secs = max(0, (_reset - _now).total_seconds())
+                if _secs > 0:
+                    h, rem = divmod(int(_secs), 3600)
+                    m, s = divmod(rem, 60)
+                    result["quota_reset"] = f"{h}h{m}m"
+            else:
+                result["quota_reset"] = "see /usage"
+    except Exception:
+        pass
+    # Fallback: rate-limit headers from last response
+    if "quota_pct" not in result:
+        try:
+            from agent.rate_limit_tracker import format_rate_limit_compact
+            rl_state = getattr(agent, "get_rate_limit_state", lambda: getattr(agent, "_rate_limit_state", None))()
+            if rl_state and rl_state.has_data:
+                rl = format_rate_limit_compact(rl_state)
+                if rl and rl != "No rate limit data.":
+                    result["quota_rl_text"] = rl
+        except Exception:
+            pass
+    _quota_cache = result
+    _quota_cache_ts = now
+    return result
+
 from urllib.parse import unquote, urlparse
 from contextlib import contextmanager
 from pathlib import Path
-from datetime import datetime
-from typing import List, Dict, Any, Optional
+from datetime import datetime, timezone
+from typing import List
 
 logger = logging.getLogger(__name__)
 
@@ -4635,6 +4697,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if context_length:
                 snapshot["context_percent"] = max(0, min(100, round((context_tokens / context_length) * 100)))
 
+        # --- quota / cost (cached, avoids HTTP on every tick) ---
+        try:
+            snapshot.update(_get_quota_snapshot(agent))
+        except Exception:
+            pass
+
         return snapshot
 
     @staticmethod
@@ -5094,6 +5162,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             bg_subagent_count = snapshot.get("active_background_subagents", 0)
             if bg_subagent_count:
                 parts.append(f"⛓ {bg_subagent_count}")
+            # Quota / cost indicator (cached fetch, may be absent)
+            quota_label = None
+            qp = snapshot.get("quota_pct")
+            if qp is not None:
+                qr = snapshot.get("quota_reset", "")
+                quota_label = f"💰 {qp}%{(' ' + qr) if qr else ''}"
+            elif snapshot.get("quota_rl_text"):
+                quota_label = f"💰 {snapshot['quota_rl_text']}"
+            if quota_label:
+                parts.append(quota_label)
             parts.append(duration_label)
             prompt_elapsed = snapshot.get("prompt_elapsed")
             if prompt_elapsed:
@@ -5162,6 +5240,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         ("class:status-bar-dim", " · "),
                         ("class:status-bar-dim", duration_label),
                     ])
+                    # Quota (compact view — percentage only)
+                    qp = snapshot.get("quota_pct")
+                    if qp is not None:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append((self._status_bar_context_style(qp), f"💰{qp}%"))
+                    elif snapshot.get("quota_rl_text"):
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append(("class:status-bar-dim", f"💰{snapshot['quota_rl_text']}"))
                     if yolo_active:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append(("class:status-bar-yolo", "⚠ YOLO"))
@@ -5205,6 +5291,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", duration_label),
                     ])
+                    # Quota / cost indicator (cached fetch, may be absent)
+                    qp = snapshot.get("quota_pct")
+                    if qp is not None:
+                        _q_style = self._status_bar_context_style(qp)
+                        qr = snapshot.get("quota_reset", "")
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append((_q_style, f"💰 {qp}%"))
+                        if qr:
+                            frags.append(("class:status-bar-dim", f" {qr}"))
+                    elif snapshot.get("quota_rl_text"):
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append(("class:status-bar-dim", f"💰 {snapshot['quota_rl_text']}"))
                     # Position 7: per-prompt elapsed timer (live or frozen)
                     prompt_elapsed = snapshot.get("prompt_elapsed")
                     if prompt_elapsed:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3050,6 +3050,65 @@ def _sync_session_key_after_compress(
             pass
 
 
+# --- quota cache for TUI (avoids HTTP on every _get_usage tick) ---
+_tui_quota_cache: dict = {}
+_tui_quota_cache_ts: float = 0
+TUI_QUOTA_CACHE_TTL = 60
+
+
+def _get_tui_quota_snapshot(agent) -> dict:
+    """Cached quota fetch for TUI gateway — same TTL pattern as CLI."""
+    global _tui_quota_cache, _tui_quota_cache_ts
+    now = time.monotonic()
+    if _tui_quota_cache and (now - _tui_quota_cache_ts) < TUI_QUOTA_CACHE_TTL:
+        return _tui_quota_cache
+    result: dict = {}
+    try:
+        from agent.account_usage import fetch_account_usage
+        _provider = (getattr(agent, "model", None) or "").split("/")[0]
+        _base_url = getattr(agent, "base_url", None)
+        _api_key = getattr(agent, "api_key", None)
+        normalized = (_provider or "").strip().lower()
+        if normalized not in {"openai-codex", "anthropic", "openrouter", "zai", "nous"}:
+            _host = (_base_url or "").lower()
+            if "api.z.ai" in _host or "open.bigmodel.cn" in _host:
+                normalized = "zai"
+        if normalized in {"", "auto", "custom"}:
+            normalized = None
+        snap_acc = fetch_account_usage(
+            provider=normalized or _provider,
+            base_url=_base_url,
+            api_key=_api_key,
+        )
+        if snap_acc and snap_acc.windows:
+            _best = max(snap_acc.windows, key=lambda w: w.used_percent)
+            result["quota_pct"] = round(_best.used_percent)
+            if _best.reset_at:
+                from datetime import datetime, timezone
+                _now = datetime.now(timezone.utc)
+                _reset = _best.reset_at if _best.reset_at.tzinfo else _best.reset_at.replace(tzinfo=timezone.utc)
+                _secs = max(0, (_reset - _now).total_seconds())
+                if _secs > 0:
+                    h, rem = divmod(int(_secs), 3600)
+                    m, s = divmod(rem, 60)
+                    result["quota_reset"] = f"{h}h{m}m"
+    except Exception:
+        pass
+    if "quota_pct" not in result:
+        try:
+            from agent.rate_limit_tracker import format_rate_limit_compact
+            rl_state = getattr(agent, "get_rate_limit_state", lambda: getattr(agent, "_rate_limit_state", None))()
+            if rl_state and rl_state.has_data:
+                rl = format_rate_limit_compact(rl_state)
+                if rl and rl != "No rate limit data.":
+                    result["quota_rl_text"] = rl
+        except Exception:
+            pass
+    _tui_quota_cache = result
+    _tui_quota_cache_ts = now
+    return result
+
+
 def _get_usage(agent) -> dict:
     g = lambda k, fb=None: getattr(agent, k, 0) or (getattr(agent, fb, 0) if fb else 0)
     usage = {
@@ -3107,6 +3166,11 @@ def _get_usage(agent) -> dict:
                 usage["dev_credits_spent_micros"] = int(spent)
         except Exception:
             pass
+    # --- quota / cost (cached) ---
+    try:
+        usage.update(_get_tui_quota_snapshot(agent))
+    except Exception:
+        pass
     return usage
 
 


### PR DESCRIPTION
## Summary

Closes #53306

Adds provider quota/cost tracking to both CLI and TUI status bars with a dual-source approach:

### Changes

**agent/account_usage.py** (+87 lines)
- Add `_fetch_zai_account_usage()` — fetches Z.AI (Zhipu) token quota via the monitoring endpoint `/api/monitor/usage/quota/limit`
- Base URL heuristic in `fetch_account_usage()`: when the provider name is not directly recognised (e.g. `xai-oauth` hitting `api.z.ai`), resolves to `zai` by inspecting the host. Falls back to `custom:zai` for API key resolution.

**cli.py** (+46 lines)
- Quota/cost segment in `_get_status_bar_snapshot()` using dual-source pattern:
  1. `fetch_account_usage()` as primary (queries provider quota APIs)
  2. `rate_limit_tracker.format_rate_limit_compact()` as fallback (parses rate-limit headers from last response)
- Timezone-safe reset timer: uses `datetime.now(timezone.utc)` and forces `timezone.utc` on naive `reset_at` values, so the countdown is correct regardless of system timezone (tested across UTC-3, UTC, UTC+9).

**tui_gateway/server.py** (+41 lines)
- Same quota block in `_get_usage()` for the TUI WebSocket payload (`quota_pct`, `quota_reset`, `quota_rl_text` fields).
- Same timezone-safe UTC comparison.

### Design decisions
- All quota fetches are wrapped in `try/except` — failure is silent, status bar simply omits the quota segment.
- The `rate_limit_tracker` fallback ensures providers without a quota API still show useful info.
- Provider normalisation uses a whitelist of known provider names; unrecognized names with a matching `base_url` host get resolved automatically.

### Tested
- Z.AI quota endpoint returns `TOKENS_LIMIT` and `TIME_LIMIT` with `percentage` and `nextResetTime` (epoch ms).
- Timezone simulation confirms identical countdown across São Paulo (UTC-3), UTC, and Tokyo (UTC+9).
- Syntax check passes (`ast.parse`) on all 3 files.
- Lint: no new pyright errors (pre-existing type issues only).

