### PR TITLE
fix(cron): run manual jobs without blocking the caller

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -576,6 +576,100 @@ def _interpreter_shutting_down(exc: Optional[BaseException] = None) -> bool:
     return False
 
 
+def _submit_with_guard(
+    job: dict,
+    pool: concurrent.futures.ThreadPoolExecutor,
+    runner,
+    *,
+    execution_source: str = "builtin",
+) -> Optional[concurrent.futures.Future]:
+    """Submit one cron job with the shared lifecycle protections.
+
+    Both ticker dispatch and one-off manual runs use this path so running-job
+    dedupe, execution-ledger ownership, ContextVar isolation, and interpreter
+    shutdown handling cannot drift between callers.
+    """
+    job_id = job["id"]
+    if _interpreter_shutting_down():
+        logger.warning(
+            "Job '%s' not dispatched — interpreter is shutting down",
+            job.get("name", job_id),
+        )
+        return None
+
+    with _running_lock:
+        if job_id in _running_job_ids:
+            logger.info("Job '%s' already running — skipping", job.get("name", job_id))
+            return None
+        _running_job_ids.add(job_id)
+
+    execution = create_execution(job_id, source=execution_source)
+    dispatched_job = dict(job, execution_id=execution["id"])
+    ctx = contextvars.copy_context()
+
+    def _run_and_release(j=dispatched_job, run_ctx=ctx):
+        try:
+            return run_ctx.run(runner, j)
+        finally:
+            with _running_lock:
+                _running_job_ids.discard(j["id"])
+
+    try:
+        return pool.submit(_run_and_release)
+    except Exception as submit_err:
+        with _running_lock:
+            _running_job_ids.discard(job_id)
+        finish_execution(
+            execution["id"],
+            success=False,
+            error=f"Executor dispatch failed: {submit_err}",
+        )
+        if isinstance(submit_err, RuntimeError) and _interpreter_shutting_down(submit_err):
+            logger.warning(
+                "Job '%s' not dispatched — interpreter is shutting down",
+                job.get("name", job_id),
+            )
+            return None
+        logger.error(
+            "Job '%s' not dispatched: %s",
+            job.get("name", job_id),
+            submit_err,
+        )
+        return None
+
+
+def dispatch_job(
+    job: dict,
+    *,
+    adapters=None,
+    loop=None,
+    verbose: bool = False,
+    max_workers: Optional[int] = None,
+    execution_source: str = "direct",
+) -> Optional[concurrent.futures.Future]:
+    """Queue one authorized cron job without blocking the caller."""
+
+    def _process_job(one_job: dict) -> bool:
+        return run_one_job(
+            one_job,
+            adapters=adapters,
+            loop=loop,
+            verbose=verbose,
+        )
+
+    pool = (
+        _get_sequential_pool()
+        if (job.get("workdir") or "").strip()
+        else _get_parallel_pool(max_workers)
+    )
+    return _submit_with_guard(
+        job,
+        pool,
+        _process_job,
+        execution_source=execution_source,
+    )
+
+
 # Backward-compatible module override used by tests and emergency monkeypatches.
 _hermes_home: Path | None = None
 
@@ -3975,13 +4069,6 @@ def tick(
                 _max_workers if _max_workers else "unbounded",
             )
 
-        def _process_job(job: dict) -> bool:
-            """Run one due job end-to-end. Thin wrapper around the shared
-            module-level ``run_one_job`` so ``tick`` and external providers
-            (Chronos ``fire_due``) use the identical execute→save→deliver→mark
-            body."""
-            return run_one_job(job, adapters=adapters, loop=loop, verbose=verbose)
-
         # Partition due jobs: those with a per-job workdir mutate
         # os.environ["TERMINAL_CWD"] inside run_job, which is process-global, so
         # they queue on the single-thread sequential pool to run one at a time.
@@ -3994,68 +4081,6 @@ def tick(
         _results: list = []
         _all_futures: list = []
 
-        def _submit_with_guard(job: dict, pool: concurrent.futures.ThreadPoolExecutor):
-            """Submit a job fire-and-forget with the in-flight dedup guard.
-
-            Returns the future, or None if the job was skipped because a prior
-            tick's run of the same job is still in flight.  The running-set
-            membership is released in the worker's finally block.
-            """
-            job_id = job["id"]
-            # A tick can race gateway teardown: once the interpreter is
-            # finalizing, ``pool.submit`` raises "cannot schedule new futures
-            # after interpreter shutdown" and crashes the tick. Skip cleanly —
-            # the job stays due and will fire on the next healthy tick
-            # (#58720, #55924).
-            if _interpreter_shutting_down():
-                logger.warning(
-                    "Job '%s' not dispatched — interpreter is shutting down",
-                    job.get("name", job_id),
-                )
-                return None
-            with _running_lock:
-                if job_id in _running_job_ids:
-                    logger.info("Job '%s' already running — skipping", job.get("name", job_id))
-                    return None
-                _running_job_ids.add(job_id)
-            # Record the attempt before executor dispatch. Recovery classifies
-            # abandoned records as unknown; it never automatically retries them.
-            execution = create_execution(job_id, source="builtin")
-            dispatched_job = dict(job, execution_id=execution["id"])
-            _ctx = contextvars.copy_context()
-
-            def _run_and_release(j=dispatched_job, ctx=_ctx):
-                try:
-                    return ctx.run(_process_job, j)
-                finally:
-                    with _running_lock:
-                        _running_job_ids.discard(j["id"])
-
-            try:
-                return pool.submit(_run_and_release)
-            except Exception as submit_err:
-                with _running_lock:
-                    _running_job_ids.discard(job_id)
-                finish_execution(
-                    execution["id"],
-                    success=False,
-                    error=f"Executor dispatch failed: {submit_err}",
-                )
-                # Interpreter began finalizing between the guard above and the
-                # submit — release the in-flight claim we just took and skip.
-                if isinstance(submit_err, RuntimeError) and _interpreter_shutting_down(submit_err):
-                    logger.warning(
-                        "Job '%s' not dispatched — interpreter is shutting down",
-                        job.get("name", job_id),
-                    )
-                    return None
-                logger.error(
-                    "Job '%s' not dispatched: %s",
-                    job.get("name", job_id),
-                    submit_err,
-                )
-                return None
-
         # Sequential pass for env-mutating (workdir) jobs.
         # Queued to a persistent single-thread pool so they run one at a time
         # WITHOUT blocking the ticker thread — a long workdir job no
@@ -4063,9 +4088,14 @@ def tick(
         # pass, just serialized).  The in-flight guard prevents a still-running
         # job from being re-queued on the next tick.
         if sequential_jobs:
-            seq_pool = _get_sequential_pool()
             for job in sequential_jobs:
-                fut = _submit_with_guard(job, seq_pool)
+                fut = dispatch_job(
+                    job,
+                    adapters=adapters,
+                    loop=loop,
+                    verbose=verbose,
+                    execution_source="builtin",
+                )
                 if fut is None:
                     continue
                 _all_futures.append(fut)
@@ -4078,9 +4108,15 @@ def tick(
         # after completion finds the job due again naturally.  No catch-up
         # queue needed.
         if parallel_jobs:
-            pool = _get_parallel_pool(_max_workers)
             for job in parallel_jobs:
-                fut = _submit_with_guard(job, pool)
+                fut = dispatch_job(
+                    job,
+                    adapters=adapters,
+                    loop=loop,
+                    verbose=verbose,
+                    max_workers=_max_workers,
+                    execution_source="builtin",
+                )
                 if fut is None:
                     continue
                 _all_futures.append(fut)

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1433,7 +1433,10 @@ class CLICommandsMixin:
                 print(f"  Next run: {result['job'].get('next_run_at')}")
             elif action == "run":
                 print(f"(^_^)b Triggered job: {result['job']['name']} ({job_id})")
-                print("  It will run on the next scheduler tick.")
+                if result["job"].get("execution_pending"):
+                    print("  Running now in the background.")
+                elif result["job"].get("execution_skipped"):
+                    print(f"  {result['job']['execution_skipped']}")
             else:
                 removed = result.get("removed_job", {})
                 print(f"(^_^)b Removed job: {removed.get('name', job_id)} ({job_id})")

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -431,13 +431,15 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
         print(f"  Next run: {result['job']['next_run_at']}")
     if action == "run":
         job = result.get("job", {})
-        if job.get("executed"):
+        if job.get("executed") and job.get("execution_pending"):
+            print("  Running now in the background.")
+        elif job.get("executed"):
             outcome = "succeeded" if job.get("execution_success") else "failed"
             print(f"  Ran now: {outcome}.")
         elif job.get("execution_skipped"):
             print(f"  {job['execution_skipped']}")
         else:
-            print("  It will run on the next scheduler tick.")
+            print("  Triggered for immediate background execution.")
     return 0
 
 

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -143,7 +143,7 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_resume.add_argument("job_id", help="Job ID to resume")
 
     cron_run = cron_subparsers.add_parser(
-        "run", help="Run a job on the next scheduler tick"
+        "run", help="Run a job immediately in the background"
     )
     cron_run.add_argument("job_id", help="Job ID to trigger")
     add_accept_hooks_flag(cron_run)

--- a/tests/cron/test_scheduler_shutdown_guard.py
+++ b/tests/cron/test_scheduler_shutdown_guard.py
@@ -52,6 +52,64 @@ class TestInterpreterShuttingDownHelper:
             assert _interpreter_shutting_down(exc) is False
 
 
+class TestDispatchSkipsDuringShutdown:
+    def test_preflight_skip_does_not_claim_running_or_submit(self):
+        import cron.scheduler as scheduler
+
+        job = {"id": "shutdown-job", "name": "shutdown"}
+        pool = MagicMock()
+        runner = MagicMock()
+        scheduler._running_job_ids.clear()
+
+        with (
+            patch("cron.scheduler._interpreter_shutting_down", return_value=True),
+            patch("cron.scheduler.create_execution") as create_execution,
+        ):
+            future = scheduler._submit_with_guard(job, pool, runner)
+
+        assert future is None
+        assert "shutdown-job" not in scheduler._running_job_ids
+        create_execution.assert_not_called()
+        pool.submit.assert_not_called()
+
+    def test_submit_shutdown_race_releases_all_local_ownership(self):
+        import cron.scheduler as scheduler
+
+        job = {"id": "shutdown-race", "name": "shutdown race"}
+        pool = MagicMock()
+        pool.submit.side_effect = RuntimeError(
+            "cannot schedule new futures after interpreter shutdown"
+        )
+        scheduler._running_job_ids.clear()
+
+        def shutting_down(exc=None):
+            return exc is not None
+
+        with (
+            patch(
+                "cron.scheduler._interpreter_shutting_down",
+                side_effect=shutting_down,
+            ),
+            patch(
+                "cron.scheduler.create_execution",
+                return_value={"id": "execution-1"},
+            ),
+            patch("cron.scheduler.finish_execution") as finish_execution,
+        ):
+            future = scheduler._submit_with_guard(job, pool, MagicMock())
+
+        assert future is None
+        assert "shutdown-race" not in scheduler._running_job_ids
+        finish_execution.assert_called_once_with(
+            "execution-1",
+            success=False,
+            error=(
+                "Executor dispatch failed: cannot schedule new futures after "
+                "interpreter shutdown"
+            ),
+        )
+
+
 class TestStandaloneDeliverySkipsDuringShutdown:
     def _telegram_cfg(self):
         from gateway.config import Platform

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -38,6 +38,7 @@ class TestCronCommandLifecycle:
         assert "Paused job" in out
         assert "Resumed job" in out
         assert "Triggered job" in out
+        assert "Running now in the background." in out
 
     def test_edit_can_replace_and_clear_skills(self, tmp_cron_dir, capsys):
         job = create_job(

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -1,81 +1,150 @@
-"""Tests for cronjob action='run' immediate execution (#41037).
+"""Tests for immediate, non-blocking manual cron execution (#41037, #52705)."""
 
-Before this fix, `cronjob(action='run')` only set next_run_at=now and returned
-success, relying on the scheduler ticker to actually run the job. With no
-gateway/ticker active (e.g. a CLI-only Windows setup) the job never executed and
-last_run_at stayed null forever. Now action='run' claims the job (at-most-once,
-blocking a concurrent tick) and fires it inline via the shared run_one_job body.
-"""
 import json
+import threading
+import time
 from unittest.mock import patch
 
-from tools.cronjob_tools import cronjob, _execute_job_now
+from tools.cronjob_tools import _execute_job_now, cronjob
 
 
-_JOB = {"id": "job-run-1", "name": "manual run", "prompt": "hi",
-        "schedule": {"kind": "cron", "expr": "0 9 * * *"}}
+_JOB = {
+    "id": "job-run-1",
+    "name": "manual run",
+    "prompt": "hi",
+    "schedule": {"kind": "cron", "expr": "0 9 * * *"},
+}
 
 
 class TestCronjobRunExecutesImmediately:
-    def test_run_action_claims_and_fires_via_run_one_job(self):
-        """action='run' must claim the job then fire it through run_one_job."""
-        ran = {"job": "after-run", "last_status": "ok", "last_error": None}
-        with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True) as m_claim, \
-             patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
-             patch("tools.cronjob_tools.get_job", return_value=ran):
+    def test_run_action_claims_and_dispatches_via_scheduler_pool(self):
+        with (
+            patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)),
+            patch(
+                "tools.cronjob_tools.claim_job_for_fire", return_value=True
+            ) as claim,
+            patch("cron.scheduler.dispatch_job", return_value=object()) as dispatch,
+            patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)),
+        ):
             out = json.loads(cronjob(action="run", job_id="job-run-1"))
 
         assert out["success"] is True
         assert out["job"]["executed"] is True
-        assert out["job"]["execution_success"] is True
-        m_claim.assert_called_once_with("job-run-1")   # at-most-once claim taken
-        m_run.assert_called_once()                       # fired via the shared body
+        assert out["job"]["execution_pending"] is True
+        assert out["job"]["execution_mode"] == "background"
+        claim.assert_called_once_with("job-run-1")
+        dispatch.assert_called_once_with(dict(_JOB))
 
-    def test_run_skips_when_claim_lost(self):
-        """If the scheduler already holds the fire claim, do NOT double-run."""
-        with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
-             patch("cron.scheduler.run_one_job") as m_run, \
-             patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)):
+    def test_run_preserves_held_claim_reason(self):
+        with (
+            patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)),
+            patch("tools.cronjob_tools.claim_job_for_fire", return_value=False),
+            patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)),
+            patch("cron.scheduler.dispatch_job") as dispatch,
+        ):
             out = json.loads(cronjob(action="run", job_id="job-run-1"))
 
-        assert out["success"] is True
+        assert out["job"]["executed"] is False
+        assert "already being fired" in out["job"]["execution_skipped"].lower()
+        dispatch.assert_not_called()
+
+    def test_run_preserves_paused_claim_reason(self):
+        paused = dict(_JOB, enabled=False, state="paused")
+        with (
+            patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)),
+            patch("tools.cronjob_tools.claim_job_for_fire", return_value=False),
+            patch("tools.cronjob_tools.get_job", return_value=paused),
+            patch("cron.scheduler.dispatch_job") as dispatch,
+        ):
+            out = json.loads(cronjob(action="run", job_id="job-run-1"))
+
+        reason = out["job"]["execution_skipped"].lower()
+        assert "paused/disabled" in reason
+        assert "already being fired" not in reason
+        dispatch.assert_not_called()
+
+    def test_run_preserves_missing_claim_reason(self):
+        with (
+            patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)),
+            patch("tools.cronjob_tools.claim_job_for_fire", return_value=False),
+            patch("tools.cronjob_tools.get_job", return_value=None),
+            patch("cron.scheduler.dispatch_job") as dispatch,
+        ):
+            out = json.loads(cronjob(action="run", job_id="job-run-1"))
+
+        reason = out["job"]["execution_skipped"].lower()
+        assert "no longer exists" in reason
+        assert "already being fired" not in reason
+        dispatch.assert_not_called()
+
+    def test_run_surfaces_dispatch_rejection(self):
+        with (
+            patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)),
+            patch("tools.cronjob_tools.claim_job_for_fire", return_value=True),
+            patch("cron.scheduler.dispatch_job", return_value=None),
+            patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)),
+        ):
+            out = json.loads(cronjob(action="run", job_id="job-run-1"))
+
         assert out["job"]["executed"] is False
         assert out["job"]["execution_success"] is False
-        assert "execution_skipped" in out["job"]
-        m_run.assert_not_called()  # claim lost -> never fired
+        assert "not dispatched" in out["job"]["execution_skipped"].lower()
 
-    def test_run_reports_failure_from_last_status(self):
-        """A failed run is reported via the re-read job's last_status/last_error."""
-        failed = {"id": "job-run-1", "last_status": "error", "last_error": "provider 500"}
-        with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
-             patch("cron.scheduler.run_one_job", return_value=True), \
-             patch("tools.cronjob_tools.get_job", return_value=failed):
-            out = json.loads(cronjob(action="run", job_id="job-run-1"))
+    def test_run_returns_before_background_job_finishes(self):
+        import cron.scheduler as scheduler
 
-        assert out["job"]["executed"] is True
-        assert out["job"]["execution_success"] is False
-        assert out["job"]["execution_error"] == "provider 500"
+        scheduler._parallel_pool = None
+        scheduler._parallel_pool_max_workers = None
+        scheduler._running_job_ids.clear()
+        barrier = threading.Barrier(2, timeout=5)
+
+        def slow_run_one_job(_job, **_kwargs):
+            barrier.wait()
+            return True
+
+        try:
+            with (
+                patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)),
+                patch("tools.cronjob_tools.claim_job_for_fire", return_value=True),
+                patch("cron.scheduler.run_one_job", side_effect=slow_run_one_job),
+                patch("cron.scheduler.create_execution", return_value={"id": "exec-1"}),
+                patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)),
+            ):
+                start = time.monotonic()
+                out = json.loads(cronjob(action="run", job_id="job-run-1"))
+                elapsed = time.monotonic() - start
+
+            assert out["job"]["executed"] is True
+            assert out["job"]["execution_pending"] is True
+            assert elapsed < 1.0
+        finally:
+            barrier.wait()
+            time.sleep(0.1)
+            scheduler._shutdown_parallel_pool()
 
     def test_execute_job_now_bails_without_claim(self):
-        """_execute_job_now never calls run_one_job when the claim is lost."""
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
-             patch("cron.scheduler.run_one_job") as m_run:
-            res = _execute_job_now(dict(_JOB))
-        assert res["claimed"] is False
-        assert res["success"] is False
-        m_run.assert_not_called()
+        with (
+            patch("tools.cronjob_tools.claim_job_for_fire", return_value=False),
+            patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)),
+            patch("cron.scheduler.dispatch_job") as dispatch,
+        ):
+            result = _execute_job_now(dict(_JOB))
+
+        assert result["claimed"] is False
+        assert result["started"] is False
+        assert result["success"] is False
+        dispatch.assert_not_called()
 
     def test_execute_job_now_marks_failure_on_exception(self):
-        """An exception during fire is captured, marked failed, not propagated."""
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
-             patch("cron.scheduler.run_one_job", side_effect=RuntimeError("boom")), \
-             patch("tools.cronjob_tools.mark_job_run") as m_mark, \
-             patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)):
-            res = _execute_job_now(dict(_JOB))
-        assert res["claimed"] is True
-        assert res["success"] is False
-        assert "boom" in res["error"]
-        m_mark.assert_called_once()
+        with (
+            patch("tools.cronjob_tools.claim_job_for_fire", return_value=True),
+            patch("cron.scheduler.dispatch_job", side_effect=RuntimeError("boom")),
+            patch("tools.cronjob_tools.mark_job_run") as mark_run,
+        ):
+            result = _execute_job_now(dict(_JOB))
+
+        assert result["claimed"] is True
+        assert result["started"] is False
+        assert result["success"] is False
+        assert "boom" in result["error"]
+        mark_run.assert_called_once()

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -602,7 +602,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
-    """Execute a cron job immediately, outside the scheduler tick.
+    """Dispatch a cron job immediately, outside the scheduler tick.
 
     Atomically claims the job first via ``claim_job_for_fire`` — the same
     at-most-once CAS the scheduler/external-provider fire path uses — so a
@@ -610,16 +610,17 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
     blocks a duplicate fire and advances ``next_run_at`` for recurring jobs).
     If the claim is lost (another fire is in flight), this is a no-op.
 
-    The actual firing is delegated to ``run_one_job`` — the single shared
-    execute→save→deliver→mark body the ticker and external providers use — so
-    failure delivery, ``[SILENT]`` handling, and live-adapter delivery stay
-    identical across paths and can't drift.
+    The actual firing is queued through ``dispatch_job`` so manual runs share
+    the ticker's pool selection, in-flight guard, execution ledger, ContextVar
+    isolation, and interpreter-shutdown protections without blocking the
+    calling agent turn.
 
-    Returns {"claimed": bool, "success": bool, "error": str|None}.
+    Returns {"claimed": bool, "started": bool, "pending": bool,
+    "success": bool|None, "error": str|None}.
     """
     job_id = job["id"]
     try:
-        from cron.scheduler import run_one_job
+        from cron.scheduler import dispatch_job
 
         # At-most-once claim: bail without running if a tick/other fire owns it.
         if not claim_job_for_fire(job_id):
@@ -634,17 +635,32 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
                 reason = "Job is paused/disabled; resume it before running."
             else:
                 reason = "Job is already being fired by the scheduler; not run again."
-            return {"claimed": False, "success": False, "error": reason}
+            return {
+                "claimed": False,
+                "started": False,
+                "pending": False,
+                "success": False,
+                "error": reason,
+            }
 
-        # run_one_job records last_run_at/last_status via mark_job_run (which
-        # also clears the fire claim) and returns True iff it processed the job.
-        processed = run_one_job(job)
-        refreshed = get_job(job_id) or {}
-        ok = refreshed.get("last_status") == "ok"
+        future = dispatch_job(job)
+        if future is None:
+            return {
+                "claimed": True,
+                "started": False,
+                "pending": False,
+                "success": False,
+                "error": (
+                    "Job was not dispatched; it may already be running or the "
+                    "scheduler may be shutting down."
+                ),
+            }
         return {
             "claimed": True,
-            "success": bool(processed and ok),
-            "error": refreshed.get("last_error"),
+            "started": True,
+            "pending": True,
+            "success": None,
+            "error": None,
         }
 
     except Exception as e:
@@ -653,7 +669,13 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
             mark_job_run(job_id, False, str(e))
         except Exception:
             pass
-        return {"claimed": True, "success": False, "error": str(e)}
+        return {
+            "claimed": True,
+            "started": False,
+            "pending": False,
+            "success": False,
+            "error": str(e),
+        }
 
 
 def cronjob(
@@ -836,20 +858,22 @@ def cronjob(
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         if normalized in {"run", "run_now", "trigger"}:
-            # Execute the job immediately rather than only scheduling it for the
+            # Start the job immediately rather than only scheduling it for the
             # next scheduler tick — a manual `run` should actually run, even when
-            # no gateway/ticker is active (the #41037 case). The claim inside
-            # _execute_job_now advances next_run_at and blocks a concurrent tick
-            # from double-firing.
+            # no gateway/ticker is active (the #41037 case) — but queue it on
+            # the scheduler pools so a long run does not block the calling agent
+            # turn (#52705).
             exec_result = _execute_job_now(job)
-            # Re-read so the response reflects the post-run last_run_at/last_status.
             result = _format_job(get_job(job_id) or {"id": job_id})
-            result["executed"] = exec_result.get("claimed", False)
-            result["execution_success"] = exec_result.get("success", False)
-            if not exec_result.get("claimed", False):
-                result["execution_skipped"] = exec_result.get("error") or (
-                    "Already being fired by the scheduler; not run again."
-                )
+            result["executed"] = exec_result.get("started", False)
+            if exec_result.get("pending", False):
+                result["execution_pending"] = True
+                result["execution_mode"] = "background"
+            success = exec_result.get("success")
+            if success is not None:
+                result["execution_success"] = success
+            if not exec_result.get("started", False) and exec_result.get("error"):
+                result["execution_skipped"] = exec_result["error"]
             elif exec_result.get("error"):
                 result["execution_error"] = exec_result["error"]
             return json.dumps({"success": True, "job": result}, indent=2)


### PR DESCRIPTION
## What does this PR do?

Fixes the synchronous `cronjob(action='run')` path so a manual cron run starts immediately without blocking the caller until the job finishes.

Before this change, the model tool claimed the job and then called `run_one_job()` inline. That kept the current agent/tool turn open for the full runtime of the cron task. This patch reuses the scheduler's persistent pools for one-off manual dispatch, so manual runs still execute right away but now return after the job is queued.

## Related Issue

Fixes #52705

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added `cron.scheduler.dispatch_job()` as the single-job, non-blocking counterpart to `tick(sync=False)`, reusing the existing running-job guard and workdir-aware pool selection.
- Switched `tools.cronjob_tools._execute_job_now()` to claim the job and dispatch it through the scheduler pool instead of calling `run_one_job()` inline.
- Updated CLI `/cron run` messaging to describe immediate background execution instead of “next scheduler tick”.
- Added regression coverage for the non-blocking manual-run path and the updated CLI output.

## How to Test

1. Run `/Users/idah/.hermes/hermes-agent-2/.venv/bin/pytest -q tests/tools/test_cronjob_run_immediate.py`
2. Run `/Users/idah/.hermes/hermes-agent-2/.venv/bin/pytest -q tests/hermes_cli/test_cron.py`
3. Run `/Users/idah/.hermes/hermes-agent-2/.venv/bin/pytest -q tests/cron/test_parallel_pool.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.7 (Darwin 24.6.0 arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
