### PR TITLE
fix(cron): change tick-skip log level from DEBUG to INFO

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3916,7 +3916,7 @@ def tick(
         elif msvcrt:
             msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
     except (OSError, IOError):
-        logger.debug("Tick skipped — another instance holds the lock")
+        logger.info("Tick skipped — another instance holds the lock")
         if lock_fd is not None:
             lock_fd.close()
         return 0


### PR DESCRIPTION
## Summary

When two cron scheduler instances run against the same `jobs.json` (e.g., a desktop Hermes `InProcessCronScheduler` and a NSSM-managed `HermesGateway`), the cross-process file lock correctly prevents the loser from firing jobs. However, the `"Tick skipped — another instance holds the lock"` message was at `DEBUG` level, making dual-scheduler suppression invisible in production logs at the default `INFO` level.

### Change

```python
# cron/scheduler.py:2864
- logger.debug("Tick skipped — another instance holds the lock")
+ logger.info("Tick skipped — another instance holds the lock")
```

### Why INFO is the right level

- `INFO` is appropriate for an expected control-flow outcome ("the system correctly detected concurrent schedulers and yielded")
- `DEBUG` implies noise only useful when actively diagnosing — but diagnosing dual-scheduler behavior is a routine operational concern
- Without this, operators have no way to tell from production logs that a second scheduler is being silently suppressed

### Risk

Trivial. No behavior change — only visibility of an already-occurring event changes.

### Closes

Closes #53720

### Checklist

- [x] One-line change, no behavior impact
- [x] Lint clean
- [x] Verified locally in dual-scheduler setup