### PR TITLE
fix(desktop): refresh context usage after cold resume (superseded)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -5,7 +5,15 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { getSessionMessages } from '@/hermes'
 import { $activeGatewayProfile, $newChatProfile } from '@/store/profile'
-import { $currentCwd, $messages, $resumeFailedSessionId, setMessages, setResumeFailedSessionId } from '@/store/session'
+import {
+  $currentCwd,
+  $currentUsage,
+  $messages,
+  $resumeFailedSessionId,
+  setCurrentUsage,
+  setMessages,
+  setResumeFailedSessionId
+} from '@/store/session'
 
 import type { ClientSessionState } from '../../types'
 
@@ -162,6 +170,7 @@ describe('resumeSession failure recovery', () => {
     cleanup()
     setResumeFailedSessionId(null)
     setMessages([])
+    setCurrentUsage({ calls: 0, input: 0, output: 0, total: 0 })
     vi.restoreAllMocks()
   })
 
@@ -255,6 +264,44 @@ describe('resumeSession failure recovery', () => {
     await runResume(requestGateway)
 
     expect($resumeFailedSessionId.get()).toBeNull()
+  })
+
+  it('refreshes context usage after a cold resume binds a runtime session', async () => {
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.resume') {
+        return { session_id: 'runtime-usage', resumed: params?.session_id, messages: [], info: {} } as never
+      }
+
+      if (method === 'session.usage') {
+        expect(params).toEqual({ session_id: 'runtime-usage' })
+
+        return {
+          context_max: 200_000,
+          context_percent: 42,
+          context_used: 84_000,
+          input: 80_000,
+          output: 4_000,
+          total: 84_000
+        } as never
+      }
+
+      return {} as never
+    })
+
+    vi.mocked(getSessionMessages).mockResolvedValue({ messages: [] } as never)
+
+    await runResume(requestGateway)
+
+    await waitFor(() =>
+      expect($currentUsage.get()).toEqual(
+        expect.objectContaining({
+          context_max: 200_000,
+          context_percent: 42,
+          context_used: 84_000
+        })
+      )
+    )
+    expect(requestGateway).toHaveBeenCalledWith('session.usage', { session_id: 'runtime-usage' })
   })
 
   it('resumes via the gateway default (deferred build) — not lazy, no eager opt-out', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -823,6 +823,21 @@ export function useSessionActions({
           }),
           storedSessionId
         )
+
+        const resumedSessionId = resumed.session_id
+
+        void requestGateway<UsageStats>('session.usage', { session_id: resumedSessionId })
+          .then(usage => {
+            if (
+              usage &&
+              resumeRequestRef.current === requestId &&
+              selectedStoredSessionIdRef.current === storedSessionId &&
+              activeSessionIdRef.current === resumedSessionId
+            ) {
+              setCurrentUsage(current => ({ ...current, ...usage }))
+            }
+          })
+          .catch(() => undefined)
       } catch (err) {
         if (!isCurrentResume()) {
           return


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop status bar showing missing or stale context usage after opening an existing session through the cold resume path.

Root cause: warm cached session switches already call `session.usage`, but a cold `session.resume` only seeds `$currentUsage` from the stored sidebar row token totals before binding the new runtime session id. Those stored row totals do not include runtime context fields like `context_used` and `context_max`, so the context-usage status item can stay empty or show `0` until a later `session.info` heartbeat updates it.

This PR refreshes `session.usage` after cold resume successfully binds the runtime session id. The refresh is non-blocking and guarded by the current resume token, selected stored session id, and active runtime session id so a late response cannot write usage into a different chat.

## Related Issue

No linked upstream issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-session-actions.ts`
  - Calls `session.usage` after a cold `session.resume` returns the runtime session id.
  - Applies returned usage only if the original resume is still current and the runtime session is still active.
  - Keeps the usage refresh asynchronous so transcript hydration is not delayed.
- `apps/desktop/src/app/session/hooks/use-session-actions.test.tsx`
  - Adds regression coverage that cold resume calls `session.usage` with the runtime session id and updates `$currentUsage` with `context_used` / `context_max` values.

## How to Test

1. `npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-session-actions.test.tsx src/app/session/hooks/use-session-state-cache.test.tsx`
2. `npm --workspace apps/desktop run typecheck`
3. `git diff --check`
4. `git merge-tree --write-tree upstream-https/main HEAD`

Observed results:

- 2 vitest files passed, 16 tests passed.
- Desktop typecheck passed.
- `git diff --check` passed.
- Merge-tree check against latest upstream `main` passed.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local checkout, automated vitest/typecheck only

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not attached. This change is covered by focused Desktop hook tests and typecheck.
