### PR TITLE
feat(delegate): optional per-task model/provider/reasoning_effort in batch mode

### DIFF
--- a/tests/tools/test_delegate_per_task_overrides.py
+++ b/tests/tools/test_delegate_per_task_overrides.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Tests for per-task model/provider/reasoning_effort overrides in
+delegate_task batch mode.
+
+Behavior contract:
+  - A batch task carrying 'model' / 'provider' / 'reasoning_effort' builds
+    its child with those values, without affecting sibling tasks.
+  - Tasks without overrides keep exactly today's inheritance defaults.
+  - Empty or invalid override strings are ignored gracefully (no error,
+    defaults preserved).
+
+Run with:  scripts/run_tests.sh tests/tools/test_delegate_per_task_overrides.py
+"""
+
+import json
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tools.delegate_tool import DELEGATE_TASK_SCHEMA, delegate_task
+
+
+def _make_mock_parent(depth=0):
+    """Create a mock parent agent with the fields delegate_task expects."""
+    parent = MagicMock()
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "test-key-parent"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-sonnet-4"
+    parent.platform = "cli"
+    parent.reasoning_config = None
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent._session_db = None
+    parent._delegate_depth = depth
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    return parent
+
+
+def _batch_results(n):
+    return [
+        {
+            "task_index": i,
+            "status": "completed",
+            "summary": f"Result {i}",
+            "api_calls": 1,
+            "duration_seconds": 1.0,
+        }
+        for i in range(n)
+    ]
+
+
+class TestPerTaskOverrideSchema(unittest.TestCase):
+    def test_task_items_expose_override_keys(self):
+        item_props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"][
+            "items"
+        ]["properties"]
+        for key in ("model", "provider", "reasoning_effort"):
+            self.assertIn(key, item_props)
+            self.assertEqual(item_props[key]["type"], "string")
+        # The keys are optional — 'goal' remains the only required field.
+        self.assertEqual(
+            DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"][
+                "required"
+            ],
+            ["goal"],
+        )
+
+
+class TestPerTaskOverrides(unittest.TestCase):
+    @patch("tools.delegate_tool._run_single_child")
+    def test_per_task_model_and_effort_override(self, mock_run):
+        """Task 0 carries overrides; task 1 keeps inherited defaults."""
+        mock_run.side_effect = _batch_results(2)
+        parent = _make_mock_parent()
+        tasks = [
+            {
+                "goal": "Task with overrides",
+                "model": "openai/gpt-5-mini",
+                "reasoning_effort": "low",
+            },
+            {"goal": "Task without overrides"},
+        ]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            result = json.loads(delegate_task(tasks=tasks, parent_agent=parent))
+
+        self.assertIn("results", result)
+        self.assertEqual(len(MockAgent.call_args_list), 2)
+        _, kwargs0 = MockAgent.call_args_list[0]
+        _, kwargs1 = MockAgent.call_args_list[1]
+        self.assertEqual(kwargs0["model"], "openai/gpt-5-mini")
+        self.assertEqual(
+            kwargs0["reasoning_config"], {"enabled": True, "effort": "low"}
+        )
+        # Sibling task is untouched — parent inheritance as before.
+        self.assertEqual(kwargs1["model"], parent.model)
+        self.assertIsNone(kwargs1["reasoning_config"])
+        self.assertEqual(kwargs1["provider"], parent.provider)
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_per_task_provider_override(self, mock_run):
+        mock_run.side_effect = _batch_results(1)
+        parent = _make_mock_parent()
+        tasks = [{"goal": "Run on zai", "provider": "zai", "model": "glm-4.7"}]
+
+        runtime_bundle = {
+            "provider": "zai",
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+            "api_key": "test-key-zai",
+            "api_mode": "anthropic_messages",
+            "model": "glm-4.7",
+        }
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=runtime_bundle,
+        ) as mock_resolve:
+            MockAgent.return_value = MagicMock()
+            result = json.loads(delegate_task(tasks=tasks, parent_agent=parent))
+
+        self.assertIn("results", result)
+        mock_resolve.assert_called_once_with(requested="zai", target_model="glm-4.7")
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["provider"], "zai")
+        self.assertEqual(kwargs["base_url"], runtime_bundle["base_url"])
+        self.assertEqual(kwargs["api_key"], runtime_bundle["api_key"])
+        self.assertEqual(kwargs["model"], "glm-4.7")
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_batch_without_overrides_unchanged(self, mock_run):
+        """No override keys → byte-identical defaults to today's behavior."""
+        mock_run.side_effect = _batch_results(2)
+        parent = _make_mock_parent()
+        tasks = [{"goal": "Plain task A"}, {"goal": "Plain task B"}]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            result = json.loads(delegate_task(tasks=tasks, parent_agent=parent))
+
+        self.assertIn("results", result)
+        for _, kwargs in MockAgent.call_args_list:
+            self.assertEqual(kwargs["model"], parent.model)
+            self.assertEqual(kwargs["provider"], parent.provider)
+            self.assertEqual(kwargs["base_url"], parent.base_url)
+            self.assertEqual(kwargs["api_key"], parent.api_key)
+            self.assertIsNone(kwargs["reasoning_config"])
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_invalid_and_empty_overrides_ignored(self, mock_run):
+        """Empty strings and unknown values degrade to defaults, no error."""
+        mock_run.side_effect = _batch_results(1)
+        parent = _make_mock_parent()
+        tasks = [
+            {
+                "goal": "Bad overrides",
+                "model": "   ",
+                "provider": "",
+                "reasoning_effort": "bananas",
+            }
+        ]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            result = json.loads(delegate_task(tasks=tasks, parent_agent=parent))
+
+        self.assertNotIn("error", result)
+        self.assertIn("results", result)
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["model"], parent.model)
+        self.assertEqual(kwargs["provider"], parent.provider)
+        self.assertIsNone(kwargs["reasoning_config"])
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_unresolvable_provider_falls_back_gracefully(self, mock_run):
+        """A provider that fails resolution warns and keeps defaults."""
+        mock_run.side_effect = _batch_results(1)
+        parent = _make_mock_parent()
+        tasks = [{"goal": "Bad provider", "provider": "no-such-provider"}]
+
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=RuntimeError("unknown provider"),
+        ):
+            MockAgent.return_value = MagicMock()
+            result = json.loads(delegate_task(tasks=tasks, parent_agent=parent))
+
+        self.assertNotIn("error", result)
+        self.assertIn("results", result)
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["model"], parent.model)
+        self.assertEqual(kwargs["provider"], parent.provider)
+        self.assertEqual(kwargs["api_key"], parent.api_key)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -915,6 +915,8 @@ def _build_child_agent(
     override_base_url: Optional[str] = None,
     override_api_key: Optional[str] = None,
     override_api_mode: Optional[str] = None,
+    # Per-task reasoning effort override (batch tasks may pin their own level)
+    override_reasoning_effort: Optional[str] = None,
     # ACP transport overrides — lets a non-ACP parent spawn ACP child agents
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
@@ -1091,22 +1093,32 @@ def _build_child_agent(
         effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 
-    # Resolve reasoning config: delegation override > parent inherit
+    # Resolve reasoning config: per-task override > delegation override > parent inherit
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
     child_reasoning = parent_reasoning
     try:
-        delegation_effort = str(delegation_cfg.get("reasoning_effort") or "").strip()
-        if delegation_effort:
-            from hermes_constants import parse_reasoning_effort
+        from hermes_constants import parse_reasoning_effort
 
+        parsed = None
+        task_effort = str(override_reasoning_effort or "").strip()
+        if task_effort:
+            parsed = parse_reasoning_effort(task_effort)
+            if parsed is None:
+                logger.warning(
+                    "Unknown per-task reasoning_effort '%s', falling back to "
+                    "delegation.reasoning_effort",
+                    task_effort,
+                )
+        delegation_effort = str(delegation_cfg.get("reasoning_effort") or "").strip()
+        if parsed is None and delegation_effort:
             parsed = parse_reasoning_effort(delegation_effort)
-            if parsed is not None:
-                child_reasoning = parsed
-            else:
+            if parsed is None:
                 logger.warning(
                     "Unknown delegation.reasoning_effort '%s', inheriting parent level",
                     delegation_effort,
                 )
+        if parsed is not None:
+            child_reasoning = parsed
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
@@ -2111,26 +2123,41 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            # Per-task model/provider override (batch mode) — falls back to
+            # the call-level creds bundle when the task carries no override.
+            task_creds = _resolve_task_credentials(t, creds, parent_agent)
+            task_effort = t.get("reasoning_effort")
+            task_effort = (
+                task_effort.strip() if isinstance(task_effort, str) else ""
+            )
+            if task_creds is not creds:
+                logger.info(
+                    "delegate_task: task %d uses per-task override model=%s provider=%s",
+                    i,
+                    task_creds.get("model"),
+                    task_creds.get("provider"),
+                )
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=task_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=task_creds["provider"],
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
+                override_reasoning_effort=task_effort or None,
                 override_acp_command=t.get("acp_command")
                 or acp_command
-                or creds.get("command"),
+                or task_creds.get("command"),
                 override_acp_args=(
                     task_acp_args
                     if task_acp_args is not None
-                    else (acp_args if acp_args is not None else creds.get("args"))
+                    else (acp_args if acp_args is not None else task_creds.get("args"))
                 ),
                 role=effective_role,
             )
@@ -2569,6 +2596,45 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     }
 
 
+def _resolve_task_credentials(task: Dict[str, Any], creds: dict, parent_agent) -> dict:
+    """Resolve per-task model/provider overrides for one batch task.
+
+    Returns ``creds`` unchanged when the task carries no override, so the
+    default path is byte-identical to today's behavior.  Empty or non-string
+    values are ignored.  An unresolvable per-task provider logs a warning and
+    falls back to the call-level credentials so one bad task does not change
+    sibling behavior.
+    """
+    task_model = task.get("model")
+    task_model = task_model.strip() if isinstance(task_model, str) else ""
+    task_provider = task.get("provider")
+    task_provider = task_provider.strip() if isinstance(task_provider, str) else ""
+
+    if not task_model and not task_provider:
+        return creds
+
+    if task_provider:
+        try:
+            return _resolve_delegation_credentials(
+                {"provider": task_provider, "model": task_model or creds.get("model")},
+                parent_agent,
+            )
+        except ValueError as exc:
+            logger.warning(
+                "Per-task provider '%s' could not be resolved (%s); "
+                "falling back to delegation credentials for this task",
+                task_provider,
+                exc,
+            )
+            if not task_model:
+                return creds
+
+    # Model-only override: keep the call-level credential bundle, swap model.
+    task_creds = dict(creds)
+    task_creds["model"] = task_model
+    return task_creds
+
+
 def _load_config() -> dict:
     """Load delegation config from CLI_CONFIG or persistent config.
 
@@ -2848,6 +2914,30 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "string",
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Per-task model override for this subagent only. "
+                                "Default: the delegation-configured or parent model."
+                            ),
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": (
+                                "Per-task provider override for this subagent only "
+                                "(e.g. 'openrouter', 'nous'). Default: the "
+                                "delegation-configured or parent provider."
+                            ),
+                        },
+                        "reasoning_effort": {
+                            "type": "string",
+                            "description": (
+                                "Per-task reasoning effort override for this subagent "
+                                "only ('none', 'minimal', 'low', 'medium', 'high', "
+                                "'xhigh'). Default: delegation.reasoning_effort or "
+                                "the parent's level."
+                            ),
                         },
                     },
                     "required": ["goal"],


### PR DESCRIPTION
## What

Adds three **optional** per-task keys — `model`, `provider`, `reasoning_effort` — to `delegate_task` **batch** task items, so a single batch can fan work across models (e.g. a Fable 5 reasoning child alongside free OpenRouter workers) instead of every child inheriting one global delegation config.

## Why (concrete consumer)

A multi-model COO/CTO fleet routes bulk subtasks to free OpenRouter workers while keeping judgment/verification children on the brain model — in one `delegate_task` batch. Today that requires one config for all children. This is a real, in-use case, not a speculative hook.

## Footprint / core-schema discipline

This touches the model tool schema, so it's deliberately minimal:

- **Three optional keys, nothing else.** `required` stays `["goal"]`. No new top-level tool params.
- **Absent keys = byte-identical behavior.** Resolution is per-task → `delegation.*` → parent, exactly today's chain when omitted. `_resolve_task_credentials()` returns the existing call-level creds object unchanged when there's no override (identity-preserving) — **prompt-cache safe, no mid-conversation cache break**.
- **Graceful, non-fatal degradation.** Invalid `reasoning_effort` falls through to the existing default chain (existing warning text preserved); an unresolvable `provider` logs a warning and falls back to global delegation creds rather than erroring.
- **No new `HERMES_*` env var, no plugin-in-core, no telemetry.**

## Tests

`tests/tools/test_delegate_per_task_overrides.py` — 6 behavior-contract tests: schema keys present; model+effort override applied to the child; provider override; defaults unchanged when keys absent; empty/invalid values ignored; unresolvable provider falls back. The 140 pre-existing `test_delegate.py` tests are **unmodified and still pass** (146/146 green via `scripts/run_tests.sh`).

## Provenance

Built and run locally as commit `9164f676`. Cherry-pickable to preserve authorship.
