### PR TITLE
fix(telegram): refresh general request pool after pool timeout

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1470,6 +1470,46 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return False
 
+    async def _drain_bot_request_pool(self, request_index: int, pool_name: str) -> None:
+        """Reset one PTB request pool in place.
+
+        PTB stores the getUpdates request and the general Bot API request in a
+        private ``Bot._request`` tuple. When one side wedges into pool timeout,
+        shutting down and re-initializing that specific request object gives the
+        next retry a fresh httpx client without disturbing the other path.
+        """
+        app = getattr(self, "_app", None)
+        bot = getattr(app, "bot", None)
+        if not bot:
+            return
+        try:
+            request_pool = bot._request[request_index]  # noqa: SLF001
+        except Exception:
+            return
+        try:
+            await request_pool.shutdown()
+        except Exception:
+            logger.debug(
+                "[%s] %s request shutdown failed (non-fatal)",
+                self.name,
+                pool_name,
+                exc_info=True,
+            )
+        try:
+            await request_pool.initialize()
+            logger.debug(
+                "[%s] %s request pool drained before retry",
+                self.name,
+                pool_name,
+            )
+        except Exception:
+            logger.debug(
+                "[%s] %s request re-initialize failed (non-fatal)",
+                self.name,
+                pool_name,
+                exc_info=True,
+            )
+
     async def _drain_polling_connections(self) -> None:
         """Reset the httpx connection pool used for getUpdates polling.
 
@@ -1487,31 +1527,11 @@ class TelegramAdapter(BasePlatformAdapter):
         ``(get_updates_request, general_request)``.  There is no public
         accessor for the polling request; review if upgrading to PTB 23+.
         """
-        if not (self._app and self._app.bot):
-            return
-        try:
-            # PTB 22.x: _request is a (get_updates, general) tuple;
-            # no public accessor exists for the polling request.
-            polling_req = self._app.bot._request[0]  # noqa: SLF001
-        except Exception:
-            return
-        try:
-            await polling_req.shutdown()
-        except Exception:
-            logger.debug(
-                "[%s] Polling request shutdown failed (non-fatal)",
-                self.name, exc_info=True,
-            )
-        try:
-            await polling_req.initialize()
-            logger.debug(
-                "[%s] Polling request pool drained before reconnect", self.name
-            )
-        except Exception:
-            logger.debug(
-                "[%s] Polling request re-initialize failed (non-fatal)",
-                self.name, exc_info=True,
-            )
+        await self._drain_bot_request_pool(0, "Polling")
+
+    async def _drain_general_request_pool(self) -> None:
+        """Reset the general Bot API request pool used for send/edit calls."""
+        await self._drain_bot_request_pool(1, "General")
 
     async def _handle_polling_network_error(self, error: Exception) -> None:
         """Reconnect polling after a transient network interruption.
@@ -2837,6 +2857,12 @@ class TelegramAdapter(BasePlatformAdapter):
                             and not self._looks_like_pool_timeout(send_err)
                         ):
                             raise
+                        if self._looks_like_pool_timeout(send_err):
+                            # The general Bot API pool is the one that backs
+                            # send/edit calls; if it wedges, refresh it before
+                            # the next retry so we do not keep hammering a dead
+                            # client.
+                            await self._drain_general_request_pool()
                         if _send_attempt < 2:
                             wait = 2 ** _send_attempt
                             logger.warning("[%s] Network error on send (attempt %d/3), retrying in %ds: %s",

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -11,6 +11,7 @@ avoid retrying with a partial topic route that can render outside the lane.
 import sys
 import types
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -1359,6 +1360,56 @@ async def test_send_marks_pool_timeout_retryable_after_exhaustion():
     assert result.success is False
     assert result.retryable is True
     assert attempt[0] == 3
+
+
+@pytest.mark.asyncio
+async def test_send_refreshes_general_pool_after_pool_timeout(monkeypatch):
+    """A wedged general request pool should be drained before retrying.
+
+    This is the recovery path for Telegram's send side: when PTB reports a
+    pool timeout, the request was never sent, so the adapter can safely reset
+    the general Bot API request object and retry with a fresh pool.
+    """
+    adapter = _make_adapter()
+
+    class _RecordingRequest:
+        def __init__(self):
+            self.shutdown = AsyncMock()
+            self.initialize = AsyncMock()
+
+    polling_request = _RecordingRequest()
+    general_request = _RecordingRequest()
+    bot = SimpleNamespace(
+        _request=[polling_request, general_request],
+        send_chat_action=AsyncMock(return_value=None),
+    )
+
+    attempt = [0]
+
+    async def mock_send_message(**kwargs):
+        attempt[0] += 1
+        if general_request.shutdown.await_count == 0:
+            raise FakeTimedOut(
+                "Pool timeout: All connections in the connection pool are "
+                "occupied. Request was *not* sent to Telegram."
+            )
+        return SimpleNamespace(message_id=203)
+
+    bot.send_message = AsyncMock(side_effect=mock_send_message)
+    adapter._bot = bot
+    adapter._app = SimpleNamespace(bot=bot)
+
+    monkeypatch.setattr("plugins.platforms.telegram.adapter.asyncio.sleep", AsyncMock())
+
+    result = await adapter.send(chat_id="123", content="test message")
+
+    assert result.success is True
+    assert result.message_id == "203"
+    assert attempt[0] == 2
+    assert general_request.shutdown.await_count == 1
+    assert general_request.initialize.await_count == 1
+    assert polling_request.shutdown.await_count == 0
+    assert polling_request.initialize.await_count == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fixes the Telegram gateway send-path failure behind #53524. When PTB reports a pool timeout on `send_message()`, the request was never sent, so the adapter now resets the general Bot API request pool before retrying. That gives the next attempt a fresh httpx client instead of hammering the same exhausted pool.

The old behavior was wrong because the send path treated pool timeout as retryable but left `_request[1]` untouched, so retries could keep failing against a wedged general request pool.

## Related Issue

Fixes #53524

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added a small helper to drain either PTB request pool in place.
- Kept polling reconnect on `_request[0]` only, and reset the general send/edit pool on send-side pool timeouts.
- Added a regression test that verifies the general request pool is refreshed before the retry succeeds.

## How to Test

1. Run `python -m pytest tests/gateway/test_telegram_thread_fallback.py -k "pool_timeout or refresh_general_pool" -q`
2. Run `python -m pytest tests/gateway/test_telegram_send_path_health.py tests/gateway/test_telegram_closewait_limits_31599.py -q`
3. Confirm both commands pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted Telegram tests and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] N/A

## Screenshots / Logs

```text
./.venv/bin/python -m pytest tests/gateway/test_telegram_thread_fallback.py -k "pool_timeout or refresh_general_pool" -q -> 3 passed
./.venv/bin/python -m pytest tests/gateway/test_telegram_send_path_health.py tests/gateway/test_telegram_closewait_limits_31599.py -q -> 6 passed
```

## Remaining Risks

- I did not run a long-lived real Telegram gateway session to reproduce the 12h live symptom end-to-end.
