### PR TITLE
fix(msgraph): scope webhook sessions by resource

### DIFF
--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -356,8 +356,18 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         receipt_key: Optional[str],
     ) -> MessageEvent:
         message_id = receipt_key or f"sha1:{sha1(json.dumps(notification, sort_keys=True).encode('utf-8')).hexdigest()}"
+        subscription_id = str(notification.get("subscriptionId", "unknown")).strip() or "unknown"
+        resource_data = notification.get("resourceData") if isinstance(notification.get("resourceData"), dict) else {}
+        resource_id = str(resource_data.get("id") or "").strip()
+        normalized_resource = self._normalize_resource_value(str(notification.get("resource") or ""))
+        if resource_id:
+            resource_scope = resource_id
+        elif normalized_resource:
+            resource_scope = f"resource_{sha1(normalized_resource.encode('utf-8')).hexdigest()[:12]}"
+        else:
+            resource_scope = "unknown"
         source = self.build_source(
-            chat_id=f"msgraph:{notification.get('subscriptionId', 'unknown')}",
+            chat_id=f"msgraph:{subscription_id}:{resource_scope}",
             chat_name="msgraph/webhook",
             chat_type="webhook",
             user_id="msgraph",

--- a/tests/gateway/test_msgraph_webhook.py
+++ b/tests/gateway/test_msgraph_webhook.py
@@ -1,6 +1,7 @@
 """Tests for the Microsoft Graph webhook adapter."""
 
 import asyncio
+from gateway.session import build_session_key
 
 import pytest
 
@@ -182,6 +183,32 @@ class TestMSGraphNotifications:
         assert event.source.platform == Platform.MSGRAPH_WEBHOOK
         assert event.source.chat_type == "webhook"
         assert event.message_id == "id:notif-1"
+
+    def test_same_subscription_different_resources_get_distinct_session_scope(self):
+        adapter = _make_adapter()
+        first = adapter._build_message_event(
+            {
+                "id": "notif-1",
+                "subscriptionId": "sub-1",
+                "changeType": "updated",
+                "resource": "communications/onlineMeetings/meeting-1",
+                "resourceData": {"id": "meeting-1"},
+            },
+            "id:notif-1",
+        )
+        second = adapter._build_message_event(
+            {
+                "id": "notif-2",
+                "subscriptionId": "sub-1",
+                "changeType": "updated",
+                "resource": "communications/onlineMeetings/meeting-2",
+                "resourceData": {"id": "meeting-2"},
+            },
+            "id:notif-2",
+        )
+
+        assert first.source.chat_id != second.source.chat_id
+        assert build_session_key(first.source) != build_session_key(second.source)
 
     @pytest.mark.anyio
     async def test_bad_client_state_rejected_as_auth_failure(self):


### PR DESCRIPTION
## Summary

This scopes Microsoft Graph webhook sessions by the underlying resource instead of only the subscription id. Notifications from the same subscription but different resources now land in distinct Hermes sessions.

## Why

`msgraph_webhook` accepts broad resource patterns such as `communications/onlineMeetings`, so one subscription can legitimately deliver notifications for many distinct resources. The adapter was using only `subscriptionId` as `chat_id`, which merged unrelated resources into the same session history, debounce lane, and interrupt path.

## Changes

- Build the webhook `chat_id` from `subscriptionId` plus a resource-specific suffix.
- Prefer `resourceData.id` when present.
- Fall back to a stable hash of the normalized resource path when the payload has no resource id.
- Add a regression test proving two notifications under the same subscription but different resource ids produce different session keys.

## Tests

```text
python -m pytest tests/gateway/test_msgraph_webhook.py -q
28 passed in 4.19s
```
