### PR TITLE
fix(tools): export environment factory for backend probes

### DIFF
--- a/tests/tools/test_environments_public_api.py
+++ b/tests/tools/test_environments_public_api.py
@@ -1,0 +1,72 @@
+"""Regression coverage for the public environments package API."""
+
+from __future__ import annotations
+
+
+def test_get_environment_is_publicly_importable_for_backend_probes(tmp_path):
+    from tools.environments import get_environment
+
+    env = get_environment({"env_type": "local", "cwd": str(tmp_path), "timeout": 5})
+
+    assert env.__class__.__name__ == "LocalEnvironment"
+    assert hasattr(env, "execute")
+
+
+def test_get_environment_forwards_container_config(monkeypatch):
+    import tools.terminal_tool as terminal_tool
+    from tools.environments import get_environment
+
+    captured = {}
+    sentinel = object()
+
+    def fake_create_environment(**kwargs):
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(terminal_tool, "_create_environment", fake_create_environment)
+
+    result = get_environment(
+        {
+            "env_type": "docker",
+            "docker_image": "example/image:latest",
+            "cwd": "/workspace",
+            "host_cwd": "/host/project",
+            "timeout": 9,
+            "container_cpu": 2,
+            "container_memory": 4096,
+            "container_disk": 20000,
+            "container_persistent": False,
+            "docker_volumes": ["/host/cache:/cache"],
+            "docker_forward_env": ["API_KEY"],
+            "docker_env": {"MODE": "test"},
+            "docker_run_as_host_user": True,
+            "docker_extra_args": ["--network=none"],
+            "docker_persist_across_processes": False,
+            "docker_mount_cwd_to_workspace": True,
+        },
+        task_id="backend-probe",
+    )
+
+    assert result is sentinel
+    assert captured["env_type"] == "docker"
+    assert captured["image"] == "example/image:latest"
+    assert captured["cwd"] == "/workspace"
+    assert captured["host_cwd"] == "/host/project"
+    assert captured["timeout"] == 9
+    assert captured["task_id"] == "backend-probe"
+    assert captured["ssh_config"] is None
+    assert captured["container_config"] == {
+        "container_cpu": 2,
+        "container_memory": 4096,
+        "container_disk": 20000,
+        "container_persistent": False,
+        "modal_mode": "auto",
+        "docker_volumes": ["/host/cache:/cache"],
+        "docker_mount_cwd_to_workspace": True,
+        "docker_forward_env": ["API_KEY"],
+        "docker_env": {"MODE": "test"},
+        "docker_run_as_host_user": True,
+        "docker_extra_args": ["--network=none"],
+        "docker_persist_across_processes": False,
+        "docker_orphan_reaper": True,
+    }

--- a/tools/environments/__init__.py
+++ b/tools/environments/__init__.py
@@ -9,6 +9,108 @@ The terminal_tool.py factory (_create_environment) selects the backend
 based on the TERMINAL_ENV configuration.
 """
 
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping
+
 from tools.environments.base import BaseEnvironment
 
-__all__ = ["BaseEnvironment"]
+_CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona"})
+_IMAGE_CONFIG_KEYS = {
+    "docker": "docker_image",
+    "singularity": "singularity_image",
+    "modal": "modal_image",
+    "daytona": "daytona_image",
+}
+
+
+def _default_cwd(env_type: str) -> str:
+    if env_type == "ssh":
+        return "~"
+    if env_type in _CONTAINER_BACKENDS:
+        return "/root"
+    try:
+        return os.getcwd()
+    except FileNotFoundError:
+        return os.path.expanduser("~")
+
+
+def get_environment(
+    config: Mapping[str, Any] | None = None,
+    *,
+    task_id: str = "default",
+) -> BaseEnvironment:
+    """Create an execution environment from terminal-style configuration.
+
+    This public wrapper supports lightweight callers, such as prompt backend
+    probes, without requiring them to import terminal_tool private helpers
+    directly. Backend construction is still delegated to the terminal tool
+    factory so behavior stays aligned with normal terminal execution.
+    """
+    config = config or {}
+    env_type = str(config.get("env_type") or "local")
+    timeout = int(config.get("timeout") or 180)
+    cwd = str(config.get("cwd") or _default_cwd(env_type))
+    image_key = _IMAGE_CONFIG_KEYS.get(env_type)
+    image = str(config.get(image_key, "") if image_key else "")
+
+    ssh_config = None
+    if env_type == "ssh":
+        ssh_config = {
+            "host": config.get("ssh_host", ""),
+            "user": config.get("ssh_user", ""),
+            "port": config.get("ssh_port", 22),
+            "key": config.get("ssh_key", ""),
+            "persistent": config.get("ssh_persistent", False),
+        }
+
+    container_config = None
+    if env_type in _CONTAINER_BACKENDS:
+        container_config = {
+            "container_cpu": config.get("container_cpu", 1),
+            "container_memory": config.get("container_memory", 5120),
+            "container_disk": config.get("container_disk", 51200),
+            "container_persistent": config.get("container_persistent", True),
+            "modal_mode": config.get("modal_mode", "auto"),
+            "docker_volumes": config.get("docker_volumes", []),
+            "docker_mount_cwd_to_workspace": config.get(
+                "docker_mount_cwd_to_workspace",
+                False,
+            ),
+            "docker_forward_env": config.get("docker_forward_env", []),
+            "docker_env": config.get("docker_env", {}),
+            "docker_run_as_host_user": config.get(
+                "docker_run_as_host_user",
+                False,
+            ),
+            "docker_extra_args": config.get("docker_extra_args", []),
+            "docker_persist_across_processes": config.get(
+                "docker_persist_across_processes",
+                True,
+            ),
+            "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
+        }
+
+    local_config = None
+    if env_type == "local":
+        local_config = {
+            "persistent": config.get("local_persistent", False),
+        }
+
+    from tools.terminal_tool import _create_environment
+
+    return _create_environment(
+        env_type=env_type,
+        image=image,
+        cwd=cwd,
+        timeout=timeout,
+        ssh_config=ssh_config,
+        container_config=container_config,
+        local_config=local_config,
+        task_id=task_id,
+        host_cwd=config.get("host_cwd"),
+    )
+
+
+__all__ = ["BaseEnvironment", "get_environment"]


### PR DESCRIPTION
## Summary
- Export `get_environment()` from `tools.environments` for backend probes.
- Delegate environment creation to the existing terminal factory so local, SSH, and container config handling stays consistent.
- Add regression coverage for public import and container config forwarding.

## Root Cause
`agent.prompt_builder._probe_remote_backend()` imports `get_environment` from `tools.environments`, but the package only exported `BaseEnvironment`. On v0.17.0 that import can fail and disable the backend probe path with the error reported in #53667.

Fixes #53667

## Tests
- `python -m pytest tests/tools/test_environments_public_api.py tests/agent/test_prompt_builder.py -q`
- `python -m pytest tests/tools/test_terminal_tool_requirements.py tests/tools/test_environments_public_api.py -q`
- `python -m py_compile tools/environments/__init__.py tests/tools/test_environments_public_api.py`
- `python -c "from tools.environments import get_environment; print(get_environment.__name__)"`
- `git diff --check`