### PR TITLE
feat(gateway): add Discord channel reasoning defaults

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -771,6 +771,8 @@ platform_toolsets:
 #   reactions: true                  # Show processing reactions (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)
+#   channel_reasoning_efforts:       # Per-channel/thread reasoning effort defaults
+#     "1234567890": xhigh           # exact channel/thread IDs win; threads fall back to parent
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Available toolsets (use these names in platform_toolsets or the toolsets list)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1021,6 +1021,14 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}
                     else:
                         bridged["channel_prompts"] = channel_prompts
+                if "channel_reasoning_efforts" in platform_cfg:
+                    channel_reasoning_efforts = platform_cfg["channel_reasoning_efforts"]
+                    if isinstance(channel_reasoning_efforts, dict):
+                        bridged["channel_reasoning_efforts"] = {
+                            str(k): v for k, v in channel_reasoning_efforts.items()
+                        }
+                    else:
+                        bridged["channel_reasoning_efforts"] = channel_reasoning_efforts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
                 enabled_was_explicit = _cfg_toplevel and "enabled" in platform_cfg

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4292,13 +4292,81 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 value_tokens.append(token)
         return " ".join(value_tokens).strip().lower(), persist_global
 
+    @staticmethod
+    def _resolve_channel_reasoning_config(source: Optional[SessionSource]) -> dict | None:
+        """Resolve per-channel reasoning effort from platform config.
+
+        Config shape:
+            discord:
+              channel_reasoning_efforts:
+                "<channel-or-thread-id>": xhigh
+
+        Exact channel/thread matches win over parent-channel fallbacks so
+        individual threads can opt out of a stricter parent default.
+        """
+        if source is None:
+            return None
+
+        try:
+            platform_key = _platform_config_key(source.platform)
+        except Exception:
+            return None
+
+        cfg = _load_gateway_runtime_config()
+        platform_blocks: list[dict] = []
+        for block in (
+            cfg.get(platform_key) if isinstance(cfg, dict) else None,
+            cfg_get(cfg, "platforms", platform_key, default=None),
+            cfg_get(cfg, "gateway", "platforms", platform_key, default=None),
+        ):
+            if isinstance(block, dict):
+                platform_blocks.append(block)
+
+        candidate_ids: list[str] = []
+        for value in (
+            getattr(source, "chat_id", None),
+            getattr(source, "thread_id", None),
+            getattr(source, "parent_chat_id", None),
+        ):
+            if value is None:
+                continue
+            text = str(value).strip()
+            if text and text not in candidate_ids:
+                candidate_ids.append(text)
+
+        if not candidate_ids:
+            return None
+
+        from hermes_constants import parse_reasoning_effort
+
+        for platform_block in platform_blocks:
+            efforts = platform_block.get("channel_reasoning_efforts") or {}
+            if not isinstance(efforts, dict):
+                continue
+            for channel_id in candidate_ids:
+                if channel_id not in efforts:
+                    continue
+                effort = str(efforts.get(channel_id) or "").strip()
+                parsed = parse_reasoning_effort(effort)
+                if parsed is not None:
+                    return parsed
+                if effort:
+                    logger.warning(
+                        "Unknown channel_reasoning_efforts value '%s' for %s channel %s; ignoring",
+                        effort,
+                        platform_key,
+                        channel_id,
+                    )
+        return None
+
     def _resolve_session_reasoning_config(
         self,
         *,
         source: Optional[SessionSource] = None,
         session_key: Optional[str] = None,
     ) -> dict | None:
-        """Resolve reasoning effort for a session, honoring session overrides."""
+        """Resolve reasoning effort, honoring session, channel, then global config."""
+
         resolved_session_key = session_key
         if not resolved_session_key and source is not None:
             try:
@@ -4309,6 +4377,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         overrides = getattr(self, "_session_reasoning_overrides", {}) or {}
         if resolved_session_key and resolved_session_key in overrides:
             return overrides[resolved_session_key]
+
+        channel_config = self._resolve_channel_reasoning_config(source)
+        if channel_config is not None:
+            return channel_config
         return self._load_reasoning_config()
 
     def _set_session_reasoning_override(

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -209,6 +209,121 @@ async def test_retry_preserves_channel_prompt(monkeypatch):
     assert retried_event.channel_prompt == "Channel prompt"
 
 
+def test_channel_reasoning_effort_overrides_global_for_matching_discord_channel(monkeypatch):
+    runner = _make_runner()
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="1512369272607866890",
+        chat_type="channel",
+        user_id="user-1",
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_runtime_config",
+        lambda: {
+            "agent": {"reasoning_effort": "high"},
+            "discord": {
+                "channel_reasoning_efforts": {
+                    "1512369272607866890": "xhigh",
+                },
+            },
+        },
+    )
+
+    assert runner._resolve_session_reasoning_config(source=source) == {
+        "enabled": True,
+        "effort": "xhigh",
+    }
+
+
+def test_channel_reasoning_effort_inherits_from_parent_channel(monkeypatch):
+    runner = _make_runner()
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="thread-1",
+        chat_type="thread",
+        thread_id="thread-1",
+        parent_chat_id="parent-1",
+        user_id="user-1",
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_runtime_config",
+        lambda: {
+            "agent": {"reasoning_effort": "high"},
+            "discord": {
+                "channel_reasoning_efforts": {
+                    "parent-1": "xhigh",
+                },
+            },
+        },
+    )
+
+    assert runner._resolve_session_reasoning_config(source=source) == {
+        "enabled": True,
+        "effort": "xhigh",
+    }
+
+
+def test_channel_reasoning_effort_exact_channel_overrides_parent(monkeypatch):
+    runner = _make_runner()
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="thread-1",
+        chat_type="thread",
+        thread_id="thread-1",
+        parent_chat_id="parent-1",
+        user_id="user-1",
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_runtime_config",
+        lambda: {
+            "agent": {"reasoning_effort": "high"},
+            "discord": {
+                "channel_reasoning_efforts": {
+                    "thread-1": "low",
+                    "parent-1": "xhigh",
+                },
+            },
+        },
+    )
+
+    assert runner._resolve_session_reasoning_config(source=source) == {
+        "enabled": True,
+        "effort": "low",
+    }
+
+
+def test_session_reasoning_override_wins_over_channel_default(monkeypatch):
+    runner = _make_runner()
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="1512369272607866890",
+        chat_type="channel",
+        user_id="user-1",
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_runtime_config",
+        lambda: {
+            "agent": {"reasoning_effort": "high"},
+            "discord": {
+                "channel_reasoning_efforts": {
+                    "1512369272607866890": "xhigh",
+                },
+            },
+        },
+    )
+    session_key = runner._session_key_for_source(source)
+    runner._session_reasoning_overrides[session_key] = {"enabled": True, "effort": "low"}
+
+    assert runner._resolve_session_reasoning_config(source=source) == {
+        "enabled": True,
+        "effort": "low",
+    }
+
+
 @pytest.mark.asyncio
 async def test_run_agent_appends_channel_prompt_to_ephemeral_system_prompt(monkeypatch, tmp_path):
     _install_fake_agent(monkeypatch)

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -316,6 +316,7 @@ discord:
   history_backfill: true          # Prepend recent channel scrollback on mention (default: true)
   history_backfill_limit: 50      # Max messages to scan backwards (default: 50)
   channel_prompts: {}             # Per-channel ephemeral system prompts
+  channel_reasoning_efforts: {}   # Per-channel/thread reasoning effort defaults
   allow_mentions:                 # What the bot is allowed to ping (safe defaults)
     everyone: false               # @everyone / @here pings (default: false)
     roles: false                  # @role pings (default: false)
@@ -442,6 +443,25 @@ Behavior:
 - Exact thread/channel ID matches win.
 - If a message arrives inside a thread or forum post and that thread has no explicit entry, Hermes falls back to the parent channel/forum ID.
 - Prompts are applied ephemerally at runtime, so changing them affects future turns immediately without rewriting past session history.
+
+#### `discord.channel_reasoning_efforts`
+
+**Type:** mapping — **Default:** `{}`
+
+Per-channel or per-thread reasoning effort defaults for Discord sessions. Use this when some Discord surfaces should consistently spend more or less reasoning budget than the global `agent.reasoning_effort` default.
+
+```yaml
+discord:
+  channel_reasoning_efforts:
+    "1234567890": xhigh     # #research: deep reasoning by default
+    "9876543210": low       # #quick-asks: faster, cheaper replies
+```
+
+Behavior:
+- Values accept the same levels as `/reasoning`: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`.
+- Exact thread/channel ID matches win.
+- If a message arrives inside a thread or forum post and that thread has no explicit entry, Hermes falls back to the parent channel/forum ID.
+- The mapping is a config default, not a hard policy: a session-scoped `/reasoning <level>` override still wins until `/reasoning reset` or session reset.
 
 #### `discord.history_backfill`
 


### PR DESCRIPTION
## What does this PR do?

Adds Discord per-channel/per-thread reasoning effort defaults via `discord.channel_reasoning_efforts`.

This lets gateway operators set a higher or lower default reasoning budget for specific Discord channels or threads without relying on channel prompts to indirectly ask the model to think harder. It mirrors the existing `discord.channel_prompts` matching behavior: exact thread/channel IDs win, and threads can inherit from their parent channel.

Session-scoped `/reasoning <level>` overrides still win over the channel default, so the new config acts as a default rather than a hard policy.

## Related Issue

No related issue found.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - Resolves `channel_reasoning_efforts` from Discord platform config.
  - Matching order: exact channel/thread ID, then parent channel/forum ID.
  - Precedence: session `/reasoning` override → channel default → global `agent.reasoning_effort`.
- `gateway/config.py`
  - Bridges `channel_reasoning_efforts` into platform config extras alongside `channel_prompts`.
- `tests/gateway/test_discord_channel_prompts.py`
  - Covers channel override, parent-channel inheritance, exact thread match precedence, and session override precedence.
- `cli-config.yaml.example` and `website/docs/user-guide/messaging/discord.md`
  - Documents the new config key and behavior.

## How to Test

```bash
python -m pytest tests/gateway/test_discord_channel_prompts.py tests/gateway/test_reasoning_command.py -q -o 'addopts='
python scripts/check-windows-footguns.py gateway/run.py gateway/config.py tests/gateway/test_discord_channel_prompts.py
python -m py_compile gateway/run.py gateway/config.py
git diff --check
```

Observed locally:

```text
32 passed, 2 warnings
✓ No Windows footguns found (3 file(s) scanned)
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(gateway): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` because this adds a config key
- [x] I've considered cross-platform impact
- [x] N/A — no tool descriptions/schemas changed

## Screenshots / Logs

N/A
