### PR TITLE
fix(windows): suppress console flash in copilot_auth gh token lookup (#53370)

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -27,6 +27,8 @@ import time
 from pathlib import Path
 from typing import Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 # OAuth device code flow constants (same client ID as opencode/Copilot CLI)
@@ -141,6 +143,7 @@ def _try_gh_cli_token() -> Optional[str]:
                 text=True,
                 timeout=5,
                 env=clean_env,
+                creationflags=windows_hide_flags(),
             )
         except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
             logger.debug("gh CLI token lookup failed (%s): %s", gh_path, exc)


### PR DESCRIPTION
## Summary

`_try_gh_cli_token()` calls `subprocess.run()` without `creationflags=windows_hide_flags()`, so Windows spawns a visible console window for every `gh.exe` invocation. The credential pool polls this every ~15 seconds, causing repeated CMD window flashes.

This was missed in the May 16 flash-suppression pass (8bf09455) that fixed `kanban_db.py`, `code_execution_tool.py`, `tools/local.py`, and `process_registry.py`.

## Fix

- Import `windows_hide_flags` from `hermes_cli._subprocess_compat`
- Add `creationflags=windows_hide_flags()` to the `subprocess.run()` call

Closes #53370