### PR TITLE
docs(webhook): clarify authenticated != trusted-content trust model

### DIFF
--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -80,7 +80,7 @@ Routes define how different webhook sources are handled. Each route is a named e
 |----------|----------|-------------|
 | `events` | No | List of event types to accept (e.g. `["pull_request"]`). If empty, all events are accepted. Event type is read from `X-GitHub-Event`, `X-GitLab-Event`, or `event_type` in the payload. |
 | `secret` | **Yes** | HMAC secret for signature validation. Falls back to the global `secret` if not set on the route. Set to `"INSECURE_NO_AUTH"` for testing only (skips validation). |
-| `prompt` | No | Template string with dot-notation payload access (e.g. `{pull_request.title}`). If omitted, the full JSON payload is dumped into the prompt. |
+| `prompt` | No | Template string with dot-notation payload access (e.g. `{pull_request.title}`). If omitted, the full JSON payload is dumped into the prompt. Payload fields are untrusted — see [Authenticated does not mean trusted](#authenticated-does-not-mean-trusted). |
 | `skills` | No | List of skill names to load for the agent run. |
 | `deliver` | No | Where to send the response: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, or `log` (default). |
 | `deliver_extra` | No | Additional delivery config — keys depend on `deliver` type (e.g. `repo`, `pr_number`, `chat_id`). Values support the same `{dot.notation}` templates as `prompt`. |
@@ -425,10 +425,17 @@ platforms:
       max_body_bytes: 2097152  # 2 MB
 ```
 
-### Prompt injection risk
+### Authenticated does not mean trusted
 
 :::warning
-Webhook payloads contain attacker-controlled data — PR titles, commit messages, issue descriptions, etc. can all contain malicious instructions. Run the gateway in a sandboxed environment (Docker, VM) when exposed to the internet. Consider using the Docker or SSH terminal backend for isolation.
+**HMAC validation authenticates the _sender_, not the _content_.** A valid signature only proves the request came from a party holding the route's secret (e.g. GitHub). It says nothing about who wrote the _business fields_ inside the payload — PR titles, commit messages, issue descriptions, and any other upstream text are authored by arbitrary third parties and must be treated as untrusted.
+
+This is the same trust model that applies to everything the agent reads: web pages, files, and tool output are all untrusted input. Hermes does not — and cannot reliably — sanitize untrusted text with a blocklist; phrasing, encoding, and translation make that trivially bypassable. **The trust boundary is the agent's capability surface, not the input channel.** Harden there:
+
+- **Sandbox the runtime.** Run the gateway with the Docker or SSH terminal backend (or in a VM) when exposed to the internet, so a hijacked turn cannot touch the host.
+- **Scope the toolset.** Disable `terminal`, `file`, and outbound-action tools on webhook-triggered sessions if the route only needs to read and summarize. Fewer capabilities means a smaller blast radius if a payload field carries injected instructions.
+- **Keep approvals on** for any destructive or outbound operation, so an injected instruction cannot act unattended.
+- **Template narrowly.** Prefer a specific `prompt` with named fields (`{pull_request.title}`) over `{__raw__}` or an empty template that dumps the whole payload, so only the fields you intend reach the prompt.
 :::
 
 ---


### PR DESCRIPTION
## Summary

Documents the webhook trust model explicitly: **HMAC authenticates the sender, not the content.** No behavior change — this is a docs-only clarification for issue #8820.

A valid signature only proves the request came from a party holding the route's secret (GitHub, GitLab, etc.). It says nothing about who wrote the *business fields* inside the payload — PR titles, commit messages, issue bodies are authored by arbitrary third parties and must be treated as untrusted, exactly like every web page, file, and tool output the agent reads. The trust boundary is the agent's capability surface, not the input channel.

## Changes

- `website/docs/user-guide/messaging/webhooks.md`: renamed the "Prompt injection risk" section to "Authenticated does not mean trusted" and expanded it with the sender-vs-content distinction plus the real hardening levers (sandbox the runtime, scope the toolset, keep approvals on, template narrowly). Added a cross-reference from the `prompt` config-table row.

## Why docs, not a sanitizer

Blocklist-style "sanitization" of untrusted payload text is the wrong layer and trivially bypassed by phrasing, encoding, or translation. Hermes' security model treats untrusted *input* as a given and hardens at the *capability* boundary (sandbox + toolset scope + approvals). This change makes that posture explicit for webhook operators instead of pretending to vet field content.

## Validation

- MDX parse parity check against `origin/main`: the file's pre-existing `{dot.notation}` / `{__raw__}` brace constructs fail a naive standalone `@mdx-js/mdx` compile both before and after this diff — no new failure introduced. My additions reuse only brace tokens already present in the file.
- `git diff --stat origin/main..HEAD` = the single docs file, base 0 commits behind main.

## Infographic

![authenticated-not-trusted](https://v3b.fal.media/files/b/0a9ff718/7bCVonSBAGRWAEcxHV0ts_r4V3y84e.png)
