### PR TITLE
fix(telegram): ignore bot-authored self-messages to stop self-ingestion (#11905)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5863,6 +5863,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def _should_observe_unmentioned_group_message(self, message: Message) -> bool:
         """Return True when a group message should be stored but not dispatched."""
+        if self._is_own_message(message):
+            return False
         if not self._telegram_observe_unmentioned_group_messages():
             return False
         if not self._is_group_chat(message):
@@ -6132,6 +6134,23 @@ class TelegramAdapter(BasePlatformAdapter):
             adapter_name = getattr(self, "name", "telegram")
             logger.warning("[%s] Failed to observe Telegram group message: %s", adapter_name, exc)
 
+    def _is_own_message(self, message: Message) -> bool:
+        """Return True when the message was sent by this bot itself.
+
+        In some Telegram environments (groups, supergroups where the bot can
+        see its own messages), getUpdates returns the bot's own outgoing
+        messages as updates.  These must be filtered out so they are not
+        counted as incoming unread messages in the Hermes inbox.
+        """
+        if not self._bot:
+            return False
+        from_user = getattr(message, "from_user", None)
+        if from_user is None:
+            return False
+        bot_id = getattr(self._bot, "id", None)
+        user_id = getattr(from_user, "id", None)
+        return bot_id is not None and user_id is not None and bot_id == user_id
+
     def _should_process_message(self, message: Message, *, is_command: bool = False) -> bool:
         """Apply Telegram group trigger rules.
 
@@ -6154,6 +6173,13 @@ class TelegramAdapter(BasePlatformAdapter):
         mentioning the bot (``@botname /command``), both of which are
         recognised as mentions by :meth:`_message_mentions_bot`.
         """
+        # Filter out the bot's own messages (returned by getUpdates in some
+        # environments like groups/supergroups where the bot can see its own
+        # messages).  Without this, outbound messages are counted as incoming
+        # unread in the Hermes inbox (#52363).
+        if self._is_own_message(message):
+            return False
+
         if not self._is_group_chat(message):
             return True
 

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -636,6 +636,66 @@ def test_invalid_regex_patterns_are_ignored():
     assert adapter._should_process_message(_group_message("hello everyone")) is False
 
 
+def test_bot_self_messages_are_ignored_in_dm_and_group():
+    """Bot-authored messages must not re-enter as fresh user turns (issue #11905).
+
+    Telegram echoes the bot's own outbound messages back through getUpdates.
+    Without a self-author guard, those echoes — including
+    ``[SYSTEM: Background process ...]`` watcher notifications — get ingested
+    as new inbound turns, producing the "haunted topic" loop. The guard keys
+    on ``from_user.id == self._bot.id`` (bot id is 999 in ``_make_adapter``).
+    """
+    adapter = _make_adapter(require_mention=False)
+
+    # Control: a real user in the same group IS processed.
+    assert adapter._should_process_message(_group_message("hi", chat_id=-100)) is True
+
+    # The exact reported symptom: a bot-authored DM-topic watcher echo.
+    self_dm = _group_message(
+        "[SYSTEM: Background process matched watch pattern ...]",
+        chat_id=555,
+        from_user_id=999,
+    )
+    self_dm.chat.type = "private"
+    assert adapter._should_process_message(self_dm) is False
+
+    # Same guard applies in groups/supergroups.
+    self_group = _group_message("status tick", chat_id=-100, from_user_id=999)
+    assert adapter._should_process_message(self_group) is False
+
+
+def test_other_bots_are_still_processed():
+    """A different bot's message must not be over-filtered.
+
+    Distinguishes the self-id guard from a blanket ``from_user.is_bot`` check,
+    which would incorrectly drop unrelated bots (weather, music, etc.) sharing
+    the same chat.
+    """
+    adapter = _make_adapter(require_mention=False)
+    other_bot = _group_message("weather update", chat_id=-100, from_user_id=555)
+    other_bot.from_user = SimpleNamespace(id=555, is_bot=True)
+    assert adapter._should_process_message(other_bot) is True
+
+
+def test_self_message_guard_skips_observe_path():
+    """Bot-authored messages are not stored via the observe-unmentioned path.
+
+    When ``_should_process_message`` rejects a message, dispatch falls through
+    to ``_should_observe_unmentioned_group_message``; the self-guard must also
+    sit there so a self-echo is neither dispatched nor stored.
+    """
+    adapter = _make_adapter(require_mention=True, observe_unmentioned_group_messages=True)
+    self_group = _group_message("status tick", chat_id=-100, from_user_id=999)
+    assert adapter._should_observe_unmentioned_group_message(self_group) is False
+
+
+def test_missing_from_user_does_not_crash():
+    adapter = _make_adapter(require_mention=False)
+    anon = _group_message("channel post", chat_id=-100)
+    anon.from_user = None
+    assert adapter._should_process_message(anon) is True
+
+
 def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()


### PR DESCRIPTION
## Summary
Telegram no longer ingests its own bot-authored messages as fresh inbound user turns. Telegram echoes the bot's outbound messages back through `getUpdates`; with no self-author guard, those echoes — including `[SYSTEM: Background process … matched watch pattern …]` watcher notifications — re-entered the conversation as new user turns, producing a "haunted topic" loop that survived `/reset`.

Root cause: `_should_process_message()` returned `True` for every DM with no check that the message's author is the bot itself. The intended watcher→agent turn comes in via the separate injection path (`_inject_watch_notification`, `internal=True`), which has no `from_user` and is structurally immune to the guard — so the agent still receives each notification exactly once. The fix removes only the spurious echo.

## Changes
- `plugins/platforms/telegram/adapter.py`: add `_is_own_message()` (keys on `from_user.id == self._bot.id`) and gate both `_should_process_message()` and the `_should_observe_unmentioned_group_message()` sibling path on it. The id-comparison drops only the bot's *own* echoes — unrelated bots (weather, music, etc.) in the same chat are still processed, unlike a blanket `from_user.is_bot` check.
- `tests/gateway/test_telegram_group_gating.py`: regression coverage — bot self-echo dropped in DM topic (the exact #11905 symptom) and in groups, other bots still processed, observe-unmentioned path also rejects self-messages, and missing `from_user` does not crash.

All four inbound dispatch paths (text, command, location, media) route through `_should_process_message` + the observe fallback, so the guard covers every entry point.

## Validation
| Path | Before | After |
|---|---|---|
| human DM | dispatched | dispatched |
| bot self-echo (`from_user.id == bot.id`) | **dispatched (bug)** | dropped |
| other bot in chat | dispatched | dispatched |
| injected watcher notification (`internal=True`) | delivered once | delivered once |

Verified end-to-end against the real `_handle_text_message` dispatch on current `main`, plus 4 new regression tests passing.

## Credit
- Fix cherry-picked from @Sahil-SS9's PR #52667 (authorship preserved).
- Test scaffolding ported from @cola-runner's PR #12817.
- Original report and root-cause analysis by @Jackten (#11905).
- Earlier fix attempt by @nightq (#11950) used a blanket `is_bot` check (over-filters other bots) — superseded by the self-id approach here.

Closes #11905.

## Infographic

![telegram-self-ingestion-guard](https://v3b.fal.media/files/b/0a9ff75c/Be9XDglRisYRDpDmbU-im_N1cPGndr.png)
