### PR TITLE
fix(gateway): read nested multiplex profiles config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -848,14 +848,13 @@ def load_gateway_config() -> GatewayConfig:
             if "thread_sessions_per_user" in yaml_cfg:
                 gw_data["thread_sessions_per_user"] = yaml_cfg["thread_sessions_per_user"]
 
-            # Multiplexing flag: accept both the top-level key and the nested
-            # gateway.multiplex_profiles form (from_dict resolves the nested
-            # fallback, but surface the top-level key here for parity with the
-            # other session-scope flags above).
+            gateway_section = yaml_cfg.get("gateway")
+            if isinstance(gateway_section, dict) and "multiplex_profiles" in gateway_section:
+                gw_data["multiplex_profiles"] = gateway_section["multiplex_profiles"]
+
             if "multiplex_profiles" in yaml_cfg:
                 gw_data["multiplex_profiles"] = yaml_cfg["multiplex_profiles"]
 
-            gateway_section = yaml_cfg.get("gateway")
             if isinstance(gateway_section, dict) and "max_concurrent_sessions" in gateway_section:
                 gw_data["max_concurrent_sessions"] = gateway_section["max_concurrent_sessions"]
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -415,6 +415,22 @@ class TestLoadGatewayConfig:
 
         assert config.thread_sessions_per_user is False
 
+    def test_bridges_nested_multiplex_profiles_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  multiplex_profiles: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.multiplex_profiles is True
+
     def test_bridges_top_level_max_concurrent_sessions_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()


### PR DESCRIPTION
## Summary
- Bridge `gateway.multiplex_profiles` from `config.yaml` into the runtime `GatewayConfig` load path.
- Preserve the existing precedence where top-level `multiplex_profiles` overrides the nested gateway value.
- Add a focused regression test for the CLI-written nested config shape.

## Root Cause
`load_gateway_config()` normalizes `config.yaml` into `gw_data` before calling `GatewayConfig.from_dict()`. The dataclass parser already knows how to read `gateway.multiplex_profiles`, but the loader never forwarded the nested `gateway` value, so configs written by `hermes config set gateway.multiplex_profiles true` were effectively ignored.

Fixes #52562

## Tests
- `python -m pytest tests/gateway/test_config.py -q`
- `python -m py_compile gateway/config.py tests/gateway/test_config.py`
- `git diff --check`
