### PR TITLE
fix(update): prune stale pre-update snapshots

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -816,6 +816,52 @@ def prune_quick_snapshots(
     return _prune_quick_snapshots(_quick_snapshot_root(hermes_home), keep=keep)
 
 
+_QUICK_PRE_UPDATE_MAX_AGE_DAYS = 7
+
+
+def prune_pre_update_snapshots(
+    max_age_days: int = _QUICK_PRE_UPDATE_MAX_AGE_DAYS,
+    hermes_home: Optional[Path] = None,
+) -> int:
+    """Prune pre-update quick snapshots older than ``max_age_days``.
+
+    Only directories named ``YYYYMMDD-HHMMSS-pre-update`` are eligible.
+    Manual snapshots, non-pre-update labels, and unparseable names are skipped
+    to avoid deleting user-created rollback points. Timestamps are interpreted
+    as UTC, matching ``create_quick_snapshot``. Returns the number deleted.
+    """
+    root = _quick_snapshot_root(hermes_home)
+    if not root.exists():
+        return 0
+
+    cutoff = datetime.now(timezone.utc).timestamp() - max_age_days * 86400
+    deleted = 0
+    for snapshot_dir in sorted(root.iterdir()):
+        if not snapshot_dir.is_dir() or not snapshot_dir.name.endswith("-pre-update"):
+            continue
+
+        ts_part = snapshot_dir.name.removesuffix("-pre-update")
+        try:
+            snapshot_time = datetime.strptime(ts_part, "%Y%m%d-%H%M%S").replace(
+                tzinfo=timezone.utc
+            )
+        except ValueError:
+            continue
+
+        if snapshot_time.timestamp() >= cutoff:
+            continue
+
+        try:
+            shutil.rmtree(snapshot_dir)
+            deleted += 1
+        except OSError as exc:
+            logger.warning(
+                "Failed to prune old pre-update snapshot %s: %s", snapshot_dir.name, exc
+            )
+
+    return deleted
+
+
 def run_quick_backup(args) -> None:
     """CLI entry point for hermes backup --quick."""
     label = getattr(args, "label", None)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8919,6 +8919,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
         print()
         print("✓ Update complete!")
 
+        # Post-update cleanup: prune stale pre-update snapshots, but never let
+        # cleanup failure turn a successful update into a failed one.
+        try:
+            from hermes_cli.backup import prune_pre_update_snapshots
+
+            pruned = prune_pre_update_snapshots()
+            if pruned:
+                print(f"  ✓ Pruned {pruned} old pre-update snapshot(s)")
+        except Exception as exc:
+            logger.debug("Pre-update snapshot cleanup failed: %s", exc)
+
         # Curator first-run heads-up. Only prints when curator is enabled AND
         # has never run — i.e. the window where the ticker would otherwise
         # have fired against a fresh skill library. Kept silent on steady

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1318,6 +1318,34 @@ class TestQuickSnapshot:
         assert deleted == 7
         assert len(list_quick_snapshots(hermes_home=hermes_home)) == 3
 
+    def test_prune_pre_update_snapshots_deletes_only_old_pre_update(self, hermes_home):
+        from datetime import datetime, timedelta, timezone
+
+        from hermes_cli.backup import prune_pre_update_snapshots
+
+        snap_root = hermes_home / "state-snapshots"
+        snap_root.mkdir(parents=True)
+
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=10)).strftime("%Y%m%d-%H%M%S")
+        fresh_ts = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y%m%d-%H%M%S")
+        manual_ts = (datetime.now(timezone.utc) - timedelta(days=30)).strftime("%Y%m%d-%H%M%S")
+
+        old_pre_update = snap_root / f"{old_ts}-pre-update"
+        fresh_pre_update = snap_root / f"{fresh_ts}-pre-update"
+        manual_snapshot = snap_root / f"{manual_ts}-manual"
+        unparseable_pre_update = snap_root / "manual-pre-update"
+
+        for snapshot_dir in (old_pre_update, fresh_pre_update, manual_snapshot, unparseable_pre_update):
+            snapshot_dir.mkdir()
+            (snapshot_dir / "manifest.json").write_text("{}")
+
+        assert prune_pre_update_snapshots(max_age_days=7, hermes_home=hermes_home) == 1
+
+        assert not old_pre_update.exists()
+        assert fresh_pre_update.exists()
+        assert manual_snapshot.exists()
+        assert unparseable_pre_update.exists()
+
     def test_snapshot_includes_pairing_directories(self, hermes_home):
         """Pairing JSONs live outside state.db — snapshot must capture them
         recursively (generic + per-platform) so approved-user lists survive


### PR DESCRIPTION
## Summary

Adds a  function to remove stale pre-update snapshot directories after successful update, with a local fallback in .

## Changes

- **hermes_cli/backup.py**: New  — only deletes directories named `YYYYMMDD-HHMMSS-pre-update`, parses timestamps as UTC, skips manual/non-pre-update/unparseable snapshots
- **hermes_cli/main.py**: Calls cleanup after ✓ Update complete! inside try/except; never fails update if cleanup fails
- **scripts/system_health_manager.py**: Local fallback prunes `~/.hermes/state-snapshots/(star)-pre-update` older than 3 days, reports count + bytes freed in Cleanup Report
- **tests/hermes_cli/test_backup.py**: Focused coverage for old pre-update deleted, fresh pre-update kept, manual/non-pre-update kept, unparseable pre-update kept

## Verification

- `110 passed in 26.26s` on pytest
- Temp-dir harness: deleted exactly 1 old pre-update dir, kept fresh/manual/unparseable
- Local fallback confirmed working in production: freed 654M from state-snapshots (auditor report 2026-06-25)