### PR TITLE
fix: allow explicit trusted LAN dashboard mode

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1814,10 +1814,15 @@ DEFAULT_CONFIG = {
         "basic_auth": {
             "username": "",  # blank → plugin no-op (no password provider)
             "password_hash": "",  # scrypt$... (preferred — no plaintext at rest)
-            "password": "",  # plaintext fallback (hashed in-memory at load)
+            "password": "",  # plaintext fallback (hashed in-memory)
             "secret": "",  # token-signing key; blank → random per-process
             "session_ttl_seconds": 0,  # 0 → plugin default (12h)
         },
+        # Explicit local-operator escape hatch for trusted LAN/VPN installs.
+        # Default remains fail-closed for every non-loopback bind; set true only
+        # when the dashboard is intentionally exposed without auth and network
+        # controls are the security boundary.
+        "allow_unauthenticated_lan": False,
         # Public URL override (env: ``HERMES_DASHBOARD_PUBLIC_URL``).
         # When set, this is the complete authority — scheme + host +
         # optional path prefix (e.g. ``https://example.com/hermes``) —

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -366,26 +366,43 @@ _LOOPBACK_HOST_VALUES: frozenset = frozenset({
 })
 
 
+def _allow_unauthenticated_lan_dashboard() -> bool:
+    """True when the operator explicitly accepts an unauthenticated LAN bind.
+
+    The default stays fail-closed for non-loopback dashboard binds. This opt-in
+    is intentionally config-backed (not a quiet resurrection of ``--insecure``)
+    so installs that need a trusted-LAN dashboard can declare that policy once
+    without filling logs with repeated safety warnings.
+    """
+    try:
+        cfg = load_config()
+        return bool(cfg_get(cfg, "dashboard", "allow_unauthenticated_lan", default=False))
+    except Exception:
+        return False
+
+
 def should_require_auth(host: str, allow_public: bool = False) -> bool:
     """Return True iff the dashboard auth gate must be active.
 
     Truth table:
       host == loopback        → False (no auth — local-only, trusted operator)
       host != loopback        → True  (gate engages — OAuth or password required)
+      host != loopback and
+        dashboard.allow_unauthenticated_lan=true
+                              → False (explicit trusted-LAN opt-in)
 
     "Loopback" is 127.0.0.1, localhost, ::1. RFC1918 / CGNAT / link-local are
-    deliberately treated as PUBLIC — a hostile device on the same LAN is exactly
+    treated as public by default — a hostile device on the same LAN is exactly
     the threat model the gate is designed for.
 
-    ``allow_public`` (the legacy ``--insecure`` escape hatch) NO LONGER disables
-    the gate. It is accepted for backward-compat with old launch scripts and
-    desktop shells but is ignored: a non-loopback bind ALWAYS requires an auth
-    provider (OAuth or the bundled password provider). This closes the
-    unauthenticated-public-dashboard hole behind the June 2026 ``hermes-0day``
-    MCP-persistence campaign, where ``--insecure --host 0.0.0.0`` left the
-    config/MCP/agent surface open to internet scanners.
+    ``allow_public`` (the legacy ``--insecure`` escape hatch) does not by
+    itself disable the gate. Operators who intentionally want an
+    unauthenticated LAN dashboard must also set
+    ``dashboard.allow_unauthenticated_lan: true`` in config.yaml.
     """
-    return host not in _LOOPBACK_HOST_VALUES
+    if host in _LOOPBACK_HOST_VALUES:
+        return False
+    return not _allow_unauthenticated_lan_dashboard()
 
 
 def _is_accepted_host(host_header: str, bound_host: str) -> bool:
@@ -12926,17 +12943,22 @@ def start_server(
     # banner, and enable uvicorn proxy_headers.
     app.state.auth_required = should_require_auth(host)
 
-    # ``--insecure`` no longer disables the auth gate (June 2026 hardening:
-    # the hermes-0day MCP-persistence campaign abused unauthenticated public
-    # dashboards). If a caller still passes it, warn that it is now a no-op
-    # rather than silently changing their expectation of an open bind.
-    if allow_public and host not in _LOOPBACK_HOST_VALUES:
+    # ``--insecure`` no longer disables the auth gate by itself (June 2026
+    # hardening: the hermes-0day MCP-persistence campaign abused
+    # unauthenticated public dashboards). If a caller still passes it on a
+    # non-loopback bind, warn only when the explicit trusted-LAN config flag is
+    # absent; otherwise the operator has intentionally accepted this mode.
+    if (
+        allow_public
+        and host not in _LOOPBACK_HOST_VALUES
+        and not _allow_unauthenticated_lan_dashboard()
+    ):
         _log.warning(
-            "--insecure no longer bypasses dashboard authentication. A "
-            "non-loopback bind (%s) now ALWAYS requires an auth provider "
-            "(OAuth or the bundled password provider). Configure one — see "
-            "below — or bind to 127.0.0.1 and reach it over an SSH tunnel / "
-            "Tailscale.", host,
+            "--insecure no longer bypasses dashboard authentication by itself. A "
+            "non-loopback bind (%s) requires an auth provider unless "
+            "dashboard.allow_unauthenticated_lan is true. Configure auth, set "
+            "that explicit trusted-LAN flag, or bind to 127.0.0.1 and reach it "
+            "over an SSH tunnel / Tailscale.", host,
         )
 
     if app.state.auth_required:

--- a/tests/hermes_cli/test_dashboard_lan_auth_opt_in.py
+++ b/tests/hermes_cli/test_dashboard_lan_auth_opt_in.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import copy
+
+from hermes_cli.config import DEFAULT_CONFIG, save_config
+from hermes_cli import web_server
+
+
+def _write_dashboard_flag(enabled: bool) -> None:
+    cfg = copy.deepcopy(DEFAULT_CONFIG)
+    cfg["dashboard"]["allow_unauthenticated_lan"] = enabled
+    save_config(cfg)
+
+
+def test_non_loopback_dashboard_requires_auth_by_default():
+    _write_dashboard_flag(False)
+
+    assert web_server.should_require_auth("192.168.2.228") is True
+
+
+def test_non_loopback_dashboard_can_be_explicitly_lan_exposed():
+    _write_dashboard_flag(True)
+
+    assert web_server.should_require_auth("192.168.2.228") is False
+    assert web_server.should_require_auth("127.0.0.1") is False


### PR DESCRIPTION
## Summary
- add `dashboard.allow_unauthenticated_lan` as an explicit opt-in for trusted LAN/VPN dashboard deployments
- keep non-loopback dashboard binds fail-closed by default
- suppress the repeated `--insecure` warning only when that explicit LAN opt-in is configured

## Tests
- `./venv/bin/python -m pytest tests/hermes_cli/test_dashboard_lan_auth_opt_in.py -q -o 'addopts='`\n- `./venv/bin/python -m py_compile hermes_cli/config.py hermes_cli/web_server.py tests/hermes_cli/test_dashboard_lan_auth_opt_in.py`\n- `git diff --check -- hermes_cli/config.py hermes_cli/web_server.py tests/hermes_cli/test_dashboard_lan_auth_opt_in.py`\n\n## Note\nThe broader Docker dashboard suite could not be completed locally because its image build fixture exceeded the available timeout while building dependencies.