### PR TITLE
fix: apply moa switches to live tui agent

### DIFF
--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import importlib
 import threading
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -77,6 +78,36 @@ def session(server):
 def _call(server, method, **params):
     handler = server._methods[method]
     return handler(1, params)
+
+
+class _FakeAgent:
+    def __init__(self):
+        self.model = "base-model"
+        self.provider = "base-provider"
+        self.base_url = "https://base.example/v1"
+        self.api_key = "base-key"
+        self.api_mode = "chat_completions"
+        self.switches = []
+
+    def switch_model(self, **kwargs):
+        self.switches.append(kwargs)
+        self.model = kwargs["new_model"]
+        self.provider = kwargs["new_provider"]
+        self.base_url = kwargs.get("base_url") or ""
+        self.api_key = kwargs.get("api_key") or ""
+        self.api_mode = kwargs.get("api_mode") or "chat_completions"
+
+
+@contextmanager
+def _patch_live_switch_side_effects(server):
+    with (
+        patch.object(server, "_restart_slash_worker"),
+        patch.object(server, "_persist_live_session_runtime"),
+        patch.object(server, "_persist_live_session_system_prompt"),
+        patch.object(server, "_emit"),
+        patch.object(server, "_session_info", return_value={}),
+    ):
+        yield
 
 
 # ── command.dispatch /goal ────────────────────────────────────────────
@@ -225,11 +256,15 @@ moa:
         model: anthropic/claude-opus-4.8
 """)
     sid, _, s = session
-    r = _call(server, "command.dispatch", name="moa", arg="", session_id=sid)
+    s["agent"] = _FakeAgent()
+    with _patch_live_switch_side_effects(server):
+        r = _call(server, "command.dispatch", name="moa", arg="", session_id=sid)
     assert r["result"]["type"] == "exec"
     assert "Model switched to MoA preset: default" in r["result"]["output"]
     assert s["model_override"]["provider"] == "moa"
     assert s["model_override"]["model"] == "default"
+    assert s["agent"].provider == "moa"
+    assert s["agent"].model == "default"
 
 
 def test_moa_exact_preset_switches_to_named_preset_model(server, session, hermes_home):
@@ -247,10 +282,14 @@ moa:
         model: anthropic/claude-opus-4.8
 """)
     sid, _, s = session
-    r = _call(server, "command.dispatch", name="moa", arg="review", session_id=sid)
+    s["agent"] = _FakeAgent()
+    with _patch_live_switch_side_effects(server):
+        r = _call(server, "command.dispatch", name="moa", arg="review", session_id=sid)
     assert r["result"]["type"] == "exec"
     assert s["model_override"]["provider"] == "moa"
     assert s["model_override"]["model"] == "review"
+    assert s["agent"].provider == "moa"
+    assert s["agent"].model == "review"
 
 
 def test_moa_non_preset_returns_one_shot_send(server, session, hermes_home):
@@ -266,12 +305,25 @@ moa:
         provider: openrouter
         model: anthropic/claude-opus-4.8
 """)
-    sid, _, _ = session
-    r = _call(server, "command.dispatch", name="moa", arg="inspect this project", session_id=sid)
+    sid, _, s = session
+    s["agent"] = _FakeAgent()
+    with _patch_live_switch_side_effects(server):
+        r = _call(server, "command.dispatch", name="moa", arg="inspect this project", session_id=sid)
     result = r["result"]
     assert result["type"] == "send"
     assert result["message"] == "inspect this project"
     assert "one-shot" in result["notice"]
+    assert s["model_override"]["provider"] == "moa"
+    assert s["model_override"]["model"] == "default"
+    assert s["agent"].provider == "moa"
+    assert s["agent"].model == "default"
+
+    with _patch_live_switch_side_effects(server):
+        server._restore_moa_one_shot(sid, s)
+
+    assert "model_override" not in s
+    assert s["agent"].provider == "base-provider"
+    assert s["agent"].model == "base-model"
 
 
 def test_pending_input_commands_includes_moa(server):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2742,6 +2742,77 @@ def _apply_model_switch(
     }
 
 
+def _moa_model_override(preset: str) -> dict[str, Any]:
+    return {
+        "model": preset,
+        "provider": "moa",
+        "base_url": "moa://local",
+        "api_key": "moa-virtual-provider",
+        "api_mode": "chat_completions",
+    }
+
+
+def _agent_model_override(agent: Any) -> dict[str, Any]:
+    return {
+        "model": getattr(agent, "model", "") or "",
+        "provider": getattr(agent, "provider", "") or "",
+        "base_url": getattr(agent, "base_url", "") or "",
+        "api_key": getattr(agent, "api_key", "") or "",
+        "api_mode": getattr(agent, "api_mode", "") or "chat_completions",
+    }
+
+
+def _apply_live_model_override(
+    sid: str,
+    session: dict,
+    override: dict[str, Any],
+    *,
+    label: str,
+) -> None:
+    agent = session.get("agent")
+    if agent is None:
+        return
+    try:
+        agent.switch_model(
+            new_model=override.get("model") or "",
+            new_provider=override.get("provider") or "",
+            api_key=override.get("api_key"),
+            base_url=override.get("base_url"),
+            api_mode=override.get("api_mode"),
+        )
+    except Exception as exc:
+        logger.warning("In-place %s switch failed for TUI agent: %s", label, exc)
+        raise ValueError(
+            f"{label} switch to {override.get('provider')}:{override.get('model')} "
+            f"failed ({exc}); staying on {getattr(agent, 'model', '')}."
+        ) from exc
+    _restart_slash_worker(sid, session)
+    _persist_live_session_runtime(session)
+    _persist_live_session_system_prompt(session)
+    _emit("session.info", sid, _session_info(agent, session))
+
+
+def _restore_moa_one_shot(sid: str, session: dict) -> None:
+    if "moa_one_shot_restore" not in session:
+        return
+    restore_override = session.pop("moa_one_shot_restore", None)
+    restore_agent = session.pop("moa_one_shot_restore_agent", None)
+    if restore_override is None:
+        session.pop("model_override", None)
+    else:
+        session["model_override"] = restore_override
+    if isinstance(restore_agent, dict):
+        try:
+            _apply_live_model_override(
+                sid,
+                session,
+                restore_agent,
+                label="MoA restore",
+            )
+        except Exception as exc:
+            logger.warning("MoA one-shot restore failed: %s", exc)
+
+
 def _sync_agent_model_with_config(sid: str, session: dict) -> None:
     """Adopt a config.yaml model change at turn start, like gateways do per
     message. Sessions pinned with /model keep their choice; a failed switch
@@ -8424,12 +8495,6 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             except (TypeError, ValueError):
                 pass
             result = agent.run_conversation(run_message, **run_kwargs)
-            if "moa_one_shot_restore" in session:
-                _restore = session.pop("moa_one_shot_restore", None)
-                if _restore is None:
-                    session.pop("model_override", None)
-                else:
-                    session["model_override"] = _restore
 
             last_reasoning = None
             status_note = None
@@ -8647,6 +8712,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             )
             _emit("error", sid, {"message": str(e)})
         finally:
+            _restore_moa_one_shot(sid, session)
             try:
                 if approval_token is not None:
                     reset_current_session_key(approval_token)
@@ -11121,7 +11187,8 @@ def _(rid, params: dict) -> dict:
     resolved = _resolve_name(name)
     if resolved != name:
         name = resolved
-    session = _sessions.get(params.get("session_id", ""))
+    sid = params.get("session_id", "")
+    session = _sessions.get(sid)
 
     qcmds = _load_cfg().get("quick_commands", {})
     if name in qcmds:
@@ -11207,7 +11274,7 @@ def _(rid, params: dict) -> dict:
     if name == "moa":
         try:
             from hermes_cli.moa_config import (
-                build_moa_turn_prompt, exact_moa_preset_name, moa_usage, normalize_moa_config
+                exact_moa_preset_name, moa_usage, normalize_moa_config
             )
 
             moa_cfg = normalize_moa_config(_load_cfg().get("moa") or {})
@@ -11215,28 +11282,36 @@ def _(rid, params: dict) -> dict:
             if matched:
                 if not session:
                     return _err(rid, 4001, "no active session")
-                session["model_override"] = {
-                    "model": matched,
-                    "provider": "moa",
-                    "base_url": "moa://local",
-                    "api_key": "moa-virtual-provider",
-                    "api_mode": "chat_completions",
-                }
+                override = _moa_model_override(matched)
+                previous_override = session.get("model_override")
+                session["model_override"] = override
                 session["moa_active_preset"] = matched
+                try:
+                    _apply_live_model_override(sid, session, override, label="MoA")
+                except Exception:
+                    if previous_override is None:
+                        session.pop("model_override", None)
+                    else:
+                        session["model_override"] = previous_override
+                    session.pop("moa_active_preset", None)
+                    raise
                 return _ok(rid, {"type": "exec", "output": f"Model switched to MoA preset: {matched}."})
             if not arg:
                 return _err(rid, 4004, moa_usage())
             if not session:
                 return _err(rid, 4001, "no active session")
             preset = moa_cfg["default_preset"]
+            agent = session.get("agent")
             session["moa_one_shot_restore"] = session.get("model_override")
-            session["model_override"] = {
-                "model": preset,
-                "provider": "moa",
-                "base_url": "moa://local",
-                "api_key": "moa-virtual-provider",
-                "api_mode": "chat_completions",
-            }
+            if agent is not None:
+                session["moa_one_shot_restore_agent"] = _agent_model_override(agent)
+            override = _moa_model_override(preset)
+            session["model_override"] = override
+            try:
+                _apply_live_model_override(sid, session, override, label="MoA")
+            except Exception:
+                _restore_moa_one_shot(sid, session)
+                raise
             return _ok(
                 rid,
                 {


### PR DESCRIPTION
Problem
TUI/Desktop /moa updated the session model override, but it did not switch the already-running session agent. That meant /moa <prompt> could show the queued notice while the next turn still ran on the previous single provider.

Summary
- Add a MoA live-switch helper for the known virtual-provider runtime values.
- Apply the helper for preset switches and one-shot MoA prompts.
- Restore both the session override and the live agent after one-shot prompts, including cleanup paths.
- Extend command-dispatch tests to assert the live agent actually switches and restores.

Validation
- $HOME/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/tui_gateway/test_goal_command.py
- $HOME/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/tui_gateway/test_goal_command.py -k moa
- $HOME/.hermes/hermes-agent/venv/bin/ruff check tui_gateway/server.py tests/tui_gateway/test_goal_command.py
- git diff --check

Fixes #53444