### PR TITLE
fix(skills): resolve paths before computing relative install path

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -688,7 +688,8 @@ def do_install(identifier: str, category: str = "", force: bool = False,
                          bundle.trust_level, "invalid_path", str(exc))
         return
     from tools.skills_hub import SKILLS_DIR
-    c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR)}")
+    install_display_path = install_dir.resolve().relative_to(SKILLS_DIR.resolve()).as_posix()
+    c.print(f"[bold green]Installed:[/] {install_display_path}")
     c.print(f"[dim]Files: {', '.join(bundle.files.keys())}[/]\n")
 
     # Blueprint detection: if the installed skill declares a

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -297,7 +297,6 @@ The registry of record is `hermes_cli/commands.py` — every consumer
 /tools               Manage tools (CLI)
 /toolsets            List toolsets (CLI)
 /skills              Search/install skills (CLI)
-/skill <name>        Load a skill into session
 /reload-skills       Re-scan ~/.hermes/skills/ for added/removed skills
 /reload              Reload .env variables into the running session (CLI)
 /reload-mcp          Reload MCP servers
@@ -343,7 +342,7 @@ The registry of record is `hermes_cli/commands.py` — every consumer
 
 ### Exit
 ```
-/quit (/exit, /q)    Exit CLI
+/quit (/exit)        Exit CLI
 ```
 
 ---

--- a/tests/skills/test_hermes_agent_skill_slash_commands.py
+++ b/tests/skills/test_hermes_agent_skill_slash_commands.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+SKILL_PATH = Path("skills/autonomous-ai-agents/hermes-agent/SKILL.md")
+COMMANDS_PATH = Path("hermes_cli/commands.py")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_skill_docs_do_not_list_phantom_skill_command():
+    skill_text = _read(SKILL_PATH)
+    commands_text = _read(COMMANDS_PATH)
+
+    assert '/skill <name>' not in skill_text
+    assert 'CommandDef("skill"' not in commands_text
+
+
+def test_skill_docs_do_not_claim_q_exits_cli():
+    skill_text = _read(SKILL_PATH)
+    commands_text = _read(COMMANDS_PATH)
+
+    assert '/quit (/exit, /q)' not in skill_text
+    assert '/quit (/exit)' in skill_text
+    assert 'CommandDef("quit", "Exit the CLI (use --delete to also remove session history)", "Exit",' in commands_text
+    assert 'aliases=("exit",), args_hint="[--delete]")' in commands_text
+    assert 'CommandDef("queue", "Queue a prompt for the next turn (doesn\'t interrupt)", "Session",' in commands_text
+    assert 'aliases=("q",), args_hint="<prompt>")' in commands_text

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3393,7 +3393,7 @@ def install_from_quarantine(
         trust_level=bundle.trust_level,
         scan_verdict=scan_result.verdict,
         skill_hash=content_hash(install_dir),
-        install_path=str(install_dir.relative_to(SKILLS_DIR)),
+        install_path=install_dir.resolve().relative_to(SKILLS_DIR.resolve()).as_posix(),
         files=list(bundle.files.keys()),
         metadata=bundle.metadata,
     )


### PR DESCRIPTION
Fixes #53403. Resolves ValueError when SKILLS_DIR or the install directory contains a symlink by calling .resolve() on both paths before computing relative_to().