### PR TITLE
fix(dashboard-auth): follow redirects on self-hosted OIDC discovery

### DIFF
--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -419,10 +419,26 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
     def _fetch_discovery(self) -> Dict[str, Any]:
         url = self._discovery_url()
         try:
+            # follow_redirects=True: many IDPs answer the discovery GET with a
+            # 3xx rather than a direct 200 — Authentik canonicalises the
+            # ``.well-known`` path, and any IDP behind a reverse proxy doing an
+            # http→https upgrade redirects too. httpx (unlike curl -L or the
+            # requests library) defaults to follow_redirects=False, so without
+            # this the redirect comes back as a bare 3xx with an empty body and
+            # the ``status != 200`` check below raises "discovery returned 302"
+            # → provider_unreachable → 503. Following the redirect is safe: the
+            # issuer-pin check and _require_https_or_loopback below still
+            # validate the *resolved* document and every endpoint in it, so a
+            # redirect to a hostile location can't smuggle in a bad issuer or a
+            # cleartext endpoint. (The token/revocation POSTs deliberately do
+            # NOT follow redirects — see _exchange — because they carry an auth
+            # code / refresh token and the endpoint is already the canonical
+            # absolute URL resolved here.)
             response = httpx.get(
                 url,
                 headers={"Accept": "application/json"},
                 timeout=_DISCOVERY_TIMEOUT_SEC,
+                follow_redirects=True,
             )
         except httpx.RequestError as exc:
             raise ProviderError(f"OIDC discovery unreachable: {exc}") from exc

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -317,6 +317,94 @@ class TestDiscovery:
 
 
 # ---------------------------------------------------------------------------
+# OIDC discovery against a REAL HTTP server that redirects (regression)
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryRealRedirect:
+    """Discovery must follow a 3xx on the .well-known GET.
+
+    The rest of the discovery suite mocks ``httpx.get`` with a canned 200, so
+    it cannot see httpx's ``follow_redirects=False`` default. Many real IDPs
+    answer the discovery GET with a redirect rather than a direct 200 —
+    Authentik canonicalises the ``.well-known`` path, and any IDP behind a
+    reverse proxy doing http→https upgrade redirects too. Before the fix the
+    bare 3xx (empty body) tripped the ``status != 200`` guard and surfaced as
+    ``provider_unreachable`` → HTTP 503 (the symptom in the user report:
+    ``curl -o`` writing zero bytes is exactly a redirect with no body).
+
+    This exercises the real httpx transport against a loopback server, so it
+    fails without ``follow_redirects=True`` and passes with it — a behaviour
+    contract, not a mock-shaped snapshot.
+    """
+
+    def _serve(self, handler_cls):
+        import http.server
+        import socketserver
+        import threading
+
+        # Bind :0 so the OS picks a free port (parallel-runner safe).
+        httpd = socketserver.TCPServer(("127.0.0.1", 0), handler_cls)
+        port = httpd.server_address[1]
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        return httpd, port
+
+    def test_discovery_follows_redirect_to_json(self):
+        import http.server
+
+        holder: Dict[str, Any] = {}
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, format, *args):  # silence test-server logging
+                pass
+
+            def do_GET(self):
+                issuer = holder["issuer"]
+                if self.path == "/.well-known/openid-configuration":
+                    # 302 with an EMPTY body — the failing shape.
+                    self.send_response(302)
+                    self.send_header(
+                        "Location", "/canonical/openid-configuration"
+                    )
+                    self.end_headers()
+                    return
+                if self.path == "/canonical/openid-configuration":
+                    body = json.dumps(
+                        {
+                            "issuer": issuer,
+                            "authorization_endpoint": f"{issuer}/authorize",
+                            "token_endpoint": f"{issuer}/token",
+                            "jwks_uri": f"{issuer}/jwks",
+                        }
+                    ).encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(body)))
+                    self.end_headers()
+                    self.wfile.write(body)
+                    return
+                self.send_response(404)
+                self.end_headers()
+
+        httpd, port = self._serve(Handler)
+        try:
+            # Loopback http is permitted by _require_https_or_loopback.
+            issuer = f"http://127.0.0.1:{port}"
+            holder["issuer"] = issuer
+            p = oidc_plugin.SelfHostedOIDCProvider(
+                issuer=issuer, client_id=_CLIENT_ID
+            )
+            disco = p._get_discovery()
+            assert disco["token_endpoint"] == f"{issuer}/token"
+            assert disco["authorization_endpoint"] == f"{issuer}/authorize"
+            assert disco["jwks_uri"] == f"{issuer}/jwks"
+        finally:
+            httpd.shutdown()
+            httpd.server_close()
+
+
+# ---------------------------------------------------------------------------
 # start_login
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Infographic

![oidc-discovery-redirect-fix](https://v3b.fal.media/files/b/0a9fede6/UfuBXjqCJMsIYZf6t9zE8_eOzuwud8.png)

## Summary

The bundled self-hosted OIDC dashboard-auth provider can't reach a class of perfectly-healthy IDPs (Authentik, and anything behind a reverse proxy doing an http→https upgrade), surfacing in the browser as:

```json
{"detail":"Auth provider 'self-hosted' unreachable"}
```

…and in `dashboard-auth.log` as `login_failure / provider_unreachable`.

## Root cause

`plugins/dashboard_auth/self_hosted/__init__.py` fetched the OIDC discovery document with a bare `httpx.get(...)`. **httpx defaults to `follow_redirects=False`** — unlike `curl -L` and the `requests` library. When an IDP answers `GET /.well-known/openid-configuration` with a `3xx`:

- **Authentik** canonicalises the `.well-known` path,
- any IDP behind a reverse proxy doing an http→https upgrade redirects,

…httpx returns the bare redirect with an **empty body**. `_fetch_discovery` hits its `status != 200` guard and raises `ProviderError("OIDC discovery returned 302 …")`, which `routes.py` maps to the `provider_unreachable` audit event → **HTTP 503**.

The reporter's smoking gun — *"curl from inside the container with `-o` writes zero bytes"* — is exactly that: a redirect with no body. The container's network path to the IDP is fine; the client just wasn't following the redirect.

### Why it looked like a regression but isn't

The provider never had `follow_redirects`. The documented Keycloak E2E demo works because **Keycloak serves the discovery doc with a direct 200**, so the bug was masked for any IDP that redirects discovery. The sense of "it worked a few days ago" comes from reconfiguring to a redirecting IDP, not a code change.

### Why the test suite was green

Every discovery test mocked `httpx.get` with a canned `200` — a mocked transport never exercises a real `3xx`. Necessary-but-not-sufficient coverage.

## The fix

Add `follow_redirects=True` to the **discovery GET only** (one call site). It's safe because the existing guards run against the *resolved* document:

- the issuer-pin check rejects a doc advertising a different `issuer`,
- `_require_https_or_loopback` validates every discovered endpoint,

…so a redirect can't smuggle in a bad issuer or a cleartext endpoint.

The token/revocation **POSTs deliberately keep the no-follow default** — they carry an authorization code / refresh token, and the endpoint is already the canonical absolute URL resolved from discovery, so it won't redirect. Following a `3xx` toward an unknown `Location` on those would be a credential-leak surface. A comment documents this.

## Test

Adds `TestDiscoveryRealRedirect` — a **real loopback HTTP server** that returns a `302` (empty body) on the `.well-known` path and serves the JSON discovery doc at the redirect target. It exercises the real httpx transport, not a mock:

- **without the fix:** fails with `ProviderError: OIDC discovery returned 302 for 'http://127.0.0.1:…/.well-known/openid-configuration'` (verified by reverting the one-line fix),
- **with the fix:** passes.

A behaviour contract, not a mock-shaped snapshot. Full self-hosted + dashboard-auth suites: **209 passed**.

## Not in scope

The `http://` callback URL the reporter also noticed is the separate, already-filed **#42780** (`HERMES_DASHBOARD_PUBLIC_URL` / proxy-header precedence). It can't bite this user yet: `start_login` dies in discovery *before* the callback URL is ever used. Fixing discovery is what lets them reach the IDP at all.
