### PR TITLE
fix(cli): commit tool scrollback in verbose mode so MoA tool calls build history

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10485,8 +10485,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         if event_type == "tool.completed":
             self._tool_start_time = 0.0
-            # Print stacked scrollback line for "all" / "new" modes
-            if function_name and self.tool_progress_mode in {"all", "new"}:
+            # Print stacked scrollback line for "new" / "all" / "verbose" modes.
+            # "verbose" was previously omitted here, so non-streaming model
+            # calls (MoA aggregator, copilot-acp) rendered each tool only into
+            # the transient spinner line — which overwrites itself, so no
+            # scrollable tool history accumulated. Streaming models hid the bug
+            # because _on_tool_gen_start commits a "preparing" line per tool;
+            # non-streaming calls never emit that, leaving verbose mode with no
+            # committed line at all. "verbose" is strictly more than "all", so
+            # it must commit at least the same line.
+            if function_name and self.tool_progress_mode in {"new", "all", "verbose"}:
                 duration = kwargs.get("duration", 0.0)
                 is_error = kwargs.get("is_error", False)
                 # Pop stored args from tool.started for this function

--- a/tests/cli/test_tool_progress_scrollback.py
+++ b/tests/cli/test_tool_progress_scrollback.py
@@ -169,14 +169,39 @@ class TestToolProgressScrollback:
 
         assert mock_print.call_count == 2
 
-    def test_verbose_mode_no_duplicate_scrollback(self):
-        """In 'verbose' mode, scrollback lines are NOT printed (run_agent handles verbose output)."""
+    def test_verbose_mode_commits_scrollback_line(self):
+        """In 'verbose' mode, tool.completed commits a persistent scrollback line.
+
+        Regression: 'verbose' used to be omitted from the scrollback gate on
+        the premise that run_agent renders verbose output. That premise is
+        false in the interactive CLI — run_agent's verbose prints are gated on
+        ``not quiet_mode`` and the interactive CLI runs quiet_mode=True. So a
+        non-streaming model call (MoA aggregator, copilot-acp) under 'verbose'
+        rendered each tool only into the self-overwriting spinner, building no
+        scrollable history. 'verbose' is strictly more than 'all', so it must
+        commit at least the same line.
+        """
         cli = _make_cli(tool_progress="verbose")
         with patch.object(_cli_mod, "_cprint") as mock_print:
             cli._on_tool_progress("tool.started", "terminal", "ls", {"command": "ls"})
             cli._on_tool_progress("tool.completed", "terminal", None, None, duration=0.5, is_error=False)
 
-        mock_print.assert_not_called()
+        mock_print.assert_called_once()
+
+    def test_verbose_mode_commits_every_call(self):
+        """In 'verbose' mode, consecutive same-tool calls each commit a line.
+
+        Mirrors 'all' (no consecutive-repeat suppression — that is 'new'-only),
+        so a multi-step turn builds a full scrollable tool history.
+        """
+        cli = _make_cli(tool_progress="verbose")
+        with patch.object(_cli_mod, "_cprint") as mock_print:
+            cli._on_tool_progress("tool.started", "terminal", "echo one", {"command": "echo one"})
+            cli._on_tool_progress("tool.completed", "terminal", None, None, duration=0.1, is_error=False)
+            cli._on_tool_progress("tool.started", "terminal", "echo two", {"command": "echo two"})
+            cli._on_tool_progress("tool.completed", "terminal", None, None, duration=0.1, is_error=False)
+
+        assert mock_print.call_count == 2
 
     def test_verbose_mode_config_does_not_enable_global_debug_logging(self):
         """display.tool_progress=verbose controls TOOL-CALL DISPLAY ONLY.


### PR DESCRIPTION
## Summary
In the interactive CLI under a MoA preset, the aggregator's tool calls now build scrollable history instead of overwriting each other. Previously each tool only updated the transient spinner line, so a multi-step turn looked like one tool replacing the last with no committed history.

Root cause: `_on_tool_progress`'s `tool.completed` branch committed a persistent scrollback line only for `tool_progress_mode in {"all", "new"}` — **`"verbose"` was omitted** on the premise that run_agent renders verbose output. That premise is false in the interactive CLI: run_agent's verbose prints are gated on `not quiet_mode`, and the interactive CLI runs `quiet_mode=True`. Streaming models hid the bug because `_on_tool_gen_start` commits a "preparing" line per tool during streaming; MoA forces `_use_streaming=False` (references + aggregator run synchronously), so under `verbose` there was no committed line at all — only the self-overwriting spinner.

This also fixes any non-streaming model call (e.g. copilot-acp) under `tool_progress: verbose`.

## Changes
- `cli.py`: include `"verbose"` in the `tool.completed` scrollback gate. `"verbose"` is strictly more than `"all"`, so it commits at least the same line. Consecutive-repeat suppression stays `"new"`-only.
- `tests/cli/test_tool_progress_scrollback.py`: flipped the stale `test_verbose_mode_no_duplicate_scrollback` (which pinned the broken behavior) to assert verbose commits a line; added a multi-call accumulation test.

## Validation
Live interactive PTY on the MoA `opus-gpt` preset (`streaming: true`, `tool_progress: verbose`):

| | Before | After |
|---|---|---|
| 3 terminal calls in one turn | one self-overwriting spinner line | 3 stacked `┊ $ echo …` lines |
| tool history across turns | none (each overwrote) | full scrollback retained |

`tests/cli/test_tool_progress_scrollback.py` → 16/16 pass.

## Infographic

![moa-tool-history](https://v3b.fal.media/files/b/0aa0033d/BMLatyqPFyJGC9EgEhrKK_Uvg6XTlK.png)
