### PR TITLE
fix(telegram): guard oversized videos from triggering infinite model fallback (#17302)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4707,8 +4707,7 @@ class TelegramAdapter(BasePlatformAdapter):
             size_text = "unknown size"
         return (
             f"[Telegram {label} skipped: file size {size_text} exceeds the "
-            f"{limit_mb} MB limit. Ask the user to send a shorter voice note "
-            "or a smaller audio file.]"
+            f"{limit_mb} MB limit. Ask the user to send a smaller file.]"
         )
 
     def _telegram_media_size_allowed(self, source: Any, label: str) -> tuple[bool, Optional[str]]:
@@ -6600,6 +6599,12 @@ class TelegramAdapter(BasePlatformAdapter):
 
         elif msg.video:
             try:
+                allowed, note = self._telegram_media_size_allowed(msg.video, "video file")
+                if not allowed:
+                    event.text = self._append_observed_note(event.text, note or "")
+                    logger.info("[Telegram] Skipped oversized user video (size=%s)", getattr(msg.video, "file_size", None))
+                    await self.handle_message(event)
+                    return
                 file_obj = await msg.video.get_file()
                 video_bytes = await file_obj.download_as_bytearray()
                 ext = ".mp4"

--- a/tests/gateway/test_telegram_voice_v0_regressions.py
+++ b/tests/gateway/test_telegram_voice_v0_regressions.py
@@ -49,6 +49,52 @@ def test_telegram_audio_size_gate_rejects_oversized_media_before_download():
 
 
 @pytest.mark.asyncio
+async def test_telegram_video_size_gate_rejects_oversized_media_before_download():
+    adapter = object.__new__(TelegramAdapter)
+    adapter._max_doc_bytes = 1024
+    adapter._should_process_message = lambda _message: True
+    adapter._build_message_event = lambda _message, _type, update_id=None: SimpleNamespace(
+        text="caption",
+        media_urls=[],
+        media_types=[],
+    )
+    adapter._apply_telegram_group_observe_attribution = lambda event: event
+
+    handled = []
+
+    async def handle_message(event):
+        handled.append(event)
+
+    adapter.handle_message = handle_message
+
+    class OversizedVideo:
+        file_size = 2048
+
+        async def get_file(self):  # pragma: no cover - failure path assertion
+            pytest.fail("oversized videos must not be downloaded")
+
+    msg = SimpleNamespace(
+        caption=None,
+        sticker=None,
+        photo=None,
+        voice=None,
+        audio=None,
+        video=OversizedVideo(),
+        document=None,
+        media_group_id=None,
+    )
+    update = SimpleNamespace(message=msg, update_id=1)
+
+    await TelegramAdapter._handle_media_message(adapter, update, SimpleNamespace())
+
+    assert len(handled) == 1
+    assert handled[0].media_urls == []
+    assert handled[0].media_types == []
+    assert "video file" in handled[0].text
+    assert "exceeds" in handled[0].text
+
+
+@pytest.mark.asyncio
 async def test_voice_tts_is_explicit_audio_reply_opt_in():
     adapter = SimpleNamespace(
         _auto_tts_disabled_chats=set(),


### PR DESCRIPTION
## Summary
Large Telegram videos (>20MB) no longer trigger an infinite model-fallback loop.

Root cause: the `msg.video` branch in `_handle_media_message` called `get_file()` with no size guard. On a >20MB video Telegram's Bot API raises `BadRequest: File is too big`, the `except` only logged a warning, and control fell through to `handle_message()` with an empty event — so the agent churned through every fallback model trying to respond to nothing. Voice and audio already gated on size via `_telegram_media_size_allowed`; video was the one media type missing the guard.

## Changes
- `plugins/platforms/telegram/adapter.py`: the `msg.video` branch now calls `_telegram_media_size_allowed()` before download — oversized videos are skipped, the event gets an explanatory note instead of empty text, and `get_file()` is never attempted. Also generalized the skip-note wording ("send a smaller file") since it now covers video too.
- `tests/gateway/test_telegram_voice_v0_regressions.py`: adds `test_telegram_video_size_gate_rejects_oversized_media_before_download` — asserts an oversized video is never downloaded and the forwarded event carries a note, not blank text.

## Validation
| | Before | After |
|---|---|---|
| >20MB video sent | `get_file()` → BadRequest → empty event → 15+ fallback retries | skipped before download, event carries a skip note |
| Targeted tests | — | `tests/gateway/test_telegram_voice_v0_regressions.py` 3/3 pass |
| E2E (50MB video) | — | `get_file` never called, event text non-empty, no loop |

Salvage of #44474 by @r266-tech, cherry-picked onto current `main` with authorship preserved (the original branch targeted the pre-migration `gateway/platforms/telegram.py` path). Supersedes #17325 (@Sanjays2402, earliest) and #18303 (@121ACE), which reimplemented the size check inline instead of reusing the existing guard infrastructure.

Closes #17302.

## Infographic
![telegram-video-fallback-loop-fixed](https://v3b.fal.media/files/b/0a9ff80e/ZjswUiF6VDs-7E06lxj0O_CC78ikK8.png)

---
Nous Research
