### PR TITLE
feat(gateway): add post-response context compression

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -34,6 +34,7 @@ _AUDIO_EXTS = frozenset({'.ogg', '.opus', '.mp3', '.wav', '.m4a', '.flac'})
 _TELEGRAM_AUDIO_ATTACHMENT_EXTS = frozenset({'.mp3', '.m4a'})
 _TELEGRAM_VOICE_EXTS = frozenset({'.ogg', '.opus'})
 _POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS = 30.0
+_POST_DELIVERY_TIMEOUT_ATTR = "_hermes_post_delivery_timeout_seconds"
 
 
 def _platform_name(platform) -> str:
@@ -3666,6 +3667,21 @@ class BasePlatformAdapter(ABC):
                     except Exception:
                         logger.debug("Post-delivery callback failed", exc_info=True)
 
+                _prev_timeout = getattr(
+                    _prev,
+                    _POST_DELIVERY_TIMEOUT_ATTR,
+                    _POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS,
+                )
+                _new_timeout = getattr(
+                    _new,
+                    _POST_DELIVERY_TIMEOUT_ATTR,
+                    _POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS,
+                )
+                try:
+                    _chain_timeout = max(float(_prev_timeout), float(_new_timeout))
+                except (TypeError, ValueError):
+                    _chain_timeout = _POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS
+                setattr(_chained, _POST_DELIVERY_TIMEOUT_ATTR, _chain_timeout)
                 callback = _chained
 
         if generation is None:
@@ -4937,10 +4953,12 @@ class BasePlatformAdapter(ABC):
                 try:
                     _post_result = _post_cb()
                     if inspect.isawaitable(_post_result):
-                        await asyncio.wait_for(
-                            _post_result,
-                            timeout=_POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS,
+                        _post_timeout = getattr(
+                            _post_cb,
+                            _POST_DELIVERY_TIMEOUT_ATTR,
+                            _POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS,
                         )
+                        await asyncio.wait_for(_post_result, timeout=_post_timeout)
                 except (asyncio.TimeoutError, Exception):
                     pass
             # Some adapters keep platform-level typing tasks.  If callback

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10303,6 +10303,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
             )
 
+            if not (
+                agent_failed_early
+                or is_context_overflow_failure
+                or agent_result.get("compression_exhausted")
+            ):
+                self._register_post_response_compression(
+                    session_key=session_key,
+                    session_entry=session_entry,
+                    source=source,
+                    agent_result=agent_result,
+                    run_generation=run_generation,
+                )
+
             # Intentional silence is a delivery decision, not a transcript
             # mutation.  The agent's [SILENT]/NO_REPLY assistant turn above is
             # still persisted in session history so later turns keep normal
@@ -10463,6 +10476,274 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         finally:
             # Restore session context variables to their pre-handler state
             self._clear_session_env(_session_env_tokens)
+
+    def _post_response_compression_settings(self) -> tuple[bool, Optional[float]]:
+        """Return gateway post-response compression settings.
+
+        The feature is opt-in because it can spend the compression-model call
+        even if the user never sends another message.  Preflight compression
+        remains the always-available safety net for the next turn.
+        """
+        try:
+            cfg = _load_gateway_config()
+        except Exception:
+            cfg = {}
+        comp = cfg.get("compression", {}) if isinstance(cfg, dict) else {}
+        if not isinstance(comp, dict):
+            return False, None
+        compression_enabled = str(comp.get("enabled", True)).lower() in {
+            "true",
+            "1",
+            "yes",
+        }
+        post_enabled = str(comp.get("post_response_enabled", False)).lower() in {
+            "true",
+            "1",
+            "yes",
+        }
+        if not compression_enabled or not post_enabled:
+            return False, None
+        raw_threshold = comp.get("post_response_threshold")
+        if raw_threshold in (None, ""):
+            return True, None
+        try:
+            threshold_ratio = float(raw_threshold)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Ignoring invalid compression.post_response_threshold=%r; "
+                "using the live compression threshold.",
+                raw_threshold,
+            )
+            return True, None
+        if not (0.0 < threshold_ratio <= 1.0):
+            logger.warning(
+                "Ignoring out-of-range compression.post_response_threshold=%r; "
+                "expected a ratio between 0.0 and 1.0.",
+                raw_threshold,
+            )
+            return True, None
+        return True, threshold_ratio
+
+    def _cached_agent_for_post_response_compression(self, session_key: str):
+        if not session_key:
+            return None
+        cache = getattr(self, "_agent_cache", None)
+        lock = getattr(self, "_agent_cache_lock", None)
+        if cache is None or lock is None:
+            return None
+        with lock:
+            cached = cache.get(session_key)
+            if not isinstance(cached, tuple) or not cached:
+                return None
+            agent = cached[0]
+            if agent is _AGENT_PENDING_SENTINEL:
+                return None
+            return agent
+
+    def _register_post_response_compression(
+        self,
+        *,
+        session_key: str,
+        session_entry: Any,
+        source: Any,
+        agent_result: Dict[str, Any],
+        run_generation: int,
+    ) -> None:
+        enabled, threshold_ratio = self._post_response_compression_settings()
+        if not enabled:
+            return
+        if not session_key or not isinstance(agent_result, dict):
+            return
+        if not agent_result.get("messages"):
+            return
+
+        adapter = (
+            self.adapters.get(source.platform)
+            if getattr(self, "adapters", None)
+            else None
+        )
+        if not adapter or not hasattr(adapter, "register_post_delivery_callback"):
+            logger.debug(
+                "Post-response compression skipped: adapter has no post-delivery callback"
+            )
+            return
+
+        async def _compress_after_delivery() -> None:
+            await self._run_post_response_compression(
+                session_key=session_key,
+                session_entry=session_entry,
+                source=source,
+                agent_result=agent_result,
+                threshold_ratio=threshold_ratio,
+            )
+        # Compression is an auxiliary LLM call and can legitimately exceed the
+        # generic post-delivery callback timeout. Delivery has already happened;
+        # keep the session guard until this finishes so the cached agent and DB
+        # are not mutated concurrently with the next turn.
+        try:
+            setattr(
+                _compress_after_delivery,
+                "_hermes_post_delivery_timeout_seconds",
+                180.0,
+            )
+        except Exception:
+            pass
+
+        try:
+            adapter.register_post_delivery_callback(
+                session_key,
+                _compress_after_delivery,
+                generation=run_generation,
+            )
+        except Exception:
+            logger.debug(
+                "Post-response compression callback registration failed",
+                exc_info=True,
+            )
+
+    async def _run_post_response_compression(
+        self,
+        *,
+        session_key: str,
+        session_entry: Any,
+        source: Any,
+        agent_result: Dict[str, Any],
+        threshold_ratio: Optional[float] = None,
+    ) -> None:
+        """Best-effort gateway compaction after the response is delivered."""
+        try:
+            await self._run_in_executor_with_context(
+                self._run_post_response_compression_sync,
+                session_key,
+                session_entry,
+                source,
+                agent_result,
+                threshold_ratio,
+            )
+        except Exception:
+            logger.warning(
+                "Post-response compression failed for session %s",
+                getattr(session_entry, "session_id", None) or session_key,
+                exc_info=True,
+            )
+
+    def _run_post_response_compression_sync(
+        self,
+        session_key: str,
+        session_entry: Any,
+        source: Any,
+        agent_result: Dict[str, Any],
+        threshold_ratio: Optional[float] = None,
+    ) -> None:
+        agent = self._cached_agent_for_post_response_compression(session_key)
+        if agent is None:
+            logger.debug(
+                "Post-response compression skipped: no cached agent for %s",
+                session_key,
+            )
+            return
+        if not getattr(agent, "compression_enabled", True):
+            return
+        compressor = getattr(agent, "context_compressor", None)
+        if compressor is None:
+            return
+
+        messages = agent_result.get("messages")
+        if not isinstance(messages, list) or len(messages) < 4:
+            return
+
+        from agent.model_metadata import estimate_request_tokens_rough
+
+        system_prompt = getattr(agent, "_cached_system_prompt", "") or ""
+        tools = getattr(agent, "tools", None) or None
+        approx_tokens = estimate_request_tokens_rough(
+            messages,
+            system_prompt=system_prompt,
+            tools=tools,
+        )
+        threshold_tokens = int(getattr(compressor, "threshold_tokens", 0) or 0)
+        if threshold_ratio is not None:
+            context_length = int(getattr(compressor, "context_length", 0) or 0)
+            if context_length > 0:
+                threshold_tokens = int(context_length * threshold_ratio)
+        if threshold_tokens <= 0 or approx_tokens < threshold_tokens:
+            logger.debug(
+                "Post-response compression skipped for %s: ~%s tokens below %s",
+                session_key,
+                f"{approx_tokens:,}",
+                f"{threshold_tokens:,}",
+            )
+            return
+
+        old_session_id = getattr(agent, "session_id", None) or getattr(
+            session_entry, "session_id", ""
+        )
+        try:
+            agent._last_compaction_in_place = False
+        except Exception:
+            pass
+
+        logger.info(
+            "Post-response compression: session=%s ~%s tokens >= %s threshold",
+            old_session_id or session_key,
+            f"{approx_tokens:,}",
+            f"{threshold_tokens:,}",
+        )
+        compressed, _ = agent._compress_context(
+            messages,
+            None,
+            approx_tokens=approx_tokens,
+            task_id=old_session_id or session_key,
+        )
+
+        new_session_id = getattr(agent, "session_id", None) or old_session_id
+        rotated = bool(new_session_id and new_session_id != old_session_id)
+        compacted_in_place = bool(getattr(agent, "_last_compaction_in_place", False))
+        if not rotated and not compacted_in_place:
+            logger.info(
+                "Post-response compression made no durable change for session=%s",
+                old_session_id or session_key,
+            )
+            return
+
+        store = getattr(self, "session_store", None)
+        if store is None:
+            return
+
+        if rotated:
+            entry = getattr(store, "_entries", {}).get(session_key, session_entry)
+            if entry is not None:
+                entry.session_id = new_session_id
+            save = getattr(store, "_save", None)
+            if callable(save):
+                save()
+            sync_binding = getattr(self, "_sync_telegram_topic_binding", None)
+            if callable(sync_binding) and entry is not None:
+                sync_binding(source, entry, reason="post-response-compression")
+            # In rotation mode _compress_context creates the continuation
+            # session, but the post-turn gateway path is already over, so write
+            # the compacted live context into the new row here.
+            rewrite = getattr(store, "rewrite_transcript", None)
+            if callable(rewrite):
+                rewrite(new_session_id, compressed)
+        elif compacted_in_place and getattr(agent, "_session_db", None) is None:
+            # With a real SessionDB, _compress_context already called
+            # archive_and_compact(), preserving inactive archived rows. Only
+            # fall back to rewrite when no DB-backed compaction was possible.
+            rewrite = getattr(store, "rewrite_transcript", None)
+            if callable(rewrite):
+                rewrite(new_session_id, compressed)
+
+        update = getattr(store, "update_session", None)
+        if callable(update):
+            update(session_key, last_prompt_tokens=0)
+        self._refresh_agent_cache_message_count(session_key, new_session_id)
+        logger.info(
+            "Post-response compression complete: session=%s messages=%d->%d",
+            new_session_id or session_key,
+            len(messages),
+            len(compressed) if isinstance(compressed, list) else 0,
+        )
 
     def _format_session_info(self) -> str:
         """Resolve current model config and return a formatted info block.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1280,6 +1280,16 @@ DEFAULT_CONFIG = {
     "compression": {
         "enabled": True,
         "threshold": 0.50,            # compress when context usage exceeds this ratio
+        "post_response_enabled": False,  # Gateway-only: when True, run a best-effort
+                                      # compression pass after a response has been
+                                      # delivered/persisted so the next turn is less
+                                      # likely to pay the compression latency.
+                                      # Default False preserves existing cost/timing:
+                                      # preflight compression still runs as the safety net.
+        "post_response_threshold": None,  # Optional ratio (0.0-1.0) for the gateway
+                                      # post-response pass. Null means reuse the
+                                      # agent's live compression threshold, including
+                                      # any model-specific auto-raise/lowering.
         "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
         "hygiene_hard_message_limit": 5000,  # gateway session-hygiene force-compress threshold by message count
@@ -6750,6 +6760,20 @@ def show_config():
     print(f"  Enabled:      {'yes' if enabled else 'no'}")
     if enabled:
         print(f"  Threshold:    {compression.get('threshold', 0.50) * 100:.0f}%")
+        _post_enabled = str(
+            compression.get('post_response_enabled', False)
+        ).lower() in {"true", "1", "yes"}
+        _post_threshold = compression.get('post_response_threshold')
+        if _post_enabled:
+            _post_label = "threshold"
+            if _post_threshold is not None:
+                try:
+                    _post_label = f"{float(_post_threshold) * 100:.0f}%"
+                except (TypeError, ValueError):
+                    _post_label = "threshold"
+            print(f"  Post-response: yes ({_post_label})")
+        else:
+            print("  Post-response: no")
         print(f"  Target ratio: {compression.get('target_ratio', 0.20) * 100:.0f}% of threshold preserved")
         print(f"  Protect last: {compression.get('protect_last_n', 20)} messages")
         print(f"  Protect first: {compression.get('protect_first_n', 3)} non-system head messages")

--- a/tests/gateway/test_post_response_compression.py
+++ b/tests/gateway/test_post_response_compression.py
@@ -1,0 +1,223 @@
+import threading
+from collections import OrderedDict
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.session import SessionEntry, SessionSource
+
+
+def _entry(session_key: str = "agent:main:discord:group:chan") -> SessionEntry:
+    return SessionEntry(
+        session_key=session_key,
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.DISCORD,
+        chat_type="group",
+    )
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="chan",
+        chat_type="group",
+        user_id="user-1",
+    )
+
+
+def _messages(content_size: int = 400) -> list[dict]:
+    return [
+        {"role": "user", "content": "u" * content_size},
+        {"role": "assistant", "content": "a" * content_size},
+        {"role": "user", "content": "u2" * content_size},
+        {"role": "assistant", "content": "a2" * content_size},
+    ]
+
+
+class _RotatingAgent:
+    compression_enabled = True
+    tools = []
+    _cached_system_prompt = ""
+    _session_db = object()
+
+    def __init__(self):
+        self.session_id = "sess-1"
+        self.context_compressor = SimpleNamespace(
+            threshold_tokens=50,
+            context_length=100,
+        )
+        self._last_compaction_in_place = False
+        self.calls = []
+
+    def _compress_context(self, messages, system_message, **kwargs):
+        self.calls.append((messages, system_message, kwargs))
+        self.session_id = "sess-2"
+        return ([{"role": "assistant", "content": "summary"}], "system")
+
+
+class _NoopAgent(_RotatingAgent):
+    def _compress_context(self, messages, system_message, **kwargs):
+        self.calls.append((messages, system_message, kwargs))
+        return (messages, "system")
+
+
+class _FailingAgent(_RotatingAgent):
+    def _compress_context(self, messages, system_message, **kwargs):
+        raise RuntimeError("compression broke")
+
+
+def _runner(agent, entry):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._agent_cache_lock = threading.Lock()
+    runner._agent_cache = OrderedDict({entry.session_key: (agent, "sig", 4)})
+    runner._session_db = MagicMock()
+    runner.session_store = MagicMock()
+    runner.session_store._entries = {entry.session_key: entry}
+    runner.session_store._save = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._sync_telegram_topic_binding = MagicMock()
+    runner._refresh_agent_cache_message_count = MagicMock()
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_post_response_compression_rotates_and_persists_live_context(monkeypatch):
+    from gateway import run as gateway_run
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "compression": {
+                "enabled": True,
+                "post_response_enabled": True,
+                "post_response_threshold": None,
+            }
+        },
+    )
+    entry = _entry()
+    agent = _RotatingAgent()
+    runner = _runner(agent, entry)
+
+    await runner._run_post_response_compression(
+        session_key=entry.session_key,
+        session_entry=entry,
+        source=_source(),
+        agent_result={"messages": _messages()},
+    )
+
+    assert entry.session_id == "sess-2"
+    runner.session_store._save.assert_called_once()
+    runner.session_store.rewrite_transcript.assert_called_once_with(
+        "sess-2",
+        [{"role": "assistant", "content": "summary"}],
+    )
+    runner.session_store.update_session.assert_called_once_with(
+        entry.session_key,
+        last_prompt_tokens=0,
+    )
+    runner._refresh_agent_cache_message_count.assert_called_once_with(
+        entry.session_key,
+        "sess-2",
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_response_compression_skips_below_threshold(monkeypatch):
+    from gateway import run as gateway_run
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "compression": {
+                "enabled": True,
+                "post_response_enabled": True,
+                "post_response_threshold": None,
+            }
+        },
+    )
+    entry = _entry()
+    agent = _RotatingAgent()
+    agent.context_compressor.threshold_tokens = 1_000_000
+    runner = _runner(agent, entry)
+
+    await runner._run_post_response_compression(
+        session_key=entry.session_key,
+        session_entry=entry,
+        source=_source(),
+        agent_result={"messages": _messages(content_size=10)},
+    )
+
+    assert agent.calls == []
+    assert entry.session_id == "sess-1"
+    runner.session_store.rewrite_transcript.assert_not_called()
+    runner.session_store.update_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_post_response_compression_noop_does_not_rewrite(monkeypatch):
+    from gateway import run as gateway_run
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "compression": {
+                "enabled": True,
+                "post_response_enabled": True,
+                "post_response_threshold": 0.01,
+            }
+        },
+    )
+    entry = _entry()
+    agent = _NoopAgent()
+    runner = _runner(agent, entry)
+
+    await runner._run_post_response_compression(
+        session_key=entry.session_key,
+        session_entry=entry,
+        source=_source(),
+        agent_result={"messages": _messages()},
+    )
+
+    assert entry.session_id == "sess-1"
+    runner.session_store.rewrite_transcript.assert_not_called()
+    runner.session_store.update_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_post_response_compression_failure_logs_and_continues(monkeypatch, caplog):
+    from gateway import run as gateway_run
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "compression": {
+                "enabled": True,
+                "post_response_enabled": True,
+                "post_response_threshold": 0.01,
+            }
+        },
+    )
+    entry = _entry()
+    runner = _runner(_FailingAgent(), entry)
+
+    await runner._run_post_response_compression(
+        session_key=entry.session_key,
+        session_entry=entry,
+        source=_source(),
+        agent_result={"messages": _messages()},
+    )
+
+    assert "Post-response compression failed for session sess-1" in caplog.text
+    runner.session_store.rewrite_transcript.assert_not_called()

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -673,6 +673,8 @@ Context compression is configured exclusively through `config.yaml` — there ar
 compression:
   enabled: true
   threshold: 0.50
+  post_response_enabled: false
+  post_response_threshold: null  # null = use the live compression threshold
   target_ratio: 0.20         # fraction of threshold to preserve as recent tail
   protect_last_n: 20         # minimum recent messages to keep uncompressed
 ```

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -734,6 +734,8 @@ All compression settings live in `config.yaml` (no environment variables).
 compression:
   enabled: true                                     # Toggle compression on/off
   threshold: 0.50                                   # Compress at this % of context limit
+  post_response_enabled: false                      # Gateway-only: compress after a delivered response (opt-in)
+  post_response_threshold: null                     # Null = use the live threshold; or set a ratio like 0.75
   target_ratio: 0.20                                # Fraction of threshold to preserve as recent tail
   protect_last_n: 20                                # Min recent messages to keep uncompressed
   protect_first_n: 3                                # Non-system head messages pinned across compactions (0 = pin nothing)
@@ -752,6 +754,10 @@ Older configs with `compression.summary_model`, `compression.summary_provider`, 
 :::
 
 `hygiene_hard_message_limit` is a gateway-only **pre-compression safety valve**. It exists to break a death spiral: when API calls keep disconnecting on an oversized session, the gateway never receives token-usage data, so the token-based threshold can't fire, so the transcript keeps growing and disconnects get worse. This count-based floor fires on message count alone (always known, regardless of API failures) to force compression and recover the session. Default `5000` — far above any normal session, including large-context (1M+) models doing thousands of short turns, which compress on the token threshold long before this. Raise it further for unusual platforms, lower it to force more aggressive compression. Editing this value on a running gateway takes effect on the next message (see below).
+
+`post_response_enabled` is a gateway-only **post-response compaction pass**. When enabled, Hermes checks the completed turn after the assistant response has been persisted and delivered, then compresses the session before releasing it for the next message. This moves compression latency out of the next user turn for long-running Discord, Telegram, Slack, and other gateway conversations. It is best-effort: delivery has already happened, failures are logged, and normal preflight compression remains the safety net. Default `false` preserves existing cost behavior because a compression-model call is otherwise spent even if the user never continues the conversation.
+
+`post_response_threshold` optionally raises or lowers that post-response trigger independently. Leave it `null` to use the live agent threshold, including model-specific threshold adjustments. Set a ratio such as `0.75` to run the post-response pass later than normal preflight compression.
 
 `protect_first_n` controls how many **non-system** head messages are pinned across every compaction. Default `3` — the opening user/assistant exchange survives every summarizer pass so the original goal stays visible. On long-running rolling-compaction sessions where the opening turn is no longer relevant, set `protect_first_n: 0` to pin nothing but the system prompt + summary + tail. The system prompt itself is always preserved regardless of this setting.
 


### PR DESCRIPTION
## Summary
- add opt-in gateway post-response context compression after delivery/persistence
- keep preflight compression as the safety net and make post-response failures best-effort/log-only
- document the new compression.post_response_enabled and compression.post_response_threshold settings

## Test Plan
- python -m pytest tests/gateway/test_post_response_compression.py tests/gateway/test_compression_concurrent_sessions.py tests/gateway/test_compress_command.py tests/hermes_cli/test_context_switch_guard.py -q -o 'addopts='
- python -m pytest tests/gateway/test_post_response_compression.py -q -o 'addopts='
- python -m py_compile gateway/run.py gateway/platforms/base.py hermes_cli/config.py
- git diff HEAD~1..HEAD --check