### PR TITLE
fix(desktop): scope audio helpers to active profile

### DIFF
--- a/apps/desktop/src/hermes-profile-scope.test.ts
+++ b/apps/desktop/src/hermes-profile-scope.test.ts
@@ -3,9 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   checkHermesUpdate,
   getActionStatus,
+  getElevenLabsVoices,
   getStatus,
   restartGateway,
+  speakText,
   setApiRequestProfile,
+  transcribeAudio,
   updateHermes
 } from './hermes'
 
@@ -44,6 +47,18 @@ describe('backend action helpers are profile-scoped', () => {
 
     for (const call of api.mock.calls) {
       expect(call[0].profile).toBe('coder')
+    }
+  })
+
+  it('forwards the active profile to desktop audio helpers', () => {
+    setApiRequestProfile('jarvis')
+
+    void transcribeAudio('data:audio/wav;base64,AAAA', 'audio/wav')
+    void speakText('hello')
+    void getElevenLabsVoices()
+
+    for (const call of api.mock.calls) {
+      expect(call[0].profile).toBe('jarvis')
     }
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -811,6 +811,7 @@ export function getActionStatus(name: string, lines = 200): Promise<ActionStatus
 
 export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<AudioTranscriptionResponse> {
   return window.hermesDesktop.api<AudioTranscriptionResponse>({
+    ...profileScoped(),
     path: '/api/audio/transcribe',
     method: 'POST',
     body: {
@@ -822,6 +823,7 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
 
 export function speakText(text: string): Promise<AudioSpeakResponse> {
   return window.hermesDesktop.api<AudioSpeakResponse>({
+    ...profileScoped(),
     path: '/api/audio/speak',
     method: 'POST',
     body: { text }
@@ -830,6 +832,7 @@ export function speakText(text: string): Promise<AudioSpeakResponse> {
 
 export function getElevenLabsVoices(): Promise<ElevenLabsVoicesResponse> {
   return window.hermesDesktop.api<ElevenLabsVoicesResponse>({
+    ...profileScoped(),
     path: '/api/audio/elevenlabs/voices'
   })
 }


### PR DESCRIPTION
## Summary
- scope desktop audio REST helpers to the active gateway profile
- fix transcribe, speak, and ElevenLabs voice-list calls so non-default profiles use their own config
- add a profile-scope regression test for the three audio helpers

Fixes #53441.

## Verification
- npm run test:ui -- src/hermes-profile-scope.test.ts
- npm run typecheck