### PR TITLE
fix(dashboard): deep-merge PUT /api/config to preserve unrelated sections

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -56,6 +56,7 @@ from hermes_cli.config import (
     get_hermes_home,
     load_config,
     load_env,
+    read_raw_config,
     save_config,
     save_env_value,
     remove_env_value,
@@ -65,6 +66,7 @@ from hermes_cli.config import (
     recommended_update_command_for_method,
     redact_key,
     write_platform_config_field,
+    _deep_merge,
 )
 from hermes_cli.memory_providers import (
     MemoryProvider,
@@ -4324,7 +4326,15 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
 async def update_config(body: ConfigUpdate, profile: Optional[str] = None):
     try:
         with _profile_scope(body.profile or profile):
-            save_config(_denormalize_config_from_web(body.config))
+            # The dashboard form is schema-driven (see CONFIG_SCHEMA). Any root
+            # key absent from the schema — most visibly ``custom_providers``, but
+            # also ``agent.personalities``, ``terminal.lifetime_seconds``, etc. —
+            # is not sent in the PUT body. A full-replace save would silently
+            # drop those keys. Deep-merge incoming over what's on disk so the
+            # frontend can only overwrite what it explicitly sends.
+            existing = read_raw_config()
+            incoming = _denormalize_config_from_web(body.config)
+            save_config(_deep_merge(existing, incoming))
         return {"ok": True}
     except HTTPException:
         raise

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "blaryx@gmail.com": "Blaryxoff",  # PR #32602 salvage (deep-merge PUT /api/config to preserve unrelated sections; #13396)
     "diamondeyesfox@gmail.com": "DiamondEyesFox",  # PR #53351 salvage (rebaseline in-place compression flushes to prevent duplicate compacted rows; #9096)
     "piyrw9754@gmail.com": "rlaope",  # PR #35075 salvage (align cron invisible-unicode set with install-time scanner; #35075)
     "rebel@rebels-Mac-Studio-2.local": "rebel0789",  # PR #47308 salvage (redact browser_type typed text across display surfaces; #47197)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2917,6 +2917,74 @@ class TestConfigRoundTrip:
         web_config["agent"]["max_turns"] = original_turns
         self.client.put("/api/config", json={"config": web_config})
 
+    def test_round_trip_preserves_custom_providers(self):
+        """``custom_providers`` is not in the dashboard schema, so the
+        frontend never sends it in PUT bodies. Saving must still preserve
+        it on disk — otherwise every dashboard click that saves silently
+        wipes the user's custom endpoints."""
+        from hermes_cli.config import load_config, save_config
+
+        save_config({
+            "model": {"default": "test/model", "provider": "custom:myprov"},
+            "custom_providers": [
+                {
+                    "name": "myprov",
+                    "base_url": "https://example.invalid/v1",
+                    "key_env": "MYPROV_API_KEY",
+                    "api_mode": "chat_completions",
+                    "model": "test/model",
+                },
+            ],
+        })
+
+        # Frontend behaviour: GET full config, then PUT without keys the
+        # schema doesn't know about (custom_providers is the prime example).
+        web_config = self.client.get("/api/config").json()
+        web_config.pop("custom_providers", None)
+        resp = self.client.put("/api/config", json={"config": web_config})
+        assert resp.status_code == 200
+
+        after = load_config()
+        cps = after.get("custom_providers")
+        assert isinstance(cps, list) and len(cps) == 1, \
+            f"custom_providers wiped by lossy PUT: {cps!r}"
+        assert cps[0].get("name") == "myprov"
+        assert cps[0].get("base_url") == "https://example.invalid/v1"
+
+    def test_round_trip_preserves_schema_invisible_nested_keys(self):
+        """Nested keys that aren't in CONFIG_SCHEMA must also survive a
+        round-trip. Deep-merge is required — a shallow merge would drop
+        ``agent.<custom_key>`` when the frontend sends a partial ``agent``
+        dict containing only schema-known sub-fields."""
+        from hermes_cli.config import load_config, read_raw_config, save_config
+
+        # Seed config with a key under `agent` that isn't in the schema.
+        # Use a sentinel name to avoid colliding with future schema fields.
+        save_config({
+            "agent": {
+                "max_turns": 50,
+                "x_dashboard_invisible_test_key": {"nested": "value"},
+            },
+        })
+
+        # PUT only schema-known agent fields, exactly like the dashboard.
+        web_config = self.client.get("/api/config").json()
+        web_config.setdefault("agent", {})
+        web_config["agent"]["max_turns"] = 75
+        # Strip our sentinel so we're sending what the schema-driven form
+        # would send.
+        web_config["agent"].pop("x_dashboard_invisible_test_key", None)
+
+        resp = self.client.put("/api/config", json={"config": web_config})
+        assert resp.status_code == 200
+
+        on_disk = read_raw_config()
+        assert on_disk.get("agent", {}).get("max_turns") == 75
+        assert on_disk.get("agent", {}).get("x_dashboard_invisible_test_key") \
+            == {"nested": "value"}, \
+            "Shallow-merge regression: agent.x_dashboard_invisible_test_key " \
+            "was wiped when the frontend sent a partial agent dict."
+
     def test_schema_types_match_config_values(self):
         """Every schema field should have a matching-type value in the config."""
         config = self.client.get("/api/config").json()


### PR DESCRIPTION
## Summary
Dashboard config saves no longer wipe sections the form doesn't manage. `PUT /api/config` now deep-merges the incoming payload over the on-disk config instead of replacing the whole file.

Root cause: `update_config()` called `save_config(_denormalize_config_from_web(body.config))`, a full-file replace. The dashboard form is schema-driven, so any root key it doesn't render (`custom_providers`, `compression`, `auxiliary`, `fallback_model`, nested non-schema keys) was absent from the PUT body and silently deleted on save.

Salvaged from #32602 (@Blaryxoff), the cleanest of three duplicates. Adapted the one-liner to run *inside* the existing `_profile_scope(...)` wrapper so per-profile dashboard writes still land in the right profile. Merge base is `read_raw_config()` (on-disk YAML only — no `DEFAULT_CONFIG` re-persisted to disk).

## Changes
- `hermes_cli/web_server.py`: `update_config()` deep-merges incoming over `read_raw_config()` inside the profile scope.
- `tests/hermes_cli/test_web_server.py`: round-trip tests for `custom_providers` + schema-invisible nested keys.
- `scripts/release.py`: AUTHOR_MAP entry for blaryx@gmail.com → Blaryxoff.

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py` → 326/326 pass.
- E2E against a temp HERMES_HOME: seeded `model`/`custom_providers`/`compression`/`auxiliary`/`fallback_model`, sent a partial PUT of only `agent`+`display`. All unrelated sections preserved; sent keys updated.

| Section | Before fix | After fix |
|---|---|---|
| custom_providers (not in PUT) | deleted | preserved |
| compression / auxiliary / fallback_model | deleted | preserved |
| agent.max_turns (in PUT) | set | set |

Closes #13396. Supersedes #13914 (@HiddenPuppy, earliest dup) and #32602 (@Blaryxoff, impl source).

## Infographic
![config-deep-merge](https://v3b.fal.media/files/b/0a9ff740/nGgqiV9pjDcZ00EiYiqie_pCVH1A5j.png)
