### PR TITLE
fix(skills): skip auto-registering /command for skills colliding with a core CommandDef

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -402,6 +402,19 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
                     if not cmd_name:
                         continue
+                    # Skip skills whose name collides with a core CommandDef.
+                    # The manual registry entry owns the /command; a skill
+                    # with the same name would otherwise auto-register a
+                    # duplicate that doubles the /help entry and can shadow
+                    # the manual command (which may carry subcommands or
+                    # custom dispatch the auto-skill path lacks).
+                    try:
+                        from hermes_cli.commands import COMMAND_REGISTRY
+                        _core_names = {cd.name for cd in COMMAND_REGISTRY}
+                    except Exception:
+                        _core_names = set()
+                    if name in _core_names or cmd_name in _core_names:
+                        continue
                     _skill_commands[f"/{cmd_name}"] = {
                         "name": name,
                         "description": description or f"Invoke the {name} skill",

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -803,3 +803,37 @@ class TestInlineShellExpansion:
         # The command's intended stdout never made it through — only the
         # timeout marker (which echoes the command text) survives.
         assert "DYN_MARKER" not in msg.replace("sleep 5 && printf DYN_MARKER", "")
+
+
+class TestSkillCommandCollisionDedupe:
+    """Skills whose name matches a core CommandDef should not auto-register
+    a duplicate /command that would shadow the manual registry entry."""
+
+    def test_skill_matching_core_command_is_skipped(self, tmp_path):
+        # Pick a name that exists in COMMAND_REGISTRY on upstream main.
+        from hermes_cli.commands import COMMAND_REGISTRY
+        core_name = next(
+            cd.name for cd in COMMAND_REGISTRY if cd.name and "_" not in cd.name
+        )
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, core_name)
+            result = scan_skill_commands()
+        assert f"/{core_name}" not in result
+
+    def test_non_colliding_skill_still_registered(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "my-custom-skill")
+            result = scan_skill_commands()
+        assert "/my-custom-skill" in result
+
+    def test_colliding_skill_does_not_block_others(self, tmp_path):
+        from hermes_cli.commands import COMMAND_REGISTRY
+        core_name = next(
+            cd.name for cd in COMMAND_REGISTRY if cd.name and "_" not in cd.name
+        )
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, core_name)
+            _make_skill(tmp_path, "non-colliding-skill")
+            result = scan_skill_commands()
+        assert f"/{core_name}" not in result
+        assert "/non-colliding-skill" in result


### PR DESCRIPTION
`scan_skill_commands()` auto-registers a `/<name>` slash command for every installed skill. When a skill's name matches a core `CommandDef` entry (e.g. a skill named `caveman` alongside `CommandDef("caveman", ...)`), the auto-registration creates a duplicate `/command` that:

- doubles the `/help` entry (two lines with the same name), and
- can shadow the manual command -- the manual `CommandDef` may carry subcommands or custom dispatch the auto-skill path doesn't have, so a user typing `/caveman` gets a coin-flip between the real command and the no-op skill-load.

This skips the skill when its name or normalized `cmd_name` collides with a core `CommandDef`. The skill is still loadable explicitly via `/skill <name>`.

## Repro

Install a skill whose name matches any core command in `COMMAND_REGISTRY`. Run `/help` -- two `/caveman` lines appear.

## Testing

- 3 new tests in `TestSkillCommandCollisionDedupe`: colliding skill skipped, non-colliding skill still registered, colliding skill doesn't block others.
- Full `tests/agent/test_skill_commands.py` suite: 44 passed, no regressions.

This is a general fix (covers any future name collision), not specific to `caveman`.