### PR TITLE
fix(nvidia): hoist chat_template_kwargs from extra_body to top-level for NVIDIA NIM (#50703)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5498,6 +5498,14 @@ def _build_call_kwargs(
     merged_extra = dict(extra_body or {})
     if provider == "nous":
         merged_extra.setdefault("tags", []).extend(_nous_portal_tags())
+
+    # NVIDIA NIM: hoist chat_template_kwargs from extra_body to top-level
+    # NVIDIA NIM expects chat_template_kwargs at the JSON top level, not
+    # nested inside the OpenAI SDK's extra_body field. (#50703)
+    _is_nvidia = "integrate.api.nvidia.com" in (base_url or "").lower()
+    if _is_nvidia and "chat_template_kwargs" in merged_extra:
+        kwargs["chat_template_kwargs"] = merged_extra.pop("chat_template_kwargs")
+
     if merged_extra:
         kwargs["extra_body"] = merged_extra
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -446,6 +446,10 @@ class ChatCompletionsTransport(ProviderTransport):
         if extra_body:
             api_kwargs["extra_body"] = extra_body
 
+        # NVIDIA NIM (legacy path): hoist chat_template_kwargs to top-level. (#50703)
+        if params.get("is_nvidia_nim", False):
+            self._hoist_nvidia_chat_template_kwargs(api_kwargs)
+
         # Request overrides last (service_tier etc.)
         overrides = params.get("request_overrides")
         if overrides:
@@ -593,7 +597,27 @@ class ChatCompletionsTransport(ProviderTransport):
             if extra_body:
                 api_kwargs["extra_body"] = extra_body
 
+        # NVIDIA NIM: hoist chat_template_kwargs to top-level. (#50703)
+        if (
+            getattr(profile, "name", "") == "nvidia"
+            or "integrate.api.nvidia.com" in (params.get("base_url") or "").lower()
+        ):
+            self._hoist_nvidia_chat_template_kwargs(api_kwargs)
+
         return api_kwargs
+
+    @staticmethod
+    def _hoist_nvidia_chat_template_kwargs(api_kwargs: dict) -> None:
+        """Hoist chat_template_kwargs from extra_body to top-level.
+
+        NVIDIA NIM expects chat_template_kwargs at the JSON top level, not
+        nested inside the OpenAI SDK's extra_body field. (#50703)
+        """
+        _nvidia_extra = api_kwargs.get("extra_body")
+        if _nvidia_extra and "chat_template_kwargs" in _nvidia_extra:
+            api_kwargs["chat_template_kwargs"] = _nvidia_extra.pop("chat_template_kwargs")
+            if not _nvidia_extra:
+                del api_kwargs["extra_body"]
 
     def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:
         """Normalize OpenAI ChatCompletion to NormalizedResponse.

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4621,3 +4621,66 @@ class TestCompressionFallbackContextFilter:
         # Empty / unknown tasks have no minimum
         assert _task_minimum_context_length("") is None
         assert _task_minimum_context_length(None) is None
+
+
+class TestNvidiaChatTemplateKwargs:
+    """Tests for NVIDIA NIM chat_template_kwargs hoisting from extra_body."""
+
+    def test_auxiliary_build_call_kwargs_nvidia_hoists_chat_template(self):
+        """When base_url is integrate.api.nvidia.com, chat_template_kwargs in
+        extra_body should be hoisted to top-level kwargs."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="nvidia",
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+            extra_body={
+                "chat_template_kwargs": {"thinking_mode": "enabled"},
+                "other_field": "value",
+            },
+            base_url="https://integrate.api.nvidia.com/v1",
+        )
+
+        # chat_template_kwargs must be at top level
+        assert "chat_template_kwargs" in kwargs
+        assert kwargs["chat_template_kwargs"] == {"thinking_mode": "enabled"}
+        # other_field stays in extra_body
+        assert "extra_body" in kwargs
+        assert kwargs["extra_body"] == {"other_field": "value"}
+
+    def test_auxiliary_build_call_kwargs_non_nvidia_keeps_in_extra_body(self):
+        """Non-NVIDIA providers keep chat_template_kwargs inside extra_body."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="openrouter",
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+            extra_body={
+                "chat_template_kwargs": {"thinking_mode": "enabled"},
+            },
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+        # chat_template_kwargs stays in extra_body for non-NVIDIA
+        assert "extra_body" in kwargs
+        assert "chat_template_kwargs" not in kwargs
+        assert kwargs["extra_body"] == {
+            "chat_template_kwargs": {"thinking_mode": "enabled"}
+        }
+
+    def test_auxiliary_build_call_kwargs_empty_extra_body(self):
+        """No crash when extra_body is None."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="nvidia",
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+            extra_body=None,
+            base_url="https://integrate.api.nvidia.com/v1",
+        )
+
+        # No crash, no extra_body key
+        assert "extra_body" not in kwargs

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -1044,3 +1044,89 @@ class TestChatCompletionsGeminiNativeExtraBodyStrip:
         )
         eb = kw.get("extra_body")
         assert eb and "tags" in eb
+
+
+class TestNvidiaChatTemplateKwargs:
+    """Tests for NVIDIA NIM chat_template_kwargs hoisting from extra_body
+    in the transport layer."""
+
+    @staticmethod
+    def _nvidia_profile():
+        from providers.base import ProviderProfile
+        return ProviderProfile(
+            name="nvidia",
+            aliases=("nvidia-nim",),
+            env_vars=("NVIDIA_API_KEY",),
+            display_name="NVIDIA NIM",
+            base_url="https://integrate.api.nvidia.com/v1",
+            default_max_tokens=16384,
+        )
+
+    def test_profile_path_hoists_chat_template_from_extra_body_additions(self):
+        """When the NVIDIA profile is used, chat_template_kwargs in
+        extra_body_additions should be hoisted to top-level api_kwargs."""
+        from agent.transports import get_transport
+
+        transport = get_transport("chat_completions")
+        kwargs = transport.build_kwargs(
+            model="nvidia/test-model",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            provider_profile=self._nvidia_profile(),
+            extra_body_additions={
+                "chat_template_kwargs": {"thinking_mode": "enabled"},
+                "other_field": "value",
+            },
+            max_tokens=None,
+        )
+
+        assert "chat_template_kwargs" in kwargs
+        assert kwargs["chat_template_kwargs"] == {"thinking_mode": "enabled"}
+        assert "extra_body" in kwargs
+        assert kwargs["extra_body"] == {"other_field": "value"}
+
+    def test_legacy_path_hoists_chat_template_from_extra_body_additions(self):
+        """When is_nvidia_nim=True (legacy path), chat_template_kwargs in
+        extra_body_additions should be hoisted to top-level api_kwargs."""
+        from agent.transports import get_transport
+
+        transport = get_transport("chat_completions")
+        kwargs = transport.build_kwargs(
+            model="minimaxai/minimax-m3",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            is_nvidia_nim=True,
+            extra_body_additions={
+                "chat_template_kwargs": {"thinking_mode": "enabled"},
+            },
+            max_tokens=None,
+        )
+
+        assert "chat_template_kwargs" in kwargs
+        assert kwargs["chat_template_kwargs"] == {"thinking_mode": "enabled"}
+        # extra_body should be empty and omitted
+        assert "extra_body" not in kwargs
+
+    def test_non_nvidia_keeps_in_extra_body(self):
+        """Non-NVIDIA providers keep chat_template_kwargs inside extra_body.
+
+        Guards against over-eager top-level hoisting: only NVIDIA NIM should
+        get chat_template_kwargs promoted out of extra_body.
+        """
+        from agent.transports import get_transport
+
+        transport = get_transport("chat_completions")
+        kwargs = transport.build_kwargs(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            is_nvidia_nim=False,
+            extra_body_additions={
+                "chat_template_kwargs": {"thinking_mode": "enabled"},
+            },
+            max_tokens=None,
+        )
+
+        # Must NOT be hoisted to top level; stays nested in extra_body
+        assert "chat_template_kwargs" not in kwargs
+        assert kwargs["extra_body"]["chat_template_kwargs"] == {"thinking_mode": "enabled"}


### PR DESCRIPTION
## Summary

NVIDIA NIM expects `chat_template_kwargs` at the **JSON top level**, not nested inside the OpenAI SDK's `extra_body` field. When `chat_template_kwargs.thinking_mode: enabled` is configured via `auxiliary.*.extra_body` or the model-level `extra_body` block, it gets wrapped in the `extra_body` JSON key and never reaches the NIM endpoint — so `reasoning_content` comes back empty and the thinking block is never rendered.

This hoists `chat_template_kwargs` out of `extra_body` to the top-level request kwargs, but **only for NVIDIA NIM** (non-NVIDIA providers keep the existing nested `extra_body` behavior).

## Root cause

Three kwargs-assembly paths place user `extra_body` config into `kwargs["extra_body"]`, which the OpenAI SDK serializes as a nested `extra_body` JSON field. NVIDIA NIM does not read `chat_template_kwargs` from that nested location.

## Fix — three call paths

1. **Auxiliary call path** (`agent/auxiliary_client.py:_build_call_kwargs`) — detect NVIDIA via `base_url`, hoist `chat_template_kwargs` to top-level `kwargs`.
2. **Main model profile path** (`agent/transports/chat_completions.py:_build_kwargs_from_profile`) — detect NVIDIA via `profile.name == "nvidia"` or `base_url`, hoist.
3. **Main model legacy path** (`agent/transports/chat_completions.py:build_kwargs`) — detect via the existing `is_nvidia_nim` flag, hoist.

Paths 2 and 3 share a private `_hoist_nvidia_chat_template_kwargs` helper. After hoisting, if `extra_body` becomes empty it is omitted from the request entirely.

## Verification

- **Fail-without-fix (RED):** the 3 hoist tests fail on `upstream/main` — `chat_template_kwargs` is found nested inside `extra_body`, not at top level.
- **With fix (GREEN):** all 6 new regression tests pass.
- **Non-regression guards:** 3 guard tests confirm non-NVIDIA providers and empty `extra_body` behave unchanged.
- **Full suites:** `test_chat_completions.py` 85 passed; `test_auxiliary_client.py` 251 passed.

```
tests/agent/test_auxiliary_client.py::TestNvidiaChatTemplateKwargs ......... (3 passed)
tests/agent/transports/test_chat_completions.py::TestNvidiaChatTemplateKwargs (3 passed)
```

## Tests

- `test_auxiliary_build_call_kwargs_nvidia_hoists_chat_template` — auxiliary path hoists for NVIDIA base_url
- `test_auxiliary_build_call_kwargs_non_nvidia_keeps_in_extra_body` — non-NVIDIA keeps nested
- `test_auxiliary_build_call_kwargs_empty_extra_body` — no crash on `None` extra_body
- `test_profile_path_hoists_chat_template_from_extra_body_additions` — profile path hoists for NVIDIA profile
- `test_legacy_path_hoists_chat_template_from_extra_body_additions` — legacy path hoists on `is_nvidia_nim`
- `test_non_nvidia_keeps_in_extra_body` — guard: non-NVIDIA does **not** hoist

Auto-published by Moonsong via Path B automated pipeline.

Fixes #50703