### PR TITLE
fix(desktop): scope audio endpoints to the active profile

### DIFF
--- a/apps/desktop/src/hermes-profile-scope.test.ts
+++ b/apps/desktop/src/hermes-profile-scope.test.ts
@@ -3,9 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   checkHermesUpdate,
   getActionStatus,
+  getElevenLabsVoices,
   getStatus,
   restartGateway,
   setApiRequestProfile,
+  speakText,
+  transcribeAudio,
   updateHermes
 } from './hermes'
 
@@ -44,6 +47,23 @@ describe('backend action helpers are profile-scoped', () => {
 
     for (const call of api.mock.calls) {
       expect(call[0].profile).toBe('coder')
+    }
+  })
+
+  // Audio endpoints (transcribe / speak / voices) write to the active
+  // profile's config in the settings UI but historically called the backend
+  // without a profile scope, so playback used the default profile's TTS/voice
+  // config instead of the active one (#53441).
+  it('forwards the active profile to audio endpoints', () => {
+    setApiRequestProfile('jarvis')
+
+    void transcribeAudio('data:audio/webm;base64,AAAA', 'audio/webm')
+    void speakText('hello')
+    void getElevenLabsVoices()
+
+    expect(api.mock.calls).toHaveLength(3)
+    for (const call of api.mock.calls) {
+      expect(call[0].profile).toBe('jarvis')
     }
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -813,6 +813,7 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
   return window.hermesDesktop.api<AudioTranscriptionResponse>({
     path: '/api/audio/transcribe',
     method: 'POST',
+    ...profileScoped(),
     body: {
       data_url: dataUrl,
       mime_type: mimeType
@@ -824,12 +825,14 @@ export function speakText(text: string): Promise<AudioSpeakResponse> {
   return window.hermesDesktop.api<AudioSpeakResponse>({
     path: '/api/audio/speak',
     method: 'POST',
+    ...profileScoped(),
     body: { text }
   })
 }
 
 export function getElevenLabsVoices(): Promise<ElevenLabsVoicesResponse> {
   return window.hermesDesktop.api<ElevenLabsVoicesResponse>({
-    path: '/api/audio/elevenlabs/voices'
+    path: '/api/audio/elevenlabs/voices',
+    ...profileScoped()
   })
 }


### PR DESCRIPTION
Fixes #53441

## Root Cause

**Symptom** — On a non-default desktop profile (e.g. `jarvis`), voice transcription / read-aloud / ElevenLabs voice listing use the *default* profile's TTS/voice config, even though the settings UI correctly saved them to the active profile's `config.yaml`.

**Root cause** — In `apps/desktop/src/hermes.ts`, almost every backend helper spreads `...profileScoped()` into its request so Electron main can route to the active profile's backend via `ensureBackend(profile)`. The three audio helpers — `transcribeAudio()` (`/api/audio/transcribe`), `speakText()` (`/api/audio/speak`), and `getElevenLabsVoices()` (`/api/audio/elevenlabs/voices`) — omitted `profileScoped()`, so their requests carried no `profile` field and resolved against the primary/default backend.

**Evidence** — Grepping `hermes.ts`, the audio helper request objects were the only backend-targeted calls missing the `...profileScoped()` spread that ~40 sibling helpers carry. A vitest assertion confirms the active profile is dropped on these three calls before the fix (see Tests).

**Fix + why this level** — Add `...profileScoped()` to the three audio request objects, matching the existing contract used by every other profile-aware helper. This is the correct layer: `profileScoped()` is the single source of truth the rest of the renderer uses to attach the active profile, and Electron main already honors `request.profile`. No backend change is needed.

**Scope / risk** — Touches only the three audio helpers. `profileScoped()` returns `{}` when no profile is active, so single-profile users are unaffected (verified by the existing "omits profile when none is active" test).

## Tests

New case `forwards the active profile to audio endpoints` in `apps/desktop/src/hermes-profile-scope.test.ts` sets the active profile and asserts all three audio calls carry it.

FAILS without the fix:
```
expect(call[0].profile).toBe("jarvis")
 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```
Passes with the fix:
```
 ✓ src/hermes-profile-scope.test.ts (3 tests) 3ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```
`tsc -b` clean.