### PR TITLE
ci(docker): skip arm64 registry cache export on pull_request builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -173,7 +173,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Build once, load into the local daemon for testing, then push
-      # by digest below. Reads AND writes the registry-backed cache so the
+      # by digest below. Reads the registry-backed cache on every event and
+      # writes it only on push-to-main / release (see cache-to below), so the
       # push reuses layers from this build and the next build starts warm.
       #
       # Registry cache (type=registry on ghcr.io) is used instead of the gha
@@ -191,7 +192,16 @@ jobs:
           build-args: |
             HERMES_GIT_SHA=${{ github.sha }}
           cache-from: type=registry,ref=ghcr.io/nousresearch/hermes-agent:buildcache-arm64
-          cache-to: type=registry,ref=ghcr.io/nousresearch/hermes-agent:buildcache-arm64,mode=max
+          # Write the shared registry cache only when the job's GITHUB_TOKEN has
+          # packages:write — i.e. on push-to-main / release. On pull_request
+          # events the token is downgraded to read-only (always for fork PRs,
+          # regardless of the packages:write permission declared above), so an
+          # unconditional cache-to fails the export with
+          # "denied: installation not allowed to Write organization package"
+          # and breaks an otherwise-green build. PRs still READ the cache
+          # (cache-from above), so they stay warm; they just never write it.
+          # An empty cache-to is a no-op, matching this step's documented intent.
+          cache-to: ${{ ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release') && 'type=registry,ref=ghcr.io/nousresearch/hermes-agent:buildcache-arm64,mode=max' || '' }}
 
       - name: Install uv for docker tests
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0


### PR DESCRIPTION
## Summary

The `build-arm64` job in `.github/workflows/docker.yml` fails on **every pull_request that rebuilds layers**, at the very last step — exporting the build cache:

```
#50 exporting cache to registry
#50 ERROR: error writing layer blob: denied: installation not allowed to Write organization package
ERROR: failed to solve: error writing layer blob: denied: installation not allowed to Write organization package
```

The image builds fine and the integration tests would pass — only the **cache write** fails.

## Root cause

`build-arm64` uses a registry-backed cache on ghcr.io:

```yaml
cache-to: type=registry,ref=ghcr.io/nousresearch/hermes-agent:buildcache-arm64,mode=max
```

This is applied **unconditionally**, on every event. Writing that cache needs `packages: write`. On `pull_request` events the job's `GITHUB_TOKEN` is downgraded to **read-only** — always for fork PRs, regardless of the `packages: write` declared on the workflow — so the export is denied and the build is marked failed.

`build-amd64` is unaffected because it uses `type=gha` cache, which is writable from PR scope.

Notably the step's own comment already documents the *intended* behavior:

> Log in to ghcr.io so the registry-backed build cache below can be **read (cache-from) on every event** and **written (cache-to) on push/release**.

…but the implementation never gated the write. This PR makes the code match that documented intent.

## Fix

Gate `cache-to` to push-to-main / release (where the token has `packages: write`):

```yaml
cache-to: ${{ ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release') && 'type=registry,ref=ghcr.io/nousresearch/hermes-agent:buildcache-arm64,mode=max' || '' }}
```

- **push-to-main / release** → the expression yields the original string **verbatim** — publish path is byte-identical.
- **any pull_request** → `''`, which build-push-action treats as a no-op (no `--cache-to` passed), so the denied write never happens.
- `cache-from` is left unchanged, so PRs still **read** the warm cache; they just never write it.

The gate predicate is identical to the eight existing publish-step `if:` conditions in this same workflow, so it inherits the same (proven) `workflow_call` event/ref propagation.

## Verification

- `actionlint` clean; YAML parses.
- Per-event evaluation of the expression confirmed for push-main / push-other / release / fork-PR / same-repo-PR.
- Confirmed at the source level that an empty `cache-to` is a no-op in `docker/build-push-action@v7.1.0` (toolkit `getList` returns `[]` for `''`), and that a `cache-from` miss is non-fatal.
- Build + `tests/docker/` still run on PRs — only the cache write is removed.

This is a CI-only change; no application code is touched.