### PR TITLE
fix(moa): keep virtual provider on MoA client + preserve slot identity (salvage #53809)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -765,7 +765,7 @@ def init_agent(
         )
         agent._client_kwargs = {}
         agent.api_key = api_key or "moa-virtual-provider"
-        agent.base_url = base_url or "moa://local"
+        agent.base_url = "moa://local"
         if not agent.quiet_mode:
             print(f"🤖 AI Agent initialized with MoA preset: {agent.model}")
     elif agent.api_mode == "bedrock_converse":

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1549,7 +1549,14 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
                 )
 
         # ── Build new client ──
-        if api_mode == "anthropic_messages":
+        if (new_provider or "").strip().lower() == "moa":
+            from agent.moa_loop import MoAClient
+
+            agent.api_key = api_key or "moa-virtual-provider"
+            agent.base_url = "moa://local"
+            agent._client_kwargs = {}
+            agent.client = MoAClient(agent.model or "default")
+        elif api_mode == "anthropic_messages":
             from agent.anthropic_adapter import (
                 build_anthropic_client,
                 resolve_anthropic_token,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -247,6 +247,11 @@ def interruptible_api_call(agent, api_kwargs: dict):
                         invalidate_runtime_client(region)
                     raise
                 result["response"] = normalize_converse_response(raw_response)
+            elif agent.provider == "moa":
+                # MoA is a virtual chat-completions provider backed by the
+                # in-process MoAClient facade. Do not rebuild a request-local
+                # OpenAI client from the virtual runtime metadata.
+                result["response"] = agent.client.chat.completions.create(**api_kwargs)
             else:
                 request_client = _set_request_client(
                     agent._create_request_openai_client(

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -55,6 +55,13 @@ def _slot_runtime(slot: dict[str, str]) -> dict[str, Any]:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
         rt = resolve_runtime_provider(requested=provider, target_model=model)
+        resolved_provider = str(rt.get("provider") or provider).strip().lower()
+        # call_llm treats an explicit base_url as a custom endpoint. That is
+        # correct for ordinary OpenAI-compatible targets, but wrong for OAuth /
+        # adapter-backed providers whose provider branch adds auth headers and
+        # request-shape adapters. Keep those providers identified by name.
+        if resolved_provider in {"openai-codex", "xai-oauth"}:
+            return out
         # Pass the resolved endpoint through so call_llm builds the request for
         # the provider's actual API surface instead of auto-detecting. base_url
         # routes call_llm to the right adapter (incl. anthropic_messages mode);

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1404,7 +1404,7 @@ def resolve_runtime_provider(
         return {
             "provider": "moa",
             "api_mode": "chat_completions",
-            "base_url": "http://127.0.0.1/v1",
+            "base_url": "moa://local",
             "api_key": "moa-virtual-provider",
             "source": "moa-virtual-provider",
             "requested_provider": requested_provider,

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -172,6 +172,32 @@ def test_moa_slots_routed_through_resolve_runtime_provider(monkeypatch):
     assert rt["api_key"] == "key-for-minimax"
 
 
+def test_moa_codex_slot_preserves_provider_identity(monkeypatch):
+    """Codex slots must not become custom chat-completions endpoints.
+
+    _resolve_task_provider_model treats any explicit base_url as provider=custom.
+    For openai-codex that bypasses the Codex auxiliary branch, losing the
+    Cloudflare headers and Responses adapter required for chatgpt.com/backend-api/codex.
+    """
+    from agent import moa_loop
+
+    def fake_resolve(*, requested, target_model=None):
+        return {
+            "provider": requested,
+            "api_mode": "codex_responses",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "codex-oauth-token",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve
+    )
+
+    rt = moa_loop._slot_runtime({"provider": "openai-codex", "model": "gpt-5.5"})
+
+    assert rt == {"provider": "openai-codex", "model": "gpt-5.5"}
+
+
 def test_moa_slot_runtime_falls_back_on_resolution_error(monkeypatch):
     """A slot whose provider can't be resolved still attempts the call with the
     bare provider/model rather than aborting the whole MoA turn."""

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -41,7 +41,7 @@ moa:
 
     agent = AIAgent(
         api_key="moa-virtual-provider",
-        base_url="moa://local",
+        base_url="http://127.0.0.1/v1",
         model="review",
         provider="moa",
         quiet_mode=True,
@@ -50,15 +50,33 @@ moa:
         enabled_toolsets=["file"],
         max_iterations=1,
     )
+    monkeypatch.setattr(
+        agent,
+        "_create_request_openai_client",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("MoA calls must use MoAClient, not a request OpenAI client")
+        ),
+    )
 
     result = agent.run_conversation("solve this")
 
     assert result["final_response"] == "aggregator acted"
+    assert agent.base_url == "moa://local"
     assert [(c["task"], c["provider"], c["model"]) for c in calls] == [
         ("moa_reference", "openai-codex", "gpt-5.5"),
         ("moa_aggregator", "openrouter", "anthropic/claude-opus-4.8"),
     ]
     assert calls[1]["tools"] is not None
+
+
+def test_moa_runtime_provider_uses_virtual_endpoint():
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    runtime = resolve_runtime_provider(requested="moa", target_model="review")
+
+    assert runtime["provider"] == "moa"
+    assert runtime["base_url"] == "moa://local"
+    assert runtime["api_key"] == "moa-virtual-provider"
 
 
 def test_moa_does_not_cap_output_tokens(monkeypatch, tmp_path):
@@ -459,4 +477,3 @@ def test_moa_facade_reruns_references_on_new_turn(monkeypatch, tmp_path):
 
     # 2 references × 2 distinct turns = 4 reference runs.
     assert len(ref_runs) == 4
-


### PR DESCRIPTION
## Summary
Salvage of #53809 by @helix4u (Gille). Fixes two MoA routing bugs so selecting a MoA preset as the active model stays on the in-process `MoAClient` facade and adapter-backed slot providers keep their provider identity.

**Bug A — fake localhost endpoint.** The non-streaming `provider="moa"` path rebuilt a real request-local OpenAI client and the virtual runtime advertised `http://127.0.0.1/v1`. On Windows boxes running IIS/another local service there, this produced confusing `Endpoint: http://127.0.0.1/v1` HTTP 404s instead of using the facade.

**Bug B — slot reclassified as custom.** `_slot_runtime()` forwarded each slot's resolved `base_url` into `call_llm()`, which treats any explicit `base_url` as a custom endpoint. A slot like `openai-codex:gpt-5.5` became `custom:gpt-5.5` at `chatgpt.com/backend-api/codex`, bypassing the Codex auth-header/Responses adapter → Cloudflare 403s.

## Changes
- `agent/chat_completion_helpers.py`: non-streaming `provider="moa"` uses the `MoAClient` facade directly instead of building a request-local OpenAI client.
- `agent/agent_init.py`: MoA agents pin `base_url = "moa://local"` instead of carrying a stale `http://127.0.0.1/v1`.
- `agent/agent_runtime_helpers.py`: mid-session switches to MoA stay on the facade.
- `agent/moa_loop.py`: `_slot_runtime()` preserves provider identity for adapter-backed slots (`openai-codex`, `xai-oauth`) so resolved URLs don't reclassify them as `custom`.
- `hermes_cli/runtime_provider.py`: reports the MoA virtual runtime as `moa://local`.
- `tests/run_agent/test_moa_loop_mode.py`: regression coverage (no request-local client for MoA, virtual endpoint, Codex slot not forwarded as custom).

## Validation
Cherry-picked both contributor commits onto current `main` (authorship preserved). The merge coexists cleanly with the recently-landed MoA reference-block + cache work (#53793).

`tests/run_agent/test_moa_loop_mode.py` → 13/13 pass (contributor's 3 routing tests + the reference-block/cache tests).

## Credit
Original PR #53809 by @helix4u — cherry-picked with authorship preserved.

## Infographic

![moa-virtual-provider-routing](https://v3b.fal.media/files/b/0aa005e7/0en3NAKiSoEaN43U6QmRm_CDwrp4Vh.png)
