### PR TITLE
fix(gateway): restore context usage on session resume

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -210,6 +210,7 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
                 billing_mode="subscription_included"
                 if cost_result.status == "included" else None,
                 model=agent.model,
+                last_prompt_tokens=prompt_tokens,
                 api_call_count=1,
             )
         except Exception as exc:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1949,6 +1949,7 @@ def run_conversation(
                                 billing_mode="subscription_included"
                                 if cost_result.status == "included" else None,
                                 model=agent.model,
+                                last_prompt_tokens=prompt_tokens,
                                 api_call_count=1,
                             )
                         except Exception as e:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -616,6 +616,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     cache_read_tokens INTEGER DEFAULT 0,
     cache_write_tokens INTEGER DEFAULT 0,
     reasoning_tokens INTEGER DEFAULT 0,
+    last_prompt_tokens INTEGER DEFAULT 0,
     cwd TEXT,
     git_branch TEXT,
     git_repo_root TEXT,
@@ -1761,6 +1762,7 @@ class SessionDB:
         billing_base_url: Optional[str] = None,
         billing_mode: Optional[str] = None,
         api_call_count: int = 0,
+        last_prompt_tokens: Optional[int] = None,
         absolute: bool = False,
     ) -> None:
         """Update token counters and backfill model if not already set.
@@ -1796,6 +1798,7 @@ class SessionDB:
                    billing_base_url = COALESCE(billing_base_url, ?),
                    billing_mode = COALESCE(billing_mode, ?),
                    model = COALESCE(model, ?),
+                   last_prompt_tokens = COALESCE(?, last_prompt_tokens),
                    api_call_count = ?
                    WHERE id = ?"""
         else:
@@ -1817,6 +1820,7 @@ class SessionDB:
                    billing_base_url = COALESCE(billing_base_url, ?),
                    billing_mode = COALESCE(billing_mode, ?),
                    model = COALESCE(model, ?),
+                   last_prompt_tokens = COALESCE(?, last_prompt_tokens),
                    api_call_count = COALESCE(api_call_count, 0) + ?
                    WHERE id = ?"""
         params = (
@@ -1835,6 +1839,7 @@ class SessionDB:
             billing_base_url,
             billing_mode,
             model,
+            last_prompt_tokens,
             api_call_count,
             session_id,
         )

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -106,6 +106,9 @@ class TestRunConversationCodexPath:
             CodexAppServerSession, "ensure_started", lambda self: "thread-usage-1"
         )
         agent = _make_codex_agent()
+        agent.session_id = "session-usage-1"
+        agent._session_db = MagicMock()
+        agent._session_db_created = True
         with patch.object(agent, "_spawn_background_review", return_value=None):
             result = agent.run_conversation("hello")
 
@@ -133,6 +136,11 @@ class TestRunConversationCodexPath:
         assert agent.context_compressor.last_completion_tokens == 25
         assert agent.context_compressor.last_total_tokens == 130
         assert agent.context_compressor.context_length == 200000
+        agent._session_db.update_token_counts.assert_called_once()
+        assert (
+            agent._session_db.update_token_counts.call_args.kwargs["last_prompt_tokens"]
+            == 100
+        )
 
     def test_projected_messages_are_spliced(self, fake_session):
         agent = _make_codex_agent()
@@ -588,4 +596,3 @@ class TestCodexToolProgressBridge:
 
         assert "on_event" in captured_init and captured_init["on_event"] is not None
         assert ("tool.started", "exec_command", "pytest") in events
-

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -210,6 +210,20 @@ class TestSessionLifecycle:
         session = db.get_session("s1")
         assert session["input_tokens"] == 300
         assert session["output_tokens"] == 150
+        assert session["last_prompt_tokens"] == 0
+
+    def test_update_token_counts_tracks_last_prompt_tokens(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.update_token_counts("s1", input_tokens=10, last_prompt_tokens=123)
+        db.update_token_counts("s1", input_tokens=5)
+
+        session = db.get_session("s1")
+        assert session["input_tokens"] == 15
+        assert session["last_prompt_tokens"] == 123
+
+        db.update_token_counts("s1", input_tokens=1, last_prompt_tokens=0)
+        session = db.get_session("s1")
+        assert session["last_prompt_tokens"] == 0
 
     def test_update_token_counts_tracks_api_call_count(self, db):
         """api_call_count increments with each update_token_counts call."""

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8197,6 +8197,158 @@ def test_start_agent_build_passes_session_model_override(monkeypatch):
         server._sessions.clear()
 
 
+# ── session.resume usage restoration ──────────────────────────────────────
+
+
+def test_restore_session_usage_copies_persisted_counters_to_agent():
+    agent = types.SimpleNamespace(
+        session_input_tokens=0,
+        session_output_tokens=0,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_reasoning_tokens=0,
+        session_prompt_tokens=0,
+        session_completion_tokens=0,
+        session_total_tokens=0,
+        session_api_calls=0,
+        session_estimated_cost_usd=0.0,
+        session_cost_status="unknown",
+    )
+
+    server._restore_session_usage(
+        agent,
+        {
+            "input_tokens": 120,
+            "output_tokens": 30,
+            "cache_read_tokens": 7,
+            "cache_write_tokens": 3,
+            "reasoning_tokens": 5,
+            "api_call_count": 4,
+            "estimated_cost_usd": 0.0123,
+            "cost_status": "estimated",
+        },
+    )
+
+    assert agent.session_input_tokens == 120
+    assert agent.session_output_tokens == 30
+    assert agent.session_cache_read_tokens == 7
+    assert agent.session_cache_write_tokens == 3
+    assert agent.session_reasoning_tokens == 5
+    assert agent.session_prompt_tokens == 130
+    assert agent.session_completion_tokens == 30
+    assert agent.session_total_tokens == 160
+    assert agent.session_api_calls == 4
+    assert agent.session_estimated_cost_usd == 0.0123
+    assert agent.session_cost_status == "estimated"
+
+
+def test_restore_session_usage_seeds_context_from_resume_history_estimate():
+    agent = types.SimpleNamespace(
+        model="restored-model",
+        session_input_tokens=0,
+        session_output_tokens=0,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_reasoning_tokens=0,
+        session_prompt_tokens=0,
+        session_completion_tokens=0,
+        session_total_tokens=0,
+        session_api_calls=0,
+        context_compressor=types.SimpleNamespace(
+            last_prompt_tokens=0,
+            context_length=1000,
+            compression_count=0,
+        ),
+    )
+
+    server._restore_session_usage(
+        agent,
+        {
+            "input_tokens": 120,
+            "output_tokens": 30,
+            "cache_read_tokens": 7,
+            "cache_write_tokens": 3,
+            "reasoning_tokens": 5,
+            "api_call_count": 4,
+        },
+        context_tokens=64,
+    )
+
+    usage = server._get_usage(agent)
+
+    assert usage["total"] == 160
+    assert usage["context_used"] == 64
+    assert usage["context_max"] == 1000
+    assert usage["context_percent"] == 6
+
+
+def test_restore_session_usage_prefers_persisted_last_prompt_tokens():
+    agent = types.SimpleNamespace(
+        model="restored-model",
+        session_input_tokens=0,
+        session_output_tokens=0,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_reasoning_tokens=0,
+        session_prompt_tokens=0,
+        session_completion_tokens=0,
+        session_total_tokens=0,
+        session_api_calls=0,
+        context_compressor=types.SimpleNamespace(
+            last_prompt_tokens=0,
+            context_length=1000,
+            compression_count=0,
+        ),
+    )
+
+    server._restore_session_usage(
+        agent,
+        {
+            "input_tokens": 120,
+            "output_tokens": 30,
+            "cache_read_tokens": 7,
+            "cache_write_tokens": 3,
+            "reasoning_tokens": 5,
+            "api_call_count": 4,
+            "last_prompt_tokens": 512,
+        },
+        context_tokens=64,
+    )
+
+    usage = server._get_usage(agent)
+
+    assert usage["context_used"] == 512
+    assert usage["context_percent"] == 51
+
+
+def test_get_usage_does_not_use_session_total_for_context_bar(monkeypatch):
+    agent = types.SimpleNamespace(
+        model="restored-model",
+        session_input_tokens=120,
+        session_output_tokens=30,
+        session_cache_read_tokens=7,
+        session_cache_write_tokens=3,
+        session_reasoning_tokens=5,
+        session_prompt_tokens=130,
+        session_completion_tokens=30,
+        session_total_tokens=18_900_000,
+        session_api_calls=4,
+        context_compressor=types.SimpleNamespace(
+            last_prompt_tokens=0,
+            context_length=1_000_000,
+            compression_count=0,
+        ),
+    )
+
+    monkeypatch.setattr("tools.async_delegation.active_count", lambda: 0)
+    usage = server._get_usage(agent)
+
+    assert usage["total"] == 18_900_000
+    assert usage["context_used"] == 0
+    assert usage["context_max"] == 1_000_000
+    assert usage["context_percent"] == 0
+
+
 # ── _get_usage active_subagents (TUI status-bar ⛓ indicator) ──────────────
 # Mirrors the classic CLI status bar: _get_usage embeds a live count of
 # background/async subagents from tools.async_delegation.active_count() so the

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -353,6 +353,12 @@ def test_session_resume_defaults_to_deferred_build(server, monkeypatch):
                 "id": target,
                 "model": "vendor/cool-model",
                 "model_config": {"provider": "vendor"},
+                "input_tokens": 120,
+                "output_tokens": 30,
+                "cache_read_tokens": 7,
+                "cache_write_tokens": 3,
+                "reasoning_tokens": 5,
+                "api_call_count": 4,
             }
 
         def get_session_by_title(self, _title):
@@ -380,6 +386,7 @@ def test_session_resume_defaults_to_deferred_build(server, monkeypatch):
     )
     monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: builds.append(sid))
     monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_resume_context_tokens", lambda history: 42)
 
     resp = server.handle_request(
         {
@@ -403,6 +410,14 @@ def test_session_resume_defaults_to_deferred_build(server, monkeypatch):
     assert result["info"]["lazy"] is True
     assert result["info"]["model"] == "vendor/cool-model"
     assert result["info"]["provider"] == "vendor"
+    assert result["info"]["usage"] == {
+        "calls": 4,
+        "input": 120,
+        "output": 30,
+        "reasoning": 5,
+        "total": 160,
+        "context_used": 42,
+    }
     assert result["info"]["desktop_contract"] == server.DESKTOP_BACKEND_CONTRACT
 
     sid = result["session_id"]
@@ -411,6 +426,8 @@ def test_session_resume_defaults_to_deferred_build(server, monkeypatch):
     # later prompt.submit / _sess() upgrade continues THIS stored conversation.
     assert session["agent"] is None
     assert session["resume_session_id"] == target
+    assert session["resume_stored_usage"]["input_tokens"] == 120
+    assert session["resume_context_tokens"] == 42
     assert not session["agent_ready"].is_set()
     # Not a watch spectator: a normal deferred resume is a real session.
     assert not session.get("lazy")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1206,6 +1206,11 @@ def _start_agent_build(sid: str, session: dict) -> None:
                     if (tier := current.get("create_service_tier_override")) is not None:
                         kw["service_tier_override"] = tier
                 agent = _make_agent(sid, key, **kw)
+                _restore_session_usage(
+                    agent,
+                    current.get("resume_stored_usage"),
+                    context_tokens=_usage_int(current.get("resume_context_tokens")),
+                )
             finally:
                 _clear_session_context(tokens)
 
@@ -2939,7 +2944,7 @@ def _get_usage(agent) -> dict:
     }
     comp = getattr(agent, "context_compressor", None)
     if comp:
-        ctx_used = getattr(comp, "last_prompt_tokens", 0) or usage["total"] or 0
+        ctx_used = _usage_int(getattr(comp, "last_prompt_tokens", 0))
         ctx_max = getattr(comp, "context_length", 0) or 0
         if ctx_max:
             usage["context_used"] = ctx_used
@@ -2964,6 +2969,102 @@ def _get_usage(agent) -> dict:
         except Exception:
             pass
     return usage
+
+
+def _usage_int(value) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _usage_float(value) -> float:
+    try:
+        return max(0.0, float(value or 0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _resume_context_tokens(history: list | None) -> int:
+    """Estimate the context currently loaded by a cold-resumed conversation."""
+    if not history:
+        return 0
+    try:
+        from agent.model_metadata import estimate_messages_tokens_rough
+
+        return _usage_int(estimate_messages_tokens_rough(history))
+    except Exception:
+        return 0
+
+
+def _stored_session_usage(stored: dict | None, *, context_tokens: int = 0) -> dict:
+    """Normalize persisted SessionDB counters into the gateway usage shape."""
+    if not stored:
+        return {"calls": 0, "input": 0, "output": 0, "reasoning": 0, "total": 0}
+    input_tokens = _usage_int(stored.get("input_tokens"))
+    output_tokens = _usage_int(stored.get("output_tokens"))
+    cache_read_tokens = _usage_int(stored.get("cache_read_tokens"))
+    cache_write_tokens = _usage_int(stored.get("cache_write_tokens"))
+    reasoning_tokens = _usage_int(stored.get("reasoning_tokens"))
+    total_tokens = input_tokens + output_tokens + cache_read_tokens + cache_write_tokens
+    context_used = _usage_int(stored.get("last_prompt_tokens")) or _usage_int(context_tokens)
+    usage = {
+        "calls": _usage_int(stored.get("api_call_count")),
+        "input": input_tokens,
+        "output": output_tokens,
+        "reasoning": reasoning_tokens,
+        "total": total_tokens,
+    }
+    if context_used:
+        usage["context_used"] = context_used
+    return usage
+
+
+def _restore_session_usage(agent, stored: dict | None, *, context_tokens: int = 0) -> None:
+    """Restore persisted token counters onto a freshly resumed agent."""
+    if agent is None or not stored:
+        return
+    usage = _stored_session_usage(stored, context_tokens=context_tokens)
+    has_usage = any(
+        _usage_int(stored.get(key))
+        for key in (
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_write_tokens",
+            "reasoning_tokens",
+            "api_call_count",
+        )
+    )
+    has_cost = stored.get("estimated_cost_usd") is not None or stored.get("cost_status")
+    if not has_usage and not has_cost:
+        return
+    setattr(agent, "session_input_tokens", usage["input"])
+    setattr(agent, "session_output_tokens", usage["output"])
+    setattr(agent, "session_cache_read_tokens", _usage_int(stored.get("cache_read_tokens")))
+    setattr(agent, "session_cache_write_tokens", _usage_int(stored.get("cache_write_tokens")))
+    setattr(agent, "session_reasoning_tokens", usage["reasoning"])
+    setattr(
+        agent,
+        "session_prompt_tokens",
+        usage["input"]
+        + _usage_int(stored.get("cache_read_tokens"))
+        + _usage_int(stored.get("cache_write_tokens")),
+    )
+    setattr(agent, "session_completion_tokens", usage["output"])
+    setattr(agent, "session_total_tokens", usage["total"])
+    setattr(agent, "session_api_calls", usage["calls"])
+    if usage.get("context_used"):
+        comp = getattr(agent, "context_compressor", None)
+        if comp is not None and _usage_int(getattr(comp, "last_prompt_tokens", 0)) == 0:
+            try:
+                comp.last_prompt_tokens = usage["context_used"]
+            except Exception:
+                pass
+    if stored.get("estimated_cost_usd") is not None:
+        setattr(agent, "session_estimated_cost_usd", _usage_float(stored.get("estimated_cost_usd")))
+    if stored.get("cost_status"):
+        setattr(agent, "session_cost_status", str(stored.get("cost_status")))
 
 
 def _probe_credentials(agent) -> str:
@@ -5075,7 +5176,13 @@ def _(rid, params: dict) -> dict:
         return _ok(rid, {"verification": {"status": "unknown", "evidence": None}})
 
 
-def _lazy_resume_info(cwd: str, *, model: str = "", provider: str = "") -> dict:
+def _lazy_resume_info(
+    cwd: str,
+    *,
+    model: str = "",
+    provider: str = "",
+    usage: dict | None = None,
+) -> dict:
     """session.info for a not-yet-built session (the shape session.create
     returns). tools/skills land later when the deferred build emits session.info."""
     info = {
@@ -5090,6 +5197,8 @@ def _lazy_resume_info(cwd: str, *, model: str = "", provider: str = "") -> dict:
     }
     if provider:
         info["provider"] = provider
+    if usage:
+        info["usage"] = usage
     return info
 
 
@@ -5107,6 +5216,8 @@ def _deferred_session_record(
     lazy: bool = False,
     model_override=None,
     resume_runtime_overrides: dict | None = None,
+    resume_context_tokens: int = 0,
+    resume_stored_usage: dict | None = None,
 ) -> dict:
     """A live-session record whose AIAgent is built later (lazy watch / cold
     resume) — _init_session's shape minus the agent."""
@@ -5134,6 +5245,8 @@ def _deferred_session_record(
         "model_override": model_override,
         "pending_title": None,
         "profile_home": str(profile_home) if profile_home is not None else None,
+        "resume_context_tokens": _usage_int(resume_context_tokens),
+        "resume_stored_usage": resume_stored_usage,
         "resume_runtime_overrides": resume_runtime_overrides,
         "resume_session_id": session_key,
         "running": False,
@@ -5362,6 +5475,8 @@ def _(rid, params: dict) -> dict:
         # the build drops the provider ("No LLM provider configured").
         overrides = _stored_session_runtime_overrides(found) or {}
         model_override = overrides.get("model_override") or {}
+        resume_context_tokens = _resume_context_tokens(history)
+        stored_usage = _stored_session_usage(found, context_tokens=resume_context_tokens)
         cwd = profile_resume_cwd or os.getenv("TERMINAL_CWD", os.getcwd())
         record = _deferred_session_record(
             target,
@@ -5375,6 +5490,8 @@ def _(rid, params: dict) -> dict:
             profile_home=profile_home,
             model_override=overrides.get("model_override"),
             resume_runtime_overrides=overrides or None,
+            resume_context_tokens=resume_context_tokens,
+            resume_stored_usage=found,
         )
         if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
             return _ok(rid, _reuse_live_payload(*live))
@@ -5394,6 +5511,7 @@ def _(rid, params: dict) -> dict:
                     cwd,
                     model=model_override.get("model") or "",
                     provider=overrides.get("provider_override") or "",
+                    usage=stored_usage,
                 ),
                 "inflight": None,
                 "running": False,
@@ -5439,6 +5557,11 @@ def _(rid, params: dict) -> dict:
                 session_id=target,
                 session_db=db,
                 **stored_runtime_overrides,
+            )
+            _restore_session_usage(
+                agent,
+                found,
+                context_tokens=_resume_context_tokens(history),
             )
         finally:
             _clear_session_context(tokens)


### PR DESCRIPTION
## What does this PR do?

Fixes resumed Desktop sessions reporting incorrect or unstable context usage after the app restarts.

Before this change, `session.resume` rebuilt a fresh gateway agent with zero live usage counters even when `state.db` already had persisted session usage. The Desktop status bar could therefore show `0/1.0M` for existing conversations until another turn updated the live agent.

This also fixes the follow-up instability where resumed context usage could initially show a history-based estimate, then shrink after the next chat turn. The persisted session row stored cumulative token totals but not the last real prompt-token count used by the context bar. After the next model response, `context_compressor.last_prompt_tokens` was replaced with the real API usage, so the status bar could change to a different accounting basis.

This PR restores persisted usage counters on resume, keeps cumulative totals out of `context_used`, and persists `last_prompt_tokens` after each successful model turn so future resumes can restore the same prompt-token basis the live status bar uses.

## Related Issue

N/A. I searched existing open and closed PRs/issues for `session resume context usage` and `last_prompt_tokens context_used` before opening this PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tui_gateway/server.py`
  - Restores persisted session usage counters onto freshly resumed agents.
  - Includes restored usage in the default deferred `session.resume` response.
  - Uses persisted `last_prompt_tokens` for resumed context usage when present.
  - Falls back to a rough loaded-history estimate only for legacy rows without stored prompt-token usage.
  - Removes the fallback that treated cumulative session total tokens as current `context_used`.
- `hermes_state.py`
  - Adds `sessions.last_prompt_tokens` with declarative schema reconciliation for existing databases.
  - Extends `SessionDB.update_token_counts()` so callers can persist the most recent prompt-token count without disturbing existing values when omitted.
- `agent/conversation_loop.py`
  - Persists the real prompt-token count returned by normal model responses.
- `agent/codex_runtime.py`
  - Persists the real prompt-token count returned by the Codex app-server runtime.
- Tests cover deferred resume payloads, restored counters, legacy estimate fallback, persisted `last_prompt_tokens` precedence, cumulative-total isolation, token-count DB updates, and Codex app-server persistence.

## How to Test

1. Run targeted resume/context usage tests:

   ```sh
   HERMES_HOME=/private/tmp/hermes-pr-refine/test-home PYTHONDONTWRITEBYTECODE=1 /Users/pink/.hermes/hermes-agent/.venv/bin/python -m pytest tests/test_hermes_state.py::TestSessionLifecycle::test_update_token_counts tests/test_hermes_state.py::TestSessionLifecycle::test_update_token_counts_tracks_last_prompt_tokens tests/test_hermes_state.py::TestSessionLifecycle::test_update_token_counts_tracks_api_call_count tests/test_hermes_state.py::TestSessionLifecycle::test_update_token_counts_api_call_count_absolute tests/test_tui_gateway_server.py::test_restore_session_usage_copies_persisted_counters_to_agent tests/test_tui_gateway_server.py::test_restore_session_usage_seeds_context_from_resume_history_estimate tests/test_tui_gateway_server.py::test_restore_session_usage_prefers_persisted_last_prompt_tokens tests/test_tui_gateway_server.py::test_get_usage_does_not_use_session_total_for_context_bar tests/tui_gateway/test_protocol.py::test_session_resume_defaults_to_deferred_build tests/run_agent/test_codex_app_server_integration.py::TestRunConversationCodexPath::test_codex_app_server_token_usage_updates_session_accounting -q -p no:cacheprovider
   ```

   Result: `10 passed`

2. Check whitespace:

   ```sh
   git diff --check
   ```

   Result: passed

3. Manual Desktop verification:
   - On macOS 26.3.1, restarted the source Desktop app and opened existing sessions.
   - Verified the status bar no longer stayed at `0/1.0M` after restart/session switch.
   - Verified the status bar no longer displayed cumulative usage as current context, e.g. `18.9M/1.0M`.
   - Verified after chatting once, the restored context usage no longer jumped from a history estimate to a different live prompt-token basis for sessions with persisted `last_prompt_tokens`.

## Regression Risk

The database migration is additive: existing `state.db` files receive a nullable/defaulted `last_prompt_tokens` column through the existing schema reconciliation path. Legacy sessions created before this column exists can still use the rough loaded-history estimate until a successful model turn persists a real prompt-token count.

## Screenshots / Logs

Manual Desktop verification was performed locally; no screenshot is attached.