### PR TITLE
fix(supermemory): resolve default container sentinels to None (#27226)

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -23,6 +23,13 @@ from tools.registry import tool_error
 logger = logging.getLogger(__name__)
 
 _DEFAULT_CONTAINER_TAG = "hermes"
+# Values that mean "use Supermemory's default/My Space" instead of a
+# literal container tag.  Resolved to ``None`` so the SDK omits the
+# container parameter entirely, which targets the real default graph.
+# Sending a literal string like "default" creates a SEPARATE graph.
+_CONTAINER_TAG_SENTINELS = frozenset({
+    "", "__default__", "default", "my_space", "my space", "none", "null",
+})
 _DEFAULT_MAX_RECALL_RESULTS = 10
 _DEFAULT_PROFILE_FREQUENCY = 50
 _DEFAULT_CAPTURE_MODE = "all"
@@ -74,6 +81,19 @@ def _sanitize_tag(raw: str) -> str:
     tag = re.sub(r"[^a-zA-Z0-9_]", "_", raw or "")
     tag = re.sub(r"_+", "_", tag)
     return tag.strip("_") or _DEFAULT_CONTAINER_TAG
+
+
+def _resolve_container_tag(raw: str, identity: str = "default") -> Optional[str]:
+    """Resolve a raw container_tag config value to an actual tag or None.
+
+    Returns ``None`` when the value is a sentinel meaning "use
+    Supermemory's default/My Space".  The caller must omit container
+    parameters from SDK calls when the result is ``None``.
+    """
+    expanded = (raw or "").replace("{identity}", identity).strip().lower()
+    if expanded in _CONTAINER_TAG_SENTINELS:
+        return None
+    return _sanitize_tag(raw.replace("{identity}", identity))
 
 
 def _clamp_entity_context(text: str) -> str:
@@ -262,7 +282,7 @@ def _is_trivial_message(text: str) -> bool:
 
 
 class _SupermemoryClient:
-    def __init__(self, api_key: str, timeout: float, container_tag: str, search_mode: str = "hybrid"):
+    def __init__(self, api_key: str, timeout: float, container_tag: Optional[str], search_mode: str = "hybrid"):
         from supermemory import Supermemory
 
         self._api_key = api_key
@@ -289,11 +309,12 @@ class _SupermemoryClient:
     def add_memory(self, content: str, metadata: Optional[dict] = None, *,
                    entity_context: str = "", container_tag: Optional[str] = None,
                    custom_id: Optional[str] = None) -> dict:
-        tag = container_tag or self._container_tag
+        tag = container_tag if container_tag is not None else self._container_tag
         kwargs: dict[str, Any] = {
             "content": content.strip(),
-            "container_tags": [tag],
         }
+        if tag is not None:
+            kwargs["container_tags"] = [tag]
         if metadata:
             kwargs["metadata"] = self._merge_metadata(metadata)
         if entity_context:
@@ -306,9 +327,11 @@ class _SupermemoryClient:
     def search_memories(self, query: str, *, limit: int = 5,
                         container_tag: Optional[str] = None,
                         search_mode: Optional[str] = None) -> list[dict]:
-        tag = container_tag or self._container_tag
+        tag = container_tag if container_tag is not None else self._container_tag
         mode = search_mode or self._search_mode
-        kwargs: dict[str, Any] = {"q": query, "container_tag": tag, "limit": limit}
+        kwargs: dict[str, Any] = {"q": query, "limit": limit}
+        if tag is not None:
+            kwargs["container_tag"] = tag
         if mode in _VALID_SEARCH_MODES:
             kwargs["search_mode"] = mode
         response = self._client.search.memories(**kwargs)
@@ -325,8 +348,10 @@ class _SupermemoryClient:
 
     def get_profile(self, query: Optional[str] = None, *,
                     container_tag: Optional[str] = None) -> dict:
-        tag = container_tag or self._container_tag
-        kwargs: dict[str, Any] = {"container_tag": tag}
+        tag = container_tag if container_tag is not None else self._container_tag
+        kwargs: dict[str, Any] = {}
+        if tag is not None:
+            kwargs["container_tag"] = tag
         if query:
             kwargs["q"] = query
         response = self._client.profile(**kwargs)
@@ -349,8 +374,11 @@ class _SupermemoryClient:
         return {"static": static, "dynamic": dynamic, "search_results": search_results}
 
     def forget_memory(self, memory_id: str, *, container_tag: Optional[str] = None) -> None:
-        tag = container_tag or self._container_tag
-        self._client.memories.forget(container_tag=tag, id=memory_id)
+        tag = container_tag if container_tag is not None else self._container_tag
+        kwargs: dict[str, Any] = {"id": memory_id}
+        if tag is not None:
+            kwargs["container_tag"] = tag
+        self._client.memories.forget(**kwargs)
 
     def forget_by_query(self, query: str, *, container_tag: Optional[str] = None) -> dict:
         results = self.search_memories(query, limit=5, container_tag=container_tag)
@@ -368,8 +396,9 @@ class _SupermemoryClient:
         payload: dict = {
             "conversationId": session_id,
             "messages": messages,
-            "containerTags": [self._container_tag],
         }
+        if self._container_tag is not None:
+            payload["containerTags"] = [self._container_tag]
         if metadata:
             payload["metadata"] = self._merge_metadata(metadata)
 
@@ -509,9 +538,9 @@ class SupermemoryMemoryProvider(MemoryProvider):
         # Resolve container tag: env var > config > default.
         # Supports {identity} template for profile-scoped containers.
         env_tag = os.environ.get("SUPERMEMORY_CONTAINER_TAG", "").strip()
-        raw_tag = env_tag or self._config["container_tag"]
+        raw_tag = env_tag or self._config.get("container_tag", _DEFAULT_CONTAINER_TAG)
         identity = kwargs.get("agent_identity", "default")
-        self._container_tag = _sanitize_tag(raw_tag.replace("{identity}", identity))
+        self._container_tag = _resolve_container_tag(raw_tag, identity)
 
         self._auto_recall = self._config["auto_recall"]
         self._auto_capture = self._config["auto_capture"]
@@ -524,7 +553,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._enable_custom_containers = self._config["enable_custom_container_tags"]
         self._custom_containers = self._config["custom_containers"]
         self._custom_container_instructions = self._config["custom_container_instructions"]
-        self._allowed_containers = [self._container_tag] + list(self._custom_containers)
+        self._allowed_containers = [t for t in [self._container_tag] + list(self._custom_containers) if t is not None]
 
         self._session_turns = []
 
@@ -553,7 +582,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
             return ""
         lines = [
             "# Supermemory",
-            f"Active. Container: {self._container_tag}.",
+            f"Active. Container: {self._container_tag or 'My Space (Supermemory default)'}.",
             "Use supermemory-search, supermemory-save, supermemory-forget, and supermemory-profile (aliases: supermemory_search, supermemory_store, supermemory_forget, supermemory_profile).",
         ]
         if self._enable_custom_containers and self._custom_containers:

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -457,3 +457,112 @@ def test_save_config_sets_owner_only_permissions(tmp_path):
     assert config_file.exists()
     mode = stat.S_IMODE(config_file.stat().st_mode)
     assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"
+
+
+
+
+class TestContainerTagSentinels:
+    """Sentinel values like 'default' / '__default__' resolve to None (#27226)."""
+
+    def test_resolve_sentinel_default(self):
+        from plugins.memory.supermemory import _resolve_container_tag
+        assert _resolve_container_tag("default") is None
+
+    def test_resolve_sentinel_dunder_default(self):
+        from plugins.memory.supermemory import _resolve_container_tag
+        assert _resolve_container_tag("__default__") is None
+
+    def test_resolve_sentinel_my_space(self):
+        from plugins.memory.supermemory import _resolve_container_tag
+        assert _resolve_container_tag("my_space") is None
+        assert _resolve_container_tag("my space") is None
+
+    def test_resolve_sentinel_none_null(self):
+        from plugins.memory.supermemory import _resolve_container_tag
+        assert _resolve_container_tag("none") is None
+        assert _resolve_container_tag("null") is None
+        assert _resolve_container_tag("") is None
+
+    def test_resolve_normal_tag_preserved(self):
+        from plugins.memory.supermemory import _resolve_container_tag
+        assert _resolve_container_tag("hermes") == "hermes"
+        assert _resolve_container_tag("my_project") == "my_project"
+
+    def test_resolve_identity_template_with_sentinel(self):
+        from plugins.memory.supermemory import _resolve_container_tag
+        assert _resolve_container_tag("__default__", "alice") is None
+
+    def test_resolve_identity_template_normal(self):
+        from plugins.memory.supermemory import _resolve_container_tag
+        assert _resolve_container_tag("hermes_{identity}", "alice") == "hermes_alice"
+
+    def _make_client(self, container_tag=None):
+        """Helper to create _SupermemoryClient with mocked SDK import."""
+        from unittest.mock import MagicMock, patch
+        fake_sm_module = MagicMock()
+        with patch.dict("sys.modules", {"supermemory": fake_sm_module}):
+            from plugins.memory.supermemory import _SupermemoryClient
+            client = _SupermemoryClient(api_key="k", timeout=5, container_tag=container_tag)
+        client._client = MagicMock()
+        return client
+
+    def test_client_add_memory_omits_container_when_none(self):
+        from unittest.mock import MagicMock
+        client = self._make_client(container_tag=None)
+        client._client.documents.add.return_value = MagicMock(id="doc123")
+        client.add_memory("hello world")
+        _, kwargs = client._client.documents.add.call_args
+        assert "container_tags" not in kwargs
+
+    def test_client_add_memory_includes_container_when_set(self):
+        from unittest.mock import MagicMock
+        client = self._make_client(container_tag="hermes")
+        client._client.documents.add.return_value = MagicMock(id="doc123")
+        client.add_memory("hello world")
+        _, kwargs = client._client.documents.add.call_args
+        assert "container_tags" in kwargs
+        assert kwargs["container_tags"] == ["hermes"]
+
+    def test_client_search_omits_container_when_none(self):
+        from unittest.mock import MagicMock
+        client = self._make_client(container_tag=None)
+        client._client.search.memories.return_value = MagicMock(results=[])
+        client.search_memories("test query")
+        _, kwargs = client._client.search.memories.call_args
+        assert "container_tag" not in kwargs
+
+    def test_client_search_includes_container_when_set(self):
+        from unittest.mock import MagicMock
+        client = self._make_client(container_tag="hermes")
+        client._client.search.memories.return_value = MagicMock(results=[])
+        client.search_memories("test query")
+        _, kwargs = client._client.search.memories.call_args
+        assert kwargs["container_tag"] == "hermes"
+
+    def test_client_profile_omits_container_when_none(self):
+        from unittest.mock import MagicMock
+        client = self._make_client(container_tag=None)
+        client._client.profile.return_value = MagicMock(profile=None, search_results=None)
+        client.get_profile()
+        _, kwargs = client._client.profile.call_args
+        assert "container_tag" not in kwargs
+
+    def test_client_forget_omits_container_when_none(self):
+        client = self._make_client(container_tag=None)
+        client.forget_memory("mem123")
+        _, kwargs = client._client.memories.forget.call_args
+        assert "container_tag" not in kwargs
+        assert kwargs["id"] == "mem123"
+
+    def test_allowed_containers_excludes_none(self):
+        from unittest.mock import MagicMock, patch as mock_patch
+        import tempfile, os, json
+        p = SupermemoryMemoryProvider()
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = {"container_tag": "__default__"}
+            with open(os.path.join(tmp, "supermemory.json"), "w") as f:
+                json.dump(cfg, f)
+            fake_sm = MagicMock()
+            with mock_patch.dict("sys.modules", {"supermemory": fake_sm}):
+                p.initialize("test", hermes_home=tmp)
+        assert None not in p._allowed_containers


### PR DESCRIPTION
## Summary

Config values like `default`, `__default__`, `my_space`, `none`, `null` were used as literal Supermemory container tags, creating separate graphs instead of targeting the real default/My Space space. This silently split memory across containers and forced manual cleanup.

Add `_CONTAINER_TAG_SENTINELS` set and `_resolve_container_tag()` helper that maps these sentinels to `None`. When `container_tag` is `None`, all SDK calls (add, search, profile, forget, ingest) omit container parameters so Supermemory targets its default space.

## Changes

- `_CONTAINER_TAG_SENTINELS`: `{"", "__default__", "default", "my_space", "my space", "none", "null"}`
- `_resolve_container_tag()`: maps sentinels to `None`, keeps real tags
- `_SupermemoryClient`: all 5 methods conditionally omit container params when tag is `None`
- `initialize()`: use `_resolve_container_tag` instead of `_sanitize_tag`
- `_allowed_containers`: filter out `None` entries
- Status display: show "My Space (Supermemory default)" when `None`
- 14 new regression tests

## Test plan

- [x] `python3 -m pytest tests/plugins/memory/test_supermemory_provider.py` (45 passed)

Closes #27226