### PR TITLE
fix(state): stable tiebreaker for default list_sessions_rich ordering

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5950,7 +5950,7 @@ class SessionDB:
                     ) AS last_active
                 FROM sessions s
                 {where_sql}
-                ORDER BY s.started_at DESC
+                ORDER BY s.started_at DESC, s.id DESC
                 LIMIT ? OFFSET ?
             """
             params.extend([limit, offset])

--- a/tests/hermes_state/test_list_sessions_rich_order.py
+++ b/tests/hermes_state/test_list_sessions_rich_order.py
@@ -1,0 +1,57 @@
+"""Ordering regression tests for ``SessionDB.list_sessions_rich``.
+
+The default listing sorts by ``started_at DESC``. When two sessions share an
+identical ``started_at`` the sort is otherwise non-deterministic, so the query
+must fall back to a stable secondary key (``id DESC``) to give callers a
+repeatable order. See the ``ORDER BY s.started_at DESC, s.id DESC`` clause in
+``hermes_state.py``.
+"""
+
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = SessionDB(tmp_path / "state.db")
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+def _make_sessions_with_equal_started_at(db: SessionDB, ids):
+    """Create top-level sessions that all share one fixed ``started_at``.
+
+    Rows are inserted in ascending-id order so that any natural/insertion
+    ordering would surface them ascending; the tiebreaker is what makes the
+    default listing return them descending.
+    """
+    started_at = time.time() - 100
+    for session_id in ids:
+        db.create_session(session_id, source="cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = ?",
+            (started_at, session_id),
+        )
+    db._conn.commit()
+
+
+def test_default_order_breaks_started_at_ties_by_id_desc(db):
+    _make_sessions_with_equal_started_at(db, ["sess_001", "sess_002", "sess_003"])
+
+    listed = [s["id"] for s in db.list_sessions_rich()]
+
+    assert listed == ["sess_003", "sess_002", "sess_001"]
+
+
+def test_tiebreaker_order_is_stable_across_calls(db):
+    _make_sessions_with_equal_started_at(db, ["sess_001", "sess_002", "sess_003"])
+
+    first = [s["id"] for s in db.list_sessions_rich()]
+    second = [s["id"] for s in db.list_sessions_rich()]
+
+    assert first == second == ["sess_003", "sess_002", "sess_001"]


### PR DESCRIPTION
## Problem

The default branch of `SessionDB.list_sessions_rich()` (the path used when `order_by_last_active=False`) orders only by:

```sql
ORDER BY s.started_at DESC
```

There's no secondary sort key, so two sessions created within the same timestamp tick come back in **nondeterministic order**. The gateway `/resume` numbered list is built from this path, so the index→session mapping can differ run to run — i.e. the same `/resume <n>` can resume a *different* session depending on row order.

## Fix

Add `s.id DESC` as a tiebreaker so the ordering is total and deterministic:

```sql
ORDER BY s.started_at DESC, s.id DESC
```

This matches the **two sibling `ORDER BY` clauses in the same method** — the `order_by_last_active` branch (`... s.started_at DESC, s.id DESC`) and the compression-chain CTE — which already break `started_at` ties on `s.id DESC`. This branch was simply missed.

## Tests

De-flakes `tests/gateway/test_resume_command.py::test_resume_by_index`, which creates two sessions in the same tick and asserts a fixed index mapping (failed nondeterministically before; now passes 5/5). `tests/gateway/test_resume_command.py` + `tests/gateway/test_session_list_allowed_sources.py` pass (21), and the `test_web_server` / achievements session-list suites pass (55).

🤖 Generated with [Claude Code](https://claude.com/claude-code)