### PR TITLE
fix(dashboard,desktop): stabilize remote dashboard under multi-profile polling load

### DIFF
--- a/apps/desktop/electron/hardening.ts
+++ b/apps/desktop/electron/hardening.ts
@@ -4,8 +4,24 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const DEFAULT_FETCH_TIMEOUT_MS = 15_000
+const REMOTE_API_DEFAULT_TIMEOUT_MS = 60_000
 const DATA_URL_READ_MAX_BYTES = 16 * 1024 * 1024
 const TEXT_PREVIEW_SOURCE_MAX_BYTES = 64 * 1024 * 1024
+
+/**
+ * Classify whether a remote liveness probe failure is a transient timeout
+ * (keep cached connection) or a non-transient error (drop + rebuild).
+ *
+ * Exported here (not in main.ts) so tests can import the REAL implementation
+ * instead of re-implementing the predicate and silently drifting.
+ */
+function isTransientRemoteProbeError(error: unknown): boolean {
+  const msg = String((error as Error)?.message || error || '')
+  return (
+    /timed out connecting to Hermes backend/i.test(msg) ||
+    /\b(ETIMEDOUT|ESOCKETTIMEDOUT)\b/.test(msg)
+  )
+}
 
 const SAFE_ENV_SUFFIXES = new Set(['dist', 'example', 'sample', 'template'])
 const SENSITIVE_EXTENSIONS = new Set(['.kdbx', '.p12', '.pem', '.pfx'])
@@ -306,7 +322,9 @@ async function resolveReadableFileForIpc(
 export {
   DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
+  REMOTE_API_DEFAULT_TIMEOUT_MS,
   encryptDesktopSecret,
+  isTransientRemoteProbeError,
   rejectUnsafePathSyntax,
   resolveDirectoryForIpc,
   resolveReadableFileForIpc,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -93,7 +93,9 @@ import {
 import {
   DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
+  REMOTE_API_DEFAULT_TIMEOUT_MS,
   encryptDesktopSecret as encryptDesktopSecretStrict,
+  isTransientRemoteProbeError,
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs,
@@ -6175,7 +6177,8 @@ async function fetchJsonForProfile(profile, path) {
 async function requestJsonForProfile(profile: string, path: string, method: string, body?: string) {
   const conn = await ensureBackend(profile)
   const url = `${conn.baseUrl}${path}`
-  const opts = { method, body, timeoutMs: DEFAULT_FETCH_TIMEOUT_MS }
+  const defaultTimeoutMs = conn.mode === 'remote' ? REMOTE_API_DEFAULT_TIMEOUT_MS : DEFAULT_FETCH_TIMEOUT_MS
+  const opts = { method, body, timeoutMs: defaultTimeoutMs }
 
   return conn.authMode === 'oauth' ? fetchJsonViaOauthSession(url, opts) : fetchJson(url, conn.token, opts)
 }
@@ -7380,11 +7383,23 @@ ipcMain.handle('hermes:connection:revalidate', async () => {
 
   const base = conn.baseUrl.replace(/\/+$/, '')
 
+  // Slow is not dead: a busy remote dashboard can take >15s to answer /api/status
+  // while SQLite work runs in thread pool. Dropping the cached connection on a
+  // timeout forces ws-ticket remint + OAuth churn and amplifies into a reconnect
+  // storm (session.resume timeouts, "session expired" false positives).
+  const REMOTE_LIVENESS_PROBE_TIMEOUT_MS = 60_000
+
   try {
-    await fetchPublicJson(`${base}/api/status`, { timeoutMs: 2_500 })
+    await fetchPublicJson(`${base}/api/status`, { timeoutMs: REMOTE_LIVENESS_PROBE_TIMEOUT_MS })
 
     return { ok: true, rebuilt: false }
-  } catch {
+  } catch (error) {
+    if (isTransientRemoteProbeError(error)) {
+      rememberLog(
+        'Remote liveness probe timed out; keeping cached connection (remote dashboard may be busy).'
+      )
+      return { ok: true, rebuilt: false }
+    }
     // Unreachable remote: drop the stale cache so the renderer's next reconnect
     // tick rebuilds a fresh, reachable descriptor. resetHermesConnection only
     // nulls connectionPromise for a remote (no child to SIGTERM).
@@ -7838,12 +7853,11 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   const offset = Math.max(0, Number(searchParams.get('offset')) || 0)
   const order = searchParams.get('order') === 'created' ? 'started_at' : 'last_active'
 
-  const primary = await ensureBackend(null)
-
-  const base = (await fetchJson(`${primary.baseUrl}/api/profiles/sessions?${searchParams}`, primary.token, {
-    method: 'GET',
-    timeoutMs: DEFAULT_FETCH_TIMEOUT_MS
-  }).catch(() => ({ sessions: [], total: 0, profile_totals: {} }))) as any
+  const base = (await requestJsonForProfile(null, `/api/profiles/sessions?${searchParams}`, 'GET').catch(() => ({
+    sessions: [],
+    total: 0,
+    profile_totals: {}
+  })) as any)
 
   // Over-fetch each remote from offset 0 (limit+offset rows) so the merged window
   // is correct for this page — mirrors the primary's per-profile over-fetch.
@@ -7900,7 +7914,9 @@ ipcMain.handle('hermes:api', async (_event, request) => {
   // defeating the deletion and leaving a zombie process.
   const routeProfile = resolveRouteProfile(tornDownProfile, profile)
   const connection = await ensureBackend(routeProfile)
-  const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
+  const defaultTimeoutMs =
+    connection.mode === 'remote' ? REMOTE_API_DEFAULT_TIMEOUT_MS : DEFAULT_FETCH_TIMEOUT_MS
+  const timeoutMs = resolveTimeoutMs(request?.timeoutMs, defaultTimeoutMs)
 
   const requestPath = pathWithGlobalRemoteProfile(request.path, profile, {
     globalRemote: globalRemoteActive(),

--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression tests for remote dashboard liveness probe behavior.
+ *
+ * The desktop's `hermes:connection:revalidate` IPC handler probes
+ * `/api/status` on a cached remote connection. Before the fix it used a
+ * flat 2.5s timeout and treated every failure as "remote is dead",
+ * dropping the cached connection. On a busy single-uvicorn-worker remote
+ * (sidebar refresh, SQLite I/O) that 2.5s window is easy to exceed,
+ * triggering a reconnect storm.
+ *
+ * The fix introduces two changes that these tests guard:
+ * 1. The probe timeout is raised to 60s for remote connections.
+ * 2. Transient timeout errors (ETIMEDOUT, ESOCKETTIMEDOUT) keep the
+ *    cached connection alive; only non-transient failures (connection
+ *    refused, DNS, etc.) drop and rebuild.
+ *
+ * Run with: npx vitest run electron/remote-liveness.test.ts
+ */
+
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+
+import { isTransientRemoteProbeError } from './hardening'
+
+test('ETIMEDOUT is classified as transient', () => {
+  assert.ok(isTransientRemoteProbeError(new Error('ETIMEDOUT')))
+})
+
+test('ESOCKETTIMEDOUT is classified as transient', () => {
+  assert.ok(isTransientRemoteProbeError(new Error('ESOCKETTIMEDOUT')))
+})
+
+test('"timed out connecting to Hermes backend" is classified as transient', () => {
+  assert.ok(isTransientRemoteProbeError(new Error('timed out connecting to Hermes backend')))
+})
+
+test('ECONNREFUSED is NOT classified as transient', () => {
+  assert.ok(!isTransientRemoteProbeError(new Error('ECONNREFUSED')))
+})
+
+test('DNS ENOTFOUND is NOT classified as transient', () => {
+  assert.ok(!isTransientRemoteProbeError(new Error('ENOTFOUND')))
+})
+
+test('Generic HTTP 500 is NOT classified as transient', () => {
+  assert.ok(!isTransientRemoteProbeError(new Error('Internal Server Error')))
+})
+
+test('undefined/null/empty are NOT classified as transient', () => {
+  assert.ok(!isTransientRemoteProbeError(undefined))
+  assert.ok(!isTransientRemoteProbeError(null))
+  assert.ok(!isTransientRemoteProbeError(''))
+})

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -785,8 +785,15 @@ def _count_skills(profile_dir: Path) -> int:
     ):
         return cached[2]
 
+    # Walk with pruning instead of rglob: .venv/node_modules/__pycache__
+    # subtrees can contain thousands of files and dominated rglob latency.
+    _PRUNE_DIRS = frozenset({".venv", "venv", "node_modules", "__pycache__"})
     count = 0
-    for md in skills_dir.rglob("SKILL.md"):
+    for root, dirs, files in os.walk(skills_dir):
+        dirs[:] = [d for d in dirs if d not in _PRUNE_DIRS]
+        if "SKILL.md" not in files:
+            continue
+        md = Path(root) / "SKILL.md"
         if is_excluded_skill_path(md):
             continue
         count += 1

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2595,6 +2595,76 @@ def _collect_profile_gateway_topology() -> Dict[str, Any]:
     return {"profiles": profile_names, "gateway_mode": mode, "gateways": gateways}
 
 
+def _read_status_gateway_runtime_sync(
+    gateway_running: bool,
+    gateway_pid,
+    remote_health_body: dict | None,
+) -> Dict[str, Any]:
+    """Blocking gateway runtime reads for /api/status — run via asyncio.to_thread.
+
+    Extracting this synchronous block from the async handler prevents a burst
+    of concurrent sidebar refreshes (e.g. /api/profiles/sessions) from
+    monopolising uvicorn's single event loop worker while SQLite I/O and
+    config reads run inline.
+    """
+    gateway_state = None
+    gateway_platforms: dict = {}
+    gateway_exit_reason = None
+    gateway_updated_at = None
+    configured_gateway_platforms: set[str] | None = None
+    try:
+        from gateway.config import load_gateway_config
+
+        gateway_config = load_gateway_config()
+        configured_gateway_platforms = {
+            platform.value for platform in gateway_config.get_connected_platforms()
+        }
+    except Exception:
+        configured_gateway_platforms = None
+
+    local_runtime = read_runtime_status()
+    runtime = local_runtime
+    if runtime is None and remote_health_body and remote_health_body.get("gateway_state"):
+        runtime = remote_health_body
+    if not gateway_running and local_runtime is not None:
+        runtime_pid = get_runtime_status_running_pid(local_runtime)
+        if runtime_pid is not None:
+            gateway_running = True
+            gateway_pid = runtime_pid
+
+    if runtime:
+        gateway_state = runtime.get("gateway_state")
+        gateway_platforms = runtime.get("platforms") or {}
+        if configured_gateway_platforms is not None:
+            gateway_platforms = {
+                key: value
+                for key, value in gateway_platforms.items()
+                if key in configured_gateway_platforms
+            }
+        gateway_exit_reason = runtime.get("exit_reason")
+        gateway_updated_at = runtime.get("updated_at")
+        if not gateway_running:
+            gateway_state = gateway_state if gateway_state in {"stopped", "startup_failed"} else "stopped"
+            gateway_platforms = {}
+        elif gateway_running and remote_health_body is not None:
+            if gateway_state in {None, "stopped"}:
+                gateway_state = "running"
+
+    if gateway_running and gateway_state is None and remote_health_body is not None:
+        gateway_state = "running"
+
+    return {
+        "gateway_running": gateway_running,
+        "gateway_pid": gateway_pid,
+        "gateway_state": gateway_state,
+        "gateway_platforms": gateway_platforms,
+        "gateway_exit_reason": gateway_exit_reason,
+        "gateway_updated_at": gateway_updated_at,
+        "runtime": runtime,
+        "configured_gateway_platforms": configured_gateway_platforms,
+    }
+
+
 @app.get("/api/status")
 async def get_status(profile: Optional[str] = None):
     status_scope = None
@@ -2613,7 +2683,7 @@ async def get_status(profile: Optional[str] = None):
         status_scope.__enter__()
 
     try:
-        current_ver, latest_ver = check_config_version()
+        current_ver, latest_ver = await asyncio.to_thread(check_config_version)
         # --- Gateway liveness detection ---
         # Try local PID check first (same-host).  If that fails and a remote
         # GATEWAY_HEALTH_URL is configured, probe the gateway over HTTP so the
@@ -2633,63 +2703,19 @@ async def get_status(profile: Optional[str] = None):
                 if remote_health_body:
                     gateway_pid = remote_health_body.get("pid")
 
-        gateway_state = None
-        gateway_platforms: dict = {}
-        gateway_exit_reason = None
-        gateway_updated_at = None
-        configured_gateway_platforms: set[str] | None = None
-        try:
-            from gateway.config import load_gateway_config
-
-            gateway_config = load_gateway_config()
-            configured_gateway_platforms = {
-                platform.value for platform in gateway_config.get_connected_platforms()
-            }
-        except Exception:
-            configured_gateway_platforms = None
-
-        # Prefer the detailed health endpoint response (has full state) when the
-        # local runtime status file is absent or stale (cross-container).
-        local_runtime = read_runtime_status()
-        runtime = local_runtime
-        if runtime is None and remote_health_body and remote_health_body.get("gateway_state"):
-            runtime = remote_health_body
-        # The runtime-status PID fallback validates liveness with a local
-        # os.kill() probe, so it must only run against the LOCAL status file —
-        # never the remote health body, whose PID belongs to another host and
-        # is display-only. (Running os.kill on a remote PID is both wrong and
-        # trips the test live-system guard.)
-        if not gateway_running and local_runtime is not None:
-            runtime_pid = get_runtime_status_running_pid(local_runtime)
-            if runtime_pid is not None:
-                gateway_running = True
-                gateway_pid = runtime_pid
-
-        if runtime:
-            gateway_state = runtime.get("gateway_state")
-            gateway_platforms = runtime.get("platforms") or {}
-            if configured_gateway_platforms is not None:
-                gateway_platforms = {
-                    key: value
-                    for key, value in gateway_platforms.items()
-                    if key in configured_gateway_platforms
-                }
-            gateway_exit_reason = runtime.get("exit_reason")
-            gateway_updated_at = runtime.get("updated_at")
-            if not gateway_running:
-                gateway_state = gateway_state if gateway_state in {"stopped", "startup_failed"} else "stopped"
-                gateway_platforms = {}
-            elif gateway_running and remote_health_body is not None:
-                # The health probe confirmed the gateway is alive, but the local
-                # runtime status file may be stale (cross-container).  Override
-                # stopped/None state so the dashboard shows the correct badge.
-                if gateway_state in {None, "stopped"}:
-                    gateway_state = "running"
-
-        # If there was no runtime info at all but the health probe confirmed alive,
-        # ensure we still report the gateway as running (no shared volume scenario).
-        if gateway_running and gateway_state is None and remote_health_body is not None:
-            gateway_state = "running"
+        runtime_bundle = await asyncio.to_thread(
+            _read_status_gateway_runtime_sync,
+            gateway_running,
+            gateway_pid,
+            remote_health_body,
+        )
+        gateway_running = runtime_bundle["gateway_running"]
+        gateway_pid = runtime_bundle["gateway_pid"]
+        gateway_state = runtime_bundle["gateway_state"]
+        gateway_platforms = runtime_bundle["gateway_platforms"]
+        gateway_exit_reason = runtime_bundle["gateway_exit_reason"]
+        gateway_updated_at = runtime_bundle["gateway_updated_at"]
+        runtime = runtime_bundle["runtime"]
 
         active_sessions = await _status_active_sessions()
 


### PR DESCRIPTION
## Summary

Hermes Desktop connecting to a remote Hermes Dashboard over a slow link (e.g. Tailscale) could enter a reconnect storm: aggressive liveness/API timeouts, synchronous profile enumeration on hot polling paths, and expensive per-profile scans starved the single uvicorn worker and caused false "session expired" / `session.resume` failures.

This PR keeps the event loop responsive under multi-profile load and aligns desktop remote timeouts with realistic dashboard latency.

## Root cause

- Hot endpoints (`GET /api/profiles/sessions`, `GET /api/profiles`, `GET /api/cron/jobs?profile=all`, `GET /api/status`) performed blocking SQLite, filesystem, YAML, and liveness work on the asyncio event loop.
- `list_profiles()` was especially expensive: `find_alias_for_profile()` read every file in `~/.local/bin` as text (including large binaries), and `_count_skills()` walked entire profile trees.
- Desktop remote liveness and API calls used 2.5s–15s timeouts; transient slow responses triggered `resetHermesConnection()` and OAuth churn.
- Repeated full scans on every poll amplified load (thundering herd on cache misses).

## Changes

### Dashboard (`hermes_cli/web_server.py`, `hermes_cli/profiles.py`)

- Offload blocking handlers to `asyncio.to_thread` (sessions, config, profiles, cron, status).
- Add short-TTL caches (30s) for profile rows and all-profiles cron job lists, with anti-thundering-herd (compute inside lock).
- Invalidate caches on synchronous mutations (profile create/delete, cron CRUD, blueprint instantiate, profile description/model updates).
- Do **not** invalidate profile cache on async skill-hub install/uninstall spawn (avoids repopulating stale `skill_count` before the child exits).
- Optimize `find_alias_for_profile()`: skip files >1MB, read only first 4KB.
- Optimize `_count_skills()`: prune `.venv`, `venv`, `node_modules`, `__pycache__` during `os.walk`.

### Desktop (`apps/desktop/electron/main.cjs`, `hardening.cjs`, `src/hermes.ts`)

- Remote liveness probe timeout: 60s (was 2.5s).
- Remote `hermes:api` default timeout: 60s (was 15s).
- Intercepted remote session/profile API requests use the remote timeout.
- Renderer session-list and config fetches use 60s timeout on remote connections.
- Do not drop the remote connection on a single transient liveness timeout.

## Validation

Tested with local Hermes Desktop → remote Hermes Dashboard (Tailscale, OAuth auth, ~43 profiles):

| Metric | Before | After |
|--------|--------|-------|
| `list_profiles()` | ~9.6s | ~1.2s |
| Dashboard CPU (avg) | ~115% | ~35% |
| `/api/status` timeout rate (30 probes) | 20/20 | 1/30 |
| Desktop soak (90+ min) | reconnect storms, `session.resume` failures | stable; no liveness/session-expired churn |

## Test plan

- [ ] `python -m py_compile hermes_cli/web_server.py hermes_cli/profiles.py`
- [ ] `node --check apps/desktop/electron/main.cjs apps/desktop/electron/hardening.cjs`
- [ ] Start dashboard with many profiles; confirm `GET /api/profiles/sessions` and `GET /api/status` stay responsive under concurrent polling
- [ ] Connect Hermes Desktop to a remote dashboard; leave open 30+ minutes; confirm no reconnect storm in desktop logs
- [ ] Verify profile list updates after create/delete and cron job list updates after blueprint instantiate
- [ ] Verify async skill-hub install/uninstall: `skill_count` may lag up to cache TTL (30s) — acceptable vs. stale cached value