### PR TITLE
fix(tools): add default prompt and empty-validation for vision/video analyze

### DIFF
--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -800,7 +800,7 @@ async def _vision_analyze_native(
 
 async def vision_analyze_tool(
     image_url: str,
-    user_prompt: str,
+    user_prompt: str = "Describe this image in detail.",
     model: str = None,
 ) -> str:
     """
@@ -837,6 +837,8 @@ async def vision_analyze_tool(
     """
     if not isinstance(user_prompt, str):
         user_prompt = str(user_prompt) if user_prompt is not None else ""
+    if not user_prompt.strip():
+        raise ValueError("user_prompt cannot be empty — provide a description or question about the image")
     debug_call_data = {
         "parameters": {
             "image_url": image_url,
@@ -1337,12 +1339,14 @@ async def _download_video(video_url: str, destination: Path, max_retries: int = 
 
 async def video_analyze_tool(
     video_url: str,
-    user_prompt: str,
+    user_prompt: str = "Describe this video in detail.",
     model: str = None,
 ) -> str:
     """Analyze a video via multimodal LLM. Returns JSON {success, analysis}."""
     if not isinstance(user_prompt, str):
         user_prompt = str(user_prompt) if user_prompt is not None else ""
+    if not user_prompt.strip():
+        raise ValueError("user_prompt cannot be empty — provide a description or question about the video")
     debug_call_data = {
         "parameters": {
             "video_url": video_url,


### PR DESCRIPTION
## Summary

`vision_analyze_tool` and `video_analyze_tool` silently coerced a missing `user_prompt` to `""`, which sent an empty text content block to the upstream API and produced a confusing HTTP 400 / AiError 3030.

### Changes

**`tools/vision_tools.py`** — 3 changes, 2 functions:

1. **Default prompt** — `user_prompt` now defaults to `"Describe this image in detail."` (vision) / `"Describe this video in detail."` (video) so calling without a prompt works out of the box
2. **Empty validation** — raises `ValueError` with a clear message if `user_prompt` is explicitly empty after stripping
3. **Applied to both** `vision_analyze_tool` and `video_analyze_tool`

### Before / After

| Call | Before | After |
|------|--------|-------|
| `vision_analyze("img.jpg")` | HTTP 400 from upstream | ✅ Returns description using default prompt |
| `vision_analyze("img.jpg", "")` | HTTP 400 from upstream | `ValueError: user_prompt cannot be empty` |
| `video_analyze("vid.mp4")` | HTTP 400 from upstream | ✅ Returns description using default prompt |

### Verification

- AST parse: ✅ clean
- Lint: ✅ clean
- Vision tests: 61/78 pass, 17 fail (pre-existing `pytest-asyncio` missing — same 17 fail on `main`)

### Closes

Closes #53638