### PR TITLE
feat(skills): add claude-import skill — migrate Claude conversations into any memory provider

### DIFF
--- a/optional-skills/migration/claude-import/SKILL.md
+++ b/optional-skills/migration/claude-import/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: claude-import
+description: Import Claude conversations into any Hermes memory provider.
+version: 1.0.0
+author: magnus919 (Magnus Hedemark), Hermes Agent (Nous Research)
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Migration, Claude, Memory, Import, Data]
+    related_skills: [hermes-agent]
+---
+
+# Claude Data Export Import
+
+Import your Claude.ai conversation history and memories into Hermes Agent
+through the configured memory provider. Uses the built-in `memory` tool so
+the import works with any provider (cashew, honcho, mem0, supermemory, etc.)
+without substrate-specific code — every `memory` call fires
+`on_memory_write()` on the active provider.
+
+This is a **1-way** import. Claude conversations are parsed and written as
+memory entries. No changes are made to your Claude export.
+
+## When to Use
+
+- You're migrating from Claude.ai to Hermes Agent
+- You have a Claude data export and want to bring conversation context into Hermes
+- You have a memory provider configured beyond the stock filesystem provider
+
+## Prerequisites
+
+- **Claude data export** downloaded from [claude.ai](https://claude.ai) settings → Export Data
+- **Hermes Agent** with an external memory provider configured:
+  ```bash
+  hermes memory setup
+  ```
+  The builtin filesystem provider is not supported — it lacks capacity for
+  the hundreds or thousands of memory entries a typical Claude export produces.
+- **Python 3.10+** in the Hermes venv
+
+## How to Run
+
+```
+/claude-import /path/to/claude-export/
+```
+
+The skill streams `conversations.json` from the export directory, extracts
+memory units, and injects them via the `memory` tool.
+
+## Procedure
+
+### 1. Verify the export path
+
+Confirm the path exists and contains `conversations.json`. The export may be
+a single directory or contain a `data-*` subdirectory.
+
+### 2. Check the active memory provider
+
+Read the configured memory provider:
+```python
+from hermes_cli.config import load_config, cfg_get
+config = load_config()
+provider = cfg_get(config, "memory", "provider")
+```
+
+- If `provider` is `None`, `""`, or not set → **builtin filesystem provider is active**.
+  Do not proceed. Tell the user:
+  > "Your Claude export contains hundreds of conversations that would generate
+  > thousands of memory entries, exceeding the builtin filesystem provider's
+  > capacity. Configure an external memory provider first:
+  >   `hermes memory setup`
+  > Then re-run this command."
+
+- If `provider` is set (e.g. `"cashew"`, `"honcho"`, `"mem0"`, `"supermemory"`) → proceed.
+
+### 3. Run the parser
+
+Run the parsing script from the skill directory to extract memory units:
+
+```bash
+python scripts/claude_parse.py /path/to/claude-export/ \
+  --output /tmp/claude-memory-units.json
+```
+
+The script is at `optional-skills/migration/claude-import/scripts/claude_parse.py`
+relative to the Hermes Agent repository root. Resolve the absolute path
+using `SkillManager` or the installed skill path at
+`~/.hermes/skills/migration/claude-import/scripts/claude_parse.py`.
+
+The script `stream_json_array()` function handles 175 MB+ files without
+loading the entire file into memory.
+
+### 4. Read the output
+
+```python
+import json
+with open("/tmp/claude-memory-units.json") as f:
+    units = json.load(f)
+```
+
+Each unit has:
+- `content` — the memory text (conversation name + summary + key exchange)
+- `source_type` — `"conversation"` or `"project_memory"`
+- `conversation_uuid` — for deduplication
+- `timestamp` — the conversation start time
+
+### 5. Batch-and-import loop
+
+Batch conversations to stay within the agent's `max_iterations` budget
+(default 90). The recommended ratio is **10 conversations per memory call**:
+
+```python
+batch_size = 10
+batches = [units[i:i + batch_size] for i in range(0, len(units), batch_size)]
+
+for i, batch in enumerate(batches):
+    # Embed structured metadata for each entry (UUID, source, timestamp)
+    # so the provider can surface traceable origin and enable dedup
+    combined = "\n\n---\n\n".join(
+        "\n".join([
+            f"[UUID: {u['conversation_uuid']}]",
+            f"[Source: claude]",
+            f"[Type: {u.get('source_type', 'conversation')}]",
+            f"[Timestamp: {u.get('timestamp', 'unknown')}]",
+            u.get("content", ""),
+        ])
+        for u in batch
+    )
+    memory(action='add', target='memory', content=combined)
+    # Each call fires on_memory_write() on the configured provider
+```
+
+- **Dedup by UUID**: Before importing, compare against existing memory or
+  skip UUIDs already seen. The `conversation_uuid` field on each unit can
+  be used to detect re-imports.
+- **Project memories** (`source_type: "project_memory"`) are higher-signal
+  than raw conversations. Import these first, or at a smaller batch size
+  (5 per call) to preserve their structure.
+
+### 6. Report
+
+After the loop completes, report:
+
+```
+Imported {N} memory units from {conversation_count} conversations
+  + {project_count} project memories
+  across {batch_count} memory tool calls.
+Source: {export_dir}
+```
+
+**Important caveat:** `on_memory_write()` returns `None` — there is
+no per-write acknowledgment from the provider. This reports what was
+dispatched to the provider, not what was accepted. Verify receipt by
+checking your provider's storage.
+
+## Batching Reference
+
+| Conversations | Batch size | Memory calls | Fits 90-iteration limit? |
+|---------------|------------|-------------|--------------------------|
+| 100           | 10         | 10          | ✅ Yes                   |
+| 500           | 10         | 50          | ✅ Yes                   |
+| 856           | 10         | 86          | ✅ Yes                   |
+| 856           | 20         | 43          | ✅ Yes (but coarser)     |
+| 2000          | 30         | 67          | ✅ Yes                   |
+
+If the number of batches exceeds the iteration limit, use `/goal` to
+drive the import across multiple turns:
+```
+/goal Import the remaining {N} batches of Claude memory units from /tmp/claude-memory-units.json
+```
+The goal judge will verify batch-by-batch completion.
+
+## Pitfalls
+
+- **Builtin provider guard is load-bearing.** Do not skip the provider check.
+  The filesystem provider will silently drop or corrupt entries beyond its
+  capacity. There is no runtime signal — `on_memory_write()` returns `None`.
+- **Memory provider must be configured BEFORE running this command.**
+  The preflight check is static — if no external provider is configured,
+  the command refuses to run.
+- **Streaming parser vs full load.** The `claude_parse.py` script streams
+  large files using `json.JSONDecoder.raw_decode` for files over 50 MB.
+  Under 50 MB it uses `json.loads` for speed.
+- **No dedup by default.** Importing the same export twice will create
+  duplicate memory entries. The skill relies on the user's memory provider
+  for dedup — if the provider doesn't deduplicate, the user will see
+  duplicates. Consider checking `conversation_uuid` before writing if
+  re-import is expected.
+- **memories.json is richer than conversations.json.** Project memories
+  contain curated knowledge summaries. If present, they produce higher-
+  quality memory entries than raw conversation dumps.
+- **File attachments are not imported.** The parser only extracts message
+  text. Uploaded files, images, and code artifacts in conversations
+  are skipped.
+
+## Verification
+
+After import, confirm the data landed:
+
+```bash
+# Check the provider's status
+hermes memory status
+# or: hermes doctor
+```

--- a/optional-skills/migration/claude-import/scripts/claude_parse.py
+++ b/optional-skills/migration/claude-import/scripts/claude_parse.py
@@ -1,0 +1,346 @@
+"""
+claude_parse — Extract memory units from a Claude.ai data export.
+
+Usage:
+    python claude_parse.py <export_dir> [--output <path>]
+
+Reads conversations.json (streaming) and memories.json from the export
+directory, produces structured memory units suitable for import via
+Hermes' built-in ``memory`` tool.
+
+Output: JSON array of memory units to stdout (or --output file). Each unit:
+
+.. code-block:: json
+
+    {
+      "content": "Conversation summary and key exchanges...",
+      "source": "claude",
+      "source_type": "conversation",
+      "conversation_uuid": "550e8400-e29b-41d4-a716-446655440000",
+      "conversation_name": "Project Planning",
+      "timestamp": "2025-08-15T14:30:00Z",
+      "updated_at": "2025-08-15T15:30:00Z"
+    }
+
+No external dependencies — uses only Python stdlib.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+from typing import Any, Dict, Iterator, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Streaming JSON array reader (stdlib only)
+# ---------------------------------------------------------------------------
+
+def stream_json_array(filepath: str) -> Iterator[Dict[str, Any]]:
+    """Yield top-level objects from a JSON array one at a time.
+
+    Uses ``json.JSONDecoder.raw_decode`` with an accumulating buffer so
+    that a 175 MB ``conversations.json`` never needs to be fully resident.
+    Falls back to ``json.loads`` for files under 50 MB (faster path).
+    """
+    size = os.path.getsize(filepath)
+    if size < 50 * 1024 * 1024:
+        # Small enough to load in one shot — faster
+        with open(filepath, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            yield from data
+        return
+
+    # Streaming path for large files
+    decoder = json.JSONDecoder()
+    buffer = ""
+    with open(filepath, "r", encoding="utf-8") as f:
+        # Consume up to the opening '['
+        while True:
+            ch = f.read(1)
+            if not ch:
+                return
+            if ch == "[":
+                break
+
+        while True:
+            ch = f.read(1)
+            if not ch:
+                break
+            buffer += ch
+
+            stripped = buffer.strip()
+            if not stripped or stripped == ",":
+                buffer = ""
+                continue
+            if stripped == "]":
+                return
+
+            try:
+                obj, idx = decoder.raw_decode(buffer)
+                yield obj
+                # Keep any trailing content (e.g. "," or "]}") for next iter
+                buffer = buffer[idx:].lstrip().lstrip(",").lstrip()
+            except json.JSONDecodeError:
+                continue
+
+
+# ---------------------------------------------------------------------------
+# Claude data model helpers
+# ---------------------------------------------------------------------------
+
+def _flatten_content(content: Any) -> str:
+    """Extract readable text from Claude's rich content blocks."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict):
+                parts.append(block.get("text", "") or "")
+            elif isinstance(block, str):
+                parts.append(block)
+        return "\n".join(p for p in parts if p)
+    return ""
+
+
+def _extract_key_exchanges(messages: List[Dict]) -> str:
+    """Summarise the first substantive exchange in a conversation.
+
+    Keeps the first human message and the first assistant response to
+    give context without bloating the memory unit.
+    """
+    exchanges: List[str] = []
+    seen_uuid: set = set()
+
+    for msg in messages:
+        mid = msg.get("uuid", "")
+        if mid in seen_uuid:
+            continue
+        seen_uuid.add(mid)
+
+        sender = msg.get("sender", "")
+        text = msg.get("text", "") or _flatten_content(msg.get("content", ""))
+        if not text.strip():
+            continue
+
+        if sender == "human":
+            # Truncate long human messages
+            if len(text) > 500:
+                text = text[:500] + "…"
+            exchanges.append(f"Q: {text.strip()}")
+        elif sender == "assistant" and exchanges:
+            # First assistant response after a human message
+            if len(text) > 800:
+                text = text[:800] + "…"
+            exchanges.append(f"A: {text.strip()}")
+            break  # One Q&A pair is enough for context
+
+    return "\n\n".join(exchanges)
+
+
+def _make_memory_unit(
+    conv: Dict[str, Any],
+    *,
+    source_type: str = "conversation",
+    content_override: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build a memory unit dict from a conversation object."""
+    conv_name = conv.get("name", "").strip() or "(untitled)"
+    conv_summary = conv.get("summary", "").strip()
+    created = conv.get("created_at", "")
+    updated = conv.get("updated_at", "")
+
+    if content_override:
+        content = content_override
+    else:
+        parts: List[str] = []
+        if conv_summary:
+            parts.append(f"Conversation: {conv_name}\nSummary: {conv_summary}")
+        else:
+            parts.append(f"Conversation: {conv_name}")
+
+        messages = conv.get("chat_messages", [])
+        key = _extract_key_exchanges(messages)
+        if key:
+            parts.append(key)
+
+        content = "\n\n".join(parts)
+
+    return {
+        "content": content,
+        "source": "claude",
+        "source_type": source_type,
+        "conversation_uuid": conv.get("uuid", ""),
+        "conversation_name": conv_name,
+        "timestamp": created,
+        "updated_at": updated,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Memories.json parser
+# ---------------------------------------------------------------------------
+
+def parse_memories(memories_path: str) -> List[Dict[str, Any]]:
+    """Parse Claude's memories.json into memory units.
+
+    memories.json contains per-conversation and per-project memory texts
+    that Claude maintains. These are higher-signal than the raw conversation
+    data because they represent the user's curated knowledge.
+    """
+    if not os.path.isfile(memories_path):
+        return []
+
+    with open(memories_path, "r", encoding="utf-8") as f:
+        raw = json.load(f)
+
+    units: List[Dict[str, Any]] = []
+
+    if isinstance(raw, list):
+        for entry in raw:
+            if not isinstance(entry, dict):
+                continue
+            # Per-conversation memories
+            conv_memory = entry.get("conversations_memory")
+            if conv_memory and isinstance(conv_memory, str) and conv_memory.strip():
+                # These are freeform memory texts without conversation UUIDs
+                # in the memory section itself — group them under a generic source
+                units.append({
+                    "content": conv_memory.strip(),
+                    "source": "claude",
+                    "source_type": "conversation_memory",
+                    "conversation_uuid": entry.get("account_uuid", ""),
+                    "conversation_name": "Claude Memory",
+                    "timestamp": "",
+                    "updated_at": "",
+                })
+
+            # Per-project memories
+            project_memories = entry.get("project_memories")
+            if project_memories and isinstance(project_memories, dict):
+                for project_uuid, memory_text in project_memories.items():
+                    if isinstance(memory_text, str) and memory_text.strip():
+                        # Extract project name from first line if possible
+                        first_line = memory_text.strip().split("\n")[0]
+                        proj_name = first_line.replace("**", "").replace("###", "").strip()
+                        if len(proj_name) > 80:
+                            proj_name = f"project_{project_uuid[:8]}"
+                        units.append({
+                            "content": memory_text.strip(),
+                            "source": "claude",
+                            "source_type": "project_memory",
+                            "conversation_uuid": project_uuid,
+                            "conversation_name": proj_name,
+                            "timestamp": "",
+                            "updated_at": "",
+                        })
+
+    return units
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def parse_export(
+    export_dir: str,
+    *,
+    include_memories: bool = True,
+) -> List[Dict[str, Any]]:
+    """Parse a Claude data export and return memory units.
+
+    Args:
+        export_dir: Path to the root of the Claude export directory.
+        include_memories: Also parse ``memories.json`` if present.
+
+    Returns:
+        List of memory unit dicts.
+    """
+    if not os.path.isdir(export_dir):
+        print(f"Error: directory not found: {export_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    convs_path = os.path.join(export_dir, "conversations.json")
+    if not os.path.isfile(convs_path):
+        # Maybe it's inside a batch subdirectory
+        batch_dirs = [
+            d for d in os.listdir(export_dir)
+            if d.startswith("data-") and os.path.isdir(os.path.join(export_dir, d))
+        ]
+        if batch_dirs:
+            convs_path = os.path.join(export_dir, batch_dirs[0], "conversations.json")
+
+    if not os.path.isfile(convs_path):
+        print(f"Error: conversations.json not found in {export_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    units: List[Dict[str, Any]] = []
+    conv_count = 0
+
+    for conv in stream_json_array(convs_path):
+        conv_count += 1
+        unit = _make_memory_unit(conv)
+        units.append(unit)
+
+    if include_memories:
+        # Try the root directory first, then the batch subdirectory
+        mem_path = os.path.join(export_dir, "memories.json")
+        if not os.path.isfile(mem_path):
+            batch_dirs = [
+                d for d in os.listdir(export_dir)
+                if d.startswith("data-") and os.path.isdir(os.path.join(export_dir, d))
+            ]
+            if batch_dirs:
+                mem_path = os.path.join(export_dir, batch_dirs[0], "memories.json")
+
+        if os.path.isfile(mem_path):
+            mem_units = parse_memories(mem_path)
+            units.extend(mem_units)
+
+    return units
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract memory units from a Claude.ai data export."
+    )
+    parser.add_argument(
+        "export_dir",
+        help="Path to the Claude data export directory",
+    )
+    parser.add_argument(
+        "--output", "-o",
+        default=None,
+        help="Output file path (default: stdout)",
+    )
+    parser.add_argument(
+        "--no-memories",
+        action="store_true",
+        help="Skip importing project/conversation memories from memories.json",
+    )
+
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.export_dir):
+        print(f"Error: directory not found: {args.export_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    units = parse_export(args.export_dir, include_memories=not args.no_memories)
+
+    output = json.dumps(units, indent=2, ensure_ascii=False)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(output)
+        print(f"Wrote {len(units)} memory units to {args.output}", file=sys.stderr)
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/skills/test_claude_import_skill.py
+++ b/tests/skills/test_claude_import_skill.py
@@ -1,0 +1,535 @@
+"""
+Tests for the claude-import skill — parse script and memory unit extraction.
+
+Tests load the script as a module (following the pattern from
+``test_openclaw_migration.py`` and ``test_telephony_skill.py``)
+and exercise its functions with synthetic Claude export data.
+
+No live filesystem or network — all test data is in-memory.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Iterator
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "migration"
+    / "claude-import"
+    / "scripts"
+    / "claude_parse.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("claude_parse", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Helpers — synthetic Claude export data
+# ---------------------------------------------------------------------------
+
+def make_conversation(
+    uuid: str = "550e8400-e29b-41d4-a716-446655440000",
+    name: str = "Test Conversation",
+    summary: str = "A discussion about testing.",
+    created: str = "2025-08-15T14:30:00Z",
+    updated: str = "2025-08-15T15:30:00Z",
+    messages: list | None = None,
+) -> dict:
+    """Build a synthetic Claude conversation object."""
+    if messages is None:
+        messages = [
+            {
+                "uuid": "msg-001",
+                "sender": "human",
+                "text": "What architecture should we use for this project?",
+                "content": [],
+                "created_at": "2025-08-15T14:30:01Z",
+                "updated_at": "2025-08-15T14:30:01Z",
+                "attachments": [],
+                "files": [],
+                "parent_message_uuid": "00000000-0000-4000-8000-000000000000",
+            },
+            {
+                "uuid": "msg-002",
+                "sender": "assistant",
+                "text": "For your use case, I'd recommend a modular monolith. "
+                        "It gives you the deployment simplicity of a monolith "
+                        "with the organizational benefits of separate modules. "
+                        "You can split into microservices later if needed.",
+                "content": [],
+                "created_at": "2025-08-15T14:30:10Z",
+                "updated_at": "2025-08-15T14:30:10Z",
+                "attachments": [],
+                "files": [],
+                "parent_message_uuid": "msg-001",
+            },
+        ]
+    return {
+        "uuid": uuid,
+        "name": name,
+        "summary": summary,
+        "created_at": created,
+        "updated_at": updated,
+        "account": {"uuid": "acct-001"},
+        "chat_messages": messages,
+    }
+
+
+def write_synthetic_export(tmp_path: Path, conversations: list[dict]) -> Path:
+    """Write a synthetic conversations.json to a temp directory."""
+    export_dir = tmp_path / "claude-export"
+    export_dir.mkdir()
+    conv_path = export_dir / "conversations.json"
+    conv_path.write_text(json.dumps(conversations), encoding="utf-8")
+    return export_dir
+
+
+# ---------------------------------------------------------------------------
+# stream_json_array
+# ---------------------------------------------------------------------------
+
+def test_stream_json_array_yields_all_items(tmp_path):
+    mod = load_module()
+    data = [
+        {"id": 1, "name": "first"},
+        {"id": 2, "name": "second"},
+        {"id": 3, "name": "third"},
+    ]
+    path = tmp_path / "test.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    result = list(mod.stream_json_array(str(path)))
+    assert len(result) == 3
+    assert result[0]["id"] == 1
+    assert result[2]["id"] == 3
+
+
+def test_stream_json_array_empty_array(tmp_path):
+    mod = load_module()
+    path = tmp_path / "empty.json"
+    path.write_text("[]", encoding="utf-8")
+
+    result = list(mod.stream_json_array(str(path)))
+    assert result == []
+
+
+def test_stream_json_array_single_item(tmp_path):
+    mod = load_module()
+    path = tmp_path / "single.json"
+    path.write_text('[{"key": "value"}]', encoding="utf-8")
+
+    result = list(mod.stream_json_array(str(path)))
+    assert len(result) == 1
+    assert result[0]["key"] == "value"
+
+
+# ---------------------------------------------------------------------------
+# _flatten_content
+# ---------------------------------------------------------------------------
+
+def test_flatten_content_string_passthrough():
+    mod = load_module()
+    assert mod._flatten_content("hello") == "hello"
+
+
+def test_flatten_content_list_of_blocks():
+    mod = load_module()
+    blocks = [
+        {"type": "text", "text": "Part one."},
+        {"type": "text", "text": "Part two."},
+    ]
+    assert mod._flatten_content(blocks) == "Part one.\nPart two."
+
+
+def test_flatten_content_list_with_empty_text():
+    mod = load_module()
+    blocks = [
+        {"type": "text", "text": ""},
+        {"type": "text", "text": "Only this."},
+    ]
+    assert mod._flatten_content(blocks) == "Only this."
+
+
+def test_flatten_content_non_dict_items():
+    mod = load_module()
+    blocks = ["plain", {"type": "text", "text": "structured"}]
+    assert mod._flatten_content(blocks) == "plain\nstructured"
+
+
+# ---------------------------------------------------------------------------
+# _extract_key_exchanges
+# ---------------------------------------------------------------------------
+
+def test_extract_key_exchanges_returns_qa_pair():
+    mod = load_module()
+    conv = make_conversation()
+    text = mod._extract_key_exchanges(conv["chat_messages"])
+    assert "Q:" in text
+    assert "A:" in text
+    assert "modular monolith" in text
+
+
+def test_extract_key_exchanges_only_one_exchange():
+    mod = load_module()
+    messages = [
+        {
+            "uuid": "m1", "sender": "human",
+            "text": "Question one?", "content": [],
+            "created_at": "2025-01-01T00:00:00Z",
+            "updated_at": "2025-01-01T00:00:00Z",
+            "attachments": [], "files": [],
+            "parent_message_uuid": "00000000-0000-4000-8000-000000000000",
+        },
+        {
+            "uuid": "m2", "sender": "assistant",
+            "text": "Answer one.", "content": [],
+            "created_at": "2025-01-01T00:00:01Z",
+            "updated_at": "2025-01-01T00:00:01Z",
+            "attachments": [], "files": [],
+            "parent_message_uuid": "m1",
+        },
+        {
+            "uuid": "m3", "sender": "human",
+            "text": "Follow-up?", "content": [],
+            "created_at": "2025-01-01T00:00:02Z",
+            "updated_at": "2025-01-01T00:00:02Z",
+            "attachments": [], "files": [],
+            "parent_message_uuid": "m2",
+        },
+        {
+            "uuid": "m4", "sender": "assistant",
+            "text": "Follow-up answer.", "content": [],
+            "created_at": "2025-01-01T00:00:03Z",
+            "updated_at": "2025-01-01T00:00:03Z",
+            "attachments": [], "files": [],
+            "parent_message_uuid": "m3",
+        },
+    ]
+    text = mod._extract_key_exchanges(messages)
+    assert "Follow-up" not in text
+    assert "Answer one" in text
+
+
+def test_extract_key_exchanges_empty_messages():
+    mod = load_module()
+    assert mod._extract_key_exchanges([]) == ""
+
+
+def test_extract_key_exchanges_no_assistant():
+    mod = load_module()
+    messages = [
+        {
+            "uuid": "m1", "sender": "human",
+            "text": "Hello?", "content": [],
+            "created_at": "2025-01-01T00:00:00Z",
+            "updated_at": "2025-01-01T00:00:00Z",
+            "attachments": [], "files": [],
+            "parent_message_uuid": "00000000-0000-4000-8000-000000000000",
+        },
+    ]
+    text = mod._extract_key_exchanges(messages)
+    assert "Hello" in text
+    assert "A:" not in text
+
+
+# ---------------------------------------------------------------------------
+# _make_memory_unit
+# ---------------------------------------------------------------------------
+
+def test_make_memory_unit_has_expected_fields():
+    mod = load_module()
+    conv = make_conversation()
+    unit = mod._make_memory_unit(conv)
+
+    assert unit["source"] == "claude"
+    assert unit["source_type"] == "conversation"
+    assert unit["conversation_uuid"] == "550e8400-e29b-41d4-a716-446655440000"
+    assert unit["conversation_name"] == "Test Conversation"
+    assert unit["timestamp"] == "2025-08-15T14:30:00Z"
+    assert unit["updated_at"] == "2025-08-15T15:30:00Z"
+
+
+def test_make_memory_unit_includes_summary():
+    mod = load_module()
+    conv = make_conversation(summary="Key insight about architecture.")
+    unit = mod._make_memory_unit(conv)
+    assert "Key insight about architecture." in unit["content"]
+
+
+def test_make_memory_unit_includes_exchange():
+    mod = load_module()
+    conv = make_conversation(
+        summary="Testing discussion.",
+        messages=[
+            {
+                "uuid": "m1", "sender": "human",
+                "text": "What is the answer?", "content": [],
+                "created_at": "2025-01-01T00:00:00Z",
+                "updated_at": "2025-01-01T00:00:00Z",
+                "attachments": [], "files": [],
+                "parent_message_uuid": "00000000-0000-4000-8000-000000000000",
+            },
+            {
+                "uuid": "m2", "sender": "assistant",
+                "text": "The answer is 42.", "content": [],
+                "created_at": "2025-01-01T00:00:01Z",
+                "updated_at": "2025-01-01T00:00:01Z",
+                "attachments": [], "files": [],
+                "parent_message_uuid": "m1",
+            },
+        ],
+    )
+    unit = mod._make_memory_unit(conv)
+    assert "What is the answer?" in unit["content"]
+    assert "The answer is 42." in unit["content"]
+
+
+def test_make_memory_unit_untitled_conversation():
+    mod = load_module()
+    conv = make_conversation(name="", summary="")
+    unit = mod._make_memory_unit(conv)
+    assert "(untitled)" in unit["conversation_name"]
+    assert "Conversation:" in unit["content"]
+
+
+def test_make_memory_unit_with_content_override():
+    mod = load_module()
+    conv = make_conversation()
+    unit = mod._make_memory_unit(conv, content_override="Custom content")
+    assert unit["content"] == "Custom content"
+
+
+# ---------------------------------------------------------------------------
+# parse_memories
+# ---------------------------------------------------------------------------
+
+def test_parse_memories_conversations_memory(tmp_path):
+    mod = load_module()
+    mem = [
+        {
+            "conversations_memory": "User prefers concise documentation.",
+            "project_memories": {},
+            "account_uuid": "acct-001",
+        }
+    ]
+    path = tmp_path / "memories.json"
+    path.write_text(json.dumps(mem), encoding="utf-8")
+
+    units = mod.parse_memories(str(path))
+    assert len(units) == 1
+    assert units[0]["source_type"] == "conversation_memory"
+    assert "concise documentation" in units[0]["content"]
+
+
+def test_parse_memories_project_memories(tmp_path):
+    mod = load_module()
+    mem = [
+        {
+            "conversations_memory": "",
+            "project_memories": {
+                "proj-001": "***Purpose & context***\nProject about building a mesh network.",
+            },
+            "account_uuid": "acct-001",
+        }
+    ]
+    path = tmp_path / "memories.json"
+    path.write_text(json.dumps(mem), encoding="utf-8")
+
+    units = mod.parse_memories(str(path))
+    assert len(units) == 1
+    assert units[0]["source_type"] == "project_memory"
+    assert "mesh network" in units[0]["content"]
+
+
+def test_parse_memories_empty_file(tmp_path):
+    mod = load_module()
+    path = tmp_path / "memories.json"
+    path.write_text("[]", encoding="utf-8")
+    assert mod.parse_memories(str(path)) == []
+
+
+def test_parse_memories_missing_file():
+    mod = load_module()
+    assert mod.parse_memories("/nonexistent/memories.json") == []
+
+
+def test_parse_memories_skips_empty_text(tmp_path):
+    mod = load_module()
+    mem = [
+        {
+            "conversations_memory": "",
+            "project_memories": {},
+            "account_uuid": "acct-001",
+        }
+    ]
+    path = tmp_path / "memories.json"
+    path.write_text(json.dumps(mem), encoding="utf-8")
+    assert mod.parse_memories(str(path)) == []
+
+
+# ---------------------------------------------------------------------------
+# parse_export — end-to-end integration
+# ---------------------------------------------------------------------------
+
+def test_parse_export_basic(tmp_path):
+    mod = load_module()
+    convs = [
+        make_conversation(
+            uuid="aa-001", name="First Chat",
+            summary="Initial brainstorming.",
+        ),
+        make_conversation(
+            uuid="bb-002", name="Deep Dive",
+            summary="Technical deep dive into architecture.",
+        ),
+    ]
+    export_dir = write_synthetic_export(tmp_path, convs)
+
+    units = mod.parse_export(str(export_dir), include_memories=False)
+    assert len(units) == 2
+    assert units[0]["conversation_name"] == "First Chat"
+    assert units[1]["conversation_name"] == "Deep Dive"
+
+
+def test_parse_export_includes_memories(tmp_path):
+    mod = load_module()
+    convs = [make_conversation(uuid="cc-001", name="Solo Chat")]
+    export_dir = write_synthetic_export(tmp_path, convs)
+
+    # Also write memories.json
+    mem = [
+        {
+            "conversations_memory": "User likes dark mode.",
+            "project_memories": {},
+            "account_uuid": "acct-001",
+        }
+    ]
+    (export_dir / "memories.json").write_text(json.dumps(mem), encoding="utf-8")
+
+    units = mod.parse_export(str(export_dir), include_memories=True)
+    # 1 conversation + 1 memory
+    assert len(units) == 2
+    memory_units = [u for u in units if u["source_type"] == "conversation_memory"]
+    assert len(memory_units) == 1
+
+
+def test_parse_export_detects_batch_subdirectory(tmp_path):
+    mod = load_module()
+    # Create a data-* batch subdirectory structure
+    batch_dir = tmp_path / "claude-export" / "data-batch-001"
+    batch_dir.mkdir(parents=True)
+    convs = [make_conversation(uuid="dd-001", name="Batch Chat")]
+    (batch_dir / "conversations.json").write_text(json.dumps(convs), encoding="utf-8")
+
+    units = mod.parse_export(str(tmp_path / "claude-export"), include_memories=False)
+    assert len(units) == 1
+    assert units[0]["conversation_name"] == "Batch Chat"
+
+
+def test_parse_export_missing_file(tmp_path):
+    mod = load_module()
+    # Should sys.exit(1) — catch it
+    try:
+        mod.parse_export(str(tmp_path / "nonexistent"), include_memories=False)
+        assert False, "Expected SystemExit"
+    except SystemExit:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+def test_long_human_message_truncated():
+    mod = load_module()
+    long_text = "A" * 1000
+    messages = [
+        {
+            "uuid": "m1", "sender": "human",
+            "text": long_text, "content": [],
+            "created_at": "2025-01-01T00:00:00Z",
+            "updated_at": "2025-01-01T00:00:00Z",
+            "attachments": [], "files": [],
+            "parent_message_uuid": "00000000-0000-4000-8000-000000000000",
+        },
+    ]
+    text = mod._extract_key_exchanges(messages)
+    assert len(text) <= 510  # 500 + "Q: " + "…"
+
+
+def test_conversation_with_no_messages():
+    mod = load_module()
+    conv = make_conversation(messages=[])
+    unit = mod._make_memory_unit(conv)
+    assert unit["content"] is not None
+    # No exchange text, just the name/summary
+    assert "Test Conversation" in unit["content"]
+
+
+def test_conversation_with_only_human_messages():
+    mod = load_module()
+    messages = [
+        {
+            "uuid": "m1", "sender": "human",
+            "text": "I need help with something.", "content": [],
+            "created_at": "2025-01-01T00:00:00Z",
+            "updated_at": "2025-01-01T00:00:00Z",
+            "attachments": [], "files": [],
+            "parent_message_uuid": "00000000-0000-4000-8000-000000000000",
+        },
+        {
+            "uuid": "m2", "sender": "human",
+            "text": "Actually never mind.", "content": [],
+            "created_at": "2025-01-01T00:00:01Z",
+            "updated_at": "2025-01-01T00:00:01Z",
+            "attachments": [], "files": [],
+            "parent_message_uuid": "m1",
+        },
+    ]
+    conv = make_conversation(messages=messages)
+    unit = mod._make_memory_unit(conv)
+    assert "I need help" in unit["content"]
+    # Only human messages appear
+    assert "A:" not in unit["content"]
+
+
+def test_rich_content_blocks():
+    mod = load_module()
+    messages = [
+        {
+            "uuid": "m1", "sender": "human",
+            "text": "Tell me something interesting.",
+            "content": [],
+            "created_at": "2025-01-01T00:00:00Z",
+            "updated_at": "2025-01-01T00:00:00Z",
+            "attachments": [], "files": [],
+            "parent_message_uuid": "00000000-0000-4000-8000-000000000000",
+        },
+        {
+            "uuid": "m2", "sender": "assistant",
+            "text": "",
+            "content": [
+                {"type": "text", "text": "Rich block answer."},
+            ],
+            "created_at": "2025-01-01T00:00:01Z",
+            "updated_at": "2025-01-01T00:00:01Z",
+            "attachments": [], "files": [],
+            "parent_message_uuid": "m1",
+        },
+    ]
+    conv = make_conversation(messages=messages)
+    unit = mod._make_memory_unit(conv)
+    assert "Rich block answer" in unit["content"]


### PR DESCRIPTION
## What does this PR do?

Clean rebuild of PR #28041 from current upstream `main` — adds a `claude-import` optional skill for migrating Claude.ai data exports into any Hermes memory provider. The original PR had a massively inflated diff (+53K lines) because the fork branch was created from a divergent upstream base. This PR ships only the 4 actual skill files (1,081 lines total).

The skill is substrate-agnostic: it goes through the built-in `memory` tool, so every call fires `on_memory_write()` on whatever provider is active. A streaming JSON parser handles 175MB+ exports without loading into memory. Includes a preflight circuit breaker that refuses to run when only the builtin filesystem provider is configured.

## Related Issue

Fixes #28033

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/migration/claude-import/SKILL.md` — Skill definition with procedure, preflight guard, batching table, and pitfalls
- `optional-skills/migration/claude-import/scripts/claude_parse.py` — Streaming JSON parser that extracts memory units from conversations.json and memories.json (stdlib-only, no external deps)
- `optional-skills/migration/claude-import/scripts/__init__.py` — Package marker
- `tests/skills/test_claude_import_skill.py` — 29 tests covering streaming parser, memory units, memories.json parsing, and edge cases

## How to Test

1. Clone the repo and check out this branch
2. `pip install -e ".[all,dev]"` and configure an external memory provider
3. Point the skill at a Claude.ai data export:
   ```
   python optional-skills/migration/claude-import/scripts/claude_parse.py /path/to/claude-export --output /tmp/units.json
   ```
4. Follow the import loop in the SKILL.md to write units through the `memory` tool
5. Verify with `hermes memory status` or `hermes doctor`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [x] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] NO external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [x] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

Previous testing (PR #28041 comment thread) validated the full pipeline in Docker: parser produces correct memory units, `on_memory_write()` accepts them, they survive provider restart, and prefetch returns stored content.

---

Filed by Jasper (AI agent on behalf of @magnus919)
