### PR TITLE
feat(bedrock): support OpenAI Responses models

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -795,6 +795,7 @@ def init_agent(
             _gr_label = " + Guardrails" if agent._bedrock_guardrail_config else ""
             print(f"🤖 AI Agent initialized with model: {agent.model} (AWS Bedrock, {agent._bedrock_region}{_gr_label})")
     else:
+        client_kwargs = {}
         if api_key and base_url:
             # Explicit credentials from CLI/gateway — construct directly.
             # The runtime provider resolver already handled auth for us.
@@ -945,6 +946,19 @@ def init_agent(
                         "select a provider, or run `hermes setup` for first-time "
                         "configuration."
                     )
+        # Bedrock GPT-5.5 uses Bedrock Mantle's OpenAI Responses endpoint.
+        # Runtime resolution uses api_key="aws-sdk" as the IAM-auth sentinel;
+        # attach an httpx client that SigV4-signs every OpenAI SDK request.
+        if "client_kwargs" in locals():
+            try:
+                from agent.bedrock_adapter import configure_bedrock_openai_client_kwargs
+                configure_bedrock_openai_client_kwargs(
+                    client_kwargs,
+                    timeout=_provider_timeout,
+                )
+            except Exception:
+                if agent.provider == "bedrock" and "bedrock-mantle." in str(client_kwargs.get("base_url", "")):
+                    raise
         
         agent._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4442,14 +4442,21 @@ def resolve_provider_client(
         return None, None
 
     elif pconfig.auth_type == "aws_sdk":
-        # AWS SDK providers (Bedrock) — use the Anthropic Bedrock client via
-        # boto3's credential chain (IAM roles, SSO, env vars, instance metadata).
+        # AWS SDK providers (Bedrock). Claude models use AnthropicBedrock;
+        # OpenAI GPT-5.5 uses Bedrock Mantle's OpenAI Responses endpoint.
         try:
-            from agent.bedrock_adapter import has_aws_credentials, resolve_bedrock_region
+            from agent.bedrock_adapter import (
+                has_aws_credentials,
+                resolve_bedrock_region,
+                is_openai_bedrock_model,
+                bedrock_openai_base_url,
+                resolve_bedrock_bearer_token,
+                configure_bedrock_openai_client_kwargs,
+            )
             from agent.anthropic_adapter import build_anthropic_bedrock_client
         except ImportError:
             logger.warning("resolve_provider_client: bedrock requested but "
-                           "boto3 or anthropic SDK not installed")
+                           "boto3, httpx/openai, or anthropic SDK not installed")
             return None, None
 
         if not has_aws_credentials():
@@ -4459,7 +4466,25 @@ def resolve_provider_client(
 
         region = resolve_bedrock_region()
         default_model = "anthropic.claude-haiku-4-5-20251001-v1:0"
-        final_model = _normalize_resolved_model(model or default_model, provider)
+        final_model = _normalize_resolved_model(model or default_model, provider) or default_model
+
+        if is_openai_bedrock_model(final_model):
+            bearer = resolve_bedrock_bearer_token()
+            base_url = bedrock_openai_base_url(region)
+            client_kwargs: Dict[str, Any] = {
+                "api_key": bearer or "aws-sdk",
+                "base_url": base_url,
+            }
+            configure_bedrock_openai_client_kwargs(client_kwargs)
+            client = OpenAI(**client_kwargs)
+            logger.debug("resolve_provider_client: bedrock-openai (%s, %s)", final_model, region)
+            if raw_codex:
+                return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                        else (client, final_model))
+            wrapped = CodexAuxiliaryClient(client, final_model)
+            return (_to_async_client(wrapped, final_model, is_vision=is_vision) if async_mode
+                    else (wrapped, final_model))
+
         try:
             real_client = build_anthropic_bedrock_client(region)
         except ImportError as exc:

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -33,6 +33,9 @@ import os
 import re
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
+
+import httpx
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +59,18 @@ except Exception:
 
 _bedrock_runtime_client_cache: Dict[str, Any] = {}
 _bedrock_control_client_cache: Dict[str, Any] = {}
+
+# Bedrock-hosted OpenAI GPT-5.5 is not exposed through the native Converse
+# runtime. AWS serves it from the Bedrock Mantle OpenAI-compatible Responses
+# endpoint instead (https://bedrock-mantle.<region>.api.aws/openai/v1).
+# Keep the allowlist intentionally narrow so OpenAI GPT-OSS models that are
+# Converse-capable continue to use the native Bedrock path.
+BEDROCK_OPENAI_RESPONSES_MODEL_IDS: Tuple[str, ...] = (
+    "openai.gpt-5.5",
+)
+_BEDROCK_OPENAI_HOST_RE = re.compile(
+    r"^bedrock-mantle\.([a-z0-9-]+)\.api\.aws$", re.IGNORECASE
+)
 
 
 _MIN_BOTO3_VERSION = (1, 34, 59)
@@ -131,6 +146,143 @@ def invalidate_runtime_client(region: str) -> bool:
     existed = region in _bedrock_runtime_client_cache
     _bedrock_runtime_client_cache.pop(region, None)
     return existed
+
+
+# ---------------------------------------------------------------------------
+# Bedrock Mantle / OpenAI Responses support
+# ---------------------------------------------------------------------------
+
+
+def is_openai_bedrock_model(model_id: str) -> bool:
+    """Return True for Bedrock-hosted OpenAI models that require Mantle.
+
+    Bedrock's GPT-OSS models are Converse-capable and intentionally do not
+    match this helper. The allowlist tracks models served by the OpenAI
+    Responses-compatible ``bedrock-mantle`` route.
+    """
+    normalized = str(model_id or "").strip().lower()
+    return normalized in {m.lower() for m in BEDROCK_OPENAI_RESPONSES_MODEL_IDS}
+
+
+def merge_bedrock_openai_model_ids(model_ids: List[str]) -> List[str]:
+    """Append Bedrock OpenAI Responses models to a discovered Bedrock list.
+
+    The Bedrock control plane's ListFoundationModels/ListInferenceProfiles
+    discovery covers Converse models but does not enumerate Mantle-only
+    OpenAI Responses models. The picker needs both surfaces under AWS Bedrock.
+    """
+    merged = list(model_ids or [])
+    seen = {str(m).lower() for m in merged}
+    for model_id in BEDROCK_OPENAI_RESPONSES_MODEL_IDS:
+        if model_id.lower() not in seen:
+            merged.append(model_id)
+            seen.add(model_id.lower())
+    return merged
+
+
+def bedrock_openai_base_url(region: str) -> str:
+    """Return Bedrock Mantle's OpenAI-compatible base URL for *region*."""
+    resolved = (region or "").strip() or resolve_bedrock_region()
+    return f"https://bedrock-mantle.{resolved}.api.aws/openai/v1"
+
+
+def bedrock_openai_region_from_base_url(base_url: str) -> Optional[str]:
+    """Extract the AWS region from a Bedrock Mantle OpenAI base URL."""
+    host = urlparse(str(base_url or "")).hostname or ""
+    match = _BEDROCK_OPENAI_HOST_RE.match(host)
+    return match.group(1) if match else None
+
+
+def is_bedrock_openai_base_url(base_url: str) -> bool:
+    """Return True for Bedrock Mantle OpenAI-compatible endpoints."""
+    parsed = urlparse(str(base_url or ""))
+    host = parsed.hostname or ""
+    if not _BEDROCK_OPENAI_HOST_RE.match(host):
+        return False
+    # The OpenAI GPT-5.5 Bedrock route lives under /openai/v1. Accept a bare
+    # host too so callers can normalize before appending the path.
+    path = (parsed.path or "").rstrip("/").lower()
+    return path in {"", "/openai", "/openai/v1"}
+
+
+def resolve_bedrock_bearer_token(env: Optional[Dict[str, str]] = None) -> str:
+    """Return AWS_BEARER_TOKEN_BEDROCK when Bedrock API-key auth is configured."""
+    env = env if env is not None else os.environ
+    return (env.get("AWS_BEARER_TOKEN_BEDROCK", "") or "").strip()
+
+
+class BedrockOpenAISigV4Auth(httpx.Auth):
+    """httpx auth hook that SigV4-signs Bedrock Mantle OpenAI requests."""
+
+    requires_request_body = True
+
+    def __init__(self, region: str, service: str = "bedrock"):
+        self.region = (region or "").strip() or resolve_bedrock_region()
+        self.service = service
+
+    def auth_flow(self, request):  # pragma: no cover - exercised by live call
+        import botocore.session
+        from botocore.auth import SigV4Auth
+        from botocore.awsrequest import AWSRequest
+
+        credentials = botocore.session.get_session().get_credentials()
+        if credentials is None:
+            raise RuntimeError(
+                "No AWS credentials available for Bedrock OpenAI Responses. "
+                "Configure AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, AWS_PROFILE, "
+                "SSO, or an instance/task role."
+            )
+        frozen = credentials.get_frozen_credentials()
+        # Drop the OpenAI SDK's placeholder bearer header before signing; SigV4
+        # must own Authorization. Keep all other SDK headers so AWS receives
+        # content-type, accept, request IDs, etc.
+        headers = {
+            str(k): str(v)
+            for k, v in request.headers.items()
+            if str(k).lower() not in {"authorization", "x-amz-date", "x-amz-security-token"}
+        }
+        aws_request = AWSRequest(
+            method=request.method,
+            url=str(request.url),
+            data=request.content or b"",
+            headers=headers,
+        )
+        SigV4Auth(frozen, self.service, self.region).add_auth(aws_request)
+        request.headers.update(dict(aws_request.headers.items()))
+        yield request
+
+
+def build_bedrock_openai_http_client(region: str, *, timeout: Optional[float] = None):
+    """Build an httpx client that SigV4-signs Bedrock OpenAI requests."""
+    import httpx
+
+    kwargs: Dict[str, Any] = {"auth": BedrockOpenAISigV4Auth(region)}
+    if isinstance(timeout, (int, float)) and not isinstance(timeout, bool) and timeout > 0:
+        kwargs["timeout"] = timeout
+    return httpx.Client(**kwargs)
+
+
+def configure_bedrock_openai_client_kwargs(
+    client_kwargs: Dict[str, Any],
+    *,
+    timeout: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Install SigV4 auth on OpenAI SDK kwargs for Bedrock Mantle.
+
+    ``AWS_BEARER_TOKEN_BEDROCK``/explicit Bedrock API keys continue to use the
+    SDK's normal bearer auth. The special ``aws-sdk`` placeholder means IAM
+    credential-chain auth, so we attach a per-request SigV4 httpx client.
+    """
+    base_url = str(client_kwargs.get("base_url") or "")
+    if not is_bedrock_openai_base_url(base_url):
+        return client_kwargs
+    api_key = client_kwargs.get("api_key")
+    if isinstance(api_key, str) and api_key.strip() and api_key not in {"aws-sdk", "no-key-required"}:
+        return client_kwargs
+    region = bedrock_openai_region_from_base_url(base_url) or resolve_bedrock_region()
+    client_kwargs["api_key"] = "aws-sdk"
+    client_kwargs["http_client"] = build_bedrock_openai_http_client(region, timeout=timeout)
+    return client_kwargs
 
 
 # ---------------------------------------------------------------------------
@@ -398,7 +550,7 @@ def bedrock_model_ids_or_none() -> Optional[List[str]]:
     try:
         discovered = discover_bedrock_models(resolve_bedrock_region())
         if discovered:
-            return [m["id"] for m in discovered]
+            return merge_bedrock_openai_model_ids([m["id"] for m in discovered])
     except Exception:
         pass
     return None

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -98,8 +98,10 @@ def _slot_runtime(slot: dict[str, str]) -> dict[str, Any]:
         # correct for ordinary OpenAI-compatible targets, but wrong for OAuth /
         # provider-backed targets whose provider branch adds auth refresh,
         # request metadata, or request-shape adapters. Keep those providers
-        # identified by name.
-        if resolved_provider in {"nous", "openai-codex", "xai-oauth"}:
+        # identified by name. The same applies to Bedrock: its api_key="aws-sdk"
+        # is a sentinel for IAM auth, not a bearer token for a generic custom
+        # endpoint.
+        if resolved_provider in {"nous", "openai-codex", "xai-oauth", "bedrock"}:
             return out
         # Pass the resolved endpoint through so call_llm builds the request for
         # the provider's actual API surface instead of auto-detecting. base_url

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -502,6 +502,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "us.anthropic.claude-opus-4-6-v1",
         "us.anthropic.claude-haiku-4-5-20251001-v1:0",
         "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "openai.gpt-5.5",
         "us.amazon.nova-pro-v1:0",
         "us.amazon.nova-lite-v1:0",
         "us.amazon.nova-micro-v1:0",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1725,6 +1725,9 @@ def resolve_runtime_provider(
             resolve_aws_auth_env_var,
             resolve_bedrock_region,
             is_anthropic_bedrock_model,
+            is_openai_bedrock_model,
+            bedrock_openai_base_url,
+            resolve_bedrock_bearer_token,
         )
         # When the user explicitly selected bedrock (not auto-detected),
         # trust boto3's credential chain — it handles IMDS, ECS task roles,
@@ -1757,11 +1760,27 @@ def resolve_runtime_provider(
                 guardrail_config["streamProcessingMode"] = _gr["stream_processing_mode"]
             if _gr.get("trace"):
                 guardrail_config["trace"] = _gr["trace"]
-        # Dual-path routing: Claude models use AnthropicBedrock SDK for full
-        # feature parity (prompt caching, thinking budgets, adaptive thinking).
-        # Non-Claude models use the Converse API for multi-model support.
+        # Triple-path routing:
+        # - OpenAI GPT-5.5 on Bedrock uses Bedrock Mantle's OpenAI Responses
+        #   endpoint (not Converse / bedrock-runtime).
+        # - Claude models use AnthropicBedrock SDK for prompt caching,
+        #   thinking budgets, and adaptive thinking.
+        # - Other models use the native Converse API.
         _current_model = str(target_model or model_cfg.get("default") or "").strip()
-        if is_anthropic_bedrock_model(_current_model):
+        if is_openai_bedrock_model(_current_model):
+            bearer = resolve_bedrock_bearer_token()
+            runtime = {
+                "provider": "bedrock",
+                "api_mode": "codex_responses",
+                "base_url": bedrock_openai_base_url(region),
+                "api_key": bearer or "aws-sdk",
+                "source": "AWS_BEARER_TOKEN_BEDROCK" if bearer else auth_source,
+                "region": region,
+                "model": _current_model,
+                "bedrock_openai": True,
+                "requested_provider": requested_provider,
+            }
+        elif is_anthropic_bedrock_model(_current_model):
             # Claude on Bedrock → AnthropicBedrock SDK → anthropic_messages path
             runtime = {
                 "provider": "bedrock",
@@ -1774,7 +1793,7 @@ def resolve_runtime_provider(
                 "requested_provider": requested_provider,
             }
         else:
-            # Non-Claude (Nova, DeepSeek, Llama, etc.) → Converse API
+            # Non-Claude/OpenAI (Nova, DeepSeek, Llama, GPT-OSS, etc.) → Converse API
             runtime = {
                 "provider": "bedrock",
                 "api_mode": "bedrock_converse",

--- a/tests/agent/test_bedrock_integration.py
+++ b/tests/agent/test_bedrock_integration.py
@@ -86,6 +86,14 @@ class TestModelCatalog:
         nova_models = [m for m in models if "amazon.nova" in m]
         assert len(nova_models) > 0
 
+    def test_bedrock_models_include_openai_gpt55(self):
+        """Bedrock GPT-5.5 is served by the OpenAI Responses-compatible
+        Bedrock Mantle endpoint, so it must be surfaced even though it is not
+        returned by the Converse/ListFoundationModels discovery path."""
+        from hermes_cli.models import _PROVIDER_MODELS
+        models = _PROVIDER_MODELS.get("bedrock", [])
+        assert "openai.gpt-5.5" in models
+
 
 class TestResolveProvider:
     """Verify resolve_provider() handles bedrock correctly."""
@@ -156,7 +164,9 @@ class TestRuntimeProvider:
         monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
 
         with patch("hermes_cli.runtime_provider.resolve_provider", return_value="bedrock"), \
-             patch("hermes_cli.runtime_provider._get_model_config", return_value={"provider": "bedrock"}):
+             patch("hermes_cli.runtime_provider._get_model_config", return_value={"provider": "bedrock"}), \
+             patch("hermes_cli.runtime_provider.load_config", return_value={}), \
+             patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="us-east-1"):
             result = resolve_runtime_provider(requested="bedrock")
 
         assert result["region"] == "us-east-1"
@@ -200,6 +210,30 @@ class TestRuntimeProvider:
             result = resolve_runtime_provider(requested="bedrock")
         assert result["provider"] == "bedrock"
         assert result["api_mode"] == "bedrock_converse"
+
+    def test_bedrock_openai_gpt55_routes_to_mantle_responses(self, monkeypatch):
+        """OpenAI GPT-5.5 on Bedrock is not a Converse model: route it to
+        bedrock-mantle's OpenAI Responses surface with IAM/AWS SDK auth."""
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+        monkeypatch.setenv("AWS_REGION", "us-east-2")
+
+        with patch("hermes_cli.runtime_provider.resolve_provider", return_value="bedrock"), \
+             patch("hermes_cli.runtime_provider._get_model_config", return_value={
+                 "provider": "bedrock",
+                 "default": "openai.gpt-5.5",
+             }):
+            result = resolve_runtime_provider(requested="bedrock")
+
+        assert result["provider"] == "bedrock"
+        assert result["api_mode"] == "codex_responses"
+        assert result["model"] == "openai.gpt-5.5"
+        assert result["region"] == "us-east-2"
+        assert result["base_url"] == "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
+        assert result["api_key"] == "aws-sdk"
+        assert result["bedrock_openai"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -590,3 +624,26 @@ class TestAuxiliaryClientBedrockResolution:
             _, model = resolve_provider_client("bedrock", None)
 
         assert "haiku" in model.lower()
+
+    def test_bedrock_openai_gpt55_aux_uses_responses_client(self, monkeypatch):
+        """Auxiliary tasks on Bedrock GPT-5.5 should use the same Mantle
+        Responses path, not the AnthropicBedrock shim."""
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+        monkeypatch.setenv("AWS_REGION", "us-east-2")
+
+        fake_openai_client = MagicMock()
+        fake_openai_client.api_key = "aws-sdk"
+        fake_openai_client.base_url = "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
+
+        with patch("agent.auxiliary_client.OpenAI", return_value=fake_openai_client) as mock_openai, \
+             patch("agent.bedrock_adapter.build_bedrock_openai_http_client", return_value=MagicMock()):
+            from agent.auxiliary_client import resolve_provider_client, CodexAuxiliaryClient
+            client, model = resolve_provider_client("bedrock", "openai.gpt-5.5")
+
+        assert model == "openai.gpt-5.5"
+        assert isinstance(client, CodexAuxiliaryClient)
+        kwargs = mock_openai.call_args.kwargs
+        assert kwargs["api_key"] == "aws-sdk"
+        assert kwargs["base_url"] == "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
+        assert "http_client" in kwargs

--- a/tests/hermes_cli/test_bedrock_model_picker.py
+++ b/tests/hermes_cli/test_bedrock_model_picker.py
@@ -75,7 +75,8 @@ class TestProviderModelIdsBedrock:
 
         assert "eu.anthropic.claude-sonnet-4-6-20250514-v1:0" in result
         assert "eu.anthropic.claude-haiku-4-5-20251015-v1:0" in result
-        assert len(result) == len(_EU_MODELS)
+        assert "openai.gpt-5.5" in result
+        assert len(result) == len(_EU_MODELS) + 1
 
     def test_region_determines_model_ids(self, monkeypatch):
         """Different regions produce different model ID prefixes (eu.* vs us.*)."""
@@ -87,8 +88,10 @@ class TestProviderModelIdsBedrock:
             with patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="us-east-1"):
                 us_result = provider_model_ids("bedrock")
 
-        assert all(m.startswith("eu.") for m in eu_result)
-        assert all(m.startswith("us.") for m in us_result)
+        assert all(m.startswith("eu.") or m == "openai.gpt-5.5" for m in eu_result)
+        assert all(m.startswith("us.") or m == "openai.gpt-5.5" for m in us_result)
+        assert "openai.gpt-5.5" in eu_result
+        assert "openai.gpt-5.5" in us_result
         assert eu_result != us_result
 
     def test_falls_back_to_static_list_when_discovery_empty(self, monkeypatch):
@@ -124,7 +127,7 @@ class TestProviderModelIdsBedrock:
              patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="us-east-1"):
             for alias in ("aws", "aws-bedrock", "amazon-bedrock"):
                 result = provider_model_ids(alias)
-                assert result == _expected_ids, \
+                assert result == _expected_ids + ["openai.gpt-5.5"], \
                     f"alias {alias!r} should return live-discovered US model IDs, got {result!r}"
 
 
@@ -165,9 +168,10 @@ class TestListAuthenticatedProvidersBedrock:
         assert bedrock is not None
 
         # All returned model IDs should have eu.* prefix — live discovery result
+        assert "openai.gpt-5.5" in bedrock["models"]
         for model_id in bedrock["models"]:
-            assert model_id.startswith("eu."), \
-                f"Expected eu.* model ID from live discovery, got {model_id!r}"
+            assert model_id.startswith("eu.") or model_id == "openai.gpt-5.5", \
+                f"Expected eu.* or Bedrock OpenAI model ID from live discovery, got {model_id!r}"
 
     def test_bedrock_total_models_matches_discovery(self, monkeypatch):
         """total_models reflects the actual discovered count."""
@@ -182,7 +186,7 @@ class TestListAuthenticatedProvidersBedrock:
 
         bedrock = next((p for p in providers if p["slug"] == "bedrock"), None)
         assert bedrock is not None
-        assert bedrock["total_models"] == len(_EU_MODELS)
+        assert bedrock["total_models"] == len(_EU_MODELS) + 1
 
     def test_bedrock_is_current_when_selected(self, monkeypatch):
         """is_current=True when current_provider matches bedrock."""
@@ -294,9 +298,10 @@ class TestBedrockRegionRouting:
 
         bedrock = next((p for p in providers if p["slug"] == "bedrock"), None)
         assert bedrock is not None
+        assert "openai.gpt-5.5" in bedrock["models"]
         for model_id in bedrock["models"]:
-            assert model_id.startswith("eu."), \
-                f"Expected eu.* model ID from eu-central-1 profile, got {model_id!r}"
+            assert model_id.startswith("eu.") or model_id == "openai.gpt-5.5", \
+                f"Expected eu.* or Bedrock OpenAI model ID from eu-central-1 profile, got {model_id!r}"
 
     def test_us_region_from_env_var_yields_us_models(self, monkeypatch):
         """Explicit AWS_REGION=us-east-1 returns us.* model IDs."""
@@ -310,9 +315,10 @@ class TestBedrockRegionRouting:
 
         bedrock = next((p for p in providers if p["slug"] == "bedrock"), None)
         assert bedrock is not None
+        assert "openai.gpt-5.5" in bedrock["models"]
         for model_id in bedrock["models"]:
-            assert model_id.startswith("us."), \
-                f"Expected us.* model ID from us-east-1, got {model_id!r}"
+            assert model_id.startswith("us.") or model_id == "openai.gpt-5.5", \
+                f"Expected us.* or Bedrock OpenAI model ID from us-east-1, got {model_id!r}"
 
     def test_env_var_takes_priority_over_botocore_profile(self, monkeypatch):
         """AWS_REGION env var wins over botocore profile region."""

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -198,6 +198,36 @@ def test_moa_codex_slot_preserves_provider_identity(monkeypatch):
     assert rt == {"provider": "openai-codex", "model": "gpt-5.5"}
 
 
+def test_moa_bedrock_slot_preserves_provider_identity(monkeypatch):
+    """Bedrock slots must stay on the aws_sdk provider branch.
+
+    Bedrock GPT-5.5 resolves to Bedrock Mantle's OpenAI Responses endpoint with
+    api_key="aws-sdk" as an IAM sentinel. If MoA forwards that base_url/api_key
+    directly, call_llm downgrades it to provider=custom and sends the sentinel
+    as an invalid bearer token. Keeping provider=bedrock lets
+    resolve_provider_client attach the SigV4 Responses client.
+    """
+    from agent import moa_loop
+
+    def fake_resolve(*, requested, target_model=None):
+        return {
+            "provider": requested,
+            "api_mode": "codex_responses",
+            "model": target_model,
+            "base_url": "https://bedrock-mantle.us-east-2.api.aws/openai/v1",
+            "api_key": "aws-sdk",
+            "bedrock_openai": True,
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve
+    )
+
+    rt = moa_loop._slot_runtime({"provider": "bedrock", "model": "openai.gpt-5.5"})
+
+    assert rt == {"provider": "bedrock", "model": "openai.gpt-5.5"}
+
+
 def test_moa_slot_runtime_falls_back_on_resolution_error(monkeypatch):
     """A slot whose provider can't be resolved still attempts the call with the
     bare provider/model rather than aborting the whole MoA turn."""


### PR DESCRIPTION
## Summary
- Add Bedrock Mantle/OpenAI Responses routing for allowlisted Bedrock OpenAI models, starting with `openai.gpt-5.5`.
- Surface `openai.gpt-5.5` in the AWS Bedrock model picker even though it is not returned by native Bedrock Converse discovery.
- Add SigV4 signing for OpenAI SDK requests to `https://bedrock-mantle.<region>.api.aws/openai/v1`, while preserving existing Claude-on-Bedrock and native Converse routing.
- Preserve Bedrock provider identity inside MoA slots so MoA presets can use Bedrock GPT-5.5 as a reference and/or aggregator without downgrading the call to a generic bearer-token custom endpoint.

## Why
Bedrock-hosted GPT-5.5 is served through the Bedrock Mantle OpenAI-compatible Responses endpoint, not `bedrock-runtime` Converse. Without a separate route, Hermes can discover/use Converse models under AWS Bedrock but cannot select or call `openai.gpt-5.5` from the Bedrock provider.

MoA slots also need provider-aware runtime handling. If a Bedrock GPT-5.5 MoA slot forwards `base_url` + `api_key="aws-sdk"` as a generic custom OpenAI endpoint, the sentinel is sent as an invalid bearer token. Keeping `provider=bedrock` lets the auxiliary provider router attach the SigV4 Responses client.

## Conflict resolution
- Rebased onto current `origin/main` (`23021be26e66e26e1b9893eda2dc943849ede03d`).
- Resolved the `agent/moa_loop.py` conflict by keeping upstream's provider-preservation guard for `nous` and adding `bedrock` to the same preserved-provider set.

## Testing
- `scripts/run_tests.sh tests/run_agent/test_moa_loop_mode.py tests/hermes_cli/test_bedrock_model_picker.py tests/agent/test_bedrock_integration.py tests/run_agent/test_callable_api_key.py tests/test_empty_model_fallback.py`
  - `127 passed, 0 failed`
- `PYTHONPATH="$WT" /Users/nathaniel/.hermes/hermes-agent/venv/bin/python -m py_compile agent/agent_init.py agent/auxiliary_client.py agent/bedrock_adapter.py agent/moa_loop.py hermes_cli/models.py hermes_cli/runtime_provider.py tests/agent/test_bedrock_integration.py tests/hermes_cli/test_bedrock_model_picker.py tests/run_agent/test_moa_loop_mode.py`
- `git diff --check origin/main...HEAD`
- `/Users/nathaniel/.hermes/hermes-agent/venv/bin/python scripts/check-windows-footguns.py agent/agent_init.py agent/auxiliary_client.py agent/bedrock_adapter.py agent/moa_loop.py hermes_cli/models.py hermes_cli/runtime_provider.py tests/agent/test_bedrock_integration.py tests/hermes_cli/test_bedrock_model_picker.py tests/run_agent/test_moa_loop_mode.py`
  - `✓ No Windows footguns found (9 file(s) scanned).`
- Manual live Bedrock GPT-5.5 smoke test on macOS 26.2 after refreshing AWS SSO:
  - `PYTHONPATH="$WT" AWS_REGION=us-east-2 /Users/nathaniel/.hermes/hermes-agent/venv/bin/hermes -z 'Reply exactly: rebase-bedrock-gpt55-ok' --provider bedrock -m openai.gpt-5.5 --toolsets ''`
  - Output: `rebase-bedrock-gpt55-ok`
- Manual live auxiliary Bedrock GPT-5.5 call through `call_llm(provider="bedrock", model="openai.gpt-5.5")`:
  - Output: `aux-bedrock-rebase-ok`
- Manual live MoA-over-Bedrock GPT-5.5 smoke test:
  - MoA preset with Bedrock GPT-5.5 as both reference and aggregator
  - `HERMES_HOME=/private/tmp/hermes-moa-bedrock-home PYTHONPATH="$WT" AWS_REGION=us-east-2 /Users/nathaniel/.hermes/hermes-agent/venv/bin/hermes -z 'Reply exactly: rebase-moa-bedrock-ok' --provider moa -m bedrock-gpt55 --toolsets ''`
  - Output: `rebase-moa-bedrock-ok`

## Duplicate check
- Searched open issues for `Bedrock GPT-5.5`.
- Searched open and closed PRs for `Bedrock OpenAI Responses`.
- No duplicate issue/PR found.
