### PR TITLE
fix: show Codex gpt-5.5 autoraise notice once

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -27,6 +27,7 @@ import threading
 import time
 import uuid
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import urlparse, parse_qs, urlunparse
 
@@ -84,6 +85,28 @@ def _build_codex_gpt55_autoraise_notice(autoraise: Dict[str, float]) -> str:
         f"summarizing.\n"
         f"  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
     )
+
+
+def _should_show_codex_gpt55_autoraise_notice_once() -> bool:
+    """Return True only the first time this profile sees the gpt-5.5 notice.
+
+    The Codex gpt-5.5 compaction autoraise is useful as an onboarding heads-up,
+    but showing it on every fresh CLI/gateway agent init is noisy. Store a tiny
+    profile-scoped marker under ``$HERMES_HOME`` so the notice is emitted once
+    per profile. If the marker cannot be written, fail open and show the notice:
+    a repeated informational line is better than silently hiding a config change.
+    """
+    marker = Path(get_hermes_home()) / "state" / "notices" / "codex_gpt55_autoraise_v1"
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        with marker.open("x", encoding="utf-8") as fh:
+            fh.write(f"shown_at={datetime.utcnow().isoformat()}Z\n")
+        return True
+    except FileExistsError:
+        return False
+    except OSError as exc:
+        logger.debug("Could not persist Codex gpt-5.5 autoraise notice marker: %s", exc)
+        return True
 
 
 def _normalized_custom_base_url(value: Any) -> str:
@@ -1769,18 +1792,26 @@ def init_agent(
             agent._ollama_num_ctx,
         )
 
+    # One-time notice when the Codex gpt-5.5 autoraise kicked in, with the
+    # exact opt-back-out command. Gate it before the CLI/gateway split so both
+    # surfaces share the same profile-scoped "shown once" marker.
+    _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
+    _show_codex_gpt55_autoraise_notice = (
+        isinstance(_autoraise, dict)
+        and compression_enabled
+        and _should_show_codex_gpt55_autoraise_notice_once()
+    )
+    _codex_gpt55_autoraise_notice = None
+    if isinstance(_autoraise, dict) and _show_codex_gpt55_autoraise_notice:
+        _codex_gpt55_autoraise_notice = _build_codex_gpt55_autoraise_notice(_autoraise)
+
     if not agent.quiet_mode:
         if compression_enabled:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {agent.context_compressor.threshold_tokens:,})")
         else:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (auto-compression disabled)")
-        # One-time notice when the Codex gpt-5.5 autoraise kicked in, with the
-        # exact opt-back-out command. Printed inline at startup for CLI users;
-        # gateway users get the same text replayed via _compression_warning on
-        # turn 1 (set below, after the warning slot is initialized).
-        _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-        if _autoraise and compression_enabled:
-            print(_build_codex_gpt55_autoraise_notice(_autoraise))
+        if _codex_gpt55_autoraise_notice:
+            print(_codex_gpt55_autoraise_notice)
 
     # Check immediately so CLI users see the warning at startup.
     # Gateway status_callback is not yet wired, so any warning is stored
@@ -1789,9 +1820,8 @@ def init_agent(
     # Gateway parity for the Codex gpt-5.5 autoraise notice: the startup print
     # above only reaches the CLI, so stash the same text here to be replayed
     # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
-    _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-    if _autoraise and compression_enabled:
-        agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise)
+    if _codex_gpt55_autoraise_notice:
+        agent._compression_warning = _codex_gpt55_autoraise_notice
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network
     # probe of the auxiliary provider chain + /models lookup) on every agent

--- a/tests/agent/test_arcee_trinity_overrides.py
+++ b/tests/agent/test_arcee_trinity_overrides.py
@@ -19,6 +19,7 @@ from agent.auxiliary_client import (
     _is_arcee_trinity_thinking,
     _is_codex_gpt55,
 )
+from agent.agent_init import _should_show_codex_gpt55_autoraise_notice_once
 
 
 @pytest.mark.parametrize(
@@ -157,3 +158,15 @@ def test_compression_threshold_opt_out_does_not_disable_trinity() -> None:
         )
         == 0.75
     )
+
+
+def test_codex_gpt55_autoraise_notice_marker_is_profile_scoped_and_once(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setattr("agent.agent_init.get_hermes_home", lambda: tmp_path)
+
+    assert _should_show_codex_gpt55_autoraise_notice_once() is True
+    assert _should_show_codex_gpt55_autoraise_notice_once() is False
+    assert (
+        tmp_path / "state" / "notices" / "codex_gpt55_autoraise_v1"
+    ).exists()


### PR DESCRIPTION
## Summary
- Store a profile-scoped marker after showing the Codex gpt-5.5 auto-compaction notice
- Suppress the startup/gateway replay notice after the first successful display
- Add regression coverage for the marker behavior

## Test Plan
- [x] python -m pytest tests/agent/test_arcee_trinity_overrides.py tests/run_agent/test_compression_feasibility.py -q -o 'addopts='