### PR TITLE
Fix: Supermemory write thread blocks process exit

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -801,7 +801,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         if self._write_thread and self._write_thread.is_alive():
             self._write_thread.join(timeout=2.0)
         self._write_thread = None
-        self._write_thread = threading.Thread(target=_run, daemon=False, name="supermemory-memory-write")
+        self._write_thread = threading.Thread(target=_run, daemon=True, name="supermemory-memory-write")
         self._write_thread.start()
 
     def shutdown(self) -> None:

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -610,3 +610,25 @@ def test_save_config_sets_owner_only_permissions(tmp_path):
     assert config_file.exists()
     mode = stat.S_IMODE(config_file.stat().st_mode)
     assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"
+
+
+def test_write_thread_is_daemon(provider):
+    """Write thread must be daemon=True so it cannot block process exit.
+
+    All other memory providers (hindsight, honcho, mem0, byterover, etc.)
+    create daemon threads for background work.  A non-daemon write thread
+    blocks process shutdown if it is stuck on a network call, causing the
+    entire gateway to hang on SIGTERM / /exit.
+
+    Regression test for the non-daemon write thread oversight.
+    """
+    provider.sync_turn("hello", "hi")
+    # Allow the thread creation to happen (sync_turn triggers _spawn_write_thread)
+    import time
+    time.sleep(0.05)
+    thread = provider._write_thread
+    if thread is not None:
+        assert thread.daemon is True, (
+            f"supermemory write thread must be daemon=True to avoid blocking "
+            f"process exit; got daemon={thread.daemon}"
+        )


### PR DESCRIPTION
### Impact

The supermemory memory provider creates its `_write_thread` with `daemon=False` (line 804), making it the **only** memory provider with a non-daemon background thread. All 28 other background threads across hindsight, honcho, mem0, byterover, retaindb, and openviking use `daemon=True`.

A non-daemon thread blocks `threading._shutdown()` at interpreter exit. If the write thread is stuck on a network call (API timeout, DNS hang, TCP reset), the gateway process hangs indefinitely on SIGTERM, `/exit`, or `docker stop`. The `shutdown()` method (line 833-836) joins with a 5s timeout, but `thread.join()` on a non-daemon thread that is still alive does NOT force-kill it — the process waits until the thread completes.

### Fix

One-line change: `daemon=False` → `daemon=True` on `plugins/memory/supermemory/__init__.py:804`.

This matches the convention of every other memory provider and ensures the write thread cannot block process exit.

### Repro

1. Configure supermemory as the memory provider
2. Start the gateway
3. Trigger a memory write (any conversation turn)
4. While the write thread is in-flight, send SIGTERM or run `/exit`
5. **Before fix:** process hangs until the write completes (can be minutes on slow network)
6. **After fix:** process exits immediately; the daemon thread is killed with the process

### Test

Regression test `test_write_thread_is_daemon` verifies the write thread's `daemon` property is `True`.

---