### PR TITLE
fix(auth): respect suppressed copilot credential sources in resolve_copilot_token

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -64,14 +64,36 @@ def validate_copilot_token(token: str) -> tuple[bool, str]:
     return True, "OK"
 
 
+def _copilot_source_suppressed(source: str) -> bool:
+    """Return True when the user explicitly removed/suppressed a Copilot
+    credential source via `hermes auth remove copilot`.
+
+    Mirrors the suppression pattern already used by agent/credential_pool.py
+    for env credential discovery. Without this, dashboard / status-probe
+    paths can silently re-discover a gh_cli token even after a user opted
+    out, repeatedly invoking `gh auth token` -- on Windows this can spawn
+    short-lived console windows that flash and steal focus (issue #53781).
+    """
+    try:
+        from hermes_cli.auth import is_source_suppressed
+
+        return is_source_suppressed("copilot", source)
+    except Exception:
+        return False
+
+
 def resolve_copilot_token() -> tuple[str, str]:
     """Resolve a GitHub token suitable for Copilot API use.
 
     Returns (token, source) where source describes where the token came from.
     Raises ValueError if only a classic PAT is available.
     """
-    # 1. Check env vars in priority order
+    # 1. Check env vars in priority order. Respect explicit removals from
+    # `hermes auth remove copilot` so dashboard/status probes do not
+    # silently re-enable a suppressed source.
     for env_var in COPILOT_ENV_VARS:
+        if _copilot_source_suppressed(f"env:{env_var}"):
+            continue
         val = os.getenv(env_var, "").strip()
         if val:
             valid, msg = validate_copilot_token(val)
@@ -82,15 +104,16 @@ def resolve_copilot_token() -> tuple[str, str]:
                 continue
             return val, env_var
 
-    # 2. Fall back to gh auth token
-    token = _try_gh_cli_token()
-    if token:
-        valid, msg = validate_copilot_token(token)
-        if not valid:
-            raise ValueError(
-                f"Token from `gh auth token` is a classic PAT (ghp_*). {msg}"
-            )
-        return token, "gh auth token"
+    # 2. Fall back to gh auth token unless the gh_cli source was suppressed.
+    if not _copilot_source_suppressed("gh_cli"):
+        token = _try_gh_cli_token()
+        if token:
+            valid, msg = validate_copilot_token(token)
+            if not valid:
+                raise ValueError(
+                    f"Token from `gh auth token` is a classic PAT (ghp_*). {msg}"
+                )
+            return token, "gh auth token"
 
     return "", ""
 

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -207,61 +207,112 @@ class TestSuppressedSources:
     so dashboard/status-probe paths don't silently re-discover a removed
     credential source (e.g. repeatedly invoking `gh auth token`, which can
     spawn flashing console windows on Windows).
+
+    These use REAL suppress_credential_source() writes against a hermetic
+    HERMES_HOME (tmp_path), not mocked is_source_suppressed() returns --
+    this exercises the actual persisted-marker round-trip a real
+    `hermes auth remove copilot` invocation would produce, not just the
+    gating logic in isolation.
     """
 
-    def test_suppressed_gh_cli_source_is_skipped(self, monkeypatch):
+    def test_suppressed_gh_cli_skips_subprocess_invocation(self, monkeypatch, tmp_path):
+        """When gh_cli is suppressed, _try_gh_cli_token must NOT be called.
+
+        Load-bearing assertion: if a future change re-introduces the
+        unconditional `gh auth token` call, the mock raises immediately --
+        a stray invocation loudly fails the test instead of silently
+        returning a token.
+        """
         from hermes_cli import copilot_auth
 
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
         monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
         monkeypatch.delenv("GH_TOKEN", raising=False)
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
 
-        with patch.object(copilot_auth, "_try_gh_cli_token") as mock_gh:
-            mock_gh.return_value = "gho_should_not_be_used"
-            with patch("hermes_cli.auth.is_source_suppressed", return_value=True):
-                token, source = copilot_auth.resolve_copilot_token()
+        from hermes_cli.auth import suppress_credential_source
+        suppress_credential_source("copilot", "gh_cli")
+
+        def _fail_if_called():
+            raise RuntimeError("_try_gh_cli_token must not be called when gh_cli is suppressed")
+
+        with patch.object(copilot_auth, "_try_gh_cli_token", side_effect=_fail_if_called):
+            token, source = copilot_auth.resolve_copilot_token()
 
         assert token == ""
         assert source == ""
-        mock_gh.assert_not_called()
 
-    def test_unsuppressed_gh_cli_source_is_used(self, monkeypatch):
+    def test_unsuppressed_gh_cli_source_is_used(self, monkeypatch, tmp_path):
         from hermes_cli import copilot_auth
 
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
         monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
         monkeypatch.delenv("GH_TOKEN", raising=False)
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
 
-        with patch.object(copilot_auth, "_try_gh_cli_token") as mock_gh:
-            mock_gh.return_value = "gho_from_gh_cli"
-            with patch("hermes_cli.auth.is_source_suppressed", return_value=False):
-                token, source = copilot_auth.resolve_copilot_token()
+        with patch.object(copilot_auth, "_try_gh_cli_token", return_value="gho_from_gh_cli"):
+            token, source = copilot_auth.resolve_copilot_token()
 
         assert token == "gho_from_gh_cli"
         assert source == "gh auth token"
-        mock_gh.assert_called_once()
 
-    def test_suppressed_env_var_source_is_skipped(self, monkeypatch):
+    def test_suppressed_env_var_falls_through_to_next(self, monkeypatch, tmp_path):
+        """Suppressing COPILOT_GITHUB_TOKEN must skip it; GITHUB_TOKEN wins
+        instead of the suppressed value being returned."""
         from hermes_cli import copilot_auth
 
-        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_should_not_be_used")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+        from hermes_cli.auth import suppress_credential_source
+        suppress_credential_source("copilot", "env:COPILOT_GITHUB_TOKEN")
+
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_should_be_ignored")
         monkeypatch.delenv("GH_TOKEN", raising=False)
-        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setenv("GITHUB_TOKEN", "gho_github_third")
 
-        def _suppress_only_copilot_env(provider, source):
-            return source == "env:COPILOT_GITHUB_TOKEN"
+        token, source = copilot_auth.resolve_copilot_token()
+        assert token == "gho_github_third"
+        assert source == "GITHUB_TOKEN"
 
-        with patch.object(copilot_auth, "_try_gh_cli_token", return_value=""):
-            with patch(
-                "hermes_cli.auth.is_source_suppressed",
-                side_effect=_suppress_only_copilot_env,
-            ):
-                token, source = copilot_auth.resolve_copilot_token()
+    def test_suppressed_env_var_is_skipped_other_unset(self, monkeypatch, tmp_path):
+        """A suppressed env:GH_TOKEN must not be returned, even when set,
+        while an unsuppressed higher-priority var still wins."""
+        from hermes_cli import copilot_auth
 
-        # The suppressed env var must be skipped, falling through to no token
-        # (gh_cli also returns empty in this test) rather than using the
-        # suppressed value.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+        from hermes_cli.auth import suppress_credential_source
+        suppress_credential_source("copilot", "env:GH_TOKEN")
+
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_copilot_first")
+        monkeypatch.setenv("GH_TOKEN", "gho_gh_should_be_ignored")
+        monkeypatch.setenv("GITHUB_TOKEN", "gho_github_third")
+
+        token, source = copilot_auth.resolve_copilot_token()
+        assert token == "gho_copilot_first"
+        assert source == "COPILOT_GITHUB_TOKEN"
+
+    def test_all_sources_suppressed_returns_empty_without_error(self, monkeypatch, tmp_path):
+        """Suppressing every Copilot source must return ("", "") cleanly,
+        with no exception even though no token is available."""
+        from hermes_cli import copilot_auth
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+        from hermes_cli.auth import suppress_credential_source
+        for env_var in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
+            suppress_credential_source("copilot", f"env:{env_var}")
+        suppress_credential_source("copilot", "gh_cli")
+
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_a")
+        monkeypatch.setenv("GH_TOKEN", "gho_b")
+        monkeypatch.setenv("GITHUB_TOKEN", "gho_c")
+
+        with patch.object(copilot_auth, "_try_gh_cli_token", side_effect=RuntimeError("must not be called")):
+            token, source = copilot_auth.resolve_copilot_token()
+
         assert token == ""
+        assert source == ""
 
     def test_suppression_check_failure_does_not_block_resolution(self, monkeypatch):
         """If is_source_suppressed() itself raises, resolution must still

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -199,3 +199,82 @@ class TestEnvVarOrder:
         assert copilot.api_key_env_vars == (
             "COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"
         )
+
+
+class TestSuppressedSources:
+    """Regression tests for issue #53781: resolve_copilot_token() must
+    respect explicit source suppression from `hermes auth remove copilot`,
+    so dashboard/status-probe paths don't silently re-discover a removed
+    credential source (e.g. repeatedly invoking `gh auth token`, which can
+    spawn flashing console windows on Windows).
+    """
+
+    def test_suppressed_gh_cli_source_is_skipped(self, monkeypatch):
+        from hermes_cli import copilot_auth
+
+        monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        with patch.object(copilot_auth, "_try_gh_cli_token") as mock_gh:
+            mock_gh.return_value = "gho_should_not_be_used"
+            with patch("hermes_cli.auth.is_source_suppressed", return_value=True):
+                token, source = copilot_auth.resolve_copilot_token()
+
+        assert token == ""
+        assert source == ""
+        mock_gh.assert_not_called()
+
+    def test_unsuppressed_gh_cli_source_is_used(self, monkeypatch):
+        from hermes_cli import copilot_auth
+
+        monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        with patch.object(copilot_auth, "_try_gh_cli_token") as mock_gh:
+            mock_gh.return_value = "gho_from_gh_cli"
+            with patch("hermes_cli.auth.is_source_suppressed", return_value=False):
+                token, source = copilot_auth.resolve_copilot_token()
+
+        assert token == "gho_from_gh_cli"
+        assert source == "gh auth token"
+        mock_gh.assert_called_once()
+
+    def test_suppressed_env_var_source_is_skipped(self, monkeypatch):
+        from hermes_cli import copilot_auth
+
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_should_not_be_used")
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        def _suppress_only_copilot_env(provider, source):
+            return source == "env:COPILOT_GITHUB_TOKEN"
+
+        with patch.object(copilot_auth, "_try_gh_cli_token", return_value=""):
+            with patch(
+                "hermes_cli.auth.is_source_suppressed",
+                side_effect=_suppress_only_copilot_env,
+            ):
+                token, source = copilot_auth.resolve_copilot_token()
+
+        # The suppressed env var must be skipped, falling through to no token
+        # (gh_cli also returns empty in this test) rather than using the
+        # suppressed value.
+        assert token == ""
+
+    def test_suppression_check_failure_does_not_block_resolution(self, monkeypatch):
+        """If is_source_suppressed() itself raises, resolution must still
+        proceed (fail open on the suppression check, not on token discovery)."""
+        from hermes_cli import copilot_auth
+
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_env_token")
+
+        with patch(
+            "hermes_cli.auth.is_source_suppressed",
+            side_effect=RuntimeError("auth store unavailable"),
+        ):
+            token, source = copilot_auth.resolve_copilot_token()
+
+        assert token == "gho_env_token"
+        assert source == "COPILOT_GITHUB_TOKEN"


### PR DESCRIPTION
## Problem

agent/credential_sources.py::_remove_copilot_gh() already suppresses gh_cli and env:<VAR> sources via suppress_credential_source() on hermes auth remove copilot -- but resolve_copilot_token() never checked it. Dashboard/status probes could silently re-discover a removed gh_cli token, repeatedly invoking gh auth token, spawning flashing console windows on Windows (issue #53781).

## Fix

_copilot_source_suppressed() gates both the env var loop and the gh_cli fallback in resolve_copilot_token(), mirroring is_source_suppressed(provider, source) already used by agent/credential_pool.py. Fails open on check errors.

## Verification

6 regression tests using REAL suppress_credential_source() writes against hermetic HERMES_HOME (tmp_path), not mocks: load-bearing gh_cli test (mock raises if _try_gh_cli_token is ever called), unsuppressed gh_cli works, env fallthrough, env skip with priority fallback, all-sources-suppressed clean empty return, fail-open on suppression-check error.

Full suite: 31 passed (25 existing + 6 new).

Fixes #53781