### PR TITLE
fix(skills): change here-now skill frontmatter name from dotted to hyphenated (#53382)

### DIFF
--- a/optional-skills/productivity/here-now/SKILL.md
+++ b/optional-skills/productivity/here-now/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: here.now
+name: here-now
 description: Publish static sites to {slug}.here.now and store private files in cloud Drives for agent-to-agent handoff.
 version: 1.15.3
 author: here.now

--- a/tests/skills/test_here_now_skill.py
+++ b/tests/skills/test_here_now_skill.py
@@ -1,0 +1,23 @@
+"""Regression coverage for the bundled here-now skill metadata."""
+
+from pathlib import Path
+
+from agent.skill_utils import parse_frontmatter
+from tools.skills_hub import UrlSource
+
+
+SKILL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "productivity"
+    / "here-now"
+    / "SKILL.md"
+)
+
+
+def test_here_now_frontmatter_name_is_installable() -> None:
+    frontmatter, _ = parse_frontmatter(SKILL_PATH.read_text(encoding="utf-8"))
+
+    name = frontmatter.get("name")
+    assert name == SKILL_PATH.parent.name == "here-now"
+    assert UrlSource._is_valid_skill_name(name)


### PR DESCRIPTION
## What

The optional `here-now` skill declared `name: here.now` in its YAML frontmatter. The skill-name validator (`UrlSource._VALID_NAME_RE = ^[a-z][a-z0-9_-]*$`) rejects dots, so the skill failed to load/validate with:

```
name contains invalid characters (must be lowercase a-z, 0-9, hyphens only)
```

Changed `name: here.now` → `name: here-now`. The description, docs links, tags, and user-facing product name still use `here.now` where appropriate — only the frontmatter identifier changed.

## Why

`here.now` (with a dot) cannot pass the strict skill-name regex on any code path, so the skill could never load. `here-now` (hyphenated) is valid.

## How verified

- Regression test `tests/skills/test_here_now_name.py` parses the real frontmatter and validates it through the real project validator (`UrlSource._is_valid_skill_name`).
- RED phase: test fails on unpatched `main` (`here.now` fails the validator).
- GREEN phase: test passes after the one-character fix.
- No other files changed; `author: here.now` and product references are untouched.

Closes #53382.

---
*Auto-published by Moonsong via Path B automated pipeline.*