### PR TITLE
fix(skills): handle symlinked skills install paths

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -711,8 +711,10 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         append_audit_log("BLOCKED", bundle.name, bundle.source,
                          bundle.trust_level, "invalid_path", str(exc))
         return
-    from tools.skills_hub import SKILLS_DIR
-    c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR)}")
+    from tools.skills_hub import install_path_relative_to_skills_dir
+    c.print(
+        f"[bold green]Installed:[/] {install_path_relative_to_skills_dir(install_dir)}"
+    )
     c.print(f"[dim]Files: {', '.join(bundle.files.keys())}[/]\n")
 
     # Blueprint detection: if the installed skill declares a

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -2358,6 +2358,57 @@ class TestInstallPathSafety:
         assert not (skills_dir / "bad-skill" / "leak.txt").exists()
         assert secret.read_text() == "data exfiltration payload\n"
 
+    def test_install_from_quarantine_records_path_when_skills_dir_is_symlink(
+        self, tmp_path
+    ):
+        """A symlinked skills root still records a relative install path."""
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        real_skills_dir = tmp_path / "real-skills"
+        real_skills_dir.mkdir()
+        skills_dir = tmp_path / "skills-link"
+        try:
+            skills_dir.symlink_to(real_skills_dir, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation unsupported on this platform")
+
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        quarantine_root.mkdir(parents=True)
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir()
+        (q_dir / "SKILL.md").write_text("---\nname: good-skill\n---\n")
+
+        bundle = hub.SkillBundle(
+            name="good-skill",
+            files={"SKILL.md": "---\nname: good-skill\n---\n"},
+            source="community",
+            identifier="x",
+            trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="good-skill",
+            source="community",
+            trust_level="community",
+            verdict="safe",
+        )
+        record_calls = []
+
+        class Lock:
+            def record_install(self, **kwargs):
+                record_calls.append(kwargs)
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root), \
+             patch.object(hub, "HubLockFile", lambda: Lock()), \
+             patch.object(hub, "append_audit_log", lambda *args, **kwargs: None):
+            install_dir = hub.install_from_quarantine(
+                q_dir, "good-skill", "", bundle, scan_result,
+            )
+
+        assert install_dir == real_skills_dir / "good-skill"
+        assert record_calls[0]["install_path"] == "good-skill"
+
 
 # ---------------------------------------------------------------------------
 # parallel_search_sources — overall_timeout must be honoured even when a

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -189,6 +189,10 @@ def _resolve_lock_install_path(install_path: str, skill_name: str) -> Path:
     return target
 
 
+def install_path_relative_to_skills_dir(install_dir: Path) -> str:
+    return install_dir.resolve().relative_to(SKILLS_DIR.resolve()).as_posix()
+
+
 def _guarded_http_get(url: str, *, timeout: int = 20) -> Optional[httpx.Response]:
     """Fetch a URL with SSRF and redirect-target validation."""
     current_url = url
@@ -3450,7 +3454,7 @@ def install_from_quarantine(
         trust_level=bundle.trust_level,
         scan_verdict=scan_result.verdict,
         skill_hash=content_hash(install_dir),
-        install_path=str(install_dir.relative_to(SKILLS_DIR)),
+        install_path=install_path_relative_to_skills_dir(install_dir),
         files=list(bundle.files.keys()),
         metadata=bundle.metadata,
     )


### PR DESCRIPTION
﻿Fixes #53403.

## What changed

Skill install path display and lock-file recording now resolve both the installed skill directory and `SKILLS_DIR` before computing the relative install path. This keeps installs working when the skills root is reached through a symlink, while still recording a normalized relative path such as `good-skill`.

## Why

`install_from_quarantine()` resolves the final install directory through the lock-path safety validator. If `SKILLS_DIR` itself is a symlink, the install directory becomes the real target path, but the old `install_dir.relative_to(SKILLS_DIR)` comparison used the unresolved symlink path. That raised `ValueError` after the skill had already moved into place. The CLI display used the same raw relative calculation.

## Verification

- Failing regression before the fix: `.venv/bin/python -m pytest tests/tools/test_skills_hub.py::TestInstallPathSafety::test_install_from_quarantine_records_path_when_skills_dir_is_symlink -q`
- Passing regression after the fix: same command passed
- `bash scripts/run_tests.sh tests/tools/test_skills_hub.py tests/hermes_cli/test_skills_hub.py` passed: 182 tests
- `.venv/bin/python -m ruff check hermes_cli/skills_hub.py tools/skills_hub.py tests/tools/test_skills_hub.py` passed
- `.venv/bin/python scripts/check-windows-footguns.py hermes_cli/skills_hub.py tools/skills_hub.py tests/tools/test_skills_hub.py` passed
- `git diff --check` passed

Note: `ruff format --check` wants to reformat large existing sections of these files, so I left formatting unchanged to keep this patch focused.