### PR TITLE
fix(feishu): restore delivery and quote safeguards

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -57,6 +57,7 @@ from agent.model_metadata import (
 from agent.process_bootstrap import _install_safe_stdio
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.retry_utils import adaptive_rate_limit_backoff, jittered_backoff
+from agent.response_truthfulness import looks_like_unbacked_file_delivery_claim
 from agent.trajectory import has_incomplete_scratchpad
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from hermes_constants import PARTIAL_STREAM_STUB_ID
@@ -581,6 +582,7 @@ def run_conversation(
     interrupted = False
     failed = False
     codex_ack_continuations = 0
+    unbacked_file_claim_continuations = 0
     length_continue_retries = 0
     truncated_tool_call_retries = 0
     truncated_response_parts: List[str] = []
@@ -785,6 +787,7 @@ def run_conversation(
                 api_msg.pop("finish_reason")
             # Strip internal thinking-prefill marker
             api_msg.pop("_thinking_prefill", None)
+            api_msg.pop("_file_delivery_recovery_synthetic", None)
             # Strip Codex Responses API fields (call_id, response_item_id) for
             # strict providers like Mistral, Fireworks, etc. that reject unknown fields.
             # Uses new dicts so the internal messages list retains the fields
@@ -4640,6 +4643,42 @@ def run_conversation(
                     length_continue_retries = 0
                 
                 final_response = agent._strip_think_blocks(final_response).strip()
+
+                if (
+                    unbacked_file_claim_continuations < 2
+                    and looks_like_unbacked_file_delivery_claim(final_response)
+                ):
+                    unbacked_file_claim_continuations += 1
+                    logger.warning(
+                        "Unbacked file delivery claim detected — asking model "
+                        "to provide a real path/link or state the blocker (%d/2)",
+                        unbacked_file_claim_continuations,
+                    )
+                    interim_msg = agent._build_assistant_message(
+                        assistant_message,
+                        "incomplete",
+                    )
+                    interim_msg["_file_delivery_recovery_synthetic"] = True
+                    messages.append(interim_msg)
+                    messages.append({
+                        "role": "user",
+                        "content": (
+                            "[System: You claimed a file or attachment was "
+                            "delivered, but your response did not include a "
+                            "MEDIA:/absolute/path directive, a real local path, "
+                            "a URL, a Markdown link, or inline file content. "
+                            "Continue now: if the artifact exists, provide the "
+                            "real deliverable path/link or MEDIA directive; if "
+                            "creation or upload failed, state the blocker. Do "
+                            "not say it is attached/sent unless there is "
+                            "delivery evidence.]"
+                        ),
+                        "_file_delivery_recovery_synthetic": True,
+                    })
+                    agent._session_messages = messages
+                    continue
+
+                unbacked_file_claim_continuations = 0
                 
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
 
@@ -4655,6 +4694,7 @@ def run_conversation(
                         messages[-1].get("_thinking_prefill")
                         or messages[-1].get("_empty_recovery_synthetic")
                         or messages[-1].get("_empty_terminal_sentinel")
+                        or messages[-1].get("_file_delivery_recovery_synthetic")
                     )
                 ):
                     messages.pop()

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -322,7 +322,14 @@ TASK_COMPLETION_GUIDANCE = (
     "approach, ask the user). NEVER substitute plausible-looking fabricated "
     "output (made-up data, invented file contents, synthesised API responses) "
     "for results you couldn't actually produce. Reporting a blocker honestly "
-    "is always better than inventing a result."
+    "is always better than inventing a result.\n"
+    "File delivery claims require proof. If the user asks you to create, "
+    "download, attach, or send a file, do not say the file is attached, below, "
+    "sent, uploaded, or available for download unless you have produced a real "
+    "artifact and included `MEDIA:/absolute/path/to/file` or a real path/link "
+    "that the current channel can use. If file creation or upload fails, state "
+    "the blocker instead of using placeholder phrases like 'file below' or "
+    "'please see attached'."
 )
 
 # Universal parallel-tool-call guidance — applied to ALL models.

--- a/agent/response_truthfulness.py
+++ b/agent/response_truthfulness.py
@@ -1,0 +1,165 @@
+"""Response-level checks for claims that need delivery evidence.
+
+The helpers here target a narrow failure mode: a model says a file or
+attachment was sent/generated, but emits no MEDIA directive, path, link, or
+inline payload the gateway can deliver.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+_DELIVERABLE_EXTS = (
+    "doc",
+    "docx",
+    "pdf",
+    "ppt",
+    "pptx",
+    "xls",
+    "xlsx",
+    "csv",
+    "htm",
+    "html",
+    "txt",
+    "md",
+    "zip",
+    "rar",
+    "7z",
+    "png",
+    "jpg",
+    "jpeg",
+    "gif",
+    "webp",
+    "mp3",
+    "wav",
+    "m4a",
+    "mp4",
+    "mov",
+)
+
+_EXT_ALT = "|".join(sorted(_DELIVERABLE_EXTS, key=len, reverse=True))
+
+_MEDIA_TAG_RE = re.compile(
+    r"MEDIA:\s*[`\"']?(?:~/|/|[A-Za-z]:[/\\])\S+\.(?:" + _EXT_ALT + r")\b",
+    re.IGNORECASE,
+)
+_LOCAL_FILE_PATH_RE = re.compile(
+    r"(?<![/:\w.])(?:~/|/|[A-Za-z]:[/\\])\S+\.(?:" + _EXT_ALT + r")\b",
+    re.IGNORECASE,
+)
+_RELATIVE_FILE_PATH_RE = re.compile(
+    r"(?<![\w:/\\.-])(?:\.{1,2}[/\\])?"
+    r"(?:[\w\u4e00-\u9fff（）()【】《》_.-]+[/\\])+\S+\.(?:"
+    + _EXT_ALT
+    + r")\b",
+    re.IGNORECASE,
+)
+_URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
+_EMAIL_ADDRESS_RE = re.compile(
+    r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b",
+    re.IGNORECASE,
+)
+_MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\([^)]+\)", re.IGNORECASE)
+_CODE_FENCE_RE = re.compile(r"```[\s\S]+```")
+
+_NEGATION_RE = re.compile(
+    r"(?:"
+    r"\b(?:cannot|can't|couldn't|unable|not able|failed|did not|haven't|hasn't)\b"
+    r"|(?:没有|还没|尚未|未能|无法|不能|失败)"
+    r")",
+    re.IGNORECASE,
+)
+
+_CLAIM_RE = re.compile(
+    r"(?:"
+    r"\b(?:file|attachment|document|docx|word|download|attached|uploaded|sent)\b"
+    r"|(?:文件|附件|文档|报告|下载|上传|发送|发给你|查收)"
+    r")",
+    re.IGNORECASE,
+)
+
+_COMPLETION_CLAIM_RE = re.compile(
+    r"(?:"
+    r"\b(?:attached|uploaded|sent|downloadable|here(?:'s| is)? the file|file is below|attachment is below)\b"
+    r"|(?:文件如下|附件如下|已附上|已上传|已发送|已下载|下载给你|下载好了|文件已生成|文件已创建|发给你|请查收|供下载)"
+    r")",
+    re.IGNORECASE,
+)
+
+_DELIVERY_PROMISE_RE = re.compile(
+    r"(?:"
+    r"\b(?:"
+    r"I(?:'ll| will)?\s+(?:re)?send"
+    r"|(?:re)?sending"
+    r"|will\s+(?:be\s+)?(?:attach|upload|send)"
+    r"|should\s+(?:appear|show up)\s+as\s+(?:an?\s+)?attachment"
+    r"|as\s+(?:an?\s+)?attachment"
+    r")\b"
+    r"|(?:"
+    r"我再发一次"
+    r"|重新发(?:一次)?"
+    r"|重发(?:一次)?"
+    r"|再发(?:一次)?"
+    r"|以附件形式"
+    r"|作为附件"
+    r"|应该会.{0,12}附件"
+    r"|会.{0,12}附件"
+    r")"
+    r")",
+    re.IGNORECASE,
+)
+
+_EMPTY_AFTER_MARKER_RE = re.compile(
+    r"(?:"
+    r"(?:文件|附件|文档|word\s*文件|\bfile\b|\battachment\b)"
+    r".{0,24}?"
+    r"(?:如下|在下方|below|attached)"
+    r")\s*[:：,.。!！-]*\s*$",
+    re.IGNORECASE,
+)
+
+_EMAIL_DELIVERY_RE = re.compile(
+    r"(?:\b(?:email|mail|emailed)\b|(?:邮件|邮箱|发送到|发到))",
+    re.IGNORECASE,
+)
+
+
+def has_file_delivery_payload(text: str) -> bool:
+    """Return True when text carries evidence of a deliverable artifact."""
+    if not text:
+        return False
+    body = str(text)
+    return bool(
+        _MEDIA_TAG_RE.search(body)
+        or _LOCAL_FILE_PATH_RE.search(body)
+        or _URL_RE.search(body)
+        or _MARKDOWN_LINK_RE.search(body)
+        or _CODE_FENCE_RE.search(body)
+    )
+
+
+def looks_like_unbacked_file_delivery_claim(text: str) -> bool:
+    """Detect short file/attachment delivery claims with no payload evidence."""
+    if not isinstance(text, str):
+        return False
+    body = " ".join(text.strip().split())
+    if not body:
+        return False
+    if has_file_delivery_payload(body):
+        return False
+    if _NEGATION_RE.search(body):
+        return False
+    if _EMAIL_ADDRESS_RE.search(body) and _EMAIL_DELIVERY_RE.search(body):
+        return False
+    if len(body) > 220:
+        return False
+    if not _CLAIM_RE.search(body):
+        return False
+    if _RELATIVE_FILE_PATH_RE.search(body):
+        return True
+    if _EMPTY_AFTER_MARKER_RE.search(body):
+        return True
+    if _DELIVERY_PROMISE_RE.search(body):
+        return True
+    return bool(_COMPLETION_CLAIM_RE.search(body) and len(body) <= 160)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -65,8 +65,11 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     thread_id = getattr(source, "thread_id", None)
     if thread_id is None:
         return None
+    platform = _platform_name(getattr(source, "platform", None))
     metadata = {"thread_id": thread_id}
-    if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
+    if platform == "feishu" and reply_to_message_id is not None:
+        metadata["reply_to_message_id"] = str(reply_to_message_id)
+    if platform == "telegram" and getattr(source, "chat_type", None) == "dm":
         metadata["telegram_dm_topic_reply_fallback"] = True
         tid = str(thread_id)
         if tid and tid not in {"", "1"}:
@@ -1760,6 +1763,22 @@ class SendResult:
     # ``None`` (unset / not classified).  Producers should set this via
     # :func:`classify_send_error`.
     error_kind: Optional[str] = None
+
+
+def format_attachment_delivery_failure_notice(
+    file_path: str,
+    error: Optional[str] = None,
+) -> str:
+    """Build a user-visible notice for native attachment delivery failures."""
+    lines = [
+        "File attachment delivery failed: the platform did not show the attachment.",
+        f"Local path: {file_path}",
+    ]
+    if error:
+        clean_error = " ".join(str(error).split())
+        if clean_error:
+            lines.append(f"Error: {clean_error[:500]}")
+    return "\n".join(lines)
 
 
 # Machine-readable send-failure categories.  Kept platform-neutral so every
@@ -4639,6 +4658,24 @@ class BasePlatformAdapter(ABC):
                 # thread-strict.
                 _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
 
+                async def _send_attachment_failure_notice(file_path: str, error: Any = None) -> None:
+                    notice = format_attachment_delivery_failure_notice(file_path, str(error or ""))
+                    try:
+                        result = await self._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=notice,
+                            reply_to=_reply_anchor_for_event(event),
+                            metadata=_final_thread_metadata,
+                        )
+                        _record_delivery(result)
+                    except Exception as notice_err:
+                        logger.warning(
+                            "[%s] Failed to send attachment failure notice for %s: %s",
+                            self.name,
+                            file_path,
+                            notice_err,
+                        )
+
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has
                 # an explicit ``/voice on|tts`` opt-in OR when ``voice.auto_tts`` is
@@ -4723,14 +4760,21 @@ class BasePlatformAdapter(ABC):
                 if images:
                     logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
                     try:
-                        await self.send_multiple_images(
+                        image_result = await self.send_multiple_images(
                             chat_id=event.source.chat_id,
                             images=images,
                             metadata=_final_thread_metadata,
                             human_delay=human_delay,
                         )
+                        _record_delivery(image_result)
+                        if getattr(image_result, "success", True) is False:
+                            await _send_attachment_failure_notice(
+                                "image batch",
+                                getattr(image_result, "error", None),
+                            )
                     except Exception as batch_err:
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
+                        await _send_attachment_failure_notice("image batch", batch_err)
 
 
                 # Send extracted media files — route by file type
@@ -4765,14 +4809,23 @@ class BasePlatformAdapter(ABC):
                 if _image_paths:
                     try:
                         _batch = [(f"file://{_quote(p)}", "") for p in _image_paths]
-                        await self.send_multiple_images(
+                        image_result = await self.send_multiple_images(
                             chat_id=event.source.chat_id,
                             images=_batch,
                             metadata=_final_thread_metadata,
                             human_delay=human_delay,
                         )
+                        _record_delivery(image_result)
+                        if getattr(image_result, "success", True) is False:
+                            for image_path in _image_paths:
+                                await _send_attachment_failure_notice(
+                                    image_path,
+                                    getattr(image_result, "error", None),
+                                )
                     except Exception as batch_err:
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
+                        for image_path in _image_paths:
+                            await _send_attachment_failure_notice(image_path, batch_err)
 
                 for media_path, is_voice in _non_image_media:
                     if human_delay > 0:
@@ -4800,8 +4853,11 @@ class BasePlatformAdapter(ABC):
 
                         if not media_result.success:
                             logger.warning("[%s] Failed to send media (%s): %s", self.name, ext, media_result.error)
+                            await _send_attachment_failure_notice(media_path, media_result.error)
+                        _record_delivery(media_result)
                     except Exception as media_err:
                         logger.warning("[%s] Error sending media: %s", self.name, media_err)
+                        await _send_attachment_failure_notice(media_path, media_err)
 
                 # Send auto-detected local non-image files as native attachments
                 for file_path in _non_image_local:
@@ -4810,19 +4866,26 @@ class BasePlatformAdapter(ABC):
                     try:
                         ext = Path(file_path).suffix.lower()
                         if ext in _VIDEO_EXTS:
-                            await self.send_video(
+                            file_result = await self.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=file_path,
                                 metadata=_final_thread_metadata,
                             )
                         else:
-                            await self.send_document(
+                            file_result = await self.send_document(
                                 chat_id=event.source.chat_id,
                                 file_path=file_path,
                                 metadata=_final_thread_metadata,
                             )
+                        _record_delivery(file_result)
+                        if getattr(file_result, "success", True) is False:
+                            await _send_attachment_failure_notice(
+                                file_path,
+                                getattr(file_result, "error", None),
+                            )
                     except Exception as file_err:
                         logger.error("[%s] Error sending local file %s: %s", self.name, file_path, file_err)
+                        await _send_attachment_failure_notice(file_path, file_err)
 
                 # A3 (#29346): if a non-empty response produced nothing
                 # deliverable, fail loudly rather than dropping it in silence.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11671,7 +11671,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # send_multiple_images (Telegram sendPhoto recompresses to ~1280px).
             force_document_attachments = "[[as_document]]" in response
 
-            from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
+            from gateway.platforms.base import (
+                BasePlatformAdapter,
+                format_attachment_delivery_failure_notice,
+                should_send_media_as_audio,
+            )
 
             media_files, cleaned = adapter.extract_media(response)
             media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
@@ -11687,6 +11691,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             local_files = BasePlatformAdapter.filter_local_delivery_paths(local_files)
 
             _thread_meta = self._thread_metadata_for_source(event.source, self._reply_anchor_for_event(event))
+
+            async def _send_attachment_failure_notice(file_path: str, error: object = None) -> None:
+                if not hasattr(adapter, "send"):
+                    return
+                try:
+                    await adapter.send(
+                        chat_id=event.source.chat_id,
+                        content=format_attachment_delivery_failure_notice(file_path, str(error or "")),
+                        metadata=_thread_meta,
+                    )
+                except Exception as notice_err:
+                    logger.warning(
+                        "[%s] Post-stream attachment failure notice failed for %s: %s",
+                        adapter.name,
+                        file_path,
+                        notice_err,
+                    )
+
+            def _send_result_failed(result: object) -> bool:
+                return getattr(result, "success", True) is False
 
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
             _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
@@ -11717,55 +11741,75 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if image_paths:
                 try:
                     images = [(f"file://{_quote(p)}", "") for p in image_paths]
-                    await adapter.send_multiple_images(
+                    image_result = await adapter.send_multiple_images(
                         chat_id=event.source.chat_id,
                         images=images,
                         metadata=_thread_meta,
                     )
+                    if _send_result_failed(image_result):
+                        for image_path in image_paths:
+                            await _send_attachment_failure_notice(
+                                image_path,
+                                getattr(image_result, "error", None),
+                            )
                 except Exception as e:
                     logger.warning("[%s] Post-stream image batch delivery failed: %s", adapter.name, e)
+                    for image_path in image_paths:
+                        await _send_attachment_failure_notice(image_path, e)
 
             for media_path, is_voice in non_image_media:
                 try:
                     ext = Path(media_path).suffix.lower()
                     if should_send_media_as_audio(event.source.platform, ext, is_voice=is_voice):
-                        await adapter.send_voice(
+                        media_result = await adapter.send_voice(
                             chat_id=event.source.chat_id,
                             audio_path=media_path,
                             metadata=_thread_meta,
                         )
                     elif ext in _VIDEO_EXTS:
-                        await adapter.send_video(
+                        media_result = await adapter.send_video(
                             chat_id=event.source.chat_id,
                             video_path=media_path,
                             metadata=_thread_meta,
                         )
                     else:
-                        await adapter.send_document(
+                        media_result = await adapter.send_document(
                             chat_id=event.source.chat_id,
                             file_path=media_path,
                             metadata=_thread_meta,
                         )
+                    if _send_result_failed(media_result):
+                        await _send_attachment_failure_notice(
+                            media_path,
+                            getattr(media_result, "error", None),
+                        )
                 except Exception as e:
                     logger.warning("[%s] Post-stream media delivery failed: %s", adapter.name, e)
+                    await _send_attachment_failure_notice(media_path, e)
 
             for file_path in non_image_local:
                 try:
                     ext = Path(file_path).suffix.lower()
                     if ext in _VIDEO_EXTS:
-                        await adapter.send_video(
+                        file_result = await adapter.send_video(
                             chat_id=event.source.chat_id,
                             video_path=file_path,
                             metadata=_thread_meta,
                         )
                     else:
-                        await adapter.send_document(
+                        file_result = await adapter.send_document(
                             chat_id=event.source.chat_id,
                             file_path=file_path,
                             metadata=_thread_meta,
                         )
+                    if _send_result_failed(file_result):
+                        await _send_attachment_failure_notice(
+                            file_path,
+                            getattr(file_result, "error", None),
+                        )
                 except Exception as e:
                     logger.warning("[%s] Post-stream file delivery failed: %s", adapter.name, e)
+                    await _send_attachment_failure_notice(file_path, e)
 
         except Exception as e:
             logger.warning("Post-stream media extraction failed: %s", e)
@@ -12731,6 +12775,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if thread_id is None:
             return None
         metadata: Dict[str, Any] = {"thread_id": thread_id}
+        if platform == Platform.FEISHU and reply_to_message_id is not None:
+            metadata["reply_to_message_id"] = str(reply_to_message_id)
         if self._is_telegram_dm_topic_target(
             platform,
             chat_id,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -67,7 +67,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, List, Literal, Optional, Sequence
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
+from urllib.parse import unquote, urlencode
 from urllib.request import Request, urlopen
 
 # aiohttp/websockets are independent optional deps — import outside lark_oapi
@@ -158,6 +158,10 @@ _MARKDOWN_HINT_RE = re.compile(
 # Feishu post-type 'md' elements do not render tables, so we force text mode.
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_FEISHU_DRIVE_FILE_LINK_RE = re.compile(
+    r"https?://[^\s<>()\"']*?(?:feishu\.cn|larksuite\.com|larksuite\.com\.cn)/file/(?P<token>[A-Za-z0-9_-]+)",
+    re.IGNORECASE,
+)
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
@@ -192,6 +196,7 @@ _MAX_TEXT_INJECT_BYTES = 100 * 1024
 _FEISHU_CONNECT_ATTEMPTS = 3
 _FEISHU_SEND_ATTEMPTS = 3
 _FEISHU_APP_LOCK_SCOPE = "feishu-app-id"
+_FEISHU_FIELD_VALIDATION_ERROR_CODE = "99992402"
 _DEFAULT_TEXT_BATCH_DELAY_SECONDS = 0.6
 _DEFAULT_TEXT_BATCH_MAX_MESSAGES = 8
 _DEFAULT_TEXT_BATCH_MAX_CHARS = 4000
@@ -541,6 +546,30 @@ def _coerce_int(value: Any, default: Optional[int] = None, min_value: int = 0) -
 def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
     parsed = _coerce_int(value, default=default, min_value=min_value)
     return default if parsed is None else parsed
+
+
+def _looks_like_feishu_thread_id(value: Any) -> bool:
+    """Best-effort guard for Feishu topic IDs vs normal message IDs."""
+    text = str(value or "").strip()
+    return text.startswith("omt")
+
+
+def _inbound_thread_id_from_message(message: Any) -> Optional[str]:
+    explicit = getattr(message, "thread_id", None)
+    if explicit:
+        return str(explicit)
+    root_id = getattr(message, "root_id", None)
+    if _looks_like_feishu_thread_id(root_id):
+        return str(root_id)
+    return None
+
+
+def _reply_to_message_id_from_message(message: Any) -> Optional[str]:
+    for attr in ("parent_id", "upper_message_id", "root_id"):
+        value = getattr(message, attr, None)
+        if value and not _looks_like_feishu_thread_id(value):
+            return str(value)
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -1131,6 +1160,19 @@ def _first_non_empty_text(*values: Any) -> str:
             if normalized:
                 return normalized
     return ""
+
+
+def _extract_feishu_drive_file_tokens(text: str) -> List[str]:
+    """Return unique Feishu Drive file tokens mentioned in user-visible text."""
+    tokens: List[str] = []
+    seen: set[str] = set()
+    for match in _FEISHU_DRIVE_FILE_LINK_RE.finditer(text or ""):
+        token = match.group("token").strip()
+        if not token or token in seen:
+            continue
+        seen.add(token)
+        tokens.append(token)
+    return tokens
 
 
 # ---------------------------------------------------------------------------
@@ -3123,13 +3165,8 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
-        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
-        reply_to_message_id = (
-            getattr(message, "parent_id", None)
-            or getattr(message, "upper_message_id", None)
-            or getattr(message, "root_id", None)
-            or None
-        )
+        thread_id = _inbound_thread_id_from_message(message)
+        reply_to_message_id = _reply_to_message_id_from_message(message)
         reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
 
         sender_primary = (
@@ -3618,8 +3655,15 @@ class FeishuAdapter(BasePlatformAdapter):
             message_id=message_id,
             normalized=normalized,
         )
-        inbound_type = self._resolve_normalized_message_type(normalized, media_types)
         text = normalized.text_content
+        drive_media_urls, drive_media_types = await self._download_feishu_drive_file_links(text)
+        if drive_media_urls:
+            media_urls.extend(drive_media_urls)
+            media_types.extend(drive_media_types)
+
+        inbound_type = self._resolve_normalized_message_type(normalized, media_types)
+        if drive_media_urls and inbound_type == MessageType.TEXT:
+            inbound_type = MessageType.DOCUMENT
 
         if (
             inbound_type in {MessageType.DOCUMENT, MessageType.AUDIO, MessageType.VIDEO, MessageType.PHOTO}
@@ -3813,6 +3857,77 @@ class FeishuAdapter(BasePlatformAdapter):
                 )
         return "", ""
 
+    async def _download_feishu_drive_file_links(self, text: str) -> tuple[List[str], List[str]]:
+        tokens = _extract_feishu_drive_file_tokens(text)
+        if not tokens:
+            return [], []
+
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        for token in tokens:
+            cached_path, media_type = await self._download_feishu_drive_file(token)
+            if not cached_path:
+                continue
+            media_urls.append(cached_path)
+            media_types.append(media_type)
+        return media_urls, media_types
+
+    async def _download_feishu_drive_file(self, file_token: str) -> tuple[str, str]:
+        if not self._client or not file_token:
+            return "", ""
+
+        # Uploaded Feishu Drive files normally download through the media
+        # endpoint. Keep a file endpoint fallback for older tenants/API shapes.
+        endpoints = (
+            "/open-apis/drive/v1/medias/:file_token/download",
+            "/open-apis/drive/v1/files/:file_token/download",
+        )
+        for uri in endpoints:
+            try:
+                request = self._build_drive_file_download_request(uri=uri, file_token=file_token)
+                response = await asyncio.to_thread(self._client.request, request)
+                if not response or not self._response_succeeded(response):
+                    logger.debug(
+                        "[Feishu] Drive file download failed for %s via %s: %s %s",
+                        file_token,
+                        uri,
+                        getattr(response, "code", "unknown"),
+                        getattr(response, "msg", "request failed"),
+                    )
+                    continue
+
+                raw_bytes = self._read_drive_binary_response(response)
+                if not raw_bytes:
+                    continue
+                content_type = self._get_response_header(response, "Content-Type")
+                filename = (
+                    self._filename_from_content_disposition(
+                        self._get_response_header_value(response, "Content-Disposition")
+                    )
+                    or getattr(response, "file_name", None)
+                    or f"feishu-file-{file_token}"
+                )
+                media_type = self._normalize_media_type(
+                    content_type,
+                    default=self._guess_document_media_type(filename),
+                )
+                if not Path(filename).suffix:
+                    ext = _DOCUMENT_MIME_TO_EXT.get(media_type) or mimetypes.guess_extension(media_type)
+                    if ext:
+                        filename = f"{filename}{ext}"
+
+                cached_path = cache_document_from_bytes(raw_bytes, filename)
+                logger.info("[Feishu] Cached Drive file link at %s", cached_path)
+                return cached_path, media_type or self._guess_document_media_type(filename)
+            except Exception:
+                logger.warning(
+                    "[Feishu] Failed to cache Drive file link %s via %s",
+                    file_token,
+                    uri,
+                    exc_info=True,
+                )
+        return "", ""
+
     # =========================================================================
     # Static helpers — extension / media-type guessing
     # =========================================================================
@@ -3827,10 +3942,52 @@ class FeishuAdapter(BasePlatformAdapter):
         return bytes(file_obj.read())
 
     @staticmethod
-    def _get_response_header(response: Any, name: str) -> str:
+    def _read_drive_binary_response(response: Any) -> bytes:
+        file_obj = getattr(response, "file", None)
+        if file_obj is not None:
+            if hasattr(file_obj, "getvalue"):
+                return bytes(file_obj.getvalue())
+            return bytes(file_obj.read())
+        raw = getattr(response, "raw", None)
+        raw_content = getattr(raw, "content", None)
+        if raw_content is not None:
+            if isinstance(raw_content, str):
+                return raw_content.encode("utf-8")
+            return bytes(raw_content)
+        content = getattr(response, "content", None)
+        if isinstance(content, str):
+            return content.encode("utf-8")
+        return bytes(content) if content is not None else b""
+
+    @staticmethod
+    def _get_response_header_value(response: Any, name: str) -> str:
         raw = getattr(response, "raw", None)
         headers = getattr(raw, "headers", {}) or {}
-        return str(headers.get(name, headers.get(name.lower(), "")) or "").split(";", 1)[0].strip().lower()
+        if not headers:
+            return ""
+        direct = headers.get(name)
+        if direct is not None:
+            return str(direct).strip()
+        lower_name = name.lower()
+        for key, value in headers.items():
+            if str(key).lower() == lower_name:
+                return str(value).strip()
+        return ""
+
+    @staticmethod
+    def _get_response_header(response: Any, name: str) -> str:
+        return FeishuAdapter._get_response_header_value(response, name).split(";", 1)[0].strip().lower()
+
+    @staticmethod
+    def _filename_from_content_disposition(content_disposition: str) -> str:
+        header = content_disposition or ""
+        star_match = re.search(r"filename\*\s*=\s*(?:UTF-8''|utf-8'')?([^;]+)", header, re.IGNORECASE)
+        if star_match:
+            return Path(unquote(star_match.group(1).strip().strip('"'))).name
+        match = re.search(r"filename\s*=\s*(\"[^\"]+\"|[^;]+)", header, re.IGNORECASE)
+        if match:
+            return Path(match.group(1).strip().strip('"')).name
+        return ""
 
     @staticmethod
     def _guess_extension(filename: str, content_type: str, default: str, *, allowed: set[str]) -> str:
@@ -4637,6 +4794,27 @@ class FeishuAdapter(BasePlatformAdapter):
                     reply_to=active_reply_to,
                     metadata=metadata,
                 )
+                if (
+                    not self._response_succeeded(response)
+                    and (metadata or {}).get("thread_id")
+                    and str(getattr(response, "code", "")) == _FEISHU_FIELD_VALIDATION_ERROR_CODE
+                ):
+                    logger.warning(
+                        "[Feishu] Threaded send to %s failed with field validation; "
+                        "falling back to plain chat message in %s",
+                        (metadata or {}).get("thread_id"),
+                        chat_id,
+                    )
+                    plain_metadata = dict(metadata or {})
+                    plain_metadata.pop("thread_id", None)
+                    plain_metadata.pop("reply_to_message_id", None)
+                    response = await self._send_raw_message(
+                        chat_id=chat_id,
+                        msg_type=msg_type,
+                        payload=payload,
+                        reply_to=None,
+                        metadata=plain_metadata,
+                    )
                 # If replying to a message failed because it was withdrawn or not found,
                 # fall back to posting a new message directly to the chat.
                 if active_reply_to and not self._response_succeeded(response):
@@ -4722,6 +4900,19 @@ class FeishuAdapter(BasePlatformAdapter):
                 .build()
             )
         return SimpleNamespace(message_id=message_id, file_key=file_key, type=resource_type)
+
+    @staticmethod
+    def _build_drive_file_download_request(*, uri: str, file_token: str) -> Any:
+        if "BaseRequest" in globals() and "HttpMethod" in globals() and "AccessTokenType" in globals():
+            return (
+                BaseRequest.builder()
+                .http_method(HttpMethod.GET)
+                .uri(uri)
+                .paths({"file_token": file_token})
+                .token_types({AccessTokenType.TENANT})
+                .build()
+            )
+        return SimpleNamespace(uri=uri, paths={"file_token": file_token})
 
     @staticmethod
     def _build_get_application_request(*, app_id: str, lang: str) -> Any:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1552,6 +1552,7 @@ class AIAgent:
             and (
                 messages[-1].get("_empty_recovery_synthetic")
                 or messages[-1].get("_empty_terminal_sentinel")
+                or messages[-1].get("_file_delivery_recovery_synthetic")
             )
         ):
             messages.pop()

--- a/tests/agent/test_response_truthfulness.py
+++ b/tests/agent/test_response_truthfulness.py
@@ -1,0 +1,32 @@
+import unittest
+
+from agent.response_truthfulness import (
+    has_file_delivery_payload,
+    looks_like_unbacked_file_delivery_claim,
+)
+
+
+class TestResponseTruthfulness(unittest.TestCase):
+    def test_unbacked_file_delivery_claim_detects_short_attachment_claims(self):
+        self.assertTrue(looks_like_unbacked_file_delivery_claim("文件已生成，请查收。"))
+        self.assertTrue(looks_like_unbacked_file_delivery_claim("I've attached the Word document below."))
+        self.assertTrue(looks_like_unbacked_file_delivery_claim("我再发一次，应该会以附件形式出现。"))
+
+    def test_unbacked_file_delivery_claim_allows_real_delivery_evidence(self):
+        self.assertFalse(looks_like_unbacked_file_delivery_claim("MEDIA:/tmp/report.docx"))
+        self.assertFalse(looks_like_unbacked_file_delivery_claim("文件路径：/tmp/report.docx"))
+        self.assertFalse(looks_like_unbacked_file_delivery_claim("下载链接：https://example.com/report.pdf"))
+        self.assertFalse(looks_like_unbacked_file_delivery_claim("```text\ninline file content\n```"))
+
+    def test_unbacked_file_delivery_claim_allows_honest_failure(self):
+        self.assertFalse(looks_like_unbacked_file_delivery_claim("文件生成失败：没有写入权限。"))
+        self.assertFalse(looks_like_unbacked_file_delivery_claim("I could not upload the attachment."))
+
+    def test_has_file_delivery_payload_recognizes_common_payloads(self):
+        self.assertTrue(has_file_delivery_payload("请打开 /tmp/a/b/report.pdf"))
+        self.assertTrue(has_file_delivery_payload("[report](https://example.com/report.pdf)"))
+        self.assertFalse(has_file_delivery_payload("文件已生成，请查收。"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -80,6 +80,18 @@ class TestConfigEnvOverrides(unittest.TestCase):
 
 
 class TestFeishuMessageNormalization(unittest.TestCase):
+    def test_extract_feishu_drive_file_tokens_dedupes_file_links(self):
+        from plugins.platforms.feishu.adapter import _extract_feishu_drive_file_tokens
+
+        self.assertEqual(
+            _extract_feishu_drive_file_tokens(
+                "A https://bjrrtx.feishu.cn/file/SyzVbpd1Lo9UJGxwonwcK6TVnyd "
+                "B https://bjrrtx.feishu.cn/file/SyzVbpd1Lo9UJGxwonwcK6TVnyd "
+                "C https://example.com/file/not-feishu"
+            ),
+            ["SyzVbpd1Lo9UJGxwonwcK6TVnyd"],
+        )
+
     def test_normalize_merge_forward_preserves_summary_lines(self):
         from plugins.platforms.feishu.adapter import normalize_feishu_message
 
@@ -1364,6 +1376,37 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(media_types, ["application/pdf"])
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_extract_text_message_downloads_drive_file_links(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._download_feishu_drive_file = AsyncMock(
+            return_value=("/tmp/doc_linked_report.pdf", "application/pdf")
+        )
+        message = SimpleNamespace(
+            message_type="text",
+            content=json.dumps(
+                {
+                    "text": (
+                        "请补充这个资料 "
+                        "https://bjrrtx.feishu.cn/file/SyzVbpd1Lo9UJGxwonwcK6TVnyd"
+                    )
+                },
+                ensure_ascii=False,
+            ),
+            message_id="om_text_link",
+        )
+
+        text, msg_type, media_urls, media_types, _mentions = asyncio.run(adapter._extract_message_content(message))
+
+        self.assertIn("请补充这个资料", text)
+        self.assertEqual(msg_type.value, "document")
+        self.assertEqual(media_urls, ["/tmp/doc_linked_report.pdf"])
+        self.assertEqual(media_types, ["application/pdf"])
+        adapter._download_feishu_drive_file.assert_awaited_once_with("SyzVbpd1Lo9UJGxwonwcK6TVnyd")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_extract_media_message_with_image_mime_becomes_photo(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
@@ -1865,6 +1908,57 @@ class TestAdapterBehavior(unittest.TestCase):
         # down, which only works by accident (httpx's eager buffering).
         self.assertLess(events.index("content_read"), events.index("client_exit"))
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_download_feishu_drive_file_caches_binary_response(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _Client:
+            def request(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    raw=SimpleNamespace(
+                        content=b"%PDF-1.4 linked file",
+                        headers={
+                            "Content-Type": "application/pdf",
+                            "Content-Disposition": "attachment; filename*=UTF-8''%E6%8A%A5%E5%91%8A.pdf",
+                        },
+                    ),
+                )
+
+        adapter._client = _Client()
+        adapter._build_drive_file_download_request = Mock(
+            side_effect=lambda *, uri, file_token: SimpleNamespace(
+                uri=uri,
+                paths={"file_token": file_token},
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with (
+            patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct),
+            patch(
+                "plugins.platforms.feishu.adapter.cache_document_from_bytes",
+                return_value="/tmp/doc_linked_report.pdf",
+            ) as cache_document,
+        ):
+            path, media_type = asyncio.run(adapter._download_feishu_drive_file("SyzVbpd1Lo9UJGxwonwcK6TVnyd"))
+
+        self.assertEqual(path, "/tmp/doc_linked_report.pdf")
+        self.assertEqual(media_type, "application/pdf")
+        self.assertEqual(
+            captured["request"].uri,
+            "/open-apis/drive/v1/medias/:file_token/download",
+        )
+        self.assertEqual(captured["request"].paths, {"file_token": "SyzVbpd1Lo9UJGxwonwcK6TVnyd"})
+        cache_document.assert_called_once_with(b"%PDF-1.4 linked file", "报告.pdf")
+
     def test_dedup_state_persists_across_adapter_restart(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
@@ -1951,6 +2045,129 @@ class TestAdapterBehavior(unittest.TestCase):
         event = adapter._dispatch_inbound_event.await_args.args[0]
         self.assertEqual(event.reply_to_message_id, "om_parent")
         self.assertEqual(event.reply_to_text, "父消息内容")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_quote_root_id_does_not_create_topic_session(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_chat", "name": "Feishu Group", "type": "group"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        adapter._fetch_message_text = AsyncMock(return_value="被引用的原消息")
+        message = SimpleNamespace(
+            chat_id="oc_chat",
+            thread_id=None,
+            root_id="om_root_message",
+            parent_id=None,
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"请重点看这句"}',
+            message_id="om_quote_followup",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="group",
+                message_id="om_quote_followup",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertIsNone(event.source.thread_id)
+        self.assertEqual(event.reply_to_message_id, "om_root_message")
+        self.assertEqual(event.reply_to_text, "被引用的原消息")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_message_preserves_explicit_feishu_topic_thread(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_chat", "name": "Feishu Group", "type": "group"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        adapter._fetch_message_text = AsyncMock(return_value="topic 内的父消息")
+        message = SimpleNamespace(
+            chat_id="oc_chat",
+            thread_id="omt_topic_123",
+            root_id="om_topic_root",
+            parent_id="om_parent",
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"继续处理"}',
+            message_id="om_topic_followup",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="group",
+                message_id="om_topic_followup",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.source.thread_id, "omt_topic_123")
+        self.assertEqual(event.reply_to_message_id, "om_parent")
+        self.assertEqual(event.reply_to_text, "topic 内的父消息")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_legacy_thread_like_root_id_remains_topic_id(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_chat", "name": "Feishu Group", "type": "group"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        adapter._fetch_message_text = AsyncMock(return_value=None)
+        message = SimpleNamespace(
+            chat_id="oc_chat",
+            thread_id=None,
+            root_id="omt_topic_legacy",
+            parent_id=None,
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"topic follow-up"}',
+            message_id="om_topic_legacy_followup",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="group",
+                message_id="om_topic_legacy_followup",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.source.thread_id, "omt_topic_legacy")
+        self.assertIsNone(event.reply_to_message_id)
+        adapter._fetch_message_text.assert_not_awaited()
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_replies_in_thread_when_thread_metadata_present(self):
@@ -2174,6 +2391,78 @@ class TestAdapterBehavior(unittest.TestCase):
 
         self.assertTrue(result.success)
         self.assertTrue(captured["request"].request_body.reply_in_thread)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_document_thread_validation_falls_back_to_plain_chat_file(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"replies": [], "creates": []}
+
+        class _FileAPI:
+            def create(self, request):
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(file_key="file_123"),
+                )
+
+        class _MessageAPI:
+            def reply(self, request):
+                captured["replies"].append(request)
+                return SimpleNamespace(
+                    success=lambda: False,
+                    code=99992402,
+                    msg="field validation failed",
+                    data=None,
+                )
+
+            def create(self, request):
+                captured["creates"].append(request)
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_plain_file_msg"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    file=_FileAPI(),
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".docx", delete=False) as tmp:
+            tmp.write(b"PK\x03\x04 test")
+            file_path = tmp.name
+
+        try:
+            with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+                result = asyncio.run(
+                    adapter.send_document(
+                        chat_id="oc_chat",
+                        file_path=file_path,
+                        metadata={
+                            "thread_id": "omt-thread",
+                            "reply_to_message_id": "om_trigger",
+                        },
+                    )
+                )
+        finally:
+            os.unlink(file_path)
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_plain_file_msg")
+        self.assertEqual(len(captured["replies"]), 1)
+        self.assertEqual(len(captured["creates"]), 1)
+        create_request = captured["creates"][0]
+        self.assertEqual(create_request.receive_id_type, "chat_id")
+        self.assertEqual(create_request.request_body.receive_id, "oc_chat")
+        self.assertEqual(create_request.request_body.msg_type, "file")
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_document_uploads_file_and_sends_file_message(self):


### PR DESCRIPTION
## Summary
- restore Feishu quote/root handling so om roots remain reply anchors while explicit omt topics stay threaded
- retry threaded Feishu file sends as plain chat messages when Feishu returns 99992402 field validation failed
- add visible attachment failure notices and an agent-side guard against unsupported file-delivery claims

## Tests
- venv/bin/python -m py_compile agent/response_truthfulness.py agent/conversation_loop.py agent/prompt_builder.py gateway/platforms/base.py gateway/run.py plugins/platforms/feishu/adapter.py run_agent.py tests/agent/test_response_truthfulness.py tests/gateway/test_feishu.py
- venv/bin/python -m unittest tests.agent.test_response_truthfulness -q
- venv/bin/python -m unittest tests.gateway.test_feishu -q