### PR TITLE
fix: add encoding='utf-8' to subprocess calls with text=True

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -359,7 +359,7 @@ def _detect_claude_code_version() -> str:
         try:
             result = _sp.run(
                 [cmd, "--version"],
-                capture_output=True, text=True, timeout=5,
+                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5,
             )
             if result.returncode == 0 and result.stdout.strip():
                 # Output is like "2.1.74 (Claude Code)" or just "2.1.74"
@@ -878,7 +878,7 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
              "-s", "Claude Code-credentials",
              "-w"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=5,
             stdin=subprocess.DEVNULL,
         )

--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -651,7 +651,7 @@ def _git(cwd: Path, *args: str) -> str:
         out = subprocess.run(
             ["git", "-C", str(cwd), *args],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=_GIT_TIMEOUT,
         )
     except (OSError, subprocess.SubprocessError):

--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -295,7 +295,7 @@ def _expand_git_reference(
             ["git", *args],
             cwd=cwd,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=30,
             stdin=subprocess.DEVNULL,
         )
@@ -488,7 +488,7 @@ def _rg_files(path: Path, cwd: Path, limit: int) -> list[Path] | None:
             ["rg", "--files", str(path.relative_to(cwd))],
             cwd=cwd,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
             stdin=subprocess.DEVNULL,
         )

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -435,7 +435,7 @@ class CopilotACPClient:
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 bufsize=1,
                 cwd=self._acp_cwd,
                 env=_build_subprocess_env(),

--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -260,7 +260,7 @@ def _install_npm(
             [npm, "install", "--prefix", str(staging), "--silent", "--no-fund", "--no-audit", *install_targets],
             check=False,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=300,
             stdin=subprocess.DEVNULL,
         )
@@ -308,7 +308,7 @@ def _install_go(pkg: str, bin_name: str) -> Optional[str]:
             [go, "install", pkg],
             check=False,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=600,
             env=env,
             stdin=subprocess.DEVNULL,
@@ -347,7 +347,7 @@ def _install_pip(pkg: str, bin_name: str) -> Optional[str]:
             [sys.executable, "-m", "pip", "install", "--target", str(pip_target), "--quiet", pkg],
             check=False,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=300,
             stdin=subprocess.DEVNULL,
         )

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -272,7 +272,7 @@ def _platform_asset_name() -> str:
             res = subprocess.run(
                 ["ldd", "--version"],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=2,
                 stdin=subprocess.DEVNULL,
             )
@@ -524,7 +524,7 @@ def _run_bws_list(
             cmd,
             env=env,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=_BWS_RUN_TIMEOUT,
             stdin=subprocess.DEVNULL,
         )

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -447,7 +447,7 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
             input=stdin_json,
             capture_output=True,
             timeout=spec.timeout,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             shell=False,
         )
     except subprocess.TimeoutExpired:

--- a/agent/skill_preprocessing.py
+++ b/agent/skill_preprocessing.py
@@ -71,7 +71,7 @@ def run_inline_shell(command: str, cwd: Path | None, timeout: int) -> str:
             ["bash", "-c", command],
             cwd=str(cwd) if cwd else None,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=max(1, int(timeout)),
             check=False,
             stdin=subprocess.DEVNULL,

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -376,7 +376,7 @@ def check_codex_binary(
         proc = subprocess.run(
             [codex_bin, "--version"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
             stdin=subprocess.DEVNULL,
         )

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -368,7 +368,7 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
         try:
             result = subprocess.run(
                 ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],
-                capture_output=True, text=True, timeout=2.0,
+                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=2.0,
             )
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             continue

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -85,7 +85,7 @@ def terminate_pid(pid: int, *, force: bool = False) -> None:
             result = subprocess.run(
                 ["taskkill", "/PID", str(pid), "/T", "/F"],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=10,
             )
         except FileNotFoundError:
@@ -169,7 +169,7 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
         result = subprocess.run(
             ["ps", "-p", str(pid), "-o", "command="],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=5,
         )
         if result.returncode == 0 and result.stdout.strip():

--- a/tui_gateway/git_probe.py
+++ b/tui_gateway/git_probe.py
@@ -49,7 +49,7 @@ def run_git(cwd: str, *args: str) -> str:
         result = subprocess.run(
             ["git", "-C", cwd, *args],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=_GIT_TIMEOUT,
             check=False,
             stdin=subprocess.DEVNULL,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -271,7 +271,7 @@ class _SlashWorker:
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             bufsize=1,
             cwd=os.getcwd(),
             env=os.environ.copy(),
@@ -9044,7 +9044,7 @@ def _(rid, params: dict) -> dict:
             str(pdf_path), str(out_prefix),
         ]
         try:
-            res = subprocess.run(argv, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL)
+            res = subprocess.run(argv, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=120, stdin=subprocess.DEVNULL)
         except subprocess.TimeoutExpired:
             return _err(rid, 5028, "pdftoppm timed out (>120s)")
         if res.returncode != 0:
@@ -11068,7 +11068,7 @@ def _(rid, params: dict) -> dict:
         r = subprocess.run(
             [sys.executable, "-m", "hermes_cli.main", *argv],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=min(int(params.get("timeout", 240)), 600),
             cwd=os.getcwd(),
             env=os.environ.copy(),
@@ -11131,7 +11131,7 @@ def _(rid, params: dict) -> dict:
                 qc.get("command", ""),
                 shell=True,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=30,
                 stdin=subprocess.DEVNULL,
             )
@@ -13452,7 +13452,7 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5001, "shell.exec unavailable: approval safety module not importable")
     try:
         r = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd(),
+            cmd, shell=True, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=30, cwd=os.getcwd(),
             stdin=subprocess.DEVNULL,
         )
         return _ok(


### PR DESCRIPTION
## Bug

On non-UTF-8 Windows locales (e.g. CP936/GBK), `subprocess.run/Popen` with `text=True` but no explicit `encoding` crashes `_readerthread` when child outputs UTF-8 text:

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0xae
```

This triggers cascading failure: pipe buffers fill → event loop stalls → `ws write slow` → TUI freezes → gateway restarts.

## Fix

Add `encoding='utf-8', errors='replace'` to all 22 bare `text=True` subprocess calls across 13 files:

- `tui_gateway/server.py` (4)
- `tui_gateway/git_probe.py` (1)
- `agent/lsp/install.py` (3)
- `agent/anthropic_adapter.py` (2)
- `agent/context_references.py` (2)
- `agent/secret_sources/bitwarden.py` (2)
- `agent/copilot_acp_client.py` (1)
- `agent/skill_preprocessing.py` (1)
- `agent/coding_context.py` (1)
- `agent/transports/codex_app_server.py` (1)
- `agent/shell_hooks.py` (1)
- `gateway/status.py` (2)
- `gateway/shutdown_forensics.py` (1)

Fixes #53428