### PR TITLE
fix(desktop): preserve active chat on reconnect

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -259,6 +259,54 @@ describe('useRouteResume', () => {
     expect(resumeSession).toHaveBeenCalledTimes(1)
     expect(resumeSession).toHaveBeenCalledWith('session-1', true)
   })
+
+  it('preserves an active new-chat session when the gateway reconnects', () => {
+    const resumeSession = vi.fn(async () => undefined)
+    const startFreshSessionDraft = vi.fn()
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: 'runtime-1' }
+    const creatingSessionRef = { current: false }
+    const runtimeIdByStoredSessionIdRef = { current: new Map<string, string>() }
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: null }
+
+    const { rerender } = render(
+      <RouteResumeHarness
+        activeSessionId="runtime-1"
+        activeSessionIdRef={activeSessionIdRef}
+        creatingSessionRef={creatingSessionRef}
+        currentView="chat"
+        freshDraftReady={false}
+        gatewayState="closed"
+        locationPathname="/"
+        resumeSession={resumeSession}
+        routedSessionId={null}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionId={null}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    rerender(
+      <RouteResumeHarness
+        activeSessionId="runtime-1"
+        activeSessionIdRef={activeSessionIdRef}
+        creatingSessionRef={creatingSessionRef}
+        currentView="chat"
+        freshDraftReady={false}
+        gatewayState="open"
+        locationPathname="/"
+        resumeSession={resumeSession}
+        routedSessionId={null}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionId={null}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    expect(startFreshSessionDraft).not.toHaveBeenCalled()
+    expect(resumeSession).not.toHaveBeenCalled()
+  })
 })
 
 describe('useRouteResume bounded auto-retry after a failed resume', () => {

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -153,6 +153,13 @@ export function useRouteResume({
       return
     }
 
+    // A sleep/wake WS reconnect can reopen on /new while the active runtime
+    // session is still the user's current chat. Preserve it instead of turning
+    // the reconnect into an explicit New Session action.
+    if (isNewChatRoute(locationPathname) && gatewayBecameOpen && activeSessionId && !freshDraftReady) {
+      return
+    }
+
     if (
       isNewChatRoute(locationPathname) &&
       !creatingSessionRef.current &&


### PR DESCRIPTION
## Summary
- keep Desktop from treating a sleep/wake WebSocket reconnect on the new-chat route as an explicit New Session action
- preserve the active runtime session when the gateway transitions back to open and the current draft is not a fresh blank draft
- add a `useRouteResume` regression test for the closed -> open reconnect path

## Root cause
On `/`, `useRouteResume` used `activeSessionId` as a reason to call `startFreshSessionDraft()` whenever the gateway was open. After a Windows sleep/wake reconnect, the renderer can still hold the active runtime session while the socket transitions back to `open`, so that branch could clear the active chat and create a fresh draft instead of preserving the session.

Fixes #53374.

## Tests
- `npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-route-resume.test.tsx` — 13 passed
- `npm --workspace apps/desktop run typecheck` — passed
- `npm --workspace apps/desktop run lint -- src/app/session/hooks/use-route-resume.ts src/app/session/hooks/use-route-resume.test.tsx` — passed with existing blank-line warnings in unrelated files
- `git diff --check` — passed with CRLF warnings only