### PR TITLE
feat(skills): add WireGuard SOCKS VPN exit routing skill

### DIFF
--- a/skills/devops/surfshark-vpn-exit/SKILL.md
+++ b/skills/devops/surfshark-vpn-exit/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: surfshark-vpn-exit
+description: Route agent egress through a WireGuard SOCKS proxy.
+version: 0.1.0
+author: Hermes Agent
+license: MIT
+platforms: [linux]
+metadata:
+  hermes:
+    tags: [VPN, WireGuard, SOCKS, Proxy, Egress, systemd]
+    category: devops
+    related_skills: [pinggy-tunnel]
+---
+
+# Surfshark VPN Exit Skill
+
+Route a host's outbound traffic through a Surfshark WireGuard tunnel exposed as
+a local SOCKS5 proxy (via `wireproxy`), so the agent and gateway egress with the
+VPN provider's IP/ASN instead of the datacenter's. This skill covers the
+userspace proxy, pointing services at it, verifying the public IP actually
+changed, and making it survive reboots. It does **not** set up kernel-level
+`wg-quick` routing, manage a Surfshark account, or guarantee any model API /
+OAuth endpoint is reachable through the VPN — those depend on the provider.
+
+## When to Use
+
+- A VPS / cloud host needs its outbound IP to read as a consumer VPN endpoint
+  rather than a datacenter ASN (geo-restricted APIs, region testing, scraping).
+- You want per-process egress routing without root-level `wg-quick`, network
+  namespaces, or touching the host routing table.
+- The agent or gateway should send traffic through the tunnel via
+  `HTTPS_PROXY` / `ALL_PROXY`, while leaving localhost and control planes direct.
+- You need the proxy to come back automatically after a reboot.
+
+If you only need to expose a local port publicly (not route egress), use the
+`pinggy-tunnel` skill instead.
+
+## Prerequisites
+
+- **Linux with systemd** and user-level lingering support (`loginctl`).
+- **`wireproxy`** on `PATH` — a userspace WireGuard client that serves SOCKS5
+  (https://github.com/pufferffish/wireproxy). No kernel module or root needed.
+- **A Surfshark WireGuard config** (private key + peer endpoint + allowed IPs),
+  generated from the Surfshark dashboard. Store it at a path you control, e.g.
+  `~/.config/wireproxy/exit.conf`. Treat the private key as a secret — never
+  commit it.
+- **`curl`** for verification. `jq` is optional (the scripts fall back to grep).
+
+No `HERMES_*` env vars are required. All tunable values are passed to the helper
+script as plain env vars (`SOCKS_PORT`, `WIREPROXY_CONF`, `VERIFY_URL`, …) or
+written into the rendered systemd units.
+
+## How to Run
+
+Drive everything through the `terminal` tool. The helper script
+`scripts/vpn-exit.sh` wraps the full lifecycle; read it with `read_file` before
+running so you can see the exact commands. Typical flow:
+
+```bash
+SKILL_DIR=skills/devops/surfshark-vpn-exit          # adjust to the installed path
+WIREPROXY_CONF=~/.config/wireproxy/exit.conf SOCKS_PORT=1080 \
+  bash "$SKILL_DIR/scripts/vpn-exit.sh" install-service
+bash "$SKILL_DIR/scripts/vpn-exit.sh" up
+bash "$SKILL_DIR/scripts/vpn-exit.sh" verify        # FAILS if egress IP did not change
+bash "$SKILL_DIR/scripts/vpn-exit.sh" persist       # enable on boot + linger
+```
+
+`verify` is the load-bearing step: it compares the direct public IP with the
+proxied public IP and exits non-zero if they match, so a silent fallback to the
+datacenter IP is treated as a failure, never a success.
+
+## Quick Reference
+
+```bash
+# 1. Render + install the user-level wireproxy service from the template
+WIREPROXY_CONF=~/.config/wireproxy/exit.conf SOCKS_PORT=1080 \
+  bash scripts/vpn-exit.sh install-service
+
+# 2. Start / stop / status
+bash scripts/vpn-exit.sh up
+bash scripts/vpn-exit.sh down
+bash scripts/vpn-exit.sh status
+
+# 3. Confirm the public IP/ASN now reads as the VPN, not the datacenter
+bash scripts/vpn-exit.sh verify
+curl --proxy socks5h://127.0.0.1:1080 -s https://ipinfo.io/json
+
+# 4. Point a systemd-managed service (e.g. the gateway) at the proxy
+bash scripts/vpn-exit.sh wire-service hermes-gateway
+
+# 5. Survive reboots
+bash scripts/vpn-exit.sh persist
+```
+
+## Procedure
+
+### 1. Bring up the SOCKS proxy
+
+`install-service` renders `templates/wireproxy.service.template` into
+`~/.config/systemd/user/<service>.service` (default `hermes-wireproxy`) pointing
+at your `WIREPROXY_CONF`. The WireGuard config must contain a `[Socks5]` section
+binding `127.0.0.1:<SOCKS_PORT>` — see `templates/wireproxy.conf.template` for
+the shape. Then `up` runs `systemctl --user start` and waits for the port to
+listen.
+
+### 2. Verify the exit IP actually changed
+
+Run `verify`. It fetches `VERIFY_URL` (default `https://ipinfo.io/json`) twice —
+once directly and once through `socks5h://127.0.0.1:<port>` — and compares the
+`ip`/`org` fields. Use `socks5h` (not `socks5`) so DNS resolves through the
+tunnel and does not leak. If the two IPs are equal, the proxy is not routing and
+the script exits non-zero. Never report success on an unverified tunnel.
+
+### 3. Point the agent / gateway egress at the proxy
+
+Egress is controlled with standard proxy env vars. For a systemd-managed Hermes
+service, `wire-service <unit>` writes a drop-in at
+`~/.config/systemd/user/<unit>.service.d/10-proxy.conf` from
+`templates/proxy-env.conf.template`, setting:
+
+```ini
+[Service]
+Environment=HTTPS_PROXY=socks5h://127.0.0.1:1080
+Environment=ALL_PROXY=socks5h://127.0.0.1:1080
+Environment=NO_PROXY=127.0.0.1,localhost,::1
+```
+
+Then `systemctl --user daemon-reload && systemctl --user restart <unit>`. Keep
+`NO_PROXY` covering loopback so health checks and the JSON-RPC control plane
+stay direct.
+
+### 4. Failover
+
+If `verify` fails or the tunnel drops, decide explicitly: either retry the
+tunnel, switch to a backup Surfshark endpoint (a second `WIREPROXY_CONF`), or
+stop egress entirely. Do **not** let traffic silently fall through to the
+datacenter IP — clear the proxy env (`down` + restart the service unproxied)
+only as a deliberate, logged choice.
+
+### 5. Persistence
+
+`persist` runs `systemctl --user enable <service>` and
+`loginctl enable-linger "$USER"` so the user service starts at boot without an
+interactive login session.
+
+## Pitfalls
+
+- **Silent fallback to the datacenter IP is the #1 failure.** If the SOCKS proxy
+  is down, a misconfigured `HTTPS_PROXY` or a tool that ignores it will egress
+  directly. Always gate on `verify`; treat "IP unchanged" as a hard failure.
+- **Use `socks5h`, not `socks5`.** `socks5h://` resolves DNS through the tunnel;
+  `socks5://` resolves locally and leaks your real DNS / location.
+- **Keep loopback in `NO_PROXY`.** Routing `127.0.0.1`/`localhost` through the
+  proxy breaks local health checks, the gateway's JSON-RPC control plane, and
+  any sidecar on the same host.
+- **VPN egress can break model APIs and OAuth.** Some provider/auth endpoints
+  block or rate-limit known VPN ASNs. Verify the specific endpoints you depend
+  on after enabling the proxy; scope the proxy to only the services that need it.
+- **Telegram / messaging reachability.** Long-poll and webhook connections may
+  behave differently from a VPN IP. Confirm the gateway can still reach its
+  platform after switching egress.
+- **Never commit the WireGuard private key.** It lives only in `WIREPROXY_CONF`
+  on the host. The templates ship with placeholders, not real keys.
+- **User services need linger.** Without `loginctl enable-linger`, a `--user`
+  systemd service stops when the SSH session ends and won't start at boot.
+
+## Verification
+
+```bash
+# Direct vs proxied public IP — must differ
+DIRECT=$(curl -s https://ipinfo.io/json | grep -o '"ip": *"[^"]*"')
+PROXIED=$(curl --proxy socks5h://127.0.0.1:1080 -s https://ipinfo.io/json | grep -o '"ip": *"[^"]*"')
+echo "direct=$DIRECT proxied=$PROXIED"
+test "$DIRECT" != "$PROXIED" && echo "OK: egress is routed" || echo "FAIL: same IP"
+
+# Or let the script do the comparison and ASN/org print-out
+bash scripts/vpn-exit.sh verify
+```
+
+Expected: the proxied `ip`/`org` reads as the VPN provider's endpoint, the
+direct values read as the host's datacenter, and `vpn-exit.sh verify` exits `0`.

--- a/skills/devops/surfshark-vpn-exit/scripts/vpn-exit.sh
+++ b/skills/devops/surfshark-vpn-exit/scripts/vpn-exit.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# vpn-exit.sh — manage a userspace WireGuard->SOCKS5 egress proxy (wireproxy)
+# exposed as socks5h://127.0.0.1:<port>, and point systemd --user services at it.
+#
+# All values are env-driven; no personal data, no hardcoded hosts or keys.
+#
+#   SOCKS_PORT      local SOCKS5 port                (default: 1080)
+#   WIREPROXY_BIN   wireproxy binary on PATH         (default: wireproxy)
+#   WIREPROXY_CONF  WireGuard config w/ [Socks5]     (default: ~/.config/wireproxy/exit.conf)
+#   SERVICE_NAME    systemd --user unit name         (default: hermes-wireproxy)
+#   VERIFY_URL      IP/ASN echo endpoint             (default: https://ipinfo.io/json)
+#
+# Usage: vpn-exit.sh {install-service|up|down|status|verify|wire-service <unit>|persist}
+set -euo pipefail
+
+SOCKS_PORT="${SOCKS_PORT:-1080}"
+WIREPROXY_BIN="${WIREPROXY_BIN:-wireproxy}"
+WIREPROXY_CONF="${WIREPROXY_CONF:-$HOME/.config/wireproxy/exit.conf}"
+SERVICE_NAME="${SERVICE_NAME:-hermes-wireproxy}"
+VERIFY_URL="${VERIFY_URL:-https://ipinfo.io/json}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATES_DIR="$(cd "$SCRIPT_DIR/../templates" && pwd)"
+UNIT_DIR="$HOME/.config/systemd/user"
+PROXY_URL="socks5h://127.0.0.1:${SOCKS_PORT}"
+
+log()  { printf '[vpn-exit] %s\n' "$*" >&2; }
+die()  { printf '[vpn-exit] ERROR: %s\n' "$*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"; }
+
+# Extract a JSON string field without requiring jq.
+json_field() { # <field> reads stdin
+  if command -v jq >/dev/null 2>&1; then
+    jq -r ".${1} // empty"
+  else
+    grep -o "\"${1}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -1 | sed 's/.*: *"\(.*\)"/\1/'
+  fi
+}
+
+public_ip() { # [proxy_url]
+  if [ -n "${1:-}" ]; then
+    curl --proxy "$1" -fsS --max-time 20 "$VERIFY_URL"
+  else
+    curl -fsS --max-time 20 "$VERIFY_URL"
+  fi
+}
+
+render() { # <template> -> stdout, expands the documented vars only
+  sed \
+    -e "s|@WIREPROXY_BIN@|${WIREPROXY_BIN}|g" \
+    -e "s|@WIREPROXY_CONF@|${WIREPROXY_CONF}|g" \
+    -e "s|@SOCKS_PORT@|${SOCKS_PORT}|g" \
+    -e "s|@PROXY_URL@|${PROXY_URL}|g" \
+    "$1"
+}
+
+cmd_install_service() {
+  need "$WIREPROXY_BIN"
+  [ -f "$WIREPROXY_CONF" ] || log "note: $WIREPROXY_CONF not found yet — create it from templates/wireproxy.conf.template"
+  mkdir -p "$UNIT_DIR"
+  render "$TEMPLATES_DIR/wireproxy.service.template" > "$UNIT_DIR/${SERVICE_NAME}.service"
+  systemctl --user daemon-reload
+  log "installed $UNIT_DIR/${SERVICE_NAME}.service (proxy=$PROXY_URL)"
+}
+
+cmd_up() {
+  systemctl --user start "${SERVICE_NAME}.service"
+  for _ in $(seq 1 20); do
+    if curl --proxy "$PROXY_URL" -fsS --max-time 3 "$VERIFY_URL" >/dev/null 2>&1; then
+      log "proxy is up on $PROXY_URL"; return 0
+    fi
+    sleep 0.5
+  done
+  die "proxy did not come up on $PROXY_URL — check: systemctl --user status ${SERVICE_NAME}"
+}
+
+cmd_down() {
+  systemctl --user stop "${SERVICE_NAME}.service" || true
+  log "stopped ${SERVICE_NAME}"
+}
+
+cmd_status() {
+  systemctl --user --no-pager status "${SERVICE_NAME}.service" || true
+}
+
+cmd_verify() {
+  need curl
+  local direct proxied dip pip dorg porg
+  direct="$(public_ip "" || true)"
+  proxied="$(public_ip "$PROXY_URL" || true)"
+  [ -n "$proxied" ] || die "no response through $PROXY_URL — tunnel down (refusing to fall back to datacenter IP)"
+  dip="$(printf '%s' "$direct"  | json_field ip)"
+  pip="$(printf '%s' "$proxied" | json_field ip)"
+  dorg="$(printf '%s' "$direct"  | json_field org)"
+  porg="$(printf '%s' "$proxied" | json_field org)"
+  log "direct : ip=${dip:-?} org=${dorg:-?}"
+  log "proxied: ip=${pip:-?} org=${porg:-?}"
+  [ -n "$pip" ] || die "could not read proxied IP from $VERIFY_URL"
+  if [ -n "$dip" ] && [ "$dip" = "$pip" ]; then
+    die "proxied IP equals direct IP ($pip) — egress is NOT routed through the VPN"
+  fi
+  log "OK: egress is routed through the VPN exit"
+}
+
+cmd_wire_service() {
+  local unit="${1:-}"
+  [ -n "$unit" ] || die "usage: vpn-exit.sh wire-service <systemd-user-unit>"
+  local dropin="$UNIT_DIR/${unit}.service.d"
+  mkdir -p "$dropin"
+  render "$TEMPLATES_DIR/proxy-env.conf.template" > "$dropin/10-proxy.conf"
+  systemctl --user daemon-reload
+  log "wired ${unit} egress to $PROXY_URL — restart it: systemctl --user restart ${unit}"
+}
+
+cmd_persist() {
+  systemctl --user enable "${SERVICE_NAME}.service"
+  loginctl enable-linger "$USER" || log "could not enable linger (needs polkit/root) — start manually after login"
+  log "enabled ${SERVICE_NAME} on boot + linger for $USER"
+}
+
+main() {
+  local sub="${1:-}"; shift || true
+  case "$sub" in
+    install-service) cmd_install_service ;;
+    up)              cmd_up ;;
+    down)            cmd_down ;;
+    status)          cmd_status ;;
+    verify)          cmd_verify ;;
+    wire-service)    cmd_wire_service "${1:-}" ;;
+    persist)         cmd_persist ;;
+    *) die "usage: vpn-exit.sh {install-service|up|down|status|verify|wire-service <unit>|persist}" ;;
+  esac
+}
+
+main "$@"

--- a/skills/devops/surfshark-vpn-exit/templates/proxy-env.conf.template
+++ b/skills/devops/surfshark-vpn-exit/templates/proxy-env.conf.template
@@ -1,0 +1,12 @@
+# systemd --user drop-in: route a service's egress through the SOCKS5 proxy.
+# Rendered by scripts/vpn-exit.sh wire-service <unit> into
+# ~/.config/systemd/user/<unit>.service.d/10-proxy.conf
+#
+# socks5h:// (not socks5://) so DNS resolves through the tunnel and does not leak.
+# NO_PROXY keeps loopback / control-plane traffic direct.
+
+[Service]
+Environment=HTTPS_PROXY=@PROXY_URL@
+Environment=HTTP_PROXY=@PROXY_URL@
+Environment=ALL_PROXY=@PROXY_URL@
+Environment=NO_PROXY=127.0.0.1,localhost,::1

--- a/skills/devops/surfshark-vpn-exit/templates/wireproxy.conf.template
+++ b/skills/devops/surfshark-vpn-exit/templates/wireproxy.conf.template
@@ -1,0 +1,22 @@
+# wireproxy config: WireGuard client + local SOCKS5 listener.
+# Fill in the values from your Surfshark WireGuard config (dashboard export).
+# This file holds a PRIVATE KEY — keep it 0600 and NEVER commit it.
+
+[Interface]
+# Your client private key (Surfshark dashboard -> WireGuard -> Manual config).
+PrivateKey = <YOUR_WIREGUARD_PRIVATE_KEY>
+# Address assigned by the provider (example shape; use what the export gives you).
+Address = 10.14.0.2/16
+DNS = 162.252.172.57, 149.154.159.92
+
+[Peer]
+# Provider server public key + endpoint for the exit location you chose.
+PublicKey = <SERVER_PUBLIC_KEY>
+Endpoint = <your-surfshark-endpoint>:51820
+# Route everything through the tunnel.
+AllowedIPs = 0.0.0.0/0, ::/0
+PersistentKeepalive = 25
+
+# Expose the tunnel as a local SOCKS5 proxy on 127.0.0.1:<port>.
+[Socks5]
+BindAddress = 127.0.0.1:@SOCKS_PORT@

--- a/skills/devops/surfshark-vpn-exit/templates/wireproxy.service.template
+++ b/skills/devops/surfshark-vpn-exit/templates/wireproxy.service.template
@@ -1,0 +1,17 @@
+# systemd --user unit for the wireproxy SOCKS5 egress proxy.
+# Rendered by scripts/vpn-exit.sh install-service into
+# ~/.config/systemd/user/<SERVICE_NAME>.service
+
+[Unit]
+Description=Userspace WireGuard SOCKS5 exit proxy (wireproxy)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=@WIREPROXY_BIN@ -c @WIREPROXY_CONF@
+Restart=on-failure
+RestartSec=3
+# Local SOCKS5 listener exposed on 127.0.0.1:@SOCKS_PORT@
+
+[Install]
+WantedBy=default.target

--- a/tests/skills/test_surfshark_vpn_exit_skill.py
+++ b/tests/skills/test_surfshark_vpn_exit_skill.py
@@ -1,0 +1,129 @@
+"""Frontmatter + structure tests for skills/devops/surfshark-vpn-exit.
+
+Stdlib + pytest only, no network. Asserts the HARDLINE skill-authoring
+constraints rather than freezing the prose content.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "skills" / "devops" / "surfshark-vpn-exit"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+
+def _read() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def _frontmatter(text: str) -> dict[str, str]:
+    m = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    assert m, "SKILL.md must open with a YAML frontmatter block"
+    fm: dict[str, str] = {}
+    for line in m.group(1).splitlines():
+        fm_match = re.match(r"^([A-Za-z0-9_]+):\s*(.*)$", line)
+        if fm_match:
+            fm[fm_match.group(1)] = fm_match.group(2).strip()
+    return fm
+
+
+def test_skill_md_exists():
+    assert SKILL_MD.is_file()
+
+
+def test_name_matches_directory():
+    fm = _frontmatter(_read())
+    assert fm.get("name") == SKILL_DIR.name == "surfshark-vpn-exit"
+
+
+def test_description_constraints():
+    fm = _frontmatter(_read())
+    desc = fm.get("description", "").strip().strip('"').strip("'")
+    assert desc, "description is required"
+    assert len(desc) <= 60, f"description must be <= 60 chars, got {len(desc)}"
+    assert desc.endswith("."), "description must end with a period"
+    assert desc.count(".") == 1, "description must be a single sentence"
+    # Must not repeat the skill name tokens.
+    lowered = desc.lower()
+    for token in ("surfshark", "exit"):
+        assert token not in lowered, f"description should not repeat skill-name token {token!r}"
+    # No marketing words.
+    for word in ("powerful", "comprehensive", "seamless", "advanced"):
+        assert word not in lowered, f"description must not contain marketing word {word!r}"
+
+
+def test_required_frontmatter_fields():
+    fm = _frontmatter(_read())
+    for field in ("name", "description", "version", "author", "license"):
+        assert fm.get(field), f"missing required frontmatter field: {field}"
+
+
+def test_linux_platform_declared():
+    # POSIX-only (systemd, wireproxy, bash) — must gate platforms to linux.
+    text = _read()
+    m = re.search(r"^platforms:\s*\[(.*?)\]", text, re.MULTILINE)
+    assert m, "platforms must be declared"
+    platforms = {p.strip() for p in m.group(1).split(",") if p.strip()}
+    assert "linux" in platforms
+    assert "macos" not in platforms and "windows" not in platforms
+
+
+def test_modern_section_order():
+    text = _read()
+    required = [
+        "# Surfshark VPN Exit Skill",
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = []
+    for heading in required:
+        idx = text.find(heading)
+        assert idx != -1, f"missing required section: {heading}"
+        positions.append(idx)
+    assert positions == sorted(positions), "sections must appear in the modern order"
+
+
+def test_helper_script_present_and_referenced():
+    script = SKILL_DIR / "scripts" / "vpn-exit.sh"
+    assert script.is_file(), "expected scripts/vpn-exit.sh"
+    assert "scripts/vpn-exit.sh" in _read(), "SKILL.md must reference the helper script"
+
+
+def test_no_personal_info_leaked():
+    """Generic contract: the skill must ship placeholders, never a real host.
+
+    We assert the *shape* of a leak (developer home paths, concrete public
+    IPs) rather than embedding any author-specific value, so the test itself
+    stays personal-info free.
+    """
+    blob = _read() + (SKILL_DIR / "scripts" / "vpn-exit.sh").read_text(encoding="utf-8")
+    for tpl in (SKILL_DIR / "templates").glob("*"):
+        blob += tpl.read_text(encoding="utf-8")
+    # No developer home directories.
+    assert "/Users/" not in blob, "macOS home path leaked"
+    assert not re.search(r"/home/[A-Za-z0-9_.-]+/", blob), "linux home path leaked"
+    # Only loopback / RFC1918 / link-local / the documented Surfshark DNS
+    # resolvers may appear as literal IPv4s. Any other concrete address is a
+    # personal-host leak (e.g. a controller or VPS public IP).
+    allowed_dns = {"162.252.172.57", "149.154.159.92"}
+    for ip in re.findall(r"\b\d{1,3}(?:\.\d{1,3}){3}\b", blob):
+        first, second, *_ = (int(o) for o in ip.split("."))
+        is_loopback = first == 127
+        is_unspecified = ip == "0.0.0.0"
+        is_rfc1918 = first == 10 or (first == 192 and second == 168) or (
+            first == 172 and 16 <= second <= 31
+        )
+        is_link_local = first == 169 and second == 254
+        if is_loopback or is_unspecified or is_rfc1918 or is_link_local:
+            continue
+        assert ip in allowed_dns, f"unexpected literal public IP leaked: {ip}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

Adds a new `devops` skill, `surfshark-vpn-exit`, for routing a host's outbound
traffic through a Surfshark WireGuard tunnel exposed as a local SOCKS5 proxy
(`wireproxy`), so the agent/gateway egress with the VPN provider's IP/ASN
instead of the datacenter's.

- Runs a userspace WireGuard -> `socks5h://127.0.0.1:<port>` proxy via `wireproxy`
  (no root, no `wg-quick`, no host routing-table changes).
- Points `systemd --user` services (e.g. the gateway) at the proxy through an
  `HTTPS_PROXY`/`ALL_PROXY` drop-in, with `NO_PROXY` keeping loopback direct.
- **Verification gates on the egress IP actually changing** — the helper script
  compares direct vs proxied public IP and fails on a silent fallback to the
  datacenter IP, rather than reporting a false success.
- Covers failover and persistence (`systemctl --user enable` + `loginctl
  enable-linger`).

### Files

- `skills/devops/surfshark-vpn-exit/SKILL.md` — modern section order, `platforms: [linux]`, description 51 chars.
- `skills/devops/surfshark-vpn-exit/scripts/vpn-exit.sh` — env-driven lifecycle (`install-service`/`up`/`down`/`status`/`verify`/`wire-service`/`persist`).
- `skills/devops/surfshark-vpn-exit/templates/` — `wireproxy.conf`, systemd unit, and proxy-env drop-in templates (placeholders only, no keys/hosts).
- `tests/skills/test_surfshark_vpn_exit_skill.py` — stdlib + pytest, no network.

All values are generic placeholders (`<your-vps-host>`, `socks5h://127.0.0.1:1080`,
`~/.config/wireproxy/exit.conf`); no real keys, hosts, or paths are committed.

## Test plan

- [x] `python -m pytest tests/skills/test_surfshark_vpn_exit_skill.py -q` — 8 passed.
- [x] `bash -n skills/devops/surfshark-vpn-exit/scripts/vpn-exit.sh` — syntax OK.
- [x] Description validated <= 60 chars (51), single sentence, ends with a period.
- [ ] Manual: on a Linux VPS, `install-service` -> `up` -> `verify` shows the
      proxied `ipinfo.io` org as the VPN endpoint and exits 0.

Made with [Cursor](https://cursor.com)