### PR TITLE
fix(error-classifier): compress large gateway 5xx sessions

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -295,6 +295,20 @@ _REQUEST_VALIDATION_PATTERNS = [
     "unsupported_parameter",
 ]
 
+# Reverse proxies and provider gateways sometimes hide an oversized prompt
+# behind a generic 5xx instead of returning the OpenAI-style 400/413 context
+# error. Explicit context wording is enough to trigger compression; generic
+# Cloudflare/gateway wording only does so when the session is already large.
+_GATEWAY_BAD_RESPONSE_PATTERNS = [
+    "bad gateway",
+    "origin_bad_gateway",
+    "error code: 502",
+    "invalid or incomplete response",
+    "cloudflare",
+    "upstream error",
+    "provider returned error",
+]
+
 # OpenRouter aggregator policy-block patterns.
 #
 # When a user's OpenRouter account privacy setting (or a per-request
@@ -918,6 +932,19 @@ def _classify_by_status(
             result_fn=result_fn,
         )
 
+    if status_code in {500, 502, 503, 504} and _large_gateway_5xx_should_compress(
+        error_msg,
+        body,
+        approx_tokens=approx_tokens,
+        context_length=context_length,
+        num_messages=num_messages,
+    ):
+        return result_fn(
+            FailoverReason.context_overflow,
+            retryable=True,
+            should_compress=True,
+        )
+
     if status_code in {500, 502}:
         # Some OpenAI-compatible gateways return request-validation errors
         # with a 5xx status (codex.nekos.me returns 502 for unknown/
@@ -936,9 +963,22 @@ def _classify_by_status(
                 retryable=False,
                 should_fallback=True,
             )
+
+        if any(p in error_msg for p in _CONTEXT_OVERFLOW_PATTERNS):
+            return result_fn(
+                FailoverReason.context_overflow,
+                retryable=True,
+                should_compress=True,
+            )
         return result_fn(FailoverReason.server_error, retryable=True)
 
     if status_code in {503, 529}:
+        if any(p in error_msg for p in _CONTEXT_OVERFLOW_PATTERNS):
+            return result_fn(
+                FailoverReason.context_overflow,
+                retryable=True,
+                should_compress=True,
+            )
         return result_fn(FailoverReason.overloaded, retryable=True)
 
     # Other 4xx — non-retryable
@@ -954,6 +994,31 @@ def _classify_by_status(
         return result_fn(FailoverReason.server_error, retryable=True)
 
     return None
+
+
+def _large_gateway_5xx_should_compress(
+    error_msg: str,
+    body: dict,
+    *,
+    approx_tokens: int,
+    context_length: int,
+    num_messages: int,
+) -> bool:
+    """Return True for Cloudflare/origin 5xx envelopes on already-large sessions."""
+    body_text = str(body or {}).lower()
+    combined = f"{error_msg} {body_text}"
+    has_origin_signal = (
+        "origin_bad_gateway" in combined
+        or "origin_unavailable" in combined
+        or "origin" in combined and "bad gateway" in combined
+        or "origin" in combined and "bad_gateway" in combined
+        or "invalid or incomplete response" in combined
+    )
+    if "cloudflare" not in combined and not has_origin_signal:
+        return False
+    return approx_tokens > context_length * 0.6 or (
+        context_length <= 256000 and (approx_tokens > 120000 or num_messages > 200)
+    )
 
 
 def _classify_402(error_msg: str, result_fn) -> ClassifiedError:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -364,6 +364,76 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.server_error
 
+    def test_502_cloudflare_large_session_context_overflow(self):
+        e = MockAPIError(
+            "HTTP 502: Error code: 502 - {'error_name': 'origin_bad_gateway', "
+            "'detail': 'The origin web server returned an invalid or incomplete "
+            "response to Cloudflare.'}",
+            status_code=502,
+        )
+        result = classify_api_error(
+            e,
+            approx_tokens=242876,
+            context_length=200000,
+            num_messages=296,
+        )
+        assert result.reason == FailoverReason.context_overflow
+        assert result.should_compress is True
+
+    def test_502_cloudflare_small_session_stays_server_error(self):
+        e = MockAPIError(
+            "HTTP 502: Error code: 502 - origin_bad_gateway via Cloudflare",
+            status_code=502,
+        )
+        result = classify_api_error(e, approx_tokens=5000, context_length=200000)
+        assert result.reason == FailoverReason.server_error
+        assert result.should_compress is False
+
+    def test_502_plain_large_session_stays_server_error(self):
+        e = MockAPIError("Bad Gateway", status_code=502)
+        result = classify_api_error(
+            e,
+            approx_tokens=242876,
+            context_length=200000,
+            num_messages=296,
+        )
+        assert result.reason == FailoverReason.server_error
+        assert result.should_compress is False
+
+    def test_500_context_size_exceeded_compresses(self):
+        e = MockAPIError(
+            "server_error: Context size has been exceeded",
+            status_code=500,
+        )
+        result = classify_api_error(e, approx_tokens=1000, context_length=200000)
+        assert result.reason == FailoverReason.context_overflow
+        assert result.should_compress is True
+
+    def test_504_cloudflare_large_session_context_overflow(self):
+        e = MockAPIError(
+            "HTTP 504: upstream timeout from Cloudflare while reading response",
+            status_code=504,
+        )
+        result = classify_api_error(
+            e,
+            approx_tokens=180000,
+            context_length=200000,
+            num_messages=240,
+        )
+        assert result.reason == FailoverReason.context_overflow
+        assert result.should_compress is True
+
+    def test_504_plain_gateway_timeout_stays_server_error(self):
+        e = MockAPIError("Gateway Timeout", status_code=504)
+        result = classify_api_error(
+            e,
+            approx_tokens=180000,
+            context_length=200000,
+            num_messages=240,
+        )
+        assert result.reason == FailoverReason.server_error
+        assert result.should_compress is False
+
     def test_503_overloaded(self):
         e = MockAPIError("Service Unavailable", status_code=503)
         result = classify_api_error(e)


### PR DESCRIPTION
## Summary

Fixes #53771.

Large chat-gateway sessions can receive a generic Cloudflare/load-balancer 5xx response, especially `502 origin_bad_gateway`, when an upstream OpenAI-compatible provider drops or rejects an oversized request without returning explicit context-overflow wording.

This keeps the existing 5xx request-validation guard first, then routes two narrow cases into the existing context-compression recovery path:

- explicit 5xx context-overflow wording, such as `context size` / `context window` / token-limit phrases
- generic gateway/proxy 5xx wording only when the request is already large enough to plausibly be context pressure

Small-session gateway 5xx responses still classify as retryable server errors, and plain 503/504 overloads still classify as overloaded.

## Tests

- `python3 -m pytest tests/agent/test_error_classifier.py -q -o 'addopts='`
- `python3 -m py_compile agent/error_classifier.py tests/agent/test_error_classifier.py`
- `git diff --check origin/main..HEAD`
