### PR TITLE
fix(desktop): enforce memory file char limits

### DIFF
--- a/apps/desktop/electron/hardening.test.ts
+++ b/apps/desktop/electron/hardening.test.ts
@@ -13,7 +13,8 @@ import {
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs,
-  sensitiveFileBlockReason
+  sensitiveFileBlockReason,
+  validateHermesMemoryFileWrite
 } from './hardening'
 
 async function rejectsWithCode(promise, code: string) {
@@ -254,6 +255,92 @@ test('resolveReadableFileForIpc blocks symlinks whose realpath is sensitive', as
     await rejectsWithCode(resolveReadableFileForIpc(linkPath, { purpose: 'File preview' }), 'sensitive-file')
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true })
+  }
+})
+
+test('validateHermesMemoryFileWrite rejects MEMORY.md over its configured limit', () => {
+  const hermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-memory-limit-'))
+
+  try {
+    const memories = path.join(hermesHome, 'memories')
+    fs.mkdirSync(memories)
+    fs.writeFileSync(
+      path.join(hermesHome, 'config.yaml'),
+      ['memory:', '  memory_char_limit: 5', '  user_char_limit: 99', ''].join('\n'),
+      'utf8'
+    )
+
+    assert.throws(
+      () => validateHermesMemoryFileWrite(path.join(memories, 'MEMORY.md'), '123456', { hermesHome }),
+      (error: any) => {
+        assert.equal(error?.code, 'memory-limit')
+        assert.match(error.message, /MEMORY\.md/)
+        assert.match(error.message, /6\/5 chars/)
+        assert.match(error.message, /memory\.memory_char_limit/)
+
+        return true
+      }
+    )
+  } finally {
+    fs.rmSync(hermesHome, { force: true, recursive: true })
+  }
+})
+
+test('validateHermesMemoryFileWrite rejects root USER.md over its configured limit', () => {
+  const hermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-user-limit-'))
+
+  try {
+    const memories = path.join(hermesHome, 'memories')
+    fs.mkdirSync(memories)
+    fs.writeFileSync(
+      path.join(hermesHome, 'config.yaml'),
+      ['memory:', '  memory_char_limit: 99', '  user_char_limit: 4', ''].join('\n'),
+      'utf8'
+    )
+
+    assert.throws(
+      () => validateHermesMemoryFileWrite(path.join(memories, 'USER.md'), '12345', { hermesHome }),
+      (error: any) => {
+        assert.equal(error?.code, 'memory-limit')
+        assert.match(error.message, /USER\.md/)
+        assert.match(error.message, /5\/4 chars/)
+        assert.match(error.message, /memory\.user_char_limit/)
+
+        return true
+      }
+    )
+  } finally {
+    fs.rmSync(hermesHome, { force: true, recursive: true })
+  }
+})
+
+test('validateHermesMemoryFileWrite applies profile config and counts Unicode characters', () => {
+  const hermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-profile-user-limit-'))
+
+  try {
+    const profileHome = path.join(hermesHome, 'profiles', 'work')
+    const memories = path.join(profileHome, 'memories')
+    fs.mkdirSync(memories, { recursive: true })
+    fs.writeFileSync(
+      path.join(profileHome, 'config.yaml'),
+      ['memory:', '  memory_char_limit: 99', '  user_char_limit: 2', ''].join('\n'),
+      'utf8'
+    )
+
+    const accepted = validateHermesMemoryFileWrite(path.join(memories, 'USER.md'), '🚀🚀', { hermesHome })
+    assert.equal(accepted?.current, 2)
+    assert.equal(accepted?.limit, 2)
+    assert.throws(
+      () => validateHermesMemoryFileWrite(path.join(memories, 'USER.md'), '🚀🚀🚀', { hermesHome }),
+      (error: any) => {
+        assert.equal(error?.code, 'memory-limit')
+        assert.match(error.message, /3\/2 chars/)
+
+        return true
+      }
+    )
+  } finally {
+    fs.rmSync(hermesHome, { force: true, recursive: true })
   }
 })
 

--- a/apps/desktop/electron/hardening.ts
+++ b/apps/desktop/electron/hardening.ts
@@ -6,9 +6,24 @@ import { fileURLToPath } from 'node:url'
 const DEFAULT_FETCH_TIMEOUT_MS = 15_000
 const DATA_URL_READ_MAX_BYTES = 16 * 1024 * 1024
 const TEXT_PREVIEW_SOURCE_MAX_BYTES = 64 * 1024 * 1024
+const DEFAULT_MEMORY_CHAR_LIMIT = 2200
+const DEFAULT_USER_CHAR_LIMIT = 1375
 
 const SAFE_ENV_SUFFIXES = new Set(['dist', 'example', 'sample', 'template'])
 const SENSITIVE_EXTENSIONS = new Set(['.kdbx', '.p12', '.pem', '.pfx'])
+
+const MEMORY_FILE_LIMITS = Object.freeze({
+  'MEMORY.md': {
+    configKey: 'memory.memory_char_limit',
+    defaultLimit: DEFAULT_MEMORY_CHAR_LIMIT,
+    limitKey: 'memory_char_limit'
+  },
+  'USER.md': {
+    configKey: 'memory.user_char_limit',
+    defaultLimit: DEFAULT_USER_CHAR_LIMIT,
+    limitKey: 'user_char_limit'
+  }
+})
 
 function resolveTimeoutMs(timeoutMs, fallbackMs = DEFAULT_FETCH_TIMEOUT_MS) {
   const fallback =
@@ -116,6 +131,126 @@ function ipcPathError(code: any, message: string): Error & { code: any } {
   ;(error as any).code = code
 
   return error
+}
+
+function pathIsInside(parent, child) {
+  const relative = path.relative(path.resolve(parent), path.resolve(child))
+
+  return relative === '' || (relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative))
+}
+
+function configuredMemoryLimit(profileHome, limitKey, fallback) {
+  let raw = ''
+
+  try {
+    raw = fs.readFileSync(path.join(profileHome, 'config.yaml'), 'utf8')
+  } catch {
+    return fallback
+  }
+
+  const lines = raw.split(/\r?\n/)
+  let inMemory = false
+  let memoryIndent = -1
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue
+    }
+
+    const indent = line.length - line.trimStart().length
+
+    if (/^memory\s*:\s*(?:#.*)?$/.test(trimmed)) {
+      inMemory = true
+      memoryIndent = indent
+
+      continue
+    }
+
+    if (inMemory && indent <= memoryIndent) {
+      inMemory = false
+    }
+
+    if (!inMemory || indent <= memoryIndent) {
+      continue
+    }
+
+    const match = trimmed.match(new RegExp(`^${limitKey}\\s*:\\s*([^#]+)`))
+
+    if (!match) {
+      continue
+    }
+
+    const normalized = match[1]
+      .trim()
+      .replace(/^['"]|['"]$/g, '')
+      .replace(/_/g, '')
+
+    if (!/^-?\d+$/.test(normalized)) {
+      return fallback
+    }
+
+    return Number.parseInt(normalized, 10)
+  }
+
+  return fallback
+}
+
+function hermesMemoryFileTarget(filePath, hermesHome) {
+  if (!hermesHome) {
+    return null
+  }
+
+  const resolvedHome = path.resolve(String(hermesHome))
+  const resolvedPath = path.resolve(String(filePath || ''))
+
+  if (!pathIsInside(resolvedHome, resolvedPath)) {
+    return null
+  }
+
+  const parts = path.relative(resolvedHome, resolvedPath).split(path.sep)
+  let profileHome = null
+  let fileName = null
+
+  if (parts.length === 2 && parts[0] === 'memories') {
+    profileHome = resolvedHome
+    fileName = parts[1]
+  } else if (parts.length === 4 && parts[0] === 'profiles' && parts[2] === 'memories') {
+    profileHome = path.join(resolvedHome, 'profiles', parts[1])
+    fileName = parts[3]
+  }
+
+  const limitInfo = fileName ? MEMORY_FILE_LIMITS[fileName] : null
+
+  return limitInfo && profileHome ? { ...limitInfo, fileName, profileHome } : null
+}
+
+function countUnicodeChars(value) {
+  return Array.from(String(value ?? '')).length
+}
+
+function validateHermesMemoryFileWrite(filePath, content, options: { hermesHome?: string } = {}) {
+  const target = hermesMemoryFileTarget(filePath, options.hermesHome)
+
+  if (!target) {
+    return null
+  }
+
+  const limit = configuredMemoryLimit(target.profileHome, target.limitKey, target.defaultLimit)
+  const current = countUnicodeChars(content)
+
+  if (current <= limit) {
+    return { current, limit, target }
+  }
+
+  const overBy = current - limit
+
+  throw ipcPathError(
+    'memory-limit',
+    `${target.fileName} is ${current}/${limit} chars, exceeding ${target.configKey}. ` +
+      `Reduce by ${overBy} chars or raise ${target.configKey} in config.yaml before saving.`
+  )
 }
 
 function rejectUnsafePathSyntax(filePath, purpose = 'File read') {
@@ -313,5 +448,6 @@ export {
   resolveRequestedPathForIpc,
   resolveTimeoutMs,
   sensitiveFileBlockReason,
-  TEXT_PREVIEW_SOURCE_MAX_BYTES
+  TEXT_PREVIEW_SOURCE_MAX_BYTES,
+  validateHermesMemoryFileWrite
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -92,7 +92,8 @@ import {
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs,
-  TEXT_PREVIEW_SOURCE_MAX_BYTES
+  TEXT_PREVIEW_SOURCE_MAX_BYTES,
+  validateHermesMemoryFileWrite
 } from './hardening'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
@@ -8428,6 +8429,8 @@ ipcMain.handle('hermes:fs:writeText', async (_event, filePath, content) => {
   if (!directoryExists(path.dirname(resolved))) {
     throw new Error('Parent directory does not exist')
   }
+
+  validateHermesMemoryFileWrite(resolved, text, { hermesHome: HERMES_HOME })
 
   await fs.promises.writeFile(resolved, text, 'utf8')
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1408,6 +1408,10 @@ _FS_TEXT_PREVIEW_MAX_BYTES = 512 * 1024
 # non-truncated text (<= the preview cap), so this is a safety ceiling against
 # a pasted-in megablob, not the expected payload size.
 _FS_TEXT_WRITE_MAX_BYTES = 8 * 1024 * 1024
+_MEMORY_FILE_LIMITS = {
+    "MEMORY.md": ("memory_char_limit", "memory.memory_char_limit", 2200),
+    "USER.md": ("user_char_limit", "memory.user_char_limit", 1375),
+}
 _FS_PREVIEW_LANGUAGE_BY_EXT = {
     ".c": "c",
     ".conf": "ini",
@@ -1482,6 +1486,67 @@ def _fs_path(raw_path: str) -> Path:
         return candidate.resolve(strict=False)
     except (OSError, RuntimeError, ValueError):
         raise HTTPException(status_code=400, detail="Invalid path")
+
+
+def _configured_memory_file_limit(
+    profile_home: Path,
+    limit_key: str,
+    default: int,
+) -> int:
+    try:
+        raw = yaml.safe_load((profile_home / "config.yaml").read_text(encoding="utf-8")) or {}
+        mem_cfg = raw.get("memory") if isinstance(raw, dict) else {}
+        if not isinstance(mem_cfg, dict):
+            return default
+        return int(mem_cfg.get(limit_key, default))
+    except Exception:
+        return default
+
+
+def _memory_file_target(path: Path) -> tuple[str, str, int] | None:
+    try:
+        target = path.resolve(strict=False)
+        root = get_hermes_home().resolve(strict=False)
+        relative = target.relative_to(root)
+    except (OSError, ValueError):
+        return None
+
+    parts = relative.parts
+    profile_home: Path | None = None
+    file_name: str | None = None
+    if len(parts) == 2 and parts[0] == "memories":
+        profile_home = root
+        file_name = parts[1]
+    elif len(parts) == 4 and parts[0] == "profiles" and parts[2] == "memories":
+        profile_home = root / "profiles" / parts[1]
+        file_name = parts[3]
+
+    if profile_home is None or file_name not in _MEMORY_FILE_LIMITS:
+        return None
+
+    limit_key, config_key, default_limit = _MEMORY_FILE_LIMITS[file_name]
+    limit = _configured_memory_file_limit(profile_home, limit_key, default_limit)
+    return file_name, config_key, limit
+
+
+def _validate_memory_file_write(path: Path, text: str) -> None:
+    target = _memory_file_target(path)
+    if target is None:
+        return
+
+    file_name, config_key, limit = target
+    current = len(text)
+    if current <= limit:
+        return
+
+    over_by = current - limit
+    raise HTTPException(
+        status_code=400,
+        detail=(
+            f"{file_name} is {current}/{limit} chars, exceeding {config_key}. "
+            f"Reduce by {over_by} chars or raise {config_key} in config.yaml before saving."
+        ),
+    )
 
 
 def _fs_mime_type(path: Path) -> str:
@@ -2242,6 +2307,8 @@ async def fs_write_text(payload: FsWriteText):
         raise HTTPException(status_code=400, detail="Only regular files can be written")
     if not target.parent.is_dir():
         raise HTTPException(status_code=400, detail="Parent directory does not exist")
+
+    _validate_memory_file_write(target, text)
 
     tmp = target.with_name(f".{target.name}.hermes-tmp-{os.getpid()}")
     try:

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -186,3 +186,58 @@ def test_fs_endpoints_require_auth(tmp_path):
     assert list_response.status_code == 401
     assert read_response.status_code == 401
     assert default_response.status_code == 401
+
+
+def test_fs_write_text_rejects_memory_md_over_configured_char_limit(client, tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    memories = home / "memories"
+    memories.mkdir(parents=True)
+    target = memories / "MEMORY.md"
+    target.write_text("old memory\n", encoding="utf-8")
+    (home / "config.yaml").write_text(
+        "memory:\n"
+        "  memory_char_limit: 5\n"
+        "  user_char_limit: 99\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: home)
+
+    response = client.post(
+        "/api/fs/write-text",
+        json={"path": str(target), "content": "123456"},
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "MEMORY.md" in detail
+    assert "6/5 chars" in detail
+    assert "memory.memory_char_limit" in detail
+    assert target.read_text(encoding="utf-8") == "old memory\n"
+
+
+def test_fs_write_text_rejects_profile_user_md_over_configured_char_limit(client, tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    profile_home = home / "profiles" / "work"
+    memories = profile_home / "memories"
+    memories.mkdir(parents=True)
+    target = memories / "USER.md"
+    target.write_text("old user\n", encoding="utf-8")
+    (profile_home / "config.yaml").write_text(
+        "memory:\n"
+        "  memory_char_limit: 99\n"
+        "  user_char_limit: 2\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: home)
+
+    response = client.post(
+        "/api/fs/write-text",
+        json={"path": str(target), "content": "🚀🚀🚀"},
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "USER.md" in detail
+    assert "3/2 chars" in detail
+    assert "memory.user_char_limit" in detail
+    assert target.read_text(encoding="utf-8") == "old user\n"


### PR DESCRIPTION
## Summary
- Enforce `memory.memory_char_limit` / `memory.user_char_limit` when the desktop spot editor saves `MEMORY.md` or `USER.md`.
- Apply the guard to both the local Electron `hermes:fs:writeText` path and the served dashboard `/api/fs/write-text` endpoint.
- Cover root and profile memory directories, preserving the existing file when an oversized save is rejected.

Fixes #53039.

## Tests
- `node --test apps/desktop/electron/hardening.test.cjs`
- `node --check apps/desktop/electron/hardening.cjs apps/desktop/electron/main.cjs apps/desktop/electron/hardening.test.cjs`
- `python -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_web_server_fs_write.py`
- `python -m pytest tests/hermes_cli/test_web_server_fs_write.py -q -rs` (skipped: `fastapi/starlette` not installed in this environment)
- `eslint electron/hardening.cjs electron/hardening.test.cjs electron/main.cjs`
- `prettier --check electron/hardening.cjs electron/hardening.test.cjs electron/main.cjs`
- `git diff --check origin/main...HEAD`
