### PR TITLE
fix: skip bogus shallow update counts

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9078,15 +9078,61 @@ def _cmd_update_impl(args, gateway_mode: bool):
             and (gateway_mode or (sys.stdin.isatty() and sys.stdout.isatty()))
         )
 
-        # Check if there are updates
-        result = subprocess.run(
-            git_cmd + ["rev-list", f"HEAD..origin/{branch}", "--count"],
+        # Check if there are updates.  Installer/source checkouts are often
+        # shallow; when HEAD and origin/<branch> have no visible merge-base,
+        # `rev-list --count` walks the remote side's available history and can
+        # report a bogus huge count.  In that case compare tip SHAs only and
+        # treat the result as presence-only.
+        count_is_precise = True
+        shallow_result = subprocess.run(
+            git_cmd + ["rev-parse", "--is-shallow-repository"],
             cwd=PROJECT_ROOT,
             capture_output=True,
             text=True,
-            check=True,
         )
-        commit_count = int(result.stdout.strip())
+        is_shallow = shallow_result.stdout.strip() == "true"
+        has_merge_base = True
+        if is_shallow:
+            merge_base_result = subprocess.run(
+                git_cmd + ["merge-base", "HEAD", f"origin/{branch}"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+            )
+            has_merge_base = merge_base_result.returncode == 0 and bool(
+                merge_base_result.stdout.strip()
+            )
+
+        if is_shallow and not has_merge_base:
+            head_result = subprocess.run(
+                git_cmd + ["rev-parse", "HEAD"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            target_result = subprocess.run(
+                git_cmd + ["rev-parse", f"origin/{branch}"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            commit_count = (
+                0
+                if head_result.stdout.strip() == target_result.stdout.strip()
+                else 1
+            )
+            count_is_precise = False
+        else:
+            result = subprocess.run(
+                git_cmd + ["rev-list", f"HEAD..origin/{branch}", "--count"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            commit_count = int(result.stdout.strip())
 
         if commit_count == 0:
             _invalidate_update_cache()
@@ -9116,7 +9162,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
             _resume_windows_gateways_after_update(_windows_gateway_resume)
             return
 
-        print(f"→ Found {commit_count} new commit(s)")
+        if count_is_precise:
+            print(f"→ Found {commit_count} new commit(s)")
+        else:
+            print(f"→ Update available (origin/{branch} differs; shallow history count skipped)")
 
         # Snapshot critical state (state.db, config, pairing JSONs, etc.)
         # before pulling so a user can recover if something goes wrong.

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -225,6 +225,41 @@ class TestCmdUpdateBranchFallback:
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
+    def test_update_shallow_without_merge_base_does_not_count_history(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        """Shallow/diverged installs should not show bogus full-history counts."""
+
+        def side_effect(cmd, **kwargs):
+            joined = " ".join(str(c) for c in cmd)
+            if "rev-parse" in joined and "--abbrev-ref" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="main\n", stderr="")
+            if "rev-parse" in joined and "--is-shallow-repository" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="true\n", stderr="")
+            if "merge-base" in joined:
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+            if "rev-parse" in joined and "HEAD" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="localsha\n", stderr="")
+            if "rev-parse" in joined and "origin/main" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="remotesha\n", stderr="")
+            if "rev-list" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="12104\n", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        mock_run.side_effect = side_effect
+
+        cmd_update(mock_args)
+
+        captured = capsys.readouterr()
+        assert "12104" not in captured.out
+        assert "Update available" in captured.out
+
+        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
+        assert not any("rev-list" in c for c in commands), commands
+        assert any("pull" in c and "origin" in c and "main" in c for c in commands), commands
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
     def test_update_on_fork_checks_upstream_when_origin_up_to_date(
         self, mock_run, _mock_which, mock_args, capsys
     ):


### PR DESCRIPTION
## Summary
- make `hermes update` skip `git rev-list --count` when a shallow install has no visible merge-base with `origin/<branch>`
- compare tip SHAs in that case and print a generic update-available message instead of a bogus full-history count
- add regression coverage for the shallow/no-merge-base update path

Fixes #53479

## Test Plan
- [x] `python -m pytest tests/hermes_cli/test_cmd_update.py::TestCmdUpdateBranchFallback::test_update_shallow_without_merge_base_does_not_count_history -q` — passed
- [x] `python -m py_compile hermes_cli/main.py tests/hermes_cli/test_cmd_update.py` — passed
- [x] `node --test apps/desktop/electron/update-count.test.cjs` — passed

## Notes
- `python -m pytest tests/hermes_cli/test_cmd_update.py -q` currently has Windows-local baseline failures unrelated to this change: one expectation assumes bare `['git']` while production uses `['git', '-c', 'windows.appendAtomically=false']`, and one npm-call assertion does not observe npm calls in this Windows mocked run. The new regression test passes independently.