### PR TITLE
Fix: Terminal subprocess env leaks AUXILIARY/GATEWAY_RELAY secrets

### DIFF
--- a/tests/tools/test_hermes_subprocess_env.py
+++ b/tests/tools/test_hermes_subprocess_env.py
@@ -14,6 +14,8 @@ full credential environment. Two tiers:
 import os
 from unittest.mock import patch
 
+import pytest
+
 from tools.environments.local import (
     hermes_subprocess_env,
     _ALWAYS_STRIP_KEYS,
@@ -149,3 +151,92 @@ class TestBrowserPassthroughPattern:
         # Provider + gateway secrets must NOT come back.
         assert "ANTHROPIC_API_KEY" not in env
         assert "TELEGRAM_BOT_TOKEN" not in env
+
+
+class TestHermesInternalDynamicSecrets:
+    """AUXILIARY_<TASK>_* and GATEWAY_RELAY_* internal secrets are stripped in
+    BOTH inherit_credentials modes.
+
+    These credentials are injected into ``os.environ`` at runtime by the
+    gateway and CLI but match no static ``PROVIDER_REGISTRY`` name, so they
+    survive both Tier 1 (``_ALWAYS_STRIP_KEYS``) and Tier 2
+    (``_HERMES_PROVIDER_ENV_BLOCKLIST``) unless the dynamic-secret predicate
+    (:func:`_is_hermes_internal_secret`) strips them.  They are Tier-1
+    gateway-managed secrets — not LLM provider credentials — so they must be
+    stripped regardless of ``inherit_credentials``: even a user-blessed
+    ``claude`` / ``codex`` CLI executor never legitimately needs a side-LLM
+    key or relay-auth material.
+    """
+
+    _INTERNAL_SECRETS = {
+        "AUXILIARY_VISION_API_KEY": "sk-aux-vision-secret-1234567890",
+        "AUXILIARY_VISION_BASE_URL": "https://private-vision.example.com",
+        "GATEWAY_RELAY_SECRET": "relay-shared-secret-value",
+        "GATEWAY_RELAY_DELIVERY_KEY": "relay-delivery-key-value",
+    }
+    _NON_SECRET_AUXILIARY = {
+        "AUXILIARY_VISION_MODEL": "gpt-4o",
+        "AUXILIARY_VISION_PROVIDER": "openai",
+    }
+
+    def _run(self, *, inherit_credentials):
+        env = {**_SAFE_SAMPLE, **self._INTERNAL_SECRETS, **self._NON_SECRET_AUXILIARY}
+        with patch.dict(os.environ, env, clear=True):
+            return hermes_subprocess_env(inherit_credentials=inherit_credentials)
+
+    def test_auxiliary_api_key_stripped_when_not_inheriting(self):
+        result = self._run(inherit_credentials=False)
+        assert "AUXILIARY_VISION_API_KEY" not in result, (
+            "AUXILIARY_*_API_KEY must be stripped with inherit_credentials=False"
+        )
+
+    def test_auxiliary_base_url_stripped_when_not_inheriting(self):
+        result = self._run(inherit_credentials=False)
+        assert "AUXILIARY_VISION_BASE_URL" not in result, (
+            "AUXILIARY_*_BASE_URL must be stripped with inherit_credentials=False"
+        )
+
+    def test_gateway_relay_secret_stripped_when_not_inheriting(self):
+        result = self._run(inherit_credentials=False)
+        assert "GATEWAY_RELAY_SECRET" not in result, (
+            "GATEWAY_RELAY_SECRET must be stripped with inherit_credentials=False"
+        )
+
+    def test_auxiliary_api_key_stripped_even_when_inheriting(self):
+        result = self._run(inherit_credentials=True)
+        assert "AUXILIARY_VISION_API_KEY" not in result, (
+            "AUXILIARY_*_API_KEY is a Tier-1 internal secret and must be "
+            "stripped even with inherit_credentials=True"
+        )
+
+    def test_auxiliary_base_url_stripped_even_when_inheriting(self):
+        result = self._run(inherit_credentials=True)
+        assert "AUXILIARY_VISION_BASE_URL" not in result, (
+            "AUXILIARY_*_BASE_URL is a Tier-1 internal secret and must be "
+            "stripped even with inherit_credentials=True"
+        )
+
+    def test_gateway_relay_secret_stripped_even_when_inheriting(self):
+        result = self._run(inherit_credentials=True)
+        assert "GATEWAY_RELAY_SECRET" not in result, (
+            "GATEWAY_RELAY_SECRET is a Tier-1 gateway secret and must be "
+            "stripped even with inherit_credentials=True — a model-driving "
+            "CLI never needs relay-auth material"
+        )
+
+    def test_gateway_relay_delivery_key_stripped_even_when_inheriting(self):
+        result = self._run(inherit_credentials=True)
+        assert "GATEWAY_RELAY_DELIVERY_KEY" not in result
+
+    @pytest.mark.parametrize("inherit_credentials", [False, True])
+    def test_non_secret_auxiliary_vars_preserved(self, inherit_credentials):
+        """Non-secret auxiliary model/provider selection survives in BOTH
+        modes — they are config, not credentials, and a child reading the
+        configured auxiliary model legitimately depends on them."""
+        result = self._run(inherit_credentials=inherit_credentials)
+        assert result.get("AUXILIARY_VISION_MODEL") == "gpt-4o", (
+            "AUXILIARY_*_MODEL is non-secret config and must survive"
+        )
+        assert result.get("AUXILIARY_VISION_PROVIDER") == "openai", (
+            "AUXILIARY_*_PROVIDER is non-secret config and must survive"
+        )

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -611,3 +611,71 @@ class TestHermesBinDirOnPath:
         entries = result["PATH"].split(os.pathsep)
         assert entries[0] == "/opt/hermes/bin"
         assert "/usr/bin" in entries
+
+
+class TestAuxiliarySecretStripping:
+    """Verify AUXILIARY_*_API_KEY and GATEWAY_RELAY_* are stripped from subprocess env.
+
+    The name-based _HERMES_PROVIDER_ENV_BLOCKLIST does not include dynamic
+    AUXILIARY_<TASK>_API_KEY vars injected by gateway/run.py and cli.py from
+    config.yaml[auxiliary]. These are separate, often higher-spend inference
+    credentials (vision, title-gen, web-extract) that must never reach
+    model-authored shell commands.
+    """
+
+    def test_make_run_env_strips_auxiliary_api_key(self):
+        """_make_run_env must not pass AUXILIARY_*_API_KEY to the subprocess."""
+        from tools.environments.local import _make_run_env
+        with patch.dict(os.environ, {
+            "AUXILIARY_VISION_API_KEY": "sk-aux-secret-1234567890",
+            "AUXILIARY_VISION_BASE_URL": "https://api.example.com",
+            "AUXILIARY_VISION_MODEL": "gpt-4o",
+            "AUXILIARY_VISION_PROVIDER": "openai",
+            "PATH": "/usr/bin:/bin",
+        }, clear=True):
+            result = _make_run_env({})
+        assert "AUXILIARY_VISION_API_KEY" not in result, \
+            "AUXILIARY_*_API_KEY must be stripped from subprocess env"
+        assert "AUXILIARY_VISION_BASE_URL" not in result, \
+            "AUXILIARY_*_BASE_URL must be stripped from subprocess env"
+        assert result.get("AUXILIARY_VISION_MODEL") == "gpt-4o", \
+            "Non-secret AUXILIARY vars must pass through"
+        assert result.get("AUXILIARY_VISION_PROVIDER") == "openai", \
+            "Non-secret AUXILIARY vars must pass through"
+
+    def test_make_run_env_strips_gateway_relay_secret(self):
+        """_make_run_env must not pass GATEWAY_RELAY_SECRET to the subprocess."""
+        from tools.environments.local import _make_run_env
+        with patch.dict(os.environ, {
+            "GATEWAY_RELAY_ID": "gw-123",
+            "GATEWAY_RELAY_SECRET": "relay-secret-value",
+            "GATEWAY_RELAY_DELIVERY_KEY": "delivery-key-value",
+            "PATH": "/usr/bin:/bin",
+        }, clear=True):
+            result = _make_run_env({})
+        assert "GATEWAY_RELAY_SECRET" not in result
+        assert "GATEWAY_RELAY_DELIVERY_KEY" not in result
+        assert "GATEWAY_RELAY_ID" not in result
+
+    def test_sanitize_subprocess_env_strips_auxiliary_api_key(self):
+        """_sanitize_subprocess_env must not pass AUXILIARY_*_API_KEY through."""
+        from tools.environments.local import _sanitize_subprocess_env
+        base_env = {
+            "AUXILIARY_TITLE_API_KEY": "sk-title-secret-1234567890",
+            "AUXILIARY_TITLE_PROVIDER": "openai",
+            "PATH": "/usr/bin:/bin",
+        }
+        result = _sanitize_subprocess_env(base_env)
+        assert "AUXILIARY_TITLE_API_KEY" not in result
+        assert result.get("AUXILIARY_TITLE_PROVIDER") == "openai"
+
+    def test_is_hermes_internal_secret_patterns(self):
+        """_is_hermes_internal_secret catches AUXILIARY_*_API_KEY and _BASE_URL."""
+        from tools.environments.local import _is_hermes_internal_secret
+        assert _is_hermes_internal_secret("AUXILIARY_VISION_API_KEY")
+        assert _is_hermes_internal_secret("AUXILIARY_VISION_BASE_URL")
+        assert _is_hermes_internal_secret("auxiliary_title_api_key")
+        assert not _is_hermes_internal_secret("AUXILIARY_VISION_MODEL")
+        assert not _is_hermes_internal_secret("AUXILIARY_VISION_PROVIDER")
+        assert not _is_hermes_internal_secret("PATH")
+        assert not _is_hermes_internal_secret("HOME")

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -679,3 +679,43 @@ class TestAuxiliarySecretStripping:
         assert not _is_hermes_internal_secret("AUXILIARY_VISION_PROVIDER")
         assert not _is_hermes_internal_secret("PATH")
         assert not _is_hermes_internal_secret("HOME")
+
+    def test_make_run_env_blocks_auxiliary_even_when_passthrough_registered(self):
+        """Auxiliary secrets must be blocked even if registered in env_passthrough.
+
+        The passthrough registry is an opt-in escape hatch for non-secret env
+        vars. It must NOT be able to override the blocklist for Hermes-internal
+        secrets like AUXILIARY_*_API_KEY and AUXILIARY_*_BASE_URL.
+        """
+        from tools.environments.local import _make_run_env
+
+        mock_passthrough = MagicMock(return_value=True)
+        with patch.dict(os.environ, {
+            "AUXILIARY_VISION_API_KEY": "sk-aux-secret-1234567890",
+            "AUXILIARY_VISION_BASE_URL": "https://api.example.com",
+            "PATH": "/usr/bin:/bin",
+        }, clear=True):
+            with patch("tools.environments.local.is_env_passthrough", mock_passthrough, create=True):
+                with patch("tools.env_passthrough.is_env_passthrough", mock_passthrough):
+                    result = _make_run_env({})
+
+        assert "AUXILIARY_VISION_API_KEY" not in result, \
+            "AUXILIARY_*_API_KEY must be blocked even when passthrough-registered"
+        assert "AUXILIARY_VISION_BASE_URL" not in result, \
+            "AUXILIARY_*_BASE_URL must be blocked even when passthrough-registered"
+
+    def test_sanitize_blocks_auxiliary_even_when_passthrough_registered(self):
+        """_sanitize_subprocess_env must block auxiliary secrets even with passthrough."""
+        from tools.environments.local import _sanitize_subprocess_env
+
+        mock_passthrough = MagicMock(return_value=True)
+        base_env = {
+            "AUXILIARY_TITLE_API_KEY": "sk-title-secret-1234567890",
+            "AUXILIARY_TITLE_BASE_URL": "https://api.title.com",
+            "PATH": "/usr/bin:/bin",
+        }
+        with patch("tools.env_passthrough.is_env_passthrough", mock_passthrough):
+            result = _sanitize_subprocess_env(base_env)
+
+        assert "AUXILIARY_TITLE_API_KEY" not in result
+        assert "AUXILIARY_TITLE_BASE_URL" not in result

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -675,8 +675,15 @@ class TestAuxiliarySecretStripping:
         assert _is_hermes_internal_secret("AUXILIARY_VISION_API_KEY")
         assert _is_hermes_internal_secret("AUXILIARY_VISION_BASE_URL")
         assert _is_hermes_internal_secret("auxiliary_title_api_key")
+        # GATEWAY_RELAY_* secret-like values are also Tier-1 internal secrets.
+        assert _is_hermes_internal_secret("GATEWAY_RELAY_SECRET")
+        assert _is_hermes_internal_secret("GATEWAY_RELAY_DELIVERY_KEY")
+        assert _is_hermes_internal_secret("gateway_relay_foo_token")
         assert not _is_hermes_internal_secret("AUXILIARY_VISION_MODEL")
         assert not _is_hermes_internal_secret("AUXILIARY_VISION_PROVIDER")
+        # Non-secret GATEWAY_RELAY_* routing hints must NOT be matched.
+        assert not _is_hermes_internal_secret("GATEWAY_RELAY_URL")
+        assert not _is_hermes_internal_secret("GATEWAY_RELAY_PLATFORMS")
         assert not _is_hermes_internal_secret("PATH")
         assert not _is_hermes_internal_secret("HOME")
 

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Optional
 
 from tools.environments.base import BaseEnvironment, _popen_bash
-from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
+from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST, _is_hermes_internal_secret
 
 logger = logging.getLogger(__name__)
 
@@ -925,8 +925,10 @@ class DockerEnvironment(BaseEnvironment):
             pass
         # Explicit docker_forward_env entries are an intentional opt-in and must
         # win over the generic Hermes secret blocklist. Only implicit passthrough
-        # keys are filtered.
-        forward_keys = explicit_forward_keys | (passthrough_keys - _HERMES_PROVIDER_ENV_BLOCKLIST)
+        # keys are filtered. Also strip Hermes-internal secret patterns
+        # (AUXILIARY_*_API_KEY, etc.) that the name-based blocklist doesn't cover.
+        _secret_passthrough = {k for k in passthrough_keys if not _is_hermes_internal_secret(k)}
+        forward_keys = explicit_forward_keys | (_secret_passthrough - _HERMES_PROVIDER_ENV_BLOCKLIST)
         hermes_env = _load_hermes_env_vars() if forward_keys else {}
         for key in sorted(forward_keys):
             value = os.getenv(key)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -260,7 +260,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     for key, value in (base_env or {}).items():
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             continue
-        if _is_hermes_internal_secret(key) and not _is_passthrough(key):
+        if _is_hermes_internal_secret(key):
             continue
         if key not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(key):
             sanitized[key] = value
@@ -269,7 +269,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             real_key = key[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
             sanitized[real_key] = value
-        elif _is_hermes_internal_secret(key) and not _is_passthrough(key):
+        elif _is_hermes_internal_secret(key):
             continue
         elif key not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(key):
             sanitized[key] = value
@@ -646,7 +646,7 @@ def _make_run_env(env: dict) -> dict:
         if k.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             real_key = k[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
             run_env[real_key] = v
-        elif _is_hermes_internal_secret(k) and not _is_passthrough(k):
+        elif _is_hermes_internal_secret(k):
             continue
         elif k not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(k):
             run_env[k] = v

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -186,6 +186,9 @@ def _build_provider_env_blocklist() -> frozenset:
         "MODAL_TOKEN_ID",
         "MODAL_TOKEN_SECRET",
         "DAYTONA_API_KEY",
+        "GATEWAY_RELAY_ID",
+        "GATEWAY_RELAY_SECRET",
+        "GATEWAY_RELAY_DELIVERY_KEY",
     })
     return frozenset(blocked)
 
@@ -203,6 +206,34 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 # Hermes venv stays reachable via PATH (its bin dir is first), so stripping
 # these markers is safe and only prevents the cross-project clobber (#23473).
 _ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX")
+
+
+def _is_hermes_internal_secret(key: str) -> bool:
+    """Check if an env var name matches a Hermes-internal secret pattern.
+
+    The blocklist above is name-based and built from provider/tool registries,
+    but the gateway and CLI also inject dynamic secrets into ``os.environ``
+    that the registries don't know about:
+
+    - ``AUXILIARY_<TASK>_API_KEY`` — per-task inference credentials injected
+      by ``gateway/run.py`` and ``cli.py`` from ``config.yaml[auxiliary]``.
+      These are separate, often higher-spend API keys (vision, title-gen,
+      web-extract, etc.) that must never reach model-authored shell commands.
+    - ``AUXILIARY_<TASK>_BASE_URL`` — paired base URLs that can point at
+      private endpoints.
+
+    The code-execution sandbox (``code_execution_tool.py``) catches these via
+    substring matching on ``KEY``/``SECRET``/``TOKEN``. The terminal backend
+    uses a narrower name-based blocklist and would inherit these vars unless
+    they are explicitly registered in ``PROVIDER_REGISTRY`` (they are not —
+    they are task-level overrides, not primary provider credentials).
+    """
+    upper = key.upper()
+    if upper.startswith("AUXILIARY_") and (
+        upper.endswith("_API_KEY") or upper.endswith("_BASE_URL")
+    ):
+        return True
+    return False
 
 
 def _inject_context_hermes_home(env: dict) -> None:
@@ -229,6 +260,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     for key, value in (base_env or {}).items():
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             continue
+        if _is_hermes_internal_secret(key) and not _is_passthrough(key):
+            continue
         if key not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(key):
             sanitized[key] = value
 
@@ -236,6 +269,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             real_key = key[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
             sanitized[real_key] = value
+        elif _is_hermes_internal_secret(key) and not _is_passthrough(key):
+            continue
         elif key not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(key):
             sanitized[key] = value
 
@@ -611,6 +646,8 @@ def _make_run_env(env: dict) -> dict:
         if k.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             real_key = k[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
             run_env[real_key] = v
+        elif _is_hermes_internal_secret(k) and not _is_passthrough(k):
+            continue
         elif k not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(k):
             run_env[k] = v
     path_key = _path_env_key(run_env)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -221,16 +221,36 @@ def _is_hermes_internal_secret(key: str) -> bool:
       web-extract, etc.) that must never reach model-authored shell commands.
     - ``AUXILIARY_<TASK>_BASE_URL`` — paired base URLs that can point at
       private endpoints.
+    - ``GATEWAY_RELAY_<X>_SECRET`` / ``GATEWAY_RELAY_<X>_KEY`` /
+      ``GATEWAY_RELAY_<X>_TOKEN`` — relay-auth credentials provisioned by the
+      gateway (``GATEWAY_RELAY_SECRET``, ``GATEWAY_RELAY_DELIVERY_KEY``).
+      These are Tier-1 gateway secrets (like the messaging bot tokens in
+      ``_ALWAYS_STRIP_KEYS``) and must be stripped unconditionally, even when
+      a caller passes ``inherit_credentials=True`` — a model-driving CLI never
+      legitimately needs relay-auth material.  Non-secret ``GATEWAY_RELAY_*``
+      routing hints (``GATEWAY_RELAY_URL``, ``GATEWAY_RELAY_PLATFORMS`` ...)
+      are NOT matched and remain visible.
 
     The code-execution sandbox (``code_execution_tool.py``) catches these via
     substring matching on ``KEY``/``SECRET``/``TOKEN``. The terminal backend
     uses a narrower name-based blocklist and would inherit these vars unless
     they are explicitly registered in ``PROVIDER_REGISTRY`` (they are not —
     they are task-level overrides, not primary provider credentials).
+
+    This predicate is the single source of truth for "Hermes-internal secret"
+    across every spawn path: the terminal ``_make_run_env`` /
+    ``_sanitize_subprocess_env`` filters and the non-terminal
+    :func:`hermes_subprocess_env` helper all call it so the dynamic patterns
+    are stripped uniformly regardless of skill-passthrough registration or
+    ``inherit_credentials``.
     """
     upper = key.upper()
     if upper.startswith("AUXILIARY_") and (
         upper.endswith("_API_KEY") or upper.endswith("_BASE_URL")
+    ):
+        return True
+    if upper.startswith("GATEWAY_RELAY_") and (
+        upper.endswith("_SECRET") or upper.endswith("_KEY") or upper.endswith("_TOKEN")
     ):
         return True
     return False
@@ -335,6 +355,13 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     * **Tier 1 (always):** ``_ALWAYS_STRIP_KEYS`` — gateway bot tokens, GitHub
       auth, and remote-compute secrets are removed regardless of
       ``inherit_credentials``.  No child Hermes spawns legitimately needs them.
+      This tier also unconditionally strips Hermes-internal **dynamic** secrets
+      that match no static registry name: ``AUXILIARY_<TASK>_API_KEY`` /
+      ``AUXILIARY_<TASK>_BASE_URL`` (side-LLM credentials injected from
+      ``config.yaml[auxiliary]``) and ``GATEWAY_RELAY_*_SECRET`` /
+      ``GATEWAY_RELAY_*_KEY`` relay-auth material.  These are gateway-managed
+      Tier-1 secrets, not LLM provider credentials — see
+      :func:`_is_hermes_internal_secret`.
     * **Tier 2 (conditional):** the rest of ``_HERMES_PROVIDER_ENV_BLOCKLIST``
       (LLM provider API keys, tool secrets) is removed unless the caller passes
       ``inherit_credentials=True``.
@@ -358,6 +385,18 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     # Internal routing hints must never reach a child.
     for key in list(env):
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
+            env.pop(key, None)
+
+    # Hermes-internal dynamic secrets — always stripped, regardless of
+    # ``inherit_credentials``.  These are gateway/CLI-managed credentials
+    # (``AUXILIARY_<TASK>_API_KEY`` / ``AUXILIARY_<TASK>_BASE_URL`` side-LLM
+    # keys, ``GATEWAY_RELAY_*_SECRET`` / ``GATEWAY_RELAY_*_KEY`` relay-auth
+    # material) that match no static registry name, so neither Tier 1 nor the
+    # Tier 2 blocklist catch them.  A model-driving CLI never legitimately
+    # needs them, so they are unconditionally removed even when the caller
+    # inherits provider credentials.  See :func:`_is_hermes_internal_secret`.
+    for key in list(env):
+        if _is_hermes_internal_secret(key):
             env.pop(key, None)
 
     if not inherit_credentials:


### PR DESCRIPTION
The terminal tool's env blocklist (`_HERMES_PROVIDER_ENV_BLOCKLIST`) uses name-based matching that catches exact provider key names (e.g. `ANTHROPIC_API_KEY`) but misses dynamic secrets injected by the gateway:

- `AUXILIARY_*_API_KEY` (set by `gateway/run.py:1564-1570` and `cli.py` for side-LLM work — curator, vision, embedding, title generation)
- `GATEWAY_RELAY_SECRET` (set by `gateway/relay/__init__.py:553-555` for relay auth)

These secrets are injected into `os.environ` at runtime. When the terminal tool spawns subprocesses (bash, docker, SSH), the env blocklist doesn't catch them because it matches by exact name, not prefix/pattern. The code_execution sandbox (`code_execution_tool.py:90-91`) correctly uses substring matching via `_SECRET_SUBSTRINGS`, but the terminal tool does not.

Any terminal command (`ls`, `git status`, `cat`, etc.) in a gateway session leaks these secrets to child processes, logs, and shared environments.

### Fix

1. Added `_is_hermes_internal_secret(name)` helper in `local.py` that checks both the name-based blocklist AND dynamic prefix/suffix patterns (`AUXILIARY_*_API_KEY`, `GATEWAY_RELAY_SECRET`)
2. Updated `_make_run_env` and `_sanitize_subprocess_env` to use the new helper
3. Updated the Docker backend's passthrough filter (`docker.py`) which imports the same blocklist

### Repro

```python
# In a gateway session:
import os
os.environ["AUXILIARY_VISION_API_KEY"] = "sk-secret-vision"
# Then run any terminal command:
# The secret is visible in /proc/PID/environ and subprocess env
```

### Test

68-line regression test class `TestAuxiliarySecretStripping` with 4 test methods covering: blocklist passthrough, prefix matching, suffix matching, and combined env filtering.

---