### PR TITLE
fix(gateway): WhatsApp/Signal hints affirm markdown instead of forbidding it

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -617,7 +617,12 @@ DEVELOPER_ROLE_MODELS = ("gpt-5", "codex")
 PLATFORM_HINTS = {
     "whatsapp": (
         "You are on a text messaging communication platform, WhatsApp. "
-        "Please do not use markdown as it does not render. "
+        "Standard markdown (**bold**, *italic*, ~~strike~~, # headers, "
+        "`code`, ```code blocks```, [links](url)) is auto-converted to "
+        "WhatsApp's native syntax (*bold*, _italic_, ~strike~, monospace) — "
+        "feel free to write in markdown, and use bullet lists ('- item') "
+        "freely. Tables are NOT supported — prefer bullet lists or labeled "
+        "key:value pairs. "
         "You can send media files natively: to deliver a file to the user, "
         "include MEDIA:/absolute/path/to/file in your response. The file "
         "will be sent as a native WhatsApp attachment — images (.jpg, .png, "
@@ -682,7 +687,11 @@ PLATFORM_HINTS = {
     ),
     "signal": (
         "You are on a text messaging communication platform, Signal. "
-        "Please do not use markdown as it does not render. "
+        "Standard markdown (**bold**, *italic*, ~~strike~~, # headers, "
+        "`code`, ```code blocks```) is auto-converted to Signal's native "
+        "rich formatting — feel free to write in markdown, and use bullet "
+        "lists ('- item') freely (they render as • bullets). Tables are NOT "
+        "supported — prefer bullet lists or labeled key:value pairs. "
         "You can send media files natively: to deliver a file to the user, "
         "include MEDIA:/absolute/path/to/file in your response. Images "
         "(.png, .jpg, .webp) appear as photos, audio as attachments, and other "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1018,6 +1018,19 @@ class TestPromptBuilderConstants:
         hint = PLATFORM_HINTS["whatsapp_cloud"]
         assert "MEDIA:" in hint
 
+    def test_markdown_converting_platform_hints_do_not_forbid_markdown(self):
+        """#12224 — WhatsApp (Baileys) and Signal adapters actively convert
+        markdown to native formatting (gateway/platforms/whatsapp_common.py
+        format_message + signal_format.markdown_to_signal: bold, italic,
+        strikethrough, headers, bullets). Their hints previously told the
+        agent "do not use markdown", which made it strip bullets/bold the
+        adapter would have rendered. The hint must affirm markdown, not
+        forbid it."""
+        for key in ("whatsapp", "signal"):
+            hint = PLATFORM_HINTS[key]
+            assert "do not use markdown" not in hint.lower()
+            assert "markdown" in hint.lower()
+
     def test_cli_hint_does_not_suggest_media_tags(self):
         # Regression: MEDIA:/path tags are intercepted only by messaging
         # gateway platforms. On the CLI they render as literal text and


### PR DESCRIPTION
## Summary
The WhatsApp and Signal `PLATFORM_HINTS` now tell the agent the truth: markdown works and is auto-converted to native formatting. Previously both said "Please do not use markdown as it does not render," which made the agent strip the bullets and bold their adapters would have rendered (#12224).

Root cause: the hint contradicted its own adapter. `whatsapp_common.format_message()` and `signal_format.markdown_to_signal()` both actively convert markdown — bold, italic, strikethrough, headers, links/code blocks, and (Signal) `- item`/`* item` bullets into `•` — yet the hint told the model to avoid markdown entirely.

## Changes
- `agent/prompt_builder.py`: rewrote the `whatsapp` and `signal` hints to mirror `whatsapp_cloud` — markdown is auto-converted to native syntax, bullet lists work, tables are not supported (prefer bullets / key:value).
- `tests/agent/test_prompt_builder.py`: added a contract test asserting markdown-converting platforms (`whatsapp`, `signal`) never forbid markdown in their hint.

## Validation
| | Before | After |
|---|---|---|
| `whatsapp` hint | "do not use markdown" | "feel free to write in markdown" |
| `signal` hint | "do not use markdown" | "feel free to write in markdown" |
| Bullets on WhatsApp/Signal | stripped by agent | rendered by adapter |
| `tests/agent/test_prompt_builder.py -k "platform_hint or markdown_converting or whatsapp"` | — | 8 passed |

Telegram (already affirms rich markdown) and genuinely-plaintext platforms (email, sms, bluebubbles — no converter) are unchanged.

Closes #12224.

## Infographic

![whatsapp-signal-markdown-hint-fix](https://v3b.fal.media/files/b/0a9ff72d/96QlA1PFnpb7O-r6xaCi0_JgnhmWfk.png)
