### PR TITLE
fix(desktop): filter pip cache wheels from artifacts

### DIFF
--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -70,6 +70,32 @@ function looksLikeArtifact(value: string): boolean {
   return value.startsWith('/') && value.includes('.')
 }
 
+function normalizedArtifactPathForFiltering(value: string): string {
+  if (/^file:\/\//i.test(value)) {
+    try {
+      return decodeURIComponent(new URL(value).pathname).replace(/\\/g, '/').toLowerCase()
+    } catch {
+      // Fall through to string normalization for malformed file URLs.
+    }
+  }
+
+  return value.replace(/\\/g, '/').toLowerCase()
+}
+
+function isDependencyCacheArtifact(value: string): boolean {
+  const normalizedPath = normalizedArtifactPathForFiltering(value)
+
+  return (
+    normalizedPath.includes('/.cache/pip/') ||
+    normalizedPath.includes('/library/caches/pip/') ||
+    normalizedPath.includes('/appdata/local/pip/cache/')
+  )
+}
+
+function shouldIndexArtifact(value: string): boolean {
+  return looksLikeArtifact(value) && !isDependencyCacheArtifact(value)
+}
+
 function artifactKind(value: string): ArtifactKind {
   if (value.startsWith('data:image/') || IMAGE_EXT_RE.test(value)) {
     return 'image'
@@ -236,7 +262,7 @@ function collectArtifactsFromMessage(message: SessionMessage, pushValue: (value:
         return
       }
 
-      if ((KEY_HINT_RE.test(keyPath) || looksLikePathOrUrl(normalized)) && looksLikeArtifact(normalized)) {
+      if ((KEY_HINT_RE.test(keyPath) || looksLikePathOrUrl(normalized)) && shouldIndexArtifact(normalized)) {
         pushValue(normalized)
       }
     })
@@ -255,7 +281,7 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
     collectArtifactsFromMessage(message, candidate => {
       const value = normalizeValue(candidate)
 
-      if (!value || !looksLikeArtifact(value)) {
+      if (!value || !shouldIndexArtifact(value)) {
         return
       }
 

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -67,6 +67,38 @@ describe('collectArtifactsForSession', () => {
     })
   })
 
+  it('excludes a plain-text Windows pip cache wheel candidate', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: [
+          'Using cached wheel:',
+          '/C:/Users/Alice/AppData/Local/pip/Cache/wheels/11/22/openai-2.24.0-py3-none-any.whl',
+          'Generated report: /tmp/hermes-session/report.pdf'
+        ].join('\n'),
+        role: 'tool',
+        timestamp: 4000
+      }
+    ])
+
+    expect(artifacts.map(artifact => artifact.value)).toEqual(['/tmp/hermes-session/report.pdf'])
+  })
+
+  it('excludes a pip cache candidate extracted from a JSON tool result', () => {
+    const cachePath = 'file:///C:/Users/Alice/AppData/Local/pip/Cache/http-v2/11/22/metadata.json'
+    const reportPath = 'file:///C:/Users/Alice/Documents/report.pdf'
+    const sourceUrl = 'https://example.com/results/latest'
+
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: JSON.stringify({ cache_path: cachePath, report_path: reportPath, source_url: sourceUrl }),
+        role: 'tool',
+        timestamp: 5000
+      }
+    ])
+
+    expect(artifacts.map(artifact => artifact.value).sort()).toEqual([reportPath, sourceUrl].sort())
+  })
+
   it('resolves remote image artifact thumbnails through the desktop fs bridge', async () => {
     const api = vi.fn(async ({ path }: { path: string }) => {
       if (path.startsWith('/api/fs/read-data-url?')) {


### PR DESCRIPTION
## Summary

Fixes #52972.

Prevent Hermes Desktop Artifacts from indexing dependency cache wheel files emitted by `pip install` output while preserving real generated files from the same transcript.

## Root Cause

Desktop artifact discovery scans assistant/tool text for path-like values. The existing `looksLikeArtifact()` heuristic accepts broad absolute paths with file extensions, so pip cache wheel paths like `Library/Caches/pip/.../*.whl` or `AppData/Local/pip/Cache/.../*.whl` can be treated as session artifacts and opened/downloaded from the Artifacts view.

## Changes

- Add a small artifact filtering helper that normalizes paths and file URLs for comparison.
- Exclude common pip cache locations:
  - `~/.cache/pip/`
  - `Library/Caches/pip/`
  - `AppData/Local/pip/Cache/`
- Apply the filter to both JSON-derived and text-derived artifact candidates.
- Add regression coverage for macOS-style pip cache paths and Windows `file:///C:/Users/.../AppData/Local/pip/Cache/...` wheel paths while preserving a generated PDF from the same output.

## Validation

- `npm run test:ui -- src/app/artifacts/index.test.ts` → `1 passed`, `3 passed`
- `npm run typecheck`
- `npx eslint src/app/artifacts/index.tsx src/app/artifacts/index.test.ts`
- `npx prettier --check src/app/artifacts/index.tsx src/app/artifacts/index.test.ts`
- `git diff --check`