### PR TITLE
fix: gate Copilot token resolution on source suppression (#53781)

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -64,14 +64,44 @@ def validate_copilot_token(token: str) -> tuple[bool, str]:
     return True, "OK"
 
 
+def _source_suppressed(source: str) -> bool:
+    """Return True when the user has suppressed a Copilot credential source.
+
+    Reads the persisted suppression marker set by ``hermes auth remove copilot``
+    (or ``hermes auth remove copilot <N>``).  When the marker is present we
+    must not invoke the underlying reader — otherwise dashboard / status
+    probes can silently re-enable a source the user explicitly opted out of
+    (e.g. spawning ``gh auth token`` on Windows causes short-lived
+    ``gh.exe`` / ``tzutil.exe`` console flashes and focus stealing).
+    """
+    try:
+        from hermes_cli.auth import is_source_suppressed
+    except Exception:
+        return False
+    try:
+        return is_source_suppressed("copilot", source)
+    except Exception:
+        return False
+
+
 def resolve_copilot_token() -> tuple[str, str]:
     """Resolve a GitHub token suitable for Copilot API use.
 
     Returns (token, source) where source describes where the token came from.
     Raises ValueError if only a classic PAT is available.
+
+    Each candidate source is gated against ``is_source_suppressed`` so an
+    explicit ``hermes auth remove copilot <N>`` actually sticks — without
+    the gate, dashboard / status probes can re-invoke ``gh auth token``
+    every time, which on Windows spawns short-lived helper processes that
+    flash the console and steal focus.
     """
-    # 1. Check env vars in priority order
+    # 1. Check env vars in priority order.  Respect explicit removals from
+    # `hermes auth remove copilot <N>` so dashboard/status probes do not
+    # silently re-enable a Copilot env source after the user opted out.
     for env_var in COPILOT_ENV_VARS:
+        if _source_suppressed(f"env:{env_var}"):
+            continue
         val = os.getenv(env_var, "").strip()
         if val:
             valid, msg = validate_copilot_token(val)
@@ -82,7 +112,13 @@ def resolve_copilot_token() -> tuple[str, str]:
                 continue
             return val, env_var
 
-    # 2. Fall back to gh auth token
+    # 2. Fall back to `gh auth token` unless the user suppressed the
+    # gh_cli source.  This avoids repeated short-lived gh.exe / tzutil.exe
+    # console flashes on Windows for users who do not use the Copilot
+    # provider but have `gh` installed and authenticated for other work.
+    if _source_suppressed("gh_cli"):
+        return "", ""
+
     token = _try_gh_cli_token()
     if token:
         valid, msg = validate_copilot_token(token)

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -107,6 +107,123 @@ class TestResolveToken:
         assert source == ""
 
 
+class TestSourceSuppression:
+    """Suppressed Copilot sources must be respected so removals actually stick.
+
+    On Windows, repeated `gh auth token` invocations from dashboard / status
+    probes can spawn short-lived `gh.exe` / `tzutil.exe` console windows that
+    flash and steal focus.  The fix: gate `resolve_copilot_token()` on the
+    persisted suppression marker so an explicit `hermes auth remove copilot`
+    suppresses the underlying reader, not just the pool entry.
+    """
+
+    def test_suppressed_env_var_is_skipped(self, monkeypatch, tmp_path):
+        """A suppressed env:GH_TOKEN must not be returned, even when set."""
+        from hermes_cli import copilot_auth
+
+        # Hermetic HERMES_HOME so is_source_suppressed reads from tmp_path
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+        from hermes_cli.auth import suppress_credential_source
+        suppress_credential_source("copilot", "env:GH_TOKEN")
+
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_copilot_first")
+        monkeypatch.setenv("GH_TOKEN", "gho_gh_should_be_ignored")
+        monkeypatch.setenv("GITHUB_TOKEN", "gho_github_third")
+
+        token, source = copilot_auth.resolve_copilot_token()
+        # Suppressed GH_TOKEN is skipped; COPILOT_GITHUB_TOKEN still wins.
+        assert token == "gho_copilot_first"
+        assert source == "COPILOT_GITHUB_TOKEN"
+
+    def test_suppressed_copilot_github_token_falls_through_to_unset_gh_token(self, monkeypatch, tmp_path):
+        """Suppressing COPILOT_GITHUB_TOKEN must not return it; next env var wins."""
+        from hermes_cli import copilot_auth
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+        from hermes_cli.auth import suppress_credential_source
+        suppress_credential_source("copilot", "env:COPILOT_GITHUB_TOKEN")
+
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_should_be_ignored")
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.setenv("GITHUB_TOKEN", "gho_github_third")
+
+        token, source = copilot_auth.resolve_copilot_token()
+        assert token == "gho_github_third"
+        assert source == "GITHUB_TOKEN"
+
+    def test_suppressed_gh_cli_skips_subprocess_invocation(self, monkeypatch, tmp_path):
+        """When gh_cli is suppressed, _try_gh_cli_token must NOT be called.
+
+        This is the load-bearing assertion: if a future change re-introduces
+        the unconditional `gh auth token` call, the subprocess will fire
+        even though the user removed the source.  Mocking with a
+        RuntimeError makes a stray invocation loudly fail the test.
+        """
+        from hermes_cli import copilot_auth
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+        from hermes_cli.auth import suppress_credential_source
+        suppress_credential_source("copilot", "gh_cli")
+
+        monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        def _must_not_run(*args, **kwargs):
+            raise AssertionError(
+                "_try_gh_cli_token must not be invoked when gh_cli is suppressed"
+            )
+
+        with patch.object(copilot_auth, "_try_gh_cli_token", side_effect=_must_not_run):
+            token, source = copilot_auth.resolve_copilot_token()
+
+        assert token == ""
+        assert source == ""
+
+    def test_unsuppressed_gh_cli_still_falls_back(self, monkeypatch, tmp_path):
+        """When gh_cli is NOT suppressed, the fallback still works."""
+        from hermes_cli import copilot_auth
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+        monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        with patch.object(copilot_auth, "_try_gh_cli_token", return_value="gho_from_cli"):
+            token, source = copilot_auth.resolve_copilot_token()
+
+        assert token == "gho_from_cli"
+        assert source == "gh auth token"
+
+    def test_all_sources_suppressed_returns_empty(self, monkeypatch, tmp_path):
+        """Suppressing every Copilot source returns empty, no errors."""
+        from hermes_cli import copilot_auth
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+        from hermes_cli.auth import suppress_credential_source
+        for env_var in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
+            suppress_credential_source("copilot", f"env:{env_var}")
+        suppress_credential_source("copilot", "gh_cli")
+
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_should_be_ignored")
+        monkeypatch.setenv("GH_TOKEN", "gho_should_be_ignored")
+        monkeypatch.setenv("GITHUB_TOKEN", "gho_should_be_ignored")
+
+        def _must_not_run(*args, **kwargs):
+            raise AssertionError("_try_gh_cli_token must not be invoked when suppressed")
+
+        with patch.object(copilot_auth, "_try_gh_cli_token", side_effect=_must_not_run):
+            token, source = copilot_auth.resolve_copilot_token()
+
+        assert token == ""
+        assert source == ""
+
+
 class TestRequestHeaders:
     """Copilot API header generation."""
 


### PR DESCRIPTION
Fixes #53781

## Description

On Windows, dashboard / status probes can repeatedly invoke `gh auth token` for Copilot credential discovery even when the user has explicitly removed the source via `hermes auth remove copilot <N>`. Each invocation spawns short-lived `gh.exe` / `tzutil.exe` helper processes that flash the console and steal focus.

The existing suppression mechanism in `hermes_cli.auth` was already honored by the credential-pool upsert path, but `resolve_copilot_token()` itself ran the readers unconditionally. This change gates each candidate source (the three env vars and the `gh_cli` fallback) on `is_source_suppressed("copilot", source)` so a user opt-out actually sticks end-to-end.

This brings Copilot in line with the documented architecture in `agent/credential_sources.py`: every reader should be gated behind `is_source_suppressed(provider, source_id)`.

## Verification

- **S1 (Secrets):** clean — `grep` for `sk-…`, `ghp_…`, `xox*…` produced no hits
- **S2 (Personal refs):** clean
- **C1 (Conventional commits):** commit message uses `fix:` prefix
- **F1 (Focused):** only `hermes_cli/copilot_auth.py` and its test file changed
- **T1 (Tests):** full `tests/hermes_cli/test_copilot_auth.py` suite (30 tests, 5 new) passes; `tests/hermes_cli/test_auth_commands.py` (52 tests) and `tests/agent/test_credential_pool.py` (79 tests) also green

New tests cover:
- suppressed `env:GH_TOKEN` is skipped, even when set
- suppressed `env:COPILOT_GITHUB_TOKEN` falls through to the next env var
- suppressed `gh_cli` does NOT invoke `_try_gh_cli_token` (load-bearing — uses a side-effect-raising mock to detect any stray subprocess call)
- unsuppressed `gh_cli` still falls back correctly
- suppressing every Copilot source returns empty without errors