### PR TITLE
fix(file_tools): strip leading slashes after ~/ in _expand_tilde

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -42,7 +42,7 @@ def _expand_tilde(path: str) -> str:
     except Exception:
         home = None
     if home and (path == "~" or path.startswith("~/")):
-        return home if path == "~" else os.path.join(home, path[2:])
+        return home if path == "~" else os.path.join(home, path[2:].lstrip('/'))
     return os.path.expanduser(path)
 
 


### PR DESCRIPTION
## Problem

`_expand_tilde()` returns system root instead of home directory when the input path has consecutive slashes after `~/`.

- `~//foo` → `/foo` ❌ (home lost)
- `~/foo` → `/home/user/foo` ✓

## Root Cause

`path[2:]` on `~//foo` yields `/foo` which is treated as absolute by `os.path.join()`, discarding the home prefix.

## Fix

Strip leading slashes from the remainder: `path[2:].lstrip('/')`

- `~//foo` → `/home/user/foo` ✓
- `~///bar` → `/home/user/bar` ✓
- `~/foo` → `/home/user/foo` ✓ (unchanged)

Closes #53432