### PR TITLE
fix(profiles): prune profile skill scans when counting skills

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import List, Optional, Tuple
 
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import iter_skill_index_files
 
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
@@ -785,11 +785,7 @@ def _count_skills(profile_dir: Path) -> int:
     ):
         return cached[2]
 
-    count = 0
-    for md in skills_dir.rglob("SKILL.md"):
-        if is_excluded_skill_path(md):
-            continue
-        count += 1
+    count = sum(1 for _ in iter_skill_index_files(skills_dir, "SKILL.md"))
     _SKILL_COUNT_CACHE[key] = (signature, now, count)
     return count
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -24,6 +24,7 @@ from hermes_cli.profiles import (
     validate_profile_name,
     get_profile_dir,
     create_profile,
+    _count_skills,
     delete_profile,
     list_profiles,
     set_active_profile,
@@ -703,6 +704,60 @@ class TestListProfiles:
         profiles = list_profiles()
         assert profiles[0].name == "default"
         assert profiles[0].is_default is True
+
+
+class TestCountSkills:
+    """Tests for _count_skills()."""
+
+    def test_prunes_excluded_and_support_dirs_without_rglob(self, profile_env, monkeypatch):
+        default_home = profile_env / ".hermes"
+        skills_dir = default_home / "skills"
+        real_skill = skills_dir / "real"
+        (real_skill / "SKILL.md").parent.mkdir(parents=True)
+        (real_skill / "SKILL.md").write_text("---\nname: real\n---\n", encoding="utf-8")
+        (skills_dir / ".venv" / "archived" / "SKILL.md").parent.mkdir(parents=True)
+        (skills_dir / ".venv" / "archived" / "SKILL.md").write_text(
+            "---\nname: archived\n---\n",
+            encoding="utf-8",
+        )
+        (skills_dir / "node_modules" / "vendor" / "SKILL.md").parent.mkdir(parents=True)
+        (skills_dir / "node_modules" / "vendor" / "SKILL.md").write_text(
+            "---\nname: vendor\n---\n",
+            encoding="utf-8",
+        )
+        (real_skill / "references" / "legacy" / "SKILL.md").parent.mkdir(parents=True)
+        (real_skill / "references" / "legacy" / "SKILL.md").write_text(
+            "---\nname: legacy\n---\n",
+            encoding="utf-8",
+        )
+
+        def _fail_rglob(self, pattern):
+            raise AssertionError(f"Path.rglob should not be used for {pattern}")
+
+        monkeypatch.setattr(Path, "rglob", _fail_rglob)
+
+        assert _count_skills(default_home) == 1
+
+    def test_reuses_cached_count_when_signature_is_unchanged(self, profile_env, monkeypatch):
+        default_home = profile_env / ".hermes"
+        skills_dir = default_home / "skills"
+        skills_dir.mkdir()
+        scan_calls = 0
+
+        def _iter_skills(_root, _index_name):
+            nonlocal scan_calls
+            scan_calls += 1
+            yield skills_dir / "one" / "SKILL.md"
+            yield skills_dir / "two" / "SKILL.md"
+
+        profiles._SKILL_COUNT_CACHE.clear()
+        monkeypatch.setattr(profiles, "iter_skill_index_files", _iter_skills)
+        monkeypatch.setattr(profiles, "_skills_dir_signature", lambda _path: 42.0)
+        monkeypatch.setattr(profiles.time, "time", lambda: 100.0)
+
+        assert _count_skills(default_home) == 2
+        assert _count_skills(default_home) == 2
+        assert scan_calls == 1
 
 
 # ===================================================================


### PR DESCRIPTION
## What does this PR do?

Profile listing and cron profile expansion count installed skills on request paths such as `/api/profiles` and `profile=all` cron views. On a cold cache miss, `hermes_cli.profiles._count_skills()` walked `skills/` with `Path.rglob("SKILL.md")`, descending into excluded dependency and support trees before filtering.

This preserves the newer mtime-signature/TTL cache on `main` and replaces only its cache-miss traversal with the shared `iter_skill_index_files(...)` scanner, which prunes excluded directories before descent.

## Related Issue

Fixes #53461

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- preserve the existing `_SKILL_COUNT_CACHE`, signature invalidation, and 30-second TTL fast path
- replace only the cold cache-miss `Path.rglob()` loop with `iter_skill_index_files(...)`
- verify excluded dirs such as `.venv`, `node_modules`, and skill `references/` trees are not counted
- add a regression proving an unchanged signature reuses the cached count without rescanning
- leave similar scans in `profile_distribution.py` and `dump.py` for focused follow-ups outside this request path

## How to Test

1. Run `pytest tests/hermes_cli/test_profiles.py -q` (157 passed).
2. Run `pytest tests/hermes_cli/test_web_server.py -k profiles_list -q` (2 passed).
3. Run `pytest tests/hermes_cli/test_web_server_cron_profiles.py -q` (23 passed).
4. Run `ruff check hermes_cli/profiles.py tests/hermes_cli/test_profiles.py`.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] My PR contains only changes related to this fix
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: macOS 15.7.7

### Documentation & Housekeeping

- [x] N/A for docs updates
- [x] N/A for `cli-config.yaml.example`
- [x] N/A for `CONTRIBUTING.md` / `AGENTS.md`
- [x] Cross-platform impact considered
- [x] N/A for tool descriptions/schemas

## Screenshots / Logs

The pre-fix regression monkeypatches `Path.rglob` to fail, landing directly in `_count_skills()` on a cold miss. The post-fix test counts only the real skill root, while a second regression confirms repeated calls with an unchanged signature scan only once.