### PR TITLE
feat: add Piper TTS provider

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -478,6 +478,13 @@ def _print_setup_summary(config: dict, hermes_home):
             tool_status.append(("Text-to-Speech (KittenTTS local)", True, None))
         else:
             tool_status.append(("Text-to-Speech (KittenTTS — not installed)", False, "run 'hermes setup tts'"))
+    elif tts_provider == "piper":
+        import shutil
+        piper_ok = shutil.which("piper") is not None
+        if piper_ok:
+            tool_status.append(("Text-to-Speech (Piper local)", True, None))
+        else:
+            tool_status.append(("Text-to-Speech (Piper — not installed)", False, "python -m pip install piper-tts"))
     else:
         tool_status.append(("Text-to-Speech (Edge TTS)", True, None))
 
@@ -1083,6 +1090,7 @@ def _setup_tts_provider(config: dict):
         "gemini": "Google Gemini TTS",
         "neutts": "NeuTTS",
         "kittentts": "KittenTTS",
+        "piper": "Piper",
     }
     current_label = provider_labels.get(current_provider, current_provider)
 
@@ -1107,9 +1115,10 @@ def _setup_tts_provider(config: dict):
             "Google Gemini TTS (30 prebuilt voices, prompt-controllable, needs API key)",
             "NeuTTS (local on-device, free, ~300MB model download)",
             "KittenTTS (local on-device, free, lightweight ~25-80MB ONNX)",
+            "Piper (local on-device, free, ONNX voice models)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts"])
+    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "piper"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1227,6 +1236,15 @@ def _setup_tts_provider(config: dict):
             else:
                 print_warning("No API key provided. Falling back to Edge TTS.")
                 selected = "edge"
+
+    elif selected == "piper":
+        import shutil
+        if shutil.which("piper"):
+            print_success("Piper is already installed")
+        else:
+            print()
+            print_info("Piper runs local ONNX voice models. Install with: python -m pip install piper-tts")
+            print_info("After setup, set tts.piper.model to your .onnx voice model path.")
 
     elif selected == "kittentts":
         # Check if already installed

--- a/tests/tools/test_tts_piper.py
+++ b/tests/tools/test_tts_piper.py
@@ -1,0 +1,76 @@
+"""Tests for the Piper local provider in tools/tts_tool.py."""
+
+import json
+from unittest.mock import MagicMock
+
+
+def test_check_piper_available_with_path(monkeypatch):
+    from tools import tts_tool as _tt
+
+    monkeypatch.setattr(_tt.shutil, "which", lambda cmd: "/usr/bin/piper" if cmd == "piper" else None)
+    assert _tt._check_piper_available({"piper": {"command": "piper"}}) is True
+
+
+def test_generate_piper_tts_invokes_cli_and_converts(tmp_path, monkeypatch):
+    from tools import tts_tool as _tt
+
+    model = tmp_path / "bmo.onnx"
+    config = tmp_path / "bmo.onnx.json"
+    model.write_bytes(b"fake-model")
+    config.write_text("{}")
+    calls = []
+
+    def fake_which(cmd):
+        return {"piper": "/usr/bin/piper", "ffmpeg": "/usr/bin/ffmpeg"}.get(cmd)
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[0] == "/usr/bin/piper":
+            (tmp_path / "out.wav").write_bytes(b"RIFFfake")
+        else:
+            (tmp_path / "out.mp3").write_bytes(b"fake-mp3")
+        return MagicMock(returncode=0)
+
+    monkeypatch.setattr(_tt.shutil, "which", fake_which)
+    monkeypatch.setattr(_tt.subprocess, "run", fake_run)
+
+    result = _tt._generate_piper_tts(
+        "Hello BMO",
+        str(tmp_path / "out.mp3"),
+        {"piper": {"model": str(model), "config": str(config), "speaker": 0}},
+    )
+
+    assert result == str(tmp_path / "out.mp3")
+    assert calls[0][0][:5] == ["/usr/bin/piper", "--model", str(model), "--output_file", str(tmp_path / "out.wav")]
+    assert calls[0][1]["input"] == "Hello BMO"
+    assert "--config" in calls[0][0]
+    assert "--speaker" in calls[0][0]
+    assert calls[1][0][0] == "/usr/bin/ffmpeg"
+    assert (tmp_path / "out.mp3").exists()
+
+
+def test_generate_piper_requires_model(tmp_path, monkeypatch):
+    from tools import tts_tool as _tt
+
+    monkeypatch.setattr(_tt.shutil, "which", lambda cmd: "/usr/bin/piper" if cmd == "piper" else None)
+    try:
+        _tt._generate_piper_tts("Hello", str(tmp_path / "out.wav"), {"piper": {}})
+    except ValueError as exc:
+        assert "tts.piper.model" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_dispatcher_returns_helpful_error_when_piper_missing(monkeypatch, tmp_path):
+    from tools import tts_tool as _tt
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(_tt.shutil, "which", lambda cmd: None)
+    (tmp_path / "config.yaml").write_text(
+        "tts:\n  provider: piper\n  piper:\n    model: /tmp/bmo.onnx\n"
+    )
+
+    result = json.loads(_tt.text_to_speech_tool("Hello"))
+    assert result["success"] is False
+    assert "piper" in result["error"].lower()
+    assert "piper-tts" in result["error"].lower()

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2,7 +2,7 @@
 """
 Text-to-Speech Tool Module
 
-Supports seven TTS providers:
+Supports ten TTS providers:
 - Edge TTS (default, free, no API key): Microsoft Edge neural voices
 - ElevenLabs (premium): High-quality voices, needs ELEVENLABS_API_KEY
 - OpenAI TTS: Good quality, needs OPENAI_API_KEY
@@ -10,6 +10,8 @@ Supports seven TTS providers:
 - Mistral (Voxtral TTS): Multilingual, native Opus, needs MISTRAL_API_KEY
 - Google Gemini TTS: Controllable, 30 prebuilt voices, needs GEMINI_API_KEY
 - NeuTTS (local, free, no API key): On-device TTS via neutts_cli, needs neutts installed
+- KittenTTS (local, free, no API key): On-device TTS via KittenTTS, needs kittentts installed
+- Piper (local, free, no API key): On-device TTS via Piper ONNX voice models
 
 Output formats:
 - Opus (.ogg) for Telegram voice bubbles (requires ffmpeg for Edge TTS)
@@ -98,6 +100,17 @@ def _import_kittentts():
     return KittenTTS
 
 
+def _check_piper_available(tts_config: Optional[Dict[str, Any]] = None) -> bool:
+    """Return True when a Piper executable is configured or on PATH."""
+    cfg = (tts_config or {}).get("piper", {}) if isinstance(tts_config, dict) else {}
+    command = str(cfg.get("command") or DEFAULT_PIPER_COMMAND).strip()
+    if not command:
+        return False
+    if Path(command).expanduser().exists():
+        return True
+    return shutil.which(command) is not None
+
+
 # ===========================================================================
 # Defaults
 # ===========================================================================
@@ -109,6 +122,8 @@ DEFAULT_ELEVENLABS_STREAMING_MODEL_ID = "eleven_flash_v2_5"
 DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts"
 DEFAULT_KITTENTTS_MODEL = "KittenML/kitten-tts-nano-0.8-int8"  # 25MB
 DEFAULT_KITTENTTS_VOICE = "Jasper"
+DEFAULT_PIPER_COMMAND = "piper"
+DEFAULT_PIPER_SAMPLE_RATE = 22050
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_MINIMAX_MODEL = "speech-2.8-hd"
@@ -152,6 +167,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "elevenlabs": 10000,  # fallback when model-aware lookup can't resolve (multilingual_v2)
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
+    "piper": 5000,        # local ONNX voices; keep requests modest
 }
 
 # ElevenLabs caps vary by model_id. https://elevenlabs.io/docs/overview/models
@@ -924,6 +940,72 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
     return output_path
 
 
+def _piper_value_args(cfg: Dict[str, Any]) -> list[str]:
+    """Build optional numeric/string Piper CLI flags from config."""
+    args: list[str] = []
+    for key, flag in (
+        ("speaker", "--speaker"),
+        ("length_scale", "--length_scale"),
+        ("noise_scale", "--noise_scale"),
+        ("noise_w", "--noise_w"),
+        ("sentence_silence", "--sentence_silence"),
+    ):
+        value = cfg.get(key)
+        if value is not None and str(value).strip() != "":
+            args.extend([flag, str(value)])
+    return args
+
+
+def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech using the local Piper CLI and an ONNX voice model."""
+    piper_config = tts_config.get("piper", {}) if isinstance(tts_config, dict) else {}
+    command = str(piper_config.get("command") or DEFAULT_PIPER_COMMAND).strip()
+    command_path = Path(command).expanduser() if command else None
+    executable = str(command_path) if command_path and command_path.exists() else shutil.which(command)
+    if not executable:
+        raise FileNotFoundError(
+            "Piper provider selected but the 'piper' executable was not found. "
+            "Install it with: python -m pip install piper-tts"
+        )
+
+    model = piper_config.get("model") or piper_config.get("model_path")
+    if not model:
+        raise ValueError("Piper provider requires tts.piper.model pointing to a .onnx voice model")
+    model_path = Path(str(model)).expanduser()
+    if not model_path.exists():
+        raise FileNotFoundError(f"Piper voice model not found: {model_path}")
+
+    config_path = piper_config.get("config") or piper_config.get("config_path")
+    if config_path:
+        config_path = str(Path(str(config_path)).expanduser())
+        if not Path(config_path).exists():
+            raise FileNotFoundError(f"Piper voice config not found: {config_path}")
+
+    wav_path = output_path if output_path.endswith(".wav") else output_path.rsplit(".", 1)[0] + ".wav"
+    cmd = [executable, "--model", str(model_path), "--output_file", wav_path]
+    if config_path:
+        cmd.extend(["--config", config_path])
+    cmd.extend(_piper_value_args(piper_config))
+
+    subprocess.run(
+        cmd,
+        input=text,
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=int(piper_config.get("timeout", 120)),
+    )
+
+    if wav_path != output_path:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            subprocess.run([ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path], check=True, timeout=30)
+            os.remove(wav_path)
+        else:
+            os.rename(wav_path, output_path)
+    return output_path
+
+
 # ===========================================================================
 # Main tool function
 # ===========================================================================
@@ -1061,6 +1143,16 @@ def text_to_speech_tool(
             logger.info("Generating speech with KittenTTS (local, ~25MB)...")
             _generate_kittentts(text, file_str, tts_config)
 
+        elif provider == "piper":
+            if not _check_piper_available(tts_config):
+                return json.dumps({
+                    "success": False,
+                    "error": "Piper provider selected but the 'piper' executable was not found. "
+                             "Install it with: python -m pip install piper-tts"
+                }, ensure_ascii=False)
+            logger.info("Generating speech with Piper (local ONNX voice)...")
+            _generate_piper_tts(text, file_str, tts_config)
+
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback
             edge_available = True
@@ -1100,7 +1192,7 @@ def text_to_speech_tool(
         # Try Opus conversion for Telegram compatibility
         # Edge TTS outputs MP3, NeuTTS/KittenTTS output WAV — all need ffmpeg conversion
         voice_compatible = False
-        if provider in ("edge", "neutts", "minimax", "xai", "kittentts") and not file_str.endswith(".ogg"):
+        if provider in ("edge", "neutts", "minimax", "xai", "kittentts", "piper") and not file_str.endswith(".ogg"):
             opus_path = _convert_to_opus(file_str)
             if opus_path:
                 file_str = opus_path
@@ -1186,6 +1278,8 @@ def check_tts_requirements() -> bool:
     if _check_neutts_available():
         return True
     if _check_kittentts_available():
+        return True
+    if _check_piper_available(_load_tts_config()):
         return True
     return False
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -14,7 +14,7 @@ If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, 
 
 ## Text-to-Speech
 
-Convert text to speech with nine providers:
+Convert text to speech with ten providers:
 
 | Provider | Quality | Cost | API Key |
 |----------|---------|------|---------|
@@ -27,6 +27,7 @@ Convert text to speech with nine providers:
 | **xAI TTS** | Excellent | Paid | `XAI_API_KEY` |
 | **NeuTTS** | Good | Free (local) | None needed |
 | **KittenTTS** | Good | Free (local) | None needed |
+| **Piper** | Good | Free (local) | None needed |
 
 ### Platform Delivery
 
@@ -42,7 +43,7 @@ Convert text to speech with nine providers:
 ```yaml
 # In ~/.hermes/config.yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper"
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -83,6 +84,11 @@ tts:
     voice: Jasper                               # Jasper, Bella, Luna, Bruno, Rosie, Hugo, Kiki, Leo
     speed: 1.0                                  # 0.5 - 2.0
     clean_text: true                            # Expand numbers, currencies, units
+  piper:
+    command: piper                              # Optional path to piper executable
+    model: ~/.hermes/voices/bmo/bmo.onnx       # Local Piper .onnx voice model
+    config: ~/.hermes/voices/bmo/bmo.onnx.json # Optional; Piper can also auto-detect adjacent .json
+    length_scale: 1.0                           # Optional Piper voice tuning
 ```
 
 **Speed control**: The global `tts.speed` value applies to all providers by default. Each provider can override it with its own `speed` setting (e.g., `tts.openai.speed: 1.5`). Provider-specific speed takes precedence over the global value. Default is `1.0` (normal speed).
@@ -98,6 +104,7 @@ Telegram voice bubbles require Opus/OGG audio format:
 - **xAI TTS** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
 - **NeuTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 - **KittenTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
+- **Piper** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 
 ```bash
 # Ubuntu/Debian
@@ -110,7 +117,7 @@ brew install ffmpeg
 sudo dnf install ffmpeg
 ```
 
-Without ffmpeg, Edge TTS, MiniMax TTS, NeuTTS, and KittenTTS audio are sent as regular audio files (playable, but shown as a rectangular player instead of a voice bubble).
+Without ffmpeg, Edge TTS, MiniMax TTS, NeuTTS, KittenTTS, and Piper audio are sent as regular audio files (playable, but shown as a rectangular player instead of a voice bubble).
 
 :::tip
 If you want voice bubbles without installing ffmpeg, switch to the OpenAI, ElevenLabs, or Mistral provider.


### PR DESCRIPTION
## Summary
- add a local Piper TTS provider for ONNX voice models
- expose Piper in TTS setup/status and docs
- add focused Piper provider tests

## Test plan
- `python -m py_compile tools/tts_tool.py hermes_cli/setup.py`
- `python -m pytest tests/tools/test_tts_piper.py tests/tools/test_tts_kittentts.py -q -o 'addopts='`\n\n## Notes\nThis enables voices such as the BMO/Bemo Piper model from https://github.com/brenpoly/be-more-agent/releases/tag/v1.0-voice via config:\n\n```yaml\ntts:\n  provider: piper\n  piper:\n    model: ~/.hermes/voices/bmo/bmo.onnx\n    config: ~/.hermes/voices/bmo/bmo.onnx.json\n```