### PR TITLE
fix(gateway): show MoA presets in the gateway model picker

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1206,6 +1206,7 @@ class GatewaySlashCommandsMixin:
                         user_providers=user_provs,
                         custom_providers=custom_provs,
                         max_models=50,
+                        include_moa=True,
                     )
                 except Exception:
                     providers = []

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -163,7 +163,7 @@ def build_models_payload(
         refresh=refresh,
     )
 
-    moa_row = _moa_provider_row(ctx)
+    moa_row = _moa_provider_row(ctx.current_provider)
     if moa_row is not None:
         rows = [moa_row] + [r for r in rows if str(r.get("slug", "")).lower() != "moa"]
 
@@ -442,7 +442,13 @@ def _apply_pricing(
                 row["unavailable_models"] = []
 
 
-def _moa_provider_row(ctx: ConfigContext) -> dict | None:
+def _moa_provider_row(current_provider: str = "") -> dict | None:
+    """Build the virtual ``moa`` provider row for model pickers.
+
+    Shared by the CLI inventory (:func:`build_models_payload`) and the gateway
+    picker path (:func:`hermes_cli.model_switch.list_picker_providers`) so the
+    row shape stays in one place. Returns ``None`` when no MoA presets exist.
+    """
     try:
         from hermes_cli.config import load_config
         from hermes_cli.moa_config import normalize_moa_config
@@ -454,7 +460,7 @@ def _moa_provider_row(ctx: ConfigContext) -> dict | None:
         return {
             "slug": "moa",
             "name": "Mixture of Agents",
-            "is_current": (ctx.current_provider or "").lower() == "moa",
+            "is_current": (current_provider or "").lower() == "moa",
             "is_user_defined": False,
             "models": models,
             "total_models": len(models),

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2283,28 +2283,15 @@ def _prepend_moa_picker_provider(providers: List[dict], current_provider: str = 
     ``list_authenticated_providers()`` only returns real/auth-backed providers.
     The CLI model inventory adds MoA separately so named presets appear next to
     normal providers; gateway pickers call ``list_picker_providers()`` directly,
-    so they need the same virtual row here.
+    so they need the same virtual row here. Reuse the inventory's single row
+    builder so the row shape stays defined in one place.
     """
     try:
-        from hermes_cli.config import load_config
-        from hermes_cli.moa_config import normalize_moa_config
+        from hermes_cli.inventory import _moa_provider_row
 
-        cfg = normalize_moa_config(load_config().get("moa") or {})
-        models = list(cfg.get("presets", {}).keys())
-        if not models:
+        moa_row = _moa_provider_row(current_provider)
+        if moa_row is None:
             return providers
-        moa_row = {
-            "slug": "moa",
-            "name": "Mixture of Agents",
-            "is_current": (current_provider or "").lower() == "moa",
-            "is_user_defined": False,
-            "models": models,
-            "total_models": len(models),
-            "source": "virtual",
-            "authenticated": True,
-            "auth_type": "virtual",
-            "warning": "Aggregator acts as the selected model; references provide analysis before each call.",
-        }
         return [moa_row] + [p for p in providers if str(p.get("slug", "")).lower() != "moa"]
     except Exception:
         return providers

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2277,6 +2277,39 @@ def list_authenticated_providers(
     return results
 
 
+def _prepend_moa_picker_provider(providers: List[dict], current_provider: str = "") -> List[dict]:
+    """Add the virtual MoA provider row used by interactive model pickers.
+
+    ``list_authenticated_providers()`` only returns real/auth-backed providers.
+    The CLI model inventory adds MoA separately so named presets appear next to
+    normal providers; gateway pickers call ``list_picker_providers()`` directly,
+    so they need the same virtual row here.
+    """
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.moa_config import normalize_moa_config
+
+        cfg = normalize_moa_config(load_config().get("moa") or {})
+        models = list(cfg.get("presets", {}).keys())
+        if not models:
+            return providers
+        moa_row = {
+            "slug": "moa",
+            "name": "Mixture of Agents",
+            "is_current": (current_provider or "").lower() == "moa",
+            "is_user_defined": False,
+            "models": models,
+            "total_models": len(models),
+            "source": "virtual",
+            "authenticated": True,
+            "auth_type": "virtual",
+            "warning": "Aggregator acts as the selected model; references provide analysis before each call.",
+        }
+        return [moa_row] + [p for p in providers if str(p.get("slug", "")).lower() != "moa"]
+    except Exception:
+        return providers
+
+
 def list_picker_providers(
     current_provider: str = "",
     current_base_url: str = "",
@@ -2284,6 +2317,7 @@ def list_picker_providers(
     custom_providers: list | None = None,
     max_models: int | None = None,
     current_model: str = "",
+    include_moa: bool = False,
 ) -> List[dict]:
     """Interactive-picker variant of :func:`list_authenticated_providers`.
 
@@ -2314,6 +2348,8 @@ def list_picker_providers(
         max_models=max_models,
         current_model=current_model,
     )
+    if include_moa:
+        providers = _prepend_moa_picker_provider(providers, current_provider=current_provider)
 
     filtered: List[dict] = []
     for p in providers:

--- a/tests/gateway/test_model_command_async_offload.py
+++ b/tests/gateway/test_model_command_async_offload.py
@@ -166,3 +166,29 @@ async def test_picker_path_offloads_list_picker_providers(_isolated_config, monk
         "list_picker_providers must be dispatched via asyncio.to_thread "
         "(it was called inline on the event loop instead)"
     )
+
+
+@pytest.mark.asyncio
+async def test_picker_path_requests_moa_presets(_isolated_config, monkeypatch):
+    """Gateway /model pickers must opt into the virtual MoA preset provider."""
+    captured = {}
+
+    def _fake_list_picker_providers(**kwargs):
+        captured.update(kwargs)
+        return [{"slug": "moa", "name": "Mixture of Agents", "is_current": False,
+                 "models": ["battle", "smart"], "total_models": 2}]
+
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_picker_providers",
+        _fake_list_picker_providers,
+    )
+
+    runner = _make_runner()
+    runner.adapters = {Platform.TELEGRAM: _FakePickerAdapter()}
+    monkeypatch.setattr(runner, "_thread_metadata_for_source", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(runner, "_reply_anchor_for_event", lambda *a, **k: None, raising=False)
+
+    result = await runner._handle_model_command(_make_event())
+
+    assert result is None
+    assert captured["include_moa"] is True

--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -109,6 +109,40 @@ def test_non_openrouter_rows_passed_through_unchanged(monkeypatch):
     assert result[1]["models"] == ["gemini-3-flash-preview"]
 
 
+def test_include_moa_adds_virtual_provider_with_named_presets(monkeypatch):
+    """Gateway pickers opt into a virtual MoA provider so presets are tappable."""
+    base = [_make_provider("minimax", models=["MiniMax-M3"])]
+    moa_config = {
+        "moa": {
+            "default_preset": "battle",
+            "presets": {
+                "battle": {"enabled": True},
+                "smart": {"enabled": True},
+            },
+        }
+    }
+
+    monkeypatch.setattr(model_switch, "list_authenticated_providers",
+                        lambda **kw: list(base))
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: moa_config)
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: pytest.fail("should not be called"))
+
+    result = model_switch.list_picker_providers(
+        current_provider="moa",
+        max_models=50,
+        include_moa=True,
+    )
+
+    assert [p["slug"] for p in result] == ["moa", "minimax"]
+    moa = result[0]
+    assert moa["name"] == "Mixture of Agents"
+    assert moa["is_current"] is True
+    assert moa["source"] == "virtual"
+    assert moa["models"] == ["battle", "smart"]
+    assert moa["total_models"] == 2
+
+
 def test_empty_models_row_dropped(monkeypatch):
     """Built-in provider with an empty ``models`` list is dropped."""
     base = [


### PR DESCRIPTION
## Summary
MoA presets now appear in the **gateway** `/model` picker (Telegram/Discord inline keyboards). The gateway picker path called `list_picker_providers()` directly, which builds on `list_authenticated_providers()` and so never injected the virtual `Mixture of Agents` provider row that the CLI/dashboard/desktop inventory adds. Result: gateway users couldn't select a MoA preset from the picker — even though #53548's docs now point them there for sticky preset selection.

Salvage of #53526 by @dodo-reach, cherry-picked onto current `main`, with a follow-up dedup commit.

## Changes
- `hermes_cli/model_switch.py`: add an opt-in `include_moa` param to `list_picker_providers()`; when set, prepend the virtual MoA provider row. Existing callers keep the old behavior. **(dodo-reach)**
- `gateway/slash_commands.py`: enable `include_moa=True` on the gateway `/model` picker path. **(dodo-reach)**
- `hermes_cli/inventory.py` + `hermes_cli/model_switch.py` **(follow-up dedup)**: the cherry-pick added a second copy of the MoA row builder. Refactored `inventory._moa_provider_row` to take a bare `current_provider` string and reused it from the gateway picker path, so the row shape lives in one place and the two surfaces can't drift.

## Validation
`scripts/run_tests.sh tests/hermes_cli/test_list_picker_providers.py tests/gateway/test_model_command_async_offload.py tests/hermes_cli/test_inventory.py` → 48/48 passed (includes the inventory tests exercising the shared row builder).

## Infographic

![moa-gateway-picker](https://v3b.fal.media/files/b/0a9ff6ff/zEF8XzmnONp-ILz7rUsV0_9QEgWXsX.png)
