### PR TITLE
fix(redact): mask quoted YAML scalars in assignment mode

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -147,17 +147,26 @@ _CFG_ANCHORED_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
-# Unquoted YAML / colon config (e.g. ``password: secret``,
+# YAML / colon config (e.g. ``password: secret``, ``password: "secret"``,
 # ``spring.datasource.password: hunter2``). The secret keyword must be part of
-# the KEY (anchored to the start of the line/indent), and the value is a single
-# whitespace-free token — so prose like ``note: secret meeting`` (keyword in the
-# value) and ``error: token expired`` are left alone. Bare ``auth`` is excluded
-# from the key set so ``Authorization:`` / ``author:`` don't match (the former
-# is masked by _AUTH_HEADER_RE); ``auth_token``/``auth-token`` still match via
-# the ``token`` keyword. Quoted values defer to _JSON_FIELD_RE via the lookahead.
+# the KEY (anchored to the start of the line/indent), so prose like
+# ``note: secret meeting`` (keyword in the value) and ``error: token expired``
+# are left alone. Bare ``auth`` is excluded from the key set so
+# ``Authorization:`` / ``author:`` don't match (the former is masked by
+# _AUTH_HEADER_RE); ``auth_token``/``auth-token`` still match via the ``token``
+# keyword. The value is either a quoted scalar (which may contain spaces, e.g. a
+# password with special characters that YAML forces to be quoted) or a single
+# whitespace-free token. Quoted values are matched here directly: _JSON_FIELD_RE
+# requires a *quoted key*, which bare-key YAML never has, so it cannot catch
+# ``password: "secret"`` — without this the quoted value leaked. The quoted
+# alternatives are escape-aware (double-quote ``\"`` / single-quote doubling
+# ``''``) and bounded to one line; a quote-started but unterminated value falls
+# through to a fail-closed match that masks to end-of-line rather than leaking
+# the rest of the value.
 _YAML_CFG_NAMES = r"(?:api[ _.\-]?key|token|secret|passwd|password|credential)"
 _YAML_ASSIGN_RE = re.compile(
-    rf"(^[ \t]*[A-Za-z0-9_.\-]*{_YAML_CFG_NAMES}[A-Za-z0-9_.\-]*)(:[ \t]*)(?!['\"])([^\s&]+)",
+    rf"(^[ \t]*[A-Za-z0-9_.\-]*{_YAML_CFG_NAMES}[A-Za-z0-9_.\-]*)(:[ \t]*)"
+    r"(\"(?:\\[^\r\n]|[^\"\\\r\n])*\"|'(?:''|[^'\r\n])*'|['\"][^\r\n]*|[^\s&]+)",
     re.IGNORECASE | re.MULTILINE,
 )
 
@@ -445,12 +454,18 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
                 return f'{key}: "{_mask_token(value)}"'
             text = _JSON_FIELD_RE.sub(_redact_json, text)
 
-        # Unquoted YAML / colon config: password: ***  (after JSON so quoted
-        # values are handled there; the lookahead in _YAML_ASSIGN_RE skips
-        # quotes). Skip URLs — web-URL query params pass through by design.
+        # YAML / colon config: password: ***  /  password: "***"  (runs after
+        # JSON; bare-key quoted values are handled here since _JSON_FIELD_RE only
+        # matches quoted keys). Skip URLs — web-URL query params pass through by
+        # design.
         if ":" in text and "://" not in text:
             def _redact_yaml(m):
                 key, sep, value = m.group(1), m.group(2), m.group(3)
+                # Quoted scalar: mask the inner secret, keep the wrapping quotes
+                # (mirrors the JSON path's ``"key": "***"`` form).
+                if len(value) >= 2 and value[0] in "\"'" and value[-1] == value[0]:
+                    quote = value[0]
+                    return f"{key}{sep}{quote}{_mask_token(value[1:-1])}{quote}"
                 return f"{key}{sep}{_mask_token(value)}"
             text = _YAML_ASSIGN_RE.sub(_redact_yaml, text)
 

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -160,16 +160,15 @@ _CFG_ANCHORED_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
-# Unquoted YAML / colon config (``password: secret``): keyword in the KEY
-# (anchored to line start) and a single whitespace-free value, so ``note:
-# secret meeting`` is left alone. Bare ``auth`` excluded so ``Authorization:``
-# (masked by _AUTH_HEADER_RE) / ``author:`` don't match; ``auth_token`` still
-# matches via ``token``. Quoted values defer to _JSON_FIELD_RE (lookahead).
+# YAML / colon config: bare-key quoted scalars cannot match _JSON_FIELD_RE.
+# Match escaped double quotes, doubled single quotes, or an unquoted token.
+# An unterminated quote masks to end-of-line; no branch crosses LF or CRLF.
 # NOTE(perf): possessive where the successor is disjoint; the leading class
 # stays backtrackable (see _CFG_DOTTED_RE).
 _YAML_CFG_NAMES = r"(?:api[ _.\-]?key|token|secret|passwd|password|credential)"
 _YAML_ASSIGN_RE = re.compile(
-    rf"(^[ \t]*+[A-Za-z0-9_.\-]*{_YAML_CFG_NAMES}[A-Za-z0-9_.\-]*+)(:[ \t]*+)(?!['\"])([^\s&]++)",
+    rf"(^[ \t]*+[A-Za-z0-9_.\-]*{_YAML_CFG_NAMES}[A-Za-z0-9_.\-]*+)(:[ \t]*+)"
+    r"(\"(?:\\[^\r\n]|[^\"\\\r\n])*\"|'(?:''|[^'\r\n])*'|['\"][^\r\n]*|[^\s&]++)",
     re.IGNORECASE | re.MULTILINE,
 )
 
@@ -529,10 +528,17 @@ def _redact_assignments(text: str) -> str:
         text = _JSON_FIELD_RE.sub(
             _assignment_sub(lambda g: f'{g[0]}: "{_mask_token(g[1])}"', check_keyword=False), text)
 
-    # YAML after JSON: quoted values are handled there (_YAML_ASSIGN_RE skips quotes).
+    # YAML after JSON; unwrap scalars before the shared assignment gate so
+    # quoted programmatic env lookups retain the same exemption as bare ones.
     if ":" in text and "://" not in text:
-        text = _YAML_ASSIGN_RE.sub(
-            _assignment_sub(lambda g: f"{g[0]}{g[1]}{_mask_token(g[2])}", check_keyword=True), text)
+        def _redact_yaml(m):
+            key, sep, value = m.groups()
+            quote = value[0] if len(value) >= 2 and value[0] in "\"'" and value[-1] == value[0] else ""
+            inner = value[1:-1] if quote else value
+            if not _should_redact_assignment(key, inner, check_keyword=True):
+                return m.group(0)
+            return f"{key}{sep}{quote}{_mask_token(inner)}{quote}"
+        text = _YAML_ASSIGN_RE.sub(_redact_yaml, text)
     return text
 
 

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -545,6 +545,85 @@ class TestLowercaseDottedConfigKeys:
         result = redact_sensitive_text(text)
         assert "hunter2pass" not in result
 
+    def test_yaml_double_quoted_password(self):
+        # #53590 added the YAML rule but its lookahead skipped ALL quoted values,
+        # claiming they "defer to _JSON_FIELD_RE" — but that rule requires a
+        # *quoted key*, which bare-key YAML never has, so `password: "secret"`
+        # leaked verbatim with redaction nominally on.
+        text = 'password: "hunter2secretval"'
+        result = redact_sensitive_text(text)
+        assert "hunter2secretval" not in result
+        assert "password:" in result
+
+    def test_yaml_single_quoted_api_key(self):
+        text = "api_key: 'ak_live_998877secretvalue'"
+        result = redact_sensitive_text(text)
+        assert "ak_live_998877secretvalue" not in result
+
+    def test_yaml_dotted_quoted_password(self):
+        text = 'spring.datasource.password: "Sup3rS3cret!"'
+        result = redact_sensitive_text(text)
+        assert "Sup3rS3cret!" not in result
+        assert "spring.datasource.password:" in result
+
+    def test_yaml_quoted_value_with_spaces(self):
+        # A quoted scalar may contain spaces (special-char passwords are forced
+        # to be quoted in YAML); the whole secret must be masked, not just the
+        # first whitespace-free token.
+        text = 'password: "correct horse battery staple"'
+        result = redact_sensitive_text(text)
+        assert "correct horse battery staple" not in result
+        assert "horse battery" not in result
+
+    def test_yaml_quoted_value_keeps_quotes(self):
+        # The wrapping quotes are preserved while the inner secret is masked,
+        # mirroring the JSON path's ``"key": "***"`` form.
+        text = 'token: "shortsecret"'
+        result = redact_sensitive_text(text)
+        assert result == 'token: "***"'
+
+    def test_yaml_double_quoted_embedded_escape(self):
+        # An escaped quote inside a double-quoted scalar must not end the match
+        # early and leak the suffix.
+        text = 'password: "abc\\"defsecretvalue"'
+        result = redact_sensitive_text(text)
+        assert "defsecretvalue" not in result
+
+    def test_yaml_single_quoted_doubled_quote(self):
+        # YAML escapes a single quote by doubling it; must not end the match early.
+        text = "password: 'abc''defsecretvalue'"
+        result = redact_sensitive_text(text)
+        assert "defsecretvalue" not in result
+
+    def test_yaml_unterminated_quote_fails_closed(self):
+        # A quote-started but unterminated value is masked to end-of-line rather
+        # than leaking the rest of a space-containing secret.
+        text = 'password: "secret value unterminated'
+        result = redact_sensitive_text(text)
+        assert "secret value unterminated" not in result
+        assert "value unterminated" not in result
+
+    def test_yaml_quoted_match_is_line_bounded(self):
+        # The quoted match must not cross a newline into the next line.
+        text = 'password: "secretval"\nhost: example.com'
+        result = redact_sensitive_text(text)
+        assert "secretval" not in result
+        assert "host: example.com" in result
+
+    def test_yaml_double_quoted_crlf_backslash_does_not_cross(self):
+        # A trailing backslash before CRLF must not let the escape branch consume
+        # the carriage return and cross into the next line.
+        text = 'password: "abc\\\r\nhost: example.com'
+        result = redact_sensitive_text(text)
+        assert "host: example.com" in result
+
+    def test_yaml_quoted_crlf_line_terminated(self):
+        # A normal CRLF-terminated quoted value masks and stays on its own line.
+        text = 'password: "secretval"\r\nhost: example.com'
+        result = redact_sensitive_text(text)
+        assert "secretval" not in result
+        assert "host: example.com" in result
+
     def test_properties_file_dump(self):
         text = (
             "server.port=8080\n"

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -190,15 +190,15 @@ class TestControlCharSplitTokens:
         assert longest not in result
 
     def test_newline_split_token_masks(self):
-        tok = "ghp_abcdef1234567890ABCDEF1234567890abcdef"
+        tok = "ghp_" + "abcdef1234567890ABCDEF1234567890abcdef"
         self._assert_split_masked(f"{tok[:10]}\n{tok[10:]}", tok)
 
     def test_esc_split_token_masks(self):
-        tok = "ghp_abcdef1234567890ABCDEF1234567890abcdef"
+        tok = "ghp_" + "abcdef1234567890ABCDEF1234567890abcdef"
         self._assert_split_masked(f"{tok[:10]}\x1b{tok[10:]}", tok)
 
     def test_zero_width_split_token_masks(self):
-        tok = "ghp_abcdef1234567890ABCDEF1234567890abcdef"
+        tok = "ghp_" + "abcdef1234567890ABCDEF1234567890abcdef"
         self._assert_split_masked(f"{tok[:10]}\u200b{tok[10:]}", tok)
 
     def test_complete_token_does_not_swallow_next_line(self):
@@ -374,10 +374,11 @@ class TestPrintenvSimulation:
     """Simulate what happens when the agent runs `env` or `printenv`."""
 
     def test_full_env_dump(self):
-        env_dump = """HOME=/home/user
+        openrouter_key = "sk-or-v1-" + "reallyLongSecretKeyValue12345678"
+        env_dump = f"""HOME=/home/user
 PATH=/usr/local/bin:/usr/bin
 OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012mno345
-OPENROUTER_API_KEY=sk-or-v1-reallyLongSecretKeyValue12345678
+OPENROUTER_API_KEY={openrouter_key}
 FIRECRAWL_API_KEY=fc-shortkey123456789012
 TELEGRAM_BOT_TOKEN=bot987654321:ABCDEfghij-KLMNopqrst_UVWXyz12345
 SHELL=/bin/bash
@@ -645,6 +646,41 @@ class TestLowercaseDottedConfigKeys:
 
 
 
+
+    @pytest.mark.parametrize("text,expected", [
+        ('password: "hunter2secretval"', 'password: "***"'),
+        ("api_key: 'shortsecret'", "api_key: '***'"),
+        ('spring.datasource.password: "Sup3rS3cret!"', 'spring.datasource.password: "***"'),
+        ('password: "correct horse battery staple"', 'password: "correc...aple"'),
+        ('password: "abc\\"defsecret"', 'password: "***"'),
+        ("password: 'abc''defsecretvalue'", "password: 'abc''d...alue'"),
+        ('password: "secret value unterminated', 'password: "secre...ated'),
+        ('password: "secretval"\nhost: example.com', 'password: "***"\nhost: example.com'),
+        ('password: "abc\\\r\nhost: example.com', 'password: ***\r\nhost: example.com'),
+        ('password: "secretval"\r\nhost: example.com', 'password: "***"\r\nhost: example.com'),
+        ('api_key: "os.getenv(\'OPENAI_API_KEY\')"', 'api_key: "os.getenv(\'OPENAI_API_KEY\')"'),
+        ("api_key: 'process.env.OPENAI_API_KEY'", "api_key: 'process.env.OPENAI_API_KEY'"),
+        ('password: "os.environ[\'PASSWORD\']"', 'password: "os.environ[\'PASSWORD\']"'),
+        ("api_key: '$ENV{OPENAI_API_KEY}'", "api_key: '$ENV{OPENAI_API_KEY}'"),
+        ('Secretary: "J. Smith"', 'Secretary: "J. Smith"'),
+    ])
+    def test_yaml_quoted_scalar(self, text, expected):
+        assert redact_sensitive_text(text) == expected
+
+    @pytest.mark.parametrize("mode,masked", [
+        ("default", True), ("env", True), ("cat", False),
+        ("code_file", False), ("file_read", False),
+    ])
+    def test_yaml_quoted_output_scope(self, mode, masked):
+        from agent.redact import redact_terminal_output
+
+        text = 'password: "shortsecret"'
+        if mode in {"env", "cat"}:
+            result = redact_terminal_output(text, "env" if mode == "env" else "cat config.yaml")
+        else:
+            kwargs = {mode: True} if mode != "default" else {}
+            result = redact_sensitive_text(text, **kwargs)
+        assert result == ('password: "***"' if masked else text)
 
     def test_properties_file_dump(self):
         text = (
@@ -1142,7 +1178,7 @@ class TestValueAwareGatingCorpus:
     # STAY masked after the gating change (fail-closed on credential shape
     # or strong key names).
     FAKE_SECRET_CORPUS = [
-        ("API_KEY=sk-fakefakefakefakefake1234567890abcd", "fakefake"),
+        ("API_KEY=" + "sk-" + "fakefakefakefakefake1234567890abcd", "fakefake"),
         ("GITHUB_TOKEN=ghp_FAKEfakeFAKEfake1234567890fake", "FAKEfake"),
         ("MY_SERVICE_TOKEN=A9f3kZq7Lm2Xw8Rt4Yv6", "A9f3kZq7"),
         ("TOKEN=6f1d2a9c8b3e4f5a6d7c8b9a0e1f2d3c", "6f1d2a9c"),


### PR DESCRIPTION
Quoted bare-key YAML secrets bypass the existing YAML assignment pass: its old lookahead skips quoted values, while the JSON rule requires a quoted key.

Match single-line quoted scalars, including escaped double quotes and YAML single-quote doubling. Unterminated quotes are masked through the end of the line. Unwrap complete scalars before applying the current shared assignment gate, retaining programmatic env-lookup exemptions, credential-key/opaque-value checks, and current regex performance guards.

The scope is the existing assignment-redaction mode used for ordinary log text and environment-dump terminal output. It does not enable that pass for `code_file=True`, `file_read=True`, or ordinary `cat config.yaml` output. Tests explicitly cover those boundaries. #97215 credits this earlier parser work and separately owns the broader forced-file redaction policy; this PR remains the narrow YAML parser fix.

Rebased onto current main and consolidated regression coverage into two parameterized tests: quoted/escaped/unterminated scalars, LF/CRLF boundaries, programmatic env references, prose preservation, and output modes.

Validation: all 136 tests in `tests/agent/test_redact.py` passed through `scripts/run_tests.sh`, including existing regex performance cases. The new coverage yields 12 failures against current upstream (eight preservation cases still pass). Ruff and `git diff --check` passed.

Existing synthetic token fixtures in the touched test file now concatenate their prefix and body, following its existing fixture convention and avoiding contiguous credential-shaped literals. Their runtime values and assertions are unchanged; all 136 tests passed again.
