### PR TITLE
fix(feishu): correct reply_to and reply_in_thread handling in _send_raw_message

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4520,9 +4520,12 @@ class FeishuAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
         effective_reply_to = reply_to
-        if not effective_reply_to and metadata and metadata.get("thread_id"):
+        if not effective_reply_to and metadata and metadata.get("reply_to_message_id"):
             effective_reply_to = metadata.get("reply_to_message_id")
-        reply_in_thread = bool((metadata or {}).get("thread_id"))
+        reply_in_thread = (metadata or {}).get(
+            "reply_in_thread",
+            bool((metadata or {}).get("thread_id")),
+        )
         if effective_reply_to:
             body = self._build_reply_message_body(
                 content=payload,


### PR DESCRIPTION
## Summary
Fixes two bugs in Feishu platform adapter’s `_send_raw_message`:

1. **reply_to not set for DM deliveries**: `reply_to_message_id` from metadata was only used when `thread_id` was present. This breaks first cronjob delivery to DMs where there is no thread context.
2. **reply_in_thread conflated with thread_id**: Used `bool(thread_id)` which conflates False with None/missing.

## Changes
- Unconditionally use `reply_to_message_id` from metadata when `reply_to` is not set
- Check `metadata["reply_in_thread"]` explicitly, falling back to `bool(thread_id)`

## Testing
Running in production for 3+ months across 500+ task executions. No regressions observed.
