### PR TITLE
fix(trajectory): clamp file-mode sample size to entry count

### DIFF
--- a/tests/test_trajectory_compressor.py
+++ b/tests/test_trajectory_compressor.py
@@ -628,3 +628,15 @@ class TestCompressionToolPairIntegrity:
             {"from": "tool", "value": "<tool_response>a</tool_response>"},
         ]
         assert tc._snap_boundary(trajectory, 1, 0, 1) == 0
+
+
+def test_file_mode_sampling_clamps_to_entry_count_on_empty_input(tmp_path):
+    """File-mode --sample_percent on an empty JSONL must not raise
+    'Sample larger than population' (mirrors the directory path's min() clamp)."""
+    from trajectory_compressor import main
+
+    empty = tmp_path / "empty.jsonl"
+    empty.write_text("", encoding="utf-8")
+    # dry_run keeps it headless (no tokenizer / network); the sampling block
+    # runs before the dry-run return, so the clamp is what's under test here.
+    main(input=str(empty), sample_percent=10, dry_run=True)

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -1457,7 +1457,7 @@ def main(
         if sample_percent is not None:
             random.seed(seed)
             sample_size = max(1, int(total_entries * sample_percent / 100))
-            entries = random.sample(entries, sample_size)
+            entries = random.sample(entries, min(sample_size, total_entries))
             print(f"   Sampled {len(entries):,} trajectories ({sample_percent}% of {total_entries:,})")
         
         if dry_run:


### PR DESCRIPTION
## What does this PR do?

Single-file `--sample_percent` sampling in `main()` computes
`sample_size = max(1, int(total_entries * sample_percent / 100))` then calls
`random.sample(entries, sample_size)` without clamping to the population. On an
empty or all-whitespace input file `total_entries == 0` → `sample_size == 1` →
`random.sample([], 1)` raises `ValueError: Sample larger than population or is
negative` (even under `--dry_run`, because the sampling block runs before the
dry-run return).

The directory-mode path already clamps with `min(sample_size, len(entries))`;
this applies the same clamp to the single-file path so an empty dataset exits
cleanly with "0 trajectories" instead of crashing.

## Related Issue

<!-- Code-originated find with no filed issue. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `trajectory_compressor.py`: in `main()`'s single-file sampling branch, clamp
  `random.sample(entries, sample_size)` to `min(sample_size, total_entries)`,
  mirroring the existing directory-mode clamp.
- `tests/test_trajectory_compressor.py`: add a regression test that runs
  `main(input=<empty.jsonl>, sample_percent=10, dry_run=True)` and asserts it
  returns without raising.

## How to Test

1. Create an empty JSONL file: `printf '' > empty.jsonl`.
2. Before the fix: `python trajectory_compressor.py --input=empty.jsonl --sample_percent=10 --dry_run`
   raises `ValueError: Sample larger than population or is negative`.
3. After the fix: the same command reports "Loaded 0 trajectories" / "Would process 0" and exits cleanly.
4. `pytest tests/test_trajectory_compressor.py -q` — 36 passed. The new test fails
   before the production change (ValueError) and passes after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/test_trajectory_compressor.py -q
....................................                                     [100%]
36 passed in 0.30s
```