### PR TITLE
fix(desktop): respect IME enter in edit composer

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -12,6 +12,7 @@ import {
   useRef,
   useState
 } from 'react'
+import { flushSync } from 'react-dom'
 
 import { COMPOSER_DROP_ACTIVE_CLASS, COMPOSER_DROP_FADE_CLASS } from '@/app/chat/composer/drop-affordance'
 import {
@@ -82,6 +83,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   const editorRef = useRef<HTMLDivElement | null>(null)
   const draftRef = useRef(draft)
   const dragDepthRef = useRef(0)
+  const composingRef = useRef(false)
   const [dragActive, setDragActive] = useState(false)
   const [trigger, setTrigger] = useState<TriggerState | null>(null)
   const [triggerActive, setTriggerActive] = useState(0)
@@ -473,6 +475,12 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
       editor.replaceChildren()
     }
 
+    // IME input events contain uncommitted preedit text. Keep it in the DOM
+    // until compositionend, when the finalized text is flushed to the draft.
+    if (composingRef.current) {
+      return
+    }
+
     syncDraftFromEditor(editor)
     window.setTimeout(refreshTrigger, 0)
   }
@@ -526,6 +534,12 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   )
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    // During IME composition, Enter confirms the candidate instead of
+    // submitting the edited message.
+    if (composingRef.current || event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) {
+      return
+    }
+
     if (trigger && triggerItems.length > 0) {
       if (event.key === 'ArrowDown') {
         event.preventDefault()
@@ -639,6 +653,16 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
               data-placeholder={copy.editMessage}
               data-slot={RICH_INPUT_SLOT}
               onBlur={() => window.setTimeout(closeTrigger, 80)}
+              onCompositionEnd={event => {
+                composingRef.current = false
+                flushSync(() => {
+                  syncDraftFromEditor(event.currentTarget)
+                })
+                window.setTimeout(refreshTrigger, 0)
+              }}
+              onCompositionStart={() => {
+                composingRef.current = true
+              }}
               onDragOver={handleDragOver}
               onDrop={handleDrop}
               onFocus={() => markActiveComposer('edit')}

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
@@ -7,7 +7,12 @@ import { ExportedMessageRepository } from '@assistant-ui/react'
 // mode (titlebar -webkit-app-region:drag swallowing clicks on *stuck* sticky
 // bubbles) is not reproducible in jsdom — see USER_BUBBLE_BASE_CLASS's no-drag
 // carve-out in thread.tsx.
-import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import {
+  type AppendMessage,
+  AssistantRuntimeProvider,
+  type ThreadMessage,
+  useExternalStoreRuntime
+} from '@assistant-ui/react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -79,7 +84,9 @@ function assistantMessage(): ThreadMessage {
 }
 
 // Mirrors chat/index.tsx: incremental runtime + messageRepository + onEdit.
-function IncrementalHarness({ onEdit }: { onEdit: () => Promise<void> }) {
+type EditHandler = (message: AppendMessage) => Promise<void>
+
+function IncrementalHarness({ onEdit }: { onEdit: EditHandler }) {
   const repository = ExportedMessageRepository.fromArray([userMessage(), assistantMessage()])
 
   const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
@@ -100,7 +107,7 @@ function IncrementalHarness({ onEdit }: { onEdit: () => Promise<void> }) {
 }
 
 // Control: stock external store runtime.
-function StockHarness({ onEdit }: { onEdit: () => Promise<void> }) {
+function StockHarness({ onEdit }: { onEdit: EditHandler }) {
   const runtime = useExternalStoreRuntime<ThreadMessage>({
     messages: [userMessage(), assistantMessage()],
     isRunning: false,
@@ -138,5 +145,83 @@ describe('click-to-edit user message', () => {
     await waitFor(() => {
       expect(container.querySelector('[data-slot="aui_edit-composer-root"]')).toBeTruthy()
     })
+  })
+
+  it('does not submit or commit IME input until composition ends', async () => {
+    const onEdit = vi.fn(async (_message: AppendMessage) => {})
+
+    render(<IncrementalHarness onEdit={onEdit} />)
+
+    const bubble = await screen.findByRole('button', { name: 'Edit message' })
+
+    fireEvent.click(bubble)
+
+    const editor = await screen.findByRole('textbox', { name: 'Edit message' })
+    const draft = editor.parentElement?.querySelector<HTMLTextAreaElement>('textarea[name="input"]')
+
+    expect(draft?.value).toBe('edit me please')
+
+    fireEvent.compositionStart(editor)
+    editor.textContent = 'に'
+    fireEvent.input(editor)
+    editor.textContent = 'こんにちは'
+    fireEvent.input(editor)
+
+    expect(draft?.value).toBe('edit me please')
+
+    fireEvent.keyDown(editor, { key: 'Enter' })
+
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+    expect(onEdit).not.toHaveBeenCalled()
+    expect(draft?.value).toBe('edit me please')
+
+    fireEvent.compositionEnd(editor)
+
+    await waitFor(() => {
+      expect(draft?.value).toBe('こんにちは')
+    })
+
+    fireEvent.keyDown(editor, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(onEdit).toHaveBeenCalledTimes(1)
+    })
+
+    expect(onEdit.mock.calls[0]?.[0].content).toEqual([{ type: 'text', text: 'こんにちは' }])
+  })
+
+  it('ignores Chromium IME Enter after composition ends and submits the finalized draft on a later Enter', async () => {
+    const onEdit = vi.fn(async (_message: AppendMessage) => {})
+
+    render(<IncrementalHarness onEdit={onEdit} />)
+
+    const bubble = await screen.findByRole('button', { name: 'Edit message' })
+
+    fireEvent.click(bubble)
+
+    const editor = await screen.findByRole('textbox', { name: 'Edit message' })
+    const draft = editor.parentElement?.querySelector<HTMLTextAreaElement>('textarea[name="input"]')
+
+    fireEvent.compositionStart(editor)
+    editor.textContent = 'こんにちは'
+    fireEvent.input(editor)
+    fireEvent.compositionEnd(editor)
+
+    await waitFor(() => {
+      expect(draft?.value).toBe('こんにちは')
+    })
+
+    fireEvent.keyDown(editor, { key: 'Enter', isComposing: false, keyCode: 229 })
+
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+    expect(onEdit).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(editor, { key: 'Enter', isComposing: false, keyCode: 13 })
+
+    await waitFor(() => {
+      expect(onEdit).toHaveBeenCalledTimes(1)
+    })
+
+    expect(onEdit.mock.calls[0]?.[0].content).toEqual([{ type: 'text', text: 'こんにちは' }])
   })
 })


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop app's inline user-message edit composer so Enter during IME composition confirms the candidate text instead of submitting the edited message.

The main message composer already tracks `compositionstart`/`compositionend` and ignores keydown while composing. This applies the same behavior to the current edit composer path (`user-edit-composer.tsx`), then flushes the finalized composition on composition end.

Guards:
- `nativeEvent.isComposing`
- local composition ref
- `keyCode === 229` (legacy IME enter on some platforms)

## Test plan
- [x] Focused Vitest IME + sanitizer: 12/12
- [x] Typecheck under Node 22
- [x] Full Desktop Vitest: 1,696 passed, 1 skipped (prior full run) + eslint/build
- [x] Rebased onto current main with range-diff equivalent patch

New head: `3374c099e0dab370f10ce9c421337343bfae1af1`
