### PR TITLE
fix(desktop): let composer status titles use row width

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -126,7 +126,7 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
       >
         <span
           className={cn(
-            'min-w-0 max-w-[18rem] truncate text-[0.73rem] leading-4',
+            'min-w-0 flex-1 truncate text-[0.73rem] leading-4',
             failed
               ? 'text-destructive/90'
               : item.todoStatus && item.todoStatus !== 'in_progress'


### PR DESCRIPTION
## What does this PR do?

Fixes premature truncation in the desktop composer status/task rows.

The task title span had a fixed `max-w-[18rem]`, so long task labels truncated early even when the status row had more horizontal space available. This replaces that fixed cap with `flex-1`, allowing the title to use the available row width before truncating.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/status-stack/status-row.tsx`: replace the status item title's fixed `max-w-[18rem]` with `flex-1` so truncation happens at the available row width.

## How to Test

1. Run `npm --workspace apps/desktop run build`.
2. Run `npm --workspace apps/desktop run pack`.
3. Launch `apps/desktop/release/win-unpacked/Hermes.exe` on Windows.
4. Send a prompt that creates several visible tasks with intentionally long titles and verify the composer task/status stack uses the available row width before truncating.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass. Not run; one-line desktop UI class change.
- [ ] I've added tests for my changes. Not added; visual layout fix covered by manual desktop validation.
- [x] I've tested on my platform: Windows 11 desktop build/manual visual check

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, desktop CSS/layout only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Validated locally on Windows with a rebuilt desktop app and long task labels in the composer task/status stack.
