### PR TITLE
fix(feishu): route markdown tables through post+tag:md, fix streaming edit fallback

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -151,12 +151,9 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _MARKDOWN_HINT_RE = re.compile(
-    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
+    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)|(^\|.*\|\n\|[-|: ]+\|)",
     re.MULTILINE,
 )
-# Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
-_MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
@@ -1853,6 +1850,22 @@ class FeishuAdapter(BasePlatformAdapter):
                 fallback_body = self._build_update_message_body(
                     msg_type="text",
                     content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
+                )
+                fallback_request = self._build_update_message_request(message_id=message_id, request_body=fallback_body)
+                fallback_response = await asyncio.to_thread(self._client.im.v1.message.update, fallback_request)
+                result = self._finalize_send_result(fallback_response, "update failed")
+            if not result.success and msg_type == "text":
+                # Text edit can fail when the original streaming chunk was sent
+                # as 'post' and the final content now routes to 'text'. Feishu
+                # does not allow changing msg_type on update, so retry as post
+                # with markdown rendering to keep the message readable.
+                logger.warning(
+                    "[Feishu] Plain-text update rejected (likely msg_type mismatch on "
+                    "streaming edit); falling back to post markdown"
+                )
+                fallback_body = self._build_update_message_body(
+                    msg_type="post",
+                    content=_build_markdown_post_payload(content),
                 )
                 fallback_request = self._build_update_message_request(message_id=message_id, request_body=fallback_body)
                 fallback_response = await asyncio.to_thread(self._client.im.v1.message.update, fallback_request)
@@ -4375,12 +4388,9 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+        # Feishu post + tag:md renders the full GFM surface (tables, bold,
+        # headings, code blocks, lists, quotes). Route any markdown-shaped
+        # content through the post payload.
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2841,6 +2841,101 @@ class TestAdapterBehavior(unittest.TestCase):
             [[{"tag": "md", "text": "---\n1. 第一项\n<u>下划线</u>\n~~删除线~~"}]],
         )
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_post_for_markdown_tables(self):
+        """Markdown tables must route through post+tag:md, not be downgraded to text.
+
+        Regression for the historic _MARKDOWN_TABLE_RE workaround that force-downgraded
+        the entire message to msg_type: text whenever a GFM table appeared. Feishu's
+        post + tag:md element renders GFM tables natively now.
+        """
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_table"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        content = "| 名称 | 重要度 |\n| --- | --- |\n| RAG | 极高 |"
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content=content,
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        payload = json.loads(captured["request"].request_body.content)
+        elements = payload["zh_cn"]["content"][0]
+        self.assertEqual(elements, [{"tag": "md", "text": content}])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_edit_message_falls_back_to_post_when_text_update_rejected(self):
+        """Text edit can fail when streaming sent the first chunk as 'post' but
+        the final content now routes to 'text'. Feishu does not allow changing
+        msg_type on update, so we retry as post with markdown rendering."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"calls": []}
+
+        class _MessageAPI:
+            def update(self, request):
+                captured["calls"].append(request)
+                # First call (text update) fails — simulates msg_type mismatch
+                if len(captured["calls"]) == 1:
+                    return SimpleNamespace(success=lambda: False, code=230002, msg="msg type not match")
+                # Second call (post fallback) succeeds
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.edit_message(
+                    chat_id="oc_chat",
+                    message_id="om_progress",
+                    content="plain text content without markdown",
+                )
+            )
+
+        self.assertTrue(result.success)
+        # First attempt: text
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "text")
+        # Fallback: post
+        self.assertEqual(captured["calls"][1].request_body.msg_type, "post")
+
 
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
 class TestHydrateBotIdentity(unittest.TestCase):


### PR DESCRIPTION
## Bug

Markdown tables in Feishu messages render as raw pipe-delimited source code instead of being rendered as proper tables. When a table appears in a message, the **entire message** is downgraded to `msg_type: text`, stripping all markdown formatting (bold, headings, code blocks, lists) from the same reply.

Related issues: #52786, #52046, #23938, #18704, #9549, #21866, #25452

## Root cause

Commit `8e18d1031` (Apr 2026) added `_MARKDOWN_TABLE_RE` to force `msg_type: text` for any content containing a markdown table. This was correct **at the time** — Feishu's post `md` element did not render tables, and sending table content as post caused blank messages.

However, **Feishu's post + `tag: md` element now renders GFM tables natively**. The workaround is obsolete and actively harmful: it downgrades the entire message to plain text, displaying raw `|` pipe-delimited source code and stripping all other formatting.

## Fix

### 1. Route tables through post (core fix)

Merge the table-detection pattern into `_MARKDOWN_HINT_RE` so tables are treated like any other markdown content — routed to `post` + `tag: md`. Remove the now-unused `_MARKDOWN_TABLE_RE` and its force-text branch in `_build_outbound_payload()`.

### 2. Streaming edit fallback (edge case no other PR handles)

During streaming, the first chunk may not yet contain a table (partial content), so it's sent as `text`. When the full content arrives and `edit_message()` detects the table, `_build_outbound_payload` returns `post`. But **Feishu does not allow changing `msg_type` on message update**, so the edit fails and the message stays as raw markdown source.

Added a `text -> post` fallback in `edit_message()`: when a text update fails, retry as post with markdown rendering.

## Prior work

- Supersedes my earlier PR #45583 (target file path was stale after the plugin migration; included ~100 lines of dead CardKit table-element code that was abandoned in favor of the post approach).
- Related PRs #52790, #52986, #53355 all implement the same core fix (route tables to post). This PR additionally handles the streaming edit edge case.
