### PR TITLE
fix(discord): register /learn slash command in Discord adapter

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3549,6 +3549,11 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_insights(interaction: discord.Interaction, days: int = 7):
             await self._run_simple_slash(interaction, f"/insights {days}")
 
+        @tree.command(name="learn", description="Learn a reusable skill from anything you describe")
+        @discord.app_commands.describe(what="What to learn from (dirs, URLs, this chat, notes)")
+        async def slash_learn(interaction: discord.Interaction, what: str = ""):
+            await self._run_simple_slash(interaction, f"/learn {what}".strip())
+
         @tree.command(name="reload-mcp", description="Reload MCP servers from config")
         async def slash_reload_mcp(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/reload-mcp")


### PR DESCRIPTION
## Problem

The `/learn` command was added to Hermes Agent (commit e32ebc6aa) with a handler in `gateway/run.py` and a `CommandDef` in `COMMAND_REGISTRY`, but it was never registered as a Discord slash command in `plugins/platforms/discord/adapter.py`.

- `/learn` works when typed as plain text (gateway run.py catches it)
- `/learn` works in CLI
- `/learn` does NOT appear in Discord's slash command menu

## Fix

Added the missing `@tree.command` block in `_register_slash_commands()` following the same pattern as `/model` and `/steer`:

```python
@tree.command(name="learn", description="Learn a reusable skill from anything you describe")
@discord.app_commands.describe(what="What to learn from (dirs, URLs, this chat, notes)")
async def slash_learn(interaction: discord.Interaction, what: str = ""):
    await self._run_simple_slash(interaction, f"/learn {what}".strip())
```