### PR TITLE
fix(redact): mask passwords in lowercase/dotted config keys (#16413)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -107,10 +107,58 @@ _PREFIX_PATTERNS = [
     r"ntn_[A-Za-z0-9]{10,}",            # Notion internal integration token
 ]
 
-# ENV assignment patterns: KEY=value where KEY contains a secret-like name
+# ENV assignment patterns: KEY=value where KEY contains a secret-like name.
+# Uppercase keys tolerate spaces around "=" (e.g. ``FOO_SECRET = bar``) because
+# an all-caps key is almost never prose/code.
 _SECRET_ENV_NAMES = r"(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTH)"
 _ENV_ASSIGN_RE = re.compile(
     rf"([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*(['\"]?)(\S+)\2",
+)
+
+# Lowercase / dotted / hyphenated config keys from config files
+# (application.properties, .env, YAML-ish dumps): ``spring.datasource.password=secret``,
+# ``app.api.key=xyz``, ``password=secret``. The uppercase _ENV_ASSIGN_RE above
+# never matched these, so config-file passwords leaked verbatim (issue #16413).
+#
+# These run only in a config-file context, NOT in prose, code, or URLs — three
+# carve-outs preserved from the original design (#4367 + the documented
+# web-URL passthrough below):
+#   1. The value is bounded by ``[^\s&]`` (stops at whitespace AND ``&``) so
+#      form-urlencoded bodies are handled pair-by-pair (by _redact_form_body),
+#      not greedily swallowed.
+#   2. _CFG_DOTTED_RE only matches when the key is NAMESPACED (contains a dot),
+#      which is unambiguously a config key — never a prose word.
+#   3. _CFG_ANCHORED_RE matches a bare secret-word key only at line start
+#      (optionally after ``export``), so conversational ``I have password=foo``
+#      mid-sentence is left alone.
+# The colon-form URL guard (skip when ``://`` present) lives at the call site.
+_SECRET_CFG_NAMES = r"(?:api[ _.\-]?key|token|secret|passwd|password|credential|auth)"
+_CFG_VALUE = r"(['\"]?)([^\s&]+?)\2(?=[\s&]|$)"
+# Namespaced (dotted) key: the secret word may sit anywhere in a dotted path.
+_CFG_DOTTED_RE = re.compile(
+    rf"((?:[A-Za-z0-9_\-]+\.)+[A-Za-z0-9_.\-]*{_SECRET_CFG_NAMES}[A-Za-z0-9_.\-]*"
+    rf"|[A-Za-z0-9_.\-]*{_SECRET_CFG_NAMES}[A-Za-z0-9_.\-]*\.[A-Za-z0-9_.\-]+)"
+    rf"={_CFG_VALUE}",
+    re.IGNORECASE,
+)
+# Line-anchored bare key: ``password=…`` / ``export api_key=…`` at start of line.
+_CFG_ANCHORED_RE = re.compile(
+    rf"(^[ \t]*(?:export[ \t]+)?[A-Za-z0-9_\-]*{_SECRET_CFG_NAMES}[A-Za-z0-9_\-]*)={_CFG_VALUE}",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Unquoted YAML / colon config (e.g. ``password: secret``,
+# ``spring.datasource.password: hunter2``). The secret keyword must be part of
+# the KEY (anchored to the start of the line/indent), and the value is a single
+# whitespace-free token — so prose like ``note: secret meeting`` (keyword in the
+# value) and ``error: token expired`` are left alone. Bare ``auth`` is excluded
+# from the key set so ``Authorization:`` / ``author:`` don't match (the former
+# is masked by _AUTH_HEADER_RE); ``auth_token``/``auth-token`` still match via
+# the ``token`` keyword. Quoted values defer to _JSON_FIELD_RE via the lookahead.
+_YAML_CFG_NAMES = r"(?:api[ _.\-]?key|token|secret|passwd|password|credential)"
+_YAML_ASSIGN_RE = re.compile(
+    rf"(^[ \t]*[A-Za-z0-9_.\-]*{_YAML_CFG_NAMES}[A-Za-z0-9_.\-]*)(:[ \t]*)(?!['\"])([^\s&]+)",
+    re.IGNORECASE | re.MULTILINE,
 )
 
 # JSON field patterns: "apiKey": "value", "token": "value", etc.
@@ -382,6 +430,13 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
                 name, quote, value = m.group(1), m.group(2), m.group(3)
                 return f"{name}={quote}{_mask_token(value)}{quote}"
             text = _ENV_ASSIGN_RE.sub(_redact_env, text)
+            # Lowercase/dotted config keys (issue #16413). Skip URLs entirely —
+            # web-URL query params are intentionally passed through (see note
+            # near the bottom of this function); _DB_CONNSTR_RE still guards
+            # connection-string passwords.
+            if "://" not in text:
+                text = _CFG_DOTTED_RE.sub(_redact_env, text)
+                text = _CFG_ANCHORED_RE.sub(_redact_env, text)
 
         # JSON fields: "apiKey": "***"  (skip for code files — false positives)
         if ":" in text and '"' in text:
@@ -389,6 +444,15 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
                 key, value = m.group(1), m.group(2)
                 return f'{key}: "{_mask_token(value)}"'
             text = _JSON_FIELD_RE.sub(_redact_json, text)
+
+        # Unquoted YAML / colon config: password: ***  (after JSON so quoted
+        # values are handled there; the lookahead in _YAML_ASSIGN_RE skips
+        # quotes). Skip URLs — web-URL query params pass through by design.
+        if ":" in text and "://" not in text:
+            def _redact_yaml(m):
+                key, sep, value = m.group(1), m.group(2), m.group(3)
+                return f"{key}{sep}{_mask_token(value)}"
+            text = _YAML_ASSIGN_RE.sub(_redact_yaml, text)
 
     # Authorization headers — _AUTH_HEADER_RE matches any scheme after
     # "[Proxy-]Authorization:" case-insensitively, so "uthorization" is the

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -504,6 +504,81 @@ class TestFormBodyRedaction:
         assert "first=1" in redact_sensitive_text(text)
 
 
+class TestLowercaseDottedConfigKeys:
+    """Issue #16413 — config-file passwords in lowercase/dotted/colon keys
+    must be redacted. The uppercase _ENV_ASSIGN_RE missed these, leaking
+    `spring.datasource.password=...` and `password: ...` from `cat`'d config
+    files. Carve-outs: prose, code (#4367), and web URLs are left untouched.
+    """
+
+    def test_spring_dotted_password_assignment(self):
+        text = "spring.datasource.password=Sup3rS3cret!"
+        result = redact_sensitive_text(text)
+        assert "Sup3rS3cret!" not in result
+        assert "spring.datasource.password=" in result
+
+    def test_dotted_api_key_split_keyword(self):
+        # 'api.key' splits the keyword across a dot — must still match.
+        text = "app.api.key=ak_live_998877"
+        result = redact_sensitive_text(text)
+        assert "ak_live_998877" not in result
+        assert "app.api.key=" in result
+
+    def test_bare_lowercase_password_at_line_start(self):
+        text = "password=mysecretvalue123"
+        result = redact_sensitive_text(text)
+        assert "mysecretvalue123" not in result
+
+    def test_quoted_lowercase_value(self):
+        text = "password='mysecretvalue123'"
+        result = redact_sensitive_text(text)
+        assert "mysecretvalue123" not in result
+
+    def test_yaml_unquoted_password(self):
+        text = "password: Sup3rS3cret!"
+        result = redact_sensitive_text(text)
+        assert "Sup3rS3cret!" not in result
+        assert "password:" in result
+
+    def test_yaml_indented_dotted(self):
+        text = "spring:\n  datasource:\n    password: hunter2pass"
+        result = redact_sensitive_text(text)
+        assert "hunter2pass" not in result
+
+    def test_properties_file_dump(self):
+        text = (
+            "server.port=8080\n"
+            "spring.datasource.username=admin\n"
+            "spring.datasource.password=Sup3rS3cret!\n"
+            "logging.level.root=INFO"
+        )
+        result = redact_sensitive_text(text)
+        assert "Sup3rS3cret!" not in result
+        assert "server.port=8080" in result  # non-secret keys preserved
+        assert "username=admin" in result
+
+    # --- carve-outs: must NOT redact ---
+
+    def test_prose_mid_sentence_password_unchanged(self):
+        # Not line-anchored, not dotted → conversational text, leave alone.
+        text = "I have password=foo and other things"
+        assert redact_sensitive_text(text) == text
+
+    def test_lowercase_code_assignment_unchanged(self):
+        # #4367 regression — spaces around '=' in code.
+        text = "const secret = await fetchSecret();"
+        assert redact_sensitive_text(text) == text
+
+    def test_url_query_param_passes_through(self):
+        # Web URLs are intentionally hands-off (documented design).
+        text = "https://example.com/api?password=opaqueval123&format=json"
+        assert redact_sensitive_text(text) == text
+
+    def test_prose_keyword_in_value_unchanged(self):
+        text = "note: secret meeting at noon"
+        assert redact_sensitive_text(text) == text
+
+
 class TestXaiToken:
     KEY = "xai-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstu"
 


### PR DESCRIPTION
## Summary

Config-file passwords now get redacted. The secret redactor only matched **uppercase** env-style keys (`[A-Z0-9_]`), so anything from a real config file — `spring.datasource.password=secret`, `app.api.key=xyz`, YAML `password: secret` — leaked verbatim when the agent ran `cat`/`grep` on `application.properties` or `.env` files (issue #16413).

## Root cause

`_ENV_ASSIGN_RE` in `agent/redact.py` used `[A-Z0-9_]` with no `IGNORECASE` and no `.`/`-` in the key, by design — the uppercase-only restriction was the #4367 fix that stopped lowercase code/prose (`const secret = await fetchSecret()`) from being redacted. So lowercase/dotted config keys were never covered.

## Changes

- `agent/redact.py`: three new case-insensitive config-key matchers, gated to run only in a config-file context:
  - `_CFG_DOTTED_RE` — namespaced keys (contain a dot), e.g. `spring.datasource.password`, `app.api.key` (matches even when the secret word is split across a dot like `api.key`).
  - `_CFG_ANCHORED_RE` — bare secret-word keys at line start (optionally after `export`), e.g. `password=secret`.
  - `_YAML_ASSIGN_RE` — unquoted colon config, e.g. `password: secret`.
- Value capture stops at whitespace **and** `&`, so form-urlencoded bodies stay pair-by-pair (handled by `_redact_form_body`) instead of being swallowed.
- The `=`/`:` passes skip any text containing `://`, preserving the **documented** web-URL passthrough (magic links, OAuth callbacks, presigned URLs). `_DB_CONNSTR_RE` still guards connection-string passwords.

## Carve-outs preserved (no false positives)

| Input | Result |
|---|---|
| `const secret = await fetchSecret();` (#4367 code) | unchanged |
| `I have password=foo and other things` (prose) | unchanged |
| `https://x/api?password=opaque&format=json` (URL) | unchanged |
| `note: secret meeting at noon` (keyword in value) | unchanged |

## Validation

| | Before | After |
|---|---|---|
| `spring.datasource.password=secret` | leaked | `=***` |
| `app.api.key=ak_live_998877` | leaked | `=***` |
| `password: hunter2` (YAML) | leaked | `: ***` |
| `tests/agent/test_redact.py` | 82 passing | 93 passing (+11) |

11 new tests cover the leak cases and every carve-out. All 82 existing redaction tests still pass.

## Infographic

![redaction-config-key-leak-fix](https://v3b.fal.media/files/b/0a9ff7e7/_98TG207PAniWtlugES6W_dwIABIAV.png)
