### PR TITLE
fix: rotate OpenCode pool on monthly usage limit

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2512,6 +2512,7 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
             else:
                 resets_in_match = re.search(
                     r"resets?\s+in\s+"
+                    r"(?:(\d+(?:\.\d+)?)\s*(?:d|day|days)\b\s*)?"
                     r"(?:(\d+(?:\.\d+)?)\s*(?:h|hr|hrs|hour|hours)\b\s*)?"
                     r"(?:(\d+(?:\.\d+)?)\s*(?:m|min|mins|minute|minutes)\b\s*)?"
                     r"(?:(\d+(?:\.\d+)?)\s*(?:s|sec|secs|second|seconds)\b)?",
@@ -2519,10 +2520,17 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
                     re.IGNORECASE,
                 )
                 if resets_in_match and any(resets_in_match.groups()):
-                    hours = float(resets_in_match.group(1) or 0)
-                    minutes = float(resets_in_match.group(2) or 0)
-                    seconds = float(resets_in_match.group(3) or 0)
-                    context["reset_at"] = time.time() + (hours * 3600) + (minutes * 60) + seconds
+                    days = float(resets_in_match.group(1) or 0)
+                    hours = float(resets_in_match.group(2) or 0)
+                    minutes = float(resets_in_match.group(3) or 0)
+                    seconds = float(resets_in_match.group(4) or 0)
+                    reset_seconds = (
+                        (days * 86400)
+                        + (hours * 3600)
+                        + (minutes * 60)
+                        + seconds
+                    )
+                    context["reset_at"] = time.time() + reset_seconds
                 else:
                     sec_match = re.search(
                         r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -790,6 +790,22 @@ def _normalize_base_url_for_match(value) -> str:
     return str(value or "").strip().rstrip("/").lower()
 
 
+def _explicit_base_url_matches_runtime(explicit_base_url: str, resolved_base_url: str) -> bool:
+    """Return True when an explicit URL is the same pool-backed endpoint.
+
+    Anthropic-style runtimes (including OpenCode Anthropic models) strip a
+    trailing /v1 before constructing SDK clients. Treat that normalization as
+    equivalent so a saved model.base_url does not detach the credential pool.
+    """
+    explicit = _normalize_base_url_for_match(explicit_base_url)
+    resolved = _normalize_base_url_for_match(resolved_base_url)
+    if not explicit or not resolved:
+        return False
+    return explicit == resolved or re.sub(r"/v1/?$", "", explicit) == re.sub(
+        r"/v1/?$", "", resolved
+    )
+
+
 def _custom_provider_request_overrides(custom_provider: Dict[str, Any]) -> Dict[str, Any]:
     extra_body = custom_provider.get("extra_body")
     if not isinstance(extra_body, dict) or not extra_body:
@@ -1334,6 +1350,39 @@ def _resolve_explicit_runtime(
 
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":
+        # A saved model.base_url is passed into this resolver as an "explicit"
+        # base URL by callers that persist per-session runtime settings.  Do
+        # not let that detach the credential pool when it names the same
+        # provider endpoint: pool attachment is what lets 429/quota recovery
+        # rotate to the next key.  An explicitly supplied API key still wins and
+        # intentionally bypasses the pool.
+        if explicit_base_url and not explicit_api_key:
+            try:
+                pool = load_pool(provider)
+            except Exception:
+                pool = None
+            if pool and pool.has_credentials():
+                entry = pool.select()
+                pool_api_key = ""
+                if entry is not None:
+                    pool_api_key = (
+                        getattr(entry, "runtime_api_key", None)
+                        or getattr(entry, "access_token", "")
+                    )
+                if entry is not None and pool_api_key:
+                    pool_runtime = _resolve_runtime_from_pool_entry(
+                        provider=provider,
+                        entry=entry,
+                        requested_provider=requested_provider,
+                        model_cfg=model_cfg,
+                        pool=pool,
+                    )
+                    if _explicit_base_url_matches_runtime(
+                        explicit_base_url,
+                        str(pool_runtime.get("base_url") or ""),
+                    ):
+                        return pool_runtime
+
         env_url = ""
         if pconfig.base_url_env_var:
             env_url = _getenv(pconfig.base_url_env_var, "").strip().rstrip("/")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "turgut.kural@outlook.com": "TurgutKural",
     "dale@dalenguyen.me": "dalenguyen",  # PR #53678 salvage (strip VIRTUAL_ENV/CONDA_PREFIX from terminal subprocess env; #23473)
     "blaryx@gmail.com": "Blaryxoff",  # PR #32602 salvage (deep-merge PUT /api/config to preserve unrelated sections; #13396)
     "diamondeyesfox@gmail.com": "DiamondEyesFox",  # PR #53351 salvage (rebaseline in-place compression flushes to prevent duplicate compacted rows; #9096)

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -112,6 +112,47 @@ def test_resolve_runtime_provider_anthropic_explicit_override_skips_pool(monkeyp
     assert resolved.get("credential_pool") is None
 
 
+def test_resolve_runtime_provider_api_key_explicit_base_url_keeps_matching_pool(monkeypatch):
+    class _Entry:
+        access_token = "pool-opencode-token"
+        source = "manual"
+        base_url = "https://opencode.ai/zen/go/v1"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    def _unexpected_env_credentials(provider):
+        raise AssertionError(f"env credentials should not be used for {provider}")
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "opencode-go",
+            "default": "deepseek-v4-pro",
+            "base_url": "https://opencode.ai/zen/go/v1",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setattr(rp, "resolve_api_key_provider_credentials", _unexpected_env_credentials)
+
+    resolved = rp.resolve_runtime_provider(
+        requested="opencode-go",
+        explicit_base_url="https://opencode.ai/zen/go/v1/",
+    )
+
+    assert resolved["provider"] == "opencode-go"
+    assert resolved["api_key"] == "pool-opencode-token"
+    assert resolved["source"] == "manual"
+    assert resolved["credential_pool"] is not None
+    assert resolved["base_url"] == "https://opencode.ai/zen/go/v1"
+
+
 def test_resolve_runtime_provider_falls_back_when_pool_empty(monkeypatch):
     class _Pool:
         def has_credentials(self):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5339,6 +5339,37 @@ class TestCredentialPoolRecovery:
         assert retry_same is False
         agent._swap_credential.assert_called_once_with(next_entry)
 
+    def test_recover_with_pool_rotates_first_429_on_usage_limit(self, agent):
+        next_entry = SimpleNamespace(label="secondary")
+        captured = {}
+
+        class _Pool:
+            def current(self):
+                return SimpleNamespace(label="primary")
+
+            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+                captured["status_code"] = status_code
+                captured["error_context"] = error_context
+                return next_entry
+
+        agent._credential_pool = _Pool()
+        agent._swap_credential = MagicMock()
+
+        recovered, retry_same = agent._recover_with_credential_pool(
+            status_code=429,
+            has_retried_429=False,
+            error_context={
+                "reason": "GoUsageLimitError",
+                "message": "Monthly usage limit reached. Resets in 9 days.",
+            },
+        )
+
+        assert recovered is True
+        assert retry_same is False
+        assert captured["status_code"] == 429
+        assert captured["error_context"]["reason"] == "GoUsageLimitError"
+        agent._swap_credential.assert_called_once_with(next_entry)
+
 
     def test_recover_with_pool_refreshes_on_401(self, agent):
         """401 with successful refresh should swap to refreshed credential."""
@@ -5459,6 +5490,25 @@ class TestCredentialPoolRecovery:
 
         assert context["reason"] == "GoUsageLimitError"
         assert context["reset_at"] == 1_000.0 + (6 * 60 * 60) + (29 * 60)
+
+    def test_extract_api_error_context_parses_resets_in_days(self, agent, monkeypatch):
+        from agent import agent_runtime_helpers
+
+        monkeypatch.setattr(agent_runtime_helpers.time, "time", lambda: 2_000.0)
+        error = SimpleNamespace(
+            body={
+                "error": {
+                    "type": "GoUsageLimitError",
+                    "message": "Monthly usage limit reached. Resets in 9 days.",
+                }
+            },
+            response=SimpleNamespace(headers={}),
+        )
+
+        context = agent._extract_api_error_context(error)
+
+        assert context["reason"] == "GoUsageLimitError"
+        assert context["reset_at"] == 2_000.0 + (9 * 24 * 60 * 60)
 
     def test_recover_with_pool_passes_error_context_on_rotated_429(self, agent):
         next_entry = SimpleNamespace(label="secondary")


### PR DESCRIPTION
## Summary

- classify OpenCode `GoUsageLimitError` monthly quota responses as billing/usage-limit failures so credential pools rotate immediately
- parse `Resets in N days` cooldown messages in API error context
- preserve matching credential pools when an explicit provider base URL matches the runtime provider base URL

## Tests

- `uv run pytest tests/hermes_cli/test_runtime_provider_resolution.py::test_resolve_runtime_provider_api_key_explicit_base_url_keeps_matching_pool tests/run_agent/test_run_agent.py::TestCredentialPoolRecovery::test_recover_with_pool_rotates_first_429_on_usage_limit tests/run_agent/test_run_agent.py::TestCredentialPoolRecovery::test_extract_api_error_context_parses_resets_in_days -q`
