### PR TITLE
fix(agent): walk cause chain when extracting wrapped API error bodies (salvage of #14287 by @LeonSGP43)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1317,19 +1317,25 @@ def _extract_status_code(error: Exception) -> Optional[int]:
 
 
 def _extract_error_body(error: Exception) -> dict:
-    """Extract the structured error body from an SDK exception."""
-    body = getattr(error, "body", None)
-    if isinstance(body, dict):
-        return body
-    # Some errors have .response.json()
-    response = getattr(error, "response", None)
-    if response is not None:
-        try:
-            json_body = response.json()
-            if isinstance(json_body, dict):
-                return json_body
-        except Exception:
-            pass
+    """Extract the structured error body from an SDK exception or its cause chain."""
+    current = error
+    for _ in range(5):  # Match _extract_status_code() traversal depth.
+        body = getattr(current, "body", None)
+        if isinstance(body, dict):
+            return body
+        # Some errors have .response.json()
+        response = getattr(current, "response", None)
+        if response is not None:
+            try:
+                json_body = response.json()
+                if isinstance(json_body, dict):
+                    return json_body
+            except Exception:
+                pass
+        cause = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
+        if cause is None or cause is current:
+            break
+        current = cause
     return {}
 
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -127,6 +127,18 @@ class TestExtractErrorBody:
         e = MockAPIError("fail", body={"error": {"message": "bad"}})
         assert _extract_error_body(e) == {"error": {"message": "bad"}}
 
+    def test_from_cause_chain_body_attr(self):
+        inner = MockAPIError(
+            "inner",
+            status_code=402,
+            body={"error": {"message": "Usage limit reached, try again in 5 minutes"}},
+        )
+        outer = Exception("outer")
+        outer.__cause__ = inner
+        assert _extract_error_body(outer) == {
+            "error": {"message": "Usage limit reached, try again in 5 minutes"},
+        }
+
     def test_empty_when_no_body(self):
         assert _extract_error_body(Exception("generic")) == {}
 
@@ -299,6 +311,21 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.billing
         assert result.retryable is False
         assert result.should_fallback is True
+
+    def test_wrapped_402_uses_nested_body_message(self):
+        inner = MockAPIError(
+            "inner",
+            status_code=402,
+            body={"error": {"message": "Usage limit reached, try again in 5 minutes"}},
+        )
+        outer = Exception("outer")
+        outer.__cause__ = inner
+
+        result = classify_api_error(outer)
+
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+        assert result.message == "Usage limit reached, try again in 5 minutes"
 
     # ── Rate limit ──
 


### PR DESCRIPTION
## Summary
Wrapped API errors now keep the nested body message, so transient 402 usage limits classify as `rate_limit` (retryable) instead of being misread as terminal `billing` failures.

Root cause: `classify_api_error()` extracted the status code via `_extract_status_code()` (which walks `__cause__`/`__context__`) but the body via `_extract_error_body()` (which only inspected the top-level exception). A wrapped 402 kept the nested status code but lost the nested "try again in 5 minutes" body, so `_classify_402()` saw no transient signal and defaulted to `billing`/non-retryable.

## Changes
- `agent/error_classifier.py`: `_extract_error_body()` now walks the `__cause__`/`__context__` chain (max depth 5), mirroring `_extract_status_code()`.
- `tests/agent/test_error_classifier.py`: covers nested-body extraction and the full wrapped-402 → `rate_limit` classification path.

## Validation
| Case | Before | After |
|---|---|---|
| Wrapped 402, nested body "Usage limit, try again in 5 min" | `billing`, retryable=False | `rate_limit`, retryable=True |
| Wrapped 402, nested body "credit balance too low" | `billing` | `billing` (no regression) |

Targeted suite: 164/164 pass. E2E verified with real imports against the live classification path.

Salvage of #14287 by @LeonSGP43 (cherry-picked onto current main, authorship preserved). Closes #14195. Duplicates: #14219 (@liuhao1024, first submitter, already closed), #14349 (@sgaofen), #14787 (@Tranquil-Flow).

## Infographic

![error-classifier-walk-the-cause-chain](https://v3b.fal.media/files/b/0a9ff7b5/oEt9gD2Kn29eYJ526h70Y_xwhiYEz0.png)
