### PR TITLE
fix(moa): tolerate non-list reference_models in hand-edited MoA preset config

### DIFF
--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -74,7 +74,13 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
     if not isinstance(raw, dict):
         raw = {}
 
-    refs = [_clean_slot(item) for item in raw.get("reference_models") or []]
+    raw_refs = raw.get("reference_models")
+    if not isinstance(raw_refs, list):
+        # A hand-edited scalar / single mapping (or a bad type) must degrade to
+        # defaults instead of crashing the iteration, mirroring the tolerance
+        # for the scalar fields below (reference_temperature / max_tokens).
+        raw_refs = [raw_refs] if isinstance(raw_refs, dict) else []
+    refs = [_clean_slot(item) for item in raw_refs]
     refs = [item for item in refs if item is not None]
     if not refs:
         refs = deepcopy(DEFAULT_MOA_REFERENCE_MODELS)

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -76,6 +76,24 @@ def test_normalize_moa_config_tolerates_non_numeric_values():
     assert preset["aggregator_temperature"] == 0.4
 
 
+def test_normalize_moa_config_tolerates_non_list_reference_models():
+    """A hand-edited scalar reference_models must degrade to defaults instead of
+    crashing normalize_moa_config with TypeError (symmetric with the non-numeric
+    scalar-field tolerance)."""
+    cfg = normalize_moa_config(
+        {"presets": {"broken": {"reference_models": 2}}}
+    )
+    assert cfg["presets"]["broken"]["reference_models"] == DEFAULT_MOA_REFERENCE_MODELS
+
+
+def test_normalize_moa_config_wraps_bare_dict_reference_models():
+    """A single reference slot written without the list wrapper is rescued."""
+    cfg = normalize_moa_config(
+        {"presets": {"p": {"reference_models": {"provider": "openai", "model": "gpt-4o"}}}}
+    )
+    assert cfg["presets"]["p"]["reference_models"] == [{"provider": "openai", "model": "gpt-4o"}]
+
+
 def test_normalize_moa_config_coerces_numeric_strings():
     """Valid numeric strings (e.g. from YAML round-trip) must coerce correctly."""
     cfg = normalize_moa_config({"max_tokens": "8192", "reference_temperature": "0.9"})


### PR DESCRIPTION
## What does this PR do?

`_normalize_preset` coerces `reference_models` by iterating
`raw.get("reference_models") or []`. When a user hand-edits the value to a
non-list scalar (e.g. `reference_models: 2`, `true`, or a single slot mapping
without the list wrapper), the iteration raises
`TypeError: 'int' object is not iterable`. Because `normalize_moa_config` runs
on every model-selection and MoA turn via `resolve_moa_preset`, the crash is
unrecoverable and blocks all MoA usage (CLI `hermes moa`, `/moa` turns, and the
MoA REST endpoints) until the config is manually fixed.

This mirrors the just-landed "tolerate non-numeric values in hand-edited MoA
preset config" fix (`f0678b031`): that guarded the scalar casts but the
`reference_models` iteration was left unguarded, and the `aggregator` slot is
already safe via `_clean_slot`'s dict check. Guard the list so a bad type
degrades to defaults (and rescue a bare single-slot mapping written without the
list wrapper), matching the existing "invalid → defaults" fallback below it.

## Related Issue

<!-- Code-originated find with no filed issue, like f0678b031 which carried none. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/moa_config.py`: in `_normalize_preset`, coerce a non-list
  `reference_models` before iterating — wrap a bare dict as a one-element list,
  otherwise fall through to `[]` so the existing "no refs → defaults" path
  applies. No behavior change for the normal list case.
- `tests/hermes_cli/test_moa_config.py`: add regression coverage for a scalar
  value (degrades to defaults) and a bare-dict value (rescued into a list).

## How to Test

1. Before the fix, `normalize_moa_config({"presets": {"broken": {"reference_models": 2}}})`
   raises `TypeError: 'int' object is not iterable`.
2. After the fix, the same call returns the default reference models, and a bare
   dict `{"provider": "openai", "model": "gpt-4o"}` is wrapped into a single-element list.
3. `pytest tests/hermes_cli/test_moa_config.py -q` — 15 passed. The two new tests
   fail before the production change (TypeError / dropped-to-default) and pass after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/hermes_cli/test_moa_config.py -q
...............                                                          [100%]
15 passed in 0.16s
```