### PR TITLE
fix(desktop): render clarify prompts from gateway events

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-event.test.tsx
@@ -1,0 +1,133 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $clarifyRequests } from '@/store/clarify'
+import { $activeSessionId } from '@/store/session'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SESSION_ID = 'runtime-session-1'
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let states = new Map<string, ClientSessionState>()
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SESSION_ID)
+  const sessionStateByRuntimeIdRef = useRef(states)
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+function emit(type: RpcEvent['type'], payload: RpcEvent['payload']) {
+  act(() => handleEvent!({ payload, session_id: SESSION_ID, type }))
+}
+
+function clarifyRequest() {
+  emit('clarify.request', {
+    choices: ['Use this chat', 'Start a new one'],
+    question: 'Where should I continue?',
+    request_id: 'clarify-1'
+  })
+}
+
+describe('useMessageStream clarify events', () => {
+  beforeEach(() => {
+    handleEvent = null
+    states = new Map([
+      [SESSION_ID, { ...createClientSessionState(), awaitingResponse: true, busy: true }]
+    ])
+    $activeSessionId.set(SESSION_ID)
+    $clarifyRequests.set({})
+  })
+
+  afterEach(() => {
+    cleanup()
+    $activeSessionId.set(null)
+    $clarifyRequests.set({})
+    vi.restoreAllMocks()
+  })
+
+  it('adds a pending clarify tool row when request arrives without tool.start', async () => {
+    await mountStream()
+
+    clarifyRequest()
+
+    const state = states.get(SESSION_ID)
+    const message = state?.messages.at(-1)
+    const part = message?.parts.at(-1)
+
+    expect(state?.needsInput).toBe(true)
+    expect(message).toMatchObject({ pending: true, role: 'assistant' })
+    expect(part).toMatchObject({
+      args: {
+        choices: ['Use this chat', 'Start a new one'],
+        question: 'Where should I continue?'
+      },
+      toolName: 'clarify',
+      type: 'tool-call'
+    })
+    expect(part).not.toHaveProperty('result')
+    expect($clarifyRequests.get()[SESSION_ID]).toMatchObject({
+      question: 'Where should I continue?',
+      requestId: 'clarify-1'
+    })
+  })
+
+  it('reuses the request row when tool.start arrives afterwards', async () => {
+    await mountStream()
+
+    clarifyRequest()
+    emit('tool.start', {
+      args: {
+        choices: ['Use this chat', 'Start a new one'],
+        question: 'Where should I continue?'
+      },
+      name: 'clarify',
+      tool_id: 'tool-call-1'
+    })
+
+    const clarifyParts = states
+      .get(SESSION_ID)
+      ?.messages.flatMap(message =>
+        message.parts.filter(part => part.type === 'tool-call' && part.toolName === 'clarify')
+      )
+
+    expect(clarifyParts).toHaveLength(1)
+    expect(clarifyParts?.[0]).toMatchObject({
+      toolCallId: 'tool-call-1',
+      toolName: 'clarify',
+      type: 'tool-call'
+    })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -489,10 +489,12 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         const question = typeof payload?.question === 'string' ? payload.question : ''
 
         if (requestId && question) {
+          const choices = Array.isArray(payload?.choices) ? payload.choices.filter(c => typeof c === 'string') : null
+
           setClarifyRequest({
             requestId,
             question,
-            choices: Array.isArray(payload?.choices) ? payload!.choices!.filter(c => typeof c === 'string') : null,
+            choices,
             sessionId: sessionId ?? null
           })
 
@@ -502,6 +504,15 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           // "needs input" indicator on its row — works for the active session
           // too, and survives alt-tab / window blur (unlike a toast).
           if (sessionId) {
+            upsertToolCall(
+              sessionId,
+              {
+                args: { choices, question },
+                name: 'clarify'
+              },
+              'running',
+              event.type
+            )
             updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
           }
 

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -390,6 +390,21 @@ describe('preserveLocalAssistantErrors', () => {
 })
 
 describe('upsertToolPart', () => {
+  it('reuses a pending clarify request when tool.start arrives later', () => {
+    const args = { choices: ['Use this chat', 'Start a new one'], question: 'Where should I continue?' }
+    let parts = upsertToolPart([], { args, name: 'clarify' }, 'running')
+
+    parts = upsertToolPart(parts, { args, name: 'clarify', tool_id: 'clarify-tool-1' }, 'running')
+
+    expect(parts).toHaveLength(1)
+    expect(parts[0]).toMatchObject({
+      args,
+      toolCallId: 'clarify-tool-1',
+      toolName: 'clarify',
+      type: 'tool-call'
+    })
+  })
+
   it('preserves inline diffs from tool completion events', () => {
     const parts = upsertToolPart(
       [],

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -348,7 +348,10 @@ function findToolPartIndex(
     // Some live streams start without an id, then complete with one. Fall
     // through to pending same-name/context matching so the completion updates
     // the synthetic live row instead of appending a duplicate completed row.
-    if (phase === 'running' && !matchValues.length) {
+    // clarify.request can synthesize the row before the matching tool.start
+    // arrives. Reuse that one pending clarify row instead of rendering a
+    // duplicate prompt card.
+    if (phase === 'running' && !matchValues.length && name !== 'clarify') {
       return -1
     }
   }


### PR DESCRIPTION
Fixes #53666.

## Summary
- Store the gateway clarify request once and synthesize a pending clarify tool part so the inline ClarifyTool can mount even when no tool.start row arrived.
- Reuse the synthesized clarify row if a matching tool.start event arrives later, avoiding duplicate prompt cards.
- Add regression coverage for clarify.request-only and clarify.request-before-tool.start event ordering.

## Tests
- `vitest run --environment jsdom src/app/session/hooks/use-message-stream.test.tsx src/lib/chat-messages.test.ts src/store/clarify.test.ts`
- `eslint src/app/session/hooks/use-message-stream.ts src/app/session/hooks/use-message-stream.test.tsx src/lib/chat-messages.ts`
- `npm run typecheck`
- `prettier --check src/app/session/hooks/use-message-stream.ts src/app/session/hooks/use-message-stream.test.tsx src/lib/chat-messages.ts`
- `git diff --check`