### PR TITLE
[codex] Add ClawOps agent orchestration bridge

### DIFF
--- a/plugins/openclaw_bridge/__init__.py
+++ b/plugins/openclaw_bridge/__init__.py
@@ -1,0 +1,58 @@
+"""Local OpenClaw delegation bridge plugin."""
+
+from __future__ import annotations
+
+from .schemas import OPENCLAW_DELEGATE
+from .tools import (
+    _env_ready,
+    handle_clawops_approve_command,
+    handle_clawops_command,
+    handle_clawops_run_command,
+    handle_openclaw_dry_run_command,
+    openclaw_delegate,
+    pre_gateway_dispatch,
+    set_clawops_host_llm,
+)
+
+
+def register(ctx) -> None:
+    """Register the OpenClaw delegation tool."""
+    try:
+        set_clawops_host_llm(ctx.llm)
+    except Exception:
+        set_clawops_host_llm(None)
+
+    ctx.register_tool(
+        name="openclaw_delegate",
+        toolset="openclaw_bridge",
+        schema=OPENCLAW_DELEGATE,
+        handler=openclaw_delegate,
+        check_fn=_env_ready,
+        description="Delegate approved mock-safe dry-run tasks to local OpenClaw.",
+        emoji="OC",
+    )
+    ctx.register_command(
+        "openclaw-dry-run",
+        handle_openclaw_dry_run_command,
+        description="Delegate an approved OpenClaw dry-run task.",
+        args_hint="<request>",
+    )
+    ctx.register_command(
+        "clawops",
+        handle_clawops_command,
+        description="Assign a task to ClawOps agents without external side effects.",
+        args_hint="<request>",
+    )
+    ctx.register_command(
+        "clawops-run",
+        handle_clawops_run_command,
+        description="Alias for /clawops.",
+        args_hint="<request>",
+    )
+    ctx.register_command(
+        "clawops-approve",
+        handle_clawops_approve_command,
+        description="Execute a pending ClawOps approval by id.",
+        args_hint="<approval_id>",
+    )
+    ctx.register_hook("pre_gateway_dispatch", pre_gateway_dispatch)

--- a/plugins/openclaw_bridge/plugin.yaml
+++ b/plugins/openclaw_bridge/plugin.yaml
@@ -1,0 +1,7 @@
+name: openclaw_bridge
+version: 1.0.0
+description: "Local OpenClaw delegation bridge for mock-safe dry-run tasks. Calls the OpenClaw hermes-bridge plugin over localhost/private HTTP."
+author: local
+kind: backend
+provides_tools:
+  - openclaw_delegate

--- a/plugins/openclaw_bridge/schemas.py
+++ b/plugins/openclaw_bridge/schemas.py
@@ -1,0 +1,57 @@
+"""Tool schema for the local OpenClaw bridge."""
+
+OPENCLAW_DELEGATE = {
+    "name": "openclaw_delegate",
+    "description": (
+        "Delegate an approved mock-safe dry-run task to the local OpenClaw "
+        "hermes-bridge plugin. Use only when the user explicitly asks Hermes "
+        "to have OpenClaw handle a task and the request is a dry-run. V1 only "
+        "supports taskId='tasks.organize_today' or taskId='agents.ask_team' and performs no external side effects."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "taskId": {
+                "type": "string",
+                "enum": ["tasks.organize_today", "agents.ask_team"],
+                "description": "Approved OpenClaw bridge task template. Use agents.ask_team only for dry-run OpenClaw team delegation.",
+            },
+            "intent": {
+                "type": "string",
+                "description": "The user's original delegation request.",
+            },
+            "dryRun": {
+                "type": "boolean",
+                "description": "Must be true. Non-dry-run execution is blocked in v1.",
+            },
+            "allowedTools": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Must be an empty array in v1.",
+            },
+            "input": {
+                "type": "object",
+                "description": "Task input passed to OpenClaw. For tasks.organize_today, include request. For agents.ask_team, include team and question.",
+                "properties": {
+                    "request": {
+                        "type": "string",
+                        "description": "The user's original request.",
+                    },
+                    "team": {
+                        "type": "string",
+                        "description": "OpenClaw team name for agents.ask_team. Use openclaw in v1.",
+                    },
+                    "question": {
+                        "type": "string",
+                        "description": "The dry-run question for the OpenClaw agent team.",
+                    },
+                },
+            },
+            "requestId": {
+                "type": "string",
+                "description": "Optional idempotency key for the OpenClaw bridge request.",
+            },
+        },
+        "required": ["taskId", "intent", "dryRun", "allowedTools", "input"],
+    },
+}

--- a/plugins/openclaw_bridge/tools.py
+++ b/plugins/openclaw_bridge/tools.py
@@ -1,0 +1,1181 @@
+"""Tool handler for the local OpenClaw bridge."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import re
+import ssl
+import urllib.error
+import urllib.request
+from typing import Any
+from datetime import datetime, timezone
+import uuid
+
+import yaml
+
+
+ALLOWED_TASKS = {"tasks.organize_today", "agents.ask_team"}
+OPENCLAW_GATEWAY_URL_ENV = "OPENCLAW_GATEWAY_URL"
+OPENCLAW_GATEWAY_TOKEN_ENV = "OPENCLAW_GATEWAY_TOKEN"
+OPENCLAW_HERMES_BRIDGE_TOKEN_ENV = "OPENCLAW_HERMES_BRIDGE_TOKEN"
+CLAWOPS_HOME_ENV = "CLAWOPS_HOME"
+CLAWOPS_GEMINI_BASE_URL_ENV = "CLAWOPS_GEMINI_BASE_URL"
+CLAWOPS_GEMINI_31_PRO_MODEL_ENV = "CLAWOPS_GEMINI_31_PRO_MODEL"
+CLAWOPS_APPROVALS_DIR_ENV = "CLAWOPS_APPROVALS_DIR"
+GOOGLE_API_KEY_ENV = "GOOGLE_API_KEY"
+GEMINI_API_KEY_ENV = "GEMINI_API_KEY"
+_CLAWOPS_HOST_LLM: Any = None
+_CLAWOPS_CODEX_APP_SERVER_ENABLED: bool | None = None
+_CLAWOPS_CODEX_APP_SERVER_SESSION_FACTORY: Any = None
+
+
+def _json_result(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+
+def set_clawops_host_llm(llm: Any) -> None:
+    global _CLAWOPS_HOST_LLM
+    _CLAWOPS_HOST_LLM = llm
+
+
+def get_clawops_host_llm() -> Any:
+    return _CLAWOPS_HOST_LLM
+
+
+def set_clawops_codex_app_server_enabled(enabled: bool | None) -> None:
+    global _CLAWOPS_CODEX_APP_SERVER_ENABLED
+    _CLAWOPS_CODEX_APP_SERVER_ENABLED = enabled
+
+
+def set_clawops_codex_app_server_session_factory(factory: Any) -> None:
+    global _CLAWOPS_CODEX_APP_SERVER_SESSION_FACTORY
+    _CLAWOPS_CODEX_APP_SERVER_SESSION_FACTORY = factory
+
+
+def _env_ready() -> bool:
+    return all(
+        os.getenv(name)
+        for name in (
+            OPENCLAW_GATEWAY_URL_ENV,
+            OPENCLAW_GATEWAY_TOKEN_ENV,
+            OPENCLAW_HERMES_BRIDGE_TOKEN_ENV,
+        )
+    )
+
+
+def _read_string(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _read_object(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _read_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    items: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        normalized = _read_string(item)
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            items.append(normalized)
+    return items
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _clawops_approvals_dir() -> Path:
+    configured = _read_string(os.getenv(CLAWOPS_APPROVALS_DIR_ENV))
+    if configured:
+        return Path(configured)
+    return Path.home() / ".hermes" / "clawops_approvals"
+
+
+def _approval_id() -> str:
+    return f"clawops-{datetime.now(timezone.utc).strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
+
+
+def _approval_path(approval_id: str) -> Path:
+    normalized = _read_string(approval_id) or ""
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+", normalized):
+        raise ValueError("Invalid ClawOps approval id.")
+    return _clawops_approvals_dir() / f"{normalized}.json"
+
+
+def _load_approval(approval_id: str) -> dict[str, Any]:
+    path = _approval_path(approval_id)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"ClawOps approval not found: {approval_id}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("ClawOps approval file is not an object.")
+    return data
+
+
+def _save_approval(record: dict[str, Any]) -> None:
+    approval_id = _read_string(record.get("id"))
+    if not approval_id:
+        raise ValueError("ClawOps approval record is missing id.")
+    directory = _clawops_approvals_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    _approval_path(approval_id).write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _normalize_clawops_actions(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    actions: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        action_type = _read_string(item.get("type"))
+        if not action_type:
+            continue
+        actions.append(
+            {
+                "type": action_type,
+                "description": _read_string(item.get("description")) or action_type,
+                "payload": item.get("payload") if isinstance(item.get("payload"), dict) else {},
+            }
+        )
+    return actions
+
+
+def _clawops_actions_from_args(args: dict[str, Any], result: dict[str, Any]) -> list[dict[str, Any]]:
+    actions = _normalize_clawops_actions(args.get("actions"))
+    if actions:
+        return actions
+    return _normalize_clawops_actions(result.get("actions") or result.get("proposedActions"))
+
+
+def _attach_approval_if_needed(result: dict[str, Any], args: dict[str, Any]) -> dict[str, Any]:
+    if result.get("ok") is not True or result.get("approvalRequired") is not True:
+        return result
+
+    actions = _clawops_actions_from_args(args, result)
+    approval_id = _approval_id()
+    record = {
+        "id": approval_id,
+        "status": "pending",
+        "createdAt": _utc_now_iso(),
+        "request": _normalize_task_value(args.get("request")) or _normalize_task_value(args.get("intent")),
+        "project": result.get("project"),
+        "taskType": result.get("taskType"),
+        "assignedAgent": result.get("assignedAgent"),
+        "modelUsed": result.get("modelUsed"),
+        "output": result.get("output"),
+        "actions": actions,
+    }
+    _save_approval(record)
+    enriched = dict(result)
+    enriched["approvalId"] = approval_id
+    enriched["approvalStatus"] = "pending"
+    enriched["executableActions"] = len(actions)
+    return enriched
+
+
+def _execute_audit_record_action(action: dict[str, Any], approval: dict[str, Any]) -> dict[str, Any]:
+    entry = {
+        "at": _utc_now_iso(),
+        "approvalId": approval.get("id"),
+        "actionType": action.get("type"),
+        "description": action.get("description"),
+        "payload": action.get("payload") if isinstance(action.get("payload"), dict) else {},
+    }
+    audit_path = _clawops_approvals_dir() / "audit.log"
+    with audit_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, ensure_ascii=False, sort_keys=True) + "\n")
+    return {"ok": True, "status": "executed", "type": "audit.record"}
+
+
+def _execute_clawops_action(action: dict[str, Any], approval: dict[str, Any]) -> dict[str, Any]:
+    action_type = _read_string(action.get("type")) or "unknown"
+    if action_type == "audit.record":
+        return _execute_audit_record_action(action, approval)
+    return {
+        "ok": False,
+        "status": "blocked",
+        "error": "unsupported_action",
+        "message": f"ClawOps action type '{action_type}' is not allowlisted yet.",
+        "type": action_type,
+    }
+
+
+def execute_clawops_approved_actions(approval_id: str) -> dict[str, Any]:
+    try:
+        approval = _load_approval(approval_id)
+    except (FileNotFoundError, ValueError) as exc:
+        return {
+            "ok": False,
+            "status": "blocked",
+            "error": "approval_not_found",
+            "message": str(exc),
+            "approvalId": _read_string(approval_id) or "unknown",
+            "externalSideEffects": False,
+        }
+
+    current_status = _read_string(approval.get("status")) or "unknown"
+    if current_status != "pending":
+        return {
+            "ok": False,
+            "status": "blocked",
+            "error": "approval_not_pending",
+            "message": f"ClawOps approval is '{current_status}', not pending.",
+            "approvalId": approval.get("id"),
+            "externalSideEffects": False,
+        }
+
+    actions = _normalize_clawops_actions(approval.get("actions"))
+    if not actions:
+        approval["status"] = "blocked"
+        approval["blockedAt"] = _utc_now_iso()
+        approval["error"] = "no_actions"
+        _save_approval(approval)
+        return {
+            "ok": False,
+            "status": "blocked",
+            "error": "no_actions",
+            "message": "ClawOps approval has no executable actions.",
+            "approvalId": approval.get("id"),
+            "externalSideEffects": False,
+        }
+
+    executed: list[dict[str, Any]] = []
+    for action in actions:
+        action_result = _execute_clawops_action(action, approval)
+        executed.append(action_result)
+        if action_result.get("ok") is not True:
+            approval["status"] = "blocked"
+            approval["blockedAt"] = _utc_now_iso()
+            approval["results"] = executed
+            approval["error"] = action_result.get("error")
+            _save_approval(approval)
+            return {
+                "ok": False,
+                "status": "blocked",
+                "error": _read_string(action_result.get("error")) or "action_failed",
+                "message": _read_string(action_result.get("message")) or "ClawOps action did not execute.",
+                "approvalId": approval.get("id"),
+                "executedActions": sum(1 for item in executed if item.get("ok") is True),
+                "externalSideEffects": False,
+                "results": executed,
+            }
+
+    approval["status"] = "executed"
+    approval["executedAt"] = _utc_now_iso()
+    approval["results"] = executed
+    _save_approval(approval)
+    return {
+        "ok": True,
+        "status": "executed",
+        "approvalId": approval.get("id"),
+        "executedActions": len(executed),
+        "externalSideEffects": True,
+        "results": executed,
+    }
+
+
+def _clawops_docs_root() -> Path:
+    configured = _read_string(os.getenv(CLAWOPS_HOME_ENV))
+    if configured:
+        return Path(configured)
+
+    candidates = [
+        Path("/Users/kj/my_agent_team/docs/projects/hub-ops"),
+        Path.cwd() / "docs" / "projects" / "hub-ops",
+        Path.cwd().parent / "docs" / "projects" / "hub-ops",
+    ]
+    for candidate in candidates:
+        if (candidate / "agent-registry.yaml").is_file() and (candidate / "routing-rules.yaml").is_file():
+            return candidate
+    return candidates[0]
+
+
+def _load_yaml_file(path: Path) -> dict[str, Any]:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise FileNotFoundError(f"ClawOps config file not found: {path}") from exc
+    if isinstance(data, dict):
+        return data
+    return {}
+
+
+def _normalize_task_value(value: Any) -> str:
+    text = _read_string(value)
+    return text or ""
+
+
+def _infer_clawops_project(text: str) -> str:
+    normalized = text.lower()
+    if "hahow" in normalized or "課程" in text:
+        return "hahow_course"
+    if "二手" in text or "secondhand" in normalized:
+        return "secondhand_commerce"
+    if "ingrids" in normalized or "網格" in text:
+        return "ingrids_marketing"
+    if "行銷" in text or "招生" in text or "marketing" in normalized:
+        return "course_marketing"
+    return "hub_ops"
+
+
+def _infer_clawops_task_type(project: str, text: str) -> str:
+    normalized = text.lower()
+    if project == "hahow_course":
+        return "course_design"
+    if project == "secondhand_commerce":
+        return "commerce_listing"
+    if project == "ingrids_marketing":
+        return "product_marketing"
+    if "crm" in normalized or "名單" in text or "跟進" in text:
+        return "crm"
+    if "報告" in text or "週報" in text or "analytics" in normalized:
+        return "analytics"
+    if "部署" in text or "config" in normalized or "設定" in text:
+        return "devops"
+    if "策略" in text or "strategy" in normalized:
+        return "strategy"
+    if project == "course_marketing":
+        return "campaign"
+    return "strategy"
+
+
+def _clawops_registry_context() -> str:
+    docs_root = _clawops_docs_root()
+    try:
+        registry = _load_yaml_file(docs_root / "agent-registry.yaml")
+    except FileNotFoundError as exc:
+        return f"ClawOps registry context unavailable: {exc}"
+
+    agents = registry.get("agents") if isinstance(registry.get("agents"), dict) else {}
+    models = registry.get("models") if isinstance(registry.get("models"), dict) else {}
+    lines = [
+        "ClawOps registry context:",
+        "Use this as grounding. Do not invent generic agent groups when answering responsibility/model questions.",
+        "Agents:",
+    ]
+    for agent_id, agent in agents.items():
+        if not isinstance(agent, dict):
+            continue
+        display_name = _normalize_task_value(agent.get("display_name")) or str(agent_id)
+        role = _normalize_task_value(agent.get("role")) or "unknown"
+        primary_model = _normalize_task_value(agent.get("primary_model")) or "unknown"
+        fallback_model = _normalize_task_value(agent.get("fallback_model")) or "unknown"
+        approval = "yes" if agent.get("approval_required") else "no"
+        lines.append(
+            f"- {display_name} ({agent_id}): role={role}; primary_model={primary_model}; "
+            f"fallback_model={fallback_model}; approval_required={approval}"
+        )
+
+    if models:
+        lines.append("Model policies:")
+        for model_id, model in models.items():
+            if not isinstance(model, dict):
+                continue
+            purpose = _normalize_task_value(model.get("purpose")) or "not specified"
+            provider = _normalize_task_value(model.get("provider")) or "unknown"
+            lines.append(f"- {model_id}: provider={provider}; purpose={purpose}")
+    return "\n".join(lines)
+
+
+def _match_route(route_match: dict[str, Any], task: dict[str, Any]) -> bool:
+    for key, expected in route_match.items():
+        actual = task.get(key)
+        if actual != expected:
+            return False
+    return True
+
+
+def _select_clawops_route(routing_rules: dict[str, Any], task: dict[str, Any]) -> dict[str, Any]:
+    for route in routing_rules.get("routes", []):
+        if not isinstance(route, dict):
+            continue
+        route_match = route.get("match")
+        assignment = route.get("assign")
+        if isinstance(route_match, dict) and isinstance(assignment, dict) and _match_route(route_match, task):
+            return assignment
+    default_route = routing_rules.get("default_route")
+    if isinstance(default_route, dict):
+        return default_route
+    return {"agent": "orchestrator", "approval_required": True, "model_policy": "use_agent_primary"}
+
+
+def _model_for_policy(policy: str, agent: dict[str, Any]) -> str:
+    if policy == "force_codex":
+        return "codex"
+    return _normalize_task_value(agent.get("primary_model")) or "codex"
+
+
+def route_clawops_task(args: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+    """Route a ClawOps task locally without external side effects."""
+    del kwargs
+
+    request_text = _normalize_task_value(args.get("request")) or _normalize_task_value(args.get("intent"))
+    project = _normalize_task_value(args.get("project")) or _infer_clawops_project(request_text)
+    task_type = _normalize_task_value(args.get("taskType")) or _normalize_task_value(args.get("task_type"))
+    if not task_type:
+        task_type = _infer_clawops_task_type(project, request_text)
+    risk_level = _normalize_task_value(args.get("riskLevel")) or _normalize_task_value(args.get("risk_level")) or "low"
+
+    docs_root = _clawops_docs_root()
+    try:
+        registry = _load_yaml_file(docs_root / "agent-registry.yaml")
+        routing_rules = _load_yaml_file(docs_root / "routing-rules.yaml")
+    except FileNotFoundError as exc:
+        return {
+            "ok": False,
+            "status": "blocked",
+            "error": "missing_clawops_config",
+            "message": str(exc),
+            "dryRun": True,
+            "externalSideEffects": False,
+        }
+
+    task = {"project": project, "task_type": task_type, "risk_level": risk_level}
+    assignment = _select_clawops_route(routing_rules, task)
+    assigned_agent = _normalize_task_value(assignment.get("agent")) or "orchestrator"
+    agents = registry.get("agents") if isinstance(registry.get("agents"), dict) else {}
+    agent = agents.get(assigned_agent)
+    if not isinstance(agent, dict):
+        return {
+            "ok": False,
+            "status": "blocked",
+            "error": "unknown_clawops_agent",
+            "message": f"ClawOps agent '{assigned_agent}' is not defined in agent-registry.yaml.",
+            "dryRun": True,
+            "externalSideEffects": False,
+        }
+
+    model_policy = _normalize_task_value(assignment.get("model_policy")) or "use_agent_primary"
+    primary_model = _model_for_policy(model_policy, agent)
+    fallback_model = _normalize_task_value(agent.get("fallback_model")) or "codex"
+    approval_required = assignment.get("approval_required")
+    if not isinstance(approval_required, bool):
+        approval_required = bool(agent.get("approval_required", True))
+
+    return {
+        "ok": True,
+        "status": "routed",
+        "project": project,
+        "taskType": task_type,
+        "riskLevel": risk_level,
+        "assignedAgent": assigned_agent,
+        "agentDisplayName": _normalize_task_value(agent.get("display_name")) or assigned_agent,
+        "primaryModel": primary_model,
+        "fallbackModel": fallback_model,
+        "approvalRequired": approval_required,
+        "dryRun": True,
+        "externalSideEffects": False,
+        "message": "ClawOps route preview completed. No external side effects were performed.",
+    }
+
+
+def _clawops_routing_fields(routing: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "project": routing.get("project"),
+        "taskType": routing.get("taskType"),
+        "riskLevel": routing.get("riskLevel"),
+        "assignedAgent": routing.get("assignedAgent"),
+        "agentDisplayName": routing.get("agentDisplayName"),
+        "primaryModel": routing.get("primaryModel"),
+        "fallbackModel": routing.get("fallbackModel"),
+        "approvalRequired": routing.get("approvalRequired"),
+        "dryRun": True,
+        "externalModelCall": False,
+        "externalSideEffects": False,
+    }
+
+
+def _redact_sensitive_text(text: str) -> str:
+    redacted = text
+    for name in (
+        GOOGLE_API_KEY_ENV,
+        GEMINI_API_KEY_ENV,
+        OPENCLAW_GATEWAY_TOKEN_ENV,
+        OPENCLAW_HERMES_BRIDGE_TOKEN_ENV,
+    ):
+        value = _read_string(os.getenv(name))
+        if value:
+            redacted = redacted.replace(value, "[REDACTED]")
+    redacted = re.sub(r"Bearer\s+[A-Za-z0-9._~+/=-]+", "Bearer [REDACTED]", redacted, flags=re.IGNORECASE)
+    return redacted[:2000]
+
+
+def _enforce_bridge_dry_run_result(result: dict[str, Any]) -> dict[str, Any]:
+    output = result.get("output")
+    if not isinstance(output, dict):
+        return result
+
+    dry_run = output.get("dryRun")
+    side_effects = output.get("sideEffectsPerformed")
+    if dry_run is False or side_effects is True:
+        return {
+            "ok": False,
+            "status": "blocked",
+            "error": "unsafe_bridge_result",
+            "message": "OpenClaw bridge returned a non-dry-run or side-effecting result; Hermes blocked the response.",
+            "taskId": result.get("taskId"),
+            "mode": result.get("mode"),
+            "output": {
+                "dryRun": dry_run,
+                "sideEffectsPerformed": side_effects,
+            },
+        }
+    return result
+
+
+def _clawops_model_api_key() -> str | None:
+    return _read_string(os.getenv(GOOGLE_API_KEY_ENV)) or _read_string(os.getenv(GEMINI_API_KEY_ENV))
+
+
+def _clawops_api_model(model: str) -> str:
+    if model == "gemini-3.1-pro":
+        return _read_string(os.getenv(CLAWOPS_GEMINI_31_PRO_MODEL_ENV)) or "gemini-3.1-pro-preview"
+    return model
+
+
+def _clawops_gemini_chat_url() -> str:
+    base_url = (
+        _read_string(os.getenv(CLAWOPS_GEMINI_BASE_URL_ENV))
+        or "https://generativelanguage.googleapis.com/v1beta/openai"
+    )
+    return base_url.rstrip("/") + "/chat/completions"
+
+
+def _clawops_https_context() -> ssl.SSLContext:
+    try:
+        import certifi
+
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
+
+
+def _clawops_system_prompt(routing: dict[str, Any]) -> str:
+    approval = "required" if routing.get("approvalRequired") else "not required for this dry-run"
+    return "\n".join(
+        [
+            "You are executing inside the Grace + ClawOps collaboration mechanism.",
+            "Grace is the chief-of-staff interface: frame the user's request, preserve context, and return the final response.",
+            "ClawOps is the multi-agent operations hub: route the task, select the agent/model policy, execute agent work, and enforce approval boundaries.",
+            f"Assigned agent id: {_read_string(routing.get('assignedAgent')) or 'unknown'}",
+            f"Project: {_read_string(routing.get('project')) or 'unknown'}",
+            f"Task type: {_read_string(routing.get('taskType')) or 'unknown'}",
+            "Boundary: dry-run only; do not perform external side effects, tool calls, purchases, writes, sends, deploys, or irreversible actions.",
+            f"Approval boundary: approval is {approval}; any real-world execution must stop and request approval.",
+            "For responsibility, routing, or model-assignment questions, answer from the ClawOps registry context and current collaboration mechanism, not from generic Strategy/Execution/Review/Ops categories.",
+            "Safety: avoid guaranteed returns, individualized financial advice, or claims that reduce crypto investment risk to zero.",
+            "Return the proposed output only.",
+        ]
+    )
+
+
+def _extract_host_llm_text(response: Any) -> str | None:
+    text = _read_string(getattr(response, "text", None))
+    if text:
+        return text
+    if isinstance(response, dict):
+        return _read_string(response.get("text")) or _read_string(response.get("output"))
+    return _read_string(response)
+
+
+def _codex_app_server_enabled() -> bool:
+    if _CLAWOPS_CODEX_APP_SERVER_ENABLED is not None:
+        return _CLAWOPS_CODEX_APP_SERVER_ENABLED
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
+        return model_cfg.get("openai_runtime") == "codex_app_server"
+    except Exception:
+        return False
+
+
+def _codex_app_server_session_factory() -> Any:
+    if _CLAWOPS_CODEX_APP_SERVER_SESSION_FACTORY is not None:
+        return _CLAWOPS_CODEX_APP_SERVER_SESSION_FACTORY
+    from agent.transports.codex_app_server_session import CodexAppServerSession
+
+    return CodexAppServerSession
+
+
+def _codex_app_server_prompt(args: dict[str, Any], routing: dict[str, Any]) -> str:
+    request_text = _normalize_task_value(args.get("request")) or _normalize_task_value(args.get("intent"))
+    return "\n\n".join(
+        [
+            _clawops_system_prompt(routing),
+            _clawops_registry_context(),
+            f"Original request:\n{request_text}",
+        ]
+    )
+
+
+def _execute_clawops_codex_app_server_task(
+    *,
+    args: dict[str, Any],
+    routing: dict[str, Any],
+    fields: dict[str, Any],
+) -> dict[str, Any]:
+    session = None
+    try:
+        session_factory = _codex_app_server_session_factory()
+        session = session_factory(cwd=str(Path.cwd()))
+        session.ensure_started()
+        turn = session.run_turn(user_input=_codex_app_server_prompt(args, routing))
+        error = _read_string(getattr(turn, "error", None))
+        if error:
+            raise RuntimeError(error)
+        output = _read_string(getattr(turn, "final_text", None))
+        if not output:
+            raise ValueError("Codex app-server response did not include final_text.")
+        return {
+            "ok": True,
+            "status": "generated",
+            **fields,
+            "modelProvider": "codex_app_server",
+            "modelUsed": "codex_app_server",
+            "externalModelCall": True,
+            "output": output,
+            "message": "ClawOps Codex agent execution generated through codex app-server. No external side effects were performed.",
+        }
+    except Exception as exc:
+        return {
+            "ok": False,
+            "status": "failed",
+            "error": "codex_app_server_request_failed",
+            "message": _redact_sensitive_text(str(exc)),
+            **fields,
+            "externalModelCall": True,
+        }
+    finally:
+        if session is not None:
+            try:
+                session.close()
+            except Exception:
+                pass
+
+
+def _execute_clawops_codex_task(
+    *,
+    args: dict[str, Any],
+    routing: dict[str, Any],
+    fields: dict[str, Any],
+) -> dict[str, Any]:
+    if _codex_app_server_enabled():
+        return _execute_clawops_codex_app_server_task(args=args, routing=routing, fields=fields)
+
+    llm = get_clawops_host_llm()
+    if llm is None:
+        return {
+            "ok": False,
+            "status": "blocked",
+            "error": "missing_host_llm",
+            "message": "ClawOps Codex execution requires Hermes host LLM access from the live plugin context.",
+            **fields,
+        }
+
+    request_text = _normalize_task_value(args.get("request")) or _normalize_task_value(args.get("intent"))
+    messages = [
+        {"role": "system", "content": "\n\n".join([_clawops_system_prompt(routing), _clawops_registry_context()])},
+        {"role": "user", "content": f"Original request:\n{request_text}"},
+    ]
+    try:
+        response = llm.complete(
+            messages,
+            temperature=0.3,
+            max_tokens=1800,
+            timeout=120,
+            purpose=f"clawops:{_read_string(routing.get('assignedAgent')) or 'unknown'}",
+        )
+        output = _extract_host_llm_text(response)
+        if not output:
+            raise ValueError("Host LLM response did not include text.")
+        return {
+            "ok": True,
+            "status": "generated",
+            **fields,
+            "modelProvider": _read_string(getattr(response, "provider", None)) or "host",
+            "modelUsed": _read_string(getattr(response, "model", None)) or _read_string(routing.get("primaryModel")) or "codex",
+            "externalModelCall": True,
+            "output": output,
+            "message": "ClawOps Codex agent execution generated through Hermes host LLM. No external side effects were performed.",
+        }
+    except Exception as exc:
+        return {
+            "ok": False,
+            "status": "failed",
+            "error": "host_llm_request_failed",
+            "message": _redact_sensitive_text(str(exc)),
+            **fields,
+            "externalModelCall": True,
+        }
+
+
+def _execute_clawops_gemini_task(
+    *,
+    args: dict[str, Any],
+    routing: dict[str, Any],
+    fields: dict[str, Any],
+    model: str,
+    fallback_used: bool = False,
+    fallback_reason: str | None = None,
+) -> dict[str, Any]:
+    api_key = _clawops_model_api_key()
+    if not api_key:
+        result = {
+            "ok": False,
+            "status": "blocked",
+            "error": "missing_model_api_key",
+            "message": "Set GOOGLE_API_KEY or GEMINI_API_KEY before using ClawOps Gemini agent execution.",
+            **fields,
+        }
+        if fallback_used:
+            result["fallbackUsed"] = True
+            result["fallbackReason"] = fallback_reason or "fallback"
+        return result
+
+    request_text = _normalize_task_value(args.get("request")) or _normalize_task_value(args.get("intent"))
+    api_model = _clawops_api_model(model)
+    payload = {
+        "model": api_model,
+        "temperature": 0.4,
+        "messages": [
+            {"role": "system", "content": "\n\n".join([_clawops_system_prompt(routing), _clawops_registry_context()])},
+            {"role": "user", "content": f"Original request:\n{request_text}"},
+        ],
+    }
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    request = urllib.request.Request(
+        _clawops_gemini_chat_url(),
+        data=body,
+        headers={
+            "authorization": f"Bearer {api_key}",
+            "content-type": "application/json",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=60, context=_clawops_https_context()) as response:
+            raw = response.read().decode("utf-8")
+            parsed = json.loads(raw)
+        choices = parsed.get("choices") if isinstance(parsed, dict) else None
+        first_choice = choices[0] if isinstance(choices, list) and choices else {}
+        message = first_choice.get("message") if isinstance(first_choice, dict) else {}
+        output = _read_string(message.get("content") if isinstance(message, dict) else None)
+        if not output:
+            raise ValueError("Model response did not include choices[0].message.content.")
+        result = {
+            "ok": True,
+            "status": "generated",
+            **fields,
+            "modelUsed": api_model,
+            "externalModelCall": True,
+            "output": output,
+            "message": "ClawOps agent execution generated. No external side effects were performed.",
+        }
+        if fallback_used:
+            result["fallbackUsed"] = True
+            result["fallbackReason"] = fallback_reason or "fallback"
+        return result
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        result = {
+            "ok": False,
+            "status": "failed",
+            "error": "model_http_error",
+            "message": _redact_sensitive_text(raw or str(exc)),
+            **fields,
+            "externalModelCall": True,
+        }
+        if fallback_used:
+            result["fallbackUsed"] = True
+            result["fallbackReason"] = fallback_reason or "fallback"
+        return result
+    except (OSError, TimeoutError, json.JSONDecodeError, ValueError) as exc:
+        result = {
+            "ok": False,
+            "status": "failed",
+            "error": "model_request_failed",
+            "message": _redact_sensitive_text(str(exc)),
+            **fields,
+            "externalModelCall": True,
+        }
+        if fallback_used:
+            result["fallbackUsed"] = True
+            result["fallbackReason"] = fallback_reason or "fallback"
+        return result
+
+
+def execute_clawops_task(args: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+    """Route and generate a ClawOps agent result without external side effects."""
+    routing = route_clawops_task(args, **kwargs)
+    if routing.get("ok") is not True:
+        return routing
+
+    fields = _clawops_routing_fields(routing)
+    primary_model = _read_string(routing.get("primaryModel")) or ""
+    if primary_model == "codex":
+        codex_result = _execute_clawops_codex_task(args=args, routing=routing, fields=fields)
+        if codex_result.get("ok") is True:
+            return _attach_approval_if_needed(codex_result, args)
+        fallback_model = _read_string(routing.get("fallbackModel")) or ""
+        if fallback_model.lower().startswith("gemini"):
+            return _attach_approval_if_needed(
+                _execute_clawops_gemini_task(
+                    args=args,
+                    routing=routing,
+                    fields=fields,
+                    model=fallback_model,
+                    fallback_used=True,
+                    fallback_reason=_read_string(codex_result.get("error")) or "codex_unavailable",
+                ),
+                args=args,
+            )
+        return codex_result
+
+    if not primary_model.lower().startswith("gemini"):
+        return {
+            "ok": False,
+            "status": "blocked",
+            "error": "unsupported_primary_model",
+            "message": f"ClawOps agent execution only supports Gemini primary models; got '{primary_model or 'unknown'}'.",
+            **fields,
+        }
+
+    return _attach_approval_if_needed(
+        _execute_clawops_gemini_task(args=args, routing=routing, fields=fields, model=primary_model),
+        args,
+    )
+
+
+def _validate_args(args: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
+    task_id = _read_string(args.get("taskId"))
+    if task_id not in ALLOWED_TASKS:
+        return None, "openclaw_delegate only allows taskId='tasks.organize_today' or taskId='agents.ask_team' in v1."
+
+    if args.get("dryRun") is not True:
+        return None, "openclaw_delegate requires dryRun=true."
+
+    allowed_tools = _read_string_list(args.get("allowedTools"))
+    if allowed_tools:
+        return None, "openclaw_delegate requires allowedTools=[] in v1."
+
+    intent = _read_string(args.get("intent")) or task_id
+    input_obj = _read_object(args.get("input"))
+    request_id = _read_string(args.get("requestId"))
+    payload: dict[str, Any] = {
+        "taskId": task_id,
+        "requestedBy": "hermes",
+        "intent": intent,
+        "priority": "normal",
+        "requiresConfirmation": False,
+        "allowedTools": [],
+        "dryRun": True,
+        "input": input_obj,
+    }
+    if request_id:
+        payload["requestId"] = request_id
+        payload["idempotencyKey"] = request_id
+    return payload, None
+
+
+def _bridge_url(base_url: str) -> str:
+    return base_url.rstrip("/") + "/api/plugins/hermes-bridge/tasks"
+
+
+
+def _looks_like_openclaw_dry_run(text: str) -> bool:
+    normalized = text.strip().lower()
+    if not normalized or normalized.startswith("/"):
+        return False
+    has_openclaw = "openclaw" in normalized
+    has_dry_run = "dry-run" in normalized or "dry run" in normalized or "只做 dry" in normalized
+    return has_openclaw and has_dry_run
+
+
+def _task_id_for_text(text: str) -> str:
+    normalized = text.lower()
+    if "agent" in normalized or "團隊" in normalized or "team" in normalized:
+        return "agents.ask_team"
+    return "tasks.organize_today"
+
+
+def build_openclaw_delegate_args(text: str) -> dict[str, Any]:
+    task_id = _task_id_for_text(text)
+    input_obj: dict[str, Any]
+    if task_id == "agents.ask_team":
+        input_obj = {"team": "openclaw", "question": text}
+    else:
+        input_obj = {"request": text}
+    return {
+        "taskId": task_id,
+        "intent": text,
+        "dryRun": True,
+        "allowedTools": [],
+        "input": input_obj,
+    }
+
+
+
+def format_openclaw_delegate_result(raw_result: str) -> str:
+    try:
+        result = json.loads(raw_result)
+    except json.JSONDecodeError:
+        return raw_result
+    if not isinstance(result, dict):
+        return raw_result
+
+    status = _read_string(result.get("status")) or "unknown"
+    summary = _read_string(result.get("summary")) or _read_string(result.get("message")) or "No summary returned."
+    task_id = _read_string(result.get("taskId")) or "unknown"
+    mode = _read_string(result.get("mode")) or "unknown"
+    ok = result.get("ok") is True
+
+    title = "OpenClaw dry-run completed" if ok else "OpenClaw dry-run did not complete"
+    lines = [title, f"Status: {status}", f"Task: {task_id}", f"Mode: {mode}", f"Summary: {summary}"]
+
+    output = result.get("output")
+    if isinstance(output, dict):
+        dry_run = output.get("dryRun")
+        if isinstance(dry_run, bool):
+            lines.append(f"Dry-run: {str(dry_run).lower()}")
+        side_effects = output.get("sideEffectsPerformed")
+        if isinstance(side_effects, bool):
+            side_effect_text = "yes" if side_effects else "no"
+            lines.append(f"External side effects: {side_effect_text}")
+        organized_tasks = output.get("organizedTasks")
+        if isinstance(organized_tasks, list):
+            lines.append(f"Organized tasks: {len(organized_tasks)}")
+
+    error = result.get("error")
+    if isinstance(error, dict):
+        error_type = _read_string(error.get("type")) or _read_string(result.get("error"))
+        error_message = _read_string(error.get("message")) or _read_string(result.get("message"))
+        if error_type:
+            lines.append(f"Error: {error_type}")
+        if error_message:
+            lines.append(f"Error detail: {error_message}")
+    elif isinstance(error, str) and error.strip():
+        lines.append(f"Error: {error.strip()}")
+
+    audit_log = result.get("auditLog")
+    if isinstance(audit_log, list) and audit_log:
+        lines.append("Audit log:")
+        for item in audit_log[:5]:
+            if not isinstance(item, dict):
+                continue
+            step = _read_string(item.get("step")) or "step"
+            message = _read_string(item.get("message")) or ""
+            lines.append(f"- {step}: {message}" if message else f"- {step}")
+
+    return "\n".join(lines)
+
+def handle_openclaw_dry_run_command(raw_args: str) -> str:
+    text = _read_string(raw_args) or "請 OpenClaw 幫我整理今天的任務，但只做 dry-run。"
+    return format_openclaw_delegate_result(openclaw_delegate(build_openclaw_delegate_args(text)))
+
+
+def format_clawops_route_result(result: dict[str, Any]) -> str:
+    if result.get("ok") is not True:
+        return "\n".join(
+            [
+                "ClawOps route preview did not complete",
+                f"Status: {_read_string(result.get('status')) or 'unknown'}",
+                f"Error: {_read_string(result.get('error')) or 'unknown'}",
+                f"Message: {_read_string(result.get('message')) or 'No detail returned.'}",
+                "External side effects: no",
+            ]
+        )
+
+    approval = "yes" if result.get("approvalRequired") else "no"
+    return "\n".join(
+        [
+            "ClawOps route preview",
+            f"Status: {_read_string(result.get('status')) or 'unknown'}",
+            f"Project: {_read_string(result.get('project')) or 'unknown'}",
+            f"Task type: {_read_string(result.get('taskType')) or 'unknown'}",
+            f"Assigned agent: {_read_string(result.get('assignedAgent')) or 'unknown'}",
+            f"Primary model: {_read_string(result.get('primaryModel')) or 'unknown'}",
+            f"Fallback model: {_read_string(result.get('fallbackModel')) or 'unknown'}",
+            f"Approval required: {approval}",
+            "Dry-run: true",
+            "External side effects: no",
+        ]
+    )
+
+
+def handle_clawops_command(raw_args: str) -> str:
+    text = _read_string(raw_args) or "請 ClawOps 執行任務。"
+    return format_clawops_execution_result(execute_clawops_task({"request": text}))
+
+
+def format_clawops_execution_result(result: dict[str, Any]) -> str:
+    approval = "yes" if result.get("approvalRequired") else "no"
+    external_actions = "pending your approval" if result.get("approvalRequired") else "none"
+    lines = [
+        "ClawOps agent execution",
+        f"Status: {_read_string(result.get('status')) or 'unknown'}",
+        f"Project: {_read_string(result.get('project')) or 'unknown'}",
+        f"Task type: {_read_string(result.get('taskType')) or 'unknown'}",
+        f"Assigned agent: {_read_string(result.get('assignedAgent')) or 'unknown'}",
+        f"Model used: {_read_string(result.get('modelUsed')) or _read_string(result.get('primaryModel')) or 'unknown'}",
+        f"Approval required: {approval}",
+        f"External model call: {'yes' if result.get('externalModelCall') else 'no'}",
+        f"External actions: {external_actions}",
+    ]
+    if result.get("fallbackUsed"):
+        lines.append("Fallback used: yes")
+        fallback_reason = _read_string(result.get("fallbackReason"))
+        if fallback_reason:
+            lines.append(f"Fallback reason: {fallback_reason}")
+    approval_id = _read_string(result.get("approvalId"))
+    if approval_id:
+        lines.append(f"Approval id: {approval_id}")
+        lines.append(f"Executable actions: {int(result.get('executableActions') or 0)}")
+        lines.append(f"Approve command: /clawops-approve {approval_id}")
+
+    if result.get("ok") is not True:
+        lines.extend(
+            [
+                f"Error: {_read_string(result.get('error')) or 'unknown'}",
+                f"Message: {_read_string(result.get('message')) or 'No detail returned.'}",
+            ]
+        )
+
+    output = _read_string(result.get("output"))
+    if output:
+        lines.extend(["Output:", output])
+    return "\n".join(lines)
+
+
+def handle_clawops_run_command(raw_args: str) -> str:
+    text = _read_string(raw_args) or "請 ClawOps 執行任務 dry-run。"
+    return format_clawops_execution_result(execute_clawops_task({"request": text}))
+
+
+def format_clawops_approval_result(result: dict[str, Any]) -> str:
+    ok = result.get("ok") is True
+    lines = [
+        "ClawOps approved actions executed" if ok else "ClawOps approved actions did not execute",
+        f"Status: {_read_string(result.get('status')) or 'unknown'}",
+        f"Approval id: {_read_string(result.get('approvalId')) or 'unknown'}",
+        f"Executed actions: {int(result.get('executedActions') or 0)}",
+        f"External side effects: {'yes' if result.get('externalSideEffects') else 'no'}",
+    ]
+    if not ok:
+        lines.append(f"Error: {_read_string(result.get('error')) or 'unknown'}")
+        lines.append(f"Message: {_read_string(result.get('message')) or 'No detail returned.'}")
+    return "\n".join(lines)
+
+
+def handle_clawops_approve_command(raw_args: str) -> str:
+    approval_id = _read_string(raw_args)
+    if not approval_id:
+        return format_clawops_approval_result(
+            {
+                "ok": False,
+                "status": "blocked",
+                "error": "missing_approval_id",
+                "message": "Provide an approval id, for example: /clawops-approve clawops-20260627-1234abcd",
+                "approvalId": "unknown",
+                "externalSideEffects": False,
+            }
+        )
+    return format_clawops_approval_result(execute_clawops_approved_actions(approval_id))
+
+
+def pre_gateway_dispatch(**kwargs: Any) -> dict[str, str] | None:
+    event = kwargs.get("event")
+    text = getattr(event, "text", "")
+    if not isinstance(text, str) or not _looks_like_openclaw_dry_run(text):
+        if isinstance(text, str) and _looks_like_clawops_request(text):
+            return {"action": "rewrite", "text": f"/clawops {text}"}
+        return None
+    return {"action": "rewrite", "text": f"/openclaw-dry-run {text}"}
+
+
+def _looks_like_clawops_request(text: str) -> bool:
+    normalized = text.strip().lower()
+    if not normalized or normalized.startswith("/"):
+        return False
+    return "clawops" in normalized or "爪控中心" in text or "openclaw 營運中樞" in normalized
+
+def openclaw_delegate(args: dict[str, Any], **kwargs: Any) -> str:
+    """Delegate one approved dry-run task to OpenClaw."""
+    del kwargs
+
+    if not _env_ready():
+        return _json_result(
+            {
+                "ok": False,
+                "status": "blocked",
+                "error": "missing_environment",
+                "message": (
+                    "Set OPENCLAW_GATEWAY_URL, OPENCLAW_GATEWAY_TOKEN, and "
+                    "OPENCLAW_HERMES_BRIDGE_TOKEN before using openclaw_delegate."
+                ),
+            }
+        )
+
+    payload, error = _validate_args(args)
+    if error:
+        return _json_result(
+            {
+                "ok": False,
+                "status": "blocked",
+                "error": "invalid_request",
+                "message": error,
+            }
+        )
+
+    gateway_url = os.environ[OPENCLAW_GATEWAY_URL_ENV]
+    gateway_token = os.environ[OPENCLAW_GATEWAY_TOKEN_ENV]
+    bridge_token = os.environ[OPENCLAW_HERMES_BRIDGE_TOKEN_ENV]
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    request = urllib.request.Request(
+        _bridge_url(gateway_url),
+        data=body,
+        headers={
+            "authorization": f"Bearer {gateway_token}",
+            "content-type": "application/json",
+            "x-openclaw-hermes-token": bridge_token,
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            raw = response.read().decode("utf-8")
+            parsed = json.loads(raw)
+            return _json_result(_enforce_bridge_dry_run_result(parsed))
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            parsed = {"ok": False, "status": "failed", "error": "http_error", "message": raw}
+        if isinstance(parsed.get("message"), str):
+            parsed["message"] = _redact_sensitive_text(parsed["message"])
+        return _json_result(parsed)
+    except (OSError, TimeoutError, json.JSONDecodeError) as exc:
+        return _json_result(
+            {
+                "ok": False,
+                "status": "failed",
+                "error": "bridge_request_failed",
+                "message": str(exc),
+            }
+        )

--- a/skills/integration/clawops/SKILL.md
+++ b/skills/integration/clawops/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: clawops
+description: Use when the user mentions ClawOps, 爪控中心, OpenClaw 營運中樞, or asks Grace to route work to the OpenClaw multi-agent operations hub.
+version: 1.0.0
+author: local
+license: MIT
+metadata:
+  hermes:
+    tags: [Integration, OpenClaw, ClawOps, operations, multi-agent]
+    related_skills: [openclaw-delegation]
+---
+
+# ClawOps
+
+## Overview
+
+ClawOps is the operating name for the OpenClaw multi-agent operations hub.
+Hermes-Grace is the chief-of-staff entry point; ClawOps is the operations hub
+Grace routes to when the user asks for coordinated agent work across course
+creation, course marketing, secondhand commerce, and ingrids.app marketing.
+
+Use the name **ClawOps** in Telegram-facing replies. Accept these aliases:
+
+- `ClawOps`
+- `爪控中心`
+- `OpenClaw 營運中樞`
+- `OpenClaw 多代理營運中樞`
+- `龍蝦團隊營運中樞`
+
+## When to Use
+
+Use this skill when the user asks Grace to:
+
+- explain ClawOps responsibilities or model assignments
+- route a task to ClawOps
+- ask which agent should handle a business operations task
+- summarize the OpenClaw Agent Team operating model
+- work on Hahow course planning, course marketing, secondhand sales, or
+  ingrids.app marketing through the multi-agent hub
+
+Do not ask the user to choose between routing and execution commands. Grace is
+the chief-of-staff interface: when the user assigns work to Grace, Grace should
+hand it to ClawOps, let ClawOps select the agent/model policy, produce the
+agent result, and stop before any external side effect that requires approval.
+
+## Grace and ClawOps Collaboration Mechanism
+
+Do not answer ClawOps responsibility/model questions as a generic lookup table
+or as generic Strategy/Execution/Review/Ops categories. The intended mechanism
+is collaborative:
+
+1. Grace receives the user's natural-language request and preserves business
+   context.
+2. Grace hands the framed task to ClawOps.
+3. ClawOps routes by project, task type, risk level, agent, model policy, and
+   approval requirement.
+4. The assigned ClawOps agent produces the answer using the ClawOps Registry as
+   grounding context.
+5. Grace returns the synthesized answer to the user and holds any external
+   action behind an approval id.
+
+For responsibility/model questions, the model should still answer as an agent,
+but the factual source must be the ClawOps Registry and routing rules. Do not
+invent agents or substitute generic categories when registry entries are
+available.
+
+## Operating Vocabulary
+
+| Layer | Name | Meaning |
+|---|---|---|
+| User-facing assistant | Hermes-Grace | Receives Telegram/CLI requests and coordinates next steps. |
+| Operations hub | ClawOps | OpenClaw multi-agent operations hub. |
+| Agent group | OpenClaw Agent Team | Specialized agents managed through ClawOps. |
+| Router | ClawOps Orchestrator | Decides project, task type, risk level, agent, and model policy. |
+| Registry | ClawOps Registry | Source of truth for agent roles, primary models, fallback models, and approval rules. |
+
+Preferred Telegram phrasing:
+
+```text
+Grace，請找 ClawOps 協助執行。
+Grace，請讓 ClawOps 判斷要派哪個 agent。
+Grace，把這個任務交給 ClawOps，需要審核的地方先不要發布。
+Grace，請整理 ClawOps 的責任分工和使用模型。
+```
+
+The live Hermes bridge also exposes:
+
+```text
+/clawops <request>
+/clawops-run <request>
+/clawops-approve <approval_id>
+```
+
+Natural-language Telegram messages that mention `ClawOps`, `爪控中心`, or
+`OpenClaw 營運中樞` may be rewritten to `/clawops <request>` before normal
+agent dispatch.
+
+Use `/clawops` as the single normal entry point. It performs routing, selects
+the assigned ClawOps agent, calls the configured model, and returns the agent
+result to Grace. `/clawops-run` is only a backwards-compatible alias for older
+operator habits.
+
+External actions are separate from model execution. Public posting, outbound
+email, data changes, deploys, credential changes, and other side effects must
+remain pending until the user explicitly approves them.
+
+When a ClawOps result requires approval, Grace should surface the approval id
+and tell the user that execution waits for:
+
+```text
+/clawops-approve <approval_id>
+```
+
+`/clawops-approve` executes only allowlisted action handlers. Unsupported
+actions must remain blocked even after confirmation until a specific connector
+has been implemented and allowlisted.
+
+## Source of Truth
+
+When available, answer from these workspace files:
+
+- `/Users/kj/my_agent_team/docs/projects/hub-ops/agent-registry.yaml`
+- `/Users/kj/my_agent_team/docs/projects/hub-ops/routing-rules.yaml`
+- `/Users/kj/my_agent_team/docs/architecture/hermes-grace-openclaw-operations-hub-v1.md`
+
+If these files are not readable in the current runtime, use the matrix below
+and say that the answer is from the ClawOps v1 operating design, not live
+runtime verification.
+
+## Agent and Model Matrix
+
+| Agent | Responsibility | Primary model | Fallback model |
+|---|---|---|---|
+| Hermes-Grace | User entry point, chief-of-staff triage, task framing | `codex` | `gemini-3.1-pro` |
+| ClawOps Orchestrator | Routing, result synthesis, final coordination | `codex` | `gemini-3.1-pro` |
+| Strategy Agent | Business positioning, offers, audience strategy | `codex` | `gemini-3.1-pro` |
+| Course Designer Agent | Hahow course planning, syllabus, lesson design | `codex` | `gemini-3.1-pro` |
+| Content Creator Agent | Social posts, scripts, article drafts | `gemini-2.5-flash` | `codex` |
+| Marketing Operator Agent | Campaign planning, channel calendars, launches | `gemini-2.5-flash` | `codex` |
+| CRM Sales Agent | Lead segmentation, follow-up drafts, sales templates | `gemini-2.5-flash` | `codex` |
+| Secondhand Commerce Agent | Resale listings, inventory workflow, buyer replies | `gemini-2.5-flash` | `codex` |
+| Ingrids Product Marketing Agent | ingrids.app positioning, SEO, demo scripts | `codex` | `gemini-3.1-pro` |
+| Risk Review Agent | Finance, crypto, trading, claim, and publication review | `codex` | `gemini-3.1-pro` |
+| Analytics Agent | Weekly reports, metrics, anomaly summaries | `gemini-2.5-flash` | `codex` |
+| DevOps Integration Agent | Config, deployment, tests, bridges | `codex` | `gemini-3.1-pro` |
+
+## Routing Rules
+
+Use `codex` for:
+
+- code, config, deployment, repository, credential, or shell work
+- business strategy, course design, and ingrids.app product marketing
+- approval gates
+- financial, crypto, trading, or performance claims
+- final synthesis across multiple agents
+- correcting conflicts between lightweight-model drafts and source evidence
+
+Use `gemini-3.1-pro` as fallback for:
+
+- business strategy
+- course design
+- long-form product marketing
+- structured planning that still needs approval before publication
+
+Use `gemini-2.5-flash` for:
+
+- high-volume drafts
+- summaries
+- classification
+- CRM templates
+- low-risk internal variants
+
+## Safety Boundary
+
+ClawOps v1 should not automatically publish, send outbound sales messages,
+commit transactions, deploy code, touch credentials, or make financial claims.
+
+Model calls are allowed for drafting, analysis, routing, and agent execution.
+Treat model calls as internal ClawOps work, not public execution. Do not send
+secrets, credentials, private customer data, or transaction instructions into
+ClawOps model prompts.
+
+Require approval for:
+
+- public content
+- Hahow proposal or publication assets
+- ingrids.app trading, backtest, performance, or product claims
+- outbound CRM/sales messages
+- secondhand transaction commitments
+- config, repository, deployment, push, destructive, or credential changes
+
+## Answer Pattern
+
+When the user asks what ClawOps is, answer directly:
+
+```text
+ClawOps 是 Grace 背後的 OpenClaw 多代理營運中樞。Grace 是入口與總特助；ClawOps 負責判斷任務類型、選擇 agent、套用主要/備援模型、保留審核邊界，並把結果回報給 Grace。
+```
+
+When the user asks why Grace gave an older bridge answer, explain:
+
+```text
+那是目前 live Hermes ↔ OpenClaw bridge 的已部署狀態；ClawOps 是新的 v1 營運中樞設計。除非 clawops skill 或相關 routing context 已安裝到 Grace 的 live profile，Grace 會優先回答它目前能驗證的 bridge/dry-run 架構。
+```
+
+When asked to assign a task, respond as Grace and hand it to ClawOps:
+
+```text
+我會交給 ClawOps 執行，外部發布或資料變更會先等你確認。
+- project:
+- task_type:
+- assigned_agent:
+- primary_model:
+- fallback_model:
+- approval_required:
+```
+
+Current runtime scope:
+
+- `/clawops` performs routing first, then calls the assigned model for the
+  ClawOps agent result. Codex-primary agents use the configured Hermes
+  `codex_app_server` runtime; Gemini-primary agents use the configured Gemini
+  endpoint. It reports the assigned agent, approval requirement, and actual
+  model used when aliases are required.
+- `/clawops-run` is a backwards-compatible alias for `/clawops`.
+- `/clawops-approve <approval_id>` executes a pending approval record through
+  the action executor. The current executor supports allowlisted handlers only;
+  unsupported publish/send/update/deploy action types are blocked until their
+  connectors are explicitly implemented.
+- It does not publish, send messages, trade, deploy, or perform external side
+  effects until the user explicitly approves those actions.
+
+Do not say a task has been executed unless a tool call or runtime action
+actually completed.

--- a/skills/integration/openclaw-delegation/SKILL.md
+++ b/skills/integration/openclaw-delegation/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: openclaw-delegation
+description: Delegate approved dry-run tasks from Hermes to local OpenClaw through the openclaw_delegate tool; use ClawOps vocabulary when the user refers to the OpenClaw operations hub.
+version: 1.0.0
+author: local
+license: MIT
+metadata:
+  hermes:
+    tags: [Integration, OpenClaw, Delegation]
+    requires_tools: [openclaw_delegate]
+required_environment_variables:
+  - name: OPENCLAW_GATEWAY_URL
+    prompt: OpenClaw Gateway URL, for example http://127.0.0.1:1455
+    required_for: Local OpenClaw bridge access
+  - name: OPENCLAW_GATEWAY_TOKEN
+    prompt: OpenClaw Gateway bearer token
+    required_for: Gateway authentication
+  - name: OPENCLAW_HERMES_BRIDGE_TOKEN
+    prompt: OpenClaw Hermes bridge shared secret
+    required_for: Plugin-local bridge authentication
+---
+
+# OpenClaw Delegation
+
+## Relationship to ClawOps
+
+ClawOps is the operating name for the OpenClaw multi-agent operations hub.
+Hermes-Grace is the user-facing chief-of-staff assistant; ClawOps is the hub
+Grace routes to when the user asks for coordinated OpenClaw agent work.
+
+This `openclaw-delegation` skill describes the current safe bridge behavior:
+Hermes can delegate approved OpenClaw dry-run requests through
+`openclaw_delegate`. Do not confuse that with full ClawOps v1 runtime execution.
+If the user asks for ClawOps responsibility or model assignments, use the
+`clawops` skill. If the user asks to run a currently supported OpenClaw dry-run,
+use this skill.
+
+## When to Use
+
+Use this skill when the user asks Hermes to have OpenClaw handle a local task and
+explicitly says it should be a dry-run or should avoid external side effects.
+
+## Procedure
+
+For the v1 bridge, only delegate this approved task:
+
+| User intent | taskId |
+| --- | --- |
+| Organize today's tasks as a dry-run | `tasks.organize_today` |
+| Ask the OpenClaw agent team for dry-run analysis | `agents.ask_team` |
+
+Call `openclaw_delegate` with:
+
+```json
+{
+  "taskId": "tasks.organize_today",
+  "intent": "<the user's original request>",
+  "dryRun": true,
+  "allowedTools": [],
+  "input": {
+    "request": "<the user's original request>"
+  }
+}
+```
+
+For OpenClaw agent team dry-runs, call `openclaw_delegate` with:
+
+```json
+{
+  "taskId": "agents.ask_team",
+  "intent": "<the user's original request>",
+  "dryRun": true,
+  "allowedTools": [],
+  "input": {
+    "team": "openclaw",
+    "question": "<the user's question for the OpenClaw agent team>"
+  }
+}
+```
+
+After the tool returns, summarize the `summary` field and include the important
+`auditLog` entries. Make clear that the task was a dry-run and that no external
+side effects were performed.
+
+## Safety Rules
+
+- Do not request real email, calendar, messaging, trading, filesystem, shell,
+  browser, node, cron, or Gateway-control execution through this bridge.
+- Do not pass arbitrary OpenClaw tool names.
+- Do not set `dryRun` to false.
+- Do not add entries to `allowedTools`.
+- If the user asks for real execution, explain that v1 supports dry-run only.
+- Do not claim live OpenClaw agents were contacted when `agents.ask_team` returns a dry-run result.
+
+## Verification
+
+A successful v1 response includes:
+
+```json
+{
+  "status": "succeeded",
+  "summary": "Dry-run completed. No external side effects were performed."
+}
+```

--- a/tests/plugins/test_openclaw_bridge_plugin.py
+++ b/tests/plugins/test_openclaw_bridge_plugin.py
@@ -1,0 +1,1044 @@
+"""Tests for the local OpenClaw bridge plugin."""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from types import SimpleNamespace
+
+
+def _decode(result: str) -> dict:
+    return json.loads(result)
+
+
+def test_openclaw_delegate_rejects_missing_env(monkeypatch):
+    from plugins.openclaw_bridge.tools import openclaw_delegate
+
+    monkeypatch.delenv("OPENCLAW_GATEWAY_URL", raising=False)
+    monkeypatch.delenv("OPENCLAW_GATEWAY_TOKEN", raising=False)
+    monkeypatch.delenv("OPENCLAW_HERMES_BRIDGE_TOKEN", raising=False)
+
+    result = _decode(openclaw_delegate({"taskId": "tasks.organize_today"}))
+
+    assert result["ok"] is False
+    assert result["status"] == "blocked"
+    assert result["error"] == "missing_environment"
+
+
+def test_openclaw_delegate_rejects_non_dry_run(monkeypatch):
+    from plugins.openclaw_bridge.tools import openclaw_delegate
+
+    monkeypatch.setenv("OPENCLAW_GATEWAY_URL", "http://127.0.0.1:1")
+    monkeypatch.setenv("OPENCLAW_GATEWAY_TOKEN", "gateway")
+    monkeypatch.setenv("OPENCLAW_HERMES_BRIDGE_TOKEN", "bridge")
+
+    result = _decode(
+        openclaw_delegate(
+            {
+                "taskId": "tasks.organize_today",
+                "intent": "run it",
+                "dryRun": False,
+                "allowedTools": [],
+                "input": {"request": "run it"},
+            }
+        )
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == "blocked"
+    assert result["error"] == "invalid_request"
+    assert "dryRun=true" in result["message"]
+
+
+def test_openclaw_delegate_rejects_unknown_task(monkeypatch):
+    from plugins.openclaw_bridge.tools import openclaw_delegate
+
+    monkeypatch.setenv("OPENCLAW_GATEWAY_URL", "http://127.0.0.1:1")
+    monkeypatch.setenv("OPENCLAW_GATEWAY_TOKEN", "gateway")
+    monkeypatch.setenv("OPENCLAW_HERMES_BRIDGE_TOKEN", "bridge")
+
+    result = _decode(
+        openclaw_delegate(
+            {
+                "taskId": "message.send",
+                "intent": "send",
+                "dryRun": True,
+                "allowedTools": [],
+                "input": {"request": "send"},
+            }
+        )
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == "blocked"
+    assert result["error"] == "invalid_request"
+    assert "tasks.organize_today" in result["message"]
+
+
+def test_openclaw_delegate_allows_agent_team_dry_run(monkeypatch):
+    from plugins.openclaw_bridge.tools import openclaw_delegate
+
+    captured: dict = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers["content-length"])
+            captured["body"] = json.loads(self.rfile.read(length))
+            payload = {
+                "ok": True,
+                "taskId": "agents.ask_team",
+                "mode": "mock",
+                "status": "succeeded",
+                "summary": "Dry-run completed. No OpenClaw agents were started.",
+                "auditLog": [{"step": "dry-run", "message": "no agents", "at": "1970-01-01T00:00:00.000Z"}],
+                "artifacts": [],
+                "output": {"team": "openclaw", "dryRun": True, "agentsStarted": False},
+            }
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):  # noqa: A002
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        monkeypatch.setenv("OPENCLAW_GATEWAY_URL", f"http://127.0.0.1:{server.server_port}")
+        monkeypatch.setenv("OPENCLAW_GATEWAY_TOKEN", "gateway-token")
+        monkeypatch.setenv("OPENCLAW_HERMES_BRIDGE_TOKEN", "bridge-token")
+
+        result = _decode(
+            openclaw_delegate(
+                {
+                    "taskId": "agents.ask_team",
+                    "intent": "請 OpenClaw agent 團隊協助分析，但只做 dry-run。",
+                    "dryRun": True,
+                    "allowedTools": [],
+                    "input": {
+                        "team": "openclaw",
+                        "question": "為何 Hermes 還無法呼叫 OpenClaw agent 團隊？",
+                    },
+                    "requestId": "team-req-1",
+                }
+            )
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    assert captured["body"]["taskId"] == "agents.ask_team"
+    assert captured["body"]["dryRun"] is True
+    assert captured["body"]["allowedTools"] == []
+    assert captured["body"]["input"]["team"] == "openclaw"
+    assert captured["body"]["idempotencyKey"] == "team-req-1"
+    assert result["status"] == "succeeded"
+    assert result["summary"] == "Dry-run completed. No OpenClaw agents were started."
+
+
+def test_openclaw_delegate_rejects_allowed_tools(monkeypatch):
+    from plugins.openclaw_bridge.tools import openclaw_delegate
+
+    monkeypatch.setenv("OPENCLAW_GATEWAY_URL", "http://127.0.0.1:1")
+    monkeypatch.setenv("OPENCLAW_GATEWAY_TOKEN", "gateway")
+    monkeypatch.setenv("OPENCLAW_HERMES_BRIDGE_TOKEN", "bridge")
+
+    result = _decode(
+        openclaw_delegate(
+            {
+                "taskId": "tasks.organize_today",
+                "intent": "run",
+                "dryRun": True,
+                "allowedTools": ["telegram.send"],
+                "input": {"request": "run"},
+            }
+        )
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == "blocked"
+    assert result["error"] == "invalid_request"
+    assert "allowedTools=[]" in result["message"]
+
+
+def test_openclaw_delegate_sends_headers_and_preserves_result(monkeypatch):
+    from plugins.openclaw_bridge.tools import openclaw_delegate
+
+    captured: dict = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers["content-length"])
+            captured["path"] = self.path
+            captured["authorization"] = self.headers.get("authorization")
+            captured["bridge_token"] = self.headers.get("x-openclaw-hermes-token")
+            captured["body"] = json.loads(self.rfile.read(length))
+            payload = {
+                "ok": True,
+                "taskId": "tasks.organize_today",
+                "mode": "mock",
+                "status": "succeeded",
+                "summary": "Dry-run completed. No external side effects were performed.",
+                "auditLog": [{"step": "dry-run", "message": "no effects", "at": "1970-01-01T00:00:00.000Z"}],
+                "artifacts": [],
+                "output": {"dryRun": True},
+            }
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):  # noqa: A002
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        monkeypatch.setenv("OPENCLAW_GATEWAY_URL", f"http://127.0.0.1:{server.server_port}")
+        monkeypatch.setenv("OPENCLAW_GATEWAY_TOKEN", "gateway-token")
+        monkeypatch.setenv("OPENCLAW_HERMES_BRIDGE_TOKEN", "bridge-token")
+
+        result = _decode(
+            openclaw_delegate(
+                {
+                    "taskId": "tasks.organize_today",
+                    "intent": "請 OpenClaw 幫我整理今天的任務，但只做 dry-run。",
+                    "dryRun": True,
+                    "allowedTools": [],
+                    "input": {"request": "請 OpenClaw 幫我整理今天的任務，但只做 dry-run。"},
+                    "requestId": "req-1",
+                }
+            )
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    assert captured["path"] == "/api/plugins/hermes-bridge/tasks"
+    assert captured["authorization"] == "Bearer gateway-token"
+    assert captured["bridge_token"] == "bridge-token"
+    assert captured["body"]["taskId"] == "tasks.organize_today"
+    assert captured["body"]["dryRun"] is True
+    assert captured["body"]["allowedTools"] == []
+    assert captured["body"]["idempotencyKey"] == "req-1"
+    assert result["status"] == "succeeded"
+    assert result["summary"] == "Dry-run completed. No external side effects were performed."
+    assert result["auditLog"][0]["step"] == "dry-run"
+
+
+def test_openclaw_delegate_blocks_unsafe_bridge_result(monkeypatch):
+    from plugins.openclaw_bridge.tools import openclaw_delegate
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            payload = {
+                "ok": True,
+                "taskId": "tasks.organize_today",
+                "mode": "live",
+                "status": "succeeded",
+                "summary": "Live execution completed.",
+                "auditLog": [],
+                "artifacts": [],
+                "output": {"dryRun": False, "sideEffectsPerformed": True},
+            }
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):  # noqa: A002
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        monkeypatch.setenv("OPENCLAW_GATEWAY_URL", f"http://127.0.0.1:{server.server_port}")
+        monkeypatch.setenv("OPENCLAW_GATEWAY_TOKEN", "gateway-token")
+        monkeypatch.setenv("OPENCLAW_HERMES_BRIDGE_TOKEN", "bridge-token")
+
+        result = _decode(
+            openclaw_delegate(
+                {
+                    "taskId": "tasks.organize_today",
+                    "intent": "請 OpenClaw 幫我整理今天的任務，但只做 dry-run。",
+                    "dryRun": True,
+                    "allowedTools": [],
+                    "input": {"request": "請 OpenClaw 幫我整理今天的任務，但只做 dry-run。"},
+                }
+            )
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    assert result["ok"] is False
+    assert result["status"] == "blocked"
+    assert result["error"] == "unsafe_bridge_result"
+    assert "dry-run" in result["message"]
+
+
+def test_plugin_registers_tool():
+    from plugins.openclaw_bridge import register
+
+    calls = []
+
+    class Ctx:
+        def register_tool(self, **kwargs):
+            calls.append(kwargs)
+
+        def register_command(self, *args, **kwargs):
+            return None
+
+        def register_hook(self, *args, **kwargs):
+            return None
+
+    register(Ctx())
+
+    assert calls[0]["name"] == "openclaw_delegate"
+    assert calls[0]["toolset"] == "openclaw_bridge"
+    assert calls[0]["schema"]["name"] == "openclaw_delegate"
+    assert callable(calls[0]["handler"])
+    assert callable(calls[0]["check_fn"])
+
+
+
+def test_plugin_registers_command_and_gateway_hook():
+    from plugins.openclaw_bridge import register
+
+    calls = {"tools": [], "commands": [], "hooks": []}
+
+    class Ctx:
+        def register_tool(self, **kwargs):
+            calls["tools"].append(kwargs)
+
+        def register_command(self, *args, **kwargs):
+            calls["commands"].append((args, kwargs))
+
+        def register_hook(self, *args, **kwargs):
+            calls["hooks"].append((args, kwargs))
+
+    register(Ctx())
+
+    assert calls["tools"][0]["name"] == "openclaw_delegate"
+    assert calls["commands"][0][0][0] == "openclaw-dry-run"
+    assert callable(calls["commands"][0][0][1])
+    assert calls["commands"][1][0][0] == "clawops"
+    assert callable(calls["commands"][1][0][1])
+    assert calls["commands"][2][0][0] == "clawops-run"
+    assert callable(calls["commands"][2][0][1])
+    assert calls["commands"][3][0][0] == "clawops-approve"
+    assert callable(calls["commands"][3][0][1])
+    assert calls["hooks"][0][0][0] == "pre_gateway_dispatch"
+    assert callable(calls["hooks"][0][0][1])
+
+
+def test_plugin_registers_host_llm_for_clawops_execution():
+    from plugins.openclaw_bridge import register
+    from plugins.openclaw_bridge import tools
+
+    fake_llm = object()
+
+    class Ctx:
+        @property
+        def llm(self):
+            return fake_llm
+
+        def register_tool(self, **kwargs):
+            return None
+
+        def register_command(self, *args, **kwargs):
+            return None
+
+        def register_hook(self, *args, **kwargs):
+            return None
+
+    tools.set_clawops_host_llm(None)
+    register(Ctx())
+
+    assert tools.get_clawops_host_llm() is fake_llm
+
+
+def test_clawops_route_hahow_course_design_uses_course_designer():
+    from plugins.openclaw_bridge.tools import route_clawops_task
+
+    result = route_clawops_task(
+        {
+            "project": "hahow_course",
+            "taskType": "course_design",
+            "riskLevel": "medium",
+            "request": "請 ClawOps 規劃 Hahow 課程大綱",
+        }
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == "routed"
+    assert result["project"] == "hahow_course"
+    assert result["taskType"] == "course_design"
+    assert result["assignedAgent"] == "course_designer"
+    assert result["primaryModel"] == "codex"
+    assert result["fallbackModel"] == "gemini-3.1-pro"
+    assert result["approvalRequired"] is False
+    assert result["dryRun"] is True
+    assert result["externalSideEffects"] is False
+
+
+def test_clawops_command_executes_agent_team_by_default(monkeypatch):
+    from plugins.openclaw_bridge import tools
+
+    def fake_execute(args, **kwargs):
+        assert args["request"] == "請規劃 Hahow 課程大綱"
+        return {
+            "ok": True,
+            "status": "generated",
+            "project": "hahow_course",
+            "taskType": "course_design",
+            "assignedAgent": "course_designer",
+            "primaryModel": "codex",
+            "fallbackModel": "gemini-3.1-pro",
+            "modelUsed": "codex_app_server",
+            "approvalRequired": False,
+            "dryRun": True,
+            "externalModelCall": True,
+            "externalSideEffects": False,
+            "output": "課程草稿：風險觀念、錢包安全、交易實作。",
+        }
+
+    monkeypatch.setattr(tools, "execute_clawops_task", fake_execute)
+
+    result = tools.handle_clawops_command("請規劃 Hahow 課程大綱")
+
+    assert "ClawOps agent execution" in result
+    assert "Status: generated" in result
+    assert "Project: hahow_course" in result
+    assert "Task type: course_design" in result
+    assert "Assigned agent: course_designer" in result
+    assert "Model used: codex_app_server" in result
+    assert "External model call: yes" in result
+    assert "External actions: none" in result
+    assert "課程草稿" in result
+    assert "routing dry-run" not in result
+
+
+def test_clawops_agent_model_registry_question_injects_registry_context():
+    from plugins.openclaw_bridge import tools
+
+    routing = tools.route_clawops_task({"request": "請幫我整理我們ClawOps的責任分工和使用的語言模型"})
+    prompt = tools._codex_app_server_prompt(
+        {"request": "請幫我整理我們ClawOps的責任分工和使用的語言模型"},
+        routing,
+    )
+
+    assert "ClawOps registry context" in prompt
+    assert "Hermes-Grace (hermes_grace)" in prompt
+    assert "Operations Orchestrator (orchestrator)" in prompt
+    assert "Course Designer Agent (course_designer)" in prompt
+    assert "Content Creator Agent (content_creator)" in prompt
+    assert "primary_model=codex" in prompt
+    assert "primary_model=gemini-2.5-flash" in prompt
+    assert "gemini-3.1-flash-lite" not in prompt
+
+
+def test_clawops_execute_codex_primary_uses_host_llm():
+    from plugins.openclaw_bridge import tools
+
+    captured: dict = {}
+
+    class FakeLlm:
+        def complete(self, messages, **kwargs):
+            captured["messages"] = messages
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(
+                text="課程設計草稿：先建立風險觀念，再進入錢包與交易所安全實作。",
+                provider="openai-codex",
+                model="gpt-5.5",
+            )
+
+    tools.set_clawops_codex_app_server_enabled(False)
+    tools.set_clawops_host_llm(FakeLlm())
+    try:
+        result = tools.execute_clawops_task({"request": "請規劃 Hahow 課程大綱"})
+    finally:
+        tools.set_clawops_host_llm(None)
+        tools.set_clawops_codex_app_server_enabled(None)
+
+    assert result["ok"] is True
+    assert result["status"] == "generated"
+    assert result["assignedAgent"] == "course_designer"
+    assert result["primaryModel"] == "codex"
+    assert result["fallbackModel"] == "gemini-3.1-pro"
+    assert result["modelUsed"] == "gpt-5.5"
+    assert result["modelProvider"] == "openai-codex"
+    assert result["externalModelCall"] is True
+    assert result["externalSideEffects"] is False
+    assert "課程設計草稿" in result["output"]
+    assert captured["kwargs"]["purpose"] == "clawops:course_designer"
+    assert captured["kwargs"]["temperature"] == 0.3
+    assert captured["messages"][0]["role"] == "system"
+    assert "course_designer" in captured["messages"][0]["content"]
+    assert "請規劃 Hahow 課程大綱" in captured["messages"][1]["content"]
+
+
+def test_clawops_execute_codex_primary_uses_codex_app_server():
+    from plugins.openclaw_bridge import tools
+
+    captured: dict = {}
+
+    class FakeTurn:
+        final_text = "Codex app-server 課程草稿：先建立風險觀念，再設計安全實作。"
+        error = None
+
+    class FakeSession:
+        def __init__(self, **kwargs):
+            captured["init"] = kwargs
+            self.closed = False
+
+        def ensure_started(self):
+            captured["started"] = True
+            return "thread-1"
+
+        def run_turn(self, user_input):
+            captured["user_input"] = user_input
+            return FakeTurn()
+
+        def close(self):
+            captured["closed"] = True
+
+    tools.set_clawops_codex_app_server_enabled(True)
+    tools.set_clawops_codex_app_server_session_factory(FakeSession)
+    try:
+        result = tools.execute_clawops_task({"request": "請規劃 Hahow 課程大綱"})
+    finally:
+        tools.set_clawops_codex_app_server_session_factory(None)
+        tools.set_clawops_codex_app_server_enabled(None)
+
+    assert result["ok"] is True
+    assert result["status"] == "generated"
+    assert result["assignedAgent"] == "course_designer"
+    assert result["primaryModel"] == "codex"
+    assert result["modelProvider"] == "codex_app_server"
+    assert result["modelUsed"] == "codex_app_server"
+    assert result["externalModelCall"] is True
+    assert result["externalSideEffects"] is False
+    assert captured["started"] is True
+    assert captured["closed"] is True
+    assert "course_designer" in captured["user_input"]
+    assert "請規劃 Hahow 課程大綱" in captured["user_input"]
+    assert "Codex app-server 課程草稿" in result["output"]
+
+
+def test_clawops_execute_codex_primary_falls_back_to_gemini(monkeypatch):
+    from plugins.openclaw_bridge import tools
+
+    captured: dict = {}
+
+    class FailingLlm:
+        def complete(self, messages, **kwargs):
+            raise RuntimeError("Codex host unavailable")
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers["content-length"])
+            captured["body"] = json.loads(self.rfile.read(length))
+            payload = {
+                "choices": [
+                    {
+                        "message": {
+                            "content": "Fallback 課程草稿：先講風險，再講錢包安全。"
+                        }
+                    }
+                ]
+            }
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):  # noqa: A002
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        tools.set_clawops_codex_app_server_enabled(False)
+        tools.set_clawops_host_llm(FailingLlm())
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+        monkeypatch.setenv("CLAWOPS_GEMINI_BASE_URL", f"http://127.0.0.1:{server.server_port}/v1beta/openai")
+
+        result = tools.execute_clawops_task({"request": "請規劃 Hahow 課程大綱"})
+    finally:
+        tools.set_clawops_host_llm(None)
+        tools.set_clawops_codex_app_server_enabled(None)
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    assert result["ok"] is True
+    assert result["status"] == "generated"
+    assert result["assignedAgent"] == "course_designer"
+    assert result["primaryModel"] == "codex"
+    assert result["fallbackModel"] == "gemini-3.1-pro"
+    assert result["fallbackUsed"] is True
+    assert result["fallbackReason"] == "host_llm_request_failed"
+    assert result["modelUsed"] == "gemini-3.1-pro-preview"
+    assert captured["body"]["model"] == "gemini-3.1-pro-preview"
+    assert "Fallback 課程草稿" in result["output"]
+
+
+def test_clawops_execute_blocks_without_gemini_key(monkeypatch):
+    from plugins.openclaw_bridge.tools import execute_clawops_task
+
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    result = execute_clawops_task(
+        {
+            "project": "course_marketing",
+            "taskType": "campaign",
+            "request": "請規劃課程招生行銷活動",
+        }
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == "blocked"
+    assert result["error"] == "missing_model_api_key"
+    assert result["assignedAgent"] == "marketing_operator"
+    assert result["primaryModel"] == "gemini-2.5-flash"
+    assert result["fallbackModel"] == "codex"
+    assert result["dryRun"] is True
+    assert result["externalSideEffects"] is False
+
+
+def test_clawops_execute_calls_gemini_openai_compatible_endpoint(monkeypatch):
+    from plugins.openclaw_bridge.tools import execute_clawops_task
+
+    captured: dict = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers["content-length"])
+            captured["path"] = self.path
+            captured["authorization"] = self.headers.get("authorization")
+            captured["content_type"] = self.headers.get("content-type")
+            captured["body"] = json.loads(self.rfile.read(length))
+            payload = {
+                "choices": [
+                    {
+                        "message": {
+                            "content": "課程草稿：第一週風險觀念，第二週錢包安全，第三週交易所實作。"
+                        }
+                    }
+                ]
+            }
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):  # noqa: A002
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+        monkeypatch.setenv("CLAWOPS_GEMINI_BASE_URL", f"http://127.0.0.1:{server.server_port}/v1beta/openai")
+
+        result = execute_clawops_task(
+            {
+                "project": "course_marketing",
+                "taskType": "campaign",
+                "request": "請規劃課程招生行銷活動",
+            }
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    assert captured["path"] == "/v1beta/openai/chat/completions"
+    assert captured["authorization"] == "Bearer test-google-key"
+    assert captured["content_type"] == "application/json"
+    assert captured["body"]["model"] == "gemini-2.5-flash"
+    assert captured["body"]["temperature"] == 0.4
+    assert captured["body"]["messages"][0]["role"] == "system"
+    assert "marketing_operator" in captured["body"]["messages"][0]["content"]
+    assert captured["body"]["messages"][1]["role"] == "user"
+    assert "請規劃課程招生行銷活動" in captured["body"]["messages"][1]["content"]
+    assert result["ok"] is True
+    assert result["status"] == "generated"
+    assert result["assignedAgent"] == "marketing_operator"
+    assert result["primaryModel"] == "gemini-2.5-flash"
+    assert result["modelUsed"] == "gemini-2.5-flash"
+    assert result["dryRun"] is True
+    assert result["externalModelCall"] is True
+    assert result["externalSideEffects"] is False
+    assert "課程草稿" in result["output"]
+
+
+def test_clawops_gemini_request_uses_https_context(monkeypatch):
+    from plugins.openclaw_bridge import tools
+
+    captured: dict = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return None
+
+        def read(self):
+            return json.dumps({"choices": [{"message": {"content": "草稿"}}]}).encode("utf-8")
+
+    def fake_urlopen(request, timeout, context=None):
+        captured["timeout"] = timeout
+        captured["context"] = context
+        return FakeResponse()
+
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+    monkeypatch.setattr(tools.urllib.request, "urlopen", fake_urlopen)
+
+    result = tools.execute_clawops_task(
+        {
+            "project": "course_marketing",
+            "taskType": "campaign",
+            "request": "請規劃課程招生行銷活動",
+        }
+    )
+
+    assert result["ok"] is True
+    assert captured["timeout"] == 60
+    assert captured["context"] is not None
+
+
+def test_clawops_execute_redacts_secret_bearing_http_errors(monkeypatch):
+    from plugins.openclaw_bridge import tools
+
+    def fake_urlopen(request, timeout, context=None):
+        body = b'{"error":{"message":"bad key test-google-key and Authorization: Bearer secret-token"}}'
+        raise urllib.error.HTTPError(request.full_url, 401, "Unauthorized", {}, None)
+
+    class FakeHttpError(urllib.error.HTTPError):
+        def read(self):
+            return b'{"error":{"message":"bad key test-google-key and Authorization: Bearer secret-token"}}'
+
+    def raise_error(request, timeout, context=None):
+        raise FakeHttpError(request.full_url, 401, "Unauthorized", {}, None)
+
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+    monkeypatch.setattr(tools.urllib.request, "urlopen", raise_error)
+
+    result = tools.execute_clawops_task(
+        {
+            "project": "course_marketing",
+            "taskType": "campaign",
+            "request": "請規劃課程招生行銷活動",
+        }
+    )
+
+    assert result["ok"] is False
+    assert result["error"] == "model_http_error"
+    assert "test-google-key" not in result["message"]
+    assert "secret-token" not in result["message"]
+    assert "[REDACTED]" in result["message"]
+
+
+def test_clawops_run_command_formats_generated_output(monkeypatch):
+    from plugins.openclaw_bridge import tools
+
+    def fake_execute(args, **kwargs):
+        return {
+            "ok": True,
+            "status": "generated",
+            "project": "hahow_course",
+            "taskType": "course_design",
+            "assignedAgent": "course_designer",
+            "primaryModel": "gemini-3.1-pro",
+            "fallbackModel": "codex",
+            "modelUsed": "gemini-3.1-pro",
+            "approvalRequired": False,
+            "dryRun": True,
+            "externalModelCall": True,
+            "externalSideEffects": False,
+            "output": "課程草稿：風險觀念、錢包安全、交易實作。",
+        }
+
+    monkeypatch.setattr(tools, "execute_clawops_task", fake_execute)
+
+    result = tools.handle_clawops_run_command("請規劃 Hahow 課程大綱")
+
+    assert "ClawOps agent execution" in result
+    assert "Status: generated" in result
+    assert "Assigned agent: course_designer" in result
+    assert "Model used: gemini-3.1-pro" in result
+    assert "External model call: yes" in result
+    assert "External actions: none" in result
+    assert "課程草稿" in result
+
+
+def test_clawops_execution_formatter_shows_fallback_usage():
+    from plugins.openclaw_bridge.tools import format_clawops_execution_result
+
+    result = format_clawops_execution_result(
+        {
+            "ok": True,
+            "status": "generated",
+            "project": "hahow_course",
+            "taskType": "course_design",
+            "assignedAgent": "course_designer",
+            "primaryModel": "codex",
+            "fallbackModel": "gemini-3.1-pro",
+            "modelUsed": "gemini-3.1-pro-preview",
+            "fallbackUsed": True,
+            "fallbackReason": "host_llm_request_failed",
+            "approvalRequired": False,
+            "dryRun": True,
+            "externalModelCall": True,
+            "externalSideEffects": False,
+            "output": "課程草稿",
+        }
+    )
+
+    assert "Fallback used: yes" in result
+    assert "Fallback reason: host_llm_request_failed" in result
+    assert "Model used: gemini-3.1-pro-preview" in result
+
+
+def test_clawops_execution_formatter_marks_external_actions_pending_approval():
+    from plugins.openclaw_bridge.tools import format_clawops_execution_result
+
+    result = format_clawops_execution_result(
+        {
+            "ok": True,
+            "status": "generated",
+            "project": "course_marketing",
+            "taskType": "campaign_planning",
+            "assignedAgent": "marketing_operator",
+            "primaryModel": "gemini-2.5-flash",
+            "fallbackModel": "codex",
+            "modelUsed": "gemini-2.5-flash",
+            "approvalRequired": True,
+            "dryRun": True,
+            "externalModelCall": True,
+            "externalSideEffects": False,
+            "output": "招募文案草稿",
+        }
+    )
+
+    assert "Approval required: yes" in result
+    assert "External actions: pending your approval" in result
+
+
+def test_clawops_approval_required_execution_creates_pending_approval(monkeypatch, tmp_path):
+    from plugins.openclaw_bridge import tools
+
+    monkeypatch.setenv("CLAWOPS_APPROVALS_DIR", str(tmp_path))
+
+    def fake_gemini_task(**kwargs):
+        fields = kwargs["fields"]
+        return {
+            "ok": True,
+            "status": "generated",
+            **fields,
+            "modelUsed": "gemini-2.5-flash",
+            "externalModelCall": True,
+            "externalSideEffects": False,
+            "output": "招生貼文草稿",
+        }
+
+    monkeypatch.setattr(tools, "_execute_clawops_gemini_task", fake_gemini_task)
+
+    result = tools.execute_clawops_task(
+        {
+            "request": "請 ClawOps 規劃招生行銷貼文，待我確認後再發文",
+            "project": "course_marketing",
+            "taskType": "campaign",
+            "actions": [
+                {
+                    "type": "audit.record",
+                    "description": "Record approved publication intent.",
+                    "payload": {"channel": "telegram", "summary": "招生貼文草稿"},
+                }
+            ],
+        }
+    )
+
+    assert result["ok"] is True
+    assert result["approvalRequired"] is True
+    assert result["approvalStatus"] == "pending"
+    assert result["approvalId"].startswith("clawops-")
+    assert result["executableActions"] == 1
+
+    approval_file = tmp_path / f"{result['approvalId']}.json"
+    assert approval_file.is_file()
+    saved = json.loads(approval_file.read_text(encoding="utf-8"))
+    assert saved["status"] == "pending"
+    assert saved["actions"][0]["type"] == "audit.record"
+
+
+def test_clawops_approve_command_executes_allowlisted_action(monkeypatch, tmp_path):
+    from plugins.openclaw_bridge import tools
+
+    monkeypatch.setenv("CLAWOPS_APPROVALS_DIR", str(tmp_path))
+    approval_id = "clawops-test-approve"
+    (tmp_path / f"{approval_id}.json").write_text(
+        json.dumps(
+            {
+                "id": approval_id,
+                "status": "pending",
+                "actions": [
+                    {
+                        "type": "audit.record",
+                        "description": "Record approved action.",
+                        "payload": {"summary": "approved"},
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = tools.handle_clawops_approve_command(approval_id)
+
+    assert "ClawOps approved actions executed" in result
+    assert "Approval id: clawops-test-approve" in result
+    assert "Executed actions: 1" in result
+    saved = json.loads((tmp_path / f"{approval_id}.json").read_text(encoding="utf-8"))
+    assert saved["status"] == "executed"
+    assert (tmp_path / "audit.log").is_file()
+
+
+def test_clawops_approve_command_blocks_unsupported_action(monkeypatch, tmp_path):
+    from plugins.openclaw_bridge import tools
+
+    monkeypatch.setenv("CLAWOPS_APPROVALS_DIR", str(tmp_path))
+    approval_id = "clawops-test-blocked"
+    (tmp_path / f"{approval_id}.json").write_text(
+        json.dumps(
+            {
+                "id": approval_id,
+                "status": "pending",
+                "actions": [
+                    {
+                        "type": "telegram.send",
+                        "description": "Send a Telegram message.",
+                        "payload": {"text": "hello"},
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = tools.handle_clawops_approve_command(approval_id)
+
+    assert "ClawOps approved actions did not execute" in result
+    assert "unsupported_action" in result
+    saved = json.loads((tmp_path / f"{approval_id}.json").read_text(encoding="utf-8"))
+    assert saved["status"] == "blocked"
+
+
+def test_pre_gateway_dispatch_rewrites_openclaw_dry_run_message():
+    from types import SimpleNamespace
+
+    from plugins.openclaw_bridge.tools import pre_gateway_dispatch
+
+    result = pre_gateway_dispatch(
+        event=SimpleNamespace(text="請 OpenClaw 幫我整理今天的任務，但只做 dry-run。")
+    )
+
+    assert result == {
+        "action": "rewrite",
+        "text": "/openclaw-dry-run 請 OpenClaw 幫我整理今天的任務，但只做 dry-run。",
+    }
+
+
+def test_pre_gateway_dispatch_rewrites_clawops_message():
+    from types import SimpleNamespace
+
+    from plugins.openclaw_bridge.tools import pre_gateway_dispatch
+
+    result = pre_gateway_dispatch(event=SimpleNamespace(text="Grace，請找 ClawOps 規劃 Hahow 課程"))
+
+    assert result == {
+        "action": "rewrite",
+        "text": "/clawops Grace，請找 ClawOps 規劃 Hahow 課程",
+    }
+
+
+def test_openclaw_dry_run_command_delegates_to_bridge(monkeypatch):
+    from plugins.openclaw_bridge.tools import handle_openclaw_dry_run_command
+
+    captured: dict = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers["content-length"])
+            captured["body"] = json.loads(self.rfile.read(length))
+            payload = {
+                "ok": True,
+                "taskId": "tasks.organize_today",
+                "mode": "mock",
+                "status": "succeeded",
+                "summary": "Dry-run completed. No external side effects were performed.",
+                "auditLog": [],
+                "artifacts": [],
+                "output": {"dryRun": True, "sideEffectsPerformed": False},
+            }
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):  # noqa: A002
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        monkeypatch.setenv("OPENCLAW_GATEWAY_URL", f"http://127.0.0.1:{server.server_port}")
+        monkeypatch.setenv("OPENCLAW_GATEWAY_TOKEN", "gateway-token")
+        monkeypatch.setenv("OPENCLAW_HERMES_BRIDGE_TOKEN", "bridge-token")
+
+        result = handle_openclaw_dry_run_command(
+            "請 OpenClaw 幫我整理今天的任務，但只做 dry-run。"
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    assert captured["body"]["taskId"] == "tasks.organize_today"
+    assert captured["body"]["dryRun"] is True
+    assert captured["body"]["allowedTools"] == []
+    assert "OpenClaw dry-run completed" in result
+    assert "Status: succeeded" in result
+    assert "Task: tasks.organize_today" in result
+    assert "Dry-run completed. No external side effects were performed." in result
+    assert "External side effects: no" in result


### PR DESCRIPTION
## Summary

Adds a local `openclaw_bridge` plugin and ClawOps skills so Hermes-Grace can route user requests into the OpenClaw/ClawOps operating model.

## What changed

- Adds `/clawops` as the single user-facing ClawOps entry point for agent execution without external side effects.
- Keeps `/clawops-run` as a backwards-compatible alias.
- Adds `/clawops-approve <approval_id>` for pending approval records and allowlisted action execution.
- Adds ClawOps registry-grounded prompt context for Grace + ClawOps collaboration, so model answers use the configured agent/model matrix instead of generic agent categories.
- Adds the `openclaw_delegate` dry-run bridge for approved local OpenClaw task templates.
- Adds ClawOps and OpenClaw delegation skills.
- Adds plugin tests covering routing, model selection, Codex app-server execution, Gemini fallback/API calls, approval records, approval execution blocking, redaction, and gateway rewrite behavior.

## Safety

- External side effects remain blocked unless routed through a pending approval record.
- The only allowlisted executor handler in this patch is `audit.record`; unsupported actions such as posting, email, deployment, or credential access remain blocked.
- Secret-bearing error messages are redacted before returning to users.

## Validation

- `.venv312/bin/python -m pytest tests/plugins/test_openclaw_bridge_plugin.py -q`
- Result: `29 passed`
