### PR TITLE
fix(desktop): route compress through session rpc

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -5,7 +5,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { textPart } from '@/lib/chat-messages'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
-import { $busy, $connection, $messages, $sessions, $turnStartedAt, setSessions } from '@/store/session'
+import {
+  $busy,
+  $connection,
+  $currentUsage,
+  $messages,
+  $sessions,
+  $turnStartedAt,
+  setCurrentUsage,
+  setMessages,
+  setSessions
+} from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
 import { uploadComposerAttachment, usePromptActions } from '.'
@@ -85,7 +95,7 @@ function Harness({
   onSeedState?: (state: Record<string, unknown>) => void
   openMemoryGraph?: () => void
   refreshSessions: () => Promise<void>
-  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  requestGateway: <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
   resumeStoredSession?: (storedSessionId: string) => Promise<void> | void
   seedMessages?: unknown[]
   selectedStoredSessionIdRef?: MutableRefObject<string | null>
@@ -377,6 +387,195 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
 
     expect($composerDraft.get()).toBe('/ pasted context that must not vanish')
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+  })
+
+  it('keeps the slash-worker failure when command.dispatch only adds unknown-command noise', async () => {
+    const states: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'slash.exec') {
+        throw new Error('slash worker timed out')
+      }
+
+      if (method === 'command.dispatch') {
+        throw new Error('not a quick/plugin/skill command: status')
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={state => states.push(state)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/status')
+
+    const renderedText = states
+      .flatMap(state => state.messages as Array<{ parts?: Array<{ text?: string }> }>)
+      .flatMap(message => (message.parts ?? []).map(part => part.text ?? ''))
+      .join('\n')
+
+    expect(renderedText).toContain('error: /status failed: slash worker timed out')
+    expect(renderedText).not.toContain('not a quick/plugin/skill command: status')
+  })
+})
+
+describe('usePromptActions /compress session isolation', () => {
+  const RUNTIME_SESSION_B = 'rt-session-b'
+
+  afterEach(() => {
+    cleanup()
+    setCurrentUsage({ calls: 0, input: 0, output: 0, total: 0 })
+    setMessages([])
+    vi.restoreAllMocks()
+  })
+
+  it('does not replace the foreground transcript or usage when compression resolves after a session switch', async () => {
+    let resolveCompress: (value: unknown) => void = () => undefined
+
+    const compressResult = new Promise(resolve => {
+      resolveCompress = resolve
+    })
+
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: RUNTIME_SESSION_ID }
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.compress') {
+        return (await compressResult) as never
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    setMessages([{ id: 'foreground-b', parts: [textPart('session B transcript')], role: 'user' }])
+    setCurrentUsage({ calls: 7, input: 70, output: 30, total: 100 })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        activeSessionIdRef={activeSessionIdRef}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    const submitted = handle!.submitText('/compress')
+    await waitFor(() =>
+      expect(requestGateway).toHaveBeenCalledWith('session.compress', { session_id: RUNTIME_SESSION_ID }, 0)
+    )
+
+    activeSessionIdRef.current = RUNTIME_SESSION_B
+    resolveCompress({
+      info: { usage: { context_used: 4_000, total: 12_000 } },
+      messages: [{ content: 'compressed session A transcript', role: 'system' }],
+      removed: 5
+    })
+    await submitted
+
+    expect($messages.get()).toEqual([{ id: 'foreground-b', parts: [textPart('session B transcript')], role: 'user' }])
+    expect($currentUsage.get()).toEqual({ calls: 7, input: 70, output: 30, total: 100 })
+  })
+
+  it('replaces the target transcript with the authoritative compression result and renders its summary', async () => {
+    const states: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.compress') {
+        return {
+          usage: { context_used: 4_000, total: 12_000 },
+          messages: [{ content: 'compressed transcript', role: 'system' }],
+          removed: 5,
+          summary: {
+            headline: 'Compressed: 8 → 3 messages',
+            token_line: 'Approx request size: ~12,000 → ~4,000 tokens'
+          }
+        } as never
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={state => states.push(state)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/compress')
+
+    expect(requestGateway).toHaveBeenCalledWith('session.compress', { session_id: RUNTIME_SESSION_ID }, 0)
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+
+    const renderedText = states
+      .flatMap(state => state.messages as Array<{ parts?: Array<{ text?: string }> }>)
+      .flatMap(message => (message.parts ?? []).map(part => part.text ?? ''))
+      .join('\n')
+
+    expect(renderedText).toContain('compressed transcript')
+    expect(renderedText).toContain('Compressed: 8 → 3 messages')
+    expect(renderedText).toContain('Approx request size: ~12,000 → ~4,000 tokens')
+    expect($currentUsage.get()).toEqual(expect.objectContaining({ context_used: 4_000, total: 12_000 }))
+  })
+
+  it('passes a focus topic to session.compress', async () => {
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.compress') {
+        return { removed: 0 } as never
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    await handle!.submitText('/compress the auth refactor')
+
+    expect(requestGateway).toHaveBeenCalledWith(
+      'session.compress',
+      { focus_topic: 'the auth refactor', session_id: RUNTIME_SESSION_ID },
+      0
+    )
+  })
+
+  it('renders a session.compress busy error inline', async () => {
+    const states: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async () => {
+      throw new Error('session busy — /interrupt the current turn before /compress')
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={state => states.push(state)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/compress')
+
+    const renderedText = states
+      .flatMap(state => state.messages as Array<{ parts?: Array<{ text?: string }> }>)
+      .flatMap(message => (message.parts ?? []).map(part => part.text ?? ''))
+      .join('\n')
+
+    expect(renderedText).toContain('error: session busy — /interrupt the current turn before /compress')
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { textPart } from '@/lib/chat-messages'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
+import { $notifications, clearNotifications } from '@/store/notifications'
 import {
   $busy,
   $connection,
@@ -69,6 +70,7 @@ interface HarnessHandle {
   cancelRun: () => Promise<void>
   restoreToMessage: (messageId: string, target?: { text?: string; userOrdinal?: number | null }) => Promise<void>
   steerPrompt: (text: string) => Promise<boolean>
+  submitTextRaw: (text: string, options?: { attachments?: ComposerAttachment[]; fromQueue?: boolean }) => Promise<boolean>
   submitText: (text: string, options?: { attachments?: ComposerAttachment[]; fromQueue?: boolean }) => Promise<boolean>
 }
 
@@ -153,6 +155,7 @@ function Harness({
         act(async () => actions.restoreToMessage(...args)) as Promise<void>,
       steerPrompt: (...args: Parameters<typeof actions.steerPrompt>) =>
         act(async () => actions.steerPrompt(...args)) as Promise<boolean>,
+      submitTextRaw: actions.submitText,
       submitText: (...args: Parameters<typeof actions.submitText>) =>
         act(async () => actions.submitText(...args)) as Promise<boolean>
     })
@@ -168,6 +171,7 @@ describe('usePromptActions /title', () => {
 
   afterEach(() => {
     cleanup()
+    clearNotifications()
     vi.restoreAllMocks()
   })
 
@@ -431,6 +435,7 @@ describe('usePromptActions /compress session isolation', () => {
 
   afterEach(() => {
     cleanup()
+    clearNotifications()
     setCurrentUsage({ calls: 0, input: 0, output: 0, total: 0 })
     setMessages([])
     vi.restoreAllMocks()
@@ -483,7 +488,7 @@ describe('usePromptActions /compress session isolation', () => {
     expect($currentUsage.get()).toEqual({ calls: 7, input: 70, output: 30, total: 100 })
   })
 
-  it('replaces the target transcript with the authoritative compression result and renders its summary', async () => {
+  it('leaves the target transcript equal to the authoritative compression result', async () => {
     const states: Record<string, unknown>[] = []
 
     const requestGateway = vi.fn(async (method: string) => {
@@ -517,15 +522,71 @@ describe('usePromptActions /compress session isolation', () => {
     expect(requestGateway).toHaveBeenCalledWith('session.compress', { session_id: RUNTIME_SESSION_ID }, 0)
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
 
-    const renderedText = states
-      .flatMap(state => state.messages as Array<{ parts?: Array<{ text?: string }> }>)
+    const finalMessages = states[states.length - 1]?.messages as Array<{ parts?: Array<{ text?: string }> }>
+    const renderedText = finalMessages
       .flatMap(message => (message.parts ?? []).map(part => part.text ?? ''))
       .join('\n')
 
-    expect(renderedText).toContain('compressed transcript')
-    expect(renderedText).toContain('Compressed: 8 → 3 messages')
-    expect(renderedText).toContain('Approx request size: ~12,000 → ~4,000 tokens')
+    expect(renderedText).toBe('compressed transcript')
     expect($currentUsage.get()).toEqual(expect.objectContaining({ context_used: 4_000, total: 12_000 }))
+  })
+
+  it('coalesces repeated compression requests for one runtime session', async () => {
+    let resolveCompress: (value: unknown) => void = () => undefined
+    const compressResult = new Promise(resolve => {
+      resolveCompress = resolve
+    })
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.compress') {
+        return (await compressResult) as never
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    const first = handle!.submitTextRaw('/compress')
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledTimes(1))
+
+    const second = handle!.submitTextRaw('/compress')
+    try {
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      await waitFor(() => expect(requestGateway).toHaveBeenCalledTimes(1))
+    } finally {
+      resolveCompress({ messages: [{ content: 'compressed transcript', role: 'system' }] })
+      await Promise.all([first, second])
+    }
+  })
+
+  it('shows compression progress outside the authoritative transcript', async () => {
+    let resolveCompress: (value: unknown) => void = () => undefined
+    const compressResult = new Promise(resolve => {
+      resolveCompress = resolve
+    })
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.compress') {
+        return (await compressResult) as never
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    const submitted = handle!.submitTextRaw('/compress')
+    await waitFor(() => expect($notifications.get().some(item => item.message === 'compressing context...')).toBe(true))
+    resolveCompress({ messages: [{ content: 'compressed transcript', role: 'system' }] })
+    await submitted
   })
 
   it('passes a focus topic to session.compress', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -210,7 +210,7 @@ export function usePromptActions({
   const copy = t.desktop
 
   const appendSessionTextMessage = useCallback(
-    (sessionId: string, role: ChatMessage['role'], text: string) => {
+    (sessionId: string, role: ChatMessage['role'], text: string, storedSessionId = selectedStoredSessionIdRef.current) => {
       // Strip ANSI: slash-command output from the backend worker carries SGR
       // color codes (e.g. "Unknown command" in red). The ESC byte is invisible
       // in the chat panel, so without this the `[1;31m…[0m` payload leaks as
@@ -234,7 +234,7 @@ export function usePromptActions({
             }
           ]
         }),
-        selectedStoredSessionIdRef.current
+        storedSessionId
       )
     },
     [selectedStoredSessionIdRef, updateSessionState]
@@ -465,8 +465,10 @@ export function usePromptActions({
     refreshSessions,
     requestGateway,
     resumeStoredSession,
+    selectedStoredSessionIdRef,
     startFreshSessionDraft,
-    submitPromptText
+    submitPromptText,
+    updateSessionState
   })
 
   const submitText = useCallback(

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -2,7 +2,7 @@ import { type MutableRefObject, useCallback } from 'react'
 
 import { getProfiles } from '@/hermes'
 import type { Translations } from '@/i18n'
-import { type ChatMessage } from '@/lib/chat-messages'
+import { type ChatMessage, toChatMessages } from '@/lib/chat-messages'
 import { parseCommandDispatch, parseSlashCommand, sessionTitle } from '@/lib/chat-runtime'
 import {
   type CommandsCatalogLike,
@@ -23,13 +23,20 @@ import {
   $connection,
   $sessions,
   $yoloActive,
+  setCurrentUsage,
   setModelPickerOpen,
   setSessionPickerOpen,
   setSessions,
   setYoloActive
 } from '@/store/session'
 
-import type { BrowserManageResponse, SessionTitleResponse, SlashExecResponse } from '../../../types'
+import type {
+  BrowserManageResponse,
+  ClientSessionState,
+  SessionCompressResponse,
+  SessionTitleResponse,
+  SlashExecResponse
+} from '../../../types'
 
 import { type GatewayRequest, isSessionIdCandidate, renderCommandsCatalog, slashStatusText } from './utils'
 
@@ -44,7 +51,12 @@ interface SlashActionCtx {
 
 interface SlashCommandDeps {
   activeSessionIdRef: MutableRefObject<string | null>
-  appendSessionTextMessage: (sessionId: string, role: ChatMessage['role'], text: string) => void
+  appendSessionTextMessage: (
+    sessionId: string,
+    role: ChatMessage['role'],
+    text: string,
+    storedSessionId?: string | null
+  ) => void
   branchCurrentSession: () => Promise<boolean>
   busyRef: MutableRefObject<boolean>
   copy: Translations['desktop']
@@ -58,11 +70,17 @@ interface SlashCommandDeps {
   refreshSessions: () => Promise<void>
   requestGateway: GatewayRequest
   resumeStoredSession: (storedSessionId: string) => Promise<void> | void
+  selectedStoredSessionIdRef: MutableRefObject<string | null>
   startFreshSessionDraft: () => void
   submitPromptText: (
     rawText: string,
     options?: { attachments?: ComposerAttachment[]; fromQueue?: boolean }
   ) => Promise<boolean>
+  updateSessionState: (
+    sessionId: string,
+    updater: (state: ClientSessionState) => ClientSessionState,
+    storedSessionId?: string | null
+  ) => ClientSessionState
 }
 
 /** The /slash command dispatcher, extracted from usePromptActions. */
@@ -80,8 +98,10 @@ export function useSlashCommand(deps: SlashCommandDeps) {
     refreshSessions,
     requestGateway,
     resumeStoredSession,
+    selectedStoredSessionIdRef,
     startFreshSessionDraft,
-    submitPromptText
+    submitPromptText,
+    updateSessionState
   } = deps
 
   return useCallback(
@@ -103,8 +123,17 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           return null
         }
 
+        // A long-running command can finish after a session switch. Keep its
+        // output bound to the stored session selected at invocation time.
+        const storedSessionId = selectedStoredSessionIdRef.current
+
         const render = (text: string) =>
-          appendSessionTextMessage(sessionId, 'system', ctx.recordInput ? slashStatusText(ctx.command, text) : text)
+          appendSessionTextMessage(
+            sessionId,
+            'system',
+            ctx.recordInput ? slashStatusText(ctx.command, text) : text,
+            storedSessionId
+          )
 
         return { render, sessionId }
       }
@@ -184,6 +213,8 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           await submitPromptText(message)
         }
 
+        let slashExecError: unknown = null
+
         try {
           const result = await requestGateway<unknown>('slash.exec', {
             session_id: sessionId,
@@ -203,8 +234,10 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           renderSlashOutput(output?.warning ? `warning: ${output.warning}\n${body}` : body)
 
           return
-        } catch {
-          // Fall back to command.dispatch for skill/send/alias directives.
+        } catch (err) {
+          // Fall back to command.dispatch for skill/send/alias directives, but
+          // keep the worker error so a generic dispatch miss cannot mask it.
+          slashExecError = err
         }
 
         try {
@@ -220,7 +253,16 @@ export function useSlashCommand(deps: SlashCommandDeps) {
 
           await handleDispatch(dispatch)
         } catch (err) {
-          renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
+          const dispatchMessage = err instanceof Error ? err.message : String(err)
+
+          if (slashExecError && /not a quick\/plugin\/skill command/i.test(dispatchMessage)) {
+            const original = slashExecError instanceof Error ? slashExecError.message : String(slashExecError)
+            renderSlashOutput(`error: /${name} failed: ${original}`)
+
+            return
+          }
+
+          renderSlashOutput(`error: ${dispatchMessage}`)
         }
       }
 
@@ -233,6 +275,65 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         },
         branch: async () => {
           await branchCurrentSession()
+        },
+        compress: async ctx => {
+          const resolved = await withSlashOutput(ctx)
+
+          if (!resolved) {
+            return
+          }
+
+          const { render: renderSlashOutput, sessionId } = resolved
+          const focusTopic = ctx.arg.trim()
+
+          try {
+            renderSlashOutput(focusTopic ? `compressing context for: ${focusTopic}` : 'compressing context...')
+
+            const result = await requestGateway<SessionCompressResponse>(
+              'session.compress',
+              {
+                session_id: sessionId,
+                ...(focusTopic ? { focus_topic: focusTopic } : {})
+              },
+              0
+            )
+
+            if (Array.isArray(result?.messages)) {
+              const compressedMessages = toChatMessages(result.messages)
+
+              // updateSessionState only publishes for the active runtime. A late
+              // result therefore refreshes its own cache without clobbering the
+              // foreground session's transcript.
+              updateSessionState(sessionId, state => ({ ...state, messages: compressedMessages }))
+            }
+
+            const usage = { ...result?.usage, ...result?.info?.usage }
+
+            if (Object.keys(usage).length && activeSessionIdRef.current === sessionId) {
+              setCurrentUsage(current => ({ ...current, ...usage }))
+            }
+
+            if (result?.info?.title !== undefined) {
+              setSessions(prev =>
+                prev.map(session => (session.id === sessionId ? { ...session, title: result.info!.title || null } : session))
+              )
+            }
+
+            if (result?.summary?.headline) {
+              renderSlashOutput(
+                [result.summary.headline, result.summary.token_line, result.summary.note]
+                  .filter((line): line is string => Boolean(line))
+                  .join('\n')
+              )
+
+              return
+            }
+
+            const removed = result?.removed ?? 0
+            renderSlashOutput(removed > 0 ? `compressed ${removed} messages` : 'nothing to compress')
+          } catch (err) {
+            renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
+          }
         },
         // /yolo maps to the status-bar YOLO control — a per-session approval
         // bypass, same scope as the TUI's Shift+Tab. With no session yet we arm
@@ -625,8 +726,10 @@ export function useSlashCommand(deps: SlashCommandDeps) {
       refreshSessions,
       requestGateway,
       resumeStoredSession,
+      selectedStoredSessionIdRef,
       startFreshSessionDraft,
-      submitPromptText
+      submitPromptText,
+      updateSessionState
     ]
   )
 }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -1,4 +1,4 @@
-import { type MutableRefObject, useCallback } from 'react'
+import { type MutableRefObject, useCallback, useRef } from 'react'
 
 import { getProfiles } from '@/hermes'
 import type { Translations } from '@/i18n'
@@ -15,7 +15,7 @@ import {
 import { setSessionYolo } from '@/lib/yolo-session'
 import { openCommandPalettePage } from '@/store/command-palette'
 import { type ComposerAttachment, setComposerDraft } from '@/store/composer'
-import { notify, notifyError } from '@/store/notifications'
+import { dismissNotification, notify, notifyError } from '@/store/notifications'
 import { setPetScale } from '@/store/pet-gallery'
 import { $petGenInput, openPetGenerate } from '@/store/pet-generate'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
@@ -103,6 +103,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
     submitPromptText,
     updateSessionState
   } = deps
+  const compressInFlightRef = useRef(new Set<string>())
 
   return useCallback(
     async (rawCommand: string, options?: { sessionId?: string; recordInput?: boolean }) => {
@@ -285,10 +286,21 @@ export function useSlashCommand(deps: SlashCommandDeps) {
 
           const { render: renderSlashOutput, sessionId } = resolved
           const focusTopic = ctx.arg.trim()
+          const noticeId = `session-compress:${sessionId}`
+
+          if (compressInFlightRef.current.has(sessionId)) {
+            return
+          }
+
+          compressInFlightRef.current.add(sessionId)
+          notify({
+            durationMs: 0,
+            id: noticeId,
+            kind: 'info',
+            message: focusTopic ? `compressing context for: ${focusTopic}` : 'compressing context...'
+          })
 
           try {
-            renderSlashOutput(focusTopic ? `compressing context for: ${focusTopic}` : 'compressing context...')
-
             const result = await requestGateway<SessionCompressResponse>(
               'session.compress',
               {
@@ -320,19 +332,30 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             }
 
             if (result?.summary?.headline) {
-              renderSlashOutput(
-                [result.summary.headline, result.summary.token_line, result.summary.note]
+              notify({
+                durationMs: 5_000,
+                id: noticeId,
+                kind: 'success',
+                message: [result.summary.headline, result.summary.token_line, result.summary.note]
                   .filter((line): line is string => Boolean(line))
                   .join('\n')
-              )
+              })
 
               return
             }
 
             const removed = result?.removed ?? 0
-            renderSlashOutput(removed > 0 ? `compressed ${removed} messages` : 'nothing to compress')
+            notify({
+              durationMs: 5_000,
+              id: noticeId,
+              kind: 'success',
+              message: removed > 0 ? `compressed ${removed} messages` : 'nothing to compress'
+            })
           } catch (err) {
+            dismissNotification(noticeId)
             renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
+          } finally {
+            compressInFlightRef.current.delete(sessionId)
           }
         },
         // /yolo maps to the status-bar YOLO control — a per-session approval

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -1,6 +1,7 @@
 import type * as React from 'react'
 
 import type { ChatMessage } from '@/lib/chat-messages'
+import type { SessionMessage, UsageStats } from '@/types/hermes'
 
 export interface ContextSuggestion {
   text: string
@@ -50,6 +51,21 @@ export interface BrowserManageResponse {
   connected?: boolean
   url?: string
   messages?: string[]
+}
+
+export interface SessionCompressResponse {
+  info?: {
+    title?: string
+    usage?: Partial<UsageStats>
+  }
+  messages?: SessionMessage[]
+  removed?: number
+  summary?: {
+    headline?: string
+    note?: null | string
+    token_line?: string
+  }
+  usage?: Partial<UsageStats>
 }
 
 export interface SessionSteerResponse {

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -73,6 +73,10 @@ describe('desktop slash command curation', () => {
     expect(resolveDesktopCommand('/browser')?.args).toBe(true)
   })
 
+  it('routes /compress through the session-compression action', () => {
+    expect(resolveDesktopCommand('/compress')?.surface).toEqual({ kind: 'action', action: 'compress' })
+  })
+
   it('routes /journey (and aliases) to the memory graph overlay action', () => {
     expect(resolveDesktopCommand('/journey')?.surface).toEqual({ kind: 'action', action: 'journey' })
     expect(resolveDesktopCommand('/memory-graph')?.surface).toEqual({ kind: 'action', action: 'journey' })

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -31,6 +31,7 @@ export interface DesktopThemeCommandOption {
 export type DesktopActionId =
   | 'branch'
   | 'browser'
+  | 'compress'
   | 'handoff'
   | 'hatch'
   | 'help'
@@ -148,7 +149,7 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     surface: exec()
   },
   { name: '/background', description: 'Run a prompt in the background', aliases: ['/bg', '/btw'], surface: exec() },
-  { name: '/compress', description: 'Compress this conversation context', surface: exec() },
+  { name: '/compress', description: 'Compress this conversation context', surface: action('compress') },
   { name: '/debug', description: 'Create a debug report', surface: exec() },
   { name: '/goal', description: 'Manage the standing goal for this session', surface: exec() },
   { name: '/personality', description: 'Switch personality for this session', surface: exec(), args: true },


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop `/compress` running through the generic slash-command fallback path.

Before this change, Desktop submitted `/compress` to `slash.exec`, then fell back through `command.dispatch` when the worker did not provide an immediate frontend command result. For long compression runs, the UI could show no useful in-progress state, eventually render fallback noise such as `not a quick/plugin/skill command: compress`, or surface a frontend timeout even though backend compression completed.

This PR routes Desktop `/compress` directly to the existing `session.compress` RPC. The composer now shows a compression progress message immediately, waits for the backend result without the default frontend timeout, refreshes usage/message state from the result, and renders the backend summary instead of the generic fallback error.

## Related Issue

N/A. I searched existing open and closed PRs/issues for `Desktop compress session.compress timeout` before opening this PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/lib/desktop-slash-commands.ts`
  - Changes `/compress` from a generic exec command to a Desktop action.
- `apps/desktop/src/app/session/hooks/use-prompt-actions.ts`
  - Adds the Desktop `/compress` action handler.
  - Calls `session.compress` directly with no client timeout.
  - Shows a `compressing context...` progress message.
  - Updates current usage, session title, and rendered messages from the compression result.
  - Preserves the original `slash.exec` error when `command.dispatch` only adds unknown-command fallback noise.
- `apps/desktop/src/app/types.ts`
  - Adds the `SessionCompressResponse` shape used by the Desktop handler.
- Tests cover the direct `/compress` route, focused compression topics, busy errors, slash fallback error preservation, and the command registry mapping.

## How to Test

1. Run the targeted Desktop UI tests:

   ```sh
   npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-prompt-actions.test.tsx src/lib/desktop-slash-commands.test.ts
   ```

   Result: `2 passed`, `55 passed`

2. Run Desktop typecheck:

   ```sh
   npm --workspace apps/desktop run typecheck
   ```

   Result: passed

3. Check whitespace:

   ```sh
   git diff --check
   ```

   Result: passed

4. Manual Desktop verification:
   - On macOS 26.3.1, ran `/compress` from the source Desktop app.
   - Verified Desktop immediately displayed `compressing context...`.
   - Verified completion did not show `not a quick/plugin/skill command: compress`.
   - Verified completion no longer surfaced the frontend `request timed out: session.compress` error.

## Screenshots / Logs

Before, `/compress` could complete on the backend but render a frontend timeout:

![Before: Desktop compress shows request timed out](https://raw.githubusercontent.com/PINKIIILQWQ/hermes-agent/refs/heads/codex/pr-assets-desktop-compress-route/desktop-compress-before-timeout.png)

After, the Desktop UI renders the backend compression summary instead of the fallback timeout/error:

![After: Desktop compress shows compressed message summary](https://raw.githubusercontent.com/PINKIIILQWQ/hermes-agent/refs/heads/codex/pr-assets-desktop-compress-route/desktop-compress-after.png)