### PR TITLE
fix(file): keep profile home when ~ is followed by consecutive slashes

### DIFF
--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -44,7 +44,14 @@ def _expand_tilde(path: str) -> str:
     except Exception:
         home = None
     if home and (path == "~" or path.startswith("~/")):
-        return home if path == "~" else os.path.join(home, path[2:])
+        if path == "~":
+            return home
+        # Strip the leading "~/" and any extra leading slashes so a path like
+        # "~//scratch" (or "~/ /" style consecutive separators) does not become
+        # an absolute path: os.path.join(home, "/scratch") returns "/scratch",
+        # silently discarding the profile home (#53432).
+        remainder = path[2:].lstrip("/")
+        return os.path.join(home, remainder)
     return os.path.expanduser(path)
 
 


### PR DESCRIPTION
Fixes #53432

## Root Cause

**Symptom** — A file-tool path written as `~//scratch/file.txt` (consecutive slashes after the tilde) resolves to `/scratch/file.txt` instead of `<profile-home>/scratch/file.txt`, silently losing the home directory and breaking the operation.

**Root cause** — In `tools/file_tools.py::_expand_tilde`, the profile-home branch does `os.path.join(home, path[2:])`. For `~//scratch`, `path[2:]` is `"/scratch"` — an absolute path. `os.path.join("/home", "/scratch")` returns `"/scratch"` (POSIX `join` discards everything before an absolute component), so the profile home is dropped.

**Evidence** — 
```
>>> os.path.join("/Users/x", "~//foo"[2:])  # path[2:] == "/foo"
/foo
```
`os.path.expanduser("~//foo")` correctly yields `"/Users/x//foo"`, confirming the regression is specific to the custom profile-home join, not expanduser.

**Fix + why this level** — Strip leading slashes from the remainder (`path[2:].lstrip("/")`) before joining, so the segment is always relative. Fixing in `_expand_tilde` is the correct layer: it is the single helper every in-process file tool routes `~` through, so the fix covers read/write/patch/search uniformly. The `os.path.expanduser` fallback path was already correct and is untouched.

## Tests

New regression test `test_consecutive_slashes_keep_profile_home` in `tests/tools/test_file_tools_tilde_profile.py` asserts `~//scratch/file.txt` resolves under the profile home. It FAILS without the fix:
```
- /opt/data/profiles/coder/home/scratch/file.txt
+ /scratch/file.txt
tests/tools/test_file_tools_tilde_profile.py:62: AssertionError
```
With the fix, the full suite passes:
```
9 passed in 0.23s
```

## Scope / risk

Touches only the profile-home branch of `_expand_tilde`. Bare `~`, `~user/...`, no-tilde paths, and the expanduser fallback are unchanged (all covered by existing tests). No behavior change for well-formed `~/path` inputs.