### PR TITLE
feat(windows): run_hidden() helper + console-spawn footgun guard

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -188,6 +188,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Full history so the console-spawn guard below can diff vs. the
+          # PR base (three-dot diff needs the merge base).
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
@@ -196,3 +200,14 @@ jobs:
 
       - name: Run footgun checker
         run: python scripts/check-windows-footguns.py --all
+
+      - name: Console-spawn guard (changed files only)
+        # Whether a console-binary spawn flashes a window depends on WHERE it
+        # runs (the windowless gateway flashes; an interactive CLI doesn't), so
+        # this rule is kept out of the repo-wide --all gate and instead blocks
+        # only NEW console spawns introduced by this PR. Pre-existing call
+        # sites are a tracked backlog, migrated to run_hidden() over time.
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          python scripts/check-windows-footguns.py --console-spawns --diff "origin/${{ github.base_ref }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -655,7 +655,11 @@ that touches the OS, assume *any* platform can hit your code path.
 
 > **Before you PR:** run `scripts/check-windows-footguns.py` to catch the
 > common Windows-unsafe patterns in your diff. It's grep-based and cheap;
-> CI runs it on every PR too.
+> CI runs it on every PR too. Spawning a console binary (`git`, `gh`, …)?
+> Use `hermes_cli._subprocess_compat.run_hidden()` / `popen_hidden()` so it
+> can't flash a console window from the windowless desktop gateway — CI's
+> `--console-spawns` guard (`check-windows-footguns.py --console-spawns
+> --diff <base>`) blocks new raw spawns introduced by your diff.
 
 ### Critical rules
 

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -28,6 +28,7 @@ guarantee.
 from __future__ import annotations
 
 import shutil
+import subprocess
 import sys
 from typing import Sequence
 
@@ -38,6 +39,8 @@ __all__ = [
     "windows_detach_flags_without_breakaway",
     "windows_hide_flags",
     "windows_detach_popen_kwargs",
+    "run_hidden",
+    "popen_hidden",
 ]
 
 
@@ -199,6 +202,35 @@ def windows_hide_flags() -> int:
     if not IS_WINDOWS:
         return 0
     return _CREATE_NO_WINDOW
+
+
+def run_hidden(*args, **kwargs):
+    """``subprocess.run`` that never flashes a console window on Windows.
+
+    Injects ``creationflags=windows_hide_flags()`` (``CREATE_NO_WINDOW`` on
+    win32, ``0`` on POSIX), OR-ed with any ``creationflags`` the caller
+    already passed, then delegates to :func:`subprocess.run`.
+
+    Use this for EVERY console-subsystem binary (``gh``, ``git``, ``where``,
+    version probes …) spawned from a windowless context. The desktop runs its
+    gateway under ``pythonw.exe``, which has no console of its own, so each
+    un-hidden console child allocates — and briefly flashes — a brand-new
+    console window. Centralizing the flag here means call sites can't forget
+    it. No-op on POSIX. See #52310.
+    """
+    kwargs["creationflags"] = kwargs.pop("creationflags", 0) | windows_hide_flags()
+    return subprocess.run(*args, **kwargs)
+
+
+def popen_hidden(*args, **kwargs):
+    """``subprocess.Popen`` counterpart of :func:`run_hidden`.
+
+    Same console-hiding contract; use when you need a handle to the running
+    child (streaming output, ``communicate()`` …) rather than ``run``'s
+    blocking call. No-op on POSIX. See #52310.
+    """
+    kwargs["creationflags"] = kwargs.pop("creationflags", 0) | windows_hide_flags()
+    return subprocess.Popen(*args, **kwargs)
 
 
 def windows_detach_popen_kwargs() -> dict:

--- a/scripts/check-windows-footguns.py
+++ b/scripts/check-windows-footguns.py
@@ -111,6 +111,8 @@ EXCLUDED_SUFFIXES = {
 EXCLUDED_FILES = {
     "scripts/check-windows-footguns.py",
     "CONTRIBUTING.md",
+    # This checker's own tests carry footgun patterns as fixture strings.
+    "tests/scripts/test_check_windows_footguns.py",
 }
 
 
@@ -327,6 +329,153 @@ FOOTGUNS: list[Footgun] = [
 ]
 
 
+# ---------------------------------------------------------------------------
+# Console-binary spawn check (multi-line aware)
+# ---------------------------------------------------------------------------
+#
+# The per-line FOOTGUNS regexes above can't reliably check this one: a
+# subprocess call that spawns a console binary (git, gh, …) usually spans
+# several lines, and the ``creationflags=`` that makes it safe sits on a
+# *different* line from the ``["git", …]`` argv. So we detect it by parsing
+# the call span instead. The bug it guards against: a console-subsystem
+# binary spawned from the windowless desktop gateway (pythonw.exe) without
+# CREATE_NO_WINDOW flashes a black console window on Windows. See #52310.
+
+# argv[0] basenames that own a console and therefore flash a window when
+# spawned without hidden-window creationflags from a windowless parent.
+CONSOLE_SPAWN_BINARIES = frozenset(
+    {
+        "git", "gh", "cmd", "where", "node", "npm", "npx", "pwsh",
+        "powershell", "wsl", "ssh", "conhost", "tmux", "rg",
+    }
+)
+
+# Tokens whose presence anywhere in the call mean the window is already
+# handled — explicit flags, the hidden/detached helpers, or a startupinfo
+# that hides the window.
+_SPAWN_FLAG_OK_TOKENS = (
+    "creationflags",
+    "windows_hide_flags",
+    "windows_detach_flags",
+    "windows_detach_popen_kwargs",
+    "run_hidden",
+    "popen_hidden",
+    "startupinfo",
+)
+
+_SPAWN_CALL_RE = re.compile(
+    r"\bsubprocess\.(?:run|Popen|call|check_call|check_output)\s*\("
+)
+_FIRST_STRING_RE = re.compile(r"""(['"])(.*?)\1""", re.DOTALL)
+
+CONSOLE_SPAWN_FOOTGUN = Footgun(
+    name="subprocess spawn of a console binary without hidden-window flags",
+    # Never matches via the per-line engine; detected by
+    # find_console_spawn_matches(), which is call-span aware.
+    pattern=re.compile(r"(?!)"),
+    message=(
+        "subprocess.run/Popen of a console-subsystem binary (git, gh, …) "
+        "without creationflags spawns a visible console window when the "
+        "parent has none — the desktop gateway runs under pythonw.exe, so "
+        "each such spawn flashes a black window on Windows."
+    ),
+    fix=(
+        "Use hermes_cli._subprocess_compat.run_hidden()/popen_hidden() (or "
+        "pass creationflags=windows_hide_flags()). If this can never run from "
+        "the windowless gateway, suppress with `# windows-footgun: ok`."
+    ),
+)
+
+
+def _balanced_call_span(text: str, open_paren_idx: int) -> str:
+    """Return a call's source from its opening ``(`` to the matching ``)``,
+    balancing nested parens and skipping string literals. Falls back to the
+    rest of the file if the parens never balance."""
+    depth = 0
+    quote: str | None = None
+    i = open_paren_idx
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if quote is not None:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "'\"":
+            quote = c
+        elif c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return text[open_paren_idx : i + 1]
+        i += 1
+    return text[open_paren_idx:]
+
+
+def _basename_no_ext(token: str) -> str:
+    base = token.replace("\\", "/").rsplit("/", 1)[-1].lower()
+    for ext in (".exe", ".cmd", ".bat", ".com"):
+        if base.endswith(ext):
+            return base[: -len(ext)]
+    return base
+
+
+def _spawn_argv0_candidates(span: str) -> set[str]:
+    """Best-effort argv[0] basenames for a call span, from its first string
+    literal. Returns both interpretations so either matches:
+    - the whole literal (an argv-list program path, may contain spaces:
+      ``"C:/Program Files/Git/bin/git.exe"`` → ``git``)
+    - its first whitespace token (a ``shell=True`` command line:
+      ``"git status"`` → ``git``)
+    Empty set when the program is a variable (no literal to read)."""
+    m = _FIRST_STRING_RE.search(span)
+    if not m:
+        return set()
+    raw = m.group(2).strip()
+    if not raw:
+        return set()
+    return {_basename_no_ext(raw), _basename_no_ext(raw.split()[0])}
+
+
+def find_console_spawn_matches(text: str) -> list[tuple[int, str, Footgun]]:
+    """Flag subprocess spawns of console binaries that don't hide the window.
+
+    Multi-line aware (see the module note above). Skips calls that already
+    pass flags / use a helper, calls whose program is a variable, calls
+    inside docstrings or comments, and any call span carrying the
+    ``# windows-footgun: ok`` marker."""
+    lines = text.splitlines()
+    out: list[tuple[int, str, Footgun]] = []
+    for m in _SPAWN_CALL_RE.finditer(text):
+        before = text[: m.start()]
+        # Heuristic docstring skip: an odd number of triple-quotes before the
+        # call means we're inside one (mirrors scan_file's docstring handling).
+        if before.count('"""') % 2 or before.count("'''") % 2:
+            continue
+        open_idx = m.end() - 1
+        span = _balanced_call_span(text, open_idx)
+        if not (_spawn_argv0_candidates(span) & CONSOLE_SPAWN_BINARIES):
+            continue
+        if any(tok in span for tok in _SPAWN_FLAG_OK_TOKENS):
+            continue
+        # The `# windows-footgun: ok` marker usually sits at the end of the
+        # line — i.e. *outside* the call's parentheses — so check every line
+        # the call spans, not just the span text.
+        start_line = before.count("\n")  # 0-based
+        end_line = text.count("\n", 0, open_idx + len(span))  # 0-based
+        call_lines = lines[start_line : end_line + 1]
+        if any(SUPPRESS_MARKER.search(cl) for cl in call_lines):
+            continue
+        first = call_lines[0] if call_lines else ""
+        if first.lstrip().startswith("#"):
+            continue
+        out.append((start_line + 1, first.rstrip(), CONSOLE_SPAWN_FOOTGUN))
+    return out
+
+
 def should_scan_file(path: Path) -> bool:
     """Return True if this file is in scope for the checker."""
     # Skip the excluded dirs
@@ -485,6 +634,17 @@ def scan_file(path: Path, footguns: list[Footgun]) -> list[tuple[int, str, Footg
     return matches
 
 
+def scan_console_spawn_file(path: Path) -> list[tuple[int, str, Footgun]]:
+    """Run only the multi-line console-spawn check on a file. Kept separate
+    from :func:`scan_file` so the repo-wide ``--all`` line-footgun gate stays
+    independent of this contextual, diff-scoped rule."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    return find_console_spawn_matches(text)
+
+
 def get_staged_files() -> list[Path]:
     """Return paths staged in the current git index. Empty on non-git trees."""
     try:
@@ -534,6 +694,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Scan files changed vs. the given git ref (e.g. --diff main).",
     )
     p.add_argument(
+        "--console-spawns",
+        action="store_true",
+        help=(
+            "Run ONLY the console-binary-spawn check (git/gh/… spawned "
+            "without hidden-window flags). Reachability is contextual, so "
+            "this is kept out of the repo-wide --all line-footgun gate and "
+            "meant to run diff-scoped (e.g. --console-spawns --diff main)."
+        ),
+    )
+    p.add_argument(
         "--list",
         action="store_true",
         help="List all known footgun rules and exit.",
@@ -543,7 +713,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 def print_rules() -> None:
     print("Known Windows footguns checked by this script:\n")
-    for i, fg in enumerate(FOOTGUNS, start=1):
+    for i, fg in enumerate([*FOOTGUNS, CONSOLE_SPAWN_FOOTGUN], start=1):
         print(f"{i:2}. {fg.name}")
         print(f"    {fg.message}")
         print(f"    Fix: {fg.fix}")
@@ -598,7 +768,11 @@ def main(argv: list[str]) -> int:
     files_scanned = 0
     for path in iter_files(roots):
         files_scanned += 1
-        matches = scan_file(path, FOOTGUNS)
+        matches = (
+            scan_console_spawn_file(path)
+            if args.console_spawns
+            else scan_file(path, FOOTGUNS)
+        )
         for lineno, line, fg in matches:
             rel = path.relative_to(REPO_ROOT).as_posix()
             print(f"{rel}:{lineno}: [{fg.name}]")

--- a/tests/scripts/test_check_windows_footguns.py
+++ b/tests/scripts/test_check_windows_footguns.py
@@ -1,0 +1,81 @@
+"""Tests for the console-binary-spawn rule in scripts/check-windows-footguns.py.
+
+The checker is a hyphenated script, so it's loaded by path. Fixtures are passed
+to ``find_console_spawn_matches`` as source strings (the test file itself is in
+the checker's EXCLUDED_FILES so its fixtures don't self-trigger the rule).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check-windows-footguns.py"
+_spec = importlib.util.spec_from_file_location("check_windows_footguns", _SCRIPT)
+cwf = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+# Register before exec: the module's @dataclass uses a string annotation, and
+# dataclass resolution looks the module up in sys.modules by name.
+sys.modules["check_windows_footguns"] = cwf
+_spec.loader.exec_module(cwf)
+
+
+def _hit_lines(src: str) -> list[int]:
+    return [lineno for lineno, _line, _fg in cwf.find_console_spawn_matches(src)]
+
+
+def test_flags_single_line_raw_spawn():
+    assert _hit_lines('subprocess.run(["git", "status"])\n') == [1]
+
+
+def test_flags_multiline_raw_spawn_at_call_start():
+    src = 'subprocess.run(\n    ["gh", "auth", "token"],\n    capture_output=True,\n)\n'
+    assert _hit_lines(src) == [1]
+
+
+def test_flags_popen_and_check_output():
+    assert _hit_lines('subprocess.Popen(["gh", "pr", "list"])\n') == [1]
+    assert _hit_lines('subprocess.check_output(["git", "rev-parse"])\n') == [1]
+
+
+def test_ignores_explicit_creationflags():
+    src = 'subprocess.run(["git"], creationflags=windows_hide_flags())\n'
+    assert _hit_lines(src) == []
+
+
+def test_ignores_hidden_helper():
+    assert _hit_lines('run_hidden(["git", "status"])\n') == []
+    assert _hit_lines('popen_hidden(["gh", "auth", "token"])\n') == []
+
+
+def test_ignores_inline_suppression_after_paren():
+    assert _hit_lines('subprocess.run(["git"])  # windows-footgun: ok\n') == []
+
+
+def test_ignores_suppression_on_multiline_close():
+    src = 'subprocess.run(\n    ["git", "diff"],\n)  # windows-footgun: ok\n'
+    assert _hit_lines(src) == []
+
+
+def test_ignores_variable_program():
+    assert _hit_lines("subprocess.run(cmd, capture_output=True)\n") == []
+
+
+def test_ignores_non_console_binary():
+    assert _hit_lines('subprocess.run(["python", "-c", "x"])\n') == []
+
+
+def test_ignores_docstring_example():
+    assert _hit_lines('"""\nsubprocess.run(["git", "status"])\n"""\n') == []
+
+
+def test_strips_path_and_exe_from_argv0():
+    src = 'subprocess.run(["C:\\\\Program Files\\\\Git\\\\bin\\\\git.exe", "x"])\n'
+    assert _hit_lines(src) == [1]
+
+
+def test_console_rule_excluded_from_all_line_run():
+    # The repo-wide --all gate must NOT include this contextual rule (it would
+    # flag dozens of legitimate CLI-interactive call sites).
+    assert cwf.CONSOLE_SPAWN_FOOTGUN not in cwf.FOOTGUNS

--- a/tests/tools/test_subprocess_compat_hidden.py
+++ b/tests/tools/test_subprocess_compat_hidden.py
@@ -1,0 +1,56 @@
+"""Tests for the run_hidden / popen_hidden console-hiding helpers."""
+
+from __future__ import annotations
+
+import subprocess
+
+from hermes_cli import _subprocess_compat as sc
+
+
+def test_run_hidden_injects_hide_flags_and_delegates(monkeypatch):
+    captured: dict = {}
+
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return "RESULT"
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    out = sc.run_hidden(["git", "status"], capture_output=True, timeout=5)
+
+    assert out == "RESULT"
+    assert captured["args"] == (["git", "status"],)
+    assert captured["kwargs"]["capture_output"] is True
+    assert captured["kwargs"]["timeout"] == 5
+    assert captured["kwargs"]["creationflags"] == sc.windows_hide_flags()
+
+
+def test_popen_hidden_injects_hide_flags_and_delegates(monkeypatch):
+    captured: dict = {}
+
+    def fake_popen(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return "PROC"
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    out = sc.popen_hidden(["gh", "auth", "token"])
+
+    assert out == "PROC"
+    assert captured["args"] == (["gh", "auth", "token"],)
+    assert captured["kwargs"]["creationflags"] == sc.windows_hide_flags()
+
+
+def test_run_hidden_ors_caller_supplied_creationflags(monkeypatch):
+    captured: dict = {}
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: captured.update(k))
+
+    sentinel = 0x1  # CREATE_NEW_CONSOLE-ish placeholder
+    sc.run_hidden(["git"], creationflags=sentinel)
+
+    assert captured["creationflags"] == (sentinel | sc.windows_hide_flags())
+
+
+def test_helpers_are_exported():
+    assert "run_hidden" in sc.__all__
+    assert "popen_hidden" in sc.__all__


### PR DESCRIPTION
## What does this PR do?

Adds a small **centralized helper** for hiding Windows console windows on subprocess spawns, plus a **CI guard** that stops *new* console-window-flash regressions from landing. It's the preventative complement to the many point-fixes in this cluster (canonical #42544): instead of patching one flashing call site at a time, it makes the safe path the easy path and lets CI catch the unsafe one.

It deliberately does **not** touch the ~38 pre-existing call sites — those stay a tracked backlog. Scope is intentionally narrow and additive.

## Why

The Windows "black console flash" keeps recurring (canonical #42544; cluster incl. #53053, #53178, #53282, #53370, #52310, …) because every `subprocess.run/Popen` of a console binary (`git`, `gh`, …) must individually remember `creationflags=CREATE_NO_WINDOW` when spawned from the windowless desktop gateway (`pythonw.exe`). Miss one → flash. There is no central choke point on the Python side (the Electron side already centralizes via `hiddenWindowsChildOptions`), and `scripts/check-windows-footguns.py` had **no rule** for this class — which is a big part of why 20+ overlapping fix PRs exist.

## Root cause (of the recurrence)

- No shared spawn helper → the flag gets copy-pasted or forgotten per call site.
- The footgun linter checked many Windows pitfalls but **not** "console binary spawned without hidden-window flags," so regressions sailed through CI.

## Fix

1. **`hermes_cli/_subprocess_compat.py`** — `run_hidden()` / `popen_hidden()`: thin wrappers that inject `creationflags=windows_hide_flags()` (`CREATE_NO_WINDOW` on win32, `0` on POSIX), OR-ing any caller-supplied flags. No-op off Windows.
2. **`scripts/check-windows-footguns.py`** — a multi-line-aware `--console-spawns` rule that flags `subprocess.run/Popen/call/check_output/check_call` of a console binary lacking `creationflags` (or the helper). It handles multi-line calls, `# windows-footgun: ok` suppression, path + `.exe` basenames, and `shell=True` command strings.
   - Kept **out of the repo-wide `--all` gate** on purpose: whether a spawn flashes depends on *where* it runs (the gateway flashes; an interactive CLI doesn't), so a blanket repo rule would false-positive on dozens of legitimate CLI call sites.
3. **`.github/workflows/lint.yml`** — a **diff-scoped** guard step (`--console-spawns --diff <base>`, pull requests only) that blocks only *newly introduced* raw console spawns. The ~38 existing sites are a documented backlog to migrate to `run_hidden()` over time.
4. **`CONTRIBUTING.md`** — point contributors at `run_hidden()`.

## Verification — Windows 11

- `pytest tests/scripts/test_check_windows_footguns.py tests/tools/test_subprocess_compat_hidden.py` → **16 passed** on Windows 11 / Python 3.11.
  - Rule: single- and multi-line detection; negatives for explicit `creationflags`, the `run_hidden`/`popen_hidden` helpers, inline & multi-line-close suppression, variable program, non-console binary, docstring example; path + `.exe` basename stripping.
  - Helpers: flag injection, OR-ing caller flags, delegation to `subprocess`.
- `python scripts/check-windows-footguns.py --all` → unchanged result (new rule excluded from the repo-wide gate, so existing CI is unaffected).
- `python scripts/check-windows-footguns.py --console-spawns --all` → surfaces the 38-site backlog (informational only).
- This PR's own diff passes the new `--console-spawns --diff` guard with **0 findings**.

## Tests

- `tests/scripts/test_check_windows_footguns.py` — 12 cases for the rule.
- `tests/tools/test_subprocess_compat_hidden.py` — 4 cases for the helpers.

## Related

- **Complements #53123** (which fixes the live `gh`/`git` probe flashes). This PR prevents the whole class from regressing.
- Canonical cluster issue: #42544. Refs #53053, #53282.

## Type of Change

- [x] 🐛 Bug fix (prevents a recurring class of bug)
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 💥 Breaking change
- [x] 🔧 Tooling / CI

## Checklist

- [x] Conventional Commit title (`feat(windows): …`)
- [x] PR contains only changes related to this feature
- [x] Added tests
- [x] Considered cross-platform impact — no-op on POSIX; the new lint rule is additive and excluded from the existing `--all` gate, so current CI is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
