### PR TITLE
fix(moa): preserve provider identity for resolved aux endpoints

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5187,6 +5187,14 @@ def _resolve_task_provider_model(
         cfg_provider, cfg_base_url = _expand_direct_api_alias(cfg_provider, cfg_base_url)
 
     if base_url:
+        # A caller may pass a resolved endpoint together with a real provider
+        # identity (MoA slots do this after resolve_runtime_provider()).  Do not
+        # collapse that back to ``custom``: provider identity controls important
+        # transport/auth behavior such as openai-codex Responses wrapping and
+        # Cloudflare headers.  Only provider-less or explicitly custom endpoints
+        # should use the generic custom route.
+        if provider and provider.strip().lower() not in {"auto", "custom"}:
+            return provider, resolved_model, base_url, api_key, resolved_api_mode
         return "custom", resolved_model, base_url, api_key, resolved_api_mode
     if provider:
         return provider, resolved_model, base_url, api_key, resolved_api_mode

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -29,6 +29,7 @@ from agent.auxiliary_client import (
     _try_payment_fallback,
     _resolve_auto,
     _resolve_xai_oauth_for_aux,
+    _resolve_task_provider_model,
     _CodexCompletionsAdapter,
 )
 
@@ -91,6 +92,38 @@ def codex_auth_dir(tmp_path, monkeypatch):
         lambda: "codex-test-token-abc123",
     )
     return codex_dir
+
+
+class TestResolveTaskProviderModel:
+    def test_explicit_base_url_preserves_known_provider_identity(self):
+        provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            task="moa_reference",
+            provider="openai-codex",
+            model="gpt-5.5",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key="codex-token",
+        )
+
+        assert provider == "openai-codex"
+        assert model == "gpt-5.5"
+        assert base_url == "https://chatgpt.com/backend-api/codex"
+        assert api_key == "codex-token"
+        assert api_mode is None
+
+    def test_explicit_base_url_without_provider_still_uses_custom(self):
+        provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            task="moa_reference",
+            provider="",
+            model="local-model",
+            base_url="http://127.0.0.1:11434/v1",
+            api_key="local-key",
+        )
+
+        assert provider == "custom"
+        assert model == "local-model"
+        assert base_url == "http://127.0.0.1:11434/v1"
+        assert api_key == "local-key"
+        assert api_mode is None
 
 
 class TestAuxiliaryMaxTokensParam:


### PR DESCRIPTION
Summary
- Preserve explicit provider identity when auxiliary calls also pass a resolved base_url.
- Keep provider-less or explicitly custom base_url calls on the generic custom route.

Session log evidence
- MoA turn started as provider=moa model=default.
- Logs showed MoA resolving a reference slot for openai-codex:gpt-5.5, then failing with Cloudflare HTML from chatgpt.com/backend-api/codex:
  - `MoA reference model openai-codex:gpt-5.5 failed: <html>`
  - `API call failed ... provider=moa base_url=http://127.0.0.1/v1 model=default summary=HTTP 403 - HTML error page`
- Local probe before the fix showed `_slot_runtime({'provider':'openai-codex','model':'gpt-5.5'})` passed provider plus `https://chatgpt.com/backend-api/codex`, but `_resolve_task_provider_model(...)` coerced that to `custom` because any explicit base_url forced the custom route.
- That dropped the openai-codex provider identity, so the request missed Codex Responses wrapping and Codex/Cloudflare headers.

Why this fix
- Provider identity controls important transport/auth behavior, including openai-codex Responses wrapping and Cloudflare headers.
- A resolved endpoint plus a known provider should not be treated the same as a provider-less custom endpoint.
- This fixes the shared auxiliary routing invariant instead of adding a MoA-only special case.

