### PR TITLE
feat(api-server): emit tool_call_id in /v1/runs SSE events and accept native tool chain

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -463,6 +463,70 @@ def _normalize_chat_content(
         return ""
 
 
+def _conversation_history_entry_validation_error(
+    entry: Dict[str, Any], index: int,
+) -> Optional[str]:
+    """Return an OpenAI-style error message, or None if the entry is valid."""
+    if not isinstance(entry, dict):
+        return f"conversation_history[{index}] must be a message object"
+    if "role" not in entry:
+        return f"conversation_history[{index}] must have 'role' field"
+    role = str(entry["role"])
+    tool_calls = entry.get("tool_calls")
+    has_tool_calls = isinstance(tool_calls, list) and len(tool_calls) > 0
+    tool_call_id = entry.get("tool_call_id") or entry.get("call_id")
+    if role == "tool":
+        if not tool_call_id:
+            return f"conversation_history[{index}] with role=tool requires 'tool_call_id'"
+        return None
+    if has_tool_calls:
+        return None
+    if "content" not in entry:
+        return f"conversation_history[{index}] must have 'content' field"
+    return None
+
+
+def _normalize_conversation_history_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize one inbound conversation_history row for run_conversation.
+
+    Simple user/assistant rows are flattened to role+content. Native tool
+    sequences (assistant ``tool_calls``, ``role=tool`` results) keep
+    correlation fields so ``repair_message_sequence`` can validate them.
+    """
+    role = str(entry["role"])
+    tool_calls = entry.get("tool_calls")
+    has_tool_calls = isinstance(tool_calls, list) and len(tool_calls) > 0
+    tool_call_id = entry.get("tool_call_id") or entry.get("call_id")
+    is_tool_message = role == "tool"
+
+    def _normalize_content_field(raw: Any) -> Any:
+        if raw is None:
+            return ""
+        try:
+            return _normalize_multimodal_content(raw)
+        except ValueError:
+            return _normalize_chat_content(raw)
+
+    if has_tool_calls or tool_call_id or is_tool_message:
+        msg: Dict[str, Any] = {
+            "role": role,
+            "content": _normalize_content_field(entry.get("content")),
+        }
+        if has_tool_calls:
+            msg["tool_calls"] = tool_calls
+        if tool_call_id:
+            msg["tool_call_id"] = str(tool_call_id)
+        tool_name = entry.get("tool_name") or entry.get("name")
+        if tool_name:
+            msg["tool_name"] = str(tool_name)
+        return msg
+
+    return {
+        "role": role,
+        "content": _normalize_multimodal_content(entry.get("content", "")),
+    }
+
+
 # Content part type aliases used by the OpenAI Chat Completions and Responses
 # APIs.  We accept both spellings on input and emit a single canonical internal
 # shape (``{"type": "text", ...}`` / ``{"type": "image_url", ...}``) that the
@@ -6110,7 +6174,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, str]] = []
+        conversation_history: List[Dict[str, Any]] = []
         raw_history = body.get("conversation_history")
         if raw_history:
             if not isinstance(raw_history, list):
@@ -6119,12 +6183,13 @@ class APIServerAdapter(BasePlatformAdapter):
                     status=400,
                 )
             for i, entry in enumerate(raw_history):
-                if not isinstance(entry, dict) or "role" not in entry or "content" not in entry:
-                    return web.json_response(
-                        _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
-                        status=400,
-                    )
-                conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
+                err = _conversation_history_entry_validation_error(entry, i)
+                if err is not None:
+                    return web.json_response(_openai_error(err), status=400)
+                try:
+                    conversation_history.append(_normalize_conversation_history_entry(entry))
+                except ValueError as exc:
+                    return _multimodal_validation_error(exc, param=f"conversation_history[{i}].content")
             if previous_response_id:
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6098,6 +6098,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
         Sync callbacks only — agent tool hooks are invoked from the executor
         thread. Queue hops use ``_push_run_sse_event`` / ``call_soon_threadsafe``.
+
+        ``tool.completed`` carries correlation metadata only (no tool-result
+        ``preview``/body): full outputs belong in the session transcript, not
+        unbounded SSE egress.
         """
         started_tool_call_ids: set[str] = set()
         tool_start_times: Dict[str, float] = {}
@@ -6126,16 +6130,13 @@ class APIServerAdapter(BasePlatformAdapter):
             started_at = tool_start_times.pop(tool_call_id, None)
             duration = round(time.time() - started_at, 3) if started_at else 0.0
             from agent.display import _detect_tool_failure
-            from agent.tool_dispatch_helpers import _multimodal_text_summary
             is_error, _ = _detect_tool_failure(function_name, function_result)
-            preview = _multimodal_text_summary(function_result) or ""
             self._push_run_sse_event(run_id, loop, {
                 "event": "tool.completed",
                 "run_id": run_id,
                 "timestamp": time.time(),
                 "tool": function_name,
                 "tool_call_id": tool_call_id,
-                "preview": preview,
                 "duration": duration,
                 "error": is_error,
             })

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5933,43 +5933,38 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_statuses[run_id] = current
         return current
 
-    def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
-        """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
-        def _push(event: Dict[str, Any]) -> None:
-            self._set_run_status(
-                run_id,
-                self._run_statuses.get(run_id, {}).get("status", "running"),
-                last_event=event.get("event"),
-            )
-            q = self._run_streams.get(run_id)
-            if q is None:
-                return
-            try:
-                loop.call_soon_threadsafe(q.put_nowait, event)
-            except Exception:
-                pass
+    def _push_run_sse_event(
+        self,
+        run_id: str,
+        loop: "asyncio.AbstractEventLoop",
+        event: Dict[str, Any],
+    ) -> None:
+        """Push a structured event onto the run's SSE queue (thread-safe)."""
+        self._set_run_status(
+            run_id,
+            self._run_statuses.get(run_id, {}).get("status", "running"),
+            last_event=event.get("event"),
+        )
+        q = self._run_streams.get(run_id)
+        if q is None:
+            return
+        try:
+            loop.call_soon_threadsafe(q.put_nowait, event)
+        except Exception:
+            pass
 
+    def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
+        """Return a tool_progress_callback that forwards reasoning/subagent events.
+
+        Tool lifecycle events (``tool.started`` / ``tool.completed``) are handled
+        by ``_make_run_tool_sse_callbacks`` via structured callbacks.  Wiring
+        them here too would duplicate every emit because ``tool_executor`` fires
+        ``tool_progress_callback`` side-by-side with ``tool_start_callback``.
+        """
         def _callback(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs):
             ts = time.time()
-            if event_type == "tool.started":
-                _push({
-                    "event": "tool.started",
-                    "run_id": run_id,
-                    "timestamp": ts,
-                    "tool": tool_name,
-                    "preview": preview,
-                })
-            elif event_type == "tool.completed":
-                _push({
-                    "event": "tool.completed",
-                    "run_id": run_id,
-                    "timestamp": ts,
-                    "tool": tool_name,
-                    "duration": round(kwargs.get("duration", 0), 3),
-                    "error": kwargs.get("is_error", False),
-                })
-            elif event_type == "reasoning.available":
-                _push({
+            if event_type == "reasoning.available":
+                self._push_run_sse_event(run_id, loop, {
                     "event": "reasoning.available",
                     "run_id": run_id,
                     "timestamp": ts,
@@ -6018,13 +6013,70 @@ class APIServerAdapter(BasePlatformAdapter):
                     ):
                         value = redact_sensitive_text(value, force=True)
                     event[key] = value
-                _push(event)
+                self._push_run_sse_event(run_id, loop, event)
             # _thinking, subagent.tool, and subagent_progress are intentionally
             # not forwarded on the /v1/runs stream: they are high-volume UI
             # noise. Lifecycle boundaries (start/complete) still need to land
             # so clients can observe delegate_task timeouts and failures.
+            # tool.started / tool.completed are intentionally omitted here —
+            # structured callbacks emit them with tool_call_id.
 
         return _callback
+
+    def _make_run_tool_sse_callbacks(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
+        """Return tool_start/tool_complete callbacks for /v1/runs SSE correlation.
+
+        Emits ``tool.started`` / ``tool.completed`` with ``tool_call_id`` so
+        downstream clients (e.g. sclaw chat_persist) can pair assistant
+        tool_calls with tool rows.  Matches chat-completions structured
+        callback wiring; does not use the camelCase hermes.tool.progress wire
+        format.
+
+        Sync callbacks only — agent tool hooks are invoked from the executor
+        thread. Queue hops use ``_push_run_sse_event`` / ``call_soon_threadsafe``.
+        """
+        started_tool_call_ids: set[str] = set()
+        tool_start_times: Dict[str, float] = {}
+
+        def _on_tool_start(tool_call_id, function_name, function_args):
+            if not tool_call_id or function_name.startswith("_"):
+                return
+            started_tool_call_ids.add(tool_call_id)
+            tool_start_times[tool_call_id] = time.time()
+            from agent.display import build_tool_preview
+            preview = build_tool_preview(function_name, function_args) or function_name
+            self._push_run_sse_event(run_id, loop, {
+                "event": "tool.started",
+                "run_id": run_id,
+                "timestamp": time.time(),
+                "tool": function_name,
+                "tool_call_id": tool_call_id,
+                "preview": preview,
+                "input": function_args or {},
+            })
+
+        def _on_tool_complete(tool_call_id, function_name, function_args, function_result):
+            if not tool_call_id or tool_call_id not in started_tool_call_ids:
+                return
+            started_tool_call_ids.discard(tool_call_id)
+            started_at = tool_start_times.pop(tool_call_id, None)
+            duration = round(time.time() - started_at, 3) if started_at else 0.0
+            from agent.display import _detect_tool_failure
+            from agent.tool_dispatch_helpers import _multimodal_text_summary
+            is_error, _ = _detect_tool_failure(function_name, function_result)
+            preview = _multimodal_text_summary(function_result) or ""
+            self._push_run_sse_event(run_id, loop, {
+                "event": "tool.completed",
+                "run_id": run_id,
+                "timestamp": time.time(),
+                "tool": function_name,
+                "tool_call_id": tool_call_id,
+                "preview": preview,
+                "duration": duration,
+                "error": is_error,
+            })
+
+        return _on_tool_start, _on_tool_complete
 
     @_admit_api_agent_request
     async def _handle_runs(self, request: "web.Request") -> "web.Response":
@@ -6130,6 +6182,7 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_approval_sessions[run_id] = approval_session_key
 
         event_cb = self._make_run_event_callback(run_id, loop)
+        tool_start_cb, tool_complete_cb = self._make_run_tool_sse_callbacks(run_id, loop)
 
         def _put_event_if_active(event: Optional[Dict]) -> None:
             """Enqueue only while this run still owns live transport state."""
@@ -6185,12 +6238,15 @@ class APIServerAdapter(BasePlatformAdapter):
                         session_id=session_id,
                         stream_delta_callback=_text_cb,
                         tool_progress_callback=event_cb,
+                        tool_start_callback=tool_start_cb,
+                        tool_complete_callback=tool_complete_cb,
                         gateway_session_key=gateway_session_key,
                         requested_model=agent_overrides.get("requested_model"),
                         requested_provider=agent_overrides.get("requested_provider"),
                         model_options=agent_overrides.get("model_options"),
                         route=route,
                     )
+
                 self._active_run_agents[run_id] = agent
 
                 def _approval_notify(approval_data: Dict[str, Any]) -> None:

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -9,6 +9,7 @@ Covers:
 """
 
 import asyncio
+import json
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -112,6 +113,143 @@ def adapter():
 @pytest.fixture
 def auth_adapter():
     return _make_adapter(api_key="sk-secret")
+
+
+def _make_tool_agent(tool_call_id="call_abc", tool_name="skill_view", tool_args=None, tool_result="skill body"):
+    """Create a mock agent that invokes structured tool callbacks during a run."""
+    if tool_args is None:
+        tool_args = {"name": "data-mask"}
+
+    captured = {}
+
+    def _fake_create(**kwargs):
+        captured["start"] = kwargs.get("tool_start_callback")
+        captured["complete"] = kwargs.get("tool_complete_callback")
+        mock_agent = MagicMock()
+
+        def _run(user_message=None, conversation_history=None, task_id=None):
+            if captured["start"]:
+                captured["start"](tool_call_id, tool_name, tool_args)
+            if captured["complete"]:
+                captured["complete"](tool_call_id, tool_name, tool_args, tool_result)
+            return {"final_response": "done"}
+
+        mock_agent.run_conversation.side_effect = _run
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+        return mock_agent
+
+    return _fake_create, captured
+
+
+# ---------------------------------------------------------------------------
+# Tool SSE callbacks (H8–H10)
+# ---------------------------------------------------------------------------
+
+
+class TestRunToolSSECallbacks:
+    @pytest.mark.asyncio
+    async def test_tool_started_includes_tool_call_id(self, adapter):
+        loop = asyncio.get_running_loop()
+        run_id = "run_tool_sse_unit"
+        q: asyncio.Queue = asyncio.Queue()
+        adapter._run_streams[run_id] = q
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+
+        on_start, on_complete = adapter._make_run_tool_sse_callbacks(run_id, loop)
+        on_start("call_abc", "skill_view", {"name": "data-mask"})
+
+        event = await asyncio.wait_for(q.get(), timeout=1.0)
+        assert event["event"] == "tool.started"
+        assert event["tool_call_id"] == "call_abc"
+        assert event["tool"] == "skill_view"
+        assert event["preview"]
+        assert event["input"] == {"name": "data-mask"}
+
+    @pytest.mark.asyncio
+    async def test_tool_completed_includes_tool_call_id_and_preview(self, adapter):
+        loop = asyncio.get_running_loop()
+        run_id = "run_tool_sse_complete"
+        q: asyncio.Queue = asyncio.Queue()
+        adapter._run_streams[run_id] = q
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+
+        on_start, on_complete = adapter._make_run_tool_sse_callbacks(run_id, loop)
+        on_start("call_abc", "skill_view", {"name": "data-mask"})
+        await q.get()
+        on_complete("call_abc", "skill_view", {"name": "data-mask"}, "masked output")
+
+        event = await asyncio.wait_for(q.get(), timeout=1.0)
+        assert event["event"] == "tool.completed"
+        assert event["tool_call_id"] == "call_abc"
+        assert event["tool"] == "skill_view"
+        assert event["preview"] == "masked output"
+        assert "duration" in event
+        assert event["error"] is False
+
+    @pytest.mark.asyncio
+    async def test_orphan_tool_completed_is_dropped(self, adapter):
+        loop = asyncio.get_running_loop()
+        run_id = "run_tool_sse_orphan"
+        q: asyncio.Queue = asyncio.Queue()
+        adapter._run_streams[run_id] = q
+
+        _, on_complete = adapter._make_run_tool_sse_callbacks(run_id, loop)
+        on_complete("call_missing", "skill_view", {}, "result")
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(q.get(), timeout=0.1)
+
+    @pytest.mark.asyncio
+    async def test_internal_tool_names_are_filtered(self, adapter):
+        loop = asyncio.get_running_loop()
+        run_id = "run_tool_sse_internal"
+        q: asyncio.Queue = asyncio.Queue()
+        adapter._run_streams[run_id] = q
+
+        on_start, on_complete = adapter._make_run_tool_sse_callbacks(run_id, loop)
+        on_start("call_internal", "_thinking", {})
+        on_complete("call_internal", "_thinking", {}, "thought")
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(q.get(), timeout=0.1)
+
+    @pytest.mark.asyncio
+    async def test_handle_runs_wires_structured_tool_callbacks(self, adapter):
+        app = _create_runs_app(adapter)
+        fake_create, _ = _make_tool_agent()
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", side_effect=fake_create) as mock_create:
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                data = await resp.json()
+                run_id = data["run_id"]
+
+                kwargs = mock_create.call_args.kwargs
+                assert kwargs.get("tool_start_callback") is not None
+                assert kwargs.get("tool_complete_callback") is not None
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                assert events_resp.status == 200
+                body = await events_resp.text()
+
+                started_payloads = []
+                for line in body.splitlines():
+                    if not line.startswith("data: "):
+                        continue
+                    payload = json.loads(line[len("data: "):])
+                    if payload.get("event") == "tool.started":
+                        started_payloads.append(payload)
+
+                assert started_payloads, "expected at least one tool.started SSE event"
+                assert started_payloads[0]["tool_call_id"] == "call_abc"
+                assert started_payloads[0]["tool"] == "skill_view"
+                assert "input" in started_payloads[0]
+
+                assert "tool.completed" in body
+                assert "skill body" in body
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -22,6 +22,8 @@ from gateway.config import PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
     _approval_event_choices,
+    _conversation_history_entry_validation_error,
+    _normalize_conversation_history_entry,
     cors_middleware,
     security_headers_middleware,
 )
@@ -250,6 +252,108 @@ class TestRunToolSSECallbacks:
 
                 assert "tool.completed" in body
                 assert "skill body" in body
+
+
+# ---------------------------------------------------------------------------
+# Conversation history normalization (H1–H3)
+# ---------------------------------------------------------------------------
+
+
+NATIVE_TOOL_HISTORY = [
+    {"role": "user", "content": "use data-mask"},
+    {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{
+            "id": "call_abc",
+            "type": "function",
+            "function": {"name": "skill_view", "arguments": '{"name":"data-mask"}'},
+        }],
+    },
+    {
+        "role": "tool",
+        "tool_call_id": "call_abc",
+        "content": "skill instructions body",
+        "name": "skill_view",
+    },
+    {"role": "assistant", "content": "ready"},
+]
+
+
+class TestRunsConversationHistory:
+    def test_normalize_preserves_assistant_tool_calls(self):
+        msg = _normalize_conversation_history_entry(NATIVE_TOOL_HISTORY[1])
+        assert msg["role"] == "assistant"
+        assert msg["tool_calls"][0]["id"] == "call_abc"
+        assert msg["content"] == ""
+
+    def test_normalize_preserves_tool_result(self):
+        msg = _normalize_conversation_history_entry(NATIVE_TOOL_HISTORY[2])
+        assert msg["role"] == "tool"
+        assert msg["tool_call_id"] == "call_abc"
+        assert msg["content"] == "skill instructions body"
+        assert msg["tool_name"] == "skill_view"
+
+    def test_normalize_simple_message_unchanged(self):
+        msg = _normalize_conversation_history_entry({"role": "user", "content": "hello"})
+        assert msg == {"role": "user", "content": "hello"}
+
+    def test_validation_requires_tool_call_id_for_tool_role(self):
+        err = _conversation_history_entry_validation_error(
+            {"role": "tool", "content": "body"}, 0,
+        )
+        assert err is not None
+        assert "tool_call_id" in err
+
+    def test_validation_allows_assistant_with_tool_calls_no_content(self):
+        err = _conversation_history_entry_validation_error(NATIVE_TOOL_HISTORY[1], 1)
+        assert err is None
+
+    @pytest.mark.asyncio
+    async def test_runs_passes_native_history_to_run_conversation(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "ok"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "continue", "conversation_history": NATIVE_TOOL_HISTORY},
+                )
+                assert resp.status == 202
+
+                for _ in range(20):
+                    if mock_agent.run_conversation.called:
+                        break
+                    await asyncio.sleep(0.05)
+
+                mock_agent.run_conversation.assert_called_once()
+                history = mock_agent.run_conversation.call_args.kwargs["conversation_history"]
+                assert len(history) == 4
+                assert history[1]["tool_calls"][0]["id"] == "call_abc"
+                assert history[2]["tool_call_id"] == "call_abc"
+                assert history[2]["tool_name"] == "skill_view"
+
+    @pytest.mark.asyncio
+    async def test_runs_rejects_tool_row_without_call_id(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/runs",
+                json={
+                    "input": "continue",
+                    "conversation_history": [
+                        {"role": "tool", "content": "orphan"},
+                    ],
+                },
+            )
+        assert resp.status == 400
+        assert adapter._run_streams == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -170,7 +170,7 @@ class TestRunToolSSECallbacks:
         assert event["input"] == {"name": "data-mask"}
 
     @pytest.mark.asyncio
-    async def test_tool_completed_includes_tool_call_id_and_preview(self, adapter):
+    async def test_tool_completed_includes_tool_call_id_without_result_preview(self, adapter):
         loop = asyncio.get_running_loop()
         run_id = "run_tool_sse_complete"
         q: asyncio.Queue = asyncio.Queue()
@@ -186,7 +186,9 @@ class TestRunToolSSECallbacks:
         assert event["event"] == "tool.completed"
         assert event["tool_call_id"] == "call_abc"
         assert event["tool"] == "skill_view"
-        assert event["preview"] == "masked output"
+        # Correlation metadata only — no unbounded tool-result egress.
+        assert "preview" not in event
+        assert "masked output" not in str(event)
         assert "duration" in event
         assert event["error"] is False
 
@@ -250,8 +252,18 @@ class TestRunToolSSECallbacks:
                 assert started_payloads[0]["tool"] == "skill_view"
                 assert "input" in started_payloads[0]
 
-                assert "tool.completed" in body
-                assert "skill body" in body
+                completed_payloads = []
+                for line in body.splitlines():
+                    if not line.startswith("data: "):
+                        continue
+                    payload = json.loads(line[len("data: "):])
+                    if payload.get("event") == "tool.completed":
+                        completed_payloads.append(payload)
+
+                assert completed_payloads, "expected at least one tool.completed SSE event"
+                assert completed_payloads[0]["tool_call_id"] == "call_abc"
+                assert "preview" not in completed_payloads[0]
+                assert "skill body" not in body
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

## What does this PR do?

Two narrow fixes to the /v1/runs endpoint in the api_server platform that together make it usable for clients that need to track tool execution or pass pre-existing tool histories.
1. Emit tool_call_id in SSE tool lifecycle events
tool.started / tool.completed SSE events carried no correlation identifier, making it impossible for downstream consumers (e.g. sclaw's chat_persist) to pair assistant tool_calls with their results. The agent core already fires tool_start_callback/tool_complete_callback with the correct tool_call_id — the API server simply wasn't wiring them through.
The fix extracts _push_run_sse_event() from the old inline closure for reuse, adds _make_run_tool_sse_callbacks() that returns structured (on_tool_start, on_tool_complete) with tool_call_id tracking and orphan-suppression, and narrows the old _make_run_event_callback to only forward reasoning.available events (the executor fires tool_progress_callback side-by-side with structured callbacks — wiring tool events in both would double-emit).
2. Accept native tool chains in conversation_history
The old validator required every entry to have both role and content, rejecting valid OpenAI-format tool sequences where an assistant message has tool_calls but empty content, or a tool result has tool_call_id but minimal content. Yet repair_message_sequence() (inside the agent core) already handles these shapes, and gateway/run.py already sends them.
The fix replaces the blanket check with per-role validation (role=tool requires tool_call_id; assistant messages with tool_calls don't need content), normalizes entries while preserving tool_calls, tool_call_id, and tool_name for tool rows, and names the exact missing field in error messages.



## Related Issue

N/A — discovered while developing tool-chain support for /v1/runs consumers; no corresponding issue.

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py` — extracted `_push_run_sse_event()`, added `_make_run_tool_sse_callbacks()` with `tool_call_id` tracking, narrowed `_make_run_event_callback()` to reasoning-only to avoid double-emit. Added `_conversation_history_entry_validation_error()`, `_normalize_conversation_history_entry()`, relaxed `_handle_runs` validation to accept native tool sequences.

- `tests/gateway/test_api_server_runs.py` — added `TestRunToolSSECallbacks` (6 tests: tool.started includes `tool_call_id`, tool.completed includes `tool_call_id` + preview, orphan completes dropped, internal tools filtered, end-to-end agent wiring). Added `TestRunsConversationHistory` (6 tests: normalization preserves `tool_calls`, `tool_call_id`, `tool_name`; validation rejects tool row without `call_id`; end-to-end run with native history).


## How to Test
Unit + integration tests for both changes
scripts/run_tests.sh -k "RunToolSSECallbacks or RunsConversationHistory" tests/gateway/test_api_server_runs.py
Or the full test file
scripts/run_tests.sh tests/gateway/test_api_server_runs.py

For manual testing with a running API server:

1. Start the gateway with the api_server platform enabled
2. Submit a run with native tool history:
```
curl -X POST http://localhost:8080/v1/runs \
  -H "Authorization: Bearer $API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "input": "use data-mask",
    "conversation_history": [
      {"role": "user", "content": "use data-mask"},
      {"role": "assistant", "content": "", "tool_calls": [{"id":"call_abc","type":"function","function":{"name":"skill_view","arguments":"{\"name\":\"data-mask\"}"}}]},
      {"role": "tool", "tool_call_id": "call_abc", "content": "masked", "name": "skill_view"}
    ]
  }'
```
3. Stream events and verify tool_call_id in tool.started / tool.completed payloads:
```
curl -N http://localhost:8080/v1/runs/$RUN_ID/events \
  -H "Authorization: Bearer $API_KEY"
```


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(api-server):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


## Screenshots / Logs

N/A — test output available via scripts/run_tests.sh command above.

