### PR TITLE
feat: add prompt cache diagnostics

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -56,6 +56,11 @@ from agent.model_metadata import (
     save_context_length,
 )
 from agent.process_bootstrap import _install_safe_stdio
+from agent.prompt_cache_diagnostics import (
+    PromptCacheDiagnostics,
+    build_prompt_cache_diagnostics,
+    format_prompt_cache_diagnostics,
+)
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.retry_utils import adaptive_rate_limit_backoff, jittered_backoff
 from agent.trajectory import has_incomplete_scratchpad
@@ -924,6 +929,24 @@ def run_conversation(
         approx_request_tokens = estimate_request_tokens_rough(
             api_messages, tools=agent.tools or None
         )
+        try:
+            prompt_cache_diag = build_prompt_cache_diagnostics(
+                api_messages,
+                tools=agent.tools or None,
+                provider=agent.provider,
+                model=agent.model,
+                session_id=agent.session_id,
+                previous=getattr(agent, "_last_prompt_cache_diagnostics", None),
+            )
+            agent._last_prompt_cache_diagnostics = prompt_cache_diag
+        except Exception as _cache_diag_exc:
+            logger.debug("Prompt cache diagnostics failed: %s", _cache_diag_exc)
+            prompt_cache_diag = PromptCacheDiagnostics(
+                provider=agent.provider,
+                model=agent.model,
+                session_id=agent.session_id,
+                possible_bust_causes=("local diagnostics unavailable",),
+            )
 
         _runtime_context_error = _ollama_context_limit_error(
             agent, approx_request_tokens
@@ -969,6 +992,7 @@ def run_conversation(
             logging.debug(f"API Request - Model: {agent.model}, Messages: {len(messages)}, Tools: {len(agent.tools) if agent.tools else 0}")
             logging.debug(f"Last message role: {messages[-1]['role'] if messages else 'none'}")
             logging.debug(f"Total message size: ~{approx_tokens:,} tokens")
+            logging.debug(format_prompt_cache_diagnostics(prompt_cache_diag))
         
         api_start_time = time.time()
         retry_count = 0
@@ -1980,11 +2004,20 @@ def run_conversation(
                     prompt = usage_dict["prompt_tokens"]
                     if (cached or written) and not agent.quiet_mode:
                         hit_pct = (cached / prompt * 100) if prompt > 0 else 0
+                        causes = ", ".join(prompt_cache_diag.possible_bust_causes) or "none detected"
                         agent._vprint(
                             f"{agent.log_prefix}   💾 Cache: "
                             f"{cached:,}/{prompt:,} tokens "
-                            f"({hit_pct:.0f}% hit, {written:,} written)"
+                            f"({hit_pct:.0f}% hit, {written:,} written, "
+                            f"{canonical_usage.input_tokens:,} uncached)"
                         )
+                        if agent.verbose_logging:
+                            agent._vprint(
+                                f"{agent.log_prefix}   💾 Cache diagnostics: "
+                                f"system={prompt_cache_diag.system_prompt_hash or '-'} "
+                                f"tools={prompt_cache_diag.tools_hash or '-'}; "
+                                f"possible bust causes: {causes}"
+                            )
                 
                 _retry.has_retried_429 = False  # Reset on success
                 # Note: don't clear the retry buffer here — an "API call

--- a/agent/prompt_cache_diagnostics.py
+++ b/agent/prompt_cache_diagnostics.py
@@ -1,0 +1,190 @@
+"""Prompt-cache diagnostics that do not mutate provider payloads.
+
+The helpers in this module compute stable, redacted fingerprints for the parts
+of an LLM request that commonly determine provider-side prompt-cache reuse.
+They are intentionally observational: no cache_control markers are added here
+and no request payload is modified.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping, Sequence
+
+
+_HASH_PREFIX_LEN = 16
+_SECRET_KEY_FRAGMENTS = (
+    "api_key",
+    "api_token",
+    "token",
+    "secret",
+    "password",
+    "credential",
+    "auth",
+)
+_MAX_HASH_BYTES = 1_000_000
+
+
+@dataclass(frozen=True)
+class PromptCacheDiagnostics:
+    """Local fingerprints for cache observability.
+
+    The hashes are best-effort local signals. They must be treated as possible
+    cache-bust evidence only because providers keep their exact cache keys
+    private and TTL/routing can invalidate a cache even when these hashes are
+    unchanged.
+    """
+
+    system_prompt_hash: str | None = None
+    tools_hash: str | None = None
+    skills_hash: str | None = None
+    message_prefix_hash: str | None = None
+    provider: str | None = None
+    model: str | None = None
+    session_id: str | None = None
+    system_prompt_tokens_estimate: int = 0
+    tools_tokens_estimate: int = 0
+    message_prefix_tokens_estimate: int = 0
+    possible_bust_causes: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _stable_json(value: Any) -> str:
+    """Return deterministic JSON for hashing serializable-ish values."""
+
+    def default(obj: Any) -> Any:
+        if hasattr(obj, "model_dump"):
+            try:
+                return obj.model_dump()
+            except Exception:
+                pass
+        if hasattr(obj, "dict"):
+            try:
+                return obj.dict()
+            except Exception:
+                pass
+        if hasattr(obj, "__dict__"):
+            return {
+                k: v
+                for k, v in vars(obj).items()
+                if not k.startswith("_")
+                and not any(fragment in k.lower() for fragment in _SECRET_KEY_FRAGMENTS)
+            }
+        rendered = repr(obj)
+        return rendered[:4096]
+
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=default)
+
+
+def stable_hash(value: Any) -> str | None:
+    """Return a short sha256 fingerprint for value, or None when empty."""
+
+    if value is None or value == "":
+        return None
+    encoded = _stable_json(value).encode("utf-8", errors="replace")[:_MAX_HASH_BYTES]
+    return hashlib.sha256(encoded).hexdigest()[:_HASH_PREFIX_LEN]
+
+
+def _rough_token_estimate(value: Any) -> int:
+    if value is None:
+        return 0
+    # Rough, deterministic estimate aligned with existing logging style. Avoid
+    # importing tokenizer-heavy modules here; diagnostics must never fail the
+    # request path.
+    return max(1, len(_stable_json(value)) // 4)
+
+
+def _system_message(messages: Sequence[Mapping[str, Any]]) -> Mapping[str, Any] | None:
+    if messages and messages[0].get("role") == "system":
+        return messages[0]
+    return None
+
+
+def build_prompt_cache_diagnostics(
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    tools: Sequence[Mapping[str, Any]] | None = None,
+    provider: str | None = None,
+    model: str | None = None,
+    session_id: str | None = None,
+    previous: PromptCacheDiagnostics | Mapping[str, Any] | None = None,
+    skills_snapshot: Any | None = None,
+) -> PromptCacheDiagnostics:
+    """Compute local cache fingerprints and possible bust causes.
+
+    ``previous`` should be the prior diagnostics object for the same live
+    conversation. The resulting causes are deliberately phrased as possible
+    causes, never as definitive provider cache-bust reasons.
+    """
+
+    system = _system_message(messages)
+    non_system = list(messages[1:] if system else messages)
+    # Prefix signal: all non-system messages except the current/tail message.
+    # This changes when history/compression/prefills alter the reusable prefix,
+    # but avoids treating every new user turn as an automatic full bust signal.
+    message_prefix = non_system[:-1] if len(non_system) > 1 else []
+
+    current = PromptCacheDiagnostics(
+        system_prompt_hash=stable_hash(system.get("content") if system else None),
+        tools_hash=stable_hash(tools or None),
+        skills_hash=stable_hash(skills_snapshot),
+        message_prefix_hash=stable_hash(message_prefix or None),
+        provider=provider,
+        model=model,
+        session_id=session_id,
+        system_prompt_tokens_estimate=_rough_token_estimate(system.get("content") if system else None),
+        tools_tokens_estimate=_rough_token_estimate(tools or None),
+        message_prefix_tokens_estimate=_rough_token_estimate(message_prefix or None),
+    )
+
+    causes: list[str] = []
+    if previous:
+        prev = previous.to_dict() if isinstance(previous, PromptCacheDiagnostics) else dict(previous)
+        comparisons = (
+            ("system_prompt_hash", "system prompt rebuilt or changed"),
+            ("tools_hash", "tool schema hash changed"),
+            ("skills_hash", "skill bundle hash changed"),
+            ("message_prefix_hash", "conversation prefix changed or was compressed"),
+            ("provider", "provider changed"),
+            ("model", "model changed"),
+            ("session_id", "session changed"),
+        )
+        for field, reason in comparisons:
+            old = prev.get(field)
+            new = getattr(current, field)
+            if old and new and old != new:
+                causes.append(reason)
+            elif old and new is None:
+                causes.append(reason)
+            elif old is None and new:
+                # The first appearance of a hash after an empty prior value may
+                # affect prefix shape, but keep it a weak local signal.
+                causes.append(reason)
+    else:
+        causes.append("first request in local diagnostics window")
+
+    return PromptCacheDiagnostics(
+        **{k: v for k, v in current.to_dict().items() if k != "possible_bust_causes"},
+        possible_bust_causes=tuple(causes),
+    )
+
+
+def format_prompt_cache_diagnostics(diag: PromptCacheDiagnostics) -> str:
+    """Human-readable one-line diagnostics for verbose logs."""
+
+    causes = ", ".join(diag.possible_bust_causes) if diag.possible_bust_causes else "none detected"
+    return (
+        "Prompt cache diagnostics: "
+        f"system={diag.system_prompt_hash or '-'} "
+        f"tools={diag.tools_hash or '-'} "
+        f"skills={diag.skills_hash or '-'} "
+        f"prefix={diag.message_prefix_hash or '-'} "
+        f"system_tokens~{diag.system_prompt_tokens_estimate:,} "
+        f"tools_tokens~{diag.tools_tokens_estimate:,} "
+        f"prefix_tokens~{diag.message_prefix_tokens_estimate:,}; "
+        f"possible bust causes: {causes}"
+    )

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -42,6 +42,15 @@ class CanonicalUsage:
         return self.input_tokens + self.cache_read_tokens + self.cache_write_tokens
 
     @property
+    def uncached_input_tokens(self) -> int:
+        return self.input_tokens
+
+    @property
+    def cache_hit_ratio(self) -> float:
+        prompt = self.prompt_tokens
+        return (self.cache_read_tokens / prompt) if prompt else 0.0
+
+    @property
     def total_tokens(self) -> int:
         return self.prompt_tokens + self.output_tokens
 
@@ -736,6 +745,12 @@ def get_pricing_entry(
     return _lookup_official_docs_pricing(route)
 
 
+def _usage_get(obj: Any, key: str, default: Any = 0) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
 def normalize_usage(
     response_usage: Any,
     *,
@@ -760,45 +775,45 @@ def normalize_usage(
     mode = (api_mode or "").strip().lower()
 
     if mode == "anthropic_messages" or provider_name == "anthropic":
-        input_tokens = _to_int(getattr(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
-        cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
-        cache_write_tokens = _to_int(getattr(response_usage, "cache_creation_input_tokens", 0))
+        input_tokens = _to_int(_usage_get(response_usage, "input_tokens", 0))
+        output_tokens = _to_int(_usage_get(response_usage, "output_tokens", 0))
+        cache_read_tokens = _to_int(_usage_get(response_usage, "cache_read_input_tokens", 0))
+        cache_write_tokens = _to_int(_usage_get(response_usage, "cache_creation_input_tokens", 0))
     elif mode == "codex_responses":
-        input_total = _to_int(getattr(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
-        details = getattr(response_usage, "input_tokens_details", None)
-        cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
+        input_total = _to_int(_usage_get(response_usage, "input_tokens", 0))
+        output_tokens = _to_int(_usage_get(response_usage, "output_tokens", 0))
+        details = _usage_get(response_usage, "input_tokens_details", None)
+        cache_read_tokens = _to_int(_usage_get(details, "cached_tokens", 0) if details else 0)
         cache_write_tokens = _to_int(
-            getattr(details, "cache_creation_tokens", 0) if details else 0
+            _usage_get(details, "cache_creation_tokens", 0) if details else 0
         )
         input_tokens = max(0, input_total - cache_read_tokens - cache_write_tokens)
     else:
-        prompt_total = _to_int(getattr(response_usage, "prompt_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "completion_tokens", 0))
-        details = getattr(response_usage, "prompt_tokens_details", None)
+        prompt_total = _to_int(_usage_get(response_usage, "prompt_tokens", 0))
+        output_tokens = _to_int(_usage_get(response_usage, "completion_tokens", 0))
+        details = _usage_get(response_usage, "prompt_tokens_details", None)
         # Primary: OpenAI-style prompt_tokens_details. Fallback: Anthropic-style
         # top-level fields that some OpenAI-compatible proxies (OpenRouter, Cline)
         # expose when routing Claude models — without this
         # fallback, cache writes are undercounted as 0 and cache reads can be
         # missed when the proxy only surfaces them at the top level.
         # Port of cline/cline#10266.
-        cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
+        cache_read_tokens = _to_int(_usage_get(details, "cached_tokens", 0) if details else 0)
         if not cache_read_tokens:
-            cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
+            cache_read_tokens = _to_int(_usage_get(response_usage, "cache_read_input_tokens", 0))
         cache_write_tokens = _to_int(
-            getattr(details, "cache_write_tokens", 0) if details else 0
+            _usage_get(details, "cache_write_tokens", 0) if details else 0
         )
         if not cache_write_tokens:
             cache_write_tokens = _to_int(
-                getattr(response_usage, "cache_creation_input_tokens", 0)
+                _usage_get(response_usage, "cache_creation_input_tokens", 0)
             )
         input_tokens = max(0, prompt_total - cache_read_tokens - cache_write_tokens)
 
     reasoning_tokens = 0
-    output_details = getattr(response_usage, "output_tokens_details", None)
+    output_details = _usage_get(response_usage, "output_tokens_details", None)
     if output_details:
-        reasoning_tokens = _to_int(getattr(output_details, "reasoning_tokens", 0))
+        reasoning_tokens = _to_int(_usage_get(output_details, "reasoning_tokens", 0))
 
     return CanonicalUsage(
         input_tokens=input_tokens,

--- a/tests/agent/test_prompt_cache_diagnostics.py
+++ b/tests/agent/test_prompt_cache_diagnostics.py
@@ -1,0 +1,66 @@
+from agent.prompt_cache_diagnostics import (
+    build_prompt_cache_diagnostics,
+    format_prompt_cache_diagnostics,
+    stable_hash,
+)
+
+
+def test_prompt_cache_diagnostics_hashes_are_stable_for_equivalent_payloads():
+    messages_a = [
+        {"role": "system", "content": "stable system"},
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "second"},
+        {"role": "user", "content": "current"},
+    ]
+    messages_b = [
+        {"content": "stable system", "role": "system"},
+        {"content": "first", "role": "user"},
+        {"content": "second", "role": "assistant"},
+        {"content": "current", "role": "user"},
+    ]
+    tools = [{"function": {"name": "demo", "parameters": {"type": "object"}}, "type": "function"}]
+
+    first = build_prompt_cache_diagnostics(messages_a, tools=tools, provider="anthropic", model="claude")
+    second = build_prompt_cache_diagnostics(messages_b, tools=tools, provider="anthropic", model="claude")
+
+    assert first.system_prompt_hash == second.system_prompt_hash
+    assert first.tools_hash == second.tools_hash
+    assert first.message_prefix_hash == second.message_prefix_hash
+    assert first.system_prompt_tokens_estimate > 0
+    assert first.tools_tokens_estimate > 0
+
+
+def test_prompt_cache_diagnostics_reports_only_possible_bust_causes():
+    previous = build_prompt_cache_diagnostics(
+        [{"role": "system", "content": "stable"}, {"role": "user", "content": "one"}],
+        tools=[{"name": "old"}],
+        provider="anthropic",
+        model="claude",
+        session_id="s1",
+    )
+
+    current = build_prompt_cache_diagnostics(
+        [{"role": "system", "content": "stable"}, {"role": "user", "content": "two"}],
+        tools=[{"name": "new"}],
+        provider="anthropic",
+        model="claude",
+        session_id="s1",
+        previous=previous,
+    )
+
+    assert "tool schema hash changed" in current.possible_bust_causes
+    assert "system prompt rebuilt or changed" not in current.possible_bust_causes
+    rendered = format_prompt_cache_diagnostics(current)
+    assert "possible bust causes" in rendered
+    assert "tools=" in rendered
+
+
+def test_stable_hash_omits_obvious_secret_attrs():
+    class Obj:
+        def __init__(self):
+            self.name = "tool"
+            self.api_key = "redacted"
+            self.api_token = "redacted"
+            self.auth_header = "redacted"
+
+    assert stable_hash(Obj()) == stable_hash({"name": "tool"})

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -35,8 +35,30 @@ def test_normalize_usage_openai_subtracts_cached_prompt_tokens():
     normalized = normalize_usage(usage, provider="openai", api_mode="chat_completions")
 
     assert normalized.input_tokens == 1200
+    assert normalized.uncached_input_tokens == 1200
     assert normalized.cache_read_tokens == 1800
+    assert normalized.cache_hit_ratio == 1800 / 3000
     assert normalized.output_tokens == 700
+
+
+def test_normalize_usage_accepts_dict_usage_shapes():
+    usage = {
+        "prompt_tokens": 3000,
+        "completion_tokens": 700,
+        "prompt_tokens_details": {"cached_tokens": 1800, "cache_write_tokens": 200},
+    }
+
+    normalized = normalize_usage(usage, provider="openai", api_mode="chat_completions")
+
+    assert normalized.input_tokens == 1000
+    assert normalized.cache_read_tokens == 1800
+    assert normalized.cache_write_tokens == 200
+    assert normalized.output_tokens == 700
+
+
+def test_normalize_usage_unknown_or_malformed_is_safe():
+    assert normalize_usage(None).total_tokens == 0
+    assert normalize_usage({"unexpected": "shape"}).total_tokens == 0
 
 
 def test_normalize_usage_openai_reads_top_level_anthropic_cache_fields():


### PR DESCRIPTION
## Summary
- Add low-risk local prompt-cache diagnostics without changing prompt assembly or provider request payloads.
- Add stable hashes for the system prompt, tools schema, and reusable message prefix to help spot local causes of cache churn.
- Make cache usage normalization tolerate dict-shaped provider usage payloads.
- Add focused tests for usage normalization and diagnostic hash stability.

## What this does not do
- Does not change cache strategy, TTL, or cache-control placement.
- Does not guarantee provider-side cache-bust attribution; reported causes are local hints only.
- Does not persist diagnostics into session/trajectory metadata yet.
- Does not wire a real skills bundle hash yet; the helper accepts an optional skills snapshot for a later integration point.
- Does not add tool-schema caching.

## Safety notes
- Diagnostics are best-effort and fail open in the conversation loop.
- Hashing filters obvious secret-like attribute names and caps hash input size.

## Verification
- `python -m pytest tests/agent/test_prompt_cache_diagnostics.py tests/agent/test_usage_pricing.py -q` → 20 passed
- `python -m pytest tests/agent/test_context_engine_host_contract.py tests/run_agent/test_session_reset_fix.py -q` → 14 passed, 3 existing deprecation warnings
- combined focused command → 34 passed, 3 existing deprecation warnings
- `python -m py_compile agent/conversation_loop.py agent/prompt_cache_diagnostics.py agent/usage_pricing.py` → passed
- `git diff --cached --check` → passed before commit
- added-line secret scan for hardcoded key/token/password patterns → PASS

## Review
- Blue/spec review: pass.
- Red/adversarial review: minor suggestions applied before commit: broader secret-name filtering, hash-size cap, fail-open wrapper.
