### PR TITLE
fix(gateway): relay _thinking bubbles when thinking_progress is on but tool_progress is off

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16278,7 +16278,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
-            agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
+            # Gate on needs_progress_queue (tool_progress OR thinking_progress)
+            # rather than tool_progress alone: the progress_callback also relays
+            # _thinking assistant scratch text, which is gated on
+            # thinking_progress and is intentionally independent of tool
+            # progress. With the old `tool_progress_enabled`-only gate, a user
+            # who set thinking_progress:true but kept tool_progress:off got a
+            # None callback — so _thinking scratch bubbles never relayed even
+            # though the progress queue was created for them.
+            agent.tool_progress_callback = progress_callback if needs_progress_queue else None
             # Discord voice verbal-ack hook (fires once per turn on first tool
             # call; armed only when in a voice channel with the mixer running).
             agent.tool_start_callback = (
@@ -17004,9 +17012,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "response_transformed": result.get("response_transformed", False),
             }
         
-        # Start progress message sender if enabled
+        # Start progress message sender if enabled. Gate on needs_progress_queue
+        # (tool_progress OR thinking_progress), not tool_progress alone: the
+        # sender drains BOTH tool-progress lines and _thinking scratch bubbles.
+        # With the old tool_progress-only gate, a thinking_progress:true /
+        # tool_progress:off user had the callback queue _thinking messages that
+        # no task ever drained — so they silently never appeared.
         progress_task = None
-        if tool_progress_enabled:
+        if needs_progress_queue:
             progress_task = asyncio.create_task(send_progress_messages())
 
         # Start stream consumer task — polls for consumer creation since it

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -145,6 +145,29 @@ class FakeAgent:
         }
 
 
+class ThinkingAgent:
+    """Agent that emits _thinking scratch text (no tool calls).
+
+    Used to prove the progress callback relays _thinking bubbles when
+    thinking_progress is enabled but tool_progress is off.
+    """
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            cb("_thinking", "weighing the options here")
+            time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class LongPreviewAgent:
     """Agent that emits a tool call with a very long preview string."""
     LONG_CMD = "cd /home/teknium/.hermes/hermes-agent/.worktrees/hermes-d8860339 && source .venv/bin/activate && python -m pytest tests/gateway/test_run_progress_topics.py -n0 -q"
@@ -1565,3 +1588,49 @@ async def test_consecutive_terminal_progress_collapses_headers(monkeypatch, tmp_
     # Exactly TWO terminal headers: one for the first run of three calls,
     # one for the terminal call after web_search broke the streak.
     assert final.count("terminal\n```") == 2
+
+
+@pytest.mark.asyncio
+async def test_run_agent_relays_thinking_when_tool_progress_off(monkeypatch, tmp_path):
+    """_thinking scratch text relays as a bubble when thinking_progress is on,
+    even with tool_progress off.
+
+    Regression: agent.tool_progress_callback used to be gated on
+    tool_progress_enabled alone, so enabling only thinking_progress left the
+    callback None and _thinking never relayed — despite the progress queue
+    being created for it (needs_progress_queue = tool OR thinking).
+    """
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "off")
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ThinkingAgent,
+        session_id="sess-thinking-on",
+        config_data={"display": {"thinking_progress": True, "tool_progress": "off"}},
+    )
+
+    assert result["final_response"] == "done"
+    blob = "\n".join(
+        [c["content"] for c in adapter.sent] + [c["content"] for c in adapter.edits]
+    )
+    assert "weighing the options here" in blob
+
+
+@pytest.mark.asyncio
+async def test_run_agent_suppresses_thinking_when_thinking_off(monkeypatch, tmp_path):
+    """With thinking_progress off and tool_progress off, _thinking is suppressed
+    (no callback wired → no relay)."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "off")
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ThinkingAgent,
+        session_id="sess-thinking-off",
+        config_data={"display": {"thinking_progress": False, "tool_progress": "off"}},
+    )
+
+    assert result["final_response"] == "done"
+    blob = "\n".join(
+        [c["content"] for c in adapter.sent] + [c["content"] for c in adapter.edits]
+    )
+    assert "weighing the options here" not in blob


### PR DESCRIPTION
## Summary
`display.thinking_progress` is documented as independent of `tool_progress` — a user can keep tool-progress bubbles quiet while opting into mid-turn `_thinking` scratch-text bubbles. But the relay was silently dead whenever `tool_progress: off`, even with `thinking_progress: true`, because two gates keyed on `tool_progress_enabled` alone.

## Root cause (two dead gates)
1. `agent.tool_progress_callback = progress_callback if tool_progress_enabled else None` — with tool progress off the callback was `None`, so the `_thinking` text was never queued.
2. `if tool_progress_enabled: progress_task = create_task(send_progress_messages())` — the drain task that flushes the queue to the platform was never started, so even a queued message had no consumer.

Both now gate on `needs_progress_queue` (`tool_progress_enabled or _thinking_enabled`) — the same condition that already decides whether the progress queue is created in the first place.

## Changes
- `gateway/run.py`: gate the `tool_progress_callback` assignment and the `send_progress_messages` task start on `needs_progress_queue` instead of `tool_progress_enabled`.
- `tests/gateway/test_run_progress_topics.py`: `ThinkingAgent` + two tests — `_thinking` relays with `thinking_progress:on`/`tool_progress:off`, and is suppressed when `thinking_progress:off`.

## Validation
| `thinking_progress` / `tool_progress` | Before | After |
|---|---|---|
| on / off | `_thinking` bubble never sent | bubble relayed |
| off / off | (none) | (none) — suppressed, unchanged |
| any / on | unchanged | unchanged |

`tests/gateway/test_run_progress_topics.py` → 35/35 pass (33 existing + 2 new).

Found while implementing MoA reference-summary relays; the gate bug is independent of MoA and fixes the documented `thinking_progress`-only configuration for every platform.

## Infographic

![thinking-bubbles-fix](https://v3b.fal.media/files/b/0aa007ce/3BwtV_cbLEX12LNR60RaF_FLQk83Ke.png)
