### PR TITLE
fix(docs): add expiration notice to Nemotron 3 Ultra free-tier guide

### DIFF
--- a/website/docs/guides/run-nemotron-3-ultra-free.md
+++ b/website/docs/guides/run-nemotron-3-ultra-free.md
@@ -1,15 +1,19 @@
 ---
-sidebar_position: 0
-title: "Run Nemotron 3 Ultra free in Hermes Agent"
-description: "Try NVIDIA Nemotron 3 Ultra on Nous Portal — free June 4–18 — with day 0 support in Hermes Agent"
+sidebar_position: 99
+title: "Run Nemotron 3 Ultra free in Hermes Agent (expired)"
+description: "This free-tier promotion ended June 18, 2026. Nemotron 3 Ultra remains available on Nous Portal at standard rates."
 ---
 
 # Run Nemotron 3 Ultra free in Hermes Agent
 
-Nous Research has been inducted into the **Nemotron Coalition** of leading AI labs working with **NVIDIA** to advance open frontier foundation models. In honor of this, we've partnered with **Nebius** to provide **Nemotron 3 Ultra** free on [Nous Portal](https://portal.nousresearch.com) for two weeks (**June 4th – June 18th**). Follow the instructions below to try the model in your Hermes Agent today.
+:::caution Offer expired
+The free `nvidia/nemotron-3-ultra:free` tier promotion ended on **June 18, 2026**. The model remains available on [Nous Portal](https://portal.nousresearch.com) at standard rates. See the [general provider setup guide](/docs/guides/run-hermes-with-nous-portal) for current options.
+:::
 
-:::info Limited-time offer
-The `nvidia/nemotron-3-ultra:free` tier is available from **June 4th to June 18th**. The `:free` tag is what keeps it on the no-cost plan — pick that exact variant.
+Nous Research has been inducted into the **Nemotron Coalition** of leading AI labs working with **NVIDIA** to advance open frontier foundation models. In honor of this, we partnered with **Nebius** to provide **Nemotron 3 Ultra** free on [Nous Portal](https://portal.nousresearch.com) for two weeks (**June 4th – June 18th, 2026**). The instructions below are preserved for reference.
+
+:::info This offer has ended
+The `nvidia/nemotron-3-ultra:free` tier was available from **June 4th to June 18th, 2026**. The `:free` tag kept it on the no-cost plan during the promotion.
 :::
 
 Pick whichever install fits you. The **desktop app** is the easiest — no terminal required. If you live in a terminal, the **command-line** install is right below it.


### PR DESCRIPTION
## What does this PR do?

Adds an expiration notice to the Nemotron 3 Ultra free-tier guide. The promotion ended June 18, 2026 (9 days ago), but the page still reads as an active offer with no warning. Users following the instructions today will attempt to select the `:free` variant that no longer exists.

The fix adds a prominent `:::caution` banner at the top, shifts the sidebar position from 0 (first entry) to 99 (bottom), updates the title/description to indicate expiration, and converts the inline "Limited-time offer" admonition to past tense.

## Related Issue

Fixes #53729

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `website/docs/guides/run-nemotron-3-ultra-free.md`: Added `:::caution Offer expired` banner at top; changed `sidebar_position` from 0 to 99; updated title to include "(expired)"; updated description to note promotion ended; converted "Limited-time offer" admonition to past tense ("This offer has ended"); updated intro text to indicate instructions are preserved for reference.

## How to Test

1. Run `cd website && npm run build` — should build without errors
2. Open `/docs/guides/run-nemotron-3-ultra-free` in the built site
3. Observed result: the caution banner appears at the top of the page reading "Offer expired — The free nvidia/nemotron-3-ultra:free tier promotion ended on June 18, 2026"
4. Observed result: the page appears near the bottom of the Guides sidebar (position 99), not as the first entry
5. Observed result: the "Limited-time offer" info box now reads "This offer has ended" in past tense

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A (docs-only change)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (docs-only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The expired notice replaces the previously misleading "Limited-time offer" info box. Before: page appeared as the first guide with no indication the offer ended. After: caution banner at top + sidebar position moved to bottom.
