### PR TITLE
fix(cron): decode job script output as UTF-8 in _run_job_script

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1635,6 +1635,8 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             argv,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=script_timeout,
             cwd=str(path.parent),
             env=_sanitize_subprocess_env(os.environ.copy()),


### PR DESCRIPTION
## Summary

On Windows hosts whose system ANSI code page is not UTF-8 (e.g. **cp949** on Korean Windows), cron data-collection scripts that print non-ASCII output (emoji, CJK text) are captured as **empty output** by the scheduler. The job then logs `script produced no output, skipping AI call` and is delivered as `[SILENT]` — **the user silently never receives the scheduled message, with no error surfaced anywhere.**

### Root cause

In `cron/scheduler.py::_run_job_script`, the script is run with:

```python
result = subprocess.run(argv, capture_output=True, text=True, ...)
```

With `text=True` and **no explicit `encoding`**, Python decodes the child's stdout using `locale.getpreferredencoding()`. On a cp949 host this is cp949, but cron scripts write UTF-8 (emoji/CJK). The mismatch makes the decoded capture empty/garbled even though the child exited 0 and printed correctly.

This is the same bug class already handled elsewhere in the codebase where text-mode subprocess calls pin `encoding="utf-8"` explicitly.

### Fix

Force UTF-8 decoding with `errors="replace"` on the capture, so cron scripts behave identically across locales:

```python
result = subprocess.run(
    argv,
    capture_output=True,
    text=True,
    encoding="utf-8",
    errors="replace",
    ...
)
```

## Reproduction

On a cp949 Windows host (System Locale = Korean):

1. Create a cron job whose script prints Korean/emoji to stdout (e.g. `print("🔩 비철금속 시황")`).
2. Trigger the job.

**Before:** output file is 0 bytes, log shows `script produced no output`, delivery is `[SILENT]`.
**After:** full output captured and delivered to the target.

## Test plan

- [x] Reproduced on a real cp949 Windows host: three cron jobs (email-briefing scripts emitting CJK + emoji) all captured 0 bytes before, full output (7–14 KB) and `delivered to telegram:...` after.
- [ ] CI green

## Scope

Single-line-class change (adds `encoding`/`errors` to one `subprocess.run`). No behavior change on UTF-8 locales where `getpreferredencoding()` already returns utf-8.
