### PR TITLE
fix(gateway): seed Discord thread session for send_message mirror

### DIFF
--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -30,12 +30,22 @@ def mirror_to_session(
     thread_id: Optional[str] = None,
     user_id: Optional[str] = None,
     role: str = "assistant",
+    seed_if_missing: bool = False,
 ) -> bool:
     """
     Append a delivery-mirror message to the target session's transcript.
 
     Finds the gateway session that matches the given platform + chat_id,
     then writes a mirror entry to both the JSONL transcript and SQLite DB.
+
+    When no matching session exists the mirror normally no-ops and returns
+    False. Pass ``seed_if_missing=True`` to instead create (seed) a session
+    for that target first, then write the mirror into it. This is how an
+    outgoing ``send_message`` to a Discord thread that has never been talked
+    to before still lands in session history, so a later ``@mention`` in that
+    same thread remembers what the bot said (issue #53414). Seeding is opt-in
+    so the cron fan-out path — which deliberately frames briefs out-of-band —
+    keeps its no-op-on-missing behavior unchanged.
 
     ``role`` defaults to ``"assistant"`` — correct for the interactive
     ``send_message`` mirror, where the mirrored text is the agent's own
@@ -59,14 +69,22 @@ def mirror_to_session(
             user_id=user_id,
         )
         if not session_id:
-            logger.debug(
-                "Mirror: no session found for %s:%s:%s:%s",
-                platform,
-                chat_id,
-                thread_id,
-                user_id,
-            )
-            return False
+            if seed_if_missing:
+                session_id = _seed_session_id(
+                    platform,
+                    str(chat_id),
+                    thread_id=thread_id,
+                    user_id=user_id,
+                )
+            if not session_id:
+                logger.debug(
+                    "Mirror: no session found for %s:%s:%s:%s",
+                    platform,
+                    chat_id,
+                    thread_id,
+                    user_id,
+                )
+                return False
 
         mirror_msg = {
             "role": role,
@@ -163,6 +181,67 @@ def _find_session_id(
 
     best_entry = max(candidates, key=lambda entry: entry.get("updated_at", ""))
     return best_entry.get("session_id")
+
+
+def _seed_session_id(
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+) -> Optional[str]:
+    """
+    Create a gateway session for *platform*/*chat_id* and return its id.
+
+    Used when a ``send_message`` targets a chat/thread that has no session yet
+    (issue #53414). Reuses the gateway's own ``SessionStore`` /
+    ``SessionSource`` so the new entry is keyed identically to one created by
+    an inbound message — same ``sessions.json`` routing index and same SQLite
+    record — and a subsequent ``_find_session_id`` for that target resolves to
+    it. Returns None (and logs at debug) if the session machinery is
+    unavailable; the caller then falls back to the no-op behavior.
+    """
+    try:
+        from gateway.config import Platform, load_gateway_config
+        from gateway.session import SessionSource, SessionStore
+
+        seed_chat_id = str(chat_id)
+        parent_chat_id = None
+        chat_type = "thread" if thread_id else "channel"
+        if thread_id and str(platform).lower() == "discord":
+            # Discord's inbound adapter keys a thread's session with the
+            # thread's OWN id as chat_id (build_source(chat_id=thread.id,
+            # thread_id=thread.id) in plugins/platforms/discord/adapter.py).
+            # A send_message target, by contrast, is parsed as
+            # ``discord:<parent_channel>:<thread>`` — chat_id is the parent.
+            # Seed with the thread id as chat_id so the session key matches the
+            # one a later @mention in that thread resolves to (issue #53414);
+            # keep the parent for routing context.
+            if seed_chat_id != str(thread_id):
+                parent_chat_id = seed_chat_id
+            seed_chat_id = str(thread_id)
+        source = SessionSource(
+            platform=Platform(str(platform).lower()),
+            chat_id=seed_chat_id,
+            chat_type=chat_type,
+            thread_id=str(thread_id) if thread_id else None,
+            user_id=str(user_id) if user_id else None,
+            parent_chat_id=parent_chat_id,
+        )
+        # Pin the store to mirror's own sessions dir so the seeded entry lands
+        # exactly where _find_session_id reads it back.
+        store = SessionStore(_SESSIONS_DIR, load_gateway_config())
+        entry = store.get_or_create_session(source)
+        return entry.session_id
+    except Exception as e:
+        logger.debug(
+            "Mirror: failed to seed session for %s:%s:%s:%s: %s",
+            platform,
+            chat_id,
+            thread_id,
+            user_id,
+            e,
+        )
+        return None
 
 
 

--- a/tests/gateway/test_mirror.py
+++ b/tests/gateway/test_mirror.py
@@ -239,7 +239,114 @@ class TestMirrorToSession:
 
         assert result is False
 
-    def test_error_returns_false(self, tmp_path):
+    def test_no_seed_by_default(self, tmp_path):
+        """Without seed_if_missing, a missing session is a no-op (cron path)."""
+        sessions_dir, index_file = _setup_sessions(tmp_path, {})
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
+             patch("gateway.mirror._seed_session_id") as mock_seed:
+            result = mirror_to_session("discord", "99999", "Hello!", thread_id="t1")
+
+        assert result is False
+        mock_seed.assert_not_called()
+
+    def test_seed_if_missing_creates_and_mirrors(self, tmp_path):
+        """seed_if_missing seeds a session then writes the mirror into it."""
+        sessions_dir, index_file = _setup_sessions(tmp_path, {})
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
+             patch("gateway.mirror._seed_session_id", return_value="sess_seeded") as mock_seed, \
+             patch("gateway.mirror._append_to_sqlite") as mock_sqlite:
+            result = mirror_to_session(
+                "discord",
+                "99999",
+                "Hello!",
+                thread_id="t1",
+                user_id="u1",
+                seed_if_missing=True,
+            )
+
+        assert result is True
+        mock_seed.assert_called_once_with("discord", "99999", thread_id="t1", user_id="u1")
+        mock_sqlite.assert_called_once()
+        assert mock_sqlite.call_args[0][0] == "sess_seeded"
+
+    def test_seed_failure_returns_false(self, tmp_path):
+        """If seeding can't produce a session, fall back to the no-op."""
+        sessions_dir, index_file = _setup_sessions(tmp_path, {})
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
+             patch("gateway.mirror._seed_session_id", return_value=None), \
+             patch("gateway.mirror._append_to_sqlite") as mock_sqlite:
+            result = mirror_to_session(
+                "discord", "99999", "Hello!", thread_id="t1", seed_if_missing=True,
+            )
+
+        assert result is False
+        mock_sqlite.assert_not_called()
+
+    def test_seed_session_id_uses_session_store(self, tmp_path):
+        """_seed_session_id reuses SessionStore/SessionSource for a thread send,
+        keyed the way the Discord adapter keys an inbound thread session
+        (chat_id == thread id) so a later @mention resolves to it (#53414)."""
+        sessions_dir, _ = _setup_sessions(tmp_path, {})
+        fake_entry = MagicMock(session_id="sess_brand_new")
+        fake_store = MagicMock()
+        fake_store.get_or_create_session.return_value = fake_entry
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch("gateway.session.SessionStore", return_value=fake_store) as mock_store_cls, \
+             patch("gateway.config.load_gateway_config", return_value=MagicMock()):
+            result = mirror_mod._seed_session_id(
+                "discord", "999parent", thread_id="555thread", user_id="u1",
+            )
+
+        assert result == "sess_brand_new"
+        fake_store.get_or_create_session.assert_called_once()
+        source = fake_store.get_or_create_session.call_args[0][0]
+        # Must match the inbound adapter shape: thread id as chat_id, parent kept.
+        assert source.chat_id == "555thread"
+        assert source.thread_id == "555thread"
+        assert source.parent_chat_id == "999parent"
+        assert source.chat_type == "thread"
+
+    def test_seeded_thread_key_matches_inbound_adapter_key(self, tmp_path):
+        """A send to discord:<parent>:<thread> must seed a session whose key
+        equals the one the Discord adapter builds for an inbound thread
+        message, so a later @mention in that thread reuses it (#53414)."""
+        from gateway.config import Platform
+        from gateway.session import SessionSource, build_session_key
+
+        sessions_dir, _ = _setup_sessions(tmp_path, {})
+        fake_store = MagicMock()
+        fake_store.get_or_create_session.return_value = MagicMock(session_id="s")
+
+        # Capture the SessionSource _seed_session_id actually builds for the
+        # send target "discord:999parent:555thread".
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch("gateway.session.SessionStore", return_value=fake_store), \
+             patch("gateway.config.load_gateway_config", return_value=MagicMock()):
+            mirror_mod._seed_session_id(
+                "discord", "999parent", thread_id="555thread", user_id="bot",
+            )
+        seed_source = fake_store.get_or_create_session.call_args[0][0]
+
+        # SessionSource as plugins/platforms/discord/adapter.py builds for an
+        # inbound thread message (chat_id == thread id), possibly a different
+        # participant — thread sessions are shared, so the user must not matter.
+        inbound_source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="555thread",
+            chat_type="thread",
+            thread_id="555thread",
+            parent_chat_id="999parent",
+            user_id="some_human",
+        )
+
+        assert build_session_key(seed_source) == build_session_key(inbound_source)
         with patch("gateway.mirror._find_session_id", side_effect=Exception("boom")):
             result = mirror_to_session("telegram", "123", "msg")
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -476,6 +476,7 @@ class TestSendMessageTool:
             source_label="telegram",
             thread_id=None,
             user_id="user-123",
+            seed_if_missing=False,
         )
 
     def test_media_tag_outside_allowed_roots_is_not_sent(self, tmp_path, monkeypatch):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -460,6 +460,7 @@ def _handle_send(args):
                     source_label=source_label,
                     thread_id=thread_id,
                     user_id=user_id,
+                    seed_if_missing=(platform_name == "discord" and bool(thread_id)),
                 ):
                     result["mirrored"] = True
             except Exception:


### PR DESCRIPTION
## What does this PR do?

Outgoing messages the agent posts to a Discord thread via the `send_message` tool weren't reaching session history when that thread had no session yet, so a later `@mention` in the same thread had no record of what the bot just said (#53414).

`tools/send_message_tool.py` mirrors a sent message into the target's gateway session via `gateway.mirror.mirror_to_session()`, but that helper returns `False` and no-ops when no matching session exists. For a brand-new Discord thread there is no session to mirror into, so the message is dropped from history.

This adds an opt-in seed step. `mirror_to_session()` gains a `seed_if_missing` flag; when set and no session is found, it creates one through the gateway's own `SessionStore`/`SessionSource` and then writes the mirror into it. The send_message mirror passes the flag for Discord thread sends only.

The seed is keyed the same way the Discord adapter keys an inbound thread message — `chat_id == thread id` (see `plugins/platforms/discord/adapter.py`, which builds the source with `chat_id=str(effective_channel.id)` and `thread_id`). A `send_message` target like `discord:<parent>:<thread>` parses to `chat_id=<parent>`, so seeding naively would key the session under the parent channel and a later thread mention would never find it. Seeding under the thread id makes the key match, and because `get_or_create_session` is idempotent on the session key, seeding is a no-op when an inbound session already exists (no duplicate).

Cron delivery also calls `mirror_to_session()` but does not opt in, so its out-of-band framing (and role-alternation behavior) is unchanged.

## Related Issue

Fixes #53414

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/mirror.py`: add `seed_if_missing` param to `mirror_to_session()` and a `_seed_session_id()` helper that creates a session via `SessionStore`/`SessionSource`, keyed to match the Discord adapter's inbound thread shape (`chat_id == thread id`, parent kept as `parent_chat_id`).
- `tools/send_message_tool.py`: pass `seed_if_missing=(platform_name == "discord" and bool(thread_id))` on the send_message mirror.
- `tests/gateway/test_mirror.py`: cover the seed path, the default no-seed (cron) path, seed failure, and that the seeded session key equals the inbound adapter key.
- `tests/tools/test_send_message_tool.py`: update the mirror call assertion for the new kwarg.

## How to Test

1. `pytest tests/tools/test_send_message_tool.py tests/gateway/test_mirror.py -q` → all pass.
2. The new `test_seeded_thread_key_matches_inbound_adapter_key` proves a `discord:<parent>:<thread>` send seeds a session whose key matches the one a later inbound thread `@mention` resolves to.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure Python)
- [x] Tool descriptions/schemas — N/A (no tool-facing behavior change)
