### PR TITLE
fix(cli): show provider in status bar model label

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4271,6 +4271,41 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         idle = max(0.0, time.time() - last_finished_at)
         return f"✓ {format_duration_compact(idle)}"
 
+    _STATUS_BAR_PROVIDER_ALIASES = {
+        "openai-codex": "codex",
+    }
+
+    def _resolve_status_bar_provider_short(self, agent: Any) -> str:
+        """Return a compact provider slug for the status bar, or ``""``."""
+        candidates: list[str] = []
+
+        agent_provider = getattr(agent, "provider", None)
+        if agent_provider and str(agent_provider).strip().lower() not in {"auto", "custom"}:
+            candidates.append(str(agent_provider))
+
+        cli_provider = getattr(self, "provider", None)
+        if cli_provider:
+            candidates.append(str(cli_provider))
+
+        requested_provider = getattr(self, "requested_provider", None)
+        if requested_provider:
+            candidates.append(str(requested_provider))
+
+        provider_source = getattr(self, "_provider_source", None)
+        if provider_source:
+            tail = str(provider_source).split(":", 1)[-1].strip()
+            if tail:
+                candidates.append(tail.lower())
+
+        for raw in candidates:
+            slug = raw.strip()
+            if slug.startswith("custom:"):
+                slug = slug.split(":", 1)[1].strip()
+            if not slug or slug.lower() in {"auto", "custom", "unknown"}:
+                continue
+            return self._STATUS_BAR_PROVIDER_ALIASES.get(slug, slug)
+        return ""
+
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
         # Prefer the agent's model name — it updates on fallback.
         # self.model reflects the originally configured model and never
@@ -4281,12 +4316,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         model_short = model_name.split("/")[-1] if "/" in model_name else model_name
         if model_short.endswith(".gguf"):
             model_short = model_short[:-5]
+
+        provider_short = self._resolve_status_bar_provider_short(agent)
+        if provider_short:
+            model_short = f"{provider_short}/{model_short}"
+
         if len(model_short) > 26:
             model_short = f"{model_short[:23]}..."
 
         elapsed_seconds = max(0.0, (datetime.now() - self.session_start).total_seconds())
         snapshot = {
             "model_name": model_name,
+            "provider_short": provider_short,
             "model_short": model_short,
             "duration": format_duration_compact(elapsed_seconds),
             "prompt_elapsed": self._format_prompt_elapsed(

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -10,6 +10,9 @@ from cli import HermesCLI
 def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
     cli_obj = HermesCLI.__new__(HermesCLI)
     cli_obj.model = model
+    cli_obj.provider = None
+    cli_obj.requested_provider = None
+    cli_obj._provider_source = None
     cli_obj.session_start = datetime.now() - timedelta(minutes=14, seconds=32)
     cli_obj.conversation_history = [{"role": "user", "content": "hi"}]
     cli_obj.agent = None
@@ -76,11 +79,75 @@ class TestCLIStatusBar:
 
         text = cli_obj._build_status_bar_text(width=120)
 
-        assert "claude-sonnet-4-20250514" in text
+        assert "anthropic/claude-sonnet" in text
         assert "12.4K/200K" in text
         assert "6%" in text
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text
+
+    def test_status_bar_snapshot_shows_openai_codex_provider_alias(self):
+        cli_obj = _make_cli(model="gpt-5.5")
+        cli_obj.provider = "openai-codex"
+        cli_obj.requested_provider = "openai-codex"
+        cli_obj.agent = SimpleNamespace(model="gpt-5.5", provider="openai-codex")
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["provider_short"] == "codex"
+        assert snapshot["model_short"] == "codex/gpt-5.5"
+
+    def test_status_bar_snapshot_preserves_named_custom_provider(self):
+        cli_obj = _make_cli(model="gpt-5.5")
+        cli_obj.provider = "custom"
+        cli_obj.requested_provider = "example-provider"
+        cli_obj.agent = SimpleNamespace(model="gpt-5.5", provider="custom")
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["provider_short"] == "example-provider"
+        assert snapshot["model_short"] == "example-provider/gpt-5.5"
+
+    def test_status_bar_snapshot_unwraps_custom_provider_slug(self):
+        cli_obj = _make_cli(model="gpt-5.5")
+        cli_obj.provider = "custom"
+        cli_obj.requested_provider = "custom:example-provider"
+        cli_obj.agent = SimpleNamespace(model="gpt-5.5", provider="custom")
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["provider_short"] == "example-provider"
+        assert snapshot["model_short"] == "example-provider/gpt-5.5"
+
+    def test_status_bar_snapshot_uses_custom_provider_source_fallback(self):
+        cli_obj = _make_cli(model="gpt-5.5")
+        cli_obj.provider = "custom"
+        cli_obj.requested_provider = "auto"
+        cli_obj._provider_source = "custom_provider:Example-Provider"
+        cli_obj.agent = SimpleNamespace(model="gpt-5.5", provider="custom")
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["provider_short"] == "example-provider"
+        assert snapshot["model_short"] == "example-provider/gpt-5.5"
+
+    def test_status_bar_snapshot_falls_back_to_model_without_provider(self):
+        cli_obj = _make_cli(model="gpt-5.5")
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["provider_short"] == ""
+        assert snapshot["model_short"] == "gpt-5.5"
+
+    def test_status_bar_snapshot_does_not_render_generic_provider(self):
+        cli_obj = _make_cli(model="gpt-5.5")
+        cli_obj.provider = "custom"
+        cli_obj.requested_provider = "auto"
+        cli_obj.agent = SimpleNamespace(model="gpt-5.5", provider="custom")
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["provider_short"] == ""
+        assert snapshot["model_short"] == "gpt-5.5"
 
     def test_post_compression_sentinel_does_not_render_negative(self):
         """Right after a compression, last_prompt_tokens is parked at the -1


### PR DESCRIPTION
## Summary
- show a compact provider/model label in the CLI/TUI status bar when a provider can be resolved
- keep generic placeholders like `custom` and `auto` out of the visible label
- preserve named custom provider slugs generically, including `custom:<slug>` and `custom_provider:<slug>` sources
- alias `openai-codex` to `codex` for a shorter status-bar label

## Why
When multiple providers expose the same model ID, the status bar can be ambiguous if it only displays the model name. For example, two configured providers serving `gpt-5.5` would both render as `gpt-5.5`.

## Tests
- `scripts/run_tests.sh tests/cli/test_cli_status_bar.py -- -q`
- `.venv/bin/python scripts/check-windows-footguns.py cli.py tests/cli/test_cli_status_bar.py`
- `.venv/bin/python -m py_compile cli.py`

I also started the full `scripts/run_tests.sh` suite locally, but did not run it to completion. This fresh checkout hit unrelated local environment failures before this change area, including missing optional `acp` imports and local Hermes home permission errors. The focused status-bar suite passed.
