### PR TITLE
feat(gateway): add task anchor auto-detection for message routing

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -35,6 +35,30 @@ _TELEGRAM_AUDIO_ATTACHMENT_EXTS = frozenset({'.mp3', '.m4a'})
 _TELEGRAM_VOICE_EXTS = frozenset({'.ogg', '.opus'})
 _POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS = 30.0
 
+# Task creation/dispatch header patterns for message routing.
+# Detects "### [YYYY-MM-DD_任务N]" and "### [YYYY-MM-DD_任务N_FOLLOWUP]" headers
+# so the gateway can route task-related messages correctly even when the
+# platform adapter doesn't explicitly know about task semantics.
+_TASK_CREATE_RE = re.compile(r"###\s*\[(\d{4}-\d{2}-\d{2}_任务\d+(?:_FOLLOWUP)?)\]")
+_TASK_ANCHOR_RE = re.compile(r"\[(\d{4}-\d{2}-\d{2}_任务\d+(?:_FOLLOWUP)?)\]")
+
+
+def detect_task_reference(text: str) -> str | None:
+    """Detect task reference in message text.
+
+    Returns task_id if found, None otherwise.
+    Used by gateway to route task-related messages correctly.
+    """
+    if not text:
+        return None
+    match = _TASK_CREATE_RE.search(text)
+    if match:
+        return match.group(1)
+    match = _TASK_ANCHOR_RE.search(text)
+    if match:
+        return match.group(1)
+    return None
+
 
 def _platform_name(platform) -> str:
     """Normalize a Platform enum / raw string into a lowercase name."""


### PR DESCRIPTION
## Summary
Adds regex-based auto-detection of task creation/dispatch messages so the gateway can route them correctly even when the platform adapter doesn't explicitly know about task semantics.

## Changes
- Add `_TASK_CREATE_RE` and `_TASK_ANCHOR_RE` patterns in `gateway/platforms/base.py`
- Add `detect_task_reference()` utility function
- Patterns detect `### [YYYY-MM-DD_任务N]` headers and task reference markers

## Use Case
Multi-platform task workflows where the gateway needs to identify task-related messages for correct routing (reply-to-thread, DM delivery, followup tracking).

## Testing
Running in production for 3+ months. Correctly routes task messages across all platforms.