### PR TITLE
fix(dingtalk): add raw_process() to _IncomingHandler for SDK >= 0.24

### DIFF
--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -1432,6 +1432,31 @@ class _IncomingHandler(
         """
         return
 
+    async def raw_process(self, callback_message: "CallbackMessage"):
+        """Bridge for dingtalk-stream >= 0.24.
+
+        The SDK dispatches incoming messages via ``raw_process()`` on
+        registered handlers.  The base ``ChatbotHandler.raw_process()``
+        calls ``self.process()`` *synchronously*, which silently drops
+        the coroutine returned by our async override.  This explicit
+        override awaits ``process()`` and returns a proper ACK.
+        """
+        try:
+            result = await self.process(callback_message)
+            if isinstance(result, tuple):
+                status, msg = result
+            else:
+                status, msg = AckMessage.STATUS_OK, "OK"
+        except Exception:
+            status, msg = AckMessage.STATUS_SYSTEM_EXCEPTION, "error"
+
+        ack = AckMessage()
+        ack.code = status
+        ack.headers.message_id = callback_message.headers.message_id
+        ack.headers.content_type = Headers.CONTENT_TYPE_APPLICATION_JSON
+        ack.message = msg
+        return ack
+
     async def process(self, message: "CallbackMessage"):
         """Called by dingtalk-stream (>=0.20) when a message arrives.
 

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -124,7 +124,7 @@ def check_dingtalk_requirements() -> bool:
     Lazy-installs dingtalk-stream via ``tools.lazy_deps.ensure("platform.dingtalk")``
     on first call if not present.
     """
-    global DINGTALK_STREAM_AVAILABLE, dingtalk_stream, ChatbotMessage, CallbackMessage, AckMessage
+    global DINGTALK_STREAM_AVAILABLE, dingtalk_stream, ChatbotMessage, CallbackMessage, AckMessage, Headers
     global HTTPX_AVAILABLE, httpx
     if not DINGTALK_STREAM_AVAILABLE or not HTTPX_AVAILABLE:
         try:
@@ -135,7 +135,7 @@ def check_dingtalk_requirements() -> bool:
         try:
             import dingtalk_stream as _ds
             from dingtalk_stream import ChatbotMessage as _CM
-            from dingtalk_stream.frames import CallbackMessage as _CBM, AckMessage as _AM
+            from dingtalk_stream.frames import CallbackMessage as _CBM, AckMessage as _AM, Headers as _H
             import httpx as _httpx
         except Exception:
             return False
@@ -143,6 +143,7 @@ def check_dingtalk_requirements() -> bool:
         ChatbotMessage = _CM
         CallbackMessage = _CBM
         AckMessage = _AM
+        Headers = _H
         httpx = _httpx
         DINGTALK_STREAM_AVAILABLE = True
         HTTPX_AVAILABLE = True

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -39,7 +39,7 @@ from typing import Any, Dict, List, Optional, Set
 try:
     import dingtalk_stream
     from dingtalk_stream import ChatbotMessage
-    from dingtalk_stream.frames import CallbackMessage, AckMessage
+    from dingtalk_stream.frames import CallbackMessage, AckMessage, Headers
 
     DINGTALK_STREAM_AVAILABLE = True
 except Exception:  # noqa: BLE001 — broad: optional SDK's transitive deps (cryptography) may raise non-ImportError; degrade gracefully (#41112)
@@ -47,6 +47,7 @@ except Exception:  # noqa: BLE001 — broad: optional SDK's transitive deps (cry
     dingtalk_stream = None  # type: ignore[assignment]
     ChatbotMessage = None  # type: ignore[assignment]
     CallbackMessage = None  # type: ignore[assignment]
+    Headers = None  # type: ignore[assignment]
     AckMessage = type(
         "AckMessage",
         (),
@@ -1454,7 +1455,7 @@ class _IncomingHandler(
         ack.code = status
         ack.headers.message_id = callback_message.headers.message_id
         ack.headers.content_type = Headers.CONTENT_TYPE_APPLICATION_JSON
-        ack.message = msg
+        ack.data = {"response": msg}
         return ack
 
     async def process(self, message: "CallbackMessage"):

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -491,6 +491,61 @@ class TestHandlerProcessIsAsync:
         assert asyncio.iscoroutinefunction(_IncomingHandler.process)
 
 
+class TestRawProcessAck:
+    """raw_process() must return a well-formed AckMessage for SDK >= 0.24."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_sdk_types(self, monkeypatch):
+        import plugins.platforms.dingtalk.adapter as dt
+
+        class _FakeAckMessage:
+            STATUS_OK = 200
+            STATUS_SYSTEM_EXCEPTION = 500
+
+            def __init__(self):
+                self.code = None
+                self.headers = SimpleNamespace(message_id=None, content_type=None)
+                self.data = None
+                self.message = None
+
+        monkeypatch.setattr(dt, "AckMessage", _FakeAckMessage)
+        monkeypatch.setattr(
+            dt, "Headers",
+            SimpleNamespace(CONTENT_TYPE_APPLICATION_JSON="application/json"),
+            raising=False,
+        )
+
+    @pytest.fixture()
+    def handler(self):
+        from plugins.platforms.dingtalk.adapter import _IncomingHandler
+        adapter = MagicMock()
+        return _IncomingHandler(adapter)
+
+    @staticmethod
+    def _make_callback(msg_id="test-msg-123"):
+        headers = SimpleNamespace(message_id=msg_id, content_type=None)
+        return SimpleNamespace(headers=headers, data={"text": "hello"})
+
+    def test_ack_shape_on_success(self, handler):
+        handler.process = AsyncMock(return_value=(200, "OK"))
+        callback = self._make_callback()
+
+        ack = asyncio.run(handler.raw_process(callback))
+
+        assert ack.code == 200
+        assert ack.headers.message_id == "test-msg-123"
+        assert ack.data == {"response": "OK"}
+
+    def test_ack_shape_on_exception(self, handler):
+        handler.process = AsyncMock(side_effect=RuntimeError("boom"))
+        callback = self._make_callback()
+
+        ack = asyncio.run(handler.raw_process(callback))
+
+        assert ack.code == 500
+        assert ack.data == {"response": "error"}
+
+
 class TestExtractText:
     """_extract_text must handle both legacy and current SDK payload shapes.
 

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -1,5 +1,6 @@
 """Tests for DingTalk platform adapter."""
 import asyncio
+import sys
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -544,6 +545,42 @@ class TestRawProcessAck:
 
         assert ack.code == 500
         assert ack.data == {"response": "error"}
+
+
+class TestLazyInstallBindsHeaders:
+    """The lazy-install path must rebind ``Headers`` alongside the other SDK types.
+
+    When the module is first imported without the SDK, ``Headers`` is ``None``.
+    ``check_dingtalk_requirements()`` lazily installs the SDK and must rebind
+    ``Headers`` too, otherwise ``raw_process()`` raises ``AttributeError`` when
+    setting ``content_type``.
+    """
+
+    def test_headers_rebound_after_lazy_install(self, monkeypatch):
+        import plugins.platforms.dingtalk.adapter as dt
+
+        fake_frames = SimpleNamespace(
+            CallbackMessage=object,
+            AckMessage=SimpleNamespace(STATUS_OK=200, STATUS_SYSTEM_EXCEPTION=500),
+            Headers=SimpleNamespace(CONTENT_TYPE_APPLICATION_JSON="application/json"),
+        )
+        fake_ds = SimpleNamespace(ChatbotMessage=object, frames=fake_frames)
+
+        # Simulate the "SDK absent at import" state.
+        monkeypatch.setattr(dt, "DINGTALK_STREAM_AVAILABLE", False)
+        monkeypatch.setattr(dt, "HTTPX_AVAILABLE", False)
+        monkeypatch.setattr(dt, "Headers", None, raising=False)
+        monkeypatch.setenv("DINGTALK_CLIENT_ID", "id")
+        monkeypatch.setenv("DINGTALK_CLIENT_SECRET", "secret")
+
+        monkeypatch.setattr("tools.lazy_deps.ensure", lambda *a, **k: None)
+        monkeypatch.setitem(sys.modules, "dingtalk_stream", fake_ds)
+        monkeypatch.setitem(sys.modules, "dingtalk_stream.frames", fake_frames)
+        monkeypatch.setitem(sys.modules, "httpx", SimpleNamespace())
+
+        assert dt.check_dingtalk_requirements() is True
+        assert dt.Headers is fake_frames.Headers
+        assert dt.Headers.CONTENT_TYPE_APPLICATION_JSON == "application/json"
 
 
 class TestExtractText:


### PR DESCRIPTION
## Summary

- `dingtalk-stream` SDK >= 0.24 dispatches incoming messages via `raw_process()` on registered handlers
- The base `ChatbotHandler.raw_process()` calls `self.process()` **synchronously**, which silently drops the coroutine returned by the async override in `_IncomingHandler`
- This causes `AttributeError: '_IncomingHandler' object has no attribute 'raw_process'` and all incoming DingTalk messages are ignored
- Added an explicit `async raw_process()` that awaits `process()` and returns a proper `AckMessage`

## Test plan

- [x] Verified on a fresh Hermes v0.17.0 install with `dingtalk-stream==0.24.3`
- [x] Before patch: gateway logs show `ERROR dingtalk_stream.client: error processing message: '_IncomingHandler' object has no attribute 'raw_process'` on every incoming message
- [x] After patch: DingTalk messages are received and processed normally