### PR TITLE
fix(desktop): steer from live composer text

### DIFF
--- a/apps/desktop/src/app/chat/composer/enter-submit-dom-race.test.tsx
+++ b/apps/desktop/src/app/chat/composer/enter-submit-dom-race.test.tsx
@@ -29,7 +29,8 @@ function Harness({
   onSubmit,
   onQueue,
   onCancel,
-  onDrain
+  onDrain,
+  onSteer
 }: {
   busy?: boolean
   disabled?: boolean
@@ -38,6 +39,7 @@ function Harness({
   onQueue: (text: string) => void
   onCancel: () => void
   onDrain: () => void
+  onSteer?: (text: string) => void
 }) {
   const editorRef = useRef<HTMLDivElement>(null)
   const draftRef = useRef('')
@@ -85,7 +87,38 @@ function Harness({
     }
   }
 
+  const steerDraft = () => {
+    if (!onSteer) {
+      return
+    }
+
+    const text = draftRef.current.trim()
+
+    if (!busy || attachments.length > 0 || !text || text.startsWith('/')) {
+      return
+    }
+
+    onSteer(text)
+  }
+
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' && (event.metaKey || event.ctrlKey) && !event.shiftKey) {
+      event.preventDefault()
+
+      const editorText = editorRef.current ? composerPlainText(editorRef.current) : draftRef.current
+      const trimmedEditorText = editorText.trim()
+      const liveCanSteer =
+        busy && !!onSteer && attachments.length === 0 && trimmedEditorText.length > 0 && !trimmedEditorText.startsWith('/')
+
+      if (liveCanSteer) {
+        draftRef.current = editorText
+        setDraft(editorText)
+        steerDraft()
+      }
+
+      return
+    }
+
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault()
 
@@ -204,6 +237,27 @@ describe('composer Enter submit — live DOM vs stale composer state (#39630)', 
     })
 
     expect(onDrain).toHaveBeenCalledTimes(1)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('steers the just-typed text on Ctrl+Enter even when composer state has not synced', async () => {
+    const onSteer = vi.fn()
+    const onQueue = vi.fn()
+    const onSubmit = vi.fn()
+
+    const { getByTestId } = render(
+      <Harness busy onCancel={vi.fn()} onDrain={vi.fn()} onQueue={onQueue} onSteer={onSteer} onSubmit={onSubmit} />
+    )
+
+    const editor = getByTestId('editor')
+
+    await act(async () => {
+      editor.textContent = 'tighten this up'
+      fireEvent.keyDown(editor, { ctrlKey: true, key: 'Enter' })
+    })
+
+    expect(onSteer).toHaveBeenCalledWith('tighten this up')
+    expect(onQueue).not.toHaveBeenCalled()
     expect(onSubmit).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1164,11 +1164,19 @@ export function ChatBar({
 
     // Cmd/Ctrl+Enter is reserved for steering the live run — never a send.
     // Steer when there's a steerable draft, otherwise swallow it so it can't
-    // surprise-send. (Plain Enter still queues while busy / sends when idle.)
+    // surprise-send. Decide from the DOM, not React state, so Ctrl+Enter right
+    // after typing doesn't miss the last keystroke while composer state lags.
     if (event.key === 'Enter' && (event.metaKey || event.ctrlKey) && !event.shiftKey) {
       event.preventDefault()
 
-      if (canSteer) {
+      const editorText = editorRef.current ? composerPlainText(editorRef.current) : draftRef.current
+      const trimmedEditorText = editorText.trim()
+      const liveCanSteer =
+        busy && !!onSteer && attachments.length === 0 && trimmedEditorText.length > 0 && !SLASH_COMMAND_RE.test(trimmedEditorText)
+
+      if (liveCanSteer) {
+        draftRef.current = editorText
+        setComposerText(editorText)
         steerDraft()
       }
 
@@ -1624,11 +1632,15 @@ export function ChatBar({
   // for snappy feedback; if the gateway rejects (no live tool window) the words
   // are re-queued so nothing is lost — same safety net as a plain queue.
   const steerDraft = useCallback(() => {
-    if (!onSteer || !canSteer) {
+    if (!onSteer) {
       return
     }
 
     const text = draftRef.current.trim()
+
+    if (!busy || attachments.length > 0 || !text || SLASH_COMMAND_RE.test(text)) {
+      return
+    }
 
     triggerHaptic('submit')
     clearDraft()
@@ -1638,7 +1650,7 @@ export function ChatBar({
         enqueueQueuedPrompt(activeQueueSessionKey, { text, attachments: [] })
       }
     })
-  }, [activeQueueSessionKey, canSteer, clearDraft, onSteer])
+  }, [activeQueueSessionKey, attachments.length, busy, clearDraft, onSteer])
 
   // All queue drain paths share one lock + send-then-remove sequence.
   // `pickEntry` lets each caller choose head, by-id, or skip-edited.


### PR DESCRIPTION
## What does this PR do?

Fixes an intermittent Hermes Desktop composer bug where `Ctrl+Enter` / `Cmd+Enter` can miss freshly typed steer text. The shortcut branch now mirrors the existing plain-Enter race fix: it reads the live `contentEditable` DOM synchronously before deciding whether steering is possible, then syncs `draftRef`/composer state before calling `steerDraft()`.

## Related Issue

Fixes #53659

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/index.tsx`
  - Makes the `Ctrl/Cmd+Enter` steer branch read `composerPlainText(editorRef.current)` instead of relying on render-derived `canSteer`.
  - Makes `steerDraft()` validate steerability from `draftRef.current` so the freshly synced text is honored in the same keydown event.
- `apps/desktop/src/app/chat/composer/enter-submit-dom-race.test.tsx`
  - Adds a regression case proving fast-typed text is steered on `Ctrl+Enter` even before composer state has synced.

## How to Test

1. Start a Desktop chat turn that is still running.
2. Type a steering message and immediately press `Ctrl+Enter` / `Cmd+Enter`.
3. The freshly typed text should steer the active run instead of being swallowed.

Local verification:

- [x] `npm --prefix apps/desktop run typecheck` — passed
- [x] `npm --prefix apps/desktop run test:ui -- src/app/chat/composer/enter-submit-dom-race.test.tsx src/app/chat/composer/composer-text-guard.test.tsx` — 2 files, 8 tests passed
- [x] `npm --prefix apps/desktop run build` — passed
- [x] `git diff --check` — passed

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No screenshot; this is a keyboard timing fix. The regression is covered by the added jsdom DOM-keydown test.
