### PR TITLE
fix: refresh active memory provider deps during update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8177,6 +8177,48 @@ def _refresh_active_lazy_features() -> None:
         print("  `hermes update` once the upstream issue is resolved.")
 
 
+def _refresh_active_memory_provider_dependencies() -> None:
+    """Refresh pip dependencies for the configured external memory provider.
+
+    Memory provider bridge packages are declared in each provider's
+    ``plugin.yaml`` rather than Hermes' editable install extras. A code update
+    can therefore leave the active provider missing or stale unless we
+    explicitly reinstall its declared Python dependencies.
+
+    Never raises. A failure here must not block the rest of the update.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+    except Exception as exc:
+        logger.debug("Memory provider refresh skipped (config load failed): %s", exc)
+        return
+
+    provider = ""
+    if isinstance(cfg, dict):
+        memory_cfg = cfg.get("memory")
+        if isinstance(memory_cfg, dict):
+            provider = str(memory_cfg.get("provider") or "").strip()
+
+    if not provider:
+        return
+
+    try:
+        from hermes_cli.memory_setup import _install_dependencies
+    except Exception as exc:
+        logger.debug("Memory provider refresh skipped (import failed): %s", exc)
+        return
+
+    print()
+    print(f"→ Refreshing active memory provider dependencies ({provider})...")
+
+    try:
+        _install_dependencies(provider, force=True)
+    except Exception as exc:
+        print(f"  ⚠ {provider} dependencies failed to refresh: {exc}")
+
+
 def _install_python_dependencies_with_optional_fallback(
     install_cmd_prefix: list[str],
     *,
@@ -9306,6 +9348,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             _install_python_dependencies_with_optional_fallback(pip_cmd, group=install_group)
 
         _refresh_active_lazy_features()
+        _refresh_active_memory_provider_dependencies()
 
         _update_node_dependencies()
         # See note above (ZIP path): core is now complete, web UI build is

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -51,8 +51,13 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
 # Provider discovery
 # ---------------------------------------------------------------------------
 
-def _install_dependencies(provider_name: str) -> None:
-    """Install pip dependencies declared in plugin.yaml."""
+def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
+    """Install pip dependencies declared in ``plugin.yaml``.
+
+    When ``force`` is true, reinstall every declared dependency even if the
+    import is currently available. This lets ``hermes update`` refresh the
+    active memory provider's pinned bridge packages after a venv rebuild.
+    """
     import subprocess
     from plugins.memory import find_provider_dir
 
@@ -82,19 +87,22 @@ def _install_dependencies(provider_name: str) -> None:
         "hindsight-all": "hindsight",
     }
 
-    # Check which packages are missing
-    missing = []
+    # Check which packages need installation.
+    packages_to_install = []
     for dep in pip_deps:
         import_name = _IMPORT_NAMES.get(dep, dep.replace("-", "_").split("[")[0])
+        if force:
+            packages_to_install.append(dep)
+            continue
         try:
             __import__(import_name)
         except ImportError:
-            missing.append(dep)
+            packages_to_install.append(dep)
 
-    if not missing:
+    if not packages_to_install:
         return
 
-    print(f"\n  Installing dependencies: {', '.join(missing)}")
+    print(f"\n  Installing dependencies: {', '.join(packages_to_install)}")
 
     import shutil
     uv_path = shutil.which("uv")
@@ -106,20 +114,20 @@ def _install_dependencies(provider_name: str) -> None:
 
     try:
         subprocess.run(
-            [uv_path, "pip", "install", "--python", sys.executable, "--quiet"] + missing,
+            [uv_path, "pip", "install", "--python", sys.executable, "--quiet"] + packages_to_install,
             check=True, timeout=120,
             capture_output=True,
         )
-        print(f"  ✓ Installed {', '.join(missing)}")
+        print(f"  ✓ Installed {', '.join(packages_to_install)}")
     except subprocess.CalledProcessError as e:
-        print(f"  ⚠ Failed to install {', '.join(missing)}")
+        print(f"  ⚠ Failed to install {', '.join(packages_to_install)}")
         stderr = (e.stderr or b"").decode()[:200]
         if stderr:
             print(f"    {stderr}")
-        print(f"  Run manually: uv pip install --python {sys.executable} {' '.join(missing)}")
+        print(f"  Run manually: uv pip install --python {sys.executable} {' '.join(packages_to_install)}")
     except Exception as e:
         print(f"  ⚠ Install failed: {e}")
-        print(f"  Run manually: uv pip install --python {sys.executable} {' '.join(missing)}")
+        print(f"  Run manually: uv pip install --python {sys.executable} {' '.join(packages_to_install)}")
 
     # Also show external dependencies (non-pip) if any
     ext_deps = meta.get("external_dependencies", [])

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -387,6 +387,42 @@ def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
     assert ".[all]" in install_cmds[0]
 
 
+def test_refresh_active_memory_provider_dependencies_reinstalls_active_provider(monkeypatch):
+    recorded = []
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": {"provider": "mem0"}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.memory_setup._install_dependencies",
+        lambda provider_name, force=False: recorded.append((provider_name, force)),
+    )
+
+    hermes_main._refresh_active_memory_provider_dependencies()
+
+    assert recorded == [("mem0", True)]
+
+
+def test_cmd_update_refreshes_active_memory_provider_dependencies(monkeypatch, tmp_path):
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    refresh_calls = []
+    monkeypatch.setattr(
+        hermes_main,
+        "_refresh_active_memory_provider_dependencies",
+        lambda: refresh_calls.append("mem0"),
+    )
+
+    side_effect, _ = _make_update_side_effect()
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    assert refresh_calls == ["mem0"]
+
+
 def test_install_with_optional_fallback_honors_custom_group(monkeypatch):
     """Termux update path should target .[termux-all] when requested."""
     calls = []


### PR DESCRIPTION
## Summary
- refresh the active external memory provider after `hermes update` reinstalls core dependencies
- let provider dependency refresh force-reinstall the `plugin.yaml` pip bridge packages so update-driven venv rebuilds do not strand Mem0 or other providers
- cover both the helper and the update integration path with regression tests

Closes #53272