### PR TITLE
fix(qqbot): add missing is_reconnect kwarg to QQAdapter.connect()

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
## Bug

`QQAdapter.connect()` lacks the `is_reconnect` keyword argument that `BasePlatformAdapter.connect()` and the gateway runner expect.

On every gateway startup (and on every reconnect watcher cycle), `gateway/run.py` calls:
- `adapter.connect(is_reconnect=False)` on startup
- `adapter.connect(is_reconnect=True)` on reconnect

This raises:
```
TypeError: QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

The qqbot platform is completely unable to connect.

## Fix

Add `is_reconnect: bool = False` keyword argument to `QQAdapter.connect()` to match the base class signature.

1 line change.

Fixes #53443