### PR TITLE
fix(desktop): extend timeout for voice transcription

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -10,7 +10,8 @@ import {
   getSessionMessages,
   getStatus,
   listAllProfileSessions,
-  listSessions
+  listSessions,
+  transcribeAudio
 } from './hermes'
 import { refreshActiveProfile } from './store/profile'
 
@@ -122,6 +123,22 @@ describe('Hermes REST session helpers', () => {
     const call = api.mock.calls[0]?.[0] as { path: string; timeoutMs?: number }
     expect(call.path).toBe('/api/status')
     expect(call.timeoutMs).toBeUndefined()
+  })
+
+  it('allows first-run local-model transcription to outlive the default fetch timeout', async () => {
+    api.mockResolvedValue({ text: 'hello' })
+
+    await transcribeAudio('data:audio/webm;base64,AAAA', 'audio/webm')
+
+    expect(api).toHaveBeenCalledWith({
+      body: {
+        data_url: 'data:audio/webm;base64,AAAA',
+        mime_type: 'audio/webm'
+      },
+      method: 'POST',
+      path: '/api/audio/transcribe',
+      timeoutMs: 60_000
+    })
   })
 
   it('tags cross-profile message reads for Electron routing and backend lookup', async () => {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -69,6 +69,7 @@ import type {
 // global default: interactive/runtime calls and the liveness poll (/api/status)
 // keep the short default so a genuinely-dead backend is still detected fast.
 export const STARTUP_REQUEST_TIMEOUT_MS = 60_000
+export const AUDIO_TRANSCRIPTION_REQUEST_TIMEOUT_MS = 60_000
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
 // prompt.submit is effectively fire-and-forget: turn completion is signaled by
@@ -998,6 +999,7 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
   return window.hermesDesktop.api<AudioTranscriptionResponse>({
     path: '/api/audio/transcribe',
     method: 'POST',
+    timeoutMs: AUDIO_TRANSCRIPTION_REQUEST_TIMEOUT_MS,
     body: {
       data_url: dataUrl,
       mime_type: mimeType


### PR DESCRIPTION
## Summary

- Add a longer default timeout for the desktop voice transcription endpoint so first local STT model loads are not cut off by the generic 15s API timeout.
- Keep the generic desktop API timeout at 15s and preserve explicit timeout overrides.
- Give backend readiness polling a 60s request/deadline window while waiting for the local dashboard to come up.

## Root Cause

Desktop voice transcription calls `/api/audio/transcribe` through the same Electron API bridge as ordinary short dashboard requests. The bridge defaulted every request to 15s, which is too short for the first local faster-whisper model load on slower machines. That timeout surfaced as `Timed out connecting to Hermes backend after 15000ms` even though the backend could complete after the model warmup.

Fixes #53130

## Tests

- `node --test electron/hardening.test.cjs electron/backend-ready.test.cjs`
- `node --check electron/hardening.cjs`
- `node --check electron/main.cjs`
- `git diff --check`

## Notes

- `npm run test:desktop:platforms` is currently blocked by an unrelated baseline failure in `electron/windows-child-process.test.cjs` (`missing call site: spawn(ps, fullArgs`). I reproduced the same failure on a clean `origin/main` worktree, so it is not introduced by this PR.
