### PR TITLE
fix(agent): flag unverified external state after tool failures

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -912,6 +912,17 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             if blocked:
                 effect_disposition = "none"
 
+            try:
+                agent._record_failed_tool_result(
+                    function_name,
+                    function_args,
+                    function_result,
+                    is_error=is_error,
+                    blocked=blocked,
+                )
+            except Exception as _ver_err:
+                logging.debug("failed-tool verifier record failed: %s", _ver_err)
+
             if not blocked:
                 function_result = agent._append_guardrail_observation(
                     function_name,
@@ -1631,6 +1642,17 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
         else:
             logger.info("tool %s completed (%.2fs, %d chars)", function_name, tool_duration, _result_len)
+
+        try:
+            agent._record_failed_tool_result(
+                function_name,
+                function_args,
+                function_result,
+                is_error=_is_error_result,
+                blocked=_execution_blocked,
+            )
+        except Exception as _ver_err:
+            logging.debug("failed-tool verifier record failed: %s", _ver_err)
 
         # Track file-mutation outcome for the turn-end verifier.  See
         # the concurrent path for the rationale; both paths must feed

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -765,8 +765,9 @@ def build_turn_context(
                 else _gateway_notes
             )
 
-    # Per-turn file-mutation verifier state.
+    # Per-turn verifier state.
     agent._turn_failed_file_mutations = {}
+    agent._turn_failed_tools = []
     agent._turn_file_mutation_paths = set()
     agent._verification_stop_nudges = 0
     agent._pre_verify_nudges = 0

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -393,6 +393,21 @@ def finalize_turn(
         except Exception as _ver_err:
             logger.debug("file-mutation verifier footer failed: %s", _ver_err)
 
+    # Tool-failure verifier footer.
+    # When one or more non-file-mutating tools failed or were blocked during
+    # this turn, add a historical record without retaining raw tool arguments
+    # or result text. A later successful result may have recovered the operation;
+    # the footer deliberately does not claim otherwise.
+    if final_response and not interrupted:
+        try:
+            _failed_tools = getattr(agent, "_turn_failed_tools", None) or []
+            if _failed_tools:
+                footer = agent._format_failed_tool_footer(_failed_tools)
+                if footer:
+                    final_response = final_response.rstrip() + "\n\n" + footer
+        except Exception as _ver_err:
+            logger.debug("failed-tool verifier footer failed: %s", _ver_err)
+
     # Turn-completion explainer.
     # When a turn ends abnormally after substantive work — empty content
     # after retries, a partial/truncated stream, a still-pending tool

--- a/run_agent.py
+++ b/run_agent.py
@@ -2991,6 +2991,63 @@ class AIAgent:
             for path in targets:
                 state.pop(path, None)
 
+    def _record_failed_tool_result(
+        self,
+        tool_name: str,
+        args: Dict[str, Any],
+        result: Any,
+        *,
+        is_error: bool,
+        blocked: bool = False,
+    ) -> None:
+        """Record a failed or blocked tool call for the turn-end verifier.
+
+        File-mutation tools already have a dedicated verifier footer, so this
+        broader tracker focuses on the remaining tools whose failures can make
+        later external-state claims unreliable.
+        """
+        state = getattr(self, "_turn_failed_tools", None)
+        if state is None or tool_name in _FILE_MUTATING_TOOLS:
+            return
+        if not (is_error or blocked):
+            return
+        if not self._failed_tool_needs_external_state_verification(
+            tool_name, blocked=blocked
+        ):
+            return
+
+        # Retain only categorical metadata. Tool arguments and error payloads
+        # can contain credentials, authorization headers, or signed URLs and
+        # must never flow into the final user-visible verifier footer.
+        state.append(
+            {
+                "tool": tool_name,
+                "blocked": bool(blocked),
+            }
+        )
+
+    @staticmethod
+    def _failed_tool_needs_external_state_verification(
+        tool_name: str,
+        *,
+        blocked: bool = False,
+    ) -> bool:
+        """Return whether a failed tool should trigger external-state caution."""
+        if tool_name in {
+            "terminal",
+            "execute_code",
+            "web_extract",
+            "send_message",
+            "process",
+            "computer_use",
+        }:
+            return True
+        if tool_name.startswith("browser_"):
+            return True
+        if blocked and tool_name == "read_file":
+            return True
+        return False
+
     def _file_mutation_verifier_enabled(self) -> bool:
         """Check whether the per-turn file-mutation verifier footer is on.
 
@@ -3086,6 +3143,37 @@ class AIAgent:
         # Neutralize any path the preview text echoed (the bullet path is
         # already backticked above; the lookbehind keeps it from being
         # double-wrapped).
+        return cls._neutralize_footer_paths("\n".join(lines))
+
+    @classmethod
+    def _format_failed_tool_footer(cls, failed_tools: List[Dict[str, Any]]) -> str:
+        """Render a concise footer when this turn had tool failures/blocks.
+
+        This makes it structurally harder for the final prose to imply that an
+        external side effect definitely happened when one or more prerequisite
+        tools actually failed or were blocked.
+        """
+        if not failed_tools:
+            return ""
+        lines = [
+            "⚠️ Tool-failure verifier (historical record): one or more tool calls failed or were "
+            "blocked this turn. These entries do not establish whether a later call recovered. "
+            "Treat any external side effect mentioned above (for example repo creation, push, "
+            "publish, deploy, or remote edits) as unverified unless a later successful tool "
+            "result explicitly confirmed it."
+        ]
+        shown = 0
+        for info in failed_tools:
+            if shown >= 5:
+                break
+            tool = str(info.get("tool") or "tool")
+            blocked = bool(info.get("blocked"))
+            detail = "blocked before execution" if blocked else "failed"
+            lines.append(f"  • `{tool}` — {detail}")
+            shown += 1
+        remaining = len(failed_tools) - shown
+        if remaining > 0:
+            lines.append(f"  • … and {remaining} more")
         return cls._neutralize_footer_paths("\n".join(lines))
 
     def _turn_completion_explainer_enabled(self) -> bool:
@@ -6177,11 +6265,37 @@ class AIAgent:
             function_result = append_toolguard_guidance(function_result, decision)
         if decision.should_halt:
             self._set_tool_guardrail_halt(decision)
+        if failed:
+            function_result = self._append_failed_tool_verification_notice(
+                tool_name, function_result
+            )
         return function_result
 
     def _guardrail_block_result(self, decision: ToolGuardrailDecision) -> str:
         self._set_tool_guardrail_halt(decision)
         return toolguard_synthetic_result(decision)
+
+    @staticmethod
+    def _append_failed_tool_verification_notice(
+        tool_name: str,
+        function_result: str,
+    ) -> str:
+        """Append a short anti-false-success notice to failed tool results."""
+        if not isinstance(function_result, str) or not function_result.strip():
+            return function_result
+        if tool_name in _FILE_MUTATING_TOOLS:
+            return function_result
+        if not AIAgent._failed_tool_needs_external_state_verification(tool_name):
+            return function_result
+        marker = "External-state verification"
+        if marker in function_result:
+            return function_result
+        return (
+            function_result
+            + "\n\n[External-state verification: this tool call failed, so any claimed external side effect "
+              "(for example repo creation, push, publish, deploy, or remote edits) remains unverified "
+              "unless a later successful tool result explicitly confirms it.]"
+        )
 
     def _execute_tool_calls(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
         """Execute tool calls from the assistant message and append results to messages.

--- a/tests/agent/test_turn_finalizer_cleanup_guard.py
+++ b/tests/agent/test_turn_finalizer_cleanup_guard.py
@@ -43,6 +43,7 @@ class _StubAgent:
         self._response_was_previewed = False
         self._skill_nudge_interval = 0
         self._iters_since_skill = 0
+        self._turn_failed_tools = []
         for attr in (
             "session_input_tokens",
             "session_output_tokens",
@@ -86,6 +87,11 @@ class _StubAgent:
 
     def _file_mutation_verifier_enabled(self):
         return False
+
+    def _format_failed_tool_footer(self, failed_tools):
+        if not failed_tools:
+            return ""
+        return "TOOL FAILURE FOOTER"
 
     def _turn_completion_explainer_enabled(self):
         return False
@@ -182,3 +188,24 @@ def test_text_response_on_last_allowed_call_is_completed():
     )
     assert result["final_response"] == "final report"
     assert result["completed"] is True
+
+
+def test_failed_tool_footer_is_appended_to_final_response():
+    agent = _StubAgent(raise_in=())
+    agent._turn_failed_tools = [
+        {
+            "tool": "terminal",
+            "blocked": True,
+            "error_preview": "Blocked by policy",
+            "command_preview": "git push origin main",
+        }
+    ]
+
+    result = _run(
+        agent,
+        final_response="reported success",
+        api_call_count=1,
+        turn_exit_reason="text_response(finish_reason=stop)",
+    )
+
+    assert result["final_response"] == "reported success\n\nTOOL FAILURE FOOTER"

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -129,6 +129,7 @@ def _bare_agent() -> AIAgent:
     """
     agent = object.__new__(AIAgent)
     agent._turn_failed_file_mutations = {}
+    agent._turn_failed_tools = []
     agent._turn_file_mutation_paths = set()
     return agent
 
@@ -271,6 +272,63 @@ class TestRecordFileMutationResult:
         )
         assert set(agent._turn_failed_file_mutations) == {"/tmp/a.md", "/tmp/b.md"}
 
+
+class TestRecordFailedToolResult:
+    def test_non_error_ignored(self):
+        agent = _bare_agent()
+        agent._record_failed_tool_result(
+            "web_search", {"q": "hi"}, json.dumps({"success": True}), is_error=False
+        )
+        assert agent._turn_failed_tools == []
+
+    def test_file_mutation_tools_deferred_to_dedicated_footer(self):
+        agent = _bare_agent()
+        agent._record_failed_tool_result(
+            "patch", {"path": "/tmp/a.py"}, json.dumps({"error": "boom"}), is_error=True
+        )
+        assert agent._turn_failed_tools == []
+
+    def test_error_is_recorded(self):
+        agent = _bare_agent()
+        agent._record_failed_tool_result(
+            "terminal",
+            {"command": "git push origin main"},
+            json.dumps({"error": "push failed"}),
+            is_error=True,
+        )
+        assert agent._turn_failed_tools == [
+            {
+                "tool": "terminal",
+                "blocked": False,
+            }
+        ]
+
+    def test_blocked_terminal_records_only_categorical_metadata(self):
+        agent = _bare_agent()
+        agent._record_failed_tool_result(
+            "terminal",
+            {"command": "git push origin main"},
+            json.dumps({"error": "Blocked by policy"}),
+            is_error=True,
+            blocked=True,
+        )
+        assert agent._turn_failed_tools == [{"tool": "terminal", "blocked": True}]
+
+    def test_sensitive_command_and_error_are_not_retained(self):
+        agent = _bare_agent()
+        secret = "ghp_super_secret_token"
+        agent._record_failed_tool_result(
+            "terminal",
+            {"command": f"git clone https://user:{secret}@github.com/org/private.git"},
+            json.dumps({"error": f"Authorization: Bearer {secret}"}),
+            is_error=True,
+        )
+
+        recorded = json.dumps(agent._turn_failed_tools)
+        assert agent._turn_failed_tools == [{"tool": "terminal", "blocked": False}]
+        assert secret not in recorded
+        assert "Authorization" not in recorded
+
     def test_no_state_dict_silent_noop(self):
         """When called outside run_conversation the state dict is absent.
 
@@ -377,6 +435,52 @@ class TestFormatFooter:
         finally:
             import shutil
             shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_failed_tool_footer_empty_returns_empty_string(self):
+        assert AIAgent._format_failed_tool_footer([]) == ""
+
+    def test_failed_tool_footer_mentions_unverified_external_state(self):
+        secret = "ghp_super_secret_token"
+        out = AIAgent._format_failed_tool_footer(
+            [
+                {
+                    "tool": "terminal",
+                    "blocked": True,
+                    "error_preview": f"Authorization: Bearer {secret}",
+                    "command_preview": f"git push https://user:{secret}@github.com/org/repo.git",
+                }
+            ]
+        )
+        assert "Tool-failure verifier" in out
+        assert "historical record" in out
+        assert "do not establish whether a later call recovered" in out
+        assert "unverified" in out
+        assert "`terminal`" in out
+        assert "blocked before execution" in out
+        assert secret not in out
+        assert "Authorization" not in out
+        assert "command:" not in out
+
+    def test_later_success_keeps_explicitly_historical_failure_record(self):
+        agent = _bare_agent()
+        agent._record_failed_tool_result(
+            "terminal",
+            {"command": "git push origin main"},
+            json.dumps({"error": "push failed"}),
+            is_error=True,
+        )
+        agent._record_failed_tool_result(
+            "terminal",
+            {"command": "git ls-remote origin"},
+            json.dumps({"exit_code": 0}),
+            is_error=False,
+        )
+
+        assert agent._turn_failed_tools == [{"tool": "terminal", "blocked": False}]
+        out = AIAgent._format_failed_tool_footer(agent._turn_failed_tools)
+        assert "historical record" in out
+        assert "do not establish whether a later call recovered" in out
+        assert "later successful tool result" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -184,6 +184,18 @@ def test_same_tool_failure_warning_tells_model_to_recover_with_tools():
     assert "different tool" in content
 
 
+def test_terminal_failure_appends_external_state_verification_notice():
+    agent = _make_agent("terminal")
+    tc = _mock_tool_call("terminal", json.dumps({"command": "git push origin main"}), "c-push")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"exit_code": 1, "error": "push failed"})):
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    assert "External-state verification" in messages[0]["content"]
+
+
 def test_config_enabled_hard_stop_concurrent_path_does_not_submit_blocked_calls_and_preserves_result_order():
     agent = _make_agent("web_search", config=_hard_stop_config())
     blocked_args = {"query": "blocked"}
@@ -266,6 +278,44 @@ def test_default_run_conversation_warns_without_guardrail_halt():
     assert result["final_response"] == "done"
     tool_contents = [m["content"] for m in result["messages"] if m.get("role") == "tool"]
     assert any("repeated_exact_failure_warning" in content for content in tool_contents)
+
+
+def test_run_conversation_appends_failed_tool_footer_after_terminal_push_error():
+    agent = _make_agent("terminal", max_iterations=10)
+    secret = "ghp_super_secret_token"
+    push_args = {"command": f"git push https://user:{secret}@github.com/org/repo.git main"}
+    responses = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call("terminal", json.dumps(push_args), "c-push")],
+        ),
+        _mock_response(content="done", finish_reason="stop", tool_calls=None),
+    ]
+    agent.client.chat.completions.create.side_effect = responses
+
+    with (
+        patch(
+            "run_agent.handle_function_call",
+            return_value=json.dumps(
+                {"exit_code": 1, "error": f"Authorization: Bearer {secret}"}
+            ),
+        ) as mock_hfc,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("publish the repo")
+
+    assert mock_hfc.call_count == 1
+    assert result["turn_exit_reason"].startswith("text_response")
+    assert result["final_response"].startswith("done")
+    assert "Tool-failure verifier" in result["final_response"]
+    assert "historical record" in result["final_response"]
+    assert "`terminal`" in result["final_response"]
+    assert secret not in result["final_response"]
+    assert "Authorization" not in result["final_response"]
+    assert "command:" not in result["final_response"]
 
 
 def test_config_enabled_hard_stop_run_conversation_returns_controlled_guardrail_halt_without_top_level_error():


### PR DESCRIPTION
## What does this PR do?

Adds a runtime backstop for false-success external-state claims after high-risk tool failures.

Issue #53072 showed Hermes could hit failed or blocked tool calls during a GitHub repo workflow and still end the turn with prose that implied the repo had been created, pushed, or published. The underlying gap was that file-mutation failures already had a turn-end verifier footer, but failed external-state tools did not.

This patch does not add a GitHub-specific verifier. Instead, it adds a narrower general safeguard for high-risk tool failures so Hermes marks those outcomes as unverified unless a later tool result in the same turn actually confirms them.

## Related Issue

Fixes #53072

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Track failed or blocked high-risk tool calls in per-turn verifier state.
- Append an `External-state verification` warning directly to failed high-risk tool results so the model sees the warning before the next reasoning step.
- Append a `Tool-failure verifier` footer to the final response when the turn contained failed high-risk tools and the model still returns normal prose.
- Keep file-mutation tools on their existing dedicated verifier path instead of broadening the footer to every tool failure.
- Add regression coverage for recorder behavior, finalizer footer behavior, failed terminal push warnings, and a full `run_conversation()` case that mirrors the issue shape.

## Why this is the right fix

The bug is in source, not just prompting: Hermes already had anti-fabrication guidance and a file-mutation verifier, but there was no runtime guard covering failed external-state workflows. That left a structural gap where the model could still summarize a blocked or failed GitHub workflow as if it had succeeded.

This patch keeps the scope narrow. It does not try to solve all GitHub verification centrally or introduce a new special-case tool. Instead, it adds a runtime backstop only for failed tools that commonly gate external side effects such as pushes, publishes, deploys, browser actions, and outbound messaging.

## How to Test

1. Reproduce the issue shape by simulating a failed high-risk tool such as `terminal` with `git push origin main`.
2. Let the next model response return ordinary completion text like `done`.
3. Confirm the final response includes the `Tool-failure verifier` footer and marks the external side effect as unverified.
4. Run the targeted regression suite:

```bash
pytest tests/run_agent/test_tool_call_guardrail_runtime.py -q
pytest tests/run_agent/test_file_mutation_verifier.py -q
pytest tests/agent/test_turn_finalizer_cleanup_guard.py -q
```

## Validation Logs

```text
Post-fix checks:
- pytest tests/run_agent/test_tool_call_guardrail_runtime.py -q -> 11 passed
- pytest tests/run_agent/test_file_mutation_verifier.py -q -> 43 passed
- pytest tests/agent/test_turn_finalizer_cleanup_guard.py -q -> 7 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
