### PR TITLE
fix(moa): keep virtual provider on MoA client

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -765,7 +765,7 @@ def init_agent(
         )
         agent._client_kwargs = {}
         agent.api_key = api_key or "moa-virtual-provider"
-        agent.base_url = base_url or "moa://local"
+        agent.base_url = "moa://local"
         if not agent.quiet_mode:
             print(f"🤖 AI Agent initialized with MoA preset: {agent.model}")
     elif agent.api_mode == "bedrock_converse":

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1549,7 +1549,14 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
                 )
 
         # ── Build new client ──
-        if api_mode == "anthropic_messages":
+        if (new_provider or "").strip().lower() == "moa":
+            from agent.moa_loop import MoAClient
+
+            agent.api_key = api_key or "moa-virtual-provider"
+            agent.base_url = "moa://local"
+            agent._client_kwargs = {}
+            agent.client = MoAClient(agent.model or "default")
+        elif api_mode == "anthropic_messages":
             from agent.anthropic_adapter import (
                 build_anthropic_client,
                 resolve_anthropic_token,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -247,6 +247,11 @@ def interruptible_api_call(agent, api_kwargs: dict):
                         invalidate_runtime_client(region)
                     raise
                 result["response"] = normalize_converse_response(raw_response)
+            elif agent.provider == "moa":
+                # MoA is a virtual chat-completions provider backed by the
+                # in-process MoAClient facade. Do not rebuild a request-local
+                # OpenAI client from the virtual runtime metadata.
+                result["response"] = agent.client.chat.completions.create(**api_kwargs)
             else:
                 request_client = _set_request_client(
                     agent._create_request_openai_client(

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -55,6 +55,13 @@ def _slot_runtime(slot: dict[str, str]) -> dict[str, Any]:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
         rt = resolve_runtime_provider(requested=provider, target_model=model)
+        resolved_provider = str(rt.get("provider") or provider).strip().lower()
+        # call_llm treats an explicit base_url as a custom endpoint. That is
+        # correct for ordinary OpenAI-compatible targets, but wrong for OAuth /
+        # adapter-backed providers whose provider branch adds auth headers and
+        # request-shape adapters. Keep those providers identified by name.
+        if resolved_provider in {"openai-codex", "xai-oauth"}:
+            return out
         # Pass the resolved endpoint through so call_llm builds the request for
         # the provider's actual API surface instead of auto-detecting. base_url
         # routes call_llm to the right adapter (incl. anthropic_messages mode);

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1404,7 +1404,7 @@ def resolve_runtime_provider(
         return {
             "provider": "moa",
             "api_mode": "chat_completions",
-            "base_url": "http://127.0.0.1/v1",
+            "base_url": "moa://local",
             "api_key": "moa-virtual-provider",
             "source": "moa-virtual-provider",
             "requested_provider": requested_provider,

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -172,6 +172,32 @@ def test_moa_slots_routed_through_resolve_runtime_provider(monkeypatch):
     assert rt["api_key"] == "key-for-minimax"
 
 
+def test_moa_codex_slot_preserves_provider_identity(monkeypatch):
+    """Codex slots must not become custom chat-completions endpoints.
+
+    _resolve_task_provider_model treats any explicit base_url as provider=custom.
+    For openai-codex that bypasses the Codex auxiliary branch, losing the
+    Cloudflare headers and Responses adapter required for chatgpt.com/backend-api/codex.
+    """
+    from agent import moa_loop
+
+    def fake_resolve(*, requested, target_model=None):
+        return {
+            "provider": requested,
+            "api_mode": "codex_responses",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "codex-oauth-token",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve
+    )
+
+    rt = moa_loop._slot_runtime({"provider": "openai-codex", "model": "gpt-5.5"})
+
+    assert rt == {"provider": "openai-codex", "model": "gpt-5.5"}
+
+
 def test_moa_slot_runtime_falls_back_on_resolution_error(monkeypatch):
     """A slot whose provider can't be resolved still attempts the call with the
     bare provider/model rather than aborting the whole MoA turn."""

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -41,7 +41,7 @@ moa:
 
     agent = AIAgent(
         api_key="moa-virtual-provider",
-        base_url="moa://local",
+        base_url="http://127.0.0.1/v1",
         model="review",
         provider="moa",
         quiet_mode=True,
@@ -50,15 +50,33 @@ moa:
         enabled_toolsets=["file"],
         max_iterations=1,
     )
+    monkeypatch.setattr(
+        agent,
+        "_create_request_openai_client",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("MoA calls must use MoAClient, not a request OpenAI client")
+        ),
+    )
 
     result = agent.run_conversation("solve this")
 
     assert result["final_response"] == "aggregator acted"
+    assert agent.base_url == "moa://local"
     assert [(c["task"], c["provider"], c["model"]) for c in calls] == [
         ("moa_reference", "openai-codex", "gpt-5.5"),
         ("moa_aggregator", "openrouter", "anthropic/claude-opus-4.8"),
     ]
     assert calls[1]["tools"] is not None
+
+
+def test_moa_runtime_provider_uses_virtual_endpoint():
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    runtime = resolve_runtime_provider(requested="moa", target_model="review")
+
+    assert runtime["provider"] == "moa"
+    assert runtime["base_url"] == "moa://local"
+    assert runtime["api_key"] == "moa-virtual-provider"
 
 
 def test_moa_does_not_cap_output_tokens(monkeypatch, tmp_path):
@@ -459,4 +477,3 @@ def test_moa_facade_reruns_references_on_new_turn(monkeypatch, tmp_path):
 
     # 2 references × 2 distinct turns = 4 reference runs.
     assert len(ref_runs) == 4
-


### PR DESCRIPTION
## What does this PR do?

Fixes two MoA routing paths so selecting a MoA preset such as `thing1` as the active model stays on the in-process MoA facade and its configured slot providers keep their provider identity.

MoA is an in-process virtual provider backed by `MoAClient`, not a real OpenAI-compatible HTTP server. Before this change, the non-streaming chat-completions path rebuilt a fresh request client for `provider="moa"`, and the virtual runtime metadata advertised `http://127.0.0.1/v1`. On Windows systems with IIS or another local service there, that produced confusing `Provider: moa / Model: thing1 / Endpoint: http://127.0.0.1/v1` HTTP errors instead of using the MoA facade.

There was also a second routing break inside MoA presets: `_slot_runtime()` resolved every reference/aggregator slot through `resolve_runtime_provider()` and forwarded the resolved `base_url` into `call_llm()`. `call_llm()` treats any explicit `base_url` as a custom endpoint, so a slot like `openai-codex:gpt-5.5` became `custom:gpt-5.5` at `https://chatgpt.com/backend-api/codex`. That bypassed the Codex auxiliary provider branch, losing the Codex Cloudflare headers and Responses adapter, and could produce Cloudflare HTML 403s even though direct `openai-codex/gpt-5.5` worked.

This keeps the invariants explicit: `provider="moa"` uses `MoAClient` and reports `moa://local`, and adapter-backed MoA slots such as `openai-codex` preserve provider identity instead of being reclassified as generic custom endpoints.

## Related Issue

No linked issue. Related-but-not-duplicate: #53802 handles restoring MoA after provider fallback; this PR handles the normal active-provider request path, switch/runtime metadata, and MoA slot provider routing.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/chat_completion_helpers.py`
  - Uses the existing `MoAClient` facade for non-streaming `provider="moa"` calls instead of creating a request-local OpenAI client.
- `agent/agent_init.py`
  - Forces MoA agents to use the virtual `moa://local` base URL instead of carrying through stale model base URLs like `http://127.0.0.1/v1`.
- `agent/agent_runtime_helpers.py`
  - Keeps mid-session switches to MoA on the `MoAClient` facade instead of building a real OpenAI client.
- `agent/moa_loop.py`
  - Preserves provider identity for adapter-backed MoA slots such as `openai-codex` and `xai-oauth` so resolved runtime URLs do not reclassify them as `custom` in `call_llm()`.
- `hermes_cli/runtime_provider.py`
  - Reports the MoA virtual runtime as `moa://local` rather than localhost.
- `tests/run_agent/test_moa_loop_mode.py`
  - Adds regression coverage that MoA calls do not invoke `_create_request_openai_client`, that the runtime endpoint is virtual, and that Codex MoA slots do not forward the Codex base URL as a custom endpoint.

## How to Test

1. `venv\Scripts\python.exe -m py_compile agent\chat_completion_helpers.py agent\agent_init.py agent\agent_runtime_helpers.py hermes_cli\runtime_provider.py tests\run_agent\test_moa_loop_mode.py`
2. `venv\Scripts\python.exe -m py_compile agent\moa_loop.py tests\run_agent\test_moa_loop_mode.py`
3. `$env:PYTHONIOENCODING='utf-8'; uv run python scripts\run_tests_parallel.py -j 4 tests\run_agent\test_moa_loop_mode.py`
4. Verify the focused MoA suite reports `13 tests passed, 0 failed`.

Local result:

- `py_compile`: passed for the touched Python files above
- `tests/run_agent/test_moa_loop_mode.py`: `13 passed, 0 failed`
- `git diff --check`: passed for the changed files
- Manual Windows/AppData smoke: after applying the slot-routing fix locally, the `thing1` MoA path no longer immediately failed through the generic `custom` Codex endpoint path

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows AppData install

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Observed local failures before the fix:

`Provider: moa  Model: thing1`
`Endpoint: http://127.0.0.1/v1`
`HTTP 404 — IIS 10.0 Detailed Error - 404.0 - Not Found`

and, after the virtual endpoint fix but before preserving Codex slot identity:

`Auxiliary moa_aggregator: using custom (gpt-5.5) at https://chatgpt.com/backend-api/codex/`
`HTTP 403 — HTML error page` with Cloudflare challenge HTML.

The regression tests now fail if the MoA acting-model path tries to create a request-local OpenAI client instead of using `MoAClient`, or if an `openai-codex` MoA slot forwards the Codex base URL in a way that makes `call_llm()` treat it as `custom`.