### PR TITLE
fix(moa): add stable prompt cache key for auxiliary Codex Responses calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -849,6 +849,104 @@ class _CodexCompletionsAdapter:
             if converted:
                 resp_kwargs["tools"] = converted
 
+        # Keep auxiliary Codex/Responses calls on the same prompt-cache routing
+        # strategy as the main transport. MoA aggregators go through this
+        # adapter, so without a stable content-addressed key their
+        # OpenAI-compatible gateway traffic stays cache-cold even while
+        # reference models hit automatic prefix caches.
+        try:
+            from agent.transports.codex import _content_cache_key
+
+            def _bounded_prompt_cache_key(value: Any) -> Optional[str]:
+                text = str(value or "").strip()
+                if not text:
+                    return None
+                if len(text) <= 64:
+                    return text
+                import hashlib
+
+                return hashlib.sha256(
+                    text.encode("utf-8", errors="replace")
+                ).hexdigest()
+
+            extra_body_prompt_cache_key = None
+            if isinstance(extra_body, dict):
+                raw_prompt_cache_key = extra_body.get("prompt_cache_key")
+                if raw_prompt_cache_key:
+                    extra_body_prompt_cache_key = _bounded_prompt_cache_key(
+                        raw_prompt_cache_key
+                    )
+
+            session_id = str(
+                kwargs.get("session_id")
+                or os.getenv("HERMES_SESSION_ID")
+                or ""
+            ).strip()
+            response_tools = resp_kwargs.get("tools")
+            cache_key = (
+                extra_body_prompt_cache_key
+                or _content_cache_key(
+                    instructions,
+                    response_tools if isinstance(response_tools, list) else None,
+                )
+                or _bounded_prompt_cache_key(session_id)
+                or None
+            )
+
+            base_url = str(getattr(self._client, "base_url", "") or "")
+
+            def _client_base_matches(domain: str) -> bool:
+                try:
+                    return base_url_host_matches(base_url, domain)
+                except Exception:
+                    return False
+
+            is_xai_responses = _client_base_matches("api.x.ai")
+            is_github_responses = any(
+                _client_base_matches(domain)
+                for domain in (
+                    "api.githubcopilot.com",
+                    "models.github.ai",
+                    "models.inference.ai.azure.com",
+                )
+            )
+            is_codex_backend = _client_base_matches("chatgpt.com")
+
+            if cache_key and not is_github_responses:
+                if is_xai_responses:
+                    merged_extra_body: Dict[str, Any] = {}
+                    existing_extra_body = resp_kwargs.get("extra_body")
+                    if isinstance(existing_extra_body, dict):
+                        merged_extra_body.update(existing_extra_body)
+                    merged_extra_body.setdefault("prompt_cache_key", cache_key)
+                    resp_kwargs["extra_body"] = merged_extra_body
+                else:
+                    resp_kwargs.setdefault("prompt_cache_key", cache_key)
+
+            if (is_codex_backend or is_xai_responses) and session_id:
+                existing_extra_headers = resp_kwargs.get("extra_headers")
+                merged_extra_headers: Dict[str, str] = {}
+                if isinstance(existing_extra_headers, dict):
+                    merged_extra_headers.update(
+                        {
+                            str(key): str(value)
+                            for key, value in existing_extra_headers.items()
+                            if key and value is not None
+                        }
+                    )
+                if is_codex_backend:
+                    merged_extra_headers["session_id"] = session_id
+                    merged_extra_headers["x-client-request-id"] = session_id
+                if is_xai_responses:
+                    merged_extra_headers["x-grok-conv-id"] = session_id
+                if merged_extra_headers:
+                    resp_kwargs["extra_headers"] = merged_extra_headers
+        except Exception:
+            logger.debug(
+                "Codex auxiliary: prompt cache routing setup failed",
+                exc_info=True,
+            )
+
         # Stream and collect the response
         text_parts: List[str] = []
         tool_calls_raw: List[Any] = []
@@ -3021,6 +3119,7 @@ def _retry_same_provider_sync(
             model=final_model,
             base_url=resolved_base_url,
             api_key=resolved_api_key,
+            api_mode=resolved_api_mode,
             async_mode=False,
         )
     else:
@@ -3078,6 +3177,7 @@ async def _retry_same_provider_async(
             model=final_model,
             base_url=resolved_base_url,
             api_key=resolved_api_key,
+            api_mode=resolved_api_mode,
             async_mode=True,
         )
     else:
@@ -4637,6 +4737,7 @@ def resolve_vision_provider_client(
     *,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
+    api_mode: Optional[str] = None,
     async_mode: bool = False,
 ) -> Tuple[Optional[str], Optional[Any], Optional[str]]:
     """Resolve the client actually used for vision tasks.
@@ -4647,7 +4748,7 @@ def resolve_vision_provider_client(
     stays conservative and only tries vision backends known to work today.
     """
     requested, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
-        "vision", provider, model, base_url, api_key
+        "vision", provider, model, base_url, api_key, api_mode
     )
     requested = _normalize_vision_provider(requested)
 
@@ -5191,6 +5292,7 @@ def _resolve_task_provider_model(
     model: str = None,
     base_url: str = None,
     api_key: str = None,
+    api_mode: str = None,
 ) -> Tuple[str, Optional[str], Optional[str], Optional[str], Optional[str]]:
     """Determine provider + model for a call.
 
@@ -5219,7 +5321,7 @@ def _resolve_task_provider_model(
         cfg_api_mode = str(task_config.get("api_mode", "")).strip() or None
 
     resolved_model = model or cfg_model
-    resolved_api_mode = cfg_api_mode
+    resolved_api_mode = (api_mode or "").strip() or cfg_api_mode
 
     # Convenience aliases for direct API-key endpoints that aren't first-class
     # providers (e.g. ``provider: openai`` → custom + api.openai.com/v1).
@@ -5626,6 +5728,7 @@ def call_llm(
     model: str = None,
     base_url: str = None,
     api_key: str = None,
+    api_mode: str = None,
     main_runtime: Optional[Dict[str, Any]] = None,
     messages: list,
     temperature: float = None,
@@ -5645,6 +5748,8 @@ def call_llm(
               Reads provider:model from config/env. Ignored if provider is set.
         provider: Explicit provider override.
         model: Explicit model override.
+        api_mode: Optional API mode override ("chat_completions",
+            "codex_responses", "anthropic_messages").
         messages: Chat messages list.
         temperature: Sampling temperature (None = provider default).
         max_tokens: Max output tokens (handles max_tokens vs max_completion_tokens).
@@ -5659,7 +5764,7 @@ def call_llm(
         RuntimeError: If no provider is configured.
     """
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
-        task, provider, model, base_url, api_key)
+        task, provider, model, base_url, api_key, api_mode)
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 
@@ -5669,6 +5774,7 @@ def call_llm(
             model=resolved_model or model,
             base_url=resolved_base_url or base_url,
             api_key=resolved_api_key or api_key,
+            api_mode=resolved_api_mode or api_mode,
             async_mode=False,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
@@ -5679,6 +5785,7 @@ def call_llm(
             effective_provider, client, final_model = resolve_vision_provider_client(
                 provider="auto",
                 model=resolved_model,
+                api_mode=resolved_api_mode or api_mode,
                 async_mode=False,
             )
         if client is None:
@@ -5724,7 +5831,12 @@ def call_llm(
             if client is None and not resolved_base_url:
                 logger.info("Auxiliary %s: provider %s unavailable, trying auto-detection chain",
                             task or "call", resolved_provider)
-                client, final_model = _get_cached_client("auto", main_runtime=main_runtime, task=task)
+                client, final_model = _get_cached_client(
+                    "auto",
+                    api_mode=resolved_api_mode,
+                    main_runtime=main_runtime,
+                    task=task,
+                )
         if client is None:
             raise RuntimeError(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
@@ -6194,6 +6306,7 @@ async def async_call_llm(
     model: str = None,
     base_url: str = None,
     api_key: str = None,
+    api_mode: str = None,
     main_runtime: Optional[Dict[str, Any]] = None,
     messages: list,
     temperature: float = None,
@@ -6207,7 +6320,7 @@ async def async_call_llm(
     Same as call_llm() but async. See call_llm() for full documentation.
     """
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
-        task, provider, model, base_url, api_key)
+        task, provider, model, base_url, api_key, api_mode)
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 
@@ -6217,6 +6330,7 @@ async def async_call_llm(
             model=resolved_model or model,
             base_url=resolved_base_url or base_url,
             api_key=resolved_api_key or api_key,
+            api_mode=resolved_api_mode or api_mode,
             async_mode=True,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
@@ -6227,6 +6341,7 @@ async def async_call_llm(
             effective_provider, client, final_model = resolve_vision_provider_client(
                 provider="auto",
                 model=resolved_model,
+                api_mode=resolved_api_mode or api_mode,
                 async_mode=True,
             )
         if client is None:
@@ -6264,7 +6379,13 @@ async def async_call_llm(
             if client is None and not resolved_base_url:
                 logger.info("Auxiliary %s: provider %s unavailable, trying auto-detection chain",
                             task or "call", resolved_provider)
-                client, final_model = _get_cached_client("auto", async_mode=True, main_runtime=main_runtime, task=task)
+                client, final_model = _get_cached_client(
+                    "auto",
+                    async_mode=True,
+                    api_mode=resolved_api_mode,
+                    main_runtime=main_runtime,
+                    task=task,
+                )
         if client is None:
             raise RuntimeError(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -70,9 +70,41 @@ def _slot_runtime(slot: dict[str, str]) -> dict[str, Any]:
             out["base_url"] = rt["base_url"]
         if rt.get("api_key"):
             out["api_key"] = rt["api_key"]
+        if rt.get("api_mode"):
+            out["api_mode"] = rt["api_mode"]
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("MoA slot runtime resolution failed for %s: %s", _slot_label(slot), exc)
     return out
+
+
+def _responses_instructions_from_messages(messages: list[dict[str, Any]]) -> str:
+    instructions = "You are a helpful assistant."
+    for msg in messages:
+        if msg.get("role") != "system":
+            continue
+        content = msg.get("content") or ""
+        instructions = content if isinstance(content, str) else str(content)
+    return instructions
+
+
+def _moa_aggregator_prompt_cache_key(
+    messages: list[dict[str, Any]],
+) -> str | None:
+    """Stable cache affinity for MoA Responses aggregators.
+
+    The acting MoA aggregator may receive a different tool set across turns as
+    Hermes enables or disables tools, but the expensive stable prefix is the
+    Hermes system instructions. Keying MoA on instructions only keeps
+    OpenAI-compatible gateway traffic on the same upstream cache shard while
+    still sending the real tool schemas in the request body.
+    """
+    try:
+        from agent.transports.codex import _content_cache_key
+
+        return _content_cache_key(_responses_instructions_from_messages(messages), None)
+    except Exception:
+        logger.debug("MoA aggregator prompt cache key setup failed", exc_info=True)
+        return None
 
 
 def _run_reference(
@@ -424,14 +456,23 @@ class MoAChatCompletions:
         # max_tokens is passed through from the caller (normally None → omitted
         # → the model's real maximum). The preset's old hardcoded 4096 default
         # is gone — it truncated long syntheses.
+        runtime = _slot_runtime(aggregator)
+        extra_body = agg_kwargs.get("extra_body")
+        if runtime.get("api_mode") == "codex_responses":
+            merged_extra_body = dict(extra_body) if isinstance(extra_body, dict) else {}
+            cache_key = _moa_aggregator_prompt_cache_key(agg_messages)
+            if cache_key:
+                merged_extra_body.setdefault("prompt_cache_key", cache_key)
+            extra_body = merged_extra_body or extra_body
+
         return call_llm(
             task="moa_aggregator",
             messages=agg_messages,
             temperature=aggregator_temperature,
             max_tokens=agg_kwargs.get("max_tokens"),
             tools=agg_kwargs.get("tools"),
-            extra_body=agg_kwargs.get("extra_body"),
-            **_slot_runtime(aggregator),
+            extra_body=extra_body,
+            **runtime,
         )
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3231,7 +3231,7 @@ class TestCodexAdapterReasoningTranslation:
     """
 
     @staticmethod
-    def _build_adapter():
+    def _build_adapter(base_url=""):
         """Build a _CodexCompletionsAdapter with a mocked responses.create()."""
         from agent.auxiliary_client import _CodexCompletionsAdapter
         from types import SimpleNamespace
@@ -3270,6 +3270,7 @@ class TestCodexAdapterReasoningTranslation:
             return _FakeCreateStream()
 
         real_client = MagicMock()
+        real_client.base_url = base_url
         real_client.responses.create = _create
         adapter = _CodexCompletionsAdapter(real_client, "gpt-5.3-codex")
         return adapter, captured_kwargs
@@ -3391,6 +3392,132 @@ class TestCodexAdapterReasoningTranslation:
         )
         assert captured.get("reasoning") == {"effort": "medium", "summary": "auto"}
         assert captured.get("include") == ["reasoning.encrypted_content"]
+
+
+class TestCodexAdapterPromptCacheKey:
+    def test_sets_content_addressed_key_for_responses(self):
+        adapter, captured = TestCodexAdapterReasoningTranslation._build_adapter()
+
+        adapter.create(
+            messages=[
+                {"role": "system", "content": "static MoA aggregator prompt"},
+                {"role": "user", "content": "first turn"},
+            ],
+            session_id="session-one",
+        )
+        first_key = captured.get("prompt_cache_key")
+
+        captured.clear()
+        adapter.create(
+            messages=[
+                {"role": "system", "content": "static MoA aggregator prompt"},
+                {"role": "user", "content": "second turn with different content"},
+            ],
+            session_id="session-two",
+        )
+
+        assert isinstance(first_key, str)
+        assert first_key.startswith("pck_")
+        assert first_key != "session-one"
+        assert captured.get("prompt_cache_key") == first_key
+
+    def test_explicit_extra_body_prompt_cache_key_wins(self):
+        adapter, captured = TestCodexAdapterReasoningTranslation._build_adapter()
+
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"prompt_cache_key": "manual-cache-key"},
+        )
+
+        assert captured.get("prompt_cache_key") == "manual-cache-key"
+
+    def test_explicit_extra_body_prompt_cache_key_is_bounded(self):
+        adapter, captured = TestCodexAdapterReasoningTranslation._build_adapter()
+
+        long_key = "manual-" + ("x" * 100)
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"prompt_cache_key": long_key},
+        )
+
+        key = captured.get("prompt_cache_key")
+        assert isinstance(key, str)
+        assert len(key) == 64
+        assert key != long_key
+
+    def test_xai_explicit_extra_body_prompt_cache_key_is_bounded(self):
+        adapter, captured = TestCodexAdapterReasoningTranslation._build_adapter(
+            base_url="https://api.x.ai/v1"
+        )
+
+        long_key = "manual-" + ("x" * 100)
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"prompt_cache_key": long_key},
+        )
+
+        key = captured.get("extra_body", {}).get("prompt_cache_key")
+        assert isinstance(key, str)
+        assert len(key) == 64
+        assert key != long_key
+
+    def test_xai_responses_puts_prompt_cache_key_in_extra_body(self):
+        adapter, captured = TestCodexAdapterReasoningTranslation._build_adapter(
+            base_url="https://api.x.ai/v1"
+        )
+
+        adapter.create(
+            messages=[
+                {"role": "system", "content": "static xai prompt"},
+                {"role": "user", "content": "hi"},
+            ],
+            session_id="xai-conv-1",
+        )
+
+        assert "prompt_cache_key" not in captured
+        cache_key = captured.get("extra_body", {}).get("prompt_cache_key")
+        assert isinstance(cache_key, str)
+        assert cache_key.startswith("pck_")
+        assert cache_key != "xai-conv-1"
+        assert captured.get("extra_headers", {}).get("x-grok-conv-id") == "xai-conv-1"
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://api.githubcopilot.com",
+            "https://models.github.ai/inference",
+            "https://models.inference.ai.azure.com",
+        ],
+    )
+    def test_github_responses_omit_prompt_cache_key(self, base_url):
+        adapter, captured = TestCodexAdapterReasoningTranslation._build_adapter(
+            base_url=base_url
+        )
+
+        adapter.create(
+            messages=[
+                {"role": "system", "content": "static github prompt"},
+                {"role": "user", "content": "hi"},
+            ],
+            session_id="github-session",
+        )
+
+        assert "prompt_cache_key" not in captured
+        assert "extra_body" not in captured
+        assert "extra_headers" not in captured
+
+    def test_codex_backend_adds_cache_scope_headers_from_session_env(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SESSION_ID", "hermes-session-123")
+        adapter, captured = TestCodexAdapterReasoningTranslation._build_adapter(
+            base_url="https://chatgpt.com/backend-api/codex"
+        )
+
+        adapter.create(messages=[{"role": "user", "content": "hi"}])
+
+        assert captured.get("prompt_cache_key", "").startswith("pck_")
+        headers = captured.get("extra_headers", {})
+        assert headers.get("session_id") == "hermes-session-123"
+        assert headers.get("x-client-request-id") == "hermes-session-123"
 
 
 class TestVisionAutoSkipsKimiCoding:

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -170,6 +170,153 @@ def test_moa_slots_routed_through_resolve_runtime_provider(monkeypatch):
     assert rt["model"] == "MiniMax-M2"
     assert rt["base_url"] == "https://minimax.example/v1"
     assert rt["api_key"] == "key-for-minimax"
+    assert rt["api_mode"] == "chat_completions"
+
+
+def test_moa_custom_responses_aggregator_gets_prompt_cache_key(monkeypatch, tmp_path):
+    """MoA custom/codex_responses aggregators must use the Responses adapter.
+
+    Regression for OpenAI-compatible MoA gateways: _slot_runtime() resolved
+    api_mode=codex_responses but did not pass it into call_llm(), so the
+    aggregator stayed on a plain chat-completions client and never emitted
+    prompt_cache_key.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      reference_models: []
+      aggregator:
+        provider: custom:responses-gateway
+        model: gpt-5.5
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    def fake_resolve(*, requested, target_model=None):
+        return {
+            "provider": requested,
+            "api_mode": "codex_responses",
+            "base_url": "https://gateway.example/v1",
+            "api_key": "test-key",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve
+    )
+
+    captured = {}
+
+    class _FakeCreateStream:
+        def __iter__(self):
+            message_item = SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text="gateway ok")],
+            )
+            return iter([
+                SimpleNamespace(type="response.created"),
+                SimpleNamespace(type="response.output_item.done", item=message_item),
+                SimpleNamespace(
+                    type="response.completed",
+                    response=SimpleNamespace(
+                        status="completed",
+                        id="resp_moa_cache",
+                        usage=SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+                    ),
+                ),
+            ])
+
+        def close(self):
+            pass
+
+    class _FakeResponses:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return _FakeCreateStream()
+
+    class _FakeOpenAI:
+        def __init__(self, *, api_key=None, base_url=None, **_kwargs):
+            self.api_key = api_key
+            self.base_url = base_url
+            self.responses = _FakeResponses()
+
+        def close(self):
+            pass
+
+    from agent import auxiliary_client
+    from agent.moa_loop import MoAChatCompletions
+
+    auxiliary_client._client_cache.clear()
+    monkeypatch.setattr(auxiliary_client, "OpenAI", _FakeOpenAI)
+
+    facade = MoAChatCompletions("review")
+    response = facade.create(
+        messages=[
+            {"role": "system", "content": "static hermes identity"},
+            {"role": "user", "content": "question"},
+        ],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "description": "Read a file",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )
+
+    assert response.choices[0].message.content == "gateway ok"
+    assert captured["stream"] is True
+    assert captured["model"] == "gpt-5.5"
+    first_key = captured["prompt_cache_key"]
+    assert first_key.startswith("pck_")
+    assert len(captured.get("tools") or []) == 1
+
+    captured.clear()
+    facade.create(
+        messages=[
+            {"role": "system", "content": "static hermes identity"},
+            {"role": "user", "content": "question with more tools"},
+        ],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "description": "Read a file",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "write_file",
+                    "description": "Write a file",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        ],
+    )
+
+    assert captured["prompt_cache_key"] == first_key
+    assert len(captured.get("tools") or []) == 2
+
+    captured.clear()
+    facade.create(
+        messages=[{"role": "user", "content": "manual key"}],
+        extra_body={"prompt_cache_key": "manual-moa-key"},
+    )
+
+    assert captured["prompt_cache_key"] == "manual-moa-key"
 
 
 def test_moa_codex_slot_preserves_provider_identity(monkeypatch):


### PR DESCRIPTION
## Summary

Fix MoA/custom Responses aggregators staying cache-cold by preserving the resolved Responses API mode and adding stable prompt-cache routing to auxiliary Codex/Responses calls.

This follows the same cache-affinity direction as the main Codex/Responses transport work in #47335, #47836, #51395, #52295, and #51037.

## Changes

- Thread `api_mode` through auxiliary `call_llm()`, `async_call_llm()`, vision resolution, and same-provider retry paths.
- Add stable, bounded `prompt_cache_key` handling to `_CodexCompletionsAdapter`.
- Preserve explicit `extra_body.prompt_cache_key`, but hash it down to 64 chars when needed.
- Keep xAI Responses `prompt_cache_key` in `extra_body`, and skip GitHub/Copilot Responses endpoints.
- Add MoA Responses aggregator cache keys derived from stable instructions while still sending the real tool schemas in the request body.
- Add regression tests for auxiliary Responses prompt-cache behavior and MoA custom Responses aggregators.

## Why

MoA aggregator slots are resolved through `resolve_runtime_provider()`, but the resolved `api_mode` was not consistently passed through the auxiliary path. A custom provider that should use `codex_responses` could therefore miss the Responses adapter and fail to emit a stable `prompt_cache_key`.

In local OpenAI-compatible gateway testing, this made the main model path much warmer than the MoA acting aggregator path. After this patch, the aggregator emits stable `pck_...` keys and cache hit share improved substantially in that environment.

## Validation

```bash
python3 -m pytest \
  tests/agent/test_auxiliary_client.py::TestCodexAdapterPromptCacheKey \
  tests/run_agent/test_moa_loop_mode.py::test_moa_custom_responses_aggregator_gets_prompt_cache_key \
  tests/run_agent/test_moa_loop_mode.py::test_moa_slots_routed_through_resolve_runtime_provider \
  -q
```

Result:

```text
11 passed
```

Additional checks:

```bash
git diff --check -- agent/auxiliary_client.py agent/moa_loop.py tests/agent/test_auxiliary_client.py tests/run_agent/test_moa_loop_mode.py
python3 -m py_compile agent/auxiliary_client.py agent/moa_loop.py
```

