### PR TITLE
fix(anthropic): tolerate null fields in gateway-translated streams

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2184,6 +2184,54 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         )
         # Use the Anthropic SDK's streaming context manager
         with agent._anthropic_client.messages.stream(**api_kwargs) as stream:
+            # Some OpenAI-compatible gateways (e.g. new-api / one-api) that
+            # translate OpenAI Chat Completions into the Anthropic Messages
+            # wire format emit a malformed ``message_start`` event whose
+            # ``message.content`` is ``null`` instead of ``[]``.  The Anthropic
+            # SDK's ``accumulate_event`` then crashes on the subsequent
+            # ``content_block_start`` with
+            # ``AttributeError: 'NoneType' object has no attribute 'append'``
+            # (current_snapshot.content.append(...)).  Wrap the SDK stream's
+            # *raw* event source so the malformed ``message_start`` is
+            # normalised to ``content=[]`` BEFORE the SDK's internal
+            # ``accumulate_event`` ever sees it.  See #NNNNN.
+            _orig_raw_stream = getattr(stream, "_raw_stream", None)
+
+            if _orig_raw_stream is not None:
+                def _normalised_raw_stream():
+                    for sse_event in _orig_raw_stream:
+                        try:
+                            _et = getattr(sse_event, "type", None)
+                            if _et == "message_start":
+                                # Some OpenAI-compat gateways emit
+                                # ``message.content`` as ``null`` instead of ``[]``.
+                                _msg = getattr(sse_event, "message", None)
+                                if _msg is not None and getattr(_msg, "content", None) is None:
+                                    _msg.content = []
+                            elif _et == "content_block_start":
+                                # Same gateways emit content blocks whose
+                                # string/list fields are ``null`` (e.g.
+                                # ``ThinkingBlock(thinking=None, signature=None)``),
+                                # which then crash the SDK's ``+=`` accumulation
+                                # in ``content_block_delta`` handlers.  Normalise
+                                # the fields the SDK will try to append to.
+                                _blk = getattr(sse_event, "content_block", None)
+                                if _blk is not None:
+                                    _bt = getattr(_blk, "type", None)
+                                    if _bt == "text":
+                                        if getattr(_blk, "text", None) is None:
+                                            _blk.text = ""
+                                        if getattr(_blk, "citations", None) is None:
+                                            _blk.citations = []
+                                    elif _bt == "thinking":
+                                        if getattr(_blk, "thinking", None) is None:
+                                            _blk.thinking = ""
+                        except Exception:
+                            pass
+                        yield sse_event
+
+                stream._raw_stream = _normalised_raw_stream()
+
             # The Anthropic SDK exposes the raw httpx response on
             # ``stream.response``.  Snapshot diagnostic headers
             # immediately so they survive a stream that dies before the


### PR DESCRIPTION
## Summary

OpenAI-compatible gateways (new-api / one-api) that translate DeepSeek and other OpenAI Chat Completions responses into the **Anthropic Messages wire format** emit malformed streaming events whose required fields are `null` instead of the spec-mandated empty values.

The Anthropic SDK's `accumulate_event()` then crashes hard — and because it's an `AttributeError`/`TypeError` (not an `APIError`), it is treated as non-retryable, killing every turn through that gateway after a 3× retry loop.

## Problem

Reproduced with `new-api` gateway (`base_url: http://<host>:4000`, `api_mode: anthropic_messages`) fronting `deepseek-v4-flash`. The gateway returns:

```json
// message_start event — content should be []
{"type":"message_start","message":{"content": null, ...}}

// content_block_start for a thinking block — thinking should be ""
{"type":"content_block_start","content_block":{"type":"thinking","thinking": null,"signature": null}}
```

Crash sites in the SDK (`anthropic/lib/streaming/_messages.py`):

| Line | Code | Error |
|------|------|-------|
| 458 | `current_snapshot.content.append(...)` | `'NoneType' object has no attribute 'append'` |
| 468 | `content.text += event.delta.text` | `unsupported operand type(s) for +=: 'NoneType' and 'str'` |
| 491 | `content.thinking += event.delta.thinking` | `unsupported operand type(s) for +=: 'NoneType' and 'str'` |

These gateways are popular in the self-hosted community (new-api has ~20k stars), so this affects a non-trivial number of users who route DeepSeek/GPT models behind a single Anthropic-protocol endpoint.

## Fix

Wrap the SDK `MessageStream`'s **raw event source** (`stream._raw_stream`) so the malformed `null` fields are normalised to their spec-correct empty values **before** the SDK's internal `accumulate_event` ever sees them:

- `message_start`: `message.content` `null` → `[]`
- `content_block_start` (text block): `text` `null` → `""`, `citations` `null` → `[]`
- `content_block_start` (thinking block): `thinking` `null` → `""`

Defensive only — zero impact on spec-compliant providers (Anthropic native, Bedrock Converse, Kimi, MiniMax, etc.), since the normalisation only fires when a field is `null` (which never happens in a spec-compliant stream).

Guarded with `getattr(stream, "_raw_stream", None)` so it's a no-op for test doubles / mock streams that don't expose `_raw_stream`.

## Verification

```
tests/run_agent/test_streaming.py   36 passed, 2 skipped
```

Includes the existing `test_anthropic_stream_parser_valueerror_retries_before_delivery` (mock-stream retry path) — confirms the guard correctly skips normalisation for objects without `_raw_stream`.

End-to-end reproduction (the exact path that was crashing):

```bash
# Before: AttributeError: 'NoneType' object has no attribute 'append' (3× retry, turn dies)
# After:
hermes chat -q '1+1=?' -m deepseek-v4-flash --provider 'custom:<gateway>:4000' -Q
# → 2
```

Tool-calling and thinking-block streams also verified working through the gateway.

## Checklist

- [x] Tests pass (`pytest tests/run_agent/test_streaming.py`)
- [x] No debug residue (no `print`/`DEBUG`/`format_exc` left in the diff)
- [x] Defensive only — no behaviour change for spec-compliant providers
