### PR TITLE
fix(agent_init): correct misleading sub-64K context_length error message

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1630,8 +1630,10 @@ def init_agent(
             f"Model {agent.model} has a context window of {_ctx:,} tokens, "
             f"which is below the minimum {MINIMUM_CONTEXT_LENGTH:,} required "
             f"by Hermes Agent.  Choose a model with at least "
-            f"{MINIMUM_CONTEXT_LENGTH // 1000}K context, or set "
-            f"model.context_length in config.yaml to override."
+            f"{MINIMUM_CONTEXT_LENGTH // 1000}K context.  If your server "
+            f"reports a window smaller than the model's true window, set "
+            f"model.context_length in config.yaml to the real value "
+            f"(this must be at least {MINIMUM_CONTEXT_LENGTH // 1000}K)."
         )
 
     # Inject context engine tool schemas (e.g. lcm_grep, lcm_describe, lcm_expand).


### PR DESCRIPTION
## Summary
The sub-64K context-window guard now tells the truth: there is no escape hatch for windows below the 64K minimum. Sub-64K models are rejected by design (tool schemas + system prompt need the headroom).

The old `ValueError` advertised *"or set `model.context_length` in config.yaml to override"* — but the guard intentionally has no sub-64K override. That misleading clause kept generating duplicate PRs from operators taking the message at its word.

## Changes
- `agent/agent_init.py`: reword the below-minimum `ValueError`. Drop the false "override" promise. State the real options: pick a ≥64K model, or — if your local server *under-reports* its true window — declare the real value (which must itself be ≥64K). Guard behavior is unchanged.

## Root cause
The error string described an override path that was never intended to exist. The 64K floor is deliberate, not a bug. The defect was purely the message.

## Validation
| | Before | After |
|---|---|---|
| Sub-64K model | rejected, message implies a fix exists | rejected, message names the real options |
| `below the minimum` substring (asserted by `test_compression_feasibility.py:121`) | present | present (test stays green) |
| Guard logic | unconditional `< 64K` raise | unchanged |

Closes the misleading-message root cause behind #11096 (Bug 1) and the dup PR cluster (#11097, #11110, #8962, #9142, #37548). Bug 2 (#11098) was declined-by-design; Bug 3 (#11103) already fixed on main via `_enable_from_env()`.

## Infographic

![honest-error-messages](https://v3b.fal.media/files/b/0a9ff744/Q4sOZBe6hyZXTm8DAzVGI_cwWbaRsA.png)
