### PR TITLE
fix(desktop): route /compress through session.rpc (superseded)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -5,7 +5,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { textPart } from '@/lib/chat-messages'
 import { $composerAttachments, type ComposerAttachment } from '@/store/composer'
-import { $busy, $connection, $messages, $sessions, setSessions } from '@/store/session'
+import {
+  $busy,
+  $connection,
+  $currentUsage,
+  $messages,
+  $sessions,
+  setCurrentUsage,
+  setMessages,
+  setSessions
+} from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
 import { uploadComposerAttachment, usePromptActions } from './use-prompt-actions'
@@ -356,22 +365,26 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
 })
 
 describe('usePromptActions /compress', () => {
+  beforeEach(() => {
+    setSessions(() => [sessionInfo()])
+  })
+
   afterEach(() => {
     cleanup()
+    setCurrentUsage({ calls: 0, input: 0, output: 0, total: 0 })
+    setMessages([])
     vi.restoreAllMocks()
   })
 
-  it('routes through session.compress with a long timeout and renders the compression summary', async () => {
+  it('shows compression progress, refreshes context usage, and renders the final summary without fallback noise', async () => {
     const states: Record<string, unknown>[] = []
+    let resolveCompress: (value: unknown) => void = () => undefined
+    const compressResult = new Promise(resolve => {
+      resolveCompress = resolve
+    })
     const requestGateway = vi.fn(async (method: string) => {
       if (method === 'session.compress') {
-        return {
-          removed: 5,
-          summary: {
-            headline: 'Compressed: 8 → 3 messages',
-            token_line: 'Approx request size: ~12,000 → ~4,000 tokens'
-          }
-        } as never
+        return (await compressResult) as never
       }
 
       throw new Error(`unexpected method: ${method}`)
@@ -387,13 +400,56 @@ describe('usePromptActions /compress', () => {
       />
     )
 
-    await handle!.submitText('/compress')
+    const submitted = handle!.submitText('/compress')
+
+    await waitFor(() => {
+      expect(renderedTextFrom(states)).toContain('compressing context...')
+    })
+
+    resolveCompress({
+      info: {
+        title: 'Compressed session',
+        usage: {
+          context_max: 100_000,
+          context_percent: 4,
+          context_used: 4_000,
+          input: 12_000,
+          output: 0,
+          total: 12_000
+        }
+      },
+      messages: [{ content: 'compressed transcript', role: 'system' }],
+      removed: 5,
+      summary: {
+        headline: 'Compressed: 8 → 3 messages',
+        token_line: 'Approx request size: ~12,000 → ~4,000 tokens'
+      }
+    })
+
+    await submitted
 
     expect(requestGateway).toHaveBeenCalledWith('session.compress', { session_id: RUNTIME_SESSION_ID }, 120_000)
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
     expect(requestGateway).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
-    expect(renderedTextFrom(states)).toContain('Compressed: 8 → 3 messages')
-    expect(renderedTextFrom(states)).toContain('Approx request size: ~12,000 → ~4,000 tokens')
+    const rendered = renderedTextFrom(states)
+    expect(rendered).toContain('Compressed: 8 → 3 messages')
+    expect(rendered).toContain('Approx request size: ~12,000 → ~4,000 tokens')
+    expect(rendered).toContain('compressed transcript')
+    expect(rendered).not.toContain('not a quick/plugin/skill command: compress')
+    expect($currentUsage.get()).toEqual(
+      expect.objectContaining({
+        context_max: 100_000,
+        context_percent: 4,
+        context_used: 4_000,
+        total: 12_000
+      })
+    )
+    expect(
+      $messages
+        .get()
+        .some(message => message.parts.some(part => 'text' in part && part.text === 'compressed transcript'))
+    ).toBe(true)
+    expect($sessions.get()[0]?.title).toBe('Compressed session')
   })
 
   it('passes a focus topic through to session.compress', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -428,7 +428,7 @@ describe('usePromptActions /compress', () => {
 
     await submitted
 
-    expect(requestGateway).toHaveBeenCalledWith('session.compress', { session_id: RUNTIME_SESSION_ID }, 120_000)
+    expect(requestGateway).toHaveBeenCalledWith('session.compress', { session_id: RUNTIME_SESSION_ID }, 0)
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
     expect(requestGateway).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
     const rendered = renderedTextFrom(states)
@@ -474,7 +474,7 @@ describe('usePromptActions /compress', () => {
         focus_topic: 'the auth refactor',
         session_id: RUNTIME_SESSION_ID
       },
-      120_000
+      0
     )
   })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -63,7 +63,12 @@ function Harness({
   onReady: (handle: HarnessHandle) => void
   onSeedState?: (state: Record<string, unknown>) => void
   refreshSessions: () => Promise<void>
-  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  requestGateway: <T>(
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+    signal?: AbortSignal
+  ) => Promise<T>
   resumeStoredSession?: (storedSessionId: string) => Promise<void> | void
   seedMessages?: unknown[]
   storedSessionId?: null | string
@@ -116,6 +121,18 @@ function Harness({
   }, [actions.cancelRun, actions.restoreToMessage, actions.steerPrompt, actions.submitText, onReady])
 
   return null
+}
+
+function renderedTextFrom(states: Record<string, unknown>[]): string {
+  return states
+    .flatMap(state => {
+      const messages = Array.isArray(state.messages)
+        ? (state.messages as Array<{ parts?: Array<{ text?: string }> }>)
+        : []
+
+      return messages.flatMap(message => (message.parts ?? []).map(part => part.text ?? ''))
+    })
+    .join('\n')
 }
 
 describe('usePromptActions /title', () => {
@@ -270,6 +287,164 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
 
     expect(renderedText).toContain('⊙ Goal set. Starting now.')
     expect(renderedText).not.toContain('/goal: no output')
+  })
+
+  it('surfaces the slash.exec failure when command.dispatch only adds unknown-command noise', async () => {
+    const states: Record<string, unknown>[] = []
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'slash.exec') {
+        throw new Error('slash worker timed out')
+      }
+
+      if (method === 'command.dispatch') {
+        throw new Error('not a quick/plugin/skill command: status')
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => states.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/status')
+
+    expect(requestGateway).toHaveBeenCalledWith('slash.exec', expect.objectContaining({ command: 'status' }))
+    expect(requestGateway).toHaveBeenCalledWith('command.dispatch', {
+      arg: '',
+      name: 'status',
+      session_id: RUNTIME_SESSION_ID
+    })
+    expect(renderedTextFrom(states)).toContain('error: /status failed: slash worker timed out')
+  })
+
+  it('still reports genuine command.dispatch failures for extension commands', async () => {
+    const states: Record<string, unknown>[] = []
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'slash.exec') {
+        throw new Error('extension command: use command.dispatch')
+      }
+
+      if (method === 'command.dispatch') {
+        throw new Error('extension command failed')
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => states.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/my-skill')
+
+    expect(renderedTextFrom(states)).toContain('error: extension command failed')
+    expect(renderedTextFrom(states)).not.toContain('/my-skill failed')
+  })
+})
+
+describe('usePromptActions /compress', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('routes through session.compress with a long timeout and renders the compression summary', async () => {
+    const states: Record<string, unknown>[] = []
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.compress') {
+        return {
+          removed: 5,
+          summary: {
+            headline: 'Compressed: 8 → 3 messages',
+            token_line: 'Approx request size: ~12,000 → ~4,000 tokens'
+          }
+        } as never
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => states.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/compress')
+
+    expect(requestGateway).toHaveBeenCalledWith('session.compress', { session_id: RUNTIME_SESSION_ID }, 120_000)
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+    expect(requestGateway).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
+    expect(renderedTextFrom(states)).toContain('Compressed: 8 → 3 messages')
+    expect(renderedTextFrom(states)).toContain('Approx request size: ~12,000 → ~4,000 tokens')
+  })
+
+  it('passes a focus topic through to session.compress', async () => {
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.compress') {
+        return { removed: 0 } as never
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    await handle!.submitText('/compress the auth refactor')
+
+    expect(requestGateway).toHaveBeenCalledWith(
+      'session.compress',
+      {
+        focus_topic: 'the auth refactor',
+        session_id: RUNTIME_SESSION_ID
+      },
+      120_000
+    )
+  })
+
+  it('surfaces session.compress busy errors directly', async () => {
+    const states: Record<string, unknown>[] = []
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.compress') {
+        throw new Error('session busy — /interrupt the current turn before /compress')
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => states.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/compress')
+
+    expect(renderedTextFrom(states)).toContain('error: session busy — /interrupt the current turn before /compress')
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -5,7 +5,7 @@ import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 import { getProfiles, transcribeAudio } from '@/hermes'
 import { translateNow, type Translations, useI18n } from '@/i18n'
 import { stripAnsi } from '@/lib/ansi'
-import { branchGroupForUser, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
+import { branchGroupForUser, type ChatMessage, chatMessageText, textPart, toChatMessages } from '@/lib/chat-messages'
 import {
   optimisticAttachmentRef,
   parseCommandDispatch,
@@ -54,6 +54,7 @@ import {
   $yoloActive,
   setAwaitingResponse,
   setBusy,
+  setCurrentUsage,
   setMessages,
   setModelPickerOpen,
   setSessionPickerOpen,
@@ -1126,6 +1127,7 @@ export function usePromptActions({
           const focusTopic = ctx.arg.trim()
 
           try {
+            renderSlashOutput(focusTopic ? `compressing context for: ${focusTopic}` : 'compressing context...')
             const result = await requestGateway<SessionCompressResponse>(
               'session.compress',
               {
@@ -1134,6 +1136,32 @@ export function usePromptActions({
               },
               SESSION_COMPRESS_TIMEOUT_MS
             )
+
+            if (result?.info?.usage) {
+              setCurrentUsage(current => ({ ...current, ...result.info!.usage }))
+            }
+
+            if (result?.info?.title !== undefined) {
+              setSessions(prev =>
+                prev.map(session =>
+                  session.id === sessionId ? { ...session, title: result.info!.title || null } : session
+                )
+              )
+            }
+
+            if (Array.isArray(result?.messages)) {
+              const compressedMessages = toChatMessages(result.messages)
+              setMessages(compressedMessages)
+              updateSessionState(
+                sessionId,
+                state => ({
+                  ...state,
+                  messages: compressedMessages
+                }),
+                selectedStoredSessionIdRef.current
+              )
+            }
+
             const summary = result?.summary
 
             if (summary?.headline) {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -230,7 +230,9 @@ type GatewayRequest = <T>(
   signal?: AbortSignal
 ) => Promise<T>
 
-const SESSION_COMPRESS_TIMEOUT_MS = 120_000
+// Compression can exceed the default JSON-RPC timeout for large contexts;
+// 0 disables the client timer so the backend can return its final transcript.
+const SESSION_COMPRESS_TIMEOUT_MS = 0
 
 /**
  * Stage one file/image attachment into the session workspace and return the

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -71,6 +71,7 @@ import type {
   HandoffRequestResponse,
   HandoffStateResponse,
   ImageAttachResponse,
+  SessionCompressResponse,
   SessionSteerResponse,
   SessionTitleResponse,
   SlashExecResponse
@@ -221,7 +222,14 @@ function friendlyRemoteAttachError(err: unknown, label: string): Error {
   return new Error(`${label} is too large to upload to the remote gateway${cap}.`)
 }
 
-type GatewayRequest = <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+type GatewayRequest = <T>(
+  method: string,
+  params?: Record<string, unknown>,
+  timeoutMs?: number,
+  signal?: AbortSignal
+) => Promise<T>
+
+const SESSION_COMPRESS_TIMEOUT_MS = 120_000
 
 /**
  * Stage one file/image attachment into the session workspace and return the
@@ -324,7 +332,7 @@ interface PromptActionsOptions {
   createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
   handleSkinCommand: (arg: string) => string
   refreshSessions: () => Promise<void>
-  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  requestGateway: GatewayRequest
   resumeStoredSession: (storedSessionId: string) => Promise<void> | void
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   startFreshSessionDraft: () => void
@@ -1043,6 +1051,8 @@ export function usePromptActions({
           await submitPromptText(message)
         }
 
+        let slashExecError: unknown = null
+
         try {
           const result = await requestGateway<unknown>('slash.exec', {
             session_id: sessionId,
@@ -1062,8 +1072,11 @@ export function usePromptActions({
           renderSlashOutput(output?.warning ? `warning: ${output.warning}\n${body}` : body)
 
           return
-        } catch {
-          // Fall back to command.dispatch for skill/send/alias directives.
+        } catch (err) {
+          // Fall back to command.dispatch for skill/send/alias directives. Keep
+          // the original error so worker failures do not get hidden behind a
+          // generic "not a quick/plugin/skill command" response.
+          slashExecError = err
         }
 
         try {
@@ -1079,7 +1092,16 @@ export function usePromptActions({
 
           await handleDispatch(dispatch)
         } catch (err) {
-          renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
+          const dispatchMessage = err instanceof Error ? err.message : String(err)
+
+          if (slashExecError && /not a quick\/plugin\/skill command/i.test(dispatchMessage)) {
+            const original = slashExecError instanceof Error ? slashExecError.message : String(slashExecError)
+            renderSlashOutput(`error: /${name} failed: ${original}`)
+
+            return
+          }
+
+          renderSlashOutput(`error: ${dispatchMessage}`)
         }
       }
 
@@ -1092,6 +1114,63 @@ export function usePromptActions({
         },
         branch: async () => {
           await branchCurrentSession()
+        },
+        compress: async ctx => {
+          const resolved = await withSlashOutput(ctx)
+
+          if (!resolved) {
+            return
+          }
+
+          const { render: renderSlashOutput, sessionId } = resolved
+          const focusTopic = ctx.arg.trim()
+
+          try {
+            const result = await requestGateway<SessionCompressResponse>(
+              'session.compress',
+              {
+                session_id: sessionId,
+                ...(focusTopic ? { focus_topic: focusTopic } : {})
+              },
+              SESSION_COMPRESS_TIMEOUT_MS
+            )
+            const summary = result?.summary
+
+            if (summary?.headline) {
+              renderSlashOutput(
+                [summary.headline, summary.token_line, summary.note]
+                  .filter((line): line is string => Boolean(line))
+                  .join('\n')
+              )
+
+              return
+            }
+
+            const beforeMessages = result?.before_messages
+            const afterMessages = result?.after_messages
+            const beforeTokens = result?.before_tokens
+            const afterTokens = result?.after_tokens
+
+            if (typeof beforeMessages === 'number' && typeof afterMessages === 'number') {
+              const headline =
+                beforeMessages === afterMessages
+                  ? `No changes from compression: ${afterMessages} messages`
+                  : `Compressed: ${beforeMessages} → ${afterMessages} messages`
+              const tokenLine =
+                typeof beforeTokens === 'number' && typeof afterTokens === 'number'
+                  ? `Approx request size: ~${beforeTokens.toLocaleString()} → ~${afterTokens.toLocaleString()} tokens`
+                  : null
+
+              renderSlashOutput([headline, tokenLine].filter((line): line is string => Boolean(line)).join('\n'))
+
+              return
+            }
+
+            const removed = result?.removed ?? 0
+            renderSlashOutput(removed > 0 ? `compressed ${removed} messages` : 'nothing to compress')
+          } catch (err) {
+            renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
+          }
         },
         // /yolo maps to the status-bar YOLO control — a per-session approval
         // bypass, same scope as the TUI's Shift+Tab. With no session yet we arm

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -1,6 +1,7 @@
 import type * as React from 'react'
 
 import type { ChatMessage } from '@/lib/chat-messages'
+import type { SessionMessage, UsageStats } from '@/types/hermes'
 
 export interface ContextSuggestion {
   text: string
@@ -57,6 +58,11 @@ export interface SessionCompressResponse {
   after_tokens?: number
   before_messages?: number
   before_tokens?: number
+  info?: {
+    title?: string
+    usage?: Partial<UsageStats>
+  }
+  messages?: SessionMessage[]
   removed?: number
   summary?: {
     headline?: string

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -52,6 +52,20 @@ export interface BrowserManageResponse {
   messages?: string[]
 }
 
+export interface SessionCompressResponse {
+  after_messages?: number
+  after_tokens?: number
+  before_messages?: number
+  before_tokens?: number
+  removed?: number
+  summary?: {
+    headline?: string
+    noop?: boolean
+    note?: null | string
+    token_line?: string
+  }
+}
+
 export interface SessionSteerResponse {
   // 'queued' == accepted into the live turn's steer slot (injected at the next
   // tool-result boundary); 'rejected' == no live tool window, caller queues.

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -73,6 +73,10 @@ describe('desktop slash command curation', () => {
     expect(resolveDesktopCommand('/browser')?.args).toBe(true)
   })
 
+  it('routes /compress through the desktop session.compress action', () => {
+    expect(resolveDesktopCommand('/compress')?.surface).toEqual({ kind: 'action', action: 'compress' })
+  })
+
   it('allows aliases to execute without cluttering the popover', () => {
     expect(isDesktopSlashSuggestion('/reset')).toBe(false)
     expect(isDesktopSlashCommand('/reset')).toBe(true)

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -31,6 +31,7 @@ export interface DesktopThemeCommandOption {
 export type DesktopActionId =
   | 'branch'
   | 'browser'
+  | 'compress'
   | 'handoff'
   | 'hatch'
   | 'help'
@@ -141,7 +142,7 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     surface: exec()
   },
   { name: '/background', description: 'Run a prompt in the background', aliases: ['/bg', '/btw'], surface: exec() },
-  { name: '/compress', description: 'Compress this conversation context', surface: exec() },
+  { name: '/compress', description: 'Compress this conversation context', surface: action('compress') },
   { name: '/debug', description: 'Create a debug report', surface: exec() },
   { name: '/goal', description: 'Manage the standing goal for this session', surface: exec() },
   { name: '/personality', description: 'Switch personality for this session', surface: exec(), args: true },


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop `/compress` taking the generic slash exec path, where compression can complete on the backend but the UI does not show an immediate "compressing" state and can still render the misleading fallback error:

`not a quick/plugin/skill command: compress`

Root cause: `/compress` was registered as a generic exec slash command even though Desktop needs to call the dedicated `session.compress` RPC and handle its structured response. For large conversations, compression can also run longer than the Desktop gateway client's default request timer, so a successful backend compression can be followed by a frontend-only `request timed out: session.compress` error.

The command is now handled as a Desktop action. The handler renders an inline compression-in-progress message before awaiting `session.compress`, disables the frontend JSON-RPC timer for that long-running RPC, applies the returned compressed transcript/title/usage when available, and renders the final manual-compression summary without falling through to `command.dispatch`.

This keeps the fix narrow while preserving the root-cause direction from #44462, whose patch no longer applies cleanly to current `main`. Broader context-usage hydration edge cases are intentionally left to a separate follow-up.

## Related Issue

Fixes #44456

Related: #44462

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/desktop-slash-commands.ts`
  - Registers `/compress` as a Desktop action instead of an exec command.
- `apps/desktop/src/app/session/hooks/use-prompt-actions.ts`
  - Adds a `compress` action handler that calls `session.compress` with optional `focus_topic`.
  - Disables the frontend JSON-RPC timeout for the long-running compression RPC.
  - Shows an inline `compressing context...` status immediately after the command is accepted.
  - Applies returned compression `messages` to the active transcript.
  - Applies returned `info.usage` when the compression RPC returns it.
  - Preserves the original `slash.exec` error when generic fallback errors are only unknown-command noise.
- `apps/desktop/src/app/types.ts`
  - Adds the `SessionCompressResponse` fields returned by `session.compress`.
- `apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx`
  - Covers immediate compression feedback, timeout-free `session.compress` routing, context usage application from the RPC response, transcript sync, focus-topic passthrough, busy errors, and absence of fallback `not a quick/plugin/skill command` noise.
- `apps/desktop/src/lib/desktop-slash-commands.test.ts`
  - Guards that `/compress` resolves to the Desktop action surface.

## How to Test

1. `npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-prompt-actions.test.tsx src/lib/desktop-slash-commands.test.ts`
2. `npm --workspace apps/desktop run typecheck`
3. `git diff --check`
4. `git merge-tree --write-tree upstream-https/main HEAD`

Observed results:

- 2 vitest files passed, 55 tests passed.
- Desktop typecheck passed.
- `git diff --check` passed.
- Merge-tree check against latest upstream `main` passed.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local checkout, automated vitest/typecheck only

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not attached. This change is covered by focused Desktop unit tests and typecheck.
