### PR TITLE
fix(skills): stabilize content_hash ordering for shared-prefix paths

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1231,6 +1231,31 @@ class TestCheckForSkillUpdates:
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
+    def test_bundle_content_hash_matches_on_disk_when_file_and_dir_share_prefix(self, tmp_path):
+        """Regression: file-vs-dir prefix collisions must not change hash ordering."""
+        from tools.skills_guard import content_hash
+
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": "same content\n",
+                "references/styles.md": "top-level style index\n",
+                "references/styles/blueprint.md": "blueprint\n",
+            },
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        skill_dir = tmp_path / "demo-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("same content\n")
+        (skill_dir / "references").mkdir()
+        (skill_dir / "references" / "styles.md").write_text("top-level style index\n")
+        (skill_dir / "references" / "styles").mkdir()
+        (skill_dir / "references" / "styles" / "blueprint.md").write_text("blueprint\n")
+
+        assert bundle_content_hash(bundle) == content_hash(skill_dir)
+
     def test_reports_update_when_remote_hash_differs(self):
         lock = MagicMock()
         lock.list_installed.return_value = [{

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -776,15 +776,28 @@ def content_hash(skill_path: Path) -> str:
     """
     h = hashlib.sha256()
     if skill_path.is_dir():
-        for f in sorted(skill_path.rglob("*")):
-            if f.is_file():
-                try:
-                    rel = f.relative_to(skill_path).as_posix()
-                    h.update(rel.encode("utf-8"))
-                    h.update(b"\x00")
-                    h.update(f.read_bytes())
-                except OSError:
-                    continue
+        file_entries = []
+        for f in skill_path.rglob("*"):
+            if not f.is_file():
+                continue
+            try:
+                file_entries.append((f.relative_to(skill_path).as_posix(), f))
+            except OSError:
+                continue
+
+        # Keep ordering symmetric with ``bundle_content_hash()``, which sorts
+        # by relative POSIX path strings. Sorting ``Path`` objects directly can
+        # disagree with pure string ordering when a skill has both a file and a
+        # nested directory sharing the same prefix (e.g. ``references/styles.md``
+        # and ``references/styles/blueprint.md``), producing false update
+        # detections for unchanged skills.
+        for rel, f in sorted(file_entries, key=lambda item: item[0]):
+            try:
+                h.update(rel.encode("utf-8"))
+                h.update(b"\x00")
+                h.update(f.read_bytes())
+            except OSError:
+                continue
     elif skill_path.is_file():
         h.update(skill_path.read_bytes())
     return f"sha256:{h.hexdigest()[:16]}"


### PR DESCRIPTION
## Summary
- make `content_hash()` sort on the same relative POSIX path string that it hashes
- keep on-disk hashing symmetric with `bundle_content_hash()`
- add a regression test for file/dir shared-prefix collisions

## Why
`content_hash()` currently sorts `Path` objects but hashes the relative POSIX string. Those two orderings are not guaranteed to match. When a skill contains both a file and a nested directory sharing a prefix (for example `references/styles.md` and `references/styles/blueprint.md`), unchanged content can hash in a different byte order and trigger false update reports.

## Test plan
- run `scripts/run_tests.sh tests/tools/test_skills_hub.py`
- verify the new regression test passes:
  - `test_bundle_content_hash_matches_on_disk_when_file_and_dir_share_prefix`

Fixes #53404
Related to #41176