### PR TITLE
fix(gateway): show MoA presets in model picker

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1206,6 +1206,7 @@ class GatewaySlashCommandsMixin:
                         user_providers=user_provs,
                         custom_providers=custom_provs,
                         max_models=50,
+                        include_moa=True,
                     )
                 except Exception:
                     providers = []

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2277,6 +2277,39 @@ def list_authenticated_providers(
     return results
 
 
+def _prepend_moa_picker_provider(providers: List[dict], current_provider: str = "") -> List[dict]:
+    """Add the virtual MoA provider row used by interactive model pickers.
+
+    ``list_authenticated_providers()`` only returns real/auth-backed providers.
+    The CLI model inventory adds MoA separately so named presets appear next to
+    normal providers; gateway pickers call ``list_picker_providers()`` directly,
+    so they need the same virtual row here.
+    """
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.moa_config import normalize_moa_config
+
+        cfg = normalize_moa_config(load_config().get("moa") or {})
+        models = list(cfg.get("presets", {}).keys())
+        if not models:
+            return providers
+        moa_row = {
+            "slug": "moa",
+            "name": "Mixture of Agents",
+            "is_current": (current_provider or "").lower() == "moa",
+            "is_user_defined": False,
+            "models": models,
+            "total_models": len(models),
+            "source": "virtual",
+            "authenticated": True,
+            "auth_type": "virtual",
+            "warning": "Aggregator acts as the selected model; references provide analysis before each call.",
+        }
+        return [moa_row] + [p for p in providers if str(p.get("slug", "")).lower() != "moa"]
+    except Exception:
+        return providers
+
+
 def list_picker_providers(
     current_provider: str = "",
     current_base_url: str = "",
@@ -2284,6 +2317,7 @@ def list_picker_providers(
     custom_providers: list | None = None,
     max_models: int | None = None,
     current_model: str = "",
+    include_moa: bool = False,
 ) -> List[dict]:
     """Interactive-picker variant of :func:`list_authenticated_providers`.
 
@@ -2314,6 +2348,8 @@ def list_picker_providers(
         max_models=max_models,
         current_model=current_model,
     )
+    if include_moa:
+        providers = _prepend_moa_picker_provider(providers, current_provider=current_provider)
 
     filtered: List[dict] = []
     for p in providers:

--- a/tests/gateway/test_model_command_async_offload.py
+++ b/tests/gateway/test_model_command_async_offload.py
@@ -166,3 +166,29 @@ async def test_picker_path_offloads_list_picker_providers(_isolated_config, monk
         "list_picker_providers must be dispatched via asyncio.to_thread "
         "(it was called inline on the event loop instead)"
     )
+
+
+@pytest.mark.asyncio
+async def test_picker_path_requests_moa_presets(_isolated_config, monkeypatch):
+    """Gateway /model pickers must opt into the virtual MoA preset provider."""
+    captured = {}
+
+    def _fake_list_picker_providers(**kwargs):
+        captured.update(kwargs)
+        return [{"slug": "moa", "name": "Mixture of Agents", "is_current": False,
+                 "models": ["battle", "smart"], "total_models": 2}]
+
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_picker_providers",
+        _fake_list_picker_providers,
+    )
+
+    runner = _make_runner()
+    runner.adapters = {Platform.TELEGRAM: _FakePickerAdapter()}
+    monkeypatch.setattr(runner, "_thread_metadata_for_source", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(runner, "_reply_anchor_for_event", lambda *a, **k: None, raising=False)
+
+    result = await runner._handle_model_command(_make_event())
+
+    assert result is None
+    assert captured["include_moa"] is True

--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -109,6 +109,40 @@ def test_non_openrouter_rows_passed_through_unchanged(monkeypatch):
     assert result[1]["models"] == ["gemini-3-flash-preview"]
 
 
+def test_include_moa_adds_virtual_provider_with_named_presets(monkeypatch):
+    """Gateway pickers opt into a virtual MoA provider so presets are tappable."""
+    base = [_make_provider("minimax", models=["MiniMax-M3"])]
+    moa_config = {
+        "moa": {
+            "default_preset": "battle",
+            "presets": {
+                "battle": {"enabled": True},
+                "smart": {"enabled": True},
+            },
+        }
+    }
+
+    monkeypatch.setattr(model_switch, "list_authenticated_providers",
+                        lambda **kw: list(base))
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: moa_config)
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: pytest.fail("should not be called"))
+
+    result = model_switch.list_picker_providers(
+        current_provider="moa",
+        max_models=50,
+        include_moa=True,
+    )
+
+    assert [p["slug"] for p in result] == ["moa", "minimax"]
+    moa = result[0]
+    assert moa["name"] == "Mixture of Agents"
+    assert moa["is_current"] is True
+    assert moa["source"] == "virtual"
+    assert moa["models"] == ["battle", "smart"]
+    assert moa["total_models"] == 2
+
+
 def test_empty_models_row_dropped(monkeypatch):
     """Built-in provider with an empty ``models`` list is dropped."""
     base = [


### PR DESCRIPTION
## What does this PR do?

Fixes the gateway `/model` picker so MoA presets appear as selectable models under the virtual `moa` provider.

MoA presets are already exposed in the CLI inventory, and the docs say presets are selectable across Hermes surfaces. However, the gateway picker path calls `list_picker_providers()` directly, bypassing the CLI inventory code that injects the virtual MoA provider row. As a result, Telegram/Discord-style model pickers showed only real providers/models, not MoA presets.

This adds an explicit `include_moa` opt-in to `list_picker_providers()` and enables it from the gateway `/model` picker path. Existing callers keep the old behavior unless they opt in.

## Related Issue

Related to #46081 and #53211, which made/documented MoA presets as selectable virtual models. This PR fixes the gateway picker path that still missed that virtual provider.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/model_switch.py`
  - Adds an opt-in virtual MoA provider row for interactive picker payloads.
  - Keeps existing `list_picker_providers()` behavior unchanged unless `include_moa=True`.
- `gateway/slash_commands.py`
  - Enables `include_moa=True` for the gateway `/model` picker path.
- `tests/hermes_cli/test_list_picker_providers.py`
  - Covers MoA preset injection and preserves existing picker filtering contracts.
- `tests/gateway/test_model_command_async_offload.py`
  - Covers that the gateway picker requests MoA preset inclusion.

## How to Test

1. Configure MoA presets in `config.yaml`.
2. Restart the gateway.
3. From Telegram, send `/model`.
4. Verify `Mixture of Agents` appears as a provider and its preset names are selectable.

Automated tests run locally:

```bash
scripts/run_tests.sh tests/hermes_cli/test_list_picker_providers.py tests/gateway/test_model_command_async_offload.py tests/gateway/test_model_picker_persist.py
```

Result:

```text
17 tests passed, 0 failed
```

Manual verification:

- Tested on macOS via Telegram gateway.
- Before the fix, `/model` showed regular providers only.
- After restarting the gateway with this patch, `/model` shows the MoA virtual provider and presets (`default`, `battle`, `smart`) as selectable options.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted tests via `scripts/run_tests.sh` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Telegram gateway

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; existing docs already describe MoA preset selection across surfaces
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A; gateway picker payload logic only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/hermes_cli/test_list_picker_providers.py tests/gateway/test_model_command_async_offload.py tests/gateway/test_model_picker_persist.py

=== Summary: 3 files, 17 tests passed, 0 failed (100% complete) ===
```
