### PR TITLE
fix(windows): tighten desktop terminal lifecycle cleanup

### DIFF
--- a/apps/desktop/electron/terminal-lifecycle.test.cjs
+++ b/apps/desktop/electron/terminal-lifecycle.test.cjs
@@ -1,0 +1,20 @@
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const ROOT = path.resolve(__dirname, '..')
+
+function readDesktopSource(...parts) {
+  return fs.readFileSync(path.join(ROOT, 'src', ...parts), 'utf8').replace(/\r\n/g, '\n')
+}
+
+test('embedded terminal cwd changes do not restart the PTY session', () => {
+  const source = readDesktopSource('app', 'right-sidebar', 'terminal', 'use-terminal-session.ts')
+
+  assert.match(source, /const launchCwdRef = useRef\(cwd\)/)
+  assert.match(source, /\.start\(\{ cols: term\.cols, cwd: launchCwdRef\.current, rows: term\.rows \}\)/)
+  assert.doesNotMatch(source, /\}, \[addSelectionToChat, cwd\]\)/)
+})

--- a/apps/desktop/electron/windows-child-process.test.cjs
+++ b/apps/desktop/electron/windows-child-process.test.cjs
@@ -68,5 +68,5 @@ test('bootstrap PowerShell runner hides Windows console children', () => {
   const source = readElectronFile('bootstrap-runner.cjs')
 
   assert.match(source, /function hiddenWindowsChildOptions\(options = \{\}\)/)
-  requireHiddenChildOptions(source, 'spawn(ps, fullArgs')
+  requireHiddenChildOptions(source, /spawn\(\s*ps,\s*fullArgs/)
 })

--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
@@ -246,6 +246,9 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
   const activeTheme = useMemo(() => terminalTheme(renderedMode, ansiPalette), [renderedMode, ansiPalette])
   const initialThemeRef = useRef(activeTheme)
   const hostRef = useRef<HTMLDivElement | null>(null)
+  // CWD is a launch parameter. Do not restart the PTY every time the active
+  // chat/session cwd changes; closing and reopening the pane picks up a new cwd.
+  const launchCwdRef = useRef(cwd)
   const termRef = useRef<Terminal | null>(null)
   const webglRef = useRef<WebglAddon | null>(null)
   const sessionIdRef = useRef<string | null>(null)
@@ -557,7 +560,7 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
 
     const startSession = () =>
       void terminalApi
-        .start({ cols: term.cols, cwd, rows: term.rows })
+        .start({ cols: term.cols, cwd: launchCwdRef.current, rows: term.rows })
         .then(session => {
           if (disposed) {
             void terminalApi.dispose(session.id)
@@ -654,7 +657,7 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
       selectionRef.current = ''
       selectionLabelRef.current = ''
     }
-  }, [addSelectionToChat, cwd])
+  }, [addSelectionToChat])
 
   useEffect(() => {
     const term = termRef.current

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -624,6 +624,22 @@ class TestSubprocessCompatHelpers:
         assert fallback & 0x00000008, "fallback missing DETACHED_PROCESS"
         assert fallback & 0x08000000, "fallback missing CREATE_NO_WINDOW"
 
+    def test_local_terminal_windows_timeout_kills_process_tree(self):
+        """Windows terminal cleanup must not leave shell descendants behind."""
+        root = Path(__file__).resolve().parents[2]
+        source = (root / "tools" / "environments" / "local.py").read_text(encoding="utf-8")
+
+        assert "def _terminate_windows_process_tree" in source
+        assert '["taskkill", "/PID", str(proc.pid), "/T", "/F"]' in source
+        assert "_terminate_windows_process_tree(proc)" in source
+
+    def test_background_terminal_windows_kill_uses_tree_termination(self):
+        """terminal(background=True) kill must target the Windows process tree."""
+        root = Path(__file__).resolve().parents[2]
+        source = (root / "tools" / "process_registry.py").read_text(encoding="utf-8")
+
+        assert "self._terminate_host_pid(session.process.pid, session.host_start_time)" in source
+
 
 # ---------------------------------------------------------------------------
 # tui_gateway/entry.py signal installation survives absent POSIX signals

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -337,6 +337,31 @@ def _find_shell() -> str:
     return _find_bash()
 
 
+def _terminate_windows_process_tree(proc: subprocess.Popen) -> None:
+    """Hard-kill a Windows process tree, not just the shell wrapper."""
+    try:
+        subprocess.run(
+            ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            creationflags=windows_hide_flags(),
+            stdin=subprocess.DEVNULL,
+        )
+        try:
+            proc.wait(timeout=1)
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        try:
+            proc.terminate()
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+
 # Standard PATH entries for environments with minimal PATH.
 _SANE_PATH = (
     "/opt/homebrew/bin:/opt/homebrew/sbin:"
@@ -780,7 +805,7 @@ class LocalEnvironment(BaseEnvironment):
 
         try:
             if _IS_WINDOWS:
-                proc.terminate()
+                _terminate_windows_process_tree(proc)
             else:
                 try:
                     pgid = os.getpgid(proc.pid)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -786,7 +786,7 @@ class ProcessRegistry:
                     except (ProcessLookupError, PermissionError, OSError):
                         proc.kill()
                 else:
-                    proc.kill()
+                    self._terminate_host_pid(proc.pid, session.host_start_time)
             except Exception:
                 pass
             try:
@@ -1388,7 +1388,7 @@ class ProcessRegistry:
                 # Local process -- kill the process tree
                 try:
                     if _IS_WINDOWS:
-                        session.process.terminate()
+                        self._terminate_host_pid(session.process.pid, session.host_start_time)
                     else:
                         import psutil
                         try:


### PR DESCRIPTION
## Summary

- keep the embedded Desktop terminal from restarting its PTY every time the active chat/session cwd changes
- treat the terminal cwd as a launch parameter; closing and reopening the pane picks up the latest cwd
- hard-kill Windows `terminal()` process trees with `taskkill /T /F` on cleanup instead of terminating only the shell wrapper
- make `terminal(background=true)` Windows kills use the existing host PID tree-kill path
- add regression coverage for PTY restart churn and Windows process-tree cleanup invariants

## Context

Fix #53555.  it addresses two concrete leak vectors that match the observed `WindowsTerminal.exe -Embedding` / `OpenConsole.exe -Embedding` accumulation:

- Desktop terminal churn: `PersistentTerminal` is intended to keep one PTY-backed terminal mounted, but `useTerminalSession` was restarting the PTY whenever `cwd` changed. If the terminal pane was active while sessions/jobs changed cwd, that could repeatedly create/dispose PTYs on Windows.
- Windows cleanup: local foreground/background terminal cleanup paths could terminate only the wrapper process on Windows. Descendant shells/hosts could survive if a command timed out, was interrupted, or was killed.


## Tests

- `node --test apps/desktop/electron/windows-child-process.test.cjs apps/desktop/electron/terminal-lifecycle.test.cjs`
- `.venv\\Scripts\\python.exe -m pytest tests/tools/test_windows_native_support.py::TestSubprocessCompatHelpers::test_local_terminal_windows_timeout_kills_process_tree tests/tools/test_windows_native_support.py::TestSubprocessCompatHelpers::test_background_terminal_windows_kill_uses_tree_termination -q`
- manual testing of the build confirm progress
