### PR TITLE
fix(cli): memoize _count_skills to stop rglob stalling the event loop

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -27,9 +27,10 @@ import shutil
 import stat
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from agent.skill_utils import is_excluded_skill_path
 
@@ -644,16 +645,33 @@ def _check_gateway_running(profile_dir: Path) -> bool:
         return False
 
 
+# ``_count_skills`` walks the whole ``skills/`` tree with ``rglob``. With 100+
+# installed skills this can block for seconds, and ``list_profiles`` is reached
+# from synchronous web-server handlers running on the asyncio event-loop thread
+# (``list_cron_jobs`` -> ``_cron_profile_dicts`` -> ``list_profiles``). On a
+# slow/large filesystem that stall trips the ws-write watchdog ("loop stalled
+# >10s"), drops the WebSocket, and restarts the gateway (#53461). The skill
+# inventory changes rarely, so memoize the count per skills dir with a short
+# TTL: the first call pays the scan, repeated calls within the window are O(1).
+_skill_count_cache: Dict[Path, Tuple[float, int]] = {}
+_SKILL_COUNT_CACHE_TTL = 300.0  # seconds
+
+
 def _count_skills(profile_dir: Path) -> int:
-    """Count installed skills in a profile."""
+    """Count installed skills in a profile (memoized with a short TTL)."""
     skills_dir = profile_dir / "skills"
     if not skills_dir.is_dir():
         return 0
+    now = time.monotonic()
+    cached = _skill_count_cache.get(skills_dir)
+    if cached is not None and now - cached[0] < _SKILL_COUNT_CACHE_TTL:
+        return cached[1]
     count = 0
     for md in skills_dir.rglob("SKILL.md"):
         if is_excluded_skill_path(md):
             continue
         count += 1
+    _skill_count_cache[skills_dir] = (now, count)
     return count
 
 

--- a/tests/hermes_cli/test_count_skills_cache.py
+++ b/tests/hermes_cli/test_count_skills_cache.py
@@ -1,0 +1,62 @@
+"""Regression tests for the _count_skills TTL cache (#53461).
+
+_count_skills walks the whole skills/ tree with rglob. It is reached from
+synchronous web-server handlers on the asyncio event-loop thread
+(list_cron_jobs -> _cron_profile_dicts -> list_profiles), so a multi-second
+scan on a large/slow filesystem stalls the loop, drops the WebSocket, and
+restarts the gateway. The count is memoized with a short TTL so only the first
+call in the window pays the scan.
+"""
+
+import time
+from pathlib import Path
+
+import hermes_cli.profiles as profiles
+
+
+def _make_skill(skills_dir: Path, name: str) -> None:
+    d = skills_dir / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(f"# {name}\n")
+
+
+class TestCountSkillsCache:
+    def setup_method(self):
+        profiles._skill_count_cache.clear()
+
+    def test_counts_skills(self, tmp_path):
+        skills = tmp_path / "skills"
+        _make_skill(skills, "alpha")
+        _make_skill(skills, "beta")
+        assert profiles._count_skills(tmp_path) == 2
+
+    def test_missing_dir_returns_zero(self, tmp_path):
+        assert profiles._count_skills(tmp_path) == 0
+
+    def test_repeat_call_does_not_rescan(self, tmp_path, monkeypatch):
+        skills = tmp_path / "skills"
+        _make_skill(skills, "alpha")
+
+        # First call populates the cache and performs the rglob scan.
+        assert profiles._count_skills(tmp_path) == 1
+
+        # Now make rglob explode: a second call within the TTL must serve the
+        # cached value WITHOUT touching the filesystem again.
+        def _boom(*args, **kwargs):
+            raise AssertionError("rglob called again within TTL — cache miss")
+
+        monkeypatch.setattr(Path, "rglob", _boom)
+        assert profiles._count_skills(tmp_path) == 1
+
+    def test_cache_expires_after_ttl(self, tmp_path, monkeypatch):
+        skills = tmp_path / "skills"
+        _make_skill(skills, "alpha")
+
+        fake_now = [1000.0]
+        monkeypatch.setattr(profiles.time, "monotonic", lambda: fake_now[0])
+        assert profiles._count_skills(tmp_path) == 1
+
+        # Add a skill, advance past the TTL — the next call must rescan.
+        _make_skill(skills, "beta")
+        fake_now[0] += profiles._SKILL_COUNT_CACHE_TTL + 1
+        assert profiles._count_skills(tmp_path) == 2


### PR DESCRIPTION
Fixes #53461

## Root Cause

**Symptom** — On Windows with 100+ installed skills, the gateway logs `ws write slow (loop stalled >10.0s)`, the dashboard WebSocket disconnects, and the gateway restarts.

**Root cause** — `hermes_cli/profiles.py::_count_skills()` walks the entire `skills/` tree with `Path.rglob("SKILL.md")` on every call. `list_profiles()` calls it once per profile, and `list_profiles()` is reached from synchronous web-server handlers that run on the asyncio event-loop thread:
```
_count_skills (hermes_cli/profiles.py:653)
list_profiles (hermes_cli/profiles.py:759)
_cron_profile_dicts (hermes_cli/web_server.py:7895)
list_cron_jobs (hermes_cli/web_server.py:7975)
```
A multi-second synchronous directory walk on that thread blocks the loop long enough to trip the ws-write watchdog.

**Evidence** — The reporter captured a py-spy stack with `MainThread` parked inside `pathlib._iterate_directories` under `rglob` under `_count_skills`, on the event-loop call chain above.

**Fix + why this level** — Memoize the count per `skills_dir` with a 5-minute TTL (`time.monotonic`). The skill inventory changes rarely, so the first call pays the scan and subsequent calls within the window are O(1). Caching at `_count_skills` is the right layer: it is the single hot scan, and the fix is transparent to every caller (`list_profiles`, cron/dashboard handlers) without changing their sync/async shape. (Moving the scan off-thread would be a larger, riskier change for a value that is effectively static between installs.)

**Scope / risk** — Only `_count_skills` changes. Counting semantics, exclusions (`is_excluded_skill_path`), and the missing-dir-returns-0 path are unchanged. Worst case is a stale count for up to 5 minutes after a skill install/remove, which is cosmetic in the profile/cron listings.

## Tests

New `tests/hermes_cli/test_count_skills_cache.py` (4 cases):
- counts skills correctly
- missing dir returns 0
- **repeat call within TTL does not rescan** — patches `Path.rglob` to raise; passes only because the cached value is served (fails without the fix: the symbol `_skill_count_cache` does not exist)
- cache expires after the TTL and rescans (picks up a newly added skill)

```
4 passed in 0.25s
```
Existing suite green: `tests/hermes_cli/test_profiles.py` — 142 passed.