### PR TITLE
feat(whatsapp): owner-aware toolset gating for shared lines

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2145,6 +2145,59 @@ def _check_unavailable_skill(command_name: str) -> str | None:
     return None
 
 
+def _whatsapp_owner_tool_gate(source, platform_key, user_config, disabled_toolsets):
+    """Optionally restrict the toolset for non-owner senders on a shared WhatsApp line.
+
+    When ``whatsapp.nonowner_disabled_toolsets`` is set (a list of tool names),
+    every sender that is NOT an owner has those tools disabled -- so a shared /
+    community WhatsApp number can answer friends and family without exposing
+    terminal / code execution / file / etc. to them. An owner is the configured
+    ``whatsapp.home_channel`` chat_id or any id in ``whatsapp.owner_users``.
+
+    No-op (returns ``disabled_toolsets`` unchanged) unless the platform is
+    WhatsApp *and* ``nonowner_disabled_toolsets`` is configured, so existing
+    deployments are unaffected. Once the feature is active it fails closed: any
+    error restricts rather than grants.
+    """
+    if platform_key != "whatsapp" or not isinstance(user_config, dict):
+        return disabled_toolsets
+    wa = user_config.get("whatsapp") or {}
+    drop = wa.get("nonowner_disabled_toolsets")
+    if not (isinstance(drop, list) and drop):
+        return disabled_toolsets  # feature disabled -> no behavior change
+
+    def _restrict():
+        base = list(disabled_toolsets or [])
+        for name in drop:
+            if name not in base:
+                base.append(name)
+        return base
+
+    try:
+        import re as _re
+
+        def _norm(value):
+            text = str(value or "").strip()
+            text = _re.sub(r":.*@", "@", text)
+            text = _re.sub(r"@.*", "", text)
+            return text.lstrip("+")
+
+        owners = set()
+        home = wa.get("home_channel") or {}
+        if isinstance(home, dict) and home.get("chat_id"):
+            owners.add(_norm(home.get("chat_id")))
+        for owner_id in (wa.get("owner_users") or []):
+            if owner_id:
+                owners.add(_norm(owner_id))
+
+        sender = getattr(source, "chat_id", None) or getattr(source, "sender_id", None) or ""
+        if sender and owners and _norm(sender) in owners:
+            return disabled_toolsets  # owner -> full toolset
+        return _restrict()
+    except Exception:
+        return _restrict()  # fail closed
+
+
 def _platform_config_key(platform: "Platform") -> str:
     """Map a Platform enum to its config.yaml key (LOCAL→"cli", rest→enum value)."""
     return "cli" if platform == Platform.LOCAL else platform.value
@@ -11849,6 +11902,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
+            disabled_toolsets = _whatsapp_owner_tool_gate(
+                source, platform_key, user_config, disabled_toolsets
+            )
 
             pr = self._provider_routing
             max_iterations = _current_max_iterations()
@@ -15163,6 +15219,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
+        disabled_toolsets = _whatsapp_owner_tool_gate(
+            source, platform_key, user_config, disabled_toolsets
+        )
 
         display_config = user_config.get("display", {})
         if not isinstance(display_config, dict):

--- a/tests/gateway/test_whatsapp_owner_tool_gate.py
+++ b/tests/gateway/test_whatsapp_owner_tool_gate.py
@@ -1,0 +1,61 @@
+"""Owner-aware WhatsApp toolset gating (``_whatsapp_owner_tool_gate``).
+
+A shared / community WhatsApp line otherwise exposes the full agent toolset
+(terminal, code execution, file, ...) to every allowlisted sender. When
+``whatsapp.nonowner_disabled_toolsets`` is configured, only owners -- the
+``whatsapp.home_channel`` chat_id or ids in ``whatsapp.owner_users`` -- keep the
+full toolset; everyone else has the configured tools disabled. The feature is
+opt-in (no config -> no behavior change) and fails closed.
+"""
+
+from types import SimpleNamespace
+
+from gateway.run import _whatsapp_owner_tool_gate
+
+OWNER = "178172540747977"
+DROP = ["terminal", "code_execution", "file"]
+CFG = {
+    "whatsapp": {
+        "home_channel": {"platform": "whatsapp", "chat_id": f"{OWNER}@lid"},
+        "owner_users": ["15551234567"],
+        "nonowner_disabled_toolsets": DROP,
+    }
+}
+
+
+def _src(chat_id):
+    return SimpleNamespace(chat_id=chat_id)
+
+
+def test_noop_when_feature_unconfigured():
+    cfg = {"whatsapp": {"home_channel": {"chat_id": f"{OWNER}@lid"}}}
+    assert _whatsapp_owner_tool_gate(_src("99999@lid"), "whatsapp", cfg, None) is None
+
+
+def test_noop_on_other_platforms():
+    assert _whatsapp_owner_tool_gate(_src("99999"), "telegram", CFG, None) is None
+
+
+def test_owner_keeps_full_toolset():
+    # home_channel owner, including a device-suffixed LID variant
+    assert _whatsapp_owner_tool_gate(_src(f"{OWNER}@lid"), "whatsapp", CFG, None) is None
+    assert _whatsapp_owner_tool_gate(_src(f"{OWNER}:12@lid"), "whatsapp", CFG, None) is None
+    # explicit owner_users entry (configured as a bare number, sender arrives as a jid)
+    assert _whatsapp_owner_tool_gate(_src("15551234567@s.whatsapp.net"), "whatsapp", CFG, None) is None
+
+
+def test_non_owner_is_restricted():
+    out = _whatsapp_owner_tool_gate(_src("19998887777@s.whatsapp.net"), "whatsapp", CFG, None)
+    assert set(DROP).issubset(set(out))
+
+
+def test_non_owner_preserves_existing_disabled():
+    out = _whatsapp_owner_tool_gate(_src("19998887777@lid"), "whatsapp", CFG, ["moa"])
+    assert "moa" in out
+    assert set(DROP).issubset(set(out))
+
+
+def test_fails_closed_when_sender_unknown():
+    # feature active but sender id missing -> restrict, never grant
+    out = _whatsapp_owner_tool_gate(SimpleNamespace(), "whatsapp", CFG, None)
+    assert set(DROP).issubset(set(out))


### PR DESCRIPTION
## Motivation

A WhatsApp line configured as a shared / community bot answers many people, but
the agent's WhatsApp toolset includes powerful tools — `terminal`,
`code_execution`, `computer_use`, `file`, `browser`, `cronjob`, … . On a line
shared with family/friends, every allowlisted sender can (deliberately, or via a
compromised/duped number) prompt-inject the agent into shell access or
exfiltration. The allowlist controls *who can talk to the agent*; it does not
control *what each of them can make it do*.

## What this adds

Opt-in, per-sender toolset gating. When `whatsapp.nonowner_disabled_toolsets` is
configured (a list of tool names), only **owners** keep the full toolset; every
other sender has those tools disabled:

```yaml
whatsapp:
  home_channel:                 # the owner's DM is an owner automatically
    platform: whatsapp
    chat_id: "<owner-id>"
  owner_users:                  # optional additional owners
    - "<id>"
  nonowner_disabled_toolsets:   # presence enables the feature
    - terminal
    - code_execution
    - computer_use
    - file
    - cronjob
    - browser
```

An **owner** is the configured `whatsapp.home_channel` chat_id or any id in
`whatsapp.owner_users`, matched after normalizing phone / LID / device-suffix
forms (same normalization the allowlist uses).

## Implementation

`_whatsapp_owner_tool_gate(...)` is applied at both `_get_platform_tools` seams
in `gateway/run.py` (the main message path and the background-task path), right
where `disabled_toolsets` is resolved. The gateway already builds a per-session
(per-sender) agent, so the adjusted `disabled_toolsets` follows the sender with
no caching changes.

## Safety

- **Backward compatible:** no-op unless platform is WhatsApp *and*
  `nonowner_disabled_toolsets` is set — existing deployments are unaffected.
- **Fails closed:** once the feature is active, any error restricts (never grants).
- Owners are unaffected (full toolset).

## Tests

`tests/gateway/test_whatsapp_owner_tool_gate.py` covers opt-in no-op, other
platforms, owner (home channel + `owner_users`, incl. a device-suffixed LID),
non-owner restriction, preserving pre-existing `disabled_toolsets`, and
fail-closed on an unknown sender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
