### PR TITLE
fix: hide console window on Windows git subprocess calls (#53631)

### DIFF
--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -60,6 +60,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger("hermes.coding_context")
 
 CODING_TOOLSET = "coding"
@@ -653,6 +655,7 @@ def _git(cwd: Path, *args: str) -> str:
             capture_output=True,
             text=True,
             timeout=_GIT_TIMEOUT,
+            creationflags=windows_hide_flags(),
         )
     except (OSError, subprocess.SubprocessError):
         return ""

--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Awaitable, Callable
 
 from agent.model_metadata import estimate_tokens_rough
+from hermes_cli._subprocess_compat import windows_hide_flags
 
 _QUOTED_REFERENCE_VALUE = r'(?:`[^`\n]+`|"[^"\n]+"|\'[^\'\n]+\')'
 REFERENCE_PATTERN = re.compile(
@@ -298,6 +299,7 @@ def _expand_git_reference(
             text=True,
             timeout=30,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
     except subprocess.TimeoutExpired:
         return f"{ref.raw}: git command timed out (30s)", None


### PR DESCRIPTION
Fixes #53631

## Description

On Windows, every agent turn that triggered git context gathering (`git status`, `git log`, `git diff`, `git rev-parse`) and every expansion of an `@diff` / `@staged` / `@git:N` reference spawned a visible CMD window that flashed on screen. The fix applies `creationflags=windows_hide_flags()` (existing helper from `hermes_cli/_subprocess_compat.py`, returns `CREATE_NO_WINDOW` on Windows, 0 on POSIX) to the two affected `subprocess.run` calls:

- `agent/coding_context.py::_git` — fires multiple times per agent turn to gather the coding-context git snapshot.
- `agent/context_references.py::_expand_git_reference` — invoked when the user references `@diff`, `@staged`, or `@git:N` in a message.

No behaviour change on Linux/macOS (`windows_hide_flags()` returns 0, and `creationflags=0` is the subprocess default).

## Verification

- S1 (Secrets): no secrets in diff
- S2 (Personal refs): no personal refs in diff
- C1 (Conventional commits): conformant
- T1 (Tests): `tests/agent/test_coding_context.py` and `tests/agent/test_context_references.py` — 67 passed.
- F1 (Focused): only the two fix files touched (+5 lines).
- Compiles clean (ast.parse).
- Module imports resolve.