### PR TITLE
harden(tools): block AUXILIARY_*_API_KEY and _BASE_URL from subprocess env

### DIFF
--- a/tests/tools/test_hermes_subprocess_env.py
+++ b/tests/tools/test_hermes_subprocess_env.py
@@ -42,6 +42,18 @@ _SAFE_SAMPLE = {
     "MY_APP_VAR": "keep-me",
 }
 
+_AUXILIARY_SAMPLE = {
+    "AUXILIARY_VISION_API_KEY": "aux-vision-key",
+    "AUXILIARY_VISION_BASE_URL": "https://vision.example/v1",
+    "AUXILIARY_COMPRESSION_API_KEY": "aux-compression-key",
+    "AUXILIARY_CUSTOM_PLUGIN_TASK_API_KEY": "aux-plugin-key",
+}
+
+_AUXILIARY_NON_SECRET_SAMPLE = {
+    "AUXILIARY_VISION_MODEL": "gpt-4o-mini",
+    "AUXILIARY_VISION_PROVIDER": "openai",
+}
+
 
 def _build(extra=None, *, inherit_credentials=False):
     env = dict(_SAFE_SAMPLE)
@@ -99,6 +111,37 @@ class TestInheritCredentials:
 
     def test_pythonutf8_set_when_inheriting(self):
         assert _build(inherit_credentials=True).get("PYTHONUTF8") == "1"
+
+
+class TestAuxiliarySecrets:
+    """AUXILIARY_*_API_KEY / _BASE_URL are dynamically generated per-task
+    credentials (gateway/run.py bridges them for vision, compression,
+    approval, and plugin-registered tasks). They can't live in the static
+    _HERMES_PROVIDER_ENV_BLOCKLIST, so hermes_subprocess_env() must strip
+    them by pattern, like _sanitize_subprocess_env() already does for the
+    terminal path."""
+
+    def test_auxiliary_secrets_stripped_by_default(self):
+        result = _build(_AUXILIARY_SAMPLE)
+        for var in _AUXILIARY_SAMPLE:
+            assert var not in result, f"{var} leaked with inherit_credentials=False"
+
+    def test_auxiliary_secrets_stripped_even_when_inheriting(self):
+        """Tier-1 behavior: a model-driving CLI that legitimately inherits
+        primary provider credentials still has no reason to see another
+        task's auxiliary credentials."""
+        result = _build(_AUXILIARY_SAMPLE, inherit_credentials=True)
+        for var in _AUXILIARY_SAMPLE:
+            assert var not in result, (
+                f"{var} leaked (auxiliary) with inherit_credentials=True"
+            )
+
+    def test_auxiliary_non_secret_vars_preserved(self):
+        """Only the _API_KEY / _BASE_URL suffixes are secrets; sibling vars
+        like _MODEL / _PROVIDER carry no credential and must pass through."""
+        result = _build(_AUXILIARY_NON_SECRET_SAMPLE)
+        for var, val in _AUXILIARY_NON_SECRET_SAMPLE.items():
+            assert result.get(var) == val, f"{var} should not be stripped"
 
 
 class TestTierInvariants:

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -713,3 +713,52 @@ class TestAuxiliaryEnvBlocklist:
         with patch.dict(os.environ, {"PATH": "/usr/bin"}, clear=True):
             result = _make_run_env({"AUXILIARY_CUSTOM_TASK_API_KEY": "sk-leaked"})
         assert "AUXILIARY_CUSTOM_TASK_API_KEY" not in result
+
+    def test_passthrough_registration_rejected_for_auxiliary_secrets(self):
+        """Passthrough bypass: register_env_passthrough must reject AUXILIARY_*_API_KEY
+        and AUXILIARY_*_BASE_URL even though they're not in the static blocklist.
+
+        Without this guard a skill could call
+        register_env_passthrough(["AUXILIARY_VISION_API_KEY"]) and the secret
+        would survive _sanitize_subprocess_env / _make_run_env because the
+        _is_auxiliary_secret() filter is guarded by `not _is_passthrough(key)`.
+        """
+        from tools.env_passthrough import (
+            clear_env_passthrough,
+            is_env_passthrough,
+            register_env_passthrough,
+        )
+        clear_env_passthrough()
+        register_env_passthrough(["AUXILIARY_VISION_API_KEY", "AUXILIARY_VISION_BASE_URL"])
+        assert not is_env_passthrough("AUXILIARY_VISION_API_KEY"), (
+            "auxiliary API key must not be registerable as passthrough"
+        )
+        assert not is_env_passthrough("AUXILIARY_VISION_BASE_URL"), (
+            "auxiliary base URL must not be registerable as passthrough"
+        )
+        clear_env_passthrough()
+
+    def test_force_prefix_cannot_inject_auxiliary_secret_via_extra_env(self):
+        """Force-prefix bypass: _HERMES_FORCE_AUXILIARY_*_API_KEY in extra_env
+        must not materialize as AUXILIARY_*_API_KEY in the sanitized dict.
+
+        Without this guard the materialization `real_key = key[len(prefix):]`
+        happened unconditionally, bypassing _is_auxiliary_secret() for the
+        force-prefix path.
+        """
+        from tools.environments.local import _sanitize_subprocess_env, _HERMES_PROVIDER_ENV_FORCE_PREFIX
+        base = {"PATH": "/usr/bin"}
+        extra = {f"{_HERMES_PROVIDER_ENV_FORCE_PREFIX}AUXILIARY_VISION_API_KEY": "sk-forced-secret"}
+        result = _sanitize_subprocess_env(base, extra)
+        assert "AUXILIARY_VISION_API_KEY" not in result
+
+    def test_force_prefix_cannot_inject_auxiliary_secret_via_make_run_env(self):
+        """Force-prefix bypass: _HERMES_FORCE_AUXILIARY_*_API_KEY in the merged
+        env must not reach the run environment via _make_run_env.
+        """
+        from tools.environments.local import _make_run_env, _HERMES_PROVIDER_ENV_FORCE_PREFIX
+        forced_key = f"{_HERMES_PROVIDER_ENV_FORCE_PREFIX}AUXILIARY_VISION_API_KEY"
+        env_override = {"PATH": "/usr/bin", forced_key: "sk-forced-secret"}
+        with patch.dict(os.environ, env_override, clear=True):
+            result = _make_run_env({})
+        assert "AUXILIARY_VISION_API_KEY" not in result

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -681,3 +681,35 @@ class TestAuxiliaryEnvBlocklist:
         extra = {"AUXILIARY_VISION_API_KEY": "sk-extra-secret"}
         result = _sanitize_subprocess_env(base, extra)
         assert "AUXILIARY_VISION_API_KEY" not in result
+
+    def test_make_run_env_blocks_auxiliary_api_keys(self, monkeypatch):
+        from tools.environments.local import _make_run_env
+        poison = {
+            "PATH": "/usr/bin",
+            "AUXILIARY_VISION_API_KEY": "sk-vision-secret",
+            "AUXILIARY_COMPRESSION_API_KEY": "sk-compress-secret",
+            "AUXILIARY_APPROVAL_BASE_URL": "https://internal.api",
+        }
+        with patch.dict(os.environ, poison, clear=True):
+            result = _make_run_env({})
+        assert "AUXILIARY_VISION_API_KEY" not in result
+        assert "AUXILIARY_COMPRESSION_API_KEY" not in result
+        assert "AUXILIARY_APPROVAL_BASE_URL" not in result
+
+    def test_make_run_env_passes_auxiliary_non_secrets(self, monkeypatch):
+        from tools.environments.local import _make_run_env
+        env = {
+            "PATH": "/usr/bin",
+            "AUXILIARY_VISION_PROVIDER": "openai-api",
+            "AUXILIARY_VISION_MODEL": "gpt-4o",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            result = _make_run_env({})
+        assert result.get("AUXILIARY_VISION_PROVIDER") == "openai-api"
+        assert result.get("AUXILIARY_VISION_MODEL") == "gpt-4o"
+
+    def test_make_run_env_blocks_auxiliary_from_caller_env(self):
+        from tools.environments.local import _make_run_env
+        with patch.dict(os.environ, {"PATH": "/usr/bin"}, clear=True):
+            result = _make_run_env({"AUXILIARY_CUSTOM_TASK_API_KEY": "sk-leaked"})
+        assert "AUXILIARY_CUSTOM_TASK_API_KEY" not in result

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -18,6 +18,8 @@ from tools.environments.local import (
     LocalEnvironment,
     _HERMES_PROVIDER_ENV_BLOCKLIST,
     _HERMES_PROVIDER_ENV_FORCE_PREFIX,
+    _is_auxiliary_secret,
+    _sanitize_subprocess_env,
 )
 
 
@@ -611,3 +613,71 @@ class TestHermesBinDirOnPath:
         entries = result["PATH"].split(os.pathsep)
         assert entries[0] == "/opt/hermes/bin"
         assert "/usr/bin" in entries
+
+
+class TestAuxiliaryEnvBlocklist:
+    """AUXILIARY_*_API_KEY and AUXILIARY_*_BASE_URL env vars written by the
+    gateway for per-task auxiliary config must not leak to subprocesses."""
+
+    def test_is_auxiliary_secret_detects_api_keys(self):
+        assert _is_auxiliary_secret("AUXILIARY_VISION_API_KEY")
+        assert _is_auxiliary_secret("AUXILIARY_COMPRESSION_API_KEY")
+        assert _is_auxiliary_secret("AUXILIARY_APPROVAL_API_KEY")
+        assert _is_auxiliary_secret("AUXILIARY_CUSTOM_RAG_API_KEY")
+
+    def test_is_auxiliary_secret_detects_base_urls(self):
+        assert _is_auxiliary_secret("AUXILIARY_VISION_BASE_URL")
+        assert _is_auxiliary_secret("AUXILIARY_WEB_EXTRACT_BASE_URL")
+
+    def test_is_auxiliary_secret_allows_non_secrets(self):
+        assert not _is_auxiliary_secret("AUXILIARY_VISION_PROVIDER")
+        assert not _is_auxiliary_secret("AUXILIARY_VISION_MODEL")
+        assert not _is_auxiliary_secret("PATH")
+        assert not _is_auxiliary_secret("HOME")
+
+    def test_sanitize_blocks_auxiliary_api_keys(self):
+        env = {
+            "PATH": "/usr/bin",
+            "AUXILIARY_VISION_API_KEY": "sk-vision-secret",
+            "AUXILIARY_COMPRESSION_API_KEY": "sk-compress-secret",
+            "AUXILIARY_APPROVAL_API_KEY": "sk-approval-secret",
+        }
+        result = _sanitize_subprocess_env(env)
+        assert "AUXILIARY_VISION_API_KEY" not in result
+        assert "AUXILIARY_COMPRESSION_API_KEY" not in result
+        assert "AUXILIARY_APPROVAL_API_KEY" not in result
+        assert result["PATH"] == "/usr/bin"
+
+    def test_sanitize_blocks_auxiliary_base_urls(self):
+        env = {
+            "PATH": "/usr/bin",
+            "AUXILIARY_WEB_EXTRACT_BASE_URL": "https://internal.api.example.com",
+        }
+        result = _sanitize_subprocess_env(env)
+        assert "AUXILIARY_WEB_EXTRACT_BASE_URL" not in result
+
+    def test_sanitize_passes_auxiliary_non_secrets(self):
+        env = {
+            "PATH": "/usr/bin",
+            "AUXILIARY_VISION_PROVIDER": "openai-api",
+            "AUXILIARY_VISION_MODEL": "gpt-4o",
+        }
+        result = _sanitize_subprocess_env(env)
+        assert result.get("AUXILIARY_VISION_PROVIDER") == "openai-api"
+        assert result.get("AUXILIARY_VISION_MODEL") == "gpt-4o"
+
+    def test_sanitize_blocks_plugin_auxiliary_keys(self):
+        env = {
+            "PATH": "/usr/bin",
+            "AUXILIARY_CUSTOM_PLUGIN_TASK_API_KEY": "sk-plugin-secret",
+            "AUXILIARY_CUSTOM_PLUGIN_TASK_BASE_URL": "https://plugin.internal",
+        }
+        result = _sanitize_subprocess_env(env)
+        assert "AUXILIARY_CUSTOM_PLUGIN_TASK_API_KEY" not in result
+        assert "AUXILIARY_CUSTOM_PLUGIN_TASK_BASE_URL" not in result
+
+    def test_sanitize_blocks_auxiliary_in_extra_env(self):
+        base = {"PATH": "/usr/bin"}
+        extra = {"AUXILIARY_VISION_API_KEY": "sk-extra-secret"}
+        result = _sanitize_subprocess_env(base, extra)
+        assert "AUXILIARY_VISION_API_KEY" not in result

--- a/tools/env_passthrough.py
+++ b/tools/env_passthrough.py
@@ -65,6 +65,16 @@ def _is_hermes_provider_credential(name: str) -> bool:
     provider credential and refuse passthrough, rather than fall open and
     let a skill tunnel a Hermes credential into the execute_code child.
     """
+    # Dynamically-generated auxiliary task secrets (AUXILIARY_*_API_KEY,
+    # AUXILIARY_*_BASE_URL) are Hermes-managed provider credentials even though
+    # they're not in the static blocklist — they're created at gateway startup
+    # per task (vision, compression, approval, plugin-registered tasks) and must
+    # never reach execute_code or terminal child processes.
+    upper = name.upper()
+    if upper.startswith("AUXILIARY_") and (
+        upper.endswith("_API_KEY") or upper.endswith("_BASE_URL")
+    ):
+        return True
     try:
         from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
     except Exception as e:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -252,6 +252,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     for key, value in (extra_env or {}).items():
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             real_key = key[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
+            if _is_auxiliary_secret(real_key):
+                continue
             sanitized[real_key] = value
         elif _is_auxiliary_secret(key) and not _is_passthrough(key):
             continue
@@ -637,6 +639,8 @@ def _make_run_env(env: dict) -> dict:
     for k, v in merged.items():
         if k.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             real_key = k[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
+            if _is_auxiliary_secret(real_key):
+                continue
             run_env[real_key] = v
         elif _is_auxiliary_secret(k) and not _is_passthrough(k):
             continue

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -319,6 +319,11 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     * **Tier 1 (always):** ``_ALWAYS_STRIP_KEYS`` — gateway bot tokens, GitHub
       auth, and remote-compute secrets are removed regardless of
       ``inherit_credentials``.  No child Hermes spawns legitimately needs them.
+      Dynamically-generated ``AUXILIARY_*_API_KEY`` / ``AUXILIARY_*_BASE_URL``
+      vars (see :func:`_is_auxiliary_secret`) get the same always-strip
+      treatment: they're per-task credentials (vision, compression, approval,
+      plugin-registered tasks) that no generic spawn — including an
+      ``inherit_credentials=True`` model-driving CLI — has a reason to read.
     * **Tier 2 (conditional):** the rest of ``_HERMES_PROVIDER_ENV_BLOCKLIST``
       (LLM provider API keys, tool secrets) is removed unless the caller passes
       ``inherit_credentials=True``.
@@ -339,9 +344,12 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     # Tier 1 — always strip.
     for key in _ALWAYS_STRIP_KEYS:
         env.pop(key, None)
-    # Internal routing hints must never reach a child.
+    # Internal routing hints and per-task auxiliary credentials must never
+    # reach a child, regardless of inherit_credentials.
     for key in list(env):
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
+            env.pop(key, None)
+        elif _is_auxiliary_secret(key):
             env.pop(key, None)
 
     if not inherit_credentials:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -217,6 +217,21 @@ def _inject_context_hermes_home(env: dict) -> None:
         pass
 
 
+def _is_auxiliary_secret(key: str) -> bool:
+    """True for dynamically-generated AUXILIARY_*_API_KEY / _BASE_URL vars.
+
+    The gateway bridges per-task auxiliary config into env vars named
+    ``AUXILIARY_{TASK}_API_KEY`` and ``AUXILIARY_{TASK}_BASE_URL``
+    (gateway/run.py ~1587-1589). These are generated at runtime for both
+    built-in tasks (vision, compression, approval) and plugin-registered
+    auxiliary tasks, so they cannot be enumerated in the static blocklist.
+    """
+    upper = key.upper()
+    return upper.startswith("AUXILIARY_") and (
+        upper.endswith("_API_KEY") or upper.endswith("_BASE_URL")
+    )
+
+
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
     """Filter Hermes-managed secrets from a subprocess environment."""
     try:
@@ -229,6 +244,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     for key, value in (base_env or {}).items():
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             continue
+        if _is_auxiliary_secret(key) and not _is_passthrough(key):
+            continue
         if key not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(key):
             sanitized[key] = value
 
@@ -236,6 +253,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             real_key = key[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
             sanitized[real_key] = value
+        elif _is_auxiliary_secret(key) and not _is_passthrough(key):
+            continue
         elif key not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(key):
             sanitized[key] = value
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -630,6 +630,8 @@ def _make_run_env(env: dict) -> dict:
         if k.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             real_key = k[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
             run_env[real_key] = v
+        elif _is_auxiliary_secret(k) and not _is_passthrough(k):
+            continue
         elif k not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(k):
             run_env[k] = v
     path_key = _path_env_key(run_env)


### PR DESCRIPTION
## Summary

- `AUXILIARY_{TASK}_API_KEY` and `AUXILIARY_{TASK}_BASE_URL` env vars written by the gateway at startup leak through `_sanitize_subprocess_env` to every `terminal()` and `process_registry.spawn()` child process
- The static `_HERMES_PROVIDER_ENV_BLOCKLIST` correctly blocks main provider keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) but does not cover the dynamically-generated `AUXILIARY_*` pattern
- `execute_code()`'s own `_scrub_child_env` is unaffected — its substring-based filter catches `"KEY"` in any var name

## Root cause

The gateway bridges per-task auxiliary config into env vars at startup (`gateway/run.py` ~1583-1589):

```python
os.environ[f"AUXILIARY_{_upper}_PROVIDER"] = _prov
os.environ[f"AUXILIARY_{_upper}_MODEL"] = _model
os.environ[f"AUXILIARY_{_upper}_BASE_URL"] = _base_url
os.environ[f"AUXILIARY_{_upper}_API_KEY"] = _api_key
```

These are generated for built-in tasks (vision, compression, approval, web_extract) and any plugin-registered auxiliary tasks. Since `_build_provider_env_blocklist()` derives its set from `PROVIDER_REGISTRY`, `OPTIONAL_ENV_VARS`, and a hardcoded set — none of which include the `AUXILIARY_*` pattern — the sanitizer passes them through.

## Changes

- `tools/environments/local.py`: add `_is_auxiliary_secret(key)` helper that matches `AUXILIARY_*_API_KEY` and `AUXILIARY_*_BASE_URL` by prefix+suffix; apply it in both loops of `_sanitize_subprocess_env` (base_env and extra_env), respecting `env_passthrough` opt-in
- `tests/tools/test_local_env_blocklist.py`: add `TestAuxiliaryEnvBlocklist` (8 tests) covering API key blocking, base URL blocking, non-secret passthrough, plugin task keys, and extra_env path

## Test plan

- [x] `test_is_auxiliary_secret_detects_api_keys` — AUXILIARY_VISION_API_KEY and siblings are detected
- [x] `test_is_auxiliary_secret_detects_base_urls` — AUXILIARY_*_BASE_URL is detected
- [x] `test_is_auxiliary_secret_allows_non_secrets` — PROVIDER and MODEL vars pass through
- [x] `test_sanitize_blocks_auxiliary_api_keys` — 3 API keys blocked, PATH preserved
- [x] `test_sanitize_blocks_auxiliary_base_urls` — BASE_URL blocked
- [x] `test_sanitize_passes_auxiliary_non_secrets` — PROVIDER and MODEL pass through
- [x] `test_sanitize_blocks_plugin_auxiliary_keys` — plugin-registered task keys blocked
- [x] `test_sanitize_blocks_auxiliary_in_extra_env` — extra_env path also blocks
- [x] All 43 existing env-blocklist tests pass, no regressions