### PR TITLE
fix(mcp): load per-server env_file before probe interpolation

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -13,6 +13,7 @@ import logging
 import os
 import re
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_cli.config import (
@@ -238,6 +239,13 @@ def _resolve_mcp_server_config(config: dict) -> dict:
     loading worked because it interpolates. (#37792)
     """
     from tools.mcp_tool import _interpolate_env_vars
+    from hermes_cli.env_loader import _load_dotenv_with_fallback
+
+    env_file = config.get("env_file")
+    if env_file:
+        env_path = Path(env_file).expanduser()
+        if env_path.exists():
+            _load_dotenv_with_fallback(env_path, override=True)
 
     try:
         from hermes_cli.env_loader import load_hermes_dotenv

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -570,6 +570,34 @@ class TestProbeEnvResolution:
         })
         assert resolved["headers"]["Authorization"] == "Bearer jwt-token-xyz"
 
+    def test_resolve_loads_env_file_before_interpolating(self, tmp_path, monkeypatch):
+        from hermes_cli.mcp_config import _resolve_mcp_server_config
+
+        env_file = tmp_path / "omi.env"
+        env_file.write_text("OMI_API_KEY=env-file-token\n")
+        monkeypatch.delenv("OMI_API_KEY", raising=False)
+
+        resolved = _resolve_mcp_server_config({
+            "env_file": str(env_file),
+            "headers": {"Authorization": "Bearer ${OMI_API_KEY}"},
+        })
+
+        assert resolved["headers"]["Authorization"] == "Bearer env-file-token"
+
+    def test_resolve_env_file_overrides_stale_shell_export(self, tmp_path, monkeypatch):
+        from hermes_cli.mcp_config import _resolve_mcp_server_config
+
+        env_file = tmp_path / "omi.env"
+        env_file.write_text("OMI_API_KEY=env-file-token\n")
+        monkeypatch.setenv("OMI_API_KEY", "stale-shell-token")
+
+        resolved = _resolve_mcp_server_config({
+            "env_file": str(env_file),
+            "headers": {"Authorization": "Bearer ${OMI_API_KEY}"},
+        })
+
+        assert resolved["headers"]["Authorization"] == "Bearer env-file-token"
+
     def test_resolve_leaves_unset_var_literal(self, monkeypatch):
         from hermes_cli.mcp_config import _resolve_mcp_server_config
 


### PR DESCRIPTION
## What does this PR do?

Fixes an MCP CLI parity gap for per-server `env_file` configs. `main` already resolves `${ENV}` placeholders in the discovery/test probe path, but it only loads `~/.hermes/.env` first. Profiles that keep bearer credentials in a server-specific `env_file` still fail `hermes mcp test <name>` unless the operator exports that file into the shell first.

This PR loads the configured `env_file` before probe-time interpolation so the CLI path matches the expected resolved config for HTTP MCP servers that rely on per-server secrets.

## Related Issue

Fixes #53646

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/mcp_config.py`
  - import `Path`
  - load `config["env_file"]` via `_load_dotenv_with_fallback(..., override=True)` before calling `load_hermes_dotenv()` and `_interpolate_env_vars(config)`
- `tests/hermes_cli/test_mcp_config.py`
  - add regression coverage for resolving auth headers from a per-server `env_file`
  - add regression coverage that `env_file` beats a stale shell export for the same key

## How to Test

1. Run:
   `python -m pytest tests/hermes_cli/test_mcp_config.py -q -o addopts=''`
2. Reproduce on clean `main` with a profile whose MCP server uses `env_file` only for auth:
   `PYTHONPATH=<clean-main> python -m hermes_cli.main --profile ruh mcp test omi`
   -> before this patch, it returns `401 Unauthorized`
3. Run the same command from the patched tree:
   `PYTHONPATH=<patched-tree> python -m hermes_cli.main --profile ruh mcp test omi`
   -> after this patch, it connects and discovers tools without exporting the env file first

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Verification used a real Ruh/Omi MCP config with a per-server `env_file`:
- clean `origin/main`: `401 Unauthorized`
- patched tree: `✓ Connected`, `✓ Tools discovered: 17`
