### PR TITLE
fix(cron): inject curated responses from context_from

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1686,6 +1686,25 @@ def _parse_wake_gate(script_output: str) -> bool:
     return gate.get("wakeAgent", True) is not False
 
 
+def _extract_cron_response_for_context(output: str) -> str:
+    """Return the curated response section from a saved cron artifact.
+
+    Cron output files for agent jobs include the assembled prompt and any
+    script stdout before the final ``## Response`` block.  Downstream
+    ``context_from`` consumers need the job's curated result, not the full
+    execution artifact.  Plain/script-only outputs have no response section and
+    intentionally fall back to their original full text for compatibility.
+    """
+    response_start = None
+    lines = output.splitlines()
+    for index, line in enumerate(lines):
+        if re.fullmatch(r"## Response[ \t]*", line):
+            response_start = index + 1
+    if response_start is None:
+        return output.strip()
+    return "\n".join(lines[response_start:]).strip()
+
+
 def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     """Build the effective prompt for a cron job, optionally loading one or more skills first.
 
@@ -1764,7 +1783,9 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 )
                 if not output_files:
                     continue  # silent skip — no output yet
-                latest_output = output_files[0].read_text(encoding="utf-8").strip()
+                latest_output = _extract_cron_response_for_context(
+                    output_files[0].read_text(encoding="utf-8")
+                )
                 # Truncate to 8K characters to avoid prompt bloat
                 _MAX_CONTEXT_CHARS = 8000
                 if len(latest_output) > _MAX_CONTEXT_CHARS:

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -102,6 +102,89 @@ class TestBuildJobPromptContextFrom:
         assert "Today's top story: AI is everywhere." in prompt
         assert f"Output from job '{job_a['id']}'" in prompt
 
+    def test_injects_response_section_from_full_cron_artifact(self, cron_env):
+        """context_from should pass curated responses, not full cron artifacts."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Find news", schedule="every 1h")
+        output_dir = OUTPUT_DIR / job_a["id"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "2026-04-22_10-00-00.md").write_text(
+            "\n".join(
+                [
+                    "# Cron Job: upstream",
+                    "",
+                    "## Prompt",
+                    "UPSTREAM PROMPT SHOULD NOT BE INJECTED",
+                    "",
+                    "## Script Output",
+                    "RAW COLLECTOR CONTEXT SHOULD NOT BE INJECTED",
+                    "",
+                    "## Response",
+                    "Curated upstream summary for the digest.",
+                    "",
+                    "## Curated Heading Inside Response",
+                    "Response-owned markdown headings stay available.",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        job_b = create_job(
+            prompt="Summarize the news",
+            schedule="every 2h",
+            context_from=job_a["id"],
+        )
+
+        prompt = _build_job_prompt(job_b)
+        assert "Curated upstream summary for the digest." in prompt
+        assert "## Curated Heading Inside Response" in prompt
+        assert "Response-owned markdown headings stay available." in prompt
+        assert "UPSTREAM PROMPT SHOULD NOT BE INJECTED" not in prompt
+        assert "RAW COLLECTOR CONTEXT SHOULD NOT BE INJECTED" not in prompt
+
+    def test_uses_last_response_section_when_script_output_mentions_response(self, cron_env):
+        """A collector mentioning ## Response must not become digest context."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Find news", schedule="every 1h")
+        output_dir = OUTPUT_DIR / job_a["id"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "2026-04-22_10-00-00.md").write_text(
+            "\n".join(
+                [
+                    "# Cron Job: upstream",
+                    "",
+                    "## Prompt",
+                    "UPSTREAM PROMPT SHOULD NOT BE INJECTED",
+                    "",
+                    "## Script Output",
+                    "```",
+                    "Collector copied a markdown heading:",
+                    "## Response",
+                    "SCRIPT OUTPUT SHOULD NOT BE INJECTED",
+                    "```",
+                    "",
+                    "## Response",
+                    "Final curated answer only.",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        job_b = create_job(
+            prompt="Summarize the news",
+            schedule="every 2h",
+            context_from=job_a["id"],
+        )
+
+        prompt = _build_job_prompt(job_b)
+        assert "Final curated answer only." in prompt
+        assert "SCRIPT OUTPUT SHOULD NOT BE INJECTED" not in prompt
+        assert "UPSTREAM PROMPT SHOULD NOT BE INJECTED" not in prompt
+
     def test_uses_most_recent_output(self, cron_env):
         from cron.jobs import create_job, OUTPUT_DIR
         from cron.scheduler import _build_job_prompt


### PR DESCRIPTION
## Summary

- Prefer the final `## Response` section when injecting upstream cron output via `context_from`
- Preserve plain/script-only output fallback when no response section exists
- Keep response-owned markdown headings and choose the last response marker so collector text cannot accidentally become digest context

## Motivation

Saved cron artifacts for agent jobs include `## Prompt` and `## Script Output` before the curated final response. Downstream digest jobs that use `context_from` should receive the curated result, not the full execution artifact, to avoid prompt bloat and raw collector context in digest prompts.

## Tests

- RED check: `tests/cron/test_cron_context_from.py::TestBuildJobPromptContextFrom::test_injects_response_section_from_full_cron_artifact` failed before the scheduler change because upstream prompt/script output was injected.
- RED check: `tests/cron/test_cron_context_from.py::TestBuildJobPromptContextFrom::test_uses_last_response_section_when_script_output_mentions_response` failed before the parser used the last response section.
- `.venv-test/bin/python -m pytest tests/cron/test_cron_context_from.py -q -o 'addopts='`
- `.venv-test/bin/python -m pytest tests/cron/test_cron_prompt_injection_skill.py -q -o 'addopts='`
- `env -u MATRIX_HOME_ROOM -u MATRIX_HOME_CHANNEL .venv-test/bin/python -m pytest tests/cron/test_scheduler.py -q -o 'addopts='`
- `.venv-test/bin/python -m py_compile cron/scheduler.py tests/cron/test_cron_context_from.py`
- `.venv-test/bin/python -m ruff check cron/scheduler.py tests/cron/test_cron_context_from.py`
- `git diff --check`

Note: an unmodified `tests/cron/test_scheduler.py` run in this LXC inherits Matrix home-channel environment and fails one routing-intent test by discovering an extra Matrix target; the isolated run above unsets those env vars and passes.
