### PR TITLE
fix(agent): classify Cloudflare 502 origin_bad_gateway as context overflow for large sessions

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -936,6 +936,27 @@ def _classify_by_status(
                 retryable=False,
                 should_fallback=True,
             )
+        # Cloudflare 502/500 with large session → probable context overflow.
+        # Cloudflare returns structured error bodies with fields like
+        # cloudflare_error, error_name ("origin_bad_gateway"), and
+        # error_category ("origin") when the upstream provider rejects an
+        # oversized request.  Retrying the same payload is futile; trigger
+        # context compression instead.  Issue #53771.
+        _err_obj = body.get("error", {}) if isinstance(body, dict) else {}
+        _is_cloudflare = (
+            (isinstance(_err_obj, dict) and _err_obj.get("cloudflare_error") is True)
+            or "cloudflare_error" in error_msg
+            or "origin_bad_gateway" in error_msg
+        )
+        if _is_cloudflare and (
+            approx_tokens > context_length * 0.4
+            or (context_length <= 256000 and (approx_tokens > 80000 or num_messages > 80))
+        ):
+            return result_fn(
+                FailoverReason.context_overflow,
+                retryable=True,
+                should_compress=True,
+            )
         return result_fn(FailoverReason.server_error, retryable=True)
 
     if status_code in {503, 529}:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -468,6 +468,61 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.server_error
         assert result.retryable is True
 
+    # ── Cloudflare 502 + large session → context overflow (#53771) ──
+
+    def test_502_cloudflare_large_session_context_overflow(self):
+        """Cloudflare 502 origin_bad_gateway with large session → compress."""
+        e = MockAPIError(
+            "Error 502: Bad gateway",
+            status_code=502,
+            body={
+                "error": {
+                    "code": 502,
+                    "message": "Error 502: Bad gateway",
+                    "error_name": "origin_bad_gateway",
+                    "error_category": "origin",
+                    "cloudflare_error": True,
+                }
+            },
+        )
+        result = classify_api_error(
+            e, approx_tokens=240000, context_length=200000, num_messages=296
+        )
+        assert result.reason == FailoverReason.context_overflow
+        assert result.retryable is True
+        assert result.should_compress is True
+
+    def test_502_cloudflare_small_session_still_server_error(self):
+        """Cloudflare 502 with small session → server_error (not overflow)."""
+        e = MockAPIError(
+            "Error 502: Bad gateway",
+            status_code=502,
+            body={
+                "error": {
+                    "code": 502,
+                    "message": "Error 502: Bad gateway",
+                    "error_name": "origin_bad_gateway",
+                    "cloudflare_error": True,
+                }
+            },
+        )
+        result = classify_api_error(e, approx_tokens=5000, context_length=200000)
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+
+    def test_502_non_cloudflare_large_session_still_server_error(self):
+        """Non-Cloudflare 502 with large session → server_error (no change)."""
+        e = MockAPIError(
+            "Bad Gateway",
+            status_code=502,
+            body={"error": {"message": "upstream connect error"}},
+        )
+        result = classify_api_error(
+            e, approx_tokens=240000, context_length=200000, num_messages=296
+        )
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+
     # ── Model not found ──
 
     def test_404_model_not_found(self):


### PR DESCRIPTION
## What does this PR do?

When a large chat-gateway session triggers a Cloudflare 502 with `origin_bad_gateway` error, the request payload is too large for the upstream provider to handle. Retrying the same oversized request is futile — it produces the same 502 after exhausting retries.

This PR adds Cloudflare-specific error detection to the 500/502 handler in `error_classifier.py`. When a 502 body contains Cloudflare signals (`cloudflare_error: true`, `error_name: origin_bad_gateway`) **and** the session exceeds the large-session threshold, the error is reclassified from `server_error` (retryable) to `context_overflow` (should_compress), triggering automatic context compression instead of a retry loop.

## Related Issue

Fixes #53771

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py`: Added Cloudflare 502 detection in the `status_code in {500, 502}` handler of `_classify_by_status()`. Checks `body.error.cloudflare_error` field and `origin_bad_gateway` in the error message. When matched with a large session (same thresholds as the existing 400 handler: >40% context, or >80k tokens/80 messages for ≤256k context), returns `FailoverReason.context_overflow` with `should_compress=True`.
- `tests/agent/test_error_classifier.py`: Added 3 tests:
  - Cloudflare 502 + large session → context_overflow with should_compress
  - Cloudflare 502 + small session → server_error (unchanged behavior)
  - Non-Cloudflare 502 + large session → server_error (no false positive)

## How to Test

1. Run `python -m pytest tests/agent/test_error_classifier.py -v` — all 169 tests should pass, including the 3 new Cloudflare tests.
2. The new tests cover: (a) large session with Cloudflare 502 triggers compression, (b) small session with Cloudflare 502 stays as retryable server error, (c) non-Cloudflare 502 with large session is not affected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (error classification logic is platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The fix targets this error pattern from the issue:

```text
API call failed after 3 retries.
HTTP 502: Error code: 502
title: Error 502: Bad gateway
error_name: origin_bad_gateway
error_category: origin
cloudflare_error: true
```

With a large session (~240k tokens, ~296 messages), this now triggers automatic compression instead of retrying the same oversized request 3 times.
