### PR TITLE
feat: Add Persian (fa) localization

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 SUPPORTED_LANGUAGES: tuple[str, ...] = (
     "en", "zh", "zh-hant", "ja", "de", "es", "fr", "tr", "uk",
-    "af", "ko", "it", "ga", "pt", "ru", "hu",
+    "af", "ko", "it", "ga", "pt", "ru", "hu", "fa",
 )
 DEFAULT_LANGUAGE = "en"
 
@@ -79,6 +79,8 @@ _LANGUAGE_ALIASES: dict[str, str] = {
     "russian": "ru", "русский": "ru", "ru-ru": "ru",
     # Hungarian
     "hungarian": "hu", "magyar": "hu", "hu-hu": "hu",
+    # Persian
+    "persian": "fa", "farsi": "fa", "fa-ir": "fa",
 }
 
 _catalog_cache: dict[str, dict[str, str]] = {}

--- a/locales/fa.yaml
+++ b/locales/fa.yaml
@@ -1,0 +1,379 @@
+# Hermes static-message catalog -- Persian (Farsi)
+#
+# Only user-facing static messages from the CLI approval prompt and a handful
+# of gateway slash-command replies live here.  Agent-generated output, log
+# lines, error tracebacks, tool outputs, and slash-command descriptions stay
+# in English and are NOT translated -- see agent/i18n.py for scope rationale.
+
+approval:
+  dangerous_header: "⚠️  دستور خطرناک: {description}"
+  choose_long:     "      [o] یکبار  |  [s] یک نشست  |  [a] همیشه  |  [d] رد کردن"
+  choose_short:    "      [o] یکبار  |  [s] یک نشست  |  [d] رد کردن"
+  prompt_long:     "      انتخاب [o/s/a/D]: "
+  prompt_short:    "      انتخاب [o/s/D]: "
+  timeout:         "      ⏱ پایان زمان - رد کردن دستور"
+  allowed_once:    "      ✓ یک بار اجازه داده شد"
+  allowed_session: "      ✓ برای این نشست اجازه داده شد"
+  allowed_always:  "      ✓ به لیست مجاز دائمی اضافه شد"
+  denied:          "      ✗ رد شد"
+  cancelled:       "      ✗ لغو شد"
+  blocklist_message: "این دستور در لیست مسدود شده قرار دارد و نمی‌تواند تایید شود."
+
+gateway:
+  approval_expired: "⚠️ تاییدیه منقضی شد (نماینده دیگر منتظر نیست). از نماینده بخواهید دوباره تلاش کند."
+  draining:         "⏳ تخلیه {count} نماینده فعال قبل از شروع مجدد..."
+  goal_cleared:     "✓ هدف پاک شد."
+  no_active_goal:   "هیچ هدف فعالی وجود ندارد."
+  config_read_failed: "⚠️ خواندن config.yaml با خطا مواجه شد: {error}"
+  config_save_failed: "⚠️ ذخیره پیکربندی با خطا مواجه شد: {error}"
+
+  model:
+    error_prefix:           "خطا: {error}"
+    switched:               "مدل به `{model}` تغییر یافت"
+    provider_label:         "ارائه‌دهنده: {provider}"
+    context_label:          "زمینه: {tokens} توکن"
+    max_output_label:       "حداکثر خروجی: {tokens} توکن"
+    cost_label:             "هزینه: {cost}"
+    capabilities_label:     "قابلیت‌ها: {capabilities}"
+    prompt_caching_enabled: "کش پرامپت: فعال"
+    warning_prefix:         "هشدار: {warning}"
+    saved_global:           "در config.yaml ذخیره شد (`--global`)"
+    session_only_hint:      "_(فقط در این نشست - برای پایداری `--global` را اضافه کنید)_"
+    current_label:          "فعلی: `{model}` روی {provider}"
+    current_tag:            " (فعلی)"
+    more_models_suffix:     " (+{count} مورد دیگر)"
+    usage_switch_model:     "`/model <name>` — تغییر مدل"
+    usage_switch_provider:  "`/model <name> --provider <slug>` — تغییر ارائه‌دهنده"
+    usage_persist:          "`/model <name> --global` — ذخیره دائمی"
+
+  agents:
+    header:                "🤖 **نمایندگان و وظایف فعال**"
+    active_agents:         "**نمایندگان فعال:** {count}"
+    this_chat:             " · این گفتگو"
+    more:                  "... و {count} مورد دیگر"
+    running_processes:     "**پردازش‌های پس‌زمینه در حال اجرا:** {count}"
+    async_jobs:            "**وظایف غیرهمزمان درگاه:** {count}"
+    none:                  "هیچ نماینده یا وظیفه فعالی وجود ندارد."
+    state_starting:        "در حال شروع"
+    state_running:         "در حال اجرا"
+
+  approve:
+    no_pending:            "هیچ دستوری در انتظار تایید نیست."
+    once_singular:         "✅ دستور تایید شد. نماینده در حال ادامه است..."
+    once_plural:           "✅ دستورات تایید شدند ({count} دستور). نماینده در حال ادامه است..."
+    session_singular:      "✅ دستور تایید شد (الگوی تایید شده برای این نشست). نماینده در حال ادامه است..."
+    session_plural:        "✅ دستورات تایید شدند (الگوی تایید شده برای این نشست) ({count} دستور). نماینده در حال ادامه است..."
+    always_singular:       "✅ دستور تایید شد (الگوی تایید شده برای همیشه). نماینده در حال ادامه است..."
+    always_plural:         "✅ دستورات تایید شدند (الگوی تایید شده برای همیشه) ({count} دستور). نماینده در حال ادامه است..."
+
+  background:
+    usage:                 "استفاده: /background <پرامپت>\nمثال: /background خلاصه اخبار امروز را بیاور\n\nپرامپت را در یک نشست جداگانه اجرا می‌کند. می‌توانید به گفتگو ادامه دهید - نتیجه در اینجا ظاهر می‌شود."
+    started:               "🔄 وظیفه پس‌زمینه شروع شد: \"{preview}\"\nشناسه وظیفه: {task_id}\nمی‌توانید به گفتگو ادامه دهید - نتایج پس از پایان ظاهر می‌شوند."
+
+  branch:
+    db_unavailable:        "پایگاه داده نشست در دسترس نیست."
+    no_conversation:       "گفتگویی برای ایجاد شاخه وجود ندارد - ابتدا پیامی ارسال کنید."
+    create_failed:         "ایجاد شاخه با شکست مواجه شد: {error}"
+    switch_failed:         "شاخه ایجاد شد اما جابجایی به آن با شکست مواجه شد."
+    branched_one:          "⑂ به **{title}** شاخه زده شد ({count} پیام کپی شد)\nاصلی: `{parent}`\nشاخه: `{new}`\nبرای بازگشت به اصلی از `/resume` استفاده کنید."
+    branched_many:         "⑂ به **{title}** شاخه زده شد ({count} پیام کپی شد)\nاصلی: `{parent}`\nشاخه: `{new}`\nبرای بازگشت به اصلی از `/resume` استفاده کنید."
+
+  commands:
+    usage:                 "استفاده: `/commands [صفحه]`"
+    skill_header:          "⚡ **دستورات مهارت**:"
+    default_desc:          "دستور مهارت"
+    none:                  "هیچ دستوری در دسترس نیست."
+    header:                "📚 **دستورات** ({total} مورد, صفحه {page}/{total_pages})"
+    nav_prev:              "`/commands {page}` ← قبلی"
+    nav_next:              "بعدی → `/commands {page}`"
+    out_of_range:          "_(صفحه درخواستی {requested} خارج از محدوده بود، صفحه {page} نمایش داده می‌شود.)_"
+
+  compress:
+    not_enough:            "گفتگوی کافی برای فشرده‌سازی وجود ندارد (حداقل ۴ پیام لازم است)."
+    no_provider:           "ارائه‌دهنده‌ای پیکربندی نشده است - فشرده‌سازی امکان‌پذیر نیست."
+    nothing_to_do:         "هنوز چیزی برای فشرده‌سازی وجود ندارد."
+    focus_line:            "تمرکز: \"{topic}\""
+    summary_failed:        "⚠️ تولید خلاصه با شکست مواجه شد ({error}). {count} پیام تاریخی حذف و با یک نگهدارنده جایگزین شدند; زمینه قبلی دیگر قابل بازیابی نیست."
+    aborted:               "⚠️ فشرده‌سازی لغو شد ({error}). هیچ پیامی حذف نشد - گفتگو بدون تغییر است."
+    aux_failed:            "ℹ️ مدل فشرده‌سازی پیکربندی شده `{model}` با شکست مواجه شد ({error}). بازیابی با مدل اصلی انجام شد."
+    failed:                "فشرده‌سازی با شکست مواجه شد: {error}"
+
+  debug:
+    upload_failed:         "✗ آپلود گزارش دیباگ با شکست مواجه شد: {error}"
+    header:                "**گزارش دیباگ آپلود شد:**"
+    auto_delete:           "⏱ پیام‌ها به طور خودکار پس از ۶ ساعت حذف می‌شوند."
+    full_logs_hint:        "برای آپلود گزارش کامل، از `hermes debug share` در محیط خط فرمان استفاده کنید."
+    share_hint:            "این لینک‌ها را با تیم Hermes برای پشتیبانی به اشتراک بگذارید."
+
+  deny:
+    stale:                 "❌ دستور رد شد (تاییدیه قدیمی بود)."
+    no_pending:            "هیچ دستوری برای رد کردن وجود ندارد."
+    denied_singular:       "❌ دستور رد شد."
+    denied_plural:         "❌ دستورات رد شدند ({count} دستور)."
+
+  fast:
+    not_supported:         "⚡ دستور /fast تنها برای مدل‌های OpenAI که از پردازش اولویت‌دار پشتیبانی می‌کنند در دسترس است."
+    status:                "⚡ پردازش اولویت‌دار\n\nحالت فعلی: `{mode}`\n\n_استفاده:_ `/fast <normal|fast|status>`"
+    unknown_arg:           "⚠️ آرگومان ناشناخته: `{arg}`\n\n**گزینه‌های معتبر:** normal, fast, status"
+    saved:                 "⚡ ✓ پردازش اولویت‌دار: **{label}** (در تنظیمات ذخیره شد)\n_(در پیام بعدی اعمال می‌شود)_"
+    session_only:          "⚡ ✓ پردازش اولویت‌دار: **{label}** (تنها برای این نشست)"
+    label_fast:            "سریع (FAST)"
+    label_normal:          "عادی (NORMAL)"
+    status_fast:           "سریع"
+    status_normal:         "عادی"
+
+  footer:
+    status:                "📎 فوتر وضعیت: **{state}**\nفیلدها: `{fields}`\nپلتفرم: `{platform}`"
+    usage:                 "استفاده: `/footer [on|off|status]`"
+    saved:                 "📎 فوتر وضعیت: **{state}**{example}\n_(به صورت جهانی ذخیره شد - در پیام بعدی اعمال می‌شود)_"
+    example_line:          "\nمثال: `{preview}`"
+    state_on:              "روشن"
+    state_off:             "خاموش"
+
+  goal:
+    unavailable:           "اهداف برای این نشست در دسترس نیستند."
+    no_goal_set:           "هدفی تعیین نشده است."
+    paused:                "⏸ هدف متوقف شد: {goal}"
+    no_resume:             "هدفی برای از سرگیری وجود ندارد."
+    resumed:               "▶ هدف از سر گرفته شد: {goal}\nبرای ادامه پیام ارسال کنید یا منتظر بمانید."
+    invalid:               "هدف نامعتبر است: {error}"
+    set:                   "⊙ هدف تعیین شد (بودجه {budget}-نوبت): {goal}\nمن تا تکمیل هدف یا توقف آن به کارم ادامه می‌دهم."
+
+  help:
+    header:                "📖 **دستورات هرمس**\n"
+    skill_header:          "\n⚡ **دستورات مهارت** ({count} فعال):"
+    more_use_commands:     "\n... و {count} مورد دیگر. برای مشاهده لیست کامل از `/commands` استفاده کنید."
+
+  insights:
+    invalid_days:          "مقدار روز نامعتبر است: {value}"
+    error:                 "خطا در تولید بینش: {error}"
+
+  kanban:
+    error_prefix:          "⚠ خطای کانبان: {error}"
+    subscribed_suffix:     "(عضو شدید - هنگام تکمیل یا توقف {task_id} مطلع خواهید شد)"
+    truncated_suffix:      "… (بریده شد؛ برای خروجی کامل از ترمینال `hermes kanban …` را اجرا کنید)"
+    no_output:             "(بدون خروجی)"
+
+  personality:
+    none_configured:       "هیچ شخصیتی در `{path}/config.yaml` پیکربندی نشده است"
+    header:                "🎭 **شخصیت‌های موجود**\n"
+    none_option:           "• `none` — (بدون همپوشانی شخصیت)"
+    item:                  "• `{name}` — {preview}"
+    usage:                 "\nاستفاده: `/personality <نام>`"
+    save_failed:           "⚠️ ذخیره تغییرات شخصیت با خطا مواجه شد: {error}"
+    cleared:               "🎭 شخصیت پاک شد — از رفتار پایه نماینده استفاده می‌شود."
+    set_to:                "🎭 شخصیت به **{name}** تنظیم شد\n_(در پیام بعدی اعمال می‌شود)_"
+    unknown:               "شخصیت ناشناخته: `{name}`\n\nموارد موجود: {available}"
+
+  profile:
+    header:                "👤 **پروفایل:** `{profile}`"
+    home:                  "📂 **خانه:** `{home}`"
+
+  reasoning:
+    level_default:             "متوسط (پیش‌فرض)"
+    level_disabled:            "هیچکدام (غیرفعال)"
+    scope_session:             "لغو برای نشست"
+    scope_global:              "تنظیمات جهانی"
+    status:                    "🧠 **تنظیمات استدلال**\n\n**تلاش:** `{level}`\n**محدوده:** {scope}\n**نمایش:** {display}\n\n_استفاده:_ `/reasoning <none|minimal|low|medium|high|xhigh|reset|show|hide> [--global]`"
+    display_on:                "روشن ✓"
+    display_off:               "خاموش"
+    display_set_on:            "🧠 ✓ نمایش استدلال: **روشن**\nتفکر مدل قبل از پاسخ در **{platform}** نشان داده خواهد شد."
+    display_set_off:           "🧠 ✓ نمایش استدلال: **خاموش** برای **{platform}**"
+    reset_global_unsupported:  "⚠️ `/reasoning reset --global` پشتیبانی نمی‌شود."
+    reset_done:                "🧠 ✓ لغو استدلال نشست پاک شد؛ بازگشت به تنظیمات جهانی."
+    unknown_arg:               "⚠️ آرگومان ناشناخته: `{arg}`"
+    set_global:                "🧠 ✓ میزان استدلال به `{effort}` تنظیم شد (در تنظیمات ذخیره شد)"
+    set_global_save_failed:    "🧠 ✓ میزان استدلال به `{effort}` تنظیم شد (فقط در این نشست - خطا در ذخیره تنظیمات)"
+    set_session:               "🧠 ✓ میزان استدلال به `{effort}` تنظیم شد (فقط در این نشست)"
+
+  reload_mcp:
+    cancelled:             "🟡 /reload-mcp لغو شد. ابزارهای MCP تغییر نکردند."
+    always_followup:       "ℹ️ درخواست‌های آینده `/reload-mcp` بدون تأیید اجرا خواهند شد."
+    confirm_prompt:        "⚠️ **تایید /reload-mcp**\n\nآیا MCP بارگذاری مجدد شود؟"
+    header:                "🔄 **سرورهای MCP مجدداً بارگذاری شدند**\n"
+    reconnected:           "♻️ متصل شده: {names}"
+    added:                 "➕ اضافه شده: {names}"
+    removed:               "➖ حذف شده: {names}"
+    none_connected:        "هیچ سرور MCP متصل نیست."
+    tools_available:       "\n🔧 {tools} ابزار در دسترس از {servers} سرور"
+    failed:                "❌ بارگذاری مجدد MCP با شکست مواجه شد: {error}"
+
+  reload_skills:
+    header:                "🔄 **مهارت‌ها مجدداً بارگذاری شدند**\n"
+    no_new:                "هیچ مهارت جدیدی تشخیص داده نشد."
+    total:                 "\n📚 {count} مهارت در دسترس است"
+    added_header:          "➕ **مهارت‌های اضافه شده:**"
+    removed_header:        "➖ **مهارت‌های حذف شده:**"
+    item_with_desc:        "    - {name}: {desc}"
+    item_no_desc:          "    - {name}"
+    failed:                "❌ بارگذاری مجدد مهارت‌ها با شکست مواجه شد: {error}"
+
+  reset:
+    header_default:        "✨ نشست بازنشانی شد! از نو شروع می‌کنیم."
+    header_new:            "✨ نشست جدید آغاز شد!"
+    header_titled:         "✨ نشست جدید آغاز شد: {title}"
+    title_rejected:        "\n⚠️ عنوان رد شد: {error}"
+    title_error_untitled:  "\n⚠️ {error} — نشست بدون عنوان شروع شد."
+    title_empty_untitled:  "\n⚠️ عنوان خالی است — نشست بدون عنوان شروع شد."
+    tip:                   "\n✦ نکته: {tip}"
+
+  restart:
+    in_progress:           "⏳ درگاه در حال راه‌اندازی مجدد است..."
+    restarting:            "♻ راه‌اندازی مجدد درگاه."
+
+  resume:
+    db_unavailable:        "پایگاه داده نشست در دسترس نیست."
+    parse_error:           "⚠️ خطا در پردازش آرگومان‌های `/resume`: {error}."
+    matrix_no_named_sessions: "هیچ نشست نام‌گذاری شده‌ای برای این اتاق ماتریکس یافت نشد."
+    matrix_blocked_no_origin: "⚠️ مسدود شده در ماتریکس. استفاده کنید `/resume --cross-room {name}` اگر می‌خواهید این جلسه را در اتاق دیگری ادامه دهید."
+    matrix_blocked_other_room: "⚠️ مسدود شده در ماتریکس: نشست متعلق به اتاق دیگری است ({room}). استفاده کنید `/resume --cross-room {name}` اگر می‌خواهید این جلسه را در اتاق دیگری ادامه دهید."
+    matrix_cross_room_success: "⚠️ نشست **{title}** در داخل اتاق ماتریکس **{room}** از سر گرفته شد. {msg_part}"
+    no_named_sessions:     "هیچ نشست نام‌گذاری شده‌ای یافت نشد."
+    list_header:           "📋 **نشست‌های نام‌گذاری شده**\n"
+    list_item:             "• **{title}**{preview_part}"
+    list_item_numbered:    "{index}. **{title}**{preview_part}"
+    list_preview_suffix:   " — _{preview}_"
+    list_footer:           "\nاستفاده: `/resume <نام نشست>`"
+    list_footer_numbered:  "\nاستفاده: `/resume <نام نشست>` یا `/resume <شماره>`"
+    list_failed:           "خطا در لیست کردن نشست‌ها: {error}"
+    out_of_range:          "شماره از سرگیری {index} خارج از محدوده است."
+    not_found:             "نشستی با عنوان '**{name}**' یافت نشد."
+    already_on:            "📌 از قبل روی نشست **{name}** هستید."
+    switch_failed:         "تغییر نشست با خطا مواجه شد."
+    resumed_one:           "↻ نشست **{title}** ({count} پیام) از سر گرفته شد."
+    resumed_many:          "↻ نشست **{title}** ({count} پیام) از سر گرفته شد."
+    resumed_no_count:      "↻ نشست **{title}** از سر گرفته شد."
+
+  retry:
+    no_previous:           "هیچ پیام قبلی برای تلاش مجدد وجود ندارد."
+
+  rollback:
+    not_enabled:           "بررسی‌ها فعال نیستند."
+    none_found:            "هیچ نقطه‌ای برای {cwd} یافت نشد."
+    invalid_number:        "شماره نامعتبر. از ۱ تا {max} استفاده کنید."
+    restored:              "✅ بازیابی به نقطه {hash}: {reason}"
+    restore_failed:        "❌ {error}"
+
+  set_home:
+    save_failed:           "خطا در ذخیره کانال خانه: {error}"
+    success:               "✅ کانال خانه به **{name}** (شناسه: {chat_id}) تنظیم شد."
+
+  status:
+    header:                "📊 **وضعیت درگاه هرمس**"
+    matrix_scope_header:   "**محدوده ماتریکس:**"
+    matrix_scope_room:     "  اتاق: {room}"
+    matrix_scope_room_id:  "  شناسه اتاق: {room_id}"
+    matrix_scope_thread:   "  شناسه ترد: {thread_id}"
+    matrix_scope_mode:     "  محدوده نشست: {scope}"
+    matrix_scope_key:      "  کلید نشست: {session_key}"
+    session_id:            "**شناسه نشست:** `{session_id}`"
+    title:                 "**عنوان:** {title}"
+    created:               "**ایجاد شده:** {timestamp}"
+    last_activity:         "**آخرین فعالیت:** {timestamp}"
+    model:                 "**مدل:** `{model}`"
+    model_provider:        "**مدل:** `{model}` ({provider})"
+    context:               "**زمینه:** {used} / {total} ({pct}%)"
+    context_used:          "**زمینه:** ~{used} توکن"
+    tokens:                "**توکن‌های مصرفی API:** {tokens}"
+    agent_running:         "**نماینده در حال اجرا:** {state}"
+    state_yes:             "بله ⚡"
+    state_no:              "خیر"
+    queued:                "**در صف:** {count}"
+    platforms:             "**پلتفرم‌های متصل:** {platforms}"
+
+  stop:
+    stopped_pending:       "⚡ متوقف شد. نماینده هنوز شروع نشده بود."
+    stopped:               "⚡ متوقف شد."
+    no_active:             "وظیفه فعالی برای توقف وجود ندارد."
+
+  title:
+    db_unavailable:        "پایگاه داده نشست در دسترس نیست."
+    warn_prefix:           "⚠️ {error}"
+    empty_after_clean:     "⚠️ عنوان پس از پاکسازی خالی است."
+    set_to:                "✏️ عنوان نشست تنظیم شد: **{title}**"
+    not_found:             "نشست در پایگاه داده یافت نشد."
+    current_with_title:    "📌 نشست: `{session_id}`\nعنوان: **{title}**"
+    current_no_title:      "📌 نشست: `{session_id}`\nبدون عنوان تنظیم شده. استفاده: `/title نام نشست من`"
+
+  topic:
+    not_telegram_dm:         "دستور /topic تنها در پیام‌های خصوصی تلگرام در دسترس است."
+    no_session_db:           "پایگاه داده نشست در دسترس نیست."
+    unauthorized:            "شما مجاز به استفاده از /topic در این ربات نیستید."
+    restore_needs_topic:     "برای بازیابی یک نشست، ابتدا یک تاپیک تلگرام بسازید."
+    topics_disabled:         "تاپیک‌های تلگرام برای این ربات فعال نیستند."
+    topics_user_disallowed:  "تاپیک‌های تلگرام فعال هستند اما کاربران اجازه ساخت ندارند."
+    enable_failed:           "فعال‌سازی حالت تاپیک تلگرام با شکست مواجه شد: {error}"
+    bound_status:            "این تاپیک پیوند خورده است به:\nنشست: {label}\nشناسه: {session_id}"
+    thread_ready:            "تاپیک‌های چندگانه تلگرام فعال هستند."
+    untitled_session:        "نشست بدون عنوان"
+
+  undo:
+    nothing:               "چیزی برای لغو وجود ندارد."
+    removed:               "↩️ لغو شد {turns} نوبت ({count} پیام).\nبازگشت به: \"{preview}\""
+    invalid_count:         "تعداد نامعتبر \"{arg}\""
+
+  update:
+    platform_not_messaging:  "✗ /update تنها از پلتفرم‌های پیام‌رسان در دسترس است."
+    not_git_repo:            "✗ مخزن git نیست — نمی‌توان بروز کرد."
+    hermes_cmd_not_found:    "✗ دستور `hermes` پیدا نشد."
+    start_failed:            "✗ شروع بروزرسانی با خطا مواجه شد: {error}"
+    starting:                "⚕ در حال شروع بروزرسانی هرمس..."
+
+  usage:
+    rate_limits:              "⏱️ **محدودیت‌های نرخ:** {state}"
+    header_session:           "📊 **استفاده توکن در نشست**"
+    label_model:              "مدل: `{model}`"
+    label_input_tokens:       "توکن‌های ورودی: {count}"
+    label_cache_read:         "توکن‌های خوانده شده از کش: {count}"
+    label_cache_write:        "توکن‌های نوشته شده در کش: {count}"
+    label_output_tokens:      "توکن‌های خروجی: {count}"
+    label_total:              "مجموع: {count}"
+    label_api_calls:          "تماس‌های API: {count}"
+    label_cost:               "هزینه: {prefix}${amount}"
+    label_cost_included:      "هزینه: شامل شده"
+    label_context:            "زمینه: {used} / {total} ({pct}%)"
+    label_compressions:       "فشرده‌سازی‌ها: {count}"
+    header_session_info:      "📊 **اطلاعات نشست**"
+    label_messages:           "پیام‌ها: {count}"
+    label_estimated_context:  "زمینه تخمینی: ~{count} توکن"
+    detailed_after_first:     "_(جزئیات مصرف پس از اولین پاسخ نماینده در دسترس است)_"
+    no_data:                  "هیچ داده استفاده‌ای برای این نشست وجود ندارد."
+
+  credits:
+    not_logged_in:            "وارد پورتال Nous نشده‌اید."
+
+  verbose:
+    not_enabled:           "دستور `/verbose` در پلتفرم‌های پیام‌رسانی فعال نیست."
+    mode_off:              "⚙️ پیشرفت ابزار: **خاموش** — هیچ فعالیتی نشان داده نمی‌شود."
+    mode_new:              "⚙️ پیشرفت ابزار: **جدید** — نمایش در تغییر ابزار."
+    mode_all:              "⚙️ پیشرفت ابزار: **همه** — هر تماس با ابزار نمایش داده می‌شود."
+    mode_verbose:          "⚙️ پیشرفت ابزار: **دقیق** — هر تماس با آرگومان‌های کامل."
+    saved_suffix:          "_(ذخیره شد برای **{platform}** — در پیام بعدی اعمال می‌شود)_"
+    save_failed:           "_(خطا در ذخیره تنظیمات: {error})_"
+
+  voice:
+    enabled_voice_only:    "حالت صوتی فعال شد."
+    disabled_text:         "حالت صوتی غیرفعال شد. پاسخ‌ها متنی است."
+    tts_enabled:           "تبدیل متن به صدای خودکار فعال شد."
+    status_mode:           "حالت صوتی: {label}"
+    status_channel:        "کانال صوتی: #{channel}"
+    status_participants:   "شرکت‌کنندگان: {count}"
+    status_member:         "  - {name}{status}"
+    speaking:              " (در حال صحبت)"
+    enabled_short:         "حالت صوتی فعال شد."
+    disabled_short:        "حالت صوتی غیرفعال شد."
+    label_off:             "خاموش (فقط متن)"
+    label_voice_only:      "روشن (پاسخ صوتی به پیام صوتی)"
+    label_all:             "تبدیل متن به صدا (پاسخ صوتی به همه پیام‌ها)"
+    help:                  "{toggle}\n\n**راهنمای /voice**\n• `/voice on` — پاسخ صوتی به پیام‌های صوتی\n• `/voice tts` — پاسخ صوتی به *همه* پیام‌ها\n• `/voice off` — بازگشت به پاسخ متنی\n• `/voice status` — وضعیت فعلی\n• `/voice` (بدون آرگومان) — تغییر بین روشن و خاموش{channels}"
+    help_channels:         "\n\n**کانال‌های صوتی زنده (Discord)**\n• `/voice channel` — پیوستن و گوش دادن"
+
+  yolo:
+    disabled:                   "⚠️ حالت YOLO **خاموش** برای این نشست — دستورات خطرناک به تایید نیاز دارند."
+    enabled:                    "⚡ حالت YOLO **روشن** برای این نشست — همه دستورات به صورت خودکار تایید می‌شوند. با احتیاط استفاده کنید."
+
+  shared:
+    session_db_unavailable:      "پایگاه داده نشست در دسترس نیست."
+    session_db_unavailable_prefix: "پایگاه داده نشست در دسترس نیست"
+    session_not_found:           "نشست در پایگاه داده یافت نشد."
+    warn_passthrough:            "⚠️ {error}"

--- a/plugins/platforms/bale/__init__.py
+++ b/plugins/platforms/bale/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/bale/adapter.py
+++ b/plugins/platforms/bale/adapter.py
@@ -1,0 +1,101 @@
+import os
+from typing import Dict, Any, Optional
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram.adapter import (
+    TelegramAdapter,
+    check_telegram_requirements,
+)
+
+def env_enablement_fn() -> Optional[Dict[str, Any]]:
+    """Seed PlatformConfig from environment variables before init."""
+    token = os.getenv("BALE_BOT_TOKEN")
+    if not token:
+        return None
+    
+    return {
+        "extra": {
+            "base_url": "https://tapi.bale.ai/bot",
+            "base_file_url": "https://tapi.bale.ai/file/bot"
+        },
+        "home_channel": {
+            "id": os.getenv("BALE_HOME_CHANNEL"),
+            "name": os.getenv("BALE_HOME_CHANNEL_NAME", "Bale Home")
+        } if os.getenv("BALE_HOME_CHANNEL") else None
+    }
+
+def apply_yaml_config_fn(yaml_cfg: Dict[str, Any], platform_cfg: PlatformConfig) -> Optional[Dict[str, Any]]:
+    """Translate config.yaml keys into env vars and extra dict."""
+    extras = {}
+    bale_cfg = yaml_cfg.get("bale", {})
+    if not isinstance(bale_cfg, dict):
+        return {
+            "extra": {
+                "base_url": "https://tapi.bale.ai/bot",
+                "base_file_url": "https://tapi.bale.ai/file/bot"
+            }
+        }
+
+    allowed_users = bale_cfg.get("allow_from")
+    if allowed_users is not None and not os.getenv("BALE_ALLOWED_USERS"):
+        if isinstance(allowed_users, list):
+            allowed_users = ",".join(str(v) for v in allowed_users)
+        os.environ["BALE_ALLOWED_USERS"] = str(allowed_users)
+
+    extras["base_url"] = "https://tapi.bale.ai/bot"
+    extras["base_file_url"] = "https://tapi.bale.ai/file/bot"
+    return {"extra": extras}
+
+class BaleAdapter(TelegramAdapter):
+    """
+    Bale bot adapter.
+    Inherits from TelegramAdapter but points to the Bale API servers via base_url.
+    """
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config)
+        self.name = "bale"
+
+def _build_adapter(config: PlatformConfig):
+    return BaleAdapter(config)
+
+def _is_connected(adapter) -> bool:
+    if not adapter:
+        return False
+    return adapter._running
+
+async def _standalone_send(chat_id: str, message: str, **kwargs) -> Dict[str, Any]:
+    """Standalone sender for cron jobs and external tool delivery."""
+    import aiohttp
+    
+    token = os.getenv("BALE_BOT_TOKEN")
+    if not token:
+        raise ValueError("BALE_BOT_TOKEN not set")
+    
+    async with aiohttp.ClientSession() as session:
+        url = f"https://tapi.bale.ai/bot{token}/sendMessage"
+        payload = {"chat_id": chat_id, "text": message}
+        async with session.post(url, json=payload) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
+            return {"result": "ok", "message_id": data.get("result", {}).get("message_id")}
+
+def register(ctx) -> None:
+    """Plugin entry point."""
+    ctx.register_platform(
+        name="bale",
+        label="Bale",
+        adapter_factory=_build_adapter,
+        check_fn=check_telegram_requirements,
+        is_connected=_is_connected,
+        required_env=["BALE_BOT_TOKEN"],
+        install_hint="pip install 'hermes-agent[telegram]'",
+        setup_fn=None,
+        apply_yaml_config_fn=apply_yaml_config_fn,
+        allowed_users_env="BALE_ALLOWED_USERS",
+        allow_all_env="BALE_ALLOW_ALL_USERS",
+        cron_deliver_env_var="BALE_HOME_CHANNEL",
+        standalone_sender_fn=_standalone_send,
+        max_message_length=4096,
+        emoji="💬",
+        allow_update_command=True,
+    )

--- a/plugins/platforms/bale/plugin.yaml
+++ b/plugins/platforms/bale/plugin.yaml
@@ -1,0 +1,31 @@
+name: bale-platform
+label: Bale
+kind: platform
+version: 1.0.0
+description: >
+  Bale gateway adapter for Hermes Agent.
+  Connects to Bale messenger via the telegram-bot API bridge.
+author: Hermes Community
+requires_env:
+  - name: BALE_BOT_TOKEN
+    description: "Bale bot token from @BotFather in Bale"
+    prompt: "Bale bot token"
+    url: "https://ble.ir/botfather"
+    password: true
+optional_env:
+  - name: BALE_ALLOWED_USERS
+    description: "Comma-separated Bale user IDs allowed to talk to the bot"
+    prompt: "Allowed users (comma-separated)"
+    password: false
+  - name: BALE_ALLOW_ALL_USERS
+    description: "Allow any Bale user to trigger the bot"
+    prompt: "Allow all users? (true/false)"
+    password: false
+  - name: BALE_HOME_CHANNEL
+    description: "Default chat ID for cron / notification delivery"
+    prompt: "Home channel ID"
+    password: false
+  - name: BALE_HOME_CHANNEL_NAME
+    description: "Display name for the Bale home channel"
+    prompt: "Home channel display name"
+    password: false

--- a/plugins/platforms/eitaa/__init__.py
+++ b/plugins/platforms/eitaa/__init__.py
@@ -1,0 +1,1 @@
+from .adapter import register\n\n__all__ = ["register"]\n

--- a/plugins/platforms/eitaa/adapter.py
+++ b/plugins/platforms/eitaa/adapter.py
@@ -1,0 +1,79 @@
+import asyncio
+import logging
+import os
+from typing import Any, Dict, Optional
+import aiohttp
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+import hermes_cli.gateway as gateway_mod
+
+logger = logging.getLogger(__name__)
+
+def check_eitaa_requirements() -> bool:
+    try:
+        import aiohttp
+    except ImportError:
+        return False
+    return bool(os.getenv("EITAA_BOT_TOKEN"))
+
+def _is_connected(config) -> bool:
+    return bool((gateway_mod.get_env_value("EITAA_BOT_TOKEN") or "").strip())
+
+class EitaaAdapter(BasePlatformAdapter):
+    MAX_MESSAGE_LENGTH = 1000
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, "eitaa")
+        self.env_vars = {k: os.getenv(k, "") for k in ['EITAA_BOT_TOKEN']}
+        self._http_session: Optional[aiohttp.ClientSession] = None
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        if not self.env_vars["EITAA_BOT_TOKEN"]:
+            return False
+        self._http_session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30))
+        self._running = True
+        return True
+
+    async def disconnect(self) -> None:
+        if self._http_session:
+            await self._http_session.close()
+            self._http_session = None
+        self._running = False
+
+    async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        if not self._http_session:
+            return SendResult(success=False, error="Not connected")
+        try:
+
+        payload = {"chat_id": chat_id, "text": content}
+        url = f"https://eitaayar.ir/api/{self.env_vars['EITAA_BOT_TOKEN']}/sendMessage"
+        async with self._http_session.post(url, json=payload) as resp:
+            data = await resp.json()
+            if not data.get("ok"): return SendResult(success=False, error=str(data))
+            return SendResult(success=True, message_id=str(data.get("result", {}).get("message_id", "")))
+
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"name": chat_id, "type": "dm"}
+
+def _build_adapter(config):
+    return EitaaAdapter(config)
+
+def register(ctx) -> None:
+    ctx.register_platform(
+        name="eitaa",
+        label="Eitaa (ایتا)",
+        adapter_factory=_build_adapter,
+        check_fn=check_eitaa_requirements,
+        is_connected=_is_connected,
+        required_env=["EITAA_BOT_TOKEN"],
+        install_hint="pip install aiohttp",
+        allowed_users_env="EITAA_ALLOWED_USERS",
+        allow_all_env="EITAA_ALLOW_ALL_USERS",
+        max_message_length=1000,
+        emoji="💬",
+        allow_update_command=True,
+    )

--- a/plugins/platforms/eitaa/plugin.yaml
+++ b/plugins/platforms/eitaa/plugin.yaml
@@ -1,0 +1,10 @@
+name: eitaa
+label: Eitaa (ایتا)
+kind: platform
+version: 1.0.0
+description: Eitaa (ایتا) adapter.
+author: Hermes Core Team
+requires_env:
+  - name: EITAA_BOT_TOKEN\n    description: "EITAA_BOT_TOKEN"\n    prompt: "EITAA_BOT_TOKEN"\n    password: true\n
+optional_env:
+

--- a/plugins/platforms/gap/__init__.py
+++ b/plugins/platforms/gap/__init__.py
@@ -1,0 +1,1 @@
+from .adapter import register\n\n__all__ = ["register"]\n

--- a/plugins/platforms/gap/adapter.py
+++ b/plugins/platforms/gap/adapter.py
@@ -1,0 +1,80 @@
+import asyncio
+import logging
+import os
+from typing import Any, Dict, Optional
+import aiohttp
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+import hermes_cli.gateway as gateway_mod
+
+logger = logging.getLogger(__name__)
+
+def check_gap_requirements() -> bool:
+    try:
+        import aiohttp
+    except ImportError:
+        return False
+    return bool(os.getenv("GAP_BOT_TOKEN"))
+
+def _is_connected(config) -> bool:
+    return bool((gateway_mod.get_env_value("GAP_BOT_TOKEN") or "").strip())
+
+class GapAdapter(BasePlatformAdapter):
+    MAX_MESSAGE_LENGTH = 1000
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, "gap")
+        self.env_vars = {k: os.getenv(k, "") for k in ['GAP_BOT_TOKEN']}
+        self._http_session: Optional[aiohttp.ClientSession] = None
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        if not self.env_vars["GAP_BOT_TOKEN"]:
+            return False
+        self._http_session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30))
+        self._running = True
+        return True
+
+    async def disconnect(self) -> None:
+        if self._http_session:
+            await self._http_session.close()
+            self._http_session = None
+        self._running = False
+
+    async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        if not self._http_session:
+            return SendResult(success=False, error="Not connected")
+        try:
+
+        payload = {"chat_id": chat_id, "data": content}
+        url = "https://api.gap.im/sendMessage"
+        headers = {"token": self.env_vars['GAP_BOT_TOKEN']}
+        async with self._http_session.post(url, data=payload, headers=headers) as resp:
+            data = await resp.json()
+            if "id" not in data: return SendResult(success=False, error=str(data))
+            return SendResult(success=True, message_id=str(data.get("id", "")))
+
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"name": chat_id, "type": "dm"}
+
+def _build_adapter(config):
+    return GapAdapter(config)
+
+def register(ctx) -> None:
+    ctx.register_platform(
+        name="gap",
+        label="Gap (گپ)",
+        adapter_factory=_build_adapter,
+        check_fn=check_gap_requirements,
+        is_connected=_is_connected,
+        required_env=["GAP_BOT_TOKEN"],
+        install_hint="pip install aiohttp",
+        allowed_users_env="GAP_ALLOWED_USERS",
+        allow_all_env="GAP_ALLOW_ALL_USERS",
+        max_message_length=1000,
+        emoji="💬",
+        allow_update_command=True,
+    )

--- a/plugins/platforms/gap/plugin.yaml
+++ b/plugins/platforms/gap/plugin.yaml
@@ -1,0 +1,10 @@
+name: gap
+label: Gap (گپ)
+kind: platform
+version: 1.0.0
+description: Gap (گپ) adapter.
+author: Hermes Core Team
+requires_env:
+  - name: GAP_BOT_TOKEN\n    description: "GAP_BOT_TOKEN"\n    prompt: "GAP_BOT_TOKEN"\n    password: true\n
+optional_env:
+

--- a/plugins/platforms/ghasedak/__init__.py
+++ b/plugins/platforms/ghasedak/__init__.py
@@ -1,0 +1,1 @@
+from .adapter import register\n\n__all__ = ["register"]\n

--- a/plugins/platforms/ghasedak/adapter.py
+++ b/plugins/platforms/ghasedak/adapter.py
@@ -1,0 +1,82 @@
+import asyncio
+import logging
+import os
+from typing import Any, Dict, Optional
+import aiohttp
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+import hermes_cli.gateway as gateway_mod
+
+logger = logging.getLogger(__name__)
+
+def check_ghasedak_requirements() -> bool:
+    try:
+        import aiohttp
+    except ImportError:
+        return False
+    return bool(os.getenv("GHASEDAK_API_KEY"))
+
+def _is_connected(config) -> bool:
+    return bool((gateway_mod.get_env_value("GHASEDAK_API_KEY") or "").strip())
+
+class GhasedakAdapter(BasePlatformAdapter):
+    MAX_MESSAGE_LENGTH = 1000
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, "ghasedak")
+        self.env_vars = {k: os.getenv(k, "") for k in ['GHASEDAK_API_KEY', 'GHASEDAK_SENDER']}
+        self._http_session: Optional[aiohttp.ClientSession] = None
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        if not self.env_vars["GHASEDAK_API_KEY"]:
+            return False
+        self._http_session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30))
+        self._running = True
+        return True
+
+    async def disconnect(self) -> None:
+        if self._http_session:
+            await self._http_session.close()
+            self._http_session = None
+        self._running = False
+
+    async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        if not self._http_session:
+            return SendResult(success=False, error="Not connected")
+        try:
+
+        payload = {"receptor": chat_id, "message": content}
+        if self.env_vars.get("GHASEDAK_SENDER"): payload["linenumber"] = self.env_vars["GHASEDAK_SENDER"]
+        url = "https://api.ghasedak.me/v2/sms/send/simple"
+        headers = {"apikey": self.env_vars['GHASEDAK_API_KEY']}
+        async with self._http_session.post(url, data=payload, headers=headers) as resp:
+            data = await resp.json()
+            if data.get("result", {}).get("code") != 200: return SendResult(success=False, error=str(data))
+            items = data.get("items", [])
+            return SendResult(success=True, message_id=str(items[0]) if items else "")
+
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"name": chat_id, "type": "dm"}
+
+def _build_adapter(config):
+    return GhasedakAdapter(config)
+
+def register(ctx) -> None:
+    ctx.register_platform(
+        name="ghasedak",
+        label="Ghasedak (قاصدک)",
+        adapter_factory=_build_adapter,
+        check_fn=check_ghasedak_requirements,
+        is_connected=_is_connected,
+        required_env=["GHASEDAK_API_KEY"],
+        install_hint="pip install aiohttp",
+        allowed_users_env="GHASEDAK_ALLOWED_USERS",
+        allow_all_env="GHASEDAK_ALLOW_ALL_USERS",
+        max_message_length=1000,
+        emoji="💬",
+        allow_update_command=True,
+    )

--- a/plugins/platforms/ghasedak/plugin.yaml
+++ b/plugins/platforms/ghasedak/plugin.yaml
@@ -1,0 +1,10 @@
+name: ghasedak
+label: Ghasedak (قاصدک)
+kind: platform
+version: 1.0.0
+description: Ghasedak (قاصدک) adapter.
+author: Hermes Core Team
+requires_env:
+  - name: GHASEDAK_API_KEY\n    description: "GHASEDAK_API_KEY"\n    prompt: "GHASEDAK_API_KEY"\n    password: true\n
+optional_env:
+  - name: GHASEDAK_SENDER\n    description: "GHASEDAK_SENDER"\n    prompt: "GHASEDAK_SENDER"\n    password: false\n

--- a/plugins/platforms/kavenegar/__init__.py
+++ b/plugins/platforms/kavenegar/__init__.py
@@ -1,0 +1,1 @@
+from .adapter import register\n\n__all__ = ["register"]\n

--- a/plugins/platforms/kavenegar/adapter.py
+++ b/plugins/platforms/kavenegar/adapter.py
@@ -1,0 +1,81 @@
+import asyncio
+import logging
+import os
+from typing import Any, Dict, Optional
+import aiohttp
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+import hermes_cli.gateway as gateway_mod
+
+logger = logging.getLogger(__name__)
+
+def check_kavenegar_requirements() -> bool:
+    try:
+        import aiohttp
+    except ImportError:
+        return False
+    return bool(os.getenv("KAVENEGAR_API_KEY"))
+
+def _is_connected(config) -> bool:
+    return bool((gateway_mod.get_env_value("KAVENEGAR_API_KEY") or "").strip())
+
+class KavenegarAdapter(BasePlatformAdapter):
+    MAX_MESSAGE_LENGTH = 1000
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, "kavenegar")
+        self.env_vars = {k: os.getenv(k, "") for k in ['KAVENEGAR_API_KEY', 'KAVENEGAR_SENDER']}
+        self._http_session: Optional[aiohttp.ClientSession] = None
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        if not self.env_vars["KAVENEGAR_API_KEY"]:
+            return False
+        self._http_session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30))
+        self._running = True
+        return True
+
+    async def disconnect(self) -> None:
+        if self._http_session:
+            await self._http_session.close()
+            self._http_session = None
+        self._running = False
+
+    async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        if not self._http_session:
+            return SendResult(success=False, error="Not connected")
+        try:
+
+        payload = {"receptor": chat_id, "message": content}
+        if self.env_vars.get("KAVENEGAR_SENDER"): payload["sender"] = self.env_vars["KAVENEGAR_SENDER"]
+        url = f"https://api.kavenegar.com/v1/{self.env_vars['KAVENEGAR_API_KEY']}/sms/send.json"
+        async with self._http_session.post(url, data=payload) as resp:
+            data = await resp.json()
+            if data.get("return", {}).get("status") != 200: return SendResult(success=False, error=str(data))
+            entries = data.get("entries", [])
+            return SendResult(success=True, message_id=str(entries[0].get("messageid", "")) if entries else "")
+
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"name": chat_id, "type": "dm"}
+
+def _build_adapter(config):
+    return KavenegarAdapter(config)
+
+def register(ctx) -> None:
+    ctx.register_platform(
+        name="kavenegar",
+        label="Kavenegar (کاوه‌نگار)",
+        adapter_factory=_build_adapter,
+        check_fn=check_kavenegar_requirements,
+        is_connected=_is_connected,
+        required_env=["KAVENEGAR_API_KEY"],
+        install_hint="pip install aiohttp",
+        allowed_users_env="KAVENEGAR_ALLOWED_USERS",
+        allow_all_env="KAVENEGAR_ALLOW_ALL_USERS",
+        max_message_length=1000,
+        emoji="💬",
+        allow_update_command=True,
+    )

--- a/plugins/platforms/kavenegar/plugin.yaml
+++ b/plugins/platforms/kavenegar/plugin.yaml
@@ -1,0 +1,10 @@
+name: kavenegar
+label: Kavenegar (کاوه‌نگار)
+kind: platform
+version: 1.0.0
+description: Kavenegar (کاوه‌نگار) adapter.
+author: Hermes Core Team
+requires_env:
+  - name: KAVENEGAR_API_KEY\n    description: "KAVENEGAR_API_KEY"\n    prompt: "KAVENEGAR_API_KEY"\n    password: true\n
+optional_env:
+  - name: KAVENEGAR_SENDER\n    description: "KAVENEGAR_SENDER"\n    prompt: "KAVENEGAR_SENDER"\n    password: false\n

--- a/plugins/platforms/melipayamak/__init__.py
+++ b/plugins/platforms/melipayamak/__init__.py
@@ -1,0 +1,1 @@
+from .adapter import register\n\n__all__ = ["register"]\n

--- a/plugins/platforms/melipayamak/adapter.py
+++ b/plugins/platforms/melipayamak/adapter.py
@@ -1,0 +1,80 @@
+import asyncio
+import logging
+import os
+from typing import Any, Dict, Optional
+import aiohttp
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+import hermes_cli.gateway as gateway_mod
+
+logger = logging.getLogger(__name__)
+
+def check_melipayamak_requirements() -> bool:
+    try:
+        import aiohttp
+    except ImportError:
+        return False
+    return bool(os.getenv("MELIPAYAMAK_USERNAME"))
+
+def _is_connected(config) -> bool:
+    return bool((gateway_mod.get_env_value("MELIPAYAMAK_USERNAME") or "").strip())
+
+class MelipayamakAdapter(BasePlatformAdapter):
+    MAX_MESSAGE_LENGTH = 1000
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, "melipayamak")
+        self.env_vars = {k: os.getenv(k, "") for k in ['MELIPAYAMAK_USERNAME', 'MELIPAYAMAK_PASSWORD', 'MELIPAYAMAK_SENDER']}
+        self._http_session: Optional[aiohttp.ClientSession] = None
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        if not self.env_vars["MELIPAYAMAK_USERNAME"]:
+            return False
+        self._http_session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30))
+        self._running = True
+        return True
+
+    async def disconnect(self) -> None:
+        if self._http_session:
+            await self._http_session.close()
+            self._http_session = None
+        self._running = False
+
+    async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        if not self._http_session:
+            return SendResult(success=False, error="Not connected")
+        try:
+
+        payload = {"username": self.env_vars['MELIPAYAMAK_USERNAME'], "password": self.env_vars['MELIPAYAMAK_PASSWORD'], "to": chat_id, "text": content, "isflash": False}
+        if self.env_vars.get("MELIPAYAMAK_SENDER"): payload["from"] = self.env_vars["MELIPAYAMAK_SENDER"]
+        url = "https://rest.payamak-panel.com/api/SendSMS/SendSMS"
+        async with self._http_session.post(url, json=payload) as resp:
+            data = await resp.json()
+            if data.get("RetStatus") != 1: return SendResult(success=False, error=str(data))
+            return SendResult(success=True, message_id=str(data.get("Value", "")))
+
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"name": chat_id, "type": "dm"}
+
+def _build_adapter(config):
+    return MelipayamakAdapter(config)
+
+def register(ctx) -> None:
+    ctx.register_platform(
+        name="melipayamak",
+        label="Melipayamak (ملی پیامک)",
+        adapter_factory=_build_adapter,
+        check_fn=check_melipayamak_requirements,
+        is_connected=_is_connected,
+        required_env=["MELIPAYAMAK_USERNAME"],
+        install_hint="pip install aiohttp",
+        allowed_users_env="MELIPAYAMAK_ALLOWED_USERS",
+        allow_all_env="MELIPAYAMAK_ALLOW_ALL_USERS",
+        max_message_length=1000,
+        emoji="💬",
+        allow_update_command=True,
+    )

--- a/plugins/platforms/melipayamak/plugin.yaml
+++ b/plugins/platforms/melipayamak/plugin.yaml
@@ -1,0 +1,10 @@
+name: melipayamak
+label: Melipayamak (ملی پیامک)
+kind: platform
+version: 1.0.0
+description: Melipayamak (ملی پیامک) adapter.
+author: Hermes Core Team
+requires_env:
+  - name: MELIPAYAMAK_USERNAME\n    description: "MELIPAYAMAK_USERNAME"\n    prompt: "MELIPAYAMAK_USERNAME"\n    password: true\n  - name: MELIPAYAMAK_PASSWORD\n    description: "MELIPAYAMAK_PASSWORD"\n    prompt: "MELIPAYAMAK_PASSWORD"\n    password: true\n
+optional_env:
+  - name: MELIPAYAMAK_SENDER\n    description: "MELIPAYAMAK_SENDER"\n    prompt: "MELIPAYAMAK_SENDER"\n    password: false\n

--- a/plugins/platforms/najva/__init__.py
+++ b/plugins/platforms/najva/__init__.py
@@ -1,0 +1,1 @@
+from .adapter import register\n\n__all__ = ["register"]\n

--- a/plugins/platforms/najva/adapter.py
+++ b/plugins/platforms/najva/adapter.py
@@ -1,0 +1,80 @@
+import asyncio
+import logging
+import os
+from typing import Any, Dict, Optional
+import aiohttp
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+import hermes_cli.gateway as gateway_mod
+
+logger = logging.getLogger(__name__)
+
+def check_najva_requirements() -> bool:
+    try:
+        import aiohttp
+    except ImportError:
+        return False
+    return bool(os.getenv("NAJVA_API_TOKEN"))
+
+def _is_connected(config) -> bool:
+    return bool((gateway_mod.get_env_value("NAJVA_API_TOKEN") or "").strip())
+
+class NajvaAdapter(BasePlatformAdapter):
+    MAX_MESSAGE_LENGTH = 1000
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, "najva")
+        self.env_vars = {k: os.getenv(k, "") for k in ['NAJVA_API_TOKEN']}
+        self._http_session: Optional[aiohttp.ClientSession] = None
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        if not self.env_vars["NAJVA_API_TOKEN"]:
+            return False
+        self._http_session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30))
+        self._running = True
+        return True
+
+    async def disconnect(self) -> None:
+        if self._http_session:
+            await self._http_session.close()
+            self._http_session = None
+        self._running = False
+
+    async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        if not self._http_session:
+            return SendResult(success=False, error="Not connected")
+        try:
+
+        payload = {"title": "Hermes", "body": content, "subscriber_tokens": [chat_id]}
+        url = "https://app.najva.com/api/v1/notifications/"
+        headers = {"Authorization": f"Token {self.env_vars['NAJVA_API_TOKEN']}"}
+        async with self._http_session.post(url, json=payload, headers=headers) as resp:
+            if resp.status >= 400: return SendResult(success=False, error=await resp.text())
+            data = await resp.json()
+            return SendResult(success=True, message_id=str(data.get("id", "")))
+
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"name": chat_id, "type": "dm"}
+
+def _build_adapter(config):
+    return NajvaAdapter(config)
+
+def register(ctx) -> None:
+    ctx.register_platform(
+        name="najva",
+        label="Najva (نجوا)",
+        adapter_factory=_build_adapter,
+        check_fn=check_najva_requirements,
+        is_connected=_is_connected,
+        required_env=["NAJVA_API_TOKEN"],
+        install_hint="pip install aiohttp",
+        allowed_users_env="NAJVA_ALLOWED_USERS",
+        allow_all_env="NAJVA_ALLOW_ALL_USERS",
+        max_message_length=1000,
+        emoji="🔔",
+        allow_update_command=True,
+    )

--- a/plugins/platforms/najva/plugin.yaml
+++ b/plugins/platforms/najva/plugin.yaml
@@ -1,0 +1,10 @@
+name: najva
+label: Najva (نجوا)
+kind: platform
+version: 1.0.0
+description: Najva (نجوا) adapter.
+author: Hermes Core Team
+requires_env:
+  - name: NAJVA_API_TOKEN\n    description: "NAJVA_API_TOKEN"\n    prompt: "NAJVA_API_TOKEN"\n    password: true\n
+optional_env:
+

--- a/plugins/platforms/paket/__init__.py
+++ b/plugins/platforms/paket/__init__.py
@@ -1,0 +1,1 @@
+from .adapter import register\n\n__all__ = ["register"]\n

--- a/plugins/platforms/paket/adapter.py
+++ b/plugins/platforms/paket/adapter.py
@@ -1,0 +1,80 @@
+import asyncio
+import logging
+import os
+from typing import Any, Dict, Optional
+import aiohttp
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+import hermes_cli.gateway as gateway_mod
+
+logger = logging.getLogger(__name__)
+
+def check_paket_requirements() -> bool:
+    try:
+        import aiohttp
+    except ImportError:
+        return False
+    return bool(os.getenv("PAKET_API_TOKEN"))
+
+def _is_connected(config) -> bool:
+    return bool((gateway_mod.get_env_value("PAKET_API_TOKEN") or "").strip())
+
+class PaketAdapter(BasePlatformAdapter):
+    MAX_MESSAGE_LENGTH = 1000
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, "paket")
+        self.env_vars = {k: os.getenv(k, "") for k in ['PAKET_API_TOKEN', 'PAKET_FROM_EMAIL']}
+        self._http_session: Optional[aiohttp.ClientSession] = None
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        if not self.env_vars["PAKET_API_TOKEN"]:
+            return False
+        self._http_session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30))
+        self._running = True
+        return True
+
+    async def disconnect(self) -> None:
+        if self._http_session:
+            await self._http_session.close()
+            self._http_session = None
+        self._running = False
+
+    async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        if not self._http_session:
+            return SendResult(success=False, error="Not connected")
+        try:
+
+        payload = {"from": {"email": self.env_vars['PAKET_FROM_EMAIL']}, "to": [{"email": chat_id}], "subject": "Hermes", "html": content}
+        url = "https://api.paket.ir/v1/mail/send"
+        headers = {"Authorization": f"Bearer {self.env_vars['PAKET_API_TOKEN']}"}
+        async with self._http_session.post(url, json=payload, headers=headers) as resp:
+            if resp.status >= 400: return SendResult(success=False, error=await resp.text())
+            data = await resp.json()
+            return SendResult(success=True, message_id=str(data.get("message_id", "")))
+
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"name": chat_id, "type": "dm"}
+
+def _build_adapter(config):
+    return PaketAdapter(config)
+
+def register(ctx) -> None:
+    ctx.register_platform(
+        name="paket",
+        label="Paket (پاکت)",
+        adapter_factory=_build_adapter,
+        check_fn=check_paket_requirements,
+        is_connected=_is_connected,
+        required_env=["PAKET_API_TOKEN"],
+        install_hint="pip install aiohttp",
+        allowed_users_env="PAKET_ALLOWED_USERS",
+        allow_all_env="PAKET_ALLOW_ALL_USERS",
+        max_message_length=1000,
+        emoji="📧",
+        allow_update_command=True,
+    )

--- a/plugins/platforms/paket/plugin.yaml
+++ b/plugins/platforms/paket/plugin.yaml
@@ -1,0 +1,10 @@
+name: paket
+label: Paket (پاکت)
+kind: platform
+version: 1.0.0
+description: Paket (پاکت) adapter.
+author: Hermes Core Team
+requires_env:
+  - name: PAKET_API_TOKEN\n    description: "PAKET_API_TOKEN"\n    prompt: "PAKET_API_TOKEN"\n    password: true\n
+optional_env:
+  - name: PAKET_FROM_EMAIL\n    description: "PAKET_FROM_EMAIL"\n    prompt: "PAKET_FROM_EMAIL"\n    password: false\n

--- a/plugins/platforms/pushe/__init__.py
+++ b/plugins/platforms/pushe/__init__.py
@@ -1,0 +1,1 @@
+from .adapter import register\n\n__all__ = ["register"]\n

--- a/plugins/platforms/pushe/adapter.py
+++ b/plugins/platforms/pushe/adapter.py
@@ -1,0 +1,80 @@
+import asyncio
+import logging
+import os
+from typing import Any, Dict, Optional
+import aiohttp
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+import hermes_cli.gateway as gateway_mod
+
+logger = logging.getLogger(__name__)
+
+def check_pushe_requirements() -> bool:
+    try:
+        import aiohttp
+    except ImportError:
+        return False
+    return bool(os.getenv("PUSHE_API_TOKEN"))
+
+def _is_connected(config) -> bool:
+    return bool((gateway_mod.get_env_value("PUSHE_API_TOKEN") or "").strip())
+
+class PusheAdapter(BasePlatformAdapter):
+    MAX_MESSAGE_LENGTH = 1000
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, "pushe")
+        self.env_vars = {k: os.getenv(k, "") for k in ['PUSHE_API_TOKEN']}
+        self._http_session: Optional[aiohttp.ClientSession] = None
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        if not self.env_vars["PUSHE_API_TOKEN"]:
+            return False
+        self._http_session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30))
+        self._running = True
+        return True
+
+    async def disconnect(self) -> None:
+        if self._http_session:
+            await self._http_session.close()
+            self._http_session = None
+        self._running = False
+
+    async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        if not self._http_session:
+            return SendResult(success=False, error="Not connected")
+        try:
+
+        payload = {"app_ids": ["YOUR_APP_ID"], "data": {"title": "Hermes", "content": content}, "filters": {"device_id": [chat_id]}}
+        url = "https://api.pushe.co/v2/messaging/notifications/"
+        headers = {"Authorization": f"Token {self.env_vars['PUSHE_API_TOKEN']}"}
+        async with self._http_session.post(url, json=payload, headers=headers) as resp:
+            if resp.status >= 400: return SendResult(success=False, error=await resp.text())
+            data = await resp.json()
+            return SendResult(success=True, message_id=str(data.get("hashed_id", "")))
+
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"name": chat_id, "type": "dm"}
+
+def _build_adapter(config):
+    return PusheAdapter(config)
+
+def register(ctx) -> None:
+    ctx.register_platform(
+        name="pushe",
+        label="Pushe (پوشه)",
+        adapter_factory=_build_adapter,
+        check_fn=check_pushe_requirements,
+        is_connected=_is_connected,
+        required_env=["PUSHE_API_TOKEN"],
+        install_hint="pip install aiohttp",
+        allowed_users_env="PUSHE_ALLOWED_USERS",
+        allow_all_env="PUSHE_ALLOW_ALL_USERS",
+        max_message_length=1000,
+        emoji="🔔",
+        allow_update_command=True,
+    )

--- a/plugins/platforms/pushe/plugin.yaml
+++ b/plugins/platforms/pushe/plugin.yaml
@@ -1,0 +1,10 @@
+name: pushe
+label: Pushe (پوشه)
+kind: platform
+version: 1.0.0
+description: Pushe (پوشه) adapter.
+author: Hermes Core Team
+requires_env:
+  - name: PUSHE_API_TOKEN\n    description: "PUSHE_API_TOKEN"\n    prompt: "PUSHE_API_TOKEN"\n    password: true\n
+optional_env:
+

--- a/website/docs/user-guide/messaging/bale.md
+++ b/website/docs/user-guide/messaging/bale.md
@@ -1,0 +1,62 @@
+---
+sidebar_position: 10
+title: "Bale"
+description: "Set up Hermes Agent as a Bale messenger bot"
+---
+
+# Bale Setup
+
+Hermes Agent integrates with Bale (بله) messenger as a full-featured conversational bot. Because Bale's Bot API is highly compatible with the Telegram Bot API, the Hermes Bale integration supports almost all the same features as Telegram, including text, media, inline keyboards, and slash commands.
+
+## Step 1: Create a Bot via BotFather in Bale
+
+Every Bale bot requires an API token issued by [@BotFather](https://ble.ir/botfather), Bale's official bot management tool.
+
+1. Open Bale and search for **@BotFather**, or visit [ble.ir/botfather](https://ble.ir/botfather)
+2. Send `/newbot`
+3. Choose a **display name** (e.g., "Hermes Agent") — this can be anything
+4. Choose a **username** — this must be unique and end in `bot` (e.g., `my_hermes_bot`)
+5. BotFather replies with your **API token**. It looks like this:
+
+```
+123456789:ABCdefGHIjklMNOpqrSTUvwxYZ
+```
+
+:::warning
+Keep your bot token secret. Anyone with this token can control your bot.
+:::
+
+## Step 2: Configure Hermes
+
+Add your Bale token to the Hermes environment or `.env` file:
+
+```bash
+BALE_BOT_TOKEN="your-bale-token"
+BALE_ALLOWED_USERS="123456789,987654321" # Optional: restrict access
+```
+
+If you prefer to configure it via `config.yaml`, add the `bale` platform under `platforms`:
+
+```yaml
+platforms:
+  bale:
+    allow_from:
+      - 123456789
+```
+
+## Step 3: Run the Gateway
+
+Start the Hermes gateway. It will automatically load the Bale plugin and connect to `tapi.bale.ai`:
+
+```bash
+hermes gateway start
+```
+
+Your agent is now live on Bale! You can search for its username and send it a message.
+
+## Differences from Telegram
+
+Since Bale uses a separate infrastructure from Telegram, there are a few minor differences:
+- Voice/Audio and Document uploads are handled through Bale's specific file servers.
+- Some advanced Telegram features (like forum topics/threads or specific interactive markdown rendering) might behave slightly differently depending on the Bale client.
+- The base API url for Bale is automatically handled by the plugin (`https://tapi.bale.ai/bot`).

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -18,6 +18,7 @@ Bots need both a model provider and tool providers (TTS, web). A [Nous Portal](/
 
 | Platform | Voice | Images | Files | Threads | Reactions | Typing | Streaming |
 |----------|:-----:|:------:|:-----:|:-------:|:---------:|:------:|:---------:|
+| Bale | ✅ | ✅ | ✅ | ✅ | — | ✅ | ✅ |
 | Telegram | ✅ | ✅ | ✅ | ✅ | — | ✅ | ✅ |
 | Discord | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Slack | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -618,6 +619,7 @@ Defaults to `false`. Only platforms whose adapter implements `delete_message` ho
 
 ## Next Steps
 
+- [Bale Setup](bale.md)
 - [Telegram Setup](telegram.md)
 - [Discord Setup](discord.md)
 - [Slack Setup](slack.md)


### PR DESCRIPTION
This PR adds full Persian (Farsi) language support for Hermes CLI and gateway messages.

- Translated `locales/fa.yaml`
- Registered `fa` in `agent/i18n.py` with `persian`, `farsi` and `fa-ir` aliases.