### PR TITLE
fix: ignore proxy-owned builtin provider creds

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1125,6 +1125,39 @@ def list_authenticated_providers(
         if normed:
             _builtin_endpoints.add(normed)
 
+    def _collect_user_provider_key_values() -> set[str]:
+        """Return configured user-provider credential values.
+
+        Proxy-backed custom providers often reuse well-known env var names
+        such as ``OPENROUTER_API_KEY`` or ``OPENAI_API_KEY`` for their own
+        local relay key. Built-in provider discovery should not treat those
+        duplicated values as proof that the direct upstream provider is
+        configured too.
+        """
+        values: set[str] = set()
+        entries: list[dict] = []
+        if isinstance(user_providers, dict):
+            entries.extend(v for v in user_providers.values() if isinstance(v, dict))
+        if isinstance(custom_providers, list):
+            entries.extend(v for v in custom_providers if isinstance(v, dict))
+
+        for cfg in entries:
+            for field in ("api_key", "key"):
+                value = str(cfg.get(field) or "").strip()
+                if value:
+                    values.add(value)
+            for field in ("key_env", "api_key_env"):
+                env_name = str(cfg.get(field) or "").strip()
+                if not env_name:
+                    continue
+                value = os.environ.get(env_name, "").strip()
+                if value:
+                    values.add(value)
+        return values
+
+    def _should_skip_builtin_from_proxy_keys(values: set[str]) -> bool:
+        return bool(values) and values.issubset(_user_provider_key_values)
+
     def _has_fast_aws_sdk_signal() -> bool:
         """Return True when explicit AWS auth config is present.
 
@@ -1165,6 +1198,7 @@ def list_authenticated_providers(
             return False
 
     data = fetch_models_dev()
+    _user_provider_key_values = _collect_user_provider_key_values()
 
     # Build curated model lists keyed by hermes provider ID
     curated: dict[str, list[str]] = dict(_PROVIDER_MODELS)
@@ -1235,7 +1269,10 @@ def list_authenticated_providers(
                 continue
 
         # Check if any env var is set
-        has_creds = any(os.environ.get(ev) for ev in env_vars)
+        env_values = {os.environ.get(ev, "").strip() for ev in env_vars if os.environ.get(ev, "").strip()}
+        has_creds = bool(env_values)
+        if has_creds and _should_skip_builtin_from_proxy_keys(env_values):
+            has_creds = False
         if not has_creds:
             try:
                 from hermes_cli.auth import _load_auth_store
@@ -1299,13 +1336,25 @@ def list_authenticated_providers(
         if overlay.auth_type == "aws_sdk":
             has_creds = _has_aws_sdk_creds_for_listing(hermes_slug)
         elif overlay.extra_env_vars:
-            has_creds = any(os.environ.get(ev) for ev in overlay.extra_env_vars)
+            overlay_env_values = {
+                os.environ.get(ev, "").strip()
+                for ev in overlay.extra_env_vars
+                if os.environ.get(ev, "").strip()
+            }
+            has_creds = bool(overlay_env_values)
+            if has_creds and _should_skip_builtin_from_proxy_keys(overlay_env_values):
+                has_creds = False
         # Also check api_key_env_vars from PROVIDER_REGISTRY for api_key auth_type
         if not has_creds and overlay.auth_type == "api_key":
             for _key in (pid, hermes_slug):
                 pcfg = _auth_registry.get(_key)
                 if pcfg and pcfg.api_key_env_vars:
-                    if any(os.environ.get(ev) for ev in pcfg.api_key_env_vars):
+                    registry_env_values = {
+                        os.environ.get(ev, "").strip()
+                        for ev in pcfg.api_key_env_vars
+                        if os.environ.get(ev, "").strip()
+                    }
+                    if registry_env_values and not _should_skip_builtin_from_proxy_keys(registry_env_values):
                         has_creds = True
                         break
         # Check auth store and credential pool for non-env-var credentials.
@@ -1415,7 +1464,14 @@ def list_authenticated_providers(
         _cp_config = _auth_registry.get(_cp.slug)
         _cp_has_creds = False
         if _cp_config and _cp_config.api_key_env_vars:
-            _cp_has_creds = any(os.environ.get(ev) for ev in _cp_config.api_key_env_vars)
+            _cp_env_values = {
+                os.environ.get(ev, "").strip()
+                for ev in _cp_config.api_key_env_vars
+                if os.environ.get(ev, "").strip()
+            }
+            _cp_has_creds = bool(_cp_env_values)
+            if _cp_has_creds and _should_skip_builtin_from_proxy_keys(_cp_env_values):
+                _cp_has_creds = False
         # Also check auth store and credential pool
         if not _cp_has_creds:
             try:

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -275,6 +275,50 @@ def test_list_authenticated_providers_openai_built_in_nonzero_total(monkeypatch)
     assert row["total_models"] > 0
 
 
+def test_list_authenticated_providers_skips_builtin_when_key_only_belongs_to_proxy(monkeypatch):
+    """A user-defined proxy that reuses a built-in env var value must not
+    make the direct built-in provider appear authenticated too."""
+    class _EmptyPool:
+        def has_credentials(self):
+            return False
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-shared-proxy-key")
+    monkeypatch.setenv("LITELLM_PROXY_KEY", "sk-shared-proxy-key")
+    monkeypatch.setattr(
+        "agent.models_dev.fetch_models_dev",
+        lambda: {
+            "openrouter": {
+                "name": "OpenRouter",
+                "env": ["OPENROUTER_API_KEY"],
+            }
+        },
+    )
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: {})
+    monkeypatch.setattr("agent.credential_pool.load_pool", lambda _slug: _EmptyPool())
+
+    user_providers = {
+        "bedrock-proxy": {
+            "name": "AWS Bedrock (via LiteLLM)",
+            "api": "http://localhost:4000/v1",
+            "key_env": "LITELLM_PROXY_KEY",
+            "default_model": "anthropic/claude-sonnet-4",
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        current_base_url="",
+        user_providers=user_providers,
+        custom_providers=[],
+        max_models=50,
+    )
+
+    slugs = [p["slug"] for p in providers]
+    assert "openrouter" not in slugs
+    assert "bedrock-proxy" in slugs
+
+
 def test_list_authenticated_providers_user_openai_official_url_fallback(monkeypatch):
     """User providers: api.openai.com with no models list uses native curated fallback."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})


### PR DESCRIPTION
## Summary
- ignore built-in provider env credentials when the same key value is already owned by a user-defined proxy provider
- apply the same guard across models.dev-mapped providers, Hermes overlays, and canonical providers
- add a regression test that isolates auth-store and credential-pool state for the shared-key proxy case

## Testing
- uv run --extra dev ruff check hermes_cli/model_switch.py tests/hermes_cli/test_user_providers_model_switch.py
- uv run --extra dev python -m pytest tests/hermes_cli/test_user_providers_model_switch.py -k skips_builtin_when_key_only_belongs_to_proxy -vv
- uv run --extra dev python -m pytest tests/hermes_cli/test_user_providers_model_switch.py

Closes #7102