### PR TITLE
fix(tts): fall back to raw provider imports

### DIFF
--- a/tests/tools/test_tts_lazy_import_fallback.py
+++ b/tests/tools/test_tts_lazy_import_fallback.py
@@ -1,0 +1,37 @@
+import sys
+import types
+
+import tools.tts_tool as tts_tool
+
+
+def test_import_edge_tts_falls_back_to_raw_import_when_lazy_ensure_fails(monkeypatch):
+    fake_edge_tts = types.ModuleType("edge_tts")
+
+    def _fail_ensure(*args, **kwargs):
+        raise RuntimeError("venv is read-only")
+
+    monkeypatch.setattr("tools.lazy_deps.ensure", _fail_ensure)
+    monkeypatch.setitem(sys.modules, "edge_tts", fake_edge_tts)
+
+    assert tts_tool._import_edge_tts() is fake_edge_tts
+
+
+def test_import_elevenlabs_falls_back_to_raw_import_when_lazy_ensure_fails(monkeypatch):
+    fake_pkg = types.ModuleType("elevenlabs")
+    fake_pkg.__path__ = []
+    fake_client = types.ModuleType("elevenlabs.client")
+
+    class FakeElevenLabs:
+        pass
+
+    fake_client.ElevenLabs = FakeElevenLabs
+    fake_pkg.client = fake_client
+
+    def _fail_ensure(*args, **kwargs):
+        raise RuntimeError("venv is read-only")
+
+    monkeypatch.setattr("tools.lazy_deps.ensure", _fail_ensure)
+    monkeypatch.setitem(sys.modules, "elevenlabs", fake_pkg)
+    monkeypatch.setitem(sys.modules, "elevenlabs.client", fake_client)
+
+    assert tts_tool._import_elevenlabs() is FakeElevenLabs

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -89,8 +89,11 @@ def _import_edge_tts():
         _lazy_ensure("tts.edge", prompt=False)
     except ImportError:
         pass
-    except Exception as e:
-        raise ImportError(str(e))
+    except Exception:
+        logger.debug(
+            "lazy_deps.ensure(tts.edge) failed; attempting raw import fallback",
+            exc_info=True,
+        )
     import edge_tts
     return edge_tts
 
@@ -100,18 +103,21 @@ def _import_elevenlabs():
     Calls :func:`tools.lazy_deps.ensure` first so the SDK gets installed on
     demand if the user picked ElevenLabs as their TTS provider but never ran
     the post-setup hook (e.g. enabled it by editing config.yaml directly).
-    Raises ``ImportError`` on lazy-install failure so existing callers'
-    error-handling paths keep working.
+    If the lazy installer fails for environmental reasons, still attempt the
+    raw import so PYTHONPATH-based installs remain usable.
     """
     try:
-        from tools.lazy_deps import FeatureUnavailable, ensure
+        from tools.lazy_deps import ensure
         ensure("tts.elevenlabs", prompt=False)
     except ImportError:
         # lazy_deps module itself missing — fall through to the raw import
         # so older code paths still get a clean ImportError.
         pass
-    except Exception as e:  # FeatureUnavailable or any unexpected error
-        raise ImportError(str(e))
+    except Exception:
+        logger.debug(
+            "lazy_deps.ensure(tts.elevenlabs) failed; attempting raw import fallback",
+            exc_info=True,
+        )
     from elevenlabs.client import ElevenLabs
     return ElevenLabs
 


### PR DESCRIPTION
## Summary
- keep Edge TTS and ElevenLabs imports usable when lazy_deps auto-install fails
- log the lazy-install failure at debug level and still attempt the raw provider import
- add regression tests for PYTHONPATH-style provider installs that bypass the venv

## Testing
- uv run --extra dev python -m pytest tests/tools/test_tts_lazy_import_fallback.py
- uv run --extra dev ruff check tools/tts_tool.py tests/tools/test_tts_lazy_import_fallback.py