### PR TITLE
docs: clarify Apple Reminders sharing handoff

### DIFF
--- a/skills/apple/apple-reminders/SKILL.md
+++ b/skills/apple/apple-reminders/SKILL.md
@@ -66,9 +66,12 @@ remindctl open --list Work --app    # Open list in Reminders.app
 `remindctl` uses public EventKit APIs and does not expose collaborator invites
 or native Reminders list sharing. When a user asks to share a list:
 
-1. Create or verify the target list with `remindctl list <name> --create`.
-2. Open it in Reminders.app with `remindctl open --list "<name>" --app`.
-3. Tell the user to use the Reminders.app Share List control to add people.
+1. Check for the target list with `remindctl list "<name>"`.
+2. If the list does not exist, create it with
+   `remindctl list "<name>" --create`. Do not pass `--create` when the list
+   already exists because it always creates a new list.
+3. Open it in Reminders.app with `remindctl open --list "<name>" --app`.
+4. Tell the user to use the Reminders.app Share List control to add people.
 
 Do not claim a terminal command can share the list directly unless `remindctl`
 adds an explicit sharing command in the future.

--- a/skills/apple/apple-reminders/SKILL.md
+++ b/skills/apple/apple-reminders/SKILL.md
@@ -58,7 +58,20 @@ remindctl list               # List all lists
 remindctl list Work          # Show specific list
 remindctl list Projects --create    # Create list
 remindctl list Work --delete        # Delete list
+remindctl open --list Work --app    # Open list in Reminders.app
 ```
+
+### Sharing Lists
+
+`remindctl` uses public EventKit APIs and does not expose collaborator invites
+or native Reminders list sharing. When a user asks to share a list:
+
+1. Create or verify the target list with `remindctl list <name> --create`.
+2. Open it in Reminders.app with `remindctl open --list "<name>" --app`.
+3. Tell the user to use the Reminders.app Share List control to add people.
+
+Do not claim a terminal command can share the list directly unless `remindctl`
+adds an explicit sharing command in the future.
 
 ### Create Reminders
 
@@ -128,3 +141,4 @@ Accepted by `--due` and date filters:
 1. When user says "remind me", clarify: Apple Reminders (syncs to phone) vs agent cronjob alert
 2. Always confirm reminder content and due date before creating
 3. Use `--json` for programmatic parsing
+4. List sharing is an app handoff: open the list in Reminders.app, then have the user finish sharing there


### PR DESCRIPTION
Summary\n- Check whether a Reminders list already exists before suggesting creation.\n- Explain that remindctl list --create always creates a new list and can duplicate an existing one.\n- Document the safe sharing handoff through Reminders.app because collaborator invites are not exposed by the current backend.\n\nProblem\nThe Apple Reminders skill could direct the agent to create a list before sharing it without first checking for an existing list. Repeating that flow could create duplicate lists, and the current backend cannot send collaborator invitations from the terminal.\n\nValidation\n- git diff --check\n\nRefs #53462