### PR TITLE
fix(docs): correct broken MCP link in web dashboard

### DIFF
--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -299,7 +299,7 @@ Browse, search, and toggle installed skills and toolsets, and install new ones f
 
 ### MCP
 
-Manage [MCP](/integrations/mcp) servers without the CLI. The same `mcp_servers`
+Manage [MCP](/user-guide/features/mcp) servers without the CLI. The same `mcp_servers`
 block in `config.yaml` that `hermes mcp` reads from.
 
 **Your MCP servers:**


### PR DESCRIPTION
The `/integrations/mcp` page does not exist (returns 404). The correct MCP feature documentation lives at `/user-guide/features/mcp`.

- File: `website/docs/user-guide/features/web-dashboard.md`
- Change: `/integrations/mcp` -> `/user-guide/features/mcp`
- Found by automated broken-link checker