### PR TITLE
fix(dashboard-auth): tolerate missing id_token on OIDC refresh grant

### DIFF
--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -364,11 +364,36 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
 
         id_token = payload.get("id_token")
         if not id_token or not isinstance(id_token, str):
-            raise ProviderError(
-                "OIDC token response missing id_token — ensure the 'openid' "
-                "scope is configured and the client is allowed to receive an "
-                "ID token."
-            )
+            # OIDC Core §12.2: the ID token is OPTIONAL on a refresh response.
+            # Many conformant self-hosted IDPs (Keycloak in common configs,
+            # Authentik, Dex) return only access_token + rotated refresh_token
+            # on the refresh grant. Treat a missing id_token as a hard error
+            # only on the authorization-code path (initial login); on the
+            # refresh path, fall back to the IDP's access_token if it is a
+            # verifiable JWT — some IDPs issue JWT access tokens that carry the
+            # same identity claims.
+            is_refresh = bool(previous_refresh_token)
+            if not is_refresh:
+                raise ProviderError(
+                    "OIDC token response missing id_token — ensure the "
+                    "'openid' scope is configured and the client is allowed "
+                    "to receive an ID token."
+                )
+            # Refresh path: try the access_token as an identity JWT fallback.
+            access_token_raw = payload.get("access_token")
+            if access_token_raw and isinstance(access_token_raw, str):
+                try:
+                    self._verify_id_token(access_token_raw)
+                    id_token = access_token_raw
+                except Exception:
+                    pass
+            if not id_token:
+                raise ProviderError(
+                    "OIDC refresh response contained neither an id_token "
+                    "nor a verifiable JWT access_token. The IDP may need "
+                    "'openid' scope configured on the refresh grant, or "
+                    "JWT access-token format enabled."
+                )
 
         token_type = str(payload.get("token_type", "")).lower()
         if token_type and token_type != "bearer":

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -775,6 +775,69 @@ class TestRefreshAndRevoke:
             session = provider.refresh_session(refresh_token="rt_kept")
         assert session.refresh_token == "rt_kept"
 
+    def test_refresh_tolerates_missing_id_token_with_jwt_access_token(
+        self, provider, rsa_keypair
+    ):
+        # OIDC Core §12.2: id_token is OPTIONAL on a refresh response.
+        # When the IDP omits it but issues a JWT access_token that passes
+        # verification, the session must succeed using that JWT.
+        jwt_at = _mint_id_token(rsa_keypair)
+        mock_resp = _mock_post(
+            200,
+            {
+                "access_token": jwt_at,
+                "token_type": "Bearer",
+                "refresh_token": "rt_new",
+            },
+        )
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post", return_value=mock_resp
+        ):
+            session = provider.refresh_session(refresh_token="rt_old")
+        assert isinstance(session, Session)
+        assert session.access_token == jwt_at
+        assert session.refresh_token == "rt_new"
+
+    def test_refresh_no_id_token_no_jwt_access_token_raises(
+        self, provider
+    ):
+        # When neither id_token nor a verifiable JWT access_token is present
+        # on a refresh response, a clear ProviderError is raised.
+        mock_resp = _mock_post(
+            200,
+            {
+                "access_token": "opaque-not-a-jwt",
+                "token_type": "Bearer",
+                "refresh_token": "rt_new",
+            },
+        )
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post", return_value=mock_resp
+        ):
+            with pytest.raises(ProviderError, match="neither.*id_token.*nor.*JWT"):
+                provider.refresh_session(refresh_token="rt_old")
+
+    def test_login_still_requires_id_token(self, provider, rsa_keypair):
+        # The authorization-code path must still hard-fail when id_token is
+        # missing — the OIDC §12.2 relaxation applies only to refresh.
+        mock_resp = _mock_post(
+            200,
+            {
+                "access_token": _mint_id_token(rsa_keypair),
+                "token_type": "Bearer",
+            },
+        )
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post", return_value=mock_resp
+        ):
+            with pytest.raises(ProviderError, match="missing id_token"):
+                provider.complete_login(
+                    code="auth-code",
+                    state="s",
+                    code_verifier="verifier",
+                    redirect_uri="https://localhost/callback",
+                )
+
     def test_refresh_400_raises_refresh_expired(self, provider):
         mock_resp = _mock_post(400, {"error": "invalid_grant"})
         with patch(


### PR DESCRIPTION
## Summary

- OIDC Core §12.2 makes the ID token **optional** on a refresh response, but `_exchange()` unconditionally required it — every refresh against a conformant IDP that omits `id_token` (Keycloak in common configs, Authentik, Dex) raised `ProviderError`, forcing a full re-login roughly every 15 minutes
- On the refresh path only, fall back to the IDP's `access_token` when it is a verifiable JWT carrying the required identity claims; the authorization-code path (initial login) still hard-fails on a missing `id_token`
- Add three regression tests covering: JWT access_token fallback succeeds, opaque access_token raises cleanly, and login path still enforces `id_token`

## Test plan

- [x] `pytest tests/plugins/dashboard_auth/test_self_hosted_provider.py` — 69/69 passed
- [ ] Manual verification against a Keycloak instance configured to omit `id_token` on refresh