### PR TITLE
fix(desktop): honor configured model reasoning policy

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -18,6 +18,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import type { HermesGateway } from '@/hermes'
 import { getGlobalModelOptions, getMoaModels } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { resolveModelReasoningPolicy } from '@/lib/model-picker-policy'
 import {
   currentPickerSelection,
   displayModelName,
@@ -161,6 +162,12 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
     const caps = provider.capabilities?.[family.id]
     const preset = modelPresets[modelPresetKey(provider.slug, family.id)] ?? {}
 
+    const reasoningPolicy = resolveModelReasoningPolicy(caps, {
+      currentEffort: '',
+      isCurrent: false,
+      presetEffort: preset.effort
+    })
+
     // Variant-fast models (no speed param) express "fast" as a separate `-fast`
     // id, so honor the saved preset by selecting that sibling. Param-fast is
     // applied via applyModelPreset below instead.
@@ -173,7 +180,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
 
     await applyModelPreset(
       {
-        effort: (caps?.reasoning ?? true) ? (preset.effort ?? 'medium') : undefined,
+        effort: reasoningPolicy.configurable ? reasoningPolicy.effort : undefined,
         fast: (caps?.fast ?? false) ? (preset.fast ?? false) : undefined
       },
       { failMessage: t.shell.modelOptions.updateFailed, request: requestGateway, sessionId: activeSessionId }
@@ -237,17 +244,24 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
                     : null
 
                 const isCurrent = activeId !== null
-                const name = modelDisplayParts(family.id).name
                 // Capabilities are looked up against the active/base id; the
                 // -fast variant carries the same param support as its base.
                 const caps = group.provider.capabilities?.[family.id]
+                const name = caps?.display_name?.trim() || modelDisplayParts(family.id).name
 
                 // Effective settings for this row: live session state when it's
                 // the active model, otherwise its remembered preset (Hermes
                 // defaults when unset). Row label AND submenu read from these so
                 // they never disagree.
                 const preset = modelPresets[modelPresetKey(group.provider.slug, family.id)] ?? {}
-                const effEffort = isCurrent ? currentReasoningEffort : (preset.effort ?? '')
+
+                const reasoningPolicy = resolveModelReasoningPolicy(caps, {
+                  currentEffort: currentReasoningEffort,
+                  isCurrent,
+                  presetEffort: preset.effort
+                })
+
+                const effEffort = reasoningPolicy.effort
                 const effFast = isCurrent ? currentFastMode : (preset.fast ?? false)
 
                 const fastControl = resolveFastControl(
@@ -259,10 +273,15 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
 
                 const meta = [
                   fastControl.kind !== 'none' && fastControl.on ? copy.fast : null,
-                  (caps?.reasoning ?? true) ? reasoningEffortLabel(effEffort) || copy.medium : null
+                  reasoningPolicy.configurable
+                    ? reasoningEffortLabel(effEffort) || copy.medium
+                    : reasoningPolicy.label ||
+                      ((caps?.reasoning ?? true) ? reasoningEffortLabel(reasoningPolicy.defaultEffort) : null)
                 ]
                   .filter(Boolean)
                   .join(' ')
+
+                const hasOptions = fastControl.kind !== 'none' || reasoningPolicy.configurable
 
                 // Every row is a hover-Edit submenu trigger. Activating it
                 // (pointer or keyboard) switches to the family's base model and
@@ -280,6 +299,28 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
                   closeMenu()
                 }
 
+                const rowContent = (
+                  <>
+                    <span className="min-w-0 flex-1 truncate">
+                      {name}
+                      {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
+                    </span>
+                    {isCurrent ? <Codicon className="ml-auto text-foreground" name="check" size="0.75rem" /> : null}
+                  </>
+                )
+
+                if (!hasOptions) {
+                  return (
+                    <DropdownMenuItem
+                      className={dropdownMenuRow}
+                      key={`${group.provider.slug}:${family.id}`}
+                      onSelect={activate}
+                    >
+                      {rowContent}
+                    </DropdownMenuItem>
+                  )
+                }
+
                 return (
                   <DropdownMenuSub key={`${group.provider.slug}:${family.id}`}>
                     <DropdownMenuSubTrigger
@@ -292,11 +333,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
                         }
                       }}
                     >
-                      <span className="min-w-0 flex-1 truncate">
-                        {name}
-                        {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
-                      </span>
-                      {isCurrent ? <Codicon className="ml-auto text-foreground" name="check" size="0.75rem" /> : null}
+                      {rowContent}
                     </DropdownMenuSubTrigger>
                     <ModelEditSubmenu
                       effort={effEffort}
@@ -305,7 +342,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
                       model={family.id}
                       onSelectModel={nextModel => switchTo(nextModel, group.provider.slug)}
                       provider={group.provider.slug}
-                      reasoning={caps?.reasoning ?? true}
+                      reasoning={reasoningPolicy.configurable}
                       requestGateway={requestGateway}
                     />
                   </DropdownMenuSub>

--- a/apps/desktop/src/lib/model-picker-policy.test.ts
+++ b/apps/desktop/src/lib/model-picker-policy.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveModelReasoningPolicy } from './model-picker-policy'
+
+describe('model picker reasoning policy', () => {
+  it('keeps the legacy medium adjustable fallback for catalog models', () => {
+    expect(
+      resolveModelReasoningPolicy({ fast: false, reasoning: true }, { currentEffort: '', isCurrent: false })
+    ).toEqual({ configurable: true, defaultEffort: 'medium', effort: 'medium', label: '' })
+  })
+
+  it('uses a configured default instead of inventing medium', () => {
+    const policy = resolveModelReasoningPolicy(
+      { fast: false, reasoning: true, reasoning_configurable: true, reasoning_default: 'high' },
+      { currentEffort: '', isCurrent: false }
+    )
+
+    expect(policy.effort).toBe('high')
+    expect(policy.configurable).toBe(true)
+  })
+
+  it('represents an externally fixed policy without an editable control', () => {
+    expect(
+      resolveModelReasoningPolicy(
+        {
+          fast: false,
+          reasoning: true,
+          reasoning_configurable: false,
+          reasoning_default: 'high',
+          reasoning_label: 'High reasoning'
+        },
+        { currentEffort: 'medium', isCurrent: true }
+      )
+    ).toEqual({ configurable: false, defaultEffort: 'high', effort: 'medium', label: 'High reasoning' })
+  })
+})

--- a/apps/desktop/src/lib/model-picker-policy.ts
+++ b/apps/desktop/src/lib/model-picker-policy.ts
@@ -1,0 +1,27 @@
+import type { ModelCapabilities } from '@/types/hermes'
+
+export interface ModelReasoningPolicy {
+  configurable: boolean
+  defaultEffort: string
+  effort: string
+  label: string
+}
+
+/** Resolve one picker row's effective reasoning policy.
+ *
+ * Built-in/catalog models retain the historical behavior (reasoning support
+ * implies an adjustable control with medium as the default). Configured proxy
+ * models can instead declare an explicit default or a fixed policy label.
+ */
+export function resolveModelReasoningPolicy(
+  capabilities: ModelCapabilities | undefined,
+  options: { currentEffort: string; isCurrent: boolean; presetEffort?: string }
+): ModelReasoningPolicy {
+  const supported = capabilities?.reasoning ?? true
+  const configurable = capabilities?.reasoning_configurable ?? supported
+  const defaultEffort = capabilities?.reasoning_default?.trim() || 'medium'
+  const effort = (options.isCurrent ? options.currentEffort : options.presetEffort)?.trim() || defaultEffort
+  const label = capabilities?.reasoning_label?.trim() || ''
+
+  return { configurable, defaultEffort, effort, label }
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -281,8 +281,17 @@ export interface ModelOptionProvider {
 }
 
 export interface ModelCapabilities {
+  /** Optional operator-curated name for custom/provider-proxied model ids. */
+  display_name?: string
   fast: boolean
   reasoning: boolean
+  /** Whether the picker may override reasoning for this model. Defaults to
+   *  `reasoning` for backward compatibility. */
+  reasoning_configurable?: boolean
+  /** Effort applied when the model has no remembered preset. */
+  reasoning_default?: string
+  /** Static policy text shown when reasoning is externally managed/fixed. */
+  reasoning_label?: string
 }
 
 export interface ModelOptionsResponse {

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -221,7 +221,7 @@ def build_models_payload(
     if pricing:
         _apply_pricing(rows, force_fresh_nous_tier=force_fresh_nous_tier)
     if capabilities:
-        _apply_capabilities(rows)
+        _apply_capabilities(rows, ctx)
 
     return {
         "providers": rows,
@@ -230,7 +230,46 @@ def build_models_payload(
     }
 
 
-def _apply_capabilities(rows: list[dict]) -> None:
+def _configured_model_metadata(
+    ctx: ConfigContext,
+    provider: str,
+    model: str,
+) -> dict:
+    """Return UI metadata declared for one configured provider model.
+
+    The keyed ``providers:`` schema lets operators curate a model list with
+    per-model metadata (``models.<id>``).  Keep picker policy beside that model
+    instead of guessing it from the provider/model name.  The compatibility
+    view is checked as a fallback so legacy ``custom_providers:`` entries get
+    the same behavior.
+    """
+    entry = ctx.user_providers.get(provider)
+    if isinstance(entry, dict):
+        models = entry.get("models")
+        if isinstance(models, dict):
+            metadata = models.get(model)
+            if isinstance(metadata, dict):
+                return metadata
+
+    provider_lower = provider.strip().lower()
+    for entry in ctx.custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        provider_key = str(entry.get("provider_key", "") or "").strip().lower()
+        name = str(entry.get("name", "") or "").strip().lower().replace(" ", "-")
+        if provider_lower not in {provider_key, f"custom:{name}"}:
+            continue
+        models = entry.get("models")
+        if not isinstance(models, dict):
+            continue
+        metadata = models.get(model)
+        if isinstance(metadata, dict):
+            return metadata
+
+    return {}
+
+
+def _apply_capabilities(rows: list[dict], ctx: ConfigContext) -> None:
     """Attach a ``{model: {fast, reasoning}}`` map to each provider row.
 
     `fast` mirrors ``model_supports_fast_mode`` (the same gate the runtime
@@ -238,6 +277,21 @@ def _apply_capabilities(rows: list[dict]) -> None:
     defaults to True otherwise — the effort dial is broadly accepted and a
     no-op on models that ignore it, whereas hiding it from a capable-but-
     uncatalogued model is the worse failure.
+
+    User-configured models may also declare picker policy beside their existing
+    per-model metadata::
+
+        models:
+          my-model:
+            display_name: My Model
+            reasoning:
+              configurable: false
+              default: high
+              label: High reasoning
+
+    ``configurable`` controls whether the UI may send a reasoning override;
+    ``default`` replaces the generic medium fallback; and ``label`` describes
+    an externally enforced/fixed policy without presenting a fake control.
     """
     from hermes_cli.models import model_supports_fast_mode
 
@@ -260,10 +314,31 @@ def _apply_capabilities(rows: list[dict]) -> None:
                 except Exception:
                     reasoning = True
 
-            caps[model] = {
+            model_caps: dict[str, bool | str] = {
                 "fast": bool(model_supports_fast_mode(model)),
                 "reasoning": reasoning,
             }
+
+            metadata = _configured_model_metadata(ctx, slug, model)
+            display_name = metadata.get("display_name")
+            if isinstance(display_name, str) and display_name.strip():
+                model_caps["display_name"] = display_name.strip()
+
+            reasoning_config = metadata.get("reasoning")
+            if isinstance(reasoning_config, dict):
+                configurable = reasoning_config.get("configurable")
+                if isinstance(configurable, bool):
+                    model_caps["reasoning_configurable"] = configurable
+
+                default = reasoning_config.get("default")
+                if isinstance(default, str) and default.strip():
+                    model_caps["reasoning_default"] = default.strip()
+
+                label = reasoning_config.get("label")
+                if isinstance(label, str) and label.strip():
+                    model_caps["reasoning_label"] = label.strip()
+
+            caps[model] = model_caps
 
         row["capabilities"] = caps
 

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -446,6 +446,87 @@ def test_canonical_order_with_unconfigured_preserves_full_universe():
 # ─── Integration: end-to-end through real load_picker_context ──────────
 
 
+def test_capabilities_include_configured_reasoning_policy():
+    """Curated proxy models can expose their real default/fixed policy.
+
+    Without this metadata the desktop assumes every uncatalogued model has an
+    adjustable medium-effort control, even when the upstream gateway enforces a
+    different fixed setting.
+    """
+    rows = [
+        {
+            "slug": "my-proxy",
+            "name": "My proxy",
+            "models": ["fixed-model", "adjustable-model"],
+            "total_models": 2,
+            "is_current": True,
+            "is_user_defined": True,
+            "source": "user-config",
+        }
+    ]
+    ctx = ConfigContext(
+        current_provider="my-proxy",
+        current_model="adjustable-model",
+        current_base_url="http://proxy/v1",
+        user_providers={
+            "my-proxy": {
+                "models": {
+                    "fixed-model": {
+                        "display_name": "Fixed Model",
+                        "reasoning": {
+                            "configurable": False,
+                            "default": "high",
+                            "label": "High reasoning",
+                        },
+                    },
+                    "adjustable-model": {
+                        "reasoning": {"configurable": True, "default": "high"},
+                    },
+                }
+            }
+        },
+        custom_providers=[],
+    )
+
+    with _list_auth_returning(rows):
+        payload = build_models_payload(ctx, capabilities=True)
+
+    provider = next(row for row in payload["providers"] if row["slug"] == "my-proxy")
+    caps = provider["capabilities"]
+    assert caps["fixed-model"] == {
+        "fast": False,
+        "reasoning": True,
+        "display_name": "Fixed Model",
+        "reasoning_configurable": False,
+        "reasoning_default": "high",
+        "reasoning_label": "High reasoning",
+    }
+    assert caps["adjustable-model"] == {
+        "fast": False,
+        "reasoning": True,
+        "reasoning_configurable": True,
+        "reasoning_default": "high",
+    }
+
+
+def test_capabilities_keep_catalog_defaults_without_configured_policy():
+    rows = [_nous_row()]
+    ctx = _empty_ctx(provider="nous", model="openai/gpt-5.5")
+
+    with (
+        _list_auth_returning(rows),
+        patch("agent.models_dev.get_model_capabilities") as mock_get_caps,
+    ):
+        mock_get_caps.return_value.supports_reasoning = True
+        payload = build_models_payload(ctx, capabilities=True)
+
+    provider = next(row for row in payload["providers"] if row["slug"] == "nous")
+    assert provider["capabilities"]["openai/gpt-5.5"] == {
+        "fast": True,
+        "reasoning": True,
+    }
+
+
 def test_end_to_end_with_real_context_no_credentials_leak(monkeypatch):
     """Full pipeline: real load_picker_context + real
     list_authenticated_providers. Verify no credential string ever
@@ -766,4 +847,3 @@ def test_list_authenticated_providers_refresh_busts_cache():
         assert clear.call_count == 0
         model_switch.list_authenticated_providers(refresh=True)
         assert clear.call_count == 1
-


### PR DESCRIPTION
## Summary

Custom/proxied models currently default to an editable Medium reasoning preset in the desktop picker whenever models.dev has no exact provider/model entry. That can contradict an operator-enforced policy at the gateway.

This adds optional per-model UI metadata under `providers.<provider>.models.<model>`:

```yaml
display_name: My Model
reasoning:
  configurable: false
  label: High reasoning
```

Adjustable models can instead declare `configurable: true` and `default: high`. The picker uses the declared default, renders fixed policies as static labels, and omits the edit submenu when no option is actually available. Existing providers retain the current reasoning/Medium fallback.

## Validation

- `tests/hermes_cli/test_inventory.py`: 36 passed
- targeted desktop picker/status tests: 13 passed
- changed desktop files: ESLint clean
- release-baseline desktop TypeScript typecheck: clean

The upstream-main full typecheck needs its newer dependency set; GitHub CI is the authoritative check for that branch.