### PR TITLE
fix(moa): lower auxiliary default timeouts

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1585,7 +1585,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
-            "timeout": 600,
+            "timeout": 120,
             "extra_body": {},
         },
         "moa_aggregator": {
@@ -1593,7 +1593,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
-            "timeout": 600,
+            "timeout": 180,
             "extra_body": {},
         },
     },

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -42,6 +42,13 @@ def test_title_generation_present_in_default_config():
     assert tg["extra_body"] == {}
 
 
+def test_moa_auxiliary_default_timeouts_are_bounded():
+    aux = DEFAULT_CONFIG["auxiliary"]
+
+    assert aux["moa_reference"]["timeout"] == 120
+    assert aux["moa_aggregator"]["timeout"] == 180
+
+
 def test_session_search_no_longer_appears_in_auxiliary_model_config():
     """session_search is a direct DB-backed tool, not an auxiliary LLM task."""
     assert "session_search" not in DEFAULT_CONFIG["auxiliary"]


### PR DESCRIPTION
## Summary
- lower MoA reference default auxiliary timeout from 600s to 120s
- lower MoA aggregator default auxiliary timeout from 600s to 180s
- add a default-config regression test for the bounded MoA timeouts

Closes #53866

## Test plan
- `python -m pytest tests/hermes_cli/test_aux_config.py -q`
- `python -m pytest tests/run_agent/test_moa_loop_mode.py -q`
