### PR TITLE
fix(vision): translate MSYS paths on Windows before resolving in vision_analyze

### DIFF
--- a/tests/tools/test_image_source_msys.py
+++ b/tests/tools/test_image_source_msys.py
@@ -1,0 +1,126 @@
+"""Regression coverage for Windows MSYS/Git Bash vision paths."""
+
+from __future__ import annotations
+
+import base64
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+
+
+def _reload(monkeypatch, hermes_home: Path):
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    import hermes_constants
+
+    importlib.reload(hermes_constants)
+    import tools.image_source as isrc
+
+    importlib.reload(isrc)
+    return isrc
+
+
+def test_translate_msys_path_uses_cygpath_without_shell(tmp_path, monkeypatch):
+    isrc = _reload(monkeypatch, tmp_path / "hermes")
+    calls = {}
+
+    def fake_run(argv, **kwargs):
+        calls["argv"] = argv
+        calls["kwargs"] = kwargs
+        return SimpleNamespace(stdout=r"C:\Users\Tony\Pictures\pic.png" + "\n")
+
+    translated = isrc._translate_msys_path(
+        "/c/Users/Tony/Pictures/pic.png",
+        is_windows=True,
+        run=fake_run,
+    )
+
+    assert translated == r"C:\Users\Tony\Pictures\pic.png"
+    assert calls["argv"] == ["cygpath", "-w", "/c/Users/Tony/Pictures/pic.png"]
+    assert calls["kwargs"] == {
+        "check": True,
+        "capture_output": True,
+        "text": True,
+        "timeout": 5,
+    }
+
+
+def test_translate_msys_path_skips_non_windows(tmp_path, monkeypatch):
+    isrc = _reload(monkeypatch, tmp_path / "hermes")
+
+    def fail_run(*_args, **_kwargs):
+        pytest.fail("cygpath must not run outside Windows")
+
+    assert (
+        isrc._translate_msys_path(
+            "/workspace/pic.png",
+            is_windows=False,
+            run=fail_run,
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_local_backend_reads_translated_msys_path(tmp_path, monkeypatch):
+    isrc = _reload(monkeypatch, tmp_path / "hermes")
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    image = tmp_path / "translated.png"
+    image.write_bytes(PNG)
+
+    monkeypatch.setattr(isrc, "_looks_like_msys_path", lambda _candidate: True)
+    monkeypatch.setattr(isrc, "_translate_msys_path", lambda _candidate: str(image))
+
+    result = await isrc.resolve_image_source(
+        "/c/Users/Tony/Pictures/pic.png",
+        isrc.ResolveContext(),
+    )
+
+    assert result.data == PNG
+    assert result.mime == "image/png"
+    assert result.origin == "file"
+
+
+@pytest.mark.asyncio
+async def test_non_local_backend_keeps_container_path(tmp_path, monkeypatch):
+    isrc = _reload(monkeypatch, tmp_path / "hermes")
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    def fail_translate(_candidate):
+        pytest.fail("container paths must never pass through cygpath")
+
+    monkeypatch.setattr(isrc, "_translate_msys_path", fail_translate)
+    encoded = base64.b64encode(PNG).decode()
+
+    with patch(
+        "tools.image_source._get_active_env",
+        return_value=SimpleNamespace(
+            execute=lambda _command: {"returncode": 0, "output": encoded}
+        ),
+    ):
+        result = await isrc.resolve_image_source(
+            "/workspace/pic.png",
+            isrc.ResolveContext(task_id="task-1"),
+        )
+
+    assert result.data == PNG
+    assert result.origin == "container"
+
+
+@pytest.mark.asyncio
+async def test_failed_msys_translation_has_actionable_error(tmp_path, monkeypatch):
+    isrc = _reload(monkeypatch, tmp_path / "hermes")
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setattr(isrc, "_looks_like_msys_path", lambda _candidate: True)
+    monkeypatch.setattr(isrc, "_translate_msys_path", lambda _candidate: None)
+
+    with pytest.raises(isrc.SourceNotFound, match="cygpath"):
+        await isrc.resolve_image_source(
+            "/c/Users/Tony/Pictures/missing.png",
+            isrc.ResolveContext(),
+        )

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -30,6 +30,7 @@ import asyncio
 import base64
 import os
 import re
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -109,6 +110,11 @@ async def resolve_image_source(src: str, ctx: ResolveContext) -> ResolvedImage:
     # Everything else is a filesystem path — including bare relative names
     # like "pic.png" (accepted on main; a path-shape gate here regressed them).
     candidate = s[len("file://"):] if s.lower().startswith("file://") else s
+    local_backend = _is_local_terminal_backend()
+    msys_input = local_backend and _looks_like_msys_path(candidate)
+    translated = _translate_msys_path(candidate) if msys_input else None
+    if translated:
+        candidate = translated
     p = Path(os.path.expanduser(candidate))
     # Confinement decision (see module docstring). Under a non-local backend
     # a path is host-readable ONLY if it lands in a media cache (after
@@ -135,9 +141,18 @@ async def resolve_image_source(src: str, ctx: ResolveContext) -> ResolvedImage:
                 raise SourceUnsafe(str(exc), src=s, origin="file")
         data = await asyncio.to_thread(host_target.read_bytes)
         return _finalize(data, "", "file", s)
-    if _is_local_terminal_backend():
+    if local_backend:
         # Local backend: any path was host-readable, so a miss simply means
         # the file doesn't exist — no sandbox to fall back to.
+        if msys_input and translated is None:
+            raise SourceNotFound(
+                f"image file not found: '{p}'. The input looks like an MSYS/Git Bash "
+                "path, but cygpath could not translate it. Install or repair Git for "
+                "Windows, or pass a native Windows path such as "
+                r"'C:\Users\you\Pictures\image.png'.",
+                src=s,
+                origin="file",
+            )
         raise SourceNotFound(f"image file not found: '{p}'", src=s, origin="file")
     # Not a permitted host read (or the host file is absent) -> read the
     # bytes inside the sandbox. Under a sandbox this reads the container's
@@ -196,6 +211,45 @@ async def _download_to_bytes(url: str) -> bytes:
         raise SourceUnsafe(str(exc), src=url, origin="http")
     finally:
         tmp.unlink(missing_ok=True)
+
+
+def _looks_like_msys_path(candidate: str, *, is_windows: Optional[bool] = None) -> bool:
+    """Return whether *candidate* needs MSYS/Git Bash path translation."""
+
+    windows = os.name == "nt" if is_windows is None else is_windows
+    return windows and candidate.startswith("/")
+
+
+def _translate_msys_path(
+    candidate: str,
+    *,
+    is_windows: Optional[bool] = None,
+    run=None,
+) -> Optional[str]:
+    """Translate an MSYS path to native Windows form with ``cygpath``.
+
+    The command is invoked without a shell and is only used for local Windows
+    backends. Container paths such as ``/workspace/image.png`` must retain their
+    sandbox meaning and therefore never pass through this helper.
+    """
+
+    if not _looks_like_msys_path(candidate, is_windows=is_windows):
+        return None
+
+    runner = subprocess.run if run is None else run
+    try:
+        result = runner(
+            ["cygpath", "-w", candidate],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    translated = result.stdout.strip()
+    return translated or None
 
 
 def _is_local_terminal_backend() -> bool:


### PR DESCRIPTION
## Summary

Fix Windows MSYS / Git Bash image paths in the current unified image-source resolver.

On a local Windows backend, paths such as `/c/Users/.../image.png` and `/tmp/...` are translated with `cygpath -w` before host-file resolution. If `cygpath` is unavailable, the resolver returns an actionable Windows-specific error instead of the generic file-not-found response.

Closes #53639.

## Current architecture

Image loading now funnels through `tools/image_source.py`, so the fix has been ported out of the removed inline branch in `tools/vision_tools.py` and into the shared resolver requested by review.

## Safety boundary

- Translation runs only for local Windows terminal backends.
- Container and remote paths such as `/workspace/image.png` retain their sandbox meaning and never pass through `cygpath`.
- `cygpath` is invoked with a fixed argument list, no shell, checked exit status, captured output, and a five-second timeout.
- Existing media-cache confinement and credential-read checks remain unchanged.

## Tests

Added `tests/tools/test_image_source_msys.py` covering:

- safe `cygpath -w` invocation and translated output;
- no translation on non-Windows platforms;
- successful local resolution through the translated path;
- preservation of non-local/container path handling;
- actionable failure when MSYS translation is unavailable.

The focused five-test regression suite passes in local isolation. Full repository CI is the authoritative validation.