### PR TITLE
fix: cache profile skill counts

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -27,6 +27,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import List, Optional, Tuple
@@ -235,6 +236,9 @@ _HERMES_SUBCOMMANDS = frozenset({
     "mcp", "sessions", "insights", "version", "update", "uninstall",
     "profile", "plugins", "honcho", "acp",
 })
+
+_SKILL_COUNT_CACHE_TTL_SECONDS = 300.0
+_skill_count_cache: dict[Path, tuple[float, int]] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -649,11 +653,20 @@ def _count_skills(profile_dir: Path) -> int:
     skills_dir = profile_dir / "skills"
     if not skills_dir.is_dir():
         return 0
+
+    now = time.monotonic()
+    cached = _skill_count_cache.get(skills_dir)
+    if cached is not None:
+        cached_at, cached_count = cached
+        if now - cached_at < _SKILL_COUNT_CACHE_TTL_SECONDS:
+            return cached_count
+
     count = 0
     for md in skills_dir.rglob("SKILL.md"):
         if is_excluded_skill_path(md):
             continue
         count += 1
+    _skill_count_cache[skills_dir] = (now, count)
     return count
 
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -14,6 +14,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 import yaml
 
+from hermes_cli import profiles as profiles_mod
 from hermes_cli.profiles import (
     normalize_profile_name,
     validate_profile_name,
@@ -57,6 +58,61 @@ def profile_env(tmp_path, monkeypatch):
     default_home.mkdir(exist_ok=True)
     monkeypatch.setenv("HERMES_HOME", str(default_home))
     return tmp_path
+
+
+class TestCountSkills:
+    """Tests for profile skill-count caching."""
+
+    def setup_method(self):
+        profiles_mod._skill_count_cache.clear()
+
+    def teardown_method(self):
+        profiles_mod._skill_count_cache.clear()
+
+    def test_count_skills_uses_ttl_cache(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / "profile"
+        skill_one = profile_dir / "skills" / "one"
+        skill_one.mkdir(parents=True)
+        (skill_one / "SKILL.md").write_text("one", encoding="utf-8")
+
+        now = [10.0]
+        calls = 0
+        real_rglob = Path.rglob
+
+        def counting_rglob(self, pattern):
+            nonlocal calls
+            if self == profile_dir / "skills" and pattern == "SKILL.md":
+                calls += 1
+            return real_rglob(self, pattern)
+
+        monkeypatch.setattr(profiles_mod.time, "monotonic", lambda: now[0])
+        monkeypatch.setattr(Path, "rglob", counting_rglob)
+
+        assert profiles_mod._count_skills(profile_dir) == 1
+        assert calls == 1
+
+        skill_two = profile_dir / "skills" / "two"
+        skill_two.mkdir()
+        (skill_two / "SKILL.md").write_text("two", encoding="utf-8")
+
+        assert profiles_mod._count_skills(profile_dir) == 1
+        assert calls == 1
+
+        now[0] += profiles_mod._SKILL_COUNT_CACHE_TTL_SECONDS + 1
+
+        assert profiles_mod._count_skills(profile_dir) == 2
+        assert calls == 2
+
+    def test_count_skills_does_not_cache_missing_skills_dir(self, tmp_path):
+        profile_dir = tmp_path / "profile"
+
+        assert profiles_mod._count_skills(profile_dir) == 0
+
+        skill_dir = profile_dir / "skills" / "later"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("later", encoding="utf-8")
+
+        assert profiles_mod._count_skills(profile_dir) == 1
 
 
 # ===================================================================


### PR DESCRIPTION
Problem
Listing profiles synchronously walked every profile skills directory with Path.rglob(). The dashboard cron/profile polling path can call that from the asyncio loop, so large skill trees on slower filesystems can stall WebSocket writes and force reconnects.

Summary
- Cache per-profile skill counts for 5 minutes after a successful skills directory scan.
- Keep missing skills directories uncached so newly created skill folders are visible immediately.
- Add regression tests for cache hits, TTL expiry, and missing-directory behavior.

Validation
- $HOME/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/hermes_cli/test_profiles.py::TestCountSkills tests/hermes_cli/test_profiles.py::TestCreateProfile::test_clone_config_copies_source_skills
- $HOME/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/hermes_cli/test_profiles.py
- $HOME/.hermes/hermes-agent/venv/bin/ruff check hermes_cli/profiles.py tests/hermes_cli/test_profiles.py
- git diff --check

Fixes #53461