### PR TITLE
fix(skills): self-heal stale lock content_hash during update checks

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1281,6 +1281,52 @@ class TestCheckForSkillUpdates:
 
         assert results[0]["status"] == "up_to_date"
 
+    def test_self_heals_stale_lock_content_hash_from_live_disk(self, tmp_path):
+        import tools.skills_hub as hub
+        from tools.skills_guard import content_hash
+
+        skills_dir = tmp_path / "skills"
+        install_dir = skills_dir / "demo-skill"
+        install_dir.mkdir(parents=True)
+        (install_dir / "SKILL.md").write_text("same content\n")
+
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={"SKILL.md": "same content\n"},
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+
+        lock = HubLockFile(path=skills_dir / ".hub" / "lock.json")
+        lock.save({
+            "version": 1,
+            "installed": {
+                "demo-skill": {
+                    "name": "demo-skill",
+                    "source": "github",
+                    "identifier": "owner/repo/demo-skill",
+                    "content_hash": "sha256:stale0000000000",
+                    "install_path": "demo-skill",
+                }
+            },
+        })
+
+        source = MagicMock()
+        source.source_id.return_value = "github"
+        source.fetch.return_value = bundle
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir):
+            results = check_for_skill_updates(lock=lock, sources=[source])
+
+        disk_hash = content_hash(install_dir)
+        saved = lock.load()["installed"]["demo-skill"]
+
+        assert results[0]["status"] == "up_to_date"
+        assert results[0]["current_hash"] == disk_hash
+        assert saved["content_hash"] == disk_hash
+        assert "updated_at" in saved
+
 
 class TestCreateSourceRouter:
     def test_includes_skills_sh_source(self):

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3559,6 +3559,30 @@ def check_for_skill_updates(
             continue
 
         current_hash = entry.get("content_hash", "")
+
+        # Prefer the live on-disk hash when the installed path exists. This
+        # self-heals lock entries created by older Hermes builds whose
+        # ``content_hash()`` ordering disagreed with ``bundle_content_hash()``,
+        # which otherwise causes false-positive update reports for unchanged
+        # skills.
+        install_rel = entry.get("install_path", "")
+        if install_rel:
+            try:
+                install_dir = _resolve_lock_install_path(install_rel, entry.get("name", ""))
+            except ValueError:
+                install_dir = None
+            if install_dir and install_dir.exists():
+                disk_hash = content_hash(install_dir)
+                if disk_hash != current_hash:
+                    current_hash = disk_hash
+                    if isinstance(lock, HubLockFile):
+                        data = lock.load()
+                        installed_entry = data.get("installed", {}).get(entry.get("name", ""))
+                        if isinstance(installed_entry, dict):
+                            installed_entry["content_hash"] = disk_hash
+                            installed_entry["updated_at"] = datetime.now(timezone.utc).isoformat()
+                            lock.save(data)
+
         latest_hash = bundle_content_hash(bundle)
         status = "up_to_date" if current_hash == latest_hash else "update_available"
         results.append({


### PR DESCRIPTION
## Summary
- prefer the live on-disk hash during `check_for_skill_updates()` when the installed path exists
- self-heal stale `lock.json` `content_hash` values left behind by older Hermes builds
- keep update checks from reporting `update_available` forever for unchanged installed skills

## Why
PR #41199 prevents future installs from recording the wrong hash in the lock, but older installs can still carry stale `content_hash` values. Without a repair path, users can remain stuck in a permanent false-positive `update_available` state even after reinstalling or updating skills.

## Test plan
- run `scripts/run_tests.sh tests/tools/test_skills_hub.py`
- verify the focused regression test passes:
  - `test_self_heals_stale_lock_content_hash_from_live_disk`

Related to #41176
Follow-up to #41199 and complementary to #53877.