### PR TITLE
fix(cron): log tick lock-skip at INFO for dual-scheduler visibility

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2861,7 +2861,7 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         elif msvcrt:
             msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
     except (OSError, IOError):
-        logger.debug("Tick skipped — another instance holds the lock")
+        logger.info("Tick skipped — another instance holds the lock")
         if lock_fd is not None:
             lock_fd.close()
         return 0

--- a/tests/cron/test_tick_skip_log_level.py
+++ b/tests/cron/test_tick_skip_log_level.py
@@ -1,0 +1,81 @@
+"""Regression test for the cron tick lock-skip log level (#53720).
+
+Background: when two scheduler instances race on the same ``.tick.lock``
+(e.g. a gateway-managed scheduler plus a desktop in-process scheduler), the
+loser correctly yields to the file-lock holder and skips the tick. The
+"Tick skipped — another instance holds the lock" line was logged at ``DEBUG``,
+which is below the default ``INFO`` log level, so the suppression was invisible
+in production logs. It must be ``INFO`` so operators can see dual-scheduler
+behavior without reconfiguring logging.
+"""
+
+import fcntl
+import logging
+
+import pytest
+
+from cron import scheduler
+
+
+def test_tick_skip_is_logged_at_info(tmp_path, monkeypatch, caplog):
+    """The lock-skip path must emit at INFO, not DEBUG."""
+    lock_dir = tmp_path / "cron"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_file = lock_dir / ".tick.lock"
+
+    monkeypatch.setattr(
+        scheduler, "_get_lock_paths", lambda: (lock_dir, lock_file)
+    )
+
+    # Pre-acquire the cross-process lock from this process so the ``tick()``
+    # call hits the non-blocking acquire failure path and skips.
+    holder = open(lock_file, "w", encoding="utf-8")
+    fcntl.flock(holder, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    try:
+        with caplog.at_level(logging.INFO, logger="cron.scheduler"):
+            executed = scheduler.tick(verbose=False)
+        assert executed == 0
+    finally:
+        fcntl.flock(holder, fcntl.LOCK_UN)
+        holder.close()
+
+    skip_records = [
+        r for r in caplog.records
+        if "Tick skipped" in r.getMessage() and "holds the lock" in r.getMessage()
+    ]
+    assert skip_records, "expected a 'Tick skipped' log record"
+    assert skip_records[0].levelno == logging.INFO, (
+        "tick lock-skip must be logged at INFO for dual-scheduler visibility (#53720)"
+    )
+
+
+def test_tick_skip_not_logged_at_debug_only(tmp_path, monkeypatch, caplog):
+    """The skip message must be visible at the INFO threshold (default level).
+
+    A regression to ``DEBUG`` would drop it under the default ``INFO`` level,
+    reproducing the invisibility reported in #53720.
+    """
+    lock_dir = tmp_path / "cron"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_file = lock_dir / ".tick.lock"
+
+    monkeypatch.setattr(
+        scheduler, "_get_lock_paths", lambda: (lock_dir, lock_file)
+    )
+
+    holder = open(lock_file, "w", encoding="utf-8")
+    fcntl.flock(holder, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    try:
+        # No at_level override -> caplog captures at WARNING by default; set
+        # INFO explicitly to model the production default log level.
+        with caplog.at_level(logging.INFO, logger="cron.scheduler"):
+            scheduler.tick(verbose=False)
+    finally:
+        fcntl.flock(holder, fcntl.LOCK_UN)
+        holder.close()
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("Tick skipped" in m for m in messages), (
+        "tick lock-skip not visible at INFO log level; would be silently dropped "
+        "in production (#53720)"
+    )


### PR DESCRIPTION
Fixes #53720

## What & why

When two cron scheduler instances race on the same `.tick.lock` (e.g. an NSSM-managed `HermesGateway` plus the desktop app's in-process `InProcessCronScheduler`), the loser correctly yields to the file-lock holder and skips the tick. However the "Tick skipped — another instance holds the lock" line was logged at `DEBUG` (`cron/scheduler.py:2864`), which is below the default `INFO` log level — so the suppression was **invisible in production logs**. There was no way to tell from `agent.log` that a second scheduler was being suppressed.

This promotes it to `INFO` so operators can see dual-scheduler behavior without reconfiguring logging.

- `INFO` is appropriate for an expected control-flow outcome ("the system correctly detected concurrent schedulers and yielded").
- `DEBUG` implies "noise only useful when actively diagnosing," but diagnosing dual-scheduler behavior **is** a routine operational concern (it can silently mask a misconfigured primary).
- Behavior is unchanged in the happy path — only the visibility of an already-occurring event changes. No new I/O, no error paths touched.

## Change

One line in `cron/scheduler.py`:

```diff
-        logger.debug("Tick skipped — another instance holds the lock")
+        logger.info("Tick skipped — another instance holds the lock")
```

## How to test

New regression test `tests/cron/test_tick_skip_log_level.py`:

1. Pre-acquires the cross-process `fcntl.flock(LOCK_EX | LOCK_NB)` on `.tick.lock` from the test process.
2. Calls `scheduler.tick(verbose=False)`, which hits the non-blocking acquire failure path and returns `0`.
3. Asserts the "Tick skipped — another instance holds the lock" record is emitted at **`INFO`** (not `DEBUG`).

The test **fails against the old `DEBUG` level** (verified by reverting the one-liner) and **passes with the fix**, so it guards the regression.

```
tests/cron/test_tick_skip_log_level.py::test_tick_skip_is_logged_at_info PASSED
tests/cron/test_tick_skip_log_level.py::test_tick_skip_not_logged_at_debug_only PASSED
```

Also ran the existing scheduler suite — no regressions:

```
tests/cron/test_scheduler.py ........ 191 passed
```

`ruff check cron/scheduler.py tests/cron/test_tick_skip_log_level.py` — clean.

## Platforms tested

- macOS (Apple Silicon) — `fcntl` path exercised by the test.
- Windows (`msvcrt`) path is the same single `logger.info` line, unchanged structurally.

## Risk

Trivial. Only changes visibility of an already-occurring event; no control-flow, error-handling, or I/O change. Exactly the fix proposed in the issue.

## Related

- Issue #53720
- The issue also notes `get_due_jobs()` at `cron/scheduler.py:2870` is not wrapped in try/except — that is a separate, larger concern and intentionally **out of scope** for this PR to keep it focused (per CONTRIBUTING "keep PRs focused: one logical change per PR").