### PR TITLE
feat(cli): clamp streaming reasoning like the non-streaming recap

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -54,6 +54,11 @@ import yaml
 from hermes_cli.fallback_config import get_fallback_chain
 from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
 from hermes_cli.cli_commands_mixin import CLICommandsMixin
+from hermes_cli.reasoning_clamp import (
+    StreamingReasoningClamp,
+    clamp_lines,
+    clamp_notice,
+)
 
 # prompt_toolkit for fixed input area TUI
 from prompt_toolkit.history import FileHistory
@@ -5233,6 +5238,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # Open reasoning box on first reasoning token
         if not getattr(self, "_reasoning_box_opened", False):
             self._reasoning_box_opened = True
+            # Start a fresh line-clamp for this box so streamed reasoning
+            # honors /reasoning clamp just like the non-streaming recap.
+            self._reasoning_clamp = StreamingReasoningClamp(
+                getattr(self, "reasoning_full", False)
+            )
             w = self._scrollback_box_width()
             r_label = " Reasoning "
             r_fill = w - 2 - len(r_label)
@@ -5241,25 +5251,37 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._reasoning_buf = getattr(self, "_reasoning_buf", "") + text
 
         # Emit complete lines, and force-flush long partial lines so
-        # reasoning is visible in real-time even without newlines.
+        # reasoning is visible in real-time even without newlines.  Each line
+        # passes through the clamp: past the threshold it's counted but not
+        # printed (the hidden total is surfaced when the box closes).
+        clamp = getattr(self, "_reasoning_clamp", None)
         while "\n" in self._reasoning_buf:
             line, self._reasoning_buf = self._reasoning_buf.split("\n", 1)
-            _cprint(f"{_DIM}{line}{_RST}")
+            if clamp is None or clamp.should_show():
+                _cprint(f"{_DIM}{line}{_RST}")
         if len(self._reasoning_buf) > 80:
-            _cprint(f"{_DIM}{self._reasoning_buf}{_RST}")
+            if clamp is None or clamp.should_show():
+                _cprint(f"{_DIM}{self._reasoning_buf}{_RST}")
             self._reasoning_buf = ""
 
     def _close_reasoning_box(self) -> None:
         """Close the live reasoning box if it's open."""
         if getattr(self, "_reasoning_box_opened", False):
-            # Flush remaining reasoning buffer
+            clamp = getattr(self, "_reasoning_clamp", None)
+            # Flush remaining reasoning buffer (still subject to the clamp).
             buf = getattr(self, "_reasoning_buf", "")
             if buf:
-                _cprint(f"{_DIM}{buf}{_RST}")
+                if clamp is None or clamp.should_show():
+                    _cprint(f"{_DIM}{buf}{_RST}")
                 self._reasoning_buf = ""
+            # Surface how many lines were withheld by the clamp.
+            hidden = getattr(clamp, "hidden", 0) if clamp is not None else 0
+            if hidden:
+                _cprint(f"{_DIM}  {clamp_notice(hidden)}{_RST}")
             w = self._scrollback_box_width()
             _cprint(f"{_DIM}└{'─' * (w - 2)}┘{_RST}")
             self._reasoning_box_opened = False
+            self._reasoning_clamp = None
 
             # Flush any content that was deferred while reasoning was rendering.
             deferred = getattr(self, "_deferred_content", "")
@@ -5562,6 +5584,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._in_reasoning_block = False
         self._stream_last_was_newline = True
         self._reasoning_box_opened = False
+        self._reasoning_clamp = None
         self._reasoning_buf = ""
         self._reasoning_preview_buf = ""
         self._deferred_content = ""
@@ -11967,14 +11990,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     r_fill = w - 2 - len(r_label)
                     r_top = f"{_DIM}┌─{r_label}{'─' * max(r_fill - 1, 0)}┐{_RST}"
                     r_bot = f"{_DIM}└{'─' * (w - 2)}┘{_RST}"
-                    # Collapse long reasoning to the first 10 lines unless the
-                    # user opted into full display via /reasoning full.
+                    # Collapse long reasoning unless the user opted into full
+                    # display via /reasoning full.  Shares the threshold and
+                    # footer with the streaming path (hermes_cli.reasoning_clamp).
                     lines = reasoning.strip().splitlines()
-                    if len(lines) > 10 and not getattr(self, "reasoning_full", False):
-                        display_reasoning = "\n".join(lines[:10])
-                        display_reasoning += f"\n{_DIM}  ... ({len(lines) - 10} more lines — /reasoning full to show){_RST}"
-                    else:
-                        display_reasoning = reasoning.strip()
+                    visible, hidden = clamp_lines(
+                        lines, getattr(self, "reasoning_full", False)
+                    )
+                    display_reasoning = "\n".join(visible)
+                    if hidden:
+                        display_reasoning += f"\n{_DIM}  {clamp_notice(hidden)}{_RST}"
                     _cprint(f"\n{r_top}\n{_DIM}{display_reasoning}{_RST}\n{r_bot}")
 
             if response and not response_previewed:

--- a/hermes_cli/reasoning_clamp.py
+++ b/hermes_cli/reasoning_clamp.py
@@ -1,0 +1,64 @@
+"""Shared reasoning-display clamp logic for the interactive CLI.
+
+The ``/reasoning`` clamp limits how much model thinking is shown: the first
+``REASONING_CLAMP_LINES`` lines, then a "... (N more lines)" footer. This
+module is the single source of truth for the threshold, the footer text, and
+the line-counting, so the streaming reasoning path (``_stream_reasoning_delta``)
+and the non-streaming recap box (``_render_assistant_response``) behave
+identically and stay in sync. Controlled by the ``display.reasoning_full``
+flag (``/reasoning full`` / ``/reasoning clamp``).
+
+Kept dependency-free and pure so it is trivially unit-testable without
+importing the heavyweight ``cli`` module.
+"""
+
+from __future__ import annotations
+
+# Max reasoning lines shown before the clamp kicks in. Hardcoded (not a config
+# key) on purpose: the non-streaming path has used 10 for a long time and a
+# configurable threshold adds surface for little value. See issue #53529.
+REASONING_CLAMP_LINES = 10
+
+
+def clamp_notice(hidden_lines: int) -> str:
+    """Footer shown when reasoning was clamped. Identical across both paths."""
+    return f"... ({hidden_lines} more lines - /reasoning full to show)"
+
+
+def clamp_lines(
+    lines: list[str], show_full: bool, threshold: int = REASONING_CLAMP_LINES,
+) -> tuple[list[str], int]:
+    """Split a full reasoning block into (visible_lines, hidden_count).
+
+    When ``show_full`` is set, or the block is within ``threshold`` lines,
+    everything is visible and ``hidden_count`` is 0. Used by the non-streaming
+    recap box, which has the whole block up front.
+    """
+    if show_full or len(lines) <= threshold:
+        return lines, 0
+    return lines[:threshold], len(lines) - threshold
+
+
+class StreamingReasoningClamp:
+    """Incremental counterpart to :func:`clamp_lines` for streamed reasoning.
+
+    The streaming path receives reasoning one line at a time and cannot see
+    the whole block up front. Call :meth:`should_show` once per line as it is
+    about to be printed: it returns ``True`` while under the threshold (or when
+    ``show_full`` is set) and otherwise returns ``False`` and counts the line
+    as hidden. After the box closes, :attr:`hidden` holds the suppressed count
+    for :func:`clamp_notice`.
+    """
+
+    def __init__(self, show_full: bool, threshold: int = REASONING_CLAMP_LINES):
+        self.show_full = show_full
+        self.threshold = threshold
+        self.emitted = 0
+        self.hidden = 0
+
+    def should_show(self) -> bool:
+        self.emitted += 1
+        if self.show_full or self.emitted <= self.threshold:
+            return True
+        self.hidden += 1
+        return False

--- a/tests/cli/test_streaming_reasoning_clamp.py
+++ b/tests/cli/test_streaming_reasoning_clamp.py
@@ -1,0 +1,63 @@
+"""Integration test: streaming reasoning honors the /reasoning clamp.
+
+Drives the real HermesCLI._stream_reasoning_delta / _close_reasoning_box with
+_cprint captured, proving the streaming path now clamps to the shared
+threshold (issue #53529) instead of flooding every line to the terminal.
+"""
+
+import pytest
+
+
+def _make_cli():
+    import cli
+    obj = object.__new__(cli.HermesCLI)
+    obj.reasoning_full = False
+    # Shadow the width helper so the box borders render without a real terminal.
+    obj._scrollback_box_width = lambda *a, **k: 60
+    return obj
+
+
+def _capture(monkeypatch):
+    import cli
+    printed = []
+    monkeypatch.setattr(cli, "_cprint", lambda *a, **k: printed.append(a[0] if a else ""))
+    return printed
+
+
+def test_streaming_reasoning_is_clamped(monkeypatch):
+    printed = _capture(monkeypatch)
+    obj = _make_cli()
+
+    obj._stream_reasoning_delta("".join(f"line{i}\n" for i in range(25)))
+    obj._close_reasoning_box()
+
+    text = "\n".join(printed)
+    assert "line9" in text          # 10th line still shown
+    assert "line10" not in text     # 11th line clamped away
+    assert "15 more lines" in text  # 25 - 10 hidden
+    assert "/reasoning full" in text
+
+
+def test_streaming_reasoning_full_shows_everything(monkeypatch):
+    printed = _capture(monkeypatch)
+    obj = _make_cli()
+    obj.reasoning_full = True
+
+    obj._stream_reasoning_delta("".join(f"line{i}\n" for i in range(25)))
+    obj._close_reasoning_box()
+
+    text = "\n".join(printed)
+    assert "line24" in text         # nothing clamped
+    assert "more lines" not in text  # no footer
+
+
+def test_streaming_reasoning_short_block_no_footer(monkeypatch):
+    printed = _capture(monkeypatch)
+    obj = _make_cli()
+
+    obj._stream_reasoning_delta("".join(f"line{i}\n" for i in range(4)))
+    obj._close_reasoning_box()
+
+    text = "\n".join(printed)
+    assert "line3" in text
+    assert "more lines" not in text

--- a/tests/hermes_cli/test_reasoning_clamp.py
+++ b/tests/hermes_cli/test_reasoning_clamp.py
@@ -1,0 +1,80 @@
+"""Tests for the shared reasoning-clamp logic (hermes_cli/reasoning_clamp.py).
+
+These cover the pure threshold/footer/counter primitives that both the
+streaming and non-streaming reasoning paths share, so a regression in either
+path shows up here first.
+"""
+
+from hermes_cli.reasoning_clamp import (
+    REASONING_CLAMP_LINES,
+    StreamingReasoningClamp,
+    clamp_lines,
+    clamp_notice,
+)
+
+
+def test_threshold_default_is_ten():
+    # The non-streaming recap historically clamped at 10; keep parity.
+    assert REASONING_CLAMP_LINES == 10
+
+
+def test_clamp_notice_is_ascii_and_mentions_count():
+    notice = clamp_notice(7)
+    assert "7 more lines" in notice
+    assert "/reasoning full" in notice
+    assert notice.isascii()
+
+
+class TestClampLines:
+    def test_short_block_unchanged(self):
+        lines = ["a", "b", "c"]
+        visible, hidden = clamp_lines(lines, show_full=False, threshold=10)
+        assert visible == lines
+        assert hidden == 0
+
+    def test_exactly_threshold_not_clamped(self):
+        lines = [str(i) for i in range(10)]
+        visible, hidden = clamp_lines(lines, show_full=False, threshold=10)
+        assert visible == lines
+        assert hidden == 0
+
+    def test_over_threshold_clamped(self):
+        lines = [str(i) for i in range(25)]
+        visible, hidden = clamp_lines(lines, show_full=False, threshold=10)
+        assert visible == lines[:10]
+        assert hidden == 15
+
+    def test_show_full_disables_clamp(self):
+        lines = [str(i) for i in range(50)]
+        visible, hidden = clamp_lines(lines, show_full=True, threshold=10)
+        assert visible == lines
+        assert hidden == 0
+
+
+class TestStreamingReasoningClamp:
+    def test_shows_up_to_threshold_then_hides(self):
+        clamp = StreamingReasoningClamp(show_full=False, threshold=3)
+        results = [clamp.should_show() for _ in range(5)]
+        assert results == [True, True, True, False, False]
+        assert clamp.hidden == 2
+        assert clamp.emitted == 5
+
+    def test_show_full_never_hides(self):
+        clamp = StreamingReasoningClamp(show_full=True, threshold=3)
+        assert all(clamp.should_show() for _ in range(20))
+        assert clamp.hidden == 0
+
+    def test_under_threshold_no_hidden(self):
+        clamp = StreamingReasoningClamp(show_full=False, threshold=10)
+        for _ in range(4):
+            clamp.should_show()
+        assert clamp.hidden == 0
+
+    def test_hidden_count_matches_clamp_lines(self):
+        # The streaming counter and the batch splitter must agree.
+        lines = [str(i) for i in range(30)]
+        clamp = StreamingReasoningClamp(show_full=False, threshold=10)
+        for _ in lines:
+            clamp.should_show()
+        _, batch_hidden = clamp_lines(lines, show_full=False, threshold=10)
+        assert clamp.hidden == batch_hidden


### PR DESCRIPTION
## What does this PR do?

The `/reasoning` clamp limits displayed model thinking to the first 10 lines with a "... (N more lines)" footer. This worked for the **non-streaming** recap box (`_render_assistant_response`) but had **no effect on the streaming path** (`_stream_reasoning_delta`) - every token line was printed in real time. On long-thinking models that floods the terminal with hundreds of dim lines every turn, regardless of the clamp setting.

This makes the streaming path honor the same clamp, and unifies both paths on a single shared threshold + footer so they can't drift apart again - exactly what the issue asks ("Both paths should reference the same threshold constant").

## Related Issue

Closes #53529

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/reasoning_clamp.py` (new) - dependency-free, unit-testable home for the shared logic: `REASONING_CLAMP_LINES` (10), `clamp_notice()`, `clamp_lines()` (batch, for the non-streaming recap), and `StreamingReasoningClamp` (incremental counter, for streaming).
- `cli.py`:
  - `_stream_reasoning_delta` - starts a `StreamingReasoningClamp` when the reasoning box opens and gates each rendered line through it; past the threshold lines are counted but not printed.
  - `_close_reasoning_box` - flushes the tail through the same clamp and prints the "... (N more lines - /reasoning full to show)" footer with the hidden count.
  - `_render_assistant_response` - non-streaming recap now uses `clamp_lines()` / `clamp_notice()` instead of an inline hardcoded `10`.
  - `_reset_stream_state` - resets the per-turn clamp.
- Behaviour stays controlled by the existing `display.reasoning_full` flag (`/reasoning full` / `/reasoning clamp`). No new config key (per the issue's rejected-alternatives note).

## How to Test

1. Run a long-thinking model with reasoning shown and the clamp on (default).
2. Send a prompt that produces a long thinking block.
3. Streaming reasoning now stops after 10 lines and shows "... (N more lines - /reasoning full to show)" when the box closes; `/reasoning full` shows everything.

Automated:
- `pytest tests/hermes_cli/test_reasoning_clamp.py -q` (shared threshold/footer/counter)
- `pytest tests/cli/test_streaming_reasoning_clamp.py -q` (drives the real streaming render path with `_cprint` captured)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (no open PR references #53529)
- [x] My PR contains **only** changes related to this feature
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] No new config keys (reuses `display.reasoning_full`) - `cli-config.yaml.example` N/A
- [x] No user-facing docs claim streaming reasoning is exempt from the clamp, so no doc change needed
- [x] Cross-platform: pure Python line-counting; ruff + `scripts/check-windows-footguns.py` clean
