### PR TITLE
fix(hindsight): add client creation lock to prevent thread race

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -656,6 +656,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._agent_workspace = ""
         self._turn_index = 0
         self._client = None
+        self._client_lock = threading.Lock()
         self._timeout = _DEFAULT_TIMEOUT
         self._idle_timeout = _DEFAULT_IDLE_TIMEOUT
         self._prefetch_result = ""
@@ -1010,8 +1011,19 @@ class HindsightMemoryProvider(MemoryProvider):
         ]
 
     def _get_client(self):
-        """Return the cached Hindsight client (created once, reused)."""
-        if self._client is None:
+        """Return the cached Hindsight client (created once, reused).
+
+        Thread-safe: a dedicated lock prevents two concurrent callers from
+        racing to create duplicate clients.  Only the first caller pays the
+        creation cost; subsequent callers return the cached instance.
+        """
+        if self._client is not None:
+            return self._client
+        with self._client_lock:
+            # Double-check after acquiring the lock — another thread may
+            # have finished creating the client while we were waiting.
+            if self._client is not None:
+                return self._client
             if self._mode == "local_embedded":
                 available, reason = _check_local_runtime()
                 if not available:

--- a/pr-bodies/P1-11-hindsight-client-lock.md
+++ b/pr-bodies/P1-11-hindsight-client-lock.md
@@ -1,0 +1,29 @@
+## Summary
+
+Fix a thread-safety bug in the Hindsight memory plugin: `_get_client()` used an unprotected check-then-act pattern that allowed two concurrent threads to race and create duplicate clients, wasting resources and potentially causing runtime errors.
+
+## Bug
+
+`_get_client()` at `plugins/memory/hindsight/__init__.py:1012` checks `if self._client is None` and then creates the client without holding a lock. In concurrent scenarios (gateway serving multiple sessions), two threads could both see `_client is None`, both create a new client, and one client's resources would leak.
+
+## Fix
+
+Added a `_client_lock` (threading.Lock) to `HindsightMemoryProvider.__init__()` and a double-checked locking pattern in `_get_client()`:
+
+1. Fast path: if `_client is not None`, return it (no lock needed)
+2. Acquire `_client_lock`
+3. Double-check: if `_client is not None` (another thread finished creating), return it
+4. Create client while holding the lock
+
+## Impact
+
+- **Severity**: P1 — resource leak in concurrent gateway deployments
+- **Scope**: Hindsight memory plugin (`plugins/memory/hindsight/__init__.py`)
+- **Risk**: Minimal — lock is per-provider instance, contention is near-zero (client created once)
+
+## Testing
+
+- `tests/plugins/memory/test_hindsight_client_lock.py`: 3 regression tests
+  - `test_concurrent_clients_created_once`: Two threads racing `_get_client` create only one client
+  - `test_second_call_returns_cached`: After creation, subsequent calls return cached client
+  - `test_lock_acquired_during_creation`: Lock is held during client creation

--- a/tests/plugins/memory/test_hindsight_client_lock.py
+++ b/tests/plugins/memory/test_hindsight_client_lock.py
@@ -1,0 +1,96 @@
+"""Tests for HindsightMemoryProvider._get_client() thread-safety.
+
+The _get_client() method uses a double-checked locking pattern so two
+concurrent callers don't race to create duplicate clients.
+"""
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_provider():
+    """Create a HindsightMemoryProvider with minimal init."""
+    from plugins.memory.hindsight import HindsightMemoryProvider
+    provider = HindsightMemoryProvider.__new__(HindsightMemoryProvider)
+    provider._config = {"mode": "cloud"}
+    provider._mode = "cloud"
+    provider._client = None
+    provider._client_lock = threading.Lock()
+    provider._api_url = "https://api.hindsight.vectorize.io"
+    provider._api_key = "test-key"
+    provider._timeout = 10
+    provider._idle_timeout = 300
+    provider._llm_base_url = ""
+    return provider
+
+
+class TestGetClientLock:
+    def test_concurrent_clients_created_once(self):
+        """Two threads racing _get_client should create only one client."""
+        provider = _make_provider()
+        creation_count = 0
+        mock_client = MagicMock()
+
+        original_init = type(mock_client).__init__
+
+        def counting_init(self_inner, *args, **kwargs):
+            nonlocal creation_count
+            creation_count += 1
+
+        mock_client.__class__.__init__ = counting_init
+
+        barrier = threading.Barrier(2)
+        results = []
+
+        def get_client():
+            barrier.wait()
+            with patch(
+                "plugins.memory.hindsight._ensure_cloud_client_dependency"
+            ), patch(
+                "plugins.memory.hindsight.Hindsight", return_value=mock_client
+            ):
+                results.append(provider._get_client())
+
+        t1 = threading.Thread(target=get_client)
+        t2 = threading.Thread(target=get_client)
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        assert len(results) == 2
+        assert results[0] is results[1]
+
+    def test_second_call_returns_cached(self):
+        """After first creation, subsequent calls return cached client."""
+        provider = _make_provider()
+        mock_client = MagicMock()
+        provider._client = mock_client
+
+        result = provider._get_client()
+        assert result is mock_client
+
+    def test_lock_acquired_during_creation(self):
+        """Lock is held during client creation."""
+        provider = _make_provider()
+        lock_acquire_count = 0
+        original_acquire = threading.Lock.acquire
+
+        def counting_acquire(self_inner, *args, **kwargs):
+            nonlocal lock_acquire_count
+            lock_acquire_count += 1
+            return original_acquire(self_inner, *args, **kwargs)
+
+        mock_client = MagicMock()
+        with patch.object(
+            threading.Lock, "acquire", counting_acquire
+        ), patch(
+            "plugins.memory.hindsight._ensure_cloud_client_dependency"
+        ), patch(
+            "plugins.memory.hindsight.Hindsight", return_value=mock_client
+        ):
+            result = provider._get_client()
+
+        assert result is mock_client
+        assert lock_acquire_count >= 1


### PR DESCRIPTION
## Summary

Fix a thread-safety bug in the Hindsight memory plugin: `_get_client()` used an unprotected check-then-act pattern that allowed two concurrent threads to race and create duplicate clients, wasting resources and potentially causing runtime errors.

## Bug

`_get_client()` at `plugins/memory/hindsight/__init__.py:1012` checks `if self._client is None` and then creates the client without holding a lock. In concurrent scenarios (gateway serving multiple sessions), two threads could both see `_client is None`, both create a new client, and one client's resources would leak.

## Fix

Added a `_client_lock` (threading.Lock) to `HindsightMemoryProvider.__init__()` and a double-checked locking pattern in `_get_client()`:

1. Fast path: if `_client is not None`, return it (no lock needed)
2. Acquire `_client_lock`
3. Double-check: if `_client is not None` (another thread finished creating), return it
4. Create client while holding the lock

## Impact

- **Severity**: P1 — resource leak in concurrent gateway deployments
- **Scope**: Hindsight memory plugin (`plugins/memory/hindsight/__init__.py`)
- **Risk**: Minimal — lock is per-provider instance, contention is near-zero (client created once)

## Testing

- `tests/plugins/memory/test_hindsight_client_lock.py`: 3 regression tests
  - `test_concurrent_clients_created_once`: Two threads racing `_get_client` create only one client
  - `test_second_call_returns_cached`: After creation, subsequent calls return cached client
  - `test_lock_acquired_during_creation`: Lock is held during client creation
