### PR TITLE
fix(auxiliary): preserve nvidia compression output cap

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5469,7 +5469,21 @@ def _build_call_kwargs(
         _effective_base = base_url or (
             _current_custom_base_url() if provider == "custom" else ""
         )
-        if _is_anthropic_compat_endpoint(provider, _effective_base):
+        _is_nvidia_nim = (
+            str(provider or "").strip().lower() in {
+                "nvidia",
+                "nvidia-nim",
+                "nim",
+                "build-nvidia",
+                "nemotron",
+            }
+            or base_url_host_matches(_effective_base, "integrate.api.nvidia.com")
+        )
+
+        if (
+            _is_anthropic_compat_endpoint(provider, _effective_base)
+            or _is_nvidia_nim
+        ):
             kwargs["max_tokens"] = max_tokens
 
     if tools:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4011,6 +4011,28 @@ class TestNvidiaBillingHeaders:
         headers = call_kwargs.get("default_headers", {})
         assert "X-BILLING-INVOKE-ORIGIN" not in headers
 
+    def test_aux_kwargs_preserve_output_cap_for_nvidia_profile(self):
+        kwargs = _build_call_kwargs(
+            "nvidia",
+            "minimaxai/minimax-m3",
+            [{"role": "user", "content": "summarize"}],
+            max_tokens=4096,
+            base_url="https://integrate.api.nvidia.com/v1",
+        )
+
+        assert kwargs["max_tokens"] == 4096
+
+    def test_aux_kwargs_still_omit_output_cap_for_plain_chat_provider(self):
+        kwargs = _build_call_kwargs(
+            "openrouter",
+            "meta-llama/llama-3.1-70b-instruct",
+            [{"role": "user", "content": "summarize"}],
+            max_tokens=4096,
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+        assert "max_tokens" not in kwargs
+
 
 class TestOpenRouterExplicitApiKey:
     """Test that explicit_api_key is correctly propagated to _try_openrouter()."""


### PR DESCRIPTION
## What does this PR do?

Preserves the compression summary output-token budget when auxiliary compression is routed through NVIDIA NIM / `integrate.api.nvidia.com`.

The support logs showed `auxiliary.compression` using `nvidia` / `minimaxai/minimax-m3`, receiving an empty `choices=[]` response, and falling back to the main Codex model. Current aux request shaping receives a computed `max_tokens` budget from compression, but `_build_call_kwargs()` drops it for normal chat-completions routes unless the endpoint is Anthropic-compatible. The main NVIDIA chat path does send an output cap through the provider profile, so this keeps the aux NVIDIA route closer to main-path behavior without changing every provider.

## Related Issue

Discord support thread: https://discord.com/channels/1053877538025386074/1520532154864504863

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`: preserve `max_tokens` for NVIDIA/NIM auxiliary chat-completions calls while keeping the existing omission behavior for ordinary chat providers.
- `tests/agent/test_auxiliary_client.py`: add coverage that NVIDIA aux kwargs keep the cap and OpenRouter still omits it.

## How to Test

1. Configure `auxiliary.compression` to use `nvidia` / `minimaxai/minimax-m3`.
2. Trigger compression with a large context.
3. Confirm the NVIDIA aux request includes the compression output cap instead of dropping it before the request.

Focused local check run:

` .venv/bin/python -m pytest tests/agent/test_auxiliary_client.py -q -k 'NvidiaBillingHeaders or invalid_empty_choices_response' `

Result: `6 passed, 244 deselected`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu / WSL checkout

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Observed in Discord support logs: NVIDIA MiniMax aux compression returned an empty `choices=[]` response and Hermes fell back to main Codex. This PR fixes the request-shaping mismatch where NVIDIA aux compression was not receiving the computed summary output cap.
