### PR TITLE
fix(context-compressor): accept Anthropic-style usage keys as fallback (salvage of #14903 by @hharry11)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -906,9 +906,16 @@ class ContextCompressor(ContextEngine):
         self._last_aux_model_failure_model: Optional[str] = None
 
     def update_from_response(self, usage: Dict[str, Any]):
-        """Update tracked token usage from API response."""
-        self.last_prompt_tokens = usage.get("prompt_tokens", 0)
-        self.last_completion_tokens = usage.get("completion_tokens", 0)
+        """Update tracked token usage from API response.
+
+        Accepts both OpenAI-style keys (prompt_tokens/completion_tokens) and
+        Anthropic-style keys (input_tokens/output_tokens) so that plugin authors
+        and OpenAI-compat local servers (e.g. mlx_vlm, NVIDIA NIM) that emit
+        Anthropic-shaped usage dicts don't silently produce zero token counts.
+        OpenAI-style keys take priority when both are present.
+        """
+        self.last_prompt_tokens = usage.get("prompt_tokens") or usage.get("input_tokens", 0)
+        self.last_completion_tokens = usage.get("completion_tokens") or usage.get("output_tokens", 0)
         self.last_total_tokens = usage.get("total_tokens", self.last_prompt_tokens + self.last_completion_tokens)
         if self.last_prompt_tokens > 0:
             self.last_real_prompt_tokens = self.last_prompt_tokens

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -62,6 +62,27 @@ class TestUpdateFromResponse:
         compressor.update_from_response({})
         assert compressor.last_prompt_tokens == 0
 
+    def test_anthropic_style_keys(self, compressor):
+        # OpenAI-compat servers (mlx_vlm, NVIDIA NIM) may return Anthropic-shaped usage
+        compressor.update_from_response({
+            "input_tokens": 4000,
+            "output_tokens": 800,
+        })
+        assert compressor.last_prompt_tokens == 4000
+        assert compressor.last_completion_tokens == 800
+        assert compressor.last_total_tokens == 4800
+
+    def test_openai_keys_take_priority(self, compressor):
+        # When both key styles are present, OpenAI-style wins
+        compressor.update_from_response({
+            "prompt_tokens": 5000,
+            "completion_tokens": 1000,
+            "input_tokens": 4000,
+            "output_tokens": 800,
+        })
+        assert compressor.last_prompt_tokens == 5000
+        assert compressor.last_completion_tokens == 1000
+
 
 class TestPreflightDeferral:
     def test_defers_when_recent_real_usage_fit_and_rough_growth_is_small(self, compressor):


### PR DESCRIPTION
## Summary

- `ContextCompressor.update_from_response()` now reads Anthropic-style usage keys (`input_tokens`/`output_tokens`) as a fallback when the OpenAI-style keys are absent.
- Fixes silent zero token counts (and disabled context compression) for OpenAI-compat servers and plugins that emit Anthropic-shaped usage dicts.

Salvage of #14903 by @hharry11, re-targeted onto current `main` (`fbf748b28`).

## Root Cause

**Symptom** — On OpenAI-compat local servers (mlx_vlm, NVIDIA NIM) and some plugins that return Anthropic-shaped `usage` dicts, the compressor's tracked prompt/completion tokens stayed at `0`, so `should_compress()` never tripped and the context window grew unbounded.

**Root cause** — `update_from_response()` (agent/context_compressor.py, ~L908) read **only** `usage.get("prompt_tokens")` / `usage.get("completion_tokens")`. Anthropic-shaped payloads carry the same numbers under `input_tokens` / `output_tokens`, so both lookups defaulted to `0`.

**Evidence** — On current `main`, feeding `{"input_tokens": 4000, "output_tokens": 800}` yields `last_prompt_tokens == 0`. The added regression test `test_anthropic_style_keys` fails without this change (`assert 0 == 4000`) and passes with it.

**Fix + why this level** — Resolve the value at the single ingestion point with an OpenAI-first fallback: `usage.get("prompt_tokens") or usage.get("input_tokens", 0)` (same for completion). This is the one chokepoint every backend funnels usage through, so a single fix covers all callers rather than patching each adapter. `last_total_tokens` already sums the resolved values, so it now reports correctly too.

**Scope / risk** — Touches only `update_from_response`. OpenAI-style payloads are unaffected (their keys take priority); empty dicts still default to `0`. No change to compression thresholds or any other logic.

## Verification

- `.venv/bin/python -m pytest tests/agent/test_context_compressor.py::TestUpdateFromResponse -q` — **4 passed**.

## Real behavior proof

- **Behavior addressed:** Anthropic-shaped usage dict silently tracked as zero tokens.
- **Regression test:** `tests/agent/test_context_compressor.py::TestUpdateFromResponse::test_anthropic_style_keys` — asserts the new behavior; **fails without the fix**, passes with it.
- **Captured output WITHOUT the fix (on this branch, source reverted):**
  ```
  >       assert compressor.last_prompt_tokens == 4000
  E       assert 0 == 4000
  E        +  where 0 = <...ContextCompressor object...>.last_prompt_tokens
  FAILED tests/agent/test_context_compressor.py::TestUpdateFromResponse::test_anthropic_style_keys
  1 failed in 0.49s
  ```
- **Captured output WITH the fix:**
  ```
  ....                                                                     [100%]
  4 passed in 0.82s
  ```

Fixes #14903.
