### PR TITLE
fix(telegram): keep edit streaming on legacy overflow cap

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -471,18 +471,26 @@ class GatewayStreamConsumer:
             if isinstance(self.adapter, _BasePlatformAdapter)
             else len
         )
+        # Resolve native draft streaming before choosing the overflow budget.
+        # Rich-capable adapters (Telegram rich messages) can raise the budget
+        # above the legacy edit limit ONLY when native drafts are active: draft
+        # frames/final sends can use the rich endpoint, while editMessageText
+        # still has the 4096-ish legacy cap for progressive edits.  If we let
+        # edit-based streaming accumulate to the rich cap, Telegram's adapter
+        # has to split the same full prefix on every edit and users see many
+        # duplicate "(1/2)" chunks before the tail arrives.
+        self._use_draft_streaming = self._resolve_draft_streaming()
         # Rich-capable adapters (Telegram rich messages) raise this above the
-        # legacy per-message limit so a reply that fits one rich send/draft
-        # isn't fragmented at 4096 while streaming.  See _raw_message_limit.
+        # legacy per-message limit so a reply that fits one rich draft/final
+        # send isn't fragmented at 4096 while draft-streaming. See
+        # _raw_message_limit.
         _raw_limit = self._raw_message_limit()
         _safe_limit = max(500, _raw_limit - _len_fn(self.cfg.cursor) - 100)
 
-        # Resolve native draft streaming once per run.  When enabled the
-        # consumer routes mid-stream frames through adapter.send_draft and
-        # leaves _message_id=None so the existing got_done path delivers the
-        # final answer as a regular sendMessage (drafts have no message_id
-        # to edit).
-        self._use_draft_streaming = self._resolve_draft_streaming()
+        # When native draft streaming is enabled the consumer routes mid-stream
+        # frames through adapter.send_draft and leaves _message_id=None so the
+        # existing got_done path delivers the final answer as a regular
+        # sendMessage (drafts have no message_id to edit).
         if self._use_draft_streaming:
             type(self)._draft_id_counter += 1
             self._draft_id = type(self)._draft_id_counter
@@ -1213,7 +1221,10 @@ class GatewayStreamConsumer:
         base = getattr(self.adapter, "MAX_MESSAGE_LENGTH", 4096)
         # isinstance gate: MagicMock adapters return mock objects (truthy, not
         # ints) for arbitrary attribute access — keep them on the base limit.
-        if isinstance(self.adapter, _BasePlatformAdapter):
+        # Also keep edit-based streaming on the legacy edit limit.  A higher
+        # rich-message cap is safe only for native draft streaming because
+        # draft/final sends can use rich endpoints; progressive edits cannot.
+        if isinstance(self.adapter, _BasePlatformAdapter) and self._use_draft_streaming:
             try:
                 cap = self.adapter.streaming_overflow_limit()
             except Exception as e:

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
 
 
 # ── _clean_for_display unit tests ────────────────────────────────────────
@@ -2112,3 +2114,49 @@ class TestFreshFinalRespectsAdapterDecline:
             f"Expected 2 send calls (initial + fresh-final), got {adapter.send.call_count}"
         )
 
+
+class _RichCapEditAdapter(BasePlatformAdapter):
+    """Minimal adapter whose rich streaming cap exceeds its edit cap."""
+
+    MAX_MESSAGE_LENGTH = 4096
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True), Platform.TELEGRAM)
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id: str, content: str, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True, message_id="msg_1")
+
+    async def edit_message(self, chat_id: str, message_id: str, content: str, *, finalize: bool = False, metadata=None) -> SendResult:
+        return SendResult(success=True, message_id=message_id)
+
+    async def get_chat_info(self, chat_id: str) -> dict:
+        return {}
+
+    def streaming_overflow_limit(self):
+        return 32768
+
+
+class TestRichCapEditStreamingOverflow:
+    def test_edit_transport_ignores_rich_overflow_cap(self):
+        """Regression: Telegram rich cap must not drive edit-based streaming.
+
+        If edit transport accumulates to the 32k rich cap, Telegram's 4096-char
+        edit path repeatedly split-delivers the same full prefix; users see many
+        duplicate ``(1/2)`` chunks before the tail. The rich cap is only safe
+        for native draft streaming, where frames/final delivery use rich send
+        endpoints instead of progressive edits.
+        """
+        consumer = GatewayStreamConsumer(_RichCapEditAdapter(), "chat")
+        consumer._use_draft_streaming = False
+        assert consumer._raw_message_limit() == _RichCapEditAdapter.MAX_MESSAGE_LENGTH
+
+    def test_draft_transport_can_use_rich_overflow_cap(self):
+        consumer = GatewayStreamConsumer(_RichCapEditAdapter(), "chat")
+        consumer._use_draft_streaming = True
+        assert consumer._raw_message_limit() == 32768


### PR DESCRIPTION
## What does this PR do?

Fixes the Telegram streaming bug where a long answer can get split into `(1/2)` / `(2/2)`, but the `(1/2)` part keeps getting sent again and again before the rest shows up.

This is the same visible problem as #48648, but the path I hit was a bit different: rich Telegram support raises the stream consumer's overflow budget to 32k, while edit-based streaming still has to use Telegram's normal ~4096 edit limit.

So with edit streaming active, the consumer was letting the buffer grow way past 4096. Then every edit tick called Telegram's overflow split path with the full accumulated text. That edits/sends chunk 1 again, adopts the continuation as the new message id, and then the next token tick does the same thing again. In Telegram this looks like a pile of repeated first chunks with `1/2` at the bottom.

The fix is to only use the higher rich-message overflow cap when native draft streaming is actually active. For edit-based streaming, stay on the legacy edit cap and let the consumer split before it gets into the repeated `_edit_overflow_split()` loop.

## Related Issue

Related to #48648. I did not open a new issue because that one already describes this family of Telegram long-message duplication bugs.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/stream_consumer.py`
  - resolve draft streaming before picking the overflow budget
  - only honor `adapter.streaming_overflow_limit()` when draft streaming is active
  - keep edit streaming on `MAX_MESSAGE_LENGTH`
- `tests/gateway/test_stream_consumer.py`
  - adds coverage for the rich-cap/edit-streaming case
  - keeps the rich cap available for draft streaming

## How to Test

1. Enable Telegram streaming with rich messages available.
2. Ask for a response long enough to cross 4096 chars.
3. It should no longer keep posting repeated `(1/2)` chunks before the continuation arrives.

Targeted tests run locally:

```bash
uv run --with pytest --with pytest-asyncio python -m pytest \
  tests/gateway/test_stream_consumer.py \
  tests/gateway/test_telegram_rich_messages.py \
  tests/gateway/test_telegram_overflow_partial.py \
  -q -o 'addopts='
```

Result:

```text
167 passed in 11.84s
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / Telegram gateway code path

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No screenshot attached. The user-visible symptom was: long Telegram streaming answer gets split, first message shows `1/2`, and that first chunk is sent around 20 times before the second chunk comes in.
