### PR TITLE
fix(windows): suppress PowerShell console window flashes in subprocess calls

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -82,11 +82,13 @@ def terminate_pid(pid: int, *, force: bool = False) -> None:
     """
     if force and _IS_WINDOWS:
         try:
+            from hermes_cli._subprocess_compat import windows_hide_flags
             result = subprocess.run(
                 ["taskkill", "/PID", str(pid), "/T", "/F"],
                 capture_output=True,
                 text=True,
                 timeout=10,
+                creationflags=windows_hide_flags(),
             )
         except FileNotFoundError:
             os.kill(pid, signal.SIGTERM)

--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Optional
 
 from hermes_cli.config import get_hermes_home, get_config_path, load_config, save_config
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_constants import get_optional_skills_dir
 from hermes_cli.setup import (
     Colors,
@@ -96,6 +97,7 @@ def _detect_openclaw_processes() -> list[str]:
             result = subprocess.run(
                 ["powershell", "-NoProfile", "-Command", ps_cmd],
                 capture_output=True, text=True, timeout=5,
+                creationflags=windows_hide_flags(),
             )
             if result.stdout.strip():
                 found.append(f"node.exe process with openclaw in command line (PID {result.stdout.strip()})")

--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -79,10 +79,12 @@ def _detect_openclaw_processes() -> list[str]:
     # -- process scan ------------------------------------------------------
     if sys.platform == "win32":
         try:
+            from hermes_cli._subprocess_compat import windows_hide_flags
             for exe in ("openclaw.exe", "clawd.exe"):
                 result = subprocess.run(
                     ["tasklist", "/FI", f"IMAGENAME eq {exe}"],
                     capture_output=True, text=True, timeout=5,
+                    creationflags=windows_hide_flags(),
                 )
                 if exe in result.stdout.lower():
                     found.append(f"process: {exe}")

--- a/hermes_cli/clipboard.py
+++ b/hermes_cli/clipboard.py
@@ -19,6 +19,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_constants import is_wsl as _is_wsl
 
 logger = logging.getLogger(__name__)
@@ -201,6 +202,7 @@ def _run_powershell(exe: str, script: str, timeout: int) -> subprocess.Completed
     return subprocess.run(
         [exe, "-NoProfile", "-NonInteractive", "-Command", script],
         capture_output=True, text=True, timeout=timeout,
+        creationflags=windows_hide_flags(),
     )
 
 
@@ -257,9 +259,10 @@ def _find_powershell() -> str | None:
     for name in ("powershell", "pwsh"):
         try:
             r = subprocess.run(
-                [name, "-NoProfile", "-NonInteractive", "-Command", "echo ok"],
-                capture_output=True, text=True, timeout=5,
-            )
+                            [name, "-NoProfile", "-NonInteractive", "-Command", "echo ok"],
+                            capture_output=True, text=True, timeout=5,
+                            creationflags=windows_hide_flags(),
+                        )
             if r.returncode == 0 and "ok" in r.stdout:
                 return name
         except FileNotFoundError:

--- a/hermes_cli/dep_ensure.py
+++ b/hermes_cli/dep_ensure.py
@@ -23,6 +23,7 @@ import sys
 from pathlib import Path
 
 from hermes_constants import agent_browser_runnable
+from hermes_cli._subprocess_compat import windows_hide_flags
 
 _IS_WINDOWS = platform.system() == "Windows"
 
@@ -152,6 +153,7 @@ def ensure_dependency(
     result = subprocess.run(
         cmd,
         env=run_env,
+        creationflags=windows_hide_flags(),
     )
     if result.returncode != 0:
         return False

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -26,6 +26,7 @@ from gateway.restart import (
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
     parse_restart_drain_timeout,
 )
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import (
     get_env_value,
     get_hermes_home,
@@ -427,6 +428,7 @@ def _scan_gateway_pids(
                         encoding="utf-8",
                         errors="ignore",
                         timeout=15,
+                        creationflags=windows_hide_flags(),
                     )
                 except (OSError, subprocess.TimeoutExpired):
                     return []

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -403,6 +403,7 @@ def _scan_gateway_pids(
                         encoding="utf-8",
                         errors="ignore",
                         timeout=10,
+                        creationflags=windows_hide_flags(),
                     )
                 except (OSError, subprocess.TimeoutExpired):
                     result = None

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -258,6 +258,7 @@ import json
 import shutil
 import stat
 import subprocess
+from hermes_cli._subprocess_compat import windows_hide_flags
 from pathlib import Path
 from typing import Optional
 
@@ -5721,6 +5722,7 @@ def _find_stale_dashboard_pids(
                 timeout=10,
                 encoding="utf-8",
                 errors="ignore",
+                creationflags=windows_hide_flags() if sys.platform == "win32" else 0,
             )
             if result.returncode != 0 or result.stdout is None:
                 return []
@@ -5961,6 +5963,7 @@ def _kill_stale_dashboard_processes(
                     capture_output=True,
                     text=True,
                     timeout=10,
+                    creationflags=windows_hide_flags(),
                 )
                 if result.returncode == 0:
                     killed.append(pid)

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -18,6 +18,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 from typing import Optional
+from hermes_cli._subprocess_compat import windows_hide_flags
 
 from hermes_constants import get_hermes_home
 
@@ -248,6 +249,7 @@ def _install_uv_windows(env: dict[str, str]) -> None:
         env=env,
         check=True,
         capture_output=True,
+        creationflags=windows_hide_flags(),
     )
 
 def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> bool:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Set
+from hermes_cli._subprocess_compat import windows_hide_flags
 
 
 from hermes_cli.config import (
@@ -872,7 +873,7 @@ def _run_cua_driver_installer(label: str = "Installing", verbose: bool = True) -
         _print_info(f"    {label} cua-driver...")
     driver_cmd = _cua_driver_cmd()
     try:
-        result = subprocess.run(install_cmd, shell=use_shell, timeout=300, env=_cua_driver_env())
+        result = subprocess.run(install_cmd, shell=use_shell, timeout=300, env=_cua_driver_env(), creationflags=windows_hide_flags() if not use_shell else 0)
         if result.returncode == 0 and shutil.which(driver_cmd):
             if verbose:
                 _print_success(f"    {driver_cmd} installed.")

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -621,7 +621,7 @@ class TestTerminatePid:
         calls = []
         monkeypatch.setattr(status, "_IS_WINDOWS", True)
 
-        def fake_run(cmd, capture_output=False, text=False, timeout=None):
+        def fake_run(cmd, capture_output=False, text=False, timeout=None, **kwargs):
             calls.append((cmd, capture_output, text, timeout))
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 


### PR DESCRIPTION
## Bug Description

On Windows, several `subprocess.run`/`Popen` calls that invoke PowerShell cause a **console window to briefly flash** on screen. This is particularly jarring in the Desktop GUI, where clipboard operations and process probes trigger PowerShell repeatedly during normal chat.

## Root Cause

Hermes already has a centralized `windows_hide_flags()` helper in `hermes_cli/_subprocess_compat.py` that returns `CREATE_NO_WINDOW` on Windows (and `0` on other platforms). However, several call sites that invoke `powershell`/`pwsh` were not using it.

The existing `scripts/check-windows-footguns.py` scanner catches bare `subprocess.run(['powershell', …])` calls without creation flags, but these particular sites used `subprocess.run` with resolved paths (via `shutil.which`), variable-command patterns, or install-script invocations that the scanner's pattern matching didn't flag.

## Fix

Add `creationflags=windows_hide_flags()` to all PowerShell-invoking `subprocess.run`/`Popen` calls that were missing it:

| File | Function | Trigger |
|------|----------|---------|
| `hermes_cli/clipboard.py` | `_run_powershell()` | Every clipboard image check/paste — **most frequent trigger** |
| `hermes_cli/clipboard.py` | `_find_powershell()` | PowerShell discovery probe (cached per process, but runs on first clipboard call) |
| `hermes_cli/gateway.py` | `Get-CimInstance` fallback | Gateway process listing during status checks |
| `hermes_cli/claw.py` | OpenClaw detector | `hermes claw` migration check |
| `hermes_cli/managed_uv.py` | `_install_uv_windows()` | uv installer invocation |
| `hermes_cli/dep_ensure.py` | `ensure_dependency()` | PowerShell-based dep install scripts |
| `hermes_cli/tools_config.py` | `_run_cua_driver_installer()` | cua-driver setup (gated: only when `not use_shell`, i.e. Windows) |

`windows_hide_flags()` returns `CREATE_NO_WINDOW` on Windows and `0` on non-Windows, so these changes are **no-ops on POSIX**.

## How to Verify

1. On Windows, launch the Desktop GUI and paste an image (or use `/paste`)
2. Before the fix: a PowerShell window flashes briefly on each clipboard operation
3. After the fix: no window appears

## Test Plan

- [x] `tests/tools/test_clipboard.py` — 107 passed
- [x] `tests/hermes_cli/test_dep_ensure.py` — 14 passed
- [x] `scripts/check-windows-footguns.py --all` — ✓ No Windows footguns found (708 files scanned)
- [x] Import sanity check: all modified modules import cleanly

## Risk Assessment

**Low** — `windows_hide_flags()` is already used widely across the codebase (terminal, browser, process_registry, environments). This PR applies the same pattern to the remaining call sites. On non-Windows platforms the function returns 0, making these changes no-ops.