### PR TITLE
fix(signal): treat RATE_LIMIT_FAILURE in send results as success

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -1021,6 +1021,15 @@ class SignalAdapter(BasePlatformAdapter):
         """Validate signal-cli send response results.
 
         Returns (success, error_message).
+
+        NOTE: signal-cli (since v0.14.3) sometimes returns RATE_LIMIT_FAILURE
+        in the results array even when the message was successfully delivered.
+        This is a known daemon quirk — it reports a rate-limit advisory on
+        every send during periods of elevated traffic, but the message still
+        lands in the recipient's inbox. Treating RATE_LIMIT_FAILURE as a hard
+        failure causes base.py to retry with a plain-text fallback, producing
+        a duplicate message with the ugly "(Response formatting failed,
+        plain text:)" prefix. So we treat it as success.
         """
         if not result or not isinstance(result, dict):
             return True, None
@@ -1031,7 +1040,9 @@ class SignalAdapter(BasePlatformAdapter):
                 if not isinstance(r, dict):
                     continue
                 rtype = r.get("type")
-                if rtype and rtype != "SUCCESS":
+                # signal-cli reports RATE_LIMIT_FAILURE as an advisory, not a
+                # true failure — the message was delivered. Skip it.
+                if rtype and rtype != "SUCCESS" and rtype != "RATE_LIMIT_FAILURE":
                     return False, str(rtype)
                 if "success" in r and not r.get("success"):
                     fail = r.get("failure")


### PR DESCRIPTION
## Problem

signal-cli >= v0.14.3 sometimes returns `RATE_LIMIT_FAILURE` in the `results` array of its `send` RPC response even when the message was successfully delivered to the recipient's inbox. This is a known daemon quirk — it reports a rate-limit advisory advisory regardless of actual delivery status.

The previous code in `_validate_send_result` treated any non-SUCCESS `type` as a hard failure, which triggered `base.py`'s `_send_with_fallback` mechanism. That mechanism appends "(Response formatting failed, plain text:)\n\n" to the original content and re-sends it, producing a duplicate message with an ugly prefix.

### Observed symptoms

- Messages (especially those containing emoji like 👍🎉🚀) arrive duplicated in Signal
- Second message has the prefix "(Response formatting failed, plain text:)" followed by the original content
- Gateway logs show: `Send failed: RATE_LIMIT_FAILURE — trying plain-text fallback`
- Despite the log saying "failed," both messages actually arrive in the recipient's inbox

### Root cause

`_validate_send_result` (line 1034) rejects any result where `type != "SUCCESS"`, including `RATE_LIMIT_FAILURE`. But signal-cli >= v0.14.3 sends this advisory in the results even on successful sends. The fallback path in base.py (line 3851) then re-sends with the prefix, and that second send also gets a RATE_LIMIT_FAILURE response — but both messages land anyway, hence the duplicates.

## Fix

Skip `RATE_LIMIT_FAILURE` entries when validating send results. The advisory is harmless — the message was delivered, just report it as such.

## Changes

- `gateway/platforms/signal.py`: Modified `_validate_send_result` to treat `RATE_LIMIT_FAILURE` as success, not failure

## Testing

1. Verified the fix resolves the duplicate message issue with emoji-containing messages
2. Confirmed normal messages still deliver correctly (no regression)
3. Gateway logs no longer show "Send failed: RATE_LIMIT_FAILURE — trying plain-text fallback"

## Related

Downstream fix for a signal-cli behavior change starting in v0.14.3.