### PR TITLE
fix(gemini): extend cooldown for quota-exhausted keys

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -35,7 +35,7 @@ from hermes_cli.timeouts import get_provider_request_timeout
 from agent.prompt_builder import format_steer_marker
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
-from agent.credential_pool import STATUS_EXHAUSTED
+from agent.credential_pool import STATUS_EXHAUSTED, is_gemini_daily_quota_error
 from agent.error_classifier import FailoverReason
 from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
 
@@ -840,7 +840,12 @@ def recover_with_credential_pool(
                 or "usage limit reached" in context_message
                 or "usage limit has been reached" in context_message
             )
-        if not has_retried_429 and not usage_limit_reached:
+        gemini_daily_quota = is_gemini_daily_quota_error(
+            getattr(agent, "provider", None),
+            status_code,
+            error_context,
+        )
+        if not has_retried_429 and not usage_limit_reached and not gemini_daily_quota:
             return False, True
         rotate_status = status_code if status_code is not None else 429
         next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -424,11 +424,11 @@ def _exhausted_until(entry: PooledCredential) -> Optional[float]:
     if reset_at is not None:
         return reset_at
     if is_gemini_daily_quota_error(
-        entry.provider,
-        entry.last_error_code,
+        getattr(entry, "provider", ""),
+        getattr(entry, "last_error_code", None),
         {
-            "reason": entry.last_error_reason,
-            "message": entry.last_error_message,
+            "reason": getattr(entry, "last_error_reason", None),
+            "message": getattr(entry, "last_error_message", None),
         },
     ):
         if entry.last_status_at:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -113,6 +113,22 @@ SUPPORTED_POOL_STRATEGIES = {
 EXHAUSTED_TTL_401_SECONDS = 5 * 60           # 5 minutes
 EXHAUSTED_TTL_429_SECONDS = 60 * 60          # 1 hour
 EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
+EXHAUSTED_TTL_GEMINI_DAILY_QUOTA_SECONDS = 24 * 60 * 60  # 24 hours
+
+_GEMINI_POOL_PROVIDERS = frozenset({
+    "gemini",
+    "google",
+    "google-gemini",
+    "google-ai-studio",
+})
+_GEMINI_DAILY_QUOTA_MARKERS = (
+    "generate_content_free_tier_requests",
+    "free_tier_requests",
+)
+_GEMINI_DAILY_QUOTA_PHRASES = (
+    "daily quota",
+    "requests per day",
+)
 
 # Pool key prefix for custom OpenAI-compatible endpoints.
 # Custom endpoints all share provider='custom' but are keyed by their
@@ -273,6 +289,56 @@ def _exhausted_ttl(error_code: Optional[int]) -> int:
     return EXHAUSTED_TTL_DEFAULT_SECONDS
 
 
+def _flatten_error_context(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, dict):
+        parts: List[str] = []
+        for key, nested in value.items():
+            parts.append(str(key))
+            parts.extend(_flatten_error_context(nested))
+        return parts
+    if isinstance(value, (list, tuple, set)):
+        parts = []
+        for item in value:
+            parts.extend(_flatten_error_context(item))
+        return parts
+    return [str(value)]
+
+
+def is_gemini_daily_quota_error(
+    provider: Optional[str],
+    status_code: Optional[int],
+    *error_contexts: Optional[Dict[str, Any]],
+) -> bool:
+    """Return True for explicit Gemini daily/free-tier quota exhaustion."""
+    if status_code != 429:
+        return False
+    normalized_provider = str(provider or "").strip().lower()
+    if normalized_provider not in _GEMINI_POOL_PROVIDERS:
+        return False
+
+    haystack = " ".join(
+        part
+        for context in error_contexts
+        for part in _flatten_error_context(context)
+    ).lower()
+    if not haystack:
+        return False
+
+    if any(marker in haystack for marker in _GEMINI_DAILY_QUOTA_MARKERS):
+        return True
+
+    quota_exhausted = "quota" in haystack and (
+        "exceeded" in haystack or "exhausted" in haystack
+    )
+    if quota_exhausted and "free tier" in haystack:
+        return True
+    return quota_exhausted and any(
+        phrase in haystack for phrase in _GEMINI_DAILY_QUOTA_PHRASES
+    )
+
+
 def _parse_absolute_timestamp(value: Any) -> Optional[float]:
     """Best-effort parse for provider reset timestamps.
 
@@ -357,6 +423,16 @@ def _exhausted_until(entry: PooledCredential) -> Optional[float]:
     reset_at = _parse_absolute_timestamp(getattr(entry, "last_error_reset_at", None))
     if reset_at is not None:
         return reset_at
+    if is_gemini_daily_quota_error(
+        entry.provider,
+        entry.last_error_code,
+        {
+            "reason": entry.last_error_reason,
+            "message": entry.last_error_message,
+        },
+    ):
+        if entry.last_status_at:
+            return entry.last_status_at + EXHAUSTED_TTL_GEMINI_DAILY_QUOTA_SECONDS
     if entry.last_status_at:
         return entry.last_status_at + _exhausted_ttl(entry.last_error_code)
     return None
@@ -628,6 +704,16 @@ class CredentialPool:
         error_context: Optional[Dict[str, Any]] = None,
     ) -> PooledCredential:
         normalized_error = _normalize_error_context(error_context)
+        marked_at = time.time()
+        if is_gemini_daily_quota_error(
+            self.provider,
+            status_code,
+            error_context,
+            normalized_error,
+        ) and "reset_at" not in normalized_error:
+            normalized_error["reset_at"] = (
+                marked_at + EXHAUSTED_TTL_GEMINI_DAILY_QUOTA_SECONDS
+            )
         # Permanent OAuth failures (token_invalidated, token_revoked, etc.)
         # transition to STATUS_DEAD instead of STATUS_EXHAUSTED.  Without this,
         # a revoked credential gets a 1-hour TTL cooldown and then re-enters
@@ -642,7 +728,7 @@ class CredentialPool:
         updated = replace(
             entry,
             last_status=terminal_status,
-            last_status_at=time.time(),
+            last_status_at=marked_at,
             last_error_code=status_code,
             last_error_reason=normalized_error.get("reason"),
             last_error_message=normalized_error.get("message"),

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -334,6 +334,136 @@ def test_explicit_reset_timestamp_overrides_default_429_ttl(tmp_path, monkeypatc
     assert pool.select() is None
 
 
+def test_gemini_free_tier_daily_quota_stays_exhausted_after_one_hour(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    now = 1_700_000_000.0
+    monkeypatch.setattr("agent.credential_pool.time.time", lambda: now)
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "gemini": [
+                    {
+                        "id": "gemini-free-tier",
+                        "label": "free-tier",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "AIza-free-tier",
+                        "last_status": "exhausted",
+                        "last_status_at": now - (2 * 60 * 60),
+                        "last_error_code": 429,
+                        "last_error_reason": "RESOURCE_EXHAUSTED",
+                        "last_error_message": (
+                            "Quota exceeded for metric: "
+                            "generativelanguage.googleapis.com/"
+                            "generate_content_free_tier_requests"
+                        ),
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("gemini")
+
+    assert pool.has_available() is False
+    assert pool.select() is None
+
+
+def test_gemini_daily_quota_preserves_shorter_provider_reset(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    now = [1_700_000_000.0]
+    monkeypatch.setattr("agent.credential_pool.time.time", lambda: now[0])
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "gemini": [
+                    {
+                        "id": "gemini-provider-reset",
+                        "label": "provider-reset",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "AIza-provider-reset",
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("gemini")
+    assert pool.select().id == "gemini-provider-reset"
+
+    provider_reset_at = now[0] + 5 * 60
+    assert pool.mark_exhausted_and_rotate(
+        status_code=429,
+        error_context={
+            "reason": "RESOURCE_EXHAUSTED",
+            "message": (
+                "Quota exceeded for metric: "
+                "generativelanguage.googleapis.com/"
+                "generate_content_free_tier_requests"
+            ),
+            "reset_at": provider_reset_at,
+        },
+    ) is None
+
+    exhausted = pool.entries()[0]
+    assert exhausted.last_error_reset_at == provider_reset_at
+    now[0] = provider_reset_at + 1
+
+    recovered = pool.select()
+    assert recovered is not None
+    assert recovered.id == "gemini-provider-reset"
+    assert recovered.last_status == "ok"
+
+
+def test_gemini_transient_retry_delay_does_not_use_daily_quota_cooldown(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    now = 1_700_000_000.0
+    monkeypatch.setattr("agent.credential_pool.time.time", lambda: now)
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "gemini": [
+                    {
+                        "id": "gemini-transient",
+                        "label": "transient",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "AIza-transient",
+                        "last_status": "exhausted",
+                        "last_status_at": now - 60,
+                        "last_error_code": 429,
+                        "last_error_message": "Rate limit exceeded. Please retry in 6.19s.",
+                        "last_error_reset_at": now - 1,
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("gemini")
+    entry = pool.select()
+
+    assert entry is not None
+    assert entry.id == "gemini-transient"
+    assert entry.last_status == "ok"
+
+
 def test_mark_exhausted_and_rotate_persists_status(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6178,6 +6178,45 @@ class TestCredentialPoolRecovery:
         agent._swap_credential.assert_called_once_with(next_entry)
 
 
+    def test_recover_with_pool_rotates_gemini_free_tier_429_without_same_key_retry(self, agent):
+        next_entry = SimpleNamespace(label="secondary")
+        captured = {}
+
+        class _Pool:
+            provider = "gemini"
+
+            def current(self):
+                return SimpleNamespace(label="primary")
+
+            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+                captured["status_code"] = status_code
+                captured["error_context"] = error_context
+                return next_entry
+
+        agent.provider = "gemini"
+        agent._credential_pool = _Pool()
+        agent._swap_credential = MagicMock()
+
+        recovered, retry_same = agent._recover_with_credential_pool(
+            status_code=429,
+            has_retried_429=False,
+            error_context={
+                "reason": "RESOURCE_EXHAUSTED",
+                "message": (
+                    "Quota exceeded for metric: "
+                    "generativelanguage.googleapis.com/"
+                    "generate_content_free_tier_requests"
+                ),
+            },
+        )
+
+        assert recovered is True
+        assert retry_same is False
+        assert captured["status_code"] == 429
+        assert captured["error_context"]["reason"] == "RESOURCE_EXHAUSTED"
+        agent._swap_credential.assert_called_once_with(next_entry)
+
+
     def test_recover_with_pool_refreshes_on_401(self, agent):
         """401 with successful refresh should swap to refreshed credential."""
         refreshed_entry = SimpleNamespace(label="refreshed-primary", id="abc")


### PR DESCRIPTION
## Summary

- Detect explicit Gemini daily/free-tier quota exhaustion from `generate_content_free_tier_requests` and related free-tier/daily quota wording.
- Keep those Gemini credentials out of rotation for a 24-hour class cooldown instead of the generic 1-hour 429 cooldown.
- Skip the normal first same-key retry for clear Gemini daily/free-tier quota 429s, while preserving transient retry-delay behavior for ordinary 429s.

## Root Cause

Gemini free-tier daily quota exhaustion was classified as a generic 429 rate limit in the credential pool. Generic 429s use a short 1-hour cooldown and the recovery path first retries the same credential once before rotating. That made daily-exhausted Gemini keys re-enter the pool before the quota reset and added repeated same-key probes across large pools.

## Tests

- `python -m pytest tests/agent/test_credential_pool.py tests/agent/test_gemini_free_tier_gate.py tests/agent/test_gemini_native_adapter.py tests/run_agent/test_run_agent.py::TestCredentialPoolRecovery tests/run_agent/test_provider_fallback.py -q`
- `python -m py_compile agent/credential_pool.py agent/agent_runtime_helpers.py`
- `git diff --check origin/main...HEAD`

Fixes #53654
