### PR TITLE
fix(file_tools): keep repeated-slash tilde paths under home

### DIFF
--- a/tests/tools/test_file_tools_tilde_profile.py
+++ b/tests/tools/test_file_tools_tilde_profile.py
@@ -36,6 +36,12 @@ class TestExpandTilde:
             result = ft._expand_tilde("~/scratch/file.txt")
         assert result == "/opt/data/profiles/coder/home/scratch/file.txt"
 
+    def test_consecutive_slashes_after_tilde_stay_under_profile_home(self):
+        """~//path still resolves under the profile home."""
+        with patch("hermes_constants.get_subprocess_home", return_value="/opt/data/profiles/coder/home"):
+            result = ft._expand_tilde("~//scratch/file.txt")
+        assert result == os.path.join("/opt/data/profiles/coder/home", "scratch/file.txt")
+
     def test_bare_tilde_expands_to_profile_home(self):
         """Bare ~ expands to the profile home."""
         with patch("hermes_constants.get_subprocess_home", return_value="/opt/data/profiles/coder/home"):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -42,7 +42,7 @@ def _expand_tilde(path: str) -> str:
     except Exception:
         home = None
     if home and (path == "~" or path.startswith("~/")):
-        return home if path == "~" else os.path.join(home, path[2:])
+        return home if path == "~" else os.path.join(home, path[2:].lstrip("/"))
     return os.path.expanduser(path)
 
 


### PR DESCRIPTION
﻿Fixes #53432.

## What changed

`_expand_tilde()` now strips extra leading slashes from the path segment after `~/` before joining it to the profile home. This keeps inputs like `~//scratch/file.txt` under the configured profile home instead of resolving them at the filesystem root.

## Why

`os.path.join(home, path[2:])` discards `home` when `path[2:]` starts with `/`. That makes `~//foo` resolve to `/foo`, which can route file operations outside the intended profile home.

## Verification

- Failing regression before the fix: `python -m pytest tests/tools/test_file_tools_tilde_profile.py::TestExpandTilde::test_consecutive_slashes_after_tilde_stay_under_profile_home -q`
- `bash scripts/run_tests.sh tests/tools/test_file_tools_tilde_profile.py` passed: 9 tests
- `bash scripts/run_tests.sh tests/tools/test_file_tools.py tests/tools/test_resolve_path.py tests/tools/test_file_read_guards.py` passed: 86 tests
- `.venv/bin/python -m ruff check tools/file_tools.py tests/tools/test_file_tools_tilde_profile.py` passed
- `.venv/bin/python scripts/check-windows-footguns.py tools/file_tools.py tests/tools/test_file_tools_tilde_profile.py` passed
- `git diff --check` passed

Note: `ruff format --check` wants to reformat large existing sections of the touched files, so I left formatting unchanged to keep this patch narrow.