### PR TITLE
fix: clarify status model semantics and show opencode keys

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4638,6 +4638,8 @@ def show_config():
     
     keys = [
         ("OPENROUTER_API_KEY", "OpenRouter"),
+        ("OPENCODE_ZEN_API_KEY", "OpenCode Zen"),
+        ("OPENCODE_GO_API_KEY", "OpenCode Go"),
         ("VOICE_TOOLS_OPENAI_KEY", "OpenAI (STT/TTS)"),
         ("EXA_API_KEY", "Exa"),
         ("PARALLEL_API_KEY", "Parallel"),

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -113,8 +113,8 @@ def show_status(args):
     except Exception:
         config = {}
 
-    print(f"  Model:        {_configured_model_label(config)}")
-    print(f"  Provider:     {_effective_provider_label()}")
+    print(f"  Configured model:    {_configured_model_label(config)}")
+    print(f"  Resolved provider:   {_effective_provider_label()}")
 
     # =========================================================================
     # API Keys
@@ -305,6 +305,8 @@ def show_status(args):
     print(color("◆ API-Key Providers", Colors.CYAN, Colors.BOLD))
 
     apikey_providers = {
+        "OpenCode Zen":     ("OPENCODE_ZEN_API_KEY",),
+        "OpenCode Go":      ("OPENCODE_GO_API_KEY",),
         "Z.AI / GLM":       ("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"),
         "Kimi / Moonshot":  ("KIMI_API_KEY",),
         "StepFun Step Plan": ("STEPFUN_API_KEY",),

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -5,13 +5,24 @@ from hermes_cli.status import show_status
 
 def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1234567890abcdef")
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1...cdef")
 
     show_status(SimpleNamespace(all=False, deep=False))
 
     output = capsys.readouterr().out
     assert "Tavily" in output
     assert "tvly...cdef" in output
+
+
+def test_show_status_includes_opencode_zen_provider(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENCODE_ZEN_API_KEY", "zen-secret-123456")
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "OpenCode Zen" in output
+    assert "configured" in output
 
 
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):

--- a/tests/hermes_cli/test_status_model_provider.py
+++ b/tests/hermes_cli/test_status_model_provider.py
@@ -43,8 +43,8 @@ def test_show_status_displays_configured_dict_model_and_provider_label(monkeypat
     status_mod.show_status(SimpleNamespace(all=False, deep=False))
 
     out = capsys.readouterr().out
-    assert "Model:        anthropic/claude-sonnet-4" in out
-    assert "Provider:     Anthropic" in out
+    assert "Configured model:    anthropic/claude-sonnet-4" in out
+    assert "Resolved provider:   Anthropic" in out
 
 
 def test_show_status_displays_legacy_string_model_and_custom_endpoint(monkeypatch, capsys, tmp_path):
@@ -59,8 +59,8 @@ def test_show_status_displays_legacy_string_model_and_custom_endpoint(monkeypatc
     status_mod.show_status(SimpleNamespace(all=False, deep=False))
 
     out = capsys.readouterr().out
-    assert "Model:        qwen3:latest" in out
-    assert "Provider:     Custom endpoint" in out
+    assert "Configured model:    qwen3:latest" in out
+    assert "Resolved provider:   Custom endpoint" in out
 
 
 def test_show_status_reports_managed_nous_features(monkeypatch, capsys, tmp_path):


### PR DESCRIPTION
## Summary
- relabel `hermes status` to distinguish configured model vs resolved provider
- show OpenCode Zen/OpenCode Go in `hermes status`
- show OpenCode Zen/OpenCode Go in `hermes config`
- add focused status tests

## Why
`hermes config`/`hermes status` made it too easy to conflate persisted config with the effective runtime route, and they omitted OpenCode Zen/Go key visibility entirely. That made debugging sub-agent/provider setup harder than it should be.

## Test Plan
- venv/bin/python -m pytest tests/hermes_cli/test_status_model_provider.py tests/hermes_cli/test_status.py -q -o 'addopts='