### PR TITLE
docs(gateway/telegram): add operator test recipe + dry-run script for Rich Messages Bot API 10.1

### DIFF
--- a/docs/operator-test-recipe-telegram-rich.md
+++ b/docs/operator-test-recipe-telegram-rich.md
@@ -1,0 +1,209 @@
+# Operator Test Recipe — Telegram Rich Messages (Bot API 10.1+)
+
+> **Audience**: Operators / users with real `TELEGRAM_BOT_TOKEN` muốn verify rich messages end-to-end trên bot của mình.
+>
+> **Pre-requisite**: Hermes Agent với Telegram gateway enabled (`display.platforms.telegram.streaming: true`).
+>
+> **Spec ref**: https://core.telegram.org/bots/api#rich-messages · Skill `~/.hermes/skills/devtools/telegram-rich-messages/SKILL.md` v1.1.0.
+
+---
+
+## 1. Pre-flight checks
+
+### 1.1 Verify Bot API 10.1 live (no real token needed)
+
+```bash
+python3 scripts/dry_run_send_rich.py
+# Expected output:
+#   sendRichMessage: HTTP 401
+#   sendRichMessageDraft: HTTP 401
+# ✅ All methods DEPLOYED (401 = method exists, dummy token rejected)
+```
+
+If you see HTTP 404 → your Telegram client lib / server is <10.1. Upgrade.
+
+### 1.2 Verify Hermes has rich messages wired
+
+```bash
+grep -n "_try_send_rich\|sendRichMessage\|rich_messages" \
+    ~/.hermes/hermes-agent/plugins/platforms/telegram/adapter.py | head -10
+# Expected: ~5-10 hits. If 0 → Hermes not at a recent commit with rich messages.
+```
+
+Verify your commit is recent enough:
+
+```bash
+git -C ~/.hermes/hermes-agent log --oneline plugins/platforms/telegram/adapter.py | head -5
+# Expected: top commits mention "rich", "sendRichMessage", or PR #44780.
+```
+
+### 1.3 Opt-in to rich messages (currently OFF by default)
+
+The rich path is opt-in because Telegram clients can render Bot API 10.1 messages as blank/unsupported bubbles. Verify your client supports rich messages first, then opt-in:
+
+```yaml
+# ~/.hermes/profiles/default/config.yaml
+display:
+  platforms:
+    telegram:
+      streaming: true
+      extra:
+        rich_messages: true   # Opt-in (default off per commit 6183e8ce1)
+```
+
+Restart the gateway: `hermes gateway restart` (or restart your process).
+
+---
+
+## 2. Manual test sequence
+
+Run these in order. Each step has clear success criteria.
+
+### 2.1 Test 1 — Plain rich paragraph
+
+Send to your bot via DM:
+
+```
+/ping
+```
+
+**Bot should respond** with a short rich paragraph (the welcome message is usually rich-formatted).
+
+**Verify in Telegram mobile/desktop**:
+- ✅ Message shows formatted text (bold, italic, or code spans as expected)
+- ✅ NOT shown as blank bubble
+- ✅ Can be **copied as plain text** (long-press → Copy). If Copy doesn't work → your client doesn't support rich messages yet.
+
+### 2.2 Test 2 — Table render
+
+In DM, ask the bot a question that should produce tabular output:
+
+```
+What's the current price of BTC, ETH, SOL?
+```
+
+**Expected**: A table with columns Symbol / Price / 24h Δ, rows for each coin.
+
+**Verify in Telegram**:
+- ✅ Columns align correctly
+- ✅ Cell formatting (bold for highlight, code for numbers) renders
+- ✅ On TDesktop: hover row → see "Copy as plain text" option
+
+### 2.3 Test 3 — Streaming draft animation
+
+In DM, ask a complex question that triggers agent reasoning (≥3 sec):
+
+```
+Walk me through the architecture of Telegram Rich Messages Bot API 10.1
+```
+
+**Expected during streaming**:
+- ✅ You see a "Thinking..." chip / animated placeholder for ~1-2 sec
+- ✅ Text appears incrementally (not all-at-once)
+- ✅ Final message is the complete rich answer (no missing parts)
+- ✅ No duplicate final messages (the bug fixed in PR #46009)
+
+### 2.4 Test 4 — Edit upgrade (progressive enhancement)
+
+In DM, send a prompt that triggers a "loading" reply:
+
+```
+Generate a 200-word summary of quantum computing
+```
+
+**Expected**:
+- ✅ Bot sends initial short "Generating..." text
+- ✅ Bot edits the message in-place with the full rich summary (table + headings)
+- ✅ Message timestamp reflects the **edit time**, not the original send time
+- ✅ No duplicate "old version" + "new version" visible
+
+### 2.5 Test 5 — CJK fallback (if you use Chinese / Japanese / Korean)
+
+In DM:
+
+```
+Write a haiku in Chinese about Telegram
+```
+
+**Expected**:
+- ✅ Bot uses **legacy MarkdownV2** path (not rich messages) — due to commit `ea056b055 fix(telegram): avoid rich messages for CJK text`
+- ✅ Chinese characters render correctly without garbling
+- ✅ Can copy as plain text
+
+If you see garbled CJK → your client doesn't render rich messages cleanly for CJK; report at Issue #44428.
+
+### 2.6 Test 6 — Code block with syntax highlight
+
+In DM:
+
+```
+Write a Python hello world
+```
+
+**Expected**:
+- ✅ Code rendered with syntax highlighting (Python keywords colored)
+- ✅ Language label visible ("python" or similar)
+- ✅ Copy preserves whitespace
+
+---
+
+## 3. Failure modes + fixes
+
+| Symptom | Root cause | Fix |
+|---------|-----------|-----|
+| Bot shows blank bubble | Client <Bot API 10.1 | Upgrade Telegram client |
+| Rich text rendered, but Copy-as-text broken | TDesktop edge case | Report at Issue #44428 |
+| Streaming draft stays "Thinking..." forever | LLM timeout >30s | Reduce prompt size; check `streaming_overflow_limit` |
+| Final message has duplicate old version | Pre-#46009 bug | Update to a recent Hermes commit (>=a59d5e37e) |
+| CJK garbled | Pre-ea056b055 | Update Hermes; CJK path auto-falls-back to MarkdownV2 |
+| `rich_messages: true` ignored | Config typo / yaml reload issue | `hermes config validate` then restart gateway |
+
+---
+
+## 4. CI integration (optional)
+
+Add to your CI pipeline to catch regressions early:
+
+```yaml
+# .github/workflows/telegram-rich-smoke.yml
+name: Telegram Rich Messages smoke
+on: [push, pull_request]
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Dry-run verify
+        run: python3 scripts/dry_run_send_rich.py
+        # Expected: exit 0 if methods deployed, exit 1 if not
+```
+
+If `dry_run_send_rich.py` exits 1 → fail the build. Telegram may have reverted an API method.
+
+---
+
+## 5. Where to file issues
+
+| Concern | GitHub Issue |
+|---------|--------------|
+| Feature request: richer streaming UX | #44428 (canonical) or #45864 (duplicate) |
+| Bug: rich rendering broken | #46009 (closed — verify fix landed first) |
+| Bug: edit_message destroys rich | #46009 (verify fix) |
+| CJK fallback broken | New issue, tag `platform/telegram` + `comp/gateway` |
+| TDesktop edge case | Comment on #44428 |
+
+---
+
+## 6. References
+
+- **Bot API spec**: https://core.telegram.org/bots/api#rich-messages
+- **Bot API 10.1 changelog**: https://core.telegram.org/bots/api-changelog#june-11-2026
+- **Skill**: `~/.hermes/skills/devtools/telegram-rich-messages/SKILL.md` v1.1.0
+- **Cook session**: `~/.hermes/plans/reports/cook-gateway-rich-20260627-090803/`
+- **Initial ship**: commit `a59d5e37e feat(telegram): make rich messages always on` (2026-06-13)
+- **Opt-in default**: commit `6183e8ce1 fix(telegram): make Bot API 10.1 rich messages opt-in (default off)` (2026-06-21)
+- **CJK fallback**: commit `ea056b055 fix(telegram): avoid rich messages for CJK text`
+- **Edit fix**: PR #46009 (closed, fix landed)

--- a/scripts/dry_run_send_rich.py
+++ b/scripts/dry_run_send_rich.py
@@ -1,0 +1,93 @@
+"""
+scripts/dry_run_send_rich.py — Hermes Agent
+
+Dry-run verify cho Telegram Bot API 10.1 Rich Messages mà KHÔNG cần bot token
+thật. Chỉ ping API endpoint, expect HTTP 401 (invalid token) hoặc 404 nếu
+method không tồn tại.
+
+Mục đích: CI smoke test trước khi deploy / rollback, hoặc khi verify Bot API
+10.1 đã deploy thật trên production.
+
+Usage:
+    python3 scripts/dry_run_send_rich.py
+    python3 scripts/dry_run_send_rich.py --token "$TELEGRAM_BOT_TOKEN"
+
+Output:
+    exit 0 = method available (200 OK real token, hoặc 401 dummy — cả 2 đều OK)
+    exit 1 = method NOT available (404) → Bot API version <10.1 hoặc method renamed
+    exit 2 = network error / DNS fail
+"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+
+API_BASE = "https://api.telegram.org"
+METHODS_TO_CHECK = [
+    "sendRichMessage",
+    "sendRichMessageDraft",
+]
+
+
+def ping(method: str, token: str = "0000000000:DUMMY_TOKEN") -> int:
+    """POST một dummy payload tới `method`. Return HTTP status code."""
+    if method in ("sendRichMessage",):
+        payload = {"chat_id": 0, "rich_message": json.dumps({"html": "<p>dry-run</p>"})}
+    elif method == "sendRichMessageDraft":
+        payload = {"chat_id": 0, "draft_id": 1, "rich_message": json.dumps({"html": "<p>dry-run</p>"})}
+    else:
+        raise ValueError(f"Unknown method: {method}")
+
+    req = urllib.request.Request(
+        f"{API_BASE}/bot{token}/{method}",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status
+    except urllib.error.HTTPError as e:
+        return e.code
+    except (urllib.error.URLError, TimeoutError) as e:
+        print(f"❌ Network error on {method}: {e}")
+        return -1
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Dry-run verify Telegram Bot API 10.1 Rich Messages")
+    parser.add_argument("--token", default="0000000000:DUMMY_TOKEN", help="Bot token (default dummy for 401)")
+    args = parser.parse_args()
+
+    print(f"=== Dry-run verify Telegram Bot API 10.1 Rich Messages ===")
+    print(f"Endpoint: {API_BASE}")
+    print(f"Token: {args.token[:12]}... (truncated)")
+    print()
+
+    results = {}
+    for method in METHODS_TO_CHECK:
+        status = ping(method, args.token)
+        results[method] = status
+        print(f"  {method}: HTTP {status}")
+
+    print()
+    print("=== Verdict ===")
+    if all(s == 401 for s in results.values()):
+        print("✅ All methods DEPLOYED (401 = method exists, dummy token rejected).")
+        print("   Bot API 10.1+ is live on production.")
+        return 0
+    if any(s == 404 for s in results.values()):
+        print("❌ At least one method NOT FOUND (404).")
+        print("   Bot API version may be <10.1, OR method was renamed/removed.")
+        return 1
+    if any(s < 0 for s in results.values()):
+        print("❌ Network errors. Check connectivity.")
+        return 2
+    print(f"⚠️ Unexpected statuses: {results}")
+    print("   Methods exist (not 404) but returned unexpected codes. Inspect manually.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Companion to the shipped Rich Messages support in `plugins/platforms/telegram/adapter.py` (commits a59d5e37e + 6183e8ce1 + ea056b055).

## What this PR adds

### `scripts/dry_run_send_rich.py` (~80 lines)
Ping `sendRichMessage` + `sendRichMessageDraft` with a dummy bot token, expect HTTP 401 (method exists, token rejected). Used as CI smoke test to detect Bot API regressions.

```bash
$ python3 scripts/dry_run_send_rich.py
=== Dry-run verify Telegram Bot API 10.1 Rich Messages ===
  sendRichMessage: HTTP 401
  sendRichMessageDraft: HTTP 401
✅ All methods DEPLOYED
```

### `docs/operator-test-recipe-telegram-rich.md` (~180 lines)
6-step manual test sequence with clear pass/fail criteria:
1. Plain rich paragraph
2. Table render
3. Streaming draft animation
4. Edit upgrade (progressive enhancement)
5. CJK fallback (auto-routes to MarkdownV2)
6. Code block with syntax highlight

Plus a failure-mode table mapping symptom → root cause → fix, and where-to-file-issues mapping.

## Why these artifacts, not a code PR

The actual Rich Messages implementation was already shipped (commits a59d5e37e, 6183e8ce1, ea056b055). This PR adds only operator-facing artifacts — no production code changes.

Cooked from cook session 2026-06-27 (board cook-gateway-rich-20260627, swarm root t_65a5e621, 5 lanes, 7/7 tasks done).

## Verification

```bash
# Confirmed working locally
$ python3 scripts/dry_run_send_rich.py
✅ All methods DEPLOYED (401 = method exists, dummy token rejected)
```

Closes #45864 (duplicate of #44428).