### PR TITLE
Add contributor author map entry

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -49,6 +49,15 @@ AUTHOR_MAP = {
     "rebel@rebels-Mac-Studio-2.local": "rebel0789",  # PR #47308 salvage (redact browser_type typed text across display surfaces; #47197)
     "267614622+agt-user@users.noreply.github.com": "agt-user",  # PR #48496 salvage (telegram CLOSE-WAIT polling heartbeat, #48495)
     "80915+DavidMetcalfe@users.noreply.github.com": "DavidMetcalfe",  # PR #52272 salvage (route reasoning-model thinking-timeouts to timeout not context_overflow + reasoning-specific guidance; #52271)
+    "DavidMetcalfe@users.noreply.github.com": "DavidMetcalfe",  # passive-intelligence stack contributor check
+    "SJWATTS89@OUTLOOK.COM": "lEWFkRAD",  # passive-intelligence stack contributor check
+    "daniel.laforce@argobox.com": "KeyArgo",  # passive-intelligence stack contributor check
+    "konsisumer@users.noreply.github.com": "konsisumer",  # passive-intelligence stack contributor check
+    "naqerl@users.noreply.github.com": "naqerl",  # passive-intelligence stack contributor check
+    "poli.koltsova@gmail.com": "wnuuee1",  # passive-intelligence stack contributor check
+    "redpiggy-cyber@users.noreply.github.com": "redpiggy-cyber",  # passive-intelligence stack contributor check
+    "vinoth12940@users.noreply.github.com": "vinoth12940",  # passive-intelligence stack contributor check
+    "xqdwww@qq.com": "xqdwww",  # passive-intelligence stack contributor check
     "66773372+Tranquil-Flow@users.noreply.github.com": "Tranquil-Flow",  # PR #52623 salvage (auxiliary Anthropic base_url host validation; #52608)
     "moonsong@nousresearch.local": "Tranquil-Flow",  # PR #52623 salvage (auxiliary Anthropic base_url host validation; #52608)
     "140971685+Dr1985@users.noreply.github.com": "Dr1985",  # PR #42567 salvage (launchd supervision detection + status reporting; #42524)


### PR DESCRIPTION
This is a separate policy-only PR for the passive-intelligence PR stack.

## Summary

Adds the contributor emails reported by `Check contributors / check-attribution` to `scripts/release.py` `AUTHOR_MAP`.

## Scope

- Changes only `scripts/release.py`.
- Does not modify passive-intelligence files.
- Does not modify task-engine prerequisite files.
- Does not amend or rewrite existing commits.

## Motivation

The passive-intelligence stacked PRs are code-clean, but their contributor attribution check fails because the current branch history includes contributor emails that are not present in `AUTHOR_MAP`.

## Validation

- `python -m py_compile scripts/release.py`
- `git diff --check`
- Contributor-check-style grep for all CI-reported missing emails

## Relationship to existing PRs

- PR1: https://github.com/NousResearch/hermes-agent/pull/53402
- PR2: https://github.com/xqdwww/hermes-agent/pull/1

This PR should be reviewed independently as a policy-only unblocking change.
