### PR TITLE
feat: add FAL media utilities and Inworld voice

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,75 +1,46 @@
-## What does this PR do?
+## Summary
 
-<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
-
-
-
-## Related Issue
-
-<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->
-
-Fixes #
-
-## Type of Change
-
-<!-- Check the one that applies. -->
-
-- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
-- [ ] ✨ New feature (non-breaking change that adds functionality)
-- [ ] 🔒 Security fix
-- [ ] 📝 Documentation update
-- [ ] ✅ Tests (adding or improving test coverage)
-- [ ] ♻️ Refactor (no behavior change)
-- [ ] 🎯 New skill (bundled or hub)
-
-## Changes Made
-
-<!-- List the specific changes. Include file paths for code changes. -->
+<!-- What changed, and why is this the right approach for Hermes? -->
 
 - 
 
-## How to Test
+## Footprint and Architecture
 
-<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->
+<!-- New capability should live at the narrowest reasonable surface. -->
 
-1. 
-2. 
-3. 
+- [ ] Extends existing code, or explains why a new surface is needed
+- [ ] Does not add a core model tool unless terminal/file/CLI/plugin/MCP cannot solve it
+- [ ] Keeps plugins inside their plugin directory; no plugin-specific core special cases
+- [ ] Preserves byte-stable system prompts and per-conversation prompt caching
+- [ ] Preserves strict role alternation; no synthetic mid-loop user messages
 
-## Checklist
+## Configuration and Secrets
 
-<!-- Complete these before requesting review. -->
+- [ ] User-facing behavioral settings live in `config.yaml`
+- [ ] `.env` additions are credentials only
+- [ ] Setup/config UI, docs, and defaults are updated together
+- [ ] No telemetry, attribution tags, or third-party identifiers without opt-in gating
 
-### Code
+## Tests
 
-- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
-- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
-- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
-- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
-- [ ] I've run `pytest tests/ -q` and all tests pass
-- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
-- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->
+<!-- Include exact commands and any intentional omissions. -->
 
-### Documentation & Housekeeping
+- [ ] Reproduces the original bug or validates the new behavior through the real path
+- [ ] Covers sibling call paths and provider/config propagation where relevant
+- [ ] Avoids change-detector assertions for model lists, versions, or enum counts
+- [ ] Commands run:
 
-<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->
+```bash
 
-- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
-- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
-- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
-- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
-- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
+```
 
-## For New Skills
+## Documentation
 
-<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->
+- [ ] User docs updated, or N/A
+- [ ] Tool/schema references updated, or N/A
+- [ ] Developer docs/skills updated, or N/A
 
-- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
-- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
-- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
-- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`
+## Reviewer Notes
 
-## Screenshots / Logs
-
-<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
+<!-- Call out risk, migration notes, follow-ups, screenshots, or logs. -->
 

--- a/agent/video_gen_provider.py
+++ b/agent/video_gen_provider.py
@@ -264,6 +264,8 @@ def success_response(
     payload: Dict[str, Any] = {
         "success": True,
         "video": video,
+        "output_url": video,
+        "media_type": "video",
         "model": model,
         "prompt": prompt,
         "modality": modality,

--- a/agent/video_gen_registry.py
+++ b/agent/video_gen_registry.py
@@ -11,7 +11,7 @@ Active selection
 The active provider is chosen by ``video_gen.provider`` in ``config.yaml``.
 If unset, :func:`get_active_provider` applies fallback logic:
 
-1. If exactly one provider is registered, use it.
+1. If exactly one provider is available, use it.
 2. Otherwise return ``None`` (the tool surfaces a helpful error pointing
    the user at ``hermes tools``).
 
@@ -78,6 +78,16 @@ def get_active_provider() -> Optional[VideoGenProvider]:
 
     Reads ``video_gen.provider`` from config.yaml; falls back per the
     module docstring.
+
+    **Availability semantics** (mirrors :mod:`agent.image_gen_registry`):
+
+    - When ``video_gen.provider`` is explicitly set, the configured
+      provider is returned even if :meth:`VideoGenProvider.is_available`
+      reports False — the dispatcher surfaces a precise setup error rather
+      than silently switching backends.
+    - When ``video_gen.provider`` is unset, fallback selection is filtered
+      by ``is_available()`` so an unavailable registered plugin cannot block
+      the one backend the user actually configured.
     """
     configured: Optional[str] = None
     try:
@@ -95,6 +105,14 @@ def get_active_provider() -> Optional[VideoGenProvider]:
     with _lock:
         snapshot = dict(_providers)
 
+    def _is_available_safe(p: VideoGenProvider) -> bool:
+        """Wrap ``is_available()`` so a buggy provider doesn't kill resolution."""
+        try:
+            return bool(p.is_available())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("video_gen provider %s.is_available() raised %s", p.name, exc)
+            return False
+
     if configured:
         provider = snapshot.get(configured)
         if provider is not None:
@@ -104,9 +122,11 @@ def get_active_provider() -> Optional[VideoGenProvider]:
             configured,
         )
 
-    # Fallback: single-provider case
-    if len(snapshot) == 1:
-        return next(iter(snapshot.values()))
+    # Fallback: single available provider. Multiple registered providers are
+    # common because plugins load even when their credentials are absent.
+    available = [p for p in snapshot.values() if _is_available_safe(p)]
+    if len(available) == 1:
+        return available[0]
 
     return None
 

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -56,13 +56,21 @@ export const PROVIDER_GROUPS: ProviderPrefix[] = [
     priority: 3
   },
   {
+    prefix: 'INWORLD_',
+    name: 'Inworld',
+    description: 'Realtime speech, speech-to-text, and text-to-speech',
+    docsUrl: 'https://platform.inworld.ai/api-keys',
+    priority: 4
+  },
+  {
     prefix: 'GOOGLE_',
     name: 'Gemini',
     description: 'Google AI Studio (Gemini 1.5 / 2.0 / 2.5)',
     docsUrl: 'https://aistudio.google.com/app/apikey',
-    priority: 4
+    priority: 5
   },
   { prefix: 'GEMINI_', name: 'Gemini', priority: 4 },
+  { prefix: 'HERMES_GEMINI_', name: 'Gemini', priority: 4 },
   {
     prefix: 'DEEPSEEK_',
     name: 'DeepSeek',
@@ -235,8 +243,8 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   'stt.elevenlabs.model_id': ['scribe_v2', 'scribe_v1'],
   'stt.local.model': ['tiny', 'base', 'small', 'medium', 'large-v3'],
   // Speech-to-text backends — kept in sync with the stt block in
-  // hermes_cli/config.py (local/groq/openai/mistral/elevenlabs).
-  'stt.provider': ['local', 'groq', 'openai', 'mistral', 'xai', 'elevenlabs'],
+  // hermes_cli/config.py (local/groq/openai/inworld/mistral/elevenlabs).
+  'stt.provider': ['local', 'groq', 'openai', 'inworld', 'mistral', 'xai', 'elevenlabs'],
   'tts.openai.voice': ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer'],
   // Text-to-speech backends — kept in sync with the built-in source of truth
   // (agent/tts_registry.py::_BUILTIN_NAMES / tools/tts_tool.py::
@@ -245,6 +253,7 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
     'edge',
     'elevenlabs',
     'openai',
+    'inworld',
     'xai',
     'minimax',
     'mistral',
@@ -254,8 +263,13 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
     'piper'
   ],
   'stt.openai.model': ['whisper-1', 'gpt-4o-mini-transcribe', 'gpt-4o-transcribe'],
+  'stt.inworld.model': ['inworld/inworld-stt-1'],
+  'stt.inworld.audio_encoding': ['AUTO_DETECT', 'LINEAR16', 'MP3', 'OGG_OPUS', 'FLAC'],
   'stt.mistral.model': ['voxtral-mini-latest', 'voxtral-mini-2602'],
   'tts.openai.model': ['gpt-4o-mini-tts', 'tts-1', 'tts-1-hd'],
+  'tts.inworld.model': ['inworld-tts-2', 'inworld-tts-1.5-max', 'inworld-tts-1.5-mini'],
+  'tts.inworld.output_format': ['ogg', 'mp3', 'wav', 'pcm'],
+  'tts.inworld.delivery_mode': ['BALANCED', 'STABLE', 'CREATIVE'],
   'tts.elevenlabs.model_id': ['eleven_multilingual_v2', 'eleven_turbo_v2_5', 'eleven_flash_v2_5'],
   // NeuTTS local inference device.
   'tts.neutts.device': ['cpu', 'cuda', 'mps'],
@@ -332,6 +346,11 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     openai: {
       model: 'OpenAI STT Model'
     },
+    inworld: {
+      model: 'Inworld STT Model',
+      audioEncoding: 'Inworld Audio Encoding',
+      language: 'Inworld Language'
+    },
     groq: {
       model: 'Groq STT Model'
     },
@@ -353,6 +372,13 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     openai: {
       model: 'OpenAI TTS Model',
       voice: 'OpenAI Voice'
+    },
+    inworld: {
+      model: 'Inworld TTS Model',
+      voice: 'Inworld Voice',
+      outputFormat: 'Inworld Audio Format',
+      sampleRate: 'Inworld Sample Rate',
+      deliveryMode: 'Inworld Delivery Mode'
     },
     elevenlabs: {
       voiceId: 'ElevenLabs Voice',
@@ -465,6 +491,11 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
     autoTts: 'Automatically speak assistant responses.'
   },
   tts: {
+    inworld: {
+      voice: 'Inworld voice ID, e.g. Dennis.',
+      outputFormat: 'Desktop voice playback works best with native OGG.',
+      deliveryMode: 'Latency/quality profile for Inworld synthesis.'
+    },
     xai: {
       voiceId: 'xAI voice ID (e.g. eve) or a custom voice ID.',
       language: 'Spoken language code, e.g. en.'
@@ -475,6 +506,9 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   },
   stt: {
     enabled: 'Enable local or provider-backed speech transcription.',
+    inworld: {
+      audioEncoding: 'AUTO_DETECT works for desktop browser recordings.'
+    },
     elevenlabs: {
       languageCode: 'Optional ISO-639-3 language code. Blank lets ElevenLabs auto-detect.'
     }
@@ -562,6 +596,11 @@ export const SECTIONS: DesktopConfigSection[] = [
       'tts.edge.voice',
       'tts.openai.model',
       'tts.openai.voice',
+      'tts.inworld.model',
+      'tts.inworld.voice',
+      'tts.inworld.output_format',
+      'tts.inworld.sample_rate',
+      'tts.inworld.delivery_mode',
       'tts.elevenlabs.voice_id',
       'tts.elevenlabs.model_id',
       'tts.xai.voice_id',
@@ -580,6 +619,9 @@ export const SECTIONS: DesktopConfigSection[] = [
       'stt.local.model',
       'stt.local.language',
       'stt.openai.model',
+      'stt.inworld.model',
+      'stt.inworld.audio_encoding',
+      'stt.inworld.language',
       'stt.groq.model',
       'stt.mistral.model',
       'stt.elevenlabs.model_id',

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -121,6 +121,7 @@ describe('settings helpers', () => {
   describe('providerGroup', () => {
     it('maps a provider env var to its labeled group', () => {
       expect(providerGroup('XAI_API_KEY')).toBe('xAI')
+      expect(providerGroup('INWORLD_API_KEY')).toBe('Inworld')
       expect(providerGroup('NOUS_API_KEY')).toBe('Nous Portal')
       expect(providerGroup('OPENROUTER_API_KEY')).toBe('OpenRouter')
     })
@@ -149,18 +150,22 @@ describe('settings helpers', () => {
       const opts = enumOptionsFor('tts.provider', 'edge', config)
       expect(opts).toBeDefined()
       expect(opts).toContain('xai')
+      expect(opts).toContain('inworld')
       expect(opts).toContain('edge')
       expect(opts).toContain('elevenlabs')
     })
 
-    it('renders a dropdown for the STT provider including xAI (Grok)', () => {
+    it('renders a dropdown for the STT provider including Inworld and xAI (Grok)', () => {
       const opts = enumOptionsFor('stt.provider', 'local', config)
-      expect(opts).toEqual(['local', 'groq', 'openai', 'mistral', 'xai', 'elevenlabs'])
+      expect(opts).toEqual(['local', 'groq', 'openai', 'inworld', 'mistral', 'xai', 'elevenlabs'])
     })
 
     it('renders dropdowns for per-backend model/device sub-fields', () => {
       expect(enumOptionsFor('stt.openai.model', 'whisper-1', config)).toContain('gpt-4o-transcribe')
+      expect(enumOptionsFor('stt.inworld.model', 'inworld/inworld-stt-1', config)).toContain('inworld/inworld-stt-1')
       expect(enumOptionsFor('tts.openai.model', 'gpt-4o-mini-tts', config)).toContain('tts-1-hd')
+      expect(enumOptionsFor('tts.inworld.model', 'inworld-tts-2', config)).toContain('inworld-tts-1.5-mini')
+      expect(enumOptionsFor('tts.inworld.output_format', 'ogg', config)).toContain('ogg')
       expect(enumOptionsFor('tts.neutts.device', 'cpu', config)).toEqual(['cpu', 'cuda', 'mps'])
     })
 

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -70,7 +70,7 @@ import { UserMessageText } from '@/components/assistant-ui/user-message-text'
 import { useElapsedSeconds } from '@/components/chat/activity-timer'
 import { ActivityTimerText } from '@/components/chat/activity-timer-text'
 import { DisclosureRow } from '@/components/chat/disclosure-row'
-import { GeneratedImage } from '@/components/chat/generated-image-result'
+import { GeneratedImage, GeneratedVideo } from '@/components/chat/generated-image-result'
 import { Intro, type IntroProps } from '@/components/chat/intro'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { Codicon } from '@/components/ui/codicon'
@@ -90,6 +90,7 @@ import { useI18n } from '@/i18n'
 import { attachmentDisplayText, attachmentId, pathLabel } from '@/lib/chat-runtime'
 import { DATA_IMAGE_URL_RE } from '@/lib/embedded-images'
 import { LinkifiedText } from '@/lib/external-link'
+import { generatedImageFromResult, generatedVideoFromResult } from '@/lib/generated-images'
 import { triggerHaptic } from '@/lib/haptics'
 import { GitBranchIcon, Loader2Icon, StopFilled, Volume2Icon, VolumeXIcon, XIcon } from '@/lib/icons'
 import { extractPreviewTargets } from '@/lib/preview-targets'
@@ -518,7 +519,10 @@ const StreamStallIndicator: FC = () => {
   )
 }
 
-const ImageGenerateTool: FC<ToolCallMessagePartProps> = ({ args, result }) => {
+const IMAGE_MEDIA_TOOLS = new Set(['image_generate', 'image_edit', 'remove_background', 'upscale_image'])
+const VIDEO_MEDIA_TOOLS = new Set(['video_generate', 'remove_video_background', 'upscale_video'])
+
+const ImageMediaTool: FC<ToolCallMessagePartProps> = ({ args, result }) => {
   const aspectRatio = typeof args?.aspect_ratio === 'string' ? args.aspect_ratio : undefined
 
   return (
@@ -528,14 +532,27 @@ const ImageGenerateTool: FC<ToolCallMessagePartProps> = ({ args, result }) => {
   )
 }
 
+const VideoMediaTool: FC<ToolCallMessagePartProps> = ({ result }) => (
+  <div className="mt-1.5">
+    <GeneratedVideo result={result} />
+  </div>
+)
+
 const ChainToolFallback: FC<ToolCallMessagePartProps> = props => {
   // todo parts are hoisted to a dedicated panel above the message content.
   if (props.toolName === 'todo') {
     return null
   }
 
-  if (props.toolName === 'image_generate') {
-    return <ImageGenerateTool {...props} />
+  if (
+    IMAGE_MEDIA_TOOLS.has(props.toolName) &&
+    (props.result === undefined || Boolean(generatedImageFromResult(props.result)))
+  ) {
+    return <ImageMediaTool {...props} />
+  }
+
+  if (VIDEO_MEDIA_TOOLS.has(props.toolName) && Boolean(generatedVideoFromResult(props.result))) {
+    return <VideoMediaTool {...props} />
   }
 
   if (props.toolName === 'clarify') {

--- a/apps/desktop/src/components/chat/generated-image-result.tsx
+++ b/apps/desktop/src/components/chat/generated-image-result.tsx
@@ -6,8 +6,15 @@ import { DiffusionCanvas } from '@/components/chat/image-generation-placeholder'
 import { ImageActionButton, ImageLightbox } from '@/components/chat/zoomable-image'
 import { useImageDownload } from '@/hooks/use-image-download'
 import { useI18n } from '@/i18n'
-import { generatedImageFromResult } from '@/lib/generated-images'
-import { filePathFromMediaPath, gatewayMediaDataUrl, isRemoteGateway, mediaExternalUrl, mediaName } from '@/lib/media'
+import { generatedImageFromResult, generatedVideoFromResult } from '@/lib/generated-images'
+import {
+  filePathFromMediaPath,
+  gatewayMediaDataUrl,
+  isRemoteGateway,
+  mediaExternalUrl,
+  mediaName,
+  mediaStreamUrl
+} from '@/lib/media'
 import { cn } from '@/lib/utils'
 
 // Aspect hint from the tool args sizes the frame *before* the image loads, so
@@ -176,5 +183,55 @@ export const GeneratedImage: FC<{ aspectRatio?: string; result?: unknown }> = ({
         />
       )}
     </>
+  )
+}
+
+function resolveVideoSrc(path: string): string {
+  if (/^https?:/i.test(path)) {
+    return path
+  }
+
+  if (isRemoteGateway()) {
+    return mediaExternalUrl(path)
+  }
+
+  return mediaStreamUrl(path)
+}
+
+export const GeneratedVideo: FC<{ result?: unknown }> = ({ result }) => {
+  const { t } = useI18n()
+  const copy = t.desktop
+  const video = result === undefined ? null : generatedVideoFromResult(result)
+
+  if (!video) {
+    return null
+  }
+
+  const src = resolveVideoSrc(video)
+
+  return (
+    <span
+      className="group/video relative mt-1.5 block max-w-full overflow-hidden rounded-2xl border border-(--ui-stroke-tertiary) bg-black"
+      data-slot="aui_generated-video"
+      style={{ width: 'min(var(--image-preview-max-width), 100%)' }}
+    >
+      <video
+        className="block aspect-video max-h-[var(--image-preview-height)] w-full bg-black object-contain"
+        controls
+        playsInline
+        preload="metadata"
+        src={src}
+      />
+      <a
+        className="absolute right-2 top-2 rounded-md border border-white/20 bg-black/60 px-2 py-1 text-[0.68rem] font-medium text-white/90 opacity-0 backdrop-blur-sm transition-opacity hover:bg-black/75 group-hover/video:opacity-100 focus-visible:opacity-100"
+        href="#"
+        onClick={event => {
+          event.preventDefault()
+          void window.hermesDesktop?.openExternal(mediaExternalUrl(video))
+        }}
+      >
+        {copy.openImage}: {mediaName(video)}
+      </a>
+    </span>
   )
 }

--- a/apps/desktop/src/lib/generated-images.test.ts
+++ b/apps/desktop/src/lib/generated-images.test.ts
@@ -4,6 +4,7 @@ import {
   dedupeGeneratedImageEchoesInParts,
   generatedImageEchoSources,
   generatedImageFromResult,
+  generatedVideoFromResult,
   stripGeneratedImageEchoes
 } from './generated-images'
 
@@ -21,6 +22,18 @@ describe('generatedImageFromResult', () => {
 
   it('ignores failed image generation results', () => {
     expect(generatedImageFromResult({ image: 'https://cdn.example/cat.png', success: false })).toBeNull()
+  })
+})
+
+describe('generatedVideoFromResult', () => {
+  it('returns the video output URL from successful media tool results', () => {
+    expect(generatedVideoFromResult({ media_type: 'video', output_url: 'https://cdn.example/out.mp4', success: true })).toBe(
+      'https://cdn.example/out.mp4'
+    )
+  })
+
+  it('ignores failed video results so the generic error row can render', () => {
+    expect(generatedVideoFromResult({ error: 'No backend configured', success: false, video: null })).toBeNull()
   })
 })
 
@@ -56,6 +69,23 @@ describe('generatedImageEchoSources', () => {
         }
       ])
     ).toEqual(['/host/cat.png', '/sandbox/cat.png'])
+  })
+
+  it('collects media URLs from new FAL utility tool results', () => {
+    expect(
+      generatedImageEchoSources([
+        {
+          result: { image: 'https://cdn.example/edited.png', output_url: 'https://cdn.example/edited.png', success: true },
+          toolName: 'image_edit',
+          type: 'tool-call'
+        },
+        {
+          result: { output_url: 'https://cdn.example/upscaled.mp4', success: true, video: 'https://cdn.example/upscaled.mp4' },
+          toolName: 'upscale_video',
+          type: 'tool-call'
+        }
+      ])
+    ).toEqual(['https://cdn.example/edited.png', 'https://cdn.example/upscaled.mp4'])
   })
 })
 

--- a/apps/desktop/src/lib/generated-images.ts
+++ b/apps/desktop/src/lib/generated-images.ts
@@ -12,8 +12,11 @@ type TextLike = {
 // Path-ish result fields the model may echo into its prose. Display prefers the
 // host path (gateway-deliverable); stripping must catch every variant so a
 // sandbox path the model restated doesn't slip through as a duplicate image.
-const DISPLAY_KEYS = ['host_image', 'image'] as const
-const ECHO_KEYS = ['host_image', 'image', 'agent_visible_image'] as const
+const IMAGE_TOOL_NAMES = new Set(['image_generate', 'image_edit', 'remove_background', 'upscale_image'])
+const VIDEO_TOOL_NAMES = new Set(['video_generate', 'remove_video_background', 'upscale_video'])
+
+const IMAGE_DISPLAY_KEYS = ['host_image', 'image', 'output_url'] as const
+const ECHO_KEYS = ['host_image', 'image', 'video', 'url', 'output_url', 'agent_visible_image'] as const
 
 function recordFromUnknown(value: unknown): Record<string, unknown> | null {
   if (value && typeof value === 'object' && !Array.isArray(value)) {
@@ -45,8 +48,12 @@ function unique(values: string[]): string[] {
   return [...new Set(values.filter(Boolean))]
 }
 
-function imageResult(part: ToolLike): Record<string, unknown> | null {
-  if (part.type !== 'tool-call' || part.toolName !== 'image_generate') {
+function mediaResult(part: ToolLike): Record<string, unknown> | null {
+  if (
+    part.type !== 'tool-call' ||
+    typeof part.toolName !== 'string' ||
+    (!IMAGE_TOOL_NAMES.has(part.toolName) && !VIDEO_TOOL_NAMES.has(part.toolName))
+  ) {
     return null
   }
 
@@ -63,12 +70,22 @@ export function generatedImageFromResult(result: unknown): string | null {
     return null
   }
 
-  return stringFields(record, DISPLAY_KEYS)[0] ?? null
+  return stringFields(record, IMAGE_DISPLAY_KEYS)[0] ?? null
+}
+
+export function generatedVideoFromResult(result: unknown): string | null {
+  const record = recordFromUnknown(result)
+
+  if (!record || record.success === false) {
+    return null
+  }
+
+  return stringFields(record, ['video', 'output_url', 'url'])[0] ?? null
 }
 
 /** Every path/URL a generated image might appear as in prose, for de-duping. */
 export function generatedImageEchoSources(parts: readonly ToolLike[]): string[] {
-  return unique(parts.flatMap(part => stringFields(imageResult(part) ?? {}, ECHO_KEYS)))
+  return unique(parts.flatMap(part => stringFields(mediaResult(part) ?? {}, ECHO_KEYS)))
 }
 
 /** Strip a generated image out of prose so it only ever shows in the tool slot.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1890,10 +1890,11 @@ DEFAULT_CONFIG = {
     # Text-to-speech configuration
     # Each provider supports an optional `max_text_length:` override for the
     # per-request input-character cap. Omit it to use the provider's documented
-    # limit (OpenAI 4096, xAI 15000, MiniMax 10000, ElevenLabs 5k-40k model-aware,
-    # Gemini 32000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS 2000).
+    # limit (OpenAI 4096, xAI 15000, MiniMax 10000, Inworld 10000,
+    # ElevenLabs 5k-40k model-aware, Gemini 32000, Edge 5000, Mistral 4000,
+    # NeuTTS/KittenTTS 2000).
     "tts": {
-        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "neutts" (local) | "kittentts" (local) | "piper" (local)
+        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "inworld" | "xai" | "minimax" | "mistral" | "gemini" | "neutts" (local) | "kittentts" (local) | "piper" (local)
         "edge": {
             "voice": "en-US-AriaNeural",
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
@@ -1906,6 +1907,13 @@ DEFAULT_CONFIG = {
             "model": "gpt-4o-mini-tts",
             "voice": "alloy",
             # Voices: alloy, echo, fable, onyx, nova, shimmer
+        },
+        "inworld": {
+            "model": "inworld-tts-2",
+            "voice": "Dennis",
+            "output_format": "ogg",
+            "sample_rate": 48000,
+            "delivery_mode": "BALANCED",
         },
         "gemini": {
             "model": "gemini-2.5-flash-preview-tts",
@@ -1953,7 +1961,7 @@ DEFAULT_CONFIG = {
     
     "stt": {
         "enabled": True,
-        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe)
+        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "inworld" | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe)
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
@@ -1969,6 +1977,35 @@ DEFAULT_CONFIG = {
             "language_code": "",  # auto-detect by default; set to "eng", "spa", "fra", etc. to force
             "tag_audio_events": False,
             "diarize": False,
+        },
+        "inworld": {
+            "model": "inworld/inworld-stt-1",
+            "audio_encoding": "AUTO_DETECT",
+            "language": "",
+        },
+    },
+
+    "realtime": {
+        "provider": "openai",  # "openai" | "inworld"; currently used by Google Meet realtime mode
+        "openai": {
+            "model": "gpt-realtime",
+            "voice": "alloy",
+            "instructions": "",
+        },
+        "inworld": {
+            "model": "openai/gpt-4o-mini",
+            "tts_model": "inworld-tts-1.5-mini",
+            "stt_model": "inworld/inworld-stt-1",
+            "voice": "Dennis",
+            "language": "",
+            "instructions": "",
+            "turn_detection": {
+                "type": "semantic_vad",
+                "eagerness": "medium",
+                "create_response": True,
+                "interrupt_response": True,
+            },
+            "provider_data": {},
         },
     },
 
@@ -3055,6 +3092,14 @@ OPTIONAL_ENV_VARS = {
         "prompt": "xAI base URL (leave empty for default)",
         "url": None,
         "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "INWORLD_API_KEY": {
+        "description": "Inworld API key for speech-to-text, text-to-speech, and realtime voice",
+        "prompt": "Inworld API key",
+        "url": "https://platform.inworld.ai/api-keys",
+        "password": True,
         "category": "provider",
         "advanced": True,
     },

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -66,7 +66,12 @@ CONFIGURABLE_TOOLSETS = [
     ("vision",          "👁️  Vision / Image Analysis",  "vision_analyze"),
     ("video",           "🎬 Video Analysis",            "video_analyze (requires video-capable model)"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),
+    ("image_edit",      "🖌️  Image Editing",            "image_edit (FAL Gemini image edit)"),
+    ("image_background_removal", "🧵 Image Background Removal", "remove_background (FAL Ideogram + BiRefNet)"),
+    ("image_upscale",   "💎 Image Upscaling",           "upscale_image (FAL SeedVR2)"),
     ("video_gen",       "🎬 Video Generation",          "video_generate (text-to-video + image-to-video)"),
+    ("video_background_removal", "🎥 Video Background Removal", "remove_video_background (FAL BiRefNet)"),
+    ("video_upscale",   "📼 Video Upscaling",           "upscale_video (FAL SeedVR2)"),
     ("x_search",        "🐦 X (Twitter) Search",        "x_search (requires xAI OAuth or XAI_API_KEY)"),
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
     ("skills",          "📚 Skills",                    "list, view, manage"),
@@ -116,6 +121,39 @@ def gui_toolset_label(label: str) -> str:
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
 _DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+
+
+_FAL_MEDIA_UTILITY_TOOLSETS = {
+    "image_edit",
+    "image_background_removal",
+    "image_upscale",
+    "video_background_removal",
+    "video_upscale",
+}
+
+
+def _fal_media_backend_available() -> bool:
+    """Return True when direct or managed FAL access is available.
+
+    These utility tools are implemented as in-tree FAL model calls, so they
+    must not be marked configured merely because a non-FAL image_gen plugin is
+    available.
+    """
+    try:
+        from tools.image_generation_tool import check_fal_api_key
+
+        return bool(check_fal_api_key())
+    except Exception:
+        return bool(fal_key_is_configured())
+
+
+def _toolset_has_configuration_surface(ts_key: str) -> bool:
+    """Return True if enabling this toolset should be allowed to open setup."""
+    return (
+        ts_key in TOOL_CATEGORIES
+        or ts_key in TOOLSET_ENV_REQUIREMENTS
+        or ts_key in _FAL_MEDIA_UTILITY_TOOLSETS
+    )
 
 
 def _xai_credentials_present() -> bool:
@@ -1759,6 +1797,9 @@ def _toolset_has_keys(
         except Exception:
             return False
 
+    if ts_key in _FAL_MEDIA_UTILITY_TOOLSETS:
+        return _fal_media_backend_available()
+
     if ts_key in {"web", "image_gen", "video_gen", "tts", "browser"}:
         features = get_nous_subscription_features(config, force_fresh=force_fresh)
         feature = features.features.get(ts_key)
@@ -1865,7 +1906,7 @@ def _prompt_toolset_checklist(
         suffix = ""
         if (
             not _toolset_has_keys(ts_key, force_fresh=force_fresh)
-            and (TOOL_CATEGORIES.get(ts_key) or TOOLSET_ENV_REQUIREMENTS.get(ts_key))
+            and _toolset_has_configuration_surface(ts_key)
         ):
             suffix = "  [no API key]"
         labels.append(f"{ts_label}  ({ts_desc}){suffix}")
@@ -1913,6 +1954,10 @@ def _configure_toolset(
     Uses TOOL_CATEGORIES for provider-aware config, falls back to simple
     env var prompts for toolsets not in TOOL_CATEGORIES.
     """
+    if ts_key in _FAL_MEDIA_UTILITY_TOOLSETS:
+        _configure_toolset("image_gen", config, force_fresh=force_fresh)
+        return
+
     cat = TOOL_CATEGORIES.get(ts_key)
 
     if cat:
@@ -2310,6 +2355,9 @@ def _toolset_needs_configuration_prompt(
     force_fresh: bool = False,
 ) -> bool:
     """Return True when enabling this toolset should open provider setup."""
+    if ts_key in _FAL_MEDIA_UTILITY_TOOLSETS:
+        return not _fal_media_backend_available()
+
     cat = TOOL_CATEGORIES.get(ts_key)
     if not cat:
         return not _toolset_has_keys(ts_key, config, force_fresh=force_fresh)
@@ -3337,7 +3385,7 @@ def _reconfigure_tool(
     for ts_key, ts_label, _ in _get_effective_configurable_toolsets():
         cat = TOOL_CATEGORIES.get(ts_key)
         reqs = TOOLSET_ENV_REQUIREMENTS.get(ts_key)
-        if cat or reqs:
+        if cat or reqs or ts_key in _FAL_MEDIA_UTILITY_TOOLSETS:
             if (
                 _toolset_has_keys(ts_key, config, force_fresh=force_fresh)
                 or _toolset_enabled_for_reconfigure(ts_key, config)
@@ -3359,7 +3407,9 @@ def _reconfigure_tool(
     ts_key, ts_label = configurable[idx]
     cat = TOOL_CATEGORIES.get(ts_key)
 
-    if cat:
+    if ts_key in _FAL_MEDIA_UTILITY_TOOLSETS:
+        _configure_toolset(ts_key, config, force_fresh=force_fresh)
+    elif cat:
         _configure_tool_category_for_reconfig(
             ts_key,
             cat,
@@ -3725,7 +3775,7 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
             # a free provider exists.
             to_configure = [
                 ts_key for ts_key in sorted(new_enabled)
-                if (TOOL_CATEGORIES.get(ts_key) or TOOLSET_ENV_REQUIREMENTS.get(ts_key))
+                if _toolset_has_configuration_surface(ts_key)
                 and ts_key not in auto_configured
             ]
 
@@ -3826,7 +3876,7 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
                             print(color(f"    - {label}", Colors.RED))
                     # Configure API keys for newly enabled tools
                     for ts_key in sorted(added):
-                        if (TOOL_CATEGORIES.get(ts_key) or TOOLSET_ENV_REQUIREMENTS.get(ts_key)):
+                        if _toolset_has_configuration_surface(ts_key):
                             if _toolset_needs_configuration_prompt(
                                 ts_key,
                                 config,
@@ -3878,7 +3928,7 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
 
             # Configure newly enabled toolsets that need API keys
             for ts_key in sorted(added):
-                if (TOOL_CATEGORIES.get(ts_key) or TOOLSET_ENV_REQUIREMENTS.get(ts_key)):
+                if _toolset_has_configuration_surface(ts_key):
                     if _toolset_needs_configuration_prompt(
                         ts_key,
                         config,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -557,14 +557,14 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "tts.provider": {
         "type": "select",
         "description": "Text-to-speech provider",
-        "options": ["edge", "elevenlabs", "openai", "neutts"],
+        "options": ["edge", "elevenlabs", "openai", "inworld", "neutts"],
     },
     "stt.provider": {
         "type": "select",
         "description": "Speech-to-text provider",
         # "mistral" temporarily removed — mistralai PyPI package quarantined
         # (malicious 2.4.6 release on 2026-05-12). Restore once available.
-        "options": ["local", "groq", "openai", "xai", "elevenlabs"],
+        "options": ["local", "groq", "openai", "xai", "elevenlabs", "inworld"],
     },
     "stt.elevenlabs.model_id": {
         "type": "select",

--- a/plugins/google_meet/README.md
+++ b/plugins/google_meet/README.md
@@ -8,7 +8,7 @@ in it, and do the followup work afterwards.
 | Version | What | Status |
 |---|---|---|
 | v1 | Transcribe-only: Playwright joins Meet, scrapes captions to transcript file | ✓ ships by default |
-| v2 | Realtime duplex audio: bot speaks in-call via OpenAI Realtime + BlackHole/PulseAudio null-sink | ✓ opt in with `mode='realtime'` |
+| v2 | Realtime duplex audio: bot speaks in-call via OpenAI or Inworld Realtime + BlackHole/PulseAudio null-sink | ✓ opt in with `mode='realtime'` |
 | v3 | Remote node host: run the bot on a different machine than the gateway | ✓ opt in with `node='<name>'` |
 
 ## Architecture
@@ -34,7 +34,7 @@ in it, and do the followup work afterwards.
 │        ├─ caption scraper → transcript.txt                           │
 │        └─ (realtime mode only) RealtimeSpeaker thread                │
 │             ↓                                                        │
-│           OpenAI Realtime WS → speaker.pcm                           │
+│           Realtime provider WS → speaker.pcm                         │
 │             ↓                                                        │
 │           paplay → null-sink ← Chrome fake mic                       │
 │                                                                      │
@@ -82,6 +82,22 @@ echo 'OPENAI_API_KEY=sk-...' >> ~/.hermes/.env
 hermes meet join https://meet.google.com/abc-defg-hij --mode realtime
 # then from the agent or CLI:
 hermes meet say "Good morning everyone, I'm the note-taker bot."
+```
+
+Inworld realtime uses the same audio bridge and `meet_say` queue. Put the secret in `.env` and provider behavior in `config.yaml`:
+
+```bash
+echo 'INWORLD_API_KEY=...' >> ~/.hermes/.env
+```
+
+```yaml
+realtime:
+  provider: inworld
+  inworld:
+    model: openai/gpt-4o-mini
+    tts_model: inworld-tts-1.5-mini
+    stt_model: inworld/inworld-stt-1
+    voice: Dennis
 ```
 
 macOS:

--- a/plugins/google_meet/SKILL.md
+++ b/plugins/google_meet/SKILL.md
@@ -27,9 +27,9 @@ The user says any of:
 | Mode | What the bot does |
 |---|---|
 | `transcribe` (default) | Joins, enables captions, scrapes a transcript. Listen-only. |
-| `realtime` | Same as transcribe PLUS speaks into the meeting via OpenAI Realtime. The agent calls `meet_say(text)` and the bot's voice comes out of the call. |
+| `realtime` | Same as transcribe PLUS speaks into the meeting via the configured realtime provider. The agent calls `meet_say(text)` and the bot's voice comes out of the call. |
 
-Pick `realtime` only when the user actually wants the agent to speak. It costs real money (OpenAI Realtime is pay-per-audio-minute) and requires a virtual audio device set up on the machine running the bot.
+Pick `realtime` only when the user actually wants the agent to speak. It costs real money and requires a virtual audio device set up on the machine running the bot.
 
 ## Two locations
 
@@ -63,7 +63,26 @@ pip install playwright websockets && python -m playwright install chromium
 #   Linux:  sudo apt install pulseaudio-utils
 #   macOS:  brew install blackhole-2ch ffmpeg
 #           → System Settings → Sound → Input → BlackHole 2ch
-#   Then set OPENAI_API_KEY or HERMES_MEET_REALTIME_KEY in ~/.hermes/.env
+#   Then set OPENAI_API_KEY, INWORLD_API_KEY, or HERMES_MEET_REALTIME_KEY in ~/.hermes/.env
+```
+
+Realtime provider selection lives in `~/.hermes/config.yaml`:
+
+```yaml
+realtime:
+  provider: openai       # or: inworld
+```
+
+For Inworld:
+
+```yaml
+realtime:
+  provider: inworld
+  inworld:
+    model: openai/gpt-4o-mini
+    tts_model: inworld-tts-1.5-mini
+    stt_model: inworld/inworld-stt-1
+    voice: Dennis
 ```
 
 For a remote node:
@@ -111,7 +130,7 @@ Run `hermes meet setup` to preflight local prereqs.
 - **Windows not supported.**
 - Realtime mode needs a virtual audio device. If the audio bridge setup fails, the bot falls back to transcribe mode and flags it in `meet_status().error`.
 - `meet_say` requires `mode='realtime'` on the originating `meet_join`. Calling it against a transcribe-mode meeting returns a clear error.
-- **Barge-in is best-effort.** When a caption arrives attributed to a real participant while the bot is generating audio, the bot sends `response.cancel` to OpenAI Realtime. Captions take ~500ms to show up, so the bot will talk over the first second or so of a human interruption.
+- **Barge-in is best-effort.** When a caption arrives attributed to a real participant while the bot is generating audio, the bot sends `response.cancel` to the realtime provider. Captions take ~500ms to show up, so the bot will talk over the first second or so of a human interruption.
 
 ## Status dict reference
 
@@ -126,7 +145,7 @@ Run `hermes meet setup` to preflight local prereqs.
 | `transcriptLines` / `lastCaptionAt` | Transcript progress. |
 | `realtime` / `realtimeReady` | Realtime mode provisioned / WS connected. |
 | `realtimeDevice` | Audio device name the bot is feeding (e.g. `hermes_meet_src`). |
-| `audioBytesOut` / `lastAudioOutAt` | How much PCM the OpenAI session has produced. |
+| `audioBytesOut` / `lastAudioOutAt` | How much PCM the realtime session has produced. |
 | `lastBargeInAt` | Timestamp of the most recent `response.cancel` sent. |
 | `leaveReason` | `duration_expired`, `lobby_timeout`, `denied`, `page_closed`, or null. |
 | `error` | Last error (soft — bot may still be running). |

--- a/plugins/google_meet/meet_bot.py
+++ b/plugins/google_meet/meet_bot.py
@@ -36,7 +36,7 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 # Match ``https://meet.google.com/abc-defg-hij`` or ``.../lookup/...`` — the
 # short three-segment code or a lookup URL. Anything else is rejected.
@@ -262,22 +262,170 @@ def _enable_captions_js() -> str:
     """
 
 
+def _load_hermes_config() -> dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        return cfg if isinstance(cfg, dict) else {}
+    except Exception:
+        return {}
+
+
+def _nested_dict(data: dict[str, Any], *keys: str) -> dict[str, Any]:
+    cur: Any = data
+    for key in keys:
+        if not isinstance(cur, dict):
+            return {}
+        cur = cur.get(key)
+    return cur if isinstance(cur, dict) else {}
+
+
+def _env_or_config(
+    env_name: str,
+    cfg: dict[str, Any],
+    key: str,
+    default: str = "",
+) -> str:
+    value = os.environ.get(env_name)
+    if value is not None:
+        return value
+    cfg_value = cfg.get(key)
+    return str(cfg_value) if cfg_value is not None else default
+
+
+def _get_realtime_api_key(provider: str) -> str:
+    explicit = os.environ.get("HERMES_MEET_REALTIME_KEY")
+    if explicit:
+        return explicit
+    if provider == "inworld":
+        try:
+            from hermes_cli.config import get_env_value
+
+            return get_env_value("INWORLD_API_KEY") or ""
+        except Exception:
+            return os.environ.get("INWORLD_API_KEY", "")
+    return os.environ.get("OPENAI_API_KEY", "")
+
+
+def _load_realtime_settings() -> dict[str, Any]:
+    cfg = _load_hermes_config()
+    realtime_cfg = _nested_dict(cfg, "realtime")
+    provider = (
+        os.environ.get("HERMES_MEET_REALTIME_PROVIDER")
+        or realtime_cfg.get("provider")
+        or "openai"
+    )
+    provider = str(provider).strip().lower() or "openai"
+
+    if provider == "inworld":
+        inworld_cfg = _nested_dict(realtime_cfg, "inworld")
+        provider_data = (
+            inworld_cfg.get("provider_data")
+            or inworld_cfg.get("providerData")
+            or {}
+        )
+        if not isinstance(provider_data, dict):
+            provider_data = {}
+        turn_detection = inworld_cfg.get("turn_detection") or {}
+        if not isinstance(turn_detection, dict):
+            turn_detection = {}
+        return {
+            "provider": "inworld",
+            "model": _env_or_config(
+                "HERMES_MEET_REALTIME_MODEL",
+                inworld_cfg,
+                "model",
+                "openai/gpt-4o-mini",
+            ),
+            "voice": _env_or_config(
+                "HERMES_MEET_REALTIME_VOICE",
+                inworld_cfg,
+                "voice",
+                "Dennis",
+            ),
+            "instructions": _env_or_config(
+                "HERMES_MEET_REALTIME_INSTRUCTIONS",
+                inworld_cfg,
+                "instructions",
+                "",
+            ),
+            "tts_model": _env_or_config(
+                "HERMES_MEET_REALTIME_TTS_MODEL",
+                inworld_cfg,
+                "tts_model",
+                "inworld-tts-1.5-mini",
+            ),
+            "stt_model": _env_or_config(
+                "HERMES_MEET_REALTIME_STT_MODEL",
+                inworld_cfg,
+                "stt_model",
+                "inworld/inworld-stt-1",
+            ),
+            "language": _env_or_config(
+                "HERMES_MEET_REALTIME_LANGUAGE",
+                inworld_cfg,
+                "language",
+                "",
+            ),
+            "turn_detection": turn_detection,
+            "provider_data": provider_data,
+            "api_key": _get_realtime_api_key("inworld"),
+        }
+
+    openai_cfg = _nested_dict(realtime_cfg, "openai")
+    return {
+        "provider": "openai",
+        "model": _env_or_config(
+            "HERMES_MEET_REALTIME_MODEL",
+            openai_cfg,
+            "model",
+            "gpt-realtime",
+        ),
+        "voice": _env_or_config(
+            "HERMES_MEET_REALTIME_VOICE",
+            openai_cfg,
+            "voice",
+            "alloy",
+        ),
+        "instructions": _env_or_config(
+            "HERMES_MEET_REALTIME_INSTRUCTIONS",
+            openai_cfg,
+            "instructions",
+            "",
+        ),
+        "tts_model": "",
+        "stt_model": "",
+        "language": "",
+        "turn_detection": {},
+        "provider_data": {},
+        "api_key": _get_realtime_api_key("openai"),
+    }
+
+
 def _start_realtime_speaker(
     *,
     rt: dict,
     out_dir: Path,
     bridge_info: dict,
     api_key: str,
+    provider: str,
     model: str,
     voice: str,
     instructions: str,
+    tts_model: str,
+    stt_model: str,
+    language: str,
+    turn_detection: dict,
+    provider_data: dict,
+    session_id: str,
     stop_flag: dict,
     state: "_BotState",
 ) -> None:
-    """Wire up the OpenAI Realtime session + speaker thread + PCM pump.
+    """Wire up the realtime session + speaker thread + PCM pump.
 
     The speaker thread reads text lines from ``say_queue.jsonl``, sends each
-    to OpenAI Realtime, and writes PCM audio into ``speaker.pcm``. A
+    to the realtime provider, and writes PCM audio into ``speaker.pcm``. A
     separate *pump* thread forwards that PCM into the OS audio sink so
     Chrome's fake mic picks it up. On Linux we pipe to ``paplay`` against
     the null-sink; on macOS the caller is expected to have the BlackHole
@@ -309,6 +457,13 @@ def _start_realtime_speaker(
             instructions=instructions,
             audio_sink_path=pcm_path,
             sample_rate=24000,
+            provider=provider,
+            tts_model=tts_model,
+            stt_model=stt_model,
+            language=language,
+            turn_detection=turn_detection,
+            provider_data=provider_data,
+            session_id=session_id,
         )
         session.connect()
     except Exception as e:
@@ -453,10 +608,12 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
     duration_s = _parse_duration(os.environ.get("HERMES_MEET_DURATION", ""))
     # v2: optional realtime mode. Enabled when HERMES_MEET_MODE=realtime.
     mode = os.environ.get("HERMES_MEET_MODE", "transcribe").strip().lower()
-    realtime_model = os.environ.get("HERMES_MEET_REALTIME_MODEL", "gpt-realtime")
-    realtime_voice = os.environ.get("HERMES_MEET_REALTIME_VOICE", "alloy")
-    realtime_instructions = os.environ.get("HERMES_MEET_REALTIME_INSTRUCTIONS", "")
-    realtime_api_key = os.environ.get("HERMES_MEET_REALTIME_KEY") or os.environ.get("OPENAI_API_KEY", "")
+    realtime = _load_realtime_settings()
+    realtime_provider = str(realtime.get("provider") or "openai")
+    realtime_model = str(realtime.get("model") or "")
+    realtime_voice = str(realtime.get("voice") or "")
+    realtime_instructions = str(realtime.get("instructions") or "")
+    realtime_api_key = str(realtime.get("api_key") or "")
 
     if not url or not _is_safe_meet_url(url):
         sys.stderr.write(
@@ -497,7 +654,17 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
     }
     if rt["enabled"]:
         if not realtime_api_key:
-            state.set(error="realtime mode requested but no API key in HERMES_MEET_REALTIME_KEY/OPENAI_API_KEY — falling back to transcribe")
+            key_hint = (
+                "HERMES_MEET_REALTIME_KEY/INWORLD_API_KEY"
+                if realtime_provider == "inworld"
+                else "HERMES_MEET_REALTIME_KEY/OPENAI_API_KEY"
+            )
+            state.set(
+                error=(
+                    f"realtime mode requested but no API key in {key_hint} "
+                    "— falling back to transcribe"
+                )
+            )
             rt["enabled"] = False
         else:
             try:
@@ -596,9 +763,16 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
                     out_dir=out_dir,
                     bridge_info=rt["bridge_info"],
                     api_key=realtime_api_key,
+                    provider=realtime_provider,
                     model=realtime_model,
                     voice=realtime_voice,
                     instructions=realtime_instructions,
+                    tts_model=str(realtime.get("tts_model") or ""),
+                    stt_model=str(realtime.get("stt_model") or ""),
+                    language=str(realtime.get("language") or ""),
+                    turn_detection=dict(realtime.get("turn_detection") or {}),
+                    provider_data=dict(realtime.get("provider_data") or {}),
+                    session_id=meeting_id,
                     stop_flag=stop_flag,
                     state=state,
                 )

--- a/plugins/google_meet/realtime/openai_client.py
+++ b/plugins/google_meet/realtime/openai_client.py
@@ -1,9 +1,9 @@
-"""OpenAI Realtime API WebSocket client + file-queue speaker.
+"""Realtime API WebSocket client + file-queue speaker.
 
 This module is the "output" side of the v2 voice bridge: it takes text,
-sends it to the OpenAI Realtime API, receives audio deltas back, and
-appends the PCM bytes to a file. A separate consumer (the audio
-bridge) streams that file into Chrome's fake microphone.
+sends it to the configured Realtime API provider, receives audio deltas
+back, and appends the PCM bytes to a file. A separate consumer (the
+audio bridge) streams that file into Chrome's fake microphone.
 
 Designed for simplicity: a single synchronous WebSocket connection per
 speaker, per session. The ``websockets`` package is imported lazily so
@@ -19,9 +19,11 @@ import time
 import uuid
 from pathlib import Path
 from typing import Any, Callable, Optional
+from urllib.parse import quote
 
 
 REALTIME_URL = "wss://api.openai.com/v1/realtime"
+INWORLD_REALTIME_URL = "wss://api.inworld.ai/api/v1/realtime/session"
 
 
 def _require_websockets():
@@ -30,14 +32,14 @@ def _require_websockets():
         from websockets.sync.client import connect as _connect  # type: ignore
     except ImportError as exc:  # pragma: no cover - exercised via test
         raise RuntimeError(
-            "websockets package is required for OpenAI Realtime; "
+            "websockets package is required for realtime voice; "
             "install with: pip install websockets"
         ) from exc
     return _connect
 
 
 class RealtimeSession:
-    """Minimal sync client for the OpenAI Realtime WebSocket API.
+    """Minimal sync client for realtime voice WebSocket APIs.
 
     Usage:
         sess = RealtimeSession(api_key=..., audio_sink_path=Path("out.pcm"))
@@ -57,6 +59,13 @@ class RealtimeSession:
         instructions: str = "",
         audio_sink_path: Optional[Path] = None,
         sample_rate: int = 24000,
+        provider: str = "openai",
+        tts_model: str = "",
+        stt_model: str = "",
+        language: str = "",
+        turn_detection: Optional[dict] = None,
+        provider_data: Optional[dict] = None,
+        session_id: Optional[str] = None,
     ) -> None:
         import threading as _threading
         self.api_key = api_key
@@ -65,6 +74,13 @@ class RealtimeSession:
         self.instructions = instructions
         self.audio_sink_path = Path(audio_sink_path) if audio_sink_path else None
         self.sample_rate = sample_rate
+        self.provider = (provider or "openai").strip().lower()
+        self.tts_model = tts_model
+        self.stt_model = stt_model
+        self.language = language
+        self.turn_detection = dict(turn_detection or {})
+        self.provider_data = dict(provider_data or {})
+        self.session_id = session_id or f"hermes-meet-{uuid.uuid4().hex}"
         self._ws: Any = None
         self._send_lock = _threading.Lock()
         self._last_response_id: Optional[str] = None
@@ -77,11 +93,16 @@ class RealtimeSession:
     def connect(self) -> None:
         """Open WS and send session.update with voice+instructions."""
         connect = _require_websockets()
-        url = f"{REALTIME_URL}?model={self.model}"
-        headers = [
-            ("Authorization", f"Bearer {self.api_key}"),
-            ("OpenAI-Beta", "realtime=v1"),
-        ]
+        if self.provider == "inworld":
+            sid = quote(self.session_id, safe="")
+            url = f"{INWORLD_REALTIME_URL}?key={sid}&protocol=realtime"
+            headers = [("Authorization", f"Basic {self.api_key}")]
+        else:
+            url = f"{REALTIME_URL}?model={self.model}"
+            headers = [
+                ("Authorization", f"Bearer {self.api_key}"),
+                ("OpenAI-Beta", "realtime=v1"),
+            ]
         # websockets.sync.client.connect accepts either additional_headers=
         # (newer) or extra_headers= depending on version; try the newer
         # name first and fall back.
@@ -90,8 +111,11 @@ class RealtimeSession:
         except TypeError:
             self._ws = connect(url, extra_headers=headers)
 
-        self._send_json(
-            {
+        self._send_json(self._session_update_payload())
+
+    def _session_update_payload(self) -> dict:
+        if self.provider != "inworld":
+            return {
                 "type": "session.update",
                 "session": {
                     "voice": self.voice,
@@ -101,7 +125,45 @@ class RealtimeSession:
                     "input_audio_format": "pcm16",
                 },
             }
-        )
+
+        turn_detection = {
+            "type": "semantic_vad",
+            "eagerness": "medium",
+            "create_response": True,
+            "interrupt_response": True,
+        }
+        turn_detection.update(self.turn_detection)
+        transcription: dict[str, Any] = {}
+        if self.stt_model:
+            transcription["model"] = self.stt_model
+        if self.language:
+            transcription["language"] = self.language
+        provider_data = dict(self.provider_data)
+        audio_input = {
+            "format": {"type": "audio/pcm", "rate": self.sample_rate},
+            "turn_detection": turn_detection,
+        }
+        if transcription:
+            audio_input["transcription"] = transcription
+        audio_output = {
+            "format": {"type": "audio/pcm", "rate": self.sample_rate},
+            "voice": self.voice,
+        }
+        if self.tts_model:
+            audio_output["model"] = self.tts_model
+        session = {
+            "type": "realtime",
+            "model": self.model,
+            "instructions": self.instructions,
+            "output_modalities": ["audio", "text"],
+            "audio": {
+                "input": audio_input,
+                "output": audio_output,
+            },
+        }
+        if provider_data:
+            session["providerData"] = provider_data
+        return {"type": "session.update", "session": session}
 
     def close(self) -> None:
         if self._ws is not None:
@@ -166,7 +228,7 @@ class RealtimeSession:
                 if not isinstance(frame, dict):
                     continue
                 ftype = frame.get("type")
-                if ftype == "response.audio.delta":
+                if ftype in {"response.audio.delta", "response.output_audio.delta"}:
                     b64 = frame.get("delta") or frame.get("audio") or ""
                     if b64 and sink_fp is not None:
                         try:
@@ -183,7 +245,12 @@ class RealtimeSession:
                     rid = (frame.get("response") or {}).get("id")
                     if rid:
                         self._last_response_id = rid
-                elif ftype in {"response.done", "response.completed", "response.cancelled"}:
+                elif ftype in {
+                    "response.done",
+                    "response.completed",
+                    "response.cancelled",
+                    "response.output_audio.done",
+                }:
                     break
                 elif ftype == "error":
                     err = frame.get("error") or frame

--- a/plugins/inworld/__init__.py
+++ b/plugins/inworld/__init__.py
@@ -1,0 +1,477 @@
+"""Inworld bundled backend plugin.
+
+Provides Text-to-Speech and Speech-to-Text providers selected with
+``tts.provider: inworld`` and ``stt.provider: inworld``.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.transcription_provider import TranscriptionProvider
+from agent.tts_provider import TTSProvider
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://api.inworld.ai"
+DEFAULT_TTS_MODEL = "inworld-tts-2"
+DEFAULT_TTS_VOICE = "Dennis"
+DEFAULT_TTS_FORMAT = "ogg"
+DEFAULT_TTS_SAMPLE_RATE = 48000
+DEFAULT_TTS_DELIVERY_MODE = "BALANCED"
+DEFAULT_STT_MODEL = "inworld/inworld-stt-1"
+DEFAULT_STT_ENCODING = "AUTO_DETECT"
+DEFAULT_STT_SAMPLE_RATE = 16000
+DEFAULT_STT_CHANNELS = 1
+
+_TTS_MODELS = [
+    {
+        "id": "inworld-tts-2",
+        "display": "Inworld TTS-2",
+        "languages": ["100+"],
+        "max_text_length": 10000,
+    },
+    {
+        "id": "inworld-tts-1.5-max",
+        "display": "Inworld TTS 1.5 Max",
+        "languages": [
+            "en", "zh", "ja", "ko", "ru", "it", "es", "pt", "fr", "de",
+            "pl", "nl", "hi", "he", "ar",
+        ],
+        "max_text_length": 10000,
+    },
+    {
+        "id": "inworld-tts-1.5-mini",
+        "display": "Inworld TTS 1.5 Mini",
+        "languages": [
+            "en", "zh", "ja", "ko", "ru", "it", "es", "pt", "fr", "de",
+            "pl", "nl", "hi", "he", "ar",
+        ],
+        "max_text_length": 10000,
+    },
+]
+
+_STT_MODELS = [
+    {"id": "inworld/inworld-stt-1", "display": "Inworld STT 1", "languages": ["30+"]},
+    {"id": "groq/whisper-large-v3", "display": "Groq Whisper Large v3", "languages": ["100+"]},
+    {
+        "id": "assemblyai/u3-rt-pro",
+        "display": "AssemblyAI Universal-3 Pro Realtime",
+        "languages": ["en", "es", "fr", "de", "it", "pt"],
+    },
+    {
+        "id": "soniox/stt-rt-v4",
+        "display": "Soniox STT RT v4",
+        "languages": ["multilingual"],
+    },
+]
+
+
+def _get_env_value(name: str) -> Optional[str]:
+    try:
+        from hermes_cli.config import get_env_value
+
+        value = get_env_value(name)
+    except Exception:
+        import os
+
+        value = os.environ.get(name)
+    return str(value).strip() if value else None
+
+
+def _load_config_section(section: str) -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        value = cfg.get(section) if isinstance(cfg, dict) else None
+        return value if isinstance(value, dict) else {}
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not load %s config: %s", section, exc)
+        return {}
+
+
+def _provider_cfg(section: str) -> Dict[str, Any]:
+    root = _load_config_section(section)
+    value = root.get("inworld")
+    return value if isinstance(value, dict) else {}
+
+
+def _base_url(section: str) -> str:
+    cfg = _provider_cfg(section)
+    return str(cfg.get("base_url") or DEFAULT_BASE_URL).strip().rstrip("/")
+
+
+def _api_key() -> Optional[str]:
+    return _get_env_value("INWORLD_API_KEY")
+
+
+def _headers() -> Dict[str, str]:
+    key = _api_key()
+    if not key:
+        raise ValueError(
+            "INWORLD_API_KEY is not set. Create one in Inworld Portal and save it in ~/.hermes/.env."
+        )
+    return {
+        "Authorization": f"Basic {key}",
+        "Content-Type": "application/json",
+    }
+
+
+def _require_requests():
+    import requests
+
+    return requests
+
+
+def _coerce_float(value: Any, default: float) -> float:
+    try:
+        if value is None or value == "":
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    try:
+        if value is None or value == "":
+            return default
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _bool_cfg(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on", "enabled"}:
+            return True
+        if normalized in {"0", "false", "no", "off", "disabled"}:
+            return False
+    return default
+
+
+def _audio_encoding_for_format(fmt: str) -> str:
+    key = (fmt or DEFAULT_TTS_FORMAT).lower().strip().lstrip(".")
+    return {
+        "mp3": "MP3",
+        "ogg": "OGG_OPUS",
+        "opus": "OGG_OPUS",
+        "wav": "WAV",
+        "flac": "WAV",
+        "pcm": "PCM",
+    }.get(key, "OGG_OPUS")
+
+
+def _suffix_for_encoding(encoding: str) -> str:
+    return {
+        "MP3": ".mp3",
+        "OGG_OPUS": ".ogg",
+        "WAV": ".wav",
+        "PCM": ".pcm",
+        "LINEAR16": ".wav",
+    }.get(encoding, ".ogg")
+
+
+def _stt_encoding_for_path(file_path: str, configured: str) -> str:
+    cfg = str(configured or DEFAULT_STT_ENCODING).strip().upper()
+    if cfg and cfg != "AUTO":
+        return cfg
+    suffix = Path(file_path).suffix.lower()
+    return {
+        ".mp3": "MP3",
+        ".ogg": "OGG_OPUS",
+        ".opus": "OGG_OPUS",
+        ".flac": "FLAC",
+        ".wav": "LINEAR16",
+        ".pcm": "LINEAR16",
+    }.get(suffix, "AUTO_DETECT")
+
+
+def _error_message(response: Any) -> str:
+    try:
+        data = response.json()
+        if isinstance(data, dict):
+            msg = data.get("message") or data.get("error")
+            if isinstance(msg, str) and msg:
+                return msg
+    except Exception:
+        pass
+    text = getattr(response, "text", "") or ""
+    return text[:500] or f"HTTP {getattr(response, 'status_code', '?')}"
+
+
+class InworldTTSProvider(TTSProvider):
+    @property
+    def name(self) -> str:
+        return "inworld"
+
+    @property
+    def display_name(self) -> str:
+        return "Inworld Realtime TTS"
+
+    @property
+    def voice_compatible(self) -> bool:
+        return True
+
+    def is_available(self) -> bool:
+        return bool(_api_key())
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Inworld Realtime TTS",
+            "badge": "paid",
+            "tag": "Realtime TTS-2, voice cloning, native Opus",
+            "env_vars": [
+                {
+                    "key": "INWORLD_API_KEY",
+                    "prompt": "Inworld API key",
+                    "url": "https://platform.inworld.ai/api-keys",
+                }
+            ],
+        }
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return list(_TTS_MODELS)
+
+    def list_voices(self) -> List[Dict[str, Any]]:
+        if not _api_key():
+            return []
+        requests = _require_requests()
+        url = f"{_base_url('tts')}/voices/v1/voices"
+        voices: List[Dict[str, Any]] = []
+        params: Dict[str, Any] = {"pageSize": 2000, "orderBy": "display_name asc"}
+        for _ in range(10):
+            response = requests.get(
+                url,
+                headers={"Authorization": f"Basic {_api_key()}"},
+                params=params,
+                timeout=30,
+            )
+            if response.status_code >= 400:
+                logger.debug("Inworld list voices failed: %s", _error_message(response))
+                return voices
+            data = response.json()
+            for voice in data.get("voices", []) if isinstance(data, dict) else []:
+                vid = voice.get("voiceId") or voice.get("voice_id")
+                if not vid:
+                    continue
+                voices.append(
+                    {
+                        "id": vid,
+                        "display": voice.get("displayName") or voice.get("display_name") or vid,
+                        "language": voice.get("langCode") or voice.get("lang_code"),
+                        "gender": voice.get("gender"),
+                    }
+                )
+            token = data.get("nextPageToken") if isinstance(data, dict) else ""
+            if not token:
+                break
+            params["pageToken"] = token
+        return voices
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_TTS_MODEL
+
+    def default_voice(self) -> Optional[str]:
+        return DEFAULT_TTS_VOICE
+
+    def synthesize(
+        self,
+        text: str,
+        output_path: str,
+        *,
+        voice: Optional[str] = None,
+        model: Optional[str] = None,
+        speed: Optional[float] = None,
+        format: str = DEFAULT_TTS_FORMAT,
+        **extra: Any,
+    ) -> str:
+        cfg = _provider_cfg("tts")
+        model_id = model or cfg.get("model") or DEFAULT_TTS_MODEL
+        voice_id = voice or cfg.get("voice") or cfg.get("voice_id") or DEFAULT_TTS_VOICE
+        requested_suffix = Path(output_path).suffix.lower().lstrip(".")
+        path_format = requested_suffix if requested_suffix and requested_suffix != "mp3" else ""
+        arg_format = str(format or "").lower().strip().lstrip(".")
+        call_format = arg_format if arg_format and arg_format != "mp3" else ""
+        fmt = str(
+            cfg.get("output_format")
+            or cfg.get("format")
+            or path_format
+            or call_format
+            or DEFAULT_TTS_FORMAT
+        )
+        encoding = _audio_encoding_for_format(fmt)
+        sample_rate = _coerce_int(
+            cfg.get("sample_rate", cfg.get("sample_rate_hertz")),
+            DEFAULT_TTS_SAMPLE_RATE,
+        )
+        speaking_rate = _coerce_float(speed if speed is not None else cfg.get("speed"), 1.0)
+        delivery_mode = str(cfg.get("delivery_mode") or DEFAULT_TTS_DELIVERY_MODE).strip().upper()
+        language = str(cfg.get("language") or "").strip()
+        apply_text_normalization = cfg.get("apply_text_normalization")
+        timestamp_type = str(cfg.get("timestamp_type") or "").strip().upper()
+
+        payload: Dict[str, Any] = {
+            "text": text,
+            "voiceId": str(voice_id),
+            "modelId": str(model_id),
+            "audioConfig": {
+                "audioEncoding": encoding,
+                "sampleRateHertz": sample_rate,
+                "speakingRate": max(0.5, min(1.5, speaking_rate)),
+            },
+            "deliveryMode": delivery_mode
+            if delivery_mode in {"STABLE", "BALANCED", "CREATIVE"}
+            else DEFAULT_TTS_DELIVERY_MODE,
+        }
+        if language:
+            payload["language"] = language
+        if isinstance(apply_text_normalization, str) and apply_text_normalization.strip():
+            payload["applyTextNormalization"] = apply_text_normalization.strip().upper()
+        if timestamp_type in {"WORD", "CHARACTER"}:
+            payload["timestampType"] = timestamp_type
+
+        out = Path(output_path).expanduser()
+        suffix = _suffix_for_encoding(encoding)
+        if out.suffix.lower() != suffix:
+            out = out.with_suffix(suffix)
+        out.parent.mkdir(parents=True, exist_ok=True)
+
+        requests = _require_requests()
+        response = requests.post(
+            f"{_base_url('tts')}/tts/v1/voice",
+            headers=_headers(),
+            json=payload,
+            timeout=_coerce_float(cfg.get("timeout"), 60.0),
+        )
+        if response.status_code >= 400:
+            raise RuntimeError(f"Inworld TTS failed: {_error_message(response)}")
+        data = response.json()
+        audio_b64 = data.get("audioContent") if isinstance(data, dict) else None
+        if not isinstance(audio_b64, str) or not audio_b64:
+            raise RuntimeError("Inworld TTS returned no audioContent")
+        out.write_bytes(base64.b64decode(audio_b64))
+        return str(out)
+
+
+class InworldTranscriptionProvider(TranscriptionProvider):
+    @property
+    def name(self) -> str:
+        return "inworld"
+
+    @property
+    def display_name(self) -> str:
+        return "Inworld Realtime STT"
+
+    def is_available(self) -> bool:
+        return bool(_api_key())
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Inworld Realtime STT",
+            "badge": "paid",
+            "tag": "Unified STT with Inworld, Groq, AssemblyAI, Soniox models",
+            "env_vars": [
+                {
+                    "key": "INWORLD_API_KEY",
+                    "prompt": "Inworld API key",
+                    "url": "https://platform.inworld.ai/api-keys",
+                }
+            ],
+        }
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return list(_STT_MODELS)
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_STT_MODEL
+
+    def transcribe(
+        self,
+        file_path: str,
+        *,
+        model: Optional[str] = None,
+        language: Optional[str] = None,
+        **extra: Any,
+    ) -> Dict[str, Any]:
+        try:
+            cfg = _provider_cfg("stt")
+            model_id = model or cfg.get("model") or DEFAULT_STT_MODEL
+            lang = language or cfg.get("language") or ""
+            encoding = _stt_encoding_for_path(
+                file_path,
+                str(cfg.get("audio_encoding") or DEFAULT_STT_ENCODING),
+            )
+            enable_voice_profile = _bool_cfg(cfg.get("voice_profile"), False)
+
+            audio = Path(file_path).expanduser()
+            audio_b64 = base64.b64encode(audio.read_bytes()).decode("ascii")
+            transcribe_config: Dict[str, Any] = {
+                "modelId": str(model_id),
+                "audioEncoding": encoding,
+                "numberOfChannels": _coerce_int(cfg.get("number_of_channels"), DEFAULT_STT_CHANNELS),
+            }
+            if lang:
+                transcribe_config["language"] = str(lang)
+            if encoding == "LINEAR16":
+                transcribe_config["sampleRateHertz"] = _coerce_int(
+                    cfg.get("sample_rate", cfg.get("sample_rate_hertz")),
+                    DEFAULT_STT_SAMPLE_RATE,
+                )
+            if enable_voice_profile:
+                transcribe_config["voiceProfileConfig"] = {
+                    "enableVoiceProfile": True,
+                    "topN": _coerce_int(cfg.get("voice_profile_top_n"), 10),
+                }
+
+            requests = _require_requests()
+            response = requests.post(
+                f"{_base_url('stt')}/stt/v1/transcribe",
+                headers=_headers(),
+                json={
+                    "transcribeConfig": transcribe_config,
+                    "audioData": {"content": audio_b64},
+                },
+                timeout=_coerce_float(cfg.get("timeout"), 90.0),
+            )
+            if response.status_code >= 400:
+                return {
+                    "success": False,
+                    "transcript": "",
+                    "provider": self.name,
+                    "error": f"Inworld STT failed: {_error_message(response)}",
+                }
+            data = response.json()
+            transcription = data.get("transcription") if isinstance(data, dict) else {}
+            transcript = transcription.get("transcript") if isinstance(transcription, dict) else ""
+            result: Dict[str, Any] = {
+                "success": True,
+                "transcript": transcript or "",
+                "provider": self.name,
+            }
+            if isinstance(data, dict):
+                if data.get("voiceProfile") is not None:
+                    result["voice_profile"] = data.get("voiceProfile")
+                if data.get("usage") is not None:
+                    result["usage"] = data.get("usage")
+            return result
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Inworld STT transcription failed: %s", exc, exc_info=True)
+            return {
+                "success": False,
+                "transcript": "",
+                "provider": self.name,
+                "error": f"Inworld STT transcription failed: {exc}",
+            }
+
+
+def register(ctx) -> None:
+    ctx.register_tts_provider(InworldTTSProvider())
+    ctx.register_transcription_provider(InworldTranscriptionProvider())

--- a/plugins/inworld/plugin.yaml
+++ b/plugins/inworld/plugin.yaml
@@ -1,0 +1,6 @@
+name: inworld
+version: 0.1.0
+description: "Inworld TTS, STT, and realtime voice backends"
+kind: backend
+requires_env:
+  - INWORLD_API_KEY

--- a/plugins/video_gen/fal/__init__.py
+++ b/plugins/video_gen/fal/__init__.py
@@ -4,8 +4,9 @@ User-facing surface: pick a **model family** (e.g. "Pixverse v6",
 "Veo 3.1", "Seedance 2.0", "Kling v3 4K", "LTX 2.3", "Happy Horse").
 The plugin auto-routes to the family's text-to-video endpoint when
 called without ``image_url``, and to its image-to-video endpoint when
-``image_url`` is provided. The agent never sees the routing — it just
-calls ``video_generate(prompt=..., image_url=...)``.
+``image_url`` is provided. Families with a reference-to-video endpoint can
+also route ``reference_image_urls`` to that endpoint. The agent never sees
+the routing — it just calls ``video_generate(...)``.
 
 Model families (each with t2v + i2v endpoints):
 
@@ -18,6 +19,7 @@ Model families (each with t2v + i2v endpoints):
     seedance-2.0  bytedance/seedance-2.0/text-to-video           /  bytedance/seedance-2.0/image-to-video
     kling-v3-4k   fal-ai/kling-video/v3/4k/text-to-video         /  fal-ai/kling-video/v3/4k/image-to-video
     happy-horse   alibaba/happy-horse/text-to-video              /  alibaba/happy-horse/image-to-video
+    happy-horse-v1.1 alibaba/happy-horse/v1.1/text-to-video      /  alibaba/happy-horse/v1.1/image-to-video
 
 Selection precedence for the active family:
     1. ``model=`` arg from the tool call
@@ -63,6 +65,7 @@ logger = logging.getLogger(__name__)
 #                    (heuristic: 2-element with gap > 1 is a range)
 #   audio          : True if generate_audio is supported
 #   negative       : True if negative_prompt is supported
+#   reference_endpoint: optional reference-to-video endpoint for image_urls
 
 FAL_FAMILIES: Dict[str, Dict[str, Any]] = {
     # ─── Cheap / fast tier ─────────────────────────────────────────────
@@ -161,6 +164,25 @@ FAL_FAMILIES: Dict[str, Dict[str, Any]] = {
         "audio": False,
         "negative": False,
     },
+    "happy-horse-v1.1": {
+        "display": "Happy Horse 1.1",
+        "speed": "~60-180s",
+        "price": "$0.14/s 720p, $0.18/s 1080p",
+        "strengths": "Alibaba #1-ranked model. 1080p, native audio, multilingual lip-sync, up to 9 references.",
+        "tier": "premium",
+        "text_endpoint": "alibaba/happy-horse/v1.1/text-to-video",
+        "image_endpoint": "alibaba/happy-horse/v1.1/image-to-video",
+        "reference_endpoint": "alibaba/happy-horse/v1.1/reference-to-video",
+        "aspect_ratios": ("16:9", "9:16", "1:1", "4:3", "3:4", "21:9", "9:21", "5:4", "4:5"),
+        "resolutions": ("720p", "1080p"),
+        "durations": (3, 15),
+        "default_duration": 5,
+        "audio": False,
+        "native_audio": True,
+        "negative": False,
+        "safety_checker": True,
+        "max_reference_images": 9,
+    },
 }
 
 DEFAULT_MODEL = "pixverse-v6"  # cheap, both modalities, sane defaults
@@ -180,6 +202,9 @@ def _clamp_duration(family: Dict[str, Any], duration: Optional[int]) -> Optional
     if not durations:
         return duration
     if duration is None:
+        default_duration = family.get("default_duration")
+        if isinstance(default_duration, int):
+            return default_duration
         return durations[0]
     if _is_duration_range(durations):
         lo, hi = durations
@@ -245,13 +270,17 @@ def _build_payload(
     negative_prompt: Optional[str],
     audio: Optional[bool],
     seed: Optional[int],
+    reference_image_urls: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """Build a family-specific payload, dropping keys the family doesn't declare."""
     payload: Dict[str, Any] = {}
 
     if prompt:
         payload["prompt"] = prompt
-    if image_url:
+    if reference_image_urls:
+        max_refs = int(family.get("max_reference_images") or len(reference_image_urls))
+        payload["image_urls"] = reference_image_urls[:max_refs]
+    elif image_url:
         # Some endpoints (e.g. Kling v3 4K image-to-video) expect
         # `start_image_url` instead of `image_url`. The family entry can
         # declare an override.
@@ -282,6 +311,9 @@ def _build_payload(
 
     if family.get("negative") and negative_prompt:
         payload["negative_prompt"] = negative_prompt
+
+    if "safety_checker" in family:
+        payload["enable_safety_checker"] = bool(family["safety_checker"])
 
     return payload
 
@@ -434,6 +466,8 @@ class FALVideoGenProvider(VideoGenProvider):
                 modalities.append("text")
             if meta.get("image_endpoint"):
                 modalities.append("image")
+            if meta.get("reference_endpoint"):
+                modalities.append("reference")
             out.append({
                 "id": fid,
                 "display": meta["display"],
@@ -452,7 +486,7 @@ class FALVideoGenProvider(VideoGenProvider):
         return {
             "name": "FAL",
             "badge": "paid",
-            "tag": "LTX, Pixverse, Veo 3.1, Seedance 2.0, Kling 4K, Happy Horse — text-to-video & image-to-video",
+            "tag": "LTX, Pixverse, Veo 3.1, Seedance 2.0, Kling 4K, Happy Horse 1.1 — text-to-video & image-to-video",
             "env_vars": [
                 {
                     "key": "FAL_KEY",
@@ -463,15 +497,31 @@ class FALVideoGenProvider(VideoGenProvider):
         }
 
     def capabilities(self) -> Dict[str, Any]:
+        _family_id, family = _resolve_family(None)
+        modalities: List[str] = []
+        if family.get("text_endpoint"):
+            modalities.append("text")
+        if family.get("image_endpoint"):
+            modalities.append("image")
+        if family.get("reference_endpoint"):
+            modalities.append("reference")
+        durations = family.get("durations")
+        min_duration = 1
+        max_duration = 15
+        if durations:
+            if _is_duration_range(durations):
+                min_duration, max_duration = durations
+            else:
+                min_duration, max_duration = min(durations), max(durations)
         return {
-            "modalities": ["text", "image"],
-            "aspect_ratios": ["16:9", "9:16", "1:1"],
-            "resolutions": ["360p", "540p", "720p", "1080p"],
-            "max_duration": 15,
-            "min_duration": 1,
-            "supports_audio": True,
-            "supports_negative_prompt": True,
-            "max_reference_images": 0,
+            "modalities": modalities,
+            "aspect_ratios": list(family.get("aspect_ratios") or []),
+            "resolutions": list(family.get("resolutions") or []),
+            "max_duration": max_duration,
+            "min_duration": min_duration,
+            "supports_audio": bool(family.get("audio")),
+            "supports_negative_prompt": bool(family.get("negative")),
+            "max_reference_images": int(family.get("max_reference_images") or 0),
         }
 
     def generate(
@@ -514,11 +564,30 @@ class FALVideoGenProvider(VideoGenProvider):
         prompt = (prompt or "").strip()
         family_id, family = _resolve_family(model)
 
-        # Route: image_url → image-to-video endpoint; else → text-to-video.
+        # Route: reference images → reference-to-video endpoint when the
+        # family supports it; else image_url → image-to-video; else text.
         image_url_norm = (image_url or "").strip() or None
-        if image_url_norm:
+        reference_images: List[str] = []
+        if isinstance(reference_image_urls, (list, tuple)):
+            reference_images = [
+                str(url).strip()
+                for url in reference_image_urls
+                if isinstance(url, str) and str(url).strip()
+            ]
+        if image_url_norm and reference_images:
+            reference_images = [image_url_norm, *reference_images]
+        max_refs = int(family.get("max_reference_images") or len(reference_images) or 0)
+        if max_refs > 0:
+            reference_images = reference_images[:max_refs]
+
+        if reference_images and family.get("reference_endpoint"):
+            endpoint = family["reference_endpoint"]
+            modality_used = "reference"
+            image_url_for_payload = None
+        elif image_url_norm:
             endpoint = family.get("image_endpoint")
             modality_used = "image"
+            image_url_for_payload = image_url_norm
             if not endpoint:
                 return error_response(
                     error=(
@@ -532,6 +601,7 @@ class FALVideoGenProvider(VideoGenProvider):
         else:
             endpoint = family.get("text_endpoint")
             modality_used = "text"
+            image_url_for_payload = None
             if not endpoint:
                 return error_response(
                     error=(
@@ -553,13 +623,14 @@ class FALVideoGenProvider(VideoGenProvider):
         payload = _build_payload(
             family,
             prompt=prompt,
-            image_url=image_url_norm,
+            image_url=image_url_for_payload,
             duration=duration,
             aspect_ratio=aspect_ratio,
             resolution=resolution,
             negative_prompt=negative_prompt,
             audio=audio,
             seed=seed,
+            reference_image_urls=reference_images if modality_used == "reference" else None,
         )
 
         try:

--- a/plugins/video_gen/fal/plugin.yaml
+++ b/plugins/video_gen/fal/plugin.yaml
@@ -1,6 +1,6 @@
 name: fal
 version: 1.0.0
-description: "FAL.ai video generation backend. Multi-model — Veo 3.1, Kling, Pixverse — covering text-to-video and image-to-video via fal_client's queue API."
+description: "FAL.ai video generation backend. Multi-model — Veo 3.1, Kling, Pixverse, Seedance, Happy Horse — covering text-to-video, image-to-video, and supported reference-to-video via fal_client's queue API."
 author: NousResearch
 kind: backend
 requires_env:

--- a/tests/agent/test_video_gen_registry.py
+++ b/tests/agent/test_video_gen_registry.py
@@ -79,14 +79,35 @@ class TestGetActiveProvider:
         assert video_gen_registry.get_active_provider() is None
 
     def test_multi_without_config_returns_none(self, tmp_path, monkeypatch):
-        """Unlike image_gen (which falls back to 'fal'), video_gen has no
-        legacy default — when there are multiple providers and no config,
-        the registry returns None and the tool surfaces a helpful error.
+        """When multiple providers are available, video_gen has no legacy
+        default and the tool surfaces a helpful setup error.
         """
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         video_gen_registry.register_provider(_FakeProvider("xai"))
         video_gen_registry.register_provider(_FakeProvider("fal"))
         assert video_gen_registry.get_active_provider() is None
+
+    def test_multi_without_config_uses_only_available_provider(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        video_gen_registry.register_provider(_FakeProvider("xai", available=False))
+        video_gen_registry.register_provider(_FakeProvider("fal", available=True))
+        active = video_gen_registry.get_active_provider()
+        assert active is not None and active.name == "fal"
+
+    def test_multi_without_config_ignores_provider_with_broken_availability(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        class BrokenAvailability(_FakeProvider):
+            def is_available(self) -> bool:
+                raise RuntimeError("boom")
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        video_gen_registry.register_provider(BrokenAvailability("xai"))
+        video_gen_registry.register_provider(_FakeProvider("fal", available=True))
+        active = video_gen_registry.get_active_provider()
+        assert active is not None and active.name == "fal"
 
     def test_config_selects_provider(self, tmp_path, monkeypatch):
         import yaml

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -11,6 +11,7 @@ from hermes_cli.tools_config import (
     _DEFAULT_OFF_TOOLSETS,
     _apply_toolset_change,
     _checklist_toolset_keys,
+    _configure_toolset,
     _configure_provider,
     _reconfigure_provider,
     _get_platform_tools,
@@ -24,6 +25,7 @@ from hermes_cli.tools_config import (
     TOOL_CATEGORIES,
     gui_toolset_label,
     _visible_providers,
+    tools_disable_enable_command,
     tools_command,
 )
 
@@ -145,6 +147,62 @@ def test_gui_toolset_label_strips_leading_emoji():
 
 def test_configurable_toolsets_include_context_engine():
     assert any(ts_key == "context_engine" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
+
+
+FAL_MEDIA_UTILITY_TOOLSETS = {
+    "image_edit",
+    "image_background_removal",
+    "image_upscale",
+    "video_background_removal",
+    "video_upscale",
+}
+
+
+def test_configurable_toolsets_include_fal_media_utilities():
+    keys = {key for key, _label, _desc in CONFIGURABLE_TOOLSETS}
+    assert FAL_MEDIA_UTILITY_TOOLSETS.issubset(keys)
+
+
+def test_get_platform_tools_resolves_fal_media_utilities():
+    config = {"platform_toolsets": {"cli": sorted(FAL_MEDIA_UTILITY_TOOLSETS)}}
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert FAL_MEDIA_UTILITY_TOOLSETS.issubset(enabled)
+
+
+def test_tools_enable_accepts_fal_media_utility_toolsets(monkeypatch):
+    config = {"platform_toolsets": {"cli": ["image_gen"]}}
+    monkeypatch.setattr("hermes_cli.tools_config.load_config", lambda: config)
+    monkeypatch.setattr("hermes_cli.tools_config.save_config", lambda _config: None)
+
+    tools_disable_enable_command(
+        SimpleNamespace(
+            tools_action="enable",
+            platform="cli",
+            names=sorted(FAL_MEDIA_UTILITY_TOOLSETS),
+        )
+    )
+
+    saved = set(config["platform_toolsets"]["cli"])
+    assert FAL_MEDIA_UTILITY_TOOLSETS.issubset(saved)
+
+
+def test_fal_media_utilities_reuse_image_gen_setup(monkeypatch):
+    configured = []
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._fal_media_backend_available",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._configure_tool_category",
+        lambda ts_key, cat, config, **kw: configured.append((ts_key, cat["name"])),
+    )
+
+    assert _toolset_needs_configuration_prompt("image_edit", {}) is True
+    _configure_toolset("image_edit", {}, force_fresh=True)
+
+    assert configured == [("image_gen", "Image Generation")]
 
 
 def test_get_platform_tools_active_context_engine_is_enabled_for_explicit_config():
@@ -1111,9 +1169,10 @@ class TestImagegenBackendRegistry:
         """catalog_fn should defer import to avoid import cycles."""
         from hermes_cli.tools_config import IMAGEGEN_BACKENDS
         catalog, default = IMAGEGEN_BACKENDS["fal"]["catalog_fn"]()
-        assert default == "fal-ai/flux-2/klein/9b"
-        assert "fal-ai/flux-2/klein/9b" in catalog
+        assert default == "fal-ai/gemini-3.1-flash-image-preview"
+        assert "fal-ai/gemini-3.1-flash-image-preview" in catalog
         assert "fal-ai/flux-2-pro" in catalog
+        assert "fal-ai/flux-2/klein/9b" in catalog
 
     def test_image_gen_providers_tagged_with_fal_backend(self):
         """Both Nous Subscription and FAL.ai providers must carry the
@@ -1136,8 +1195,8 @@ class TestImagegenModelPicker:
         # Force _prompt_choice to pick index 1 (second-in-ordered-list).
         with patch("hermes_cli.tools_config._prompt_choice", return_value=1):
             _configure_imagegen_model("fal", config)
-        # ordered[0] == current (default klein), ordered[1] == first non-default
-        assert config["image_gen"]["model"] != "fal-ai/flux-2/klein/9b"
+        # ordered[0] == current (default gemini preview), ordered[1] == first non-default
+        assert config["image_gen"]["model"] != "fal-ai/gemini-3.1-flash-image-preview"
         assert config["image_gen"]["model"].startswith("fal-ai/")
 
     def test_picker_with_gpt_image_does_not_prompt_quality(self):
@@ -1182,7 +1241,7 @@ class TestImagegenModelPicker:
         with patch("hermes_cli.tools_config._prompt_choice", return_value=0):
             _configure_imagegen_model("fal", config)
         assert isinstance(config["image_gen"], dict)
-        assert config["image_gen"]["model"] == "fal-ai/flux-2/klein/9b"
+        assert config["image_gen"]["model"] == "fal-ai/gemini-3.1-flash-image-preview"
 
 
 def test_save_platform_tools_normalizes_numeric_entries():
@@ -1255,7 +1314,14 @@ def test_get_platform_tools_recovers_non_configurable_toolsets_from_composite():
     }
     fake_toolsets["hermes-_test_platform"] = {
         "description": "test composite",
-        "tools": ["web_search", "web_extract", "terminal", "process", "_test_special_tool"],
+        "tools": [
+            "web_search",
+            "web_extract",
+            "terminal",
+            "process",
+            "read_terminal",
+            "_test_special_tool",
+        ],
         "includes": [],
     }
 
@@ -1596,8 +1662,6 @@ def test_real_configurable_changes_still_reported_in_diff():
     # User adds 'vision' (configurable) — must still report as added.
     new_enabled2 = (current - {"kanban"}) | {"vision"}
     assert ((new_enabled2 - current) & universe) == {"vision"}
-
-
 def test_vision_picker_writes_provider_and_model(tmp_path, monkeypatch):
     """Picking a provider+model persists auxiliary.vision.{provider,model}.
 
@@ -1674,5 +1738,3 @@ def test_vision_picker_custom_endpoint(tmp_path, monkeypatch):
     # provider pinned to "custom" so the resolver routes through base_url.
     assert v.get("provider") == "custom"
     save_env.assert_called_once_with("OPENAI_API_KEY", "sk-secret")
-
-

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1163,6 +1163,30 @@ class TestWebServerEndpoints:
         # The handler streams the bytes back and removes the temp file.
         assert not audio_file.exists()
 
+    def test_speak_text_returns_ogg_data_url_for_inworld_style_output(self, monkeypatch, tmp_path):
+        import tools.tts_tool as tts_tool
+
+        audio_file = tmp_path / "speech.ogg"
+        audio_file.write_bytes(b"OggSfake-audio-bytes")
+
+        def fake_tts(text):
+            return json.dumps({
+                "success": True,
+                "file_path": str(audio_file),
+                "provider": "inworld",
+            })
+
+        monkeypatch.setattr(tts_tool, "text_to_speech_tool", fake_tts)
+
+        resp = self.client.post("/api/audio/speak", json={"text": "hello there"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["mime_type"] == "audio/ogg"
+        assert body["data_url"].startswith("data:audio/ogg;base64,")
+        assert body["provider"] == "inworld"
+        assert not audio_file.exists()
+
     def test_speak_text_requires_nonempty_text(self):
         resp = self.client.post("/api/audio/speak", json={"text": "   "})
         assert resp.status_code == 400
@@ -1454,6 +1478,12 @@ class TestWebServerEndpoints:
         data = resp.json()
         # Should contain known env var names
         assert any(k.endswith("_API_KEY") or k.endswith("_TOKEN") for k in data.keys())
+
+    def test_get_env_vars_surfaces_inworld_api_key(self):
+        data = self.client.get("/api/env").json()
+        assert "INWORLD_API_KEY" in data
+        assert data["INWORLD_API_KEY"]["category"] in {"provider", "tool"}
+        assert data["INWORLD_API_KEY"]["provider_label"] in {"Inworld", ""}
 
     def test_get_env_vars_marks_channel_managed_keys(self):
         from hermes_cli.web_server import _channel_managed_env_keys

--- a/tests/plugins/test_google_meet_plugin.py
+++ b/tests/plugins/test_google_meet_plugin.py
@@ -721,6 +721,42 @@ def test_realtime_session_counters_initialized():
     assert sess.last_audio_out_at is None
 
 
+def test_meet_bot_loads_inworld_realtime_settings(monkeypatch):
+    from plugins.google_meet import meet_bot
+
+    monkeypatch.setenv("INWORLD_API_KEY", "basic-token")
+    monkeypatch.delenv("HERMES_MEET_REALTIME_KEY", raising=False)
+    monkeypatch.delenv("HERMES_MEET_REALTIME_PROVIDER", raising=False)
+    monkeypatch.setattr(
+        meet_bot,
+        "_load_hermes_config",
+        lambda: {
+            "realtime": {
+                "provider": "inworld",
+                "inworld": {
+                    "model": "openai/gpt-4o-mini",
+                    "tts_model": "inworld-tts-1.5-mini",
+                    "stt_model": "inworld/inworld-stt-1",
+                    "voice": "Dennis",
+                    "language": "en",
+                    "turn_detection": {"eagerness": "high"},
+                    "provider_data": {"backchannel": {"enabled": True}},
+                },
+            }
+        },
+    )
+
+    settings = meet_bot._load_realtime_settings()
+
+    assert settings["provider"] == "inworld"
+    assert settings["api_key"] == "basic-token"
+    assert settings["model"] == "openai/gpt-4o-mini"
+    assert settings["tts_model"] == "inworld-tts-1.5-mini"
+    assert settings["stt_model"] == "inworld/inworld-stt-1"
+    assert settings["turn_detection"] == {"eagerness": "high"}
+    assert settings["provider_data"] == {"backchannel": {"enabled": True}}
+
+
 # ---------------------------------------------------------------------------
 # hermes meet install CLI
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_google_meet_realtime.py
+++ b/tests/plugins/test_google_meet_realtime.py
@@ -117,6 +117,47 @@ def test_connect_sends_session_update_with_voice_and_instructions(monkeypatch):
     assert s["input_audio_format"] == "pcm16"
 
 
+def test_inworld_connect_uses_basic_auth_and_provider_payload(monkeypatch):
+    from plugins.google_meet.realtime.openai_client import RealtimeSession
+
+    ws = _FakeWS(recv_frames=[])
+    captured = _install_fake_websockets(monkeypatch, ws)
+
+    sess = RealtimeSession(
+        api_key="base64-key",
+        provider="inworld",
+        session_id="meet id",
+        model="openai/gpt-4o-mini",
+        tts_model="inworld-tts-1.5-mini",
+        stt_model="inworld/inworld-stt-1",
+        voice="Dennis",
+        instructions="Be helpful.",
+        language="en",
+        turn_detection={"eagerness": "high"},
+        provider_data={"backchannel": {"enabled": True}},
+    )
+    sess.connect()
+
+    assert captured["url"].startswith("wss://api.inworld.ai/api/v1/realtime/session")
+    assert "key=meet%20id" in captured["url"]
+    assert "protocol=realtime" in captured["url"]
+    headers = dict(captured["headers"] or [])
+    assert headers["Authorization"] == "Basic base64-key"
+
+    update = ws.sent[0]
+    assert update["type"] == "session.update"
+    session = update["session"]
+    assert session["type"] == "realtime"
+    assert session["model"] == "openai/gpt-4o-mini"
+    assert session["audio"]["input"]["format"] == {"type": "audio/pcm", "rate": 24000}
+    assert session["audio"]["input"]["transcription"]["model"] == "inworld/inworld-stt-1"
+    assert session["audio"]["input"]["transcription"]["language"] == "en"
+    assert session["audio"]["input"]["turn_detection"]["eagerness"] == "high"
+    assert session["audio"]["output"]["model"] == "inworld-tts-1.5-mini"
+    assert session["audio"]["output"]["voice"] == "Dennis"
+    assert session["providerData"] == {"backchannel": {"enabled": True}}
+
+
 # ---------------------------------------------------------------------------
 # speak()
 # ---------------------------------------------------------------------------
@@ -160,6 +201,26 @@ def test_speak_sends_create_and_response_and_writes_audio(monkeypatch, tmp_path)
     assert result["ok"] is True
     assert result["bytes_written"] == len(audio_bytes) + len(b"more")
     assert result["duration_ms"] >= 0.0
+
+
+def test_speak_accepts_inworld_output_audio_delta(monkeypatch, tmp_path):
+    from plugins.google_meet.realtime.openai_client import RealtimeSession
+
+    audio_bytes = b"inworld-pcm"
+    recv_frames = [
+        {"type": "response.output_audio.delta", "delta": base64.b64encode(audio_bytes).decode()},
+        {"type": "response.output_audio.done"},
+    ]
+    ws = _FakeWS(recv_frames=recv_frames)
+    _install_fake_websockets(monkeypatch, ws)
+
+    sink = tmp_path / "out.pcm"
+    sess = RealtimeSession(api_key="base64-key", provider="inworld", audio_sink_path=sink)
+    sess.connect()
+    result = sess.speak("Hello")
+
+    assert sink.read_bytes() == audio_bytes
+    assert result["bytes_written"] == len(audio_bytes)
 
 
 def test_speak_raises_on_error_frame(monkeypatch, tmp_path):

--- a/tests/plugins/test_inworld_plugin.py
+++ b/tests/plugins/test_inworld_plugin.py
@@ -1,0 +1,121 @@
+"""Tests for the bundled Inworld backend plugin."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+
+class _Response:
+    def __init__(self, status_code=200, data=None, text=""):
+        self.status_code = status_code
+        self._data = data or {}
+        self.text = text
+
+    def json(self):
+        return self._data
+
+
+class _Requests:
+    def __init__(self):
+        self.posts = []
+        self.gets = []
+
+    def post(self, url, **kwargs):
+        self.posts.append({"url": url, **kwargs})
+        if url.endswith("/tts/v1/voice"):
+            return _Response(data={"audioContent": base64.b64encode(b"opus").decode()})
+        return _Response(data={"transcription": {"transcript": "hello world"}})
+
+    def get(self, url, **kwargs):
+        self.gets.append({"url": url, **kwargs})
+        return _Response(
+            data={
+                "voices": [
+                    {
+                        "voiceId": "Dennis",
+                        "displayName": "Dennis",
+                        "langCode": "en",
+                    }
+                ]
+            }
+        )
+
+
+def test_inworld_tts_synthesizes_native_ogg(monkeypatch, tmp_path):
+    import plugins.inworld as inworld
+
+    requests = _Requests()
+    monkeypatch.setenv("INWORLD_API_KEY", "basic-token")
+    monkeypatch.setattr(inworld, "_require_requests", lambda: requests)
+    monkeypatch.setattr(
+        inworld,
+        "_load_config_section",
+        lambda section: {
+            "inworld": {
+                "model": "inworld-tts-2",
+                "voice": "Dennis",
+                "sample_rate": 48000,
+                "delivery_mode": "BALANCED",
+            }
+        },
+    )
+
+    provider = inworld.InworldTTSProvider()
+    out = provider.synthesize("Hello", str(tmp_path / "speech.mp3"))
+
+    assert Path(out).suffix == ".ogg"
+    assert Path(out).read_bytes() == b"opus"
+    req = requests.posts[0]
+    assert req["url"] == "https://api.inworld.ai/tts/v1/voice"
+    assert req["headers"]["Authorization"] == "Basic basic-token"
+    assert req["json"]["voiceId"] == "Dennis"
+    assert req["json"]["audioConfig"]["audioEncoding"] == "OGG_OPUS"
+    assert req["json"]["audioConfig"]["sampleRateHertz"] == 48000
+
+
+def test_inworld_stt_posts_audio_data(monkeypatch, tmp_path):
+    import plugins.inworld as inworld
+
+    requests = _Requests()
+    audio = tmp_path / "clip.wav"
+    audio.write_bytes(b"pcm-data")
+    monkeypatch.setenv("INWORLD_API_KEY", "basic-token")
+    monkeypatch.setattr(inworld, "_require_requests", lambda: requests)
+    monkeypatch.setattr(
+        inworld,
+        "_load_config_section",
+        lambda section: {
+            "inworld": {
+                "model": "inworld/inworld-stt-1",
+                "audio_encoding": "AUTO_DETECT",
+                "language": "en",
+            }
+        },
+    )
+
+    provider = inworld.InworldTranscriptionProvider()
+    result = provider.transcribe(str(audio))
+
+    assert result["success"] is True
+    assert result["transcript"] == "hello world"
+    req = requests.posts[0]
+    assert req["url"] == "https://api.inworld.ai/stt/v1/transcribe"
+    assert req["headers"]["Authorization"] == "Basic basic-token"
+    assert req["json"]["transcribeConfig"]["modelId"] == "inworld/inworld-stt-1"
+    assert req["json"]["transcribeConfig"]["audioEncoding"] == "AUTO_DETECT"
+    assert req["json"]["audioData"]["content"] == base64.b64encode(b"pcm-data").decode()
+
+
+def test_inworld_lists_voices(monkeypatch):
+    import plugins.inworld as inworld
+
+    requests = _Requests()
+    monkeypatch.setenv("INWORLD_API_KEY", "basic-token")
+    monkeypatch.setattr(inworld, "_require_requests", lambda: requests)
+    monkeypatch.setattr(inworld, "_load_config_section", lambda section: {"inworld": {}})
+
+    voices = inworld.InworldTTSProvider().list_voices()
+
+    assert voices == [{"id": "Dennis", "display": "Dennis", "language": "en", "gender": None}]
+    assert requests.gets[0]["headers"]["Authorization"] == "Basic basic-token"

--- a/tests/plugins/video_gen/test_fal_plugin.py
+++ b/tests/plugins/video_gen/test_fal_plugin.py
@@ -37,6 +37,7 @@ def test_fal_family_catalog():
         "ltx-2.3", "pixverse-v6",
         # premium
         "veo3.1", "seedance-2.0", "kling-v3-4k", "happy-horse",
+        "happy-horse-v1.1",
     }
     assert expected.issubset(set(FAL_FAMILIES.keys())), (
         f"missing families: {expected - set(FAL_FAMILIES.keys())}"
@@ -77,7 +78,7 @@ def test_fal_list_models_advertises_both_modalities():
 
     models = FALVideoGenProvider().list_models()
     for m in models:
-        assert set(m["modalities"]) == {"text", "image"}, (
+        assert {"text", "image"}.issubset(set(m["modalities"])), (
             f"{m['id']} doesn't advertise both modalities — every family "
             f"should have t2v + i2v"
         )
@@ -238,6 +239,44 @@ class TestFamilyRouting:
         assert with_fake_fal["arguments"].get("start_image_url") == "https://example.com/frame.png"
         assert "image_url" not in with_fake_fal["arguments"]
 
+    def test_happy_horse_v11_reference_routes_to_reference_endpoint(self, with_fake_fal):
+        from plugins.video_gen.fal import FALVideoGenProvider
+
+        result = FALVideoGenProvider().generate(
+            "character1 dances with character2",
+            model="happy-horse-v1.1",
+            reference_image_urls=[
+                "https://example.com/one.png",
+                "https://example.com/two.png",
+            ],
+        )
+
+        assert result["success"] is True
+        assert result["modality"] == "reference"
+        assert with_fake_fal["endpoint"] == "alibaba/happy-horse/v1.1/reference-to-video"
+        assert with_fake_fal["arguments"]["image_urls"] == [
+            "https://example.com/one.png",
+            "https://example.com/two.png",
+        ]
+
+    def test_happy_horse_v11_image_plus_references_caps_at_nine(self, with_fake_fal):
+        from plugins.video_gen.fal import FALVideoGenProvider
+
+        refs = [f"https://example.com/ref-{i}.png" for i in range(12)]
+        result = FALVideoGenProvider().generate(
+            "character1 leads the scene",
+            model="happy-horse-v1.1",
+            image_url="https://example.com/start.png",
+            reference_image_urls=refs,
+        )
+
+        assert result["success"] is True
+        assert with_fake_fal["endpoint"] == "alibaba/happy-horse/v1.1/reference-to-video"
+        assert with_fake_fal["arguments"]["image_urls"] == [
+            "https://example.com/start.png",
+            *refs[:8],
+        ]
+
 
 class TestPayloadBuilder:
     def test_drops_unsupported_keys(self):
@@ -340,3 +379,47 @@ class TestPayloadBuilder:
         )
         # Only prompt — no payload bloat for fields we can't verify
         assert p == {"prompt": "a horse galloping"}
+
+    def test_happy_horse_v11_payload_supports_documented_controls(self):
+        from plugins.video_gen.fal import FAL_FAMILIES, _build_payload
+
+        meta = FAL_FAMILIES["happy-horse-v1.1"]
+        p = _build_payload(
+            meta,
+            prompt="a cinematic walk",
+            image_url=None,
+            reference_image_urls=["https://example.com/character.png"],
+            duration=99,
+            aspect_ratio="9:21",
+            resolution="1080p",
+            negative_prompt="watermark",
+            audio=True,
+            seed=123,
+        )
+
+        assert p == {
+            "prompt": "a cinematic walk",
+            "image_urls": ["https://example.com/character.png"],
+            "seed": 123,
+            "aspect_ratio": "9:21",
+            "resolution": "1080p",
+            "duration": "15",
+            "enable_safety_checker": True,
+        }
+
+    def test_happy_horse_v11_default_duration_is_five(self):
+        from plugins.video_gen.fal import FAL_FAMILIES, _build_payload
+
+        p = _build_payload(
+            FAL_FAMILIES["happy-horse-v1.1"],
+            prompt="x",
+            image_url=None,
+            duration=None,
+            aspect_ratio="16:9",
+            resolution="1080p",
+            negative_prompt=None,
+            audio=None,
+            seed=None,
+        )
+
+        assert p["duration"] == "5"

--- a/tests/tools/test_fal_media_utility_tools.py
+++ b/tests/tools/test_fal_media_utility_tools.py
@@ -1,0 +1,324 @@
+"""Tests for dedicated FAL media utility tools."""
+
+import json
+
+
+class _FakeFalHandler:
+    def __init__(self, endpoint: str):
+        self.endpoint = endpoint
+
+    def get(self):
+        if self.endpoint in {
+            "fal-ai/birefnet/v2/video",
+            "fal-ai/seedvr/upscale/video",
+        }:
+            return {
+                "video": {
+                    "url": "https://example.test/out.mp4",
+                    "width": 1920,
+                    "height": 1080,
+                    "fps": 24,
+                    "duration": 1,
+                    "num_frames": 24,
+                    "content_type": "video/mp4",
+                },
+                "seed": 123,
+            }
+        if self.endpoint in {
+            "fal-ai/birefnet/v2",
+            "fal-ai/ideogram/remove-background",
+            "fal-ai/seedvr/upscale/image",
+        }:
+            return {
+                "image": {
+                    "url": "https://example.test/out.png",
+                    "width": 1024,
+                    "height": 1024,
+                    "content_type": "image/png",
+                },
+                "seed": 123,
+            }
+        return {
+            "images": [
+                {
+                    "url": "https://example.test/edit.png",
+                    "width": 1024,
+                    "height": 1024,
+                }
+            ]
+        }
+
+
+def test_fal_media_utility_tools_dispatch_to_expected_endpoints(monkeypatch):
+    monkeypatch.setenv("FAL_KEY", "dummy")
+
+    import model_tools  # noqa: F401 - triggers tool discovery
+    import tools.fal_image_edit_tool as image_edit_tool
+    import tools.fal_remove_background_tool as remove_background_tool
+    import tools.fal_remove_video_background_tool as remove_video_background_tool
+    import tools.fal_upscale_image_tool as upscale_image_tool
+    import tools.fal_upscale_video_tool as upscale_video_tool
+    from tools.registry import registry
+
+    calls = []
+
+    def fake_submit(endpoint, arguments):
+        calls.append({"endpoint": endpoint, "arguments": arguments})
+        return _FakeFalHandler(endpoint)
+
+    for module in (
+        image_edit_tool,
+        remove_background_tool,
+        remove_video_background_tool,
+        upscale_image_tool,
+        upscale_video_tool,
+    ):
+        monkeypatch.setattr(module, "_submit_fal_request", fake_submit)
+
+    results = {
+        "image_edit": registry.dispatch(
+            "image_edit",
+            {
+                "prompt": "make the product blue",
+                "image_url": "https://example.test/in.png",
+            },
+        ),
+        "remove_background": registry.dispatch(
+            "remove_background",
+            {"image_url": "https://example.test/in.png"},
+        ),
+        "remove_video_background": registry.dispatch(
+            "remove_video_background",
+            {"video_url": "https://example.test/in.mp4"},
+        ),
+        "upscale_image": registry.dispatch(
+            "upscale_image",
+            {"image_url": "https://example.test/in.png"},
+        ),
+        "upscale_video": registry.dispatch(
+            "upscale_video",
+            {"video_url": "https://example.test/in.mp4"},
+        ),
+    }
+
+    assert {name: json.loads(raw)["success"] for name, raw in results.items()} == {
+        "image_edit": True,
+        "remove_background": True,
+        "remove_video_background": True,
+        "upscale_image": True,
+        "upscale_video": True,
+    }
+    assert [call["endpoint"] for call in calls] == [
+        "fal-ai/gemini-3.1-flash-image-preview/edit",
+        "fal-ai/ideogram/remove-background",
+        "fal-ai/birefnet/v2/video",
+        "fal-ai/seedvr/upscale/image",
+        "fal-ai/seedvr/upscale/video",
+    ]
+    assert calls[0]["arguments"]["image_urls"] == ["https://example.test/in.png"]
+    assert calls[1]["arguments"]["image_url"] == "https://example.test/in.png"
+    assert set(calls[1]["arguments"]) == {"image_url", "sync_mode"}
+    assert calls[2]["arguments"]["video_url"] == "https://example.test/in.mp4"
+    assert calls[3]["arguments"]["image_url"] == "https://example.test/in.png"
+    assert calls[4]["arguments"]["video_url"] == "https://example.test/in.mp4"
+
+
+def test_remove_background_can_use_birefnet_model(monkeypatch):
+    monkeypatch.setenv("FAL_KEY", "dummy")
+
+    import tools.fal_remove_background_tool as remove_background_tool
+
+    calls = []
+
+    def fake_submit(endpoint, arguments):
+        calls.append({"endpoint": endpoint, "arguments": arguments})
+        return _FakeFalHandler(endpoint)
+
+    monkeypatch.setattr(remove_background_tool, "_submit_fal_request", fake_submit)
+
+    result = json.loads(
+        remove_background_tool.remove_background_tool(
+            image_url="https://example.test/in.png",
+            model="General Use (Light)",
+            output_mask=True,
+        )
+    )
+
+    assert result["success"] is True
+    assert result["model"] == "General Use (Light)"
+    assert calls == [
+        {
+            "endpoint": "fal-ai/birefnet/v2",
+            "arguments": {
+                "image_url": "https://example.test/in.png",
+                "model": "General Use (Light)",
+                "operating_resolution": "1024x1024",
+                "output_format": "png",
+                "output_mask": True,
+                "mask_only": False,
+                "refine_foreground": True,
+                "sync_mode": False,
+            },
+        }
+    ]
+
+
+def test_upscale_video_rejects_image_inputs(monkeypatch):
+    monkeypatch.setenv("FAL_KEY", "dummy")
+
+    import tools.fal_upscale_video_tool as upscale_video_tool
+
+    result = json.loads(
+        upscale_video_tool.upscale_video_tool(
+            video_url="https://example.test/not-a-video.png",
+        )
+    )
+
+    assert result["success"] is False
+    assert result["error_type"] == "ValueError"
+    assert "must reference a video file" in result["error"]
+
+
+def test_upscale_video_uploads_local_video_before_submit(monkeypatch, tmp_path):
+    monkeypatch.setenv("FAL_KEY", "dummy")
+
+    import tools.image_generation_tool as image_tool
+    import tools.fal_upscale_video_tool as upscale_video_tool
+
+    local_video = tmp_path / "input.mp4"
+    local_video.write_bytes(b"fake mp4")
+    submitted = {}
+
+    class FakeFalClient:
+        @staticmethod
+        def upload_file(path):
+            assert path == str(local_video)
+            return "https://fal.media/uploaded/input.mp4"
+
+    class Handler:
+        def get(self):
+            return {"video": {"url": "https://example.test/out.mp4"}}
+
+    def fake_submit(_endpoint, arguments):
+        submitted.update(arguments)
+        return Handler()
+
+    monkeypatch.setattr(image_tool, "fal_client", FakeFalClient)
+    monkeypatch.setattr(upscale_video_tool, "_submit_fal_request", fake_submit)
+
+    result = json.loads(upscale_video_tool.upscale_video_tool(video_url=str(local_video)))
+
+    assert result["success"] is True
+    assert submitted["video_url"] == "https://fal.media/uploaded/input.mp4"
+    assert submitted["output_format"] == "X264 (.mp4)"
+    assert submitted["output_quality"] == "high"
+    assert submitted["output_write_mode"] == "balanced"
+
+
+def test_upscale_video_local_video_requires_direct_fal_key(monkeypatch, tmp_path):
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.delenv("FAL_API_KEY", raising=False)
+
+    import tools.fal_upscale_video_tool as upscale_video_tool
+
+    local_video = tmp_path / "input.mp4"
+    local_video.write_bytes(b"fake mp4")
+
+    result = json.loads(upscale_video_tool.upscale_video_tool(video_url=str(local_video)))
+
+    assert result["success"] is False
+    assert result["error_type"] == "ValueError"
+    assert "Local video file inputs require a direct FAL_KEY" in result["error"]
+
+
+def test_remove_video_background_uploads_local_video_before_submit(monkeypatch, tmp_path):
+    monkeypatch.setenv("FAL_KEY", "dummy")
+
+    import tools.image_generation_tool as image_tool
+    import tools.fal_remove_video_background_tool as remove_video_background_tool
+
+    local_video = tmp_path / "input.webm"
+    local_video.write_bytes(b"fake webm")
+    submitted = {}
+
+    class FakeFalClient:
+        @staticmethod
+        def upload_file(path):
+            assert path == str(local_video)
+            return "https://fal.media/uploaded/input.webm"
+
+    class Handler:
+        def get(self):
+            return {"video": {"url": "https://example.test/out.webm"}}
+
+    def fake_submit(_endpoint, arguments):
+        submitted.update(arguments)
+        return Handler()
+
+    monkeypatch.setattr(image_tool, "fal_client", FakeFalClient)
+    monkeypatch.setattr(remove_video_background_tool, "_submit_fal_request", fake_submit)
+
+    result = json.loads(
+        remove_video_background_tool.remove_video_background_tool(video_url=str(local_video))
+    )
+
+    assert result["success"] is True
+    assert submitted["video_url"] == "https://fal.media/uploaded/input.webm"
+
+
+def test_upscale_video_rejects_documentation_page_urls(monkeypatch):
+    monkeypatch.setenv("FAL_KEY", "dummy")
+
+    import tools.fal_upscale_video_tool as upscale_video_tool
+
+    result = json.loads(
+        upscale_video_tool.upscale_video_tool(
+            video_url="https://docs.fal.ai/model/fal-ai/seedvr/upscale/video",
+        )
+    )
+
+    assert result["success"] is False
+    assert result["error_type"] == "ValueError"
+    assert "direct, publicly downloadable video file URL" in result["error"]
+
+
+def test_remove_video_background_rejects_documentation_page_urls(monkeypatch):
+    monkeypatch.setenv("FAL_KEY", "dummy")
+
+    import tools.fal_remove_video_background_tool as remove_video_background_tool
+
+    result = json.loads(
+        remove_video_background_tool.remove_video_background_tool(
+            video_url="https://docs.fal.ai/model/fal-ai/birefnet/v2/video",
+        )
+    )
+
+    assert result["success"] is False
+    assert result["error_type"] == "ValueError"
+    assert "direct, publicly downloadable video file URL" in result["error"]
+
+
+def test_upscale_video_omits_missing_metadata(monkeypatch):
+    monkeypatch.setenv("FAL_KEY", "dummy")
+
+    import tools.fal_upscale_video_tool as upscale_video_tool
+
+    class Handler:
+        def get(self):
+            return {"video": {"url": "https://example.test/out.mp4"}}
+
+    monkeypatch.setattr(upscale_video_tool, "_submit_fal_request", lambda *_args, **_kw: Handler())
+
+    result = json.loads(
+        upscale_video_tool.upscale_video_tool(
+            video_url="https://example.test/in.mp4",
+        )
+    )
+
+    assert result["success"] is True
+    assert result["video"] == "https://example.test/out.mp4"
+    assert result["output_url"] == "https://example.test/out.mp4"
+    assert result["media_type"] == "video"
+    assert "width" not in result
+    assert "height" not in result
+    assert "fps" not in result

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -33,8 +33,8 @@ def image_tool():
 class TestFalCatalog:
     """Every FAL_MODELS entry must have a consistent shape."""
 
-    def test_default_model_is_klein(self, image_tool):
-        assert image_tool.DEFAULT_MODEL == "fal-ai/flux-2/klein/9b"
+    def test_default_model_is_gemini_preview(self, image_tool):
+        assert image_tool.DEFAULT_MODEL == "fal-ai/gemini-3.1-flash-image-preview"
 
     def test_default_model_in_catalog(self, image_tool):
         assert image_tool.DEFAULT_MODEL in image_tool.FAL_MODELS
@@ -309,7 +309,7 @@ class TestModelResolution:
     def test_no_config_falls_back_to_default(self, image_tool):
         with patch("hermes_cli.config.load_config", return_value={}):
             mid, meta = image_tool._resolve_fal_model()
-        assert mid == "fal-ai/flux-2/klein/9b"
+        assert mid == "fal-ai/gemini-3.1-flash-image-preview"
 
     def test_valid_config_model_is_used(self, image_tool):
         with patch("hermes_cli.config.load_config",
@@ -322,7 +322,7 @@ class TestModelResolution:
         with patch("hermes_cli.config.load_config",
                    return_value={"image_gen": {"model": "fal-ai/nonexistent-9000"}}):
             mid, _ = image_tool._resolve_fal_model()
-        assert mid == "fal-ai/flux-2/klein/9b"
+        assert mid == "fal-ai/gemini-3.1-flash-image-preview"
 
     def test_env_var_fallback_when_no_config(self, image_tool, monkeypatch):
         monkeypatch.setenv("FAL_IMAGE_MODEL", "fal-ai/z-image/turbo")

--- a/tests/tools/test_video_generation_tool_surface_matrix.py
+++ b/tests/tools/test_video_generation_tool_surface_matrix.py
@@ -182,6 +182,31 @@ def test_fal_text_plus_image_routes_to_image_endpoint(matrix_env, family_id):
     )
 
 
+def test_fal_happy_horse_v11_reference_images_route_to_reference_endpoint(matrix_env):
+    home, fal_calls, _ = matrix_env
+
+    result = _invoke_tool(
+        home,
+        {"video_gen": {"provider": "fal", "model": "happy-horse-v1.1"}},
+        {
+            "prompt": "character1 and character2 dance",
+            "reference_image_urls": [
+                "https://example.com/a.png",
+                "https://example.com/b.png",
+            ],
+        },
+    )
+
+    assert result["success"] is True, result.get("error")
+    assert result["modality"] == "reference"
+    assert len(fal_calls) == 1
+    assert fal_calls[0]["endpoint"] == "alibaba/happy-horse/v1.1/reference-to-video"
+    assert fal_calls[0]["arguments"]["image_urls"] == [
+        "https://example.com/a.png",
+        "https://example.com/b.png",
+    ]
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # xAI: text-only / text+image both go to /videos/generations
 # (xAI uses one endpoint with an optional 'image' field, not separate URLs)

--- a/tools/fal_image_edit_tool.py
+++ b/tools/fal_image_edit_tool.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+FAL Image Edit Tool
+
+Dedicated image-to-image / editing tool for FAL.ai backends.
+Uses the active ``image_gen.model`` (default: Gemini 3.1 Flash Image Preview)
+and routes to its declared ``edit_endpoint``.
+"""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from tools.image_generation_tool import (
+    DEFAULT_ASPECT_RATIO,
+    FAL_MODELS,
+    VALID_ASPECT_RATIOS,
+    _build_fal_edit_payload,
+    _resolve_fal_model,
+    _submit_fal_request,
+    check_fal_api_key,
+)
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_edit_model(model_id: Optional[str] = None) -> tuple:
+    """Return the model id + metadata to use for editing.
+
+    If ``model_id`` is provided and known, use it; otherwise fall back to the
+    configured image_gen model. Raises ValueError if the chosen model has no
+    edit endpoint.
+    """
+    if model_id and model_id.strip() in FAL_MODELS:
+        chosen = model_id.strip()
+        meta = FAL_MODELS[chosen]
+    else:
+        chosen, meta = _resolve_fal_model()
+
+    if not meta.get("edit_endpoint"):
+        raise ValueError(
+            f"Model '{meta.get('display', chosen)}' ({chosen}) does not support "
+            f"image editing. Choose an edit-capable model via `hermes tools` → "
+            f"Image Generation."
+        )
+
+    return chosen, meta
+
+
+def image_edit_tool(
+    prompt: str,
+    image_url: str,
+    reference_image_urls: Optional[List[str]] = None,
+    aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+    seed: Optional[int] = None,
+    model: Optional[str] = None,
+) -> str:
+    """Edit or transform an existing image using the active FAL edit model.
+
+    Required: ``prompt`` (edit instruction) and ``image_url`` (source image).
+    Optional ``reference_image_urls`` for style / composition guidance.
+    """
+    response_data: Dict[str, Any] = {
+        "success": False,
+        "image": None,
+        "error": None,
+        "error_type": None,
+    }
+
+    try:
+        if not prompt or not isinstance(prompt, str) or not prompt.strip():
+            raise ValueError("prompt is required and must be a non-empty string")
+        if not image_url or not isinstance(image_url, str) or not image_url.strip():
+            raise ValueError("image_url is required for image editing")
+
+        if not check_fal_api_key():
+            raise ValueError(
+                "FAL_KEY is not set and no managed FAL gateway is available. "
+                "Set FAL_KEY or enable the Nous Subscription image_gen provider."
+            )
+
+        model_id, meta = _resolve_edit_model(model)
+        edit_endpoint = meta["edit_endpoint"]
+
+        aspect_lc = (aspect_ratio or DEFAULT_ASPECT_RATIO).lower().strip()
+        if aspect_lc not in VALID_ASPECT_RATIOS:
+            logger.warning(
+                "Invalid aspect_ratio '%s', defaulting to '%s'",
+                aspect_ratio, DEFAULT_ASPECT_RATIO,
+            )
+            aspect_lc = DEFAULT_ASPECT_RATIO
+
+        sources = [image_url.strip()]
+        if reference_image_urls:
+            for ref in reference_image_urls:
+                if isinstance(ref, str) and ref.strip():
+                    sources.append(ref.strip())
+
+        max_refs = int(meta.get("max_reference_images") or 1)
+        clamped_sources = sources[:max_refs] if max_refs > 0 else sources
+
+        arguments = _build_fal_edit_payload(
+            model_id, prompt, clamped_sources, aspect_lc, seed=seed
+        )
+
+        logger.info(
+            "Editing image with %s (%s) — %d source image(s), prompt: %s",
+            meta.get("display", model_id), edit_endpoint, len(clamped_sources),
+            prompt[:80],
+        )
+
+        handler = _submit_fal_request(edit_endpoint, arguments=arguments)
+        result = handler.get()
+
+        if not result or "images" not in result:
+            raise ValueError("Invalid response from FAL.ai API — no images returned")
+
+        images = result.get("images", [])
+        if not images:
+            raise ValueError("No edited images were returned")
+
+        img = images[0]
+        response_data = {
+            "success": True,
+            "image": img.get("url"),
+            "output_url": img.get("url"),
+            "media_type": "image",
+            "width": img.get("width", 0),
+            "height": img.get("height", 0),
+            "modality": "image",
+        }
+
+        if len(images) > 1:
+            response_data["images"] = [
+                {"url": i.get("url"), "width": i.get("width", 0), "height": i.get("height", 0)}
+                for i in images
+            ]
+
+        return json.dumps(response_data, indent=2, ensure_ascii=False)
+
+    except Exception as exc:
+        logger.error("Error editing image: %s", exc, exc_info=True)
+        response_data["error"] = str(exc)
+        response_data["error_type"] = type(exc).__name__
+        return json.dumps(response_data, indent=2, ensure_ascii=False)
+
+
+def _handle_image_edit(args: Dict[str, Any], **kw) -> str:
+    prompt = args.get("prompt", "")
+    image_url = args.get("image_url")
+    reference_image_urls = args.get("reference_image_urls")
+    aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    seed = args.get("seed")
+    model = args.get("model")
+
+    if not prompt:
+        return tool_error("prompt is required for image editing")
+    if not image_url:
+        return tool_error("image_url is required for image editing")
+
+    return image_edit_tool(
+        prompt=prompt,
+        image_url=image_url,
+        reference_image_urls=reference_image_urls,
+        aspect_ratio=aspect_ratio,
+        seed=seed,
+        model=model,
+    )
+
+
+IMAGE_EDIT_SCHEMA = {
+    "name": "image_edit",
+    "description": (
+        "Edit or transform an existing image using a FAL.ai image-to-image "
+        "model (default: Gemini 3.1 Flash Image Preview). Provide a natural-"
+        "language edit instruction in ``prompt`` and the source image in "
+        "``image_url``. Add ``reference_image_urls`` for style or composition "
+        "references when supported."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "The edit instruction, e.g. 'make the background a sunset beach'.",
+            },
+            "image_url": {
+                "type": "string",
+                "description": "Public URL or absolute local path of the image to edit.",
+            },
+            "reference_image_urls": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional reference images for style / composition. "
+                    "Capped per-model."
+                ),
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": list(VALID_ASPECT_RATIOS),
+                "description": "Output aspect ratio. 'landscape' is 16:9, 'portrait' is 9:16, 'square' is 1:1.",
+                "default": DEFAULT_ASPECT_RATIO,
+            },
+            "seed": {
+                "type": "integer",
+                "description": "Optional seed for reproducible output.",
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Optional FAL model override. If omitted, the configured "
+                    "``image_gen.model`` is used."
+                ),
+            },
+        },
+        "required": ["prompt", "image_url"],
+    },
+}
+
+
+registry.register(
+    name="image_edit",
+    toolset="image_edit",
+    schema=IMAGE_EDIT_SCHEMA,
+    handler=_handle_image_edit,
+    check_fn=check_fal_api_key,
+    requires_env=[],
+    is_async=False,
+    emoji="🖌️",
+)

--- a/tools/fal_remove_background_tool.py
+++ b/tools/fal_remove_background_tool.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+FAL Background Removal Tool
+
+Removes backgrounds from images using Ideogram Remove Background or
+BiRefNet V2 via FAL.ai.
+"""
+
+import json
+import logging
+from typing import Any, Dict
+
+from tools.image_generation_tool import _submit_fal_request, check_fal_api_key
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+IDEOGRAM_REMOVE_BACKGROUND_MODEL = "fal-ai/ideogram/remove-background"
+BIREFNET_MODEL = "fal-ai/birefnet/v2"
+IDEOGRAM_MODEL = "Ideogram Remove Background"
+
+BIREFNET_MODELS = (
+    "General Use (Light)",
+    "General Use (Light 2K)",
+    "General Use (Heavy)",
+    "Matting",
+    "Portrait",
+    "General Use (Dynamic)",
+)
+
+VALID_MODELS = (IDEOGRAM_MODEL, *BIREFNET_MODELS)
+VALID_RESOLUTIONS = ("1024x1024", "2048x2048", "2304x2304")
+
+VALID_OUTPUT_FORMATS = ("webp", "png", "gif")
+
+
+def remove_background_tool(
+    image_url: str,
+    model: str = IDEOGRAM_MODEL,
+    operating_resolution: str = "1024x1024",
+    output_format: str = "png",
+    output_mask: bool = False,
+    mask_only: bool = False,
+    refine_foreground: bool = True,
+    sync_mode: bool = False,
+) -> str:
+    """Remove the background from an image using Ideogram or BiRefNet V2.
+
+    Returns a JSON string with ``success``, ``image`` (URL), and optionally
+    ``mask_image``.
+    """
+    response_data: Dict[str, Any] = {
+        "success": False,
+        "image": None,
+        "error": None,
+        "error_type": None,
+    }
+
+    try:
+        if not image_url or not isinstance(image_url, str) or not image_url.strip():
+            raise ValueError("image_url is required")
+
+        if not check_fal_api_key():
+            raise ValueError(
+                "FAL_KEY is not set and no managed FAL gateway is available."
+            )
+
+        if model not in VALID_MODELS:
+            raise ValueError(
+                f"Invalid model '{model}'. Choose one of: {', '.join(VALID_MODELS)}"
+            )
+
+        if model == IDEOGRAM_MODEL:
+            arguments = {
+                "image_url": image_url.strip(),
+                "sync_mode": sync_mode,
+            }
+            endpoint = IDEOGRAM_REMOVE_BACKGROUND_MODEL
+            logger.info("Removing background from %s with Ideogram", image_url)
+        else:
+            if operating_resolution not in VALID_RESOLUTIONS:
+                raise ValueError(
+                    f"Invalid operating_resolution '{operating_resolution}'. "
+                    f"Choose one of: {', '.join(VALID_RESOLUTIONS)}"
+                )
+
+            if output_format not in VALID_OUTPUT_FORMATS:
+                raise ValueError(
+                    f"Invalid output_format '{output_format}'. "
+                    f"Choose one of: {', '.join(VALID_OUTPUT_FORMATS)}"
+                )
+
+            # 2304x2304 is only valid for the Dynamic model.
+            if operating_resolution == "2304x2304" and model != "General Use (Dynamic)":
+                raise ValueError(
+                    "Resolution 2304x2304 is only available for the "
+                    "'General Use (Dynamic)' model."
+                )
+
+            arguments = {
+                "image_url": image_url.strip(),
+                "model": model,
+                "operating_resolution": operating_resolution,
+                "output_format": output_format,
+                "output_mask": output_mask,
+                "mask_only": mask_only,
+                "refine_foreground": refine_foreground,
+                "sync_mode": sync_mode,
+            }
+            endpoint = BIREFNET_MODEL
+            logger.info("Removing background from %s with BiRefNet V2", image_url)
+
+        handler = _submit_fal_request(endpoint, arguments=arguments)
+        result = handler.get()
+
+        if not result or "image" not in result:
+            raise ValueError("Invalid response from FAL.ai API — no image returned")
+
+        img = result["image"]
+        response_data = {
+            "success": True,
+            "image": img.get("url"),
+            "output_url": img.get("url"),
+            "media_type": "image",
+            "model": model,
+            "width": img.get("width", 0),
+            "height": img.get("height", 0),
+            "content_type": img.get("content_type"),
+        }
+
+        if result.get("mask_image"):
+            mask = result["mask_image"]
+            response_data["mask_image"] = {
+                "url": mask.get("url"),
+                "width": mask.get("width", 0),
+                "height": mask.get("height", 0),
+                "content_type": mask.get("content_type"),
+            }
+
+        return json.dumps(response_data, indent=2, ensure_ascii=False)
+
+    except Exception as exc:
+        logger.error("Error removing background: %s", exc, exc_info=True)
+        response_data["error"] = str(exc)
+        response_data["error_type"] = type(exc).__name__
+        return json.dumps(response_data, indent=2, ensure_ascii=False)
+
+
+def _handle_remove_background(args: Dict[str, Any], **kw) -> str:
+    image_url = args.get("image_url")
+    if not image_url:
+        return tool_error("image_url is required")
+
+    return remove_background_tool(
+        image_url=image_url,
+        model=args.get("model", IDEOGRAM_MODEL),
+        operating_resolution=args.get("operating_resolution", "1024x1024"),
+        output_format=args.get("output_format", "png"),
+        output_mask=args.get("output_mask", False),
+        mask_only=args.get("mask_only", False),
+        refine_foreground=args.get("refine_foreground", True),
+        sync_mode=args.get("sync_mode", False),
+    )
+
+
+REMOVE_BACKGROUND_SCHEMA = {
+    "name": "remove_background",
+    "description": (
+        "Remove the background from an image using FAL.ai Ideogram Remove "
+        "Background by default, or BiRefNet V2 variants when selected. "
+        "Returns the foreground image (and optionally a mask for BiRefNet)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "image_url": {
+                "type": "string",
+                "description": "URL or absolute path of the image to process.",
+            },
+            "model": {
+                "type": "string",
+                "enum": list(VALID_MODELS),
+                "description": (
+                    "Background-removal model. Ideogram is the default; "
+                    "BiRefNet variants remain available for mask output and "
+                    "resolution/model controls."
+                ),
+                "default": IDEOGRAM_MODEL,
+            },
+            "operating_resolution": {
+                "type": "string",
+                "enum": list(VALID_RESOLUTIONS),
+                "description": "Processing resolution. 2304x2304 requires 'General Use (Dynamic)'.",
+                "default": "1024x1024",
+            },
+            "output_format": {
+                "type": "string",
+                "enum": list(VALID_OUTPUT_FORMATS),
+                "description": "Output image format.",
+                "default": "png",
+            },
+            "output_mask": {
+                "type": "boolean",
+                "description": "Also return the segmentation mask used to remove the background.",
+                "default": False,
+            },
+            "mask_only": {
+                "type": "boolean",
+                "description": "Return only the segmentation mask without applying it.",
+                "default": False,
+            },
+            "refine_foreground": {
+                "type": "boolean",
+                "description": "Refine the foreground using the estimated mask.",
+                "default": True,
+            },
+            "sync_mode": {
+                "type": "boolean",
+                "description": "Return media as a data URI and skip request history.",
+                "default": False,
+            },
+        },
+        "required": ["image_url"],
+    },
+}
+
+
+registry.register(
+    name="remove_background",
+    toolset="image_background_removal",
+    schema=REMOVE_BACKGROUND_SCHEMA,
+    handler=_handle_remove_background,
+    check_fn=check_fal_api_key,
+    requires_env=[],
+    is_async=False,
+    emoji="🧵",
+)

--- a/tools/fal_remove_video_background_tool.py
+++ b/tools/fal_remove_video_background_tool.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+FAL Video Background Removal Tool
+
+Removes backgrounds from videos using BiRefNet V2 Video via FAL.ai.
+"""
+
+import json
+import logging
+from typing import Any, Dict
+
+from tools.image_generation_tool import _submit_fal_request, check_fal_api_key
+from tools.fal_video_input import resolve_fal_video_input
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+BIREFNET_VIDEO_MODEL = "fal-ai/birefnet/v2/video"
+
+VALID_MODELS = (
+    "General Use (Light)",
+    "General Use (Light 2K)",
+    "General Use (Heavy)",
+    "Matting",
+    "Portrait",
+    "General Use (Dynamic)",
+)
+
+VALID_RESOLUTIONS = ("1024x1024", "2048x2048", "2304x2304")
+VALID_OUTPUT_TYPES = ("X264 (.mp4)", "VP9 (.webm)", "PRORES4444 (.mov)", "GIF (.gif)")
+VALID_QUALITIES = ("low", "medium", "high", "maximum")
+VALID_WRITE_MODES = ("fast", "balanced", "small")
+
+
+def _copy_present_video_metadata(response: Dict[str, Any], video: Dict[str, Any]) -> None:
+    for key in ("width", "height", "fps", "duration", "num_frames"):
+        value = video.get(key)
+        if value not in (None, "", 0):
+            response[key] = value
+    if video.get("content_type"):
+        response["content_type"] = video.get("content_type")
+
+
+def remove_video_background_tool(
+    video_url: str,
+    model: str = "General Use (Light)",
+    operating_resolution: str = "1024x1024",
+    video_output_type: str = "X264 (.mp4)",
+    video_quality: str = "high",
+    video_write_mode: str = "balanced",
+    output_mask: bool = False,
+    refine_foreground: bool = True,
+    sync_mode: bool = False,
+) -> str:
+    """Remove the background from a video using BiRefNet V2 Video."""
+    response_data: Dict[str, Any] = {
+        "success": False,
+        "video": None,
+        "error": None,
+        "error_type": None,
+    }
+
+    try:
+        resolved_video_url = resolve_fal_video_input(
+            video_url,
+            image_error=(
+                "video_url must reference a video file, not an image. "
+                "Use remove_background for still images."
+            ),
+        )
+
+        if not check_fal_api_key():
+            raise ValueError(
+                "FAL_KEY is not set and no managed FAL gateway is available."
+            )
+
+        if model not in VALID_MODELS:
+            raise ValueError(
+                f"Invalid model '{model}'. Choose one of: {', '.join(VALID_MODELS)}"
+            )
+        if operating_resolution not in VALID_RESOLUTIONS:
+            raise ValueError(
+                f"Invalid operating_resolution '{operating_resolution}'. "
+                f"Choose one of: {', '.join(VALID_RESOLUTIONS)}"
+            )
+        if video_output_type not in VALID_OUTPUT_TYPES:
+            raise ValueError(
+                f"Invalid video_output_type '{video_output_type}'. "
+                f"Choose one of: {', '.join(VALID_OUTPUT_TYPES)}"
+            )
+        if video_quality not in VALID_QUALITIES:
+            raise ValueError(
+                f"Invalid video_quality '{video_quality}'. "
+                f"Choose one of: {', '.join(VALID_QUALITIES)}"
+            )
+        if video_write_mode not in VALID_WRITE_MODES:
+            raise ValueError(
+                f"Invalid video_write_mode '{video_write_mode}'. "
+                f"Choose one of: {', '.join(VALID_WRITE_MODES)}"
+            )
+        if operating_resolution == "2304x2304" and model != "General Use (Dynamic)":
+            raise ValueError(
+                "Resolution 2304x2304 is only available for the "
+                "'General Use (Dynamic)' model."
+            )
+
+        arguments: Dict[str, Any] = {
+            "video_url": resolved_video_url,
+            "model": model,
+            "operating_resolution": operating_resolution,
+            "video_output_type": video_output_type,
+            "video_quality": video_quality,
+            "video_write_mode": video_write_mode,
+            "output_mask": output_mask,
+            "refine_foreground": refine_foreground,
+            "sync_mode": sync_mode,
+        }
+
+        logger.info("Removing background from video %s with BiRefNet V2", resolved_video_url)
+        handler = _submit_fal_request(BIREFNET_VIDEO_MODEL, arguments=arguments)
+        result = handler.get()
+
+        if not result or "video" not in result:
+            raise ValueError("Invalid response from FAL.ai API — no video returned")
+
+        video = result["video"]
+        response_data = {
+            "success": True,
+            "video": video.get("url"),
+            "output_url": video.get("url"),
+            "media_type": "video",
+        }
+        _copy_present_video_metadata(response_data, video)
+
+        if result.get("mask_video"):
+            mask = result["mask_video"]
+            response_data["mask_video"] = {
+                "url": mask.get("url"),
+            }
+            _copy_present_video_metadata(response_data["mask_video"], mask)
+
+        return json.dumps(response_data, indent=2, ensure_ascii=False)
+
+    except Exception as exc:
+        logger.error("Error removing video background: %s", exc, exc_info=True)
+        response_data["error"] = str(exc)
+        response_data["error_type"] = type(exc).__name__
+        return json.dumps(response_data, indent=2, ensure_ascii=False)
+
+
+def _handle_remove_video_background(args: Dict[str, Any], **kw) -> str:
+    video_url = args.get("video_url")
+    if not video_url:
+        return tool_error("video_url is required")
+
+    return remove_video_background_tool(
+        video_url=video_url,
+        model=args.get("model", "General Use (Light)"),
+        operating_resolution=args.get("operating_resolution", "1024x1024"),
+        video_output_type=args.get("video_output_type", "X264 (.mp4)"),
+        video_quality=args.get("video_quality", "high"),
+        video_write_mode=args.get("video_write_mode", "balanced"),
+        output_mask=args.get("output_mask", False),
+        refine_foreground=args.get("refine_foreground", True),
+        sync_mode=args.get("sync_mode", False),
+    )
+
+
+REMOVE_VIDEO_BACKGROUND_SCHEMA = {
+    "name": "remove_video_background",
+    "description": (
+        "Remove the background from a video using FAL.ai BiRefNet V2 Video. "
+        "Returns the foreground video (and optionally a mask video)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "video_url": {
+                "type": "string",
+                "description": "URL or absolute path of the video to process.",
+            },
+            "model": {
+                "type": "string",
+                "enum": list(VALID_MODELS),
+                "description": "BiRefNet model variant.",
+                "default": "General Use (Light)",
+            },
+            "operating_resolution": {
+                "type": "string",
+                "enum": list(VALID_RESOLUTIONS),
+                "description": "Processing resolution. 2304x2304 requires 'General Use (Dynamic)'.",
+                "default": "1024x1024",
+            },
+            "video_output_type": {
+                "type": "string",
+                "enum": list(VALID_OUTPUT_TYPES),
+                "description": "Container/codec of the output video.",
+                "default": "X264 (.mp4)",
+            },
+            "video_quality": {
+                "type": "string",
+                "enum": list(VALID_QUALITIES),
+                "description": "Output video quality.",
+                "default": "high",
+            },
+            "video_write_mode": {
+                "type": "string",
+                "enum": list(VALID_WRITE_MODES),
+                "description": "Trade-off between speed, size, and quality.",
+                "default": "balanced",
+            },
+            "output_mask": {
+                "type": "boolean",
+                "description": "Also return the segmentation mask video.",
+                "default": False,
+            },
+            "refine_foreground": {
+                "type": "boolean",
+                "description": "Refine the foreground using the estimated mask.",
+                "default": True,
+            },
+            "sync_mode": {
+                "type": "boolean",
+                "description": "Return media as a data URI and skip request history.",
+                "default": False,
+            },
+        },
+        "required": ["video_url"],
+    },
+}
+
+
+registry.register(
+    name="remove_video_background",
+    toolset="video_background_removal",
+    schema=REMOVE_VIDEO_BACKGROUND_SCHEMA,
+    handler=_handle_remove_video_background,
+    check_fn=check_fal_api_key,
+    requires_env=[],
+    is_async=False,
+    emoji="🎥",
+)

--- a/tools/fal_upscale_image_tool.py
+++ b/tools/fal_upscale_image_tool.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""
+FAL Image Upscale Tool
+
+Upscales images using SeedVR2 via FAL.ai.
+"""
+
+import json
+import logging
+from typing import Any, Dict, Optional
+
+from tools.image_generation_tool import _submit_fal_request, check_fal_api_key
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+SEEDVR_UPSCALE_IMAGE_MODEL = "fal-ai/seedvr/upscale/image"
+
+VALID_MODES = ("target", "factor")
+VALID_TARGET_RESOLUTIONS = ("720p", "1080p", "1440p", "2160p")
+VALID_OUTPUT_FORMATS = ("png", "jpg", "webp")
+
+
+def upscale_image_tool(
+    image_url: str,
+    upscale_mode: str = "factor",
+    upscale_factor: float = 2.0,
+    target_resolution: str = "1080p",
+    noise_scale: float = 0.1,
+    output_format: str = "jpg",
+    seed: Optional[int] = None,
+    sync_mode: bool = False,
+) -> str:
+    """Upscale an image using SeedVR2.
+
+    Either ``upscale_factor`` (when mode='factor') or ``target_resolution``
+    (when mode='target') is used by the API.
+    """
+    response_data: Dict[str, Any] = {
+        "success": False,
+        "image": None,
+        "error": None,
+        "error_type": None,
+    }
+
+    try:
+        if not image_url or not isinstance(image_url, str) or not image_url.strip():
+            raise ValueError("image_url is required")
+
+        if not check_fal_api_key():
+            raise ValueError(
+                "FAL_KEY is not set and no managed FAL gateway is available."
+            )
+
+        if upscale_mode not in VALID_MODES:
+            raise ValueError(
+                f"Invalid upscale_mode '{upscale_mode}'. Choose one of: {', '.join(VALID_MODES)}"
+            )
+        if target_resolution not in VALID_TARGET_RESOLUTIONS:
+            raise ValueError(
+                f"Invalid target_resolution '{target_resolution}'. "
+                f"Choose one of: {', '.join(VALID_TARGET_RESOLUTIONS)}"
+            )
+        if output_format not in VALID_OUTPUT_FORMATS:
+            raise ValueError(
+                f"Invalid output_format '{output_format}'. "
+                f"Choose one of: {', '.join(VALID_OUTPUT_FORMATS)}"
+            )
+        if not (1.0 <= upscale_factor <= 10.0):
+            raise ValueError("upscale_factor must be between 1.0 and 10.0")
+        if not (0.0 <= noise_scale <= 1.0):
+            raise ValueError("noise_scale must be between 0.0 and 1.0")
+
+        arguments: Dict[str, Any] = {
+            "image_url": image_url.strip(),
+            "upscale_mode": upscale_mode,
+            "upscale_factor": upscale_factor,
+            "target_resolution": target_resolution,
+            "noise_scale": noise_scale,
+            "output_format": output_format,
+            "sync_mode": sync_mode,
+        }
+        if seed is not None:
+            arguments["seed"] = seed
+
+        logger.info("Upscaling image %s with SeedVR2", image_url)
+        handler = _submit_fal_request(SEEDVR_UPSCALE_IMAGE_MODEL, arguments=arguments)
+        result = handler.get()
+
+        if not result or "image" not in result:
+            raise ValueError("Invalid response from FAL.ai API — no image returned")
+
+        img = result["image"]
+        response_data = {
+            "success": True,
+            "image": img.get("url"),
+            "output_url": img.get("url"),
+            "media_type": "image",
+            "width": img.get("width", 0),
+            "height": img.get("height", 0),
+            "content_type": img.get("content_type"),
+            "seed": result.get("seed"),
+        }
+
+        return json.dumps(response_data, indent=2, ensure_ascii=False)
+
+    except Exception as exc:
+        logger.error("Error upscaling image: %s", exc, exc_info=True)
+        response_data["error"] = str(exc)
+        response_data["error_type"] = type(exc).__name__
+        return json.dumps(response_data, indent=2, ensure_ascii=False)
+
+
+def _handle_upscale_image(args: Dict[str, Any], **kw) -> str:
+    image_url = args.get("image_url")
+    if not image_url:
+        return tool_error("image_url is required")
+
+    return upscale_image_tool(
+        image_url=image_url,
+        upscale_mode=args.get("upscale_mode", "factor"),
+        upscale_factor=args.get("upscale_factor", 2.0),
+        target_resolution=args.get("target_resolution", "1080p"),
+        noise_scale=args.get("noise_scale", 0.1),
+        output_format=args.get("output_format", "jpg"),
+        seed=args.get("seed"),
+        sync_mode=args.get("sync_mode", False),
+    )
+
+
+UPSCALE_IMAGE_SCHEMA = {
+    "name": "upscale_image",
+    "description": (
+        "Upscale an image using FAL.ai SeedVR2. Supports factor-based or "
+        "target-resolution upscaling."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "image_url": {
+                "type": "string",
+                "description": "URL or absolute path of the image to upscale.",
+            },
+            "upscale_mode": {
+                "type": "string",
+                "enum": list(VALID_MODES),
+                "description": "'factor' multiplies dimensions; 'target' uses target_resolution.",
+                "default": "factor",
+            },
+            "upscale_factor": {
+                "type": "number",
+                "description": "Multiplier when upscale_mode='factor' (1.0-10.0).",
+                "default": 2.0,
+            },
+            "target_resolution": {
+                "type": "string",
+                "enum": list(VALID_TARGET_RESOLUTIONS),
+                "description": "Target resolution when upscale_mode='target'.",
+                "default": "1080p",
+            },
+            "noise_scale": {
+                "type": "number",
+                "description": "Noise scale for the generation process (0.0-1.0).",
+                "default": 0.1,
+            },
+            "output_format": {
+                "type": "string",
+                "enum": list(VALID_OUTPUT_FORMATS),
+                "description": "Output image format.",
+                "default": "jpg",
+            },
+            "seed": {
+                "type": "integer",
+                "description": "Optional seed for reproducible output.",
+            },
+            "sync_mode": {
+                "type": "boolean",
+                "description": "Return media as a data URI and skip request history.",
+                "default": False,
+            },
+        },
+        "required": ["image_url"],
+    },
+}
+
+
+registry.register(
+    name="upscale_image",
+    toolset="image_upscale",
+    schema=UPSCALE_IMAGE_SCHEMA,
+    handler=_handle_upscale_image,
+    check_fn=check_fal_api_key,
+    requires_env=[],
+    is_async=False,
+    emoji="💎",
+)

--- a/tools/fal_upscale_video_tool.py
+++ b/tools/fal_upscale_video_tool.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""
+FAL Video Upscale Tool
+
+Upscales videos using SeedVR2 Video via FAL.ai.
+
+Note: the public documentation snippet for the video endpoint was incomplete,
+so this implementation uses the standard SeedVR2 video-upscale shape
+(video_url + upscale_factor / target_resolution) and the canonical
+``fal-ai/seedvr/upscale/video`` endpoint. Verify against the live FAL schema
+if you hit parameter errors.
+"""
+
+import json
+import logging
+from typing import Any, Dict, Optional
+
+from tools.image_generation_tool import _submit_fal_request, check_fal_api_key
+from tools.fal_video_input import resolve_fal_video_input
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+SEEDVR_UPSCALE_VIDEO_MODEL = "fal-ai/seedvr/upscale/video"
+
+VALID_MODES = ("target", "factor")
+VALID_TARGET_RESOLUTIONS = ("720p", "1080p", "1440p", "2160p")
+VALID_OUTPUT_FORMATS = ("X264 (.mp4)", "VP9 (.webm)", "PRORES4444 (.mov)", "GIF (.gif)")
+VALID_OUTPUT_QUALITIES = ("low", "medium", "high", "maximum")
+VALID_OUTPUT_WRITE_MODES = ("fast", "balanced", "small")
+
+
+def _copy_present_video_metadata(response: Dict[str, Any], video: Dict[str, Any]) -> None:
+    for key in ("width", "height", "fps", "duration", "num_frames"):
+        value = video.get(key)
+        if value not in (None, "", 0):
+            response[key] = value
+    if video.get("content_type"):
+        response["content_type"] = video.get("content_type")
+
+
+def upscale_video_tool(
+    video_url: str,
+    upscale_mode: str = "factor",
+    upscale_factor: float = 2.0,
+    target_resolution: str = "1080p",
+    noise_scale: float = 0.1,
+    output_format: str = "X264 (.mp4)",
+    output_quality: str = "high",
+    output_write_mode: str = "balanced",
+    seed: Optional[int] = None,
+    sync_mode: bool = False,
+) -> str:
+    """Upscale a video using SeedVR2 Video."""
+    response_data: Dict[str, Any] = {
+        "success": False,
+        "video": None,
+        "error": None,
+        "error_type": None,
+    }
+
+    try:
+        resolved_video_url = resolve_fal_video_input(
+            video_url,
+            image_error=(
+                "video_url must reference a video file, not an image. "
+                "Use image-to-video generation first, then pass the resulting video URL."
+            ),
+        )
+
+        if not check_fal_api_key():
+            raise ValueError(
+                "FAL_KEY is not set and no managed FAL gateway is available."
+            )
+
+        if upscale_mode not in VALID_MODES:
+            raise ValueError(
+                f"Invalid upscale_mode '{upscale_mode}'. Choose one of: {', '.join(VALID_MODES)}"
+            )
+        if target_resolution not in VALID_TARGET_RESOLUTIONS:
+            raise ValueError(
+                f"Invalid target_resolution '{target_resolution}'. "
+                f"Choose one of: {', '.join(VALID_TARGET_RESOLUTIONS)}"
+            )
+        if not (1.0 <= upscale_factor <= 10.0):
+            raise ValueError("upscale_factor must be between 1.0 and 10.0")
+        if not (0.0 <= noise_scale <= 1.0):
+            raise ValueError("noise_scale must be between 0.0 and 1.0")
+        if output_format not in VALID_OUTPUT_FORMATS:
+            raise ValueError(
+                f"Invalid output_format '{output_format}'. Choose one of: {', '.join(VALID_OUTPUT_FORMATS)}"
+            )
+        if output_quality not in VALID_OUTPUT_QUALITIES:
+            raise ValueError(
+                f"Invalid output_quality '{output_quality}'. Choose one of: {', '.join(VALID_OUTPUT_QUALITIES)}"
+            )
+        if output_write_mode not in VALID_OUTPUT_WRITE_MODES:
+            raise ValueError(
+                f"Invalid output_write_mode '{output_write_mode}'. "
+                f"Choose one of: {', '.join(VALID_OUTPUT_WRITE_MODES)}"
+            )
+
+        arguments: Dict[str, Any] = {
+            "video_url": resolved_video_url,
+            "upscale_mode": upscale_mode,
+            "upscale_factor": upscale_factor,
+            "target_resolution": target_resolution,
+            "noise_scale": noise_scale,
+            "output_format": output_format,
+            "output_quality": output_quality,
+            "output_write_mode": output_write_mode,
+            "sync_mode": sync_mode,
+        }
+        if seed is not None:
+            arguments["seed"] = seed
+
+        logger.info("Upscaling video %s with SeedVR2", resolved_video_url)
+        handler = _submit_fal_request(SEEDVR_UPSCALE_VIDEO_MODEL, arguments=arguments)
+        result = handler.get()
+
+        if not result or "video" not in result:
+            raise ValueError("Invalid response from FAL.ai API — no video returned")
+
+        video = result["video"]
+        response_data = {
+            "success": True,
+            "video": video.get("url"),
+            "output_url": video.get("url"),
+            "media_type": "video",
+            "seed": result.get("seed"),
+        }
+        _copy_present_video_metadata(response_data, video)
+
+        return json.dumps(response_data, indent=2, ensure_ascii=False)
+
+    except Exception as exc:
+        logger.error("Error upscaling video: %s", exc, exc_info=True)
+        response_data["error"] = str(exc)
+        response_data["error_type"] = type(exc).__name__
+        return json.dumps(response_data, indent=2, ensure_ascii=False)
+
+
+def _handle_upscale_video(args: Dict[str, Any], **kw) -> str:
+    video_url = args.get("video_url")
+    if not video_url:
+        return tool_error("video_url is required")
+
+    return upscale_video_tool(
+        video_url=video_url,
+        upscale_mode=args.get("upscale_mode", "factor"),
+        upscale_factor=args.get("upscale_factor", 2.0),
+        target_resolution=args.get("target_resolution", "1080p"),
+        noise_scale=args.get("noise_scale", 0.1),
+        output_format=args.get("output_format", "X264 (.mp4)"),
+        output_quality=args.get("output_quality", "high"),
+        output_write_mode=args.get("output_write_mode", "balanced"),
+        seed=args.get("seed"),
+        sync_mode=args.get("sync_mode", False),
+    )
+
+
+UPSCALE_VIDEO_SCHEMA = {
+    "name": "upscale_video",
+    "description": (
+        "Upscale a video using FAL.ai SeedVR2 Video. Supports factor-based "
+        "or target-resolution upscaling."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "video_url": {
+                "type": "string",
+                "description": "URL or absolute path of the video to upscale.",
+            },
+            "upscale_mode": {
+                "type": "string",
+                "enum": list(VALID_MODES),
+                "description": "'factor' multiplies dimensions; 'target' uses target_resolution.",
+                "default": "factor",
+            },
+            "upscale_factor": {
+                "type": "number",
+                "description": "Multiplier when upscale_mode='factor' (1.0-10.0).",
+                "default": 2.0,
+            },
+            "target_resolution": {
+                "type": "string",
+                "enum": list(VALID_TARGET_RESOLUTIONS),
+                "description": "Target resolution when upscale_mode='target'.",
+                "default": "1080p",
+            },
+            "noise_scale": {
+                "type": "number",
+                "description": "Noise scale for the generation process (0.0-1.0).",
+                "default": 0.1,
+            },
+            "output_format": {
+                "type": "string",
+                "enum": list(VALID_OUTPUT_FORMATS),
+                "description": "Container/codec of the output video.",
+                "default": "X264 (.mp4)",
+            },
+            "output_quality": {
+                "type": "string",
+                "enum": list(VALID_OUTPUT_QUALITIES),
+                "description": "Output video quality.",
+                "default": "high",
+            },
+            "output_write_mode": {
+                "type": "string",
+                "enum": list(VALID_OUTPUT_WRITE_MODES),
+                "description": "Trade-off between speed, size, and quality.",
+                "default": "balanced",
+            },
+            "seed": {
+                "type": "integer",
+                "description": "Optional seed for reproducible output.",
+            },
+            "sync_mode": {
+                "type": "boolean",
+                "description": "Return media as a data URI and skip request history.",
+                "default": False,
+            },
+        },
+        "required": ["video_url"],
+    },
+}
+
+
+registry.register(
+    name="upscale_video",
+    toolset="video_upscale",
+    schema=UPSCALE_VIDEO_SCHEMA,
+    handler=_handle_upscale_video,
+    check_fn=check_fal_api_key,
+    requires_env=[],
+    is_async=False,
+    emoji="📼",
+)

--- a/tools/fal_video_input.py
+++ b/tools/fal_video_input.py
@@ -1,0 +1,98 @@
+"""Input normalization for FAL video-to-video tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+from tools.image_generation_tool import _load_fal_client
+from tools.tool_backend_helpers import fal_key_is_configured
+
+
+IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp", ".svg")
+VIDEO_EXTENSIONS = (".mp4", ".webm", ".mov", ".m4v", ".avi", ".mpeg", ".mpg", ".mkv")
+WEBPAGE_EXTENSIONS = (".html", ".htm", ".php", ".asp", ".aspx")
+
+
+def _path_without_query(value: str) -> str:
+    return value.strip().lower().split("?", 1)[0].split("#", 1)[0]
+
+
+def looks_like_image_url(value: str) -> bool:
+    lower = _path_without_query(value)
+    return lower.startswith("data:image/") or lower.endswith(IMAGE_EXTENSIONS)
+
+
+def looks_like_webpage_url(value: str) -> bool:
+    raw = value.strip()
+    lower = raw.lower()
+    if lower.startswith("data:text/html"):
+        return True
+
+    parsed = urlparse(raw)
+    host = (parsed.netloc or "").lower()
+    path = (parsed.path or "").lower()
+    if host in {"docs.fal.ai", "docs.fal.co"}:
+        return True
+    if host.endswith(".fal.ai") and path.startswith("/docs"):
+        return True
+    return path.endswith(WEBPAGE_EXTENSIONS)
+
+
+def _local_path_from_video_url(value: str) -> Path | None:
+    raw = value.strip()
+    parsed = urlparse(raw)
+    if parsed.scheme in {"http", "https", "data"}:
+        return None
+    if parsed.scheme == "file":
+        return Path(unquote(parsed.path)).expanduser()
+    if parsed.scheme:
+        return None
+    return Path(raw).expanduser()
+
+
+def resolve_fal_video_input(video_url: str, *, image_error: str) -> str:
+    """Return a FAL-readable video URL, uploading local files when needed."""
+    if not video_url or not isinstance(video_url, str) or not video_url.strip():
+        raise ValueError("video_url is required")
+    if looks_like_image_url(video_url):
+        raise ValueError(image_error)
+    if looks_like_webpage_url(video_url):
+        raise ValueError(
+            "video_url must be a direct, publicly downloadable video file URL, "
+            "not a documentation page or webpage. Use a .mp4/.webm URL or the "
+            "video/output_url returned by video_generate."
+        )
+
+    local_path = _local_path_from_video_url(video_url)
+    if local_path is None:
+        return video_url.strip()
+
+    if not local_path.exists():
+        raise ValueError(
+            "video_url must be a direct public video URL or an existing local "
+            f"video file path; file not found: {local_path}"
+        )
+    if not local_path.is_file():
+        raise ValueError(f"video_url local path is not a file: {local_path}")
+    if local_path.suffix.lower() not in VIDEO_EXTENSIONS:
+        raise ValueError(
+            "video_url local path must reference a video file "
+            f"({', '.join(VIDEO_EXTENSIONS)}): {local_path}"
+        )
+    if not fal_key_is_configured():
+        raise ValueError(
+            "Local video file inputs require a direct FAL_KEY so Hermes can "
+            "upload the file to FAL storage before processing. Set FAL_KEY or "
+            "pass a direct public video URL."
+        )
+
+    fal_client = _load_fal_client()
+    upload_file = getattr(fal_client, "upload_file", None)
+    if upload_file is None:
+        raise RuntimeError("fal_client.upload_file is required for local video inputs")
+
+    uploaded_url = upload_file(str(local_path))
+    if not isinstance(uploaded_url, str) or not uploaded_url.strip():
+        raise RuntimeError("fal_client.upload_file did not return a video URL")
+    return uploaded_url.strip()

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -95,6 +95,40 @@ logger = logging.getLogger(__name__)
 # ``upscale`` controls whether to chain Clarity Upscaler after generation.
 
 FAL_MODELS: Dict[str, Dict[str, Any]] = {
+    "fal-ai/gemini-3.1-flash-image-preview": {
+        "display": "Gemini 3.1 Flash Image Preview",
+        "speed": "~1s",
+        "strengths": "Fast Gemini image gen + edit",
+        "price": "$0.08/image (1K)",
+        "size_style": "aspect_ratio",
+        "sizes": {
+            "landscape": "16:9",
+            "square": "1:1",
+            "portrait": "9:16",
+        },
+        "defaults": {
+            "num_images": 1,
+            "output_format": "png",
+            "safety_tolerance": "4",
+            "resolution": "1K",
+            "limit_generations": True,
+        },
+        "supports": {
+            "prompt", "aspect_ratio", "num_images", "output_format",
+            "safety_tolerance", "seed", "sync_mode", "resolution",
+            "limit_generations", "enable_web_search", "system_prompt",
+            "thinking_level",
+        },
+        "upscale": False,
+        "edit_endpoint": "fal-ai/gemini-3.1-flash-image-preview/edit",
+        "edit_supports": {
+            "prompt", "image_urls", "aspect_ratio", "num_images",
+            "output_format", "safety_tolerance", "seed", "sync_mode",
+            "resolution", "limit_generations", "enable_web_search",
+            "system_prompt", "thinking_level", "video_url", "audio_url", "pdf_url",
+        },
+        "max_reference_images": 9,
+    },
     "fal-ai/flux-2/klein/9b": {
         "display": "FLUX 2 Klein 9B",
         "speed": "<1s",
@@ -420,7 +454,7 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
 }
 
 # Default model is the fastest reasonable option. Kept cheap and sub-1s.
-DEFAULT_MODEL = "fal-ai/flux-2/klein/9b"
+DEFAULT_MODEL = "fal-ai/gemini-3.1-flash-image-preview"
 
 DEFAULT_ASPECT_RATIO = "landscape"
 VALID_ASPECT_RATIOS = ("landscape", "square", "portrait")
@@ -1006,6 +1040,8 @@ def image_generate_tool(
         response_data = {
             "success": True,
             "image": formatted_images[0]["url"] if formatted_images else None,
+            "output_url": formatted_images[0]["url"] if formatted_images else None,
+            "media_type": "image",
             "modality": modality,
         }
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -226,6 +226,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "mistral": 4000,      # conservative; no published per-request cap
     "gemini": 32000,      # Gemini TTS has a 32k-token context window; char cap is conservative
     "elevenlabs": 10000,  # fallback when model-aware lookup can't resolve (multilingual_v2)
+    "inworld": 10000,     # Inworld TTS models accept long-form requests; conservative cap
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
     "piper": 5000,        # local VITS model, phoneme-based; practical cap

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1163,6 +1163,8 @@ def check_voice_requirements() -> Dict[str, Any]:
         details_parts.append("STT provider: OK (Groq)")
     elif stt_provider == "openai":
         details_parts.append("STT provider: OK (OpenAI)")
+    elif stt_provider == "inworld":
+        details_parts.append("STT provider: OK (Inworld)")
     else:
         details_parts.append(
             "STT provider: MISSING (uv pip install faster-whisper — "

--- a/toolsets.py
+++ b/toolsets.py
@@ -134,6 +134,24 @@ TOOLSETS = {
         "includes": []
     },
 
+    "image_edit": {
+        "description": "Edit or transform existing images via FAL.ai",
+        "tools": ["image_edit"],
+        "includes": []
+    },
+
+    "image_background_removal": {
+        "description": "Remove backgrounds from images via FAL.ai BiRefNet V2",
+        "tools": ["remove_background"],
+        "includes": []
+    },
+
+    "image_upscale": {
+        "description": "Upscale images via FAL.ai SeedVR2",
+        "tools": ["upscale_image"],
+        "includes": []
+    },
+
     "video_gen": {
         "description": (
             "Video generation tools. Single ``video_generate`` tool covers "
@@ -142,6 +160,18 @@ TOOLSETS = {
             "``hermes tools`` → Video Generation."
         ),
         "tools": ["video_generate"],
+        "includes": []
+    },
+
+    "video_background_removal": {
+        "description": "Remove backgrounds from videos via FAL.ai BiRefNet V2 Video",
+        "tools": ["remove_video_background"],
+        "includes": []
+    },
+
+    "video_upscale": {
+        "description": "Upscale videos via FAL.ai SeedVR2 Video",
+        "tools": ["upscale_video"],
         "includes": []
     },
 

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -116,6 +116,18 @@ Scoped to the Feishu document-comment handler. Drives comment read/write operati
 |------|-------------|----------------------|
 | `image_generate` | Generate images from text prompts (text-to-image) or edit/transform an existing image (image-to-image) via the user-configured backend (FAL.ai, OpenAI, xAI, Krea). Pass `image_url` to edit an image and `reference_image_urls` for style references; omit both for text-to-image. The model is user-configured and not selectable by the agent. Returns a single image URL or local path. | FAL_KEY / OPENAI_API_KEY / xAI OAuth / KREA_API_KEY |
 
+## FAL media utility toolsets
+
+These opt-in toolsets use the same FAL.ai credential or managed Nous FAL gateway as Image Generation.
+
+| Toolset | Tool | Description | Requires environment |
+|---------|------|-------------|----------------------|
+| `image_edit` | `image_edit` | Edit or transform an existing image with Gemini 3.1 Flash Image Preview edit support. | FAL_KEY or managed Nous FAL gateway |
+| `image_background_removal` | `remove_background` | Remove an image background with Ideogram Remove Background by default, with BiRefNet V2 variants still selectable. | FAL_KEY or managed Nous FAL gateway |
+| `image_upscale` | `upscale_image` | Upscale an image with SeedVR2. | FAL_KEY or managed Nous FAL gateway |
+| `video_background_removal` | `remove_video_background` | Remove a video background with BiRefNet V2 Video. | FAL_KEY or managed Nous FAL gateway |
+| `video_upscale` | `upscale_video` | Upscale a video with SeedVR2 Video. | FAL_KEY or managed Nous FAL gateway |
+
 ## `kanban` toolset
 
 Registered when the agent is either (a) spawned by the kanban dispatcher (`HERMES_KANBAN_TASK` env set) or (b) running in a profile that explicitly enables the `kanban` toolset. Task-scoped workers use lifecycle tools for their assigned task; orchestrator profiles additionally get board-routing tools like `kanban_list` and `kanban_unblock`. See [Kanban Multi-Agent](/user-guide/features/kanban) for the full workflow.
@@ -192,7 +204,7 @@ Opt-in toolset (not loaded in the default `hermes-cli` set). Add via `--toolsets
 Backends ship as plugins under `plugins/video_gen/<name>/`:
 
 - **xAI Grok-Imagine** — text-to-video and image-to-video (SuperGrok OAuth or `XAI_API_KEY`).
-- **FAL.ai** — Veo 3.1, Pixverse v6, Kling O3 (requires `FAL_KEY`).
+- **FAL.ai** — Veo 3.1, Pixverse v6, Seedance 2.0, Kling 4K, Happy Horse 1.1 (requires `FAL_KEY`; Happy Horse 1.1 also supports reference images).
 
 The single `video_generate` tool covers both modalities — pass `image_url` to animate a still, omit it to generate from text alone. The active backend auto-routes to the right endpoint. The tool's description is rebuilt at session start to reflect the active backend's actual capabilities (modalities, aspect ratios, resolutions, duration range, max reference images, audio support). See [Video Generation Provider Plugins](/developer-guide/video-gen-provider-plugin) for backend authoring.
 
@@ -260,5 +272,3 @@ Registered only on the `hermes-yuanbao` platform toolset. Yuanbao is Tencent's c
 | `yb_send_dm` | Send a private/direct message to a user in a group, with optional media files. | Yuanbao credentials |
 | `yb_search_sticker` | Search the built-in Yuanbao sticker (TIM face) catalogue by keyword. | Yuanbao credentials |
 | `yb_send_sticker` | Send a built-in sticker to the current Yuanbao chat. | Yuanbao credentials |
-
-

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -67,7 +67,12 @@ Or in-session:
 | `computer_use` | `computer_use` | Background desktop control via cua-driver — does not steal cursor/focus. Works with any tool-capable model. macOS, Windows, and Linux; requires `cua-driver` on `$PATH`. |
 | `context_engine` | (varies) | Runtime tools exposed by the active context-engine plugin (empty until a plugin populates it). |
 | `image_gen` | `image_generate` | Text-to-image generation via FAL.ai (with opt-in OpenAI / xAI backends). |
-| `video_gen` | `video_generate` | Text-to-video and image-to-video via plugin-registered backends (xAI Grok-Imagine, FAL.ai Veo 3.1 / Pixverse v6 / Kling O3). Pass `image_url` to animate an image; omit it for text-to-video. |
+| `image_edit` | `image_edit` | Edit or transform existing images via FAL.ai Gemini image edit. Opt-in; uses `FAL_KEY` or the managed Nous FAL gateway. |
+| `image_background_removal` | `remove_background` | Remove image backgrounds via FAL.ai Ideogram Remove Background by default, with BiRefNet V2 variants still selectable. Opt-in; uses `FAL_KEY` or the managed Nous FAL gateway. |
+| `image_upscale` | `upscale_image` | Upscale images via FAL.ai SeedVR2. Opt-in; uses `FAL_KEY` or the managed Nous FAL gateway. |
+| `video_gen` | `video_generate` | Text-to-video and image-to-video via plugin-registered backends (xAI Grok-Imagine, FAL.ai Veo 3.1 / Pixverse v6 / Seedance 2.0 / Kling 4K / Happy Horse 1.1). Pass `image_url` to animate an image; pass `reference_image_urls` when the active backend supports references. |
+| `video_background_removal` | `remove_video_background` | Remove video backgrounds via FAL.ai BiRefNet V2 Video. Opt-in; uses `FAL_KEY` or the managed Nous FAL gateway. |
+| `video_upscale` | `upscale_video` | Upscale videos via FAL.ai SeedVR2 Video. Opt-in; uses `FAL_KEY` or the managed Nous FAL gateway. |
 | `kanban` | `kanban_block`, `kanban_comment`, `kanban_complete`, `kanban_create`, `kanban_heartbeat`, `kanban_link`, `kanban_list`, `kanban_show`, `kanban_unblock` | Multi-agent coordination tools. Registered for dispatcher-spawned task workers (`HERMES_KANBAN_TASK`) and for profiles that explicitly list the `kanban` toolset by name (the `all`/`*` wildcard does **not** enable it). Workers mark tasks done, block, heartbeat, comment, and create/link follow-up tasks; orchestrator profiles additionally get board-routing tools like list/unblock. |
 | `memory` | `memory` | Persistent cross-session memory management. |
 | `messaging` | `send_message` | Send messages to other platforms (Telegram, Discord, etc.) from within a session. |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1321,7 +1321,7 @@ agent:
 
 ```yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "inworld" | "minimax" | "mistral" | "gemini" | "xai" | "neutts"
   speed: 1.0                    # Global speed multiplier (fallback for all providers)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -1334,6 +1334,12 @@ tts:
     voice: "alloy"              # alloy, echo, fable, onyx, nova, shimmer
     speed: 1.0                  # Speed multiplier (clamped to 0.25–4.0 by the API)
     base_url: "https://api.openai.com/v1"  # Override for OpenAI-compatible TTS endpoints
+  inworld:
+    model: "inworld-tts-2"
+    voice: "Dennis"
+    output_format: "ogg"
+    sample_rate: 48000
+    delivery_mode: "BALANCED"
   minimax:
     speed: 1.0                  # Speech speed multiplier
     # base_url: ""              # Optional: override for OpenAI-compatible TTS endpoints
@@ -1496,11 +1502,15 @@ Hashes are deterministic — the same user always maps to the same hash, so the 
 
 ```yaml
 stt:
-  provider: "local"            # "local" | "groq" | "openai" | "mistral"
+  provider: "local"            # "local" | "groq" | "openai" | "inworld" | "mistral"
   local:
     model: "base"              # tiny, base, small, medium, large-v3
   openai:
     model: "whisper-1"         # whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe
+  inworld:
+    model: "inworld/inworld-stt-1"
+    audio_encoding: "AUTO_DETECT"
+    language: ""
   # model: "whisper-1"         # Legacy fallback key still respected
 ```
 
@@ -1509,8 +1519,40 @@ Provider behavior:
 - `local` uses `faster-whisper` running on your machine. Install it separately with `pip install faster-whisper`.
 - `groq` uses Groq's Whisper-compatible endpoint and reads `GROQ_API_KEY`.
 - `openai` uses the OpenAI speech API and reads `VOICE_TOOLS_OPENAI_KEY`.
+- `inworld` uses Inworld Speech-to-Text and reads `INWORLD_API_KEY`.
 
 If the requested provider is unavailable, Hermes falls back automatically in this order: `local` → `groq` → `openai`.
+
+## Realtime Voice Providers
+
+Google Meet realtime mode uses the `realtime` config block. Secrets still live in `~/.hermes/.env`:
+
+```bash
+OPENAI_API_KEY=sk-...           # for realtime.provider: openai
+INWORLD_API_KEY=...             # for realtime.provider: inworld
+```
+
+```yaml
+realtime:
+  provider: "openai"            # "openai" | "inworld"
+  openai:
+    model: "gpt-realtime"
+    voice: "alloy"
+    instructions: ""
+  inworld:
+    model: "openai/gpt-4o-mini"
+    tts_model: "inworld-tts-1.5-mini"
+    stt_model: "inworld/inworld-stt-1"
+    voice: "Dennis"
+    language: ""
+    instructions: ""
+    turn_detection:
+      type: "semantic_vad"
+      eagerness: "medium"
+      create_response: true
+      interrupt_response: true
+    provider_data: {}
+```
 
 Groq and OpenAI model overrides are environment-driven:
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -14,13 +14,14 @@ If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, 
 
 ## Text-to-Speech
 
-Convert text to speech with ten providers:
+Convert text to speech with eleven providers:
 
 | Provider | Quality | Cost | API Key |
 |----------|---------|------|---------|
 | **Edge TTS** (default) | Good | Free | None needed |
 | **ElevenLabs** | Excellent | Paid | `ELEVENLABS_API_KEY` |
 | **OpenAI TTS** | Good | Paid | `VOICE_TOOLS_OPENAI_KEY` |
+| **Inworld TTS** | Excellent | Paid | `INWORLD_API_KEY` |
 | **MiniMax TTS** | Excellent | Paid | `MINIMAX_API_KEY` |
 | **Mistral (Voxtral TTS)** | Excellent | Paid | `MISTRAL_API_KEY` |
 | **Google Gemini TTS** | Excellent | Free tier | `GEMINI_API_KEY` |
@@ -43,7 +44,7 @@ Convert text to speech with ten providers:
 ```yaml
 # In ~/.hermes/config.yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "inworld" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper"
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -56,6 +57,12 @@ tts:
     voice: "alloy"              # alloy, echo, fable, onyx, nova, shimmer
     base_url: "https://api.openai.com/v1"  # Override for OpenAI-compatible TTS endpoints
     speed: 1.0                  # 0.25 - 4.0
+  inworld:
+    model: "inworld-tts-2"      # also: inworld-tts-1.5-max, inworld-tts-1.5-mini
+    voice: "Dennis"             # use hermes tools to save INWORLD_API_KEY, then list voices
+    output_format: "ogg"        # native Opus/OGG for voice bubbles
+    sample_rate: 48000
+    delivery_mode: "BALANCED"   # STABLE | BALANCED | CREATIVE
   minimax:
     model: "speech-2.8-hd"     # speech-2.8-hd (default), speech-2.8-turbo
     voice_id: "English_Graceful_Lady"  # See https://platform.minimax.io/faq/system-voice-id
@@ -136,6 +143,7 @@ Each provider has a documented per-request input-character cap. Hermes truncates
 |----------|---------------------|
 | Edge TTS | 5000 |
 | OpenAI | 4096 |
+| Inworld | 10000 |
 | xAI | 15000 |
 | MiniMax | 10000 |
 | Mistral | 4000 |
@@ -169,7 +177,7 @@ Only positive integers are honored. Zero, negative, non-numeric, or boolean valu
 
 Telegram voice bubbles require Opus/OGG audio format:
 
-- **OpenAI, ElevenLabs, and Mistral** produce Opus natively — no extra setup
+- **OpenAI, ElevenLabs, Inworld, and Mistral** produce Opus natively — no extra setup
 - **Edge TTS** (default) outputs MP3 and needs **ffmpeg** to convert:
 - **MiniMax TTS** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
 - **Google Gemini TTS** outputs raw PCM and uses **ffmpeg** to encode Opus directly for Telegram voice bubbles
@@ -192,7 +200,7 @@ sudo dnf install ffmpeg
 Without ffmpeg, Edge TTS, MiniMax TTS, NeuTTS, KittenTTS, and Piper audio are sent as regular audio files (playable, but shown as a rectangular player instead of a voice bubble).
 
 :::tip
-If you want voice bubbles without installing ffmpeg, switch to the OpenAI, ElevenLabs, or Mistral provider.
+If you want voice bubbles without installing ffmpeg, switch to the OpenAI, ElevenLabs, Inworld, or Mistral provider.
 :::
 
 ### xAI Custom Voices (voice cloning)

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -95,6 +95,7 @@ Add to `~/.hermes/.env`:
 # pip install faster-whisper          # Free, runs locally, recommended
 GROQ_API_KEY=your-key                 # Groq Whisper — fast, free tier (cloud)
 VOICE_TOOLS_OPENAI_KEY=your-key       # OpenAI Whisper — paid (cloud)
+INWORLD_API_KEY=your-key              # Inworld STT/TTS/Realtime — paid (cloud)
 
 # Text-to-Speech (optional — Edge TTS and NeuTTS work without any key)
 ELEVENLABS_API_KEY=***           # ElevenLabs — premium quality
@@ -104,6 +105,31 @@ ELEVENLABS_API_KEY=***           # ElevenLabs — premium quality
 :::tip
 If `faster-whisper` is installed, voice mode works with **zero API keys** for STT. The model (~150 MB for `base`) downloads automatically on first use.
 :::
+
+### Inworld STT and TTS
+
+Inworld can provide both speech-to-text and text-to-speech. Store only the secret in `~/.hermes/.env`:
+
+```bash
+INWORLD_API_KEY=your-base64-api-key
+```
+
+Then select it in `~/.hermes/config.yaml`:
+
+```yaml
+stt:
+  provider: inworld
+  inworld:
+    model: inworld/inworld-stt-1
+    audio_encoding: AUTO_DETECT
+
+tts:
+  provider: inworld
+  inworld:
+    model: inworld-tts-2
+    voice: Dennis
+    output_format: ogg
+```
 
 ---
 


### PR DESCRIPTION
## Summary

- Add opt-in FAL media utility toolsets for image editing, image background removal, image upscaling, video background removal, and video upscaling.
- Fix desktop chat media rendering so generated image/video outputs from these tools are surfaced inline instead of being lost in tool JSON.
- Improve FAL video handling: local video paths are uploaded to FAL storage before remote processing, docs/webpage/image inputs fail locally with clearer errors, and successful media responses include `output_url` / `media_type`.
- Make `video_generate` resolve the single available backend when multiple plugins are registered but only one is configured/available.
- Add FAL video-family updates and Inworld STT/TTS provider support, including Google Meet realtime Inworld integration.
- Default still-image background removal to Ideogram Remove Background while keeping BiRefNet variants selectable.
- Add/update setup UI, config schema, docs, tests, and the repo PR template for the new surfaces.

## Footprint and Architecture

- [x] Extends existing code, or explains why a new surface is needed
- [x] Does not add a core model tool unless terminal/file/CLI/plugin/MCP cannot solve it
- [x] Keeps plugins inside their plugin directory; no plugin-specific core special cases
- [x] Preserves byte-stable system prompts and per-conversation prompt caching
- [x] Preserves strict role alternation; no synthetic mid-loop user messages

Notes:
- The new media capabilities are opt-in toolsets, not default core tools.
- Inworld is implemented as a plugin under `plugins/inworld/`.
- Desktop changes consume existing tool outputs and do not alter the agent loop or message role structure.

## Configuration and Secrets

- [x] User-facing behavioral settings live in `config.yaml`
- [x] `.env` additions are credentials only
- [x] Setup/config UI, docs, and defaults are updated together
- [x] No telemetry, attribution tags, or third-party identifiers without opt-in gating

Notes:
- FAL utility tools reuse existing FAL key / managed gateway configuration.
- Inworld credentials remain env/secret material; behavioral provider choices are represented in config/setup surfaces.

## Tests

- [x] Reproduces the original bug or validates the new behavior through the real path
- [x] Covers sibling call paths and provider/config propagation where relevant
- [x] Avoids change-detector assertions for model lists, versions, or enum counts
- [x] Commands run:

```bash
venv/bin/python -m pytest tests/tools/test_fal_media_utility_tools.py tests/agent/test_video_gen_registry.py tests/tools/test_video_generation_dispatch.py tests/tools/test_video_generation_tool_surface_matrix.py tests/hermes_cli/test_tools_config.py tests/plugins/test_inworld_plugin.py tests/plugins/video_gen/test_fal_plugin.py tests/plugins/test_google_meet_plugin.py tests/plugins/test_google_meet_realtime.py
npm --workspace apps/desktop run typecheck
npm --workspace apps/desktop run test:ui -- src/lib/generated-images.test.ts src/app/settings/helpers.test.ts
```

Results:

```text
245 passed, 1 warning
Desktop typecheck passed
2 desktop test files passed, 30 tests passed
```

I also ran targeted compile checks while developing the media tools and registry changes. I did not run a live paid FAL video upscale/background-removal job from this branch; the FAL request paths are covered with mocked submit/upload behavior and the user-provided FAL schema was used to align payload fields.

## Documentation

- [x] User docs updated, or N/A
- [x] Tool/schema references updated, or N/A
- [x] Developer docs/skills updated, or N/A

Updated docs include:
- FAL media utility tool references and toolsets.
- Configuration docs for new provider/tool settings.
- TTS/voice-mode docs for Inworld.
- Google Meet Inworld realtime docs/skill text.

## Reviewer Notes

- This is intentionally broad: it wires media generation/editing utilities through tools, config, docs, tests, and desktop rendering so generated media is visible in the Hermes desktop UX.
- The most important bug fixes are desktop inline media rendering, local video upload before FAL video processing, availability-aware video backend selection, and clearer validation for invalid video inputs.
- Still-image background removal now defaults to Ideogram Remove Background. Existing BiRefNet variants remain available through the `model` parameter for mask/resolution-specific workflows.
- After rebasing, I refreshed local npm dependencies because latest `main` added CodeMirror packages needed by desktop typecheck. No tracked files changed from that install.
