### PR TITLE
fix(file_tools): strip leading slashes after ~/ in _expand_tilde

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -42,7 +42,7 @@ def _expand_tilde(path: str) -> str:
     except Exception:
         home = None
     if home and (path == "~" or path.startswith("~/")):
-        return home if path == "~" else os.path.join(home, path[2:])
+        return home if path == "~" else os.path.join(home, path[2:].lstrip("/"))
     return os.path.expanduser(path)
 
 


### PR DESCRIPTION
## Bug

`_expand_tilde()` uses `path[2:]` to strip `~/` prefix, but when input contains consecutive slashes (e.g. `~//foo`), `path[2:]` produces a leading `/` that causes `os.path.join(home, '/foo')` to discard `home`.

```python
# Before
os.path.join(home, path[2:])  # ~//foo → /foo (WRONG)

# After
os.path.join(home, path[2:].lstrip('/'))  # ~//foo → /home/user/foo (CORRECT)
```

Fixes #53432