### PR TITLE
fix(platforms): don't drop table columns whose value matches the heading

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -312,9 +312,11 @@ def _render_table_block(table_block: list[str]) -> str:
     """Render a detected GFM table as bold-heading + bullet groups.
 
     Uses the same alignment logic as Telegram's renderer: for non-row-label
-    tables, ``data_cells = cells`` (the full row) and the bullet whose value
-    duplicates the heading is skipped.  This keeps header→value alignment
-    correct.
+    tables, ``data_cells = cells`` (the full row) and the bullet for the cell
+    promoted to the heading is skipped by its column *position*.  Keying on
+    position rather than value avoids dropping a distinct column that happens
+    to hold the same string as the heading, while keeping header→value
+    alignment correct.
     """
     if len(table_block) < 3:
         return "\n".join(table_block)
@@ -336,8 +338,12 @@ def _render_table_block(table_block: list[str]) -> str:
         if has_row_label_col:
             heading = cells[0] if cells and cells[0] else f"Row {index}"
             data_cells = cells[1:]
+            heading_idx = None
         else:
-            heading = next((cell for cell in cells if cell), f"Row {index}")
+            heading_idx = next(
+                (k for k, cell in enumerate(cells) if cell), None
+            )
+            heading = cells[heading_idx] if heading_idx is not None else f"Row {index}"
             data_cells = cells
 
         if len(data_cells) < len(headers):
@@ -346,8 +352,8 @@ def _render_table_block(table_block: list[str]) -> str:
             data_cells = data_cells[: len(headers)]
 
         bullets: list[str] = []
-        for header, value in zip(headers, data_cells):
-            if not has_row_label_col and value == heading:
+        for col, (header, value) in enumerate(zip(headers, data_cells)):
+            if not has_row_label_col and col == heading_idx:
                 continue
             bullets.append(f"• {header}: {value}")
 

--- a/tests/gateway/test_table_helpers.py
+++ b/tests/gateway/test_table_helpers.py
@@ -135,3 +135,18 @@ class TestConvertTableToBullets:
         out = convert_table_to_bullets(text)
         assert "• B: 1\n\n**y**" in out
         assert "\n\n• " not in out
+
+    def test_value_equal_to_heading_not_dropped(self):
+        # A non-heading column whose value coincides with the auto-selected
+        # heading value must still render — suppression is keyed on the
+        # heading cell's column position, not on string equality.
+        text = (
+            "| Service | Status | Region |\n"
+            "|---------|--------|--------|\n"
+            "| api     | api    | us-east |"
+        )
+        out = convert_table_to_bullets(text)
+        assert "**api**" in out
+        assert "• Service: api" not in out  # heading cell still suppressed
+        assert "• Status: api" in out  # FAILS before fix (column dropped)
+        assert "• Region: us-east" in out


### PR DESCRIPTION
## What does this PR do?

`_render_table_block()` in `gateway/platforms/helpers.py` rewrites GFM pipe tables into bold-heading + bullet groups. For non-row-label tables it auto-selects the heading as the first non-empty cell's **value**, then suppresses the redundant heading bullet by **value equality** (`value == heading`).

That equality check over-matches: any *other* column whose value coincidentally equals the auto-selected heading string is silently dropped from the rendered bullet list. Status/state tables, score tables, and any table with a repeated value lose a column when rendered to Discord or Telegram.

This fix keys the suppression to the heading cell's column **position** instead of its value, so only the promoted heading cell is skipped. The shared helper is used by both the Discord adapter and the Telegram adapter, so the fix applies to both platforms.

## Related Issue

No filed issue — found by reading the follow-up code of #53284 (the original table→bullets feature).

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/helpers.py`: capture the heading cell's column index (`heading_idx`) and skip the bullet by position (`col == heading_idx`) instead of by value (`value == heading`). Row-label tables are unaffected (`heading_idx = None`, no positional skip).
- `tests/gateway/test_table_helpers.py`: add `test_value_equal_to_heading_not_dropped` regression test.

## How to Test

Reproduction (before the fix, the Status column is dropped):

```
| Service | Status | Region |
|---------|--------|--------|
| api     | api    | us-east |
```

- **Before:** renders `**api**` + `• Region: us-east` — the `Status` column ("api") is silently lost because its value equals the heading.
- **After:** renders `**api**` + `• Status: api` + `• Region: us-east` (heading cell `Service: api` still suppressed).

Run the tests:

1. `pytest tests/gateway/test_table_helpers.py -q` — 19 passed (18 existing + 1 new).
2. The new test fails on `assert "• Status: api" in out` if the production change is reverted (verified fail-before / pass-after both directions).
3. Adjacent format tests stay green: `pytest tests/gateway/test_table_helpers.py tests/gateway/test_discord_format.py tests/gateway/test_telegram_format.py tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_rich_newlines.py -q` — 208 passed.

All existing `convert_table_to_bullets` tests stay byte-identical: in the standard cases the heading cell is at index 0, so it is still suppressed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated the `_render_table_block` docstring to describe position-based suppression
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure string logic, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A