### PR TITLE
fix: preserve native paste transactions for ime

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -47,7 +47,7 @@ import {
   composerPlainText,
   deleteChipBeforeCaret,
   deleteSelectionInEditor,
-  insertPlainTextAtCaret,
+  insertPastedTextAtCaret,
   normalizeComposerEditorDom,
   RICH_INPUT_SLOT
 } from './rich-editor'
@@ -357,7 +357,7 @@ export function ChatBar({
     }
 
     event.preventDefault()
-    insertPlainTextAtCaret(event.currentTarget, pastedText)
+    insertPastedTextAtCaret(event.currentTarget, pastedText)
     scheduleFlushEditorToDraft(event.currentTarget)
   }
 

--- a/apps/desktop/src/app/chat/composer/rich-editor.test.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.test.ts
@@ -4,7 +4,9 @@ import { insertInlineRefsIntoEditor } from './inline-refs'
 import {
   composerPlainText,
   deleteSelectionInEditor,
+  insertPastedTextAtCaret,
   insertPlainTextAtCaret,
+  NATIVE_PASTE_INSERT_MAX_CHARS,
   normalizeComposerEditorDom,
   refChipElement,
   renderComposerContents,
@@ -107,6 +109,88 @@ describe('insertPlainTextAtCaret', () => {
     expect(composerPlainText(editor)).toBe('abcdef')
 
     editor.remove()
+  })
+})
+
+describe('insertPastedTextAtCaret', () => {
+  const runFallbackCase = (execCommand: typeof document.execCommand) => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    document.body.append(editor)
+    caretIn(editor)
+
+    const original = document.execCommand
+    document.execCommand = execCommand
+
+    try {
+      insertPastedTextAtCaret(editor, 'pasted')
+      expect(composerPlainText(editor)).toBe('pasted')
+    } finally {
+      document.execCommand = original
+      editor.remove()
+    }
+  }
+
+  it('uses the native insertText transaction for normal-sized pastes', () => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    document.body.append(editor)
+    caretIn(editor)
+
+    const original = document.execCommand
+    const calls: Array<[string, string | undefined]> = []
+
+    document.execCommand = ((command: string, _showDefaultUI?: boolean, value?: string) => {
+      calls.push([command, value])
+      editor.textContent = value ?? ''
+
+      return true
+    }) as typeof document.execCommand
+
+    try {
+      insertPastedTextAtCaret(editor, 'pasted')
+      expect(calls).toEqual([['insertText', 'pasted']])
+      expect(composerPlainText(editor)).toBe('pasted')
+    } finally {
+      document.execCommand = original
+      editor.remove()
+    }
+  })
+
+  it('falls back when native insertText returns false', () => {
+    runFallbackCase((() => false) as typeof document.execCommand)
+  })
+
+  it('falls back when native insertText throws', () => {
+    runFallbackCase((() => {
+      throw new Error('unsupported')
+    }) as typeof document.execCommand)
+  })
+
+  it('falls back to manual insertion for very large pastes', () => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    document.body.append(editor)
+    caretIn(editor)
+
+    const original = document.execCommand
+    const calls: string[] = []
+    const pasted = 'x'.repeat(NATIVE_PASTE_INSERT_MAX_CHARS + 1)
+
+    document.execCommand = ((command: string) => {
+      calls.push(command)
+
+      return true
+    }) as typeof document.execCommand
+
+    try {
+      insertPastedTextAtCaret(editor, pasted)
+      expect(calls).toEqual([])
+      expect(composerPlainText(editor)).toBe(pasted)
+    } finally {
+      document.execCommand = original
+      editor.remove()
+    }
   })
 })
 

--- a/apps/desktop/src/app/chat/composer/rich-editor.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.ts
@@ -17,6 +17,7 @@ import {
 } from '@/components/assistant-ui/directive-text'
 
 export const RICH_INPUT_SLOT = 'composer-rich-input'
+export const NATIVE_PASTE_INSERT_MAX_CHARS = 16_000
 
 export const REF_RE = /@(file|folder|url|image|tool|line|terminal|session):(`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)/g
 
@@ -170,6 +171,26 @@ export function insertPlainTextAtCaret(editor: HTMLElement, text: string) {
     selection?.removeAllRanges()
     selection?.addRange(caret)
   }
+}
+
+export function insertPastedTextAtCaret(editor: HTMLElement, text: string) {
+  const hit = composerSelectionRange(editor)
+
+  if (
+    hit &&
+    text.length <= NATIVE_PASTE_INSERT_MAX_CHARS &&
+    typeof document.execCommand === 'function'
+  ) {
+    try {
+      if (document.execCommand('insertText', false, text)) {
+        return
+      }
+    } catch {
+      // Fall back to manual insertion below.
+    }
+  }
+
+  insertPlainTextAtCaret(editor, text)
 }
 
 /** Backspace at a collapsed caret immediately after a chip: delete the chip AND


### PR DESCRIPTION
Problem
Desktop text paste always used manual DOM insertion. That kept large paste performance reasonable, but normal short pastes bypassed Chromium's native edit transaction, leaving a timing window where some Windows IMEs could treat the first post-paste keystroke as raw Latin input instead of composition input.

Summary
- Route normal-sized text paste through native insertText so Chromium/IME state observes a real edit transaction.
- Keep the existing manual insertion path as a fallback and for very large pastes.
- Add rich-editor tests for native paste insertion and large-paste fallback behavior.

Validation
- npx vitest run --environment jsdom src/app/chat/composer/rich-editor.test.ts
- npx eslint src/app/chat/composer/rich-editor.ts src/app/chat/composer/index.tsx src/app/chat/composer/rich-editor.test.ts
- git diff --check

Fixes #53446