### PR TITLE
fix(docker): preserve sanitized skills host path inode across mounts

### DIFF
--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -173,6 +173,65 @@ class TestSkillsDirectoryMount:
 
         assert mounts[0]["host_path"] == str(skills_dir)
 
+    def test_sanitized_mount_lifecycle_is_stable(self, tmp_path):
+        """Repeated calls to get_skills_directory_mount() with symlinks must:
+        - Return the same stable host path (no path identity changes).
+        - Correctly synchronize added/modified files in-place.
+        - Delete files that are removed from the source.
+        - Skip symlinks entirely.
+        """
+        hermes_home = tmp_path / ".hermes"
+        skills_dir = hermes_home / "skills"
+        skills_dir.mkdir(parents=True)
+        
+        # 1. Setup initial files with a dummy file that we mock as a symlink
+        (skills_dir / "file1.txt").write_text("content1")
+        (skills_dir / "link.txt").write_text("mocked-symlink")
+
+        # Mock Path.is_symlink to treat link.txt as a symlink
+        original_is_symlink = Path.is_symlink
+        def mock_is_symlink(self_path):
+            if self_path.name == "link.txt":
+                return True
+            return original_is_symlink(self_path)
+
+        # Mock os.readlink to return a dummy target for link.txt
+        original_readlink = os.readlink
+        def mock_readlink(path):
+            if Path(path).name == "link.txt":
+                return "mocked-target"
+            return original_readlink(path)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}), \
+             patch.object(Path, "is_symlink", mock_is_symlink), \
+             patch("os.readlink", mock_readlink):
+            mounts1 = get_skills_directory_mount()
+            assert len(mounts1) >= 1
+            host_path1 = mounts1[0]["host_path"]
+            
+            # Verify file1 exists but mocked symlink is skipped
+            assert (Path(host_path1) / "file1.txt").exists()
+            assert (Path(host_path1) / "file1.txt").read_text() == "content1"
+            assert not (Path(host_path1) / "link.txt").exists()
+
+            # 2. Modify files (add file2.txt, delete file1.txt)
+            (skills_dir / "file2.txt").write_text("content2")
+            (skills_dir / "file1.txt").unlink()
+
+            mounts2 = get_skills_directory_mount()
+            assert len(mounts2) >= 1
+            host_path2 = mounts2[0]["host_path"]
+
+            # 3. Assertions
+            # Path must remain stable
+            assert host_path1 == host_path2
+            
+            # Synchronization updates
+            assert (Path(host_path2) / "file2.txt").exists()
+            assert (Path(host_path2) / "file2.txt").read_text() == "content2"
+            assert not (Path(host_path2) / "file1.txt").exists()
+            assert not (Path(host_path2) / "link.txt").exists()
+
 
 class TestIterSkillsFiles:
     def test_returns_files_skipping_symlinks(self, tmp_path):

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -175,10 +175,12 @@ class TestSkillsDirectoryMount:
 
     def test_sanitized_mount_lifecycle_is_stable(self, tmp_path):
         """Repeated calls to get_skills_directory_mount() with symlinks must:
-        - Return the same stable host path (no path identity changes).
+        - Return the same stable host path and inode (no directory recreation).
         - Correctly synchronize added/modified files in-place.
         - Delete files that are removed from the source.
         - Skip symlinks entirely.
+        - Handle file ↔ directory type transitions without crashing.
+        - Remove any symlinks found in the destination.
         """
         hermes_home = tmp_path / ".hermes"
         skills_dir = hermes_home / "skills"
@@ -222,15 +224,48 @@ class TestSkillsDirectoryMount:
             assert len(mounts2) >= 1
             host_path2 = mounts2[0]["host_path"]
 
-            # 3. Assertions
-            # Path must remain stable
+            # Path and inode must remain stable
             assert host_path1 == host_path2
+            assert os.stat(host_path1).st_ino == os.stat(host_path2).st_ino
             
             # Synchronization updates
             assert (Path(host_path2) / "file2.txt").exists()
             assert (Path(host_path2) / "file2.txt").read_text() == "content2"
             assert not (Path(host_path2) / "file1.txt").exists()
             assert not (Path(host_path2) / "link.txt").exists()
+
+            # 3. Type transitions: file2.txt (file) → directory, add beta/ then remove it next round
+            (skills_dir / "file2.txt").unlink()
+            (skills_dir / "file2.txt").mkdir()
+            (skills_dir / "file2.txt" / "SKILL.md").write_text("# skill")
+            (skills_dir / "beta").mkdir()
+            (skills_dir / "beta" / "child.txt").write_text("child")
+
+            mounts3 = get_skills_directory_mount()
+            host_path3 = mounts3[0]["host_path"]
+
+            assert host_path1 == host_path3
+            assert os.stat(host_path1).st_ino == os.stat(host_path3).st_ino
+            # file→dir: file2.txt is now a directory with SKILL.md inside
+            assert (Path(host_path3) / "file2.txt").is_dir()
+            assert (Path(host_path3) / "file2.txt" / "SKILL.md").read_text() == "# skill"
+
+            # 4. Reverse: file2.txt (dir) → file, beta (dir) → removed
+            import shutil
+            shutil.rmtree(skills_dir / "file2.txt")
+            (skills_dir / "file2.txt").write_text("flat again")
+            shutil.rmtree(skills_dir / "beta")
+
+            mounts4 = get_skills_directory_mount()
+            host_path4 = mounts4[0]["host_path"]
+
+            assert host_path1 == host_path4
+            assert os.stat(host_path1).st_ino == os.stat(host_path4).st_ino
+            # dir→file: file2.txt is a file again
+            assert (Path(host_path4) / "file2.txt").is_file()
+            assert (Path(host_path4) / "file2.txt").read_text() == "flat again"
+            assert not (Path(host_path4) / "beta").exists()
+
 
 
 class TestIterSkillsFiles:

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -211,9 +211,11 @@ def get_skills_directory_mount(
     **Security:** Bind mounts follow symlinks, so a malicious symlink inside
     the skills tree could expose arbitrary host files to the container.  When
     symlinks are detected, this function creates a sanitized copy (regular
-    files only) in a temp directory and returns that path instead.  When no
-    symlinks are present (the common case), the original directory is returned
-    directly with zero overhead.
+    files only) in a stable cache directory under ``{HERMES_HOME}/cache/skills_sanitized/``
+    and returns that path instead. The stable directory is reused across calls and only
+    the contents are refreshed in-place, preserving Docker bind-mount validity for persistent
+    containers. When no symlinks are present (the common case), the original directory is
+    returned directly with zero overhead.
 
     Returns a list of dicts with ``host_path`` and ``container_path`` keys.
     The local skills dir mounts at ``<container_base>/skills``, external dirs
@@ -223,7 +225,7 @@ def get_skills_directory_mount(
     hermes_home = _resolve_hermes_home()
     skills_dir = hermes_home / "skills"
     if skills_dir.is_dir():
-        host_path = _safe_skills_path(skills_dir)
+        host_path = _safe_skills_path(skills_dir, "local")
         mounts.append({
             "host_path": host_path,
             "container_path": f"{container_base.rstrip('/')}/skills",
@@ -234,7 +236,7 @@ def get_skills_directory_mount(
         from agent.skill_utils import get_external_skills_dirs
         for idx, ext_dir in enumerate(get_external_skills_dirs()):
             if ext_dir.is_dir():
-                host_path = _safe_skills_path(ext_dir)
+                host_path = _safe_skills_path(ext_dir, f"ext_{idx}")
                 mounts.append({
                     "host_path": host_path,
                     "container_path": f"{container_base.rstrip('/')}/external_skills/{idx}",
@@ -245,13 +247,57 @@ def get_skills_directory_mount(
     return mounts
 
 
-_safe_skills_tempdir: Path | None = None
+def _sync_dir(src: Path, dst: Path) -> None:
+    """Synchronize source directory to destination directory in-place.
+
+    Skips symlinks on the source. Removes files/dirs from destination if
+    they are missing or are symlinks in the source.
+    """
+    import shutil
+    dst.mkdir(parents=True, exist_ok=True)
+
+    # 1. Copy new or modified files
+    for item in src.rglob("*"):
+        if item.is_symlink():
+            continue
+        rel = item.relative_to(src)
+        target = dst / rel
+        if item.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+        elif item.is_file():
+            try:
+                src_stat = item.stat()
+                if not target.exists():
+                    should_copy = True
+                else:
+                    tgt_stat = target.stat()
+                    should_copy = (src_stat.st_mtime != tgt_stat.st_mtime or 
+                                   src_stat.st_size != tgt_stat.st_size)
+            except OSError:
+                should_copy = True
+
+            if should_copy:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(str(item), str(target))
+
+    # 2. Clean up removed or symlinked files in destination
+    for item in list(dst.rglob("*")):
+        if not item.exists():
+            continue
+        rel = item.relative_to(dst)
+        src_item = src / rel
+        if not src_item.exists() or src_item.is_symlink():
+            if item.is_dir():
+                shutil.rmtree(item, ignore_errors=True)
+            else:
+                try:
+                    item.unlink(missing_ok=True)
+                except OSError:
+                    pass
 
 
-def _safe_skills_path(skills_dir: Path) -> str:
-    """Return *skills_dir* if symlink-free, else a sanitized temp copy."""
-    global _safe_skills_tempdir
-
+def _safe_skills_path(skills_dir: Path, suffix: str = "local") -> str:
+    """Return *skills_dir* if symlink-free, else a sanitized stable cache copy."""
     symlinks = [p for p in skills_dir.rglob("*") if p.is_symlink()]
     if not symlinks:
         return str(skills_dir)
@@ -260,34 +306,12 @@ def _safe_skills_path(skills_dir: Path) -> str:
         logger.warning("credential_files: skipping symlink in skills dir: %s -> %s",
                        link, os.readlink(link))
 
-    import atexit
-    import shutil
-    import tempfile
+    cache_root = _resolve_hermes_home() / "cache" / "skills_sanitized"
+    safe_dir = cache_root / suffix
 
-    # Reuse the same temp dir across calls to avoid accumulation.
-    if _safe_skills_tempdir and _safe_skills_tempdir.is_dir():
-        shutil.rmtree(_safe_skills_tempdir, ignore_errors=True)
+    _sync_dir(skills_dir, safe_dir)
 
-    safe_dir = Path(tempfile.mkdtemp(prefix="hermes-skills-safe-"))
-    _safe_skills_tempdir = safe_dir
-
-    for item in skills_dir.rglob("*"):
-        if item.is_symlink():
-            continue
-        rel = item.relative_to(skills_dir)
-        target = safe_dir / rel
-        if item.is_dir():
-            target.mkdir(parents=True, exist_ok=True)
-        elif item.is_file():
-            target.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(str(item), str(target))
-
-    def _cleanup():
-        if safe_dir.is_dir():
-            shutil.rmtree(safe_dir, ignore_errors=True)
-
-    atexit.register(_cleanup)
-    logger.info("credential_files: created symlink-safe skills copy at %s", safe_dir)
+    logger.info("credential_files: updated symlink-safe skills copy at %s", safe_dir)
     return str(safe_dir)
 
 

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -263,6 +263,9 @@ def _sync_dir(src: Path, dst: Path) -> None:
         rel = item.relative_to(src)
         target = dst / rel
         if item.is_dir():
+            # Remove conflicting file/symlink so mkdir succeeds
+            if target.is_symlink() or (target.exists() and not target.is_dir()):
+                target.unlink()
             target.mkdir(parents=True, exist_ok=True)
         elif item.is_file():
             try:
@@ -278,10 +281,18 @@ def _sync_dir(src: Path, dst: Path) -> None:
 
             if should_copy:
                 target.parent.mkdir(parents=True, exist_ok=True)
+                # Remove conflicting dir/symlink so copy2 replaces correctly
+                if target.is_symlink():
+                    target.unlink()
+                elif target.is_dir():
+                    shutil.rmtree(target, ignore_errors=True)
                 shutil.copy2(str(item), str(target))
 
     # 2. Clean up removed or symlinked files in destination
     for item in list(dst.rglob("*")):
+        if item.is_symlink():
+            item.unlink(missing_ok=True)
+            continue
         if not item.exists():
             continue
         rel = item.relative_to(dst)


### PR DESCRIPTION
## What does this PR do?

When executing skills in a persistent Docker container, Hermes sanitizes symlinks by copying skills files into a local folder and bind-mounting that folder.

Previously, this copy was created using `tempfile.mkdtemp()`. On subsequent executions, Hermes deleted the old temp copy and created a new one. Because persistent Docker containers track the original host directory's filesystem inode, deleting the directory unlinked the bind mount, causing `/root/.hermes/skills` inside the running container to appear empty.

This PR replaces the ephemeral temp-directory approach with a stable, profile-scoped cache folder: `{HERMES_HOME}/cache/skills_sanitized/local` (and `ext_<index>` for external skills). Instead of deleting the root directory, it synchronizes contents in-place using a lightweight `_sync_dir()` helper. This preserves the root folder inode and maintains bind mount validity across multiple tool executions in persistent containers.


## Related Issue

Fixes #53630


## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)


## Changes Made

### `tools/credential_files.py`
- Removed obsolete `_safe_skills_tempdir`, `tempfile.mkdtemp()`, and the `atexit`-registered cleanup callbacks.
- Added `_sync_dir(src, dst)` to recursively mirror source directories to stable destination folders in-place (comparing modification times and sizes to skip redundant copying, and purging deleted/symlinked items).
- Updated `_safe_skills_path()` to use the stable cache directory under `{HERMES_HOME}/cache/skills_sanitized/` and update contents in-place.
- Refreshed docstring for `get_skills_directory_mount()` to remove obsolete references to temp directories.

### `tests/tools/test_credential_files.py`
- Added the regression test `test_sanitized_mount_lifecycle_is_stable()` matching the test suite's existing style, with a robust mock strategy for `is_symlink` and `os.readlink` to ensure cross-platform execution (avoiding privilege errors on native Windows setups).


## How to Test

1. Create a mock skills directory containing a file and a symlink.
2. Trigger the skills mount call:
   ```python
   from tools.credential_files import get_skills_directory_mount
   mounts1 = get_skills_directory_mount()
   host_path1 = mounts1[0]["host_path"]
