### PR TITLE
fix(telegram): route home forum updates missing thread ids

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7086,8 +7086,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
         When non-empty, group/supergroup messages from other topics are
         silently ignored. DMs are never filtered by topic. Telegram may omit
-        ``message_thread_id`` for the forum General topic, so ``None`` is
-        treated as topic ``1`` for matching purposes.
+        ``message_thread_id`` for forum messages, so inbound gates use
+        :meth:`_effective_message_thread_id` before matching.
         """
         raw = self.config.extra.get("allowed_topics")
         if raw is None:
@@ -7162,8 +7162,7 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_type = str(getattr(chat, "type", "")).split(".")[-1].lower()
         return chat_type in {"group", "supergroup"}
 
-    @classmethod
-    def _effective_message_thread_id(cls, message: Message) -> Optional[str]:
+    def _effective_message_thread_id(self, message: Message) -> Optional[str]:
         """Return the routable thread id for a Telegram message.
 
         Forum supergroup messages posted in the General topic arrive with
@@ -7186,7 +7185,16 @@ class TelegramAdapter(BasePlatformAdapter):
                 return str(raw)
             return None
         if is_forum_group:
-            return cls._GENERAL_TOPIC_THREAD_ID
+            home_channel = getattr(self.config, "home_channel", None)
+            home_thread_id = getattr(home_channel, "thread_id", None)
+            if (
+                home_channel is not None
+                and home_thread_id not in (None, "")
+                and normalize_telegram_chat_id(getattr(home_channel, "chat_id", None))
+                == normalize_telegram_chat_id(getattr(chat, "id", None))
+            ):
+                return str(home_thread_id)
+            return self._GENERAL_TOPIC_THREAD_ID
         return None
 
     def _is_reply_to_bot(self, message: Message) -> bool:
@@ -7364,7 +7372,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._is_group_chat(message):
             return False
 
-        thread_id = getattr(message, "message_thread_id", None)
+        thread_id = self._effective_message_thread_id(message)
         allowed_topics = self._telegram_allowed_topics()
         if allowed_topics:
             topic_id = str(thread_id) if thread_id is not None else self._GENERAL_TOPIC_THREAD_ID

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -3,7 +3,7 @@ import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
-from gateway.config import Platform, PlatformConfig, load_gateway_config
+from gateway.config import HomeChannel, Platform, PlatformConfig, load_gateway_config
 from gateway.platforms.base import MessageType
 from gateway.session import SessionSource
 
@@ -619,6 +619,57 @@ def test_allowed_topics_treat_missing_thread_as_general_topic():
 
     assert adapter._should_process_message(_group_message("hello", thread_id=None)) is True
     assert adapter._should_process_message(_group_message("hello", thread_id=8)) is False
+
+
+def test_home_forum_missing_thread_uses_configured_topic_for_gating_and_event():
+    adapter = _make_adapter(require_mention=False, allowed_topics=["846"])
+    adapter.config.home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="-1003946573900",
+        name="Work",
+        thread_id="846",
+    )
+    message = _group_message("hello", chat_id=-1003946573900, thread_id=None)
+    message.chat.is_forum = True
+
+    assert adapter._should_process_message(message) is True
+    event = adapter._build_message_event(message, MessageType.TEXT, update_id=1005)
+    assert event.source.thread_id == "846"
+
+
+def test_non_home_forum_missing_thread_remains_general_topic():
+    adapter = _make_adapter(require_mention=False, allowed_topics=["846"])
+    adapter.config.home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="-1003946573900",
+        name="Work",
+        thread_id="846",
+    )
+    message = _group_message("hello", chat_id=-100999, thread_id=None)
+    message.chat.is_forum = True
+
+    assert adapter._effective_message_thread_id(message) == "1"
+    assert adapter._should_process_message(message) is False
+
+
+def test_observed_unmentioned_gate_uses_home_forum_topic_fallback():
+    adapter = _make_adapter(
+        require_mention=True,
+        allowed_topics=["846"],
+        allowed_chats=["-1003946573900"],
+        group_allowed_chats=["-1003946573900"],
+        observe_unmentioned_group_messages=True,
+    )
+    adapter.config.home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="-1003946573900",
+        name="Work",
+        thread_id="846",
+    )
+    message = _group_message("side chatter", chat_id=-1003946573900, thread_id=None)
+    message.chat.is_forum = True
+
+    assert adapter._should_observe_unmentioned_group_message(message) is True
 
 
 def _forum_message(*, chat_id, thread_id, is_topic_message, is_forum, chat_type="supergroup"):


### PR DESCRIPTION
## Summary
- Resolve missing Telegram `message_thread_id` values against the configured home forum topic when the update comes from that exact home chat.
- Reuse the resolved topic id for inbound allowed-topic gates and message-event routing.
- Add a regression test for the env-only work-profile setup from the issue.

## Root Cause
Telegram forum updates can arrive without `message_thread_id`. The gateway treated those as General topic `1` for allowed-topic filtering, so a setup with `TELEGRAM_HOME_CHANNEL_THREAD_ID=846` and `TELEGRAM_ALLOWED_TOPICS=846` dropped the update before the normal inbound/message log path.

The fallback is intentionally narrow: it only applies to forum group updates whose chat id matches the configured Telegram home channel and where the home channel has a thread id. Other missing-thread group/forum updates continue to route as General topic.

Fixes #52635

## Tests
- `python -m pytest tests/gateway/test_telegram_group_gating.py -q`
- `python -m pytest tests/gateway/test_telegram_topic_mode.py -q`
- `python -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_group_gating.py`
- `git diff --check`
