### PR TITLE
fix(moa): restore virtual runtime after fallback

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1018,7 +1018,15 @@ def restore_primary_runtime(agent) -> bool:
         )
 
         # ── Rebuild client for the primary provider ──
-        if agent.api_mode == "anthropic_messages":
+        if agent.provider == "moa":
+            # MoA is a virtual chat-completions provider.  It never has real
+            # OpenAI client kwargs; restoring it after a fallback must recreate
+            # the facade, not call OpenAI() with an empty api_key.
+            from agent.moa_loop import MoAClient
+
+            agent.client = MoAClient(agent.model or "default")
+            agent._anthropic_client = None
+        elif agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
             agent._anthropic_api_key = rt["anthropic_api_key"]
             agent._anthropic_base_url = rt["anthropic_base_url"]

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -61,6 +61,67 @@ moa:
     assert calls[1]["tools"] is not None
 
 
+def test_moa_primary_restore_rebuilds_virtual_facade(monkeypatch, tmp_path):
+    """MoA sessions must restore from fallback without constructing OpenAI().
+
+    Regression for a long-lived MoA session that failed over to a real provider:
+    the next turn restored provider/model to MoA but tried to rebuild the shared
+    client from MoA's empty client_kwargs, raising "api_key client option must be
+    set" and then "Failed to recreate closed OpenAI client".
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      reference_models:
+        - provider: openai-codex
+          model: gpt-5.5
+      aggregator:
+        provider: openrouter
+        model: anthropic/claude-opus-4.8
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    agent = AIAgent(
+        api_key="moa-virtual-provider",
+        base_url="moa://local",
+        model="review",
+        provider="moa",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        enabled_toolsets=["file"],
+        max_iterations=1,
+    )
+    primary_client = agent.client
+
+    def fail_openai_rebuild(*_args, **_kwargs):
+        raise AssertionError("MoA restore must not build a real OpenAI client")
+
+    monkeypatch.setattr(agent, "_create_openai_client", fail_openai_rebuild)
+    setattr(agent, "_fallback_activated", True)
+    setattr(agent, "provider", "zai")
+    setattr(agent, "model", "glm-5.2")
+    agent.base_url = "https://api.z.ai/api/coding/paas/v4"
+    agent.api_key = "fallback-key"
+    setattr(agent, "_client_kwargs", {"api_key": "fallback-key", "base_url": agent.base_url})
+    agent.client = SimpleNamespace(close=lambda: None, _client=SimpleNamespace(is_closed=True))
+
+    assert agent._restore_primary_runtime() is True
+    assert getattr(agent, "provider") == "moa"
+    assert getattr(agent, "model") == "review"
+    assert agent.client is not primary_client
+    assert hasattr(agent.client.chat, "completions")
+    assert getattr(agent, "_fallback_activated") is False
+
+
+
 def test_moa_does_not_cap_output_tokens(monkeypatch, tmp_path):
     """MoA must not inject an output cap on reference or aggregator calls.
 


### PR DESCRIPTION
## What does this PR do?

Fixes MoA primary-runtime restoration after provider fallback.

MoA is a virtual provider: it uses a `MoAClient` facade and intentionally does not have real OpenAI client kwargs. If a long-lived MoA session falls back to a concrete provider, then the next turn restores `provider=model` back to MoA. Before this fix, restoration could try to rebuild a real OpenAI client from MoA's empty/virtual client kwargs, causing restore failure instead of recreating the MoA facade.

The restore path now special-cases `provider == "moa"` and recreates `MoAClient(agent.model or "default")` instead of calling the OpenAI client builder.

## Related Issue

No linked issue. Found while testing MoA sessions with fallback/restore behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/agent_runtime_helpers.py`
  - Rebuilds the virtual MoA facade when restoring the primary runtime to `provider="moa"`.
  - Avoids constructing a real OpenAI client for MoA's virtual runtime.
- `tests/run_agent/test_moa_loop_mode.py`
  - Adds a regression test that simulates fallback to Z.AI, then verifies primary restore returns to MoA without calling `_create_openai_client`.

## How to Test

1. `python -m py_compile agent/agent_runtime_helpers.py`
2. `pytest -q tests/run_agent/test_moa_loop_mode.py tests/run_agent/test_primary_runtime_restore.py`

Results locally:

- `py_compile`: passed
- MoA loop + primary runtime restore tests: `40 passed`
- Additional adversarial review reran the focused restore test plus primary restore suite: `32 passed`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The regression test guards the original failure mode by making `_create_openai_client` raise if the MoA restore path tries to build a real OpenAI client.
