### PR TITLE
fix(supermemory): read API key from .env via get_env_value() (#34994)

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -95,6 +95,24 @@ def _as_bool(value: Any, default: bool) -> bool:
     return default
 
 
+def _get_env(key: str, default: str = "") -> str:
+    """Read an env var from the Hermes .env file first, then os.environ.
+
+    Worker processes skip loading ``.env`` into ``os.environ``
+    (see ``_profile_env``), so a plain ``os.environ.get()`` misses keys
+    stored in ``~/.hermes/.env``.  This helper bridges the gap by calling
+    :func:`hermes_cli.config.get_env_value` which always reads the file.
+    """
+    try:
+        from hermes_cli.config import get_env_value
+        value = get_env_value(key)
+        if value:
+            return value
+    except Exception:
+        pass
+    return os.environ.get(key, default)
+
+
 def _load_supermemory_config(hermes_home: str) -> dict:
     config = _default_config()
     config_path = Path(hermes_home) / "supermemory.json"
@@ -473,7 +491,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         return "supermemory"
 
     def is_available(self) -> bool:
-        api_key = os.environ.get("SUPERMEMORY_API_KEY", "")
+        api_key = _get_env("SUPERMEMORY_API_KEY")
         if not api_key:
             return False
         try:
@@ -504,11 +522,11 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._session_id = session_id
         self._turn_count = 0
         self._config = _load_supermemory_config(self._hermes_home)
-        self._api_key = os.environ.get("SUPERMEMORY_API_KEY", "")
+        self._api_key = _get_env("SUPERMEMORY_API_KEY")
 
         # Resolve container tag: env var > config > default.
         # Supports {identity} template for profile-scoped containers.
-        env_tag = os.environ.get("SUPERMEMORY_CONTAINER_TAG", "").strip()
+        env_tag = _get_env("SUPERMEMORY_CONTAINER_TAG").strip()
         raw_tag = env_tag or self._config["container_tag"]
         identity = kwargs.get("agent_identity", "default")
         self._container_tag = _sanitize_tag(raw_tag.replace("{identity}", identity))

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -457,3 +457,66 @@ def test_save_config_sets_owner_only_permissions(tmp_path):
     assert config_file.exists()
     mode = stat.S_IMODE(config_file.stat().st_mode)
     assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"
+
+
+class TestGetEnv:
+    """_get_env reads API keys from Hermes .env file, not just os.environ (#34994)."""
+
+    def test_reads_from_dotenv_when_not_in_os_environ(self, monkeypatch):
+        """When key is in .env but not os.environ, _get_env still finds it."""
+        from plugins.memory.supermemory import _get_env
+        monkeypatch.delenv("SUPERMEMORY_API_KEY", raising=False)
+        from unittest.mock import patch as mock_patch
+        with mock_patch("hermes_cli.config.get_env_value", return_value="***"):
+            result = _get_env("SUPERMEMORY_API_KEY")
+        assert result == "***"
+
+    def test_falls_back_to_os_environ(self, monkeypatch):
+        """When .env has nothing, _get_env falls back to os.environ."""
+        from plugins.memory.supermemory import _get_env
+        monkeypatch.setenv("SUPERMEMORY_API_KEY", "***")
+        from unittest.mock import patch as mock_patch
+        with mock_patch("hermes_cli.config.get_env_value", return_value=None):
+            result = _get_env("SUPERMEMORY_API_KEY")
+        assert result == "***"
+
+    def test_returns_empty_when_nowhere(self, monkeypatch):
+        """When key is nowhere, _get_env returns empty string."""
+        from plugins.memory.supermemory import _get_env
+        monkeypatch.delenv("SUPERMEMORY_API_KEY", raising=False)
+        from unittest.mock import patch as mock_patch
+        with mock_patch("hermes_cli.config.get_env_value", return_value=None):
+            result = _get_env("SUPERMEMORY_API_KEY")
+        assert result == ""
+
+    def test_dotenv_takes_precedence(self, monkeypatch):
+        """When key is in .env, it wins over os.environ."""
+        from plugins.memory.supermemory import _get_env
+        monkeypatch.setenv("SUPERMEMORY_API_KEY", "***")
+        from unittest.mock import patch as mock_patch
+        with mock_patch("hermes_cli.config.get_env_value", return_value="***"):
+            result = _get_env("SUPERMEMORY_API_KEY")
+        assert result == "***"
+
+    def test_is_available_finds_key_from_dotenv(self, monkeypatch):
+        """is_available() finds API key from .env even when os.environ is empty."""
+        monkeypatch.delenv("SUPERMEMORY_API_KEY", raising=False)
+        p = SupermemoryMemoryProvider()
+        from unittest.mock import patch as mock_patch, MagicMock
+        with mock_patch("hermes_cli.config.get_env_value", return_value="sk_test_123"):
+            fake_sm = MagicMock()
+            with mock_patch.dict("sys.modules", {"supermemory": fake_sm}):
+                assert p.is_available() is True
+
+    def test_initialize_reads_key_from_dotenv(self, monkeypatch, tmp_path):
+        """initialize() picks up API key from .env when os.environ is empty."""
+        monkeypatch.delenv("SUPERMEMORY_API_KEY", raising=False)
+        monkeypatch.delenv("SUPERMEMORY_CONTAINER_TAG", raising=False)
+        p = SupermemoryMemoryProvider()
+        from unittest.mock import patch as mock_patch, MagicMock
+        with mock_patch("hermes_cli.config.get_env_value", side_effect=lambda k: {
+            "SUPERMEMORY_API_KEY": "***",
+            "SUPERMEMORY_CONTAINER_TAG": "",
+        }.get(k)):
+            p.initialize("test-session", hermes_home=str(tmp_path))
+        assert p._api_key == "***"


### PR DESCRIPTION
## Summary

The supermemory plugin used `os.environ.get()` to find `SUPERMEMORY_API_KEY` and `SUPERMEMORY_CONTAINER_TAG`. Worker processes skip loading `.env` into `os.environ` (see `_profile_env`), so `is_available()` returns `False` and the 4 supermemory tools never register when the key is stored in `~/.hermes/.env`.

Add `_get_env()` helper that reads from `hermes_cli.config.get_env_value()` (which always reads the `.env` file) first, then falls back to `os.environ`.

## Changes

- `plugins/memory/supermemory/__init__.py`: add `_get_env()` helper; replace 3 `os.environ.get()` calls with `_get_env()`
- `tests/plugins/memory/test_supermemory_provider.py`: 6 new regression tests

## Test plan

- [x] `python3 -m pytest tests/plugins/memory/test_supermemory_provider.py` (37 passed — 31 existing + 6 new)

Closes #34994