### PR TITLE
fix(telegram): gate channel posts through routing rules

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5695,7 +5695,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if not chat:
             return False
         chat_type = str(getattr(chat, "type", "")).split(".")[-1].lower()
-        return chat_type in {"group", "supergroup"}
+        return chat_type in {"group", "supergroup", "channel"}
 
     def _is_reply_to_bot(self, message: Message) -> bool:
         if not self._bot or not getattr(message, "reply_to_message", None):

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -1289,3 +1289,81 @@ def test_unmentioned_unsupported_document_observed_and_cached(monkeypatch):
         assert "program.exe" in message["content"]
 
     asyncio.run(_run())
+
+
+# --- Channel post gating regression tests (#53674) ---
+
+
+def _channel_message(
+    text="hello",
+    *,
+    chat_id=-200,
+    from_user_id=111,
+    from_user_name="Alice Example",
+    thread_id=None,
+    reply_to_bot=False,
+    entities=None,
+    caption=None,
+    caption_entities=None,
+):
+    reply_to_message = None
+    if reply_to_bot:
+        reply_to_message = SimpleNamespace(from_user=SimpleNamespace(id=999), message_id=10, text="previous bot reply", caption=None)
+    return SimpleNamespace(
+        message_id=50,
+        text=text,
+        caption=caption,
+        entities=entities or [],
+        caption_entities=caption_entities or [],
+        message_thread_id=thread_id,
+        is_topic_message=thread_id is not None,
+        chat=SimpleNamespace(id=chat_id, type="channel", title="Test Channel", is_forum=False),
+        from_user=SimpleNamespace(id=from_user_id, full_name=from_user_name, first_name=from_user_name.split()[0]),
+        reply_to_message=reply_to_message,
+        date=None,
+    )
+
+
+def test_channel_post_blocked_when_not_in_allowed_chats():
+    """Channel posts outside allowed_chats must be dropped (#53674)."""
+    adapter = _make_adapter(require_mention=True, allowed_chats=["-100"])
+
+    assert adapter._should_process_message(_channel_message("breaking news", chat_id=-200)) is False
+
+
+def test_channel_post_allowed_when_in_allowed_chats():
+    """Channel posts inside allowed_chats should be accepted when require_mention is off."""
+    adapter = _make_adapter(require_mention=False, allowed_chats=["-200"])
+
+    assert adapter._should_process_message(_channel_message("breaking news", chat_id=-200)) is True
+
+
+def test_channel_post_allowed_in_allowed_chats_with_mention():
+    """Channel posts in allowed_chats pass with require_mention when bot is mentioned."""
+    adapter = _make_adapter(require_mention=True, allowed_chats=["-200"])
+
+    text = "hello @hermes_bot"
+    assert adapter._should_process_message(
+        _channel_message(text, chat_id=-200, entities=[_mention_entity(text)])
+    ) is True
+
+
+def test_channel_post_respects_require_mention():
+    """Channel posts must respect require_mention when no allowed_chats is set."""
+    adapter = _make_adapter(require_mention=True)
+
+    # Unmentioned channel post should be dropped
+    assert adapter._should_process_message(_channel_message("hello")) is False
+
+    # Mentioned channel post should be accepted
+    text = "hello @hermes_bot"
+    assert adapter._should_process_message(
+        _channel_message(text, entities=[_mention_entity(text)])
+    ) is True
+
+
+def test_channel_post_open_when_require_mention_disabled():
+    """Channel posts pass freely when require_mention is disabled and no allowed_chats."""
+    adapter = _make_adapter(require_mention=False)
+
+    assert adapter._should_process_message(_channel_message("any message")) is True


### PR DESCRIPTION
## Summary

Channel posts (`chat.type == "channel"`) bypassed **all** routing gates because `_is_group_chat()` only checked for `{"group", "supergroup"}`. Channel posts took the DM fast-path in `_should_process_message()` and were processed unconditionally — ignoring `allowed_chats`, `require_mention`, `free_response_chats`, `allowed_topics`, and `ignored_threads`.

### Root Cause

`plugins/platforms/telegram/adapter.py:5698`:
```python
# Before: channel missing from group-like set
return chat_type in {"group", "supergroup"}
```

When a channel post arrived → `_is_group_chat()` returned `False` → `_should_process_message()` hit line 6185 `if not self._is_group_chat(message): return True` → unconditional accept.

### Fix

```python
return chat_type in {"group", "supergroup", "channel"}
```

One line. Channel posts now go through the same gates as group messages.

### Impact Analysis

All 4 callers of `_is_group_chat()` are safe with this change:

| Caller | Effect of adding "channel" |
|--------|---------------------------|
| `_should_process_message()` (L6185, L6203) | Channel posts now gated by allowed_chats, require_mention, etc. ✅ |
| `_should_process_observe_message()` (L5872) | Channel observe mode properly gated ✅ |
| `_apply_telegram_group_observe_attribution()` (L5943) | Channel observe attribution applied correctly ✅ |

### Regression Tests (5 new tests)

| Test | Scenario | Expected |
|------|----------|----------|
| `test_channel_post_blocked_when_not_in_allowed_chats` | Channel not in whitelist | ❌ dropped |
| `test_channel_post_allowed_when_in_allowed_chats` | Channel in whitelist, no mention required | ✅ accepted |
| `test_channel_post_allowed_in_allowed_chats_with_mention` | Channel in whitelist + mention | ✅ accepted |
| `test_channel_post_respects_require_mention` | No whitelist, require_mention on | ❌/✅ per mention |
| `test_channel_post_open_when_require_mention_disabled` | No whitelist, require_mention off | ✅ accepted |

All 54 tests pass (49 existing + 5 new).

### Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Channel post, not in `allowed_chats` | ✅ processed (BUG) | ❌ dropped |
| Channel post, in `allowed_chats` + mention | ✅ processed | ✅ processed |
| Channel post, no `allowed_chats`, `require_mention` on | ✅ processed (BUG) | ❌ dropped (no mention) |
| Channel post, no config restrictions | ✅ processed | ✅ processed |

### Closes

Closes #53674

### Checklist

- [x] Root cause identified and fixed
- [x] All callers of modified function analyzed for safety
- [x] 5 regression tests covering the security boundary
- [x] 54/54 tests pass
- [x] Lint clean