### PR TITLE
fix: clear ended_at metadata when messages are appended to an ended session

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2802,12 +2802,14 @@ class SessionDB:
             if num_tool_calls > 0:
                 conn.execute(
                     """UPDATE sessions SET message_count = message_count + 1,
-                       tool_call_count = tool_call_count + ? WHERE id = ?""",
+                       tool_call_count = tool_call_count + ?,
+                       ended_at = NULL, end_reason = NULL WHERE id = ?""",
                     (num_tool_calls, session_id),
                 )
             else:
                 conn.execute(
-                    "UPDATE sessions SET message_count = message_count + 1 WHERE id = ?",
+                    "UPDATE sessions SET message_count = message_count + 1, "
+                    "ended_at = NULL, end_reason = NULL WHERE id = ?",
                     (session_id,),
                 )
             return msg_id

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3114,11 +3114,13 @@ class TestListSessionsRich:
         db.create_session("root1", "cli")
         with db._lock:
             db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "root1"))
+        # Message comes BEFORE the session is ended (realistic order)
+        db.append_message("root1", "user", "old ask")
+        with db._lock:
             db._conn.execute(
                 "UPDATE sessions SET ended_at=?, end_reason=? WHERE id=?",
                 (t0 + 100, "compression", "root1"),
             )
-        db.append_message("root1", "user", "old ask")
 
         # Continuation tip created after root ended; last activity much later.
         db.create_session("tip1", "cli", parent_session_id="root1")


### PR DESCRIPTION
## Problem

`append_message()` in the SessionDB increments `message_count` on the sessions row but never clears `ended_at` or `end_reason`. When a session is ended (e.g. by daily reset or idle timeout) and later receives new messages, the stale `ended_at` causes `hermes sessions list` to sort the session by its old end time rather than the actual last activity.

This produces incorrect ranking: the session can appear at position #29 instead of its true rank (~#12) by last-message timestamp.

## Fix

Add `ended_at = NULL, end_reason = NULL` to the existing UPDATE in `append_message()`, in both the tool-call and non-tool-call branches. This is free — the row is already being written. For the 99.9% of sessions where `ended_at` is already NULL, the SET NULL is a no-op. It only affects the edge case where messages arrive for a previously-ended session.

## Test

Adjusted the compression-tip ordering test so the root message is appended before the root is ended (realistic order), matching the fix's assumption that `append_message` clears `ended_at`. All 288 tests in `test_hermes_state.py` pass.

## Implementation

```python
# Before
UPDATE sessions SET message_count = message_count + 1 WHERE id = ?

# After
UPDATE sessions SET message_count = message_count + 1,
                    ended_at = NULL, end_reason = NULL WHERE id = ?
```