### PR TITLE
fix(auxiliary): segregate copilot transports in the client cache key

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4800,9 +4800,34 @@ _client_cache_lock = threading.Lock()
 _CLIENT_CACHE_MAX_SIZE = 64  # safety belt — evict oldest when exceeded
 
 
+def _transport_discriminator(provider: str, model: Optional[str]) -> str:
+    """Tag clients that are NOT interchangeable across models on one endpoint.
+
+    Most OpenAI-compatible endpoints serve every model through one identical
+    client, so the client is cached once per provider+base_url+key and the
+    model string is just swapped at call time (the GMI-style reuse the cache
+    is designed around). But a few providers pick a *different client wrapper
+    per model*: Copilot routes GPT-5.x through the Responses API (wrapped in
+    CodexAuxiliaryClient) and Claude / gpt-5-mini through Chat Completions.
+    Those two wrappers are not interchangeable — reusing one for the other
+    yields ``400 unsupported_api_for_model`` (the MoA gpt-5.5-reference +
+    opus-aggregator collision). Folding only this transport tag into the cache
+    key keeps each transport its own entry without exploding the cache for
+    normal providers (whose tag is always "").
+    """
+    if provider == "copilot" and model:
+        try:
+            from hermes_cli.models import _should_use_copilot_responses_api
+            return "responses" if _should_use_copilot_responses_api(model) else "chat"
+        except Exception:
+            return ""
+    return ""
+
+
 def _client_cache_key(
     provider: str,
     *,
+    model: Optional[str] = None,
     async_mode: bool,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
@@ -4818,7 +4843,12 @@ def _client_cache_key(
     # old cache shape because the explicit provider/model tuple is sufficient.
     task_key = (task or "") if provider == "auto" else ""
     pool_hint = _pool_cache_hint(provider, main_runtime=main_runtime)
-    return (provider, async_mode, base_url or "", api_key or "", api_mode or "", runtime_key, is_vision, task_key, pool_hint)
+    # Transport tag: empty for normal providers (preserves one-client-per-
+    # endpoint reuse across models), non-empty only where the wrapper differs
+    # per model (Copilot Responses vs Chat). This is what prevents a cached
+    # gpt-5.5 Responses client from being reused for a claude-opus-4.8 call.
+    transport = _transport_discriminator(provider, model)
+    return (provider, async_mode, base_url or "", api_key or "", api_mode or "", transport, runtime_key, is_vision, task_key, pool_hint)
 
 
 def _store_cached_client(cache_key: tuple, client: Any, default_model: Optional[str], *, bound_loop: Any = None) -> None:
@@ -4868,6 +4898,7 @@ def _refresh_nous_auxiliary_client(
 
     cache_key = _client_cache_key(
         cache_provider,
+        model=model,
         async_mode=async_mode,
         base_url=base_url,
         api_key=api_key,
@@ -5043,6 +5074,7 @@ def _get_cached_client(
     runtime = _normalize_main_runtime(main_runtime)
     cache_key = _client_cache_key(
         provider,
+        model=model,
         async_mode=async_mode,
         base_url=base_url,
         api_key=api_key,

--- a/tests/agent/test_auxiliary_client_cache_key_model.py
+++ b/tests/agent/test_auxiliary_client_cache_key_model.py
@@ -1,0 +1,129 @@
+"""Regression: the auxiliary client cache key must isolate per-model transports.
+
+Root cause (fixed 2026-06-27): ``_client_cache_key`` did not distinguish
+clients that pick a *different transport wrapper per model* on the same
+endpoint. Copilot routes GPT-5.x through the Responses API (CodexAuxiliaryClient
+wrapper) and Claude / gpt-5-mini through Chat Completions, but ``api_mode`` is
+empty for all of them at key-construction time. So two Copilot models sharing
+one base_url+api_key collided on a single cache entry: whichever ran first
+(e.g. a ``gpt-5.5`` MoA reference) installed its Responses-API wrapper, and the
+next model (e.g. a ``claude-opus-4.8`` aggregator) reused it and got
+``400 unsupported_api_for_model``. This made every "two same-provider models
+with different transports" MoA preset fail deterministically.
+
+The fix folds a *transport discriminator* into the key — non-empty ONLY where
+the wrapper genuinely differs per model (Copilot). Normal OpenAI-compatible
+providers keep their single-client-per-endpoint reuse (one client, model
+swapped at call time), so this must NOT split their cache entries.
+
+These are behavior-contract tests (assert the invariant), not snapshots.
+"""
+
+from agent.auxiliary_client import _client_cache_key, _transport_discriminator
+
+
+def _key(provider, model, **kw):
+    return _client_cache_key(provider, model=model, async_mode=False, **kw)
+
+
+# ── The bug: Copilot transports must not collide ─────────────────────────
+
+def test_copilot_responses_and_chat_models_get_distinct_keys():
+    """The exact MoA failure mode: gpt-5.5 (Responses) and claude-opus-4.8
+    (Chat) on one Copilot base_url+key must NOT share a cache entry."""
+    base = "https://api.githubcopilot.com"
+    key = "tok-abc"
+    k_gpt = _key("copilot", "gpt-5.5", base_url=base, api_key=key)
+    k_opus = _key("copilot", "claude-opus-4.8", base_url=base, api_key=key)
+    assert k_gpt != k_opus, (
+        "gpt-5.5 (Responses) and claude-opus-4.8 (Chat) collided — the wrapper "
+        "would leak between them (400 unsupported_api_for_model)"
+    )
+
+
+def test_transport_discriminator_classifies_copilot_models():
+    assert _transport_discriminator("copilot", "gpt-5.5") == "responses"
+    assert _transport_discriminator("copilot", "gpt-5.4") == "responses"
+    assert _transport_discriminator("copilot", "claude-opus-4.8") == "chat"
+    assert _transport_discriminator("copilot", "gpt-5-mini") == "chat"  # documented exception
+
+
+# ── The constraint: normal providers must keep one-client reuse ──────────
+
+def test_non_copilot_models_share_key_preserving_client_reuse():
+    """GMI / OpenRouter / any normal endpoint serves all models through one
+    client; two models on the same endpoint MUST map to the same cache key so
+    the client is built once and reused (model swapped at call time)."""
+    base = "https://api.gmi-serving.com/v1"
+    k_a = _key("gmi", "google/gemini-3.1-flash-lite-preview", base_url=base, api_key="gmi-key")
+    k_b = _key("gmi", "openai/gpt-5.4-mini", base_url=base, api_key="gmi-key")
+    assert k_a == k_b, "normal-provider models must reuse one cached client"
+    assert _transport_discriminator("gmi", "anything") == ""
+
+
+def test_same_copilot_model_is_cache_stable():
+    base = "https://api.githubcopilot.com"
+    a = _key("copilot", "gpt-5.5", base_url=base, api_key="tok")
+    b = _key("copilot", "gpt-5.5", base_url=base, api_key="tok")
+    assert a == b
+
+
+# ── End-to-end through the real cache: client identity is the true contract ──
+# These mirror the existing GMI reuse test (TestAuxiliaryPoolAwareness::
+# test_cached_gmi_client_keeps_explicit_slash_model_override) but exercise the
+# Copilot collision the fix targets. Asserting on the *client object* (built vs
+# reused) is a stronger behavior contract than asserting on the key tuple — it
+# proves the actual runtime effect (no wrapper leak), not the key's shape.
+
+def test_copilot_two_transports_build_two_clients_no_collision():
+    """Two Copilot models with different transports on one base_url+key must
+    each get their OWN cached client — the gpt-5.5 Responses wrapper must NOT
+    be reused for claude-opus-4.8 (which caused 400 unsupported_api_for_model).
+    """
+    import agent.auxiliary_client as aux
+    from unittest.mock import patch
+
+    base = "https://api.githubcopilot.com"
+    # Distinct sentinels so we can prove which client each call returns.
+    responses_client = object()
+    chat_client = object()
+
+    def fake_resolve(provider, model, *a, **kw):
+        # Mimic the real per-model transport split without network.
+        if model and model.startswith("gpt-5") and not model.startswith("gpt-5-mini"):
+            return responses_client, model
+        return chat_client, model
+
+    with patch("agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve):
+        aux.shutdown_cached_clients()
+        try:
+            c_ref, _ = aux._get_cached_client("copilot", "gpt-5.5", base_url=base, api_key="k")
+            c_agg, _ = aux._get_cached_client("copilot", "claude-opus-4.8", base_url=base, api_key="k")
+        finally:
+            aux.shutdown_cached_clients()
+
+    assert c_ref is responses_client
+    assert c_agg is chat_client
+    assert c_ref is not c_agg, "Copilot transports collided — the bug is back"
+
+
+def test_copilot_same_model_reuses_one_client():
+    """The cache must still WORK for Copilot: repeated calls for the same model
+    reuse one client (build happens once), so the fix doesn't defeat caching."""
+    import agent.auxiliary_client as aux
+    from unittest.mock import patch
+
+    base = "https://api.githubcopilot.com"
+    with patch(
+        "agent.auxiliary_client.resolve_provider_client",
+        return_value=(object(), "gpt-5.5"),
+    ) as mock_resolve:
+        aux.shutdown_cached_clients()
+        try:
+            c1, _ = aux._get_cached_client("copilot", "gpt-5.5", base_url=base, api_key="k")
+            c2, _ = aux._get_cached_client("copilot", "gpt-5.5", base_url=base, api_key="k")
+        finally:
+            aux.shutdown_cached_clients()
+
+    assert c1 is c2
+    assert mock_resolve.call_count == 1, "same Copilot model rebuilt — caching defeated"


### PR DESCRIPTION
## Symptom

A Mixture-of-Agents preset that puts **two Copilot models on one `base_url`+`api_key`** fails deterministically with:

```
openai.BadRequestError: Error code: 400 -
{'error': {'message': 'model claude-opus-4.8 does not support Responses API.',
           'code': 'unsupported_api_for_model'}}
```

Concretely, a preset with a `copilot/gpt-5.5` reference and a `copilot/claude-opus-4.8` aggregator (both via `https://api.githubcopilot.com`) raises on the aggregator call **every time** — the reference works, then the aggregator dies. Reproduces on current `main`.

> No public issue — found in local MoA use. The added regression tests reproduce the collision on `main` at the failing boundary (see Test evidence).

## Root cause

For Copilot, the transport is chosen **per model, after the auxiliary client cache key is built**:

- `gpt-5.x` (except `gpt-5-mini`) → OpenAI **Responses API** (wrapped in `CodexAuxiliaryClient`)
- `claude-*`, `gpt-5-mini` → **Chat Completions** (plain client)

`agent/auxiliary_client.py::_client_cache_key` keys on `(provider, async_mode, base_url, api_key, api_mode, …)` — **no model**, and `api_mode` is empty for both at key-construction time. So two Copilot models sharing one `base_url`+`api_key` map to **one cache entry**. In a single MoA turn the references run first: `gpt-5.5` builds and caches a Responses-API client wrapper; the `claude-opus-4.8` aggregator then computes the **identical** key, hits the cache, and reuses the Responses wrapper → `400 unsupported_api_for_model`.

The cache is correct for single-transport providers; it's only wrong where one provider serves **both** transports behind one endpoint.

## Fix

Add a small `_transport_discriminator(provider, model)` and fold its result into the cache key:

- returns `"responses"` / `"chat"` for **copilot** (via the existing `hermes_cli.models._should_use_copilot_responses_api`)
- returns `""` for **every other provider**

This gives Copilot's two transports separate cache entries while leaving all other providers' keys unchanged.

## Why this shape (and not "put the model in the key")

Deliberately **not** per-model. Only Copilot mixes Chat + Responses behind one provider/`base_url`:

| provider | transport(s) | collision-prone? |
|---|---|---|
| copilot | Responses (gpt-5.x) **and** Chat (claude, gpt-5-mini) | **yes** |
| openai-codex, xai | uniformly Responses | no |
| openrouter, gmi, … | uniformly Chat | no |

Keying on the **transport family (2 values)** rather than the raw model fixes the actual collision while preserving the intended **one-client-per-endpoint reuse** for normal providers (a model is just swapped at call time). That reuse is locked by the existing `TestAuxiliaryPoolAwareness::test_cached_gmi_client_keeps_explicit_slash_model_override` test, which stays green. A blanket "model in the key" change would split every provider's cache and defeat that reuse.

## Test evidence

New behavior-contract tests (`tests/agent/test_auxiliary_client_cache_key_model.py`) — they assert **client identity / reuse behavior**, not the key tuple's shape:

- `test_copilot_two_transports_build_two_clients_no_collision` — the two Copilot transports get **distinct client objects** (mirrors the GMI test pattern; mocks `resolve_provider_client`). Verified to **fail** when the discriminator is disabled (reproduces the collision) and **pass** with the fix.
- `test_copilot_same_model_reuses_one_client` — same Copilot model still builds **once** (`call_count == 1`); caching not defeated.
- `test_non_copilot_models_share_key_preserving_client_reuse` — GMI/OpenRouter models still share one entry.
- plus distinct-key and classifier-contract checks.

```
$ python -m pytest tests/agent/test_auxiliary_client.py \
    tests/agent/test_crossloop_client_cache.py \
    tests/agent/test_auxiliary_transport_autodetect.py \
    tests/agent/test_auxiliary_client_cache_key_model.py -o 'addopts=' -q \
    --deselect tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterTimeout::test_enforces_total_timeout_while_stream_keeps_emitting_events
279 passed, 1 deselected
```

(The deselected test is a pre-existing timing flake — fails on unmodified `main` too; confirmed via a stash baseline. Not touched by this change.)

## Blast radius

Scoped to the auxiliary client **object cache** only.

> This is the auxiliary client OBJECT cache, not prompt caching. The discriminator is empty for non-Copilot providers and groups Copilot by transport family (2 values), not by model, so prompt-cache prefixes and endpoint reuse are unchanged.

Not touched: prompt caching, message contents, role alternation, config resolution, the main conversation-loop client builder. No new env vars, no config keys, no public API change.
