### PR TITLE
fix: scope desktop audio requests to profile

### DIFF
--- a/apps/desktop/src/hermes-profile-scope.test.ts
+++ b/apps/desktop/src/hermes-profile-scope.test.ts
@@ -3,9 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   checkHermesUpdate,
   getActionStatus,
+  getElevenLabsVoices,
   getStatus,
   restartGateway,
   setApiRequestProfile,
+  speakText,
+  transcribeAudio,
   updateHermes
 } from './hermes'
 
@@ -41,6 +44,9 @@ describe('backend action helpers are profile-scoped', () => {
     void updateHermes()
     void checkHermesUpdate()
     void getActionStatus('gateway-restart')
+    void transcribeAudio('data:audio/webm;base64,AAAA', 'audio/webm')
+    void speakText('hello')
+    void getElevenLabsVoices()
 
     for (const call of api.mock.calls) {
       expect(call[0].profile).toBe('coder')

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -811,6 +811,7 @@ export function getActionStatus(name: string, lines = 200): Promise<ActionStatus
 
 export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<AudioTranscriptionResponse> {
   return window.hermesDesktop.api<AudioTranscriptionResponse>({
+    ...profileScoped(),
     path: '/api/audio/transcribe',
     method: 'POST',
     body: {
@@ -822,6 +823,7 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
 
 export function speakText(text: string): Promise<AudioSpeakResponse> {
   return window.hermesDesktop.api<AudioSpeakResponse>({
+    ...profileScoped(),
     path: '/api/audio/speak',
     method: 'POST',
     body: { text }
@@ -830,6 +832,7 @@ export function speakText(text: string): Promise<AudioSpeakResponse> {
 
 export function getElevenLabsVoices(): Promise<ElevenLabsVoicesResponse> {
   return window.hermesDesktop.api<ElevenLabsVoicesResponse>({
+    ...profileScoped(),
     path: '/api/audio/elevenlabs/voices'
   })
 }


### PR DESCRIPTION
Problem
Desktop voice and speech requests did not include the active profile in their Electron API request objects. That meant transcription, TTS playback, and ElevenLabs voice listing could be served by the default backend even when the UI was connected to another profile.

Summary
- Add the existing profile scope helper to desktop audio transcription, speech playback, and ElevenLabs voice-list requests.
- Extend the profile-routing regression test so these audio helpers must forward the active profile.

Validation
- npx vitest run --environment jsdom src/hermes-profile-scope.test.ts
- git diff --check

Note
- npm run typecheck is blocked in this checkout by missing local packages unrelated to this change: use-stick-to-bottom and CodeMirror dependencies.

Fixes #53441