### PR TITLE
fix(skills): resolve symlinks before relative_to in skill install

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3450,7 +3450,7 @@ def install_from_quarantine(
         trust_level=bundle.trust_level,
         scan_verdict=scan_result.verdict,
         skill_hash=content_hash(install_dir),
-        install_path=str(install_dir.relative_to(SKILLS_DIR)),
+        install_path=str(install_dir.resolve().relative_to(SKILLS_DIR.resolve())),
         files=list(bundle.files.keys()),
         metadata=bundle.metadata,
     )


### PR DESCRIPTION
## Bug

After a skill is successfully installed, `do_install` tries to print the install location relative to `SKILLS_DIR`. It calls `Path.relative_to()` on raw (unresolved) paths.

When either `SKILLS_DIR` or the install directory contains a symlink component (common when `~/.hermes` or its `skills/` dir is itself a symlink), the lexical prefix check in `relative_to` fails and raises `ValueError`, aborting an otherwise-successful install.

## Fix

Resolve both paths before calling `relative_to()`:

```python
# Before
install_path=str(install_dir.relative_to(SKILLS_DIR))

# After  
install_path=str(install_dir.resolve().relative_to(SKILLS_DIR.resolve()))
```

1 line change.

Fixes #53403