### PR TITLE
fix: tolerate streamed final text artifacts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -103,6 +103,41 @@ def _gateway_surface_passes_raw_text(platform: Any) -> bool:
     return _gateway_platform_value(platform) in _GATEWAY_RAW_TEXT_PLATFORMS
 
 
+_STREAM_VISIBLE_FINAL_MIN_COVERAGE = 0.80
+_STREAM_CURSOR_SUFFIX_RE = re.compile(r"[▉█]+$")
+
+
+def _normalize_stream_delivery_text(value: Any) -> str:
+    text = str(value or "")
+    text = _STREAM_CURSOR_SUFFIX_RE.sub("", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _stream_visible_matches_final(visible: Any, final: Any) -> bool:
+    """Return True when streamed visible text already covers final text."""
+    visible_norm = _normalize_stream_delivery_text(visible)
+    final_norm = _normalize_stream_delivery_text(final)
+    if not visible_norm or not final_norm:
+        return False
+    if visible_norm == final_norm or visible_norm.startswith(final_norm):
+        return True
+    if final_norm.startswith(visible_norm):
+        return len(visible_norm) / max(len(final_norm), 1) >= _STREAM_VISIBLE_FINAL_MIN_COVERAGE
+    return False
+
+
+def _stream_consumer_visible_text(stream_consumer: Any) -> str:
+    if stream_consumer is None:
+        return ""
+    visible_fn = getattr(stream_consumer, "_visible_prefix", None)
+    if callable(visible_fn):
+        try:
+            return str(visible_fn() or "")
+        except Exception:
+            return ""
+    return str(getattr(stream_consumer, "_last_sent_text", "") or "")
+
+
 _GATEWAY_PROVIDER_ERROR_RE = re.compile(
     r"("  # infrastructure/provider error preambles, not ordinary assistant prose
     r"api\s+(?:call\s+)?failed"
@@ -17522,12 +17557,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         except Exception as e:
                             logger.debug("Stream consumer wait before queued message failed: %s", e)
                     _previewed = bool(result.get("response_previewed"))
+                    first_response = result.get("final_response", "")
+                    _visible_matches_final = bool(
+                        _sc and _stream_visible_matches_final(
+                            _stream_consumer_visible_text(_sc),
+                            first_response,
+                        )
+                    )
                     _already_streamed = bool(
                         (_sc and getattr(_sc, "final_response_sent", False))
                         or _previewed
                         or (_sc and getattr(_sc, "final_content_delivered", False))
+                        or _visible_matches_final
                     )
-                    first_response = result.get("final_response", "")
                     if first_response and not _already_streamed:
                         try:
                             logger.info(
@@ -17543,8 +17585,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             logger.warning("Failed to send first response before queued message: %s", e)
                     elif first_response:
                         logger.info(
-                            "Queued follow-up for session %s: skipping resend because final streamed delivery was confirmed.",
+                            "Queued follow-up for session %s: skipping resend because final streamed delivery was confirmed (visible_matches_final=%s).",
                             session_key or "?",
+                            _visible_matches_final,
                         )
                     # Release deferred bg-review notifications now that the
                     # first response has been delivered.  Pop from the
@@ -17707,17 +17750,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _content_delivered = bool(
                 _sc and getattr(_sc, "final_content_delivered", False)
             )
+            _visible_matches_final = bool(
+                _sc and _stream_visible_matches_final(
+                    _stream_consumer_visible_text(_sc),
+                    _final,
+                )
+            )
             # Plugin hooks (e.g. transform_llm_output) may have appended content
             # after streaming finished — when the response was transformed, always
             # send the final version so the appended content reaches the client.
             _transformed = bool(response.get("response_transformed"))
-            if not _is_empty_sentinel and not _transformed and (_streamed or _previewed or _content_delivered):
+            if (
+                not _is_empty_sentinel
+                and not _transformed
+                and (
+                    _streamed
+                    or _previewed
+                    or _content_delivered
+                    or _visible_matches_final
+                )
+            ):
                 logger.info(
-                    "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s).",
+                    "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s visible_matches_final=%s).",
                     session_key or "?",
                     _streamed,
                     _previewed,
                     _content_delivered,
+                    _visible_matches_final,
                 )
                 response["already_sent"] = True
             elif not _is_empty_sentinel and _transformed and _sc is not None:

--- a/tests/gateway/test_duplicate_reply_suppression.py
+++ b/tests/gateway/test_duplicate_reply_suppression.py
@@ -23,6 +23,7 @@ from gateway.platforms.base import (
     MessageEvent,
     SendResult,
 )
+from gateway.run import _stream_consumer_visible_text, _stream_visible_matches_final
 from gateway.session import SessionSource, build_session_key
 
 
@@ -241,6 +242,40 @@ class TestOnlyFinalStreamDeliverySuppressesFinalSend:
                 response["already_sent"] = True
 
         assert "already_sent" not in response
+
+
+class TestTolerantVisibleFinalMatching:
+    def test_whitespace_and_cursor_artifacts_match(self):
+        visible = "Here is the answer.\n\n" + "\u2589"
+        final = "Here is the answer."
+
+        assert _stream_visible_matches_final(visible, final) is True
+
+    def test_visible_superset_matches_final(self):
+        visible = "Here is the answer.\n\n"
+        final = "Here is the answer."
+
+        assert _stream_visible_matches_final(visible, final) is True
+
+    def test_high_coverage_visible_prefix_matches_final(self):
+        visible = "Here is the answer with almost all details"
+        final = "Here is the answer with almost all details included."
+
+        assert _stream_visible_matches_final(visible, final) is True
+
+    def test_low_coverage_prefix_does_not_match_final(self):
+        visible = "Here is"
+        final = "Here is the answer with important missing details."
+
+        assert _stream_visible_matches_final(visible, final) is False
+
+    def test_empty_visible_text_does_not_match_final(self):
+        assert _stream_visible_matches_final("", "final answer") is False
+
+    def test_reads_visible_prefix_from_consumer(self):
+        sc = SimpleNamespace(_visible_prefix=lambda: "shown")
+
+        assert _stream_consumer_visible_text(sc) == "shown"
 
 
 # ===================================================================


### PR DESCRIPTION
Problem
Telegram streaming could show a complete short reply, lose the stream-consumer delivery flags, then send the same final response again. The fallback duplicate-suppression path only trusted strict flags and exact text equality, so cursor, whitespace, or formatting residue caused the normal final send to fire.

Summary
- Add normalized visible-vs-final comparison for streamed text.
- Treat exact normalized matches, visible supersets, and high-coverage visible prefixes as already delivered.
- Use that check for both queued-follow-up delivery and the final already_sent suppression path.
- Add regression tests for cursor/whitespace residue and high-vs-low coverage prefixes.

Validation
- $HOME/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/gateway/test_duplicate_reply_suppression.py
- $HOME/.hermes/hermes-agent/venv/bin/ruff check gateway/run.py tests/gateway/test_duplicate_reply_suppression.py
- git diff --check

Fixes #53449