### PR TITLE
fix(qqbot): accept is_reconnect kwarg in connect() to match base adapter interface

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
## Problem

The QQ bot adapter's `connect()` method does not accept the `is_reconnect` keyword argument that `gateway/run.py` passes during reconnection:

```
QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

This causes an infinite crash-restart loop — the gateway catches the `TypeError`, waits 60s, retries, crashes again.

## Root Cause

`gateway/run.py` line 3132 calls:
```python
return await adapter.connect(is_reconnect=is_reconnect)
```

The base class (`base.py`) defines:
```python
async def connect(self, *, is_reconnect: bool = False) -> bool:
```

All other platform adapters already implement this signature:
- `signal.py` ✅
- `weixin.py` ✅
- `whatsapp_cloud.py` ✅
- `bluebubbles.py` ✅
- `yuanbao.py` ✅
- `api_server.py` ✅
- **`qqbot/adapter.py`** ❌ — missing the parameter

## Fix

One-line change to match the base class interface:

```python
- async def connect(self) -> bool:
+ async def connect(self, *, is_reconnect: bool = False) -> bool:
```

## Verification

- All 161 tests in `tests/gateway/test_qqbot.py` pass
- Change is backward compatible (keyword-only with default value)
- QQ bot successfully connects after applying the fix