### PR TITLE
fix(agent): inject tool-use-enforcement guidance model-driven, not to…

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -228,34 +228,53 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     #   true  — always inject (all models)
     #   false — never inject
     #   list  — custom model-name substrings to match
-    if agent.valid_tool_names:
-        _enforce = agent._tool_use_enforcement
+    #
+    # NOTE: the original `if agent.valid_tool_names:` wrapper here caused
+    # Telegram / Discord sessions on z-ai/glm-5.2 (and other weak
+    # tool_use-format-trained models) to receive ZERO guidance — the
+    # entire tool-use enforcement block was skipped when the session
+    # started without tools loaded, which is the default for many gateway
+    # entry points.  On a model that already emits tool intent as plain
+    # text or markdown instead of structured ``tool_calls``, that omission
+    # produces the "stall after one assistant turn" failure mode (the
+    # model writes ``bash`` code blocks or ``[TOOL_CALL]`` markers, the
+    # runtime sees ``tool_calls=None``, and the conversation loop ends
+    # with ``finish_reason=stop`` after one turn).  The guidance must be
+    # model-driven, not tool-driven — if the model is in
+    # TOOL_USE_ENFORCEMENT_MODELS the model needs the instruction,
+    # regardless of whether the current session happens to have tools
+    # loaded.  See ``TestToolUseEnforcementInjectionWithoutTools`` for
+    # the regression coverage.
+    _enforce = agent._tool_use_enforcement
+    _inject = False
+    if _enforce is True or (isinstance(_enforce, str) and _enforce.lower() in {"true", "always", "yes", "on"}):
+        _inject = True
+    elif _enforce is False or (isinstance(_enforce, str) and _enforce.lower() in {"false", "never", "no", "off"}):
         _inject = False
-        if _enforce is True or (isinstance(_enforce, str) and _enforce.lower() in {"true", "always", "yes", "on"}):
-            _inject = True
-        elif _enforce is False or (isinstance(_enforce, str) and _enforce.lower() in {"false", "never", "no", "off"}):
-            _inject = False
-        elif isinstance(_enforce, list):
-            model_lower = (agent.model or "").lower()
-            _inject = any(p.lower() in model_lower for p in _enforce if isinstance(p, str))
-        else:
-            # "auto" or any unrecognised value — use hardcoded defaults
-            model_lower = (agent.model or "").lower()
-            _inject = any(p in model_lower for p in TOOL_USE_ENFORCEMENT_MODELS)
-        if _inject:
-            stable_parts.append(TOOL_USE_ENFORCEMENT_GUIDANCE)
-            _model_lower = (agent.model or "").lower()
-            # Google model operational guidance (conciseness, absolute
-            # paths, parallel tool calls, verify-before-edit, etc.)
-            if "gemini" in _model_lower or "gemma" in _model_lower:
-                stable_parts.append(GOOGLE_MODEL_OPERATIONAL_GUIDANCE)
-            # OpenAI GPT/Codex execution discipline (tool persistence,
-            # prerequisite checks, verification, anti-hallucination).
-            # Also applied to xAI Grok — same failure modes (claims completion
-            # without tool calls, suggests workarounds instead of using
-            # existing tools, replies with plans instead of executing).
-            if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower:
-                stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
+    elif isinstance(_enforce, list):
+        model_lower = (agent.model or "").lower()
+        _inject = any(p.lower() in model_lower for p in _enforce if isinstance(p, str))
+    else:
+        # "auto" or any unrecognised value — use hardcoded defaults
+        model_lower = (agent.model or "").lower()
+        _inject = any(p in model_lower for p in TOOL_USE_ENFORCEMENT_MODELS)
+    if _inject:
+        stable_parts.append(TOOL_USE_ENFORCEMENT_GUIDANCE)
+        _model_lower = (agent.model or "").lower()
+        # Google model operational guidance (conciseness, absolute
+        # paths, parallel tool calls, verify-before-edit, etc.) — only
+        # inject when the session has tools loaded, because the
+        # guidance is about how to use them (file paths, edit-before-
+        # verify, non-interactive flags).  No tools → no point.
+        if agent.valid_tool_names and ("gemini" in _model_lower or "gemma" in _model_lower):
+            stable_parts.append(GOOGLE_MODEL_OPERATIONAL_GUIDANCE)
+        # OpenAI GPT/Codex execution discipline (tool persistence,
+        # prerequisite checks, verification, anti-hallucination).
+        # Also applied to xAI Grok — same failure modes (claims completion
+        # without tool calls, suggests workarounds instead of using
+        # existing tools, replies with plans instead of executing).
+        if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower:
+            stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
 
     has_skills_tools = any(name in agent.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
     if has_skills_tools:

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -99,3 +99,106 @@ class TestCodingContextBlock:
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         agent = _make_agent(valid_tool_names=[], platform="cli")
         assert "coding agent" not in _stable_prompt(agent)
+
+
+class TestToolUseEnforcementInjectionWithoutTools:
+    """Regression tests for the tool_use-enforcement guidance block when
+    the session starts with ``valid_tool_names=[]``.
+
+    Background — 2026-06-28 Telegram stall (session
+    ``20260628_003118_249c66d5``): the system prompt was 20,401 chars
+    and contained none of ``Tool-use enforcement`` /
+    ``Parallel tool calls`` markers. The GLM-5.2 model emitted its tool
+    intent as a literal ``bash`` markdown code block (different syntax
+    than the earlier ``[TOOL_CALL]`` markers but identical underlying
+    failure mode), the runtime saw ``tool_calls=None``, and the
+    conversation loop ended with ``finish_reason=stop`` after one turn.
+
+    Root cause: the tool-use-enforcement block was wrapped in
+    ``if agent.valid_tool_names:`` so the entire guidance — including
+    the ``TOOL_USE_ENFORCEMENT_GUIDANCE`` text the model needs to emit
+    structured ``tool_calls`` instead of markdown — was skipped when
+    the session happened to have no tools loaded. Telegram/Discord
+    gateway entry points often start without tools, so this affected
+    every GLM/Qwen/DeepSeek session that arrived through those
+    channels.
+
+    The fix decouples the guidance injection from ``valid_tool_names``:
+    the model-name gate drives whether the block lands, the
+    ``valid_tool_names`` check is preserved only for the
+    Google-operational sub-block (whose content is about how to use
+    file/edit tools, irrelevant without tools) and for
+    ``parallel_tool_call_guidance`` (no point steering a no-tool session
+    to batch calls).
+    """
+
+    def _prompt(self, model, *, valid_tool_names=(), tool_use_enforcement="auto"):
+        # type: ignore[assignment]
+        agent = _make_agent(
+            valid_tool_names=list(valid_tool_names),
+            model=model,
+            _tool_use_enforcement=tool_use_enforcement,
+        )
+        return _stable_prompt(agent)
+
+    def test_glm_5_2_receives_enforcement_guidance_without_tools(self):
+        # The exact reproduction conditions for the 2026-06-28 stall.
+        stable = self._prompt("z-ai/glm-5.2")
+        assert "Tool-use enforcement" in stable
+
+    def test_qwen_receives_enforcement_guidance_without_tools(self):
+        stable = self._prompt("qwen/qwen-3-max")
+        assert "Tool-use enforcement" in stable
+
+    def test_deepseek_receives_enforcement_guidance_without_tools(self):
+        stable = self._prompt("deepseek/deepseek-v4-pro")
+        assert "Tool-use enforcement" in stable
+
+    def test_anthropic_opus_does_not_receive_enforcement_guidance(self):
+        # Opus is not in TOOL_USE_ENFORCEMENT_MODELS — the no-tools
+        # path must NOT accidentally inject guidance for models that
+        # don't need it.
+        stable = self._prompt("anthropic/claude-opus-4.8")
+        assert "Tool-use enforcement" not in stable
+
+    def test_parallel_tool_call_guidance_still_tools_gated(self):
+        # Parallel-call guidance is about batching tool calls — without
+        # tools there's nothing to batch, so the gate stays. This is
+        # intentional and prevents prompt-bloat for read-only sessions.
+        stable = self._prompt("z-ai/glm-5.2", valid_tool_names=())
+        assert "Parallel tool calls" not in stable
+
+    def test_parallel_tool_call_guidance_present_with_tools(self):
+        # Sanity check: with tools, both blocks land as before.
+        stable = self._prompt(
+            "z-ai/glm-5.2",
+            valid_tool_names=("terminal", "read_file"),
+        )
+        assert "Tool-use enforcement" in stable
+        assert "Parallel tool calls" in stable
+
+    def test_enforcement_off_still_disables_without_tools(self):
+        # The config knob still works on the no-tools path — turning
+        # off enforcement means no guidance, period.
+        stable = self._prompt(
+            "z-ai/glm-5.2",
+            valid_tool_names=(),
+            tool_use_enforcement=False,
+        )
+        assert "Tool-use enforcement" not in stable
+
+    def test_enforcement_explicit_on_injects_for_all_models(self):
+        # The "true" override should land guidance even for models not
+        # in TOOL_USE_ENFORCEMENT_MODELS — this is the escape hatch.
+        stable = self._prompt(
+            "anthropic/claude-opus-4.8",
+            valid_tool_names=(),
+            tool_use_enforcement=True,
+        )
+        assert "Tool-use enforcement" in stable
+
+    def test_google_operational_block_still_tools_gated(self):
+        # The Gemini/Gemma-specific block is about file paths and edit
+        # commands — without tools the content is irrelevant noise.
+        stable = self._prompt("google/gemini-2.5-pro")
+        assert "Google model operational directives" not in stable


### PR DESCRIPTION
…ol-driven

Telegram session 20260628_003118_249c66d5 stalled after one assistant turn on z-ai/glm-5.2: the system prompt was 20,401 chars and contained NONE of 'Tool-use enforcement' / 'Execution discipline' / 'Parallel tool calls' markers. The model emitted its tool intent as a literal bash markdown code block (different syntax than the earlier [TOOL_CALL] markers but identical underlying failure mode), the runtime saw tool_calls=None, and the conversation loop ended with finish_reason=stop after one turn.

Root cause: the tool-use-enforcement block in
agent/system_prompt.py was wrapped in 'if agent.valid_tool_names:' so the entire guidance was skipped when the session happened to have no tools loaded. Telegram/Discord gateway entry points commonly start without tools, so every GLM/Qwen/DeepSeek session arriving through those channels got zero guidance.

The fix decouples the guidance injection from valid_tool_names: the model-name gate (TOOL_USE_ENFORCEMENT_MODELS substring check) now drives whether the block lands, independent of whether the current session has tools loaded. The valid_tool_names check is preserved only for:

  - Google-operational sub-block (content is about file paths and edit commands — irrelevant without tools)
  - parallel_tool_call_guidance (no point steering a no-tool session to batch calls)
  - task_completion_guidance (no point steering a session with no work to 'finish')

The model needs the instruction regardless of whether the current session happens to have tools loaded — a no-tools GLM session today may turn into a tools session tomorrow, and even within a single session the model needs to know it should emit structured tool_calls when those become available rather than falling back to markdown.

This is independent of PR #35087 (which widens the OPENAI_ gate to cover glm/qwen/deepseek via a config-driven tuple) — that PR was open for 28 days before this issue surfaced. PR #35087 addresses the wrong-family gate; this PR addresses the wrong-gate wrapper. Both are needed; both can land in any order.

Files:
  agent/system_prompt.py             +49/-22
  tests/agent/test_system_prompt.py  +103/-0

Tests: 14/14 pass in test_system_prompt.py, 170/170 pass in test_system_prompt.py + test_prompt_builder.py. ruff + ty clean. 9 new regression tests in TestToolUseEnforcementInjectionWithoutTools cover glm/qwen/deepseek positive, opus negative, parallel-call still tools-gated, enforce-off respected, explicit-on escape hatch, and google-operational block still tools-gated.

E2E confirmation: after merge, send a fresh Telegram prompt with z-ai/glm-5.2 and verify the assistant turn is followed by tool execution instead of a 1-turn stall.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

