### PR TITLE
[codex] add codex capacity governor

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2393,6 +2393,41 @@ def _normalize_chain_label(provider: str) -> str:
     return _AUX_UNHEALTHY_LABEL_ALIASES.get(p, p)
 
 
+def _capacity_governor_allows_provider(
+    provider: str,
+    model: Optional[str],
+    task: Optional[str],
+    *,
+    raw_codex: bool = False,
+) -> bool:
+    try:
+        from agent.capacity_governor import (
+            check_capacity,
+            format_capacity_block_message,
+            task_class_for_auxiliary_task,
+        )
+
+        decision = check_capacity(
+            provider=provider,
+            model=model,
+            task_class=task_class_for_auxiliary_task(task, raw_codex=raw_codex),
+        )
+        if not decision.allowed:
+            logger.info(
+                "Auxiliary %s: %s",
+                task or "call",
+                format_capacity_block_message(decision),
+            )
+            return False
+    except Exception:
+        logger.debug(
+            "Auxiliary %s: capacity governor check failed; allowing call",
+            task or "call",
+            exc_info=True,
+        )
+    return True
+
+
 def _mark_provider_unhealthy(provider: str, ttl: Optional[float] = None) -> None:
     """Mark ``provider`` as recently-402'd, hidden from chain iteration
     until the TTL expires. Called from the payment-fallback branches in
@@ -3188,7 +3223,7 @@ def _try_main_agent_model_fallback(
 
     try:
         client, resolved_model = resolve_provider_client(
-            provider=main_provider, model=main_model,
+            provider=main_provider, model=main_model, task=task,
         )
     except Exception:
         client, resolved_model = None, None
@@ -3605,6 +3640,7 @@ def _resolve_auto(
                 explicit_base_url=explicit_base_url,
                 explicit_api_key=explicit_api_key,
                 api_mode=runtime_api_mode or None,
+                task=task,
             )
             if client is not None:
                 logger.info("Auxiliary auto-detect: using main provider %s (%s)",
@@ -3916,6 +3952,13 @@ def resolve_provider_client(
 
     # ── OpenAI Codex (OAuth → Responses API) ─────────────────────────
     if provider == "openai-codex":
+        if not _capacity_governor_allows_provider(
+            provider,
+            model,
+            task,
+            raw_codex=raw_codex,
+        ):
+            return None, None
         if not model:
             logger.warning(
                 "resolve_provider_client: openai-codex requested without a "
@@ -4979,6 +5022,9 @@ def _get_cached_client(
     preventing the fd-exhaustion that previously occurred in long-running
     gateways where recycled worker threads created unbounded entries (#10200).
     """
+    if not _capacity_governor_allows_provider(provider, model, task):
+        return None, None
+
     # Resolve the current event loop for async clients so we can validate
     # cached entries.  Loop identity is NOT in the cache key — instead we
     # check at hit time whether the cached loop is still current and open.

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -620,6 +620,28 @@ def _run_review_in_thread(
             # -> codex_responses downgrade is applied inside the resolver.
             _rt = _resolve_review_runtime(agent)
             _routed = bool(_rt.get("routed"))
+            try:
+                from agent.capacity_governor import (
+                    check_capacity,
+                    format_capacity_block_message,
+                )
+
+                _capacity_decision = check_capacity(
+                    provider=_rt.get("provider") or agent.provider,
+                    model=_rt.get("model") or agent.model,
+                    task_class="background_review",
+                )
+                if not _capacity_decision.allowed:
+                    logger.info(
+                        "Background review deferred by capacity governor: %s",
+                        format_capacity_block_message(_capacity_decision),
+                    )
+                    return
+            except Exception:
+                logger.debug(
+                    "Background review capacity governor check failed; allowing review",
+                    exc_info=True,
+                )
             # skip_memory=True keeps the review fork from
             # touching external memory plugins (honcho, mem0,
             # supermemory, etc.).  Without it, the fork's

--- a/agent/capacity_governor.py
+++ b/agent/capacity_governor.py
@@ -94,11 +94,18 @@ def _load_governor_config(config: Optional[Dict[str, Any]] = None) -> Dict[str, 
 
 def _blocked_task_classes(raw_cfg: Dict[str, Any]) -> set[str]:
     raw = raw_cfg.get("block_task_classes")
-    if raw is None:
-        return set(DEFAULT_BLOCKED_TASK_CLASSES)
     if not isinstance(raw, list):
-        return set(DEFAULT_BLOCKED_TASK_CLASSES)
-    return {str(item).strip().lower() for item in raw if str(item).strip()}
+        computed = set(DEFAULT_BLOCKED_TASK_CLASSES)
+    else:
+        computed = {str(item).strip().lower() for item in raw if str(item).strip()}
+    # PROTECTED classes must NEVER be blockable, regardless of config. A
+    # misconfigured block list (e.g. protect_interactive_main=False AND
+    # "interactive_main" added to block_task_classes) must not be able to defer
+    # the interactive main loop or the critical compression path — that would
+    # surface as a hard RuntimeError in conversation_loop and crash the user's
+    # turn. This subtraction is the real guarantee; the protect_interactive_main
+    # flag is only an early-allow optimisation.
+    return computed - PROTECTED_TASK_CLASSES
 
 
 def _codex_status() -> Dict[str, Any]:

--- a/agent/capacity_governor.py
+++ b/agent/capacity_governor.py
@@ -1,0 +1,185 @@
+"""Pre-flight capacity checks for provider-backed LLM calls.
+
+The governor is deliberately fail-open and disabled by default. When enabled,
+it prevents non-interactive growth/background work from spending calls on a
+provider that Hermes already knows is quota-exhausted, while preserving the
+interactive main loop and critical compression path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+DEFAULT_BLOCKED_TASK_CLASSES = {
+    "background_review",
+    "title",
+    "session_search",
+    "skills_hub",
+    "profile_describer",
+    "triage_specifier",
+    "curator",
+    "cron_judgment",
+    "delegation",
+}
+
+PROTECTED_TASK_CLASSES = {
+    "interactive_main",
+    "compression_critical",
+}
+
+
+@dataclass(frozen=True)
+class CapacityDecision:
+    allowed: bool
+    provider: str
+    model: Optional[str]
+    task_class: str
+    reason: str = ""
+    reset_at: Optional[float] = None
+    action: str = "allow"
+
+
+def normalize_provider(provider: Optional[str]) -> str:
+    raw = str(provider or "").strip().lower()
+    if raw in {"codex", "openai_codex"}:
+        return "openai-codex"
+    return raw
+
+
+def is_codex_provider(provider: Optional[str]) -> bool:
+    return normalize_provider(provider) == "openai-codex"
+
+
+def task_class_for_auxiliary_task(
+    task: Optional[str],
+    *,
+    raw_codex: bool = False,
+) -> str:
+    if raw_codex and not task:
+        return "interactive_main"
+    normalized = str(task or "").strip().lower()
+    if normalized in {"compression", "context_compression", "summary"}:
+        return "compression_critical"
+    if normalized in {"title", "title_generation", "generate_title"}:
+        return "title"
+    if normalized.startswith("curator"):
+        return "curator"
+    if normalized in {
+        "session_search",
+        "skills_hub",
+        "profile_describer",
+        "triage_specifier",
+        "vision",
+        "web_extract",
+        "mcp",
+    }:
+        return normalized
+    return normalized or "auxiliary"
+
+
+def _load_governor_config(config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    cfg = config
+    if cfg is None:
+        try:
+            from hermes_cli.config import load_config
+
+            cfg = load_config()
+        except Exception:
+            cfg = {}
+    raw = (cfg or {}).get("capacity_governor") or {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _blocked_task_classes(raw_cfg: Dict[str, Any]) -> set[str]:
+    raw = raw_cfg.get("block_task_classes")
+    if raw is None:
+        return set(DEFAULT_BLOCKED_TASK_CLASSES)
+    if not isinstance(raw, list):
+        return set(DEFAULT_BLOCKED_TASK_CLASSES)
+    return {str(item).strip().lower() for item in raw if str(item).strip()}
+
+
+def _codex_status() -> Dict[str, Any]:
+    from hermes_cli.auth import get_codex_auth_status
+
+    return get_codex_auth_status() or {}
+
+
+def _is_rate_limited(status: Dict[str, Any]) -> bool:
+    return bool(
+        status.get("rate_limited")
+        or status.get("error_code") == "codex_rate_limited"
+    )
+
+
+def check_capacity(
+    *,
+    provider: Optional[str],
+    model: Optional[str] = None,
+    task_class: str,
+    estimated_tokens: Optional[int] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> CapacityDecision:
+    """Return whether a call should proceed.
+
+    ``estimated_tokens`` is accepted for the public API but not enforced yet;
+    the first implementation only gates known exhausted providers.
+    """
+    del estimated_tokens
+    normalized_provider = normalize_provider(provider)
+    normalized_task = str(task_class or "auxiliary").strip().lower()
+    cfg = _load_governor_config(config)
+
+    if not cfg.get("enabled", False):
+        return CapacityDecision(True, normalized_provider, model, normalized_task)
+    if not is_codex_provider(normalized_provider):
+        return CapacityDecision(True, normalized_provider, model, normalized_task)
+    if normalized_task in PROTECTED_TASK_CLASSES and cfg.get("protect_interactive_main", True):
+        return CapacityDecision(True, normalized_provider, model, normalized_task)
+
+    try:
+        status = _codex_status()
+    except Exception:
+        return CapacityDecision(True, normalized_provider, model, normalized_task)
+
+    if not _is_rate_limited(status):
+        return CapacityDecision(True, normalized_provider, model, normalized_task)
+
+    if normalized_task not in _blocked_task_classes(cfg):
+        return CapacityDecision(True, normalized_provider, model, normalized_task)
+
+    reset_at = status.get("reset_at")
+    if not isinstance(reset_at, (int, float)):
+        reset_at = None
+    reason = (
+        f"Codex quota is exhausted; deferred {normalized_task}"
+        + (f" until reset_at={reset_at}" if reset_at else "")
+    )
+    return CapacityDecision(
+        False,
+        normalized_provider,
+        model,
+        normalized_task,
+        reason=reason,
+        reset_at=float(reset_at) if reset_at else None,
+        action="defer",
+    )
+
+
+def reserve(*args: Any, **kwargs: Any) -> CapacityDecision:
+    """Compatibility entry point for future token reservation accounting."""
+    return check_capacity(*args, **kwargs)
+
+
+def release(*args: Any, **kwargs: Any) -> None:
+    """No-op placeholder for the future reservation API."""
+    del args, kwargs
+    return None
+
+
+def format_capacity_block_message(decision: CapacityDecision) -> str:
+    if decision.reason:
+        return decision.reason
+    return f"Capacity governor blocked {decision.task_class} on {decision.provider}"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1180,6 +1180,27 @@ def run_conversation(
                         )
                     return agent._interruptible_api_call(next_api_kwargs)
 
+                try:
+                    from agent.capacity_governor import (
+                        check_capacity,
+                        format_capacity_block_message,
+                    )
+
+                    _capacity_decision = check_capacity(
+                        provider=agent.provider,
+                        model=agent.model,
+                        task_class="interactive_main",
+                    )
+                    if not _capacity_decision.allowed:
+                        raise RuntimeError(format_capacity_block_message(_capacity_decision))
+                except RuntimeError:
+                    raise
+                except Exception:
+                    logger.debug(
+                        "Interactive capacity governor check failed; allowing main call",
+                        exc_info=True,
+                    )
+
                 from hermes_cli.middleware import run_llm_execution_middleware
 
                 response = run_llm_execution_middleware(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2427,6 +2427,31 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 f"(or pin the original values to keep them). See #44585."
             )
 
+        try:
+            from agent.capacity_governor import (
+                check_capacity,
+                format_capacity_block_message,
+            )
+
+            _capacity_decision = check_capacity(
+                provider=runtime.get("provider"),
+                model=model,
+                task_class="cron_judgment",
+                config=_cfg,
+            )
+            if not _capacity_decision.allowed:
+                message = format_capacity_block_message(_capacity_decision)
+                logger.warning("Job '%s': skipped by capacity governor: %s", job_id, message)
+                raise RuntimeError(message)
+        except RuntimeError:
+            raise
+        except Exception as gov_exc:
+            logger.debug(
+                "Job '%s': capacity governor check failed; allowing cron run: %s",
+                job_id,
+                gov_exc,
+            )
+
         fallback_model = _cfg.get("fallback_providers") or _cfg.get("fallback_model") or None
         credential_pool = None
         runtime_provider = str(runtime.get("provider") or "").strip().lower()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -906,6 +906,25 @@ DEFAULT_CONFIG = {
     # sessions (no live client) so accumulated agents don't pile up under memory
     # pressure. Reopening one re-resumes it from disk. 0/null disables.
     "max_live_sessions": 16,
+    # Pre-flight provider capacity governor. Disabled by default. When enabled,
+    # known exhausted Codex capacity defers non-interactive growth/background
+    # work while keeping the interactive main loop and critical compression
+    # path available.
+    "capacity_governor": {
+        "enabled": False,
+        "protect_interactive_main": True,
+        "block_task_classes": [
+            "background_review",
+            "title",
+            "session_search",
+            "skills_hub",
+            "profile_describer",
+            "triage_specifier",
+            "curator",
+            "cron_judgment",
+            "delegation",
+        ],
+    },
     "agent": {
         "max_turns": 90,
         # Inactivity timeout for gateway agent execution (seconds).

--- a/tests/agent/test_capacity_governor.py
+++ b/tests/agent/test_capacity_governor.py
@@ -1,0 +1,160 @@
+from types import SimpleNamespace
+
+from agent.capacity_governor import (
+    check_capacity,
+    release,
+    reserve,
+    task_class_for_auxiliary_task,
+)
+
+
+def _enabled_config(blocked=None):
+    return {
+        "capacity_governor": {
+            "enabled": True,
+            "protect_interactive_main": True,
+            "block_task_classes": blocked
+            or [
+                "background_review",
+                "title",
+                "session_search",
+                "cron_judgment",
+            ],
+        }
+    }
+
+
+def test_disabled_governor_allows_codex_background(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"rate_limited": True, "reset_at": 123.0},
+    )
+
+    decision = check_capacity(
+        provider="openai-codex",
+        model="gpt-5.5",
+        task_class="background_review",
+        config={"capacity_governor": {"enabled": False}},
+    )
+
+    assert decision.allowed is True
+
+
+def test_codex_exhausted_blocks_background_when_enabled(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"rate_limited": True, "reset_at": 123.0},
+    )
+
+    decision = check_capacity(
+        provider="codex",
+        model="gpt-5.5",
+        task_class="background_review",
+        config=_enabled_config(),
+    )
+
+    assert decision.allowed is False
+    assert decision.action == "defer"
+    assert decision.reset_at == 123.0
+
+
+def test_governor_preserves_interactive_and_compression(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"rate_limited": True, "reset_at": 123.0},
+    )
+    cfg = _enabled_config()
+
+    assert check_capacity(
+        provider="openai-codex",
+        model="gpt-5.5",
+        task_class="interactive_main",
+        config=cfg,
+    ).allowed is True
+    assert check_capacity(
+        provider="openai-codex",
+        model="gpt-5.5",
+        task_class="compression_critical",
+        config=cfg,
+    ).allowed is True
+
+
+def test_governor_allows_non_codex_provider(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: (_ for _ in ()).throw(AssertionError("should not check codex")),
+    )
+
+    decision = check_capacity(
+        provider="anthropic",
+        model="claude-sonnet",
+        task_class="background_review",
+        config=_enabled_config(),
+    )
+
+    assert decision.allowed is True
+
+
+def test_task_class_for_auxiliary_task_maps_protected_and_low_risk_tasks():
+    assert task_class_for_auxiliary_task("compression") == "compression_critical"
+    assert task_class_for_auxiliary_task("title_generation") == "title"
+    assert task_class_for_auxiliary_task("curator_merge") == "curator"
+    assert task_class_for_auxiliary_task(None, raw_codex=True) == "interactive_main"
+
+
+def test_reserve_release_api_is_available(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"rate_limited": False},
+    )
+
+    assert reserve(
+        provider="openai-codex",
+        model="gpt-5.5",
+        task_class="background_review",
+        config=_enabled_config(),
+    ).allowed is True
+    assert release(provider="openai-codex", task_class="background_review") is None
+
+
+def test_aux_auto_skips_codex_main_for_blocked_low_risk_task(monkeypatch):
+    import agent.auxiliary_client as aux
+
+    fallback_client = SimpleNamespace(name="fallback")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: _enabled_config())
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"rate_limited": True, "reset_at": 123.0},
+    )
+    monkeypatch.setattr(aux, "_read_main_provider", lambda: "openai-codex")
+    monkeypatch.setattr(aux, "_read_main_model", lambda: "gpt-5.5")
+    monkeypatch.setattr(aux, "_build_codex_client", lambda model: (SimpleNamespace(name="codex"), model))
+    monkeypatch.setattr(aux, "_try_configured_fallback_chain", lambda *a, **k: (None, None, ""))
+    monkeypatch.setattr(aux, "_try_main_fallback_chain", lambda *a, **k: (None, None, ""))
+    monkeypatch.setattr(aux, "_get_provider_chain", lambda: [("openrouter", lambda: (fallback_client, "fallback-model"))])
+
+    client, model = aux._resolve_auto(task="title_generation")
+
+    assert client is fallback_client
+    assert model == "fallback-model"
+
+
+def test_aux_auto_keeps_codex_main_for_compression(monkeypatch):
+    import agent.auxiliary_client as aux
+
+    codex_client = SimpleNamespace(name="codex")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: _enabled_config())
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"rate_limited": True, "reset_at": 123.0},
+    )
+    monkeypatch.setattr(aux, "_read_main_provider", lambda: "openai-codex")
+    monkeypatch.setattr(aux, "_read_main_model", lambda: "gpt-5.5")
+    monkeypatch.setattr(aux, "_build_codex_client", lambda model: (codex_client, model))
+
+    client, model = aux._resolve_auto(task="compression")
+
+    assert client is codex_client
+    assert model == "gpt-5.5"

--- a/tests/agent/test_capacity_governor.py
+++ b/tests/agent/test_capacity_governor.py
@@ -158,3 +158,82 @@ def test_aux_auto_keeps_codex_main_for_compression(monkeypatch):
 
     assert client is codex_client
     assert model == "gpt-5.5"
+
+
+# --- Adversarial-review hardening (2026-06-27): foot-gun + fail-open ---
+
+
+def test_protected_class_never_blocked_even_if_misconfigured(monkeypatch):
+    """A misconfigured block list must NOT be able to defer the interactive
+    main loop or compression — that would crash the user's turn via
+    conversation_loop's RuntimeError. PROTECTED is unconditionally excluded."""
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"rate_limited": True, "reset_at": 123.0},
+    )
+    hostile_cfg = {
+        "capacity_governor": {
+            "enabled": True,
+            # Operator turns protection off AND adds critical classes to the
+            # block list — the worst-case misconfiguration.
+            "protect_interactive_main": False,
+            "block_task_classes": ["interactive_main", "compression_critical"],
+        }
+    }
+    for task in ("interactive_main", "compression_critical"):
+        decision = check_capacity(
+            provider="openai-codex",
+            model="gpt-5.5",
+            task_class=task,
+            config=hostile_cfg,
+        )
+        assert decision.allowed is True, f"{task} must never be deferred"
+
+
+def test_failopen_when_codex_status_raises(monkeypatch):
+    """The #1 safety property: if the codex status lookup throws, the gate must
+    allow (fail-open), never block a real call."""
+
+    def _boom():
+        raise RuntimeError("auth lookup exploded")
+
+    monkeypatch.setattr("hermes_cli.auth.get_codex_auth_status", _boom)
+
+    decision = check_capacity(
+        provider="openai-codex",
+        model="gpt-5.5",
+        task_class="background_review",  # would be blocked if status said exhausted
+        config=_enabled_config(),
+    )
+    assert decision.allowed is True
+
+
+def test_failopen_when_config_missing(monkeypatch):
+    """No config (None) → governor disabled by default → allow."""
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"rate_limited": True, "reset_at": 123.0},
+    )
+    decision = check_capacity(
+        provider="openai-codex",
+        model="gpt-5.5",
+        task_class="background_review",
+        config=None,
+    )
+    assert decision.allowed is True
+
+
+def test_allows_exhausted_codex_for_task_outside_block_list(monkeypatch):
+    """Even when codex is exhausted, a task that is not in the block list must
+    pass — only explicitly blocked classes are deferred."""
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"rate_limited": True, "reset_at": 123.0},
+    )
+    decision = check_capacity(
+        provider="openai-codex",
+        model="gpt-5.5",
+        task_class="some_unlisted_task",
+        config=_enabled_config(),  # block list does not contain this task
+    )
+    assert decision.allowed is True


### PR DESCRIPTION
## Summary

Adds a default-off capacity governor for Codex quota exhaustion.

When enabled, Hermes checks known Codex quota state before provider-backed LLM calls and defers non-interactive work such as background review, low-risk auxiliary tasks, cron judgment, curator, and delegation. The interactive main loop and critical compression path stay protected by default.

## Why

Recent usage analysis showed background review and other growth-loop work can continue spending Codex calls after the account is already exhausted or close to exhaustion. Hermes had status visibility but no pre-flight call gate. This adds the first conservative governor layer without changing default behavior.

## What Changed

- Added `agent.capacity_governor` with `check_capacity()`, `reserve()`, and `release()` API entry points.
- Added default-off `capacity_governor` config.
- Inserted capacity checks before:
  - interactive main LLM execution
  - background review fork creation
  - auxiliary Codex client resolution, including cached clients and auto main-provider routing
  - cron agent execution
- Added focused tests for policy behavior and auxiliary auto fallback from exhausted Codex.

## Validation

- `python3 -m py_compile agent/capacity_governor.py agent/auxiliary_client.py agent/background_review.py agent/conversation_loop.py cron/scheduler.py`
- `uv run pytest tests/agent/test_capacity_governor.py -q`
- `uv run pytest tests/agent/test_capacity_governor.py tests/agent/test_auxiliary_client.py::TestCompressionFallbackContextFilter tests/run_agent/test_background_review_cost_controls.py tests/run_agent/test_background_review.py tests/run_agent/test_background_review_summary.py tests/cron/test_run_one_job.py tests/cron/test_scheduler_provider.py tests/hermes_cli/test_config.py -q`
- `git diff --check`

## Notes

The governor is intentionally fail-open and disabled by default. This PR establishes the core pre-flight mechanism; local profiles can enable it after deployment.
