### PR TITLE
fix(cron): correct schedule description so bare '30m' reads as a one-shot, not recurring

### DIFF
--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -888,7 +888,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "schedule": {
                 "type": "string",
-                "description": "REQUIRED for action=create. For create/update: '30m', 'every 2h', '0 9 * * *', or ISO timestamp. Examples: '30m' (every 30 minutes), 'every 2h' (every 2 hours), '0 9 * * *' (daily at 9am), '2026-06-01T09:00:00' (one-shot). You MUST include this field when action=create."
+                "description": "REQUIRED for action=create. Schedule forms: (1) relative one-shot - '30m', '2h', '1d' fire ONCE that far from now (use this for 'remind me in N minutes/hours' - do NOT hand-compute an absolute timestamp); (2) recurring interval - 'every 30m', 'every 2h'; (3) cron - '0 9 * * *' (daily at 9am); (4) absolute one-shot - ISO timestamp like '2026-06-01T09:00:00' (only when the user gives a specific clock time/date). Examples: '3m' (once in 3 minutes), 'every 2h' (recurring every 2 hours), '0 9 * * *' (daily at 9am), '2026-06-01T09:00:00' (once at that time). You MUST include this field when action=create."
             },
             "name": {
                 "type": "string",


### PR DESCRIPTION
## Problem

The `cronjob` tool's `schedule` parameter description tells the model:

> Examples: `'30m' (every 30 minutes)`, ...

but `cron/jobs.py::parse_schedule` treats a **bare duration** as a **one-shot**:

```python
# Duration like "30m", "2h", "1d" → one-shot from now
minutes = parse_duration(schedule)
run_at = _hermes_now() + timedelta(minutes=minutes)
return {"kind": "once", "run_at": run_at.isoformat(), ...}
```

Only the `every 30m` form is a recurring interval.

Because the description mislabels the relative one-shot as "every 30 minutes",
the model avoids `3m` / `30m` for *"remind me in N minutes"* requests and instead
emits an **absolute ISO timestamp it computes itself**. The system prompt
deliberately carries only the date (not minute-precision wall-clock time, for
prefix-cache stability — see `agent/system_prompt.py`), so the model guesses the
current time and the reminder lands minutes-to-hours off.

**Observed:** *"remind me in 3 minutes"* was scheduled ~**31 minutes** out.

## Fix

Rewrite the `schedule` description to match `parse_schedule`'s actual behavior and
steer relative requests to the bare-duration one-shot form. **Description string
only — no logic change.**

## Why it's safe

`parse_schedule("3m")` already returns `{"kind": "once", "run_at": now + 3m}`;
this PR only makes the tool description say so, so the model picks the form that
already works instead of guessing an absolute time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
