### PR TITLE
fix(desktop): settle in-progress todo spinner when turn ends

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -2216,6 +2216,7 @@ export function ChatBar({
               its own --status-stack-measured-height so the thread's clearance
               accounts for it. Collapses to nothing when every status is empty. */}
           <ComposerStatusStack
+            busy={busy}
             queue={
               activeQueueSessionKey && queuedPrompts.length > 0 ? (
                 <QueuePanel

--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -20,6 +20,7 @@ import {
   stopBackgroundProcess
 } from '@/store/composer-status'
 import { $previewStatusBySession, dismissPreviewArtifact } from '@/store/preview-status'
+import { $workingSessionIds } from '@/store/session'
 import { $threadScrolledUp } from '@/store/thread-scroll'
 import { openSessionInNewWindow } from '@/store/windows'
 
@@ -69,6 +70,7 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
   const itemsBySession = useStore($statusItemsBySession)
   const previewsBySession = useStore($previewStatusBySession)
   const scrolledUp = useStore($threadScrolledUp)
+  const workingSessionIds = useStore($workingSessionIds)
 
   const groups = useMemo(
     () => groupStatusItems(sessionId ? (itemsBySession[sessionId] ?? []) : []),
@@ -76,6 +78,7 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
   )
 
   const previews = sessionId ? (previewsBySession[sessionId] ?? []) : []
+  const sessionWorking = !!sessionId && workingSessionIds.includes(sessionId)
 
   // Seed from the registry on session open; event-driven refreshes (terminal /
   // process tool completions) live in use-message-stream.
@@ -145,6 +148,7 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
             key={item.id}
             onDismiss={sessionId ? id => dismissBackgroundProcess(sessionId, id) : undefined}
             onOpen={() => openSubagent(item)}
+            sessionWorking={sessionWorking}
             onStop={sessionId ? id => void stopBackgroundProcess(sessionId, id) : undefined}
           />
         ))}

--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -20,7 +20,6 @@ import {
   stopBackgroundProcess
 } from '@/store/composer-status'
 import { $previewStatusBySession, dismissPreviewArtifact } from '@/store/preview-status'
-import { $workingSessionIds } from '@/store/session'
 import { $threadScrolledUp } from '@/store/thread-scroll'
 import { openSessionInNewWindow } from '@/store/windows'
 
@@ -53,6 +52,9 @@ const groupLabel = (group: StatusGroup, s: Translations['statusStack']) => {
 }
 
 interface ComposerStatusStackProps {
+  /** Foreground turn state from ChatBar; in-progress todos animate only while
+   *  the visible session is actually running. */
+  busy?: boolean
   /** The queue, built by the composer (it owns the queue's callbacks). Rendered
    *  as the last group so it stays fused to the composer like before. */
   queue: ReactNode
@@ -64,13 +66,12 @@ interface ComposerStatusStackProps {
  * every session-scoped status — subagents, background tasks, queue — grouped by
  * type and separated by light dividers. Collapses to nothing when empty.
  */
-export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackProps) {
+export function ComposerStatusStack({ busy = false, queue, sessionId }: ComposerStatusStackProps) {
   const { t } = useI18n()
   const navigate = useNavigate()
   const itemsBySession = useStore($statusItemsBySession)
   const previewsBySession = useStore($previewStatusBySession)
   const scrolledUp = useStore($threadScrolledUp)
-  const workingSessionIds = useStore($workingSessionIds)
 
   const groups = useMemo(
     () => groupStatusItems(sessionId ? (itemsBySession[sessionId] ?? []) : []),
@@ -78,7 +79,7 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
   )
 
   const previews = sessionId ? (previewsBySession[sessionId] ?? []) : []
-  const sessionWorking = !!sessionId && workingSessionIds.includes(sessionId)
+  const sessionWorking = busy
 
   // Seed from the registry on session open; event-driven refreshes (terminal /
   // process tool completions) live in use-message-stream.

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { ComposerStatusItem } from '@/store/composer-status'
+
+import { StatusItemRow } from './status-row'
+
+const inProgressTodo: ComposerStatusItem = {
+  id: 'todo:1',
+  state: 'running',
+  title: 'Wire the status stack',
+  todoStatus: 'in_progress',
+  type: 'todo'
+}
+
+function renderRow(item: ComposerStatusItem, sessionWorking: boolean) {
+  return render(<StatusItemRow item={item} sessionWorking={sessionWorking} />)
+}
+
+describe('StatusItemRow in-progress todo spinner', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('spins while the owning session is working', () => {
+    renderRow(inProgressTodo, true)
+
+    expect(screen.getByRole('status')).toBeTruthy()
+  })
+
+  it('settles when the owning session is idle', () => {
+    renderRow(inProgressTodo, false)
+
+    expect(screen.queryByRole('status')).toBeNull()
+    expect(screen.getByText('Wire the status stack')).toBeTruthy()
+  })
+
+  it('keeps running background rows spinning regardless of sessionWorking', () => {
+    renderRow(
+      {
+        id: 'bg:1',
+        state: 'running',
+        title: 'npm run dev',
+        type: 'background'
+      },
+      false
+    )
+
+    expect(screen.getByRole('status')).toBeTruthy()
+  })
+
+  it('does not spin for a completed todo', () => {
+    renderRow(
+      {
+        ...inProgressTodo,
+        state: 'done',
+        todoStatus: 'completed'
+      },
+      true
+    )
+
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
@@ -1,8 +1,11 @@
 import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import type { ComposerStatusItem } from '@/store/composer-status'
+import { $todosBySession } from '@/store/todos'
 
+import { ComposerStatusStack } from './index'
 import { StatusItemRow } from './status-row'
 
 const inProgressTodo: ComposerStatusItem = {
@@ -18,8 +21,19 @@ function renderRow(item: ComposerStatusItem, sessionWorking: boolean) {
 }
 
 describe('StatusItemRow in-progress todo spinner', () => {
+  beforeAll(() => {
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        disconnect() {}
+        observe() {}
+      }
+    )
+  })
+
   afterEach(() => {
     cleanup()
+    $todosBySession.set({})
   })
 
   it('spins while the owning session is working', () => {
@@ -30,6 +44,35 @@ describe('StatusItemRow in-progress todo spinner', () => {
 
   it('settles when the owning session is idle', () => {
     renderRow(inProgressTodo, false)
+
+    expect(screen.queryByRole('status')).toBeNull()
+    expect(screen.getByText('Wire the status stack')).toBeTruthy()
+  })
+
+  it('keeps the visible session todo spinning from the chat busy signal', () => {
+    $todosBySession.set({
+      'session-1': [{ content: 'Wire the status stack', id: '1', status: 'in_progress' }]
+    })
+
+    render(
+      <MemoryRouter>
+        <ComposerStatusStack busy queue={null} sessionId="session-1" />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('status')).toBeTruthy()
+  })
+
+  it('settles the visible session todo when the chat is idle', () => {
+    $todosBySession.set({
+      'session-1': [{ content: 'Wire the status stack', id: '1', status: 'in_progress' }]
+    })
+
+    render(
+      <MemoryRouter>
+        <ComposerStatusStack queue={null} sessionId="session-1" />
+      </MemoryRouter>
+    )
 
     expect(screen.queryByRole('status')).toBeNull()
     expect(screen.getByText('Wire the status stack')).toBeTruthy()

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -27,9 +27,9 @@ const TODO_GLYPHS: Record<Exclude<TodoStatus, 'in_progress' | 'pending'>, { icon
   completed: { icon: 'pass-filled', tone: 'text-emerald-500/80' }
 }
 
-// Left slot: braille spinner while running, otherwise a small status dot
+// Left slot: braille spinner while actively running, otherwise a status glyph
 // (green = done, red = failed) so the slot is always filled and rows align.
-function leadingGlyph(item: ComposerStatusItem, s: Translations['statusStack']): ReactNode {
+function leadingGlyph(item: ComposerStatusItem, s: Translations['statusStack'], sessionWorking: boolean): ReactNode {
   if (item.todoStatus === 'pending') {
     return (
       <span
@@ -45,7 +45,9 @@ function leadingGlyph(item: ComposerStatusItem, s: Translations['statusStack']):
     return <Codicon className={glyph.tone} name={glyph.icon} size="0.8rem" />
   }
 
-  if (item.state === 'running') {
+  const isTodoInProgress = item.todoStatus === 'in_progress'
+
+  if (item.state === 'running' && (sessionWorking || !isTodoInProgress)) {
     return (
       <GlyphSpinner
         ariaLabel={s.running}
@@ -53,6 +55,10 @@ function leadingGlyph(item: ComposerStatusItem, s: Translations['statusStack']):
         spinner="braille"
       />
     )
+  }
+
+  if (isTodoInProgress) {
+    return <span aria-hidden className="box-border size-[0.7rem] rounded-full border border-muted-foreground/60" />
   }
 
   return (
@@ -70,6 +76,9 @@ interface StatusItemRowProps {
   /** Open the subagent's own session window, livestreamed by the gateway's
    *  child-session mirror (Agents view fallback for older gateways). */
   onOpen?: () => void
+  /** Whether this item's owning session currently has a running turn. Gates
+   *  the todo in-progress spinner so it can settle between turns. */
+  sessionWorking?: boolean
   /** Cancel a running background task. */
   onStop?: (id: string) => void
 }
@@ -79,7 +88,13 @@ interface StatusItemRowProps {
  * Memoised + keyed by id so parent re-renders never remount it (the spinner
  * keeps ticking instead of resetting).
  */
-export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOpen, onStop }: StatusItemRowProps) {
+export const StatusItemRow = memo(function StatusItemRow({
+  item,
+  onDismiss,
+  onOpen,
+  onStop,
+  sessionWorking = false
+}: StatusItemRowProps) {
   const { t } = useI18n()
   const s = t.statusStack
   const [outputOpen, setOutputOpen] = useState(false)
@@ -100,7 +115,7 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
   return (
     <Fragment>
       <StatusRow
-        leading={leadingGlyph(item, s)}
+        leading={leadingGlyph(item, s, sessionWorking)}
         onActivate={onActivate}
         trailing={
           action ? (


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop composer status stack showing an animated spinner forever for a todo left in `in_progress` after the visible chat turn has settled.

Root cause: todo rows map `todoStatus: 'in_progress'` to row `state: 'running'` so they remain visible between turns, but the row glyph previously treated that persisted state as proof that work was still happening. This made an idle session look active. The spinner now follows the foreground ChatBar `busy` state instead: an `in_progress` todo spins while the visible session is actually running and settles to a static hollow ring when the chat becomes idle. Running background rows still use their own running state.

This keeps the fix narrow while preserving the root-cause direction from #48741, whose patch no longer applies cleanly to current `main`.

## Related Issue

Fixes #42662

Related: #48741

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/app/chat/composer/index.tsx`
  - Passes the visible ChatBar `busy` state into the session status stack.
- `apps/desktop/src/app/chat/composer/status-stack/index.tsx`
  - Forwards the visible chat busy state to each status row as the live-turn signal.
- `apps/desktop/src/app/chat/composer/status-stack/status-row.tsx`
  - Keeps `in_progress` todo rows spinning only while the visible chat turn is busy.
  - Renders an idle `in_progress` todo as a static hollow ring.
  - Leaves running background rows spinning regardless of chat busy state.
- `apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx`
  - Adds focused regression tests for working/idle todo rows, full status-stack busy wiring, background rows, and completed todos.

## How to Test

1. `npm --workspace apps/desktop run test:ui -- src/app/chat/composer/status-stack/status-row.test.tsx src/store/todos.test.ts src/store/composer-status.test.ts`
2. `npm --workspace apps/desktop run typecheck`
3. `git diff --check`
4. `git merge-tree --write-tree upstream-https/main HEAD`

Observed results:

- 3 vitest files passed, 21 tests passed.
- Desktop typecheck passed.
- `git diff --check` passed.
- Merge-tree check against latest upstream `main` passed.

## Screenshots / Logs

Not attached. This change is covered by focused Desktop unit tests and typecheck.