### PR TITLE
fix: preserve gateway voice config hygiene

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1618,6 +1618,13 @@ if _config_path.exists():
                 os.environ["HERMES_GATEWAY_BUSY_TEXT_MODE"] = str(_display_cfg["busy_text_mode"])
             if "busy_ack_enabled" in _display_cfg:
                 os.environ["HERMES_GATEWAY_BUSY_ACK_ENABLED"] = str(_display_cfg["busy_ack_enabled"])
+        _gateway_cfg = _cfg.get("gateway", {})
+        if (
+            _gateway_cfg
+            and isinstance(_gateway_cfg, dict)
+            and "busy_ack_enabled" in _gateway_cfg
+        ):
+            os.environ["HERMES_GATEWAY_BUSY_ACK_ENABLED"] = str(_gateway_cfg["busy_ack_enabled"])
         # Timezone: bridge config.yaml → HERMES_TIMEZONE env var.
         _tz_cfg = _cfg.get("timezone", "")
         if _tz_cfg and isinstance(_tz_cfg, str):
@@ -1718,6 +1725,7 @@ from gateway.config import (
     GatewayConfig,
     HomeChannel,
     PlatformConfig,
+    _coerce_bool,
     load_gateway_config,
 )
 from gateway.session import (
@@ -4774,8 +4782,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Check if busy ack is disabled — skip sending but still process the input.
         # Placed before debounce so we don't stamp a "last ack" timestamp that was
-        # never actually delivered.
-        busy_ack_enabled = os.environ.get("HERMES_GATEWAY_BUSY_ACK_ENABLED", "true").lower() == "true"
+        # never actually delivered. Prefer config.yaml when the key is present;
+        # fall back to the legacy env var for deployments that have not migrated.
+        busy_ack_enabled = True
+        try:
+            gateway_config = _load_gateway_config()
+            gateway_cfg = gateway_config.get("gateway") or {}
+            display_cfg = gateway_config.get("display") or {}
+            if "busy_ack_enabled" in gateway_cfg:
+                busy_ack_enabled = _coerce_bool(
+                    gateway_cfg.get("busy_ack_enabled"),
+                    True,
+                )
+            elif "busy_ack_enabled" in display_cfg:
+                busy_ack_enabled = _coerce_bool(
+                    display_cfg.get("busy_ack_enabled"),
+                    True,
+                )
+            else:
+                busy_ack_raw = os.environ.get("HERMES_GATEWAY_BUSY_ACK_ENABLED", "").strip()
+                busy_ack_enabled = _coerce_bool(busy_ack_raw, True) if busy_ack_raw else True
+        except Exception:
+            busy_ack_raw = os.environ.get("HERMES_GATEWAY_BUSY_ACK_ENABLED", "").strip()
+            busy_ack_enabled = _coerce_bool(busy_ack_raw, True) if busy_ack_raw else True
         if not busy_ack_enabled:
             logger.debug("Busy ack suppressed for session %s", session_key)
             return True  # input still processed, just no ack sent
@@ -11532,14 +11561,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return
 
-        # Show transcript in text channel (after auth, with mention sanitization)
+        # Optionally show the raw transcript in the linked text channel (after
+        # auth, with mention sanitization).  Public Discord channels become
+        # unreadable if every STT fragment is echoed, so deployments can keep
+        # voice input functional while hiding raw transcripts via
+        # discord.voice_transcript_echo: false.
         try:
-            channel = adapter._client.get_channel(text_ch_id)
-            if channel:
-                safe_text = transcript[:2000].replace("@everyone", "@\u200beveryone").replace("@here", "@\u200bhere")
-                await channel.send(f"**[Voice]** <@{user_id}>: {safe_text}")
+            discord_cfg = (_load_gateway_config().get("discord") or {})
+            echo_voice = _coerce_bool(discord_cfg.get("voice_transcript_echo"), True)
         except Exception:
-            pass
+            echo_voice = True
+        if echo_voice:
+            try:
+                client = getattr(adapter, "_client", None)
+                channel = client.get_channel(text_ch_id) if client else None
+                if channel:
+                    safe_text = transcript[:2000].replace("@everyone", "@\u200beveryone").replace("@here", "@\u200bhere")
+                    await channel.send(f"**[Voice]** <@{user_id}>: {safe_text}")
+            except Exception:
+                pass
 
         # Build a synthetic MessageEvent and feed through the normal pipeline
         # Use SimpleNamespace as raw_message so _get_guild_id() can extract

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2247,6 +2247,9 @@ DEFAULT_CONFIG = {
         # list_roles, member_info, search_members, fetch_messages, list_pins,
         # pin_message, unpin_message, create_thread, add_role, remove_role.
         "server_actions": "",
+        # Echo raw Discord voice transcripts into the linked text channel.
+        # Set false to keep voice input active without cluttering public channels.
+        "voice_transcript_echo": True,
         # DEPRECATED / no-op. Any uploaded file is now always cached and
         # surfaced to the agent regardless of file type — authorization to
         # message the agent is the gate, not the extension. Kept so existing
@@ -2638,6 +2641,10 @@ DEFAULT_CONFIG = {
         "scale_to_zero": {
             "idle_timeout_minutes": 5,
         },
+        # Send an acknowledgment when a new message arrives while a gateway
+        # session is already running. Legacy env override:
+        # HERMES_GATEWAY_BUSY_ACK_ENABLED.
+        "busy_ack_enabled": True,
 
         # Inject a human-readable timestamp prefix (e.g.
         # "[Tue 2026-04-28 13:40:53 CEST]") onto user messages IN THE MODEL'S

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -474,6 +474,61 @@ class TestBusySessionAck:
         assert adapter._send_with_retry.call_count == 2
 
     @pytest.mark.asyncio
+    async def test_busy_ack_can_be_disabled_from_gateway_config(self, monkeypatch):
+        """gateway.busy_ack_enabled: false suppresses only the ack send."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {"gateway": {"busy_ack_enabled": "false"}},
+        )
+        monkeypatch.setenv("HERMES_GATEWAY_BUSY_ACK_ENABLED", "true")
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = _make_event(text="hello?")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 120
+        runner.adapters[event.source.platform] = adapter
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        agent.interrupt.assert_called_once_with("hello?")
+        adapter._send_with_retry.assert_not_called()
+        assert sk not in runner._busy_ack_ts
+
+    @pytest.mark.asyncio
+    async def test_legacy_busy_ack_env_used_when_config_absent(self, monkeypatch):
+        """Legacy HERMES_GATEWAY_BUSY_ACK_ENABLED still works without config."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+        monkeypatch.setenv("HERMES_GATEWAY_BUSY_ACK_ENABLED", "false")
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = _make_event(text="hello?")
+        sk = build_session_key(event.source)
+
+        runner._running_agents[sk] = MagicMock()
+        runner._running_agents_ts[sk] = time.time() - 120
+        runner.adapters[event.source.platform] = adapter
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        adapter._send_with_retry.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_includes_status_detail_when_opted_in(self, monkeypatch):
         """Ack message should include iteration and tool info when available."""
         import gateway.run as _gr

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1015,6 +1015,34 @@ class TestVoiceChannelCommands:
         assert "42" in msg  # user_id in mention
 
     @pytest.mark.asyncio
+    async def test_input_can_disable_transcript_echo(self, runner, monkeypatch):
+        """discord.voice_transcript_echo: false keeps dispatching without echo."""
+        from gateway.config import Platform
+        import gateway.run as _gr
+
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {"discord": {"voice_transcript_echo": "false"}},
+        )
+
+        mock_adapter = AsyncMock()
+        mock_adapter._voice_text_channels = {111: 123}
+        mock_adapter._voice_sources = {}
+        mock_channel = AsyncMock()
+        mock_adapter._client = MagicMock()
+        mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter.handle_message = AsyncMock()
+        runner.adapters[Platform.DISCORD] = mock_adapter
+
+        await runner._handle_voice_channel_input(111, 42, "Hidden transcript")
+
+        mock_channel.send.assert_not_called()
+        mock_adapter.handle_message.assert_called_once()
+        event = mock_adapter.handle_message.call_args[0][0]
+        assert event.text == "Hidden transcript"
+
+    @pytest.mark.asyncio
     async def test_input_suppresses_duplicate_transcript(self, runner):
         """Near-immediate duplicate STT output should not dispatch twice."""
         from gateway.config import Platform

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -868,12 +868,27 @@ class TestWhisperHallucinationFilter:
         assert is_whisper_hallucination("  Thank you.  ") is True  # with whitespace
         assert is_whisper_hallucination("you") is True
 
+    def test_korean_subtitle_credit_hallucinations(self):
+        from tools.voice_mode import is_whisper_hallucination
+
+        assert is_whisper_hallucination("시청해 주셔서 감사합니다") is True
+        assert is_whisper_hallucination("시청해주셔서 감사합니다.") is True
+        assert is_whisper_hallucination("자막 제공 및 자막을 사용하였습니다. 감사합니다") is True
+        assert is_whisper_hallucination("한글자막 by 한효주") is True
+        assert is_whisper_hallucination("구독과 좋아요 부탁드립니다") is True
+        assert is_whisper_hallucination("자막 제작: example") is True
+        assert is_whisper_hallucination("자막 사용") is True
+
     def test_real_speech_not_filtered(self):
         from tools.voice_mode import is_whisper_hallucination
 
         assert is_whisper_hallucination("Hello, how are you?") is False
         assert is_whisper_hallucination("Thank you for your help with the project.") is False
         assert is_whisper_hallucination("Can you explain this code?") is False
+        assert is_whisper_hallucination("감사합니다") is False
+        assert is_whisper_hallucination("감사합니다.") is False
+        assert is_whisper_hallucination("감사합니다 감사합니다") is False
+        assert is_whisper_hallucination("감사합니다. 감사합니다.") is False
 
 
 # ============================================================================

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -849,11 +849,22 @@ WHISPER_HALLUCINATIONS = {
     "amara.org",
     "www.mooji.org",
     "ご視聴ありがとうございました",
+    # Korean subtitle-credit hallucinations (common with short/silent Discord audio)
+    "시청해주셔서 감사합니다",
+    "시청해 주셔서 감사합니다",
+    "자막 제공 및 자막을 사용하였습니다",
+    "자막 제공 및 자막을 사용하였습니다. 감사합니다",
+    "한글자막 by 한효주",
 }
 
 # Regex patterns for repetitive hallucinations (e.g. "Thank you. Thank you. Thank you.")
 _HALLUCINATION_REPEAT_RE = re.compile(
     r'^(?:thank you|thanks|bye|you|ok|okay|the end|\.|\s|,|!)+$',
+    flags=re.IGNORECASE,
+)
+
+_HALLUCINATION_SUBTITLE_RE = re.compile(
+    r'(?:자막\s*(?:제공|사용|제작)|한글\s*자막|시청해\s*주셔서\s*감사|구독과\s*좋아요)',
     flags=re.IGNORECASE,
 )
 
@@ -868,6 +879,8 @@ def is_whisper_hallucination(transcript: str) -> bool:
         return True
     # Repetitive patterns (e.g. "Thank you. Thank you. Thank you. you")
     if _HALLUCINATION_REPEAT_RE.match(cleaned):
+        return True
+    if _HALLUCINATION_SUBTITLE_RE.search(cleaned):
         return True
     return False
 


### PR DESCRIPTION
## Summary
- add config.yaml defaults for gateway busy ack and Discord voice transcript echo
- preserve legacy busy ack env fallback while allowing `gateway.busy_ack_enabled`
- filter Korean Whisper subtitle/credit hallucinations for short/silent voice input without filtering standalone real-speech `감사합니다`

## Tests
- `python -m py_compile gateway/run.py tools/voice_mode.py hermes_cli/config.py tests/gateway/test_busy_session_ack.py tests/gateway/test_voice_command.py tests/tools/test_voice_mode.py`
- `python -m pytest tests/gateway/test_voice_command.py tests/gateway/test_busy_session_ack.py -q`
- `python -m pytest focused 6 node ids covering hallucination/config echo -q`
- `python -m pytest tests/tools/test_voice_mode.py::TestWhisperHallucinationFilter -q`

Note: full `tests/tools/test_voice_mode.py` still has 3 pre-existing `PIPEWIRE_REMOTE` audio-environment failures on `origin/main` in this WSL/container environment.
