### PR TITLE
fix(agent): tolerate null Responses stream output

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -438,6 +438,13 @@ def _event_field(event: Any, name: str, default: Any = None) -> Any:
     return value if value is not None else default
 
 
+def _is_sdk_null_output_parse_error(exc: BaseException) -> bool:
+    if not isinstance(exc, TypeError):
+        return False
+    message = str(exc).lower()
+    return "nonetype" in message and "not iterable" in message
+
+
 def _raise_stream_error(event: Any) -> None:
     """Raise a ``_StreamErrorEvent`` from a ``type=error`` SSE frame.
 
@@ -507,7 +514,24 @@ def _consume_codex_event_stream(
     terminal_error: Any = None
     saw_terminal = False
 
-    for event in event_iter:
+    event_iterator = iter(event_iter)
+    while True:
+        try:
+            event = next(event_iterator)
+        except StopIteration:
+            break
+        except TypeError as exc:
+            if not _is_sdk_null_output_parse_error(exc):
+                raise
+            logger.debug(
+                "Codex Responses SDK raised while parsing stream terminal output; "
+                "treating terminal output as empty. error=%s",
+                exc,
+            )
+            saw_terminal = True
+            terminal_status = terminal_status or "completed"
+            break
+
         if on_event is not None:
             try:
                 on_event(event)

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -690,6 +690,48 @@ def test_run_codex_stream_ignores_completed_response_with_null_output(monkeypatc
     assert response.usage.total_tokens == 11
 
 
+def test_run_codex_stream_treats_sdk_null_output_parse_error_as_empty_terminal_output(monkeypatch):
+    """Regression: some Responses-compatible stream iterators raise before
+    yielding ``response.completed`` when that event carries ``output:null``.
+
+    Hermes has already consumed the durable ``response.output_item.done`` items
+    at that point, so the SDK parse failure should behave like an empty/null
+    terminal output field rather than crashing the turn.
+    """
+    agent = _build_agent(monkeypatch)
+    output_item = SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="item arrived before parse error")],
+    )
+
+    class _SdkNullOutputParseErrorStream:
+        closed = False
+
+        def __iter__(self):
+            yield SimpleNamespace(type="response.created")
+            yield SimpleNamespace(type="response.output_item.done", item=output_item)
+            raise TypeError("'NoneType' object is not iterable")
+
+        def close(self):
+            self.closed = True
+
+    create_stream = _SdkNullOutputParseErrorStream()
+
+    def _fake_create(**kwargs):
+        assert kwargs.get("stream") is True
+        return create_stream
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=_fake_create),
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert create_stream.closed is True
+    assert response.status == "completed"
+    assert response.output == [output_item]
+
+
 def test_run_conversation_codex_plain_text(monkeypatch):
     agent = _build_agent(monkeypatch)
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: _codex_message_response("OK"))


### PR DESCRIPTION
## Summary

Fixes #53405.

Harden the Codex/Responses streaming path against OpenAI SDK parse failures triggered by third-party Responses-compatible endpoints that emit `output: null` in a terminal event.

## Root Cause

Hermes already avoids reading terminal `response.output` when reconstructing streamed content, but the SDK can raise before yielding the terminal `response.completed` event. When the SDK parses `output: null`, its internal `for output in response.output` raises `TypeError: 'NoneType' object is not iterable`, escaping `_consume_codex_event_stream()` and crashing the turn.

## Changes

- Add a narrow predicate for the known SDK null-output parse failure.
- Consume the stream with an explicit iterator loop so this specific `TypeError` can be handled at the `next()` boundary.
- Treat the terminal null-output parse failure as an empty completed terminal event, preserving previously collected `response.output_item.done` items.
- Add a regression test that simulates the SDK raising after yielding durable output items.

## Validation

- `python -m pytest tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_treats_sdk_null_output_parse_error_as_empty_terminal_output tests/run_agent/test_run_agent_codex_responses.py -q` -> `78 passed`
- `python -m py_compile agent/codex_runtime.py tests/run_agent/test_run_agent_codex_responses.py`
- `git diff --check`
