### PR TITLE
fix(cron): record no_agent runs as sessions so they show in run history

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1983,9 +1983,13 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     # stdout to telegram" watchdog pattern. The agent path is skipped
     # entirely: no AIAgent, no prompt, no tool loop, no token spend.
     #
-    # We check this BEFORE importing run_agent / constructing SessionDB so
-    # a pure-script tick never pays for the agent machinery it isn't going
-    # to use. Keep this block self-contained.
+    # We check this BEFORE importing run_agent so a pure-script tick never
+    # pays for the agent machinery it isn't going to use. The run is still
+    # recorded as a ``cron_{job_id}_{ts}`` session (a cheap sqlite write,
+    # same shape as agent runs) so it appears in the run-history endpoint
+    # (``/api/cron/jobs/{id}/runs``) and the desktop GUI — without it,
+    # no_agent runs are invisible after a manual trigger (#44080). Keep
+    # this block self-contained.
     #
     # Semantics:
     #   - script stdout (trimmed) → delivered verbatim as the final message
@@ -2000,6 +2004,63 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             err = "no_agent=True but no script is set for this job"
             logger.error("Job '%s': %s", job_id, err)
             return False, "", "", err
+
+        # Record this run as a session BEFORE executing the script: the run
+        # session's open/ended state is what the desktop run-history endpoint
+        # uses for its "running" indicator (``is_active``), and the session
+        # row is the run record itself. Best-effort — a missing/broken state
+        # store degrades to the old no-record behaviour, never blocks the run.
+        _session_db = None
+        _run_session_id = None
+        try:
+            from hermes_state import SessionDB
+            _session_db = SessionDB()
+            _run_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+            _session_db.create_session(_run_session_id, source="cron")
+            # First user message becomes the run's preview in run history.
+            _session_db.append_message(
+                _run_session_id, "user", f"no_agent script: {script_path}"
+            )
+        except (Exception, KeyboardInterrupt) as e:
+            logger.debug(
+                "Job '%s': SQLite session store not available for no_agent run: %s",
+                job_id, e,
+            )
+            _session_db = None
+
+        def _record_run(run_doc: str, success: bool = True) -> None:
+            """Persist the outcome and close out this run's session record."""
+            if not _session_db:
+                return
+            try:
+                _session_db.append_message(_run_session_id, "assistant", run_doc)
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug(
+                    "Job '%s': failed to record no_agent run output: %s", job_id, e
+                )
+            # Same titling scheme as the agent path so sidebars/history show a
+            # meaningful label; the run-time suffix keeps it unique against
+            # the sessions.title index across runs.
+            try:
+                _title_base = " ".join(job_name.split())[:60].strip() or f"cron {job_id}"
+                _session_db.set_session_title(
+                    _run_session_id,
+                    f"{_title_base} · {_hermes_now().strftime('%b %d %H:%M')}",
+                )
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug("Job '%s': failed to set cron session title: %s", job_id, e)
+            try:
+                _session_db.end_session(
+                    _run_session_id, "cron_complete" if success else "cron_failed"
+                )
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug("Job '%s': failed to end session: %s", job_id, e)
+            try:
+                _session_db.close()
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug(
+                    "Job '%s': failed to close SQLite session store: %s", job_id, e
+                )
 
         # Apply workdir if configured — lets scripts use predictable relative
         # paths. For no_agent jobs this is just the subprocess cwd (not an
@@ -2041,6 +2102,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 f"**Status:** script failed\n\n"
                 f"{output}\n"
             )
+            _record_run(doc, success=False)
             return False, doc, alert, output
 
         # Honour the wakeAgent gate as a silent signal — `wakeAgent: false`
@@ -2056,6 +2118,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** silent (wakeAgent=false)\n"
             )
+            _record_run(silent_doc)
             return True, silent_doc, SILENT_MARKER, None
 
         if not output.strip():
@@ -2067,6 +2130,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** silent (empty output)\n"
             )
+            _record_run(silent_doc)
             return True, silent_doc, SILENT_MARKER, None
 
         doc = (
@@ -2077,6 +2141,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             f"---\n\n"
             f"{output}\n"
         )
+        _record_run(doc)
         return True, doc, output, None
 
     # ---------------------------------------------------------------

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -31,6 +31,8 @@ def hermes_env(tmp_path, monkeypatch):
     import importlib
     import hermes_constants
     importlib.reload(hermes_constants)
+    import hermes_state
+    importlib.reload(hermes_state)  # DEFAULT_DB_PATH binds at import time
     import cron.jobs
     importlib.reload(cron.jobs)
     import cron.scheduler
@@ -329,3 +331,126 @@ def test_run_job_script_path_traversal_still_blocked(hermes_env):
     ok, output = _run_job_script("/etc/passwd")
     assert ok is False
     assert "Blocked" in output or "outside" in output
+
+
+# ---------------------------------------------------------------------------
+# run_job: no_agent runs are recorded as run-history sessions (#44080)
+# ---------------------------------------------------------------------------
+
+
+def _job_runs(job_id):
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        return db.list_cron_job_runs(job_id)
+    finally:
+        db.close()
+
+
+def _session_messages(session_id):
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        return db.get_messages(session_id)
+    finally:
+        db.close()
+
+
+def test_run_job_no_agent_success_records_run_session(hermes_env):
+    """A successful no_agent run must appear in the job's run history."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "alert.sh"
+    script_path.write_text("#!/bin/bash\necho 'RAM 92% on host'\n")
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="alert.sh", no_agent=True, deliver="local"
+    )
+    success, _, _, _ = run_job(job)
+    assert success is True
+
+    runs = _job_runs(job["id"])
+    assert len(runs) == 1
+    run = runs[0]
+    assert run["id"].startswith(f"cron_{job['id']}_")
+    assert run["source"] == "cron"
+    # The run finished, so the GUI must not show it as still active.
+    assert run["ended_at"] is not None
+    assert run["end_reason"] == "cron_complete"
+
+    # Script output is persisted so the GUI can show what the run produced.
+    messages = _session_messages(run["id"])
+    roles = [m["role"] for m in messages]
+    assert "user" in roles and "assistant" in roles
+    assistant_text = " ".join(
+        str(m.get("content") or "") for m in messages if m["role"] == "assistant"
+    )
+    assert "RAM 92% on host" in assistant_text
+
+
+def test_run_job_no_agent_failure_records_run_session(hermes_env):
+    """A failed script run must be visible in run history, not silent."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "broken.sh"
+    script_path.write_text("#!/bin/bash\necho oops >&2\nexit 3\n")
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="broken.sh", no_agent=True, deliver="local"
+    )
+    success, _, _, _ = run_job(job)
+    assert success is False
+
+    runs = _job_runs(job["id"])
+    assert len(runs) == 1
+    run = runs[0]
+    assert run["ended_at"] is not None
+    assert run["end_reason"] == "cron_failed"
+
+    messages = _session_messages(run["id"])
+    assistant_text = " ".join(
+        str(m.get("content") or "") for m in messages if m["role"] == "assistant"
+    )
+    assert "script failed" in assistant_text
+
+
+def test_run_job_no_agent_silent_records_run_session(hermes_env):
+    """A silent run (empty stdout) still leaves a run record."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "quiet.sh"
+    script_path.write_text("#!/bin/bash\ntrue\n")
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="quiet.sh", no_agent=True, deliver="local"
+    )
+    success, _, _, _ = run_job(job)
+    assert success is True
+
+    runs = _job_runs(job["id"])
+    assert len(runs) == 1
+    assert runs[0]["ended_at"] is not None
+
+
+def test_run_job_no_agent_broken_session_store_does_not_break_run(hermes_env):
+    """A broken SessionDB must not prevent the script from running."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "ok.sh"
+    script_path.write_text("#!/bin/bash\necho fine\n")
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="ok.sh", no_agent=True, deliver="local"
+    )
+
+    with patch("hermes_state.SessionDB", side_effect=RuntimeError("db locked")):
+        success, output, final_response, error = run_job(job)
+
+    assert success is True
+    assert "fine" in output


### PR DESCRIPTION
## Problem

`no_agent: true` cron jobs short-circuit `run_job()` (`cron/scheduler.py`) before any `SessionDB` work, so they never produce the `cron_{job_id}_{timestamp}` session row that the run-history endpoint (`GET /api/cron/jobs/{id}/runs`, backed by `SessionDB.list_cron_job_runs`) is built from. Manually triggering such a job from the Desktop GUI gives zero feedback: no running indicator, no run record, no output — the script runs fine, the GUI just can't see it.

Reported in #44080 and #42433.

## Fix

In the `no_agent` branch of `run_job()`:

- **Before executing the script**, create the run session (`cron_{job_id}_{ts}`, `source='cron'` — the exact shape the agent path produces) plus a short user message (`no_agent script: <path>`) that becomes the run's preview. Because the session is open while the script runs, the runs endpoint's existing `is_active` computation now yields a *running* indicator for in-flight manual triggers, with no frontend changes needed.
- **After execution**, persist the outcome doc (status + script output, already redacted by `_run_job_script`) as an assistant message, title the session using the same scheme as the agent path, and `end_session(..., "cron_complete")`.

This covers all four exit paths: success, script failure, empty-stdout silent run, and `wakeAgent=false` silent run.

### Design notes

- **Best-effort recording.** A missing/broken state store degrades to the old no-record behaviour and never blocks the script run (guarded the same way the agent path guards its `SessionDB` use).
- **The no_agent cost contract is preserved.** `run_agent`/`AIAgent` are still never imported on this path (existing `test_run_job_no_agent_never_invokes_aiagent` still passes); the only addition is a cheap sqlite session write.
- **No new surface.** The Desktop GUI, `/runs` endpoint, and `list_cron_job_runs` already do the right thing once the session rows exist — the fix is purely making the no_agent path produce the records everything else already consumes.

## Tests

Added to `tests/cron/test_cron_no_agent.py`:

- `test_run_job_no_agent_success_records_run_session` — success run appears in `list_cron_job_runs` with `source='cron'`, ended state, `cron_complete`, and the script output persisted in the run's messages
- `test_run_job_no_agent_failure_records_run_session` — failed run is recorded (not silent) with `cron_failed` end reason
- `test_run_job_no_agent_silent_records_run_session` — silent run (empty stdout) still leaves a run record
- `test_run_job_no_agent_broken_session_store_does_not_break_run` — a broken SessionDB raising doesn't break the run itself

The shared `hermes_env` fixture now also reloads `hermes_state` so `DEFAULT_DB_PATH` (bound at import time) points at the per-test `HERMES_HOME` — keeping the new tests hermetic.

`tests/cron/`: **22 passed**, 0 failures.

## Relationship to existing PR

Supersedes #44087 — same approach, rebased on current `main` (1479 commits ahead of #44087's base) so it merges cleanly without conflicts.

Fixes #44080.
Related: #42433, #41935.