### PR TITLE
fix(tirith): honour tirith_fail_open=false when the circuit breaker is open

### DIFF
--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -1324,6 +1324,53 @@ class TestSpawnWarningDedup:
         assert len(none_warnings) == 1
 
 
+class TestCircuitBreakerFailClosed:
+    """When the circuit breaker is open, the breaker branch must still honor
+    ``tirith_fail_open``. Every other failure path in check_command_security
+    (path-None, OSError spawn, timeout, unknown exit) blocks when fail_open is
+    False; the breaker branch must do the same instead of allowing
+    unconditionally (sibling of #20733)."""
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_circuit_breaker_fail_closed(self, mock_cfg, mock_run):
+        mock_cfg.return_value = {
+            "tirith_enabled": True, "tirith_path": "tirith",
+            "tirith_timeout": 5, "tirith_fail_open": False,
+        }
+        mock_run.side_effect = FileNotFoundError("No such file: tirith")
+
+        # Drive _CRASH_LIMIT consecutive spawn failures to open the breaker.
+        for _ in range(_tirith_mod._CRASH_LIMIT):
+            check_command_security("echo hi")
+        assert _tirith_mod._circuit_open is True
+
+        # The next call short-circuits in the breaker branch. With
+        # fail_open=False it must block (fail-closed), not allow.
+        result = check_command_security("echo hi")
+        assert result["action"] == "block"
+        assert "fail-closed" in result["summary"]
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_circuit_breaker_fail_open_unchanged(self, mock_cfg, mock_run):
+        """With the default fail_open=True the breaker still allows — the
+        #41400 hang-prevention behavior must be untouched."""
+        mock_cfg.return_value = {
+            "tirith_enabled": True, "tirith_path": "tirith",
+            "tirith_timeout": 5, "tirith_fail_open": True,
+        }
+        mock_run.side_effect = FileNotFoundError("No such file: tirith")
+
+        for _ in range(_tirith_mod._CRASH_LIMIT):
+            check_command_security("echo hi")
+        assert _tirith_mod._circuit_open is True
+
+        result = check_command_security("echo hi")
+        assert result["action"] == "allow"
+        assert "circuit breaker" in result["summary"]
+
+
 # ---------------------------------------------------------------------------
 # .app TLD suppression (issue #24461)
 # ---------------------------------------------------------------------------

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -750,7 +750,9 @@ def check_command_security(command: str) -> dict:
     # → fail-open → agent retry loop, hanging the user for 20+ minutes
     # (issue #41400).
     if _circuit_open:
-        return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
+        if cfg["tirith_fail_open"]:
+            return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
+        return {"action": "block", "findings": [], "summary": "tirith disabled (circuit breaker, fail-closed)"}
 
     # Unsupported platform (Windows etc.) — tirith has no binary here and
     # never will. Skip the resolver entirely so we don't even try to spawn.


### PR DESCRIPTION
## This is a sibling follow-up to #20733

- #20733 established `security.tirith_fail_open: false` as the explicit fail-closed operator opt-in for the ImportError path in the same security module.
- It did NOT touch the circuit-breaker branch of `check_command_security()` in `tools/tirith_security.py`.
- This PR makes that one remaining unguarded failure path consult `tirith_fail_open`, just like every other failure path in the function already does.

## What does this PR do?

When the tirith circuit breaker opens — after 3 consecutive spawn/timeout failures, the hang-prevention guard added in #41400 — `check_command_security()` returned `"allow"` **unconditionally**, ignoring `security.tirith_fail_open`. The breaker was the *only* failure path in the function that never consulted `fail_open`: the path-None, OSError-spawn, timeout, and unknown-exit paths all already return `"block"` when `fail_open` is false.

This change makes the breaker branch mirror the sibling crash paths: it returns `"block"` (fail-closed) when `tirith_fail_open` is false, and keeps returning `"allow"` when it is true (the default), so the #41400 hang-prevention behavior is unchanged.

## Related Issue

Fixes #41400

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `tools/tirith_security.py`: in the `if _circuit_open:` branch, consult `cfg["tirith_fail_open"]`; return `"block"` with a `(circuit breaker, fail-closed)` summary when false, unchanged `"allow"` when true.
- `tests/tools/test_tirith_security.py`: add `TestCircuitBreakerFailClosed` with a fail-closed regression test and a fail-open-unchanged guard test.

## Why it matters

An operator who set `tirith_fail_open: false` (security-conscious / regulated deploy) lost **all** tirith enforcement for the rest of the process once a corrupted, missing, or slow binary tripped the breaker — exactly the #41400 failure mode, so the bypass coincided with when enforcement matters most. In headless cron/gateway contexts the absent approval prompt (approval.py treats `"allow"` as no-warning → approved) means commands then run with zero gate.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/tools/test_tirith_security.py -q` — all pass.
2. Regression check: revert the `tools/tirith_security.py` hunk and re-run — `test_circuit_breaker_fail_closed` fails (`assert 'allow' == 'block'`); restore the hunk and it passes.
3. `test_circuit_breaker_fail_open_unchanged` confirms the default (`fail_open=True`) still allows after the breaker opens — #41400 behavior intact.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A