### PR TITLE
fix(cli): suppress gh auth token console flash on Windows

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -27,6 +27,8 @@ import time
 from pathlib import Path
 from typing import Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 # OAuth device code flow constants (same client ID as opencode/Copilot CLI)
@@ -141,6 +143,7 @@ def _try_gh_cli_token() -> Optional[str]:
                 text=True,
                 timeout=5,
                 env=clean_env,
+                creationflags=windows_hide_flags(),
             )
         except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
             logger.debug("gh CLI token lookup failed (%s): %s", gh_path, exc)

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -1,5 +1,8 @@
 """Tests for hermes_cli.copilot_auth — Copilot token validation and resolution."""
 
+import subprocess
+from unittest import mock
+
 import pytest
 from unittest.mock import patch
 
@@ -105,6 +108,46 @@ class TestResolveToken:
             token, source = resolve_copilot_token()
         assert token == ""
         assert source == ""
+
+    def test_gh_cli_token_uses_windows_hide_flags(self, monkeypatch):
+        from hermes_cli.copilot_auth import _try_gh_cli_token
+
+        monkeypatch.setattr(
+            "hermes_cli.copilot_auth.shutil.which",
+            lambda command: "C:/Program Files/GitHub CLI/gh.exe",
+        )
+        monkeypatch.setattr(
+            "hermes_cli.copilot_auth.windows_hide_flags",
+            lambda: 0x08000000,
+        )
+
+        calls = []
+
+        class _Result:
+            returncode = 0
+            stdout = "gho_from_cli\n"
+
+        def _fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return _Result()
+
+        monkeypatch.setattr("hermes_cli.copilot_auth.subprocess.run", _fake_run)
+
+        assert _try_gh_cli_token() == "gho_from_cli"
+        assert calls == [
+            (
+                ["C:/Program Files/GitHub CLI/gh.exe", "auth", "token"],
+                {
+                    "capture_output": True,
+                    "text": True,
+                    "timeout": 5,
+                    "env": mock.ANY,
+                    "creationflags": subprocess.CREATE_NO_WINDOW
+                    if hasattr(subprocess, "CREATE_NO_WINDOW")
+                    else 0x08000000,
+                },
+            )
+        ]
 
 
 class TestRequestHeaders:


### PR DESCRIPTION
## What does this PR do?

This fixes the Windows console-window flash caused by the `gh auth token` fallback in `hermes_cli/copilot_auth.py`. The Copilot credential lookup now uses the shared `windows_hide_flags()` helper so Hermes can poll GitHub CLI credentials without spawning a visible console window on native Windows.

## Related Issue

Fixes #53370

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 🔒 Security fix
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/copilot_auth.py`: pass `creationflags=windows_hide_flags()` to the synchronous `gh auth token` subprocess so Windows hides the transient console window while preserving captured stdout.
- `tests/hermes_cli/test_copilot_auth.py`: add a regression test asserting `_try_gh_cli_token()` forwards the Windows hide flags into `subprocess.run()`.

## How to Test

1. On Windows, configure GitHub CLI auth so `gh auth token` returns a valid token, then trigger a Copilot credential lookup path that falls back to `_try_gh_cli_token()` and confirm no console window flashes.
2. Run `pytest tests/hermes_cli/test_copilot_auth.py tests/hermes_cli/test_api_key_providers.py -q`.
3. Run `python scripts/check-windows-footguns.py --diff HEAD` and `git diff --check`.

## What platforms tested on

- macOS 15 / darwin-arm64 (local sandbox)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Local direct coverage: `pytest tests/hermes_cli/test_copilot_auth.py tests/hermes_cli/test_api_key_providers.py -q` → `191 passed`.
- `python scripts/check-windows-footguns.py --diff HEAD` → no Windows footguns found.
- `ruff check hermes_cli/copilot_auth.py tests/hermes_cli/test_copilot_auth.py` → clean.
- Broad local suite caveat: the required bounded full-suite command stopped during unrelated collection because this sandbox lacks `fastapi` / `uvicorn`; broader importer subsets also exposed unrelated pre-existing failures in `tests/run_agent/test_run_agent_codex_responses.py`, `tests/hermes_cli/test_auth_commands.py`, and `tests/agent/test_credential_pool.py`.

<!-- autocontrib:worker-id=issue-new-f7e21ce3 kind=pr-open -->