### PR TITLE
fix(profiles): cache skill counts for 5 minutes

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -27,6 +27,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import List, Optional, Tuple
@@ -58,6 +59,9 @@ _CLONE_CONFIG_FILES = [
     ".env",
     "SOUL.md",
 ]
+
+_SKILL_COUNT_CACHE_TTL_SECONDS = 300.0
+_skill_count_cache: dict[Path, tuple[float, int]] = {}
 
 # Subdirectory files copied during --clone (path relative to profile root).
 # Memory files are part of the agent's curated identity — just as important
@@ -647,13 +651,21 @@ def _check_gateway_running(profile_dir: Path) -> bool:
 def _count_skills(profile_dir: Path) -> int:
     """Count installed skills in a profile."""
     skills_dir = profile_dir / "skills"
+    now = time.monotonic()
+    cached = _skill_count_cache.get(skills_dir)
+    if cached is not None:
+        cached_at, cached_count = cached
+        if now - cached_at < _SKILL_COUNT_CACHE_TTL_SECONDS:
+            return cached_count
     if not skills_dir.is_dir():
-        return 0
-    count = 0
-    for md in skills_dir.rglob("SKILL.md"):
-        if is_excluded_skill_path(md):
-            continue
-        count += 1
+        count = 0
+    else:
+        count = 0
+        for md in skills_dir.rglob("SKILL.md"):
+            if is_excluded_skill_path(md):
+                continue
+            count += 1
+    _skill_count_cache[skills_dir] = (now, count)
     return count
 
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -13,6 +13,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 import yaml
+import hermes_cli.profiles as profiles_mod
 
 from hermes_cli.profiles import (
     normalize_profile_name,
@@ -36,6 +37,7 @@ from hermes_cli.profiles import (
     NO_BUNDLED_SKILLS_MARKER,
     backfill_profile_envs,
     profiles_to_serve,
+    _count_skills,
 )
 from hermes_cli.config import DEFAULT_CONFIG
 
@@ -616,6 +618,32 @@ class TestListProfiles:
         profiles = list_profiles()
         assert profiles[0].name == "default"
         assert profiles[0].is_default is True
+
+
+class TestCountSkills:
+    """Tests for _count_skills()."""
+
+    def test_uses_ttl_cache_until_expiry(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / "profile"
+        skills_dir = profile_dir / "skills"
+        (skills_dir / "alpha").mkdir(parents=True)
+        (skills_dir / "alpha" / "SKILL.md").write_text("alpha", encoding="utf-8")
+
+        now = [100.0]
+        monkeypatch.setattr(profiles_mod.time, "monotonic", lambda: now[0])
+        monkeypatch.setattr(profiles_mod, "_SKILL_COUNT_CACHE_TTL_SECONDS", 300.0)
+        monkeypatch.setattr(profiles_mod, "_skill_count_cache", {})
+
+        assert _count_skills(profile_dir) == 1
+
+        (skills_dir / "beta").mkdir()
+        (skills_dir / "beta" / "SKILL.md").write_text("beta", encoding="utf-8")
+
+        now[0] = 399.0
+        assert _count_skills(profile_dir) == 1
+
+        now[0] = 401.0
+        assert _count_skills(profile_dir) == 2
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary\n- cache per-profile skill counts for 5 minutes to avoid repeated recursive scans on dashboard/profile reads\n- recompute after the TTL expires so newly added skills eventually surface\n- add a regression test covering cache hit before expiry and refresh after expiry\n\n## Testing\n- uv run --extra dev python -m pytest tests/hermes_cli/test_profiles.py -k TestCountSkills\n- uv run --extra dev ruff check hermes_cli/profiles.py tests/hermes_cli/test_profiles.py\n- git diff --check