### PR TITLE
fix: default busy input to steer and prefer native vision

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -17,13 +17,13 @@ It reads ``agent.image_input_mode`` from config.yaml (``auto`` | ``native``
 | ``text``, default ``auto``) and the active model's capability metadata.
 
 In ``auto`` mode:
-  - If the user has explicitly configured ``auxiliary.vision.provider``
-    (i.e. not ``auto`` and not empty), we assume they want the text pipeline
-    regardless of the main model — they've opted in to a specific vision
-    backend for a reason (cost, quality, local-only, etc.).
-  - Otherwise, if the active model reports ``supports_vision=True`` in its
-    models.dev metadata, we attach natively.
-  - Otherwise (non-vision model, no explicit override), we fall back to text.
+  - If the active model reports ``supports_vision=True`` in config or its
+    models.dev metadata, we attach natively so vision-capable main models see
+    the pixels directly.
+  - Otherwise, if the user has explicitly configured ``auxiliary.vision``, we
+    use the text pre-analysis pipeline.
+  - Otherwise (non-vision/unknown model, no auxiliary backend), we fall back to
+    text.
 
 This keeps ``vision_analyze`` surfaced as a tool in every session — skills
 and agent flows that chain it (browser screenshots, deeper inspection of
@@ -286,6 +286,18 @@ def _explicit_aux_vision_override(cfg: Optional[Dict[str, Any]]) -> bool:
     return True
 
 
+def _get_model_capabilities(provider: str, model: str):
+    """Import-light wrapper for models.dev capability lookup.
+
+    Tests patch this wrapper instead of importing ``agent.models_dev`` at
+    collection time; that module has optional network dependencies in lean test
+    environments.
+    """
+    from agent.models_dev import get_model_capabilities
+
+    return get_model_capabilities(provider, model)
+
+
 def _lookup_supports_vision(
     provider: str,
     model: str,
@@ -303,8 +315,13 @@ def _lookup_supports_vision(
     if not provider or not model:
         return None
     try:
-        from agent.models_dev import get_model_capabilities
-        caps = get_model_capabilities(provider, model)
+        caps = _get_model_capabilities(provider, model)
+        # Some provider adapters expose the runtime model as a provider-prefixed
+        # slug (e.g. ``openai-codex/gpt-5.5``). models.dev may know the bare
+        # model slug (``gpt-5.5``) instead. Only retry on a complete miss so a
+        # real provider-scoped entry remains authoritative.
+        if caps is None and "/" in model:
+            caps = _get_model_capabilities(provider, model.rsplit("/", 1)[-1])
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("image_routing: caps lookup failed for %s:%s — %s", provider, model, exc)
         return None
@@ -336,13 +353,15 @@ def decide_image_input_mode(
     if mode_cfg == "text":
         return "text"
 
-    # auto
-    if _explicit_aux_vision_override(cfg):
-        return "text"
-
+    # auto: prefer native pixels whenever the active main model is known to be
+    # vision-capable. Auxiliary vision remains the fallback for text-only or
+    # unknown-capability models, not something that silently masks a multimodal
+    # main model.
     supports = _lookup_supports_vision(provider, model, cfg)
     if supports is True:
         return "native"
+    if _explicit_aux_vision_override(cfg):
+        return "text"
     return "text"
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2506,7 +2506,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # Class-level defaults so partial construction in tests doesn't
     # blow up on attribute access.
     _running_agents_ts: Dict[str, float] = {}
-    _busy_input_mode: str = "interrupt"
+    _busy_input_mode: str = "steer"
     _busy_text_mode: str = "interrupt"
     _restart_drain_timeout: float = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     _exit_code: Optional[int] = None
@@ -3987,14 +3987,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return "queue"
         if mode == "steer":
             return "steer"
-        return "interrupt"
+        if mode == "interrupt":
+            return "interrupt"
+        return "steer"
 
     @staticmethod
     def _load_busy_text_mode() -> str:
         """Resolve normal busy TEXT follow-up behavior.
 
         ``busy_input_mode`` is the single source of truth (default
-        ``interrupt``). The legacy ``busy_text_mode`` knob is honored only
+        ``steer``). The legacy ``busy_text_mode`` knob is honored only
         when a user explicitly set it, so existing queue setups keep
         working; new installs follow ``busy_input_mode``. Returns one of
         ``interrupt`` | ``queue`` (``steer`` is handled upstream by

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -97,11 +97,16 @@ class TestDecideImageInputMode:
         with patch("agent.image_routing._lookup_supports_vision", return_value=None):
             assert decide_image_input_mode("openrouter", "brand-new-slug", {}) == "text"
 
-    def test_auto_respects_aux_vision_override_even_for_vision_model(self):
-        """If the user configured a dedicated vision backend, don't bypass it."""
+    def test_auto_prefers_vision_model_over_aux_vision_override(self):
+        """Vision-capable main models should see pixels directly by default."""
         cfg = {"auxiliary": {"vision": {"provider": "openrouter", "model": "google/gemini-2.5-flash"}}}
         with patch("agent.image_routing._lookup_supports_vision", return_value=True):
-            assert decide_image_input_mode("anthropic", "claude-sonnet-4", cfg) == "text"
+            assert decide_image_input_mode("anthropic", "claude-sonnet-4", cfg) == "native"
+
+    def test_auto_uses_aux_vision_override_for_non_vision_model(self):
+        cfg = {"auxiliary": {"vision": {"provider": "openrouter", "model": "google/gemini-2.5-flash"}}}
+        with patch("agent.image_routing._lookup_supports_vision", return_value=False):
+            assert decide_image_input_mode("openrouter", "qwen/qwen3-235b", cfg) == "text"
 
     def test_none_config_is_auto(self):
         with patch("agent.image_routing._lookup_supports_vision", return_value=True):
@@ -113,18 +118,8 @@ class TestDecideImageInputMode:
             assert decide_image_input_mode("anthropic", "claude-sonnet-4", cfg) == "native"
 
     def test_auto_uses_text_for_text_only_modalities_even_with_attachment_flag(self):
-        registry = {
-            "xiaomi": {
-                "models": {
-                    "mimo-v2.5-pro": {
-                        "attachment": True,
-                        "modalities": {"input": ["text"]},
-                        "tool_call": True,
-                    },
-                },
-            },
-        }
-        with patch("agent.models_dev.fetch_models_dev", return_value=registry):
+        fake_caps = type("Caps", (), {"supports_vision": False})()
+        with patch("agent.image_routing._get_model_capabilities", return_value=fake_caps):
             assert decide_image_input_mode("xiaomi", "mimo-v2.5-pro", {}) == "text"
 
 
@@ -232,29 +227,42 @@ class TestLookupSupportsVisionOverride:
     def test_config_override_short_circuits_models_dev(self):
         # Config says True, models.dev says None — config wins.
         cfg = {"model": {"supports_vision": True}}
-        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+        with patch("agent.image_routing._get_model_capabilities", return_value=None):
             assert _lookup_supports_vision("custom", "my-llava", cfg) is True
 
     def test_config_override_false_beats_vision_capable_models_dev(self):
         # User explicitly disables vision on a models.dev-vision-capable model.
         fake_caps = type("Caps", (), {"supports_vision": True})()
         cfg = {"model": {"supports_vision": False}}
-        with patch("agent.models_dev.get_model_capabilities", return_value=fake_caps):
+        with patch("agent.image_routing._get_model_capabilities", return_value=fake_caps):
             assert _lookup_supports_vision("anthropic", "claude-sonnet-4", cfg) is False
 
     def test_no_override_falls_back_to_models_dev(self):
         fake_caps = type("Caps", (), {"supports_vision": True})()
-        with patch("agent.models_dev.get_model_capabilities", return_value=fake_caps):
+        with patch("agent.image_routing._get_model_capabilities", return_value=fake_caps):
             assert _lookup_supports_vision("anthropic", "claude-sonnet-4", {}) is True
 
     def test_no_override_no_models_dev_entry_returns_none(self):
-        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+        with patch("agent.image_routing._get_model_capabilities", return_value=None):
             assert _lookup_supports_vision("custom", "my-llava", {}) is None
 
     def test_cfg_none_falls_back_to_models_dev(self):
         # Caller didn't pass cfg at all — old call sites must still work.
-        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+        with patch("agent.image_routing._get_model_capabilities", return_value=None):
             assert _lookup_supports_vision("openrouter", "x", None) is None
+
+    def test_provider_prefixed_model_slug_falls_back_to_bare_slug(self):
+        fake_caps = type("Caps", (), {"supports_vision": True})()
+
+        def fake_lookup(provider, model):
+            if model == "openai-codex/gpt-5.5":
+                return None
+            if model == "gpt-5.5":
+                return fake_caps
+            raise AssertionError(f"unexpected lookup: {provider=} {model=}")
+
+        with patch("agent.image_routing._get_model_capabilities", side_effect=fake_lookup):
+            assert _lookup_supports_vision("openai-codex", "openai-codex/gpt-5.5", {}) is True
 
 
 # ─── decide_image_input_mode with auto + override ────────────────────────────
@@ -266,28 +274,29 @@ class TestAutoModeRespectsOverride:
         # Without the override, auto falls back to text. With it, auto picks
         # native — no need to also set agent.image_input_mode: native.
         cfg = {"model": {"supports_vision": True}}
-        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+        with patch("agent.image_routing._get_model_capabilities", return_value=None):
             assert decide_image_input_mode("custom", "qwen3.6-35b", cfg) == "native"
 
     def test_auto_text_for_custom_with_supports_vision_false(self):
         cfg = {"model": {"supports_vision": False}}
-        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+        with patch("agent.image_routing._get_model_capabilities", return_value=None):
             assert decide_image_input_mode("custom", "some-text-only", cfg) == "text"
 
     def test_auto_text_for_custom_with_no_override(self):
         # Unchanged baseline: unknown custom model → text.
-        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+        with patch("agent.image_routing._get_model_capabilities", return_value=None):
             assert decide_image_input_mode("custom", "unknown", {}) == "text"
 
-    def test_explicit_aux_vision_override_still_wins(self):
-        # If the user has configured a dedicated vision aux backend, respect
-        # it even when supports_vision: true is also set.
+    def test_supports_vision_override_wins_over_explicit_aux_vision(self):
+        # In auto mode, known vision-capable main models should receive native
+        # pixels. The dedicated aux backend remains a fallback for models that
+        # cannot accept images.
         cfg = {
             "model": {"supports_vision": True},
             "auxiliary": {"vision": {"provider": "openrouter", "model": "gemini-2.5-pro"}},
         }
-        with patch("agent.models_dev.get_model_capabilities", return_value=None):
-            assert decide_image_input_mode("custom", "qwen3.6-35b", cfg) == "text"
+        with patch("agent.image_routing._get_model_capabilities", return_value=None):
+            assert decide_image_input_mode("custom", "qwen3.6-35b", cfg) == "native"
 
 
 # ─── build_native_content_parts ──────────────────────────────────────────────

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -93,7 +93,7 @@ def test_load_busy_input_mode_prefers_env_then_config_then_default(tmp_path, mon
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("HERMES_GATEWAY_BUSY_INPUT_MODE", raising=False)
 
-    assert gateway_run.GatewayRunner._load_busy_input_mode() == "interrupt"
+    assert gateway_run.GatewayRunner._load_busy_input_mode() == "steer"
 
     (tmp_path / "config.yaml").write_text(
         "display:\n  busy_input_mode: queue\n", encoding="utf-8"
@@ -111,9 +111,9 @@ def test_load_busy_input_mode_prefers_env_then_config_then_default(tmp_path, mon
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "steer")
     assert gateway_run.GatewayRunner._load_busy_input_mode() == "steer"
 
-    # Unknown values fall through to the safe default
+    # Unknown values fall through to the default
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "bogus")
-    assert gateway_run.GatewayRunner._load_busy_input_mode() == "interrupt"
+    assert gateway_run.GatewayRunner._load_busy_input_mode() == "steer"
 
 
 def test_load_busy_text_mode_follows_input_mode_and_honors_legacy(tmp_path, monkeypatch):
@@ -121,7 +121,8 @@ def test_load_busy_text_mode_follows_input_mode_and_honors_legacy(tmp_path, monk
     monkeypatch.delenv("HERMES_GATEWAY_BUSY_TEXT_MODE", raising=False)
     monkeypatch.delenv("HERMES_GATEWAY_BUSY_INPUT_MODE", raising=False)
 
-    # No knobs set → follows busy_input_mode, which defaults to interrupt.
+    # No knobs set → follows busy_input_mode, which defaults to steer.
+    # Steer is handled by busy_input_mode and maps to non-queue text handling here.
     assert gateway_run.GatewayRunner._load_busy_text_mode() == "interrupt"
 
     # busy_input_mode=queue propagates to text handling (single source of truth).
@@ -144,7 +145,8 @@ def test_load_busy_text_mode_follows_input_mode_and_honors_legacy(tmp_path, monk
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_TEXT_MODE", "queue")
     assert gateway_run.GatewayRunner._load_busy_text_mode() == "queue"
 
-    # Bogus legacy value is ignored → falls through to busy_input_mode (interrupt).
+    # Bogus legacy value is ignored → falls through to busy_input_mode (steer,
+    # which maps to non-queue text handling here).
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_TEXT_MODE", "bogus")
     assert gateway_run.GatewayRunner._load_busy_text_mode() == "interrupt"
 


### PR DESCRIPTION
## Summary
- Change the gateway busy-input default from `interrupt` to `steer`, including invalid-config fallback behavior.
- Prefer native multimodal image routing in `auto` mode when the active main model is vision-capable, using auxiliary vision only as fallback for text-only/unknown models.
- Retry model capability lookup with a bare model slug when providers expose prefixed slugs like `openai-codex/gpt-5.5`.

## Verification
- `uv run pytest tests/agent/test_image_routing.py tests/gateway/test_native_image_buffer_isolation.py -q` → 80 passed
- `uv run pytest tests/gateway/test_restart_drain.py tests/gateway/test_session_race_guard.py tests/gateway/test_telegram_topic_mode.py tests/gateway/test_config_env_bridge_authority.py -q` → 88 passed
