### PR TITLE
fix(agent): compress large cloudflare origin failures

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1302,6 +1302,18 @@ def _classify_by_status(
             result_fn=result_fn,
         )
 
+    should_compress_cloudflare_origin = (
+        status_code in {500, 502, 503, 529}
+        and _looks_like_cloudflare_origin_5xx(error_msg, body)
+        and (
+            approx_tokens > context_length * 0.4
+            or (
+                context_length <= 256000
+                and (approx_tokens > 100000 or num_messages > 100)
+            )
+        )
+    )
+
     if status_code in {500, 502}:
         # Some OpenAI-compatible gateways return request-validation errors
         # with a 5xx status (codex.nekos.me returns 502 for unknown/
@@ -1340,6 +1352,12 @@ def _classify_by_status(
                 retryable=True,
                 should_compress=True,
             )
+        if should_compress_cloudflare_origin:
+            return result_fn(
+                FailoverReason.context_overflow,
+                retryable=True,
+                should_compress=True,
+            )
         return result_fn(FailoverReason.server_error, retryable=True)
 
     if status_code in {503, 529}:
@@ -1354,6 +1372,12 @@ def _classify_by_status(
                 should_compress=False,
             )
         if any(p in error_msg for p in _CONTEXT_OVERFLOW_PATTERNS):
+            return result_fn(
+                FailoverReason.context_overflow,
+                retryable=True,
+                should_compress=True,
+            )
+        if should_compress_cloudflare_origin:
             return result_fn(
                 FailoverReason.context_overflow,
                 retryable=True,
@@ -1385,6 +1409,33 @@ def _classify_by_status(
         return result_fn(FailoverReason.server_error, retryable=True)
 
     return None
+
+
+def _looks_like_cloudflare_origin_5xx(error_msg: str, body: dict) -> bool:
+    """Return True for Cloudflare/origin 5xx envelopes without overflow text."""
+    body_text = str(body or {}).lower()
+    combined = f"{error_msg} {body_text}"
+    if "cloudflare" not in combined:
+        return False
+
+    payloads = [body] if isinstance(body, dict) else []
+    nested_error = body.get("error") if isinstance(body, dict) else None
+    if isinstance(nested_error, dict):
+        payloads.append(nested_error)
+
+    for payload in payloads:
+        category = str(payload.get("error_category") or "").lower()
+        name = str(payload.get("error_name") or "").lower()
+        if "origin" in category:
+            return True
+        if "origin" in name and ("gateway" in name or "unavailable" in name):
+            return True
+
+    return (
+        "origin_bad_gateway" in combined
+        or ("origin" in combined and "bad gateway" in combined)
+        or ("origin" in combined and "bad_gateway" in combined)
+    )
 
 
 def _classify_402(error_msg: str, result_fn) -> ClassifiedError:

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1090,6 +1090,18 @@ def _classify_by_status(
             result_fn=result_fn,
         )
 
+    should_compress_cloudflare_origin = (
+        status_code in {500, 502, 503, 529}
+        and _looks_like_cloudflare_origin_5xx(error_msg, body)
+        and (
+            approx_tokens > context_length * 0.4
+            or (
+                context_length <= 256000
+                and (approx_tokens > 100000 or num_messages > 100)
+            )
+        )
+    )
+
     if status_code in {500, 502}:
         # Some OpenAI-compatible gateways return request-validation errors
         # with a 5xx status (codex.nekos.me returns 502 for unknown/
@@ -1128,6 +1140,12 @@ def _classify_by_status(
                 retryable=True,
                 should_compress=True,
             )
+        if should_compress_cloudflare_origin:
+            return result_fn(
+                FailoverReason.context_overflow,
+                retryable=True,
+                should_compress=True,
+            )
         return result_fn(FailoverReason.server_error, retryable=True)
 
     if status_code in {503, 529}:
@@ -1142,6 +1160,12 @@ def _classify_by_status(
                 should_compress=False,
             )
         if any(p in error_msg for p in _CONTEXT_OVERFLOW_PATTERNS):
+            return result_fn(
+                FailoverReason.context_overflow,
+                retryable=True,
+                should_compress=True,
+            )
+        if should_compress_cloudflare_origin:
             return result_fn(
                 FailoverReason.context_overflow,
                 retryable=True,
@@ -1173,6 +1197,33 @@ def _classify_by_status(
         return result_fn(FailoverReason.server_error, retryable=True)
 
     return None
+
+
+def _looks_like_cloudflare_origin_5xx(error_msg: str, body: dict) -> bool:
+    """Return True for Cloudflare/origin 5xx envelopes without overflow text."""
+    body_text = str(body or {}).lower()
+    combined = f"{error_msg} {body_text}"
+    if "cloudflare" not in combined:
+        return False
+
+    payloads = [body] if isinstance(body, dict) else []
+    nested_error = body.get("error") if isinstance(body, dict) else None
+    if isinstance(nested_error, dict):
+        payloads.append(nested_error)
+
+    for payload in payloads:
+        category = str(payload.get("error_category") or "").lower()
+        name = str(payload.get("error_name") or "").lower()
+        if "origin" in category:
+            return True
+        if "origin" in name and ("gateway" in name or "unavailable" in name):
+            return True
+
+    return (
+        "origin_bad_gateway" in combined
+        or ("origin" in combined and "bad gateway" in combined)
+        or ("origin" in combined and "bad_gateway" in combined)
+    )
 
 
 def _classify_402(error_msg: str, result_fn) -> ClassifiedError:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -421,6 +421,109 @@ class TestClassifyApiError:
 
 
 
+    def test_large_cloudflare_origin_502_triggers_compression(self):
+        """Very large Cloudflare/origin 502s should use compression recovery."""
+        e = MockAPIError(
+            "Bad Gateway",
+            status_code=502,
+            body={
+                "title": "Error 502: Bad gateway",
+                "error_name": "origin_bad_gateway",
+                "error_category": "origin",
+                "cloudflare_error": True,
+            },
+        )
+        result = classify_api_error(
+            e,
+            approx_tokens=150000,
+            context_length=200000,
+            num_messages=120,
+        )
+        assert result.reason == FailoverReason.context_overflow
+        assert result.retryable is True
+        assert result.should_compress is True
+
+    def test_small_cloudflare_origin_502_stays_server_error(self):
+        """Cloudflare/origin 502 alone is not enough to compress."""
+        e = MockAPIError(
+            "Bad Gateway",
+            status_code=502,
+            body={
+                "title": "Error 502: Bad gateway",
+                "error_name": "origin_bad_gateway",
+                "error_category": "origin",
+                "cloudflare_error": True,
+            },
+        )
+        result = classify_api_error(
+            e,
+            approx_tokens=5000,
+            context_length=200000,
+            num_messages=8,
+        )
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+        assert result.should_compress is False
+
+    def test_large_plain_502_still_server_error(self):
+        """Large sessions still need the Cloudflare/origin signal."""
+        e = MockAPIError("Bad Gateway", status_code=502)
+        result = classify_api_error(
+            e,
+            approx_tokens=150000,
+            context_length=200000,
+            num_messages=120,
+        )
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+        assert result.should_compress is False
+
+    def test_large_cloudflare_validation_error_stays_format_error(self):
+        """Deterministic validation failures take priority over the heuristic."""
+        e = MockAPIError(
+            "Unsupported parameter: logprobs",
+            status_code=502,
+            body={
+                "error_category": "origin",
+                "cloudflare_error": True,
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "Unsupported parameter: logprobs",
+                },
+            },
+        )
+        result = classify_api_error(
+            e,
+            approx_tokens=150000,
+            context_length=200000,
+            num_messages=120,
+        )
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_compress is False
+
+    def test_large_cloudflare_origin_503_triggers_compression(self):
+        """The same guarded recovery applies to overloaded 5xx envelopes."""
+        e = MockAPIError(
+            "Service Unavailable",
+            status_code=503,
+            body={
+                "title": "Error 503: Origin unavailable",
+                "error_name": "origin_unavailable",
+                "error_category": "origin",
+                "cloudflare_error": True,
+            },
+        )
+        result = classify_api_error(
+            e,
+            approx_tokens=150000,
+            context_length=200000,
+            num_messages=120,
+        )
+        assert result.reason == FailoverReason.context_overflow
+        assert result.retryable is True
+        assert result.should_compress is True
+
     # ── Model not found ──
 
     def test_404_model_not_found(self):
@@ -1290,5 +1393,4 @@ class TestExpandedOverflowPatterns:
         )
         result = classify_api_error(e, provider="openrouter", model="m")
         assert result.reason == FailoverReason.context_overflow
-
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -562,6 +562,109 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.overloaded
         assert result.should_compress is False
 
+    def test_large_cloudflare_origin_502_triggers_compression(self):
+        """Very large Cloudflare/origin 502s should use compression recovery."""
+        e = MockAPIError(
+            "Bad Gateway",
+            status_code=502,
+            body={
+                "title": "Error 502: Bad gateway",
+                "error_name": "origin_bad_gateway",
+                "error_category": "origin",
+                "cloudflare_error": True,
+            },
+        )
+        result = classify_api_error(
+            e,
+            approx_tokens=150000,
+            context_length=200000,
+            num_messages=120,
+        )
+        assert result.reason == FailoverReason.context_overflow
+        assert result.retryable is True
+        assert result.should_compress is True
+
+    def test_small_cloudflare_origin_502_stays_server_error(self):
+        """Cloudflare/origin 502 alone is not enough to compress."""
+        e = MockAPIError(
+            "Bad Gateway",
+            status_code=502,
+            body={
+                "title": "Error 502: Bad gateway",
+                "error_name": "origin_bad_gateway",
+                "error_category": "origin",
+                "cloudflare_error": True,
+            },
+        )
+        result = classify_api_error(
+            e,
+            approx_tokens=5000,
+            context_length=200000,
+            num_messages=8,
+        )
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+        assert result.should_compress is False
+
+    def test_large_plain_502_still_server_error(self):
+        """Large sessions still need the Cloudflare/origin signal."""
+        e = MockAPIError("Bad Gateway", status_code=502)
+        result = classify_api_error(
+            e,
+            approx_tokens=150000,
+            context_length=200000,
+            num_messages=120,
+        )
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+        assert result.should_compress is False
+
+    def test_large_cloudflare_validation_error_stays_format_error(self):
+        """Deterministic validation failures take priority over the heuristic."""
+        e = MockAPIError(
+            "Unsupported parameter: logprobs",
+            status_code=502,
+            body={
+                "error_category": "origin",
+                "cloudflare_error": True,
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "Unsupported parameter: logprobs",
+                },
+            },
+        )
+        result = classify_api_error(
+            e,
+            approx_tokens=150000,
+            context_length=200000,
+            num_messages=120,
+        )
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_compress is False
+
+    def test_large_cloudflare_origin_503_triggers_compression(self):
+        """The same guarded recovery applies to overloaded 5xx envelopes."""
+        e = MockAPIError(
+            "Service Unavailable",
+            status_code=503,
+            body={
+                "title": "Error 503: Origin unavailable",
+                "error_name": "origin_unavailable",
+                "error_category": "origin",
+                "cloudflare_error": True,
+            },
+        )
+        result = classify_api_error(
+            e,
+            approx_tokens=150000,
+            context_length=200000,
+            num_messages=120,
+        )
+        assert result.reason == FailoverReason.context_overflow
+        assert result.retryable is True
+        assert result.should_compress is True
+
     # ── Model not found ──
 
     def test_404_model_not_found(self):
@@ -2240,5 +2343,4 @@ class TestExpandedOverflowPatterns:
         )
         result = classify_api_error(e, provider="ollama", model="m")
         assert result.reason == FailoverReason.context_overflow
-
 


### PR DESCRIPTION
## What does this PR do?

Large chat-gateway sessions can receive a generic Cloudflare/origin 5xx envelope, such as `502 origin_bad_gateway`, when the upstream request is too large. Hermes otherwise treats that as a normal retryable server error and resends the same oversized request until retries are exhausted.

This PR adds a narrow classifier fallback for Cloudflare/origin-shaped 5xx responses when the current request is already large. In that case, Hermes uses the existing context-overflow compression recovery path. Small Cloudflare 502s and large plain 502s keep the existing retry behavior.

The branch is rebased on current `main`. Deterministic request-validation errors and explicit context-overflow text are classified first; the size-and-origin heuristic handles only the ambiguous fallback case.

## Related Issue

Fixes #53771

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/error_classifier.py`
  - Detects Cloudflare/origin-shaped `500`, `502`, `503`, and `529` envelopes.
  - Routes only large sessions to `FailoverReason.context_overflow` with `should_compress=True`.
  - Preserves current-main request-validation and explicit overflow-text classification priority.
  - Leaves small Cloudflare 502s and large plain 502s on their existing retry paths.
- `tests/agent/test_error_classifier.py`
  - Covers large Cloudflare/origin 502 and 503 compression recovery.
  - Guards small Cloudflare/origin 502 and large plain 502 behavior.
  - Verifies that a large Cloudflare envelope cannot mask an invalid request.

## How to Test

1. `pytest tests/agent/test_error_classifier.py -q`
2. `pytest tests/run_agent/test_31273_402_not_retried.py -q`
3. `ruff check agent/error_classifier.py tests/agent/test_error_classifier.py`
4. `git diff --check origin/main...HEAD`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS, focused classifier and recovery-path tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`README`, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact - classifier-only change, platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## For New Skills

N/A

## Verification

```text
pytest tests/agent/test_error_classifier.py -q
198 passed in 0.50s

pytest tests/run_agent/test_31273_402_not_retried.py -q
5 passed in 0.56s

ruff check agent/error_classifier.py tests/agent/test_error_classifier.py
All checks passed!

git diff --check origin/main...HEAD
```
