### PR TITLE
Hide memory tool when built-in memory is disabled

### DIFF
--- a/tests/tools/test_memory_tool_schema.py
+++ b/tests/tools/test_memory_tool_schema.py
@@ -18,8 +18,12 @@ backends reject.
 """
 
 import json
+from types import SimpleNamespace
+from unittest.mock import patch
 
-from tools.memory_tool import MEMORY_SCHEMA
+from agent.prompt_builder import MEMORY_GUIDANCE
+from agent.system_prompt import build_system_prompt_parts
+from tools.memory_tool import MEMORY_SCHEMA, check_memory_requirements
 
 
 _FORBIDDEN_TOP_LEVEL_KEYS = ("allOf", "anyOf", "oneOf", "enum", "not")
@@ -52,3 +56,93 @@ def test_memory_schema_is_well_formed():
 
 def test_memory_schema_is_json_serializable():
     json.dumps(MEMORY_SCHEMA)
+
+
+def test_memory_tool_hidden_when_built_in_memory_disabled(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": {"memory_enabled": False, "user_profile_enabled": False}},
+    )
+
+    assert check_memory_requirements() is False
+
+
+def test_memory_tool_available_when_memory_enabled(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": {"memory_enabled": True, "user_profile_enabled": False}},
+    )
+
+    assert check_memory_requirements() is True
+
+
+def test_memory_tool_available_when_user_profile_enabled(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": {"memory_enabled": False, "user_profile_enabled": True}},
+    )
+
+    assert check_memory_requirements() is True
+
+
+def test_memory_tool_registry_gate_updates_immediately(monkeypatch):
+    from model_tools import get_tool_definitions
+    from tools.registry import invalidate_check_fn_cache
+
+    state = {"memory_enabled": True, "user_profile_enabled": False}
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": dict(state)},
+    )
+    invalidate_check_fn_cache()
+
+    enabled = get_tool_definitions(enabled_toolsets=["memory"], quiet_mode=False)
+    assert {tool["function"]["name"] for tool in enabled} == {"memory"}
+
+    state["memory_enabled"] = False
+    disabled = get_tool_definitions(enabled_toolsets=["memory"], quiet_mode=False)
+    assert "memory" not in {tool["function"]["name"] for tool in disabled}
+
+
+def test_memory_guidance_follows_registry_filtered_tool_names(monkeypatch):
+    from model_tools import get_tool_definitions
+    from tools.registry import invalidate_check_fn_cache
+
+    state = {"memory_enabled": True, "user_profile_enabled": False}
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": dict(state)},
+    )
+    invalidate_check_fn_cache()
+
+    def stable_prompt_for_registry_tools():
+        tools = get_tool_definitions(enabled_toolsets=["memory"], quiet_mode=False)
+        agent = SimpleNamespace(
+            load_soul_identity=False,
+            skip_context_files=False,
+            valid_tool_names={tool["function"]["name"] for tool in tools},
+            _task_completion_guidance=False,
+            _parallel_tool_call_guidance=False,
+            _tool_use_enforcement=False,
+            _environment_probe=False,
+            _kanban_worker_guidance="",
+            _memory_store=None,
+            _memory_manager=None,
+            model="",
+            provider="",
+            platform="",
+            pass_session_id=False,
+            session_id="",
+        )
+        with (
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.build_context_files_prompt", return_value=""),
+        ):
+            return build_system_prompt_parts(agent)["stable"]
+
+    assert MEMORY_GUIDANCE in stable_prompt_for_registry_tools()
+
+    state["memory_enabled"] = False
+    assert MEMORY_GUIDANCE not in stable_prompt_for_registry_tools()

--- a/tests/tools/test_terminal_tool_requirements.py
+++ b/tests/tools/test_terminal_tool_requirements.py
@@ -153,6 +153,27 @@ class TestCheckFnTransientFailureSuppression:
         t["now"] += reg._CHECK_FN_FAILURE_GRACE_SECONDS + 1
         assert reg._check_fn_cached(probe) is False
 
+    def test_check_fn_can_opt_out_of_ttl_and_failure_grace(self, monkeypatch):
+        import tools.registry as reg
+
+        state = {"ok": True}
+        calls = {"n": 0}
+
+        def config_gate():
+            calls["n"] += 1
+            return state["ok"]
+
+        config_gate._hermes_check_fn_cache_ttl_seconds = 0.0
+        config_gate._hermes_check_fn_failure_grace_seconds = 0.0
+
+        t = {"now": 1000.0}
+        monkeypatch.setattr(reg.time, "monotonic", lambda: t["now"])
+
+        assert reg._check_fn_cached(config_gate) is True
+        state["ok"] = False
+        assert reg._check_fn_cached(config_gate) is False
+        assert calls["n"] == 2
+
     def test_subagent_keeps_file_tools_through_docker_flake(self, monkeypatch):
         """End-to-end: a docker probe that flakes on the 2nd build keeps the
         file/terminal toolset available for the subagent being constructed."""

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1035,8 +1035,25 @@ def memory_tool(
 
 
 def check_memory_requirements() -> bool:
-    """Memory tool has no external requirements -- always available."""
-    return True
+    """Expose the built-in memory tool only when built-in memory is enabled."""
+    try:
+        from hermes_cli.config import load_config
+
+        memory_config = load_config().get("memory", {})
+    except Exception:
+        return False
+    return bool(
+        memory_config.get("memory_enabled")
+        or memory_config.get("user_profile_enabled")
+    )
+
+
+# This predicate is a deterministic config gate, not a flaky external probe.
+# It must reflect user config changes immediately so the memory tool and
+# MEMORY_GUIDANCE do not stay exposed after both built-in memory surfaces are
+# disabled. See tools.registry._check_fn_cached().
+check_memory_requirements._hermes_check_fn_cache_ttl_seconds = 0.0
+check_memory_requirements._hermes_check_fn_failure_grace_seconds = 0.0
 
 
 def apply_memory_pending(payload: Dict[str, Any], store: "MemoryStore") -> Dict[str, Any]:
@@ -1146,7 +1163,5 @@ registry.register(
     check_fn=check_memory_requirements,
     emoji="🧠",
 )
-
-
 
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -151,6 +151,27 @@ _check_fn_last_good: Dict[Callable, float] = {}
 _check_fn_cache_lock = threading.Lock()
 
 
+def _check_fn_ttl_seconds(fn: Callable) -> float:
+    """Return this check_fn's cache TTL.
+
+    Deterministic config gates can set
+    ``_hermes_check_fn_cache_ttl_seconds = 0`` to force a fresh read on every
+    availability pass. External probes keep the default TTL.
+    """
+    try:
+        return float(getattr(fn, "_hermes_check_fn_cache_ttl_seconds"))
+    except (AttributeError, TypeError, ValueError):
+        return _CHECK_FN_TTL_SECONDS
+
+
+def _check_fn_failure_grace_seconds(fn: Callable) -> float:
+    """Return this check_fn's transient-failure grace window."""
+    try:
+        return float(getattr(fn, "_hermes_check_fn_failure_grace_seconds"))
+    except (AttributeError, TypeError, ValueError):
+        return _CHECK_FN_FAILURE_GRACE_SECONDS
+
+
 def _check_fn_cached(fn: Callable) -> bool:
     """Return bool(fn()), TTL-cached across calls.
 
@@ -161,11 +182,13 @@ def _check_fn_cached(fn: Callable) -> bool:
     contention, probe timeout) from silently stripping tools mid-session.
     """
     now = time.monotonic()
+    ttl_seconds = _check_fn_ttl_seconds(fn)
+    failure_grace_seconds = _check_fn_failure_grace_seconds(fn)
     with _check_fn_cache_lock:
         cached = _check_fn_cache.get(fn)
-        if cached is not None:
+        if cached is not None and ttl_seconds > 0:
             ts, value = cached
-            if now - ts < _CHECK_FN_TTL_SECONDS:
+            if now - ts < ttl_seconds:
                 return value
 
     raised = False
@@ -177,12 +200,22 @@ def _check_fn_cached(fn: Callable) -> bool:
 
     with _check_fn_cache_lock:
         if value:
-            _check_fn_last_good[fn] = now
-            _check_fn_cache[fn] = (now, True)
+            if failure_grace_seconds > 0:
+                _check_fn_last_good[fn] = now
+            else:
+                _check_fn_last_good.pop(fn, None)
+            if ttl_seconds > 0:
+                _check_fn_cache[fn] = (now, True)
+            else:
+                _check_fn_cache.pop(fn, None)
             return True
 
         last_good = _check_fn_last_good.get(fn)
-        if last_good is not None and now - last_good < _CHECK_FN_FAILURE_GRACE_SECONDS:
+        if (
+            failure_grace_seconds > 0
+            and last_good is not None
+            and now - last_good < failure_grace_seconds
+        ):
             # Recent success → treat this failure as a flake. Serve last-good
             # True and do NOT cache the failure, so the next call re-probes
             # rather than pinning a stale verdict for the full TTL.
@@ -191,7 +224,7 @@ def _check_fn_cached(fn: Callable) -> bool:
                 "treating as transient and keeping tool(s) available",
                 getattr(fn, "__qualname__", fn),
                 "raised" if raised else "returned False",
-                _CHECK_FN_FAILURE_GRACE_SECONDS,
+                failure_grace_seconds,
             )
             return True
 
@@ -202,7 +235,12 @@ def _check_fn_cached(fn: Callable) -> bool:
             getattr(fn, "__qualname__", fn),
             "raised" if raised else "returned False",
         )
-        _check_fn_cache[fn] = (now, False)
+        if ttl_seconds > 0:
+            _check_fn_cache[fn] = (now, False)
+        else:
+            _check_fn_cache.pop(fn, None)
+        if failure_grace_seconds <= 0:
+            _check_fn_last_good.pop(fn, None)
         return False
 
 


### PR DESCRIPTION
## Summary
- hide the built-in memory tool unless built-in memory or the user profile store is enabled
- rely on the existing system-prompt gate so memory guidance is not injected when the memory tool is unavailable
- add coverage for disabled memory, enabled memory, and enabled user profile cases

## Why
Hermes can run with built-in memory disabled. In that state, the built-in memory tool should not remain available, because its presence also causes memory-specific prompt guidance to be injected.

## Tests
- python3 -m pytest tests/tools/test_memory_tool_schema.py
- python3 -m pytest tests/run_agent/test_run_agent.py -k 'memory_guidance_when_memory_tool_loaded or no_memory_guidance_without_tool'