### PR TITLE
fix(acp,file): isolate session env vars and resolve V4A patch paths

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1471,7 +1471,10 @@ class HermesACPAgent(acp.Agent):
                     clear_session_vars,
                     set_session_vars,
                 )
-                session_tokens = set_session_vars(session_key=session_id)
+                session_tokens = set_session_vars(
+                    session_key=session_id,
+                    session_id=session_id,
+                )
             except Exception:
                 session_tokens = None
                 clear_session_vars = None  # type: ignore[assignment]

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock, patch
 
@@ -51,6 +52,16 @@ def mock_manager():
 def agent(mock_manager):
     """HermesACPAgent backed by a mock session manager."""
     return HermesACPAgent(session_manager=mock_manager)
+
+
+@pytest.fixture(autouse=True)
+def stub_concurrent_log_handler(monkeypatch):
+    """Windows test envs may not have concurrent-log-handler installed."""
+    monkeypatch.setitem(
+        sys.modules,
+        "concurrent_log_handler",
+        SimpleNamespace(ConcurrentRotatingFileHandler=MagicMock()),
+    )
 
 
 @pytest.mark.asyncio
@@ -1249,6 +1260,74 @@ class TestPrompt:
         assert captured["inner"] == new_resp.session_id
         # Outer scope must be restored.
         assert os.environ.get("HERMES_SESSION_ID") == "outer-sess"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_prompts_do_not_cross_leak_subprocess_session_id(self, agent, monkeypatch):
+        """ACP subprocess env must not inherit another concurrent session's id.
+
+        The ACP adapter mirrors HERMES_SESSION_ID through process-global
+        os.environ around run_conversation(). local._make_run_env() starts from
+        os.environ and only overlays ContextVar session vars when they are
+        truthy. ACP binds session_key but leaves the ContextVar session_id empty,
+        so a concurrent session can overwrite the global value seen by child
+        subprocesses.
+        """
+        import threading
+        from tools.environments.local import _make_run_env
+
+        monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+
+        resp_a = await agent.new_session(cwd=".")
+        resp_b = await agent.new_session(cwd=".")
+        state_a = agent.session_manager.get_session(resp_a.session_id)
+        state_b = agent.session_manager.get_session(resp_b.session_id)
+
+        started_a = threading.Event()
+        started_b = threading.Event()
+        release_a = threading.Event()
+        release_b = threading.Event()
+        captured: dict[str, str | None] = {}
+
+        def run_a(*args, **kwargs):
+            captured["a_before"] = os.environ.get("HERMES_SESSION_ID")
+            started_a.set()
+            if not release_a.wait(timeout=5):
+                raise AssertionError("run_a release timed out")
+            captured["a_child"] = _make_run_env({}).get("HERMES_SESSION_ID")
+            return {"final_response": "A", "messages": []}
+
+        def run_b(*args, **kwargs):
+            captured["b_before"] = os.environ.get("HERMES_SESSION_ID")
+            started_b.set()
+            if not release_b.wait(timeout=5):
+                raise AssertionError("run_b release timed out")
+            return {"final_response": "B", "messages": []}
+
+        state_a.agent.run_conversation = run_a
+        state_b.agent.run_conversation = run_b
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        prompt_a = asyncio.create_task(
+            agent.prompt(prompt=[TextContentBlock(type="text", text="hi a")], session_id=resp_a.session_id)
+        )
+        await asyncio.to_thread(started_a.wait, 5)
+
+        prompt_b = asyncio.create_task(
+            agent.prompt(prompt=[TextContentBlock(type="text", text="hi b")], session_id=resp_b.session_id)
+        )
+        await asyncio.to_thread(started_b.wait, 5)
+
+        release_a.set()
+        await prompt_a
+        release_b.set()
+        await prompt_b
+
+        assert captured["a_before"] == resp_a.session_id
+        assert captured["b_before"] == resp_b.session_id
+        assert captured["a_child"] == resp_a.session_id
 
     @pytest.mark.asyncio
     async def test_prompt_does_not_duplicate_streamed_final_message(self, agent):

--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -325,6 +325,43 @@ def test_patch_reports_resolved_absolute_path(_isolated_cwd, monkeypatch):
 # env's live cwd only when the resolving session owns it.)
 
 
+def test_v4a_patch_applies_to_resolved_workspace_not_backend_cwd(_isolated_cwd, monkeypatch):
+    """V4A patch headers must resolve to the same absolute path the tool reports."""
+    workspace, decoy = _isolated_cwd
+    task_id = "sess-v4a"
+
+    monkeypatch.setattr(ft, "_get_live_tracking_cwd", lambda task_id="default": None)
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    terminal_tool.register_task_env_overrides(task_id, {"cwd": str(workspace)})
+
+    from tools.environments.local import LocalEnvironment
+    from tools.file_operations import ShellFileOperations
+
+    env = LocalEnvironment(cwd=str(decoy))
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": ShellFileOperations(env))
+
+    import json
+    out = json.loads(ft.patch_tool(
+        mode="patch",
+        patch=(
+            "*** Begin Patch\n"
+            "*** Update File: target.py\n"
+            "@@\n"
+            "-WORKSPACE_ORIGINAL\n"
+            "+WORKSPACE_PATCHED\n"
+            "*** End Patch\n"
+        ),
+        task_id=task_id,
+    ))
+
+    expected = str((workspace / "target.py").resolve())
+    assert not out.get("error"), out
+    assert out.get("resolved_path") == expected
+    assert out.get("files_modified") == [expected]
+    assert (workspace / "target.py").read_text() == "WORKSPACE_PATCHED\n"
+    assert (decoy / "target.py").read_text() == "DECOY_ORIGINAL\n"
+
+
 class _FakeOwnedEnv:
     def __init__(self, cwd: str, cwd_owner: str):
         self.cwd = cwd

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -5,6 +5,7 @@ import errno
 import json
 import logging
 import os
+import re
 import threading
 from pathlib import Path
 
@@ -330,6 +331,43 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
             )
     except Exception:
         return None
+
+
+_V4A_FILE_HEADER_RE = re.compile(
+    r"^(\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*)(.+)$",
+    re.MULTILINE,
+)
+
+
+def _file_ops_uses_host_paths(file_ops) -> bool:
+    """Return True when file_ops targets the same host filesystem as Hermes."""
+    env = getattr(file_ops, "env", None)
+    if env is None:
+        return True
+    try:
+        from tools.environments.local import LocalEnvironment
+    except ImportError:
+        return True
+    return isinstance(env, LocalEnvironment)
+
+
+def _rewrite_v4a_patch_paths_for_host(
+    patch: str,
+    path_to_resolved: dict[str, str | None],
+    file_ops,
+) -> str:
+    """Rewrite local V4A headers to the exact resolved host paths."""
+    if not _file_ops_uses_host_paths(file_ops):
+        return patch
+
+    def _replace(match: re.Match) -> str:
+        original = match.group(2).strip()
+        resolved = path_to_resolved.get(original)
+        if not resolved:
+            return match.group(0)
+        return f"{match.group(1)}{resolved}"
+
+    return _V4A_FILE_HEADER_RE.sub(_replace, patch)
 
 
 def _is_blocked_device_path(path: str) -> bool:
@@ -1511,7 +1549,12 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             elif mode == "patch":
                 if not patch:
                     return tool_error("patch content required")
-                result = file_ops.patch_v4a(patch)
+                patch_for_ops = _rewrite_v4a_patch_paths_for_host(
+                    patch,
+                    _path_to_resolved,
+                    file_ops,
+                )
+                result = file_ops.patch_v4a(patch_for_ops)
             else:
                 return tool_error(f"Unknown mode: {mode}")
 


### PR DESCRIPTION
## Summary

Fixes two runtime/tooling issues:

- Pass `session_id` into `set_session_vars()` in the ACP adapter so concurrent prompts do not leak `HERMES_SESSION_ID` into child subprocess environments.
- Rewrite V4A patch file headers to the resolved host workspace path before applying patches through local file operations.

## Why

ACP prompt handling mirrors session state through environment/session vars. When concurrent sessions run, a child subprocess can inherit another session's `HERMES_SESSION_ID` unless the active session id is bound in the session ContextVar.

Separately, V4A patch headers using relative paths can resolve against the backend cwd instead of the intended workspace path. Rewriting headers to the resolved host path makes patch application target the same file path reported by the tool.

## Changes

- Pass `session_id=session_id` to `set_session_vars()` in `acp_adapter/server.py`.
- Add a regression test for concurrent ACP prompts preventing subprocess session-id cross-leak.
- Rewrite V4A patch headers to resolved host paths in `tools/file_tools.py`.
- Add a regression test proving patches apply to the resolved workspace, not a backend cwd decoy.

## Tests

```text
pytest ...