### PR TITLE
fix(agent): validate OpenRouter provider.data_collection before request dispatch

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -38,6 +38,7 @@ from utils import base_url_host_matches, base_url_hostname, env_float, env_int
 
 logger = logging.getLogger(__name__)
 _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
+_OPENROUTER_PROVIDER_DATA_COLLECTION_VALUES = {"allow", "deny"}
 
 
 def _ra():
@@ -129,6 +130,23 @@ def _validated_openrouter_provider_sort(raw_sort: Any) -> Optional[str]:
         "Ignoring invalid OpenRouter provider.sort value %r (allowed: %s)",
         raw_sort,
         ", ".join(sorted(_OPENROUTER_PROVIDER_SORT_VALUES)),
+    )
+    return None
+
+
+def _validated_openrouter_provider_data_collection(raw_data_collection: Any) -> Optional[str]:
+    """Return a normalized OpenRouter provider.data_collection value or None."""
+    if not isinstance(raw_data_collection, str):
+        return None
+    data_collection_value = raw_data_collection.strip().lower()
+    if not data_collection_value:
+        return None
+    if data_collection_value in _OPENROUTER_PROVIDER_DATA_COLLECTION_VALUES:
+        return data_collection_value
+    logger.warning(
+        "Ignoring invalid OpenRouter provider.data_collection value %r (allowed: %s)",
+        raw_data_collection,
+        ", ".join(sorted(_OPENROUTER_PROVIDER_DATA_COLLECTION_VALUES)),
     )
     return None
 
@@ -721,8 +739,9 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         _prefs["sort"] = _provider_sort
     if agent.provider_require_parameters:
         _prefs["require_parameters"] = True
-    if agent.provider_data_collection:
-        _prefs["data_collection"] = agent.provider_data_collection
+    _provider_data_collection = _validated_openrouter_provider_data_collection(agent.provider_data_collection)
+    if _provider_data_collection:
+        _prefs["data_collection"] = _provider_data_collection
 
     # Claude max-output override on aggregators
     _ant_max = None

--- a/tests/agent/test_chat_completion_helpers_provider_sort.py
+++ b/tests/agent/test_chat_completion_helpers_provider_sort.py
@@ -1,4 +1,7 @@
-from agent.chat_completion_helpers import _validated_openrouter_provider_sort
+from agent.chat_completion_helpers import (
+    _validated_openrouter_provider_data_collection,
+    _validated_openrouter_provider_sort,
+)
 
 
 def test_validated_openrouter_provider_sort_accepts_valid_values():
@@ -11,3 +14,15 @@ def test_validated_openrouter_provider_sort_rejects_invalid_values():
     assert _validated_openrouter_provider_sort("intelligence") is None
     assert _validated_openrouter_provider_sort("") is None
     assert _validated_openrouter_provider_sort(None) is None
+
+
+def test_validated_openrouter_provider_data_collection_accepts_valid_values():
+    assert _validated_openrouter_provider_data_collection("allow") == "allow"
+    assert _validated_openrouter_provider_data_collection(" Deny ") == "deny"
+    assert _validated_openrouter_provider_data_collection("DENY") == "deny"
+
+
+def test_validated_openrouter_provider_data_collection_rejects_invalid_values():
+    assert _validated_openrouter_provider_data_collection("denyy") is None
+    assert _validated_openrouter_provider_data_collection("") is None
+    assert _validated_openrouter_provider_data_collection(None) is None


### PR DESCRIPTION
## This is a sibling follow-up to commit 1b6ebb24c

- `1b6ebb24c` ("validate OpenRouter provider sort before request dispatch") added `_validated_openrouter_provider_sort` and wired it into the dispatch `_prefs` dict so an invalid `provider.sort` value is normalized/dropped instead of breaking the request.
- It did NOT touch the adjacent `provider.data_collection` knob, which is read from the same config block and assembled into the same `_prefs` dict two lines later.
- This PR adds the symmetric `data_collection` validator. `data_collection` has the same enum constraint and the same break-on-invalid contract but was left unguarded.

## What does this PR do?

`agent.provider_data_collection` is forwarded **raw** into the OpenRouter dispatch `provider_preferences` dict (`agent/chat_completion_helpers.py`) with no validation. OpenRouter accepts only `"allow"`/`"deny"` for `data_collection` (`website/docs/reference/environment-variables.md`: "`allow` (default) or `deny`"; `provider-routing.md`). Any other value — a typo, wrong case, or stale config — is sent verbatim, and OpenRouter rejects the **entire request** with a 400. That's exactly the dispatch break the sort validator already prevents for the sibling knob.

This PR adds `_validated_openrouter_provider_data_collection`, mirroring `_validated_openrouter_provider_sort` exactly: normalize via `.strip().lower()`, accept only `{"allow","deny"}`, and warn-and-drop on anything else (graceful degradation — the request proceeds without the bad preference rather than 400ing).

## Related Issue

<!-- No filed issue; symmetric sibling of the sort-validation fix in 1b6ebb24c. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py`: add `_OPENROUTER_PROVIDER_DATA_COLLECTION_VALUES = {"allow", "deny"}` and `_validated_openrouter_provider_data_collection`; route `agent.provider_data_collection` through it in `build_api_kwargs` before adding it to `_prefs`. Single-site — the summary path doesn't build `data_collection`.
- `tests/agent/test_chat_completion_helpers_provider_sort.py`: add accept/reject tests for the new validator.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/agent/test_chat_completion_helpers_provider_sort.py -q` — all pass.
2. Regression check: remove `_validated_openrouter_provider_data_collection` and re-run — the new tests fail at import (the function doesn't exist before the fix); restore and they pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A