### PR TITLE
feat(mcp): add catalog JSON output

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -311,6 +311,57 @@ def catalog_diagnostics() -> List[tuple]:
     return list(_CATALOG_DIAGNOSTICS)
 
 
+def catalog_api_payload() -> Dict[str, Any]:
+    """Return the machine-readable catalog contract used by dashboard + CLI.
+
+    Keep this payload in sync with ``GET /api/mcp/catalog`` so command-line
+    consumers can build against the same stable shape as the control-center UI.
+    Secret values are never included; required env specs expose names/prompts
+    only.
+    """
+    catalog_entries = list_catalog()
+    installed_state = {
+        e.name: (is_installed(e.name), is_enabled(e.name))
+        for e in catalog_entries
+    }
+
+    entries = []
+    for entry in catalog_entries:
+        auth = entry.auth
+        transport = entry.transport
+        install = entry.install
+        entries.append({
+            "name": entry.name,
+            "description": entry.description,
+            "source": entry.source,
+            "transport": transport.type,
+            "auth_type": getattr(auth, "type", "none"),
+            "required_env": [
+                {"name": e.name, "prompt": e.prompt, "required": e.required}
+                for e in getattr(auth, "env", []) or []
+            ],
+            "command": transport.command,
+            "args": list(transport.args or []),
+            "url": transport.url,
+            "install_url": install.url if install else None,
+            "install_ref": install.ref if install else None,
+            "bootstrap": list(install.bootstrap) if install else [],
+            "default_enabled": list(entry.tools.default_enabled)
+            if entry.tools.default_enabled is not None
+            else None,
+            "post_install": entry.post_install or "",
+            "needs_install": entry.install is not None,
+            "installed": installed_state.get(entry.name, (False, False))[0],
+            "enabled": installed_state.get(entry.name, (False, False))[1],
+        })
+
+    diagnostics = [
+        {"name": n, "kind": k, "message": m}
+        for (n, k, m) in catalog_diagnostics()
+    ]
+    return {"entries": entries, "diagnostics": diagnostics}
+
+
 def get_entry(name: str) -> Optional[CatalogEntry]:
     """Look up a single entry by name. ``official/<name>`` prefix accepted."""
     if name.startswith("official/"):

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -868,7 +868,7 @@ def mcp_command(args):
         return
     if action == "catalog":
         from hermes_cli.mcp_picker import show_catalog
-        show_catalog()
+        show_catalog(json_output=getattr(args, "json", False))
         return
     if action == "install":
         from hermes_cli.mcp_picker import install_by_name

--- a/hermes_cli/mcp_picker.py
+++ b/hermes_cli/mcp_picker.py
@@ -18,6 +18,7 @@ entries in one session.
 
 from __future__ import annotations
 
+import json
 import sys
 from dataclasses import dataclass
 from typing import List, Optional
@@ -28,6 +29,7 @@ from hermes_cli.curses_ui import curses_single_select
 from hermes_cli.mcp_catalog import (
     CatalogEntry,
     CatalogError,
+    catalog_api_payload,
     catalog_diagnostics,
     install_entry,
     is_enabled,
@@ -266,8 +268,11 @@ def _print_rows_text(rows: List[_Row]) -> None:
     print()
 
 
-def show_catalog() -> None:
+def show_catalog(*, json_output: bool = False) -> None:
     """`hermes mcp catalog` — print the curated list + custom servers, no interaction."""
+    if json_output:
+        print(json.dumps(catalog_api_payload(), indent=2))
+        return
     _print_rows_text(_build_rows())
 
 

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -91,9 +91,14 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         "picker",
         help="Interactive catalog picker (also the default for `hermes mcp`)",
     )
-    mcp_sub.add_parser(
+    mcp_catalog_p = mcp_sub.add_parser(
         "catalog",
         help="List Nous-approved MCPs available for one-click install",
+    )
+    mcp_catalog_p.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the same machine-readable payload as GET /api/mcp/catalog",
     )
     mcp_install_p = mcp_sub.add_parser(
         "install",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8223,65 +8223,15 @@ async def list_mcp_catalog(profile: Optional[str] = None):
         _log.exception("mcp_catalog import failed")
         raise HTTPException(status_code=500, detail=f"Catalog unavailable: {exc}")
 
-    entries = []
     try:
         with _profile_scope(profile):
-            catalog_entries = list(mcp_catalog.list_catalog())
-            installed_state = {
-                e.name: (mcp_catalog.is_installed(e.name), mcp_catalog.is_enabled(e.name))
-                for e in catalog_entries
-            }
-        for entry in catalog_entries:
-            auth = entry.auth
-            transport = entry.transport
-            install = entry.install
-            entries.append({
-                "name": entry.name,
-                "description": entry.description,
-                "source": entry.source,
-                "transport": transport.type,
-                "auth_type": getattr(auth, "type", "none"),
-                # Env vars the user must supply (names + prompts only, never values).
-                "required_env": [
-                    {"name": e.name, "prompt": e.prompt, "required": e.required}
-                    for e in getattr(auth, "env", []) or []
-                ],
-                # Transport details so the UI can show exactly what connects/runs.
-                # The trust model (docs: user-guide/features/mcp) tells users to
-                # inspect command/args/url and the install bootstrap before
-                # installing — surface them rather than hiding them in the repo.
-                "command": transport.command,
-                "args": list(transport.args or []),
-                "url": transport.url,
-                # Git bootstrap (present only for entries that clone + build).
-                "install_url": install.url if install else None,
-                "install_ref": install.ref if install else None,
-                "bootstrap": list(install.bootstrap) if install else [],
-                # Default tool pre-selection hint and post-install guidance.
-                "default_enabled": list(entry.tools.default_enabled)
-                if entry.tools.default_enabled is not None
-                else None,
-                "post_install": entry.post_install or "",
-                "needs_install": entry.install is not None,
-                "installed": installed_state.get(entry.name, (False, False))[0],
-                "enabled": installed_state.get(entry.name, (False, False))[1],
-            })
+            return mcp_catalog.catalog_api_payload()
     except HTTPException:
         # Unknown/invalid profile → 404, not a silently-empty catalog.
         raise
     except Exception:
         _log.exception("list_mcp_catalog failed")
-
-    diagnostics = []
-    try:
-        diagnostics = [
-            {"name": n, "kind": k, "message": m}
-            for (n, k, m) in mcp_catalog.catalog_diagnostics()
-        ]
-    except Exception:
-        pass
-
-    return {"entries": entries, "diagnostics": diagnostics}
+        return {"entries": [], "diagnostics": []}
 
 
 class MCPCatalogInstall(BaseModel):

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -7,6 +7,7 @@ launch an MCP is mocked.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -812,3 +813,73 @@ class TestShippedCatalog:
             assert entry.name
             assert entry.description
             assert entry.transport.type in ("stdio", "http")
+
+
+class TestCatalogJsonOutput:
+    def test_catalog_payload_matches_dashboard_contract(self, catalog_dir):
+        _write_manifest(
+            catalog_dir,
+            "demo",
+            _basic_manifest(
+                auth={
+                    "type": "api_key",
+                    "env": [
+                        {
+                            "name": "DEMO_KEY",
+                            "prompt": "API key",
+                            "required": True,
+                            "secret": True,
+                        }
+                    ],
+                },
+                install={
+                    "type": "git",
+                    "url": "https://example.com/demo.git",
+                    "ref": "v1.0.0",
+                    "bootstrap": ["uv sync"],
+                },
+                tools={"default_enabled": ["search"]},
+                post_install="Restart Hermes.",
+            ),
+        )
+
+        from hermes_cli.mcp_catalog import catalog_api_payload
+
+        assert catalog_api_payload() == {
+            "entries": [
+                {
+                    "name": "demo",
+                    "description": "Demo MCP",
+                    "source": "https://example.com",
+                    "transport": "stdio",
+                    "auth_type": "api_key",
+                    "required_env": [
+                        {"name": "DEMO_KEY", "prompt": "API key", "required": True}
+                    ],
+                    "command": "npx",
+                    "args": ["-y", "demo-mcp"],
+                    "url": None,
+                    "install_url": "https://example.com/demo.git",
+                    "install_ref": "v1.0.0",
+                    "bootstrap": ["uv sync"],
+                    "default_enabled": ["search"],
+                    "post_install": "Restart Hermes.",
+                    "needs_install": True,
+                    "installed": False,
+                    "enabled": False,
+                }
+            ],
+            "diagnostics": [],
+        }
+
+    def test_catalog_json_cli_prints_payload(self, catalog_dir, capsys):
+        _write_manifest(catalog_dir, "demo", _basic_manifest())
+
+        from hermes_cli.mcp_picker import show_catalog
+
+        show_catalog(json_output=True)
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["entries"][0]["name"] == "demo"
+        assert payload["entries"][0]["transport"] == "stdio"
+        assert payload["diagnostics"] == []


### PR DESCRIPTION
## Summary
- add `hermes mcp catalog --json` for the same machine-readable payload as `GET /api/mcp/catalog`
- centralize the catalog payload shape in `mcp_catalog.catalog_api_payload()` and reuse it from the dashboard endpoint
- cover the shared payload contract and CLI JSON output with tests

## Test Plan
- `python3 -m pytest tests/hermes_cli/test_mcp_catalog.py::TestCatalogJsonOutput -q -o 'addopts='`
- `python3 -m pytest tests/hermes_cli/test_mcp_catalog.py -q -o 'addopts='`
- `tmp=$(mktemp -d); HERMES_HOME="$tmp" python3 -m hermes_cli.main mcp catalog --json > /tmp/mcp-catalog.json && python3 - <<'PY' ...`
- `python3 -m py_compile hermes_cli/mcp_catalog.py hermes_cli/mcp_picker.py hermes_cli/mcp_config.py hermes_cli/subcommands/mcp.py hermes_cli/web_server.py`
