### PR TITLE
fix(tui): run prompt submits off the RPC loop

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1707,6 +1707,29 @@ def test_dispatch_session_compress_does_not_block_fast_handler(server):
     released.set()
 
 
+def test_dispatch_prompt_submit_does_not_block_fast_handler(server):
+    """A prompt turn can run tools, so it must not block the TUI RPC loop."""
+    released = threading.Event()
+
+    def slow_submit(rid, params):
+        released.wait(timeout=5)
+        return server._ok(rid, {"done": True})
+
+    server._methods["prompt.submit"] = slow_submit
+    server._methods["fast.ping"] = lambda rid, params: server._ok(rid, {"pong": True})
+
+    t0 = time.monotonic()
+    assert server.dispatch({"id": "slow", "method": "prompt.submit", "params": {}}) is None
+
+    fast_resp = server.dispatch({"id": "fast", "method": "fast.ping", "params": {}})
+    fast_elapsed = time.monotonic() - t0
+
+    assert fast_resp["result"] == {"pong": True}
+    assert fast_elapsed < 0.5, f"fast handler blocked for {fast_elapsed:.2f}s behind prompt.submit"
+
+    released.set()
+
+
 def test_dispatch_long_handler_exception_produces_error_response(capture):
     """An exception inside a pool-dispatched handler still yields a JSON-RPC error."""
     server, buf = capture

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -197,6 +197,7 @@ _LONG_HANDLERS = frozenset(
         "projects.for_cwd",
         "projects.tree",
         "projects.project_sessions",
+        "prompt.submit",
         "session.branch",
         "session.compress",
         "session.resume",


### PR DESCRIPTION
## Summary
- Route `prompt.submit` through the TUI gateway long-handler thread pool instead of running it inline on the RPC loop.
- Add a regression test proving a slow prompt submit does not block a fast RPC handler.

## Root cause
`prompt.submit` can run the full prompt turn, including tool execution paths that may block while waiting for subprocesses. Because it was not listed in `_LONG_HANDLERS`, dispatch ran it inline, so a long terminal/file-tool path could stall the TUI RPC loop and cascade into slow websocket writes or disconnects.

## Validation
- `bash scripts/run_tests.sh tests/tui_gateway/test_protocol.py` could not start on this Windows host due to the local Bash/CallMsi `REGDB_E_CLASSNOTREG` launcher error.
- `.\.venv\Scripts\python.exe -m pytest tests/tui_gateway/test_protocol.py -q` -> `72 passed`
- `.\.venv\Scripts\python.exe -m pytest tests/test_tui_gateway_server.py -q` -> `299 passed`
- `ruff check tui_gateway/server.py tests/tui_gateway/test_protocol.py` -> passed
- `git diff --check` -> passed, with only existing CRLF conversion warnings

Fixes #53420
