### PR TITLE
fix(tui): join slash worker drain threads

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 import sys
 import threading
 import time
@@ -57,6 +58,66 @@ def test_write_json_returns_false_on_broken_pipe(monkeypatch):
     monkeypatch.setattr(server, "_real_stdout", _BrokenStdout())
 
     assert server.write_json({"ok": True}) is False
+
+
+def test_slash_worker_close_joins_drain_threads_and_closes_pipes(monkeypatch):
+    started_threads = []
+
+    class _FakeThread:
+        def __init__(self, *, target, daemon):
+            self.target = target
+            self.daemon = daemon
+            self.join_calls: list[float | None] = []
+            started_threads.append(self)
+
+        def start(self):
+            return None
+
+        def join(self, timeout=None):
+            self.join_calls.append(timeout)
+
+    class _FakeStream:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class _FakeProc:
+        def __init__(self):
+            self.stdin = _FakeStream()
+            self.stdout = _FakeStream()
+            self.stderr = _FakeStream()
+            self.terminated = False
+            self.killed = False
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            self.terminated = True
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            self.killed = True
+
+    fake_proc = _FakeProc()
+
+    monkeypatch.setattr(server.threading, "Thread", _FakeThread)
+    monkeypatch.setattr(server.subprocess, "Popen", lambda *args, **kwargs: fake_proc)
+
+    worker = server._SlashWorker("session-1", "gpt-5")
+    worker.close()
+
+    assert len(started_threads) == 2
+    assert fake_proc.terminated is True
+    assert fake_proc.killed is False
+    assert fake_proc.stdin.closed is True
+    assert fake_proc.stdout.closed is True
+    assert fake_proc.stderr.closed is True
+    assert [t.join_calls for t in started_threads] == [[1.0], [1.0]]
 
 
 def test_tui_verbose_tool_details_fail_closed_when_redaction_fails(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -210,8 +210,10 @@ class _SlashWorker:
             cwd=os.getcwd(),
             env=os.environ.copy(),
         )
-        threading.Thread(target=self._drain_stdout, daemon=True).start()
-        threading.Thread(target=self._drain_stderr, daemon=True).start()
+        self._stdout_thread = threading.Thread(target=self._drain_stdout, daemon=True)
+        self._stderr_thread = threading.Thread(target=self._drain_stderr, daemon=True)
+        self._stdout_thread.start()
+        self._stderr_thread.start()
 
     def _drain_stdout(self):
         for line in self.proc.stdout or []:
@@ -263,6 +265,19 @@ class _SlashWorker:
                 self.proc.kill()
             except Exception:
                 pass
+        finally:
+            for stream in (self.proc.stdin, self.proc.stdout, self.proc.stderr):
+                if stream is None:
+                    continue
+                try:
+                    stream.close()
+                except Exception:
+                    pass
+            for thread in (self._stdout_thread, self._stderr_thread):
+                try:
+                    thread.join(timeout=1.0)
+                except Exception:
+                    pass
 
 
 def _load_busy_input_mode() -> str:


### PR DESCRIPTION
## Summary
- keep explicit references to slash worker stdout/stderr drain threads
- close worker stdio pipes and join both drain threads during worker shutdown
- add a focused regression test for `_SlashWorker.close()` plus the existing session create/close race guard

## Testing
- uv run python --version
- git diff --check
- uv run --extra dev python -m pytest tests/test_tui_gateway_server.py -k "slash_worker_close_joins_drain_threads_and_closes_pipes or session_create_close_race_does_not_orphan_worker"
- uv run --extra dev ruff check tui_gateway/server.py tests/test_tui_gateway_server.py

## Notes
- `tests/test_tui_gateway_server.py::test_browser_manage_connect_default_local_reports_launch_hint` is already failing on an untouched browser-manage path and was treated as unrelated baseline noise for this narrow change.