### PR TITLE
fix(agent): inject OPENAI_MODEL_EXECUTION_GUIDANCE for GLM/Qwen/DeepSeek

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -251,10 +251,21 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
                 stable_parts.append(GOOGLE_MODEL_OPERATIONAL_GUIDANCE)
             # OpenAI GPT/Codex execution discipline (tool persistence,
             # prerequisite checks, verification, anti-hallucination).
-            # Also applied to xAI Grok — same failure modes (claims completion
-            # without tool calls, suggests workarounds instead of using
-            # existing tools, replies with plans instead of executing).
-            if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower:
+            # Also applied to xAI Grok and the broader non-Google tool-use-
+            # enforcement set — the same failure modes appear on GLM,
+            # DeepSeek, Qwen (claims completion without tool calls, suggests
+            # workarounds instead of using existing tools, replies with plans
+            # or plain-text ``[TOOL_CALL]`` markers instead of executing via
+            # the structured tool_calls channel). The OPENAI_ prefix
+            # reflects origin, not exclusivity — see the comment in
+            # ``prompt_builder.OPENAI_MODEL_EXECUTION_GUIDANCE``. Google
+            # models are skipped because they get the more specific
+            # ``GOOGLE_MODEL_OPERATIONAL_GUIDANCE`` block above.
+            _openai_exec_families = tuple(
+                m for m in TOOL_USE_ENFORCEMENT_MODELS
+                if m not in ("gemini", "gemma")
+            )
+            if any(fam in _model_lower for fam in _openai_exec_families):
                 stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
 
     has_skills_tools = any(name in agent.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -99,3 +99,73 @@ class TestCodingContextBlock:
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         agent = _make_agent(valid_tool_names=[], platform="cli")
         assert "coding agent" not in _stable_prompt(agent)
+
+
+class TestOpenAIExecutionGuidanceInjection:
+    """Regression tests for the tool_use enforcement / OPENAI execution
+    discipline injection block in ``build_system_prompt_parts``.
+
+    Background — 2026-06-27 Telegram stall: GLM-5.2 replied with a
+    plain-text ``[TOOL_CALL]...[/TOOL_CALL]`` marker instead of a
+    structured ``tool_calls`` JSON block, so the runtime saw
+    ``tool_calls=None`` and finished with ``finish_reason=stop`` after
+    one assistant turn. Root cause: the system prompt injector only
+    added ``OPENAI_MODEL_EXECUTION_GUIDANCE`` for ``gpt/codex/grok``
+    substrings, so non-Google TOOL_USE_ENFORCEMENT_MODELS families
+    (``glm``, ``qwen``, ``deepseek``) got the lighter ``TOOL_USE_
+    ENFORCEMENT_GUIDANCE`` block but not the execution-discipline
+    block (tool persistence, anti-fabrication, mandatory_tool_use).
+    """
+
+    def _prompt(self, model, *, valid_tool_names=("terminal", "read_file"),
+                tool_use_enforcement=True):
+        agent = _make_agent(
+            valid_tool_names=list(valid_tool_names),
+            model=model,
+            _tool_use_enforcement=tool_use_enforcement,
+        )
+        return _stable_prompt(agent)
+
+    def test_glm_5_2_receives_openai_execution_guidance(self):
+        # The exact model from the 2026-06-27 Telegram stall reproduction.
+        stable = self._prompt("z-ai/glm-5.2")
+        assert "Execution discipline" in stable
+        assert "<tool_persistence>" in stable
+        assert "<mandatory_tool_use>" in stable
+
+    def test_deepseek_receives_openai_execution_guidance(self):
+        stable = self._prompt("deepseek/deepseek-v4-pro")
+        assert "Execution discipline" in stable
+
+    def test_qwen_receives_openai_execution_guidance(self):
+        stable = self._prompt("qwen/qwen-3-max")
+        assert "Execution discipline" in stable
+
+    def test_gpt_still_receives_openai_execution_guidance(self):
+        # No regression on the original coverage.
+        stable = self._prompt("openai/gpt-5.5")
+        assert "Execution discipline" in stable
+
+    def test_grok_still_receives_openai_execution_guidance(self):
+        stable = self._prompt("xai/grok-4")
+        assert "Execution discipline" in stable
+
+    def test_anthropic_opus_does_not_receive_openai_execution_guidance(self):
+        # Claude has its own anthropic-transport guidance; OPENAI_ block
+        # is body-agnostic but conceptually targeted at the families that
+        # share GPT/Grok/GLM failure modes. Don't double-inject.
+        stable = self._prompt("anthropic/claude-opus-4.8")
+        assert "Execution discipline" not in stable
+
+    def test_google_gemini_does_not_receive_openai_execution_guidance(self):
+        # Google gets the more specific GOOGLE_MODEL_OPERATIONAL block
+        # instead. Adding OPENAI_ would duplicate the parallel-call steer.
+        stable = self._prompt("google/gemini-2.5-pro")
+        assert "Execution discipline" not in stable
+        assert "Google model operational directives" in stable
+
+    def test_disabled_when_enforcement_off(self):
+        stable = self._prompt("z-ai/glm-5.2", tool_use_enforcement=False)
+        # When the whole block is off neither guidance should land.
+        assert "Execution discipline" not in stable
+        assert "Tool-use enforcement" not in stable


### PR DESCRIPTION
Telegram sessions on z-ai/glm-5.2 stalled after one assistant turn: the model replied with a plain-text '[TOOL_CALL]...[/TOOL_CALL]' marker instead of a structured tool_calls JSON block, so the runtime saw tool_calls=None and finished with finish_reason=stop. Two sessions on 2026-06-27 (20260627_144930_7531d0bd, 20260627_145132_ 3c5abc52) reproduced this — 3 messages, 0 tool_calls each, then silence.

Root cause: build_system_prompt_parts only appended OPENAI_MODEL_EXECUTION_GUIDANCE when the model name contained 'gpt', 'codex', or 'grok'. GLM/Qwen/DeepSeek matched TOOL_USE_ENFORCEMENT_MODELS (so they got the lighter TOOL_USE_ENFORCEMENT_GUIDANCE block) but not the execution-discipline block (tool persistence, mandatory_tool_use, anti-fabrication). On a weaker tool_use format-trained model that lighter block alone is not enough to stop the model from emitting its tool intent as natural- language markdown.

The OPENAI_ prefix reflects origin, not exclusivity (see the comment on prompt_builder.OPENAI_MODEL_EXECUTION_GUIDANCE). Expand the gate to the non-Google slice of TOOL_USE_ENFORCEMENT_MODELS — Google keeps its own more specific GOOGLE_MODEL_OPERATIONAL_GUIDANCE block, so we skip gemini/gemma here to avoid a duplicate parallel-tool-call steer.

Tests: 8 regression tests in TestOpenAIExecutionGuidanceInjection cover GLM/DeepSeek/Qwen (positive), GPT/Grok (no regression), Opus/Gemini (no false-positive), and the off-switch. 169/169 pass in test_prompt_builder.py + test_system_prompt.py; full suite minus the unrelated pre-existing test_anthropic_adapter.py MagicMock failure also clean.

Reproduction evidence (from ~/.hermes/state.db on 2026-06-27):

  SELECT message_count, tool_call_count, end_reason FROM sessions
  WHERE id IN ('20260627_144930_7531d0bd','20260627_145132_3c5abc52');
  -> 3|0||  (both)

  SELECT substr(content, 1, 200) FROM messages
  WHERE session_id='20260627_144930_7531d0bd' AND role='assistant';
  -> 'Ik ga die 3 commits lezen. Eerst kijken waar ik sta...
      [TOOL_CALL]\nrun_command\ncommand=cd /Users/guidolassally/esmi-dashboard
      2>/dev/null && git log --oneline -1 cc3cd6b92 && ...'

  finish_reason was 'stop' and tool_calls was NULL on both sessions.

Live verification (after patch):

  python -c 'from unittest.mock import patch; from types import
  SimpleNamespace; ... build_system_prompt_parts(agent)["stable"]'
  for z-ai/glm-5.2 now contains 'Execution discipline',
  '<tool_persistence>', and '<mandatory_tool_use>' sections that
  previously were absent.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

