### PR TITLE
Add generic platform runtime hooks

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1653,6 +1653,10 @@ class MessageEvent:
     # completion notifications) that must bypass user authorization checks.
     internal: bool = False
 
+    # Optional platform-level routing preference for messages that arrive while
+    # a turn is already running. Supported values are "queue" and "interrupt".
+    delivery_intent: Optional[str] = None
+
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
     
@@ -2191,6 +2195,8 @@ class BasePlatformAdapter(ABC):
         self._post_delivery_callbacks: Dict[str, Any] = {}
         self._expected_cancelled_tasks: set[asyncio.Task] = set()
         self._busy_session_handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]] = None
+        self._runtime_control_handler: Optional[Callable[[MessageEvent, str, str], Awaitable[bool]]] = None
+        self._queue_depth_provider: Optional[Callable[[str], int]] = None
         # Auto-TTS on voice input: ``_auto_tts_default`` is the global default
         # (``voice.auto_tts`` in config.yaml, pushed by GatewayRunner on connect).
         # Per-chat overrides live in two sets populated from ``_voice_mode``:
@@ -2622,6 +2628,17 @@ class BasePlatformAdapter(ABC):
     def set_busy_session_handler(self, handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]]) -> None:
         """Set an optional handler for messages arriving during active sessions."""
         self._busy_session_handler = handler
+
+    def set_runtime_control_handler(
+        self,
+        handler: Optional[Callable[[MessageEvent, str, str], Awaitable[bool]]],
+    ) -> None:
+        """Set an optional handler for trusted platform runtime controls."""
+        self._runtime_control_handler = handler
+
+    def set_queue_depth_provider(self, provider: Optional[Callable[[str], int]]) -> None:
+        """Set an optional queue-depth provider owned by the gateway runner."""
+        self._queue_depth_provider = provider
     
     def set_session_store(self, session_store: Any) -> None:
         """
@@ -3714,6 +3731,15 @@ class BasePlatformAdapter(ABC):
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Hook called when background processing begins."""
 
+    async def on_gateway_message_accepted(
+        self,
+        event: MessageEvent,
+        session_key: str,
+        *,
+        phase: str = "active",
+    ) -> None:
+        """Hook called after the gateway accepts an authorized inbound event."""
+
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Hook called when background processing completes."""
 
@@ -3726,6 +3752,16 @@ class BasePlatformAdapter(ABC):
             await hook(*args, **kwargs)
         except Exception as e:
             logger.warning("[%s] %s hook failed: %s", self.name, hook_name, e)
+
+    def prepare_streaming_preview(
+        self,
+        *,
+        metadata: Optional[dict[str, Any]] = None,
+        cursor: str = "",
+        buffer_only: bool = False,
+    ) -> dict[str, Any]:
+        """Allow adapters to adjust stream-consumer metadata/config."""
+        return {}
 
     @staticmethod
     def _is_retryable_error(error: Optional[str]) -> bool:
@@ -4542,7 +4578,19 @@ class BasePlatformAdapter(ABC):
                 typing_task,
             )
         
+        processing_started = False
         try:
+            runtime_start = getattr(self, "_on_runtime_turn_start", None)
+            if callable(runtime_start):
+                try:
+                    await runtime_start(event, session_key)
+                except Exception:
+                    logger.debug(
+                        "[%s] Runtime turn start hook failed",
+                        self.name,
+                        exc_info=True,
+                    )
+            processing_started = True
             await self._run_processing_hook("on_processing_start", event)
 
             # Call the handler (this can take a while with tool calls)
@@ -4895,9 +4943,31 @@ class BasePlatformAdapter(ABC):
             outcome = ProcessingOutcome.CANCELLED
             if current_task is None or current_task not in self._expected_cancelled_tasks:
                 outcome = ProcessingOutcome.FAILURE
+            runtime_complete = getattr(self, "_on_runtime_turn_complete", None)
+            if processing_started and callable(runtime_complete):
+                try:
+                    await runtime_complete(event, session_key, outcome)
+                except Exception:
+                    logger.debug(
+                        "[%s] Runtime turn completion hook failed",
+                        self.name,
+                        exc_info=True,
+                    )
+                processing_started = False
             await self._run_processing_hook("on_processing_complete", event, outcome)
             raise
         except Exception as e:
+            runtime_complete = getattr(self, "_on_runtime_turn_complete", None)
+            if processing_started and callable(runtime_complete):
+                try:
+                    await runtime_complete(event, session_key, ProcessingOutcome.FAILURE)
+                except Exception:
+                    logger.debug(
+                        "[%s] Runtime turn completion hook failed",
+                        self.name,
+                        exc_info=True,
+                    )
+                processing_started = False
             await self._run_processing_hook("on_processing_complete", event, ProcessingOutcome.FAILURE)
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
             # Send the error to the user so they aren't left with radio silence
@@ -4921,6 +4991,27 @@ class BasePlatformAdapter(ABC):
             # callbacks may perform platform I/O; a stuck callback must not
             # leave the typing refresh task running indefinitely.
             await _stop_typing_task()
+            runtime_complete = getattr(self, "_on_runtime_turn_complete", None)
+            if processing_started and callable(runtime_complete):
+                try:
+                    await runtime_complete(event, session_key, ProcessingOutcome.SUCCESS)
+                except Exception:
+                    logger.debug(
+                        "[%s] Runtime turn completion hook failed",
+                        self.name,
+                        exc_info=True,
+                    )
+                processing_started = False
+            runtime_queue_changed = getattr(self, "_on_runtime_queue_changed", None)
+            if callable(runtime_queue_changed):
+                try:
+                    await runtime_queue_changed(session_key)
+                except Exception:
+                    logger.debug(
+                        "[%s] Runtime queue-change hook failed",
+                        self.name,
+                        exc_info=True,
+                    )
             # Fire any one-shot post-delivery callback registered for this
             # session (e.g. deferred background-review notifications).
             #

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3995,6 +3995,56 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     queued_events.pop(session_key, None)
         return removed
 
+    async def _notify_adapter_message_accepted(
+        self,
+        event: MessageEvent,
+        session_key: str,
+        *,
+        phase: str = "active",
+    ) -> None:
+        source = getattr(event, "source", None)
+        platform = getattr(source, "platform", None)
+        if platform is None:
+            return
+        adapter = self.adapters.get(platform)
+        if adapter is None:
+            return
+        hook = getattr(adapter, "on_gateway_message_accepted", None)
+        if not callable(hook):
+            return
+        try:
+            result = hook(event, session_key, phase=phase)
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            logger.debug("Adapter accepted-message hook failed", exc_info=True)
+
+    @staticmethod
+    def _apply_streaming_preview_hook(
+        adapter: Any,
+        *,
+        metadata: Optional[Dict[str, Any]],
+        cursor: str,
+        buffer_only: bool,
+    ) -> tuple[Optional[Dict[str, Any]], str, bool]:
+        hook = getattr(adapter, "prepare_streaming_preview", None)
+        if not callable(hook):
+            return metadata, cursor, buffer_only
+        try:
+            overrides = hook(metadata=metadata, cursor=cursor, buffer_only=buffer_only)
+        except Exception:
+            logger.debug("Adapter streaming-preview hook failed", exc_info=True)
+            return metadata, cursor, buffer_only
+        if not isinstance(overrides, dict):
+            return metadata, cursor, buffer_only
+        if isinstance(overrides.get("metadata"), dict):
+            metadata = overrides["metadata"]
+        if "cursor" in overrides:
+            cursor = str(overrides.get("cursor") or "")
+        if "buffer_only" in overrides:
+            buffer_only = bool(overrides.get("buffer_only"))
+        return metadata, cursor, buffer_only
+
     def _goal_still_active_for_session(self, session_id: str) -> bool:
         """Best-effort fresh DB check before running a queued continuation."""
         if not session_id:
@@ -4642,6 +4692,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return True  # handled (silently dropped); do not fall through
 
+        await self._notify_adapter_message_accepted(event, session_key, phase="busy")
+
         # --- Draining case (gateway restarting/stopping) ---
         if self._draining:
             adapter = self.adapters.get(event.source.platform)
@@ -4692,9 +4744,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         running_agent = self._running_agents.get(session_key)
 
         effective_mode = self._busy_input_mode
+        delivery_intent = str(getattr(event, "delivery_intent", "") or "").strip().lower()
+        if delivery_intent == "queue":
+            effective_mode = "queue"
+        elif delivery_intent == "interrupt":
+            effective_mode = "interrupt"
+
         busy_text_mode = getattr(self, "_busy_text_mode", "interrupt")
         if (
-            event.message_type == MessageType.TEXT
+            not delivery_intent
+            and event.message_type == MessageType.TEXT
             and busy_text_mode == "queue"
             and effective_mode != "steer"
         ):
@@ -4758,7 +4817,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # turn in arrival order while still preserving photo-burst / album
         # merge semantics for media.
         if not steered:
-            self._queue_or_replace_pending_event(session_key, event)
+            if delivery_intent == "interrupt":
+                adapter._pending_messages[session_key] = event
+            else:
+                self._queue_or_replace_pending_event(session_key, event)
+            queue_changed = getattr(adapter, "_on_runtime_queue_changed", None)
+            if callable(queue_changed):
+                try:
+                    await queue_changed(session_key)
+                except Exception:
+                    logger.debug("Runtime queue-change hook failed", exc_info=True)
 
         is_queue_mode = effective_mode == "queue"
         is_steer_mode = effective_mode == "steer"
@@ -4893,6 +4961,51 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("Failed to send busy-ack: %s", e)
 
         return True
+
+    async def _handle_runtime_control_signal(
+        self,
+        event: MessageEvent,
+        session_key: str,
+        signal: str,
+    ) -> bool:
+        """Handle trusted platform runtime controls without user-text dispatch."""
+        source = event.source
+        adapter = self.adapters.get(source.platform) if source else None
+        if not source or not session_key:
+            return False
+
+        if signal in {"interrupt", "stop_and_drop"}:
+            if signal == "stop_and_drop":
+                if adapter is not None and hasattr(adapter, "_pending_messages"):
+                    adapter._pending_messages.pop(session_key, None)
+                queued_events = getattr(self, "_queued_events", None)
+                if isinstance(queued_events, dict):
+                    queued_events.pop(session_key, None)
+            await self._interrupt_and_clear_session(
+                session_key,
+                source,
+                interrupt_reason=_INTERRUPT_REASON_STOP,
+                invalidation_reason=f"runtime_control_{signal}",
+                discard_pending=signal == "stop_and_drop",
+            )
+            return True
+
+        if signal == "new_session":
+            if adapter is not None and hasattr(adapter, "_pending_messages"):
+                adapter._pending_messages.pop(session_key, None)
+            queued_events = getattr(self, "_queued_events", None)
+            if isinstance(queued_events, dict):
+                queued_events.pop(session_key, None)
+            await self._interrupt_and_clear_session(
+                session_key,
+                source,
+                interrupt_reason=_INTERRUPT_REASON_RESET,
+                invalidation_reason="runtime_control_new_session",
+            )
+            await self._handle_reset_command(event)
+            return True
+
+        return False
 
     async def _drain_active_agents(self, timeout: float) -> tuple[Dict[str, Any], bool]:
         snapshot = self._snapshot_running_agents()
@@ -6065,6 +6178,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
             adapter._busy_text_mode = self._busy_text_mode
+            if hasattr(adapter, "set_runtime_control_handler"):
+                adapter.set_runtime_control_handler(self._handle_runtime_control_signal)
+            if hasattr(adapter, "set_queue_depth_provider"):
+                adapter.set_queue_depth_provider(
+                    lambda session_key, _adapter=adapter: self._queue_depth(
+                        session_key,
+                        adapter=_adapter,
+                    )
+                )
             
             # Try to connect
             logger.info("Connecting to %s...", platform.value)
@@ -6865,6 +6987,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
                     adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
                     adapter._busy_text_mode = self._busy_text_mode
+                    if hasattr(adapter, "set_runtime_control_handler"):
+                        adapter.set_runtime_control_handler(self._handle_runtime_control_signal)
+                    if hasattr(adapter, "set_queue_depth_provider"):
+                        adapter.set_queue_depth_provider(
+                            lambda session_key, _adapter=adapter: self._queue_depth(
+                                session_key,
+                                adapter=_adapter,
+                            )
+                        )
 
                     # Reconnect after an outage: preserve the platform's
                     # server-side update queue so messages sent while the bot
@@ -7537,6 +7668,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
             adapter._busy_text_mode = self._busy_text_mode
+            if hasattr(adapter, "set_runtime_control_handler"):
+                adapter.set_runtime_control_handler(self._handle_runtime_control_signal)
+            if hasattr(adapter, "set_queue_depth_provider"):
+                adapter.set_queue_depth_provider(
+                    lambda session_key, _adapter=adapter: self._queue_depth(
+                        session_key,
+                        adapter=_adapter,
+                    )
+                )
 
             try:
                 with _profile_runtime_scope(profile_home):
@@ -7871,6 +8011,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Otherwise control/session commands like /new or /help get silently
         # consumed as update answers instead of being dispatched normally.
         _quick_key = self._session_key_for_source(source)
+        await self._notify_adapter_message_accepted(event, _quick_key)
         _update_prompts = getattr(self, "_update_prompt_pending", {})
         if _update_prompts.get(_quick_key):
             raw = (event.text or "").strip()
@@ -14877,6 +15018,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if source.platform == Platform.MATRIX:
                         _effective_cursor = ""
                         _buffer_only = True
+                    _stream_metadata, _effective_cursor, _buffer_only = self._apply_streaming_preview_hook(
+                        _adapter,
+                        metadata=_thread_metadata,
+                        cursor=_effective_cursor,
+                        buffer_only=_buffer_only,
+                    )
                     # Fresh-final applies to Telegram only — other
                     # platforms either edit in place cheaply (Discord,
                     # Slack) or don't have the timestamp-on-edit
@@ -14899,7 +15046,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         adapter=_adapter,
                         chat_id=source.chat_id,
                         config=_consumer_cfg,
-                        metadata=_thread_metadata,
+                        metadata=_stream_metadata,
                         on_before_finalize=_pause_typing_before_finalize,
                         initial_reply_to_id=event_message_id,
                     )
@@ -16067,6 +16214,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if source.platform == Platform.MATRIX:
                             _effective_cursor = ""
                             _buffer_only = True
+                        _stream_metadata, _effective_cursor, _buffer_only = self._apply_streaming_preview_hook(
+                            _adapter,
+                            metadata=_status_thread_metadata,
+                            cursor=_effective_cursor,
+                            buffer_only=_buffer_only,
+                        )
                         # Fresh-final applies to Telegram only — other
                         # platforms either edit in place cheaply or don't
                         # have the edit-timestamp-stays-stale problem.
@@ -16089,7 +16242,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             adapter=_adapter,
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
-                            metadata=_status_thread_metadata,
+                            metadata=_stream_metadata,
                             on_new_message=(
                                 (lambda: progress_queue.put(("__reset__",)))
                                 if progress_queue is not None

--- a/tests/gateway/test_platform_plugin_runtime_hooks.py
+++ b/tests/gateway/test_platform_plugin_runtime_hooks.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import sys
+import threading
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_tg = types.ModuleType("telegram")
+_tg.constants = types.ModuleType("telegram.constants")
+_ct = MagicMock()
+_ct.SUPERGROUP = "supergroup"
+_ct.GROUP = "group"
+_ct.PRIVATE = "private"
+_tg.constants.ChatType = _ct
+sys.modules.setdefault("telegram", _tg)
+sys.modules.setdefault("telegram.constants", _tg.constants)
+sys.modules.setdefault("telegram.ext", types.ModuleType("telegram.ext"))
+
+from gateway.config import Platform, PlatformConfig  # noqa: E402
+from gateway.platforms.base import (  # noqa: E402
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    ProcessingOutcome,
+    SendResult,
+    SessionSource,
+    build_session_key,
+)
+from gateway.run import GatewayRunner  # noqa: E402
+
+
+class _StubAdapter(BasePlatformAdapter):
+    def __init__(self) -> None:
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="msg-1")
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        user_id="user1",
+    )
+
+
+def _event(text: str = "hello", *, delivery_intent: str | None = None) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=_source(),
+        message_id="msg1",
+        delivery_intent=delivery_intent,
+    )
+
+
+def _runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._busy_ack_ts = {}
+    runner._draining = False
+    runner._busy_text_mode = "interrupt"
+    runner._queued_events = {}
+    runner.adapters = {}
+    runner._is_user_authorized = lambda _source: True
+    return runner
+
+
+def _running_agent() -> MagicMock:
+    agent = MagicMock()
+    agent._active_children = []
+    agent._active_children_lock = threading.Lock()
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_delivery_intent_queue_overrides_interrupt_mode(monkeypatch) -> None:
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_ACK_ENABLED", "false")
+    runner = _runner()
+    runner._busy_input_mode = "interrupt"
+    adapter = _StubAdapter()
+    adapter._on_runtime_queue_changed = AsyncMock()
+    adapter.on_gateway_message_accepted = AsyncMock()
+    event = _event(delivery_intent="queue")
+    session_key = build_session_key(event.source)
+    agent = _running_agent()
+    runner.adapters[event.source.platform] = adapter
+    runner._running_agents[session_key] = agent
+
+    handled = await runner._handle_active_session_busy_message(event, session_key)
+
+    assert handled is True
+    assert adapter._pending_messages[session_key] is event
+    agent.interrupt.assert_not_called()
+    adapter.on_gateway_message_accepted.assert_awaited_once_with(
+        event,
+        session_key,
+        phase="busy",
+    )
+    adapter._on_runtime_queue_changed.assert_awaited_once_with(session_key)
+
+
+@pytest.mark.asyncio
+async def test_delivery_intent_interrupt_overrides_queue_mode(monkeypatch) -> None:
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_ACK_ENABLED", "false")
+    runner = _runner()
+    runner._busy_input_mode = "queue"
+    adapter = _StubAdapter()
+    adapter._on_runtime_queue_changed = AsyncMock()
+    event = _event("now", delivery_intent="interrupt")
+    session_key = build_session_key(event.source)
+    old_event = _event("old")
+    adapter._pending_messages[session_key] = old_event
+    agent = _running_agent()
+    runner.adapters[event.source.platform] = adapter
+    runner._running_agents[session_key] = agent
+
+    handled = await runner._handle_active_session_busy_message(event, session_key)
+
+    assert handled is True
+    assert adapter._pending_messages[session_key] is event
+    agent.interrupt.assert_called_once_with("now")
+    adapter._on_runtime_queue_changed.assert_awaited_once_with(session_key)
+
+
+@pytest.mark.asyncio
+async def test_runtime_control_stop_and_drop_clears_pending_work() -> None:
+    runner = _runner()
+    adapter = _StubAdapter()
+    event = _event()
+    session_key = build_session_key(event.source)
+    adapter._pending_messages[session_key] = event
+    runner._queued_events[session_key] = [_event("later")]
+    runner.adapters[event.source.platform] = adapter
+    runner._interrupt_and_clear_session = AsyncMock()
+
+    handled = await runner._handle_runtime_control_signal(event, session_key, "stop_and_drop")
+
+    assert handled is True
+    assert session_key not in adapter._pending_messages
+    assert session_key not in runner._queued_events
+    runner._interrupt_and_clear_session.assert_awaited_once()
+    assert runner._interrupt_and_clear_session.await_args.kwargs["discard_pending"] is True
+
+
+@pytest.mark.asyncio
+async def test_accepted_message_hook_is_best_effort() -> None:
+    runner = _runner()
+    adapter = _StubAdapter()
+    adapter.on_gateway_message_accepted = AsyncMock()
+    event = _event()
+    session_key = build_session_key(event.source)
+    runner.adapters[event.source.platform] = adapter
+
+    await runner._notify_adapter_message_accepted(event, session_key, phase="queued")
+
+    adapter.on_gateway_message_accepted.assert_awaited_once_with(
+        event,
+        session_key,
+        phase="queued",
+    )
+
+
+def test_streaming_preview_hook_can_override_consumer_options() -> None:
+    class Adapter:
+        def prepare_streaming_preview(self, *, metadata, cursor, buffer_only):
+            return {
+                "metadata": {"thread_id": "preview"},
+                "cursor": "",
+                "buffer_only": True,
+            }
+
+    metadata, cursor, buffer_only = GatewayRunner._apply_streaming_preview_hook(
+        Adapter(),
+        metadata={"thread_id": "original"},
+        cursor="▌",
+        buffer_only=False,
+    )
+
+    assert metadata == {"thread_id": "preview"}
+    assert cursor == ""
+    assert buffer_only is True
+
+
+@pytest.mark.asyncio
+async def test_base_adapter_runtime_lifecycle_hooks() -> None:
+    adapter = _StubAdapter()
+    adapter.set_message_handler(AsyncMock(return_value=None))
+    adapter._on_runtime_turn_start = AsyncMock()
+    adapter._on_runtime_turn_complete = AsyncMock()
+    adapter._on_runtime_queue_changed = AsyncMock()
+    event = _event()
+    session_key = build_session_key(event.source)
+
+    await adapter._process_message_background(event, session_key)
+
+    adapter._on_runtime_turn_start.assert_awaited_once_with(event, session_key)
+    adapter._on_runtime_turn_complete.assert_awaited_once_with(
+        event,
+        session_key,
+        ProcessingOutcome.SUCCESS,
+    )
+    adapter._on_runtime_queue_changed.assert_awaited_once_with(session_key)


### PR DESCRIPTION
## What does this PR do?

Adds small generic hooks that platform plugins can opt into for runtime-aware messaging behavior, without adding any platform-specific code to Hermes core.

The hooks let adapters:
- express whether busy-session messages should queue or interrupt per event;
- receive trusted runtime-control callbacks for interrupt, stop-and-drop, and new-session actions;
- report queue depth and queue changes;
- observe when an authorized inbound message is accepted by the gateway;
- adjust stream-consumer metadata/cursor/buffer options for platform-native previews;
- receive runtime turn start/complete lifecycle callbacks from `BasePlatformAdapter`.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py`: add optional adapter/runtime hooks and `MessageEvent.delivery_intent`.
- `gateway/run.py`: wire runtime controls, queue-depth providers, accepted-message hooks, delivery intent, and streaming-preview overrides.
- `tests/gateway/test_platform_plugin_runtime_hooks.py`: add focused coverage for the new platform hook behavior.

## How to Test

1. `uv run --extra dev python -m pytest tests/gateway/test_platform_plugin_runtime_hooks.py tests/gateway/test_internal_event_never_interrupts_busy_session.py tests/gateway/test_queue_consumption.py -q`
2. `uv run --extra dev ruff check gateway/run.py gateway/platforms/base.py tests/gateway/test_platform_plugin_runtime_hooks.py`
3. `uv run --extra dev python -m py_compile gateway/run.py gateway/platforms/base.py tests/gateway/test_platform_plugin_runtime_hooks.py`
4. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.12 via `uv`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted local checks pass:

```text
22 passed in 0.40s
All checks passed!
```
