### PR TITLE
fix(gateway): cache runtime lock probes

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -17,6 +17,7 @@ import os
 import signal
 import subprocess
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from hermes_constants import get_hermes_home
@@ -35,6 +36,8 @@ _IS_WINDOWS = sys.platform == "win32"
 _UNSET = object()
 _GATEWAY_LOCK_FILENAME = "gateway.lock"
 _gateway_lock_handle = None
+_GATEWAY_RUNTIME_LOCK_PROBE_CACHE_TTL_S = 1.0
+_gateway_runtime_lock_probe_cache: dict[str, tuple[float, bool, bool, int | None]] = {}
 # Windows byte-range locks are mandatory for other readers. Lock a byte well
 # past the JSON payload so runtime status / PID readers can still read the file
 # while another process holds the mutual-exclusion lock.
@@ -71,6 +74,27 @@ def _get_lock_dir() -> Path:
 
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _gateway_runtime_lock_cache_key(lock_path: Path) -> str:
+    return str(lock_path)
+
+
+def _clear_gateway_runtime_lock_probe_cache(lock_path: Optional[Path] = None) -> None:
+    if lock_path is None:
+        _gateway_runtime_lock_probe_cache.clear()
+        return
+    _gateway_runtime_lock_probe_cache.pop(_gateway_runtime_lock_cache_key(lock_path), None)
+
+
+def _get_gateway_runtime_lock_file_state(lock_path: Path) -> tuple[bool, int | None]:
+    try:
+        stat_result = lock_path.stat()
+    except FileNotFoundError:
+        return False, None
+    except OSError:
+        return False, None
+    return True, stat_result.st_mtime_ns
 
 
 def terminate_pid(pid: int, *, force: bool = False) -> None:
@@ -436,6 +460,7 @@ def acquire_gateway_runtime_lock() -> bool:
         return False
     _write_gateway_lock_record(handle)
     _gateway_lock_handle = handle
+    _clear_gateway_runtime_lock_probe_cache(path)
     return True
 
 
@@ -446,6 +471,7 @@ def release_gateway_runtime_lock() -> None:
     if handle is None:
         return
     _gateway_lock_handle = None
+    _clear_gateway_runtime_lock_probe_cache(_get_gateway_lock_path())
     _release_file_lock(handle)
     try:
         handle.close()
@@ -460,15 +486,32 @@ def is_gateway_runtime_lock_active(lock_path: Optional[Path] = None) -> bool:
     if _gateway_lock_handle is not None and resolved_lock_path == _get_gateway_lock_path():
         return True
 
-    if not resolved_lock_path.exists():
+    exists, mtime_ns = _get_gateway_runtime_lock_file_state(resolved_lock_path)
+    cache_key = _gateway_runtime_lock_cache_key(resolved_lock_path)
+    now = time.monotonic()
+    cached = _gateway_runtime_lock_probe_cache.get(cache_key)
+    if cached is not None:
+        cached_at, cached_active, cached_exists, cached_mtime_ns = cached
+        if (
+            now - cached_at <= _GATEWAY_RUNTIME_LOCK_PROBE_CACHE_TTL_S
+            and cached_exists == exists
+            and cached_mtime_ns == mtime_ns
+        ):
+            return cached_active
+
+    if not exists:
+        _gateway_runtime_lock_probe_cache[cache_key] = (now, False, False, None)
         return False
 
     handle = open(resolved_lock_path, "a+", encoding="utf-8")
     try:
         if _try_acquire_file_lock(handle):
             _release_file_lock(handle)
-            return False
-        return True
+            active = False
+        else:
+            active = True
+        _gateway_runtime_lock_probe_cache[cache_key] = (now, active, True, mtime_ns)
+        return active
     finally:
         try:
             handle.close()

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -1,5 +1,6 @@
 """Tests for gateway runtime status tracking."""
 
+import builtins
 import json
 import os
 from pathlib import Path
@@ -156,6 +157,62 @@ class TestGatewayPidState:
         status.release_gateway_runtime_lock()
 
         assert status.is_gateway_runtime_lock_active() is False
+
+    def test_runtime_lock_probe_reuses_cached_status_when_file_is_unchanged(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        lock_path = tmp_path / "gateway.lock"
+        lock_path.write_text("{}", encoding="utf-8")
+
+        open_calls = 0
+        original_open = builtins.open
+        times = iter([100.0, 100.2])
+
+        def counting_open(*args, **kwargs):
+            nonlocal open_calls
+            open_calls += 1
+            return original_open(*args, **kwargs)
+
+        monkeypatch.setattr(status, "open", counting_open, raising=False)
+        monkeypatch.setattr(status.time, "monotonic", lambda: next(times))
+        monkeypatch.setattr(status, "_try_acquire_file_lock", lambda handle: False)
+
+        assert status.is_gateway_runtime_lock_active(lock_path) is True
+        assert status.is_gateway_runtime_lock_active(lock_path) is True
+        assert open_calls == 1
+
+    def test_runtime_lock_probe_refreshes_when_lock_file_mtime_changes(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        lock_path = tmp_path / "gateway.lock"
+        lock_path.write_text("{}", encoding="utf-8")
+
+        open_calls = 0
+        original_open = builtins.open
+        times = iter([200.0, 200.2])
+        lock_results = iter([False, True])
+
+        def counting_open(*args, **kwargs):
+            nonlocal open_calls
+            open_calls += 1
+            return original_open(*args, **kwargs)
+
+        monkeypatch.setattr(status, "open", counting_open, raising=False)
+        monkeypatch.setattr(status.time, "monotonic", lambda: next(times))
+        monkeypatch.setattr(status, "_try_acquire_file_lock", lambda handle: next(lock_results))
+
+        assert status.is_gateway_runtime_lock_active(lock_path) is True
+
+        stat_result = lock_path.stat()
+        os.utime(
+            lock_path,
+            ns=(stat_result.st_atime_ns, stat_result.st_mtime_ns + 1_000_000),
+        )
+
+        assert status.is_gateway_runtime_lock_active(lock_path) is False
+        assert open_calls == 2
 
     def test_get_running_pid_treats_pid_file_as_stale_without_runtime_lock(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## Summary
- cache gateway runtime lock probe results for a short TTL when the lock file is unchanged
- invalidate the cache on in-process acquire/release so gateway-owned transitions stay immediate
- add gateway status tests that cover cache hits and mtime-based refresh behavior

## Testing
- uv run python --version
- git diff --check
- uv run --extra dev python -m pytest tests/gateway/test_status.py -k "runtime_lock_probe_reuses_cached_status_when_file_is_unchanged or runtime_lock_probe_refreshes_when_lock_file_mtime_changes or runtime_lock_claims_and_releases_liveness"
- uv run --extra dev python -m pytest tests/gateway/test_status.py
- uv run --extra dev ruff check gateway/status.py tests/gateway/test_status.py