### PR TITLE
fix(desktop-update): block in-app updates during active work

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2558,6 +2558,71 @@ async function releaseBackendLock(updateRoot, tag) {
   return { unlocked: false }
 }
 
+const ACTIVE_WORK_UPDATE_MESSAGE =
+  'Hermes is still running a chat or background task. Finish or stop active work before updating.'
+
+interface ActiveWorkSnapshot {
+  active: boolean
+  running_sessions: number
+  waiting_sessions: number
+  starting_sessions: number
+  active_subagents: number
+}
+
+function numericSnapshotField(value: unknown): number {
+  return Number.isFinite(Number(value)) ? Number(value) : 0
+}
+
+function normalizeActiveWorkSnapshot(value: unknown): ActiveWorkSnapshot | null {
+  if (!value || typeof value !== 'object') return null
+  const record = value as Record<string, unknown>
+
+  return {
+    active: Boolean(record.active),
+    running_sessions: numericSnapshotField(record.running_sessions),
+    waiting_sessions: numericSnapshotField(record.waiting_sessions),
+    starting_sessions: numericSnapshotField(record.starting_sessions),
+    active_subagents: numericSnapshotField(record.active_subagents)
+  }
+}
+
+function activeWorkUpdateResult(snapshot: ActiveWorkSnapshot) {
+  return {
+    ok: false,
+    error: 'active-work',
+    message: ACTIVE_WORK_UPDATE_MESSAGE,
+    activeWork: snapshot
+  }
+}
+
+async function probeLocalBackendActiveWork(): Promise<ActiveWorkSnapshot | null> {
+  const connection = await ensureBackend(null)
+  if (connection.mode !== 'local') return null
+
+  try {
+    const snapshot = await fetchJson(`${connection.baseUrl}/api/runtime/active-work`, connection.token, {
+      timeoutMs: 5000
+    })
+    return normalizeActiveWorkSnapshot(snapshot)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    rememberLog(`[updates] active-work probe unavailable; falling back to renderer preflight: ${message}`)
+    return null
+  }
+}
+
+async function blockIfLocalBackendHasActiveWork() {
+  const snapshot = await probeLocalBackendActiveWork()
+  if (!snapshot?.active) return null
+
+  rememberLog(
+    `[updates] blocked apply while backend reports active work: ` +
+      `sessions=${snapshot.running_sessions || 0}, waiting=${snapshot.waiting_sessions || 0}, ` +
+      `starting=${snapshot.starting_sessions || 0}, subagents=${snapshot.active_subagents || 0}`
+  )
+  return activeWorkUpdateResult(snapshot)
+}
+
 // applyUpdates — hand off to the installer's --update flow, then exit.
 //
 // The desktop is a pure consumer: it does NOT git pull / pip install / rebuild
@@ -2579,6 +2644,8 @@ async function applyUpdates(opts = {}) {
     const updater = resolveUpdaterBinary()
 
     if (!updater && !IS_WINDOWS) {
+      const blocked = await blockIfLocalBackendHasActiveWork()
+      if (blocked) return blocked
       // macOS/Linux drag-install: no staged Tauri hermes-setup. Unlike Windows
       // (where a venv-shim file lock forces the quit→hand-off→rebuild dance),
       // there's no mandatory file locking here, so the desktop can drive the
@@ -2621,6 +2688,9 @@ async function applyUpdates(opts = {}) {
 
       return { ok: true, manual: true, command, hermesRoot: updateRoot }
     }
+
+    const blocked = await blockIfLocalBackendHasActiveWork()
+    if (blocked) return blocked
 
     emitUpdateProgress({
       stage: 'restart',

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -68,11 +68,13 @@ export function UpdatesOverlay() {
   const behind = status?.behind ?? 0
   const updateAvailable = status?.updateAvailable || behind > 0
 
-  const phase: 'idle' | 'applying' | 'manual' | 'guiSkew' | 'error' =
+  const phase: 'idle' | 'applying' | 'manual' | 'guiSkew' | 'blocked' | 'error' =
     apply.stage === 'manual'
       ? 'manual'
       : apply.stage === 'guiSkew'
         ? 'guiSkew'
+        : apply.stage === 'blocked'
+          ? 'blocked'
         : apply.applying || apply.stage === 'restart'
           ? 'applying'
           : apply.stage === 'error'
@@ -88,7 +90,13 @@ export function UpdatesOverlay() {
 
     if (
       !next &&
-      (apply.stage === 'error' || apply.stage === 'restart' || apply.stage === 'manual' || apply.stage === 'guiSkew')
+      (
+        apply.stage === 'blocked' ||
+        apply.stage === 'error' ||
+        apply.stage === 'restart' ||
+        apply.stage === 'manual' ||
+        apply.stage === 'guiSkew'
+      )
     ) {
       resetUpdateApplyState()
     }
@@ -114,6 +122,10 @@ export function UpdatesOverlay() {
         )}
 
         {phase === 'guiSkew' && <GuiSkewView message={apply.message} onDone={() => handleClose(false)} />}
+
+        {phase === 'blocked' && (
+          <BlockedView message={apply.message} onDismiss={() => handleClose(false)} onRetry={handleInstall} />
+        )}
 
         {phase === 'error' && (
           <ErrorView message={apply.message} onDismiss={() => handleClose(false)} onRetry={handleInstall} />
@@ -366,6 +378,33 @@ function GuiSkewView({ message, onDone }: { message?: string; onDone: () => void
       <Button className="font-semibold" onClick={onDone} size="lg" variant="secondary">
         {u.done}
       </Button>
+    </div>
+  )
+}
+
+function BlockedView({ message, onDismiss, onRetry }: { message: string; onDismiss: () => void; onRetry: () => void }) {
+  const { t } = useI18n()
+  const u = t.updates
+
+  return (
+    <div className="grid gap-5 px-6 pb-6 pt-7 pr-8">
+      <div className="flex flex-col items-center gap-3 text-center">
+        <AlertCircle className="size-8 text-amber-500" />
+
+        <DialogTitle className="text-center text-xl">{u.activeWorkTitle}</DialogTitle>
+        <DialogDescription className="max-w-prose text-center text-sm leading-5 text-muted-foreground">
+          {message || u.activeWorkBody}
+        </DialogDescription>
+      </div>
+
+      <div className="grid gap-2">
+        <Button className="font-semibold" onClick={onRetry} size="lg">
+          {u.tryAgain}
+        </Button>
+        <Button className="font-medium" onClick={onDismiss} type="button" variant="text">
+          {u.notNow}
+        </Button>
+      </div>
     </div>
   )
 }

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -348,6 +348,15 @@ export interface DesktopUpdateApplyResult {
   /** True when the auto-relaunch was skipped specifically because the rebuilt
    *  chrome-sandbox helper is not launchable (not root:root + setuid). */
   sandboxBlocked?: boolean
+  /** Backend-authoritative active-work details when the Electron handoff blocks
+   *  an update after the renderer's optimistic preflight missed it. */
+  activeWork?: {
+    active?: boolean
+    running_sessions?: number
+    waiting_sessions?: number
+    starting_sessions?: number
+    active_subagents?: number
+  } | null
   /** True when a detached relauncher took over (macOS bundle swap / Linux
    *  re-exec): the app is about to quit and reopen itself. */
   handedOff?: boolean
@@ -368,6 +377,9 @@ export type DesktopUpdateStage =
    *  changed — the user must update/reinstall the desktop app. Terminal,
    *  closeable; never claims the GUI was updated. (#45205) */
   | 'guiSkew'
+  /** Local work is still running, so the desktop updater must wait until the
+   *  active session and background workers settle. */
+  | 'blocked'
   | 'error'
 
 export interface DesktopUpdateProgress {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1920,6 +1920,7 @@ export const en: Translations = {
       done: 'Update complete',
       manual: 'Update from your terminal',
       guiSkew: 'Update the desktop app',
+      blocked: 'Finish running work first',
       error: 'Update paused'
     },
     checking: 'Looking for updates…',
@@ -1945,6 +1946,9 @@ export const en: Translations = {
     guiSkewTitle: 'Update the desktop app',
     guiSkewBody:
       'The backend was updated, but this desktop app package wasn’t changed. Update or reinstall the Hermes desktop app (your AppImage / .deb / .rpm) to match.',
+    activeWorkTitle: 'Finish current work first',
+    activeWorkBody:
+      'Hermes is still running a chat or background worker. Let that work finish before updating from inside the app.',
     copy: 'Copy',
     copied: 'Copied',
     done: 'Done',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1844,6 +1844,7 @@ export const ja = defineLocale({
       done: '更新が完了しました',
       manual: 'ターミナルから更新',
       guiSkew: 'デスクトップアプリを更新してください',
+      blocked: '実行中の作業が終わるまで待ってください',
       error: '更新が一時停止中'
     },
     checking: '更新を確認中…',
@@ -1871,6 +1872,9 @@ export const ja = defineLocale({
     guiSkewTitle: 'デスクトップアプリを更新してください',
     guiSkewBody:
       'バックエンドは更新されましたが、このデスクトップアプリのパッケージは変更されていません。一致させるために Hermes デスクトップアプリ（AppImage / .deb / .rpm）を更新または再インストールしてください。',
+    activeWorkTitle: '現在の作業を先に完了してください',
+    activeWorkBody:
+      'Hermes はまだチャットまたはバックグラウンドのサブエージェントを実行中です。アプリ内から更新する前に、その作業が終わるまで待ってください。',
     copy: 'コピー',
     copied: 'コピーしました',
     done: '完了',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1606,6 +1606,8 @@ export interface Translations {
      *  package (AppImage/.deb/.rpm) was not changed and must be reinstalled. */
     guiSkewTitle: string
     guiSkewBody: string
+    activeWorkTitle: string
+    activeWorkBody: string
     copy: string
     copied: string
     done: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1790,6 +1790,7 @@ export const zhHant = defineLocale({
       done: '更新完成',
       manual: '從終端機更新',
       guiSkew: '請更新桌面應用程式',
+      blocked: '請先等目前工作結束',
       error: '更新已暫停'
     },
     checking: '正在檢查更新…',
@@ -1815,6 +1816,8 @@ export const zhHant = defineLocale({
     guiSkewTitle: '請更新桌面應用程式',
     guiSkewBody:
       '後端已更新，但此桌面應用程式套件未變更。請更新或重新安裝 Hermes 桌面應用程式（你的 AppImage / .deb / .rpm）以保持一致。',
+    activeWorkTitle: '請先完成目前工作',
+    activeWorkBody: 'Hermes 仍在執行聊天或背景子代理。請等這些工作完成後，再從應用程式內更新。',
     copy: '複製',
     copied: '已複製',
     done: '完成',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2100,6 +2100,7 @@ export const zh: Translations = {
       done: '更新完成',
       manual: '从终端更新',
       guiSkew: '请更新桌面应用',
+      blocked: '请先等当前工作结束',
       error: '更新已暂停'
     },
     checking: '正在检查更新…',
@@ -2125,6 +2126,8 @@ export const zh: Translations = {
     guiSkewTitle: '请更新桌面应用',
     guiSkewBody:
       '后端已更新，但此桌面应用包未更改。请更新或重新安装 Hermes 桌面应用（你的 AppImage / .deb / .rpm）以保持一致。',
+    activeWorkTitle: '请先完成当前工作',
+    activeWorkBody: 'Hermes 仍在运行对话或后台子代理。请等这些工作完成后，再从应用内更新。',
     copy: '复制',
     copied: '已复制',
     done: '完成',

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { DesktopUpdateStatus } from '@/global'
+import type { SubagentProgress } from '@/store/subagents'
 
 const storage = new Map<string, string>()
 
@@ -20,7 +21,37 @@ vi.mock('@/lib/storage', () => ({
 
     return value === undefined ? fallback : value === 'true'
   },
-  storedString: (key: string) => storage.get(key) ?? null
+  storedString: (key: string) => storage.get(key) ?? null,
+  persistStringArray: (key: string, value: readonly string[]) => storage.set(key, JSON.stringify(value)),
+  storedStringArray: (key: string) => {
+    try {
+      const parsed = JSON.parse(storage.get(key) ?? '[]')
+
+      return Array.isArray(parsed) ? parsed.filter(value => typeof value === 'string') : []
+    } catch {
+      return []
+    }
+  },
+  persistStringRecord: (key: string, value: Record<string, string>) => storage.set(key, JSON.stringify(value)),
+  storedStringRecord: (key: string) => {
+    try {
+      const parsed = JSON.parse(storage.get(key) ?? '{}')
+
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {}
+    } catch {
+      return {}
+    }
+  },
+  readKey: (key: string, fallback: string | null = null) => storage.get(key) ?? fallback,
+  readJson: (_key: string, fallback: unknown) => fallback,
+  writeJson: (key: string, value: unknown) => storage.set(key, JSON.stringify(value)),
+  writeKey: (key: string, value: null | string) => {
+    if (value === null) {
+      storage.delete(key)
+    } else {
+      storage.set(key, value)
+    }
+  }
 }))
 
 const notifySpy = vi.fn()
@@ -38,7 +69,8 @@ const getActionStatusSpy = vi.fn()
 vi.mock('@/hermes', () => ({
   checkHermesUpdate: (...args: unknown[]) => checkHermesUpdateSpy(...args),
   updateHermes: (...args: unknown[]) => updateHermesSpy(...args),
-  getActionStatus: (...args: unknown[]) => getActionStatusSpy(...args)
+  getActionStatus: (...args: unknown[]) => getActionStatusSpy(...args),
+  setApiRequestProfile: vi.fn()
 }))
 
 const {
@@ -58,6 +90,8 @@ const {
 } = await import('./updates')
 
 const { setConnection } = await import('./session')
+const { $subagentsBySession } = await import('./subagents')
+const { clearAllSessionStates, publishSessionState } = await import('./session-states')
 
 const status = (over: Partial<DesktopUpdateStatus> = {}): DesktopUpdateStatus => ({
   supported: true,
@@ -68,6 +102,11 @@ const status = (over: Partial<DesktopUpdateStatus> = {}): DesktopUpdateStatus =>
 })
 
 const lastToast = () => notifySpy.mock.calls.at(-1)?.[0] as { onDismiss: () => void }
+const publishWorkingSession = (runtimeId: string, storedSessionId: string) =>
+  publishSessionState(runtimeId, {
+    busy: true,
+    storedSessionId
+  } as Parameters<typeof publishSessionState>[1])
 
 describe('maybeNotifyUpdateAvailable', () => {
   beforeEach(() => {
@@ -257,12 +296,29 @@ describe('checkBackendUpdates', () => {
 describe('applyUpdates terminal state', () => {
   const applyMock = vi.fn()
 
+  const runningSubagent = (over: Partial<SubagentProgress> = {}): SubagentProgress => ({
+    id: 'subagent-1',
+    parentId: null,
+    goal: 'Investigate',
+    status: 'running',
+    taskCount: 1,
+    taskIndex: 0,
+    startedAt: 1,
+    updatedAt: 1,
+    filesRead: [],
+    filesWritten: [],
+    stream: [],
+    ...over
+  })
+
   beforeEach(() => {
     storage.clear()
     notifySpy.mockClear()
     dismissSpy.mockClear()
     applyMock.mockReset()
     resetUpdateApplyState()
+    clearAllSessionStates()
+    $subagentsBySession.set({})
     $updateOverlayOpen.set(true)
     ;(globalThis as unknown as { window: unknown }).window = {
       hermesDesktop: { updates: { apply: applyMock } }
@@ -272,6 +328,7 @@ describe('applyUpdates terminal state', () => {
 
   afterEach(() => {
     delete (globalThis as unknown as { window?: unknown }).window
+    clearAllSessionStates()
   })
 
   it('holds the restart view when a relauncher hands off (no close, no toast)', async () => {
@@ -284,6 +341,45 @@ describe('applyUpdates terminal state', () => {
     expect($updateApply.get().applying).toBe(true)
     expect($updateOverlayOpen.get()).toBe(true)
     expect(notifySpy).not.toHaveBeenCalled()
+  })
+
+  it('refuses to start the desktop updater while a local session is still running', async () => {
+    publishWorkingSession('runtime-1', 'session-1')
+
+    const result = await applyUpdates()
+
+    expect(result).toMatchObject({ ok: false, error: 'active-work' })
+    expect(applyMock).not.toHaveBeenCalled()
+    expect($updateApply.get().applying).toBe(false)
+    expect($updateApply.get().stage).toBe('blocked')
+    expect($updateApply.get().message).toMatch(/still running a chat/i)
+  })
+
+  it('refuses to start the desktop updater while background subagents are still running', async () => {
+    $subagentsBySession.set({ 'session-1': [runningSubagent()] })
+
+    const result = await applyUpdates()
+
+    expect(result).toMatchObject({ ok: false, error: 'active-work' })
+    expect(applyMock).not.toHaveBeenCalled()
+    expect($updateApply.get().stage).toBe('blocked')
+  })
+
+  it('maps Electron active-work rejection when renderer-side activity went stale', async () => {
+    applyMock.mockResolvedValue({
+      ok: false,
+      error: 'active-work',
+      message: 'Hermes is still running a chat or background task.',
+      activeWork: { active: true, running_sessions: 1, active_subagents: 0 }
+    })
+
+    const result = await applyUpdates()
+
+    expect(applyMock).toHaveBeenCalledTimes(1)
+    expect(result).toMatchObject({ ok: false, error: 'active-work' })
+    expect($updateApply.get().applying).toBe(false)
+    expect($updateApply.get().stage).toBe('blocked')
+    expect($updateApply.get().message).toMatch(/still running/i)
   })
 
   it('closes the overlay + toasts when updated but not relaunched in place', async () => {

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -18,6 +18,8 @@ import { translateNow } from '@/i18n'
 import { persistString, storedString } from '@/lib/storage'
 import { dismissNotification, notify } from '@/store/notifications'
 import { $connection } from '@/store/session'
+import { $workingSessionIds } from '@/store/session-states'
+import { $subagentsBySession, activeSubagentCount } from '@/store/subagents'
 import type { BackendUpdateCheckResponse } from '@/types/hermes'
 
 export interface UpdateApplyState {
@@ -363,11 +365,34 @@ export async function checkUpdates(): Promise<DesktopUpdateStatus | null> {
   }
 }
 
+function hasActiveClientUpdateWork(): boolean {
+  return (
+    $workingSessionIds.get().length > 0 ||
+    Object.values($subagentsBySession.get()).some(items => activeSubagentCount(items) > 0)
+  )
+}
+
 export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promise<DesktopUpdateApplyResult> {
   const bridge = window.hermesDesktop?.updates
 
   if (!bridge) {
     return { ok: false, error: 'unavailable', message: 'Desktop bridge unavailable.' }
+  }
+
+  // The in-app client updater tears down the local backend pool as part of the
+  // handoff. Refuse to start while any local session or background subagent is
+  // still running so we don't kill active work out from under the user.
+  if (!isRemoteMode() && hasActiveClientUpdateWork()) {
+    const message = translateNow('updates.activeWorkBody')
+    $updateApply.set({
+      ...IDLE,
+      applying: false,
+      stage: 'blocked',
+      error: 'active-work',
+      message
+    })
+
+    return { ok: false, error: 'active-work', message }
   }
 
   dismissNotification(UPDATE_TOAST_ID)
@@ -386,6 +411,18 @@ export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promis
         stage: 'manual',
         message: result.command ?? 'hermes update',
         command: result.command ?? 'hermes update'
+      })
+
+      return result
+    }
+
+    if (result?.error === 'active-work') {
+      $updateApply.set({
+        ...IDLE,
+        applying: false,
+        stage: 'blocked',
+        error: 'active-work',
+        message: result.message ?? translateNow('updates.activeWorkBody')
       })
 
       return result
@@ -619,6 +656,7 @@ function ingestProgress(payload: DesktopUpdateProgress): void {
   const log = [...current.log, { stage: payload.stage, message: payload.message, at: payload.at }].slice(-50)
 
   const terminal =
+    payload.stage === 'blocked' ||
     payload.stage === 'error' ||
     payload.stage === 'restart' ||
     payload.stage === 'manual' ||

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2992,6 +2992,15 @@ async def get_status(profile: Optional[str] = None):
             status_scope.__exit__(*sys.exc_info())
 
 
+@app.get("/api/runtime/active-work")
+async def get_runtime_active_work(request: Request):
+    """Authenticated active-work probe for destructive desktop handoffs."""
+    _require_token(request)
+    from tui_gateway.server import active_work_snapshot
+
+    return active_work_snapshot()
+
+
 _WINDOWS_11_MIN_BUILD = 22000
 
 

--- a/tests/hermes_cli/test_dashboard_active_work_endpoint.py
+++ b/tests/hermes_cli/test_dashboard_active_work_endpoint.py
@@ -1,0 +1,50 @@
+from fastapi.testclient import TestClient
+
+from hermes_cli import web_server
+from hermes_cli.dashboard_auth import clear_providers
+
+
+def test_runtime_active_work_requires_dashboard_token():
+    clear_providers()
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.auth_required = False
+    try:
+        client = TestClient(web_server.app, base_url="http://127.0.0.1:8080")
+
+        response = client.get("/api/runtime/active-work")
+
+        assert response.status_code == 401
+    finally:
+        web_server.app.state.auth_required = prev_required
+
+
+def test_runtime_active_work_returns_backend_snapshot(monkeypatch):
+    clear_providers()
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.auth_required = False
+    monkeypatch.setattr(
+        "tui_gateway.server.active_work_snapshot",
+        lambda: {
+            "active": True,
+            "running_sessions": 1,
+            "waiting_sessions": 0,
+            "starting_sessions": 0,
+            "active_subagents": 2,
+        },
+    )
+    try:
+        client = TestClient(web_server.app, base_url="http://127.0.0.1:8080")
+        client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+
+        response = client.get("/api/runtime/active-work")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "active": True,
+            "running_sessions": 1,
+            "waiting_sessions": 0,
+            "starting_sessions": 0,
+            "active_subagents": 2,
+        }
+    finally:
+        web_server.app.state.auth_required = prev_required

--- a/tests/tui_gateway/test_active_work_snapshot.py
+++ b/tests/tui_gateway/test_active_work_snapshot.py
@@ -1,0 +1,71 @@
+import threading
+
+import tui_gateway.server as server
+
+
+def _clear_runtime_state():
+    with server._sessions_lock:
+        server._sessions.clear()
+    server._pending.clear()
+    server._pending_prompt_payloads.clear()
+
+
+def test_active_work_snapshot_reports_running_session_without_active_session_cap():
+    _clear_runtime_state()
+    try:
+        with server._sessions_lock:
+            server._sessions["sid-1"] = {"running": True}
+
+        snapshot = server.active_work_snapshot()
+
+        assert snapshot["active"] is True
+        assert snapshot["running_sessions"] == 1
+    finally:
+        _clear_runtime_state()
+
+
+def test_active_work_snapshot_reports_agent_build_starting():
+    _clear_runtime_state()
+    ready = threading.Event()
+    try:
+        with server._sessions_lock:
+            server._sessions["sid-1"] = {
+                "agent_build_started": True,
+                "agent_ready": ready,
+                "running": False,
+            }
+
+        snapshot = server.active_work_snapshot()
+
+        assert snapshot["active"] is True
+        assert snapshot["starting_sessions"] == 1
+    finally:
+        _clear_runtime_state()
+
+
+def test_active_work_snapshot_merges_subagent_registries(monkeypatch):
+    import tools.async_delegation as async_delegation
+    import tools.delegate_tool as delegate_tool
+
+    _clear_runtime_state()
+    monkeypatch.setattr(delegate_tool, "list_active_subagents", lambda: [{"id": "native"}])
+    monkeypatch.setattr(async_delegation, "active_count", lambda: 2)
+
+    snapshot = server.active_work_snapshot()
+
+    assert snapshot["active"] is True
+    assert snapshot["active_subagents"] == 3
+
+
+def test_active_work_snapshot_is_idle_when_only_detached_idle_sessions_exist():
+    _clear_runtime_state()
+    try:
+        with server._sessions_lock:
+            server._sessions["sid-1"] = {"running": False}
+
+        snapshot = server.active_work_snapshot()
+
+        assert snapshot["active"] is False
+        assert snapshot["running_sessions"] == 0
+    finally:
+        _clear_runtime_state()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6540,6 +6540,54 @@ def _session_live_status(sid: str, session: dict) -> str:
     return "idle"
 
 
+def active_work_snapshot() -> dict:
+    """Return the backend-authoritative active-work state for update guards."""
+    with _sessions_lock:
+        running_sessions = [
+            sid for sid, session in _sessions.items() if bool(session.get("running"))
+        ]
+        waiting_sessions = [
+            sid for sid, _session in _sessions.items() if _session_pending_kind(sid)
+        ]
+        starting_sessions = [
+            sid
+            for sid, session in _sessions.items()
+            if (ready := session.get("agent_ready")) is not None
+            and not ready.is_set()
+            and session.get("agent_build_started")
+        ]
+
+    delegate_subagents = 0
+    async_subagents = 0
+    try:
+        from tools.delegate_tool import list_active_subagents
+
+        delegate_subagents = len(list_active_subagents())
+    except Exception:
+        delegate_subagents = 0
+    try:
+        from tools.async_delegation import active_count
+
+        async_subagents = int(active_count())
+    except Exception:
+        async_subagents = 0
+
+    active_subagents = delegate_subagents + async_subagents
+    active = bool(
+        running_sessions
+        or waiting_sessions
+        or starting_sessions
+        or active_subagents > 0
+    )
+    return {
+        "active": active,
+        "running_sessions": len(running_sessions),
+        "waiting_sessions": len(waiting_sessions),
+        "starting_sessions": len(starting_sessions),
+        "active_subagents": active_subagents,
+    }
+
+
 def _message_preview(history: list) -> str:
     for msg in reversed(history or []):
         text = _content_display_text(msg.get("content", msg.get("text", ""))).strip()


### PR DESCRIPTION
## What does this PR do?

This partially addresses #53480 for the Desktop in-app update path.

Before this patch, the renderer could hand off to the Electron updater while local chat work was still active. That handoff tears down backend processes, so starting an update during an active local session could interrupt live work.

This fix keeps the scope narrow and source-focused:
- it blocks the local Desktop client update path before the update bridge call when renderer activity is current
- it re-checks backend-owned active work inside Electron main immediately before updater handoff / in-app update work begins
- it surfaces a dedicated blocked overlay state so the user sees why the update did not start

## Related Issue

Partially addresses #53480.

This PR covers the Desktop in-app updater button/path. It does not claim to cover a user manually running `hermes update` from a Desktop-hosted terminal; that CLI/Electron terminal path needs a separate guard if maintainers want the same policy there.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Why this is the right fix

The confirmed live failure mode is the Desktop renderer starting an in-app client update while local work is still running. The dangerous point is the Electron update handoff, because it can release/kill backend processes before launching the updater.

The original renderer preflight is useful for instant UI feedback, but it is not authoritative: renderer working-session state can be cleared by the session watchdog after stream silence. The backend now exposes an authenticated active-work snapshot from the TUI gateway's live session/subagent registries, and Electron main probes that snapshot again immediately before entering the destructive update path.

## Changes Made

- add backend-authoritative `active_work_snapshot()` in `tui_gateway/server.py` for running, waiting, starting sessions and active subagents
- expose the snapshot through authenticated `GET /api/runtime/active-work` in `hermes_cli/web_server.py`
- have Electron `applyUpdates()` call the backend probe before staged-updater handoff and before POSIX in-app update work
- map Electron-side `active-work` rejections back to the existing renderer `blocked` update state
- align the renderer preflight with current `main`'s `session-states.ts` working-session projection after resolving merge drift
- extend Desktop update typings for the active-work payload
- add regression coverage for stale renderer activity, backend snapshot behavior, and the authenticated REST probe

## How to Test

1. From `apps/desktop`, run:
   - `npm run test:ui -- src/store/updates.test.ts`
2. From the repo root, run:
   - `scripts/run_tests.sh tests/tui_gateway/test_active_work_snapshot.py tests/hermes_cli/test_dashboard_active_work_endpoint.py`
3. From `apps/desktop`, run:
   - `npx tsc -p tsconfig.electron.json --noEmit`

## Compatibility Notes

- idle local Desktop client updates continue through the existing path unchanged
- remote/backend update flow is unchanged
- if the backend active-work probe is unavailable, Electron logs the probe failure and continues after the renderer preflight so GUI/backend skew does not become a permanent update dead end
- this PR does not add a force-update UX for active work; it only blocks the confirmed unsafe local in-app updater path

## Validation Logs

```text
Automated checks after merging upstream/main:
- npm run test:ui -- src/store/updates.test.ts -> passed (28 tests)
- scripts/run_tests.sh tests/tui_gateway/test_active_work_snapshot.py tests/hermes_cli/test_dashboard_active_work_endpoint.py -> passed (6 tests)

Conflict/mergeability check:
- GitHub GraphQL mergeable -> MERGEABLE
- mergeStateStatus -> BLOCKED because CI/checks are pending, not because of file conflicts

Known validation gap:
- npx tsc -p tsconfig.electron.json --noEmit -> blocked only by pre-existing missing `simple-git` type/module resolution in electron/git-review-ops.ts
- npm run typecheck -> still blocked by unrelated missing packages / upstream type drift outside the update files (`@xterm/addon-serialize`, CodeMirror packages, assistant-ui streamdown exports, `fflate`, etc.)
```

## Remaining Risks

- manual end-to-end Desktop update reproduction was not run in this lane
- the Desktop-hosted terminal `hermes update` path remains outside this PR's scope
- CI is still running on the pushed conflict-resolution branch

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No screenshots. See validation logs above.
