### PR TITLE
fix(desktop): add Linux close fallback when no titlebar overlay

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -44,7 +44,10 @@ const { fetchMarketplaceThemes, searchMarketplaceThemes } = require('./vscode-ma
 const { buildDesktopBackendEnv, normalizeHermesHomeRoot } = require('./backend-env.cjs')
 const { readWindowsUserEnvVar } = require('./windows-user-env.cjs')
 const { readWslWindowsClipboardImage } = require('./wsl-clipboard-image.cjs')
-const { nativeOverlayWidth: computeNativeOverlayWidth } = require('./titlebar-overlay-width.cjs')
+const {
+  nativeOverlayWidth: computeNativeOverlayWidth,
+  shouldShowWindowControlsFallback: computeShouldShowWindowControlsFallback
+} = require('./titlebar-overlay-width.cjs')
 const { readDirForIpc } = require('./fs-read-dir.cjs')
 const { readLiveUpdateMarker } = require('./update-marker.cjs')
 const {
@@ -3791,10 +3794,15 @@ function getNativeOverlayWidth() {
   return computeNativeOverlayWidth({ isWindows: IS_WINDOWS, isWsl: IS_WSL })
 }
 
+function shouldShowWindowControlsFallback() {
+  return computeShouldShowWindowControlsFallback({ isMac: IS_MAC, isWindows: IS_WINDOWS, isWsl: IS_WSL })
+}
+
 function getWindowState() {
   return {
     isFullscreen: Boolean(mainWindow?.isFullScreen?.()),
     nativeOverlayWidth: getNativeOverlayWidth(),
+    showWindowControlsFallback: shouldShowWindowControlsFallback(),
     windowButtonPosition: getWindowButtonPosition()
   }
 }
@@ -5994,6 +6002,15 @@ ipcMain.handle('hermes:window:openSession', async (_event, sessionId, opts) => {
 ipcMain.handle('hermes:window:openNewSession', async () => {
   createNewSessionWindow()
 
+  return { ok: true }
+})
+ipcMain.handle('hermes:window:close', async event => {
+  const win = BrowserWindow.fromWebContents(event.sender)
+  if (!win || win.isDestroyed()) {
+    return { ok: false, error: 'missing-window' }
+  }
+
+  win.close()
   return { ok: true }
 })
 

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -7,6 +7,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   getGatewayWsUrl: profile => ipcRenderer.invoke('hermes:gateway:ws-url', profile),
   openSessionWindow: (sessionId, opts) => ipcRenderer.invoke('hermes:window:openSession', sessionId, opts),
   openNewSessionWindow: () => ipcRenderer.invoke('hermes:window:openNewSession'),
+  closeWindow: () => ipcRenderer.invoke('hermes:window:close'),
   petOverlay: {
     // Main renderer → main process: window lifecycle + drag. `request` is
     // `{ bounds, screen }`; resolves with the screen bounds it actually used.

--- a/apps/desktop/electron/titlebar-overlay-width.cjs
+++ b/apps/desktop/electron/titlebar-overlay-width.cjs
@@ -8,4 +8,9 @@ function nativeOverlayWidth({ isWindows = false, isWsl = false } = {}) {
   return isWindows || isWsl ? OVERLAY_FALLBACK_WIDTH : 0
 }
 
-module.exports = { OVERLAY_FALLBACK_WIDTH, nativeOverlayWidth }
+/** @param {{ isMac?: boolean, isWindows?: boolean, isWsl?: boolean }} opts */
+function shouldShowWindowControlsFallback({ isMac = false, isWindows = false, isWsl = false } = {}) {
+  return !isMac && nativeOverlayWidth({ isWindows, isWsl }) === 0
+}
+
+module.exports = { OVERLAY_FALLBACK_WIDTH, nativeOverlayWidth, shouldShowWindowControlsFallback }

--- a/apps/desktop/electron/titlebar-overlay-width.test.cjs
+++ b/apps/desktop/electron/titlebar-overlay-width.test.cjs
@@ -1,7 +1,11 @@
 const assert = require('node:assert/strict')
 const test = require('node:test')
 
-const { OVERLAY_FALLBACK_WIDTH, nativeOverlayWidth } = require('./titlebar-overlay-width.cjs')
+const {
+  OVERLAY_FALLBACK_WIDTH,
+  nativeOverlayWidth,
+  shouldShowWindowControlsFallback
+} = require('./titlebar-overlay-width.cjs')
 
 // This static reservation is only the pre-layout FALLBACK. Once laid out the
 // renderer reads the exact width from navigator.windowControlsOverlay
@@ -26,4 +30,11 @@ test('plain Linux and macOS reserve nothing', () => {
 
 test('the fallback width is a sane positive pixel value', () => {
   assert.ok(Number.isInteger(OVERLAY_FALLBACK_WIDTH) && OVERLAY_FALLBACK_WIDTH > 0)
+})
+
+test('only plain Linux shows the custom window-controls fallback', () => {
+  assert.equal(shouldShowWindowControlsFallback({ isMac: true }), false)
+  assert.equal(shouldShowWindowControlsFallback({ isWindows: true }), false)
+  assert.equal(shouldShowWindowControlsFallback({ isWsl: true }), false)
+  assert.equal(shouldShowWindowControlsFallback(), true)
 })

--- a/apps/desktop/src/app/shell/app-shell.tsx
+++ b/apps/desktop/src/app/shell/app-shell.tsx
@@ -24,7 +24,7 @@ import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '../layout-constants'
 import { useWindowControlsOverlayWidth } from './hooks/use-window-controls-overlay-width'
 import { KeybindPanel } from './keybind-panel'
 import { StatusbarControls, type StatusbarItem } from './statusbar-controls'
-import { TITLEBAR_HEIGHT, titlebarControlsPosition } from './titlebar'
+import { showTitlebarCloseFallback, TITLEBAR_HEIGHT, titlebarControlsPosition, titlebarSystemToolCount } from './titlebar'
 import { TitlebarControls, type TitlebarTool } from './titlebar-controls'
 
 interface AppShellProps {
@@ -96,6 +96,7 @@ export function AppShell({
   const measuredOverlayWidth = useWindowControlsOverlayWidth()
   const staticOverlayWidth = connection?.nativeOverlayWidth ?? 0
   const nativeOverlayWidth = measuredOverlayWidth ?? staticOverlayWidth
+  const showWindowCloseFallback = showTitlebarCloseFallback(connection, isFullscreen)
   const titlebarToolsRight = nativeOverlayWidth > 0 ? `${nativeOverlayWidth}px` : '0.75rem'
 
   // When the native window controls overlay our titlebar band — Windows and
@@ -134,7 +135,7 @@ export function AppShell({
   // between the pane-tool cluster and the system cluster so they don't sit
   // flush against each other. Modeled as N gaps (N - 1 inner + 1 trailing)
   // to keep the formula generic for any pane-tool count.
-  const SYSTEM_TOOL_COUNT = 4
+  const SYSTEM_TOOL_COUNT = titlebarSystemToolCount(showWindowCloseFallback)
   const paneToolCount = titlebarTools?.filter(tool => !tool.hidden).length ?? 0
   const systemToolsWidth = `calc(${SYSTEM_TOOL_COUNT} * (var(--titlebar-control-size) + 0.25rem))`
 
@@ -186,7 +187,12 @@ export function AppShell({
       }
     >
       {!hideTitlebarControls && (
-        <TitlebarControls leftTools={leftTitlebarTools} onOpenSettings={onOpenSettings} tools={titlebarTools} />
+        <TitlebarControls
+          leftTools={leftTitlebarTools}
+          onOpenSettings={onOpenSettings}
+          showWindowCloseFallback={showWindowCloseFallback}
+          tools={titlebarTools}
+        />
       )}
 
       {nativeOverlayWidth > 0 && (

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -44,9 +44,15 @@ interface TitlebarControlsProps extends ComponentProps<'div'> {
   leftTools?: readonly TitlebarTool[]
   tools?: readonly TitlebarTool[]
   onOpenSettings: () => void
+  showWindowCloseFallback?: boolean
 }
 
-export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }: TitlebarControlsProps) {
+export function TitlebarControls({
+  leftTools = [],
+  tools = [],
+  onOpenSettings,
+  showWindowCloseFallback = false
+}: TitlebarControlsProps) {
   const { t } = useI18n()
   const navigate = useNavigate()
   const location = useLocation()
@@ -108,6 +114,19 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
       rightEdge.toggle()
     }
   }
+
+  const closeWindowTool: TitlebarTool | null = showWindowCloseFallback
+    ? {
+        className: 'hover:bg-destructive hover:text-white focus-visible:ring-destructive/20',
+        icon: <Codicon name="close" />,
+        id: 'window-close',
+        label: t.titlebar.closeWindow,
+        onSelect: () => {
+          triggerHaptic('tap')
+          void window.hermesDesktop.closeWindow()
+        }
+      }
+    : null
 
   // Static system tools — always pinned to the screen's right edge.
   const systemTools: TitlebarTool[] = [
@@ -192,6 +211,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
         ))}
         {settingsTool && <TitlebarToolButton navigate={navigate} tool={settingsTool} />}
         <TitlebarToolButton navigate={navigate} tool={rightSidebarTool} />
+        {closeWindowTool && <TitlebarToolButton navigate={navigate} tool={closeWindowTool} />}
       </div>
     </>
   )

--- a/apps/desktop/src/app/shell/titlebar.test.ts
+++ b/apps/desktop/src/app/shell/titlebar.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  showTitlebarCloseFallback,
   TITLEBAR_CONTROL_OFFSET_X,
   TITLEBAR_EDGE_INSET,
   TITLEBAR_FALLBACK_WINDOW_BUTTON_X,
-  titlebarControlsPosition
+  titlebarControlsPosition,
+  titlebarSystemToolCount
 } from './titlebar'
 
 describe('titlebarControlsPosition', () => {
@@ -22,5 +24,16 @@ describe('titlebarControlsPosition', () => {
 
   it('uses the macOS fallback while the initial window state is unknown', () => {
     expect(titlebarControlsPosition(undefined).left).toBe(TITLEBAR_FALLBACK_WINDOW_BUTTON_X + TITLEBAR_CONTROL_OFFSET_X)
+  })
+
+  it('shows the custom close button only on non-fullscreen fallback platforms', () => {
+    expect(showTitlebarCloseFallback({ isFullscreen: false, showWindowControlsFallback: true })).toBe(true)
+    expect(showTitlebarCloseFallback({ isFullscreen: true, showWindowControlsFallback: true })).toBe(false)
+    expect(showTitlebarCloseFallback({ isFullscreen: false, showWindowControlsFallback: false })).toBe(false)
+  })
+
+  it('accounts for the optional close button in the fixed tool cluster width', () => {
+    expect(titlebarSystemToolCount()).toBe(4)
+    expect(titlebarSystemToolCount(true)).toBe(5)
   })
 })

--- a/apps/desktop/src/app/shell/titlebar.ts
+++ b/apps/desktop/src/app/shell/titlebar.ts
@@ -1,4 +1,4 @@
-import type { HermesConnection } from '@/global'
+import type { HermesConnection, HermesWindowState } from '@/global'
 
 export const TITLEBAR_HEIGHT = 34
 export const MACOS_TRAFFIC_LIGHTS_HEIGHT = 14
@@ -26,6 +26,20 @@ export const titlebarHeaderTitleClass = 'min-w-0 flex-1 overflow-hidden'
 
 export const titlebarHeaderShadowClass =
   "after:pointer-events-none after:absolute after:left-0 after:right-0 after:top-full after:h-4 after:bg-linear-to-b after:from-(--ui-chat-surface-background) after:to-transparent after:content-['']"
+
+export function showTitlebarCloseFallback(
+  windowState:
+    | Pick<HermesConnection, 'isFullscreen' | 'showWindowControlsFallback'>
+    | Pick<HermesWindowState, 'isFullscreen' | 'showWindowControlsFallback'>
+    | undefined,
+  isFullscreen = windowState?.isFullscreen ?? false
+) {
+  return Boolean(windowState?.showWindowControlsFallback) && !isFullscreen
+}
+
+export function titlebarSystemToolCount(showCloseFallback = false) {
+  return 4 + Number(showCloseFallback)
+}
 
 export function titlebarControlsPosition(
   windowButtonPosition: HermesConnection['windowButtonPosition'] | undefined,

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -33,6 +33,8 @@ declare global {
       openSessionWindow: (sessionId: string, opts?: { watch?: boolean }) => Promise<{ ok: boolean; error?: string }>
       // Open (or focus) a compact secondary window on the new-session draft.
       openNewSessionWindow: () => Promise<{ ok: boolean; error?: string }>
+      // Close the current desktop window from a custom titlebar control.
+      closeWindow: () => Promise<{ ok: boolean; error?: string }>
       // The pop-out pet overlay: a transparent always-on-top window hosting only
       // the mascot. The main renderer drives it (open/close/drag + state push);
       // the overlay sends control messages back (pop-in, composer submit).
@@ -357,6 +359,7 @@ export interface HermesConnection {
   mode?: 'local' | 'remote'
   authMode?: 'oauth' | 'token'
   nativeOverlayWidth: number
+  showWindowControlsFallback: boolean
   source?: 'env' | 'local' | 'settings'
   token: string
   wsUrl: string
@@ -375,6 +378,7 @@ export interface HermesTitleBarTheme {
 export interface HermesWindowState {
   isFullscreen: boolean
   nativeOverlayWidth: number
+  showWindowControlsFallback: boolean
   windowButtonPosition: { x: number; y: number } | null
 }
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -181,7 +181,8 @@ export const en: Translations = {
     muteHaptics: 'Mute haptics',
     unmuteHaptics: 'Unmute haptics',
     openSettings: 'Open settings',
-    openKeybinds: 'Keyboard shortcuts'
+    openKeybinds: 'Keyboard shortcuts',
+    closeWindow: 'Close window'
   },
 
   keybinds: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -181,7 +181,9 @@ export const ja = defineLocale({
     showRightSidebar: '右サイドバーを表示',
     muteHaptics: '触覚フィードバックをオフ',
     unmuteHaptics: '触覚フィードバックをオン',
-    openSettings: '設定を開く'
+    openSettings: '設定を開く',
+    openKeybinds: 'キーボードショートカット',
+    closeWindow: 'ウィンドウを閉じる'
   },
 
   language: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -224,6 +224,7 @@ export interface Translations {
     unmuteHaptics: string
     openSettings: string
     openKeybinds: string
+    closeWindow: string
   }
 
   keybinds: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -175,7 +175,9 @@ export const zhHant = defineLocale({
     showRightSidebar: '顯示右側邊欄',
     muteHaptics: '靜音觸感回饋',
     unmuteHaptics: '開啟觸感回饋',
-    openSettings: '開啟設定'
+    openSettings: '開啟設定',
+    openKeybinds: '鍵盤快速鍵',
+    closeWindow: '關閉視窗'
   },
 
   language: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -176,7 +176,8 @@ export const zh: Translations = {
     muteHaptics: '关闭触感反馈',
     unmuteHaptics: '开启触感反馈',
     openSettings: '打开设置',
-    openKeybinds: '键盘快捷键'
+    openKeybinds: '键盘快捷键',
+    closeWindow: '关闭窗口'
   },
 
   keybinds: {

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -177,6 +177,7 @@ describe('checkBackendUpdates', () => {
       isFullscreen: false,
       mode: on ? 'remote' : 'local',
       nativeOverlayWidth: 0,
+      showWindowControlsFallback: false,
       token: 't',
       wsUrl: 'ws://box:9119',
       logs: [],


### PR DESCRIPTION
## Summary
- add a renderer-visible fallback flag for platforms that hide the title bar but do not expose a native window-controls overlay
- expose a close-window IPC bridge and render a custom close button in the desktop titlebar on plain Linux
- reserve titlebar cluster width for the extra control and cover the new platform logic with desktop tests

## Testing
- npm run test:ui -- src/app/shell/titlebar.test.ts
- node --test electron/titlebar-overlay-width.test.cjs
- npx eslint src/app/shell/app-shell.tsx src/app/shell/titlebar-controls.tsx src/app/shell/titlebar.ts src/app/shell/titlebar.test.ts src/global.d.ts src/store/updates.test.ts src/i18n/en.ts src/i18n/zh.ts src/i18n/zh-hant.ts src/i18n/ja.ts electron/main.cjs electron/preload.cjs electron/titlebar-overlay-width.cjs electron/titlebar-overlay-width.test.cjs

Closes #53514