### PR TITLE
fix(agent): match overload patterns against the wrapped error cause chain

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -510,11 +510,17 @@ def classify_api_error(
     # the body message so patterns like "try again" in 402 disambiguation
     # are detected even when only present in the structured body.
     #
+    # Walk the __cause__/__context__ chain for the raw text too (mirroring the
+    # status-code and body traversals above): a transport/SDK layer may
+    # re-raise ``... from inner`` where the overload/rate-limit signal lives
+    # only in str(inner) with no structured body, so reading str(outer) alone
+    # would miss it and the 429-overload disambiguation below would not fire.
+    #
     # Also extract metadata.raw — OpenRouter wraps upstream provider errors
     # inside {"error": {"message": "Provider returned error", "metadata":
     # {"raw": "<actual error JSON>"}}} and the real error message (e.g.
     # "context length exceeded") is only in the inner JSON.
-    _raw_msg = str(error).lower()
+    _raw_msg = _extract_error_text(error).lower()
     _body_msg = ""
     _metadata_msg = ""
     if isinstance(body, dict):
@@ -1371,6 +1377,28 @@ def _extract_error_body(error: Exception) -> dict:
             break
         current = cause
     return {}
+
+
+def _extract_error_text(error: Exception) -> str:
+    """Join ``str()`` of the error and its cause chain.
+
+    Mirrors the ``_extract_status_code`` / ``_extract_error_body`` traversal
+    depth so overload/rate-limit signals carried only in an inner exception's
+    text (e.g. a transport layer re-raising ``... from inner`` where ``inner``
+    holds the "overloaded" message with no structured body) are visible to
+    pattern matching, not just ``str(outer)``.
+    """
+    parts: list = []
+    current = error
+    for _ in range(5):  # Match _extract_status_code() traversal depth.
+        text = str(current)
+        if text and text not in parts:
+            parts.append(text)
+        cause = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
+        if cause is None or cause is current:
+            break
+        current = cause
+    return " ".join(parts)
 
 
 def _extract_error_code(body: dict) -> str:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -410,6 +410,44 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.rate_limit
         assert result.should_rotate_credential is True
 
+    def test_wrapped_429_overloaded_in_inner_text_is_overloaded(self):
+        """A transport/SDK layer that re-raises a 429 ``... from inner`` where
+        the overload signal lives only in the inner exception's text (no
+        structured body) must still classify as overloaded — back off + retry
+        the same key — NOT rate_limit (which would rotate and exhaust the pool).
+
+        _extract_status_code / _extract_error_body already walk the cause chain;
+        the pattern-matching text must too, otherwise the inner 429 status is
+        found but the overload signal is invisible and the error mis-rotates the
+        credential pool (the wrapped-path twin of #14038)."""
+        inner = MockAPIError(
+            "The service may be temporarily overloaded, please try again later",
+            status_code=429,
+        )  # MockAPIError defaults body={}, so the signal is str-only.
+        outer = Exception("upstream request failed")
+        outer.__cause__ = inner
+
+        result = classify_api_error(outer, provider="zai")
+
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_rotate_credential is False
+
+    def test_wrapped_429_genuine_rate_limit_still_rotates(self):
+        """Guard: a wrapped genuine 429 rate limit (inner text has no overload
+        language) must still classify as rate_limit and rotate — proves the
+        cause-chain text traversal doesn't over-broaden the overload path."""
+        inner = MockAPIError(
+            "Rate limit exceeded: too many requests", status_code=429
+        )
+        outer = Exception("upstream request failed")
+        outer.__cause__ = inner
+
+        result = classify_api_error(outer, provider="zai")
+
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
+
     # ── 5xx that are actually request-validation errors ──
     # Some OpenAI-compatible gateways (e.g. codex.nekos.me) return
     # request-validation failures with a 5xx status. These are


### PR DESCRIPTION
## What does this PR do?

Routes the overload/rate-limit pattern-matching text through the error's `__cause__`/`__context__` chain in `classify_api_error`, mirroring the existing status-code and error-body cause-chain traversals. A wrapped 429 whose "overloaded" signal lives only in an inner exception's text is now correctly classified as `overloaded` (back off + retry the same key) instead of `rate_limit` (rotate credential / exhaust the pool).

`_extract_status_code` and `_extract_error_body` already walk the cause chain to depth 5, but `_raw_msg` (the text fed to pattern matching) read only `str(outer)`. For a wrapped 429 with no structured inner body, the inner 429 status was found but the overload text was invisible — so the new 429-overload disambiguation (commit 38e7bd8a0) never fired, and the error mis-rotated the credential pool. This is exactly the failure mode 38e7bd8a0 was written to prevent, still live on the wrapped path. This change is the symmetric sibling of the body-cause-chain traversal: status and body traverse, the message text now does too.

The fix is minimal and single-concern: a small `_extract_error_text` helper (an exact structural copy of the existing depth-5 traversals) plus the one-line change at the `_raw_msg` assignment. No behavior change for unwrapped errors.

## Related Issue

<!-- No filed issue; author-found regression in the just-landed wrapped-error / overload-classification family (38e7bd8a0, 45ce35ed7, e7c013494). -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py`: add `_extract_error_text(error)` helper that joins `str()` of the error and its `__cause__`/`__context__` chain (depth 5, matching `_extract_status_code`/`_extract_error_body`); use it to build `_raw_msg` instead of `str(error)`.
- `tests/agent/test_error_classifier.py`: add `test_wrapped_429_overloaded_in_inner_text_is_overloaded` (the regression) and `test_wrapped_429_genuine_rate_limit_still_rotates` (guard against over-broadening).

## How to Test

1. A 429 whose overload signal is only in a wrapped inner exception's text:
   ```python
   inner = MockAPIError("The service may be temporarily overloaded, please try again later", status_code=429)  # body={}
   outer = Exception("upstream request failed"); outer.__cause__ = inner
   classify_api_error(outer)  # reason == overloaded, should_rotate_credential is False
   ```
   Before this change: `rate_limit` / `should_rotate_credential=True` (mis-rotates the pool). After: `overloaded` / no rotation.
2. Guard: a wrapped genuine 429 rate limit (inner text has no overload language, e.g. "rate limit exceeded") still classifies `rate_limit` / rotate=True — proves the traversal doesn't over-broaden.
3. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/agent/test_error_classifier.py -q` → 168 passed. Stashing only the production line reverts test 1 to red while the guard stays green (fail-before/pass-after verified both directions).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A