### PR TITLE
fix(update): normalize Windows gateway resume launchers

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -809,6 +809,68 @@ def _build_gateway_argv() -> tuple[list[str], str, dict[str, str]]:
     return argv, working_dir, env_overlay
 
 
+def _visible_profile_args(argv: list[str]) -> list[str]:
+    """Return an explicit ``--profile``/``-p`` selector from a captured argv."""
+    for index, token in enumerate(argv):
+        lowered = token.lower()
+        if lowered in ("--profile", "-p"):
+            if index + 1 < len(argv):
+                return [token, argv[index + 1]]
+            return []
+        if lowered.startswith("--profile=") or lowered.startswith("-p="):
+            return [token]
+    return []
+
+
+def _gateway_run_tail(argv: list[str]) -> list[str] | None:
+    """Return the ``gateway run ...`` tail from a captured launcher argv."""
+    lowered = [token.lower() for token in argv]
+    for index, token in enumerate(lowered):
+        if token == "gateway" and index + 1 < len(lowered) and lowered[index + 1] == "run":
+            return argv[index:]
+    return None
+
+
+def _looks_like_python_executable(value: str) -> bool:
+    name = Path(value).name.lower()
+    return name in {
+        "python",
+        "python.exe",
+        "pythonw",
+        "pythonw.exe",
+        "python3",
+        "python3.exe",
+    }
+
+
+def _canonical_gateway_restart_from_wrapper(
+    run_argv: list[str],
+) -> tuple[list[str], str, dict[str, str]] | None:
+    """Return a direct windowless gateway argv for captured Hermes launchers."""
+    if not run_argv:
+        return None
+    launcher = Path(run_argv[0]).name.lower()
+    if launcher not in {"hermes", "hermes.exe", "hermes.cmd", "hermes.bat"}:
+        return None
+    gateway_tail = _gateway_run_tail(run_argv)
+    if gateway_tail is None:
+        return None
+
+    base_argv, working_dir, env_overlay = _build_gateway_argv()
+    try:
+        gateway_index = next(
+            index for index, token in enumerate(base_argv) if token.lower() == "gateway"
+        )
+    except StopIteration:
+        return None
+
+    prefix = base_argv[:gateway_index]
+    profile_args = _visible_profile_args(run_argv)
+    if profile_args:
+        prefix = [base_argv[0], "-m", "hermes_cli.main", *profile_args]
+    return [*prefix, *gateway_tail], working_dir, env_overlay
+
+
 def windowless_gateway_restart_spec(
     run_argv: list[str],
 ) -> tuple[list[str], str, dict[str, str]]:
@@ -829,11 +891,12 @@ def windowless_gateway_restart_spec(
     (VIRTUAL_ENV, PYTHONPATH) the base interpreter needs to resolve the
     ``hermes_cli`` package without the venv launcher's site config.
 
-    Returns ``(new_argv, working_dir, env_overlay)``.  ``new_argv``
-    preserves every argument after the interpreter (``-m hermes_cli.main
-    [--profile X] gateway run [--replace]``) verbatim.  On non-Windows, or
-    if ``run_argv`` doesn't start with a resolvable python, the argv is
-    returned unchanged with an empty overlay.
+    Returns ``(new_argv, working_dir, env_overlay)``.  Python-led argv preserve
+    every argument after the interpreter (``-m hermes_cli.main [--profile X]
+    gateway run [--replace]``) verbatim.  Captured Windows wrapper argv such as
+    ``hermes.exe gateway run`` are normalized to the same direct ``pythonw``
+    command used by a fresh gateway start, so post-update resume does not
+    relaunch a terminal/console wrapper.
     """
     if not run_argv:
         return run_argv, "", {}
@@ -846,15 +909,22 @@ def windowless_gateway_restart_spec(
     python_exe = run_argv[0]
     rest = run_argv[1:]
 
-    # Only rewrite when the leading token actually looks like a python
-    # interpreter we can find a windowless sibling for.  If a caller passed
-    # something else (a captured argv whose argv[0] is already pythonw, or a
-    # non-python launcher), leave it alone.
+    # Only rewrite Python interpreters or real Hermes launcher wrappers.  Other
+    # captured commands are left untouched so the respawn path stays conservative.
+    if not _looks_like_python_executable(python_exe):
+        wrapper_spec = _canonical_gateway_restart_from_wrapper(run_argv)
+        if wrapper_spec is not None:
+            return wrapper_spec
+        return run_argv, "", {}
+
     try:
         windowless_python, venv_dir, extra_pythonpath = _resolve_detached_python(
             python_exe
         )
     except Exception:
+        wrapper_spec = _canonical_gateway_restart_from_wrapper(run_argv)
+        if wrapper_spec is not None:
+            return wrapper_spec
         return run_argv, "", {}
 
     new_argv = [windowless_python, *rest]

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 import signal
+import subprocess
 import sys
 from pathlib import Path
 from unittest import mock
@@ -1052,6 +1053,49 @@ class TestGatewayDetachedWatcherWindowsFlags:
             "HERMES_HOME) so the windowless base pythonw resolves hermes_cli."
         )
 
+    def test_watcher_normalizes_captured_hermes_launcher(self, monkeypatch):
+        """The live watcher path must not replay a captured ``hermes.exe`` wrapper."""
+        import hermes_cli.gateway as gateway_mod
+
+        popen_calls = []
+
+        def fake_popen(argv, **kwargs):
+            popen_calls.append((argv, kwargs))
+            proc = mock.Mock()
+            proc.pid = 12345
+            return proc
+
+        canonical_argv = [
+            "C:/base/pythonw.exe",
+            "-m",
+            "hermes_cli.main",
+            "gateway",
+            "run",
+        ]
+        with mock.patch.object(gateway_mod.sys, "platform", "win32"), mock.patch(
+            "hermes_cli.gateway_windows.windowless_gateway_restart_spec",
+            return_value=(
+                canonical_argv,
+                "C:/hermes",
+                {"VIRTUAL_ENV": "C:/venv", "PYTHONPATH": "C:/hermes"},
+            ),
+        ), mock.patch("subprocess.Popen", side_effect=fake_popen):
+            assert gateway_mod._spawn_gateway_restart_watcher(
+                101,
+                ["C:/venv/Scripts/hermes.exe", "gateway", "run"],
+            )
+
+        assert len(popen_calls) == 1
+        watcher_argv, watcher_kwargs = popen_calls[0]
+        assert watcher_argv[3:] == ["101", *canonical_argv]
+        assert "C:/venv/Scripts/hermes.exe" not in watcher_argv
+        assert "C:/base/pythonw.exe" in watcher_argv
+        watcher_source = watcher_argv[2]
+        assert '"VIRTUAL_ENV": "C:/venv"' in watcher_source
+        assert '"PYTHONPATH": "C:/hermes"' in watcher_source
+        assert watcher_kwargs["stdout"] == subprocess.DEVNULL
+        assert watcher_kwargs["stderr"] == subprocess.DEVNULL
+
 
 class TestWindowlessGatewayRestartSpec:
     """gateway_windows.windowless_gateway_restart_spec — the helper that
@@ -1122,3 +1166,58 @@ class TestWindowlessGatewayRestartSpec:
         assert env["VIRTUAL_ENV"] == str(Path("C:/venv"))
         assert "PYTHONPATH" in env
         assert "site-packages" in env["PYTHONPATH"]
+
+    def test_windows_normalizes_non_python_gateway_launcher(self):
+        """Captured wrapper argv must not be replayed after update.
+
+        Regression guard for the post-update Windows resume path: if an
+        unmapped gateway was captured as ``hermes.exe gateway run``, replaying
+        that launcher can leave a terminal window open. Normalize it to the
+        same direct windowless argv used by a clean gateway start.
+        """
+        import hermes_cli.gateway_windows as gw
+
+        argv = [
+            "C:/Users/me/AppData/Local/hermes/hermes-agent/venv/Scripts/hermes.exe",
+            "--profile",
+            "work",
+            "gateway",
+            "run",
+            "--replace",
+        ]
+        canonical = (
+            ["C:/base/pythonw.exe", "-m", "hermes_cli.main", "gateway", "run"],
+            "C:/hermes",
+            {"VIRTUAL_ENV": "C:/venv", "PYTHONPATH": "C:/hermes"},
+        )
+
+        with mock.patch.object(gw.sys, "platform", "win32"), mock.patch.object(
+            gw,
+            "_resolve_detached_python",
+            side_effect=AssertionError("hermes.exe is a launcher, not Python"),
+        ), mock.patch.object(gw, "_build_gateway_argv", return_value=canonical):
+            new_argv, cwd, env = gw.windowless_gateway_restart_spec(list(argv))
+
+        assert new_argv == [
+            "C:/base/pythonw.exe",
+            "-m",
+            "hermes_cli.main",
+            "--profile",
+            "work",
+            "gateway",
+            "run",
+            "--replace",
+        ]
+        assert cwd == "C:/hermes"
+        assert env == {"VIRTUAL_ENV": "C:/venv", "PYTHONPATH": "C:/hermes"}
+
+    def test_windows_leaves_unrelated_non_python_launcher_unchanged(self):
+        import hermes_cli.gateway_windows as gw
+
+        argv = ["C:/tools/not-hermes.exe", "gateway", "run"]
+        with mock.patch.object(gw.sys, "platform", "win32"):
+            new_argv, cwd, env = gw.windowless_gateway_restart_spec(list(argv))
+
+        assert new_argv == argv
+        assert cwd == ""
+        assert env == {}


### PR DESCRIPTION
## What does this PR do?

Fixes the Windows post-update gateway resume path when the captured gateway command line is a Hermes launcher wrapper such as `hermes.exe gateway run` instead of a Python interpreter argv.

Current `main` already routes the live restart watcher through `gateway_windows.windowless_gateway_restart_spec()` before respawning the gateway. That helper rewrites console `python.exe` argv to windowless `pythonw.exe`, but it still returned non-Python launcher argv unchanged. So an unmapped gateway captured as `hermes.exe gateway run` could still be replayed as the wrapper after update, preserving the console-wrapper shape this path is supposed to avoid.

This change teaches the helper to conservatively recognize captured Hermes gateway launchers and normalize them to the same direct `pythonw.exe -m hermes_cli.main ... gateway run` argv used by a clean Windows gateway start. Explicit `--profile` / `-p` selectors and `gateway run` tail args such as `--replace` are preserved.

This is the narrow follow-up to the closed #53260: the older PR mixed the mapped pid-file drain wait and wrapper normalization. This PR only addresses the wrapper replay issue, and adds a regression test through `_spawn_gateway_restart_watcher()` so the normalization is proven to sit on the live respawn path.

## Related Issue

Follow-up to #53260.

Related Windows console-wrapper/update-resume work: #52239.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway_windows.py`
  - Add conservative detection for captured Hermes launcher wrappers (`hermes`, `hermes.exe`, `hermes.cmd`, `hermes.bat`) that contain a `gateway run` tail.
  - Normalize those wrapper argv to direct windowless gateway argv from `_build_gateway_argv()`.
  - Preserve explicit profile selectors and the captured `gateway run ...` tail.
  - Leave unrelated non-Python launchers unchanged.
- `tests/tools/test_windows_native_support.py`
  - Add helper coverage for non-Python Hermes launcher normalization.
  - Add a live watcher-path regression test proving `_spawn_gateway_restart_watcher()` passes the normalized argv into the watcher command instead of replaying `hermes.exe`.

## How to Test

1. Run syntax checks:
   `python -m py_compile hermes_cli\gateway_windows.py tests\tools\test_windows_native_support.py`
2. Run the focused Windows restart-spec tests:
   `python scripts\run_tests_parallel.py -j 4 tests\tools\test_windows_native_support.py -- -k "GatewayDetachedWatcherWindowsFlags or WindowlessGatewayRestartSpec"`

Focused test result: 11 passed, 0 failed.

Note: the Windows local runner printed a post-summary cp1252 progress-callback traceback while rendering a checkmark, but the test command exited 0 and reported 100% pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass. Not run; used focused `scripts/run_tests_parallel.py -j 4` coverage for the changed Windows restart path.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / AppData Hermes checkout, focused mocked Windows regression tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows-only helper path, no-op off Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused checks passed locally:

- `python -m py_compile hermes_cli\gateway_windows.py tests\tools\test_windows_native_support.py`
- `python scripts\run_tests_parallel.py -j 4 tests\tools\test_windows_native_support.py -- -k "GatewayDetachedWatcherWindowsFlags or WindowlessGatewayRestartSpec"` — 11 passed, 0 failed
- `git diff --check -- hermes_cli/gateway_windows.py tests/tools/test_windows_native_support.py`
