### PR TITLE
fix(auxiliary): pass max_tokens explicitly for LiteLLM/Bedrock proxies

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5201,6 +5201,12 @@ def _build_call_kwargs(
         )
         if _is_anthropic_compat_endpoint(provider, _effective_base):
             kwargs["max_tokens"] = max_tokens
+        elif max_tokens is not None:
+            # Pass max_tokens explicitly. Some LiteLLM proxies default to a
+            # very large value when max_tokens is omitted, which Bedrock
+            # rejects with a 400 ("exceeds the model limit").
+            _mt = auxiliary_max_tokens_param(max_tokens, model=model)
+            kwargs.update(_mt)
 
     if tools:
         # Defensive dedup: providers like Google Vertex, Azure, and Bedrock


### PR DESCRIPTION
## Problem

Auxiliary vision calls fail with HTTP 400 when using a LiteLLM proxy as a custom provider for Bedrock-backed models (e.g. `claude-sonnet-4-6-bedrock`):

```
litellm.BadRequestError: BedrockException - {
  "message": "The maximum tokens you requested exceeds the model limit of 128000.
  Try again with a maximum tokens value that is lower than 128000."
}
```

LiteLLM then falls back to another model group (e.g. `glm-5-1`), which fails to handle the image input in this auxiliary vision call, causing the entire request to fail.

## Root Cause

In `_build_call_kwargs()` (`agent/auxiliary_client.py`), `max_tokens` is only passed explicitly for Anthropic-compatible endpoints:

```python
if _is_anthropic_compat_endpoint(provider, _effective_base):
    kwargs["max_tokens"] = max_tokens
```

For all other endpoints, `max_tokens` is **omitted entirely** (the comment says *"We do NOT cap output by default"*). This works for direct OpenAI/Anthropic API calls, but **LiteLLM proxy fills in a very large default value** when `max_tokens` is absent, which Bedrock rejects.

## Fix

Pass `max_tokens` explicitly for non-Anthropic endpoints too, using the existing `auxiliary_max_tokens_param()` helper (which correctly handles `max_completion_tokens` for GPT-5/o-series models):

```diff
         if _is_anthropic_compat_endpoint(provider, _effective_base):
             kwargs["max_tokens"] = max_tokens
+        elif max_tokens is not None:
+            # Pass max_tokens explicitly. Some LiteLLM proxies default to a
+            # very large value when max_tokens is omitted, which Bedrock
+            # rejects with a 400 ("exceeds the model limit").
+            _mt = auxiliary_max_tokens_param(max_tokens, model=model)
+            kwargs.update(_mt)
```

## Why this is safe

- `auxiliary_max_tokens_param()` already handles the `max_tokens` vs `max_completion_tokens` distinction for GPT-5/o-series models
- The `max_tokens is not None` guard preserves existing behavior for callers that don't set it
- Anthropic-compat endpoints keep their existing code path unchanged
- Verified with manual tests:
  - LiteLLM + Bedrock (`claude-sonnet-4-6-bedrock`): ✅ `max_tokens=2000` passed correctly
  - GPT-5 model: ✅ `max_completion_tokens=2000` used automatically
  - No `max_tokens` set: ✅ not passed (unchanged behavior)

## Testing

Verified the fix locally with a LiteLLM proxy + Bedrock backend:
- Before: `vision_analyze` → `Connection error` / `400 exceeds model limit`
- After: `vision_analyze` → ✅ image analyzed successfully

Fixes #53677

