### PR TITLE
fix(desktop): attach backend port watcher before boot await

### DIFF
--- a/apps/desktop/electron/backend-ready.test.cjs
+++ b/apps/desktop/electron/backend-ready.test.cjs
@@ -126,6 +126,21 @@ test('a late announcement after timeout does not throw (listeners torn down)', a
   })
 })
 
+test('desktop starts the primary port watcher before async boot progress', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'main.cjs'), 'utf8').replace(/\r\n/g, '\n')
+  const spawnIndex = source.indexOf('hermesProcess = spawn(')
+  const progressIndex = source.indexOf("await advanceBootProgress('backend.port'", spawnIndex)
+  const watcherIndex = source.indexOf('waitForDashboardPortAnnouncement(hermesProcess', spawnIndex)
+
+  assert.notEqual(spawnIndex, -1, 'expected primary Hermes spawn site')
+  assert.notEqual(progressIndex, -1, 'expected backend.port boot-progress update')
+  assert.notEqual(watcherIndex, -1, 'expected primary backend port watcher')
+  assert.ok(
+    watcherIndex < progressIndex,
+    'the stdout watcher must attach before any awaited boot progress can miss the READY line'
+  )
+})
+
 // ---------------------------------------------------------------------------
 // ready-file port announcement
 // ---------------------------------------------------------------------------

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5251,9 +5251,11 @@ async function spawnPoolBackend(profile, entry) {
       )
     }
   })
+  const portAnnouncement = waitForDashboardPortAnnouncement(child, { readyFile })
+  const portReady = Promise.race([portAnnouncement, startFailed])
 
   // Discover the ephemeral port the child bound to
-  const port = await Promise.race([waitForDashboardPortAnnouncement(child, { readyFile }), startFailed])
+  const port = await portReady
   if (readyFile) {
     fs.unlink(readyFile, () => {})
   }
@@ -5506,13 +5508,15 @@ async function startHermes() {
         )
       }
     })
+    const portAnnouncement = waitForDashboardPortAnnouncement(hermesProcess, { readyFile })
+    const portReady = Promise.race([portAnnouncement, backendStartFailed])
+    // BOOT_FAKE_MODE can await below; consume early failures now and rethrow at
+    // the real await site.
+    void portReady.catch(() => undefined)
 
     await advanceBootProgress('backend.port', 'Waiting for Hermes backend to launch', 86)
     // Discover the ephemeral port the child bound to
-    const port = await Promise.race([
-      waitForDashboardPortAnnouncement(hermesProcess, { readyFile }),
-      backendStartFailed
-    ])
+    const port = await portReady
     if (readyFile) {
       fs.unlink(readyFile, () => {})
     }


### PR DESCRIPTION
## Summary
- attach the dashboard port watcher immediately after spawning primary/profile backends, before awaited boot progress can miss HERMES_DASHBOARD_READY
- reuse the early port-ready promise when discovering the random dashboard port
- add a regression test that guards the primary startup sequencing

Fixes #53097

## Tests
- node --test electron/backend-ready.test.cjs
- node --check electron/main.cjs
- git diff --check
- npm run test:desktop:platforms (fails on existing unrelated windows-child-process.test.cjs source-inspection expectation for bootstrap-runner.cjs; this PR does not touch that file)