### PR TITLE
fix(auxiliary): preserve provider when base_url is passed explicitly

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5146,9 +5146,11 @@ def _resolve_task_provider_model(
       3. "auto" (full auto-detection chain)
 
     Returns (provider, model, base_url, api_key, api_mode) where model may
-    be None (use provider default). When base_url is set, provider is forced
-    to "custom" and the task uses that direct endpoint. api_mode is one of
-    "chat_completions", "codex_responses", or None (auto-detect).
+    be None (use provider default). When base_url is set without an explicit
+    provider, provider is forced to "custom". When both provider and base_url
+    are given, the provider is preserved so credentials can be resolved from
+    its env vars. api_mode is one of "chat_completions", "codex_responses",
+    or None (auto-detect).
     """
     cfg_provider = None
     cfg_model = None
@@ -5187,6 +5189,13 @@ def _resolve_task_provider_model(
         cfg_provider, cfg_base_url = _expand_direct_api_alias(cfg_provider, cfg_base_url)
 
     if base_url:
+        # When both an explicit provider and base_url are given, keep the
+        # provider name so resolve_provider_client can resolve credentials
+        # from env vars (e.g. ZAI_API_KEY, OPENROUTER_API_KEY). Only fall
+        # back to "custom" when no provider was specified. Mirrors the
+        # config-based logic below (cfg_base_url + cfg_provider).
+        if provider and provider not in {"", "auto", "custom"}:
+            return provider, resolved_model, base_url, api_key, resolved_api_mode
         return "custom", resolved_model, base_url, api_key, resolved_api_mode
     if provider:
         return provider, resolved_model, base_url, api_key, resolved_api_mode


### PR DESCRIPTION
## Fix: preserve provider when base_url is passed explicitly

Fixes #53687

### Problem

`_resolve_task_provider_model()` forces the provider to `"custom"` whenever `base_url` is passed as an explicit argument — even when a real provider name (`"zai"`, `"openrouter"`, etc.) was also provided. This causes credential resolution to fail because `resolve_provider_client("custom", ...)` doesn't know about provider-specific env vars (`ZAI_API_KEY`, `OPENROUTER_API_KEY`, etc.) and falls back to `"no-key-required"`, producing **401 errors** on every call.

### Root Cause

The explicit-args path and the config-based path handle `base_url` differently:

```python
# BUG — explicit args path (line 5189):
if base_url:
    return "custom", resolved_model, base_url, api_key, resolved_api_mode

# CORRECT — config path (line 5199):
if cfg_base_url and cfg_provider and cfg_provider != "auto":
    return cfg_provider, resolved_model, cfg_base_url, None, resolved_api_mode
```

The config path correctly preserves `cfg_provider` when `cfg_base_url` is set. The explicit path doesn't.

This matters because `resolve_vision_provider_client()` internally re-calls `_resolve_task_provider_model()` with explicit args (provider + base_url), which triggers the buggy path:

1. Config sets `provider: zai, base_url: https://api.z.ai/...` → `_resolve_task_provider_model("vision")` returns `("zai", model, base_url, None, None)` ✅
2. `resolve_vision_provider_client(provider="zai", base_url="https://...", api_key=None)` re-calls `_resolve_task_provider_model("vision", "zai", ..., base_url="https://...", None)` with explicit args
3. The explicit `base_url` branch returns `("custom", ...)` instead of `("zai", ...)` ← **bug**
4. `resolve_provider_client("custom", ...)` → `api_key = "no-key-required"` → **401**

### Fix

Make the explicit-args `base_url` branch preserve the provider name when one is given (and it's not `"auto"` or `"custom"`), mirroring the existing config-based logic:

```python
if base_url:
    if provider and provider not in {"", "auto", "custom"}:
        return provider, resolved_model, base_url, api_key, resolved_api_mode
    return "custom", resolved_model, base_url, api_key, resolved_api_mode
```

### Verification

Tested with ZAI/GLM provider:
- Before: `vision_analyze` → `401: token expired or incorrect` (client created with `api_key='no-key-required'`)
- After: `vision_analyze` → works correctly (client created with real API key from `GLM_API_KEY`)

```python
# Before fix:
_resolve_task_provider_model("vision", "zai", "glm-4.6V", "https://api.z.ai/api/coding/paas/v4", None)
→ ("custom", "glm-4.6V", "https://...", None, None)  # ← credentials lost

# After fix:
→ ("zai", "glm-4.6V", "https://...", None, None)  # ← credentials resolved from env
```

Also updated the docstring to accurately reflect the new behavior.
