### PR TITLE
feat(skills): let profiles opt into default skills

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1613,10 +1613,9 @@ def build_skills_system_prompt(
 
     Falls back to a full filesystem scan when both layers miss.
 
-    External skill directories (``skills.external_dirs`` in config.yaml) are
-    scanned alongside the local ``~/.hermes/skills/`` directory.  External dirs
-    are read-only — they appear in the index but new skills are always created
-    in the local dir.  Local skills take precedence when names collide.
+    Additional visible skill directories — the explicitly included default
+    profile and ``skills.external_dirs`` — are scanned after the active
+    profile's local directory. Local skills take precedence when names collide.
 
     ``compact_categories`` (e.g. from the coding posture — see
     agent/coding_context.py) demotes whole categories to a names-only line in
@@ -1625,9 +1624,9 @@ def build_skills_system_prompt(
     descriptions are dropped, and a footer note explains the demotion.
     """
     skills_dir = get_skills_dir()
-    external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
+    additional_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
 
-    if not skills_dir.exists() and not external_dirs:
+    if not skills_dir.exists() and not additional_dirs:
         return ""
 
     # ── Layer 1: in-process LRU cache ─────────────────────────────────
@@ -1637,7 +1636,7 @@ def build_skills_system_prompt(
     disabled = get_disabled_skill_names(_platform_hint or None)
     cache_key = (
         str(skills_dir),
-        tuple(str(d) for d in external_dirs),
+        tuple(str(d) for d in additional_dirs),
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
@@ -1753,16 +1752,15 @@ def build_skills_system_prompt(
             category_descriptions,
         )
 
-    # ── External skill directories ─────────────────────────────────────
-    # Scan external dirs directly (no snapshot caching — they're read-only
-    # and typically small).  Local skills already in skills_by_category take
-    # precedence: we track seen names and skip duplicates from external dirs.
+    # ── Additional skill directories ───────────────────────────────────
+    # Scan additional roots directly. Local skills already in
+    # skills_by_category take precedence: track seen names and skip duplicates.
     seen_skill_names: set[str] = set()
     for cat_skills in skills_by_category.values():
         for name, _desc in cat_skills:
             seen_skill_names.add(name)
 
-    for ext_dir in external_dirs:
+    for ext_dir in additional_dirs:
         if not ext_dir.exists():
             continue
         for skill_file in iter_skill_index_files(ext_dir, "SKILL.md"):

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -348,7 +348,7 @@ def _build_skill_message(
         try:
             skill_view_target = str(skill_dir.relative_to(SKILLS_DIR))
         except ValueError:
-            # Skill is from an external dir — use the skill name instead
+            # Skill is from a non-local visible root — use its name instead
             skill_view_target = skill_dir.name
         parts.append("")
         parts.append("[This skill has supporting files:]")
@@ -382,16 +382,12 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     _skill_commands = {}
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
-        from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+        from agent.skill_utils import get_all_skills_dirs, iter_skill_index_files
         from hermes_cli.commands import resolve_command
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
 
-        # Scan local dir first, then external dirs
-        dirs_to_scan = []
-        if SKILLS_DIR.exists():
-            dirs_to_scan.append(SKILLS_DIR)
-        dirs_to_scan.extend(get_external_skills_dirs())
+        dirs_to_scan = list(get_all_skills_dirs(SKILLS_DIR))
 
         for scan_dir in dirs_to_scan:
             for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
@@ -485,9 +481,9 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
 def reload_skills() -> Dict[str, Any]:
     """Re-scan the skills directory and return a diff of what changed.
 
-    Rescans ``~/.hermes/skills/`` and any ``skills.external_dirs`` so the
-    slash-command map (``agent.skill_commands._skill_commands``) reflects
-    skills added or removed on disk.
+    Rescans every visible skill root so the slash-command map
+    (``agent.skill_commands._skill_commands``) reflects skills added or
+    removed on disk.
 
     This does NOT invalidate the skills system-prompt cache. Skills are
     called by name via ``/skill-name``, ``skills_list``, or ``skill_view``

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -12,7 +12,12 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from hermes_constants import get_config_path, get_skills_dir, is_termux
+from hermes_constants import (
+    get_config_path,
+    get_default_hermes_root,
+    get_skills_dir,
+    is_termux,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -579,14 +584,39 @@ def get_external_skills_dirs() -> List[Path]:
     return result
 
 
-def get_all_skills_dirs() -> List[Path]:
-    """Return all skill directories: local ``~/.hermes/skills/`` first, then external.
+def get_all_skills_dirs(local_skills_dir: Path | None = None) -> List[Path]:
+    """Return configured skill directories in precedence order.
 
-    The local dir is always first (and always included even if it doesn't exist
-    yet — callers handle that).  External dirs follow in config order.
+    The active profile's local directory is always first.  A named profile can
+    explicitly include the default profile's skills by setting
+    ``skills.include_default_profile: true``.  External dirs follow in config
+    order.  Resolved duplicate paths are included only once.
     """
-    dirs = [get_skills_dir()]
-    dirs.extend(get_external_skills_dirs())
+    local_skills = (
+        Path(local_skills_dir)
+        if local_skills_dir is not None
+        else get_skills_dir()
+    )
+    dirs = [local_skills]
+    seen = {local_skills.resolve()}
+
+    parsed = _load_raw_config()
+    skills_cfg = parsed.get("skills") if isinstance(parsed, dict) else None
+    if (
+        isinstance(skills_cfg, dict)
+        and skills_cfg.get("include_default_profile") is True
+    ):
+        default_skills = get_default_hermes_root() / "skills"
+        resolved_default = default_skills.resolve()
+        if resolved_default not in seen:
+            dirs.append(default_skills)
+            seen.add(resolved_default)
+
+    for external_dir in get_external_skills_dirs():
+        resolved_external = external_dir.resolve()
+        if resolved_external not in seen:
+            dirs.append(external_dir)
+            seen.add(resolved_external)
     return dirs
 
 
@@ -594,10 +624,10 @@ def normalize_skill_lookup_name(identifier: str) -> str:
     """Normalize a skill identifier to a ``skill_view()``-safe relative path.
 
     Slash commands and cron jobs may store absolute paths to skills that live
-    under ``~/.hermes/skills/`` (including via symlinks) or configured
-    ``skills.external_dirs``. ``skill_view()`` rejects absolute names for
-    security, so callers must translate trusted absolute paths to their
-    relative form first.
+    under the active profile, its explicitly included default-profile root, or
+    configured ``skills.external_dirs``. ``skill_view()`` rejects absolute
+    names for security, so callers must translate trusted absolute paths to
+    their relative form first.
     """
     raw_identifier = (identifier or "").strip()
     if not raw_identifier:
@@ -619,11 +649,10 @@ def normalize_skill_lookup_name(identifier: str) -> str:
     except Exception:
         primary_root = get_skills_dir()
 
-    trusted_roots = [primary_root]
     try:
-        trusted_roots.extend(get_external_skills_dirs())
+        trusted_roots = list(get_all_skills_dirs(primary_root))
     except Exception:
-        pass
+        trusted_roots = [primary_root]
 
     # Prefer the lexical path under a trusted skill root before resolving
     # symlinks. Slash-command discovery can legitimately find a skill via
@@ -656,16 +685,16 @@ def _resolve_for_skill_ownership(path) -> Path:
 
 
 def is_external_skill_path(path) -> bool:
-    """Return True when ``path`` lives under a configured external skills dir.
+    """Return True when ``path`` lives under a non-local skills root.
 
-    ``skills.external_dirs`` are externally owned: Hermes can discover and view
-    their skills, and foreground user-directed tool calls may still edit them,
-    but autonomous lifecycle maintenance must treat them as read-only. This
-    helper centralizes the ownership boundary so curator/reporting/tool paths do
-    not each need to re-interpret the config.
+    Configured external dirs and an explicitly included default-profile skills
+    dir are not owned by the active profile. Hermes can discover and view their
+    skills, and foreground user-directed tool calls may still edit them, but
+    autonomous lifecycle maintenance must treat them as read-only. This helper
+    centralizes that ownership boundary.
     """
     candidate = _resolve_for_skill_ownership(path)
-    for root in get_external_skills_dirs():
+    for root in get_all_skills_dirs()[1:]:
         resolved_root = _resolve_for_skill_ownership(root)
         try:
             candidate.relative_to(resolved_root)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -926,19 +926,15 @@ def _collect_gateway_skill_entries(
     try:
         from agent.skill_commands import get_skill_commands
         from tools.skills_tool import SKILLS_DIR
-        from agent.skill_utils import get_external_skills_dirs
-        _skills_dir = str(SKILLS_DIR.resolve())
+        from agent.skill_utils import get_all_skills_dirs
         _hub_dir = str((SKILLS_DIR / ".hub").resolve()).rstrip("/") + "/"
-        # Build set of allowed directory prefixes: local skills dir + any
-        # user-configured ``skills.external_dirs``. Ensure each prefix ends
-        # with ``/`` so ``/my-skills`` does not also match ``/my-skills-extra``.
-        # Without this widening, external skills are visible in
-        # ``hermes skills list`` and the agent's ``/skill-name`` dispatch but
-        # silently excluded from gateway slash menus (#8110).
-        _allowed_prefixes = [_skills_dir.rstrip("/") + "/"]
-        _allowed_prefixes.extend(
-            str(d).rstrip("/") + "/" for d in get_external_skills_dirs()
-        )
+        # Keep gateway menus aligned with skill discovery. Ensure each prefix
+        # ends with ``/`` so ``/my-skills`` does not also match
+        # ``/my-skills-extra``.
+        _allowed_prefixes = [
+            str(directory.resolve()).rstrip("/") + "/"
+            for directory in get_all_skills_dirs(SKILLS_DIR)
+        ]
         skill_cmds = get_skill_commands()
         for cmd_key in sorted(skill_cmds):
             info = skill_cmds[cmd_key]
@@ -1056,12 +1052,11 @@ def discord_skill_commands_by_category(
     scan root) are returned as
     *uncategorized*.
 
-    Scan roots include the local ``SKILLS_DIR`` **and** any configured
-    ``skills.external_dirs`` — matching the widened filter applied to the
-    flat ``discord_skill_commands()`` collector in #18741. Without this
-    parity, external-dir skills are visible via ``hermes skills list`` and
-    the agent's ``/skill-name`` dispatch but silently absent from Discord's
-    ``/skill`` autocomplete.
+    Scan roots include every visible skill directory — matching the widened
+    filter applied to the flat ``discord_skill_commands()`` collector in
+    #18741. Without this parity, non-local skills are visible via
+    ``hermes skills list`` and the agent's ``/skill-name`` dispatch but
+    silently absent from Discord's ``/skill`` autocomplete.
 
     Filtering mirrors :func:`discord_skill_commands`: hub skills excluded,
     per-platform disabled excluded, names clamped to 32 chars, descriptions
@@ -1106,17 +1101,16 @@ def discord_skill_commands_by_category(
 
     try:
         from agent.skill_commands import get_skill_commands
-        from agent.skill_utils import get_external_skills_dirs
+        from agent.skill_utils import get_all_skills_dirs
         from tools.skills_tool import SKILLS_DIR
 
-        _skills_dir = SKILLS_DIR.resolve()
         _hub_dir = (SKILLS_DIR / ".hub").resolve()
-        # Build list of (resolved_root, is_local) tuples. Each external dir
-        # becomes its own scan root for category derivation — a skill at
-        # ``<external>/mlops/foo/SKILL.md`` is still categorized as "mlops".
-        _scan_roots: list[_P] = [_skills_dir]
+        # Each visible directory becomes its own scan root for category
+        # derivation — a skill at ``<root>/mlops/foo/SKILL.md`` is still
+        # categorized as "mlops".
+        _scan_roots: list[_P] = []
         try:
-            for ext in get_external_skills_dirs():
+            for ext in get_all_skills_dirs(SKILLS_DIR):
                 try:
                     _scan_roots.append(_P(ext).resolve())
                 except Exception:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1828,10 +1828,13 @@ DEFAULT_CONFIG = {
         },
     },
 
-    # Skills — external skill directories for sharing skills across tools/agents.
-    # Each path is expanded (~, ${VAR}) and resolved.  Read-only — skill creation
-    # always goes to ~/.hermes/skills/.
+    # Skills — profile sharing and external skill directories.
+    # External paths are expanded (~, ${VAR}) and resolved. New skills are
+    # created locally; foreground edits update an existing skill where found.
     "skills": {
+        # Named profiles remain isolated by default. Opt in to also scan the
+        # default profile's skills after the active profile's local skills.
+        "include_default_profile": False,
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id

--- a/tests/agent/test_external_skills.py
+++ b/tests/agent/test_external_skills.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -62,6 +63,36 @@ class TestGetAllSkillsDirs:
             result = get_all_skills_dirs()
         assert result[0] == hermes_home / "skills"
         assert result[1] == external_skills_dir.resolve()
+
+    def test_default_profile_skills_require_explicit_opt_in(
+        self, tmp_path, external_skills_dir
+    ):
+        hermes_root = tmp_path / ".hermes"
+        profile_home = hermes_root / "profiles" / "coder"
+        profile_skills = profile_home / "skills"
+        default_skills = hermes_root / "skills"
+        profile_skills.mkdir(parents=True)
+        default_skills.mkdir(parents=True)
+        (profile_home / "config.yaml").write_text(
+            "skills:\n"
+            "  include_default_profile: true\n"
+            "  external_dirs:\n"
+            f"    - {external_skills_dir}\n"
+        )
+
+        with (
+            patch.object(Path, "home", return_value=tmp_path),
+            patch.dict(os.environ, {"HERMES_HOME": str(profile_home)}),
+        ):
+            from agent.skill_utils import get_all_skills_dirs
+
+            result = get_all_skills_dirs()
+
+        assert result == [
+            profile_skills,
+            default_skills,
+            external_skills_dir.resolve(),
+        ]
 
 
 class TestExternalSkillsInFindAll:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -4,6 +4,7 @@ import builtins
 import importlib
 import logging
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -281,6 +282,38 @@ class TestBuildSkillsSystemPrompt:
         clear_skills_system_prompt_cache(clear_snapshot=True)
 
 
+
+    def test_named_profile_default_skills_follow_explicit_opt_in(
+        self, monkeypatch, tmp_path
+    ):
+        hermes_root = tmp_path / ".hermes"
+        profile_home = hermes_root / "profiles" / "coder"
+        profile_skill = profile_home / "skills" / "coding" / "profile-skill"
+        default_skill = hermes_root / "skills" / "shared" / "default-skill"
+        profile_skill.mkdir(parents=True)
+        default_skill.mkdir(parents=True)
+        (profile_skill / "SKILL.md").write_text(
+            "---\nname: profile-skill\ndescription: Profile skill\n---\n"
+        )
+        (default_skill / "SKILL.md").write_text(
+            "---\nname: default-skill\ndescription: Default skill\n---\n"
+        )
+        (profile_home / "config.yaml").write_text("skills: {}\n")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        isolated = build_skills_system_prompt()
+        assert "profile-skill" in isolated
+        assert "default-skill" not in isolated
+
+        (profile_home / "config.yaml").write_text(
+            "skills:\n  include_default_profile: true\n"
+        )
+
+        shared = build_skills_system_prompt()
+        assert "profile-skill" in shared
+        assert "default-skill" in shared
 
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -919,5 +952,4 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -1,5 +1,6 @@
 """Tests for agent/skill_utils.py."""
 
+from pathlib import Path
 from unittest.mock import patch
 
 from agent.skill_utils import (
@@ -73,6 +74,28 @@ skills:
 
 
 
+
+
+def test_default_profile_skill_is_non_local_when_opted_in(tmp_path, monkeypatch):
+    from agent import skill_utils
+
+    hermes_root = tmp_path / ".hermes"
+    profile_home = hermes_root / "profiles" / "coder"
+    profile_skills = profile_home / "skills"
+    default_skills = hermes_root / "skills"
+    profile_skills.mkdir(parents=True)
+    default_skills.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text(
+        "skills:\n  include_default_profile: true\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    skill_utils._external_dirs_cache_clear()
+
+    assert is_external_skill_path(default_skills / "shared" / "SKILL.md") is True
+    assert is_external_skill_path(profile_skills / "local" / "SKILL.md") is False
 
 
 def test_iter_skill_index_files_prunes_skill_support_dirs(tmp_path):
@@ -193,6 +216,30 @@ class TestNormalizeSkillLookupName:
         # Relative identifiers early-return before any root lookup.
         assert normalize_skill_lookup_name("foo/bar") == "foo/bar"
 
+
+    def test_absolute_under_opted_in_default_profile_becomes_relative(
+        self, tmp_path, monkeypatch
+    ):
+        from agent import skill_utils
+        from agent.skill_utils import normalize_skill_lookup_name
+
+        hermes_root = tmp_path / ".hermes"
+        profile_home = hermes_root / "profiles" / "coder"
+        profile_skills = profile_home / "skills"
+        default_skill = hermes_root / "skills" / "shared" / "runbook"
+        profile_skills.mkdir(parents=True)
+        default_skill.mkdir(parents=True)
+        (profile_home / "config.yaml").write_text(
+            "skills:\n  include_default_profile: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", profile_skills)
+        skill_utils._external_dirs_cache_clear()
+
+        assert normalize_skill_lookup_name(str(default_skill)) == "shared/runbook"
 
     def test_absolute_via_symlink_uses_lexical_relative_path(self, tmp_path, monkeypatch):
         from agent.skill_utils import normalize_skill_lookup_name

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -1,5 +1,7 @@
 """Tests for the central command registry and autocomplete."""
 
+from pathlib import Path
+
 from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.document import Document
 
@@ -702,6 +704,40 @@ class TestTelegramMenuCommands:
         assert "lookalike_skill" not in menu_names, (
             "prefix-match sibling directories must not be admitted"
         )
+
+    def test_opted_in_default_profile_skill_appears_in_telegram_menu(
+        self, tmp_path, monkeypatch
+    ):
+        from unittest.mock import patch
+
+        hermes_root = tmp_path / ".hermes"
+        profile_home = hermes_root / "profiles" / "coder"
+        local_dir = profile_home / "skills"
+        default_dir = hermes_root / "skills"
+        local_dir.mkdir(parents=True)
+        default_dir.mkdir(parents=True)
+        (profile_home / "config.yaml").write_text(
+            "skills:\n  include_default_profile: true\n",
+            encoding="utf-8",
+        )
+        fake_cmds = {
+            "/shared-runbook": {
+                "name": "shared-runbook",
+                "description": "Default profile skill",
+                "skill_md_path": f"{default_dir}/shared-runbook/SKILL.md",
+                "skill_dir": f"{default_dir}/shared-runbook",
+            }
+        }
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        with (
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", local_dir),
+        ):
+            menu, _ = telegram_menu_commands(max_commands=100)
+
+        assert "shared_runbook" in {name for name, _ in menu}
 
     def test_special_chars_in_skill_names_sanitized(self, tmp_path, monkeypatch):
         """Skills with +, /, or other special chars produce valid Telegram names."""

--- a/tests/tools/test_skills_tool_profile_scope.py
+++ b/tests/tools/test_skills_tool_profile_scope.py
@@ -54,6 +54,61 @@ def test_skill_view_uses_live_profile_home_after_module_import(tmp_path, monkeyp
     assert "orchestrator profile" in result["content"]
 
 
+def test_skills_list_can_include_default_profile_when_enabled(tmp_path, monkeypatch):
+    """A named profile may explicitly opt into the default profile's skills."""
+    hermes_root = tmp_path / ".hermes"
+    profile_home = hermes_root / "profiles" / "orchestrator"
+    _write_skill(hermes_root, "autonomous-ai-agents", "default-only", "default home")
+    _write_skill(
+        profile_home,
+        "software-development",
+        "kanban-orchestrator-operations",
+        "orchestrator profile",
+    )
+    (profile_home / "config.yaml").write_text(
+        "skills:\n  include_default_profile: true\n",
+        encoding="utf-8",
+    )
+
+    skills_tool = _reload_skills_tool(hermes_root, monkeypatch)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    result = json.loads(skills_tool.skills_list())
+    names = {skill["name"] for skill in result["skills"]}
+
+    assert result["success"] is True
+    assert "kanban-orchestrator-operations" in names
+    assert "default-only" in names
+
+
+def test_skill_view_can_load_default_profile_when_enabled(tmp_path, monkeypatch):
+    """The opt-in applies to direct skill loading as well as discovery."""
+    hermes_root = tmp_path / ".hermes"
+    profile_home = hermes_root / "profiles" / "orchestrator"
+    default_skill_dir = _write_skill(
+        hermes_root,
+        "autonomous-ai-agents",
+        "default-only",
+        "default home",
+    )
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text(
+        "skills:\n  include_default_profile: true\n",
+        encoding="utf-8",
+    )
+
+    skills_tool = _reload_skills_tool(hermes_root, monkeypatch)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    result = json.loads(skills_tool.skill_view("default-only", preprocess=False))
+
+    assert result["success"] is True
+    assert Path(result["skill_dir"]) == default_skill_dir
+    assert "default home" in result["content"]
+
+
 def test_explicit_skills_dir_monkeypatch_still_wins(tmp_path, monkeypatch):
     """Existing tests can still override tools.skills_tool.SKILLS_DIR directly."""
     default_home = tmp_path / "default-home"

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -565,16 +565,15 @@ def _get_category_from_path(skill_path: Path) -> Optional[str]:
     Extract category from skill path based on directory structure.
 
     For paths like: ~/.hermes/skills/mlops/axolotl/SKILL.md -> "mlops"
-    Also works for external skill dirs configured via skills.external_dirs.
+    Also works for explicitly included default-profile and external roots.
     """
-    # Try the active profile skills dir first (respects monkeypatching in tests),
-    # then fall back to external dirs from config.
-    dirs_to_check = [_skills_dir()]
+    # Try visible skill roots in precedence order while preserving the live
+    # active-profile directory (and explicit test monkeypatches).
     try:
-        from agent.skill_utils import get_external_skills_dirs
-        dirs_to_check.extend(get_external_skills_dirs())
+        from agent.skill_utils import get_all_skills_dirs
+        dirs_to_check = list(get_all_skills_dirs(_skills_dir()))
     except Exception:
-        pass
+        dirs_to_check = [_skills_dir()]
     for skills_dir in dirs_to_check:
         try:
             rel_path = skill_path.relative_to(skills_dir)
@@ -668,7 +667,7 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
 
 
 def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
-    """Recursively find all skills in ~/.hermes/skills/ and external dirs.
+    """Recursively find all skills visible to the active profile.
 
     Args:
         skip_disabled: If True, return ALL skills regardless of disabled
@@ -682,7 +681,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     signature changes (dir/category mtimes or the disabled-set) and expires
     after a short TTL to bound staleness from in-place SKILL.md edits.
     """
-    from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+    from agent.skill_utils import get_all_skills_dirs, iter_skill_index_files
 
     cache_key = _SKILLS_CACHE_KEY_DISABLED if skip_disabled else _SKILLS_CACHE_KEY_FILTERED
 
@@ -693,11 +692,8 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     # Collect directories to scan — same resolution as the scan loop below
     # (_skills_dir() resolves the LIVE profile HERMES_HOME; the module-level
     # SKILLS_DIR can be stale in long-lived runtimes).
-    dirs_to_scan: list = []
     active_skills_dir = _skills_dir()
-    if active_skills_dir.exists():
-        dirs_to_scan.append(active_skills_dir)
-    dirs_to_scan.extend(get_external_skills_dirs())
+    dirs_to_scan = list(get_all_skills_dirs(active_skills_dir))
 
     signature = _skills_scan_signature(dirs_to_scan, disabled)
     now = time.monotonic()
@@ -716,7 +712,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     skills = []
     seen_names: set = set()
 
-    # Scan local dir first, then external dirs (local takes precedence) —
+    # Scan visible roots in precedence order —
     # dirs_to_scan already resolved above for the signature.
     for scan_dir in dirs_to_scan:
         for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
@@ -1152,7 +1148,7 @@ def skill_view(
             if bare:
                 local_category_name = f"{namespace}/{bare}"
 
-        from agent.skill_utils import get_external_skills_dirs
+        from agent.skill_utils import get_all_skills_dirs
 
         # The categorized fall-through form (namespace/bare) joins onto each
         # search dir too; re-validate it since `bare` is not namespace-checked.
@@ -1169,13 +1165,10 @@ def skill_view(
                 )
 
         # Build list of all skill directories to search
-        all_dirs = []
         active_skills_dir = _skills_dir()
-        if active_skills_dir.exists():
-            all_dirs.append(active_skills_dir)
-        all_dirs.extend(get_external_skills_dirs())
+        all_dirs = list(get_all_skills_dirs(active_skills_dir))
 
-        if not all_dirs:
+        if not any(directory.is_dir() for directory in all_dirs):
             return json.dumps(
                 {
                     "success": False,
@@ -1279,7 +1272,7 @@ def skill_view(
                     "success": False,
                     "error": (
                         f"Ambiguous skill name '{name}': {len(candidates)} skills "
-                        "match across your local skills dir and external_dirs. "
+                        "match across your configured skill directories. "
                         "Refusing to guess — load one explicitly by its categorized path."
                     ),
                     "matches": paths,
@@ -1319,8 +1312,7 @@ def skill_view(
                 ensure_ascii=False,
             )
 
-        # Security: warn if skill is loaded from outside trusted directories
-        # (local skills dir + configured external_dirs are all trusted)
+        # Security: warn if skill is loaded from outside visible skill roots.
         _outside_skills_dir = True
         _trusted_dirs = [active_skills_dir.resolve()]
         try:

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -8,9 +8,15 @@ description: "On-demand knowledge documents — progressive disclosure, agent-ma
 
 Skills are on-demand knowledge documents the agent can load when needed. They follow a **progressive disclosure** pattern to minimize token usage and are compatible with the [agentskills.io](https://agentskills.io/specification) open standard.
 
-All skills live in **`~/.hermes/skills/`** — the primary directory and source of truth. On fresh install, bundled skills are copied from the repo. Hub-installed and agent-created skills also go here. The agent can modify or delete any skill.
+Each profile has its own local skills directory. The default profile uses
+**`~/.hermes/skills/`**; named profiles use
+**`~/.hermes/profiles/<name>/skills/`**. On fresh install, bundled skills are
+copied into the active profile. Hub-installed and agent-created skills also go
+there.
 
-You can also point Hermes at **external skill directories** — additional folders scanned alongside the local one. See [External Skill Directories](#external-skill-directories) below.
+Named profiles keep their own skills isolated by default. They can explicitly
+reuse the default profile's skills, or point Hermes at **external skill
+directories**. See the sharing options below.
 
 See also:
 
@@ -330,6 +336,38 @@ and `examples/`. Unreferenced repository files are not copied. Hermes scans the
 complete quarantined bundle and records the source URL, exact content hash,
 scanner version, findings, timestamp, and fresh-or-cached status in
 `skills/.hub/lock.json`.
+
+## Reusing Default Profile Skills
+
+Named profiles normally scan only their own directory:
+`~/.hermes/profiles/<name>/skills/`. Skills installed in the default profile at
+`~/.hermes/skills/` stay hidden.
+
+To let one named profile also use the default profile's skills, enable the
+option in that profile's `config.yaml`:
+
+```yaml
+skills:
+  include_default_profile: true
+```
+
+This is opt-in and does not weaken isolation for any other profile. The search
+order becomes:
+
+1. The active profile's local skills
+2. The default profile's skills
+3. `skills.external_dirs`, in configured order
+
+The additional skills appear in the system prompt index, `skills_list`,
+`skill_view`, and generated slash-command menus. Listings and the prompt index
+prefer the first matching name. Direct `skill_view` calls retain the normal
+collision check and may require a distinct categorized path or renaming when
+multiple skills match.
+
+The included default-profile directory follows the same foreground editing
+semantics as `external_dirs`: an explicit `skill_manage` edit updates the skill
+where it is found. Autonomous lifecycle maintenance treats it as non-local and
+does not modify it.
 
 ## External Skill Directories
 


### PR DESCRIPTION
## What changed

Named profiles continue to see only their own skills by default, preserving the profile-isolation contract. A profile that intentionally wants to reuse the default profile's skills can now opt in with:

```yaml
skills:
  include_default_profile: true
```

When enabled, the search order is:

1. Active profile skills
2. Default profile skills
3. `skills.external_dirs`

The first matching skill name remains preferred for listings and prompt discovery. This replaces the original unconditional fallback proposal in response to review: sharing is explicit, default-off, and scoped to the profile that enables it.

Closes #32773.

## Implementation

- Centralize visible skill-root resolution in `get_all_skills_dirs()`.
- Apply the same roots to the prompt index, `skills_list`, `skill_view`, slash commands, and generated gateway menus.
- Treat an opted-in default-profile root as non-local for autonomous skill lifecycle maintenance.
- Document the setting and its precedence rules.

## Validation

- `scripts/run_tests.sh tests/agent/test_external_skills.py tests/agent/test_prompt_builder.py tests/agent/test_skill_utils.py tests/hermes_cli/test_commands.py tests/tools/test_skills_tool_profile_scope.py --basetemp=/dev/shm/hermes-agent-pr53534-opt-in -j 1` — 379 passed
- `./.venv/bin/ruff check agent/prompt_builder.py agent/skill_commands.py agent/skill_utils.py hermes_cli/commands.py hermes_cli/config.py tools/skills_tool.py` — passed

Tested on Ubuntu 24.04.