### PR TITLE
fix(temperature): set temperature=1 for Kimi coding models on /coding/ endpoint (#53455)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -281,6 +281,16 @@ def _fixed_temperature_for_model(
         ``None`` — no override; caller should use its own default.
     """
     if _is_kimi_model(model):
+        # Kimi Coding API (api.kimi.com/coding/v1) models like
+        # kimi-k2.7-code strictly require temperature=1 and 400 on
+        # any other value or omission — see issue #53455.
+        # Only models with "-code" in their name are coding-specific;
+        # regular kimi models on the coding endpoint still get OMIT.
+        if base_url and "/coding/" in base_url and "-code" in (model or ""):
+            logger.debug(
+                "Setting temperature=1 for Kimi coding model %r (coding endpoint)", model
+            )
+            return 1.0
         logger.debug("Omitting temperature for Kimi model %r (server-managed)", model)
         return OMIT_TEMPERATURE
     if _is_arcee_trinity_thinking(model):

--- a/tests/agent/test_arcee_trinity_overrides.py
+++ b/tests/agent/test_arcee_trinity_overrides.py
@@ -14,10 +14,12 @@ from __future__ import annotations
 import pytest
 
 from agent.auxiliary_client import (
+    OMIT_TEMPERATURE,
     _compression_threshold_for_model,
     _fixed_temperature_for_model,
     _is_arcee_trinity_thinking,
     _is_codex_gpt55,
+    _is_kimi_model,
 )
 
 
@@ -157,3 +159,79 @@ def test_compression_threshold_opt_out_does_not_disable_trinity() -> None:
         )
         == 0.75
     )
+
+
+# ---------------------------------------------------------------------------
+# Kimi Coding temperature (issue #53455)
+#
+# Regular Kimi models (e.g. kimi-k2, kimi-k2.5) manage temperature server-side
+# and we omit it (OMIT_TEMPERATURE). But models on the Kimi Coding API
+# (api.kimi.com/coding/v1) like kimi-k2.7-code strictly REQUIRE temperature=1
+# and 400 on any other value or omission.  Detect the coding endpoint by
+# its base_url and return 1.0 instead of OMIT_TEMPERATURE.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "kimi-k2",
+        "kimi-k2.5",
+        "kimi-k2.5-pro",
+        "moonshot-v1-8k",  # starts with moonshot not kimi-, so NOT a match
+        None,
+        "",
+    ],
+)
+def test_is_kimi_model_matches(model) -> None:
+    if model and model.startswith("kimi-"):
+        assert _is_kimi_model(model) is True
+    else:
+        assert _is_kimi_model(model) is False
+
+
+def test_fixed_temperature_kimi_regular_omits() -> None:
+    """Regular Kimi API (non-coding) models omit temperature."""
+    from agent.auxiliary_client import _fixed_temperature_for_model, OMIT_TEMPERATURE
+
+    # Regular kimi models: OMIT_TEMPERATURE
+    assert _fixed_temperature_for_model("kimi-k2") is OMIT_TEMPERATURE
+    assert _fixed_temperature_for_model("kimi-k2.5") is OMIT_TEMPERATURE
+    # No base_url → treat as regular kimi
+    assert _fixed_temperature_for_model("kimi-k2.7-code") is OMIT_TEMPERATURE
+
+
+def test_fixed_temperature_kimi_coding_requires_1() -> None:
+    """Kimi Coding API models (base_url contains /coding/) must use temperature=1."""
+    from agent.auxiliary_client import _fixed_temperature_for_model
+
+    # kimi-k2.7-code on the coding endpoint → must be 1.0
+    assert (
+        _fixed_temperature_for_model(
+            "kimi-k2.7-code", base_url="https://api.kimi.com/coding/v1"
+        )
+        == 1.0
+    )
+    # Same model with no base_url → OMIT (treated as regular kimi)
+    assert (
+        _fixed_temperature_for_model("kimi-k2.7-code") is OMIT_TEMPERATURE
+    )
+    # kimi-k2.5 on coding endpoint → still OMIT (only coding models need T=1)
+    assert (
+        _fixed_temperature_for_model(
+            "kimi-k2.5", base_url="https://api.kimi.com/coding/v1"
+        )
+        is OMIT_TEMPERATURE
+    )
+
+
+def test_fixed_temperature_kimi_coding_variants() -> None:
+    """Various kimi models tested with coding/non-coding base URLs."""
+    from agent.auxiliary_client import _fixed_temperature_for_model, OMIT_TEMPERATURE
+
+    # Non-kimi model unaffected
+    assert _fixed_temperature_for_model("claude-sonnet-4.6", "https://api.kimi.com/coding/v1") is None
+    # kimi-k2 on coding — only coding-* models should get the override
+    assert _fixed_temperature_for_model("kimi-k2", "https://api.kimi.com/coding/v1") is OMIT_TEMPERATURE
+    # kimi-k2.7-code with /coding in path gets 1.0
+    assert _fixed_temperature_for_model("kimi-k2.7-code", "https://api.kimi.com/coding/v1") == 1.0


### PR DESCRIPTION
## What

`kimi-k2.7-code` on the Kimi Coding API (`api.kimi.com/coding/v1`) strictly requires `temperature: 1` and returns a **400** (`invalid temperature: only 1 is allowed for this model`) on any other value or omission. Previously `_fixed_temperature_for_model()` returned `OMIT_TEMPERATURE` for **all** Kimi models regardless of endpoint, so every `vision_analyze` call (and any auxiliary call) against this model failed.

## Fix

In `_fixed_temperature_for_model()`, when the model is a Kimi model **and** the `base_url` contains `/coding/` **and** the model name contains `-code`, return `1.0` instead of `OMIT_TEMPERATURE`. This:

- Fixes `kimi-k2.7-code` on the coding endpoint (now sends `temperature=1`).
- Leaves regular Kimi models (`kimi-k2`, `kimi-k2.5`) **unchanged** — they still get `OMIT_TEMPERATURE` even on the coding endpoint, since only coding-specific models enforce `temperature=1`.
- Leaves non-Kimi models unchanged (`None`).
- Also resolves the reported "config `temperature: 1` is ignored" symptom: coding models now always get the only valid value (`1.0`) regardless of config.

Closes #53455.

## How verified

RED → GREEN on `refs/remotes/upstream/main` (882730026):

- **Before fix:** `_fixed_temperature_for_model("kimi-k2.7-code", base_url="https://api.kimi.com/coding/v1")` → `OMIT_TEMPERATURE` (the `base_url` was ignored). New tests asserting `== 1.0` **fail**.
- **After fix:** same call → `1.0`. Tests **pass**.

### Test results

- `tests/agent/test_arcee_trinity_overrides.py` — **49 passed** (incl. 9 new Kimi-coding cases)
- `tests/tools/test_vision_tools.py` — **78 passed**
- `tests/agent/test_unsupported_temperature_retry.py` — **19 passed**

### Edge cases covered

- `kimi-k2.7-code` + coding `base_url` → `1.0` ✓
- `kimi-k2.7-code` + no `base_url` → `OMIT_TEMPERATURE` (treated as regular kimi) ✓
- `kimi-k2.5` + coding `base_url` → `OMIT_TEMPERATURE` (only `-code` models get the override) ✓
- non-Kimi model + coding `base_url` → `None` (unaffected) ✓

## Competing PRs

None found at time of publication.

---

Auto-published by Moonsong via Path B automated pipeline.