### PR TITLE
fix: harden gateway status and Photon sidecar startup

### DIFF
--- a/gateway/long_run_status.py
+++ b/gateway/long_run_status.py
@@ -1,0 +1,365 @@
+"""Optional enrichment for long-running gateway status messages.
+
+This module is deliberately fail-soft: callers already have a deterministic
+heartbeat. Enrichment may make that heartbeat more readable, but it must never
+be required for chat liveness.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from hermes_constants import get_hermes_home
+
+
+_STATUS_LINE_RE = re.compile(r"^[\w\s,./:;()+#\-]+$")
+_SECRET_WORD_RE = re.compile(r"\b(token|secret|password|api[_ -]?key|bearer|sk-[A-Za-z0-9])\b", re.I)
+_ALLOWED_STATUS_LABELS = (
+    "running tests",
+    "waiting on network",
+    "reading files",
+    "editing code",
+    "using terminal",
+    "using browser",
+    "checking logs",
+    "verifying results",
+    "working",
+)
+
+
+@dataclass(frozen=True)
+class LongRunStatusEnrichmentConfig:
+    enabled: bool = False
+    local_enabled: bool = True
+    local_url: str = "http://127.0.0.1:11434"
+    local_model: str = "qwen2.5:0.5b"
+    local_timeout_seconds: float = 1.5
+    local_keep_alive: str = "0s"
+    cloud_enabled: bool = True
+    cloud_provider: str = "openrouter"
+    cloud_model: str = "deepseek/deepseek-v4-flash"
+    cloud_timeout_seconds: float = 3.0
+    cloud_max_calls_per_day: int = 20
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return bool(value)
+
+
+def _as_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def config_from_gateway_config(user_config: Mapping[str, Any] | None) -> LongRunStatusEnrichmentConfig:
+    """Resolve enrichment config from ``agent.gateway_status_enrichment``.
+
+    Unknown/malformed values fall back to safe defaults. Environment variables
+    are intentionally not used here; this is a per-gateway UX knob, not a secret.
+    """
+    agent_cfg = (user_config or {}).get("agent") if isinstance(user_config, Mapping) else None
+    raw = agent_cfg.get("gateway_status_enrichment") if isinstance(agent_cfg, Mapping) else None
+    if not isinstance(raw, Mapping):
+        raw = {}
+    raw_local = raw.get("local")
+    raw_cloud = raw.get("cloud")
+    local: Mapping[str, Any] = raw_local if isinstance(raw_local, Mapping) else {}
+    cloud: Mapping[str, Any] = raw_cloud if isinstance(raw_cloud, Mapping) else {}
+    return LongRunStatusEnrichmentConfig(
+        enabled=_as_bool(raw.get("enabled"), False),
+        local_enabled=_as_bool(local.get("enabled"), True),
+        local_url=str(local.get("url") or "http://127.0.0.1:11434").rstrip("/"),
+        local_model=str(local.get("model") or "qwen2.5:0.5b"),
+        local_timeout_seconds=max(0.1, _as_float(local.get("timeout_seconds"), 1.5)),
+        local_keep_alive=str(local.get("keep_alive") or "0s"),
+        cloud_enabled=_as_bool(cloud.get("enabled"), True),
+        cloud_provider=str(cloud.get("provider") or "openrouter"),
+        cloud_model=str(cloud.get("model") or "deepseek/deepseek-v4-flash"),
+        cloud_timeout_seconds=max(0.1, _as_float(cloud.get("timeout_seconds"), 3.0)),
+        cloud_max_calls_per_day=max(0, _as_int(cloud.get("max_calls_per_day"), 20)),
+    )
+
+
+def sanitize_activity_snapshot(snapshot: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Keep only non-sensitive telemetry for model-based status wording."""
+    src = snapshot or {}
+    out: dict[str, Any] = {}
+    for key in (
+        "elapsed_seconds",
+        "api_call_count",
+        "max_iterations",
+        "current_tool",
+        "last_activity_desc",
+        "platform",
+    ):
+        value = src.get(key)
+        if value is None:
+            continue
+        if isinstance(value, (int, float)):
+            out[key] = value
+        else:
+            text = str(value).strip()
+            # Keep status generic. Do not ship arbitrary tool args/output.
+            if len(text) > 80:
+                text = text[:77] + "..."
+            if _SECRET_WORD_RE.search(text):
+                continue
+            out[key] = text
+    return out
+
+
+def normalize_status_line(text: Any) -> Optional[str]:
+    """Validate and normalize one model-produced status phrase."""
+    raw = str(text or "")
+    if "\n" in raw or "\r" in raw:
+        return None
+    line = raw.strip().strip('"').strip("'")
+    if not line:
+        return None
+    line = re.sub(r"\s+", " ", line)
+    if len(line) > 96:
+        line = line[:93].rstrip() + "..."
+    if _SECRET_WORD_RE.search(line):
+        return None
+    if not _STATUS_LINE_RE.match(line):
+        return None
+    return line.rstrip(".")
+
+
+def normalize_status_label(text: Any) -> Optional[str]:
+    """Reduce model output to one approved status label.
+
+    Small local models may embellish even when instructed not to. Treat their
+    output as a fuzzy classifier, not prose: accept only a known label, or a
+    sentence containing exactly one known label.
+    """
+    line = normalize_status_line(text)
+    if not line:
+        return None
+    lowered = line.lower()
+    if "test" in lowered or "pytest" in lowered:
+        return "running tests"
+    if "network" in lowered or "http" in lowered or "api" in lowered:
+        return "waiting on network"
+    if "log" in lowered or "journal" in lowered:
+        return "checking logs"
+    if "verify" in lowered or "checking" in lowered:
+        return "verifying results"
+    if "read" in lowered or "file" in lowered:
+        return "reading files"
+    if "edit" in lowered or "patch" in lowered or "code" in lowered:
+        return "editing code"
+    if "terminal" in lowered or "shell" in lowered:
+        return "using terminal"
+    if "browser" in lowered:
+        return "using browser"
+    matches = [label for label in _ALLOWED_STATUS_LABELS if label in lowered]
+    if len(matches) == 1:
+        return matches[0]
+    if lowered in _ALLOWED_STATUS_LABELS:
+        return lowered
+    return None
+
+
+def _prompt_for(snapshot: Mapping[str, Any]) -> list[dict[str, str]]:
+    payload = json.dumps(snapshot, sort_keys=True, separators=(",", ":"))
+    return [
+        {
+            "role": "system",
+            "content": (
+                "Choose exactly one status label from this list: "
+                "running tests, waiting on network, reading files, editing code, "
+                "using terminal, using browser, checking logs, verifying results, working. "
+                "Return only the label. Do not add details."
+            ),
+        },
+        {"role": "user", "content": payload},
+    ]
+
+
+def _ollama_chat_sync(config: LongRunStatusEnrichmentConfig, snapshot: Mapping[str, Any]) -> Optional[str]:
+    body = {
+        "model": config.local_model,
+        "messages": _prompt_for(snapshot),
+        "stream": False,
+        "keep_alive": config.local_keep_alive,
+        "think": False,
+        "options": {
+            "temperature": 0,
+            "num_predict": 24,
+            "num_ctx": 512,
+        },
+    }
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        f"{config.local_url}/api/chat",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=config.local_timeout_seconds) as resp:
+            payload = json.loads(resp.read().decode("utf-8", errors="replace"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
+        return None
+    message = payload.get("message") if isinstance(payload, dict) else None
+    content = message.get("content") if isinstance(message, dict) else None
+    return normalize_status_label(content)
+
+
+def _openrouter_key() -> str:
+    key = os.environ.get("OPENROUTER_API_KEY", "").strip()
+    if key:
+        return key
+    # Gateway normally loads ~/.hermes/.env, but standalone tests/smokes may not.
+    env_path = get_hermes_home() / ".env"
+    try:
+        for line in env_path.read_text(encoding="utf-8").splitlines():
+            if line.startswith("OPENROUTER_API_KEY="):
+                return line.split("=", 1)[1].strip().strip('"').strip("'")
+    except OSError:
+        return ""
+    return ""
+
+
+def _state_path() -> Path:
+    return get_hermes_home() / "run-state" / "long-run-status-enrichment.json"
+
+
+def _today() -> str:
+    return time.strftime("%Y-%m-%d", time.localtime())
+
+
+def _cloud_budget_available(config: LongRunStatusEnrichmentConfig) -> bool:
+    if config.cloud_max_calls_per_day <= 0:
+        return False
+    path = _state_path()
+    try:
+        state = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+    except (OSError, json.JSONDecodeError):
+        state = {}
+    today = _today()
+    if state.get("date") != today:
+        return True
+    return int(state.get("cloud_calls", 0) or 0) < config.cloud_max_calls_per_day
+
+
+def _record_cloud_call() -> None:
+    path = _state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    today = _today()
+    try:
+        state = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+    except (OSError, json.JSONDecodeError):
+        state = {}
+    if state.get("date") != today:
+        state = {"date": today, "cloud_calls": 0}
+    state["cloud_calls"] = int(state.get("cloud_calls", 0) or 0) + 1
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _openrouter_chat_sync(config: LongRunStatusEnrichmentConfig, snapshot: Mapping[str, Any]) -> Optional[str]:
+    if config.cloud_provider != "openrouter":
+        return None
+    if not _cloud_budget_available(config):
+        return None
+    key = _openrouter_key()
+    if not key:
+        return None
+    body = {
+        "model": config.cloud_model,
+        "messages": _prompt_for(snapshot),
+        "temperature": 0,
+        "max_tokens": 32,
+        "reasoning": {"enabled": False},
+    }
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        "https://openrouter.ai/api/v1/chat/completions",
+        data=data,
+        headers={
+            "Authorization": f"Bearer {key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://hermes-agent.local/long-run-status",
+            "X-Title": "Hermes long-run status enrichment",
+        },
+        method="POST",
+    )
+    _record_cloud_call()
+    try:
+        with urllib.request.urlopen(req, timeout=config.cloud_timeout_seconds) as resp:
+            payload = json.loads(resp.read().decode("utf-8", errors="replace"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
+        return None
+    choices = payload.get("choices") if isinstance(payload, dict) else None
+    if not choices:
+        return None
+    message = choices[0].get("message") if isinstance(choices[0], dict) else None
+    content = message.get("content") if isinstance(message, dict) else None
+    return normalize_status_label(content)
+
+
+async def enrich_long_run_status(
+    snapshot: Mapping[str, Any] | None,
+    config: LongRunStatusEnrichmentConfig,
+) -> Optional[str]:
+    """Return one optional enriched status phrase.
+
+    Local Ollama is tried first. Cheap cloud fallback is only tried if local is
+    unavailable/fails and the daily call budget allows it. All inputs are
+    sanitized run metadata, never user transcript or tool output.
+    """
+    if not config.enabled:
+        return None
+    clean = sanitize_activity_snapshot(snapshot)
+    if not clean:
+        return None
+    if config.local_enabled:
+        try:
+            local = await asyncio.wait_for(
+                asyncio.to_thread(_ollama_chat_sync, config, clean),
+                timeout=config.local_timeout_seconds + 0.2,
+            )
+        except (asyncio.TimeoutError, OSError):
+            local = None
+        if local:
+            return local
+    if config.cloud_enabled:
+        try:
+            return await asyncio.wait_for(
+                asyncio.to_thread(_openrouter_chat_sync, config, clean),
+                timeout=config.cloud_timeout_seconds + 0.2,
+            )
+        except (asyncio.TimeoutError, OSError):
+            return None
+    return None

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -88,6 +88,20 @@ def _hermes_version() -> str:
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
+
+CLAUDE_HANDOFF_REQUIRED_SECTIONS = [
+    "Session context",
+    "Key decisions",
+    "Open questions",
+    "Artifacts produced",
+    "Relevant existing memories",
+    "What Hermes should know",
+]
+CLAUDE_HANDOFF_ALLOWED_SURFACES = {"claudeai", "claudecode-linux", "claudecode-macbook"}
+CLAUDE_HANDOFF_NAME_RE = re.compile(
+    r"^handoff-(claudeai|claudecode-linux|claudecode-macbook)-(\d{4}-\d{2}-\d{2})-([A-Za-z0-9_-]+)$"
+)
+CLAUDE_HANDOFF_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversations with tool calls
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
@@ -1201,6 +1215,114 @@ class APIServerAdapter(BasePlatformAdapter):
             ],
         })
 
+    @staticmethod
+    def _claude_handoff_sections(body: str) -> Optional[str]:
+        """Return a validation error for a Claude handoff body, or None."""
+        headings: List[tuple[str, int, int]] = []
+        for match in re.finditer(r"(?m)^\s{0,3}#{1,6}\s+(.+?)\s*$", body):
+            headings.append((match.group(1).strip(), match.start(), match.end()))
+        if [title for title, _, _ in headings] != CLAUDE_HANDOFF_REQUIRED_SECTIONS:
+            return "body must contain the required section headings in canonical order: " + ", ".join(
+                CLAUDE_HANDOFF_REQUIRED_SECTIONS
+            )
+        for idx, (title, _, content_start) in enumerate(headings):
+            content_end = headings[idx + 1][1] if idx + 1 < len(headings) else len(body)
+            if not body[content_start:content_end].strip():
+                return f"section is empty: {title}"
+        return None
+
+    @staticmethod
+    def _derive_claude_handoff_name(surface: str, session_date: str, description: str, body: str, source_session_id: str) -> str:
+        seed = source_session_id.strip() or f"{description}\n{body}"
+        short_id = hashlib.sha256(seed.encode("utf-8", "replace")).hexdigest()[:10]
+        return f"handoff-{surface}-{session_date}-{short_id}"
+
+    async def _handle_claude_handoff_memory(self, request: "web.Request") -> "web.Response":
+        """POST /v1/claude/handoff-memory — durable Claude handoff receipt.
+
+        Claude.ai remains read-only. This endpoint is the narrow mediated path:
+        Hermes validates the structured packet and writes a pending Clarence
+        memory row for later review/promotion by Hermes-owned tooling.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body_json = await request.json()
+        except Exception:
+            return web.json_response({"accepted": False, "durable": False, "error": "invalid JSON body"}, status=400)
+        if not isinstance(body_json, dict):
+            return web.json_response({"accepted": False, "durable": False, "error": "JSON body must be an object"}, status=400)
+
+        description = str(body_json.get("description") or "").strip()
+        handoff_body = str(body_json.get("body") or "")
+        surface = str(body_json.get("surface") or "claudeai").strip().lower()
+        source_session_id = str(body_json.get("source_session_id") or "").strip()
+        replace_existing = bool(body_json.get("replace_existing"))
+        if not description:
+            return web.json_response({"accepted": False, "durable": False, "error": "description is required"}, status=400)
+        if not handoff_body.strip():
+            return web.json_response({"accepted": False, "durable": False, "error": "body is required"}, status=400)
+        if surface not in CLAUDE_HANDOFF_ALLOWED_SURFACES:
+            return web.json_response({"accepted": False, "durable": False, "error": f"invalid surface: {surface}"}, status=400)
+
+        section_error = self._claude_handoff_sections(handoff_body)
+        if section_error:
+            return web.json_response({"accepted": False, "durable": False, "error": section_error}, status=400)
+
+        session_date = str(body_json.get("session_date") or "").strip()
+        if session_date and not CLAUDE_HANDOFF_DATE_RE.match(session_date):
+            return web.json_response({"accepted": False, "durable": False, "error": "session_date must be YYYY-MM-DD"}, status=400)
+        if not session_date:
+            session_date = time.strftime("%Y-%m-%d")
+
+        name = str(body_json.get("name") or "").strip()
+        if name:
+            match = CLAUDE_HANDOFF_NAME_RE.match(name)
+            if not match:
+                return web.json_response({"accepted": False, "durable": False, "error": "invalid handoff name"}, status=400)
+            if match.group(1) != surface:
+                return web.json_response({"accepted": False, "durable": False, "error": "handoff name surface does not match payload surface"}, status=400)
+            if match.group(2) != session_date:
+                return web.json_response({"accepted": False, "durable": False, "error": "handoff name date does not match session_date"}, status=400)
+        else:
+            name = self._derive_claude_handoff_name(surface, session_date, description, handoff_body, source_session_id)
+
+        workspace_scripts = Path.home() / ".openclaw" / "workspace" / "scripts"
+        try:
+            import sys as _sys
+            if str(workspace_scripts) not in _sys.path:
+                _sys.path.insert(0, str(workspace_scripts))
+            from clarence_db import ClarenceDB  # type: ignore
+
+            with ClarenceDB() as db:
+                result = db.write_memory(
+                    name=name,
+                    type="reference",
+                    description=description,
+                    body=handoff_body,
+                    tags=["handoff-pending", "claude-handoff", surface, session_date],
+                    kind="state",
+                    author_agent="claude-external",
+                    confidence=1.0,
+                    replace_existing=replace_existing,
+                )
+        except Exception as exc:  # noqa: BLE001 - return stable bridge-safe JSON
+            logger.exception("Claude handoff memory write failed")
+            status = 409 if exc.__class__.__name__ in {"ContradictoryWriteError", "StaleWriteError"} else 500
+            return web.json_response({"accepted": False, "durable": False, "error": str(exc)}, status=status)
+
+        memory_id = int(result.get("memory_id"))
+        return web.json_response({
+            "status": result.get("status", "created"),
+            "accepted": True,
+            "durable": True,
+            "memory_id": memory_id,
+            "memory": {"id": memory_id, "name": name, "type": "reference"},
+            "name": name,
+        })
+
     async def _handle_capabilities(self, request: "web.Request") -> "web.Response":
         """GET /v1/capabilities — advertise the stable API surface.
 
@@ -1249,6 +1371,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "admin_config_rw": False,
                 "jobs_admin": False,
                 "memory_write_api": False,
+                "claude_handoff_memory": True,
                 "skills_api": True,
                 "audio_api": False,
                 "realtime_voice": False,
@@ -1262,6 +1385,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "models": {"method": "GET", "path": "/v1/models"},
                 "chat_completions": {"method": "POST", "path": "/v1/chat/completions"},
                 "responses": {"method": "POST", "path": "/v1/responses"},
+                "claude_handoff_memory": {"method": "POST", "path": "/v1/claude/handoff-memory"},
                 "runs": {"method": "POST", "path": "/v1/runs"},
                 "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
@@ -4445,6 +4569,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/api/sessions/{session_id}/chat/stream", self._handle_session_chat_stream)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
             self._app.router.add_post("/v1/responses", self._handle_responses)
+            self._app.router.add_post("/v1/claude/handoff-memory", self._handle_claude_handoff_memory)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)
             self._app.router.add_delete("/v1/responses/{response_id}", self._handle_delete_response)
             # Cron jobs management API

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -55,6 +55,14 @@ from typing import Dict, Optional, Any, List, Union
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import safe_schedule_threadsafe
 from agent.i18n import t
+from gateway.turn_usage import (
+    agent_usage_snapshot,
+    budget_status,
+    format_compact_usage,
+    should_show_usage_receipt,
+    turn_usage_from_result,
+    usage_delta,
+)
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
@@ -2039,6 +2047,7 @@ def _dequeue_pending_event(adapter, session_key: str) -> MessageEvent | None:
 _INTERRUPT_REASON_STOP = "Stop requested"
 _INTERRUPT_REASON_RESET = "Session reset requested"
 _INTERRUPT_REASON_TIMEOUT = "Execution timed out (inactivity)"
+_INTERRUPT_REASON_USAGE_BUDGET = "Telegram usage budget reached"
 _INTERRUPT_REASON_SSE_DISCONNECT = "SSE client disconnected"
 _INTERRUPT_REASON_GATEWAY_SHUTDOWN = "Gateway shutting down"
 _INTERRUPT_REASON_GATEWAY_RESTART = "Gateway restarting"
@@ -2048,6 +2057,7 @@ _CONTROL_INTERRUPT_MESSAGES = frozenset(
         _INTERRUPT_REASON_STOP.lower(),
         _INTERRUPT_REASON_RESET.lower(),
         _INTERRUPT_REASON_TIMEOUT.lower(),
+        _INTERRUPT_REASON_USAGE_BUDGET.lower(),
         _INTERRUPT_REASON_SSE_DISCONNECT.lower(),
         _INTERRUPT_REASON_GATEWAY_SHUTDOWN.lower(),
         _INTERRUPT_REASON_GATEWAY_RESTART.lower(),
@@ -10289,6 +10299,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _platform_name, source.chat_id or "unknown",
                 _response_time, _api_calls, _resp_len,
             )
+            _usage_receipt_line = ""
+            try:
+                _turn_usage_obj = turn_usage_from_result(agent_result, elapsed_seconds=_response_time)
+                if (
+                    _platform_name == "telegram"
+                    and _usage_receipts_enabled
+                    and should_show_usage_receipt(
+                        _turn_usage_obj,
+                        min_api_calls=_usage_receipt_min_api_calls,
+                        min_tokens=_usage_receipt_min_tokens,
+                        min_seconds=_usage_receipt_min_seconds,
+                    )
+                ):
+                    _usage_receipt_line = format_compact_usage(_turn_usage_obj, prefix="usage")
+                    logger.info(
+                        "turn usage receipt: platform=%s chat=%s %s",
+                        _platform_name, source.chat_id or "unknown", _usage_receipt_line,
+                    )
+            except Exception as _usage_receipt_err:
+                logger.debug("usage receipt build failed: %s", _usage_receipt_err)
 
             # Re-baseline the cached agent's message_count snapshot now that
             # this turn has completed and the agent has flushed its rows to
@@ -10703,6 +10733,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
                 await self._send_voice_reply(event, response)
 
+            if _usage_receipt_line and response and not _already_sent:
+                response = f"{response}\n\n{_usage_receipt_line}"
+
             # If streaming already delivered the response, extract and
             # deliver any MEDIA: files before returning None.  Streaming
             # sends raw text chunks that include MEDIA: tags — the normal
@@ -10725,17 +10758,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # intentionally held back (see the `not already_sent` gate above).
                 # Send it now as a small trailing message so Telegram/Discord/etc.
                 # still surface the runtime metadata on the final reply.
-                if _footer_line:
+                if _footer_line or _usage_receipt_line:
                     try:
                         _foot_adapter = self.adapters.get(source.platform)
                         if _foot_adapter:
+                            _trail = "\n".join(x for x in (_footer_line, _usage_receipt_line) if x)
                             await _foot_adapter.send(
                                 source.chat_id,
-                                _footer_line,
+                                _trail,
                                 metadata=self._thread_metadata_for_source(source, self._reply_anchor_for_event(event)),
                             )
                     except Exception as _e:
-                        logger.debug("trailing footer send failed: %s", _e)
+                        logger.debug("trailing footer/usage send failed: %s", _e)
                 return None
 
             return response
@@ -15195,6 +15229,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
+        _usage_receipts_enabled = bool(agent_cfg_local.get("gateway_usage_receipts", True))
+        _usage_receipt_min_api_calls = int(agent_cfg_local.get("gateway_usage_receipt_min_api_calls", 2) or 2)
+        _usage_receipt_min_tokens = int(agent_cfg_local.get("gateway_usage_receipt_min_tokens", 25_000) or 25_000)
+        _usage_receipt_min_seconds = float(agent_cfg_local.get("gateway_usage_receipt_min_seconds", 30) or 30)
+        _usage_warn_api_calls = int(agent_cfg_local.get("gateway_usage_warn_api_calls", 8) or 8)
+        _usage_warn_tokens = int(agent_cfg_local.get("gateway_usage_warn_tokens", 100_000) or 100_000)
+        _usage_hard_api_calls = int(agent_cfg_local.get("gateway_usage_hard_api_calls", 30) or 30)
+        _usage_hard_tokens = int(agent_cfg_local.get("gateway_usage_hard_tokens", 350_000) or 350_000)
 
         display_config = user_config.get("display", {})
         if not isinstance(display_config, dict):
@@ -15892,6 +15934,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         result_holder = [None]  # Mutable container for the result
         tools_holder = [None]   # Mutable container for the tool definitions
         stream_consumer_holder = [None]  # Mutable container for stream consumer
+        turn_usage_baseline_holder = [None]  # Cumulative counters at turn start
         
         # Bridge sync step_callback → async hooks.emit for agent:step events
         _loop_for_step = asyncio.get_running_loop()
@@ -16798,6 +16841,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 else:
                     _run_message = message
 
+                turn_usage_baseline_holder[0] = agent_usage_snapshot(agent)
                 _api_run_message = _wrap_current_message_with_observed_context(
                     _run_message,
                     observed_group_context,
@@ -16815,6 +16859,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _persist_user_timestamp_override is not None:
                     _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
                 result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
+                try:
+                    _turn_usage = usage_delta(
+                        agent_usage_snapshot(agent),
+                        turn_usage_baseline_holder[0],
+                    )
+                    _turn_usage["api_calls"] = int(result.get("api_calls", 0) or 0)
+                    _turn_usage["elapsed_seconds"] = max(0.0, time.time() - _notify_start)
+                    result["turn_usage"] = _turn_usage
+                except Exception:
+                    pass
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 # Cancel any pending clarify entries so blocked agent
@@ -16939,6 +16993,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
                     "context_length": _context_length,
+                    "turn_usage": result.get("turn_usage", {}),
                 }
             
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -17040,6 +17095,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "model": _resolved_model,
                 "context_length": _context_length,
                 "session_id": effective_session_id,
+                "turn_usage": result_holder[0].get("turn_usage", {}) if result_holder[0] else {},
                 "response_previewed": result.get("response_previewed", False),
                 "response_transformed": result.get("response_transformed", False),
             }
@@ -17228,6 +17284,73 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _status_enrichment_config = None
             _enrich_long_run_status = None
         _status_enrichment_tasks: set[asyncio.Task] = set()
+        _usage_budget_warn_sent = False
+        _usage_budget_hard_sent = False
+
+        def _current_turn_usage(elapsed_seconds: float):
+            _agent_ref = agent_holder[0]
+            if not _agent_ref or not turn_usage_baseline_holder[0]:
+                return None
+            try:
+                _live = usage_delta(
+                    agent_usage_snapshot(_agent_ref),
+                    turn_usage_baseline_holder[0],
+                )
+                try:
+                    _act = _agent_ref.get_activity_summary()
+                    _live["api_calls"] = int(_act.get("api_call_count", 0) or 0)
+                except Exception:
+                    pass
+                _live["elapsed_seconds"] = max(0.0, elapsed_seconds)
+                return turn_usage_from_result({"turn_usage": _live, "api_calls": _live.get("api_calls", 0)}, elapsed_seconds=elapsed_seconds)
+            except Exception:
+                return None
+
+        async def _maybe_emit_usage_budget_notice(elapsed_seconds: float) -> bool:
+            nonlocal _usage_budget_warn_sent, _usage_budget_hard_sent
+            if platform_key != "telegram":
+                return False
+            _usage = _current_turn_usage(elapsed_seconds)
+            if _usage is None:
+                return False
+            _state = budget_status(
+                _usage,
+                warn_api_calls=_usage_warn_api_calls,
+                warn_tokens=_usage_warn_tokens,
+                hard_api_calls=_usage_hard_api_calls,
+                hard_tokens=_usage_hard_tokens,
+            )
+            if _state is None:
+                return False
+            _budget_adapter = self.adapters.get(source.platform)
+            if not _budget_adapter:
+                return False
+            _line = format_compact_usage(_usage, prefix="usage")
+            if _state == "warn" and not _usage_budget_warn_sent:
+                _usage_budget_warn_sent = True
+                try:
+                    await _budget_adapter.send(
+                        source.chat_id,
+                        f"⚠️ High-usage Telegram turn: {_line}. Continuing unless you send /stop.",
+                        metadata=_non_conversational_metadata(_status_thread_metadata, platform=source.platform),
+                    )
+                except Exception as _usage_warn_err:
+                    logger.debug("Usage-budget warning send failed: %s", _usage_warn_err)
+            if _state == "hard" and not _usage_budget_hard_sent:
+                _usage_budget_hard_sent = True
+                try:
+                    await _budget_adapter.send(
+                        source.chat_id,
+                        f"🛑 Telegram turn budget reached: {_line}. Stopping this turn before it burns more; start a fresh /new if you want to continue.",
+                        metadata=_non_conversational_metadata(_status_thread_metadata, platform=source.platform),
+                    )
+                except Exception as _usage_hard_err:
+                    logger.debug("Usage-budget hard-stop notice send failed: %s", _usage_hard_err)
+                _agent_ref = agent_holder[0]
+                if _agent_ref and hasattr(_agent_ref, "interrupt"):
+                    _agent_ref.interrupt(_INTERRUPT_REASON_USAGE_BUDGET)
+                return True
+            return False
 
         async def _notify_long_running():
             if _NOTIFY_INITIAL_DELAY is None:
@@ -17357,6 +17480,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _action = _a.get("current_tool") or _a.get("last_activity_desc")
                         if _action:
                             _parts.append(str(_action))
+                        _usage = _current_turn_usage(time.time() - _notify_start)
+                        if _usage:
+                            _parts.append(format_compact_usage(_usage, prefix="usage"))
                         if _parts:
                             _status_detail = "; ".join(_parts)
                     except Exception:
@@ -17452,6 +17578,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             )
                             _backup_agent.interrupt(_bp_text)
                             _interrupt_detected.set()
+                    if await _maybe_emit_usage_budget_notice(time.time() - _notify_start):
+                        continue
             else:
                 # Poll loop: check the agent's built-in activity tracker
                 # (updated by _touch_activity() on every tool call, API
@@ -17512,6 +17640,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             )
                             _backup_agent.interrupt(_bp_text)
                             _interrupt_detected.set()
+                    await _maybe_emit_usage_budget_notice(time.time() - _notify_start)
 
             if _inactivity_timeout:
                 # Build a diagnostic summary from the agent's activity tracker.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -622,6 +622,34 @@ def _float_env(name: str, default: float) -> float:
         return float(default)
 
 
+def _format_long_running_notification(
+    *,
+    elapsed_seconds: float,
+    status_detail: str = "",
+    initial: bool = False,
+) -> str:
+    """Build a concise user-facing notice for long gateway turns.
+
+    Messaging users cannot see the gateway executor thread, so the first notice
+    must explicitly say the turn is still running and that terminal recovery is
+    not needed. Later updates stay shorter and edit the same bubble when the
+    adapter supports it.
+    """
+    elapsed = max(0.0, float(elapsed_seconds or 0.0))
+    elapsed_mins = int(elapsed // 60)
+    elapsed_text = "<1 min" if elapsed_mins < 1 else f"{elapsed_mins} min"
+    detail = str(status_detail or "").strip()
+    detail_text = f" Status: {detail}." if detail else ""
+    if initial:
+        return (
+            "⏳ Long-running task: still working in this chat "
+            f"for {elapsed_text}. Background status updates will stay here; "
+            "no terminal check needed. Send /stop to cancel."
+            f"{detail_text}"
+        )
+    return f"⏳ Still working: {elapsed_text}.{detail_text}"
+
+
 def _is_fresh_gateway_interruption(
     value: Any,
     *,
@@ -1604,6 +1632,10 @@ if _config_path.exists():
                 os.environ["HERMES_AGENT_TIMEOUT_WARNING"] = str(_agent_cfg["gateway_timeout_warning"])
             if "gateway_notify_interval" in _agent_cfg:
                 os.environ["HERMES_AGENT_NOTIFY_INTERVAL"] = str(_agent_cfg["gateway_notify_interval"])
+            if "gateway_background_notice_after" in _agent_cfg:
+                os.environ["HERMES_AGENT_BACKGROUND_NOTICE_AFTER"] = str(
+                    _agent_cfg["gateway_background_notice_after"]
+                )
             if "restart_drain_timeout" in _agent_cfg:
                 os.environ["HERMES_RESTART_DRAIN_TIMEOUT"] = str(_agent_cfg["restart_drain_timeout"])
             if "gateway_auto_continue_freshness" in _agent_cfg:
@@ -17156,13 +17188,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         interrupt_monitor = asyncio.create_task(monitor_for_interrupt())
 
-        # Periodic "still working" notifications for long-running tasks.
-        # Fires every N seconds so the user knows the agent hasn't died.
-        # Config: agent.gateway_notify_interval in config.yaml, or
-        # HERMES_AGENT_NOTIFY_INTERVAL env var.  Default 180s (3 min).
-        # 0 = disable notifications.
+        # Periodic long-turn notifications for messaging users.
+        # First notice is early and explicit so a live Telegram turn does not
+        # look like a dead chat; later notices edit the same bubble when the
+        # adapter supports it. Config:
+        # - agent.gateway_background_notice_after / HERMES_AGENT_BACKGROUND_NOTICE_AFTER
+        #   default 30s; <=0 falls back to the repeat interval.
+        # - agent.gateway_notify_interval / HERMES_AGENT_NOTIFY_INTERVAL
+        #   default 180s; <=0 disables all long-turn notifications.
         _NOTIFY_INTERVAL_RAW = _float_env("HERMES_AGENT_NOTIFY_INTERVAL", 180)
         _NOTIFY_INTERVAL = _NOTIFY_INTERVAL_RAW if _NOTIFY_INTERVAL_RAW > 0 else None
+        _NOTIFY_INITIAL_RAW = _float_env("HERMES_AGENT_BACKGROUND_NOTICE_AFTER", 30)
+        _NOTIFY_INITIAL_DELAY = (
+            _NOTIFY_INITIAL_RAW
+            if _NOTIFY_INITIAL_RAW > 0
+            else _NOTIFY_INTERVAL
+        )
+        if _NOTIFY_INTERVAL is None:
+            _NOTIFY_INITIAL_DELAY = None
         if not bool(
             resolve_display_setting(
                 user_config,
@@ -17172,28 +17215,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         ):
             _NOTIFY_INTERVAL = None
+            _NOTIFY_INITIAL_DELAY = None
         _notify_start = time.time()
 
         async def _notify_long_running():
-            if _NOTIFY_INTERVAL is None:
-                return  # Notifications disabled (gateway_notify_interval: 0)
+            if _NOTIFY_INITIAL_DELAY is None:
+                return  # Notifications disabled
             _notify_adapter = self.adapters.get(source.platform)
             if not _notify_adapter:
                 return
             # Track the heartbeat message id so we can edit-in-place on
             # platforms that support it (Telegram, Discord, Slack, etc.)
-            # instead of spamming a new "Still working" bubble every
-            # interval. Falls back to send-new when edit fails or isn't
-            # supported by the adapter.
+            # instead of spamming a new status bubble every interval. Falls
+            # back to send-new when edit fails or isn't supported by the
+            # adapter.
             _heartbeat_msg_id: Optional[str] = None
+            _first_notice = True
             while True:
-                await asyncio.sleep(_NOTIFY_INTERVAL)
+                _sleep_for = _NOTIFY_INITIAL_DELAY if _first_notice else _NOTIFY_INTERVAL
+                if _sleep_for is None:
+                    break
+                await asyncio.sleep(_sleep_for)
                 # Stop heartbeating once this run no longer owns the session
-                # slot or the executor has finished — otherwise a stale
-                # "running: delegate_task" bubble can outlive the run that
-                # spawned it (#12029). _executor_task is a closure var bound
-                # just after this task is scheduled; tolerate the brief window
-                # before then (the first wake is _NOTIFY_INTERVAL away anyway).
+                # slot or the executor has finished; otherwise a stale status
+                # bubble can outlive the run that spawned it (#12029).
                 try:
                     _exec_ref = _executor_task
                 except NameError:
@@ -17202,7 +17247,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_key, agent_holder[0], _exec_ref
                 ):
                     break
-                _elapsed_mins = int((time.time() - _notify_start) // 60)
                 # Include agent activity context if available. Default
                 # heartbeat is terse: elapsed + current tool. Verbose
                 # iteration counter is gated on busy_ack_detail so users
@@ -17229,10 +17273,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if _action:
                             _parts.append(str(_action))
                         if _parts:
-                            _status_detail = " — " + ", ".join(_parts)
+                            _status_detail = "; ".join(_parts)
                     except Exception:
                         pass
-                _heartbeat_text = f"⏳ Working — {_elapsed_mins} min{_status_detail}"
+                _heartbeat_text = _format_long_running_notification(
+                    elapsed_seconds=time.time() - _notify_start,
+                    status_detail=_status_detail,
+                    initial=_first_notice,
+                )
                 try:
                     _notify_res = None
                     if _heartbeat_msg_id:
@@ -17243,7 +17291,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 _heartbeat_text,
                             )
                         except Exception as _ee:
-                            logger.debug("Heartbeat edit failed: %s", _ee)
+                            logger.debug("Long-running status edit failed: %s", _ee)
                             _notify_res = None
                     if not (_notify_res and getattr(_notify_res, "success", False)):
                         _notify_res = await _notify_adapter.send(
@@ -17257,6 +17305,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _heartbeat_msg_id = str(_notify_res.message_id)
                             if _cleanup_progress:
                                 _cleanup_msg_ids.append(_heartbeat_msg_id)
+                    _first_notice = False
                 except Exception as _ne:
                     logger.debug("Long-running notification error: %s", _ne)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15229,14 +15229,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
+        def _agent_cfg_int(key: str, default: int) -> int:
+            """Read an integer agent config value while preserving explicit 0.
+
+            The Telegram usage budget treats 0 as "disabled". Using ``value or
+            default`` here silently re-enabled hard stops after James set them to
+            0, which made Telegram unusable.
+            """
+            value = agent_cfg_local.get(key, default)
+            if value is None or value == "":
+                value = default
+            return int(value)
+
+        def _agent_cfg_float(key: str, default: float) -> float:
+            value = agent_cfg_local.get(key, default)
+            if value is None or value == "":
+                value = default
+            return float(value)
+
         _usage_receipts_enabled = bool(agent_cfg_local.get("gateway_usage_receipts", True))
-        _usage_receipt_min_api_calls = int(agent_cfg_local.get("gateway_usage_receipt_min_api_calls", 2) or 2)
-        _usage_receipt_min_tokens = int(agent_cfg_local.get("gateway_usage_receipt_min_tokens", 25_000) or 25_000)
-        _usage_receipt_min_seconds = float(agent_cfg_local.get("gateway_usage_receipt_min_seconds", 30) or 30)
-        _usage_warn_api_calls = int(agent_cfg_local.get("gateway_usage_warn_api_calls", 8) or 8)
-        _usage_warn_tokens = int(agent_cfg_local.get("gateway_usage_warn_tokens", 100_000) or 100_000)
-        _usage_hard_api_calls = int(agent_cfg_local.get("gateway_usage_hard_api_calls", 30) or 30)
-        _usage_hard_tokens = int(agent_cfg_local.get("gateway_usage_hard_tokens", 350_000) or 350_000)
+        _usage_receipt_min_api_calls = _agent_cfg_int("gateway_usage_receipt_min_api_calls", 2)
+        _usage_receipt_min_tokens = _agent_cfg_int("gateway_usage_receipt_min_tokens", 25_000)
+        _usage_receipt_min_seconds = _agent_cfg_float("gateway_usage_receipt_min_seconds", 30)
+        _usage_warn_api_calls = _agent_cfg_int("gateway_usage_warn_api_calls", 8)
+        _usage_warn_tokens = _agent_cfg_int("gateway_usage_warn_tokens", 100_000)
+        _usage_hard_api_calls = _agent_cfg_int("gateway_usage_hard_api_calls", 30)
+        _usage_hard_tokens = _agent_cfg_int("gateway_usage_hard_tokens", 350_000)
 
         display_config = user_config.get("display", {})
         if not isinstance(display_config, dict):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17217,6 +17217,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _NOTIFY_INTERVAL = None
             _NOTIFY_INITIAL_DELAY = None
         _notify_start = time.time()
+        try:
+            from gateway.long_run_status import (
+                config_from_gateway_config as _status_enrichment_config_from_gateway_config,
+                enrich_long_run_status as _enrich_long_run_status,
+            )
+            _status_enrichment_config = _status_enrichment_config_from_gateway_config(user_config)
+        except Exception as _status_enrich_cfg_err:
+            logger.debug("Long-running status enrichment config failed: %s", _status_enrich_cfg_err)
+            _status_enrichment_config = None
+            _enrich_long_run_status = None
+        _status_enrichment_tasks: set[asyncio.Task] = set()
 
         async def _notify_long_running():
             if _NOTIFY_INITIAL_DELAY is None:
@@ -17231,6 +17242,67 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # adapter.
             _heartbeat_msg_id: Optional[str] = None
             _first_notice = True
+
+            async def _enrich_and_edit_status(
+                message_id: str,
+                initial_notice: bool,
+                snapshot: dict[str, Any],
+            ) -> None:
+                if not _status_enrichment_config or not _enrich_long_run_status:
+                    return
+                try:
+                    enriched_detail = await _enrich_long_run_status(
+                        snapshot,
+                        _status_enrichment_config,
+                    )
+                    if not enriched_detail:
+                        return
+                    try:
+                        _exec_ref = _executor_task
+                    except NameError:
+                        _exec_ref = None
+                    if not self._should_emit_long_running_notification(
+                        session_key, agent_holder[0], _exec_ref
+                    ):
+                        return
+                    enriched_text = _format_long_running_notification(
+                        elapsed_seconds=float(
+                            snapshot.get("elapsed_seconds", time.time() - _notify_start)
+                        ),
+                        status_detail=enriched_detail,
+                        initial=initial_notice,
+                    )
+                    await _notify_adapter.edit_message(
+                        source.chat_id,
+                        message_id,
+                        enriched_text,
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as _enrich_err:
+                    logger.debug("Long-running status enrichment skipped: %s", _enrich_err)
+
+            def _schedule_status_enrichment(
+                message_id: Optional[str],
+                initial_notice: bool,
+                snapshot: dict[str, Any],
+            ) -> None:
+                if (
+                    not message_id
+                    or not _status_enrichment_config
+                    or not getattr(_status_enrichment_config, "enabled", False)
+                ):
+                    return
+                # Do not stack model calls. One tiny enrich attempt per status
+                # interval is plenty; the deterministic heartbeat already landed.
+                if any(not task.done() for task in _status_enrichment_tasks):
+                    return
+                task = asyncio.create_task(
+                    _enrich_and_edit_status(message_id, initial_notice, snapshot)
+                )
+                _status_enrichment_tasks.add(task)
+                task.add_done_callback(_status_enrichment_tasks.discard)
+
             while True:
                 _sleep_for = _NOTIFY_INITIAL_DELAY if _first_notice else _NOTIFY_INTERVAL
                 if _sleep_for is None:
@@ -17253,6 +17325,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # who want it can opt in per platform.
                 _agent_ref = agent_holder[0]
                 _status_detail = ""
+                _activity_snapshot: dict[str, Any] = {
+                    "elapsed_seconds": time.time() - _notify_start,
+                    "platform": platform_key,
+                }
                 _want_iteration_detail = bool(
                     resolve_display_setting(
                         user_config,
@@ -17264,6 +17340,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _agent_ref and hasattr(_agent_ref, "get_activity_summary"):
                     try:
                         _a = _agent_ref.get_activity_summary()
+                        if isinstance(_a, dict):
+                            for _k in (
+                                "api_call_count",
+                                "max_iterations",
+                                "current_tool",
+                                "last_activity_desc",
+                            ):
+                                if _k in _a:
+                                    _activity_snapshot[_k] = _a.get(_k)
                         _parts = []
                         if _want_iteration_detail:
                             _parts.append(
@@ -17305,6 +17390,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _heartbeat_msg_id = str(_notify_res.message_id)
                             if _cleanup_progress:
                                 _cleanup_msg_ids.append(_heartbeat_msg_id)
+                    _schedule_status_enrichment(
+                        _heartbeat_msg_id,
+                        _first_notice,
+                        _activity_snapshot,
+                    )
                     _first_notice = False
                 except Exception as _ne:
                     logger.debug("Long-running notification error: %s", _ne)
@@ -17770,6 +17860,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 progress_task.cancel()
             interrupt_monitor.cancel()
             _notify_task.cancel()
+            for _status_task in list(_status_enrichment_tasks):
+                _status_task.cancel()
 
             # Wait for stream consumer to finish its final edit
             if stream_task:
@@ -17814,7 +17906,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._update_runtime_status("draining")
             
             # Wait for cancelled tasks
-            for task in [progress_task, interrupt_monitor, tracking_task, _notify_task]:
+            for task in [progress_task, interrupt_monitor, tracking_task, _notify_task, *list(_status_enrichment_tasks)]:
                 if task:
                     try:
                         await task

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3537,6 +3537,25 @@ class GatewaySlashCommandsMixin:
             if ctx.compression_count:
                 lines.append(t("gateway.usage.label_compressions", count=ctx.compression_count))
 
+            # Messaging sessions can feel fresh while reusing a cached prompt
+            # and transcript. Surface those hidden dimensions directly so
+            # Telegram token burn is no longer opaque.
+            try:
+                sys_prompt_chars = len(getattr(agent, "_cached_system_prompt", "") or "")
+                agent_messages = getattr(agent, "messages", None) or []
+                session_id = getattr(agent, "session_id", "") or ""
+                lines.append("")
+                lines.append("🔎 **Session diagnostics**")
+                lines.append(f"Session ID: `{session_id}`" if session_id else "Session ID: unknown")
+                lines.append(f"Cached system prompt: {sys_prompt_chars:,} chars")
+                lines.append(f"Messages in agent context: {len(agent_messages):,}")
+                if sys_prompt_chars >= 100_000:
+                    lines.append("⚠ Cached prompt is large; use /new at a task boundary if usage feels abnormal.")
+                if input_tokens >= 100_000 or cache_read >= 100_000:
+                    lines.append("⚠ This session is already in high-token territory; consider /new after this task.")
+            except Exception:
+                pass
+
             if account_lines:
                 lines.append("")
                 lines.extend(account_lines)

--- a/gateway/turn_usage.py
+++ b/gateway/turn_usage.py
@@ -1,0 +1,180 @@
+"""Gateway-facing turn usage telemetry.
+
+Small, dependency-free helpers for making long messaging turns visible without
+changing the agent prompt or tool schema.  All values are best-effort: missing
+provider usage should degrade to elapsed/API-call telemetry, never break a turn.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class TurnUsage:
+    api_calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    total_tokens: int = 0
+    estimated_cost_usd: float | None = None
+    cost_status: str | None = None
+    elapsed_seconds: float = 0.0
+    model: str | None = None
+    provider: str | None = None
+    context_tokens: int = 0
+    context_length: int = 0
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def agent_usage_snapshot(agent: Any) -> dict[str, Any]:
+    """Return cumulative usage counters from an AIAgent-like object."""
+    ctx = getattr(agent, "context_compressor", None)
+    return {
+        "input_tokens": _as_int(getattr(agent, "session_input_tokens", 0)),
+        "output_tokens": _as_int(getattr(agent, "session_output_tokens", 0)),
+        "cache_read_tokens": _as_int(getattr(agent, "session_cache_read_tokens", 0)),
+        "cache_write_tokens": _as_int(getattr(agent, "session_cache_write_tokens", 0)),
+        "prompt_tokens": _as_int(getattr(agent, "session_prompt_tokens", 0)),
+        "completion_tokens": _as_int(getattr(agent, "session_completion_tokens", 0)),
+        "total_tokens": _as_int(getattr(agent, "session_total_tokens", 0)),
+        "estimated_cost_usd": _as_float(getattr(agent, "session_estimated_cost_usd", None)),
+        "cost_status": getattr(agent, "session_cost_status", None),
+        "model": getattr(agent, "model", None),
+        "provider": getattr(agent, "provider", None),
+        "context_tokens": _as_int(getattr(ctx, "last_prompt_tokens", 0)) if ctx else 0,
+        "context_length": _as_int(getattr(ctx, "context_length", 0)) if ctx else 0,
+    }
+
+
+def usage_delta(after: Mapping[str, Any] | None, before: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Compute a non-negative usage delta between cumulative snapshots."""
+    after = after or {}
+    before = before or {}
+    out: dict[str, Any] = {}
+    for key in (
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_write_tokens",
+        "prompt_tokens",
+        "completion_tokens",
+        "total_tokens",
+    ):
+        out[key] = max(0, _as_int(after.get(key)) - _as_int(before.get(key)))
+
+    after_cost = _as_float(after.get("estimated_cost_usd"))
+    before_cost = _as_float(before.get("estimated_cost_usd"))
+    if after_cost is not None and before_cost is not None:
+        out["estimated_cost_usd"] = max(0.0, after_cost - before_cost)
+    elif after_cost is not None:
+        out["estimated_cost_usd"] = after_cost
+    else:
+        out["estimated_cost_usd"] = None
+
+    for key in ("cost_status", "model", "provider", "context_tokens", "context_length"):
+        out[key] = after.get(key)
+    return out
+
+
+def turn_usage_from_result(result: Mapping[str, Any] | None, *, elapsed_seconds: float = 0.0) -> TurnUsage:
+    """Build a TurnUsage from a gateway result dict."""
+    result_map: Mapping[str, Any] = result or {}
+    raw_value = result_map.get("turn_usage")
+    raw: Mapping[str, Any] = raw_value if isinstance(raw_value, Mapping) else result_map
+    total = _as_int(raw.get("total_tokens"))
+    if total <= 0:
+        total = (
+            _as_int(raw.get("input_tokens"))
+            + _as_int(raw.get("output_tokens"))
+            + _as_int(raw.get("cache_read_tokens"))
+            + _as_int(raw.get("cache_write_tokens"))
+        )
+    return TurnUsage(
+        api_calls=_as_int(result_map.get("api_calls") or raw.get("api_calls")),
+        input_tokens=_as_int(raw.get("input_tokens")),
+        output_tokens=_as_int(raw.get("output_tokens")),
+        cache_read_tokens=_as_int(raw.get("cache_read_tokens")),
+        cache_write_tokens=_as_int(raw.get("cache_write_tokens")),
+        total_tokens=total,
+        estimated_cost_usd=_as_float(raw.get("estimated_cost_usd")),
+        cost_status=str(raw.get("cost_status") or "") or None,
+        elapsed_seconds=max(0.0, float(elapsed_seconds or raw.get("elapsed_seconds") or 0.0)),
+        model=str(raw.get("model") or result_map.get("model") or "") or None,
+        provider=str(raw.get("provider") or result_map.get("provider") or "") or None,
+        context_tokens=_as_int(raw.get("context_tokens") or result_map.get("last_prompt_tokens")),
+        context_length=_as_int(raw.get("context_length") or result_map.get("context_length")),
+    )
+
+
+def format_compact_usage(usage: TurnUsage, *, prefix: str = "usage") -> str:
+    """Render one compact, James-facing usage line."""
+    parts = [f"{prefix}: {usage.api_calls} calls"]
+    if usage.input_tokens or usage.output_tokens or usage.cache_read_tokens or usage.cache_write_tokens:
+        parts.append(f"{usage.input_tokens:,} in")
+        if usage.cache_read_tokens:
+            parts.append(f"{usage.cache_read_tokens:,} cache-r")
+        if usage.cache_write_tokens:
+            parts.append(f"{usage.cache_write_tokens:,} cache-w")
+        parts.append(f"{usage.output_tokens:,} out")
+    if usage.estimated_cost_usd is not None and usage.cost_status != "included":
+        marker = "~" if usage.cost_status == "estimated" else ""
+        parts.append(f"{marker}${usage.estimated_cost_usd:.4f}")
+    elif usage.cost_status == "included":
+        parts.append("included")
+    if usage.elapsed_seconds:
+        if usage.elapsed_seconds >= 60:
+            parts.append(f"{usage.elapsed_seconds / 60:.1f}m")
+        else:
+            parts.append(f"{usage.elapsed_seconds:.0f}s")
+    return " · ".join(parts)
+
+
+def should_show_usage_receipt(
+    usage: TurnUsage,
+    *,
+    min_api_calls: int = 2,
+    min_tokens: int = 25_000,
+    min_seconds: float = 30.0,
+) -> bool:
+    return (
+        usage.api_calls >= max(1, int(min_api_calls))
+        or usage.total_tokens >= max(0, int(min_tokens))
+        or usage.elapsed_seconds >= max(0.0, float(min_seconds))
+    )
+
+
+def budget_status(
+    usage: TurnUsage,
+    *,
+    warn_api_calls: int = 8,
+    warn_tokens: int = 100_000,
+    hard_api_calls: int = 30,
+    hard_tokens: int = 350_000,
+) -> str | None:
+    """Return None, 'warn', or 'hard' for a Telegram turn budget."""
+    if hard_api_calls > 0 and usage.api_calls >= hard_api_calls:
+        return "hard"
+    if hard_tokens > 0 and usage.total_tokens >= hard_tokens:
+        return "hard"
+    if warn_api_calls > 0 and usage.api_calls >= warn_api_calls:
+        return "warn"
+    if warn_tokens > 0 and usage.total_tokens >= warn_tokens:
+        return "warn"
+    return None

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1011,6 +1011,17 @@ DEFAULT_CONFIG = {
         # (60+ tool iterations with tiny output) before users assume the
         # bot is dead and /restart.
         "gateway_notify_interval": 180,
+        # Telegram-visible usage telemetry. Receipts are appended after
+        # nontrivial Telegram turns; warning thresholds send a live notice;
+        # hard thresholds interrupt the turn before a hidden loop burns more.
+        "gateway_usage_receipts": True,
+        "gateway_usage_receipt_min_api_calls": 2,
+        "gateway_usage_receipt_min_tokens": 25000,
+        "gateway_usage_receipt_min_seconds": 30,
+        "gateway_usage_warn_api_calls": 8,
+        "gateway_usage_warn_tokens": 100000,
+        "gateway_usage_hard_api_calls": 30,
+        "gateway_usage_hard_tokens": 350000,
         # Freshness window for the gateway auto-continue note (seconds).
         # After a gateway crash/restart/SIGTERM mid-run, the next user
         # message gets a "[System note: your previous turn was

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1742,7 +1742,14 @@ def get_systemd_unit_path(system: bool = False) -> Path:
     name = get_service_name()
     if system:
         return Path("/etc/systemd/system") / f"{name}.service"
-    return Path.home() / ".config" / "systemd" / "user" / f"{name}.service"
+    from hermes_constants import get_real_home
+
+    # Named Hermes profiles may run with HOME={HERMES_HOME}/home so external
+    # CLIs can be isolated. systemd user units, however, live under the OS
+    # user's real home. Looking under profile HOME makes
+    # `hermes -p <name> gateway status` miss an active profile service and
+    # falsely report a manual process.
+    return Path(get_real_home()) / ".config" / "systemd" / "user" / f"{name}.service"
 
 
 class UserSystemdUnavailableError(RuntimeError):
@@ -2015,8 +2022,10 @@ def _legacy_unit_search_paths() -> list[tuple[bool, Path]]:
     Factored out so tests can monkeypatch the search roots without touching
     real filesystem paths.
     """
+    from hermes_constants import get_real_home
+
     return [
-        (False, Path.home() / ".config" / "systemd" / "user"),
+        (False, Path(get_real_home()) / ".config" / "systemd" / "user"),
         (True, Path("/etc/systemd/system")),
     ]
 
@@ -2699,7 +2708,9 @@ WantedBy=multi-user.target
 
     hermes_home = str(get_hermes_home().resolve())
     profile_arg = _profile_arg(hermes_home)
-    path_entries.extend(_build_user_local_paths(Path.home(), path_entries))
+    from hermes_constants import get_real_home
+
+    path_entries.extend(_build_user_local_paths(Path(get_real_home()), path_entries))
     path_entries.extend(_build_wsl_interop_paths(path_entries))
     path_entries.extend(common_bin_paths)
     sane_path = ":".join(path_entries)

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -165,12 +165,15 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        # ``status --all`` is described as "redacted for sharing" and must
+        # never print raw credential material.  It may show more rows/details,
+        # but API-key values stay masked.
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================
@@ -517,9 +520,16 @@ def show_status(args):
         try:
             with open(jobs_file, encoding="utf-8") as f:
                 data = json.load(f)
+            if isinstance(data, list):
+                jobs = data
+            elif isinstance(data, dict):
                 jobs = data.get("jobs", [])
-                enabled_jobs = [j for j in jobs if j.get("enabled", True)]
-                print(f"  Jobs:         {len(enabled_jobs)} active, {len(jobs)} total")
+            else:
+                jobs = []
+            if not isinstance(jobs, list):
+                jobs = []
+            enabled_jobs = [j for j in jobs if isinstance(j, dict) and j.get("enabled", True)]
+            print(f"  Jobs:         {len(enabled_jobs)} active, {len(jobs)} total")
         except Exception:
             print("  Jobs:         (error reading jobs file)")
     else:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -879,15 +879,21 @@ def is_container() -> bool:
                 return True
     except OSError:
         pass
-    # cgroup v2: /proc/1/cgroup is just "0::/" with no marker. The container
-    # runtime still shows up in the mount table (overlay rootfs, runtime mount
-    # paths), so scan mountinfo as a last resort.
+    # cgroup v2: /proc/1/cgroup is just "0::/" with no marker. In real
+    # containerd/CRI-O containers the *root mount* often carries overlay/runtime
+    # paths. Do not scan every mountinfo line: Linux hosts that run containers
+    # may expose unrelated container rootfs mounts in the host namespace, which
+    # would falsely classify the host itself as a container.
     try:
         with open("/proc/self/mountinfo", "r", encoding="utf-8") as f:
-            mountinfo = f.read()
-            if any(marker in mountinfo for marker in ("kubepods", "containerd", "crio")):
-                _container_detected = True
-                return True
+            for line in f:
+                parts = line.split()
+                mount_point = parts[4] if len(parts) > 4 else ""
+                if mount_point == "/" and any(
+                    marker in line for marker in ("kubepods", "containerd", "crio")
+                ):
+                    _container_detected = True
+                    return True
     except OSError:
         pass
     _container_detected = False

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -620,6 +620,19 @@ class PhotonAdapter(BasePlatformAdapter):
                 [],
             )
 
+        def _normalize_richlink_payload(payload: Dict[str, Any]) -> str:
+            url = str(payload.get("url") or "").strip()
+            title = str(payload.get("title") or "").strip()
+            summary = str(payload.get("summary") or "").strip()
+            parts: List[str] = []
+            if title and title != url:
+                parts.append(title)
+            if url:
+                parts.append(url)
+            if summary and summary not in parts:
+                parts.append(summary)
+            return "\n".join(parts) or "[Photon richlink received without URL]"
+
         ctype = content.get("type")
         if ctype == "reaction":
             # Route only tapbacks on messages WE sent — those are implicitly
@@ -674,6 +687,9 @@ class PhotonAdapter(BasePlatformAdapter):
             mtype = MessageType.TEXT
         elif ctype in {"attachment", "voice"}:
             text, mtype, media_urls, media_types = _normalize_binary_payload(content)
+        elif ctype == "richlink":
+            text = _normalize_richlink_payload(content)
+            mtype = MessageType.TEXT
         elif ctype == "group":
             text_parts: List[str] = []
             mtype = MessageType.TEXT
@@ -699,6 +715,9 @@ class PhotonAdapter(BasePlatformAdapter):
                     media_types.extend(item_types)
                     if not item_urls:
                         text_parts.append(marker)
+                    continue
+                if item_type == "richlink":
+                    text_parts.append(_normalize_richlink_payload(item_content))
                     continue
                 if item_type:
                     text_parts.append(f"[Photon content type not handled: {item_type}]")

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -214,7 +214,10 @@ if (!projectId || !projectSecret || !sharedToken) {
 // Lazy-load spectrum-ts so a missing install fails with a clear message
 // instead of a cryptic module-resolution error during import. Apply Hermes'
 // pinned-sdk compatibility patch first so existing installs self-heal at
-// runtime, not only during npm postinstall.
+// runtime, not only during npm postinstall. The patch preserves text on mixed
+// text+attachment iMessage bubbles, but it is not required for basic Photon
+// transport. If Spectrum reshapes its package layout, keep the sidecar alive
+// and warn instead of taking down all iMessage replies.
 try {
   const patchResult = patchSpectrumTs();
   if (patchResult.patched) {
@@ -224,13 +227,13 @@ try {
   }
 } catch (e) {
   console.error(
-    "photon-sidecar: spectrum mixed attachment patch failed. " +
+    "photon-sidecar: spectrum mixed attachment patch failed; " +
+      "continuing without mixed text+attachment preservation. " +
       "Run `npm install` inside plugins/platforms/photon/sidecar/ or " +
       "upgrade the Photon sidecar patch for the pinned spectrum-ts version. " +
       "Original error: " +
       (e && e.stack ? e.stack : String(e))
   );
-  process.exit(3);
 }
 let Spectrum,
   imessage,

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -444,6 +444,17 @@ async function normalizeContent(content) {
   if (content.type === "attachment" || content.type === "voice") {
     return await normalizeBinaryContent(content);
   }
+  if (content.type === "richlink") {
+    return {
+      type: "richlink",
+      url: typeof content.url === "string" ? content.url : null,
+      // Do not call lazy metadata accessors here. They may fetch remote OpenGraph
+      // data and stall the inbound iMessage stream; the URL is the durable bit.
+      title: typeof content.title === "string" ? content.title : null,
+      summary: typeof content.summary === "string" ? content.summary : null,
+      cover: typeof content.cover === "string" ? content.cover : null,
+    };
+  }
   if (content.type === "group") {
     const items = [];
     for (const item of Array.isArray(content.items) ? content.items : []) {

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -421,6 +421,114 @@ class TestAuth:
 
 
 # ---------------------------------------------------------------------------
+# Claude handoff memory endpoint
+# ---------------------------------------------------------------------------
+
+
+def _valid_claude_handoff_body() -> str:
+    return "\n".join(
+        [
+            "# Session context",
+            "Claude investigated the current issue.",
+            "# Key decisions",
+            "Hermes remains the memory writer.",
+            "# Open questions",
+            "None.",
+            "# Artifacts produced",
+            "A short handoff packet.",
+            "# Relevant existing memories",
+            "No direct memory writes from Claude.",
+            "# What Hermes should know",
+            "Review this packet before promotion.",
+        ]
+    )
+
+
+class TestClaudeHandoffMemory:
+    def test_requires_canonical_sections(self):
+        bad_body = "# Session context\nOnly one section."
+        error = APIServerAdapter._claude_handoff_sections(bad_body)
+        assert error is not None
+        assert "required section headings" in error
+
+    @pytest.mark.asyncio
+    async def test_rejects_mismatched_handoff_name_surface(self):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        request = MagicMock()
+        request.headers = {}
+        request.json = AsyncMock(
+            return_value={
+                "description": "Test handoff",
+                "body": _valid_claude_handoff_body(),
+                "surface": "claudeai",
+                "session_date": "2026-06-23",
+                "name": "handoff-claudecode-linux-2026-06-23-abc123",
+            }
+        )
+
+        response = await adapter._handle_claude_handoff_memory(request)
+        payload = json.loads(response.text)
+
+        assert response.status == 400
+        assert payload["accepted"] is False
+        assert payload["error"] == "handoff name surface does not match payload surface"
+
+    @pytest.mark.asyncio
+    async def test_writes_pending_handoff_memory(self, monkeypatch):
+        import sys
+        import types
+
+        captured = {}
+
+        class FakeClarenceDB:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def write_memory(self, **kwargs):
+                captured.update(kwargs)
+                return {"status": "created", "memory_id": 42}
+
+        fake_module = types.ModuleType("clarence_db")
+        setattr(fake_module, "ClarenceDB", FakeClarenceDB)
+        monkeypatch.setitem(sys.modules, "clarence_db", fake_module)
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        request = MagicMock()
+        request.headers = {}
+        request.json = AsyncMock(
+            return_value={
+                "description": "Test handoff",
+                "body": _valid_claude_handoff_body(),
+                "surface": "claudeai",
+                "session_date": "2026-06-23",
+                "source_session_id": "claude-session-1",
+            }
+        )
+
+        response = await adapter._handle_claude_handoff_memory(request)
+        payload = json.loads(response.text)
+
+        assert response.status == 200
+        assert payload["accepted"] is True
+        assert payload["durable"] is True
+        assert payload["memory_id"] == 42
+        assert payload["name"].startswith("handoff-claudeai-2026-06-23-")
+        assert captured["name"] == payload["name"]
+        assert captured["type"] == "reference"
+        assert captured["kind"] == "state"
+        assert captured["author_agent"] == "claude-external"
+        assert captured["tags"] == [
+            "handoff-pending",
+            "claude-handoff",
+            "claudeai",
+            "2026-06-23",
+        ]
+
+
+# ---------------------------------------------------------------------------
 # Concurrency cap (gateway.api_server.max_concurrent_runs) — #7483
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_api_server_claude_handoff.py
+++ b/tests/gateway/test_api_server_claude_handoff.py
@@ -1,0 +1,106 @@
+import asyncio
+import json
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+def _valid_claude_handoff_body() -> str:
+    return "\n".join(
+        [
+            "# Session context",
+            "Claude investigated the current issue.",
+            "# Key decisions",
+            "Hermes remains the memory writer.",
+            "# Open questions",
+            "None.",
+            "# Artifacts produced",
+            "A short handoff packet.",
+            "# Relevant existing memories",
+            "No direct memory writes from Claude.",
+            "# What Hermes should know",
+            "Review this packet before promotion.",
+        ]
+    )
+
+
+class TestClaudeHandoffMemory:
+    def test_requires_canonical_sections(self):
+        bad_body = "# Session context\nOnly one section."
+        error = APIServerAdapter._claude_handoff_sections(bad_body)
+        assert error is not None
+        assert "required section headings" in error
+
+    def test_rejects_mismatched_handoff_name_surface(self):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        request = MagicMock()
+        request.headers = {}
+        request.json = AsyncMock(
+            return_value={
+                "description": "Test handoff",
+                "body": _valid_claude_handoff_body(),
+                "surface": "claudeai",
+                "session_date": "2026-06-23",
+                "name": "handoff-claudecode-linux-2026-06-23-abc123",
+            }
+        )
+
+        response = asyncio.run(adapter._handle_claude_handoff_memory(request))
+        payload = json.loads(response.text)
+
+        assert response.status == 400
+        assert payload["accepted"] is False
+        assert payload["error"] == "handoff name surface does not match payload surface"
+
+    def test_writes_pending_handoff_memory(self, monkeypatch):
+        captured = {}
+
+        class FakeClarenceDB:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def write_memory(self, **kwargs):
+                captured.update(kwargs)
+                return {"status": "created", "memory_id": 42}
+
+        fake_module = types.ModuleType("clarence_db")
+        setattr(fake_module, "ClarenceDB", FakeClarenceDB)
+        monkeypatch.setitem(sys.modules, "clarence_db", fake_module)
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        request = MagicMock()
+        request.headers = {}
+        request.json = AsyncMock(
+            return_value={
+                "description": "Test handoff",
+                "body": _valid_claude_handoff_body(),
+                "surface": "claudeai",
+                "session_date": "2026-06-23",
+                "source_session_id": "claude-session-1",
+            }
+        )
+
+        response = asyncio.run(adapter._handle_claude_handoff_memory(request))
+        payload = json.loads(response.text)
+
+        assert response.status == 200
+        assert payload["accepted"] is True
+        assert payload["durable"] is True
+        assert payload["memory_id"] == 42
+        assert payload["name"].startswith("handoff-claudeai-2026-06-23-")
+        assert captured["name"] == payload["name"]
+        assert captured["type"] == "reference"
+        assert captured["kind"] == "state"
+        assert captured["author_agent"] == "claude-external"
+        assert captured["tags"] == [
+            "handoff-pending",
+            "claude-handoff",
+            "claudeai",
+            "2026-06-23",
+        ]

--- a/tests/gateway/test_gateway_long_running_notifications.py
+++ b/tests/gateway/test_gateway_long_running_notifications.py
@@ -1,0 +1,35 @@
+from gateway.run import _format_long_running_notification
+
+
+def test_initial_long_running_notice_says_background_and_no_terminal():
+    notice = _format_long_running_notification(
+        elapsed_seconds=31,
+        status_detail="iteration 2/90; terminal",
+        initial=True,
+    )
+
+    assert "Long-running task" in notice
+    assert "still working in this chat" in notice
+    assert "Background status updates will stay here" in notice
+    assert "no terminal check needed" in notice
+    assert "/stop" in notice
+    assert "Status: iteration 2/90; terminal." in notice
+
+
+def test_followup_long_running_notice_is_short_and_keeps_status():
+    notice = _format_long_running_notification(
+        elapsed_seconds=185,
+        status_detail="computer_use",
+        initial=False,
+    )
+
+    assert notice == "⏳ Still working: 3 min. Status: computer_use."
+
+
+def test_subminute_long_running_notice_uses_subminute_label():
+    notice = _format_long_running_notification(
+        elapsed_seconds=12,
+        initial=True,
+    )
+
+    assert "for <1 min" in notice

--- a/tests/gateway/test_long_run_status_enrichment.py
+++ b/tests/gateway/test_long_run_status_enrichment.py
@@ -1,0 +1,117 @@
+import asyncio
+
+from gateway import long_run_status as lrs
+
+
+def test_status_enrichment_config_defaults_disabled_and_small_local_model():
+    cfg = lrs.config_from_gateway_config({})
+
+    assert cfg.enabled is False
+    assert cfg.local_model == "qwen2.5:0.5b"
+    assert cfg.local_keep_alive == "0s"
+    assert cfg.cloud_model == "deepseek/deepseek-v4-flash"
+
+
+def test_status_enrichment_config_reads_nested_gateway_values():
+    cfg = lrs.config_from_gateway_config(
+        {
+            "agent": {
+                "gateway_status_enrichment": {
+                    "enabled": "true",
+                    "local": {
+                        "enabled": "true",
+                        "model": "qwen3:0.6b",
+                        "timeout_seconds": "0.7",
+                        "keep_alive": "0s",
+                    },
+                    "cloud": {
+                        "enabled": "false",
+                        "max_calls_per_day": "3",
+                    },
+                }
+            }
+        }
+    )
+
+    assert cfg.enabled is True
+    assert cfg.local_model == "qwen3:0.6b"
+    assert cfg.local_timeout_seconds == 0.7
+    assert cfg.cloud_enabled is False
+    assert cfg.cloud_max_calls_per_day == 3
+
+
+def test_sanitize_activity_snapshot_keeps_only_safe_telemetry():
+    snap = lrs.sanitize_activity_snapshot(
+        {
+            "elapsed_seconds": 42,
+            "api_call_count": 3,
+            "current_tool": "terminal",
+            "last_activity_desc": "OPENROUTER_API_KEY=secret should not pass",
+            "user_message": "never include transcript",
+        }
+    )
+
+    assert snap == {
+        "elapsed_seconds": 42,
+        "api_call_count": 3,
+        "current_tool": "terminal",
+    }
+
+
+def test_normalize_status_line_rejects_secret_or_multiline():
+    assert lrs.normalize_status_line("running focused tests") == "running focused tests"
+    assert lrs.normalize_status_line("line one\nline two") is None
+    assert lrs.normalize_status_line("using bearer token") is None
+
+
+def test_normalize_status_label_accepts_only_known_labels():
+    assert lrs.normalize_status_label("Running tests.") == "running tests"
+    assert (
+        lrs.normalize_status_label(
+            "Running focused tests, optimizing code quality, enhancing system performance."
+        )
+        == "running tests"
+    )
+    assert lrs.normalize_status_label("inventing a detailed story") is None
+
+
+def test_enrich_prefers_local_and_skips_cloud(monkeypatch):
+    calls = {"cloud": 0}
+
+    monkeypatch.setattr(lrs, "_ollama_chat_sync", lambda _cfg, _snap: "running tests")
+
+    def fake_cloud(_cfg, _snap):
+        calls["cloud"] += 1
+        return "cloud should not run"
+
+    monkeypatch.setattr(lrs, "_openrouter_chat_sync", fake_cloud)
+    cfg = lrs.LongRunStatusEnrichmentConfig(enabled=True)
+
+    result = asyncio.run(lrs.enrich_long_run_status({"elapsed_seconds": 40}, cfg))
+
+    assert result == "running tests"
+    assert calls["cloud"] == 0
+
+
+def test_enrich_falls_back_to_cloud_when_local_unavailable(monkeypatch):
+    monkeypatch.setattr(lrs, "_ollama_chat_sync", lambda _cfg, _snap: None)
+    monkeypatch.setattr(lrs, "_openrouter_chat_sync", lambda _cfg, _snap: "waiting on network")
+    cfg = lrs.LongRunStatusEnrichmentConfig(enabled=True)
+
+    result = asyncio.run(lrs.enrich_long_run_status({"elapsed_seconds": 40}, cfg))
+
+    assert result == "waiting on network"
+
+
+def test_enrich_disabled_returns_none_without_provider_calls(monkeypatch):
+    monkeypatch.setattr(lrs, "_ollama_chat_sync", lambda _cfg, _snap: (_ for _ in ()).throw(AssertionError("local called")))
+    monkeypatch.setattr(lrs, "_openrouter_chat_sync", lambda _cfg, _snap: (_ for _ in ()).throw(AssertionError("cloud called")))
+
+    result = asyncio.run(
+        lrs.enrich_long_run_status(
+            {"elapsed_seconds": 40},
+            lrs.LongRunStatusEnrichmentConfig(enabled=False),
+        )
+    )
+
+    assert result is None

--- a/tests/gateway/test_turn_usage.py
+++ b/tests/gateway/test_turn_usage.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+
+from gateway.turn_usage import (
+    agent_usage_snapshot,
+    budget_status,
+    format_compact_usage,
+    should_show_usage_receipt,
+    turn_usage_from_result,
+    usage_delta,
+)
+
+
+def test_usage_delta_nonnegative_and_formats_compact_line():
+    before = {
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "cache_read_tokens": 30,
+        "cache_write_tokens": 0,
+        "total_tokens": 150,
+        "estimated_cost_usd": 0.10,
+        "cost_status": "estimated",
+        "model": "gpt-5.5",
+        "provider": "openai-codex",
+    }
+    after = {
+        "input_tokens": 1100,
+        "output_tokens": 120,
+        "cache_read_tokens": 230,
+        "cache_write_tokens": 10,
+        "total_tokens": 1460,
+        "estimated_cost_usd": 0.25,
+        "cost_status": "estimated",
+        "model": "gpt-5.5",
+        "provider": "openai-codex",
+    }
+
+    delta = usage_delta(after, before)
+    delta["api_calls"] = 3
+    usage = turn_usage_from_result({"api_calls": 3, "turn_usage": delta}, elapsed_seconds=62)
+
+    assert usage.input_tokens == 1000
+    assert usage.output_tokens == 100
+    assert usage.cache_read_tokens == 200
+    assert usage.cache_write_tokens == 10
+    assert usage.total_tokens == 1310
+    assert usage.estimated_cost_usd == 0.15
+    assert format_compact_usage(usage) == "usage: 3 calls · 1,000 in · 200 cache-r · 10 cache-w · 100 out · ~$0.1500 · 1.0m"
+
+
+def test_agent_usage_snapshot_reads_context_and_counters():
+    agent = SimpleNamespace(
+        session_input_tokens=10,
+        session_output_tokens=2,
+        session_cache_read_tokens=3,
+        session_cache_write_tokens=4,
+        session_prompt_tokens=17,
+        session_completion_tokens=2,
+        session_total_tokens=19,
+        session_estimated_cost_usd=0.01,
+        session_cost_status="estimated",
+        model="gpt-5.5",
+        provider="openai-codex",
+        context_compressor=SimpleNamespace(last_prompt_tokens=123, context_length=1000),
+    )
+
+    snap = agent_usage_snapshot(agent)
+
+    assert snap["total_tokens"] == 19
+    assert snap["context_tokens"] == 123
+    assert snap["context_length"] == 1000
+
+
+def test_receipt_and_budget_thresholds():
+    usage = turn_usage_from_result(
+        {
+            "api_calls": 8,
+            "turn_usage": {"input_tokens": 100_000, "output_tokens": 1_000, "total_tokens": 101_000},
+        },
+        elapsed_seconds=10,
+    )
+
+    assert should_show_usage_receipt(usage, min_api_calls=2, min_tokens=25_000, min_seconds=30)
+    assert budget_status(usage, warn_api_calls=8, warn_tokens=100_000, hard_api_calls=30, hard_tokens=350_000) == "warn"
+
+    hard = turn_usage_from_result({"api_calls": 30, "turn_usage": {"total_tokens": 10}}, elapsed_seconds=1)
+    assert budget_status(hard, warn_api_calls=8, warn_tokens=100_000, hard_api_calls=30, hard_tokens=350_000) == "hard"

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -21,6 +21,9 @@ def _make_mock_agent(**overrides):
         "session_output_tokens": 10_000,
         "session_cache_read_tokens": 5_000,
         "session_cache_write_tokens": 2_000,
+        "_cached_system_prompt": "system" * 100,
+        "session_id": "sess-usage-1",
+        "messages": [{"role": "user", "content": "hi"}],
     }
     defaults.update(overrides)
     for k, v in defaults.items():
@@ -90,6 +93,9 @@ class TestUsageCachedAgent:
         assert "Cache read" not in result
         assert "Cache write" not in result
         assert "Cost" not in result
+        assert "Session diagnostics" in result
+        assert "Cached system prompt: 600 chars" in result
+        assert "Messages in agent context: 1" in result
 
     @pytest.mark.asyncio
     async def test_running_agent_preferred_over_cache(self):

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -589,6 +589,27 @@ def test_systemd_status_warns_when_linger_disabled(monkeypatch, tmp_path, capsys
     assert "loginctl enable-linger" in out
 
 
+def test_profile_systemd_unit_path_uses_real_home_when_home_is_profile_home(monkeypatch, tmp_path):
+    real_home = tmp_path / "real-home"
+    profile_home = tmp_path / ".hermes" / "profiles" / "coder"
+    isolated_home = profile_home / "home"
+    real_local_bin = real_home / ".local" / "bin"
+    isolated_home.mkdir(parents=True)
+    real_local_bin.mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.setenv("HOME", str(isolated_home))
+    monkeypatch.setenv("HERMES_REAL_HOME", str(real_home))
+
+    unit_dir = real_home / ".config" / "systemd" / "user"
+    assert gateway.get_service_name() == "hermes-gateway-coder"
+    assert gateway.get_systemd_unit_path() == unit_dir / "hermes-gateway-coder.service"
+    assert gateway._legacy_unit_search_paths()[0] == (False, unit_dir)
+    generated = gateway.generate_systemd_unit()
+    assert str(real_local_bin) in generated
+    assert str(isolated_home / ".local" / "bin") not in generated
+
+
 def test_systemd_install_checks_linger_status(monkeypatch, tmp_path, capsys):
     unit_path = tmp_path / "systemd" / "user" / "hermes-gateway.service"
 

--- a/tests/hermes_cli/test_status_redaction.py
+++ b/tests/hermes_cli/test_status_redaction.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+
+
+def _stub_status_dependencies(monkeypatch, status, auth, *, env_values=None, hermes_home=None):
+    env_values = env_values or {}
+    monkeypatch.setattr(status, "get_env_value", lambda name, *args, **kwargs: env_values.get(name, ""))
+    monkeypatch.setattr(status, "get_env_path", lambda: SimpleNamespace(exists=lambda: True))
+    monkeypatch.setattr(status, "load_config", lambda: {"model": {"default": "test-model"}})
+    monkeypatch.setattr(status, "_effective_provider_label", lambda: "Test Provider")
+    monkeypatch.setattr(auth, "get_anthropic_key", lambda: env_values.get("ANTHROPIC_API_KEY", ""))
+    monkeypatch.setattr(auth, "get_nous_auth_status", lambda: {})
+    monkeypatch.setattr(auth, "get_codex_auth_status", lambda: {})
+    monkeypatch.setattr(auth, "get_qwen_auth_status", lambda: {})
+    monkeypatch.setattr(auth, "get_minimax_oauth_auth_status", lambda: {})
+    monkeypatch.setattr(auth, "get_xai_oauth_auth_status", lambda: {})
+    if hermes_home is not None:
+        monkeypatch.setattr(status, "get_hermes_home", lambda: hermes_home)
+
+
+def test_status_all_redacts_api_key_values(monkeypatch, capsys):
+    from hermes_cli import auth, status
+
+    secrets = {
+        "OPENROUTER_API_KEY": "sk-or-...7890",
+        "ANTHROPIC_API_KEY": "sk-ant...7890",
+    }
+
+    _stub_status_dependencies(monkeypatch, status, auth, env_values=secrets)
+
+    status.show_status(SimpleNamespace(all=True, deep=False))
+
+    out = capsys.readouterr().out
+    assert secrets["OPENROUTER_API_KEY"] not in out
+    assert secrets["ANTHROPIC_API_KEY"] not in out
+    assert status.redact_key(secrets["OPENROUTER_API_KEY"]) in out
+    assert status.redact_key(secrets["ANTHROPIC_API_KEY"]) in out
+
+
+def test_status_accepts_legacy_bare_list_jobs_file(monkeypatch, capsys, tmp_path):
+    from hermes_cli import auth, status
+
+    cron_dir = tmp_path / "cron"
+    cron_dir.mkdir()
+    (cron_dir / "jobs.json").write_text("[]", encoding="utf-8")
+    _stub_status_dependencies(monkeypatch, status, auth, hermes_home=tmp_path)
+
+    status.show_status(SimpleNamespace(all=True, deep=False))
+
+    out = capsys.readouterr().out
+    assert "Jobs:         0 active, 0 total" in out
+    assert "error reading jobs file" not in out

--- a/tests/plugins/platforms/photon/test_mention_gating.py
+++ b/tests/plugins/platforms/photon/test_mention_gating.py
@@ -41,9 +41,38 @@ def _group_payload(text: str) -> dict:
 def _dm_payload(text: str) -> dict:
     return {
         "messageId": f"dm-{abs(hash(text))}",
-        "space": {"id": "+15551234567", "type": "dm", "phone": "+15551234567"},
-        "sender": {"id": "+15551234567"},
+        "space": {"id": "+155****4567", "type": "dm", "phone": "+155****4567"},
+        "sender": {"id": "+155****4567"},
         "content": {"type": "text", "text": text},
+        "timestamp": "2026-05-14T19:06:32.000Z",
+    }
+
+
+def _richlink_payload(url: str, *, title: str | None = None) -> dict:
+    content = {"type": "richlink", "url": url}
+    if title is not None:
+        content["title"] = title
+    return {
+        "messageId": f"link-{abs(hash((url, title)))}",
+        "space": {"id": "+155****4567", "type": "dm", "phone": "+155****4567"},
+        "sender": {"id": "+155****4567"},
+        "content": content,
+        "timestamp": "2026-05-14T19:06:32.000Z",
+    }
+
+
+def _group_with_richlink_payload(text: str, url: str) -> dict:
+    return {
+        "messageId": f"grp-link-{abs(hash((text, url)))}",
+        "space": {"id": "group-guid-xyz", "type": "group", "phone": None},
+        "sender": {"id": "+155****4567"},
+        "content": {
+            "type": "group",
+            "items": [
+                {"content": {"type": "text", "text": text}},
+                {"content": {"type": "richlink", "url": url}},
+            ],
+        },
         "timestamp": "2026-05-14T19:06:32.000Z",
     }
 
@@ -93,6 +122,30 @@ async def test_dm_never_gated(monkeypatch: pytest.MonkeyPatch) -> None:
     await adapter._dispatch_inbound(_dm_payload("no wake word here"))
     assert len(captured) == 1
     assert captured[0].text == "no wake word here"
+
+
+@pytest.mark.asyncio
+async def test_dm_richlink_extracts_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    await adapter._dispatch_inbound(
+        _richlink_payload("https://example.com/article", title="Example Article")
+    )
+    assert len(captured) == 1
+    assert captured[0].text == "Example Article\nhttps://example.com/article"
+
+
+@pytest.mark.asyncio
+async def test_group_richlink_preserves_text_and_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    await adapter._dispatch_inbound(
+        _group_with_richlink_payload("Evaluate this", "https://example.com/article")
+    )
+    assert len(captured) == 1
+    assert captured[0].text == "Evaluate this\nhttps://example.com/article"
 
 
 @pytest.mark.asyncio

--- a/tests/plugins/platforms/photon/test_spectrum_patch.py
+++ b/tests/plugins/platforms/photon/test_spectrum_patch.py
@@ -17,6 +17,14 @@ def test_sidecar_applies_spectrum_patch_before_importing_sdk() -> None:
     assert index.index("patchSpectrumTs();") < index.index('await import("spectrum-ts")')
 
 
+def test_sidecar_keeps_running_if_optional_spectrum_patch_fails() -> None:
+    """Mixed-attachment preservation is optional; Photon text transport should survive patch drift."""
+    index = Path("plugins/platforms/photon/sidecar/index.mjs").read_text(encoding="utf-8")
+    patch_block = index[index.index("try {\n  const patchResult = patchSpectrumTs();"):index.index("let Spectrum,")]
+    assert "continuing without mixed text+attachment preservation" in patch_block
+    assert "process.exit(3)" not in patch_block
+
+
 def test_sidecar_healthz_reports_stream_health() -> None:
     """Local process health must include upstream stream health."""
     index = Path("plugins/platforms/photon/sidecar/index.mjs").read_text(encoding="utf-8")

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -391,7 +391,7 @@ class TestIsContainer:
         assert is_container() is True
 
     def test_detects_cgroup_v2_via_mountinfo(self, monkeypatch, tmp_path):
-        """cgroup v2 (0::/ only) falls back to containerd marker in mountinfo."""
+        """cgroup v2 (0::/ only) falls back to containerd marker in root mountinfo."""
         import builtins
         self._reset_cache(monkeypatch)
         monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
@@ -413,6 +413,34 @@ class TestIsContainer:
 
         monkeypatch.setattr("builtins.open", _fake_open)
         assert is_container() is True
+
+    def test_mountinfo_containerd_non_root_mount_does_not_mark_host_container(
+        self, monkeypatch, tmp_path
+    ):
+        """Hosts running containers can expose containerd mounts without being containers."""
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("0::/init.scope\n")
+        mountinfo_file = tmp_path / "mountinfo"
+        mountinfo_file.write_text(
+            "27 32 0:24 / /sys rw - sysfs sysfs rw\n"
+            "1549 32 0:88 / /var/lib/docker/rootfs/overlayfs/abc rw "
+            "- overlay overlay rw,lowerdir=/var/lib/containerd/snapshots/1/fs\n"
+        )
+        _real_open = builtins.open
+
+        def _fake_open(p, *a, **kw):
+            if p == "/proc/1/cgroup":
+                return _real_open(str(cgroup_file), *a, **kw)
+            if p == "/proc/self/mountinfo":
+                return _real_open(str(mountinfo_file), *a, **kw)
+            return _real_open(p, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", _fake_open)
+        assert is_container() is False
 
     def test_caches_result(self, monkeypatch):
         """Second call uses cached value without re-probing."""


### PR DESCRIPTION
## Summary
- Preserve the Claude handoff memory endpoint on the API server.
- Add safer gateway long-turn notices and turn-usage reporting.
- Preserve explicit zero budget settings in gateway usage handling.
- Tighten profile gateway/status detection, including systemd profile services, bare-list cron stores, and host-vs-container detection.
- Keep the Photon sidecar alive if the optional Spectrum mixed-attachment compatibility patch fails, so basic iMessage transport is not taken down by patch/package-layout drift.

## Test plan
- `node --check plugins/platforms/photon/sidecar/index.mjs`
- `node --check plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs`
- `./venv/bin/python -m py_compile gateway/platforms/api_server.py gateway/run.py gateway/long_run_status.py gateway/turn_usage.py gateway/slash_commands.py hermes_cli/config.py hermes_cli/gateway.py hermes_cli/status.py hermes_constants.py plugins/platforms/photon/adapter.py`
- `./venv/bin/python -m pytest -q tests/gateway/test_api_server.py tests/gateway/test_api_server_claude_handoff.py tests/gateway/test_gateway_long_running_notifications.py tests/gateway/test_long_run_status_enrichment.py tests/gateway/test_turn_usage.py tests/gateway/test_usage_command.py tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_status_redaction.py tests/plugins/platforms/photon/test_mention_gating.py tests/plugins/platforms/photon/test_spectrum_patch.py tests/test_hermes_constants.py -o 'addopts='`

Local result: 513 passed, 112 warnings.
