### PR TITLE
fix(api-server): surface agent failures in SSE chat completions stream

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2225,25 +2225,69 @@ class APIServerAdapter(BasePlatformAdapter):
 
                 last_activity = await _emit(delta)
 
-            # Get usage from completed agent
+            # Get usage from completed agent. The agent can fail two ways
+            # after the content queue terminates cleanly: (1) ``agent_task``
+            # raises, or (2) it returns a ``result`` dict flagged
+            # failed/partial/incomplete. Both previously fell through to a
+            # ``finish_reason: "stop"`` chunk, so OpenAI-compatible clients
+            # saw a fake success. Surface either as a non-"stop" finish so
+            # the failure is detectable — mirroring the non-streaming path's
+            # decision logic (see the finish_reason block above).
             usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            result = None
+            agent_error = None
             try:
                 result, agent_usage = await agent_task
                 usage = agent_usage or usage
             except Exception as exc:
-                logger.warning("Agent task %s failed, usage data lost: %s", completion_id, exc)
+                agent_error = exc
+                logger.error(
+                    "Agent task %s failed during SSE streaming: %s", completion_id, exc
+                )
+
+            # Inspect the result dict for a flagged (non-exception) failure.
+            is_partial = bool(result.get("partial")) if isinstance(result, dict) else False
+            is_failed = bool(result.get("failed")) if isinstance(result, dict) else False
+            completed = bool(result.get("completed", True)) if isinstance(result, dict) else True
+            err_msg = result.get("error") if isinstance(result, dict) else None
+            if agent_error is not None:
+                is_failed = True
+                err_msg = err_msg or str(agent_error)
+
+            # Decide finish_reason, matching the non-streaming logic: "length"
+            # for truncation, "error" for failure, "stop" for normal completion.
+            if is_partial and err_msg and "truncat" in err_msg.lower():
+                finish_reason = "length"
+            elif agent_error is not None or is_failed or (not completed and err_msg):
+                finish_reason = "error"
+            else:
+                finish_reason = "stop"
 
             # Finish chunk
             finish_chunk = {
                 "id": completion_id, "object": "chat.completion.chunk",
                 "created": created, "model": model,
-                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}],
                 "usage": {
                     "prompt_tokens": usage.get("input_tokens", 0),
                     "completion_tokens": usage.get("output_tokens", 0),
                     "total_tokens": usage.get("total_tokens", 0),
                 },
             }
+            if finish_reason != "stop":
+                finish_chunk["choices"][0]["delta"] = {}
+                if err_msg:
+                    finish_chunk["error"] = {
+                        "message": err_msg,
+                        "type": type(agent_error).__name__ if agent_error else "agent_error",
+                    }
+                finish_chunk["hermes"] = {
+                    "completed": completed,
+                    "partial": is_partial,
+                    "failed": is_failed,
+                    "error": err_msg,
+                    "error_code": "output_truncated" if finish_reason == "length" else "agent_error",
+                }
             await response.write(f"data: {json.dumps(finish_chunk)}\n\n".encode())
             await response.write(b"data: [DONE]\n\n")
         except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, OSError):

--- a/tests/gateway/test_sse_agent_cancel.py
+++ b/tests/gateway/test_sse_agent_cancel.py
@@ -276,3 +276,108 @@ class TestSSEAgentCancelOnDisconnect:
             assert agent_task.cancelled() or agent_task.done()
 
         asyncio.run(run())
+
+
+def _capturing_response():
+    """Mock StreamResponse that records all written SSE bytes as text."""
+    from aiohttp import web
+
+    chunks: list = []
+    resp = AsyncMock(spec=web.StreamResponse)
+    resp.prepare = AsyncMock()
+
+    async def _write(data):
+        chunks.append(data.decode() if isinstance(data, (bytes, bytearray)) else data)
+
+    resp.write = AsyncMock(side_effect=_write)
+    return resp, chunks
+
+
+def _finish_reason(chunks: list):
+    """Extract the terminal finish_reason and its chunk from captured SSE."""
+    import json
+
+    sse = "".join(chunks)
+    finish = None
+    for line in sse.splitlines():
+        if line.startswith("data: ") and '"finish_reason"' in line:
+            obj = json.loads(line[6:])
+            if obj["choices"][0].get("finish_reason") is not None:
+                finish = obj
+    return (finish["choices"][0]["finish_reason"] if finish else None), finish, sse
+
+
+class TestSSEAgentFailureFinishReason:
+    """gateway/platforms/api_server.py — _write_sse_chat_completion()
+
+    A clean stream-queue termination (sentinel received) followed by an agent
+    failure must NOT report finish_reason: "stop". Both failure modes — an
+    ``agent_task`` that raises and a ``result`` dict flagged failed — surface
+    as finish_reason: "error", mirroring the non-streaming path. Issue #12422.
+    """
+
+    def _run(self, fake_agent, queue_items=("partial",)):
+        adapter = _make_adapter()
+        stream_q = queue.Queue()
+        for item in queue_items:
+            stream_q.put(item)
+        stream_q.put(None)  # clean end-of-stream sentinel
+
+        async def run():
+            agent_task = asyncio.ensure_future(fake_agent())
+            resp, chunks = _capturing_response()
+            with patch("gateway.platforms.api_server.web.StreamResponse",
+                       return_value=resp):
+                await adapter._write_sse_chat_completion(
+                    _make_request(), "cmpl-fail", "gpt-4", 1234567890,
+                    stream_q, agent_task,
+                )
+            return _finish_reason(chunks)
+
+        return asyncio.run(run())
+
+    def test_agent_task_raises_reports_error_not_stop(self):
+        async def crash():
+            raise RuntimeError("boom from agent")
+
+        reason, finish, sse = self._run(crash)
+        assert reason == "error"
+        assert "error" in finish
+        assert "data: [DONE]" in sse
+
+    def test_failed_result_dict_reports_error_not_stop(self):
+        async def failed():
+            return (
+                {"final_response": "", "failed": True, "completed": False,
+                 "error": "upstream model 500"},
+                {"input_tokens": 5, "output_tokens": 0, "total_tokens": 5},
+            )
+
+        reason, finish, _ = self._run(failed)
+        assert reason == "error"
+        assert finish.get("hermes", {}).get("failed") is True
+
+    def test_truncated_result_reports_length(self):
+        async def trunc():
+            return (
+                {"final_response": "half", "partial": True, "completed": False,
+                 "error": "output was truncated"},
+                {"input_tokens": 5, "output_tokens": 3, "total_tokens": 8},
+            )
+
+        reason, finish, _ = self._run(trunc)
+        assert reason == "length"
+        assert finish["hermes"]["error_code"] == "output_truncated"
+
+    def test_successful_completion_reports_stop(self):
+        async def ok():
+            return (
+                {"final_response": "hi", "completed": True},
+                {"input_tokens": 5, "output_tokens": 2, "total_tokens": 7},
+            )
+
+        reason, finish, _ = self._run(ok)
+        assert reason == "stop"
+        # No error/hermes pollution on the happy path.
+        assert "error" not in finish
+        assert "hermes" not in finish


### PR DESCRIPTION
## Summary
Streaming `/v1/chat/completions` now reports a non-`stop` `finish_reason` when the agent fails, so OpenAI-compatible clients can detect an internal crash instead of seeing a fake success.

Root cause: after the content queue terminated cleanly, `_write_sse_chat_completion()` either swallowed the `agent_task` exception or ignored a flagged `result` dict, then always emitted `finish_reason: "stop"` + `[DONE]`.

Salvages #12422 / PR #12504 (@flobo3) and widens it to the sibling failure mode (failed `result` dict) the original fix didn't cover.

## Changes
- `gateway/platforms/api_server.py`: capture both failure modes after the stream queue terminates — (1) `agent_task` raising, (2) a `result` dict flagged `failed`/`partial`/`incomplete` — and mirror the non-streaming `finish_reason` decision logic (`error` for failure, `length` for truncation, `stop` for success). Non-`stop` finishes carry an `error` object + `hermes` extras block, matching the non-streaming envelope.
- `tests/gateway/test_sse_agent_cancel.py`: new `TestSSEAgentFailureFinishReason` covering crash, failed-result, truncation, and the success happy path.

## Validation
Drove the real `_write_sse_chat_completion()` end-to-end with a live queue + asyncio task, capturing SSE bytes:

| Scenario | Before | After |
|---|---|---|
| `agent_task` raises (issue repro) | `stop` | `error` |
| `result` flagged `failed` | `stop` | `error` |
| `result` flagged `partial`+truncated | `stop` | `length` |
| normal completion | `stop` | `stop` (no error/hermes pollution) |

`tests/gateway/test_sse_agent_cancel.py`: 10 passed (6 existing + 4 new). Existing SSE/chat-completion tests in `test_api_server.py`: 29 passed.

## Infographic

![sse-stream-tells-the-truth](https://v3b.fal.media/files/b/0a9ff73e/pbuTrAc6nAJUX_wt_PxTm_8IQiavh0.png)
