### PR TITLE
fix: gate per-platform streaming behind global streaming.enabled (#53697)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4370,10 +4370,9 @@ class TurnRunner:
             ctx.user_config, platform_key, "streaming"
         )
         # None = no per-platform override → follow global config
-        _streaming_enabled = (
-            _scfg.enabled and _scfg.transport != "off"
-            if _plat_streaming is None
-            else bool(_plat_streaming)
+        _global_streaming_enabled = bool(_scfg.enabled) and _scfg.transport != "off"
+        _streaming_enabled = _global_streaming_enabled and (
+            True if _plat_streaming is None else bool(_plat_streaming)
         )
         _want_stream_deltas = _streaming_enabled
         _want_interim_messages = ctx.interim_assistant_messages_enabled
@@ -23678,10 +23677,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _plat_streaming = resolve_display_setting(
             user_config, platform_key, "streaming"
         )
-        _streaming_enabled = (
-            _scfg.enabled and _scfg.transport != "off"
-            if _plat_streaming is None
-            else bool(_plat_streaming)
+        _global_streaming_enabled = bool(_scfg.enabled) and _scfg.transport != "off"
+        _streaming_enabled = _global_streaming_enabled and (
+            True if _plat_streaming is None else bool(_plat_streaming)
         )
 
         _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -980,6 +980,31 @@ async def test_display_streaming_does_not_enable_gateway_streaming(monkeypatch, 
     assert [call["content"] for call in adapter.sent] == ["I'll inspect the repo first."]
 
 
+@pytest.mark.asyncio
+async def test_per_platform_streaming_does_not_override_global_disabled(monkeypatch, tmp_path):
+    """Regression for #53697: display.platforms.telegram.streaming=True must not
+    re-enable gateway streaming when streaming.enabled=False (global master switch)."""
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryAgent,
+        session_id="sess-per-platform-streaming-global-off",
+        config_data={
+            "display": {
+                "platforms": {
+                    "telegram": {"streaming": True},
+                },
+                "interim_assistant_messages": True,
+            },
+            "streaming": {"enabled": False},
+        },
+        platform=Platform.TELEGRAM,
+    )
+
+    assert result.get("already_sent") is not True
+    assert adapter.edits == []
+
+
 class TransformedStreamAgent:
     """Streams a response, then signals the gateway that a plugin hook
     (``transform_llm_output``) modified the final text after streaming


### PR DESCRIPTION
Fixes #53697

## Description

The effective streaming resolver in `gateway/run.py` had two sites where per-platform `display.platforms.<plat>.streaming` values were used directly without checking the global `streaming.enabled` master switch.

When `streaming.enabled: false` was set globally, the Telegram platform still had streaming enabled because its per-platform default `true` bypassed the global gate.

## Fix

Introduce an intermediate `_global_streaming_enabled` variable that combines `_scfg.enabled` and `_scfg.transport != "off"`, then AND it with the per-platform override (or default-true when no override exists).

This ensures `streaming.enabled: false` acts as a hard global kill switch regardless of per-platform defaults or overrides.

## Verification

- Compiled: `python -c "compile(...)"` passes
- Related test suite: `tests/gateway/test_per_platform_streaming_defaults.py` (4/4 pass)
- `tests/test_gateway_streaming_nested_config.py` (3/3 pass)
- Custom verification script covering 7 scenarios (global off + per-platform on = off, transport=off, etc.) — all pass
- Quality gates: S1 (secrets), S2 (personal refs), C1 (conventional commits), F1 (focused diff) — all clean