### PR TITLE
feat(discord): add voice auto-join follow mode

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3063,6 +3063,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if mode in {"voice_only", "all"} and key.startswith(prefix)
             )
 
+    def _sync_voice_auto_join_state_to_adapter(self, adapter) -> None:
+        """Wire Discord voice auto-join callbacks onto a live adapter."""
+        if getattr(adapter, "platform", None) != Platform.DISCORD:
+            return
+        if hasattr(adapter, "_voice_auto_join_callback"):
+            adapter._voice_auto_join_callback = self._handle_discord_voice_auto_join
+
     async def _safe_adapter_disconnect(self, adapter, platform) -> None:
         """Call adapter.disconnect() defensively, swallowing any error.
 
@@ -6079,6 +6086,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if success:
                     self.adapters[platform] = adapter
                     self._sync_voice_mode_state_to_adapter(adapter)
+                    self._sync_voice_auto_join_state_to_adapter(adapter)
                     connected_count += 1
                     self._update_platform_runtime_status(
                         platform.value,
@@ -6875,6 +6883,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if success:
                         self.adapters[platform] = adapter
                         self._sync_voice_mode_state_to_adapter(adapter)
+                        self._sync_voice_auto_join_state_to_adapter(adapter)
                         self.delivery_router.adapters = self.adapters
                         del self._failed_platforms[platform]
                         self._update_platform_runtime_status(
@@ -11354,6 +11363,95 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return raw.guild.id
         return None
 
+    async def _handle_discord_voice_auto_join(
+        self,
+        *,
+        guild_id: int,
+        user_id: str,
+        voice_channel_id: str,
+        text_channel_id: str,
+    ) -> bool:
+        """Auto-join Discord voice by reusing the manual /voice join path."""
+        adapter = self.adapters.get(Platform.DISCORD)
+        if not adapter or "get_user_voice_channel" not in dir(adapter):
+            return False
+
+        text_channel = None
+        client = getattr(adapter, "_client", None)
+        if client is not None:
+            try:
+                text_channel = client.get_channel(int(text_channel_id))
+            except Exception:
+                text_channel = None
+            if text_channel is None and hasattr(client, "fetch_channel"):
+                try:
+                    text_channel = await client.fetch_channel(int(text_channel_id))
+                except Exception:
+                    text_channel = None
+        if text_channel is None:
+            logger.warning(
+                "Discord voice auto-join skipped: linked text channel %s is unavailable",
+                text_channel_id,
+            )
+            return False
+
+        chat_name = getattr(text_channel, "name", str(text_channel_id))
+        guild = getattr(text_channel, "guild", None)
+        if guild is not None and getattr(guild, "name", None):
+            chat_name = f"{guild.name} / #{chat_name}"
+        parent_id = str(getattr(text_channel, "parent_id", "") or "")
+        channel_prompt = None
+        if "_resolve_channel_prompt" in dir(adapter):
+            try:
+                channel_prompt = adapter._resolve_channel_prompt(str(text_channel_id), parent_id or None)
+            except Exception:
+                channel_prompt = None
+
+        source = adapter.build_source(
+            chat_id=str(text_channel_id),
+            chat_name=chat_name,
+            chat_type="group",
+            user_id=str(user_id),
+            user_name=str(user_id),
+            guild_id=str(guild_id),
+            parent_chat_id=parent_id or None,
+        ) if "build_source" in dir(adapter) else SessionSource(
+            platform=Platform.DISCORD,
+            chat_id=str(text_channel_id),
+            chat_name=chat_name,
+            chat_type="group",
+            user_id=str(user_id),
+            user_name=str(user_id),
+            guild_id=str(guild_id),
+            parent_chat_id=parent_id or None,
+        )
+
+        from types import SimpleNamespace
+        event = MessageEvent(
+            text="/voice join",
+            message_type=MessageType.COMMAND,
+            source=source,
+            raw_message=SimpleNamespace(guild_id=int(guild_id), guild=guild),
+            channel_prompt=channel_prompt,
+        )
+
+        result = await self._handle_voice_channel_join(event)
+        success = (
+            "is_in_voice_channel" in dir(adapter)
+            and adapter.is_in_voice_channel(int(guild_id))
+            and str(getattr(adapter, "_voice_text_channels", {}).get(int(guild_id))) == str(text_channel_id)
+        )
+        if success and "mark_voice_auto_join_target" in dir(adapter):
+            adapter.mark_voice_auto_join_target(
+                int(guild_id),
+                user_id=str(user_id),
+                voice_channel_id=str(voice_channel_id),
+                text_channel_id=str(text_channel_id),
+            )
+        if not success:
+            logger.debug("Discord voice auto-join did not connect: %s", result)
+        return bool(success)
+
 
     async def _handle_voice_channel_join(self, event: MessageEvent) -> str:
         """Join the user's current Discord voice channel."""
@@ -11422,6 +11520,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if not hasattr(adapter, "is_in_voice_channel") or not adapter.is_in_voice_channel(guild_id):
             return "Not in a voice channel."
+
+        suppress_auto_join = (
+            getattr(adapter, "suppress_voice_auto_join", None)
+            if "suppress_voice_auto_join" in dir(adapter)
+            else None
+        )
+        if suppress_auto_join is not None:
+            voice_channel_id = None
+            get_user_voice_channel = (
+                getattr(adapter, "get_user_voice_channel", None)
+                if "get_user_voice_channel" in dir(adapter)
+                else None
+            )
+            if get_user_voice_channel is not None:
+                try:
+                    voice_channel = await get_user_voice_channel(
+                        guild_id,
+                        event.source.user_id,
+                    )
+                    voice_channel_id = getattr(voice_channel, "id", None)
+                except Exception:
+                    voice_channel_id = None
+            suppress_auto_join(
+                guild_id,
+                user_id=event.source.user_id,
+                channel_id=str(voice_channel_id) if voice_channel_id is not None else None,
+            )
 
         try:
             await adapter.leave_voice_channel(guild_id)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2258,6 +2258,21 @@ DEFAULT_CONFIG = {
         # real memory cost. Default 32 MiB matches the historical hardcoded
         # cap. Set to 0 for no cap. Env override: DISCORD_MAX_ATTACHMENT_BYTES.
         "max_attachment_bytes": 33554432,
+        # Voice auto-join/follow mode. OFF by default and requires explicit
+        # allowed user IDs, allowed voice-channel IDs, and a linked text
+        # channel ID. No live Discord IDs are inferred.
+        "voice_auto_join": {
+            "enabled": False,
+            "allowed_user_ids": [],
+            "allowed_voice_channel_ids": [],
+            "text_channel_id": "",
+            "idle_timeout_seconds": 300,
+            "target_leave_cleanup": True,
+            "stay_while_target_present": False,
+            "manual_leave_cooldown_seconds": 300,
+            "reconnect_cooldown_seconds": 15,
+            "failure_backoff_seconds": 60,
+        },
         # Voice-channel audio effects (the continuous mixer). OFF by default.
         # When enabled, the bot installs a software mixer on the outgoing voice
         # stream so a low ambient "thinking" bed, verbal acknowledgements, and

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -263,6 +263,52 @@ def _clean_discord_id(entry: str) -> str:
     return entry.strip()
 
 
+def _clean_discord_channel_id(entry: str) -> str:
+    """Normalize a Discord channel/voice-channel ID pasted from config."""
+    entry = str(entry or "").strip()
+    if entry.startswith("<#") and entry.endswith(">"):
+        entry = entry[2:-1]
+    for prefix in ("channel:", "voice:", "vc:", "text:"):
+        if entry.lower().startswith(prefix):
+            entry = entry[len(prefix):]
+            break
+    return entry.strip()
+
+
+def _discord_config_id_set(value: Any, *, channel: bool = False) -> set[str]:
+    if value is None:
+        return set()
+    if isinstance(value, (list, tuple, set)):
+        entries = value
+    else:
+        entries = str(value).split(",")
+    cleaner = _clean_discord_channel_id if channel else _clean_discord_id
+    return {cleaner(str(entry)) for entry in entries if cleaner(str(entry))}
+
+
+def _discord_config_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+        return default
+    return bool(value)
+
+
+def _discord_config_float(value: Any, default: float, *, minimum: float = 0.0) -> float:
+    if value is None:
+        return default
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, parsed)
+
+
 def check_discord_requirements() -> bool:
     """Check if Discord dependencies are available.
 
@@ -761,6 +807,12 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
         self._voice_input_callback: Optional[Callable] = None  # set by run.py
         self._on_voice_disconnect: Optional[Callable] = None  # set by run.py
+        self._voice_auto_join_callback: Optional[Callable] = None  # set by run.py
+        self._voice_auto_join_cfg: Dict[str, Any] = self._load_voice_auto_join_config()
+        self._voice_timeout_seconds: float = self._voice_auto_join_cfg["idle_timeout_seconds"]
+        self._voice_auto_join_targets: Dict[int, Dict[str, str]] = {}
+        self._voice_auto_join_suppressed_until: Dict[Tuple[int, str, str], float] = {}
+        self._voice_auto_join_next_attempt_at: Dict[Tuple[int, str], float] = {}
         # Resolves the current voice-reply mode ("off"|"voice_only"|"all") for a
         # linked text-channel id; set by run.py. Lets the inactivity timer leave
         # the bot in the channel when the user deliberately picked text-only
@@ -1090,35 +1142,7 @@ class DiscordAdapter(BasePlatformAdapter):
             @self._client.event
             async def on_voice_state_update(member, before, after):
                 """Track voice channel join/leave events."""
-                # Only track channels where the bot is connected
-                bot_guild_ids = set(adapter_self._voice_clients.keys())
-                if not bot_guild_ids:
-                    return
-                guild_id = member.guild.id
-                if guild_id not in bot_guild_ids:
-                    return
-                # Ignore the bot itself
-                if member == adapter_self._client.user:
-                    return
-
-                joined = before.channel is None and after.channel is not None
-                left = before.channel is not None and after.channel is None
-                switched = (
-                    before.channel is not None
-                    and after.channel is not None
-                    and before.channel != after.channel
-                )
-
-                if joined or left or switched:
-                    logger.info(
-                        "Voice state: %s (%d) %s (guild %d)",
-                        member.display_name,
-                        member.id,
-                        "joined " + after.channel.name if joined
-                        else "left " + before.channel.name if left
-                        else f"moved {before.channel.name} -> {after.channel.name}",
-                        guild_id,
-                    )
+                await adapter_self._handle_voice_state_update(member, before, after)
 
             # Register slash commands
             if self._slash_commands:
@@ -2245,6 +2269,102 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.debug("Could not load discord.voice_fx config: %s", e)
         return defaults
 
+    def _load_voice_auto_join_config(self) -> Dict[str, Any]:
+        """Read Discord voice auto-join/follow settings from config.yaml.
+
+        Behavioral settings live under ``discord.voice_auto_join`` and are
+        disabled by default. IDs must be explicit; Hermes never infers live
+        Discord users or channels for this feature.
+        """
+        defaults: Dict[str, Any] = {
+            "enabled": False,
+            "allowed_user_ids": set(),
+            "allowed_voice_channel_ids": set(),
+            "text_channel_id": None,
+            "idle_timeout_seconds": float(self.VOICE_TIMEOUT),
+            "target_leave_cleanup": True,
+            "stay_while_target_present": False,
+            "manual_leave_cooldown_seconds": 300.0,
+            "reconnect_cooldown_seconds": 15.0,
+            "failure_backoff_seconds": 60.0,
+        }
+        raw: Dict[str, Any] = {}
+        try:
+            from hermes_cli.config import read_raw_config
+            cfg = read_raw_config() or {}
+            discord_cfg = cfg.get("discord") or {}
+            if isinstance(discord_cfg, dict):
+                block = discord_cfg.get("voice_auto_join") or {}
+                if isinstance(block, dict):
+                    raw.update(block)
+                # Top-level timeout alias so manual /voice joins can also use
+                # the configurable Discord voice inactivity timeout.
+                if "voice_idle_timeout_seconds" in discord_cfg:
+                    raw.setdefault(
+                        "idle_timeout_seconds",
+                        discord_cfg.get("voice_idle_timeout_seconds"),
+                    )
+        except Exception as e:
+            logger.debug("Could not load discord.voice_auto_join config: %s", e)
+
+        extra_block = {}
+        try:
+            extra_block = (getattr(self.config, "extra", {}) or {}).get("voice_auto_join") or {}
+        except Exception:
+            extra_block = {}
+        if isinstance(extra_block, dict):
+            raw.update(extra_block)
+
+        allowed_users = (
+            raw.get("allowed_user_ids")
+            if "allowed_user_ids" in raw
+            else raw.get("allowed_users")
+        )
+        allowed_vcs = (
+            raw.get("allowed_voice_channel_ids")
+            if "allowed_voice_channel_ids" in raw
+            else raw.get("allowed_voice_channels", raw.get("allowed_vcs"))
+        )
+        text_channel = raw.get(
+            "text_channel_id",
+            raw.get("linked_text_channel_id", raw.get("linked_text_channel")),
+        )
+        cleaned_text_channel = _clean_discord_channel_id(text_channel) if text_channel is not None else ""
+
+        defaults["enabled"] = _discord_config_bool(raw.get("enabled"), False)
+        defaults["allowed_user_ids"] = _discord_config_id_set(allowed_users)
+        defaults["allowed_voice_channel_ids"] = _discord_config_id_set(allowed_vcs, channel=True)
+        defaults["text_channel_id"] = cleaned_text_channel or None
+        defaults["idle_timeout_seconds"] = _discord_config_float(
+            raw.get("idle_timeout_seconds", raw.get("idle_timeout", raw.get("timeout_seconds"))),
+            defaults["idle_timeout_seconds"],
+            minimum=0.0,
+        )
+        defaults["target_leave_cleanup"] = _discord_config_bool(
+            raw.get("target_leave_cleanup"),
+            True,
+        )
+        defaults["stay_while_target_present"] = _discord_config_bool(
+            raw.get("stay_while_target_present"),
+            False,
+        )
+        defaults["manual_leave_cooldown_seconds"] = _discord_config_float(
+            raw.get("manual_leave_cooldown_seconds", raw.get("manual_leave_cooldown")),
+            defaults["manual_leave_cooldown_seconds"],
+            minimum=0.0,
+        )
+        defaults["reconnect_cooldown_seconds"] = _discord_config_float(
+            raw.get("reconnect_cooldown_seconds", raw.get("reconnect_cooldown")),
+            defaults["reconnect_cooldown_seconds"],
+            minimum=0.0,
+        )
+        defaults["failure_backoff_seconds"] = _discord_config_float(
+            raw.get("failure_backoff_seconds", raw.get("failure_backoff")),
+            defaults["failure_backoff_seconds"],
+            minimum=0.0,
+        )
+        return defaults
+
     def _get_ambient_pcm(self) -> Optional[bytes]:
         """Return decoded 48k/stereo/s16le PCM for the ambient idle bed.
 
@@ -2361,6 +2481,239 @@ class DiscordAdapter(BasePlatformAdapter):
         """True when a continuous mixer is installed for this guild."""
         mixers = getattr(self, "_voice_mixers", None)
         return bool(mixers) and mixers.get(guild_id) is not None
+
+    def suppress_voice_auto_join(
+        self,
+        guild_id: int,
+        *,
+        user_id: Optional[str] = None,
+        channel_id: Optional[str] = None,
+        seconds: Optional[float] = None,
+    ) -> None:
+        """Suppress auto-rejoin after an intentional manual /voice leave."""
+        cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
+        cooldown = cfg.get("manual_leave_cooldown_seconds", 300.0) if seconds is None else seconds
+        cooldown = _discord_config_float(cooldown, 300.0, minimum=0.0)
+        if cooldown <= 0:
+            return
+
+        channel_ids = {str(channel_id)} if channel_id is not None else set()
+        if not channel_ids:
+            current = self._voice_clients.get(int(guild_id))
+            current_channel = getattr(current, "channel", None)
+            current_channel_id = getattr(current_channel, "id", None)
+            if current_channel_id is not None:
+                channel_ids.add(str(current_channel_id))
+        if not channel_ids:
+            return
+
+        user_ids = {str(user_id)} if user_id is not None else set()
+        if not user_ids:
+            user_ids.update(cfg.get("allowed_user_ids") or set())
+        if not user_ids:
+            return
+
+        until = time.monotonic() + cooldown
+        for target_user_id in user_ids:
+            for target_channel_id in channel_ids:
+                self._voice_auto_join_suppressed_until[
+                    (int(guild_id), str(target_user_id), str(target_channel_id))
+                ] = until
+
+    def _is_voice_auto_join_suppressed(self, guild_id: int, user_id: str, channel_id: str) -> bool:
+        key = (int(guild_id), str(user_id), str(channel_id))
+        until = self._voice_auto_join_suppressed_until.get(key)
+        if until is None:
+            return False
+        if time.monotonic() >= until:
+            self._voice_auto_join_suppressed_until.pop(key, None)
+            return False
+        return True
+
+    def _clear_voice_auto_join_suppression(self, guild_id: int, user_id: str, channel_id: str) -> None:
+        self._voice_auto_join_suppressed_until.pop(
+            (int(guild_id), str(user_id), str(channel_id)),
+            None,
+        )
+
+    def mark_voice_auto_join_target(
+        self,
+        guild_id: int,
+        *,
+        user_id: str,
+        voice_channel_id: str,
+        text_channel_id: str,
+    ) -> None:
+        """Record which configured user/channel this guild is following."""
+        self._voice_auto_join_targets[int(guild_id)] = {
+            "user_id": str(user_id),
+            "voice_channel_id": str(voice_channel_id),
+            "text_channel_id": str(text_channel_id),
+        }
+
+    def _voice_auto_join_target_present(self, guild_id: int) -> bool:
+        target = self._voice_auto_join_targets.get(int(guild_id))
+        if not target:
+            return False
+        vc = self._voice_clients.get(int(guild_id))
+        channel = getattr(vc, "channel", None)
+        if channel is None:
+            return False
+        if str(getattr(channel, "id", "")) != str(target.get("voice_channel_id")):
+            return False
+        for member in getattr(channel, "members", []) or []:
+            if str(getattr(member, "id", "")) == str(target.get("user_id")):
+                return True
+        return False
+
+    async def _handle_voice_state_update(self, member, before, after) -> None:
+        """Handle Discord voice-state changes for logging and auto-follow."""
+        if self._client is not None and member == getattr(self._client, "user", None):
+            return
+
+        before_channel = getattr(before, "channel", None)
+        after_channel = getattr(after, "channel", None)
+        joined = before_channel is None and after_channel is not None
+        left = before_channel is not None and after_channel is None
+        switched = (
+            before_channel is not None
+            and after_channel is not None
+            and before_channel != after_channel
+        )
+        if not (joined or left or switched):
+            return
+
+        await self._maybe_handle_voice_auto_join(member, before_channel, after_channel)
+
+        guild = getattr(member, "guild", None)
+        guild_id = getattr(guild, "id", None)
+        if guild_id in set(getattr(self, "_voice_clients", {}).keys()):
+            before_name = getattr(before_channel, "name", "")
+            after_name = getattr(after_channel, "name", "")
+            logger.info(
+                "Voice state: %s (%d) %s (guild %d)",
+                getattr(member, "display_name", str(getattr(member, "id", ""))),
+                getattr(member, "id", 0),
+                "joined " + after_name if joined
+                else "left " + before_name if left
+                else f"moved {before_name} -> {after_name}",
+                guild_id,
+            )
+
+    async def _maybe_handle_voice_auto_join(self, member, before_channel, after_channel) -> None:
+        guild = getattr(member, "guild", None)
+        guild_id = getattr(guild, "id", None)
+        user_id = str(getattr(member, "id", "") or "")
+        if guild_id is None or not user_id:
+            return
+        guild_id = int(guild_id)
+
+        if before_channel is not None:
+            await self._maybe_cleanup_voice_auto_join_target(
+                guild_id,
+                user_id,
+                before_channel,
+                after_channel,
+            )
+
+        if after_channel is None:
+            return
+
+        cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
+        if not cfg.get("enabled", False):
+            return
+
+        allowed_users = cfg.get("allowed_user_ids") or set()
+        allowed_channels = cfg.get("allowed_voice_channel_ids") or set()
+        text_channel_id = cfg.get("text_channel_id")
+        voice_channel_id = str(getattr(after_channel, "id", "") or "")
+        if not allowed_users or user_id not in allowed_users:
+            return
+        if not allowed_channels or voice_channel_id not in allowed_channels:
+            return
+        if not text_channel_id:
+            return
+
+        existing = self._voice_clients.get(guild_id)
+        if existing and existing.is_connected() and str(getattr(existing.channel, "id", "")) == voice_channel_id:
+            self.mark_voice_auto_join_target(
+                guild_id,
+                user_id=user_id,
+                voice_channel_id=voice_channel_id,
+                text_channel_id=str(text_channel_id),
+            )
+            return
+
+        if self._is_voice_auto_join_suppressed(guild_id, user_id, voice_channel_id):
+            return
+
+        attempt_key = (guild_id, voice_channel_id)
+        now = time.monotonic()
+        next_allowed = self._voice_auto_join_next_attempt_at.get(attempt_key, 0.0)
+        if now < next_allowed:
+            return
+
+        cooldown = float(cfg.get("reconnect_cooldown_seconds", 15.0) or 0.0)
+        self._voice_auto_join_next_attempt_at[attempt_key] = now + cooldown
+
+        callback = getattr(self, "_voice_auto_join_callback", None)
+        if callback is None:
+            return
+
+        success = False
+        try:
+            success = bool(await callback(
+                guild_id=guild_id,
+                user_id=user_id,
+                voice_channel_id=voice_channel_id,
+                text_channel_id=str(text_channel_id),
+            ))
+        except Exception as exc:
+            logger.warning("Discord voice auto-join failed: %s", exc, exc_info=True)
+
+        if success:
+            self.mark_voice_auto_join_target(
+                guild_id,
+                user_id=user_id,
+                voice_channel_id=voice_channel_id,
+                text_channel_id=str(text_channel_id),
+            )
+            return
+
+        backoff = float(cfg.get("failure_backoff_seconds", 60.0) or 0.0)
+        self._voice_auto_join_next_attempt_at[attempt_key] = now + max(cooldown, backoff)
+
+    async def _maybe_cleanup_voice_auto_join_target(
+        self,
+        guild_id: int,
+        user_id: str,
+        before_channel,
+        after_channel,
+    ) -> None:
+        before_channel_id = str(getattr(before_channel, "id", "") or "")
+        self._clear_voice_auto_join_suppression(guild_id, user_id, before_channel_id)
+
+        target = self._voice_auto_join_targets.get(int(guild_id))
+        if not target:
+            return
+        if str(target.get("user_id")) != str(user_id):
+            return
+        if str(target.get("voice_channel_id")) != before_channel_id:
+            return
+        if after_channel is not None and str(getattr(after_channel, "id", "")) == before_channel_id:
+            return
+
+        self._voice_auto_join_targets.pop(int(guild_id), None)
+        cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
+        if not cfg.get("target_leave_cleanup", True):
+            return
+        text_ch_id = self._voice_text_channels.get(int(guild_id))
+        await self.leave_voice_channel(int(guild_id))
+        if self._on_voice_disconnect and text_ch_id:
+            try:
+                self._on_voice_disconnect(str(text_ch_id))
+            except Exception:
+                pass
 
     async def join_voice_channel(self, channel) -> bool:
         """Join a Discord voice channel. Returns True on success."""
@@ -2535,8 +2888,9 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _voice_timeout_handler(self, guild_id: int) -> None:
         """Auto-disconnect after VOICE_TIMEOUT seconds of inactivity."""
+        timeout_seconds = float(getattr(self, "_voice_timeout_seconds", self.VOICE_TIMEOUT))
         try:
-            await asyncio.sleep(self.VOICE_TIMEOUT)
+            await asyncio.sleep(timeout_seconds)
         except asyncio.CancelledError:
             return
         text_ch_id = self._voice_text_channels.get(guild_id)
@@ -2554,6 +2908,12 @@ class DiscordAdapter(BasePlatformAdapter):
                     return
             except Exception:
                 pass
+        auto_join_cfg = getattr(self, "_voice_auto_join_cfg", {}) or {}
+        if (
+            auto_join_cfg.get("stay_while_target_present")
+            and self._voice_auto_join_target_present(guild_id)
+        ):
+            return
         await self.leave_voice_channel(guild_id)
         # Notify the runner so it can clean up voice_mode state
         if self._on_voice_disconnect and text_ch_id:

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -926,6 +926,25 @@ class TestVoiceChannelCommands:
         assert runner._voice_mode["discord:123"] == "off"
         mock_adapter.leave_voice_channel.assert_called_once_with(111)
 
+    @pytest.mark.asyncio
+    async def test_leave_suppresses_voice_auto_rejoin(self, runner):
+        """Manual /voice leave starts the adapter's auto-join cooldown."""
+        mock_adapter = AsyncMock()
+        mock_adapter.is_in_voice_channel = MagicMock(return_value=True)
+        mock_adapter.leave_voice_channel = AsyncMock()
+        mock_adapter.get_user_voice_channel = AsyncMock(return_value=SimpleNamespace(id=222))
+        mock_adapter.suppress_voice_auto_join = MagicMock()
+        event = self._make_discord_event("/voice leave")
+        runner.adapters[event.source.platform] = mock_adapter
+
+        await runner._handle_voice_channel_leave(event)
+
+        mock_adapter.suppress_voice_auto_join.assert_called_once_with(
+            111,
+            user_id="user1",
+            channel_id="222",
+        )
+
     # -- _handle_voice_channel_input --
 
     @pytest.mark.asyncio
@@ -1081,6 +1100,201 @@ class TestVoiceChannelCommands:
         event.raw_message = SimpleNamespace(guild_id=None, guild=None)
         result = runner._get_guild_id(event)
         assert result is None
+
+
+class TestDiscordVoiceAutoJoin:
+    """Regression coverage for Discord voice auto-join/follow mode."""
+
+    @staticmethod
+    def _make_adapter(auto_join=None):
+        from plugins.platforms.discord.adapter import DiscordAdapter
+        from gateway.config import Platform, PlatformConfig
+
+        config = PlatformConfig(
+            enabled=True,
+            extra={"voice_auto_join": auto_join or {}},
+        )
+        config.token = "fake-token"
+        adapter = object.__new__(DiscordAdapter)
+        adapter.platform = Platform.DISCORD
+        adapter.config = config
+        adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))
+        adapter._voice_clients = {}
+        adapter._voice_locks = {}
+        adapter._voice_text_channels = {}
+        adapter._voice_sources = {}
+        adapter._voice_timeout_tasks = {}
+        adapter._voice_receivers = {}
+        adapter._voice_listen_tasks = {}
+        adapter._voice_input_callback = None
+        adapter._on_voice_disconnect = None
+        adapter._voice_auto_join_callback = AsyncMock(return_value=True)
+        adapter._voice_auto_join_cfg = adapter._load_voice_auto_join_config()
+        adapter._voice_timeout_seconds = adapter._voice_auto_join_cfg["idle_timeout_seconds"]
+        adapter._voice_auto_join_targets = {}
+        adapter._voice_auto_join_suppressed_until = {}
+        adapter._voice_auto_join_next_attempt_at = {}
+        return adapter
+
+    @staticmethod
+    def _voice_state(user_id="42", channel_id=222, before_channel=None):
+        guild = SimpleNamespace(id=111, name="Guild")
+        channel = SimpleNamespace(id=channel_id, name="General", guild=guild, members=[])
+        member = SimpleNamespace(id=int(user_id), display_name="Martin", guild=guild)
+        before = SimpleNamespace(channel=before_channel)
+        after = SimpleNamespace(channel=channel)
+        return member, before, after, channel
+
+    @pytest.mark.asyncio
+    async def test_auto_join_disabled_by_default(self):
+        adapter = self._make_adapter()
+        member, before, after, _channel = self._voice_state()
+
+        await adapter._handle_voice_state_update(member, before, after)
+
+        adapter._voice_auto_join_callback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allowed_user_and_channel_auto_join(self):
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+        })
+        member, before, after, _channel = self._voice_state()
+
+        await adapter._handle_voice_state_update(member, before, after)
+
+        adapter._voice_auto_join_callback.assert_awaited_once_with(
+            guild_id=111,
+            user_id="42",
+            voice_channel_id="222",
+            text_channel_id="333",
+        )
+        assert adapter._voice_auto_join_targets[111]["user_id"] == "42"
+
+    @pytest.mark.asyncio
+    async def test_disallowed_user_or_channel_ignored(self):
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["99"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+        })
+        member, before, after, _channel = self._voice_state(user_id="42")
+
+        await adapter._handle_voice_state_update(member, before, after)
+
+        adapter._voice_auto_join_callback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manual_leave_cooldown_blocks_immediate_rejoin(self):
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+        })
+        adapter.suppress_voice_auto_join(111, user_id="42", channel_id="222", seconds=30)
+        member, before, after, _channel = self._voice_state()
+
+        await adapter._handle_voice_state_update(member, before, after)
+
+        adapter._voice_auto_join_callback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failure_backoff_prevents_reconnect_thrash(self):
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "reconnect_cooldown_seconds": 0,
+            "failure_backoff_seconds": 60,
+        })
+        adapter._voice_auto_join_callback = AsyncMock(return_value=False)
+        member, before, after, _channel = self._voice_state()
+
+        await adapter._handle_voice_state_update(member, before, after)
+        await adapter._handle_voice_state_update(member, before, after)
+
+        adapter._voice_auto_join_callback.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_target_leave_cleanup_disconnects_and_notifies_runner(self):
+        adapter = self._make_adapter({
+            "enabled": True,
+            "allowed_user_ids": ["42"],
+            "allowed_voice_channel_ids": ["222"],
+            "text_channel_id": "333",
+            "target_leave_cleanup": True,
+        })
+        guild = SimpleNamespace(id=111, name="Guild")
+        before_channel = SimpleNamespace(id=222, name="General", guild=guild)
+        member = SimpleNamespace(id=42, display_name="Martin", guild=guild)
+        adapter._voice_auto_join_targets[111] = {
+            "user_id": "42",
+            "voice_channel_id": "222",
+            "text_channel_id": "333",
+        }
+        adapter._voice_text_channels[111] = 333
+        adapter.leave_voice_channel = AsyncMock()
+        disconnect_calls = []
+        adapter._on_voice_disconnect = lambda chat_id: disconnect_calls.append(chat_id)
+
+        await adapter._handle_voice_state_update(
+            member,
+            SimpleNamespace(channel=before_channel),
+            SimpleNamespace(channel=None),
+        )
+
+        adapter.leave_voice_channel.assert_awaited_once_with(111)
+        assert disconnect_calls == ["333"]
+        assert 111 not in adapter._voice_auto_join_targets
+
+    @pytest.mark.asyncio
+    async def test_runner_auto_join_reuses_manual_join_wiring(self, tmp_path):
+        from gateway.config import Platform
+
+        runner = _make_runner(tmp_path)
+        guild = SimpleNamespace(id=111, name="Guild")
+        text_channel = SimpleNamespace(id=333, name="voice-chat", guild=guild, parent_id=None)
+        voice_channel = SimpleNamespace(id=222, name="General", guild=guild)
+        adapter = MagicMock()
+        adapter._client = MagicMock()
+        adapter._client.get_channel = MagicMock(return_value=text_channel)
+        adapter.get_user_voice_channel = AsyncMock(return_value=voice_channel)
+        adapter.join_voice_channel = AsyncMock(return_value=True)
+        adapter.is_in_voice_channel = MagicMock(return_value=True)
+        adapter._voice_text_channels = {}
+        adapter._voice_sources = {}
+        adapter._voice_input_callback = None
+        adapter._on_voice_disconnect = None
+        adapter._voice_mode_getter = None
+        adapter._auto_tts_enabled_chats = set()
+        adapter._auto_tts_disabled_chats = set()
+        adapter.mark_voice_auto_join_target = MagicMock()
+        runner.adapters[Platform.DISCORD] = adapter
+
+        success = await runner._handle_discord_voice_auto_join(
+            guild_id=111,
+            user_id="42",
+            voice_channel_id="222",
+            text_channel_id="333",
+        )
+
+        assert success is True
+        adapter.join_voice_channel.assert_awaited_once_with(voice_channel)
+        assert runner._voice_mode["discord:333"] == "all"
+        assert adapter._auto_tts_enabled_chats == {"333"}
+        adapter.mark_voice_auto_join_target.assert_called_once_with(
+            111,
+            user_id="42",
+            voice_channel_id="222",
+            text_channel_id="333",
+        )
 
 
 # =====================================================================
@@ -1997,6 +2211,48 @@ class TestVoiceTimeoutCleansRunnerState:
 
         assert 111 not in adapter._voice_clients
         assert disconnect_calls == ["999"]
+
+    @pytest.mark.asyncio
+    async def test_timeout_uses_configured_seconds(self, adapter):
+        adapter._voice_timeout_seconds = 17
+        adapter._voice_auto_join_cfg = {}
+
+        mock_vc = MagicMock()
+        mock_vc.is_connected.return_value = True
+        mock_vc.disconnect = AsyncMock()
+        adapter._voice_clients[111] = mock_vc
+        adapter._voice_text_channels[111] = 999
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await adapter._voice_timeout_handler(111)
+
+        mock_sleep.assert_awaited_once_with(17)
+
+    @pytest.mark.asyncio
+    async def test_timeout_stays_while_auto_join_target_present(self, adapter):
+        adapter._voice_timeout_seconds = 17
+        adapter._voice_auto_join_cfg = {"stay_while_target_present": True}
+        adapter._voice_auto_join_targets = {
+            111: {
+                "user_id": "42",
+                "voice_channel_id": "222",
+                "text_channel_id": "999",
+            }
+        }
+
+        target_member = SimpleNamespace(id=42)
+        mock_vc = MagicMock()
+        mock_vc.is_connected.return_value = True
+        mock_vc.disconnect = AsyncMock()
+        mock_vc.channel = SimpleNamespace(id=222, members=[target_member])
+        adapter._voice_clients[111] = mock_vc
+        adapter._voice_text_channels[111] = 999
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await adapter._voice_timeout_handler(111)
+
+        assert 111 in adapter._voice_clients
+        mock_vc.disconnect.assert_not_called()
 
 
 # =====================================================================


### PR DESCRIPTION
## Summary
- add disabled-by-default Discord voice auto-join/follow config with explicit allowed users, allowed voice channels, linked text channel, timeout, manual-leave cooldown, and reconnect/backoff settings
- route Discord voice-state joins/moves through the existing /voice join wiring so text binding, voice mode, callback setup, and auto-TTS behavior stay shared
- add target-leave cleanup plus optional stay-while-target-present timeout behavior

## Validation
- scripts/run_tests.sh tests/gateway/test_voice_command.py tests/gateway/test_discord_race_polish.py tests/gateway/test_discord_voice_mixer.py
  - 214 passed