### PR TITLE
fix(credential_files): use stable hermes-relative path for symlink-safe skills copy

### DIFF
--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -173,6 +173,71 @@ class TestSkillsDirectoryMount:
 
         assert mounts[0]["host_path"] == str(skills_dir)
 
+    def test_mount_source_is_stable_across_calls(self, tmp_path):
+        """Regression for #53630: sanitized mount source must be stable.
+
+        Once Hermes has returned a sanitized mount source for a skills dir
+        that contains a symlink, every subsequent call must return the *same*
+        path — never a fresh temp directory.  Otherwise a long-lived Docker
+        container that was bind-mounted to the old source loses its mount
+        contents the moment Hermes refreshes the copy.
+        """
+        hermes_home = tmp_path / ".hermes"
+        skills_dir = hermes_home / "skills"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "legit.md").write_text("# real skill")
+        # Force the symlink-sanitized code path.
+        secret = tmp_path / "secret.txt"
+        secret.write_text("TOP SECRET")
+        (skills_dir / "evil_link").symlink_to(secret)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            first = get_skills_directory_mount()[0]["host_path"]
+            second = get_skills_directory_mount()[0]["host_path"]
+            third = get_skills_directory_mount()[0]["host_path"]
+
+        # The mount source must be stable across all calls.
+        assert first == second == third
+        # And it must live under a stable hermes-relative path, never
+        # /var/folders or /tmp (which is what broke long-lived containers).
+        assert first.startswith(str(hermes_home))
+        assert "hermes-skills-safe-" not in first
+        # The directory itself must still exist on disk.
+        assert Path(first).is_dir()
+        # And the legitimate file must be present.
+        assert (Path(first) / "legit.md").is_file()
+
+    def test_mount_source_refreshes_in_place(self, tmp_path):
+        """Regression for #53630: contents must be refreshed in place.
+
+        Adding a new non-symlink file to the source skills dir must show up
+        in the sanitized copy on the next call — without the copy's path
+        changing and without any prior files being lost.
+        """
+        hermes_home = tmp_path / ".hermes"
+        skills_dir = hermes_home / "skills"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "old.md").write_text("old content")
+        secret = tmp_path / "secret.txt"
+        secret.write_text("TOP SECRET")
+        (skills_dir / "evil_link").symlink_to(secret)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            first = get_skills_directory_mount()[0]["host_path"]
+            # Add a new file after the first call.
+            (skills_dir / "new.md").write_text("new content")
+            second = get_skills_directory_mount()[0]["host_path"]
+
+        # The path is stable.
+        assert first == second
+        safe_path = Path(first)
+        # Old content survives.
+        assert (safe_path / "old.md").read_text() == "old content"
+        # New content is present.
+        assert (safe_path / "new.md").read_text() == "new content"
+        # Symlink remains excluded.
+        assert not (safe_path / "evil_link").exists()
+
 
 class TestIterSkillsFiles:
     def test_returns_files_skipping_symlinks(self, tmp_path):

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -238,6 +238,73 @@ class TestSkillsDirectoryMount:
         # Symlink remains excluded.
         assert not (safe_path / "evil_link").exists()
 
+    def test_mount_source_handles_file_to_dir_transition(self, tmp_path):
+        """A source path changing from a file to a directory must not raise.
+
+        Regression: `expected` used to track only the path, not its kind.  If
+        ``foo`` went from a file to a directory, the old ``safe_dir/foo`` file
+        was retained and ``target.mkdir()`` raised ``FileExistsError``.
+        """
+        hermes_home = tmp_path / ".hermes"
+        skills_dir = hermes_home / "skills"
+        skills_dir.mkdir(parents=True)
+        # Force the symlink-sanitized path so we exercise the copy refresh.
+        secret = tmp_path / "secret.txt"
+        secret.write_text("TOP SECRET")
+        (skills_dir / "evil_link").symlink_to(secret)
+        # Start with a file at the transition path.
+        (skills_dir / "foo").write_text("file content")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            first = get_skills_directory_mount()[0]["host_path"]
+            safe_path = Path(first)
+            assert (safe_path / "foo").is_file()
+            assert (safe_path / "foo").read_text() == "file content"
+
+            # Replace the source file with a directory of the same name.
+            (skills_dir / "foo").unlink()
+            (skills_dir / "foo").mkdir()
+            (skills_dir / "foo" / "inner.md").write_text("inner content")
+            second = get_skills_directory_mount()[0]["host_path"]
+
+        # Path stays stable and the transition is handled cleanly.
+        assert first == second
+        assert (safe_path / "foo").is_dir()
+        assert (safe_path / "foo" / "inner.md").read_text() == "inner content"
+
+    def test_mount_source_handles_dir_to_file_transition(self, tmp_path):
+        """A source path changing from a directory to a file must copy correctly.
+
+        Regression: the reverse transition — ``foo`` going from a directory to
+        a file — used to copy into the stale ``safe_dir/foo`` directory instead
+        of replacing it with a file.
+        """
+        hermes_home = tmp_path / ".hermes"
+        skills_dir = hermes_home / "skills"
+        skills_dir.mkdir(parents=True)
+        secret = tmp_path / "secret.txt"
+        secret.write_text("TOP SECRET")
+        (skills_dir / "evil_link").symlink_to(secret)
+        # Start with a directory at the transition path.
+        (skills_dir / "foo").mkdir()
+        (skills_dir / "foo" / "old.md").write_text("old inner content")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            first = get_skills_directory_mount()[0]["host_path"]
+            safe_path = Path(first)
+            assert (safe_path / "foo").is_dir()
+
+            # Replace the source directory with a file of the same name.
+            (skills_dir / "foo" / "old.md").unlink()
+            (skills_dir / "foo").rmdir()
+            (skills_dir / "foo").write_text("now a file")
+            second = get_skills_directory_mount()[0]["host_path"]
+
+        # Path stays stable and the stale directory was replaced by a file.
+        assert first == second
+        assert (safe_path / "foo").is_file()
+        assert (safe_path / "foo").read_text() == "now a file"
+
 
 class TestIterSkillsFiles:
     def test_returns_files_skipping_symlinks(self, tmp_path):

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -245,12 +245,17 @@ def get_skills_directory_mount(
     return mounts
 
 
-_safe_skills_tempdir: Path | None = None
-
-
 def _safe_skills_path(skills_dir: Path) -> str:
-    """Return *skills_dir* if symlink-free, else a sanitized temp copy."""
-    global _safe_skills_tempdir
+    """Return *skills_dir* if symlink-free, else a sanitized copy.
+
+    The sanitized copy lives at a stable, host-relative path under
+    ``$HERMES_HOME/sandboxes/skills-safe/<hash>`` derived from the canonical
+    skills dir.  Contents are refreshed in place on every call — the directory
+    itself is never deleted, so a Docker container bind-mounted to it stays
+    valid across multiple invocations.  See #53630.
+    """
+    import hashlib
+    import shutil
 
     symlinks = [p for p in skills_dir.rglob("*") if p.is_symlink()]
     if not symlinks:
@@ -260,17 +265,65 @@ def _safe_skills_path(skills_dir: Path) -> str:
         logger.warning("credential_files: skipping symlink in skills dir: %s -> %s",
                        link, os.readlink(link))
 
-    import atexit
+    # Stable, hermes-relative path.  The hash mixes in a literal "skills-safe"
+    # marker so this never collides with other sandbox state under the same
+    # hermes home.  Resolve the skills_dir so symlinked skills homes still
+    # produce a deterministic key.
+    try:
+        canonical = str(skills_dir.resolve())
+    except OSError:
+        canonical = str(skills_dir)
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+    hermes_home = _resolve_hermes_home()
+    safe_dir = hermes_home / "sandboxes" / "skills-safe" / digest
+    safe_dir.mkdir(parents=True, exist_ok=True)
+
+    # Refresh contents in place: remove any stale entries, then copy the
+    # non-symlink subset.  We deliberately never rmtree(safe_dir) — the dir
+    # is a bind-mount source for live Docker containers and removing it
+    # would invalidate those mounts (issue #53630).
+    _refresh_skills_copy(skills_dir, safe_dir)
+
+    logger.info("credential_files: stable symlink-safe skills copy at %s", safe_dir)
+    return str(safe_dir)
+
+
+def _refresh_skills_copy(skills_dir: Path, safe_dir: Path) -> None:
+    """Refresh *safe_dir* with a symlink-free copy of *skills_dir* in place.
+
+    Removes stale files and empty directories that no longer exist in the
+    source, then copies over the current non-symlink contents.  Never touches
+    the safe_dir itself — see the comment in :func:`_safe_skills_path` for why.
+    """
     import shutil
-    import tempfile
 
-    # Reuse the same temp dir across calls to avoid accumulation.
-    if _safe_skills_tempdir and _safe_skills_tempdir.is_dir():
-        shutil.rmtree(_safe_skills_tempdir, ignore_errors=True)
+    # Build the set of relative paths that should exist (non-symlink entries).
+    expected: set = set()
+    for item in skills_dir.rglob("*"):
+        if item.is_symlink():
+            continue
+        expected.add(item.relative_to(skills_dir))
 
-    safe_dir = Path(tempfile.mkdtemp(prefix="hermes-skills-safe-"))
-    _safe_skills_tempdir = safe_dir
+    # Remove stale entries that no longer correspond to anything in the source.
+    if safe_dir.exists():
+        for existing in safe_dir.rglob("*"):
+            try:
+                rel = existing.relative_to(safe_dir)
+            except ValueError:
+                continue
+            if rel in expected:
+                continue
+            try:
+                if existing.is_dir() and not existing.is_symlink():
+                    # Leave empty dirs alone — they get cleaned if they become
+                    # empty via the rmdir pass below.
+                    continue
+                existing.unlink()
+            except FileNotFoundError:
+                pass
 
+    # Now copy the current contents.
     for item in skills_dir.rglob("*"):
         if item.is_symlink():
             continue
@@ -282,13 +335,13 @@ def _safe_skills_path(skills_dir: Path) -> str:
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(str(item), str(target))
 
-    def _cleanup():
-        if safe_dir.is_dir():
-            shutil.rmtree(safe_dir, ignore_errors=True)
-
-    atexit.register(_cleanup)
-    logger.info("credential_files: created symlink-safe skills copy at %s", safe_dir)
-    return str(safe_dir)
+    # Best-effort: prune now-empty directories (top-down, safe because rmdir
+    # only succeeds on empty dirs).
+    for dirpath in [p for p in safe_dir.rglob("*") if p.is_dir()]:
+        try:
+            dirpath.rmdir()
+        except OSError:
+            pass
 
 
 def iter_skills_files(

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -298,30 +298,49 @@ def _refresh_skills_copy(skills_dir: Path, safe_dir: Path) -> None:
     """
     import shutil
 
-    # Build the set of relative paths that should exist (non-symlink entries).
-    expected: set = set()
+    # Build the map of relative paths that should exist (non-symlink entries)
+    # together with the kind (file vs directory) each must be.  Tracking the
+    # kind matters: if a source entry changes from a file to a directory (or
+    # vice versa) between calls, the old *safe_dir* entry has the wrong kind
+    # and must be removed before we copy — otherwise ``mkdir`` raises
+    # ``FileExistsError`` (file -> dir) or we copy into a stale directory
+    # (dir -> file).
+    expected: Dict[str, str] = {}
     for item in skills_dir.rglob("*"):
         if item.is_symlink():
             continue
-        expected.add(item.relative_to(skills_dir))
+        rel = str(item.relative_to(skills_dir))
+        expected[rel] = "dir" if item.is_dir() else "file"
 
-    # Remove stale entries that no longer correspond to anything in the source.
+    # Remove stale or incompatible destination entries.  We snapshot the
+    # listing first because removing entries mid-iteration can skip items.
     if safe_dir.exists():
-        for existing in safe_dir.rglob("*"):
+        for existing in list(safe_dir.rglob("*")):
             try:
-                rel = existing.relative_to(safe_dir)
+                rel = str(existing.relative_to(safe_dir))
             except ValueError:
                 continue
-            if rel in expected:
-                continue
-            try:
+            expected_kind = expected.get(rel)
+            if expected_kind is None:
+                # Truly stale — no matching source entry.
                 if existing.is_dir() and not existing.is_symlink():
-                    # Leave empty dirs alone — they get cleaned if they become
-                    # empty via the rmdir pass below.
-                    continue
-                existing.unlink()
-            except FileNotFoundError:
-                pass
+                    shutil.rmtree(existing, ignore_errors=True)
+                else:
+                    try:
+                        existing.unlink()
+                    except FileNotFoundError:
+                        pass
+                continue
+            # Same path still exists in the source, but its kind changed.
+            if existing.is_dir() and not existing.is_symlink():
+                if expected_kind != "dir":
+                    shutil.rmtree(existing, ignore_errors=True)
+            elif existing.is_file():
+                if expected_kind != "file":
+                    try:
+                        existing.unlink()
+                    except FileNotFoundError:
+                        pass
 
     # Now copy the current contents.
     for item in skills_dir.rglob("*"):


### PR DESCRIPTION
Fixes #53630

## Description

When `~/.hermes/skills` contains a symlink, Hermes creates a sanitized copy of the skills tree and bind-mounts that into Docker at `/root/.hermes/skills`. The previous implementation placed that copy in a `tempfile.mkdtemp(prefix="hermes-skills-safe-")` directory under the OS temp area, then on every later call to `get_skills_directory_mount()` it `shutil.rmtree`'d the previous copy and created a new one. Any long-lived Docker container that had been bind-mounted to the old source immediately lost its contents — the in-container mount became an empty read-only tmpfs — so skill helper scripts that lived there started failing with `No such file or directory` even though the agent had been told the correct path.

This change replaces the ephemeral temp directory with a deterministic, hermes-relative mount source:

- `safe_dir = $HERMES_HOME/sandboxes/skills-safe/<sha256[:16]>`, where the hash is over the canonical (resolved) source skills path.
- The directory is never deleted after it has been used as a bind source — Docker containers that were attached to it stay valid.
- Contents are refreshed in place: stale non-symlink entries that no longer exist in the source are removed, the current non-symlink subset is copied over, and any directories that end up empty are pruned. Symlinks are still excluded entirely.
- A per-skills-dir hash key means external skills dirs each get their own stable mount source instead of all sharing one global temp dir.

## Verification

- `pytest tests/tools/test_credential_files.py -q` — 35 passed (33 pre-existing + 2 new regression tests).
- New regression tests:
  - `test_mount_source_is_stable_across_calls` — three back-to-back calls to `get_skills_directory_mount()` all return the same `host_path` and that path is anchored under `HERMES_HOME` (not the OS temp area).
  - `test_mount_source_refreshes_in_place` — adding a new file to the source skills dir after the first call shows up in the sanitized copy on the next call, with the mount path unchanged and the symlink still excluded.
- Compiles cleanly: `python -c "import tools.credential_files"` succeeds.
- Quality gates S1 (secrets) and S2 (personal refs) clean; C1 conventional-commit format; F1 diff limited to the two files above.