### PR TITLE
fix(tui): fail open on pet.cells + doctor partial-install check

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -225,6 +225,34 @@ def _read_pyproject_version() -> str | None:
     return None
 
 
+def _check_agent_source_consistency(issues: list[str]) -> None:
+    """Detect partial installs where agent modules drift out of sync.
+
+    An interrupted ``git pull`` / ``hermes update`` can leave
+    ``conversation_loop`` importing symbols that ``message_sanitization`` no
+    longer exports, crashing every agent turn with ImportError until a full
+    reinstall and hard process kill.
+    """
+    import importlib
+
+    try:
+        mod = importlib.import_module("agent.message_sanitization")
+        if not callable(getattr(mod, "close_interrupted_tool_sequence", None)):
+            raise ImportError(
+                "agent.message_sanitization missing close_interrupted_tool_sequence"
+            )
+    except ImportError as exc:
+        _fail_and_issue(
+            "Agent core modules out of sync (partial install)",
+            str(exc),
+            "Run `hermes update`, then kill any stale gateway/TUI processes "
+            "(stop/restart may leave old code in memory)",
+            issues,
+        )
+        return
+    check_ok("Agent core imports consistent")
+
+
 def _check_version_consistency(issues: list[str]) -> None:
     """Verify pyproject.toml version matches hermes_cli.__version__.
 
@@ -628,6 +656,7 @@ def run_doctor(args):
     # Detect drift between pyproject.toml and hermes_cli/__init__.py versions
     # (a git conflict resolution can silently revert one but not the other).
     _check_version_consistency(issues)
+    _check_agent_source_consistency(issues)
 
     _section("SSL / CA Certificates")
     check_certificates()

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1450,3 +1450,33 @@ def test_npm_audit_fix_hint_avoids_crashing_workspace_flag(monkeypatch, tmp_path
     assert "build-time tooling" in out
     assert "known npm bug" in out
     assert "lockfile bump" in out
+
+
+class TestAgentSourceConsistency:
+    def test_check_agent_source_consistency_ok(self):
+        issues: list[str] = []
+        doctor._check_agent_source_consistency(issues)
+        assert issues == []
+
+    def test_check_agent_source_consistency_detects_partial_install(self, monkeypatch, capsys):
+        import importlib
+        import types
+
+        issues: list[str] = []
+        stub = types.ModuleType("agent.message_sanitization")
+        real_import_module = importlib.import_module
+
+        def fake_import_module(name, package=None):
+            if name == "agent.message_sanitization":
+                return stub
+            return real_import_module(name, package)
+
+        monkeypatch.setattr(importlib, "import_module", fake_import_module)
+        doctor._check_agent_source_consistency(issues)
+
+        out = capsys.readouterr().out
+        assert "partial install" in out.lower()
+        assert issues == [
+            "Run `hermes update`, then kill any stale gateway/TUI processes "
+            "(stop/restart may leave old code in memory)",
+        ]

--- a/ui-tui/src/__tests__/rpc.test.ts
+++ b/ui-tui/src/__tests__/rpc.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
+import { asRpcResult, isMissingRpcMethod, rpcErrorMessage } from '../lib/rpc.js'
 
 describe('asRpcResult', () => {
   it('keeps plain object payloads', () => {
@@ -23,5 +23,18 @@ describe('rpcErrorMessage', () => {
   it('falls back for unknown errors', () => {
     expect(rpcErrorMessage('broken')).toBe('broken')
     expect(rpcErrorMessage({ code: 500 })).toBe('request failed')
+  })
+})
+
+describe('isMissingRpcMethod', () => {
+  it('detects JSON-RPC unknown-method errors', () => {
+    expect(isMissingRpcMethod(new Error('unknown method: pet.cells'))).toBe(true)
+    expect(isMissingRpcMethod(new Error('Method not found'))).toBe(true)
+    expect(isMissingRpcMethod(new Error('request failed -32601'))).toBe(true)
+  })
+
+  it('returns false for unrelated failures', () => {
+    expect(isMissingRpcMethod(new Error('handler error: boom'))).toBe(false)
+    expect(isMissingRpcMethod(null)).toBe(false)
   })
 })

--- a/ui-tui/src/app/usePet.ts
+++ b/ui-tui/src/app/usePet.ts
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { PetGrid } from '../components/petSprite.js'
 
+import { isMissingRpcMethod } from '../lib/rpc.js'
+
 import { useGateway } from './gatewayContext.js'
 import { $overlayState, getOverlayState } from './overlayStore.js'
 import { $petFlash } from './petFlashStore.js'
@@ -107,12 +109,15 @@ export interface PetRender {
  * live. The frame cache is keyed by `slug:state` so a switch re-pulls cleanly.
  */
 export function usePet(): PetRender {
-  const { rpc } = useGateway()
+  const { gw } = useGateway()
   const { write } = useStdout()
   const [enabled, setEnabled] = useState(false)
   const [grid, setGrid] = useState<PetGrid | null>(null)
   const [kitty, setKitty] = useState<KittyView | null>(null)
 
+  // Older gateways (pre-pet.cells) must not spam the transcript via the shared
+  // `rpc` wrapper, which logs every failure to sys().
+  const petCellsSupportedRef = useRef(true)
   const cache = useRef<Map<string, CacheEntry>>(new Map())
   const slugRef = useRef('')
   const scaleRef = useRef(0)
@@ -193,8 +198,12 @@ export function usePet(): PetRender {
   // config, so its `slug`/`enabled` are the source of truth.
   const sync = useCallback(
     async (state: PetState) => {
+      if (!petCellsSupportedRef.current) {
+        return
+      }
+
       try {
-        const res = (await rpc('pet.cells', { graphics: IS_TTY, state })) as PetCellsResult | null
+        const res = await gw.request<PetCellsResult>('pet.cells', { graphics: IS_TTY, state })
 
         if (!res) {
           return
@@ -243,11 +252,20 @@ export function usePet(): PetRender {
         }
 
         setEnabled(true)
-      } catch {
-        // cosmetic — ignore RPC failures
+      } catch (err) {
+        if (isMissingRpcMethod(err)) {
+          petCellsSupportedRef.current = false
+          releaseKitty()
+          slugRef.current = ''
+          cache.current.clear()
+          setGrid(null)
+          setKitty(null)
+          setEnabled(false)
+        }
+        // cosmetic — never surface pet RPC failures in the transcript
       }
     },
-    [rpc, releaseKitty]
+    [gw, releaseKitty]
   )
 
   // Pull frames whenever the state changes (if not already cached for the

--- a/ui-tui/src/lib/rpc.ts
+++ b/ui-tui/src/lib/rpc.ts
@@ -47,3 +47,7 @@ export const asCommandDispatch = (value: unknown): CommandDispatchResponse | nul
 
 export const rpcErrorMessage = (err: unknown) =>
   err instanceof Error && err.message ? err.message : typeof err === 'string' && err.trim() ? err : 'request failed'
+
+/** True when the gateway backend predates a cosmetic RPC (e.g. pet.cells). */
+export const isMissingRpcMethod = (err: unknown) =>
+  /method not found|-32601|unknown method|no such method/i.test(rpcErrorMessage(err))


### PR DESCRIPTION
## Summary

- After a partial Hermes update, the new TUI polls `pet.cells` every 2.5s while an older `tui_gateway` does not register the RPC. The shared `rpc()` wrapper logged each failure into the transcript (`error: unknown method: pet.cells`), even though `usePet` intended cosmetic fail-open.
- Route pet frame fetches through `gw.request` directly and latch off when the method is missing (`isMissingRpcMethod`).
- Add `hermes doctor` check for `agent.message_sanitization` drift so partial installs that break `close_interrupted_tool_sequence` imports are surfaced before every agent turn crashes with ImportError.

## Root cause

Version skew / stale process after update — not a logic bug on current main. User workaround (reinstall + hard kill) confirms deployment class.

## Test plan

- [x] `npx vitest run ui-tui/src/__tests__/rpc.test.ts` (6 passed)
- [x] `tests/hermes_cli/test_doctor.py::TestAgentSourceConsistency` (added; run in CI)
