### PR TITLE
fix: handle legacy function roles in compression

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -201,6 +201,12 @@ _SUMMARY_TOKENS_CEILING = 10_000
 # Placeholder used when pruning old tool results
 _PRUNED_TOOL_PLACEHOLDER = "[Old tool output cleared to save context space]"
 
+_TOOL_RESULT_ROLES = frozenset({"tool", "function"})
+
+
+def _is_tool_result_role(role: Any) -> bool:
+    return role in _TOOL_RESULT_ROLES
+
 # Chars per token rough estimate
 _CHARS_PER_TOKEN = 4
 # Flat token cost per attached image part.  Real cost varies by provider and
@@ -1494,7 +1500,7 @@ class ContextCompressor(ContextEngine):
         content_hashes: dict = {}  # hash -> (index, tool_call_id)
         for i in range(len(result) - 1, -1, -1):
             msg = result[i]
-            if msg.get("role") != "tool":
+            if not _is_tool_result_role(msg.get("role")):
                 continue
             content = msg.get("content") or ""
             # Multimodal content — dedupe by the text summary if available.
@@ -1517,7 +1523,7 @@ class ContextCompressor(ContextEngine):
         # Pass 2: Replace old tool results with informative summaries
         for i in range(prune_boundary):
             msg = result[i]
-            if msg.get("role") != "tool":
+            if not _is_tool_result_role(msg.get("role")):
                 continue
             content = msg.get("content", "")
             # Multimodal content (base64 screenshots etc.): strip the image
@@ -1635,7 +1641,7 @@ class ContextCompressor(ContextEngine):
                 content = strip_think_blocks(None, content)
 
             # Tool results: keep enough content for the summarizer
-            if role == "tool":
+            if _is_tool_result_role(role):
                 tool_id = msg.get("tool_call_id", "")
                 if len(content) > self._CONTENT_MAX:
                     content = content[:self._CONTENT_HEAD] + "\n...[truncated]...\n" + content[-self._CONTENT_TAIL:]
@@ -1771,7 +1777,7 @@ class ContextCompressor(ContextEngine):
                     )
                 elif text:
                     assistant_actions.append(text)
-            elif role == "tool":
+            elif _is_tool_result_role(role):
                 call_id = str(msg.get("tool_call_id") or "")
                 tool_name, tool_args = call_id_to_tool.get(call_id, ("unknown", ""))
                 tool_actions.append(
@@ -2470,7 +2476,7 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         result_call_ids: set = set()
         for msg in messages:
-            if msg.get("role") == "tool":
+            if _is_tool_result_role(msg.get("role")):
                 cid = msg.get("tool_call_id")
                 if cid:
                     result_call_ids.add(cid)
@@ -2480,7 +2486,10 @@ This compaction should PRIORITISE preserving all information related to the focu
         if orphaned_results:
             messages = [
                 m for m in messages
-                if not (m.get("role") == "tool" and m.get("tool_call_id") in orphaned_results)
+                if not (
+                    _is_tool_result_role(m.get("role"))
+                    and m.get("tool_call_id") in orphaned_results
+                )
             ]
             if not self.quiet_mode:
                 logger.info("Compression sanitizer: removed %d orphaned tool result(s)", len(orphaned_results))
@@ -2519,10 +2528,10 @@ This compaction should PRIORITISE preserving all information related to the focu
     def _align_boundary_forward(self, messages: List[Dict[str, Any]], idx: int) -> int:
         """Push a compress-start boundary forward past any orphan tool results.
 
-        If ``messages[idx]`` is a tool result, slide forward until we hit a
-        non-tool message so we don't start the summarised region mid-group.
+        If ``messages[idx]`` is a tool/function result, slide forward until we
+        hit a non-result message so we don't start the summarised region mid-group.
         """
-        while idx < len(messages) and messages[idx].get("role") == "tool":
+        while idx < len(messages) and _is_tool_result_role(messages[idx].get("role")):
             idx += 1
         return idx
 
@@ -2582,9 +2591,9 @@ This compaction should PRIORITISE preserving all information related to the focu
         """
         if idx <= 0 or idx >= len(messages):
             return idx
-        # Walk backward past consecutive tool results
+        # Walk backward past consecutive tool/function results
         check = idx - 1
-        while check >= 0 and messages[check].get("role") == "tool":
+        while check >= 0 and _is_tool_result_role(messages[check].get("role")):
             check -= 1
         # If we landed on the parent assistant with tool_calls, pull the
         # boundary before it so the whole group gets summarised together.
@@ -2797,7 +2806,7 @@ This compaction should PRIORITISE preserving all information related to the focu
     ) -> int:
         """Return the index *after* the complete turn-pair starting at *user_idx*.
 
-        A turn-pair is: ``user`` -> ``assistant`` [-> zero-or-more ``tool``
+        A turn-pair is: ``user`` -> ``assistant`` [-> zero-or-more tool/function
         results].  Returns the index of the first message that does *not*
         belong to the pair, i.e. the natural cut point that keeps the pair
         intact on one side of the boundary.
@@ -2813,7 +2822,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             return idx  # no assistant reply immediately following
         idx += 1
         # Include any tool results that belong to this assistant turn.
-        while idx < n and messages[idx].get("role") == "tool":
+        while idx < n and _is_tool_result_role(messages[idx].get("role")):
             idx += 1
         return idx
 
@@ -3224,7 +3233,11 @@ This compaction should PRIORITISE preserving all information related to the focu
                 _force_user_leading = True
         # Pick a role that avoids consecutive same-role with both neighbors.
         # Priority: avoid colliding with head (already committed), then tail.
-        if last_head_role in {"assistant", "tool"} or _force_user_leading:
+        if (
+            last_head_role == "assistant"
+            or _is_tool_result_role(last_head_role)
+            or _force_user_leading
+        ):
             summary_role = "user"
         else:
             summary_role = "assistant"

--- a/tests/agent/test_compressor_legacy_function_role.py
+++ b/tests/agent/test_compressor_legacy_function_role.py
@@ -1,0 +1,101 @@
+from unittest.mock import MagicMock, patch
+
+
+def _compressor():
+    from agent.context_compressor import ContextCompressor
+
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=100_000,
+    ):
+        return ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=0,
+            protect_last_n=1,
+            quiet_mode=True,
+        )
+
+
+def _legacy_tool_turns():
+    return [
+        {"role": "user", "content": "question"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "function",
+            "tool_call_id": "call-1",
+            "name": "lookup",
+            "content": "legacy result",
+        },
+        {"role": "user", "content": "tail"},
+    ]
+
+
+def test_align_boundary_forward_skips_legacy_function_results():
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "function", "name": "old_tool", "content": "legacy result"},
+        {"role": "user", "content": "next user"},
+    ]
+
+    assert _compressor()._align_boundary_forward(messages, 1) == 2
+
+
+def test_align_boundary_backward_keeps_legacy_function_result_with_parent_call():
+    assert _compressor()._align_boundary_backward(_legacy_tool_turns(), 3) == 1
+
+
+def test_turn_pair_includes_legacy_function_results():
+    assert _compressor()._find_turn_pair_end(_legacy_tool_turns(), 0) == 3
+
+
+def test_summary_serialization_labels_legacy_function_as_tool_result():
+    serialized = _compressor()._serialize_for_summary([_legacy_tool_turns()[2]])
+
+    assert serialized == "[TOOL RESULT call-1]: legacy result"
+
+
+def test_static_fallback_extracts_legacy_function_result_facts():
+    with patch(
+        "agent.context_compressor._summarize_tool_result",
+        return_value="preserved legacy fact",
+    ) as summarize:
+        summary = _compressor()._build_static_fallback_summary(
+            _legacy_tool_turns()[1:3]
+        )
+
+    summarize.assert_called_once_with("lookup", "{}", "legacy result")
+    assert "preserved legacy fact" in summary
+
+
+def test_system_only_protected_head_still_forces_user_summary_role():
+    compressor = _compressor()
+    compressor.compression_count = 1
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "question 1"},
+        {"role": "assistant", "content": "answer 1"},
+        {"role": "user", "content": "question 2"},
+        {"role": "assistant", "content": "answer 2"},
+        {"role": "user", "content": "question 3"},
+        {"role": "assistant", "content": "answer 3"},
+    ]
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = "compressed middle"
+
+    with patch("agent.context_compressor.call_llm", return_value=response):
+        compressed = compressor.compress(messages)
+
+    non_system = [msg for msg in compressed if msg.get("role") != "system"]
+    assert non_system[0]["role"] == "user"


### PR DESCRIPTION
Problem
The compressor treated only role="tool" as a tool-result boundary role, even though legacy transcripts can still contain role="function". It also did not clearly preserve the intended assistant summary role when the protected head contains only system-like messages.

Summary
- Add a shared predicate for tool-result roles that covers both tool and legacy function messages.
- Use it for boundary alignment, tool-result serialization, sanitizer result detection, and summary role selection.
- Add regression tests for legacy function boundaries and system-head summary role selection.

Validation
- $HOME/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/agent/test_compressor_legacy_function_role.py tests/agent/test_compressor_assistant_tail_anchor.py
- $HOME/.hermes/hermes-agent/venv/bin/ruff check agent/context_compressor.py tests/agent/test_compressor_legacy_function_role.py
- git diff --check

Fixes #53463