### PR TITLE
fix(config): accept placeholder base_url in custom provider validation (#14457)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4269,6 +4269,14 @@ def _normalize_custom_provider_entry(
         raw_url = entry.get(url_key)
         if isinstance(raw_url, str) and raw_url.strip():
             candidate = raw_url.strip()
+            # Accept URLs containing unresolved placeholder tokens — both
+            # ``${ENV_VAR}`` env-refs and bare ``{region}``-style templates —
+            # without URL validation. They are expanded at runtime, so a
+            # caller reaching this normalizer with raw (un-expanded) config
+            # would otherwise see the provider silently dropped (#14457).
+            if re.search(r"\{[^}]+\}", candidate):
+                base_url = candidate
+                break
             parsed = urlparse(candidate)
             if parsed.scheme and parsed.netloc:
                 base_url = candidate

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -191,3 +191,49 @@ class TestNormalizeCustomProviderEntry:
         result = _normalize_custom_provider_entry(entry)
         assert result is not None
         assert "models" not in result
+
+    def test_env_var_placeholder_in_base_url_not_rejected(self):
+        """A base_url that is an un-expanded ${ENV_VAR} placeholder must not be
+        rejected as an invalid URL — it is expanded at runtime, so a caller
+        reaching this normalizer with raw config would otherwise see the
+        provider silently dropped. Regression test for #14457."""
+        entry = {
+            "name": "PROVIDER_A",
+            "base_url": "${PROVIDER_A_BASE_URL}",
+            "key_env": "PROVIDER_A_API_KEY",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="PROVIDER_A")
+        assert result is not None
+        assert result["base_url"] == "${PROVIDER_A_BASE_URL}"
+
+    def test_multiple_env_vars_in_base_url(self):
+        """base_url with multiple ${VAR} placeholders is accepted verbatim."""
+        entry = {
+            "name": "multi-var-provider",
+            "base_url": "${SCHEME}://${HOST}:${PORT}/v1",
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert result["base_url"] == "${SCHEME}://${HOST}:${PORT}/v1"
+
+    def test_bare_brace_region_placeholder_accepted(self):
+        """A bare {region}-style template token (not an env-ref) is also
+        accepted without validation, supporting region-substitution URLs."""
+        entry = {
+            "name": "regional",
+            "base_url": "https://{region}.api.example.com/v1",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="regional")
+        assert result is not None
+        assert result["base_url"] == "https://{region}.api.example.com/v1"
+
+    def test_invalid_url_without_placeholder_still_rejected(self):
+        """A malformed URL with no scheme/host AND no placeholder token is
+        still rejected — the placeholder bypass must not weaken validation of
+        ordinary literal URLs."""
+        entry = {
+            "name": "bad",
+            "base_url": "not-a-url",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="bad")
+        assert result is None


### PR DESCRIPTION
## Summary
Custom providers whose `base_url` is an un-expanded placeholder (`${ENV_VAR}` or a bare `{region}` token) are no longer silently dropped.

Root cause: `_normalize_custom_provider_entry()` ran `urlparse()` on `base_url` and required a scheme+host, so any caller reaching the normalizer with raw (un-expanded) config — e.g. the Dockerized gateway path in the report — rejected the placeholder as "not a valid URL" and skipped the provider.

## Changes
- `hermes_cli/config.py`: in `_normalize_custom_provider_entry()`, accept a `base_url` candidate without URL validation when it contains a placeholder token (`{...}`), covering both `${ENV_VAR}` env-refs and bare `{region}`-style templates. Literal URLs are still validated; malformed literals without a placeholder are still rejected.
- `tests/hermes_cli/test_provider_config_validation.py`: regression coverage for env-ref placeholders, multi-var URLs, bare-brace region tokens, and the still-rejected malformed-literal case.

## Validation
| Case | Before | After |
|---|---|---|
| `base_url: ${PROVIDER_A_BASE_URL}` | dropped (None) | kept verbatim |
| `https://{region}.api.example.com/v1` | dropped | kept |
| `https://api.example.com/v1` (literal) | kept | kept |
| `not-a-url` (malformed, no placeholder) | rejected | rejected |

- `scripts/run_tests.sh tests/hermes_cli/test_provider_config_validation.py` → 21 passed
- E2E: full `get_compatible_custom_providers()` compat path with two `${VAR}` providers → both survive (previously both dropped).

Note: the gateway-side expansion the reporter also blamed is already resolved on current `main` via `_load_gateway_runtime_config()`, so this PR is scoped to the remaining root cause in the normalizer.

This salvages the cluster of independent fixes for the same issue. Earliest finder: @zjc-enigma (#14524). Implementation salvaged from @ms-alan (#14628), with the bare-`{region}` token coverage from @Tranquil-Flow (#15378) folded in. Authorship preserved via @ms-alan's commit.

Closes #14457

## Infographic
![Placeholder URLs no longer dropped](https://v3b.fal.media/files/b/0a9ff7c4/3uDhtZan_MFPAq297wK8h_6Xay4Hau.png)
