### PR TITLE
fix(moa): route auxiliary calls through concrete providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3633,6 +3633,12 @@ def _resolve_auto(
             resolved_provider = "custom"
             explicit_base_url = runtime_base_url
             explicit_api_key = runtime_api_key or None
+        elif main_provider == "moa":
+            # MoA is a virtual provider. Its runtime base/key are placeholders
+            # for the main agent's aggregator client, not credentials that
+            # should be forwarded into the resolved aggregator provider.
+            explicit_base_url = None
+            explicit_api_key = None
         elif runtime_api_key:
             # Pin auxiliary to the same api_key as the active main chat session
             # so that a working key is reused instead of re-selecting from the pool
@@ -3647,12 +3653,13 @@ def _resolve_auto(
         if main_chain_label and _is_provider_unhealthy(main_chain_label):
             _log_skip_unhealthy(main_chain_label)
         else:
+            call_api_mode = None if main_provider == "moa" else (runtime_api_mode or None)
             client, resolved = resolve_provider_client(
                 resolved_provider,
                 main_model,
                 explicit_base_url=explicit_base_url,
                 explicit_api_key=explicit_api_key,
-                api_mode=runtime_api_mode or None,
+                api_mode=call_api_mode,
             )
             if client is not None:
                 logger.info("Auxiliary auto-detect: using main provider %s (%s)",
@@ -3792,7 +3799,7 @@ def resolve_provider_client(
     raw_codex: bool = False,
     explicit_base_url: str = None,
     explicit_api_key: str = None,
-    api_mode: str = None,
+    api_mode: Optional[str] = None,
     main_runtime: Optional[Dict[str, Any]] = None,
     is_vision: bool = False,
     task: Optional[str] = None,
@@ -3931,6 +3938,37 @@ def resolve_provider_client(
         final_model = model or resolved
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
+
+    # ── Mixture of Agents virtual provider ────────────────────────
+    if provider == "moa":
+        try:
+            from hermes_cli.config import load_config
+            from hermes_cli.moa_config import resolve_moa_preset
+
+            moa_cfg = (load_config() or {}).get("moa") or {}
+            preset = resolve_moa_preset(moa_cfg, model)
+            aggregator = preset.get("aggregator") or {}
+            agg_provider = str(aggregator.get("provider") or "").strip()
+            agg_model = str(aggregator.get("model") or "").strip()
+            if not agg_provider or agg_provider == "moa":
+                logger.warning(
+                    "resolve_provider_client: moa preset %r has invalid aggregator %r",
+                    model,
+                    aggregator,
+                )
+                return None, None
+            return resolve_provider_client(
+                agg_provider,
+                model=agg_model,
+                async_mode=async_mode,
+                raw_codex=raw_codex,
+                main_runtime=main_runtime,
+                is_vision=is_vision,
+                task=task,
+            )
+        except Exception as exc:
+            logger.warning("resolve_provider_client: moa requested but preset resolution failed: %s", exc)
+            return None, None
 
     # ── OpenRouter ───────────────────────────────────────────
     if provider == "openrouter":

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -51,6 +51,13 @@ def _slot_runtime(slot: dict[str, str]) -> dict[str, Any]:
     model = str(slot.get("model") or "").strip()
     out: dict[str, Any] = {"provider": provider, "model": model}
     try:
+        # Codex's ChatGPT-account backend needs the specialized auxiliary
+        # wrapper/headers from resolve_provider_client(). Passing the raw
+        # runtime URL/token here bypasses that wrapper and can hit Cloudflare
+        # HTML challenges even though the normal Codex path works.
+        if provider == "openai-codex":
+            return out
+
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
         rt = resolve_runtime_provider(requested=provider, target_model=model)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -698,6 +698,78 @@ class TestResolveProviderClientUniversalModelFallback:
         assert mock_build.call_args.args[0] == "grok-4.20-multi-agent"
 
 
+class TestResolveProviderClientMoA:
+    def _moa_config(self):
+        return {
+            "moa": {
+                "default_preset": "review",
+                "presets": {
+                    "review": {
+                        "reference_models": [
+                            {"provider": "vibeproxy", "model": "gpt-5.5"},
+                            {"provider": "zai", "model": "glm-5.2"},
+                        ],
+                        "aggregator": {
+                            "provider": "openrouter",
+                            "model": "anthropic/claude-opus-4.8",
+                        },
+                        "enabled": True,
+                    }
+                },
+            }
+        }
+
+    def test_moa_provider_resolves_to_aggregator_without_virtual_credentials(self):
+        seen = {}
+
+        def fake_try_openrouter(*, explicit_api_key=None, model=None):
+            seen["explicit_api_key"] = explicit_api_key
+            seen["model"] = model
+            return MagicMock(name="openrouter-client"), "openrouter-default"
+
+        with (
+            patch("hermes_cli.config.load_config", return_value=self._moa_config()),
+            patch("agent.auxiliary_client._try_openrouter", side_effect=fake_try_openrouter),
+        ):
+            client, model = resolve_provider_client(
+                "moa",
+                "review",
+                explicit_base_url="moa://virtual-provider/review",
+                explicit_api_key="moa-virtual-provider",
+                api_mode="chat_completions",
+            )
+
+        assert client is not None
+        assert model == "anthropic/claude-opus-4.8"
+        assert seen == {"explicit_api_key": None, "model": None}
+
+    def test_auto_with_moa_main_returns_aggregator_model_not_preset_name(self):
+        seen = {}
+
+        def fake_try_openrouter(*, explicit_api_key=None, model=None):
+            seen["explicit_api_key"] = explicit_api_key
+            seen["model"] = model
+            return MagicMock(name="openrouter-client"), "openrouter-default"
+
+        with (
+            patch("hermes_cli.config.load_config", return_value=self._moa_config()),
+            patch("agent.auxiliary_client._try_openrouter", side_effect=fake_try_openrouter),
+        ):
+            client, model = _resolve_auto(
+                main_runtime={
+                    "provider": "moa",
+                    "model": "review",
+                    "base_url": "moa://virtual-provider/review",
+                    "api_key": "moa-virtual-provider",
+                    "api_mode": "chat_completions",
+                }
+            )
+
+        assert client is not None
+        assert model == "anthropic/claude-opus-4.8"
+        assert seen == {"explicit_api_key": None, "model": None}
+
+
 class TestExpiredCodexFallback:
     """Test that expired Codex tokens don't block the auto chain."""
 

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -154,6 +154,28 @@ def test_moa_slots_routed_through_resolve_runtime_provider(monkeypatch):
     assert rt["api_key"] == "key-for-minimax"
 
 
+def test_moa_openai_codex_slot_uses_auxiliary_wrapper_not_raw_runtime(monkeypatch):
+    """Codex references must not receive raw ChatGPT backend credentials.
+
+    The regular openai-codex auxiliary client adds the right wrapper/headers.
+    Passing resolve_runtime_provider's raw base_url/api_key into call_llm
+    bypasses that path and can trigger Cloudflare HTML challenges.
+    """
+    from agent import moa_loop
+
+    def fail_if_called(*, requested, target_model=None):
+        raise AssertionError("openai-codex should not use raw runtime resolution")
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", fail_if_called
+    )
+
+    rt = moa_loop._slot_runtime({"provider": "openai-codex", "model": "gpt-5.5"})
+    assert rt == {"provider": "openai-codex", "model": "gpt-5.5"}
+    assert "base_url" not in rt
+    assert "api_key" not in rt
+
+
 def test_moa_slot_runtime_falls_back_on_resolution_error(monkeypatch):
     """A slot whose provider can't be resolved still attempts the call with the
     bare provider/model rather than aborting the whole MoA turn."""


### PR DESCRIPTION
## What does this PR do?

Fixes two MoA auxiliary-routing edge cases:

1. Auxiliary calls made while the main runtime is `provider: moa` now resolve to the active preset's concrete aggregator provider/model instead of trying to construct a client for the virtual `moa` provider.
2. `openai-codex` MoA reference slots no longer receive raw runtime `base_url`/`api_key` values from `resolve_runtime_provider()`. That bypasses the Codex auxiliary wrapper and can hit ChatGPT/Cloudflare HTML even though the normal Codex auxiliary route works. The slot now stays as `provider=openai-codex, model=...`, so `call_llm()` uses the existing Codex auxiliary client path.

This keeps MoA's provider-aware slot resolution for normal API/custom providers, while preserving specialized adapter behavior for Codex.

## Related Issue

No linked issue. Found while testing a MoA preset with:

- references: `openai-codex:gpt-5.5`, `zai:glm-5.2`
- aggregator: `custom:vibe-proxy:claude-opus-4-8`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/auxiliary_client.py`
  - Resolves `provider="moa"` auxiliary calls through the active MoA preset aggregator.
  - Prevents virtual MoA runtime values (`moa://...`, virtual API key, MoA api mode) from leaking into concrete aggregator resolution.
  - Makes auto auxiliary resolution return the concrete aggregator model when the main runtime is MoA.
- `agent/moa_loop.py`
  - Skips raw runtime credential injection for `openai-codex` slots so Codex uses its existing auxiliary wrapper.
- `tests/agent/test_auxiliary_client.py`
  - Adds direct and auto-mode MoA auxiliary regression coverage.
- `tests/run_agent/test_moa_loop_mode.py`
  - Adds regression coverage for `openai-codex` MoA slots using the auxiliary wrapper path.

## How to Test

1. `python -m py_compile agent/auxiliary_client.py agent/moa_loop.py`
2. `pytest -q tests/run_agent/test_moa_loop_mode.py tests/agent/test_auxiliary_client.py::TestResolveProviderClientMoA tests/gateway/test_moa_one_shot_restore.py tests/cli/test_moa_command.py`
3. `pytest -q tests/agent/test_auxiliary_client.py tests/run_agent/test_moa_loop_mode.py`

Results locally:

- `py_compile`: passed
- Focused MoA/auxiliary set: `19 passed`
- Full affected test files: `259 passed`

I also tried `scripts/run_tests.sh` per the contributing guide, but this worktree's repo `venv` does not have pytest installed, so the wrapper failed before exercising this patch with repeated `No module named pytest` errors. Direct pytest in the active development environment passed the affected suites above.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Observed local smoke before the fix: MoA with an `openai-codex:gpt-5.5` reference could produce:

```text
WARNING agent.moa_loop: MoA reference model openai-codex:gpt-5.5 failed: <html>
```

After the fix, the same MoA preset completed without that warning.
