### PR TITLE
refactor: replace len(x) == 0 / len(x) > 0 with Pythonic idioms

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -1730,7 +1730,7 @@ class ExtractContentMiddleware(InboundMiddleware):
                 # Prefer medium image (index 1), fallback to index 0
                 if len(image_info_array) > 1 and isinstance(image_info_array[1], dict):
                     image_info = image_info_array[1]
-                elif len(image_info_array) > 0 and isinstance(image_info_array[0], dict):
+                elif image_info_array and isinstance(image_info_array[0], dict):
                     image_info = image_info_array[0]
                 image_url = str((image_info or {}).get("url") or "").strip()
                 rid = cls._parse_resource_id(image_url)
@@ -1830,7 +1830,7 @@ class ExtractContentMiddleware(InboundMiddleware):
                 image_info = None
                 if len(image_info_array) > 1 and isinstance(image_info_array[1], dict):
                     image_info = image_info_array[1]
-                elif len(image_info_array) > 0 and isinstance(image_info_array[0], dict):
+                elif image_info_array and isinstance(image_info_array[0], dict):
                     image_info = image_info_array[0]
                 image_url = str((image_info or {}).get("url") or "").strip()
                 if image_url:
@@ -4813,7 +4813,7 @@ class MessageSender:
         Returns:
             Error description (str) if validation fails, otherwise None.
         """
-        if file_bytes is None or len(file_bytes) == 0:
+        if not file_bytes:
             return f"Empty file: {filename}"
         max_bytes = max_size_mb * 1024 * 1024
         if len(file_bytes) > max_bytes:

--- a/gateway/relay/auth.py
+++ b/gateway/relay/auth.py
@@ -67,7 +67,7 @@ def verify_signature(payload: str, sig_hex: str, secrets: Sequence[str]) -> bool
         sig_buf = bytes.fromhex(sig_hex)
     except (ValueError, TypeError):
         return False
-    if len(sig_buf) == 0:
+    if not sig_buf:
         return False
     for secret in secrets:
         if not secret:

--- a/gateway/scale_to_zero.py
+++ b/gateway/scale_to_zero.py
@@ -80,7 +80,7 @@ def messaging_is_relay_only_or_absent(platforms: Iterable[Any]) -> bool:
     """
     names = {_platform_name(p) for p in platforms}
     names.discard("relay")
-    return len(names) == 0
+    return not names
 
 
 def _platform_name(platform: Any) -> str:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1721,7 +1721,7 @@ class SlashCommandCompleter(Completer):
         trailing_space = sub_text.endswith(" ")
 
         # Subcommand stage: zero words typed, or completing the first word.
-        if len(parts) == 0 or (len(parts) == 1 and not trailing_space):
+        if not parts or (len(parts) == 1 and not trailing_space):
             partial = sub_text if not trailing_space else ""
             for sub in SUBS:
                 if sub.startswith(partial.lower()) and sub != partial.lower():

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5190,9 +5190,9 @@ def _is_service_running() -> bool:
         if gateway_windows.is_installed():
             # "installed" doesn't necessarily mean "running" on Windows. The
             # canonical check is whether a gateway process actually exists.
-            return len(find_gateway_pids()) > 0
+            return bool(find_gateway_pids())
     # Check for manual processes
-    return len(find_gateway_pids()) > 0
+    return bool(find_gateway_pids())
 
 
 def _setup_weixin():

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -17,7 +17,7 @@ def _has_configured_mcp_servers() -> bool:
         from hermes_cli.config import read_raw_config
 
         mcp_servers = (read_raw_config() or {}).get("mcp_servers")
-        return isinstance(mcp_servers, dict) and len(mcp_servers) > 0
+        return isinstance(mcp_servers, dict) and bool(mcp_servers)
     except Exception:
         # Be conservative: if config probing fails, try discovery in the
         # background so startup still can't block.

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -898,7 +898,7 @@ def image_generate_tool(
     start_time = datetime.datetime.now()
 
     try:
-        if not prompt or not isinstance(prompt, str) or len(prompt.strip()) == 0:
+        if not prompt or not isinstance(prompt, str) or not prompt.strip():
             raise ValueError("Prompt is required and must be a non-empty string")
 
         if not (fal_key_is_configured() or _resolve_managed_fal_gateway()):


### PR DESCRIPTION
## Summary

Replace verbose `len(x) == 0` and `len(x) > 0` checks with idiomatic Python truthiness tests.

## Changes

| Pattern | Replacement |
|---------|------------|
| `len(x) == 0` | `not x` |
| `len(x) > 0` | `bool(x)` where return type matters |
| `x is None or len(x) == 0` | `not x` (combined None/empty) |

10 instances across 7 files:
- `gateway/scale_to_zero.py`
- `gateway/relay/auth.py`
- `gateway/platforms/yuanbao.py` (3)
- `hermes_cli/gateway.py` (2)
- `hermes_cli/commands.py`
- `hermes_cli/mcp_startup.py`
- `tools/image_generation_tool.py`

## Why

These are clearer, more Pythonic, and avoid an unnecessary `len()` function call. Per PEP 8: *"For sequences, use the fact that empty sequences are falsy."*