### PR TITLE
fix(moa): tolerate non-list reference_models in hand-edited MoA preset config

### DIFF
--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -74,7 +74,13 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
     if not isinstance(raw, dict):
         raw = {}
 
-    refs = [_clean_slot(item) for item in raw.get("reference_models") or []]
+    raw_refs = raw.get("reference_models")
+    if not isinstance(raw_refs, list):
+        # A hand-edited scalar / single mapping (or a bad type) must degrade to
+        # defaults instead of crashing the iteration, mirroring the tolerance
+        # for the scalar fields below (reference_temperature / max_tokens).
+        raw_refs = [raw_refs] if isinstance(raw_refs, dict) else []
+    refs = [_clean_slot(item) for item in raw_refs]
     refs = [item for item in refs if item is not None]
     if not refs:
         refs = deepcopy(DEFAULT_MOA_REFERENCE_MODELS)

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -76,6 +76,24 @@ def test_normalize_moa_config_tolerates_non_numeric_values():
     assert preset["aggregator_temperature"] == 0.4
 
 
+def test_normalize_moa_config_tolerates_non_list_reference_models():
+    """A hand-edited scalar reference_models must degrade to defaults instead of
+    crashing normalize_moa_config with TypeError (symmetric with the non-numeric
+    scalar-field tolerance)."""
+    cfg = normalize_moa_config(
+        {"presets": {"broken": {"reference_models": 2}}}
+    )
+    assert cfg["presets"]["broken"]["reference_models"] == DEFAULT_MOA_REFERENCE_MODELS
+
+
+def test_normalize_moa_config_wraps_bare_dict_reference_models():
+    """A single reference slot written without the list wrapper is rescued."""
+    cfg = normalize_moa_config(
+        {"presets": {"p": {"reference_models": {"provider": "openai", "model": "gpt-4o"}}}}
+    )
+    assert cfg["presets"]["p"]["reference_models"] == [{"provider": "openai", "model": "gpt-4o"}]
+
+
 def test_normalize_moa_config_coerces_numeric_strings():
     """Valid numeric strings (e.g. from YAML round-trip) must coerce correctly."""
     cfg = normalize_moa_config({"max_tokens": "8192", "reference_temperature": "0.9"})


### PR DESCRIPTION
## Summary
A hand-edited non-list `reference_models` in a MoA preset (e.g. `reference_models: 2`, or a single slot mapping written without the list wrapper) no longer crashes every MoA operation. `_normalize_preset` runs on every model-selection and MoA turn via `resolve_moa_preset`, so the unguarded iteration made the crash unrecoverable until the config was manually fixed.

Salvage of #53467 by @briandevans, cherry-picked onto current `main`.

## Changes
- `hermes_cli/moa_config.py`: in `_normalize_preset`, coerce a non-list `reference_models` before iterating — a bare dict is wrapped into a one-element list, anything else falls through to `[]` so the existing "no refs → defaults" path applies. No behavior change for the normal list case. This completes the same "tolerate hand-edited values" class as the prior `f0678b031` scalar-field guards; `aggregator` was already safe via `_clean_slot`'s dict check.
- `tests/hermes_cli/test_moa_config.py`: regression coverage for a scalar value (degrades to defaults) and a bare-dict value (rescued into a list).

## Validation
`scripts/run_tests.sh tests/hermes_cli/test_moa_config.py` → 15/15 passed.

## Infographic

![moa-nonlist-refs](https://v3b.fal.media/files/b/0a9ff6d8/nVx0-m8bthVrLRgFVqvZI_Kv8p30l6.png)
