### PR TITLE
fix(agent): stop repeated read-only no-progress loops by default

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -64,13 +64,17 @@ MUTATING_TOOL_NAMES = frozenset(
 class ToolCallGuardrailConfig:
     """Thresholds for per-turn tool-call loop detection.
 
-    Warnings are enabled by default and never prevent tool execution. Hard stops
-    are explicit opt-in so interactive CLI/TUI sessions get a gentle nudge unless
-    the user enables circuit-breaker behavior in config.yaml.
+    Warnings are enabled by default and never prevent tool execution. Failure
+    hard stops are explicit opt-in so interactive CLI/TUI sessions get a gentle
+    nudge unless the user enables circuit-breaker behavior in config.yaml.
+    Repeating the exact same read-only result is treated more strictly by
+    default because it often means the requested state is already satisfied and
+    the model is stuck in an instruction-reality mismatch loop.
     """
 
     warnings_enabled: bool = True
     hard_stop_enabled: bool = False
+    no_progress_hard_stop_enabled: bool = True
     exact_failure_warn_after: int = 2
     exact_failure_block_after: int = 5
     same_tool_failure_warn_after: int = 3
@@ -97,6 +101,10 @@ class ToolCallGuardrailConfig:
         return cls(
             warnings_enabled=_as_bool(data.get("warnings_enabled"), defaults.warnings_enabled),
             hard_stop_enabled=_as_bool(data.get("hard_stop_enabled"), defaults.hard_stop_enabled),
+            no_progress_hard_stop_enabled=_as_bool(
+                data.get("no_progress_hard_stop_enabled"),
+                defaults.no_progress_hard_stop_enabled,
+            ),
             exact_failure_warn_after=_positive_int(
                 warn_after.get("exact_failure", data.get("exact_failure_warn_after")),
                 defaults.exact_failure_warn_after,
@@ -240,27 +248,25 @@ class ToolCallGuardrailController:
 
     def before_call(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
         signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
-        if not self.config.hard_stop_enabled:
-            return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
+        if self.config.hard_stop_enabled:
+            exact_count = self._exact_failure_counts.get(signature, 0)
+            if exact_count >= self.config.exact_failure_block_after:
+                decision = ToolGuardrailDecision(
+                    action="block",
+                    code="repeated_exact_failure_block",
+                    message=(
+                        f"Blocked {tool_name}: the same tool call failed {exact_count} "
+                        "times with identical arguments. Stop retrying it unchanged; "
+                        "change strategy or explain the blocker."
+                    ),
+                    tool_name=tool_name,
+                    count=exact_count,
+                    signature=signature,
+                )
+                self._halt_decision = decision
+                return decision
 
-        exact_count = self._exact_failure_counts.get(signature, 0)
-        if exact_count >= self.config.exact_failure_block_after:
-            decision = ToolGuardrailDecision(
-                action="block",
-                code="repeated_exact_failure_block",
-                message=(
-                    f"Blocked {tool_name}: the same tool call failed {exact_count} "
-                    "times with identical arguments. Stop retrying it unchanged; "
-                    "change strategy or explain the blocker."
-                ),
-                tool_name=tool_name,
-                count=exact_count,
-                signature=signature,
-            )
-            self._halt_decision = decision
-            return decision
-
-        if self._is_idempotent(tool_name):
+        if self.config.no_progress_hard_stop_enabled and self._is_idempotent(tool_name):
             record = self._no_progress.get(signature)
             if record is not None:
                 _result_hash, repeat_count = record
@@ -271,7 +277,9 @@ class ToolCallGuardrailController:
                         message=(
                             f"Blocked {tool_name}: this read-only call returned the same "
                             f"result {repeat_count} times. Stop repeating it unchanged; "
-                            "use the result already provided or try a different query."
+                            "use the result already provided or try a different query. "
+                            "If the current state already satisfies the user's request, "
+                            "stop and report that no changes are needed."
                         ),
                         tool_name=tool_name,
                         count=repeat_count,
@@ -365,7 +373,8 @@ class ToolCallGuardrailController:
                 message=(
                     f"{tool_name} returned the same result {repeat_count} times. "
                     "Use the result already provided or change the query instead of "
-                    "repeating it unchanged."
+                    "repeating it unchanged. If the current state already satisfies "
+                    "the user's request, stop and explain that no changes are needed."
                 ),
                 tool_name=tool_name,
                 count=repeat_count,

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -370,12 +370,15 @@ browser:
 # Tool Loop Guardrails
 # =============================================================================
 # Soft warnings are enabled by default. They append guidance to repeated failed
-# or non-progressing tool results but still let the tool execute. Hard stops are
-# opt-in circuit breakers for autonomous/cron sessions where stopping a loop is
-# preferable to spending the full iteration budget.
+# or non-progressing tool results. Failure hard stops stay opt-in circuit
+# breakers for autonomous/cron sessions where stopping a loop is preferable to
+# spending the full iteration budget. Repeated identical read-only results are
+# stricter by default because they often mean the task is already satisfied and
+# the model is stuck looping on stale instructions.
 tool_loop_guardrails:
   warnings_enabled: true
   hard_stop_enabled: false
+  no_progress_hard_stop_enabled: true
   warn_after:
     exact_failure: 2
     same_tool_failure: 3

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -38,6 +38,7 @@ def test_default_config_is_soft_warning_only_with_hard_stop_disabled():
 
     assert cfg.warnings_enabled is True
     assert cfg.hard_stop_enabled is False
+    assert cfg.no_progress_hard_stop_enabled is True
     assert cfg.exact_failure_warn_after == 2
     assert cfg.same_tool_failure_warn_after == 3
     assert cfg.no_progress_warn_after == 2
@@ -51,6 +52,7 @@ def test_config_parses_nested_warn_and_hard_stop_thresholds():
         {
             "warnings_enabled": False,
             "hard_stop_enabled": True,
+            "no_progress_hard_stop_enabled": False,
             "warn_after": {
                 "exact_failure": 3,
                 "same_tool_failure": 4,
@@ -66,6 +68,7 @@ def test_config_parses_nested_warn_and_hard_stop_thresholds():
 
     assert cfg.warnings_enabled is False
     assert cfg.hard_stop_enabled is True
+    assert cfg.no_progress_hard_stop_enabled is False
     assert cfg.exact_failure_warn_after == 3
     assert cfg.same_tool_failure_warn_after == 4
     assert cfg.no_progress_warn_after == 5
@@ -188,27 +191,52 @@ def test_hard_stop_enabled_halts_same_tool_varying_args_failure_streak():
     assert third.count == 3
 
 
-def test_idempotent_no_progress_repeated_result_warns_without_blocking_by_default():
+def test_idempotent_no_progress_repeated_result_blocks_future_repeat_by_default():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)
     )
     args = {"path": "/tmp/same.txt"}
     result = "same file contents"
 
-    for _ in range(4):
-        assert controller.before_call("read_file", args).action == "allow"
-        decision = controller.after_call("read_file", args, result, failed=False)
-
+    assert controller.before_call("read_file", args).action == "allow"
+    assert controller.after_call("read_file", args, result, failed=False).action == "allow"
+    assert controller.before_call("read_file", args).action == "allow"
+    decision = controller.after_call("read_file", args, result, failed=False)
     assert decision.action == "warn"
     assert decision.code == "idempotent_no_progress_warning"
-    assert controller.before_call("read_file", args).action == "allow"
-    assert controller.halt_decision is None
+    blocked = controller.before_call("read_file", args)
+    assert blocked.action == "block"
+    assert blocked.code == "idempotent_no_progress_block"
+    assert controller.halt_decision == blocked
 
 
-def test_hard_stop_enabled_blocks_idempotent_no_progress_future_repeat():
+def test_warnings_disabled_does_not_disable_no_progress_hard_stop():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(
-            hard_stop_enabled=True,
+            warnings_enabled=False,
+            hard_stop_enabled=False,
+            no_progress_hard_stop_enabled=True,
+            no_progress_warn_after=2,
+            no_progress_block_after=2,
+        )
+    )
+    args = {"path": "/tmp/same.txt"}
+    result = "same file contents"
+
+    assert controller.before_call("read_file", args).action == "allow"
+    assert controller.after_call("read_file", args, result, failed=False).action == "allow"
+    assert controller.before_call("read_file", args).action == "allow"
+    assert controller.after_call("read_file", args, result, failed=False).action == "allow"
+
+    blocked = controller.before_call("read_file", args)
+    assert blocked.action == "block"
+    assert blocked.code == "idempotent_no_progress_block"
+
+
+def test_opt_out_disables_default_idempotent_no_progress_block():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            no_progress_hard_stop_enabled=False,
             no_progress_warn_after=2,
             no_progress_block_after=2,
         )
@@ -223,9 +251,8 @@ def test_hard_stop_enabled_blocks_idempotent_no_progress_future_repeat():
     assert warn.action == "warn"
     assert warn.code == "idempotent_no_progress_warning"
 
-    blocked = controller.before_call("read_file", args)
-    assert blocked.action == "block"
-    assert blocked.code == "idempotent_no_progress_block"
+    assert controller.before_call("read_file", args).action == "allow"
+    assert controller.halt_decision is None
 
 
 def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_success_output_by_default():

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -75,6 +75,7 @@ def _hard_stop_config(**overrides) -> dict:
         "tool_loop_guardrails": {
             "warnings_enabled": True,
             "hard_stop_enabled": True,
+            "no_progress_hard_stop_enabled": True,
             "hard_stop_after": {
                 "exact_failure": 2,
                 "same_tool_failure": 8,
@@ -266,6 +267,78 @@ def test_default_run_conversation_warns_without_guardrail_halt():
     assert result["final_response"] == "done"
     tool_contents = [m["content"] for m in result["messages"] if m.get("role") == "tool"]
     assert any("repeated_exact_failure_warning" in content for content in tool_contents)
+
+
+def test_default_run_conversation_halts_repeated_idempotent_no_progress_loop():
+    agent = _make_agent("read_file", max_iterations=10)
+    same_args = {"path": "/tmp/same.txt"}
+    responses = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call("read_file", json.dumps(same_args), f"c{i}")],
+        )
+        for i in range(1, 8)
+    ]
+    agent.client.chat.completions.create.side_effect = responses
+
+    with (
+        patch("run_agent.handle_function_call", return_value="same file contents") as mock_hfc,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("check whether the file already has the right content")
+
+    assert mock_hfc.call_count == 5
+    assert result["api_calls"] == 6
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    assert result["completed"] is True
+    assert "idempotent_no_progress_block" in result["final_response"]
+    assert "5 repeated non-progressing attempts" in result["final_response"]
+    assert result["guardrail"]["code"] == "idempotent_no_progress_block"
+    assert result["guardrail"]["tool_name"] == "read_file"
+
+
+def test_config_can_disable_default_idempotent_no_progress_halt():
+    agent = _make_agent(
+        "read_file",
+        max_iterations=10,
+        config={
+            "tool_loop_guardrails": {
+                "warnings_enabled": True,
+                "hard_stop_enabled": False,
+                "no_progress_hard_stop_enabled": False,
+                "warn_after": {"idempotent_no_progress": 2},
+                "hard_stop_after": {"idempotent_no_progress": 5},
+            }
+        },
+    )
+    same_args = {"path": "/tmp/same.txt"}
+    responses = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call("read_file", json.dumps(same_args), f"c{i}")],
+        )
+        for i in range(1, 4)
+    ]
+    responses.append(_mock_response(content="done", finish_reason="stop", tool_calls=None))
+    agent.client.chat.completions.create.side_effect = responses
+
+    with (
+        patch("run_agent.handle_function_call", return_value="same file contents") as mock_hfc,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("check whether the file already has the right content")
+
+    assert mock_hfc.call_count == 3
+    assert result["turn_exit_reason"].startswith("text_response")
+    assert "guardrail" not in result
+    tool_contents = [m["content"] for m in result["messages"] if m.get("role") == "tool"]
+    assert any("idempotent_no_progress_warning" in content for content in tool_contents)
 
 
 def test_config_enabled_hard_stop_run_conversation_returns_controlled_guardrail_halt_without_top_level_error():

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1404,14 +1404,15 @@ agent:
 
 ## Tool-Loop Guardrails
 
-Hermes detects when the agent is stuck in an unproductive tool-calling loop — the same tool call failing repeatedly, the same tool failing over and over, or an idempotent call returning the same result with no progress. By default it injects a **warning** into the tool result so the model self-corrects; it does not hard-stop, since a person watching the CLI/TUI can intervene.
+Hermes detects when the agent is stuck in an unproductive tool-calling loop — the same tool call failing repeatedly, the same tool failing over and over, or an idempotent read-only call returning the same result with no progress. Failure loops are warning-first by default so a person watching the CLI/TUI can intervene. Repeated identical results from idempotent read-only tools are blocked by default once they reach the no-progress threshold, because another identical call cannot provide new information.
 
 For unattended gateway / server deployments, enable hard stops so a stuck agent is circuit-broken instead of burning the iteration budget:
 
 ```yaml
 tool_loop_guardrails:
-  warnings_enabled: true       # inject warnings into tool results (default: true)
-  hard_stop_enabled: false     # also BLOCK the call past the hard-stop threshold (default: false)
+  warnings_enabled: true               # inject warnings into tool results (default: true)
+  hard_stop_enabled: false             # block repeated failures (default: false)
+  no_progress_hard_stop_enabled: true  # block repeated identical read-only results (default: true)
   warn_after:
     exact_failure: 2           # identical failing call repeated N times
     same_tool_failure: 3       # same tool failing N times (different args)
@@ -1422,7 +1423,13 @@ tool_loop_guardrails:
     idempotent_no_progress: 5
 ```
 
-`hard_stop_enabled` defaults to `false` because interactive sessions have a human in the loop. In unattended deployments (gateway, cron, kanban workers) set it to `true` so repeated failures are blocked rather than only warned. See also [Docker / unattended deployments](docker.md).
+The three controls are independent:
+
+- `warnings_enabled` controls only the guidance appended to tool results. Setting it to `false` does not disable either hard-stop gate.
+- `hard_stop_enabled` controls hard stops for repeated tool failures and defaults to `false`. In unattended deployments (gateway, cron, kanban workers), set it to `true` so repeated failures are blocked rather than only warned.
+- `no_progress_hard_stop_enabled` controls hard stops for repeated identical results from idempotent read-only tools and defaults to `true`. Set it to `false` to opt out, even when `hard_stop_enabled` is `true`.
+
+Both hard-stop gates use their corresponding values under `hard_stop_after`. See also [Docker / unattended deployments](docker.md).
 
 ## TTS Configuration
 

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -71,15 +71,19 @@ See the [Where the logs go](#where-the-logs-go) section below for the full routi
 :::
 
 :::note Tool-loop hard stops for unattended gateways
-The `tool_loop_guardrails.hard_stop_enabled` setting defaults to `false`, which is reasonable for interactive CLI and TUI sessions where a person can see repeated tool-call warnings. In unattended gateway or server deployments, warnings alone may not stop an agent that gets stuck in a repeated tool-call loop. Operators who want circuit-breaker behavior should explicitly enable hard stops in the profile's `config.yaml`:
+Failure-based hard stops remain opt-in: `tool_loop_guardrails.hard_stop_enabled` defaults to `false`, which is reasonable for interactive CLI and TUI sessions where a person can see repeated tool-call warnings. Repeated identical results from idempotent read-only tools use the independent `no_progress_hard_stop_enabled` gate, which defaults to `true`. For unattended gateway or server deployments, enable failure hard stops explicitly in the profile's `config.yaml`:
 
 ```yaml
 tool_loop_guardrails:
+  warnings_enabled: true
   hard_stop_enabled: true
+  no_progress_hard_stop_enabled: true
   hard_stop_after:
     exact_failure: 5
     idempotent_no_progress: 5
 ```
+
+Set `no_progress_hard_stop_enabled: false` to opt out of blocking repeated identical read-only results, even when `hard_stop_enabled` is `true`. Setting `warnings_enabled: false` only suppresses warning guidance; it does not disable either hard-stop gate.
 :::
 
 Note: the API server is gated on `API_SERVER_ENABLED=true`. To expose it beyond `127.0.0.1` inside the container, also set `API_SERVER_HOST=0.0.0.0` and an `API_SERVER_KEY` (minimum 8 characters — generate one with `openssl rand -hex 32`). Example:


### PR DESCRIPTION
## What does this PR do?

Stops a common instruction-reality mismatch loop by default when Hermes keeps
calling the same read-only tool with the same arguments and gets the exact same
result back. Before this change, the runtime only warned on repeated
idempotent no-progress results unless the user opted into hard stops globally,
so the agent could keep burning iterations even when the current state already
matched the user's request.

This keeps failure-based hard stops opt-in, but treats repeated identical
read-only results as a narrower default-stop case. That lets Hermes halt and
surface a controlled explanation when it is clearly not learning anything new
from another identical read.

## Related Issue

Fixes #53361

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `no_progress_hard_stop_enabled` to the tool loop guardrail config and
  made it default to `true` for repeated identical read-only results.
- Split `before_call()` so failure-based hard stops still honor
  `hard_stop_enabled`, while repeated idempotent no-progress results can block
  independently.
- Tightened the no-progress warning/block messages to explicitly tell the model
  to stop and report when the current state already satisfies the request.
- Updated `cli-config.yaml.example` to document the new default behavior and
  opt-out key.
- Added controller-level and runtime-level tests for the new default halt path
  and the config opt-out path.

## How to Test

1. Run `pytest tests/agent/test_tool_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py -q`
2. Confirm the new runtime test halts a repeated `read_file` loop with
   `idempotent_no_progress_block` by default.
3. Confirm the opt-out config test still allows warnings-only behavior when
   `no_progress_hard_stop_enabled` is set to `false`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation:

```text
$ pytest tests/agent/test_tool_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py -q
24 passed in 11.96s
```
