### PR TITLE
docs: clarify SiYuan jq requirement

### DIFF
--- a/optional-skills/productivity/siyuan/SKILL.md
+++ b/optional-skills/productivity/siyuan/SKILL.md
@@ -24,7 +24,7 @@ required_environment_variables:
 
 # SiYuan Note API
 
-Use the [SiYuan](https://github.com/siyuan-note/siyuan) kernel API via curl to search, read, create, update, and delete blocks and documents in a self-hosted knowledge base. No extra tools needed -- just curl and an API token.
+Use the [SiYuan](https://github.com/siyuan-note/siyuan) kernel API via curl to search, read, create, update, and delete blocks and documents in a self-hosted knowledge base. No SDK needed -- just curl, jq, and an API token.
 
 ## Prerequisites
 

--- a/website/docs/user-guide/skills/optional/productivity/productivity-siyuan.md
+++ b/website/docs/user-guide/skills/optional/productivity/productivity-siyuan.md
@@ -31,7 +31,7 @@ The following is the complete skill definition that Hermes loads when this skill
 
 # SiYuan Note API
 
-Use the [SiYuan](https://github.com/siyuan-note/siyuan) kernel API via curl to search, read, create, update, and delete blocks and documents in a self-hosted knowledge base. No extra tools needed -- just curl and an API token.
+Use the [SiYuan](https://github.com/siyuan-note/siyuan) kernel API via curl to search, read, create, update, and delete blocks and documents in a self-hosted knowledge base. No SDK needed -- just curl, jq, and an API token.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Clarifies the SiYuan optional skill prerequisites.

The skill frontmatter lists `jq` as a required command and the examples pipe responses through `jq`, but the intro said “No extra tools needed.” This updates the wording to say no SDK is needed, while still mentioning `curl`, `jq`, and an API token.

The generated SiYuan docs page was updated to keep it in sync with the source skill.

## Validation

- Confirmed `commands: [curl, jq]` is present in the SiYuan skill metadata.
- Confirmed the old `No extra tools needed` wording no longer appears in the touched files.
- Confirmed the new wording appears in both the source skill and generated docs page.
- `git diff --check -- optional-skills/productivity/siyuan/SKILL.md website/docs/user-guide/skills/optional/productivity/productivity-siyuan.md`
