### PR TITLE
fix(agent): walk error cause chain in image-shrink recovery helper (follow-up to #53582)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -74,31 +74,48 @@ INTERRUPT_WAITING_FOR_MODEL_PREFIX = "Operation interrupted: waiting for model r
 
 
 def _image_error_max_dimension(error: Exception) -> Optional[int]:
-    """Extract a provider-reported image dimension ceiling, if present."""
-    parts = []
-    for value in (
-        error,
-        getattr(error, "message", None),
-        getattr(error, "body", None),
-    ):
-        if value:
-            try:
-                parts.append(str(value))
-            except Exception:
-                pass
-    text = " ".join(parts).lower()
-    if "image" not in text or "dimension" not in text or "max allowed size" not in text:
-        return None
+    """Extract a provider-reported image dimension ceiling, if present.
 
-    match = re.search(r"max allowed size(?:\s+for [^:]+)?:\s*(\d{3,5})\s*pixels?", text)
-    if not match:
-        return None
-    try:
-        max_dimension = int(match.group(1))
-    except ValueError:
-        return None
-    if 512 <= max_dimension <= 8000:
-        return max_dimension
+    Walks the ``__cause__``/``__context__`` chain so a ceiling carried on a
+    wrapped error is still found. classify_api_error already classifies such
+    wrapped errors as image_too_large (it walks the same chain since #53582);
+    without matching the walk here the helper returns None on a wrapped error
+    and the caller falls back to an 8000px cap, shrinking the image to the
+    wrong size so the provider re-rejects it.
+    """
+    current: Optional[BaseException] = error
+    for _ in range(5):  # Match _extract_status_code()/_extract_error_body() traversal depth.
+        if current is None:
+            break
+        # Evaluate each exception in the chain independently: the trigger terms
+        # and the pixel ceiling must come from the SAME error, so a generic
+        # wrapper and an unrelated cause can't be concatenated into a spurious
+        # match.
+        parts = []
+        for value in (
+            current,
+            getattr(current, "message", None),
+            getattr(current, "body", None),
+        ):
+            if value:
+                try:
+                    parts.append(str(value))
+                except Exception:
+                    pass
+        text = " ".join(parts).lower()
+        if "image" in text and "dimension" in text and "max allowed size" in text:
+            match = re.search(r"max allowed size(?:\s+for [^:]+)?:\s*(\d{3,5})\s*pixels?", text)
+            if match:
+                try:
+                    max_dimension = int(match.group(1))
+                except ValueError:
+                    max_dimension = None
+                if max_dimension is not None and 512 <= max_dimension <= 8000:
+                    return max_dimension
+        cause = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
+        if cause is None or cause is current:
+            break
+        current = cause
     return None
 
 

--- a/tests/run_agent/test_image_shrink_recovery.py
+++ b/tests/run_agent/test_image_shrink_recovery.py
@@ -97,6 +97,60 @@ class TestImageTooLargeClassification:
         assert result.retryable is True
         assert _image_error_max_dimension(err) == 2000
 
+    def test_dimension_limit_on_wrapped_error_cause_chain(self):
+        """A ceiling carried on a wrapped error's __cause__ is still extracted.
+
+        classify_api_error already classifies wrapped image-dimension 400s as
+        image_too_large (it walks the cause chain since #53582); the recovery
+        helper must read the same chain, otherwise it returns None on a wrapped
+        error and the caller falls back to the 8000px cap and re-rejects.
+        """
+        inner = _FakeApiError(
+            status_code=400,
+            message=(
+                "messages.0.content.1.image.source.base64.data: At least one of "
+                "the image dimensions exceed max allowed size for many-image "
+                "requests: 2000 pixels"
+            ),
+        )
+        try:
+            raise RuntimeError("upstream provider request failed") from inner
+        except RuntimeError as wrapped:
+            # Top-level text has no ceiling; it must be found on __cause__.
+            assert _image_error_max_dimension(wrapped) == 2000
+
+    def test_dimension_limit_on_deep_context_chain(self):
+        """Implicit-chained (__context__) ceilings are found within the depth bound."""
+        api_err = _FakeApiError(
+            status_code=400,
+            message=(
+                "image dimensions exceed max allowed size: 1536 pixels"
+            ),
+        )
+        try:
+            try:
+                raise api_err
+            except _FakeApiError:
+                raise ValueError("re-raised during handling")  # sets __context__
+        except ValueError as exc:
+            assert _image_error_max_dimension(exc) == 1536
+
+    def test_trigger_terms_split_across_chain_not_matched(self):
+        """Trigger terms split across different chain levels must not synthesize a match.
+
+        Each exception is evaluated independently: a wrapper that merely mentions
+        'image' plus an unrelated cause that happens to carry a 'max allowed size'
+        ceiling is not an image-dimension limit and must return None.
+        """
+        inner = _FakeApiError(
+            status_code=400,
+            message="request dimension metadata invalid; max allowed size: 2000 pixels",
+        )
+        try:
+            raise RuntimeError("image upload failed") from inner
+        except RuntimeError as wrapped:
+            assert _image_error_max_dimension(wrapped) is None
+
 
 # ─── Shrink helper ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Follow-up to #53582.

## The gap #53582 left

#53582 made `error_classifier` walk the `__cause__`/`__context__` chain, so a **wrapped** image-dimension 400 (the common case when a provider/gateway re-wraps the SDK error) now correctly classifies as `FailoverReason.image_too_large` and enters image-shrink recovery.

But the recovery-side helper that decides *how small* to shrink — `_image_error_max_dimension` in `conversation_loop.py` — still read only the top-level exception:

```python
for value in (error, getattr(error, "message", None), getattr(error, "body", None)):
```

On a wrapped error the provider's `max allowed size: N pixels` lives on `__cause__`, so the helper returned `None`, and the caller falls back to an 8000px cap:

```python
image_max_dimension = _image_error_max_dimension(api_error) or 8000
```

So the recovery #53582 just enabled fires, but shrinks the image to the wrong ceiling, the provider re-rejects it, and the session bricks — arguably worse than before #53582, because recovery now triggers but still fails.

## Fix

Walk the same cause chain in `_image_error_max_dimension`, depth-bounded to 5 and breaking on `None`/self-cycle, mirroring `error_classifier._extract_status_code` / `_extract_error_body`. Each exception in the chain is evaluated **independently** — the trigger terms (`image` + `dimension` + `max allowed size`) and the pixel ceiling must come from the same error, so a generic wrapper plus an unrelated cause can't be concatenated into a spurious match. Unwrapped errors behave exactly as before.

Scope is intentionally just this one recovery helper, so it reads as completing #53582's chain-walk on the recovery side. The sibling image-rejection matcher and `retry_utils._error_text` are left untouched as separate follow-ups.

## Tests

`tests/run_agent/test_image_shrink_recovery.py::TestImageTooLargeClassification` passes, with new cases for the wrapped `__cause__` path, an implicit `__context__` chain, and a split-across-levels non-match (terms spread across different exceptions must not synthesize a false ceiling).

If this has already been handled via a separate patch, feel free to close — happy to defer.
