### PR TITLE
fix(feishu): reconnect when the websocket worker exits after startup

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1434,6 +1434,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_future: Optional[asyncio.Future] = None
         self._ws_thread_loop: Optional[asyncio.AbstractEventLoop] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._disconnecting = False
         self._webhook_runner: Optional[Any] = None
         self._webhook_site: Optional[Any] = None
         self._event_handler: Optional[Any] = None
@@ -1662,6 +1663,7 @@ class FeishuAdapter(BasePlatformAdapter):
             return False
 
         try:
+            self._disconnecting = False
             self._app_lock_identity = self._app_id
             acquired, existing = acquire_scoped_lock(
                 _FEISHU_APP_LOCK_SCOPE,
@@ -1693,6 +1695,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         """Disconnect from Feishu/Lark."""
+        self._disconnecting = True
         self._running = False
         await self._cancel_pending_tasks(self._pending_text_batch_tasks)
         await self._cancel_pending_tasks(self._pending_media_batch_tasks)
@@ -4507,6 +4510,54 @@ class FeishuAdapter(BasePlatformAdapter):
     def _response_succeeded(response: Any) -> bool:
         return bool(response and getattr(response, "success", lambda: False)())
 
+    def _handle_ws_future_done(self, future: Any) -> None:
+        """Bridge post-startup websocket exits into the gateway retry ladder."""
+        if future is not self._ws_future:
+            return
+
+        if self._disconnecting or not self._running:
+            try:
+                future.result()
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                logger.debug("[Feishu] Websocket thread exited during shutdown", exc_info=True)
+            return
+
+        exc: Optional[BaseException] = None
+        try:
+            future.result()
+        except asyncio.CancelledError as err:
+            exc = err
+        except Exception as err:
+            exc = err
+
+        if exc is None:
+            message = "Feishu websocket thread exited without an exception"
+            exc_info: Any = False
+        else:
+            message = f"Feishu websocket thread exited: {exc}"
+            exc_info = exc
+
+        logger.error("[Feishu] %s", message, exc_info=exc_info)
+        self._set_fatal_error("feishu_websocket_exited", message, retryable=True)
+        self._ws_future = None
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        loop.create_task(self._notify_feishu_runtime_fatal())
+
+    async def _notify_feishu_runtime_fatal(self) -> None:
+        try:
+            await self._notify_fatal_error()
+        except Exception:
+            logger.warning(
+                "[Feishu] Failed to notify gateway supervisor about websocket exit",
+                exc_info=True,
+            )
+
     @staticmethod
     def _extract_response_field(response: Any, field_name: str) -> Any:
         if not FeishuAdapter._response_succeeded(response):
@@ -4590,6 +4641,7 @@ class FeishuAdapter(BasePlatformAdapter):
             self._ws_client,
             self,
         )
+        self._ws_future.add_done_callback(self._handle_ws_future_done)
 
     async def _connect_webhook(self) -> None:
         if not FEISHU_WEBHOOK_AVAILABLE:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -281,6 +281,53 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         "FEISHU_APP_ID": "cli_app",
         "FEISHU_APP_SECRET": "secret_app",
     }, clear=True)
+    def test_connect_registers_ws_future_supervisor_callback(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        ws_client = SimpleNamespace()
+
+        class _Future:
+            def __init__(self):
+                self.callbacks = []
+
+            def add_done_callback(self, callback):
+                self.callbacks.append(callback)
+
+        future = _Future()
+
+        with (
+            patch("plugins.platforms.feishu.adapter.FEISHU_AVAILABLE", True),
+            patch("plugins.platforms.feishu.adapter.FEISHU_WEBSOCKET_AVAILABLE", True),
+            patch("plugins.platforms.feishu.adapter.lark", SimpleNamespace(LogLevel=SimpleNamespace(INFO="INFO", WARNING="WARNING"))),
+            patch("plugins.platforms.feishu.adapter.EventDispatcherHandler") as mock_handler_class,
+            patch("plugins.platforms.feishu.adapter.FeishuWSClient", return_value=ws_client),
+            patch("plugins.platforms.feishu.adapter._run_official_feishu_ws_client"),
+            patch("plugins.platforms.feishu.adapter.acquire_scoped_lock", return_value=(True, None)),
+            patch("plugins.platforms.feishu.adapter.release_scoped_lock"),
+            patch.object(adapter, "_hydrate_bot_identity", new=AsyncMock()),
+            patch.object(adapter, "_build_lark_client", return_value=SimpleNamespace()),
+        ):
+            _mock_event_dispatcher_builder(mock_handler_class)
+
+            class _Loop:
+                def run_in_executor(self, *_args, **_kwargs):
+                    return future
+
+                def is_closed(self):
+                    return False
+
+            with patch("plugins.platforms.feishu.adapter.asyncio.get_running_loop", return_value=_Loop()):
+                connected = asyncio.run(adapter.connect())
+
+        self.assertTrue(connected)
+        self.assertEqual(future.callbacks, [adapter._handle_ws_future_done])
+
+    @patch.dict(os.environ, {
+        "FEISHU_APP_ID": "cli_app",
+        "FEISHU_APP_SECRET": "secret_app",
+    }, clear=True)
     def test_connect_retries_transient_startup_failure(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
@@ -558,6 +605,182 @@ class TestAdapterModule(unittest.TestCase):
         self.assertEqual(fake_client._reconnect_nonce, 2)
         self.assertEqual(fake_client._reconnect_interval, 3)
         self.assertEqual(fake_client._ping_interval, 4)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_ws_future_exit_sets_retryable_fatal_and_notifies_supervisor(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._running = True
+        adapter._disconnecting = False
+        adapter._notify_fatal_error = AsyncMock()
+
+        class _Future:
+            def result(self):
+                raise RuntimeError("receive message loop exit")
+
+        scheduled = []
+
+        class _Loop:
+            def create_task(self, coro):
+                scheduled.append(coro)
+                return SimpleNamespace()
+
+        future = _Future()
+        adapter._ws_future = future
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.get_running_loop", return_value=_Loop()):
+            adapter._handle_ws_future_done(future)
+
+        self.assertEqual(adapter.fatal_error_code, "feishu_websocket_exited")
+        self.assertTrue(adapter.fatal_error_retryable)
+        self.assertIn("receive message loop exit", adapter.fatal_error_message)
+        self.assertIsNone(adapter._ws_future)
+        self.assertEqual(len(scheduled), 1)
+        asyncio.run(scheduled[0])
+        adapter._notify_fatal_error.assert_awaited_once()
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_ws_future_normal_completion_sets_retryable_fatal(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._running = True
+        adapter._disconnecting = False
+        adapter._notify_fatal_error = AsyncMock()
+
+        class _Future:
+            def result(self):
+                return None
+
+        scheduled = []
+
+        class _Loop:
+            def create_task(self, coro):
+                scheduled.append(coro)
+                return SimpleNamespace()
+
+        future = _Future()
+        adapter._ws_future = future
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.get_running_loop", return_value=_Loop()):
+            adapter._handle_ws_future_done(future)
+
+        self.assertEqual(adapter.fatal_error_code, "feishu_websocket_exited")
+        self.assertTrue(adapter.fatal_error_retryable)
+        self.assertEqual(
+            adapter.fatal_error_message,
+            "Feishu websocket thread exited without an exception",
+        )
+        self.assertIsNone(adapter._ws_future)
+        self.assertEqual(len(scheduled), 1)
+        asyncio.run(scheduled[0])
+        adapter._notify_fatal_error.assert_awaited_once()
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_ws_future_exit_removes_adapter_and_queues_gateway_retry(self):
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.run import GatewayRunner
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        async def run_scenario():
+            platform_config = PlatformConfig(enabled=True, token="test")
+            runner = object.__new__(GatewayRunner)
+            runner.config = GatewayConfig(platforms={Platform.FEISHU: platform_config})
+            runner.adapters = {}
+            runner.delivery_router = SimpleNamespace(adapters=runner.adapters)
+            runner._failed_platforms = {}
+            runner._exit_reason = None
+            runner._exit_with_failure = False
+            runner._update_platform_runtime_status = Mock()
+            runner.stop = AsyncMock()
+
+            adapter = FeishuAdapter(platform_config)
+            adapter._running = True
+            adapter._disconnecting = False
+            adapter.disconnect = AsyncMock()
+            adapter.set_fatal_error_handler(runner._handle_adapter_fatal_error)
+            runner.adapters[Platform.FEISHU] = adapter
+
+            future = asyncio.get_running_loop().create_future()
+            future.set_exception(RuntimeError("receive message loop exit"))
+            adapter._ws_future = future
+
+            scheduled = []
+            real_loop = asyncio.get_running_loop()
+
+            class _Loop:
+                def create_task(self, coro):
+                    task = real_loop.create_task(coro)
+                    scheduled.append(task)
+                    return task
+
+            before = time.monotonic()
+            with patch(
+                "plugins.platforms.feishu.adapter.asyncio.get_running_loop",
+                return_value=_Loop(),
+            ):
+                adapter._handle_ws_future_done(future)
+            await scheduled[0]
+            after = time.monotonic()
+
+            self.assertNotIn(Platform.FEISHU, runner.adapters)
+            self.assertIs(runner.delivery_router.adapters, runner.adapters)
+            adapter.disconnect.assert_awaited_once()
+            retry = runner._failed_platforms[Platform.FEISHU]
+            self.assertIs(retry["config"], platform_config)
+            self.assertEqual(retry["attempts"], 0)
+            self.assertLessEqual(before, retry["next_retry"])
+            self.assertLessEqual(retry["next_retry"], after)
+            runner.stop.assert_not_awaited()
+
+        asyncio.run(run_scenario())
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_ws_future_exit_during_disconnect_does_not_raise_fatal(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._running = False
+        adapter._disconnecting = True
+        adapter._notify_fatal_error = AsyncMock()
+
+        class _Future:
+            def result(self):
+                raise RuntimeError("disconnect race")
+
+        future = _Future()
+        adapter._ws_future = future
+
+        adapter._handle_ws_future_done(future)
+
+        self.assertIsNone(adapter.fatal_error_code)
+        adapter._notify_fatal_error.assert_not_called()
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_ws_future_cancel_during_disconnect_does_not_raise_fatal(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._running = False
+        adapter._disconnecting = True
+        adapter._notify_fatal_error = AsyncMock()
+
+        class _Future:
+            def result(self):
+                raise asyncio.CancelledError()
+
+        future = _Future()
+        adapter._ws_future = future
+
+        adapter._handle_ws_future_done(future)
+
+        self.assertIsNone(adapter.fatal_error_code)
+        adapter._notify_fatal_error.assert_not_called()
 
 
 def _admits_group(adapter, message, sender_id, chat_id=""):


### PR DESCRIPTION
## What does this PR do?

Fixes a Feishu/Lark failure mode where the websocket worker can die after startup, leaving the gateway process alive but permanently deaf to new inbound messages.

On current `main`, `_run_official_feishu_ws_client()` runs inside `run_in_executor(...)`, and `_connect_websocket()` stores the resulting `_ws_future`, but nothing bridges an unexpected post-startup `_ws_future` exit into Hermes' existing retryable fatal/reconnect path. If the Lark receive loop exits, the adapter stays installed and the gateway stays healthy-looking, but no new Feishu events arrive.

This patch adds the missing bridge and keeps the scope intentionally narrow:

- register a done-callback on `_ws_future`
- treat unexpected post-startup websocket worker exit as a retryable fatal adapter error
- notify the existing gateway supervisor so the normal background reconnect ladder can recover the platform in-process
- preserve the clean `disconnect()` path so intentional shutdown/cancellation does not trigger a false reconnect

This is deliberately smaller than the broader Feishu-specific reconnect/watchdog proposals already in the queue. It does not add a second reconnect strategy inside the adapter; it only connects Feishu's runtime websocket worker exit to infrastructure Hermes already has.

## Related Issue

Fixes #53477

Related: #24807, #10616
Overlaps with the same bug cluster as #31386, but keeps the fix narrower by reusing the existing gateway retry ladder instead of adding adapter-local reconnect orchestration.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Why this is the right fix

The source-level gap on current `main` is not that Hermes lacks any reconnect machinery. The gap is that Feishu's websocket worker can finish after startup without surfacing that failure to the machinery that already exists.

By converting unexpected `_ws_future` completion into `_set_fatal_error(..., retryable=True)` + supervisor notification, this patch keeps the behavior aligned with the rest of the gateway's adapter-failure handling:

- retryable runtime failure becomes background reconnection
- non-failure shutdown stays a no-op
- no new config keys
- no new watchdog timers
- no second backoff policy to maintain

That makes the patch easier to reason about and lower-risk than introducing a Feishu-only reconnect loop on top of the gateway's existing retry ladder.

## Changes Made

- `plugins/platforms/feishu/adapter.py`
- Added `_disconnecting` state so intentional teardown does not look like a runtime failure.
- Added `_handle_ws_future_done()` to detect unexpected websocket worker exit after startup.
- Added `_notify_feishu_runtime_fatal()` to hand unexpected exits to the existing gateway fatal-error supervisor.
- Registered the websocket worker done-callback in `_connect_websocket()`.
- Treated `CancelledError` during disconnect as a clean shutdown boundary.

- `tests/gateway/test_feishu.py`
- Added coverage that `_connect_websocket()` registers the websocket worker supervisor callback.
- Added coverage that unexpected websocket worker exit becomes a retryable fatal error and schedules supervisor notification.
- Added coverage that disconnect-time exit/cancel does not raise a false fatal error.

## How to Test

1. Reproduce the current source-level gap on `upstream/main`:
   - Feishu websocket worker exits after startup
   - gateway remains alive
   - adapter never enters the existing retryable reconnect path

2. Apply this patch and run the focused regression suite:

```bash
python -m pytest tests/gateway/test_feishu.py -q
```

3. Verify the new covered behavior:
   - websocket worker future registers a done-callback
   - unexpected worker exit sets `fatal_error_code == "feishu_websocket_exited"`
   - the fatal is retryable and notifies the supervisor
   - `disconnect()` / cancellation does not trigger a false reconnect

## Validation Logs

```text
Baseline commit:
- upstream/main @ 882730026739c51e6ae5c7cbe47e9b64a920a065

Post-fix checks:
- python -m pytest tests/gateway/test_feishu.py -q -> 209 passed
```

## Remaining Risks

- I did not run a live Feishu gateway against a real Lark keepalive-timeout incident in this worktree.
- This PR intentionally does not solve broader silent-half-open liveness detection; it only fixes the concrete runtime path where the websocket worker actually exits after startup.
