### PR TITLE
fix(doctor): check /usr/local/bin for the hermes command link on root FHS installs

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -19,6 +19,12 @@ PROJECT_ROOT = get_project_root()
 HERMES_HOME = get_hermes_home()
 _DHH = display_hermes_home()  # user-facing display path (e.g. ~/.hermes or ~/.hermes/profiles/coder)
 
+# Command-link location for a root FHS-layout install (install.sh's
+# get_command_link_dir ROOT_FHS_LAYOUT branch: /usr/local/bin/hermes).
+# Module-level so the Command Installation check and its tests reference the
+# same path (tests monkeypatch it to a tmp dir to avoid touching /usr/local).
+_ROOT_FHS_LINK = Path("/usr/local/bin/hermes")
+
 # Load environment variables from ~/.hermes/.env so API key checks work
 _env_path = get_env_path()
 load_hermes_dotenv(hermes_home=_env_path.parent, project_env=PROJECT_ROOT / ".env")
@@ -1337,6 +1343,17 @@ def run_doctor(args):
         if _is_termux_env and _prefix:
             _cmd_link_dir = Path(_prefix) / "bin"
             _cmd_link_display = "$PREFIX/bin"
+        elif (
+            sys.platform == "linux"
+            and getattr(os, "geteuid", lambda: 1)() == 0
+            and (_ROOT_FHS_LINK.is_symlink() or _ROOT_FHS_LINK.exists())
+        ):
+            # Root Linux FHS install (install.sh ROOT_FHS_LAYOUT): the command
+            # link lives at /usr/local/bin/hermes, not ~/.local/bin. Key on the
+            # link existing so legacy root installs (link still under
+            # ~/.local/bin) fall through to the else branch unchanged.
+            _cmd_link_dir = _ROOT_FHS_LINK.parent
+            _cmd_link_display = "/usr/local/bin"
         else:
             _cmd_link_dir = Path.home() / ".local" / "bin"
             _cmd_link_display = "~/.local/bin"

--- a/tests/hermes_cli/test_doctor_command_install.py
+++ b/tests/hermes_cli/test_doctor_command_install.py
@@ -1,5 +1,6 @@
 """Tests for the Command Installation check in hermes doctor."""
 
+import os
 import sys
 import types
 from argparse import Namespace
@@ -238,6 +239,70 @@ class TestDoctorCommandInstallation:
         out = _run_doctor(fix=False)
         assert "Command Installation" in out
         assert "$PREFIX/bin" in out
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Symlink check is Unix-only")
+    def test_root_fhs_uses_usr_local_bin(self, monkeypatch, tmp_path):
+        """On a root Linux FHS install the command link is /usr/local/bin/hermes,
+        not ~/.local/bin (mirrors install.sh's ROOT_FHS_LAYOUT branch)."""
+        home, project, hermes_bin = _setup_doctor_env(monkeypatch, tmp_path)
+
+        # FHS command link in a tmp dir standing in for /usr/local/bin.
+        fhs_bin_dir = tmp_path / "usr_local_bin"
+        fhs_bin_dir.mkdir(parents=True)
+        fhs_link = fhs_bin_dir / "hermes"
+        fhs_link.symlink_to(hermes_bin)
+
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
+        monkeypatch.setattr(doctor_mod, "_ROOT_FHS_LINK", fhs_link)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out = _run_doctor(fix=False)
+        assert "Command Installation" in out
+        assert "/usr/local/bin" in out
+        assert "correct target" in out
+        # Must NOT fall into the ~/.local/bin branch and report a false miss.
+        assert "~/.local/bin/hermes not found" not in out
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Symlink check is Unix-only")
+    def test_root_fhs_fix_does_not_create_stray_local_bin(self, monkeypatch, tmp_path):
+        """`doctor --fix` on a healthy root FHS install must not litter a
+        wrong-PATH ~/.local/bin/hermes symlink."""
+        home, project, hermes_bin = _setup_doctor_env(monkeypatch, tmp_path)
+
+        fhs_bin_dir = tmp_path / "usr_local_bin"
+        fhs_bin_dir.mkdir(parents=True)
+        fhs_link = fhs_bin_dir / "hermes"
+        fhs_link.symlink_to(hermes_bin)
+
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
+        monkeypatch.setattr(doctor_mod, "_ROOT_FHS_LINK", fhs_link)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        _run_doctor(fix=True)
+        assert not (tmp_path / ".local" / "bin" / "hermes").exists()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Symlink check is Unix-only")
+    def test_legacy_root_install_falls_through_to_local_bin(self, monkeypatch, tmp_path):
+        """A root install whose link is still under ~/.local/bin (no FHS link)
+        must fall through to the legacy branch unchanged."""
+        home, project, hermes_bin = _setup_doctor_env(monkeypatch, tmp_path)
+
+        # No /usr/local/bin/hermes link exists — point the probe at a missing path.
+        fhs_link = tmp_path / "usr_local_bin" / "hermes"
+        cmd_link_dir = tmp_path / ".local" / "bin"
+        cmd_link_dir.mkdir(parents=True)
+        (cmd_link_dir / "hermes").symlink_to(hermes_bin)
+
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
+        monkeypatch.setattr(doctor_mod, "_ROOT_FHS_LINK", fhs_link)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out = _run_doctor(fix=False)
+        assert "~/.local/bin/hermes → correct target" in out
+        assert "/usr/local/bin" not in out
 
     def test_windows_skips_check(self, monkeypatch, tmp_path):
         """On Windows, the Command Installation section is skipped."""


### PR DESCRIPTION
## What does this PR do?

`hermes doctor`'s Command Installation check only knows two command-link layouts — termux (`$PREFIX/bin`) and the user default (`~/.local/bin`) — behind a comment claiming it "mirrors install.sh logic". It doesn't: `install.sh`'s `get_command_link_dir` (scripts/install.sh:448-456) has **three** branches, and the middle one — `ROOT_FHS_LAYOUT → /usr/local/bin` — is missing from doctor.

`ROOT_FHS_LAYOUT` is set for a fresh root Linux install (`OS=linux`, `id -u == 0`, no pre-existing `$HERMES_HOME/hermes-agent/.git`), which installs to `/usr/local/lib/hermes-agent` and links the command at `/usr/local/bin/hermes`. `main.py`'s `_ensure_fhs_path_guard` already encodes this same `/usr/local/bin/hermes` layout for root-Linux.

This PR adds the missing root-FHS branch so doctor mirrors `install.sh` exactly. It mirrors the resolver precedence: termux (`$PREFIX/bin`) > root FHS (`/usr/local/bin`) > user (`~/.local/bin`).

## Related Issue

<!-- No open issue tracks this specific doctor gap; found by comparing doctor's command-link resolver against install.sh. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/doctor.py`: add a root-FHS branch (`sys.platform == "linux"` AND `os.geteuid() == 0` AND the `/usr/local/bin/hermes` link exists) between the termux and `~/.local/bin` branches, resolving the command-link dir to `/usr/local/bin`. The link path is a new module-level `_ROOT_FHS_LINK` constant so the check and its tests share it without touching the real `/usr/local`.
- `tests/hermes_cli/test_doctor_command_install.py`: add `test_root_fhs_uses_usr_local_bin`, `test_root_fhs_fix_does_not_create_stray_local_bin`, and `test_legacy_root_install_falls_through_to_local_bin`.

## Symptom (before this fix)

On a fresh root Linux install (`curl … | sudo bash` — the documented default; Docker base images, CI containers, VPS/bare-metal `sudo`), doctor fell into the `~/.local/bin` branch, checked `/root/.local/bin/hermes` (which doesn't exist), and printed a false `✗ ~/.local/bin/hermes not found` while the command worked fine at `/usr/local/bin/hermes`. Worse, `hermes doctor --fix` then created a stray `/root/.local/bin/hermes` symlink that isn't on the FHS PATH.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_doctor_command_install.py -q` — all pass.
2. Regression check: revert the `hermes_cli/doctor.py` branch and re-run — `test_root_fhs_uses_usr_local_bin` and `test_root_fhs_fix_does_not_create_stray_local_bin` fail; restore and they pass.
3. `test_legacy_root_install_falls_through_to_local_bin` confirms a root install whose link is still under `~/.local/bin` (no FHS link) is unaffected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Linux-root path exercised via monkeypatched `sys.platform`/`os.geteuid`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A