### PR TITLE
fix(anthropic): honor 'max' effort on manual thinking path + clamp budget to output ceiling

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -55,7 +55,7 @@ def _get_anthropic_sdk():
 
 logger = logging.getLogger(__name__)
 
-THINKING_BUDGET = {"xhigh": 32000, "high": 16000, "medium": 8000, "low": 4000}
+THINKING_BUDGET = {"max": 64000, "xhigh": 32000, "high": 16000, "medium": 8000, "low": 4000}
 # Hermes effort → Anthropic adaptive-thinking effort (output_config.effort).
 # Anthropic exposes 5 levels on 4.7+: low, medium, high, xhigh, max.
 # Opus/Sonnet 4.6 only expose 4 levels: low, medium, high, max — no xhigh.
@@ -2527,6 +2527,16 @@ def build_anthropic_kwargs(
                     "effort": adaptive_effort,
                 }
             else:
+                # Clamp the thinking budget to the model's output ceiling so
+                # the enforced max_tokens (budget + 4096 headroom) never exceeds
+                # what the API will accept. Without this, high/xhigh/max can
+                # push max_tokens past the output cap and 400 on models with
+                # smaller ceilings (e.g. Sonnet 4.5 / Opus 4.5 at 64K, or
+                # Claude 3.5 at 8K). The 1024 floor keeps thinking above
+                # Anthropic's minimum budget.
+                _out_ceiling = _get_anthropic_max_output(model)
+                if _out_ceiling > 0:
+                    budget = min(budget, max(1024, _out_ceiling - 4096))
                 kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
                 # Anthropic requires temperature=1 when thinking is enabled on older models
                 kwargs["temperature"] = 1

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -10,6 +10,7 @@ import pytest
 
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.anthropic_adapter import (
+    _get_anthropic_max_output,
     _is_azure_anthropic_endpoint,
     _is_oauth_token,
     _refresh_oauth_token,
@@ -1248,6 +1249,75 @@ class TestBuildAnthropicKwargs:
         assert kwargs["temperature"] == 1
         assert kwargs["max_tokens"] >= 16000 + 4096
         assert "output_config" not in kwargs
+
+    def test_max_effort_budget_on_manual_thinking_path(self):
+        # Regression for #49580: the manual/non-adaptive thinking path looks
+        # the budget up via THINKING_BUDGET.get(effort, 8000). Before "max"
+        # had a key it fell through to the 8000 default — BELOW xhigh's 32000 —
+        # silently under-budgeting the strongest tier on pre-adaptive Claude.
+        # On a model with a large output ceiling, "max" resolves to its full
+        # 64000 budget and max_tokens grows to fit it.
+        kwargs = build_anthropic_kwargs(
+            model="claude-3-7-sonnet-20250219",  # 128K output ceiling, manual path
+            messages=[{"role": "user", "content": "think as hard as possible"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "max"},
+        )
+        assert kwargs["thinking"]["type"] == "enabled"
+        assert "output_config" not in kwargs  # proves we stayed on the manual path
+        assert kwargs["thinking"]["budget_tokens"] == 64000
+        assert kwargs["thinking"]["budget_tokens"] > 32000  # never under-budget vs xhigh
+        assert kwargs["max_tokens"] >= 64000 + 4096
+
+    def test_manual_thinking_budget_clamped_to_output_ceiling(self):
+        # The enforced max_tokens is max(requested, budget + 4096). A large
+        # effort budget must NOT drive max_tokens past the model's output
+        # ceiling, or the Anthropic API 400s. The budget is clamped to
+        # (ceiling - 4096) so max_tokens lands at the ceiling, not above it.
+        # claude-sonnet-4-20250514 has a 64K output ceiling on the manual path.
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-20250514",
+            messages=[{"role": "user", "content": "max it out"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "max"},
+        )
+        assert kwargs["thinking"]["type"] == "enabled"
+        assert "output_config" not in kwargs
+        ceiling = _get_anthropic_max_output("claude-sonnet-4-20250514")
+        # budget clamped below the raw 64000 so it fits under the ceiling
+        assert kwargs["thinking"]["budget_tokens"] <= ceiling - 4096
+        # critical invariant: max_tokens never exceeds the output ceiling
+        assert kwargs["max_tokens"] <= ceiling
+
+    @pytest.mark.parametrize(
+        "model,effort",
+        [
+            ("claude-sonnet-4-20250514", "max"),    # 64K ceiling
+            ("claude-opus-4-1", "max"),             # 32K ceiling
+            ("claude-3-5-sonnet-20241022", "max"),  # 8K ceiling
+            # pre-existing bug class: high/xhigh could also overrun small caps
+            ("claude-3-5-sonnet-20241022", "xhigh"),
+            ("claude-3-5-sonnet-20241022", "high"),
+        ],
+    )
+    def test_manual_thinking_respects_output_ceiling_across_tiers(self, model, effort):
+        # Invariant for #49580 (whole bug class): on the manual thinking path,
+        # the effort-driven budget must never push max_tokens above the model's
+        # output ceiling, for ANY effort tier — not just "max". Budget stays at
+        # or above Anthropic's 1024 minimum.
+        kwargs = build_anthropic_kwargs(
+            model=model,
+            messages=[{"role": "user", "content": "think"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": effort},
+        )
+        ceiling = _get_anthropic_max_output(model)
+        assert "output_config" not in kwargs  # manual path
+        assert kwargs["thinking"]["budget_tokens"] >= 1024
+        assert kwargs["max_tokens"] <= ceiling
 
     def test_reasoning_config_maps_to_adaptive_thinking_for_4_6_models(self):
         kwargs = build_anthropic_kwargs(


### PR DESCRIPTION
## What does this PR do?

Fixes a two-part bug in the Anthropic adapter's **manual (non-adaptive) thinking path** so the `max` reasoning effort is honored without exceeding model output caps.

**Part 1 — `max` was silently under-budgeted.** The manual path resolves its thinking budget via `THINKING_BUDGET.get(effort, 8000)` (`agent/anthropic_adapter.py:58`, used at `:2515`). The dict had no `"max"` key, so `max` fell through to the `8000` default — *below* `xhigh`'s `32000` — on pre-adaptive Claude. (The adaptive path, Opus/Sonnet 4.7+, already handles `max` via `ADAPTIVE_EFFORT_MAP` + `output_config.effort`, so only the manual path was affected.) This is exactly the gap reported in #49580.

**Part 2 — the obvious fix alone causes a 400.** Just adding `"max": 64000` is unsafe: the manual path sets `max_tokens = max(requested, budget + 4096)`, which drives the output cap to `68096`. That exceeds the output ceiling on `claude-sonnet-4-*` / `claude-opus-4-5` (64K), `claude-opus-4-1` (32K), and `claude-3-5-sonnet` (8K) -> API 400. So this PR also **clamps the budget to `output_ceiling - 4096`** (with a 1024 floor, Anthropic's minimum) before computing `max_tokens`, guaranteeing the request fits. This additionally fixes the **pre-existing latent case** where `high`/`xhigh` could overrun small ceilings — the whole bug class, not just `max`.

The adaptive path is untouched (the change is confined to the manual `else` branch; tests pin this by asserting `output_config` is absent).

## Related Issue

Fixes #49580

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_adapter.py`
  - Add `"max": 64000` to `THINKING_BUDGET`.
  - In the manual-thinking branch, clamp `budget = min(budget, max(1024, _get_anthropic_max_output(model) - 4096))` so the enforced `max_tokens` never exceeds the model's output ceiling.
- `tests/agent/test_anthropic_adapter.py`
  - `test_max_effort_budget_on_manual_thinking_path` — `max` yields the full 64000 budget on a high-ceiling model (3.7 Sonnet, 128K); asserts manual path (`output_config` absent).
  - `test_manual_thinking_budget_clamped_to_output_ceiling` — on a 64K model, budget is clamped and `max_tokens <= ceiling`.
  - `test_manual_thinking_respects_output_ceiling_across_tiers` — parametrized over 64K/32K/8K ceilings and `max`/`xhigh`/`high` tiers; locks the bug-class invariant `max_tokens <= ceiling` and `budget >= 1024`.

## How to Test

1. `pytest tests/agent/test_anthropic_adapter.py -q` -> all pass (173).
2. Proof the tests catch the bug (not change-detectors):
   - Revert only the `"max"` key -> `test_max_effort_budget_on_manual_thinking_path` fails with `8000 == 64000`.
   - Revert only the clamp (keep the key) -> `test_manual_thinking_budget_clamped_to_output_ceiling` fails with `64000 <= 59904` (max_tokens would be 68096 > 64000 ceiling, the API 400).
3. Behavior check:
   - `claude-3-7-sonnet` (128K): `max` -> budget 64000, max_tokens 68096 (under ceiling)
   - `claude-sonnet-4-20250514` (64K): budget 59904, max_tokens 64000 (at ceiling)
   - `claude-3-5-sonnet` (8K): budget 4096, max_tokens 8192 (at ceiling)
   - `claude-opus-4-8` (adaptive): unchanged, `output_config={"effort":"max"}`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(anthropic): ...`)
- [x] I searched for existing PRs/issues to make sure this isn't a duplicate (found #49580, which this fixes; no competing PR)
- [x] My PR contains **only** changes related to this fix (2 files)
- [x] I've run `pytest tests/agent/test_anthropic_adapter.py -q` and all tests pass
- [x] I've added tests for my changes (3 new, all verified to fail without the fix)
- [x] I've tested on my platform: Ubuntu (Linux 6.8)

### Documentation & Housekeeping

- [x] N/A — no docs/config keys/tool schemas changed (internal budget-resolution fix)
- [x] Cross-platform: pure-Python logic, no platform-specific calls

## Screenshots / Logs

```
# without the "max" key:
>  assert kwargs["thinking"]["budget_tokens"] == 64000
E  assert 8000 == 64000

# without the clamp (key present):
>  assert kwargs["thinking"]["budget_tokens"] <= ceiling - 4096
E  assert 64000 <= (64000 - 4096)

# final:
173 passed in 5.25s
```
