### PR TITLE
skill: add cognitive review loop

### DIFF
--- a/optional-skills/software-development/cognitive-review-loop/SKILL.md
+++ b/optional-skills/software-development/cognitive-review-loop/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: cognitive-review-loop
+description: >
+  Structured cognitive review workflow for complex engineering work, bug triage,
+  PR review, agent self-improvement, and post-failure analysis. Use when a task
+  needs deliberate reflection before action: clarify the objective, inspect
+  source evidence, identify contradictions or stale assumptions, choose the
+  smallest useful intervention, verify the result, and capture a reusable lesson.
+version: 1.0.0
+author: TheSmokeDev
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [software-development, debugging, code-review, reflection, self-improvement, planning]
+    category: software-development
+    related_skills: [systematic-debugging, writing-plans, test-driven-development, requesting-code-review]
+---
+
+# Cognitive Review Loop
+
+Use this skill to slow down just enough to avoid confident-but-wrong engineering work. The loop is evidence-first: inspect what is true, name contradictions, make one bounded move, verify it, then capture the lesson so the next similar task is cheaper.
+
+## Use Cases
+
+- Debugging a failure whose cause is not obvious.
+- Reviewing a PR or implementation plan against a stated goal.
+- Resuming work after context loss, branch drift, or failed validation.
+- Hardening an agent workflow after it made a bad assumption.
+- Deciding whether to patch, split, close, or rewrite an existing contribution.
+- Writing a short postmortem or reusable lesson after a fix.
+
+Do not use this for simple questions, single-command lookups, or tasks where the user already gave an exact implementation plan.
+
+## Loop
+
+### 1. State The Objective
+
+Write one sentence that names the desired outcome and the evidence needed to call it done.
+
+Good:
+
+```text
+Make the Windows MCP env-var PR mergeable by rebasing it, proving the focused tests pass, and keeping the diff to one file.
+```
+
+Avoid:
+
+```text
+Improve the PR.
+```
+
+### 2. Gather Source Evidence
+
+Inspect the smallest set of sources that can prove the current state.
+
+For code work, prefer:
+
+- Current branch and diff.
+- Relevant issue, PR, or failing test.
+- Owning module and nearby tests.
+- Repo instructions such as `AGENTS.md`, `CONTRIBUTING.md`, or package scripts.
+
+Record facts separately from interpretations.
+
+```text
+Fact: PR #123 changes one file and is labeled P2.
+Fact: The branch is 400 commits behind main.
+Inference: A clean rebase is likely a higher-leverage move than adding scope.
+```
+
+### 3. Name Contradictions And Stale Assumptions
+
+Look for mismatches before editing:
+
+- Claimed behavior vs actual diff.
+- Test proof vs runtime proof.
+- Old branch base vs current main.
+- User request vs implementation scope.
+- Documentation vs code path.
+- Local success vs CI or platform constraints.
+
+If no contradiction is found, say so and continue.
+
+### 4. Choose One Bounded Move
+
+Pick the smallest action that moves the task toward done.
+
+Prefer:
+
+- Rebase before redesign.
+- Focused fix before broad cleanup.
+- One-file skill before core runtime changes.
+- Existing test target before new validation machinery.
+- Comment with exact evidence before vague maintainer pings.
+
+Reject moves that make review harder unless the evidence requires them.
+
+### 5. Execute And Verify
+
+Run the most specific verification first, then broaden only if the change justifies it.
+
+Examples:
+
+```bash
+scripts/run_tests.sh tests/tools/test_mcp_tool.py
+python -m pytest tests/tools/test_mcp_tool.py::TestBuildSafeEnv -q
+ruff check tools/mcp_tool.py
+```
+
+When a preferred command cannot run, report why and use the closest valid alternative. Do not present fallback verification as identical to the preferred path.
+
+### 6. Capture The Lesson
+
+End with a reusable lesson in one to three bullets. Keep it concrete enough to guide future work.
+
+Useful lesson:
+
+```text
+- For first-time upstream contribution, ship one optional skill or one P2 bug fix before proposing core memory changes.
+```
+
+Weak lesson:
+
+```text
+- Be careful next time.
+```
+
+## Output Format
+
+Use this compact shape unless the user asks for a different artifact:
+
+```markdown
+**Objective**
+[one sentence]
+
+**Evidence**
+- [fact with source]
+- [fact with source]
+
+**Contradictions**
+- [mismatch, stale assumption, or "None found"]
+
+**Move**
+[one bounded action and why]
+
+**Verification**
+- `[command]` -> [result]
+
+**Lesson**
+- [reusable rule]
+```
+
+## Review Checklist
+
+Before finishing, confirm:
+
+- The objective is concrete.
+- Evidence comes from source files, tests, issues, PRs, or runtime output.
+- Inferences are labeled as inferences.
+- The action is smaller than the problem.
+- Verification matches the actual behavior changed.
+- The final lesson is reusable without needing this conversation.

--- a/optional-skills/software-development/cognitive-review-loop/SKILL.md
+++ b/optional-skills/software-development/cognitive-review-loop/SKILL.md
@@ -1,163 +1,147 @@
 ---
 name: cognitive-review-loop
-description: >
-  Structured cognitive review workflow for complex engineering work, bug triage,
-  PR review, agent self-improvement, and post-failure analysis. Use when a task
-  needs deliberate reflection before action: clarify the objective, inspect
-  source evidence, identify contradictions or stale assumptions, choose the
-  smallest useful intervention, verify the result, and capture a reusable lesson.
+description: Evidence-first reflection before risky engineering moves.
 version: 1.0.0
-author: TheSmokeDev
+author: SmokeDev (TheSmokeDev)
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [software-development, debugging, code-review, reflection, self-improvement, planning]
     category: software-development
-    related_skills: [systematic-debugging, writing-plans, test-driven-development, requesting-code-review]
+    related_skills: [systematic-debugging, plan, test-driven-development, requesting-code-review]
 ---
 
-# Cognitive Review Loop
+# Cognitive Review Loop Skill
 
-Use this skill to slow down just enough to avoid confident-but-wrong engineering work. The loop is evidence-first: inspect what is true, name contradictions, make one bounded move, verify it, then capture the lesson so the next similar task is cheaper.
+A six-step reflection loop for engineering work where a confident-but-wrong move
+is expensive: state the objective, gather source evidence, name contradictions,
+make one bounded move, verify it, and capture a reusable lesson. It structures
+reasoning around existing tools (`read_file`, `search_files`, `terminal`); it
+adds no automation and is not for tasks that already have an exact plan.
 
-## Use Cases
+## When to Use
 
 - Debugging a failure whose cause is not obvious.
 - Reviewing a PR or implementation plan against a stated goal.
 - Resuming work after context loss, branch drift, or failed validation.
-- Hardening an agent workflow after it made a bad assumption.
+- Hardening an agent workflow after it acted on a bad assumption.
 - Deciding whether to patch, split, close, or rewrite an existing contribution.
 - Writing a short postmortem or reusable lesson after a fix.
 
-Do not use this for simple questions, single-command lookups, or tasks where the user already gave an exact implementation plan.
+Skip it for simple questions, single-command lookups, or tasks where the user
+already supplied an exact implementation plan.
 
-## Loop
+## Prerequisites
 
-### 1. State The Objective
+None. The skill is prose-only: no env vars, no scripts, no network access.
+Evidence gathering uses the native `read_file`, `search_files`, and `terminal`
+tools.
 
-Write one sentence that names the desired outcome and the evidence needed to call it done.
+## How to Run
 
-Good:
+Work through the six Procedure steps in order and finish with the compact
+output block from the Quick Reference. Gather evidence with `read_file`
+(file contents), `search_files` (symbols and paths), and `terminal`
+(git state, test runs).
 
-```text
-Make the Windows MCP env-var PR mergeable by rebasing it, proving the focused tests pass, and keeping the diff to one file.
+## Quick Reference
+
+| Step | Action |
+|---|---|
+| 1 | State the objective in one sentence, with the evidence needed to call it done |
+| 2 | Gather source evidence; record facts separately from inferences |
+| 3 | Name contradictions and stale assumptions, or state "None found" |
+| 4 | Choose one bounded move |
+| 5 | Execute, then verify with the most specific check first |
+| 6 | Capture a reusable lesson in 1-3 bullets |
+
+Output shape:
+
+```markdown
+**Objective** [one sentence]
+**Evidence** - [fact with source]
+**Contradictions** - [mismatch, stale assumption, or "None found"]
+**Move** [one bounded action and why]
+**Verification** - `[command]` -> [result]
+**Lesson** - [reusable rule]
 ```
 
-Avoid:
+## Procedure
 
-```text
-Improve the PR.
-```
+### 1. State the objective
 
-### 2. Gather Source Evidence
+One sentence naming the desired outcome and the evidence needed to call it
+done. "Make the Windows MCP env-var PR mergeable by rebasing it and proving
+the focused tests pass" is an objective; "improve the PR" is not.
 
-Inspect the smallest set of sources that can prove the current state.
+### 2. Gather source evidence
 
-For code work, prefer:
-
-- Current branch and diff.
-- Relevant issue, PR, or failing test.
-- Owning module and nearby tests.
-- Repo instructions such as `AGENTS.md`, `CONTRIBUTING.md`, or package scripts.
-
-Record facts separately from interpretations.
+Inspect the smallest set of sources that can prove the current state: the
+current branch and diff (`terminal`), the failing test or linked issue, the
+owning module and its nearby tests (`read_file`, `search_files`), and repo
+instructions such as `AGENTS.md` or `CONTRIBUTING.md`. Record facts separately
+from interpretations:
 
 ```text
 Fact: PR #123 changes one file and is labeled P2.
 Fact: The branch is 400 commits behind main.
-Inference: A clean rebase is likely a higher-leverage move than adding scope.
+Inference: A clean rebase is a higher-leverage move than adding scope.
 ```
 
-### 3. Name Contradictions And Stale Assumptions
+### 3. Name contradictions and stale assumptions
 
-Look for mismatches before editing:
+Look for mismatches before editing: claimed behavior vs actual diff, test
+proof vs runtime proof, old branch base vs current main, user request vs
+implementation scope, documentation vs code path, local success vs CI or
+platform constraints. If no contradiction is found, say so and continue.
 
-- Claimed behavior vs actual diff.
-- Test proof vs runtime proof.
-- Old branch base vs current main.
-- User request vs implementation scope.
-- Documentation vs code path.
-- Local success vs CI or platform constraints.
+### 4. Choose one bounded move
 
-If no contradiction is found, say so and continue.
+Pick the smallest action that moves the task toward done: rebase before
+redesign, focused fix before broad cleanup, one-file skill before core runtime
+changes, existing test target before new validation machinery, a comment with
+exact evidence before a vague maintainer ping. Reject moves that make review
+harder unless the evidence requires them.
 
-### 4. Choose One Bounded Move
+### 5. Execute and verify
 
-Pick the smallest action that moves the task toward done.
-
-Prefer:
-
-- Rebase before redesign.
-- Focused fix before broad cleanup.
-- One-file skill before core runtime changes.
-- Existing test target before new validation machinery.
-- Comment with exact evidence before vague maintainer pings.
-
-Reject moves that make review harder unless the evidence requires them.
-
-### 5. Execute And Verify
-
-Run the most specific verification first, then broaden only if the change justifies it.
-
-Examples:
+Run the most specific verification first, then broaden only if the change
+justifies it. In this repository:
 
 ```bash
-scripts/run_tests.sh tests/tools/test_mcp_tool.py
-python -m pytest tests/tools/test_mcp_tool.py::TestBuildSafeEnv -q
+scripts/run_tests.sh tests/tools/test_mcp_tool.py -q
 ruff check tools/mcp_tool.py
 ```
 
-When a preferred command cannot run, report why and use the closest valid alternative. Do not present fallback verification as identical to the preferred path.
+When a preferred command cannot run, report why and use the closest valid
+alternative. Do not present fallback verification as identical to the
+preferred path.
 
-### 6. Capture The Lesson
+### 6. Capture the lesson
 
-End with a reusable lesson in one to three bullets. Keep it concrete enough to guide future work.
+End with 1-3 concrete, reusable bullets. "For a first upstream contribution,
+ship one optional skill or one P2 bug fix before proposing core memory
+changes" is reusable; "be careful next time" is not.
 
-Useful lesson:
+## Pitfalls
 
-```text
-- For first-time upstream contribution, ship one optional skill or one P2 bug fix before proposing core memory changes.
+- A vague objective ("improve X") makes every later step unverifiable.
+- Evidence recalled from memory instead of re-read from source files.
+- Inferences presented as facts instead of being labeled.
+- Scope creep inside the "one bounded move" step.
+- Fallback verification reported as if it were the preferred check.
+- Lessons too generic to guide the next similar task.
+
+## Verification
+
+The skill ships a standards test covering frontmatter shape, description
+budget, section order, and wrapper-only test invocations:
+
+```bash
+scripts/run_tests.sh tests/skills/test_cognitive_review_loop_skill.py -q
 ```
 
-Weak lesson:
-
-```text
-- Be careful next time.
-```
-
-## Output Format
-
-Use this compact shape unless the user asks for a different artifact:
-
-```markdown
-**Objective**
-[one sentence]
-
-**Evidence**
-- [fact with source]
-- [fact with source]
-
-**Contradictions**
-- [mismatch, stale assumption, or "None found"]
-
-**Move**
-[one bounded action and why]
-
-**Verification**
-- `[command]` -> [result]
-
-**Lesson**
-- [reusable rule]
-```
-
-## Review Checklist
-
-Before finishing, confirm:
-
-- The objective is concrete.
-- Evidence comes from source files, tests, issues, PRs, or runtime output.
-- Inferences are labeled as inferences.
-- The action is smaller than the problem.
-- Verification matches the actual behavior changed.
-- The final lesson is reusable without needing this conversation.
+A completed loop is verifiable when the output block's Verification line
+contains a command actually run this session and the Lesson stands on its own
+without the surrounding conversation.

--- a/tests/skills/test_cognitive_review_loop_skill.py
+++ b/tests/skills/test_cognitive_review_loop_skill.py
@@ -1,0 +1,104 @@
+"""Standards tests for the cognitive-review-loop optional skill.
+
+The skill is prose-only (no scripts), so these tests pin the contributed
+SKILL.md to the hardline authoring standards in AGENTS.md: frontmatter shape,
+the 60-char description budget, the modern section order, and wrapper-only
+pytest invocations.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "software-development"
+    / "cognitive-review-loop"
+)
+
+MARKETING_WORDS = ("powerful", "comprehensive", "seamless", "advanced")
+
+REQUIRED_SECTIONS = [
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+]
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_text: str) -> dict:
+    m = re.search(r"^---\n(.*?)\n---", skill_text, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+def test_skill_md_present() -> None:
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_name_matches_dir(frontmatter: dict) -> None:
+    assert frontmatter["name"] == "cognitive-review-loop"
+
+
+def test_description_hardline(frontmatter: dict) -> None:
+    desc = frontmatter["description"]
+    assert isinstance(desc, str), "description must be a plain string, not a folded block"
+    assert len(desc) <= 60, f"description is {len(desc)} chars (hardline <=60): {desc!r}"
+    assert desc.endswith("."), "description must end with a period"
+    assert ". " not in desc, "description must be a single sentence"
+    lowered = desc.lower()
+    assert not any(w in lowered for w in MARKETING_WORDS), "no marketing words in description"
+    assert "cognitive-review-loop" not in lowered, "description must not repeat the skill name"
+
+
+def test_platforms_all_three(frontmatter: dict) -> None:
+    # Prose-only skill: nothing platform-bound, so all three are declared.
+    assert set(frontmatter["platforms"]) == {"linux", "macos", "windows"}
+
+
+def test_author_credits_contributor(frontmatter: dict) -> None:
+    assert "TheSmokeDev" in frontmatter["author"]
+
+
+def test_license_mit(frontmatter: dict) -> None:
+    assert frontmatter["license"] == "MIT"
+
+
+def test_related_skills_exist_in_repo(frontmatter: dict) -> None:
+    repo_root = SKILL_DIR.parents[2]
+    for related in frontmatter["metadata"]["hermes"]["related_skills"]:
+        matches = list(repo_root.glob(f"skills/**/{related}/SKILL.md")) + list(
+            repo_root.glob(f"optional-skills/**/{related}/SKILL.md")
+        )
+        assert matches, f"related skill does not exist in repo: {related!r}"
+
+
+def test_modern_section_order(skill_text: str) -> None:
+    positions = [skill_text.find(h) for h in REQUIRED_SECTIONS]
+    missing = [h for h, p in zip(REQUIRED_SECTIONS, positions) if p == -1]
+    assert not missing, f"missing required sections: {missing}"
+    assert positions == sorted(positions), "sections out of the AGENTS.md order"
+
+
+def test_no_direct_pytest_invocation(skill_text: str) -> None:
+    # AGENTS.md: always scripts/run_tests.sh, never bare pytest.
+    assert "python -m pytest" not in skill_text
+    assert "scripts/run_tests.sh" in skill_text
+
+
+def test_line_budget(skill_text: str) -> None:
+    # ~100 lines for a simple skill, ~200 for a complex one; this is a simple one.
+    assert len(skill_text.splitlines()) <= 200

--- a/tests/skills/test_cognitive_review_loop_skill.py
+++ b/tests/skills/test_cognitive_review_loop_skill.py
@@ -4,6 +4,9 @@ The skill is prose-only (no scripts), so these tests pin the contributed
 SKILL.md to the hardline authoring standards in AGENTS.md: frontmatter shape,
 the 60-char description budget, the modern section order, and wrapper-only
 pytest invocations.
+
+Stdlib + pytest only, per the skill-test rule in AGENTS.md, so the frontmatter
+is read by the narrow parser below instead of PyYAML.
 """
 from __future__ import annotations
 
@@ -11,7 +14,6 @@ import re
 from pathlib import Path
 
 import pytest
-import yaml
 
 SKILL_DIR = (
     Path(__file__).resolve().parents[2]
@@ -33,6 +35,59 @@ REQUIRED_SECTIONS = [
 ]
 
 
+def _unquote(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value
+
+
+def _parse_value(raw: str, lineno: int) -> str | list[str]:
+    value = raw.strip()
+    if value in (">", "|", ">-", "|-", ">+", "|+"):
+        raise AssertionError(
+            f"line {lineno}: folded/literal blocks are not allowed in skill frontmatter"
+        )
+    if value.startswith("[") and value.endswith("]"):
+        inner = value[1:-1].strip()
+        return [_unquote(part.strip()) for part in inner.split(",")] if inner else []
+    return _unquote(value)
+
+
+def _parse_frontmatter(block: str) -> dict:
+    """Parse the fixed frontmatter subset: scalars, inline lists, nested maps.
+
+    Deliberately narrow. Anything outside the supported subset raises rather
+    than silently mis-parsing, so a malformed SKILL.md fails loudly here
+    instead of quietly passing the standards assertions below.
+    """
+    root: dict = {}
+    stack: list[tuple[int, dict]] = [(-1, root)]
+
+    for lineno, line in enumerate(block.splitlines(), start=1):
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        stripped = line.lstrip(" ")
+        indent = len(line) - len(stripped)
+        if stripped.startswith("- "):
+            raise AssertionError(f"line {lineno}: block sequences unsupported, use [a, b]")
+        if ":" not in stripped:
+            raise AssertionError(f"line {lineno}: unparsable frontmatter line {line!r}")
+
+        key, _, raw = stripped.partition(":")
+        while len(stack) > 1 and indent <= stack[-1][0]:
+            stack.pop()
+        parent = stack[-1][1]
+
+        if raw.strip():
+            parent[key.strip()] = _parse_value(raw, lineno)
+        else:
+            child: dict = {}
+            parent[key.strip()] = child
+            stack.append((indent, child))
+
+    return root
+
+
 @pytest.fixture(scope="module")
 def skill_text() -> str:
     return (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
@@ -42,7 +97,7 @@ def skill_text() -> str:
 def frontmatter(skill_text: str) -> dict:
     m = re.search(r"^---\n(.*?)\n---", skill_text, re.DOTALL)
     assert m, "SKILL.md missing YAML frontmatter"
-    return yaml.safe_load(m.group(1))
+    return _parse_frontmatter(m.group(1))
 
 
 def test_skill_md_present() -> None:


### PR DESCRIPTION
## What

Adds an optional software-development skill, `cognitive-review-loop`, for structured engineering reflection before action:

- clarify the objective and done evidence
- gather source evidence before inference
- identify contradictions or stale assumptions
- choose one bounded move
- verify the result
- capture a reusable lesson

## Why

This gives Hermes a lightweight, optional workflow for complex bug triage, PR review, branch-drift recovery, and post-failure agent improvement without touching core runtime or memory code. It is intentionally source-only: no scripts, no dependencies, and not active by default.

Install path after merge:

```bash
hermes skills install official/software-development/cognitive-review-loop
```

## Validation

```text
uv run --python 3.13 --extra dev python -c "from pathlib import Path; import yaml; p=Path('optional-skills/software-development/cognitive-review-loop/SKILL.md'); s=p.read_text(encoding='utf-8'); end=s.index('\n---\n',4); fm=yaml.safe_load(s[4:end]); assert fm['name']=='cognitive-review-loop'; assert fm['license']=='MIT'; assert 'Use when' in fm['description']"

uv run --python 3.13 --extra dev python -c "from tools.skills_hub import OptionalSkillSource; src=OptionalSkillSource(); meta=src.inspect('official/software-development/cognitive-review-loop'); assert meta and meta.name=='cognitive-review-loop'; bundle=src.fetch('official/software-development/cognitive-review-loop'); assert bundle and 'SKILL.md' in bundle.files"

uv run --python 3.13 --extra dev python -m pytest tests/tools/test_skills_tool.py::TestParseFrontmatter tests/tools/test_skills_tool.py::TestSkillMatchesPlatform -q
# 17 passed
```