### PR TITLE
feat: expose compression lifecycle plugin hooks

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1701,6 +1701,24 @@ def init_agent(
         except Exception as _ce_err:
             _ra().logger.debug("Context engine on_session_start: %s", _ce_err)
 
+    # Notify generic plugins of session start too.  Plugins that persist
+    # task-state can pair this with pre_context_compression + pre_llm_call to
+    # implement Marveen-style compact/resume replay without touching the system
+    # prompt or mutating the cached prefix.
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        _invoke_hook(
+            "on_session_start",
+            session_id=agent.session_id,
+            hermes_home=str(get_hermes_home()),
+            platform=agent.platform or "cli",
+            model=agent.model,
+            context_length=getattr(agent.context_compressor, "context_length", 0),
+            conversation_id=getattr(agent, "_gateway_session_key", None),
+        )
+    except Exception as _plugin_err:
+        _ra().logger.debug("Plugin on_session_start: %s", _plugin_err)
+
     agent._subdirectory_hints = SubdirectoryHintTracker(
         working_dir=os.getenv("TERMINAL_CWD") or None,
     )

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -483,6 +483,27 @@ def compress_context(
         except Exception:
             pass
 
+    # Notify generic plugins before compression discards/summarizes older turns.
+    # Observer-only: return values are ignored. Plugins can persist task-state,
+    # handoff breadcrumbs, or external-memory snapshots without mutating the
+    # live conversation or breaking prompt caching.
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        _invoke_hook(
+            "pre_context_compression",
+            session_id=agent.session_id or "",
+            task_id=task_id,
+            conversation_history=list(messages),
+            approx_tokens=approx_tokens,
+            focus_topic=focus_topic,
+            force=force,
+            model=getattr(agent, "model", ""),
+            platform=getattr(agent, "platform", None) or "cli",
+            conversation_id=getattr(agent, "_gateway_session_key", None),
+        )
+    except Exception as _plugin_err:
+        logger.debug("plugin pre_context_compression failed: %s", _plugin_err)
+
     try:
         compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic, force=force)
     except TypeError:
@@ -734,6 +755,26 @@ def compress_context(
             )
     except Exception as _ce_err:
         logger.debug("context engine on_session_start (compression): %s", _ce_err)
+
+    # Notify generic plugins of the same compaction boundary.  A plugin can use
+    # this to mark a task-state record replayable for the next turn/session, and
+    # then return that state through the existing pre_llm_call context-injection
+    # contract. Return values are ignored here to keep compression cache-safe.
+    try:
+        if _is_boundary:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _invoke_hook(
+                "on_session_start",
+                session_id=agent.session_id or "",
+                boundary_reason="compression",
+                old_session_id=_boundary_parent,
+                platform=getattr(agent, "platform", None) or "cli",
+                model=getattr(agent, "model", ""),
+                context_length=getattr(agent.context_compressor, "context_length", None),
+                conversation_id=getattr(agent, "_gateway_session_key", None),
+            )
+    except Exception as _plugin_err:
+        logger.debug("plugin on_session_start (compression): %s", _plugin_err)
 
     # Notify memory providers of the compaction boundary so provider-cached
     # per-session state (Hindsight's _document_id, accumulated turn buffers,

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -79,10 +79,30 @@ emitted by each built-in hook site.
     api_request_id  – current API request id
     middleware_trace – list of dicts from tool middleware chain
 
-``on_session_start`` (emitted from ``agent/conversation_loop.py``)::
+``on_session_start`` (emitted from agent init / compression boundary)::
 
     model           – model name (e.g. "claude-sonnet-4-20250514")
     platform        – platform identifier (e.g. "cli", "whatsapp")
+    boundary_reason – optional reason such as "compression"
+    old_session_id  – previous session id for boundary transitions
+
+``on_session_resume`` (emitted after CLI/gateway /resume switches session)::
+
+    old_session_id  – session id that was active before resume
+    title           – resumed session title, when available
+    message_count   – number of user messages in the resumed transcript
+    total_messages  – total resumed transcript row count, when available
+    platform        – platform identifier (e.g. "cli", "telegram")
+
+``pre_context_compression`` (emitted before compaction drops/summarizes turns)::
+
+    task_id          – current task id, when available
+    conversation_history – active messages about to be compressed
+    approx_tokens    – rough prompt token count that triggered compression
+    focus_topic      – optional user-provided compression focus
+    force            – whether compression was manually forced
+    model            – current model name
+    platform         – platform identifier
 
 ``on_session_end`` (emitted from ``agent/turn_finalizer.py``)::
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3248,6 +3248,23 @@ class GatewaySlashCommandsMixin:
         msg_count = len([m for m in history if m.get("role") == "user"]) if history else 0
         msg_part = f" ({msg_count} message{'s' if msg_count != 1 else ''})" if msg_count else ""
 
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _invoke_hook(
+                "on_session_resume",
+                session_id=target_id,
+                old_session_id=current_entry.session_id or "",
+                title=title or "",
+                message_count=msg_count,
+                total_messages=len(history or []),
+                platform=source.platform.value if source.platform else "unknown",
+                session_key=session_key,
+                chat_id=str(source.chat_id) if source.chat_id is not None else "",
+                thread_id=str(source.thread_id) if source.thread_id is not None else "",
+            )
+        except Exception:
+            logger.debug("on_session_resume hook failed", exc_info=True)
+
         if source.platform == Platform.MATRIX and allow_cross_room:
             return t(
                 "gateway.resume.matrix_cross_room_success",

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -768,6 +768,19 @@ class CLICommandsMixin:
 
         title_part = f" \"{session_meta['title']}\"" if session_meta.get("title") else ""
         msg_count = len([m for m in self.conversation_history if m.get("role") == "user"])
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _invoke_hook(
+                "on_session_resume",
+                session_id=target_id,
+                old_session_id=old_session_id or "",
+                title=session_meta.get("title") or "",
+                message_count=msg_count,
+                total_messages=len(self.conversation_history),
+                platform="cli",
+            )
+        except Exception:
+            pass
         if self.conversation_history:
             _cprint(
                 f"  ↻ Resumed session {target_id}{title_part}"

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -147,6 +147,13 @@ _DEFAULT_PAYLOADS = {
         "platform": "cli",
     },
     "on_session_start": {"session_id": "test-session"},
+    "on_session_resume": {
+        "session_id": "resumed-session",
+        "old_session_id": "previous-session",
+        "title": "Example resumed work",
+        "message_count": 3,
+        "platform": "cli",
+    },
 
     "on_session_end": {"session_id": "test-session"},
     "on_session_finalize": {"session_id": "test-session"},

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -137,9 +137,17 @@ _DEFAULT_PAYLOADS = {
     "post_llm_call": {
         "session_id": "test-session",
         "model": "gpt-4",
+    },
+    "pre_context_compression": {
+        "session_id": "test-session",
+        "task_id": "default",
+        "conversation_history": [{"role": "user", "content": "hello"}],
+        "approx_tokens": 100000,
+        "model": "gpt-4",
         "platform": "cli",
     },
     "on_session_start": {"session_id": "test-session"},
+
     "on_session_end": {"session_id": "test-session"},
     "on_session_finalize": {"session_id": "test-session"},
     "on_session_reset": {"session_id": "test-session"},

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -139,6 +139,10 @@ VALID_HOOKS: Set[str] = {
     "pre_api_request",
     "post_api_request",
     "api_request_error",
+    # Fired immediately before context compression drops/summarizes older
+    # turns. Observer-only: return values are ignored. Plugins can persist
+    # task-state or handoff breadcrumbs without mutating the live message list.
+    "pre_context_compression",
     "on_session_start",
     "on_session_end",
     "on_session_finalize",

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -144,6 +144,7 @@ VALID_HOOKS: Set[str] = {
     # task-state or handoff breadcrumbs without mutating the live message list.
     "pre_context_compression",
     "on_session_start",
+    "on_session_resume",
     "on_session_end",
     "on_session_finalize",
     "on_session_reset",

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -172,6 +172,23 @@ class TestSerializePayload:
         payload = json.loads(raw)
         assert payload["extra"]["obj"] == "<weird>"
 
+    def test_session_resume_payload_shape(self):
+        raw = shell_hooks._serialize_payload(
+            "on_session_resume",
+            {
+                "session_id": "resumed",
+                "old_session_id": "old",
+                "title": "Work",
+                "message_count": 2,
+                "platform": "cli",
+            },
+        )
+        payload = json.loads(raw)
+        assert payload["hook_event_name"] == "on_session_resume"
+        assert payload["session_id"] == "resumed"
+        assert payload["extra"]["old_session_id"] == "old"
+        assert payload["extra"]["message_count"] == 2
+
 
 # ── Matcher behaviour ─────────────────────────────────────────────────────
 

--- a/tests/cli/test_cli_resume_command.py
+++ b/tests/cli/test_cli_resume_command.py
@@ -63,6 +63,32 @@ class TestCliResumeCommand:
         assert "Resumed session sess_001" in printed
         assert "Research" in printed
 
+    def test_handle_resume_fires_session_resume_hook(self):
+        cli_obj = _make_cli()
+        cli_obj._session_db.get_session.return_value = {"id": "sess_alpha", "title": "Alpha"}
+        cli_obj._session_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "hello"},
+        ]
+        cli_obj._session_db.resolve_resume_session_id.return_value = "sess_alpha"
+
+        with (
+            patch("hermes_cli.main._resolve_session_by_name_or_id", return_value="sess_alpha"),
+            patch("cli._cprint"),
+            patch("hermes_cli.plugins.invoke_hook") as invoke_hook,
+        ):
+            cli_obj._handle_resume_command("/resume Alpha")
+
+        resume_calls = [
+            c for c in invoke_hook.call_args_list
+            if c.args and c.args[0] == "on_session_resume"
+        ]
+        assert resume_calls, f"on_session_resume did not fire: {invoke_hook.call_args_list!r}"
+        call = resume_calls[-1]
+        assert call.kwargs["old_session_id"] == "current_session"
+        assert call.kwargs["session_id"] == "sess_alpha"
+        assert call.kwargs["message_count"] == 1
+        assert call.kwargs["platform"] == "cli"
+
     def test_handle_resume_by_index_out_of_range(self):
         cli_obj = _make_cli()
         cli_obj._list_recent_sessions = MagicMock(return_value=[

--- a/tests/cli/test_session_boundary_hooks.py
+++ b/tests/cli/test_session_boundary_hooks.py
@@ -5,9 +5,10 @@ from cli import HermesCLI
 
 
 def test_session_hooks_in_valid_hooks():
-    """Verify on_session_finalize and on_session_reset are registered as valid hooks."""
+    """Verify session lifecycle hooks are registered as valid hooks."""
     assert "on_session_finalize" in VALID_HOOKS
     assert "on_session_reset" in VALID_HOOKS
+    assert "on_session_resume" in VALID_HOOKS
 
 
 @patch("hermes_cli.plugins.invoke_hook")

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -5,7 +5,7 @@ across gateway messenger platforms.
 """
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -221,6 +221,44 @@ class TestHandleResumeCommand:
         # Should resolve to #2 (latest in lineage)
         call_args = runner.session_store.switch_session.call_args
         assert call_args[0][1] == "sess_v2"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_fires_session_resume_hook(self, tmp_path):
+        """Gateway resume emits an observer hook after switching sessions."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("target_session", "telegram")
+        db.set_session_title("target_session", "Target")
+        db.append_message("target_session", "user", "hello")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume Target")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        runner.session_store.load_transcript.return_value = [
+            {"role": "user", "content": "hello"},
+        ]
+
+        from hermes_cli import plugins
+        with patch.object(plugins, "invoke_hook") as invoke_hook:
+            result = await runner._handle_resume_command(event)
+
+        assert "Resumed" in result
+        resume_calls = [
+            c for c in invoke_hook.call_args_list
+            if c.args and c.args[0] == "on_session_resume"
+        ]
+        assert resume_calls, f"on_session_resume did not fire: {invoke_hook.call_args_list!r}"
+        call = resume_calls[-1]
+        assert call.kwargs["old_session_id"] == "current_session_001"
+        assert call.kwargs["session_id"] == "target_session"
+        assert call.kwargs["message_count"] == 1
+        assert call.kwargs["platform"] == "telegram"
         db.close()
 
     @pytest.mark.asyncio

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -36,6 +36,24 @@ class TestCompressionBoundaryHook:
             agent.compression_in_place = False
             return agent
 
+    def test_plugin_on_session_start_called_on_agent_init(self):
+        """Generic plugins are notified when an agent binds to a session."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            with patch("hermes_cli.plugins.invoke_hook") as invoke_hook:
+                agent = self._make_agent(db)
+
+        start_calls = [
+            c for c in invoke_hook.call_args_list
+            if c.args and c.args[0] == "on_session_start"
+        ]
+        assert start_calls, f"plugin on_session_start did not fire on init: {invoke_hook.call_args_list!r}"
+        call = start_calls[-1]
+        assert call.kwargs["session_id"] == agent.session_id
+        assert call.kwargs["model"] == "test/model"
+
     def test_on_session_start_called_with_compression_boundary(self):
         from hermes_state import SessionDB
 
@@ -162,6 +180,67 @@ class TestCompressionBoundaryHook:
             )
             assert compressed
             assert agent.session_id != original_sid
+
+    def test_pre_context_compression_plugin_hook_fires_before_compress(self):
+        """Plugins can persist task-state before compression drops middle turns."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+            compressor = MagicMock()
+            compressor.compress.return_value = [{"role": "user", "content": "summary"}]
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            agent.context_compressor = compressor
+            messages = [{"role": "user", "content": "important task context"}]
+
+            with patch("hermes_cli.plugins.invoke_hook") as invoke_hook:
+                agent._compress_context(messages, "sys", approx_tokens=123, task_id="task-1")
+
+            pre_calls = [
+                c for c in invoke_hook.call_args_list
+                if c.args and c.args[0] == "pre_context_compression"
+            ]
+            assert pre_calls, f"pre_context_compression hook did not fire: {invoke_hook.call_args_list!r}"
+            call = pre_calls[0]
+            assert call.kwargs["session_id"] == "original-session"
+            assert call.kwargs["task_id"] == "task-1"
+            assert call.kwargs["approx_tokens"] == 123
+            assert call.kwargs["conversation_history"] == messages
+
+    def test_plugin_on_session_start_called_with_compression_boundary(self):
+        """Generic plugins get the same compression boundary signal as context engines."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+            compressor = MagicMock()
+            compressor.compress.return_value = [{"role": "user", "content": "summary"}]
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            agent.context_compressor = compressor
+            original_sid = agent.session_id
+
+            with patch("hermes_cli.plugins.invoke_hook") as invoke_hook:
+                agent._compress_context([{"role": "user", "content": "m"}], "sys", approx_tokens=100)
+
+            start_calls = [
+                c for c in invoke_hook.call_args_list
+                if c.args and c.args[0] == "on_session_start"
+                and c.kwargs.get("boundary_reason") == "compression"
+            ]
+            assert start_calls, f"plugin on_session_start compression boundary did not fire: {invoke_hook.call_args_list!r}"
+            call = start_calls[-1]
+            assert call.kwargs["session_id"] == agent.session_id
+            assert call.kwargs["old_session_id"] == original_sid
 
 
 class TestSessionCompressEvent:


### PR DESCRIPTION
## Summary
- add a generic pre_context_compression plugin hook before context compaction drops/summarizes turns
- invoke generic plugin on_session_start when an agent binds to a session and when compression creates a boundary
- add synthetic hook-test payload and compression-boundary tests

## Motivation
This gives plugins a cache-safe way to persist task-state before compaction and replay it via existing pre_llm_call context injection, enabling Marveen-style handoff/resume workflows without mutating the system prompt.

## Test Plan
- python -m pytest tests/run_agent/test_compression_boundary_hook.py tests/hermes_cli/test_hooks_cli.py -q -o 'addopts='
- python -m pytest tests/run_agent/test_compression_boundary_hook.py tests/agent/test_context_engine_host_contract.py tests/hermes_cli/test_hooks_cli.py tests/test_transform_llm_output_hook.py tests/tools/test_approval_plugin_hooks.py -q -o 'addopts='