### PR TITLE
feat(reasoning): add 'max' effort tier with provider-safe clamping

### DIFF
--- a/agent/lmstudio_reasoning.py
+++ b/agent/lmstudio_reasoning.py
@@ -13,12 +13,13 @@ from __future__ import annotations
 from typing import List, Optional
 
 # LM Studio accepts these top-level reasoning_effort values via its
-# OpenAI-compatible chat.completions endpoint.
+# OpenAI-compatible chat.completions endpoint. `max` is clamped to `xhigh`
+# (Anthropic-only) before checking model-level allowed_options.
 _LM_VALID_EFFORTS = {"none", "minimal", "low", "medium", "high", "xhigh"}
 
 # Toggle-style models publish allowed_options as ["off","on"] in /api/v1/models.
 # Map them onto the OpenAI-compatible request vocabulary.
-_LM_EFFORT_ALIASES = {"off": "none", "on": "medium"}
+_LM_EFFORT_ALIASES = {"off": "none", "on": "medium", "max": "xhigh"}
 
 
 def resolve_lmstudio_effort(

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -357,6 +357,22 @@ def grok_supports_reasoning_effort(model: str) -> bool:
     return any(name.startswith(prefix) for prefix in _GROK_EFFORT_CAPABLE_PREFIXES)
 
 
+# ── Reasoning-effort ceiling normalization ───────────────────────────────
+# ``max`` is the TOP of Anthropic's adaptive-thinking ladder
+# (low<medium<high<xhigh<max) and is Anthropic-only. OpenAI Responses and
+# xAI Grok reject it with HTTP 400 (OpenAI verified live 2026-06-21:
+# "Invalid value: 'max'. Supported: none,minimal,low,medium,high,xhigh";
+# xAI rejection inferred from the same OpenAI-compat effort vocabulary, not
+# yet live-probed). A single global ``agent.reasoning_effort: max`` must stay
+# model-agnostic, so NON-Anthropic emitters route the resolved effort through
+# this helper, which degrades ``max`` to the OpenAI/xAI ceiling ``xhigh``.
+#
+# `max` is Anthropic-only; non-Anthropic emitters degrade to `xhigh`.
+def clamp_effort_for_openai_compat(effort: str | None) -> str | None:
+    """Degrade ``max`` → ``xhigh`` for non-Anthropic emit sites."""
+    return "xhigh" if effort == "max" else effort
+
+
 _CONTEXT_LENGTH_KEYS = (
     "context_length",
     "context_window",

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -53,7 +53,7 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
     if normalized_model.startswith("gemini-2.5-"):
         return thinking_config
 
-    if effort not in {"minimal", "low", "medium", "high", "xhigh"}:
+    if effort not in {"minimal", "low", "medium", "high", "xhigh", "max"}:
         effort = "medium"
 
     # Gemini 3 Flash documents low/medium/high thinking levels; Gemini 3 Pro
@@ -63,13 +63,13 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
         if "flash" in normalized_model:
             if effort in {"minimal", "low"}:
                 thinking_config["thinkingLevel"] = "low"
-            elif effort in {"high", "xhigh"}:
+            elif effort in {"high", "xhigh", "max"}:
                 thinking_config["thinkingLevel"] = "high"
             else:
                 thinking_config["thinkingLevel"] = "medium"
         elif "pro" in normalized_model:
             thinking_config["thinkingLevel"] = (
-                "high" if effort in {"high", "xhigh"} else "low"
+                "high" if effort in {"high", "xhigh", "max"} else "low"
             )
 
     return thinking_config

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -164,6 +164,10 @@ class ResponsesApiTransport(ProviderTransport):
 
         _effort_clamp = {"minimal": "low"}
         reasoning_effort = _effort_clamp.get(reasoning_effort, reasoning_effort)
+        # Anthropic-only `max` -> OpenAI/xAI ceiling `xhigh` (this transport only
+        # ever serves non-Anthropic Responses families: OpenAI codex + xAI Grok).
+        from agent.model_metadata import clamp_effort_for_openai_compat
+        reasoning_effort = clamp_effort_for_openai_compat(reasoning_effort)
 
         response_tools = _responses_tools(tools)
 

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -1192,7 +1192,7 @@ def main(
         providers_order (str): Comma-separated list of OpenRouter providers to try in order (e.g. "anthropic,openai,google")
         provider_sort (str): Sort providers by "price", "throughput", or "latency" (OpenRouter only)
         max_tokens (int): Maximum tokens for model responses (optional, uses model default if not set)
-        reasoning_effort (str): OpenRouter reasoning effort level: "none", "minimal", "low", "medium", "high", "xhigh" (default: "medium")
+        reasoning_effort (str): OpenRouter reasoning effort level: "none", "minimal", "low", "medium", "high", "xhigh", "max" (default: "medium")
         reasoning_disabled (bool): Completely disable reasoning/thinking tokens (default: False)
         prefill_messages_file (str): Path to JSON file containing prefill messages (list of {role, content} dicts)
         max_samples (int): Only process the first N samples from the dataset (optional, processes all if not set)
@@ -1261,7 +1261,7 @@ def main(
         print("🧠 Reasoning: DISABLED (effort=none)")
     elif reasoning_effort:
         # Use specified effort level
-        valid_efforts = ["none", "minimal", "low", "medium", "high", "xhigh"]
+        valid_efforts = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
         if reasoning_effort not in valid_efforts:
             print(f"❌ Error: --reasoning_effort must be one of: {', '.join(valid_efforts)}")
             return

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4255,7 +4255,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Load reasoning effort from config.yaml.
 
         Reads agent.reasoning_effort from config.yaml. Valid: "none",
-        "minimal", "low", "medium", "high", "xhigh". Returns None to use
+        "minimal", "low", "medium", "high", "xhigh", "max". Returns None to use
         default (medium).
         """
         from hermes_constants import parse_reasoning_effort

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2398,7 +2398,7 @@ class GatewaySlashCommandsMixin:
             return t("gateway.reasoning.reset_done")
         if effort == "none":
             parsed = {"enabled": False}
-        elif effort in {"minimal", "low", "medium", "high", "xhigh"}:
+        elif effort in {"minimal", "low", "medium", "high", "xhigh", "max"}:
             parsed = {"enabled": True, "effort": effort}
         else:
             return t(

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2435,7 +2435,7 @@ class CLICommandsMixin:
             full_state = "full" if getattr(self, "reasoning_full", False) else "clamped to 10 lines"
             _cprint(f"  {_ACCENT}Reasoning effort:  {level}{_RST}")
             _cprint(f"  {_ACCENT}Reasoning display: {display_state} ({full_state}){_RST}")
-            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|show|hide|full|clamp>{_RST}")
+            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|max|show|hide|full|clamp>{_RST}")
             return
 
         arg = parts[1].strip().lower()
@@ -2476,7 +2476,7 @@ class CLICommandsMixin:
         parsed = _parse_reasoning_config(arg)
         if parsed is None:
             _cprint(f"  {_DIM}(._.) Unknown argument: {arg}{_RST}")
-            _cprint(f"  {_DIM}Valid levels: none, minimal, low, medium, high, xhigh{_RST}")
+            _cprint(f"  {_DIM}Valid levels: none, minimal, low, medium, high, xhigh, max{_RST}")
             _cprint(f"  {_DIM}Display:      show, hide{_RST}")
             return
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -150,7 +150,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                "Configuration"),
     CommandDef("reasoning", "Manage reasoning effort and display", "Configuration",
                args_hint="[level|show|hide|full|clamp]",
-               subcommands=("none", "minimal", "low", "medium", "high", "xhigh", "show", "hide", "on", "off", "full", "clamp")),
+               subcommands=("none", "minimal", "low", "medium", "high", "xhigh", "max", "show", "hide", "on", "off", "full", "clamp")),
     CommandDef("fast", "Toggle fast mode — OpenAI Priority Processing / Anthropic Fast Mode (Normal/Fast)", "Configuration",
                args_hint="[normal|fast|status]",
                subcommands=("normal", "fast", "status", "on", "off")),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2049,7 +2049,7 @@ DEFAULT_CONFIG = {
                                      # (API, tools, iteration budget), never a delegation
                                      # stopwatch. Set a positive number of seconds
                                      # (floor 30s) to enforce a hard cap.
-        "reasoning_effort": "",  # reasoning effort for subagents: "xhigh", "high", "medium",
+        "reasoning_effort": "",  # reasoning effort for subagents: "max", "xhigh", "high", "medium",
                                  # "low", "minimal", "none" (empty = inherit parent's level)
         "max_concurrent_children": 3,  # max parallel children per batch; floor of 1 enforced, no ceiling
         "max_async_children": 3,  # max concurrent background (background=true) subagents; new dispatches rejected at capacity

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3883,7 +3883,7 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
             str(effort).strip().lower() for effort in efforts if str(effort).strip()
         )
     )
-    canonical_order = ("minimal", "low", "medium", "high", "xhigh")
+    canonical_order = ("minimal", "low", "medium", "high", "xhigh", "max")
     ordered = [effort for effort in canonical_order if effort in deduped]
     ordered.extend(effort for effort in deduped if effort not in canonical_order)
     if not ordered:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -726,13 +726,17 @@ def apply_subprocess_home_env(env: dict[str, str]) -> None:
         env["HOME"] = home
 
 
-VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
+VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max")
 
 
 def parse_reasoning_effort(effort: str) -> dict | None:
     """Parse a reasoning effort level into a config dict.
 
-    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh".
+    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh", "max".
+    "max" is the top of Anthropic's adaptive ladder (Opus 4.8+); for
+    non-Anthropic backends it is degraded to that backend's ceiling at the
+    emit sites (see agent.model_metadata.clamp_effort_for_openai_compat), so
+    a single global setting stays model-agnostic.
     Returns None when the input is empty or unrecognized (caller uses default).
     Returns {"enabled": False} for "none".
     Returns {"enabled": True, "effort": <level>} for valid effort levels.

--- a/plugins/model-providers/copilot/__init__.py
+++ b/plugins/model-providers/copilot/__init__.py
@@ -35,9 +35,17 @@ class CopilotProfile(ProviderProfile):
                 supported_efforts = github_model_reasoning_efforts(model)
                 if supported_efforts and reasoning_config:
                     effort = reasoning_config.get("effort", "medium")
-                    # Normalize non-standard effort levels to the nearest supported
-                    if effort == "xhigh":
-                        effort = "high"
+                    # Degrade to the highest SUPPORTED effort at or below the
+                    # requested level, walking an ordered ladder. `max` is
+                    # Anthropic-only and GitHub/Copilot models top out at `high`
+                    # today, so this lands on the real ceiling instead of being
+                    # dropped when an exact match is absent.
+                    _ladder = ["minimal", "low", "medium", "high", "xhigh", "max"]
+                    if effort in _ladder:
+                        for cand in reversed(_ladder[: _ladder.index(effort) + 1]):
+                            if cand in supported_efforts:
+                                effort = cand
+                                break
                     if effort in supported_efforts:
                         extra_body["reasoning"] = {"effort": effort}
                 elif supported_efforts:

--- a/plugins/model-providers/nous/__init__.py
+++ b/plugins/model-providers/nous/__init__.py
@@ -30,6 +30,12 @@ class NousProfile(ProviderProfile):
                 if rc.get("enabled") is False:
                     pass  # Nous omits reasoning when disabled
                 else:
+                    # Degrade Anthropic-only `max` to the non-Anthropic ceiling.
+                    # Nous Portal serves Nous's own (non-Anthropic) models, so
+                    # `max` always degrades here; model passed for guard symmetry.
+                    from agent.model_metadata import clamp_effort_for_openai_compat
+                    if rc.get("effort") is not None:
+                        rc["effort"] = clamp_effort_for_openai_compat(rc.get("effort"))
                     extra_body["reasoning"] = rc
             else:
                 extra_body["reasoning"] = {"enabled": True, "effort": "medium"}

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -155,7 +155,14 @@ class OpenRouterProfile(ProviderProfile):
                 if cfg.get("enabled", True) is not False and effort and effort != "none":
                     top_level["verbosity"] = effort
             elif reasoning_config is not None:
-                extra_body["reasoning"] = dict(reasoning_config)
+                # Non-Anthropic model: degrade Anthropic-only `max` to the
+                # OpenAI/xAI ceiling so a global `max` doesn't 400 here. Only
+                # the effort field is touched; all other keys pass through.
+                from agent.model_metadata import clamp_effort_for_openai_compat
+                rc = dict(reasoning_config)
+                if rc.get("effort") is not None:
+                    rc["effort"] = clamp_effort_for_openai_compat(rc.get("effort"))
+                extra_body["reasoning"] = rc
             else:
                 extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -4986,6 +4986,11 @@ class AIAgent:
         else:
             requested_effort = "medium"
 
+        if requested_effort == "max":
+            # Anthropic-only `max` -> `xhigh`, which then degrades to the
+            # model's real ceiling via the steps below (no GitHub model
+            # currently exposes `xhigh`, so this lands on `high`, not `medium`).
+            requested_effort = "xhigh"
         if requested_effort == "xhigh" and "high" in supported_efforts:
             requested_effort = "high"
         elif requested_effort not in supported_efforts:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -29,6 +29,7 @@ from agent.model_metadata import (
     save_context_length,
     fetch_model_metadata,
     _MODEL_CACHE_TTL,
+    clamp_effort_for_openai_compat,
 )
 
 
@@ -1524,3 +1525,17 @@ class TestGrok43StaleCacheGuard:
                 slug, base_url=base, api_key="", provider="xai"
             )
             assert ctx == 256_000, f"{slug} should stay 256000, got {ctx}"
+
+
+# =========================================================================
+# Reasoning-effort ceiling clamp (LOCAL PATCH: provider-safe `max`)
+# =========================================================================
+
+class TestClampEffortForOpenAICompat:
+    """`max` is Anthropic-only; non-Anthropic emitters degrade to `xhigh`."""
+
+    def test_clamp(self):
+        assert clamp_effort_for_openai_compat("max") == "xhigh"
+        assert clamp_effort_for_openai_compat("xhigh") == "xhigh"
+        assert clamp_effort_for_openai_compat("high") == "high"
+        assert clamp_effort_for_openai_compat(None) is None

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -194,6 +194,30 @@ class TestOpenRouterParity:
         )
         assert kw["extra_body"]["reasoning"] == {"enabled": True, "effort": "medium"}
 
+    def test_max_effort_clamped_for_non_anthropic(self, transport):
+        """LOCAL PATCH: `max` degrades to `xhigh` for non-Anthropic OpenRouter."""
+        kw = transport.build_kwargs(
+            model="deepseek/deepseek-chat",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("openrouter"),
+            supports_reasoning=True,
+            reasoning_config={"enabled": True, "effort": "max"},
+        )
+        assert kw["extra_body"]["reasoning"] == {"enabled": True, "effort": "xhigh"}
+
+    def test_non_max_effort_passes_through_unchanged(self, transport):
+        """LOCAL PATCH: only `max` is touched; `high` passes through."""
+        kw = transport.build_kwargs(
+            model="deepseek/deepseek-chat",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("openrouter"),
+            supports_reasoning=True,
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert kw["extra_body"]["reasoning"] == {"enabled": True, "effort": "high"}
+
 
 class TestNousParity:
     """Nous: product tags, reasoning, omit when disabled."""

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -446,6 +446,7 @@ class TestParseReasoningEffort:
             ("High", "high"),
             ("  low  ", "low"),
             ("\tXHIGH\n", "xhigh"),
+            (" MAX ", "max"),
             ("None", False),
         ],
     )
@@ -459,7 +460,7 @@ class TestParseReasoningEffort:
 
     @pytest.mark.parametrize(
         "value",
-        ["bogus", "very-high", "max", "0", "off", "true", "default"],
+        ["bogus", "very-high", "0", "off", "true", "default"],
     )
     def test_unknown_levels_return_none(self, value):
         """Unrecognized strings fall back to the caller default (None)."""
@@ -468,11 +469,11 @@ class TestParseReasoningEffort:
     def test_known_supported_levels_are_documented(self):
         """Guard against silently dropping a documented level.
 
-        The docstring promises "minimal", "low", "medium", "high", "xhigh".
+        The docstring promises "minimal", "low", "medium", "high", "xhigh", "max".
         If someone removes one from VALID_REASONING_EFFORTS without updating
         the docstring, this test will fail and force the call out.
         """
-        documented = {"minimal", "low", "medium", "high", "xhigh"}
+        documented = {"minimal", "low", "medium", "high", "xhigh", "max"}
         assert documented.issubset(set(VALID_REASONING_EFFORTS))
 
 


### PR DESCRIPTION
## What

Adds a `max` reasoning effort tier above `xhigh` for models that expose a distinct top reasoning level (e.g. Anthropic Opus), with **provider-safe clamping** so backends that lack a separate top tier degrade `max` to their ceiling instead of erroring.

`VALID_REASONING_EFFORTS` currently stops at `xhigh` (`hermes_constants.py:788`). Models with a genuine tier above that have no way to request it, and naively adding the enum value makes every non-supporting backend 400 on an unknown effort.

## How

- **Central parser / enum:** `max` added to `VALID_REASONING_EFFORTS` + docstring (`hermes_constants.py`).
- **Provider-safe clamp at each emit site** (so `max` never reaches a backend that rejects it):
  - `openai-codex` / xAI — clamp `max` → `xhigh` in the transport (`agent/transports/codex.py`)
  - `copilot` — ordered-ladder fallback into the probed support set (`plugins/model-providers/copilot/__init__.py`)
  - `openrouter` / `nous` — clamp at emit sites
  - Gemini — treat `max` as `xhigh` → high in the effort validator (`agent/transports/chat_completions.py`)
  - LM Studio — map `max` → `xhigh` via reasoning alias (`agent/lmstudio_reasoning.py`)
- **Surface wiring** so `config.yaml` `agent.reasoning_effort: max` and CLI `/reasoning max` both work: `gateway/slash_commands.py`, `hermes_cli/{commands,cli_commands_mixin,config,main}.py`, `gateway/run.py`, `batch_runner.py`, `run_agent.py`.
- **Tests:** clamp + transport-parity regressions in `tests/agent/test_model_metadata.py`, `tests/providers/test_transport_parity.py`, `tests/test_hermes_constants.py`.

## Behavior

- Anthropic (Opus): `max` passes through as the top tier.
- Every other backend: `max` degrades to that provider's ceiling — no 400s, no silent fallthrough to `medium`.

## Tests

`tests/agent/test_model_metadata.py`, `tests/providers/test_transport_parity.py`, `tests/test_hermes_constants.py` all green locally. Clamp behavior is asserted per-provider so a new emit site that forgets to clamp trips parity.
