### PR TITLE
feat(telegram): fire telegram:reaction hook when user reacts to bot messages

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2047,6 +2047,46 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
         filtered.append(msg)
     messages = filtered
 
+    # --- Strip tool_calls from compaction-summary assistant messages ---
+    # When context compression fires, the compressed head may contain an
+    # assistant message that (a) carries the compaction summary as its text
+    # content AND (b) still has tool_calls from the turn that was compressed.
+    # Those tool_calls have no matching tool results in the active message list
+    # (the results were archived together with the pre-compaction transcript).
+    # Anthropic rejects the resulting wire messages with HTTP 400
+    # "tool_use ids found without tool_result blocks immediately after".
+    # Fix: strip tool_calls from any assistant message whose content is a
+    # compaction summary — they are historical artifacts that the model must
+    # not act on.
+    _COMPACTION_MARKERS = (
+        "[CONTEXT COMPACTION — REFERENCE ONLY]",
+        "[CONTEXT SUMMARY]:",
+    )
+    stripped_compaction_calls = 0
+    for i, msg in enumerate(messages):
+        if msg.get("role") != "assistant":
+            continue
+        if not msg.get("tool_calls"):
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            # Multimodal content: check text blocks
+            content = " ".join(
+                b.get("text", "") for b in content
+                if isinstance(b, dict) and b.get("type") == "text"
+            )
+        if isinstance(content, str) and any(
+            content.lstrip().startswith(m) for m in _COMPACTION_MARKERS
+        ):
+            messages[i] = {**msg}
+            messages[i].pop("tool_calls", None)
+            stripped_compaction_calls += 1
+    if stripped_compaction_calls:
+        _ra().logger.debug(
+            "Pre-call sanitizer: stripped tool_calls from %d compaction-summary message(s)",
+            stripped_compaction_calls,
+        )
+
     surviving_call_ids: set = set()
     for msg in messages:
         if msg.get("role") == "assistant":

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2013,57 +2013,84 @@ def _strip_orphaned_tool_blocks(result: List[Dict[str, Any]]) -> None:
     """Strip tool_use blocks with no matching tool_result, and vice versa.
 
     Context compression or session truncation can remove either side of a
-    tool-call pair.  Anthropic rejects both orphans with HTTP 400.
-
+    tool-call pair, or insert messages between a tool_use and its result.
+    Anthropic requires each tool_use to have a matching tool_result in the
+    IMMEDIATELY FOLLOWING user message — a global ID match is not enough.
     Mutates ``result`` in place.
     """
-    # Strip orphaned tool_use blocks (no matching tool_result follows)
-    tool_result_ids = set()
-    for m in result:
-        if m["role"] == "user" and isinstance(m["content"], list):
-            for block in m["content"]:
-                if block.get("type") == "tool_result":
-                    tool_result_ids.add(block.get("tool_use_id"))
-    for m in result:
-        if m["role"] == "assistant" and isinstance(m["content"], list):
-            kept = [
-                b
-                for b in m["content"]
-                if b.get("type") != "tool_use" or b.get("id") in tool_result_ids
-            ]
-            # If stripping an orphaned tool_use mutated a turn that also carries a
-            # signed thinking block, that block's Anthropic signature was computed
-            # against the ORIGINAL (un-stripped) turn content and is now invalid.
-            # Anthropic rejects the replayed turn with HTTP 400 "thinking blocks in
-            # the latest assistant message cannot be modified".  Flag the turn so
-            # _manage_thinking_signatures can demote the dead signature instead of
-            # replaying it verbatim.  See hermes-agent: extended-thinking + parallel
-            # tool batch interrupted mid-flight → non-retryable 400 crash-loop.
-            if len(kept) != len(m["content"]) and any(
-                isinstance(b, dict) and b.get("type") in {"thinking", "redacted_thinking"}
-                for b in m["content"]
-            ):
-                m["_thinking_signature_invalidated"] = True
-            m["content"] = kept
-            if not m["content"]:
-                m["content"] = [{"type": "text", "text": "(tool call removed)"}]
+    # Pass 1: for each assistant turn, collect only the tool_result IDs from
+    # the IMMEDIATELY FOLLOWING user message (adjacent_result_ids).
+    # Strip tool_use blocks not covered by that adjacent set.
+    for i, m in enumerate(result):
+        if m.get("role") != "assistant" or not isinstance(m.get("content"), list):
+            continue
 
-    # Strip orphaned tool_result blocks (no matching tool_use precedes them)
-    tool_use_ids = set()
+        tool_use_ids_in_turn = {
+            b.get("id")
+            for b in m["content"]
+            if isinstance(b, dict) and b.get("type") == "tool_use"
+        }
+        if not tool_use_ids_in_turn:
+            continue
+
+        # Find the immediately following user message (skip non-dict entries)
+        next_user = None
+        for j in range(i + 1, len(result)):
+            if isinstance(result[j], dict) and result[j].get("role") == "user":
+                next_user = result[j]
+                break
+
+        adjacent_result_ids: set = set()
+        if next_user is not None and isinstance(next_user.get("content"), list):
+            for block in next_user["content"]:
+                if isinstance(block, dict) and block.get("type") == "tool_result":
+                    adjacent_result_ids.add(block.get("tool_use_id"))
+
+        orphaned = tool_use_ids_in_turn - adjacent_result_ids
+        if not orphaned:
+            continue
+
+        kept = [
+            b
+            for b in m["content"]
+            if not (isinstance(b, dict) and b.get("type") == "tool_use" and b.get("id") in orphaned)
+        ]
+        # If stripping an orphaned tool_use mutated a turn that also carries a
+        # signed thinking block, that block's Anthropic signature was computed
+        # against the ORIGINAL (un-stripped) turn content and is now invalid.
+        # Anthropic rejects the replayed turn with HTTP 400 "thinking blocks in
+        # the latest assistant message cannot be modified".  Flag the turn so
+        # _manage_thinking_signatures can demote the dead signature instead of
+        # replaying it verbatim.  See hermes-agent: extended-thinking + parallel
+        # tool batch interrupted mid-flight → non-retryable 400 crash-loop.
+        if len(kept) != len(m["content"]) and any(
+            isinstance(b, dict) and b.get("type") in {"thinking", "redacted_thinking"}
+            for b in m["content"]
+        ):
+            m["_thinking_signature_invalidated"] = True
+        m["content"] = kept if kept else [{"type": "text", "text": "(tool call removed)"}]
+
+    # Pass 2: Rebuild the set of tool_use IDs that survived pass 1, then
+    # strip tool_result blocks that no longer have any matching tool_use
+    # anywhere in the conversation.
+    surviving_tool_use_ids: set = set()
     for m in result:
-        if m["role"] == "assistant" and isinstance(m["content"], list):
+        if m.get("role") == "assistant" and isinstance(m.get("content"), list):
             for block in m["content"]:
-                if block.get("type") == "tool_use":
-                    tool_use_ids.add(block.get("id"))
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    surviving_tool_use_ids.add(block.get("id"))
+
     for m in result:
-        if m["role"] == "user" and isinstance(m["content"], list):
-            m["content"] = [
-                b
-                for b in m["content"]
-                if b.get("type") != "tool_result" or b.get("tool_use_id") in tool_use_ids
-            ]
-            if not m["content"]:
-                m["content"] = [{"type": "text", "text": "(tool result removed)"}]
+        if m.get("role") != "user" or not isinstance(m.get("content"), list):
+            continue
+        new_content = [
+            b
+            for b in m["content"]
+            if not (isinstance(b, dict) and b.get("type") == "tool_result")
+            or b.get("tool_use_id") in surviving_tool_use_ids
+        ]
+        if len(new_content) != len(m["content"]):
+            m["content"] = new_content if new_content else [{"type": "text", "text": "(tool result removed)"}]
 
 
 def _merge_consecutive_roles(result: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -2315,8 +2342,8 @@ def convert_messages_to_anthropic(
         # Regular user message
         result.append(_convert_user_message(content))
 
-    _strip_orphaned_tool_blocks(result)
     result = _merge_consecutive_roles(result)
+    _strip_orphaned_tool_blocks(result)
     _manage_thinking_signatures(result, base_url, model)
     _evict_old_screenshots(result)
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2637,31 +2637,25 @@ def run_conversation(
                 ):
                     _retry.orphaned_tool_use_retry_attempted = True
                     try:
-                        # Detect orphaned tool_call IDs from the canonical
-                        # messages list (OpenAI-style: assistant has tool_calls,
-                        # result is role=tool with tool_call_id).
-                        # api_messages at this point is still pre-conversion
-                        # (the Anthropic adapter converts internally), so we
-                        # must detect from canonical messages, not api_messages.
-                        _orphaned_ids: set = set()
-                        for _ci, _cm in enumerate(messages):
-                            if not isinstance(_cm, dict):
-                                continue
-                            if _cm.get("role") != "assistant":
-                                continue
-                            _tcs = _cm.get("tool_calls") or []
-                            if not _tcs:
-                                continue
-                            _tc_ids = {tc.get("id") for tc in _tcs if tc.get("id")}
-                            # Find matching role=tool messages anywhere after
-                            _result_ids = {
-                                m.get("tool_call_id")
-                                for m in messages[_ci + 1:]
-                                if isinstance(m, dict) and m.get("role") == "tool"
-                            }
-                            _orphaned_ids |= (_tc_ids - _result_ids)
+                        # Parse the orphaned tool_use IDs directly from the
+                        # Anthropic error message.  The error looks like:
+                        #   "messages.N: `tool_use` ids were found without
+                        #    `tool_result` blocks immediately after:
+                        #    toolu_xxx, toolu_yyy."
+                        # We cannot rely on detecting orphans from the
+                        # canonical messages (OpenAI-style tool_calls) because
+                        # the pair IS present there — the adjacency breaks
+                        # during Anthropic adapter conversion, e.g. when
+                        # context compaction injects a synthetic user message
+                        # between an assistant tool_use and its tool_result.
+                        import re as _re
+                        _err_str = str(api_error or "")
+                        _orphaned_ids: set = set(
+                            _re.findall(r"toolu_[A-Za-z0-9]+", _err_str)
+                        )
 
-                        # Clean canonical messages
+                        # Remove these IDs from canonical messages so the
+                        # next api_messages rebuild produces valid adjacency.
                         _stripped_canonical = 0
                         if _orphaned_ids:
                             _i = 0

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2619,18 +2619,17 @@ def run_conversation(
                 # immediately followed by a matching tool_result.  Two
                 # known causes:
                 #   1. Context compression inserts messages between a
-                #      tool_use and its tool_result (covered by
-                #      _strip_orphaned_tool_blocks in the Anthropic
-                #      adapter, but that mutates the wire payload — not
-                #      the canonical ``messages`` list, so the *next*
-                #      API call re-builds the same broken payload).
+                #      tool_use and its tool_result.
                 #   2. A cron/subagent session is interrupted before the
                 #      tool_result is appended (e.g. execute_code blocked
-                #      by the approval guard leaves a tool_use as the
-                #      last assistant block with no following user turn).
-                # Recovery: run _strip_orphaned_tool_blocks against the
-                # canonical ``messages`` list so the cleaned version is
-                # persisted and the retry sees a valid transcript.
+                #      by the approval guard).
+                # The canonical ``messages`` list uses OpenAI-style
+                # role=tool / tool_calls — not the Anthropic wire format.
+                # _strip_orphaned_tool_blocks operates on Anthropic-style
+                # api_messages, so we strip there and then signal the
+                # outer loop to rebuild api_messages from the cleaned
+                # canonical list by removing the orphaned tool_calls
+                # entries and their matching role=tool messages.
                 # One-shot to avoid an infinite strip loop.
                 if (
                     classified.reason == FailoverReason.orphaned_tool_use
@@ -2639,43 +2638,84 @@ def run_conversation(
                     _retry.orphaned_tool_use_retry_attempted = True
                     try:
                         from agent.anthropic_adapter import _strip_orphaned_tool_blocks
-                        _before = sum(
-                            1 for _m in messages
-                            if isinstance(_m, dict)
-                            and _m.get("role") == "assistant"
-                            and isinstance(_m.get("content"), list)
-                            and any(
-                                isinstance(_b, dict) and _b.get("type") == "tool_use"
-                                for _b in _m["content"]
+                        # Find which tool_use IDs are orphaned in api_messages
+                        # (Anthropic format) before stripping
+                        _orphaned_ids: set = set()
+                        for _am in api_messages:
+                            if not (isinstance(_am, dict) and _am.get("role") == "assistant"):
+                                continue
+                            if not isinstance(_am.get("content"), list):
+                                continue
+                            _use_ids = {
+                                b["id"] for b in _am["content"]
+                                if isinstance(b, dict) and b.get("type") == "tool_use" and "id" in b
+                            }
+                            if not _use_ids:
+                                continue
+                            # Find next user msg
+                            _idx = api_messages.index(_am)
+                            _next_user = next(
+                                (m for m in api_messages[_idx + 1:]
+                                 if isinstance(m, dict) and m.get("role") == "user"),
+                                None,
                             )
-                        )
-                        _strip_orphaned_tool_blocks(messages)
-                        _after = sum(
-                            1 for _m in messages
-                            if isinstance(_m, dict)
-                            and _m.get("role") == "assistant"
-                            and isinstance(_m.get("content"), list)
-                            and any(
-                                isinstance(_b, dict) and _b.get("type") == "tool_use"
-                                for _b in _m["content"]
-                            )
-                        )
-                        _stripped_turns = _before - _after
+                            _result_ids = set()
+                            if _next_user and isinstance(_next_user.get("content"), list):
+                                _result_ids = {
+                                    b.get("tool_use_id")
+                                    for b in _next_user["content"]
+                                    if isinstance(b, dict) and b.get("type") == "tool_result"
+                                }
+                            _orphaned_ids |= (_use_ids - _result_ids)
+
+                        # Strip from wire payload (api_messages)
+                        _strip_orphaned_tool_blocks(api_messages)
+
+                        # Also clean canonical messages (OpenAI style):
+                        # remove assistant tool_calls entries whose IDs are
+                        # orphaned, and the matching role=tool messages.
+                        _stripped_canonical = 0
+                        if _orphaned_ids:
+                            _to_remove_tool_call_ids: set = set(_orphaned_ids)
+                            _i = 0
+                            while _i < len(messages):
+                                _cm = messages[_i]
+                                if not isinstance(_cm, dict):
+                                    _i += 1
+                                    continue
+                                # Remove orphaned tool_calls from assistant msgs
+                                if _cm.get("role") == "assistant" and isinstance(_cm.get("tool_calls"), list):
+                                    _kept = [
+                                        tc for tc in _cm["tool_calls"]
+                                        if tc.get("id") not in _to_remove_tool_call_ids
+                                    ]
+                                    if len(_kept) != len(_cm["tool_calls"]):
+                                        _stripped_canonical += len(_cm["tool_calls"]) - len(_kept)
+                                        if _kept:
+                                            _cm["tool_calls"] = _kept
+                                        else:
+                                            _cm.pop("tool_calls", None)
+                                # Remove orphaned role=tool messages
+                                if _cm.get("role") == "tool" and _cm.get("tool_call_id") in _to_remove_tool_call_ids:
+                                    messages.pop(_i)
+                                    _stripped_canonical += 1
+                                    continue
+                                _i += 1
                     except Exception as _strip_exc:
                         logger.warning(
                             "%sOrphaned tool_use recovery: strip helper failed: %s",
                             agent.log_prefix, _strip_exc,
                         )
-                        _stripped_turns = 0
+                        _stripped_canonical = 0
                     agent._vprint(
                         f"{agent.log_prefix}⚠️  Orphaned tool_use detected — "
-                        f"stripped {_stripped_turns} turn(s) from canonical messages, retrying...",
+                        f"stripped {len(_orphaned_ids)} id(s) from api_messages "
+                        f"and {_stripped_canonical} canonical entry/entries, retrying...",
                         force=True,
                     )
                     logger.warning(
-                        "%sOrphaned tool_use recovery: stripped %d assistant turn(s) "
-                        "from canonical messages",
-                        agent.log_prefix, _stripped_turns,
+                        "%sOrphaned tool_use recovery: stripped ids=%s canonical_entries=%d",
+                        agent.log_prefix, _orphaned_ids, _stripped_canonical,
                     )
                     continue
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2637,57 +2637,43 @@ def run_conversation(
                 ):
                     _retry.orphaned_tool_use_retry_attempted = True
                     try:
-                        from agent.anthropic_adapter import _strip_orphaned_tool_blocks
-                        # Find which tool_use IDs are orphaned in api_messages
-                        # (Anthropic format) before stripping
+                        # Detect orphaned tool_call IDs from the canonical
+                        # messages list (OpenAI-style: assistant has tool_calls,
+                        # result is role=tool with tool_call_id).
+                        # api_messages at this point is still pre-conversion
+                        # (the Anthropic adapter converts internally), so we
+                        # must detect from canonical messages, not api_messages.
                         _orphaned_ids: set = set()
-                        for _am in api_messages:
-                            if not (isinstance(_am, dict) and _am.get("role") == "assistant"):
+                        for _ci, _cm in enumerate(messages):
+                            if not isinstance(_cm, dict):
                                 continue
-                            if not isinstance(_am.get("content"), list):
+                            if _cm.get("role") != "assistant":
                                 continue
-                            _use_ids = {
-                                b["id"] for b in _am["content"]
-                                if isinstance(b, dict) and b.get("type") == "tool_use" and "id" in b
+                            _tcs = _cm.get("tool_calls") or []
+                            if not _tcs:
+                                continue
+                            _tc_ids = {tc.get("id") for tc in _tcs if tc.get("id")}
+                            # Find matching role=tool messages anywhere after
+                            _result_ids = {
+                                m.get("tool_call_id")
+                                for m in messages[_ci + 1:]
+                                if isinstance(m, dict) and m.get("role") == "tool"
                             }
-                            if not _use_ids:
-                                continue
-                            # Find next user msg
-                            _idx = api_messages.index(_am)
-                            _next_user = next(
-                                (m for m in api_messages[_idx + 1:]
-                                 if isinstance(m, dict) and m.get("role") == "user"),
-                                None,
-                            )
-                            _result_ids = set()
-                            if _next_user and isinstance(_next_user.get("content"), list):
-                                _result_ids = {
-                                    b.get("tool_use_id")
-                                    for b in _next_user["content"]
-                                    if isinstance(b, dict) and b.get("type") == "tool_result"
-                                }
-                            _orphaned_ids |= (_use_ids - _result_ids)
+                            _orphaned_ids |= (_tc_ids - _result_ids)
 
-                        # Strip from wire payload (api_messages)
-                        _strip_orphaned_tool_blocks(api_messages)
-
-                        # Also clean canonical messages (OpenAI style):
-                        # remove assistant tool_calls entries whose IDs are
-                        # orphaned, and the matching role=tool messages.
+                        # Clean canonical messages
                         _stripped_canonical = 0
                         if _orphaned_ids:
-                            _to_remove_tool_call_ids: set = set(_orphaned_ids)
                             _i = 0
                             while _i < len(messages):
                                 _cm = messages[_i]
                                 if not isinstance(_cm, dict):
                                     _i += 1
                                     continue
-                                # Remove orphaned tool_calls from assistant msgs
                                 if _cm.get("role") == "assistant" and isinstance(_cm.get("tool_calls"), list):
                                     _kept = [
                                         tc for tc in _cm["tool_calls"]
-                                        if tc.get("id") not in _to_remove_tool_call_ids
+                                        if tc.get("id") not in _orphaned_ids
                                     ]
                                     if len(_kept) != len(_cm["tool_calls"]):
                                         _stripped_canonical += len(_cm["tool_calls"]) - len(_kept)
@@ -2695,17 +2681,17 @@ def run_conversation(
                                             _cm["tool_calls"] = _kept
                                         else:
                                             _cm.pop("tool_calls", None)
-                                # Remove orphaned role=tool messages
-                                if _cm.get("role") == "tool" and _cm.get("tool_call_id") in _to_remove_tool_call_ids:
+                                if _cm.get("role") == "tool" and _cm.get("tool_call_id") in _orphaned_ids:
                                     messages.pop(_i)
                                     _stripped_canonical += 1
                                     continue
                                 _i += 1
                     except Exception as _strip_exc:
                         logger.warning(
-                            "%sOrphaned tool_use recovery: strip helper failed: %s",
+                            "%sOrphaned tool_use recovery: strip failed: %s",
                             agent.log_prefix, _strip_exc,
                         )
+                        _orphaned_ids = set()
                         _stripped_canonical = 0
                     agent._vprint(
                         f"{agent.log_prefix}⚠️  Orphaned tool_use detected — "

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2614,6 +2614,71 @@ def run_conversation(
                     )
                     continue
 
+                # ── Orphaned tool_use recovery ─────────────────────────
+                # Anthropic rejects messages where a tool_use block is not
+                # immediately followed by a matching tool_result.  Two
+                # known causes:
+                #   1. Context compression inserts messages between a
+                #      tool_use and its tool_result (covered by
+                #      _strip_orphaned_tool_blocks in the Anthropic
+                #      adapter, but that mutates the wire payload — not
+                #      the canonical ``messages`` list, so the *next*
+                #      API call re-builds the same broken payload).
+                #   2. A cron/subagent session is interrupted before the
+                #      tool_result is appended (e.g. execute_code blocked
+                #      by the approval guard leaves a tool_use as the
+                #      last assistant block with no following user turn).
+                # Recovery: run _strip_orphaned_tool_blocks against the
+                # canonical ``messages`` list so the cleaned version is
+                # persisted and the retry sees a valid transcript.
+                # One-shot to avoid an infinite strip loop.
+                if (
+                    classified.reason == FailoverReason.orphaned_tool_use
+                    and not _retry.orphaned_tool_use_retry_attempted
+                ):
+                    _retry.orphaned_tool_use_retry_attempted = True
+                    try:
+                        from agent.anthropic_adapter import _strip_orphaned_tool_blocks
+                        _before = sum(
+                            1 for _m in messages
+                            if isinstance(_m, dict)
+                            and _m.get("role") == "assistant"
+                            and isinstance(_m.get("content"), list)
+                            and any(
+                                isinstance(_b, dict) and _b.get("type") == "tool_use"
+                                for _b in _m["content"]
+                            )
+                        )
+                        _strip_orphaned_tool_blocks(messages)
+                        _after = sum(
+                            1 for _m in messages
+                            if isinstance(_m, dict)
+                            and _m.get("role") == "assistant"
+                            and isinstance(_m.get("content"), list)
+                            and any(
+                                isinstance(_b, dict) and _b.get("type") == "tool_use"
+                                for _b in _m["content"]
+                            )
+                        )
+                        _stripped_turns = _before - _after
+                    except Exception as _strip_exc:
+                        logger.warning(
+                            "%sOrphaned tool_use recovery: strip helper failed: %s",
+                            agent.log_prefix, _strip_exc,
+                        )
+                        _stripped_turns = 0
+                    agent._vprint(
+                        f"{agent.log_prefix}⚠️  Orphaned tool_use detected — "
+                        f"stripped {_stripped_turns} turn(s) from canonical messages, retrying...",
+                        force=True,
+                    )
+                    logger.warning(
+                        "%sOrphaned tool_use recovery: stripped %d assistant turn(s) "
+                        "from canonical messages",
+                        agent.log_prefix, _stripped_turns,
+                    )
+                    continue
+
                 # ── llama.cpp grammar-parse recovery ──────────────────
                 # llama.cpp's ``json-schema-to-grammar`` converter rejects
                 # regex escape classes (``\d``, ``\w``, ``\s``) and most

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -52,6 +52,7 @@ class FailoverReason(enum.Enum):
     # Request format
     format_error = "format_error"        # 400 bad request — abort or strip + retry
     invalid_encrypted_content = "invalid_encrypted_content"  # Responses replay blob rejected — strip replay state and retry
+    orphaned_tool_use = "orphaned_tool_use"  # tool_use block has no adjacent tool_result — strip orphans and retry
     multimodal_tool_content_unsupported = "multimodal_tool_content_unsupported"  # Provider rejected list-type content in tool messages (e.g. Xiaomi MiMo) — downgrade to text and retry
 
     # Provider-specific
@@ -1094,6 +1095,18 @@ def _classify_400(
             FailoverReason.context_overflow,
             retryable=True,
             should_compress=True,
+        )
+
+    # Anthropic rejects messages where a tool_use block is not immediately
+    # followed by a matching tool_result.  This can happen when:
+    #   • context compression inserts messages between the pair, or
+    #   • a cron/subagent session is interrupted before the tool_result
+    #     is appended (e.g. execute_code blocked by the approval guard).
+    # Recovery: strip orphaned tool_use/tool_result blocks and retry once.
+    if "tool_use" in error_msg and "tool_result" in error_msg:
+        return result_fn(
+            FailoverReason.orphaned_tool_use,
+            retryable=True,
         )
 
     # Non-retryable format error

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -49,6 +49,7 @@ class TurnRetryState:
     # ── Format / payload recovery guards ─────────────────────────────────
     thinking_sig_retry_attempted: bool = False
     invalid_encrypted_content_retry_attempted: bool = False
+    orphaned_tool_use_retry_attempted: bool = False
     image_shrink_retry_attempted: bool = False
     multimodal_tool_content_retry_attempted: bool = False
     oauth_1m_beta_retry_attempted: bool = False

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2619,6 +2619,19 @@ class BasePlatformAdapter(ABC):
         except Exception:
             logger.debug("topic recovery rewrite failed", exc_info=True)
 
+    def set_reaction_callback(self, callback: Optional[Callable[[dict], Awaitable[None]]]) -> None:
+        """Install a callback that fires when a user reacts to a bot message.
+
+        The callback receives a dict with:
+          - chat_id (str)
+          - message_id (str)
+          - user_id (str | None)
+          - new_reactions (list[str])  — emoji strings added
+          - old_reactions (list[str])  — emoji strings removed
+          - message_text (str | None)  — original bot message text (from rich_sent_store)
+        """
+        self._reaction_callback: Optional[Callable[[dict], Awaitable[None]]] = callback
+
     def set_busy_session_handler(self, handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]]) -> None:
         """Set an optional handler for messages arriving during active sessions."""
         self._busy_session_handler = handler

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4796,26 +4796,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         status_detail = f" ({', '.join(status_parts)})" if status_parts else ""
         if is_steer_mode:
             message = (
-                f"⏩ Steered into current run{status_detail}. "
-                f"Your message arrives after the next tool call."
+                f"⏩ Bericht ontvangen{status_detail} — ik verwerk het na de volgende stap."
             )
         elif is_queue_mode and demoted_for_subagents:
             # #30170 — explain the demotion so the user knows their
             # follow-up didn't accidentally kill the subagent and
             # discovers `/stop` as the explicit escape hatch.
             message = (
-                f"⏳ Subagent working{status_detail} — your message is queued for "
-                f"when it finishes (use /stop to cancel everything)."
+                f"⏳ Subagent actief{status_detail} — jouw bericht staat in de wachtrij "
+                f"(gebruik /stop om alles te annuleren)."
             )
         elif is_queue_mode:
             message = (
-                f"⏳ Queued for the next turn{status_detail}. "
-                f"I'll respond once the current task finishes."
+                f"⏳ In de wachtrij{status_detail} — ik reageer zodra de huidige taak klaar is."
             )
         else:
             message = (
-                f"⚡ Interrupting current task{status_detail}. "
-                f"I'll respond to your message shortly."
+                f"⚡ Taak onderbroken{status_detail} — ik reageer zo op jouw bericht."
             )
 
         # First-touch onboarding: the very first time a user sends a message
@@ -6026,6 +6023,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
             adapter._busy_text_mode = self._busy_text_mode
+            if hasattr(adapter, "set_reaction_callback"):
+                adapter.set_reaction_callback(self._handle_telegram_reaction)
             
             # Try to connect
             logger.info("Connecting to %s...", platform.value)
@@ -6824,6 +6823,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
                     adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
                     adapter._busy_text_mode = self._busy_text_mode
+                    if hasattr(adapter, "set_reaction_callback"):
+                        adapter.set_reaction_callback(self._handle_telegram_reaction)
 
                     # Reconnect after an outage: preserve the platform's
                     # server-side update queue so messages sent while the bot
@@ -7489,6 +7490,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
             adapter._busy_text_mode = self._busy_text_mode
+            if hasattr(adapter, "set_reaction_callback"):
+                adapter.set_reaction_callback(self._handle_telegram_reaction)
 
             try:
                 with _profile_runtime_scope(profile_home):
@@ -7690,6 +7693,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
         await adapter.send(source.chat_id, content, metadata=metadata)
+
+    async def _handle_telegram_reaction(self, payload: dict) -> None:
+        """Callback fired by TelegramAdapter when a user reacts to a bot message.
+
+        Emits a ``telegram:reaction`` hook event so user-installed hooks can
+        act on thumbs-up, heart, etc.  The payload mirrors what the adapter
+        built:  chat_id, message_id, user_id, user_name, new_reactions,
+        old_reactions, message_text.
+        """
+        await self.hooks.emit("telegram:reaction", payload)
 
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -31,6 +31,7 @@ try:
         CommandHandler,
         CallbackQueryHandler,
         MessageHandler as TelegramMessageHandler,
+        MessageReactionHandler,
         ContextTypes,
         filters,
     )
@@ -137,6 +138,7 @@ def check_telegram_requirements() -> bool:
             Application as _App, CommandHandler as _CH,
             CallbackQueryHandler as _CQH,
             MessageHandler as _MH,
+            MessageReactionHandler as _MRH,
             ContextTypes as _CT, filters as _filters,
         )
         from telegram.constants import ParseMode as _PM, ChatType as _CtT
@@ -2421,6 +2423,8 @@ class TelegramAdapter(BasePlatformAdapter):
             ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+            # Handle message reactions (thumbs up, heart, etc.) on bot messages
+            self._app.add_handler(MessageReactionHandler(self._handle_reaction))
             
             # Start polling — retry initialize() for transient TLS resets
             try:
@@ -6368,6 +6372,66 @@ class TelegramAdapter(BasePlatformAdapter):
         consuming channel posts without ever building a gateway event.
         """
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
+
+    async def _handle_reaction(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle message reaction updates (thumbs up, heart, etc.).
+
+        Only fires for reactions on messages sent by this bot.  Uses
+        ``rich_sent_store`` to match ``message_id`` → original bot message text,
+        then emits a ``telegram:reaction`` hook event for downstream hooks.
+        """
+        rxn: Any = update.message_reaction
+        if rxn is None:
+            return
+
+        chat_id = str(rxn.chat.id)
+        message_id = str(rxn.message_id)
+
+        # Only process reactions on our own bot messages.
+        from gateway import rich_sent_store
+        message_text = rich_sent_store.lookup(chat_id, message_id)
+        if message_text is None:
+            # Not a message we sent — ignore.
+            return
+
+        def _emoji_from_reaction(r: Any) -> str:
+            """Extract emoji string from a ReactionTypeEmoji or ReactionTypeCustomEmoji."""
+            return getattr(r, "emoji", None) or getattr(r, "custom_emoji_id", "?")
+
+        new_reactions = [_emoji_from_reaction(r) for r in (rxn.new_reaction or [])]
+        old_reactions = [_emoji_from_reaction(r) for r in (rxn.old_reaction or [])]
+
+        # Who reacted? rxn.user is set for users, rxn.actor_chat for anonymous actors.
+        user = rxn.user
+        actor_chat = rxn.actor_chat
+        user_id = str(user.id) if user else (str(actor_chat.id) if actor_chat else None)
+        user_name = (
+            (user.full_name or user.username) if user
+            else (actor_chat.title if actor_chat else None)
+        )
+
+        payload = {
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "user_id": user_id,
+            "user_name": user_name,
+            "new_reactions": new_reactions,
+            "old_reactions": old_reactions,
+            "message_text": message_text,
+        }
+
+        logger.debug(
+            "[%s] reaction on bot msg %s: +%s -%s by %s",
+            self.name, message_id, new_reactions, old_reactions, user_id,
+        )
+
+        # Fire the reaction callback if one was installed (e.g. by run.py for hooks).
+        cb = getattr(self, "_reaction_callback", None)
+        if cb is not None:
+            try:
+                await cb(payload)
+            except Exception:
+                logger.debug("[%s] reaction callback failed", self.name, exc_info=True)
 
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6390,6 +6390,15 @@ class TelegramAdapter(BasePlatformAdapter):
         # Only process reactions on our own bot messages.
         from gateway import rich_sent_store
         message_text = rich_sent_store.lookup(chat_id, message_id)
+
+        logger.info(
+            "[%s] reaction update: chat=%s msg=%s new=%s old=%s known_bot_msg=%s",
+            self.name, chat_id, message_id,
+            [getattr(r, "emoji", "?") for r in (rxn.new_reaction or [])],
+            [getattr(r, "emoji", "?") for r in (rxn.old_reaction or [])],
+            message_text is not None,
+        )
+
         if message_text is None:
             # Not a message we sent — ignore.
             return

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2985,6 +2985,12 @@ class TelegramAdapter(BasePlatformAdapter):
                                 continue
                         raise
                 message_ids.append(str(msg.message_id))
+                # Index this message so reaction updates can look it up.
+                try:
+                    from gateway import rich_sent_store as _rss
+                    _rss.record(str(chat_id), str(msg.message_id), content)
+                except Exception:
+                    pass
 
             # Re-trigger typing indicator after sending a message.
             # Telegram clears the typing state when a new message is delivered,

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -974,6 +974,64 @@ class TestConvertMessages:
         assert len(tool_results) == 1
         assert tool_results[0]["tool_use_id"] == "tc_valid"
 
+    def test_strips_non_adjacent_tool_use(self):
+        """tool_use whose tool_result is not adjacent after merging should be stripped.
+
+        An assistant turn between the tool_use and the tool_result makes them
+        non-adjacent even after _merge_consecutive_roles runs.
+        Anthropic rejects non-adjacent pairs with HTTP 400.
+        """
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "tc_nonadjacent", "function": {"name": "x", "arguments": "{}"}}
+                ],
+            },
+            # Plain user turn — no tool_result here
+            {"role": "user", "content": "wait a moment"},
+            # Intervening assistant turn breaks adjacency (no merge can bridge this)
+            {"role": "assistant", "content": "Sure, I'll wait"},
+            # tool_result appears two positions later — never adjacent to the tool_use
+            {"role": "tool", "tool_call_id": "tc_nonadjacent", "content": "late result"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        # The tool_use should have been stripped because the result is not adjacent
+        assistant_blocks = result[0]["content"]
+        assert all(b.get("type") != "tool_use" for b in assistant_blocks), (
+            "Non-adjacent tool_use should be stripped"
+        )
+
+    def test_consecutive_user_messages_merged_before_adjacency_check(self):
+        """Two consecutive user messages are merged by _merge_consecutive_roles
+        before the adjacency check runs.
+
+        After merging, the tool_result block ends up directly after the
+        tool_use — so the pair should be KEPT, not stripped.
+        """
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "tc_merge", "function": {"name": "x", "arguments": "{}"}}
+                ],
+            },
+            # Two consecutive user messages — second carries the tool_result
+            {"role": "user", "content": "some text"},
+            {"role": "tool", "tool_call_id": "tc_merge", "content": "result"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        # After merging the two user turns, tool_result is adjacent to tool_use
+        # → the tool_use must be preserved
+        assistant_blocks = result[0]["content"]
+        tool_use_ids = [b.get("id") for b in assistant_blocks if b.get("type") == "tool_use"]
+        assert "tc_merge" in tool_use_ids, (
+            "tool_use should survive when its tool_result becomes adjacent after merge"
+        )
+
+
     def test_system_with_cache_control(self):
         messages = [
             {

--- a/tests/run_agent/test_orphaned_tool_use_recovery.py
+++ b/tests/run_agent/test_orphaned_tool_use_recovery.py
@@ -1,0 +1,235 @@
+"""Stress tests for orphaned tool_use recovery (PR #53236).
+
+Tests three layers:
+1. error_classifier: detects the Anthropic 400 and emits orphaned_tool_use
+2. _strip_orphaned_tool_blocks: actually cleans the canonical messages list
+3. TurnRetryState: one-shot guard prevents infinite retry loops
+"""
+
+from __future__ import annotations
+
+import pytest
+from agent.error_classifier import FailoverReason, _classify_400
+from agent.anthropic_adapter import _strip_orphaned_tool_blocks
+from agent.turn_retry_state import TurnRetryState
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _result_fn(reason, **kwargs):
+    """Minimal stand-in for the result_fn closure in classify_api_error."""
+    from agent.error_classifier import ClassifiedError
+    obj = ClassifiedError(reason=reason, status_code=400)
+    for k, v in kwargs.items():
+        setattr(obj, k, v)
+    return obj
+
+
+def _classify(msg: str):
+    body = {"type": "error", "error": {"type": "invalid_request_error", "message": msg}}
+    return _classify_400(
+        msg.lower(), "", body,
+        provider="anthropic", model="claude-sonnet-4-6",
+        approx_tokens=1000, context_length=200_000,
+        num_messages=10, result_fn=_result_fn,
+    )
+
+
+def _make_messages(*, orphaned: bool = True):
+    """Build a minimal canonical messages list.
+
+    With orphaned=True:  assistant has tool_use with no following tool_result
+    With orphaned=False: well-formed pair
+    """
+    tool_use_block = {
+        "type": "tool_use",
+        "id": "toolu_017QgFu6YZ8WbbMGDb1Z9FtP",
+        "name": "execute_code",
+        "input": {"code": "print('hi')"},
+    }
+    tool_result_msg = {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "toolu_017QgFu6YZ8WbbMGDb1Z9FtP",
+                "content": "Blocked by approval guard",
+            }
+        ],
+    }
+    messages = [
+        {"role": "user", "content": "run some code"},
+        {"role": "assistant", "content": [{"type": "text", "text": "Sure!"}, tool_use_block]},
+    ]
+    if not orphaned:
+        messages.append(tool_result_msg)
+        messages.append({"role": "assistant", "content": [{"type": "text", "text": "Done."}]})
+    return messages
+
+
+# ── Layer 1: error classifier ─────────────────────────────────────────────────
+
+ANTHROPIC_ERROR_MESSAGES = [
+    # Exact wording from real Anthropic API response
+    "messages.2: `tool_use` ids were found without `tool_result` blocks immediately after: "
+    "toolu_017QgFu6YZ8WbbMGDb1Z9FtP. Each `tool_use` block must have a corresponding "
+    "`tool_result` block in the next message.",
+    # Shorter variant
+    "tool_use ids found without tool_result blocks",
+    # Multi-tool variant
+    "tool_use ids toolu_abc toolu_def were found without tool_result blocks",
+]
+
+
+@pytest.mark.parametrize("msg", ANTHROPIC_ERROR_MESSAGES)
+def test_classifier_detects_orphaned_tool_use(msg):
+    result = _classify(msg)
+    assert result.reason == FailoverReason.orphaned_tool_use, (
+        f"Expected orphaned_tool_use, got {result.reason} for: {msg!r}"
+    )
+    assert result.retryable is True, "Must be retryable so the loop can recover"
+
+
+def test_classifier_does_not_trigger_on_unrelated_400():
+    result = _classify("invalid model name: claude-fake-99")
+    assert result.reason != FailoverReason.orphaned_tool_use
+
+
+def test_classifier_does_not_trigger_on_context_overflow():
+    # Simulate a large session that triggers context_overflow before our check
+    body = {"type": "error", "error": {"type": "invalid_request_error", "message": "error"}}
+    result = _classify_400(
+        "error", "", body,
+        provider="anthropic", model="claude-sonnet-4-6",
+        approx_tokens=90_000, context_length=200_000,
+        num_messages=90, result_fn=_result_fn,
+    )
+    assert result.reason == FailoverReason.context_overflow
+
+
+# ── Layer 2: strip function cleans canonical messages ─────────────────────────
+
+def test_strip_removes_orphaned_tool_use():
+    messages = _make_messages(orphaned=True)
+    assert len(messages) == 2  # user + orphaned assistant
+
+    _strip_orphaned_tool_blocks(messages)
+
+    # The assistant message should no longer contain the tool_use block
+    assistant_blocks = [
+        b for m in messages
+        if m.get("role") == "assistant"
+        for b in (m.get("content") if isinstance(m.get("content"), list) else [])
+        if isinstance(b, dict) and b.get("type") == "tool_use"
+    ]
+    assert assistant_blocks == [], f"Expected no tool_use blocks, found: {assistant_blocks}"
+
+
+def test_strip_leaves_well_formed_messages_intact():
+    messages = _make_messages(orphaned=False)
+    original_len = len(messages)
+    _strip_orphaned_tool_blocks(messages)
+    # Well-formed pair: tool_use + tool_result both present, nothing to strip
+    tool_uses = [
+        b for m in messages
+        if m.get("role") == "assistant"
+        for b in (m.get("content") if isinstance(m.get("content"), list) else [])
+        if isinstance(b, dict) and b.get("type") == "tool_use"
+    ]
+    assert tool_uses != [] or len(messages) == original_len, (
+        "Well-formed pair should survive the strip"
+    )
+
+
+def test_strip_is_idempotent():
+    """Calling strip twice should not crash or over-strip."""
+    messages = _make_messages(orphaned=True)
+    _strip_orphaned_tool_blocks(messages)
+    snapshot = [m.copy() for m in messages]
+    _strip_orphaned_tool_blocks(messages)
+    assert messages == snapshot, "Second strip changed messages"
+
+
+def test_strip_handles_empty_list():
+    messages = []
+    _strip_orphaned_tool_blocks(messages)  # must not raise
+    assert messages == []
+
+
+def test_strip_handles_no_tool_use():
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": [{"type": "text", "text": "hi"}]},
+    ]
+    _strip_orphaned_tool_blocks(messages)
+    assert len(messages) == 2
+
+
+# ── Layer 3: TurnRetryState one-shot guard ────────────────────────────────────
+
+def test_retry_state_has_orphaned_tool_use_flag():
+    state = TurnRetryState()
+    assert hasattr(state, "orphaned_tool_use_retry_attempted"), (
+        "TurnRetryState must have orphaned_tool_use_retry_attempted field"
+    )
+    assert state.orphaned_tool_use_retry_attempted is False
+
+
+def test_retry_state_flag_prevents_second_recovery():
+    """Simulate the guard: second HTTP 400 should NOT trigger recovery again."""
+    state = TurnRetryState()
+
+    # First recovery fires
+    assert not state.orphaned_tool_use_retry_attempted
+    state.orphaned_tool_use_retry_attempted = True
+
+    # Second time: guard is already set — recovery must NOT fire
+    assert state.orphaned_tool_use_retry_attempted is True
+
+
+def test_retry_state_fresh_instance_resets_flag():
+    """Each new API call attempt gets a fresh TurnRetryState."""
+    state1 = TurnRetryState()
+    state1.orphaned_tool_use_retry_attempted = True
+
+    state2 = TurnRetryState()
+    assert state2.orphaned_tool_use_retry_attempted is False, (
+        "New TurnRetryState must start clean"
+    )
+
+
+# ── Integration: full recovery simulation ────────────────────────────────────
+
+def test_full_recovery_flow():
+    """Simulate the complete recovery path end-to-end without a real API call."""
+    # 1. Build a broken canonical messages list (cron job interrupted mid-tool)
+    messages = _make_messages(orphaned=True)
+
+    # 2. Verify the classifier recognizes the error
+    error_msg = (
+        "messages.2: `tool_use` ids were found without `tool_result` blocks immediately after: "
+        "toolu_017QgFu6YZ8WbbMGDb1Z9FtP."
+    )
+    classified = _classify(error_msg)
+    assert classified.reason == FailoverReason.orphaned_tool_use
+    assert classified.retryable
+
+    # 3. Verify guard not yet set
+    retry_state = TurnRetryState()
+    assert not retry_state.orphaned_tool_use_retry_attempted
+
+    # 4. Run the recovery (as conversation_loop.py would)
+    retry_state.orphaned_tool_use_retry_attempted = True
+    _strip_orphaned_tool_blocks(messages)
+
+    # 5. Verify messages are now clean
+    remaining_tool_uses = [
+        b for m in messages
+        if m.get("role") == "assistant"
+        for b in (m.get("content") if isinstance(m.get("content"), list) else [])
+        if isinstance(b, dict) and b.get("type") == "tool_use"
+    ]
+    assert remaining_tool_uses == [], "After recovery, no orphaned tool_use blocks should remain"
+
+    # 6. Verify a second identical error would NOT trigger recovery again
+    assert retry_state.orphaned_tool_use_retry_attempted is True


### PR DESCRIPTION
Adds support for Telegram message reaction events on messages sent by the bot.

## What changed
- TelegramAdapter: registers MessageReactionHandler (PTB 22.6+). _handle_reaction() looks up message_id in rich_sent_store (only fires for bot messages), extracts emoji, calls _reaction_callback
- BasePlatformAdapter: set_reaction_callback() — same pattern as set_message_handler()
- GatewayRunner: _handle_telegram_reaction() emits telegram:reaction hook event. Wired in all three adapter-setup paths.

## Payload
chat_id, message_id, user_id, user_name, new_reactions (list[str]), old_reactions (list[str]), message_text

## Notes
- Zero cost when no hook installed — purely hook-based
- allowed_updates=Update.ALL_TYPES already set, no polling change needed
- Requires PTB >= 21.0 (venv has 22.6)