### PR TITLE
fix(gemini): route delegated native calls with empty base url

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1710,14 +1710,19 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
         )
         return client
     if agent.provider == "gemini":
-        from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
+        from agent.gemini_native_adapter import (
+            DEFAULT_GEMINI_BASE_URL,
+            GeminiNativeClient,
+            is_native_gemini_base_url,
+        )
 
-        base_url = str(client_kwargs.get("base_url", "") or "")
+        base_url = str(client_kwargs.get("base_url", "") or "").strip() or DEFAULT_GEMINI_BASE_URL
         if is_native_gemini_base_url(base_url):
             safe_kwargs = {
                 k: v for k, v in client_kwargs.items()
                 if k in {"api_key", "base_url", "default_headers", "timeout", "http_client"}
             }
+            safe_kwargs["base_url"] = base_url
             if "http_client" not in safe_kwargs:
                 keepalive_http = agent._build_keepalive_http_client(
                     base_url, verify=httpx_verify,

--- a/tests/run_agent/test_create_openai_client_kwargs_isolation.py
+++ b/tests/run_agent/test_create_openai_client_kwargs_isolation.py
@@ -35,3 +35,32 @@ def test_create_openai_client_does_not_mutate_input_kwargs(mock_openai):
     assert kwargs == snapshot, (
         f"_create_openai_client mutated input kwargs; expected {snapshot}, got {kwargs}"
     )
+
+
+@patch("run_agent.OpenAI")
+@patch("agent.gemini_native_adapter.GeminiNativeClient")
+def test_create_openai_client_routes_empty_gemini_base_url_to_native_client(mock_gemini, mock_openai):
+    from agent.gemini_native_adapter import DEFAULT_GEMINI_BASE_URL
+
+    native_client = MagicMock()
+    mock_gemini.return_value = native_client
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.provider = "gemini"
+    agent.model = "gemini-2.5-flash"
+    agent.base_url = ""
+    agent._client_kwargs = {}
+    agent._build_keepalive_http_client = lambda base_url="", **_kwargs: None
+
+    kwargs = {"api_key": "AIza-test-key", "base_url": ""}
+    snapshot = dict(kwargs)
+
+    client = agent._create_openai_client(kwargs, reason="test", shared=False)
+
+    assert client is native_client
+    mock_openai.assert_not_called()
+    mock_gemini.assert_called_once_with(
+        api_key="AIza-test-key",
+        base_url=DEFAULT_GEMINI_BASE_URL,
+    )
+    assert kwargs == snapshot

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1230,6 +1230,40 @@ class TestDelegationCredentialResolution(unittest.TestCase):
             _resolve_delegation_credentials(cfg, parent)
         self.assertIn("no API key", str(ctx.exception))
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_provider_resolution_forwards_configured_api_key_when_base_url_empty(self, mock_resolve):
+        """delegation.api_key must be honored when provider routing supplies the endpoint."""
+        def fake_resolve(**kwargs):
+            return {
+                "provider": "gemini",
+                "model": kwargs.get("target_model"),
+                "base_url": "https://generativelanguage.googleapis.com/v1beta",
+                "api_key": kwargs.get("explicit_api_key") or "",
+                "api_mode": "chat_completions",
+            }
+
+        mock_resolve.side_effect = fake_resolve
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "gemma-4-31b-it",
+            "provider": "gemini",
+            "base_url": "",
+            "api_key": "delegation-gemini-key",
+        }
+
+        creds = _resolve_delegation_credentials(cfg, parent)
+
+        self.assertEqual(creds["provider"], "gemini")
+        self.assertEqual(creds["model"], "gemma-4-31b-it")
+        self.assertEqual(creds["base_url"], "https://generativelanguage.googleapis.com/v1beta")
+        self.assertEqual(creds["api_key"], "delegation-gemini-key")
+        self.assertEqual(creds["api_mode"], "chat_completions")
+        mock_resolve.assert_called_once_with(
+            requested="gemini",
+            target_model="gemma-4-31b-it",
+            explicit_api_key="delegation-gemini-key",
+        )
+
     def test_missing_config_keys_inherit_parent(self):
         """When config dict has no model/provider keys at all, inherits parent."""
         parent = _make_mock_parent(depth=0)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3137,7 +3137,13 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
-        runtime = resolve_runtime_provider(requested=configured_provider, target_model=configured_model)
+        resolve_kwargs = {
+            "requested": configured_provider,
+            "target_model": configured_model,
+        }
+        if configured_api_key:
+            resolve_kwargs["explicit_api_key"] = configured_api_key
+        runtime = resolve_runtime_provider(**resolve_kwargs)
     except Exception as exc:
         raise ValueError(
             f"Cannot resolve delegation provider '{configured_provider}': {exc}. "


### PR DESCRIPTION
## Summary
- Route Gemini client construction with an empty base_url through the native Gemini endpoint instead of the OpenAI-compatible fallback.
- Forward delegation.api_key into runtime provider resolution when delegation.provider supplies the endpoint, covering delegation.provider: gemini with base_url: "".
- Add focused regressions for the delegation credential path and empty-base Gemini client construction.

## Root Cause
The delegation provider path ignored delegation.api_key unless delegation.base_url was set, so a config that supplied provider: gemini and api_key with an empty base_url could resolve without the configured key. Separately, _create_openai_client only selected GeminiNativeClient when the provided base_url already looked native; an empty base_url fell through to OpenAI construction even though the Gemini provider has a native default endpoint.

## Scope Note
This PR addresses the routing/API-key failure mode from #53436. It intentionally keeps the issue referenced instead of auto-closing it because #53436 also mentions a separate proposed Gemini reasoning-history/prefill behavior; the existing reasoning-prefill regression tests below still pass with this routing fix.

## Tests
- python -m pytest tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_provider_resolution_forwards_configured_api_key_when_base_url_empty tests/run_agent/test_create_openai_client_kwargs_isolation.py::test_create_openai_client_routes_empty_gemini_base_url_to_native_client -q
- python -m pytest tests/tools/test_delegate.py tests/run_agent/test_create_openai_client_kwargs_isolation.py tests/agent/test_gemini_native_adapter.py tests/hermes_cli/test_gemini_provider.py::TestGeminiAgentInit -q
- python -m pytest tests/run_agent/test_run_agent.py -k "reasoning_only_response_prefill_then_empty or reasoning_only_prefill_succeeds_on_continuation" -q
- python -m py_compile agent/agent_runtime_helpers.py tools/delegate_tool.py tests/tools/test_delegate.py tests/run_agent/test_create_openai_client_kwargs_isolation.py
- git diff --check

Refs #53436