### PR TITLE
fix(cron): MCP tools must respect enabled_toolsets on cron jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -182,19 +182,20 @@ def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
 
 
 def _merge_mcp_into_per_job_toolsets(per_job: list[str], cfg: dict) -> list[str]:
-    """Layer enabled MCP servers onto a per-job ``enabled_toolsets`` allowlist.
+    """Apply MCP server allowlist semantics to per-job ``enabled_toolsets``.
 
-    A per-job list scopes the *native* toolsets, but on its own it silently
-    drops every MCP server: ``discover_mcp_tools()`` registers the tools into
-    the global registry, yet ``get_tool_definitions(enabled_toolsets=...)``
-    only keeps toolsets named in the list. The agent then rejects every
-    ``mcp_*`` call with "Unknown tool". This restores parity with
-    ``_get_platform_tools`` MCP semantics:
+    A per-job ``enabled_toolsets`` is the user's explicit allowlist: they get
+    exactly the native toolsets and MCP server names they listed.  Unlike the
+    platform-default path (``_get_platform_tools``), per-job lists do NOT
+    auto-add every globally-enabled MCP server — that would bypass the
+    restrictive intent of ``enabled_toolsets`` and let cron jobs access
+    desktop/browser automation tools the user never opted into (#53416).
 
       * ``no_mcp`` sentinel present  -> no MCP servers (sentinel stripped)
       * one or more MCP server names already listed -> treat as an allowlist,
         add nothing further (the user named exactly the servers they want)
-      * otherwise -> union in every globally-enabled MCP server
+      * otherwise -> no MCP servers added (the list already says everything
+        the user wants)
     """
     result = [t for t in per_job if t != "no_mcp"]
     if "no_mcp" in per_job:
@@ -206,9 +207,8 @@ def _merge_mcp_into_per_job_toolsets(per_job: list[str], cfg: dict) -> list[str]
     enabled_mcp = enabled_mcp_server_names(cfg)
     if set(result) & enabled_mcp:
         return result
-    for name in sorted(enabled_mcp):
-        if name not in result:
-            result.append(name)
+    # Per-job enabled_toolsets is a restrictive allowlist — do NOT auto-add
+    # all globally-enabled MCP servers. The user gets exactly what they listed.
     return result
 
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -30,11 +30,16 @@ class TestPerJobToolsetMcpMerge:
     def _enabled_names(self):
         return {"finnhub", "playwright", "string_enabled"}
 
-    def test_native_only_list_gets_all_enabled_mcp_servers(self):
+    def test_native_only_list_gets_no_mcp_servers(self):
+        """A native-only list gets no MCP servers — enabled_toolsets is restrictive."""
         result = _merge_mcp_into_per_job_toolsets(["web", "terminal"], self.CFG)
-        assert result[:2] == ["web", "terminal"]
-        assert set(result) == {"web", "terminal"} | self._enabled_names()
+        assert result == ["web", "terminal"]
+        assert not (set(result) & self._enabled_names())
 
+    def test_disabled_servers_are_not_added(self):
+        result = _merge_mcp_into_per_job_toolsets(["web"], self.CFG)
+        assert result == ["web"]
+        assert "disabled_one" not in result
 
     def test_explicit_mcp_name_is_treated_as_allowlist(self):
         # User named one server -> add nothing further.
@@ -47,6 +52,19 @@ class TestPerJobToolsetMcpMerge:
         assert result == ["web"]
         assert not (set(result) & self._enabled_names())
 
+    def test_no_mcp_config_adds_nothing(self):
+        result = _merge_mcp_into_per_job_toolsets(["web"], {})
+        assert result == ["web"]
+
+    def test_no_duplicate_when_listed_name_also_globally_enabled(self):
+        result = _merge_mcp_into_per_job_toolsets(["finnhub", "finnhub"], self.CFG)
+        assert result.count("finnhub") == 2  # input dups preserved, none added
+
+    def test_resolver_uses_merge_for_per_job_lists(self):
+        job = {"enabled_toolsets": ["web", "terminal"]}
+        result = _resolve_cron_enabled_toolsets(job, self.CFG)
+        assert set(result) == {"web", "terminal"}
+        assert not (set(result) & self._enabled_names())
 
     def test_resolver_empty_per_job_falls_through_to_platform(self):
         # No per-job list -> must delegate to _get_platform_tools (the platform
@@ -1899,5 +1917,3 @@ class TestSetCronSessionTitle:
         out = _set_cron_session_title(db, "sess-1", "Nightly Synthesis")
         assert out == "Nightly Synthesis #2"
         db.get_next_title_in_lineage.assert_called_once_with("Nightly Synthesis")
-
-


### PR DESCRIPTION
Fixes #53416

## Description

When a cron job specifies `enabled_toolsets` (e.g. `["web", "file"]`), 
all globally-enabled MCP servers were unconditionally auto-added to the 
toolset list by `_merge_mcp_into_per_job_toolsets`. This meant a cron job
restricted to API-only tools could still access desktop/browser automation
tools from MCP servers — bypassing the restrictive intent of `enabled_toolsets`.

Per-job `enabled_toolsets` is now treated as a true restrictive allowlist:
the user gets exactly the native toolsets and MCP server names they listed.
No auto-addition of globally-enabled MCP servers unless the user explicitly
named them.

The platform-default path (`_get_platform_tools`) is unchanged — toolsets
resolved from `platform_toolsets` still auto-include MCP servers as before,
so users who don't set per-job `enabled_toolsets` keep their existing MCP
access.

## Semantics (after fix)

| Per-job enabled_toolsets | MCP servers available |
|---|---|
| `["web", "file"]` | None (user didn't name any MCP server) |
| `["web", "cua-driver"]` | Only `mcp-cua-driver` |
| `["no_mcp"]` | None (explicit sentinel) |
| `None` (not set) | Platform default (may include all enabled MCP servers) |

## Verification

- 8/8 targeted tests pass (`TestPerJobToolsetMcpMerge`)  
- Secrets scan: clean  
- Personal refs scan: clean  
- Compile-check: both modified files pass `compile()`  
- Only the two intended files changed