### PR TITLE
fix(update): avoid bogus shallow commit counts in cmd_update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8989,9 +8989,24 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # against.
         branch = _resolve_update_branch(args)
 
+        # Installer-managed clones are shallow (`git clone --depth 1`).
+        # Keep fetches shallow so update checks do not silently unshallow the
+        # repo before we decide whether an exact commit count is trustworthy.
+        is_shallow = (
+            subprocess.run(
+                git_cmd + ["rev-parse", "--is-shallow-repository"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+            == "true"
+        )
+        depth_args = ["--depth", "1"] if is_shallow else []
+
         print("→ Fetching updates...")
         fetch_result = subprocess.run(
-            git_cmd + ["fetch", "origin", branch],
+            git_cmd + ["fetch"] + depth_args + ["origin", branch],
             cwd=PROJECT_ROOT,
             capture_output=True,
             text=True,
@@ -9078,15 +9093,37 @@ def _cmd_update_impl(args, gateway_mode: bool):
             and (gateway_mode or (sys.stdin.isatty() and sys.stdout.isatty()))
         )
 
-        # Check if there are updates
-        result = subprocess.run(
-            git_cmd + ["rev-list", f"HEAD..origin/{branch}", "--count"],
-            cwd=PROJECT_ROOT,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        commit_count = int(result.stdout.strip())
+        # Managed installer checkouts are shallow (`git clone --depth 1`).
+        # Counting across that boundary can yield a huge bogus "behind" value,
+        # so preserve the existing `--check` behavior here: compare tip SHAs
+        # and treat the result as presence-only instead of an exact count.
+        commit_count = None
+        if is_shallow:
+            head_sha = subprocess.run(
+                git_cmd + ["rev-parse", "HEAD"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+            target_sha = subprocess.run(
+                git_cmd + ["rev-parse", f"origin/{branch}"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+            if head_sha and target_sha and head_sha == target_sha:
+                commit_count = 0
+        else:
+            result = subprocess.run(
+                git_cmd + ["rev-list", f"HEAD..origin/{branch}", "--count"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            commit_count = int(result.stdout.strip())
 
         if commit_count == 0:
             _invalidate_update_cache()
@@ -9116,7 +9153,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
             _resume_windows_gateways_after_update(_windows_gateway_resume)
             return
 
-        print(f"→ Found {commit_count} new commit(s)")
+        if commit_count is None:
+            print(f"→ Update available (behind origin/{branch}).")
+        else:
+            print(f"→ Found {commit_count} new commit(s)")
 
         # Snapshot critical state (state.db, config, pairing JSONs, etc.)
         # before pulling so a user can recover if something goes wrong.

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -530,6 +530,9 @@ def test_install_heartbeat_prints_when_dependency_install_is_silent(monkeypatch,
 def _make_update_side_effect(
     current_branch="main",
     commit_count="3",
+    is_shallow=False,
+    head_sha="local-sha",
+    target_sha="origin-sha",
     ff_only_fails=False,
     reset_fails=False,
     fetch_fails=False,
@@ -547,6 +550,16 @@ def _make_update_side_effect(
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "rev-parse" in joined and "--abbrev-ref" in joined:
             return SimpleNamespace(stdout=f"{current_branch}\n", stderr="", returncode=0)
+        if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
+            return SimpleNamespace(
+                stdout="true\n" if is_shallow else "false\n",
+                stderr="",
+                returncode=0,
+            )
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return SimpleNamespace(stdout=f"{head_sha}\n", stderr="", returncode=0)
+        if len(cmd) == 3 and cmd[:2] == ["git", "rev-parse"] and cmd[2].startswith("origin/"):
+            return SimpleNamespace(stdout=f"{target_sha}\n", stderr="", returncode=0)
         if "checkout" in joined and "main" in joined:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "rev-list" in joined:
@@ -702,6 +715,65 @@ def test_cmd_update_fetch_is_scoped_to_target_branch(monkeypatch, tmp_path):
     fetch_calls = [c for c in recorded if "fetch" in c]
     assert fetch_calls == [["git", "fetch", "origin", "main"]]
     assert ["git", "fetch", "origin"] not in recorded
+
+
+def test_cmd_update_shallow_clone_skips_exact_count_when_up_to_date(monkeypatch, tmp_path, capsys):
+    """Shallow checkouts should compare SHAs and never run rev-list."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    side_effect, recorded = _make_update_side_effect(
+        commit_count="12492",
+        is_shallow=True,
+        head_sha="same-sha",
+        target_sha="same-sha",
+    )
+
+    def fake_run(cmd, **kwargs):
+        if "rev-list" in " ".join(str(c) for c in cmd):
+            raise AssertionError("shallow path must not count across the boundary")
+        return side_effect(cmd, **kwargs)
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert "Already up to date!" in out
+    assert ["git", "fetch", "--depth", "1", "origin", "main"] in recorded
+    assert not any("rev-list" in " ".join(c) for c in recorded)
+    assert not any(c[:3] == ["git", "pull", "--ff-only"] for c in recorded)
+
+
+def test_cmd_update_shallow_clone_reports_generic_update_without_rev_list(
+    monkeypatch, tmp_path, capsys
+):
+    """Shallow checkouts should avoid bogus exact counts before updating."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(hermes_main, "_is_termux_env", lambda env=None: False)
+
+    side_effect, recorded = _make_update_side_effect(
+        commit_count="12492",
+        is_shallow=True,
+        head_sha="local-sha",
+        target_sha="upstream-sha",
+    )
+
+    def fake_run(cmd, **kwargs):
+        if "rev-list" in " ".join(str(c) for c in cmd):
+            raise AssertionError("shallow path must not count across the boundary")
+        return side_effect(cmd, **kwargs)
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert "Update available (behind origin/main)." in out
+    assert "Found 12492 new commit(s)" not in out
+    assert ["git", "fetch", "--depth", "1", "origin", "main"] in recorded
+    assert not any("rev-list" in " ".join(c) for c in recorded)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes the `hermes update` execution path for shallow installer checkouts.

`cmd_update()` was still fetching without `--depth 1` and always running `git rev-list HEAD..origin/<branch> --count`, even though the update banner and `hermes update --check` already treat shallow clones as a presence-only check. On a managed shallow checkout that could surface a bogus exact count before the pull.

This patch keeps shallow fetches shallow, compares `HEAD` and `origin/<branch>` by SHA in the shallow path, and prints a generic update-available message instead of a bogus exact commit count.

## Related Issue

Fixes #53479

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- detect shallow Git checkouts in `hermes_cli/main.py` before fetching updates
- preserve the shallow boundary with `git fetch --depth 1 origin <branch>` in `cmd_update()`
- skip `rev-list --count` in the shallow `cmd_update()` path and fall back to SHA comparison
- add shallow-clone regression coverage in `tests/hermes_cli/test_update_autostash.py`

## How to Test

1. Run `./.venv/bin/pytest tests/hermes_cli/test_update_autostash.py tests/hermes_cli/test_update_check.py -q`
2. Run `./.venv/bin/pytest tests/hermes_cli/test_update_autostash.py -k shallow_clone -q`
3. In a shallow checkout, run `hermes update` and confirm it prints a generic update-available message instead of a bogus exact commit count.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] N/A — no documentation changes needed
- [x] N/A — no `cli-config.yaml.example` changes needed
- [x] N/A — no `CONTRIBUTING.md` or `AGENTS.md` changes needed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] N/A — no tool descriptions/schemas changed

## Screenshots / Logs

- Validation run: `./.venv/bin/pytest tests/hermes_cli/test_update_autostash.py tests/hermes_cli/test_update_check.py -q` (`50 passed`)
- Validation run: `./.venv/bin/pytest tests/hermes_cli/test_update_autostash.py -k shallow_clone -q` (`2 passed`)
- Not yet run manually end-to-end inside a real shallow checkout; this PR adds regression coverage for the source path and keeps the shallow behavior aligned with the already-fixed banner / `hermes update --check` paths.
