### PR TITLE
fix(gemini): map BLOCKLIST/PROHIBITED_CONTENT/SPII/IMAGE_SAFETY finish reasons to content_filter

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -462,6 +462,15 @@ def _map_gemini_finish_reason(reason: str) -> str:
         "MAX_TOKENS": "length",
         "SAFETY": "content_filter",
         "RECITATION": "content_filter",
+        # Remaining content-safety block reasons in Gemini's FinishReason enum.
+        # Siblings of SAFETY/RECITATION: the candidate carries no content, so
+        # without these they fall through to the "stop" default and surface as
+        # an empty normal completion — the content_filter handler never fires
+        # and the agent retries a deterministically-blocked prompt.
+        "BLOCKLIST": "content_filter",
+        "PROHIBITED_CONTENT": "content_filter",
+        "SPII": "content_filter",
+        "IMAGE_SAFETY": "content_filter",
         "OTHER": "stop",
     }
     return mapping.get(str(reason or "").upper(), "stop")

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -155,6 +155,34 @@ def test_translate_native_response_surfaces_reasoning_and_tool_calls():
     assert json.loads(choice.message.tool_calls[0].function.arguments) == {"q": "hermes"}
 
 
+@pytest.mark.parametrize(
+    "reason",
+    ["BLOCKLIST", "PROHIBITED_CONTENT", "SPII", "IMAGE_SAFETY"],
+)
+def test_content_safety_finish_reasons_map_to_content_filter(reason):
+    """Gemini's BLOCKLIST/PROHIBITED_CONTENT/SPII/IMAGE_SAFETY FinishReason
+    values are content-safety blocks — siblings of SAFETY/RECITATION — and must
+    map to content_filter, not fall through to the "stop" default."""
+    from agent.gemini_native_adapter import _map_gemini_finish_reason
+
+    assert _map_gemini_finish_reason(reason) == "content_filter"
+
+
+def test_translate_native_response_surfaces_content_block_as_content_filter():
+    """A content-blocked native-Gemini turn carries no parts; without the block
+    reason mapped to content_filter it would surface as an empty normal
+    completion (finish_reason="stop"), the content_filter handler would never
+    fire, and the agent would retry a deterministically-blocked prompt."""
+    from agent.gemini_native_adapter import translate_gemini_response
+
+    payload = {"candidates": [{"finishReason": "PROHIBITED_CONTENT"}]}
+
+    response = translate_gemini_response(payload, model="gemini-2.5-flash")
+    choice = response.choices[0]
+    assert choice.finish_reason == "content_filter"
+    assert choice.message.content is None
+
+
 def test_native_client_uses_x_goog_api_key_and_native_models_endpoint(monkeypatch):
     from agent.gemini_native_adapter import GeminiNativeClient
 


### PR DESCRIPTION
## What does this PR do?

Maps Gemini's `BLOCKLIST`, `PROHIBITED_CONTENT`, `SPII`, and `IMAGE_SAFETY` finish reasons to `content_filter` in `_map_gemini_finish_reason`, completing the content-safety family alongside the already-handled `SAFETY`/`RECITATION`.

These four are genuine values in Gemini's `FinishReason` enum and are all content-safety blocks — exact siblings of the mapped `SAFETY`/`RECITATION`. They were missing from the mapping table and fell through to the `"stop"` default. When native Gemini blocks a prompt with one of them, the candidate carries no content, so the response was built with `content=None` + `finish_reason="stop"`; the dedicated `content_filter` handler (`conversation_loop.py`, `if finish_reason == "content_filter"`) never fired, the agent saw an empty normal completion and routed into the empty-response **retry** path — re-sending a deterministically-blocked prompt. The user gets silent empty turns + wasted retries instead of a clear content block. Completing the family makes the block visible and stops the retry loop.

The single shared mapping covers both the non-stream (`translate_gemini_response`) and stream (`translate_stream_event`) paths, so one change fixes both. `LANGUAGE` and `MALFORMED_FUNCTION_CALL` are deliberately left out — they are different classes, correctly not `content_filter`.

Complementary to #43478 (different concern): that PR preserves terminal stream finish reasons at the call-site; this PR completes the mapping table the call-site reads from. #43478's own `SAFETY`→`content_filter` stream test confirms maintainers want this mapping.

## Related Issue

<!-- No filed issue; author-found gap completing the SAFETY/RECITATION content-filter finish-reason family. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/gemini_native_adapter.py`: add `BLOCKLIST`, `PROHIBITED_CONTENT`, `SPII`, `IMAGE_SAFETY` → `content_filter` to the `_map_gemini_finish_reason` mapping table (next to `SAFETY`/`RECITATION`).
- `tests/agent/test_gemini_native_adapter.py`: add a parametrized direct-mapping test for all four reasons, plus an end-to-end `translate_gemini_response` test that a content-blocked candidate (no parts) surfaces `finish_reason == "content_filter"`.

## How to Test

1. Direct: `_map_gemini_finish_reason("PROHIBITED_CONTENT")` → `"content_filter"` (was `"stop"`). Same for `BLOCKLIST`, `SPII`, `IMAGE_SAFETY`.
2. End-to-end: `translate_gemini_response({"candidates": [{"finishReason": "PROHIBITED_CONTENT"}]}, model="gemini-2.5-flash").choices[0].finish_reason` → `"content_filter"`.
3. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/agent/test_gemini_native_adapter.py -q` → 25 passed. Removing only the four mapping lines reverts the five new test cases to red (fail-before/pass-after verified both directions).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A