### PR TITLE
fix: restore root-only deps after workspace install in hermes update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7850,6 +7850,25 @@ def _update_node_dependencies() -> None:
         if stderr:
             print(f"    {stderr.splitlines()[-1]}")
 
+    # Step 3: re-restore root-only deps (e.g. agent-browser) that step 2's
+    # ``npm ci`` may have wiped.  Use plain ``npm install`` (additive) — NOT
+    # ``npm ci`` (which deletes node_modules first) — so workspace packages
+    # installed in step 2 survive.  --no-package-lock prevents lockfile drift.
+    restore_env = {**os.environ, **nixos_env, "CI": "1"}
+    restore_result = subprocess.run(
+        [npm, "install", *extra_args, "--workspaces=false", "--no-package-lock"],
+        cwd=PROJECT_ROOT,
+        env=restore_env,
+        capture_output=False,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if restore_result.returncode != 0:
+        print("  ⚠ root-only dep restore failed")
+        print("    Run manually: npm install --workspaces=false")
+
 
 class _UpdateOutputStream:
     """Stream wrapper used during ``hermes update`` to survive terminal loss.


### PR DESCRIPTION
## Problem

`hermes update` silently loses root-only npm dependencies (notably `agent-browser`) on every run.

## Root Cause

`_update_node_dependencies()` in `hermes_cli/main.py` runs a two-step `npm ci`:

1. **Step 1:** `npm ci --workspaces=false` — installs root-only deps (including `agent-browser`)
2. **Step 2:** `npm ci --workspace ui-tui --workspace web` — installs workspace deps

`npm ci` deletes the entire `node_modules/` directory before installing. Step 2 wipes root-only deps that no workspace declares as a dependency. Since `agent-browser` is declared only in the root `package.json` (no workspace depends on it), Step 2 does not reinstall it.

**Result:** after every `hermes update`, `agent-browser` is gone. Users see `⚠ agent-browser not installed` in `hermes doctor` and must manually reinstall it.

## Fix

Add **Step 3** after the workspace install: a plain `npm install --workspaces=false --no-package-lock` that additively restores root-only deps.

- Uses `npm install` (not `npm ci`) — additive, does not delete `node_modules/`, so workspace packages from Step 2 survive
- `--no-package-lock` prevents lockfile drift
- `CI=1` env matches the existing steps' convention (suppresses postinstall animations)

## Verification

- Python syntax check: `ast.parse` passes
- `hermes doctor` confirms `✓ agent-browser (Node.js)` after install
- Step 3 is idempotent — `npm install` is a no-op when deps are already present

## Test Plan

- [ ] Run `hermes update` and confirm `agent-browser` survives in `node_modules/`
- [ ] Run `hermes doctor` — no `agent-browser not installed` warning
- [ ] Verify workspace packages (ui-tui, web) are not affected by Step 3