### PR TITLE
feat: add Discord busy-turn choices

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -69,14 +69,15 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
-_TELEGRAM_NOISY_STATUS_RE = re.compile(
-    r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
+_GATEWAY_NOISY_STATUS_RE = re.compile(
+    r"("  # transient/auxiliary status that should stay in logs, not chat
     r"auxiliary\s+.+\s+failed"
     r"|compression\s+summary\s+failed"
     r"|fallback\s+context\s+marker"
     r"|configured\s+compression\s+model\s+.+\s+failed"
     r"|no\s+auxiliary\s+llm\s+provider\s+configured"
     r"|auto-lowered\s+compression\s+threshold"
+    r"|codex\s+gpt-5\.5\s+caps\s+context"
     r"|compacting\s+context\s+[—-]\s+summarizing\s+earlier\s+conversation"
     r"|preflight\s+compression"
     r"|rate\s+limited\.\s+waiting\s+\d"
@@ -412,12 +413,15 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     text = str(message or "").strip()
     if not text:
         return None
+    platform_value = _gateway_platform_value(platform)
     if _gateway_surface_passes_raw_text(platform):
+        return text
+    if platform_value in {"telegram", "discord"} and _GATEWAY_NOISY_STATUS_RE.search(text):
+        return None
+    if platform_value != "telegram":
         return text
 
     text = _redact_gateway_user_facing_secrets(text)
-    if _TELEGRAM_NOISY_STATUS_RE.search(text):
-        return None
     if _looks_like_gateway_provider_error(text):
         return _gateway_provider_error_reply(text)
     return text
@@ -4372,6 +4376,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return "queue"
         if mode == "steer":
             return "steer"
+        if mode in {"choice", "choices", "ask"}:
+            return "choice"
         return "interrupt"
 
     @staticmethod
@@ -4625,6 +4631,76 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         self._enqueue_fifo(session_key, event, adapter)
 
+    async def handle_busy_turn_choice(
+        self,
+        session_key: str,
+        choice: str,
+        event: MessageEvent,
+    ) -> str:
+        """Apply an explicit busy-turn choice from an interactive gateway UI.
+
+        This is a thin UX wrapper over existing busy-turn primitives.  It keeps
+        queue/steer/interrupt semantics centralized in the runner so Discord
+        buttons do not mutate transcripts or re-enter message handling.
+        """
+        normalized = str(choice or "").strip().lower()
+        adapter = self.adapters.get(event.source.platform)
+        running_agent = self._running_agents.get(session_key)
+
+        if normalized == "cancel":
+            return "Cancelled — your message was not sent to the current run."
+
+        active_now = running_agent is not None
+        if normalized in {"queue", "steer", "interrupt"} and not active_now:
+            if adapter is not None and hasattr(adapter, "handle_message"):
+                maybe_result = adapter.handle_message(event)
+                if inspect.isawaitable(maybe_result):
+                    await maybe_result
+                return "The previous task already finished — starting your message now."
+            await self._handle_message(event)
+            return "The previous task already finished — starting your message now."
+
+        if normalized == "queue":
+            self._queue_or_replace_pending_event(session_key, event)
+            depth = self._queue_depth(session_key, adapter=adapter)
+            suffix = f" ({depth} queued)" if depth > 1 else ""
+            return f"Queued for the next turn{suffix}."
+
+        if normalized == "steer":
+            steer_text = (event.text or "").strip()
+            can_steer = (
+                bool(steer_text)
+                and running_agent is not None
+                and running_agent is not _AGENT_PENDING_SENTINEL
+                and hasattr(running_agent, "steer")
+            )
+            steer_fn = getattr(running_agent, "steer", None) if can_steer else None
+            if steer_fn is not None:
+                try:
+                    if bool(steer_fn(steer_text)):
+                        return "Steered into the current run — it will arrive after the next tool call."
+                except Exception as exc:
+                    logger.warning("Gateway busy-turn steer failed for session %s: %s", session_key, exc)
+            self._queue_or_replace_pending_event(session_key, event)
+            return "Could not steer right now, so I queued it for the next turn."
+
+        if normalized == "interrupt":
+            if adapter is not None and hasattr(adapter, "_pending_messages"):
+                merge_pending_message_event(
+                    adapter._pending_messages,
+                    session_key,
+                    event,
+                    merge_text=event.message_type == MessageType.TEXT,
+                )
+            if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+                try:
+                    running_agent.interrupt(event.text)
+                except Exception as exc:
+                    logger.debug("Busy-turn interrupt failed for session %s: %s", session_key, exc)
+            return "Interrupting current task — I'll respond to your message shortly."
+
+        return "Unknown busy-turn choice."
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
@@ -4699,6 +4775,66 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             and effective_mode != "steer"
         ):
             return False
+
+        # Choice mode: defer queue/steer/interrupt until the user clicks an
+        # interactive gateway control.  This gives Discord the bridge-style
+        # busy-turn UX without mutating transcript state before a decision.
+        if effective_mode == "choice":
+            reply_anchor = self._reply_anchor_for_event(event)
+            thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
+            send_choices = getattr(adapter, "send_busy_turn_choices", None)
+            if callable(send_choices):
+                try:
+                    from tools import busy_turn_choice as _busy_turn_choice
+
+                    choice_id = _busy_turn_choice.register(
+                        session_key,
+                        event,
+                        lambda choice, chosen_event: self.handle_busy_turn_choice(
+                            session_key,
+                            choice,
+                            chosen_event,
+                        ),
+                    )
+                    preview = (event.text or "").strip()
+                    if len(preview) > 280:
+                        preview = preview[:277] + "..."
+                    message = "Hermes is still working. What should I do with your message?"
+                    if preview:
+                        message = f"{message}\n\n> {preview}"
+                    _maybe_result = send_choices(
+                        chat_id=event.source.chat_id,
+                        message=message,
+                        session_key=session_key,
+                        choice_id=choice_id,
+                        metadata=thread_meta,
+                    )
+                    result = await _maybe_result if inspect.isawaitable(_maybe_result) else _maybe_result
+                    if result and getattr(result, "success", False):
+                        return True
+                    _busy_turn_choice.discard(choice_id)
+                except Exception as exc:
+                    try:
+                        _busy_turn_choice.discard(choice_id)  # type: ignore[name-defined]
+                    except Exception:
+                        pass
+                    logger.warning("Failed to send busy-turn choices for session %s: %s", session_key, exc)
+            # Non-interactive fallback: queue so the message is not lost and
+            # does not auto-interrupt when the configured intent was to ask.
+            self._queue_or_replace_pending_event(session_key, event)
+            await adapter._send_with_retry(
+                chat_id=event.source.chat_id,
+                content="⏳ Queued for the next turn. This platform could not render busy-turn choices.",
+                reply_to=(
+                    reply_anchor
+                    if event.source.platform == Platform.TELEGRAM
+                    and event.source.chat_type == "dm"
+                    and event.source.thread_id
+                    else (None if event.source.platform == Platform.TELEGRAM and event.source.thread_id else event.message_id)
+                ),
+                metadata=thread_meta,
+            )
+            return True
 
         # Steer mode: inject mid-run via running_agent.steer() instead of
         # queueing + interrupting.  If the agent isn't running yet
@@ -11411,6 +11547,93 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Join failed — clear callback
         adapter._voice_input_callback = None
         return "Failed to join voice channel. Check bot permissions (Connect + Speak)."
+
+    async def _handle_discord_auto_voice_join(
+        self,
+        *,
+        guild_id: int,
+        voice_channel: Any,
+        text_channel_id: int,
+        text_channel_name: Optional[str] = None,
+    ) -> bool:
+        """Join a configured Discord voice channel without a slash command event.
+
+        Used by the Discord adapter when a configured user joins a configured
+        voice channel. Mirrors /voice join side effects: callbacks are wired,
+        the guild is bound to a text channel, and the text channel is switched
+        to spoken replies ("all" / /voice tts).
+        """
+        adapter = self.adapters.get(Platform.DISCORD)
+        if not adapter or not hasattr(adapter, "join_voice_channel"):
+            return False
+
+        if hasattr(adapter, "is_in_voice_channel") and adapter.is_in_voice_channel(guild_id):
+            return True
+
+        if hasattr(adapter, "_voice_input_callback"):
+            adapter._voice_input_callback = self._handle_voice_channel_input
+        if hasattr(adapter, "_on_voice_disconnect"):
+            adapter._on_voice_disconnect = self._handle_voice_timeout_cleanup
+        if hasattr(adapter, "_voice_mode_getter"):
+            adapter._voice_mode_getter = lambda chat_id: self._voice_mode.get(
+                self._voice_key(Platform.DISCORD, str(chat_id)), "off"
+            )
+
+        try:
+            success = await adapter.join_voice_channel(voice_channel)
+        except Exception as e:
+            logger.warning("Failed to auto-join voice channel: %s", e)
+            if hasattr(adapter, "_voice_input_callback"):
+                adapter._voice_input_callback = None
+            return False
+
+        if not success:
+            if hasattr(adapter, "_voice_input_callback"):
+                adapter._voice_input_callback = None
+            return False
+
+        chat_id = str(text_channel_id)
+        if hasattr(adapter, "_voice_text_channels"):
+            adapter._voice_text_channels[int(guild_id)] = int(text_channel_id)
+        if hasattr(adapter, "_voice_sources"):
+            adapter._voice_sources[int(guild_id)] = SessionSource(
+                chat_id=chat_id,
+                user_id="discord-auto-voice",
+                platform=Platform.DISCORD,
+                chat_type="group",
+                chat_name=text_channel_name or f"Discord / #{chat_id}",
+                thread_id=None,
+            ).to_dict()
+        self._voice_mode[self._voice_key(Platform.DISCORD, chat_id)] = "all"
+        self._save_voice_modes()
+        self._set_adapter_auto_tts_enabled(adapter, chat_id, enabled=True)
+        return True
+
+    async def _handle_discord_auto_voice_leave(
+        self,
+        *,
+        guild_id: int,
+        text_channel_id: int,
+    ) -> bool:
+        """Leave a Discord voice channel when the configured auto-join user leaves."""
+        adapter = self.adapters.get(Platform.DISCORD)
+        if not adapter or not hasattr(adapter, "leave_voice_channel"):
+            return False
+        try:
+            if hasattr(adapter, "is_in_voice_channel") and not adapter.is_in_voice_channel(guild_id):
+                return True
+            await adapter.leave_voice_channel(guild_id)
+        except Exception as e:
+            logger.warning("Failed to auto-leave voice channel: %s", e)
+            return False
+
+        chat_id = str(text_channel_id)
+        self._voice_mode[self._voice_key(Platform.DISCORD, chat_id)] = "off"
+        self._save_voice_modes()
+        self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
+        if hasattr(adapter, "_voice_input_callback"):
+            adapter._voice_input_callback = None
+        return True
 
     async def _handle_voice_channel_leave(self, event: MessageEvent) -> str:
         """Leave the Discord voice channel."""

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -480,20 +480,25 @@ class VoiceReceiver:
         if ssrc == self._bot_ssrc:
             return
 
-        # Calculate dynamic RTP header size (RFC 9335 / rtpsize mode)
+        # Calculate RTP header sizes for aead_*_rtpsize.
+        # The fixed RTP header (+ CSRC list) is AEAD associated data. If the
+        # extension bit is set, Discord leaves the 4-byte extension preamble
+        # unencrypted before the encrypted extension payload; do not include
+        # that preamble in AEAD AAD or encrypted bytes.
         cc = first_byte & 0x0F  # CSRC count
         has_extension = bool(first_byte & 0x10)  # extension bit
         has_padding = bool(first_byte & 0x20)  # padding bit (RFC 3550 §5.1)
-        header_size = 12 + (4 * cc) + (4 if has_extension else 0)
+        rtp_header_size = 12 + (4 * cc)
+        extension_preamble_size = 4 if has_extension else 0
+        payload_offset = rtp_header_size + extension_preamble_size
 
-        if len(data) < header_size + 4:  # need at least header + nonce
+        if len(data) < payload_offset + 4:  # need at least header/preamble + nonce
             return
 
         # Read extension length from preamble (for skipping after decrypt)
         ext_data_len = 0
         if has_extension:
-            ext_preamble_offset = 12 + (4 * cc)
-            ext_words = struct.unpack_from(">H", data, ext_preamble_offset + 2)[0]
+            ext_words = struct.unpack_from(">H", data, rtp_header_size + 2)[0]
             ext_data_len = ext_words * 4
 
         if self._packet_debug_count <= 10:
@@ -501,11 +506,11 @@ class VoiceReceiver:
                 known_user = self._ssrc_to_user.get(ssrc, "unknown")
             logger.debug(
                 "RTP packet: ssrc=%d, seq=%d, user=%s, hdr=%d, ext_data=%d",
-                ssrc, seq, known_user, header_size, ext_data_len,
+                ssrc, seq, known_user, rtp_header_size, ext_data_len,
             )
 
-        header = bytes(data[:header_size])
-        payload_with_nonce = data[header_size:]
+        header = bytes(data[:rtp_header_size])
+        payload_with_nonce = data[payload_offset:]
 
         # --- NaCl transport decrypt (aead_xchacha20_poly1305_rtpsize) ---
         if len(payload_with_nonce) < 4:
@@ -520,7 +525,7 @@ class VoiceReceiver:
             decrypted = box.decrypt(encrypted, header, bytes(nonce))
         except Exception as e:
             if self._packet_debug_count <= 10:
-                logger.warning("NaCl decrypt failed: %s (hdr=%d, enc=%d)", e, header_size, len(encrypted))
+                logger.warning("NaCl decrypt failed: %s (hdr=%d, enc=%d)", e, rtp_header_size, len(encrypted))
             return
 
         # Skip encrypted extension data to get the actual opus payload
@@ -762,6 +767,8 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_receivers: Dict[int, VoiceReceiver] = {}  # guild_id -> VoiceReceiver
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
         self._voice_input_callback: Optional[Callable] = None  # set by run.py
+        self._voice_auto_join_callback: Optional[Callable[..., Any]] = None  # set by run.py / gateway_runner
+        self._voice_auto_leave_callback: Optional[Callable[..., Any]] = None  # set by run.py / gateway_runner
         self._on_voice_disconnect: Optional[Callable] = None  # set by run.py
         # Resolves the current voice-reply mode ("off"|"voice_only"|"all") for a
         # linked text-channel id; set by run.py. Lets the inactivity timer leave
@@ -1092,6 +1099,8 @@ class DiscordAdapter(BasePlatformAdapter):
             @self._client.event
             async def on_voice_state_update(member, before, after):
                 """Track voice channel join/leave events."""
+                await adapter_self._maybe_auto_join_from_voice_state(member, before, after)
+
                 # Only track channels where the bot is connected
                 bot_guild_ids = set(adapter_self._voice_clients.keys())
                 if not bot_guild_ids:
@@ -2363,6 +2372,91 @@ class DiscordAdapter(BasePlatformAdapter):
         """True when a continuous mixer is installed for this guild."""
         mixers = getattr(self, "_voice_mixers", None)
         return bool(mixers) and mixers.get(guild_id) is not None
+
+    async def _maybe_auto_join_from_voice_state(self, member, before, after) -> bool:
+        """Auto-join a configured Discord voice channel when an allowed user enters it."""
+        cfg = (self.config.extra or {}).get("voice_auto_join") or {}
+        if not isinstance(cfg, dict) or not cfg.get("enabled", False):
+            return False
+
+        before_channel = getattr(before, "channel", None)
+        after_channel = getattr(after, "channel", None)
+        if before_channel == after_channel:
+            return False
+
+        guild = getattr(member, "guild", None)
+        guild_id = getattr(guild, "id", None)
+        member_id = getattr(member, "id", None)
+
+        def _as_int(value, default=None):
+            try:
+                return int(str(value).strip())
+            except (TypeError, ValueError):
+                return default
+
+        wanted_guild_id = _as_int(cfg.get("guild_id"))
+        wanted_voice_channel_id = _as_int(cfg.get("voice_channel_id"))
+        text_channel_id = _as_int(cfg.get("text_channel_id"))
+        raw_user_ids = cfg.get("user_ids") or []
+        if isinstance(raw_user_ids, str):
+            try:
+                parsed_user_ids = json.loads(raw_user_ids)
+                raw_user_ids = parsed_user_ids if isinstance(parsed_user_ids, list) else [raw_user_ids]
+            except Exception:
+                raw_user_ids = [part.strip() for part in raw_user_ids.split(",")]
+        wanted_user_ids = {_as_int(uid) for uid in raw_user_ids}
+        wanted_user_ids.discard(None)
+
+        if not wanted_guild_id or not wanted_voice_channel_id or not text_channel_id:
+            logger.warning("Discord voice_auto_join enabled but missing guild_id, voice_channel_id, or text_channel_id")
+            return False
+        if int(guild_id or 0) != wanted_guild_id:
+            return False
+        if wanted_user_ids and int(member_id or 0) not in wanted_user_ids:
+            return False
+
+        before_voice_channel_id = _as_int(getattr(before_channel, "id", None))
+        after_voice_channel_id = _as_int(getattr(after_channel, "id", None))
+        moved_out_of_configured = before_voice_channel_id == wanted_voice_channel_id and after_voice_channel_id != wanted_voice_channel_id
+        moved_into_configured = after_voice_channel_id == wanted_voice_channel_id
+
+        if moved_out_of_configured:
+            callback = self._voice_auto_leave_callback
+            if callback is None and self.gateway_runner is not None:
+                callback = getattr(self.gateway_runner, "_handle_discord_auto_voice_leave", None)
+            if callback is None:
+                return False
+            try:
+                return bool(await callback(guild_id=wanted_guild_id, text_channel_id=text_channel_id))
+            except Exception as exc:
+                logger.warning("Discord voice_auto_leave failed: %s", exc, exc_info=True)
+                return False
+
+        if not moved_into_configured:
+            return False
+
+        callback = self._voice_auto_join_callback
+        if callback is None and self.gateway_runner is not None:
+            callback = getattr(self.gateway_runner, "_handle_discord_auto_voice_join", None)
+        if callback is None:
+            return False
+
+        text_channel_name = None
+        get_channel = getattr(guild, "get_channel", None)
+        if callable(get_channel):
+            text_channel = get_channel(text_channel_id)
+            text_channel_name = getattr(text_channel, "name", None)
+
+        try:
+            return bool(await callback(
+                guild_id=wanted_guild_id,
+                voice_channel=after_channel,
+                text_channel_id=text_channel_id,
+                text_channel_name=text_channel_name,
+            ))
+        except Exception as exc:
+            logger.warning("Discord voice_auto_join failed: %s", exc, exc_info=True)
+            return False
 
     async def join_voice_channel(self, channel) -> bool:
         """Join a Discord voice channel. Returns True on success."""
@@ -4778,6 +4872,53 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception as e:
             return SendResult(success=False, error=str(e))
 
+    async def send_busy_turn_choices(
+        self,
+        chat_id: str,
+        message: str,
+        session_key: str,
+        choice_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send bridge-style busy-turn choice buttons for a mid-run message."""
+        if not self._client or not DISCORD_AVAILABLE:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            target_id = chat_id
+            if metadata and metadata.get("thread_id"):
+                target_id = metadata["thread_id"]
+
+            channel = self._client.get_channel(int(target_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(target_id))
+
+            max_desc = 4088
+            body = str(message or "").strip()
+            if len(body) > max_desc:
+                body = body[: max_desc - 3] + "..."
+            embed = discord.Embed(
+                title="Hermes is still working",
+                description=body or "What should I do with your message?",
+                color=discord.Color.blue(),
+            )
+            embed.add_field(
+                name="Choose one",
+                value="Interrupt, steer into the current run, queue it for next turn, or cancel this follow-up.",
+                inline=False,
+            )
+            view = BusyTurnChoiceView(
+                choice_id=choice_id,
+                session_key=session_key,
+                allowed_user_ids=self._allowed_user_ids,
+                allowed_role_ids=self._allowed_role_ids,
+            )
+            msg = await channel.send(embed=embed, view=view)
+            view._message = msg
+            return SendResult(success=True, message_id=str(msg.id))
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
     async def send_clarify(
         self,
         chat_id: str,
@@ -5795,7 +5936,7 @@ def _define_discord_view_classes() -> None:
     lazy install sets DISCORD_AVAILABLE=True but leaves the classes
     undefined, causing NameError on the first button interaction.
     """
-    global ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView
+    global ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView, BusyTurnChoiceView
 
     class ExecApprovalView(discord.ui.View):
         """
@@ -6019,6 +6160,121 @@ def _define_discord_view_classes() -> None:
                     if embed:
                         embed.color = discord.Color.greyple()
                         embed.set_footer(text="⏱ Prompt expired — no action taken")
+                    await msg.edit(embed=embed, view=self)
+                except Exception:
+                    pass
+
+    class BusyTurnChoiceView(discord.ui.View):
+        """Four-button busy-turn choice prompt for Discord gateway sessions."""
+
+        def __init__(
+            self,
+            choice_id: str,
+            session_key: str,
+            allowed_user_ids: set,
+            allowed_role_ids: Optional[set] = None,
+        ):
+            super().__init__(timeout=300)
+            self.choice_id = choice_id
+            self.session_key = session_key
+            self.allowed_user_ids = allowed_user_ids
+            self.allowed_role_ids = allowed_role_ids or set()
+            self.resolved = False
+
+        def _check_auth(self, interaction: discord.Interaction) -> bool:
+            return _component_check_auth(
+                interaction, self.allowed_user_ids, self.allowed_role_ids,
+            )
+
+        async def _resolve(
+            self,
+            interaction: discord.Interaction,
+            choice: str,
+            color: discord.Color,
+            label: str,
+        ):
+            if self.resolved:
+                await interaction.response.send_message(
+                    "This busy-turn choice has already been resolved~",
+                    ephemeral=True,
+                )
+                return
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized to control this Hermes turn~",
+                    ephemeral=True,
+                )
+                return
+
+            self.resolved = True
+            for child in self.children:
+                child.disabled = True
+
+            embed = interaction.message.embeds[0] if interaction.message and interaction.message.embeds else None
+            if embed:
+                embed.color = color
+                embed.set_footer(text=f"{label} by {interaction.user.display_name}")
+
+            await interaction.response.edit_message(embed=embed, view=self)
+
+            try:
+                from tools import busy_turn_choice as _busy_turn_choice
+                result_text = await _busy_turn_choice.resolve(self.choice_id, choice)
+                if result_text:
+                    await interaction.followup.send(result_text)
+                logger.info(
+                    "Discord busy-turn choice resolved for session %s (choice=%s, user=%s)",
+                    self.session_key,
+                    choice,
+                    interaction.user.display_name,
+                )
+            except Exception as exc:
+                logger.error("Discord busy-turn choice resolve failed: %s", exc, exc_info=True)
+                try:
+                    await interaction.followup.send(f"Failed to apply busy-turn choice: {exc}")
+                except Exception:
+                    pass
+
+        @discord.ui.button(label="Interrupt", style=discord.ButtonStyle.red)
+        async def interrupt(
+            self, interaction: discord.Interaction, button: discord.ui.Button,
+        ):
+            await self._resolve(interaction, "interrupt", discord.Color.red(), "Interrupting")
+
+        @discord.ui.button(label="Steer", style=discord.ButtonStyle.blurple)
+        async def steer(
+            self, interaction: discord.Interaction, button: discord.ui.Button,
+        ):
+            await self._resolve(interaction, "steer", discord.Color.blue(), "Steering")
+
+        @discord.ui.button(label="Queue Next", style=discord.ButtonStyle.grey)
+        async def queue_next(
+            self, interaction: discord.Interaction, button: discord.ui.Button,
+        ):
+            await self._resolve(interaction, "queue", discord.Color.gold(), "Queued")
+
+        @discord.ui.button(label="Cancel", style=discord.ButtonStyle.secondary)
+        async def cancel(
+            self, interaction: discord.Interaction, button: discord.ui.Button,
+        ):
+            await self._resolve(interaction, "cancel", discord.Color.greyple(), "Cancelled")
+
+        async def on_timeout(self):
+            try:
+                from tools import busy_turn_choice as _busy_turn_choice
+                _busy_turn_choice.discard(self.choice_id)
+            except Exception:
+                pass
+            self.resolved = True
+            for child in self.children:
+                child.disabled = True
+            msg = getattr(self, '_message', None)
+            if msg:
+                try:
+                    embed = msg.embeds[0] if msg.embeds else None
+                    if embed:
+                        embed.color = discord.Color.greyple()
+                        embed.set_footer(text="⏱ Busy-turn prompt expired — no action taken")
                     await msg.edit(embed=embed, view=self)
                 except Exception:
                     pass

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -28,6 +28,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     Platform,
+    SendResult,
     SessionSource,
     build_session_key,
 )
@@ -715,6 +716,196 @@ class TestBusySessionOnboardingHint:
         assert "/busy interrupt" in content
         # Must NOT tell the user to /busy queue when they're already on queue.
         assert "/busy queue" not in content
+
+    @pytest.mark.asyncio
+    async def test_busy_choice_mode_sends_controls_without_mutating_state(self):
+        """choice mode defers queue/steer/interrupt until the user clicks a control."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "choice"
+        runner._busy_text_mode = "interrupt"
+        runner._thread_metadata_for_source = lambda source, reply_to_message_id=None: {}
+        runner._reply_anchor_for_event = lambda event: None
+
+        adapter = _make_adapter("discord")
+        adapter.send_busy_turn_choices = AsyncMock(
+            return_value=SendResult(success=True, message_id="choice-1")
+        )
+
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="123",
+            chat_type="group",
+            user_id="user1",
+        )
+        event = MessageEvent(
+            text="do this next",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="m-choice",
+        )
+        sk = build_session_key(source)
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner.adapters[source.platform] = adapter
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        adapter.send_busy_turn_choices.assert_awaited_once()
+        kwargs = adapter.send_busy_turn_choices.await_args.kwargs
+        assert kwargs["session_key"] == sk
+        assert kwargs["choice_id"].startswith("busy-")
+        assert "do this next" in kwargs["message"]
+        assert sk not in adapter._pending_messages
+        agent.interrupt.assert_not_called()
+        adapter._send_with_retry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_busy_turn_choice_queue_steer_interrupt_cancel(self):
+        """The explicit button actions map to the existing busy-turn primitives."""
+        runner, _sentinel = _make_runner()
+        adapter = _make_adapter("discord")
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="123",
+            chat_type="group",
+            user_id="user1",
+        )
+        sk = build_session_key(source)
+        runner.adapters[source.platform] = adapter
+        runner._running_agents[sk] = MagicMock()
+
+        queue_event = MessageEvent(
+            text="queue me",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="queue",
+        )
+        queue_text = await runner.handle_busy_turn_choice(sk, "queue", queue_event)
+        assert "Queued" in queue_text
+        assert adapter._pending_messages[sk] is queue_event
+
+        steer_event = MessageEvent(
+            text="steer me",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="steer",
+        )
+        steer_agent = MagicMock()
+        steer_agent.steer.return_value = True
+        runner._running_agents[sk] = steer_agent
+        steer_text = await runner.handle_busy_turn_choice(sk, "steer", steer_event)
+        assert "Steered" in steer_text
+        steer_agent.steer.assert_called_once_with("steer me")
+        assert steer_event not in adapter._pending_messages.values()
+
+        interrupt_event = MessageEvent(
+            text="interrupt me",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="interrupt",
+        )
+        interrupt_agent = MagicMock()
+        runner._running_agents[sk] = interrupt_agent
+        interrupt_text = await runner.handle_busy_turn_choice(sk, "interrupt", interrupt_event)
+        assert "Interrupting" in interrupt_text
+        assert interrupt_agent.interrupt.call_args.args == ("interrupt me",)
+        assert sk in adapter._pending_messages
+
+        before_pending = dict(adapter._pending_messages)
+        cancel_event = MessageEvent(
+            text="never mind",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="cancel",
+        )
+        cancel_text = await runner.handle_busy_turn_choice(sk, "cancel", cancel_event)
+        assert "Cancelled" in cancel_text
+        assert adapter._pending_messages == before_pending
+
+    @pytest.mark.asyncio
+    async def test_late_busy_turn_choice_starts_message_instead_of_stranding(self):
+        """If the original run finished before a click, the clicked message starts now."""
+        runner, _sentinel = _make_runner()
+        adapter = _make_adapter("discord")
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="123",
+            chat_type="group",
+            user_id="user1",
+        )
+        sk = build_session_key(source)
+        runner.adapters[source.platform] = adapter
+        adapter.handle_message = AsyncMock(return_value=None)
+        runner._handle_message = AsyncMock(return_value=None)
+
+        event = MessageEvent(
+            text="do this now",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="late-choice",
+        )
+
+        text = await runner.handle_busy_turn_choice(sk, "queue", event)
+
+        assert "already finished" in text
+        adapter.handle_message.assert_awaited_once_with(event)
+        runner._handle_message.assert_not_awaited()
+        assert sk not in adapter._pending_messages
+
+    @pytest.mark.asyncio
+    async def test_busy_choice_send_failure_discards_registry_entry(self):
+        """If Discord cannot render buttons, fallback queue must not leak a registry entry."""
+        from tools import busy_turn_choice
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "choice"
+        runner._busy_text_mode = "interrupt"
+        runner._thread_metadata_for_source = lambda source, reply_to_message_id=None: {}
+        runner._reply_anchor_for_event = lambda event: None
+        runner._queued_events = {}
+
+        adapter = _make_adapter("discord")
+        adapter.send_busy_turn_choices = AsyncMock(
+            return_value=SendResult(success=False, error="cannot render")
+        )
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="123",
+            chat_type="group",
+            user_id="user1",
+        )
+        event = MessageEvent(
+            text="do this next",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="m-choice-fail",
+        )
+        sk = build_session_key(source)
+        runner._running_agents[sk] = MagicMock()
+        runner.adapters[source.platform] = adapter
+
+        before = busy_turn_choice.pending_count()
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        assert busy_turn_choice.pending_count() == before
+        assert sk in adapter._pending_messages
+        adapter._send_with_retry.assert_awaited_once()
+
+    def test_busy_choice_registry_prunes_expired_entries(self, monkeypatch):
+        """Expired button choices are pruned even if Discord never calls timeout."""
+        from tools import busy_turn_choice
+
+        start = busy_turn_choice.time.time()
+        before = busy_turn_choice.pending_count()
+        choice_id = busy_turn_choice.register("s", object(), lambda choice, event: "ok")
+        assert choice_id.startswith("busy-")
+        assert busy_turn_choice.pending_count() == before + 1
+
+        monkeypatch.setattr(busy_turn_choice.time, "time", lambda: start + 301)
+        assert busy_turn_choice.pending_count() <= before
+        assert choice_id not in busy_turn_choice._entries
 
 
 class TestLongRunningNotificationOwnership:

--- a/tests/gateway/test_discord_race_polish.py
+++ b/tests/gateway/test_discord_race_polish.py
@@ -2,19 +2,20 @@
 double-invoke channel.connect() on the same guild."""
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from gateway.config import Platform, PlatformConfig
 
 
-def _make_adapter():
+def _make_adapter(extra=None):
     from plugins.platforms.discord.adapter import DiscordAdapter
 
     adapter = object.__new__(DiscordAdapter)
     adapter._platform = Platform.DISCORD
-    adapter.config = PlatformConfig(enabled=True, token="t")
+    adapter.config = PlatformConfig(enabled=True, token="t", extra=extra or {})
     adapter._ready_event = asyncio.Event()
     adapter._allowed_user_ids = set()
     adapter._allowed_role_ids = set()
@@ -77,3 +78,110 @@ async def test_concurrent_joins_do_not_double_connect():
     )
     assert r1 is True and r2 is True
     assert 42 in adapter._voice_clients
+
+
+@pytest.mark.asyncio
+async def test_auto_voice_join_configured_user_joining_configured_channel_triggers_callback():
+    adapter = _make_adapter({
+        "voice_auto_join": {
+            "enabled": True,
+            "guild_id": "42",
+            "voice_channel_id": "111",
+            "text_channel_id": "222",
+            "user_ids": '["999"]',
+        }
+    })
+    adapter._voice_auto_join_callback = AsyncMock(return_value=True)
+
+    channel = SimpleNamespace(id=111, name="hermes-voice")
+    guild = SimpleNamespace(id=42, get_channel=lambda cid: SimpleNamespace(id=cid, name="hermes"))
+    member = SimpleNamespace(id=999, guild=guild)
+    before = SimpleNamespace(channel=None)
+    after = SimpleNamespace(channel=channel)
+
+    result = await adapter._maybe_auto_join_from_voice_state(member, before, after)
+
+    assert result is True
+    adapter._voice_auto_join_callback.assert_awaited_once_with(
+        guild_id=42,
+        voice_channel=channel,
+        text_channel_id=222,
+        text_channel_name="hermes",
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_voice_join_ignores_unconfigured_user():
+    adapter = _make_adapter({
+        "voice_auto_join": {
+            "enabled": True,
+            "guild_id": "42",
+            "voice_channel_id": "111",
+            "text_channel_id": "222",
+            "user_ids": ["999"],
+        }
+    })
+    adapter._voice_auto_join_callback = AsyncMock(return_value=True)
+
+    channel = SimpleNamespace(id=111, name="hermes-voice")
+    member = SimpleNamespace(id=123, guild=SimpleNamespace(id=42))
+    before = SimpleNamespace(channel=None)
+    after = SimpleNamespace(channel=channel)
+
+    result = await adapter._maybe_auto_join_from_voice_state(member, before, after)
+
+    assert result is False
+    adapter._voice_auto_join_callback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_voice_join_leaves_when_configured_user_leaves_channel():
+    adapter = _make_adapter({
+        "voice_auto_join": {
+            "enabled": True,
+            "guild_id": "42",
+            "voice_channel_id": "111",
+            "text_channel_id": "222",
+            "user_ids": ["999"],
+        }
+    })
+    adapter._voice_auto_join_callback = AsyncMock(return_value=True)
+    adapter._voice_auto_leave_callback = AsyncMock(return_value=True)
+
+    channel = SimpleNamespace(id=111, name="hermes-voice")
+    member = SimpleNamespace(id=999, guild=SimpleNamespace(id=42))
+    before = SimpleNamespace(channel=channel)
+    after = SimpleNamespace(channel=None)
+
+    result = await adapter._maybe_auto_join_from_voice_state(member, before, after)
+
+    assert result is True
+    adapter._voice_auto_join_callback.assert_not_awaited()
+    adapter._voice_auto_leave_callback.assert_awaited_once_with(guild_id=42, text_channel_id=222)
+
+
+@pytest.mark.asyncio
+async def test_auto_voice_join_leaves_when_configured_user_moves_out_of_channel():
+    adapter = _make_adapter({
+        "voice_auto_join": {
+            "enabled": True,
+            "guild_id": "42",
+            "voice_channel_id": "111",
+            "text_channel_id": "222",
+            "user_ids": ["999"],
+        }
+    })
+    adapter._voice_auto_join_callback = AsyncMock(return_value=True)
+    adapter._voice_auto_leave_callback = AsyncMock(return_value=True)
+
+    configured_channel = SimpleNamespace(id=111, name="hermes-voice")
+    other_channel = SimpleNamespace(id=333, name="other")
+    member = SimpleNamespace(id=999, guild=SimpleNamespace(id=42))
+    before = SimpleNamespace(channel=configured_channel)
+    after = SimpleNamespace(channel=other_channel)
+
+    result = await adapter._maybe_auto_join_from_voice_state(member, before, after)
+
+    assert result is True
+    adapter._voice_auto_join_callback.assert_not_awaited()
+    adapter._voice_auto_leave_callback.assert_awaited_once_with(guild_id=42, text_channel_id=222)

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import os
 import queue
+import struct
 import sys
 import threading
 import time
@@ -52,6 +53,7 @@ def _ensure_discord_mock():
 _ensure_discord_mock()
 
 from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+from gateway.config import Platform
 
 
 # ---------------------------------------------------------------------------
@@ -754,6 +756,40 @@ class TestVoiceReceiver:
         receiver._on_packet(b"\x00" * 10)
         assert len(receiver._buffers) == 0
 
+    def test_on_packet_uses_fixed_rtp_header_as_aead_associated_data(self, monkeypatch):
+        """rtpsize AEAD authenticates the fixed RTP header, not extension data."""
+        import nacl.secret
+
+        receiver = self._make_receiver()
+        receiver._running = True
+        receiver._secret_key = b"\x00" * 32
+        receiver._bot_ssrc = 9999
+        receiver._dave_session = None
+
+        seen = {}
+
+        class FakeAead:
+            def __init__(self, key):
+                seen["key"] = key
+
+            def decrypt(self, encrypted, aad, nonce):
+                seen["aad_len"] = len(aad)
+                raise RuntimeError("stop after aad assertion")
+
+        monkeypatch.setattr(nacl.secret, "Aead", FakeAead)
+        # RTP V2 + extension bit, payload type 120, no CSRCs. The 4-byte RTP
+        # extension preamble follows the fixed 12-byte RTP header, but must not
+        # be included in AEAD associated data.
+        fixed_header = struct.pack(">BBHII", 0x90, 0x78, 1, 1234, 5909)
+        extension_preamble = struct.pack(">HH", 0xBEDE, 1)
+        extension_payload = b"\x10\x00\x00\x00"
+        encrypted_audio = b"\xAA" * 24
+        nonce_suffix = b"\x01\x02\x03\x04"
+
+        receiver._on_packet(fixed_header + extension_preamble + extension_payload + encrypted_audio + nonce_suffix)
+
+        assert seen["aad_len"] == 12
+
     def test_on_packet_skips_non_rtp(self):
         receiver = self._make_receiver()
         receiver.start()
@@ -845,6 +881,33 @@ class TestVoiceChannelCommands:
         assert runner._voice_mode["discord:123"] == "all"
         assert mock_adapter._voice_sources[111]["chat_id"] == "123"
         assert mock_adapter._voice_sources[111]["chat_type"] == "group"
+
+    @pytest.mark.asyncio
+    async def test_auto_join_specific_channel_binds_configured_text_channel(self, runner):
+        """Auto-join can join a configured VC without a slash command event."""
+        mock_channel = MagicMock()
+        mock_channel.name = "hermes-voice"
+        mock_adapter = AsyncMock()
+        mock_adapter.join_voice_channel = AsyncMock(return_value=True)
+        mock_adapter.is_in_voice_channel = MagicMock(return_value=False)
+        mock_adapter._voice_text_channels = {}
+        mock_adapter._voice_sources = {}
+        mock_adapter._voice_input_callback = None
+        runner.adapters[Platform.DISCORD] = mock_adapter
+
+        result = await runner._handle_discord_auto_voice_join(
+            guild_id=111,
+            voice_channel=mock_channel,
+            text_channel_id=123,
+            text_channel_name="Hermes Server / #hermes",
+        )
+
+        assert result is True
+        mock_adapter.join_voice_channel.assert_awaited_once_with(mock_channel)
+        assert runner._voice_mode["discord:123"] == "all"
+        assert mock_adapter._voice_text_channels[111] == 123
+        assert mock_adapter._voice_sources[111]["chat_id"] == "123"
+        assert mock_adapter._voice_sources[111]["chat_name"] == "Hermes Server / #hermes"
 
     @pytest.mark.asyncio
     async def test_join_failure(self, runner):

--- a/tests/integration/test_voice_channel_flow.py
+++ b/tests/integration/test_voice_channel_flow.py
@@ -110,7 +110,11 @@ def _build_padded_rtp_packet(
     nonce_counter = struct.pack(">I", seq)
     full_nonce = nonce_counter + b"\x00" * 20
 
-    enc_msg = box.encrypt(plaintext, header, full_nonce)
+    # Discord's aead_*_rtpsize authenticates the fixed RTP header as AAD. For
+    # extension packets, the 4-byte extension preamble remains clear in the
+    # packet but is not included in AAD; extension data itself is encrypted.
+    aad = fixed_header
+    enc_msg = box.encrypt(plaintext, aad, full_nonce)
     ciphertext = enc_msg.ciphertext
 
     return header + ciphertext + nonce_counter

--- a/tools/busy_turn_choice.py
+++ b/tools/busy_turn_choice.py
@@ -1,0 +1,85 @@
+"""Gateway busy-turn choice registry.
+
+Discord and other interactive gateways use this tiny process-local registry to
+turn a button click into one of the existing busy-turn actions: queue, steer,
+interrupt, or cancel.  It deliberately stores only pending choices for the
+current gateway process; restart expiry is fine because the current running turn
+is also process-local.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import inspect
+import itertools
+import time
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+Handler = Callable[[str, Any], Awaitable[str] | str]
+
+
+@dataclass
+class BusyTurnChoiceEntry:
+    session_key: str
+    event: Any
+    handler: Handler
+    created_at: float
+    resolved: bool = False
+
+
+_entries: Dict[str, BusyTurnChoiceEntry] = {}
+_counter = itertools.count(1)
+
+_VALID_CHOICES = {"queue", "steer", "interrupt", "cancel"}
+_ENTRY_TTL_SECS = 5 * 60
+
+
+def _prune(now: Optional[float] = None) -> None:
+    """Drop expired entries so timed-out Discord prompts don't leak events."""
+    current = time.time() if now is None else now
+    expired = [
+        choice_id
+        for choice_id, entry in _entries.items()
+        if entry.resolved or current - entry.created_at > _ENTRY_TTL_SECS
+    ]
+    for choice_id in expired:
+        _entries.pop(choice_id, None)
+
+
+def register(session_key: str, event: Any, handler: Handler) -> str:
+    """Register a pending busy-turn prompt and return a choice id."""
+    now = time.time()
+    _prune(now)
+    choice_id = f"busy-{int(now * 1000)}-{next(_counter)}"
+    _entries[choice_id] = BusyTurnChoiceEntry(
+        session_key=session_key,
+        event=event,
+        handler=handler,
+        created_at=now,
+    )
+    return choice_id
+
+async def resolve(choice_id: str, choice: str) -> Optional[str]:
+    """Resolve *choice_id* with one of queue/steer/interrupt/cancel."""
+    normalized = str(choice or "").strip().lower()
+    if normalized not in _VALID_CHOICES:
+        raise ValueError(f"Unknown busy-turn choice: {choice!r}")
+    _prune()
+    entry = _entries.pop(choice_id, None)
+    if entry is None or entry.resolved:
+        return None
+    entry.resolved = True
+    result = entry.handler(normalized, entry.event)
+    if inspect.isawaitable(result):
+        result = await result
+    return str(result or "")
+
+
+def discard(choice_id: str) -> None:
+    """Discard a pending choice without applying an action."""
+    _entries.pop(choice_id, None)
+
+
+def pending_count() -> int:
+    _prune()
+    return len(_entries)


### PR DESCRIPTION
## Summary
- add Discord busy-turn controls for active gateway sessions: Interrupt, Steer, Queue Next, Cancel
- route button choices through a short-lived registry so Discord UI does not mutate transcript state before the user chooses
- preserve existing queue/steer/interrupt semantics, including fallback when a run has already completed or steering is unavailable
- add focused gateway tests for busy-turn choice behavior and Discord race/voice coverage touched by the adapter changes

## Verification
After rebasing onto current `origin/main`:
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/gateway/test_busy_session_ack.py -q` → 28 passed
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/gateway/test_discord_race_polish.py tests/gateway/test_voice_command.py tests/integration/test_voice_channel_flow.py -q` → 191 passed, 34 deselected, 2 existing async cleanup warnings

## Notes
This implements the bridge-style UX where a message sent while Hermes is busy prompts the user to choose whether to queue, steer, interrupt, or cancel instead of automatically interrupting.
