### PR TITLE
fix(moa): sanitize failed reference outputs and add per-preset timeout

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -922,6 +922,10 @@ def run_conversation(
                     temperature=_preset_temperature(moa_config, "reference_temperature"),
                     aggregator_temperature=_preset_temperature(moa_config, "aggregator_temperature"),
                     max_tokens=moa_config.get("reference_max_tokens"),
+                    reference_timeout=float(moa_config.get("reference_timeout") or 30.0),
+                    degraded_reference_policy=str(
+                        moa_config.get("degraded_reference_policy") or "loud"
+                    ),
                 )
                 if _moa_context:
                     for _msg in reversed(api_messages):

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -267,8 +267,9 @@ def _run_reference(
     *,
     temperature: float | None = None,
     max_tokens: int | None = None,
+    reference_timeout: float = 30.0,
 ) -> tuple[str, str, Any]:
-    """Call one reference model and return ``(label, text, usage)``.
+    """Call one reference model and return ``(label, text, accounting)``.
 
     The slot is resolved to its provider's real runtime (via ``_slot_runtime``)
     and called through the same ``call_llm`` request-building path any model
@@ -319,6 +320,7 @@ def _run_reference(
             messages=messages,
             temperature=temperature,
             max_tokens=max_tokens,
+            timeout=reference_timeout,
             reasoning_config=_slot_reasoning_config(slot),
             **runtime,
         )
@@ -384,6 +386,7 @@ def _run_references_parallel(
     *,
     temperature: float | None = None,
     max_tokens: int | None = None,
+    reference_timeout: float = 30.0,
 ) -> list[tuple[str, str, Any]]:
     """Fan out all reference models in parallel, returning outputs in order.
 
@@ -393,8 +396,8 @@ def _run_references_parallel(
     ``Reference {idx}`` labelling stays stable. MoA presets that reference
     another MoA preset are skipped here (recursion guard) with a labelled note.
 
-    Each element is ``(label, text, usage)`` where usage is a
-    ``CanonicalUsage`` (zeroed for skipped/failed references).
+    Each element is ``(label, text, accounting)`` where accounting is a
+    ``_RefAccounting`` object (zeroed for skipped/failed references).
     """
     from agent.usage_pricing import CanonicalUsage
 
@@ -426,6 +429,7 @@ def _run_references_parallel(
                     ref_messages,
                     temperature=temperature,
                     max_tokens=max_tokens,
+                    reference_timeout=reference_timeout,
                 )
             ] = idx
         # Collect every reference before returning — the aggregator needs the
@@ -660,6 +664,30 @@ def _preset_temperature(preset: dict[str, Any], key: str) -> float | None:
         return None
 
 
+def _is_failed_reference(text: str) -> bool:
+    """Return whether a reference output is the internal failure sentinel."""
+    return text.lstrip().lower().startswith("[failed:")
+
+
+def _successful_references(
+    reference_outputs: list[tuple[str, str, Any]],
+) -> list[tuple[str, str, Any]]:
+    """Filter failed advice while preserving each accounting payload."""
+    return [output for output in reference_outputs if not _is_failed_reference(output[1])]
+
+
+def _failed_reference_labels(
+    reference_outputs: list[tuple[str, str, Any]],
+) -> list[str]:
+    return [label for label, text, _accounting in reference_outputs if _is_failed_reference(text)]
+
+
+def _degraded_notice(failed_labels: list[str], policy: str) -> str:
+    if not failed_labels or policy.strip().lower() == "silent":
+        return ""
+    return f"[Reference models unavailable: {', '.join(failed_labels)}]"
+
+
 def aggregate_moa_context(
     *,
     user_prompt: str,
@@ -669,6 +697,8 @@ def aggregate_moa_context(
     temperature: float | None = None,
     aggregator_temperature: float | None = None,
     max_tokens: int | None = None,
+    reference_timeout: float = 30.0,
+    degraded_reference_policy: str = "loud",
 ) -> str:
     """Run configured reference models and synthesize their advice.
 
@@ -693,12 +723,18 @@ def aggregate_moa_context(
         ref_messages,
         temperature=temperature,
         max_tokens=max_tokens,
+        reference_timeout=reference_timeout,
     )
 
+    successful_outputs = _successful_references(reference_outputs)
+    failed_labels = _failed_reference_labels(reference_outputs)
     joined = "\n\n".join(
         f"Reference {idx} — {label}:\n{text}"
-        for idx, (label, text, _usage) in enumerate(reference_outputs, start=1)
+        for idx, (label, text, _accounting) in enumerate(successful_outputs, start=1)
     )
+    degraded = _degraded_notice(failed_labels, degraded_reference_policy)
+    if degraded:
+        joined = f"{joined}\n\n{degraded}" if joined else degraded
     synth_prompt = (
         "You are the aggregator in a Mixture of Agents process. Synthesize the "
         "reference responses into concise, actionable guidance for the main "
@@ -936,6 +972,10 @@ class MoAChatCompletions:
         # explicit values. See _preset_temperature.
         temperature = _preset_temperature(preset, "reference_temperature")
         aggregator_temperature = _preset_temperature(preset, "aggregator_temperature")
+        reference_timeout = float(preset.get("reference_timeout") or 30.0)
+        degraded_reference_policy = str(
+            preset.get("degraded_reference_policy") or "loud"
+        )
         if aggregator_temperature is None and api_kwargs.get("temperature") is not None:
             # The acting agent's own configured temperature (if any) still
             # applies to the aggregator, which IS the acting model.
@@ -1010,6 +1050,7 @@ class MoAChatCompletions:
                 ref_messages,
                 temperature=temperature,
                 max_tokens=reference_max_tokens,
+                reference_timeout=reference_timeout,
             )
             self._ref_cache_key = _cache_key
             self._ref_cache_outputs = list(reference_outputs)
@@ -1050,7 +1091,7 @@ class MoAChatCompletions:
             # visible rather than a silent pause. Best-effort: never blocks the
             # turn.
             _ref_count = len(reference_outputs)
-            for _idx, (_label, _text, _usage) in enumerate(reference_outputs, start=1):
+            for _idx, (_label, _text, _accounting) in enumerate(reference_outputs, start=1):
                 self._emit(
                     "moa.reference",
                     index=_idx,
@@ -1066,11 +1107,18 @@ class MoAChatCompletions:
                 )
 
         agg_messages = [dict(m) for m in messages]
-        if reference_outputs:
-            joined = "\n\n".join(
-                f"Reference {idx} — {label}:\n{text}"
-                for idx, (label, text, _usage) in enumerate(reference_outputs, start=1)
+        successful_outputs = _successful_references(reference_outputs)
+        failed_labels = _failed_reference_labels(reference_outputs)
+        joined = "\n\n".join(
+            f"Reference {idx} — {label}:\n{text}"
+            for idx, (label, text, _accounting) in enumerate(
+                successful_outputs, start=1
             )
+        )
+        degraded = _degraded_notice(failed_labels, degraded_reference_policy)
+        if degraded:
+            joined = f"{joined}\n\n{degraded}" if joined else degraded
+        if joined:
             guidance = (
                 "[Mixture of Agents reference context]\n"
                 f"Preset: {self.preset_name}\n"

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -869,6 +869,7 @@ export interface MoaConfigResponse {
     {
       aggregator: MoaModelSlot
       aggregator_temperature: number
+      degraded_reference_policy: 'loud' | 'silent'
       enabled: boolean
       max_tokens: number
       reference_models: MoaModelSlot[]
@@ -877,14 +878,17 @@ export interface MoaConfigResponse {
       reference_max_tokens?: number | null
       /** Fan-out cadence (per_iteration | user_turn) — round-tripped. */
       fanout?: string
+      reference_timeout: number
     }
   >
   aggregator: MoaModelSlot
   aggregator_temperature: number
+  degraded_reference_policy: 'loud' | 'silent'
   enabled: boolean
   max_tokens: number
   reference_models: MoaModelSlot[]
   reference_temperature: number
+  reference_timeout: number
 }
 
 export interface ModelAssignmentRequest {

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+import math
 from copy import deepcopy
 from typing import Any
 
@@ -20,6 +21,9 @@ DEFAULT_MOA_AGGREGATOR: dict[str, str] = {
     "model": "anthropic/claude-opus-4.8",
 }
 
+DEFAULT_MOA_REFERENCE_TIMEOUT = 30.0
+MAX_MOA_REFERENCE_TIMEOUT = 300.0
+
 
 def _coerce_float_or_none(value: Any) -> float | None:
     """Coerce to a float, or None when unset/blank/invalid.
@@ -35,6 +39,25 @@ def _coerce_float_or_none(value: Any) -> float | None:
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def _coerce_reference_timeout(value: Any) -> float:
+    """Return a finite positive advisor timeout capped at five minutes."""
+    if isinstance(value, bool):
+        return DEFAULT_MOA_REFERENCE_TIMEOUT
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError):
+        return DEFAULT_MOA_REFERENCE_TIMEOUT
+    if not math.isfinite(timeout) or timeout <= 0:
+        return DEFAULT_MOA_REFERENCE_TIMEOUT
+    return min(timeout, MAX_MOA_REFERENCE_TIMEOUT)
+
+
+def _coerce_degraded_reference_policy(value: Any) -> str:
+    """Normalize failed-advisor disclosure policy; unknown values fail loud."""
+    policy = str(value or "loud").strip().lower()
+    return policy if policy in {"loud", "silent"} else "loud"
 
 
 def _coerce_int(value: Any, default: int) -> int:
@@ -187,6 +210,8 @@ def _default_preset() -> dict[str, Any]:
         # matching single-model agent behavior.
         "reference_temperature": None,
         "aggregator_temperature": None,
+        "reference_timeout": DEFAULT_MOA_REFERENCE_TIMEOUT,
+        "degraded_reference_policy": "loud",
         "max_tokens": 4096,
         "reference_max_tokens": None,
         "fanout": "per_iteration",
@@ -217,6 +242,10 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         "aggregator": aggregator,
         "reference_temperature": _coerce_float_or_none(raw.get("reference_temperature")),
         "aggregator_temperature": _coerce_float_or_none(raw.get("aggregator_temperature")),
+        "reference_timeout": _coerce_reference_timeout(raw.get("reference_timeout")),
+        "degraded_reference_policy": _coerce_degraded_reference_policy(
+            raw.get("degraded_reference_policy")
+        ),
         "max_tokens": _coerce_int(raw.get("max_tokens"), 4096),
         # Optional cap on how much each reference ADVISOR may generate per turn.
         # None (default) = uncapped: advisors write full-length advice, matching
@@ -278,6 +307,8 @@ def normalize_moa_config(raw: Any) -> dict[str, Any]:
         "aggregator": deepcopy(active["aggregator"]),
         "reference_temperature": active["reference_temperature"],
         "aggregator_temperature": active["aggregator_temperature"],
+        "reference_timeout": active["reference_timeout"],
+        "degraded_reference_policy": active["degraded_reference_policy"],
         "max_tokens": active["max_tokens"],
         "reference_max_tokens": active.get("reference_max_tokens"),
         "fanout": active.get("fanout", "per_iteration"),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -25,6 +25,7 @@ import inspect
 import importlib.util
 import json
 import logging
+import math
 import mimetypes
 import os
 import re
@@ -44,7 +45,7 @@ import zipfile
 from hermes_cli._subprocess_compat import windows_detach_flags, windows_hide_flags
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import yaml
 
@@ -100,7 +101,7 @@ try:
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
     from fastapi.staticfiles import StaticFiles
-    from pydantic import BaseModel, SecretStr
+    from pydantic import BaseModel, SecretStr, field_validator
     from starlette.concurrency import run_in_threadpool
 except ImportError:
     # First try lazy-installing the dashboard extras. Only the user actually
@@ -116,7 +117,7 @@ except ImportError:
         from fastapi.middleware.cors import CORSMiddleware
         from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
         from fastapi.staticfiles import StaticFiles
-        from pydantic import BaseModel, SecretStr
+        from pydantic import BaseModel, SecretStr, field_validator
         from starlette.concurrency import run_in_threadpool
     except Exception:
         raise SystemExit(
@@ -1003,15 +1004,34 @@ class MoaModelSlot(BaseModel):
     reasoning_effort: Optional[str] = None
 
 
-class MoaPresetPayload(BaseModel):
+class _MoaReferenceControls(BaseModel):
+    reference_timeout: float = 30.0
+    degraded_reference_policy: Literal["loud", "silent"] = "loud"
+
+    @field_validator("reference_timeout", mode="before")
+    @classmethod
+    def _validate_reference_timeout(cls, value: Any) -> float:
+        """Reject JSON booleans/non-finite values before float coercion."""
+        if isinstance(value, bool):
+            raise ValueError("reference_timeout must be a finite positive number")
+        try:
+            timeout = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "reference_timeout must be a finite positive number"
+            ) from exc
+        if not math.isfinite(timeout) or timeout <= 0:
+            raise ValueError("reference_timeout must be a finite positive number")
+        return timeout
+
+
+class MoaPresetPayload(_MoaReferenceControls):
     reference_models: list[MoaModelSlot] = []
     aggregator: MoaModelSlot = MoaModelSlot()
     # None = temperature omitted from API calls (provider default), matching
     # single-model agent behavior.
     reference_temperature: Optional[float] = None
     aggregator_temperature: Optional[float] = None
-    reference_timeout: float = 30.0
-    degraded_reference_policy: str = "loud"
     max_tokens: int = 4096
     # Newer per-preset knobs (see moa_config._normalize_preset). Optional so
     # older clients that never send them keep working; declared so clients
@@ -1021,7 +1041,7 @@ class MoaPresetPayload(BaseModel):
     enabled: bool = True
 
 
-class MoaConfigPayload(BaseModel):
+class MoaConfigPayload(_MoaReferenceControls):
     default_preset: str = "default"
     active_preset: str = ""
     presets: dict[str, MoaPresetPayload] = {}
@@ -1031,8 +1051,6 @@ class MoaConfigPayload(BaseModel):
     aggregator: MoaModelSlot = MoaModelSlot()
     reference_temperature: Optional[float] = None
     aggregator_temperature: Optional[float] = None
-    reference_timeout: float = 30.0
-    degraded_reference_policy: str = "loud"
     max_tokens: int = 4096
     reference_max_tokens: Optional[int] = None
     fanout: Optional[str] = None

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1010,6 +1010,8 @@ class MoaPresetPayload(BaseModel):
     # single-model agent behavior.
     reference_temperature: Optional[float] = None
     aggregator_temperature: Optional[float] = None
+    reference_timeout: float = 30.0
+    degraded_reference_policy: str = "loud"
     max_tokens: int = 4096
     # Newer per-preset knobs (see moa_config._normalize_preset). Optional so
     # older clients that never send them keep working; declared so clients
@@ -1029,6 +1031,8 @@ class MoaConfigPayload(BaseModel):
     aggregator: MoaModelSlot = MoaModelSlot()
     reference_temperature: Optional[float] = None
     aggregator_temperature: Optional[float] = None
+    reference_timeout: float = 30.0
+    degraded_reference_policy: str = "loud"
     max_tokens: int = 4096
     reference_max_tokens: Optional[int] = None
     fanout: Optional[str] = None
@@ -5752,6 +5756,8 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                 "aggregator": _slot_dict(preset.aggregator),
                 "reference_temperature": preset.reference_temperature,
                 "aggregator_temperature": preset.aggregator_temperature,
+                "reference_timeout": preset.reference_timeout,
+                "degraded_reference_policy": preset.degraded_reference_policy,
                 "max_tokens": preset.max_tokens,
                 "reference_max_tokens": preset.reference_max_tokens,
                 "fanout": preset.fanout,
@@ -5773,6 +5779,8 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                         aggregator=body.aggregator,
                         reference_temperature=body.reference_temperature,
                         aggregator_temperature=body.aggregator_temperature,
+                        reference_timeout=body.reference_timeout,
+                        degraded_reference_policy=body.degraded_reference_policy,
                         max_tokens=body.max_tokens,
                         reference_max_tokens=body.reference_max_tokens,
                         fanout=body.fanout,
@@ -5792,7 +5800,6 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                     status_code=422,
                     detail="Invalid MoA config: " + "; ".join(problems),
                 )
-
             normalized = normalize_moa_config(raw)
             cfg["moa"] = normalized
             save_config(cfg)

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -461,3 +461,29 @@ def test_validate_moa_payload_rejects_non_dict():
     assert validate_moa_payload(None)
     assert validate_moa_payload([1, 2])
     assert validate_moa_payload({"presets": {"p": "not-a-dict"}})
+
+
+def test_reference_failure_controls_are_normalized_per_preset_and_flattened():
+    cfg = normalize_moa_config(
+        _preset(reference_timeout="120.5", degraded_reference_policy="silent")
+    )
+
+    preset = cfg["presets"]["p"]
+    assert preset["reference_timeout"] == 120.5
+    assert preset["degraded_reference_policy"] == "silent"
+    assert cfg["reference_timeout"] == 120.5
+    assert cfg["degraded_reference_policy"] == "silent"
+
+
+@pytest.mark.parametrize("value", [None, "", 0, -1, "bad"])
+def test_reference_timeout_invalid_values_fall_back_to_default(value):
+    assert resolve_moa_preset(_preset(reference_timeout=value), "p")["reference_timeout"] == 30.0
+
+
+def test_reference_timeout_is_capped_and_unknown_policy_is_loud():
+    preset = resolve_moa_preset(
+        _preset(reference_timeout=9999, degraded_reference_policy="wat"), "p"
+    )
+
+    assert preset["reference_timeout"] == 300.0
+    assert preset["degraded_reference_policy"] == "loud"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -864,6 +864,9 @@ class TestWebServerEndpoints:
         assert cfg["moa"]["aggregator"] == payload["aggregator"]
         assert cfg["moa"]["reference_timeout"] == 44.5
         assert cfg["moa"]["degraded_reference_policy"] == "silent"
+        returned = self.client.get("/api/model/moa").json()
+        assert returned["reference_timeout"] == 44.5
+        assert returned["degraded_reference_policy"] == "silent"
 
     def test_put_moa_models_persists_reference_failure_controls_per_preset(self):
         from hermes_cli.config import load_config
@@ -960,6 +963,34 @@ class TestWebServerEndpoints:
         fetched = self.client.get("/api/model/moa").json()
         assert fetched["presets"]["default"]["fanout"] == "user_turn"
         assert fetched["presets"]["default"]["reference_max_tokens"] == 600
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"reference_timeout": True},
+            {"reference_timeout": False},
+            {"reference_timeout": "nan"},
+            {"reference_timeout": "inf"},
+            {"presets": {"review": {"reference_timeout": True}}},
+            {"presets": {"review": {"reference_timeout": "-inf"}}},
+        ],
+    )
+    def test_put_moa_models_rejects_invalid_reference_timeout(self, payload):
+        resp = self.client.put("/api/model/moa", json=payload)
+
+        assert resp.status_code == 422
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"degraded_reference_policy": "verbose"},
+            {"presets": {"review": {"degraded_reference_policy": "verbose"}}},
+        ],
+    )
+    def test_put_moa_models_rejects_invalid_degraded_reference_policy(self, payload):
+        resp = self.client.put("/api/model/moa", json=payload)
+
+        assert resp.status_code == 422
 
     # ── GET /api/media (remote image display) ───────────────────────────
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -850,6 +850,8 @@ class TestWebServerEndpoints:
             "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
             "reference_temperature": 0.6,
             "aggregator_temperature": 0.4,
+            "reference_timeout": 44.5,
+            "degraded_reference_policy": "silent",
             "max_tokens": 4096,
             "enabled": True,
         }
@@ -860,6 +862,38 @@ class TestWebServerEndpoints:
         cfg = load_config()
         assert cfg["moa"]["reference_models"] == payload["reference_models"]
         assert cfg["moa"]["aggregator"] == payload["aggregator"]
+        assert cfg["moa"]["reference_timeout"] == 44.5
+        assert cfg["moa"]["degraded_reference_policy"] == "silent"
+
+    def test_put_moa_models_persists_reference_failure_controls_per_preset(self):
+        from hermes_cli.config import load_config
+
+        payload = {
+            "default_preset": "review",
+            "presets": {
+                "review": {
+                    "reference_models": [
+                        {"provider": "openai-codex", "model": "gpt-5.5"}
+                    ],
+                    "aggregator": {
+                        "provider": "openrouter",
+                        "model": "anthropic/claude-opus-4.8",
+                    },
+                    "reference_timeout": 87.5,
+                    "degraded_reference_policy": "silent",
+                }
+            },
+        }
+
+        resp = self.client.put("/api/model/moa", json=payload)
+
+        assert resp.status_code == 200
+        saved = load_config()["moa"]["presets"]["review"]
+        assert saved["reference_timeout"] == 87.5
+        assert saved["degraded_reference_policy"] == "silent"
+        returned = self.client.get("/api/model/moa").json()["presets"]["review"]
+        assert returned["reference_timeout"] == 87.5
+        assert returned["degraded_reference_policy"] == "silent"
 
     def test_put_moa_models_rejects_half_filled_slot_with_422(self):
         """#64156: a mid-edit autosave (provider picked, model empty) used to be

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -1265,3 +1265,179 @@ def test_reference_messages_drops_whitespace_only_string_user_turn():
     assert view[0] == {"role": "assistant", "content": "a"}
     assert view[-1] == {"role": "user", "content": "real"}
     assert all(str(m["content"]).strip() for m in view)
+
+
+def test_reference_filtering_preserves_accounting_triples():
+    from agent.moa_loop import (
+        _RefAccounting,
+        _failed_reference_labels,
+        _successful_references,
+    )
+    from agent.usage_pricing import CanonicalUsage
+
+    good_accounting = _RefAccounting(CanonicalUsage(input_tokens=7), 0.07)
+    failed_accounting = _RefAccounting(CanonicalUsage(input_tokens=5), 0.05)
+    outputs = [
+        ("good-model", "useful advice", good_accounting),
+        ("bad-model", "[failed: raw provider secret]", failed_accounting),
+    ]
+
+    successful = _successful_references(outputs)
+    assert successful == [outputs[0]]
+    assert successful[0][2] is good_accounting
+    assert _failed_reference_labels(outputs) == ["bad-model"]
+
+
+def test_aggregate_moa_context_sanitizes_failed_reference_and_forwards_timeout(monkeypatch):
+    from agent import moa_loop
+    from agent.usage_pricing import CanonicalUsage
+
+    outputs = [
+        ("good-model", "useful advice", moa_loop._RefAccounting(CanonicalUsage())),
+        (
+            "bad-model",
+            "[failed: HTTP 401 key=super-secret]",
+            moa_loop._RefAccounting(CanonicalUsage()),
+        ),
+    ]
+    fanout_kwargs = {}
+    aggregator_calls = []
+
+    def fake_fanout(*args, **kwargs):
+        fanout_kwargs.update(kwargs)
+        return outputs
+
+    def fake_call_llm(**kwargs):
+        aggregator_calls.append(kwargs)
+        return _response("synthesized guidance")
+
+    monkeypatch.setattr(moa_loop, "_run_references_parallel", fake_fanout)
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {"provider": slot["provider"], "model": slot["model"]},
+    )
+
+    result = moa_loop.aggregate_moa_context(
+        user_prompt="review this",
+        api_messages=[{"role": "user", "content": "review this"}],
+        reference_models=[
+            {"provider": "openrouter", "model": "good-model"},
+            {"provider": "openrouter", "model": "bad-model"},
+        ],
+        aggregator={"provider": "openrouter", "model": "aggregator"},
+        reference_timeout=17.5,
+        degraded_reference_policy="loud",
+    )
+
+    assert fanout_kwargs["reference_timeout"] == 17.5
+    private_prompt = aggregator_calls[0]["messages"][0]["content"]
+    assert "useful advice" in private_prompt
+    assert "super-secret" not in private_prompt
+    assert "Reference models unavailable: bad-model" in private_prompt
+    assert "super-secret" not in result
+
+
+def test_moa_facade_sanitizes_failures_without_breaking_accounting(monkeypatch, tmp_path):
+    from agent import moa_loop
+    from agent.usage_pricing import CanonicalUsage
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      reference_timeout: 19
+      degraded_reference_policy: silent
+      reference_models:
+        - provider: openrouter
+          model: good-model
+        - provider: openrouter
+          model: bad-model
+      aggregator:
+        provider: openrouter
+        model: aggregator
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    outputs = [
+        (
+            "good-model",
+            "useful advice",
+            moa_loop._RefAccounting(CanonicalUsage(input_tokens=7), 0.07),
+        ),
+        (
+            "bad-model",
+            "[failed: HTTP 401 key=super-secret]",
+            moa_loop._RefAccounting(CanonicalUsage(input_tokens=5), 0.05),
+        ),
+    ]
+    fanout_kwargs = {}
+    aggregator_calls = []
+
+    def fake_fanout(*args, **kwargs):
+        fanout_kwargs.update(kwargs)
+        return outputs
+
+    def fake_call_llm(**kwargs):
+        aggregator_calls.append(kwargs)
+        return _response("aggregator acted")
+
+    monkeypatch.setattr(moa_loop, "_run_references_parallel", fake_fanout)
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {"provider": slot["provider"], "model": slot["model"]},
+    )
+
+    facade = moa_loop.MoAChatCompletions("review")
+    facade.create(messages=[{"role": "user", "content": "review this"}], tools=[])
+
+    assert fanout_kwargs["reference_timeout"] == 19.0
+    private_prompt = str(aggregator_calls[0]["messages"])
+    assert "useful advice" in private_prompt
+    assert "super-secret" not in private_prompt
+    assert "Reference models unavailable" not in private_prompt
+    usage, cost = facade.consume_reference_usage()
+    assert usage.input_tokens == 12
+    assert cost == pytest.approx(0.12)
+    assert facade._pending_trace["reference_outputs"] == outputs
+
+
+def test_run_reference_forwards_configured_timeout(monkeypatch):
+    from agent import moa_loop
+
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _response("advice")
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {"provider": "openrouter", "model": slot["model"]},
+    )
+    monkeypatch.setattr(
+        "agent.usage_pricing.estimate_usage_cost",
+        lambda *args, **kwargs: SimpleNamespace(
+            amount_usd=None, status="unavailable", source=None
+        ),
+    )
+
+    label, text, accounting = moa_loop._run_reference(
+        {"provider": "openrouter", "model": "advisor"},
+        [{"role": "user", "content": "review"}],
+        reference_timeout=23.5,
+    )
+
+    assert (label, text) == ("openrouter:advisor", "advice")
+    assert calls[0]["timeout"] == 23.5
+    assert isinstance(accounting, moa_loop._RefAccounting)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2336,6 +2336,8 @@ export interface MoaConfigResponse {
     aggregator: MoaModelSlot;
     reference_temperature: number;
     aggregator_temperature: number;
+    reference_timeout: number;
+    degraded_reference_policy: "loud" | "silent";
     max_tokens: number;
     /** Optional advisor output cap — round-tripped, not edited here. */
     reference_max_tokens?: number | null;
@@ -2347,6 +2349,8 @@ export interface MoaConfigResponse {
   aggregator: MoaModelSlot;
   reference_temperature: number;
   aggregator_temperature: number;
+  reference_timeout: number;
+  degraded_reference_policy: "loud" | "silent";
   max_tokens: number;
   enabled: boolean;
 }

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -747,6 +747,8 @@ function MoaModelsModal({
       aggregator: draft.aggregator,
       reference_temperature: draft.reference_temperature,
       aggregator_temperature: draft.aggregator_temperature,
+      reference_timeout: draft.reference_timeout,
+      degraded_reference_policy: draft.degraded_reference_policy,
       max_tokens: draft.max_tokens,
       enabled: draft.enabled,
     };


### PR DESCRIPTION
## Problem

When a MoA reference model fails or times out, its raw error body (for example `[failed: timed out]`) is injected verbatim into the aggregator prompt. The aggregator can then echo this in user-visible text, leaking private MoA scaffolding.

The old wrapper `[Mixture of Agents reference context]` was also easy for the acting model to quote verbatim.

Additionally, reference calls used the fast-path timeout with no per-preset override, which makes deeper reference presets hard to configure safely.

## Fix

**Reference output sanitization**
- Failed references are filtered out before aggregator guidance is built.
- Only successful reference responses are injected as private context.
- A controlled `[MoA degraded: reference failed or timed out: provider:model]` marker replaces raw error text.

**Wrapper improvement**
- Replaces `[Mixture of Agents reference context]` / `[Mixture of Agents context]` with `[MoA private guidance — do not quote this scaffolding verbatim. Use it only to improve the answer.]`.
- The wording tells the model to use the guidance while avoiding verbatim scaffold leakage.

**Per-preset timeout / degraded policy**
- Adds `reference_timeout` (default `30.0`, capped at `300.0`).
- Adds `degraded_reference_policy` (`loud` / `silent`, default `loud`).

## Important compatibility note

This PR is rebased on current `origin/main` after the MoA reference-display/caching work and preserves newer MoA behavior:
- `_slot_runtime(...)` provider runtime resolution remains intact.
- MoA still passes `max_tokens=None` for reference calls so it does not impose an output cap.
- Reference output display/callback and turn-scoped reference cache remain intact.
- Existing tolerant `reference_models` normalization for scalar/dict hand-edited config remains intact.

## Tests

Local focused tests run against this PR head:

```text
PYTHONPATH=/tmp/hermes-pr-53784 /opt/hermes/venv/bin/python -m pytest \
  tests/hermes_cli/test_moa_config.py \
  tests/run_agent/test_moa_loop_mode.py -q

29 passed, 5 warnings
```

Additional regression harness result:

```text
base_aggregate     raw_failed_leak=True,  old_wrapper=True,  degraded_marker=False
base_chat          raw_failed_leak=True,  old_wrapper=True,  degraded_marker=False
patched_aggregate  raw_failed_leak=False, old_wrapper=False, degraded_marker=True
patched_chat       raw_failed_leak=False, old_wrapper=False, degraded_marker=True
REGRESSION_OK
```

## Known limitation

`_is_failed_reference()` currently detects failed references via the existing sentinel string prefix (`[failed:`). A structural success/failure flag from the reference-call layer would be more robust long-term, but this keeps the patch small and compatible with the current MoA return shape.
