### PR TITLE
fix(desktop): refresh active session for external messages

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -130,6 +130,10 @@ import { PersistentTerminal, TerminalSlot } from './right-sidebar/terminal/persi
 import { CRON_ROUTE, NEW_CHAT_ROUTE, routeSessionId, sessionRoute, SETTINGS_ROUTE } from './routes'
 import { SessionPickerOverlay } from './session-picker-overlay'
 import { SessionSwitcher } from './session-switcher'
+import {
+  sameSessionRefreshRows,
+  useActiveSessionExternalRefresh
+} from './session/hooks/use-active-session-external-refresh'
 import { useContextSuggestions } from './session/hooks/use-context-suggestions'
 import { useCwdActions } from './session/hooks/use-cwd-actions'
 import { useHermesConfig } from './session/hooks/use-hermes-config'
@@ -235,6 +239,8 @@ export function DesktopController() {
   const previewPaneOpen = useStore($paneOpen(PREVIEW_PANE_ID))
   const panesFlipped = useStore($panesFlipped)
   const profileScope = useStore($profileScope)
+  const sessions = useStore($sessions)
+  const messagingSessions = useStore($messagingSessions)
   // Below SIDEBAR_COLLAPSE_BREAKPOINT_PX there's no room for a docked rail —
   // collapse both sidebars (without touching their stored open state) so the
   // hover-reveal overlay becomes the way in. Restores once it's wide again.
@@ -438,7 +444,7 @@ export function DesktopController() {
       // sources) — those stay in local recents, not a platform section.
       const rows = result.sessions.filter(s => isMessagingSource(s.source))
 
-      setMessagingSessions(prev => (sameCronSignature(prev, rows) ? prev : rows))
+      setMessagingSessions(prev => (sameSessionRefreshRows(prev, rows) ? prev : rows))
       // Hit the cap → at least one platform may have more on disk than loaded,
       // so platform sections offer their own per-platform "load more".
       setMessagingTruncated(result.sessions.length >= MESSAGING_SECTION_LIMIT)
@@ -651,9 +657,12 @@ export function DesktopController() {
         return
       }
 
-      const storedProfile = $sessions
-        .get()
-        .find(session => session.id === storedSessionId || session._lineage_root_id === storedSessionId)?.profile
+      const sessionMatchesStoredId = (session: SessionInfo) =>
+        session.id === storedSessionId || session._lineage_root_id === storedSessionId
+
+      const storedProfile =
+        $sessions.get().find(sessionMatchesStoredId)?.profile ??
+        $messagingSessions.get().find(sessionMatchesStoredId)?.profile
 
       for (let index = 0; index < Math.max(1, attempts); index += 1) {
         try {
@@ -691,6 +700,15 @@ export function DesktopController() {
     },
     [activeSessionIdRef, selectedStoredSessionIdRef, updateSessionState]
   )
+
+  useActiveSessionExternalRefresh({
+    activeSessionId,
+    hydrateFromStoredSession,
+    messagingSessions,
+    selectedStoredSessionId,
+    sessionStateByRuntimeIdRef,
+    sessions
+  })
 
   const { handleGatewayEvent } = useMessageStream({
     activeSessionIdRef,

--- a/apps/desktop/src/app/session/hooks/use-active-session-external-refresh.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-active-session-external-refresh.test.tsx
@@ -1,0 +1,203 @@
+import { cleanup, render } from '@testing-library/react'
+import type { MutableRefObject } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import type { SessionInfo } from '@/types/hermes'
+
+import { sameSessionRefreshRows, useActiveSessionExternalRefresh } from './use-active-session-external-refresh'
+
+interface HarnessProps {
+  activeSessionId: string | null
+  hydrateFromStoredSession: (
+    attempts?: number,
+    storedSessionId?: string | null,
+    runtimeSessionId?: string | null
+  ) => Promise<void>
+  messagingSessions: SessionInfo[]
+  selectedStoredSessionId: string | null
+  sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>>
+  sessions: SessionInfo[]
+}
+
+function Harness(props: HarnessProps) {
+  useActiveSessionExternalRefresh(props)
+
+  return null
+}
+
+function session(over: Partial<SessionInfo>): SessionInfo {
+  return {
+    archived: false,
+    cwd: null,
+    ended_at: null,
+    id: 'session-1',
+    input_tokens: 0,
+    is_active: false,
+    last_active: 0,
+    message_count: 0,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    source: null,
+    started_at: 0,
+    title: null,
+    tool_call_count: 0,
+    ...over
+  }
+}
+
+function clientSessionState(over: Partial<ClientSessionState> = {}): ClientSessionState {
+  return {
+    awaitingResponse: false,
+    branch: '',
+    busy: false,
+    cwd: '',
+    fast: false,
+    interrupted: false,
+    messages: [],
+    model: '',
+    needsInput: false,
+    pendingBranchGroup: null,
+    personality: '',
+    provider: '',
+    reasoningEffort: '',
+    sawAssistantPayload: false,
+    serviceTier: '',
+    storedSessionId: 'session-1',
+    streamId: null,
+    turnStartedAt: null,
+    yolo: false,
+    ...over
+  }
+}
+
+function message(id: string): ClientSessionState['messages'][number] {
+  return { id, parts: [{ text: id, type: 'text' }], role: 'user' }
+}
+
+describe('useActiveSessionExternalRefresh', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('treats externally appended messaging metadata as a changed row', () => {
+    const before = [
+      session({ id: 'signal-1', last_active: 10, message_count: 2, preview: 'old', source: 'signal', title: 'setup' })
+    ]
+
+    const after = [
+      session({ id: 'signal-1', last_active: 20, message_count: 4, preview: 'new', source: 'signal', title: 'setup' })
+    ]
+
+    expect(sameSessionRefreshRows(before, after)).toBe(false)
+  })
+
+  it('hydrates the open messaging session when its refreshed row changes', () => {
+    const hydrateFromStoredSession = vi.fn(async () => undefined)
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['runtime-1', clientSessionState({ storedSessionId: 'signal-1' })]])
+    }
+
+    const { rerender } = render(
+      <Harness
+        activeSessionId="runtime-1"
+        hydrateFromStoredSession={hydrateFromStoredSession}
+        messagingSessions={[
+          session({ id: 'signal-1', last_active: 10, message_count: 2, preview: 'old', source: 'signal' })
+        ]}
+        selectedStoredSessionId="signal-1"
+        sessions={[]}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+
+    expect(hydrateFromStoredSession).not.toHaveBeenCalled()
+
+    rerender(
+      <Harness
+        activeSessionId="runtime-1"
+        hydrateFromStoredSession={hydrateFromStoredSession}
+        messagingSessions={[
+          session({ id: 'signal-1', last_active: 20, message_count: 4, preview: 'new', source: 'signal' })
+        ]}
+        selectedStoredSessionId="signal-1"
+        sessions={[]}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+
+    expect(hydrateFromStoredSession).toHaveBeenCalledTimes(1)
+    expect(hydrateFromStoredSession).toHaveBeenCalledWith(1, 'signal-1', 'runtime-1')
+  })
+
+  it('does not hydrate a busy local runtime from an external metadata refresh', () => {
+    const hydrateFromStoredSession = vi.fn(async () => undefined)
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['runtime-1', clientSessionState({ busy: true, storedSessionId: 'signal-1' })]])
+    }
+
+    const { rerender } = render(
+      <Harness
+        activeSessionId="runtime-1"
+        hydrateFromStoredSession={hydrateFromStoredSession}
+        messagingSessions={[session({ id: 'signal-1', last_active: 10, message_count: 2, source: 'signal' })]}
+        selectedStoredSessionId="signal-1"
+        sessions={[]}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+
+    rerender(
+      <Harness
+        activeSessionId="runtime-1"
+        hydrateFromStoredSession={hydrateFromStoredSession}
+        messagingSessions={[session({ id: 'signal-1', last_active: 20, message_count: 4, source: 'signal' })]}
+        selectedStoredSessionId="signal-1"
+        sessions={[]}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+
+    expect(hydrateFromStoredSession).not.toHaveBeenCalled()
+  })
+
+  it('does not hydrate when refreshed metadata does not add persisted messages', () => {
+    const hydrateFromStoredSession = vi.fn(async () => undefined)
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([
+        ['runtime-1', clientSessionState({ messages: [message('m1'), message('m2')], storedSessionId: 'signal-1' })]
+      ])
+    }
+
+    const { rerender } = render(
+      <Harness
+        activeSessionId="runtime-1"
+        hydrateFromStoredSession={hydrateFromStoredSession}
+        messagingSessions={[session({ id: 'signal-1', last_active: 10, message_count: 2, source: 'signal' })]}
+        selectedStoredSessionId="signal-1"
+        sessions={[]}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+
+    rerender(
+      <Harness
+        activeSessionId="runtime-1"
+        hydrateFromStoredSession={hydrateFromStoredSession}
+        messagingSessions={[
+          session({ id: 'signal-1', last_active: 20, message_count: 2, source: 'signal', title: 'renamed' })
+        ]}
+        selectedStoredSessionId="signal-1"
+        sessions={[]}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+
+    expect(hydrateFromStoredSession).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-active-session-external-refresh.ts
+++ b/apps/desktop/src/app/session/hooks/use-active-session-external-refresh.ts
@@ -1,0 +1,135 @@
+import { type MutableRefObject, useEffect, useRef } from 'react'
+
+import type { ClientSessionState } from '@/app/types'
+import type { SessionInfo } from '@/types/hermes'
+
+interface ActiveSessionExternalRefreshOptions {
+  activeSessionId: string | null
+  hydrateFromStoredSession: (
+    attempts?: number,
+    storedSessionId?: string | null,
+    runtimeSessionId?: string | null
+  ) => Promise<void>
+  messagingSessions: SessionInfo[]
+  selectedStoredSessionId: string | null
+  sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>>
+  sessions: SessionInfo[]
+}
+
+interface ObservedSessionRow {
+  key: string
+  signature: string | null
+}
+
+function sessionMatchesStoredId(session: SessionInfo, storedSessionId: string): boolean {
+  return session.id === storedSessionId || session._lineage_root_id === storedSessionId
+}
+
+function findSessionRowByStoredId(rows: SessionInfo[], storedSessionId: string): SessionInfo | null {
+  return rows.find(session => sessionMatchesStoredId(session, storedSessionId)) ?? null
+}
+
+export function sessionRefreshSignature(session: SessionInfo): string {
+  return JSON.stringify([
+    session.id,
+    session._lineage_root_id ?? null,
+    session.last_active,
+    session.message_count,
+    session.preview ?? null,
+    session.title ?? null,
+    session.input_tokens,
+    session.output_tokens,
+    session.tool_call_count,
+    session.ended_at,
+    session.is_active,
+    session.source ?? null,
+    session.profile ?? null
+  ])
+}
+
+export function sameSessionRefreshRows(a: SessionInfo[], b: SessionInfo[]): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+
+  return a.every((session, index) => sessionRefreshSignature(session) === sessionRefreshSignature(b[index]))
+}
+
+export function activeSessionRefreshRow(
+  sessions: SessionInfo[],
+  messagingSessions: SessionInfo[],
+  storedSessionId: string
+): SessionInfo | null {
+  return (
+    findSessionRowByStoredId(sessions, storedSessionId) ?? findSessionRowByStoredId(messagingSessions, storedSessionId)
+  )
+}
+
+export function useActiveSessionExternalRefresh({
+  activeSessionId,
+  hydrateFromStoredSession,
+  messagingSessions,
+  selectedStoredSessionId,
+  sessionStateByRuntimeIdRef,
+  sessions
+}: ActiveSessionExternalRefreshOptions): void {
+  const observedSessionRowRef = useRef<ObservedSessionRow | null>(null)
+
+  useEffect(() => {
+    if (!activeSessionId || !selectedStoredSessionId) {
+      observedSessionRowRef.current = null
+
+      return
+    }
+
+    const key = `${activeSessionId}\u0000${selectedStoredSessionId}`
+    const row = activeSessionRefreshRow(sessions, messagingSessions, selectedStoredSessionId)
+    const signature = row ? sessionRefreshSignature(row) : null
+    const observed = observedSessionRowRef.current
+
+    if (!observed || observed.key !== key) {
+      observedSessionRowRef.current = { key, signature }
+
+      return
+    }
+
+    if (observed.signature === signature) {
+      return
+    }
+
+    observedSessionRowRef.current = { key, signature }
+
+    if (!row || !signature) {
+      return
+    }
+
+    const state = sessionStateByRuntimeIdRef.current.get(activeSessionId)
+    const stateStoredSessionId = state?.storedSessionId
+
+    const stateMatchesSelectedSession =
+      !stateStoredSessionId ||
+      stateStoredSessionId === selectedStoredSessionId ||
+      sessionMatchesStoredId(row, stateStoredSessionId)
+
+    const hasUnloadedPersistedMessages = row.message_count > (state?.messages.length ?? 0)
+
+    if (
+      !state ||
+      !stateMatchesSelectedSession ||
+      !hasUnloadedPersistedMessages ||
+      state.busy ||
+      state.awaitingResponse
+    ) {
+      return
+    }
+
+    void hydrateFromStoredSession(1, selectedStoredSessionId, activeSessionId).catch(() => undefined)
+  }, [
+    activeSessionId,
+    hydrateFromStoredSession,
+    messagingSessions,
+    selectedStoredSessionId,
+    sessionStateByRuntimeIdRef,
+    sessions
+  ])
+}


### PR DESCRIPTION
## Summary

Fixes #53563.

Hermes Desktop now reacts when the currently open persisted session row is refreshed with additional externally appended messages. This covers Signal/gateway sessions whose sidebar metadata updates while the active chat timeline still has an older transcript loaded.

## Root cause

The messaging sidebar slice used an `id/title`-only equality check, so Signal rows whose `last_active`, `message_count`, or preview changed could keep the same atom reference. Even when the session list refreshed, the active chat state did not observe that metadata change and did not rehydrate the open transcript.

## Changes

- Add `useActiveSessionExternalRefresh` to watch the selected stored session row across recents and messaging slices.
- Hydrate the active runtime session when the refreshed persisted row has more messages than the in-memory transcript and the runtime is idle.
- Use a fuller messaging row signature so external metadata changes update the messaging session atom.
- Let stored-session hydration resolve profile metadata from messaging sessions as well as local recents.
- Add focused jsdom regression coverage for external Signal-style row updates, busy-runtime skips, and metadata-only updates.

## Validation

- `npm run test:ui -- use-active-session-external-refresh.test.tsx use-session-state-cache.test.tsx`
- `npm run typecheck`
- `npx eslint src/app/desktop-controller.tsx src/app/session/hooks/use-active-session-external-refresh.ts src/app/session/hooks/use-active-session-external-refresh.test.tsx`
- `npx prettier --check src/app/desktop-controller.tsx src/app/session/hooks/use-active-session-external-refresh.ts src/app/session/hooks/use-active-session-external-refresh.test.tsx`
- `git diff --cached --check`