### PR TITLE
fix: resolve vision capability for prefixed model slugs

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -491,57 +491,51 @@ def lookup_models_dev_context(provider: str, model: str) -> Optional[int]:
     """Look up context_length for a provider+model combo in models.dev.
 
     Returns the context window in tokens, or None if not found.
-    Handles case-insensitive matching and filters out context=0 entries.
+    Delegates primary lookup to ``_find_model_entry`` so vendor-prefix
+    stripping and case-insensitive matching apply uniformly with capability
+    lookups. Filters out context=0 entries.
+
+    Also applies a suffix-aware fallback: some providers (e.g. ollama-cloud)
+    store model IDs with ``:cloud`` / ``-cloud`` suffixes in models.dev while
+    the live API returns bare names. Without this, ``kimi-k2.6`` misses the
+    ``kimi-k2.6:cloud`` entry and falls through to stale OpenRouter metadata
+    reporting 32768 — tripping the 64k minimum-context guard. The
+    suffix-stripping in ``fetch_ollama_cloud_models()`` handles the
+    model-picker UX; this handles the context-length lookup path.
     """
-    mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(provider)
-    if not mdev_provider_id:
+    models = _get_provider_models(provider)
+    if models is None:
         return None
 
-    data = fetch_models_dev()
-    provider_data = data.get(mdev_provider_id)
-    if not isinstance(provider_data, dict):
-        return None
-
-    models = provider_data.get("models", {})
-    if not isinstance(models, dict):
-        return None
-
-    # Exact match
-    entry = models.get(model)
-    if entry:
+    entry = _find_model_entry(models, model)
+    if entry is not None:
         ctx = _extract_context(entry)
         if ctx:
             return ctx
 
-    # Case-insensitive match
-    model_lower = model.lower()
-    for mid, mdata in models.items():
-        if mid.lower() == model_lower:
-            ctx = _extract_context(mdata)
-            if ctx:
-                return ctx
+    # Build suffix candidates from the raw slug and, on miss, the bare name
+    # after a leading vendor/ prefix (same candidate set as _find_model_entry).
+    suffix_bases = [model]
+    if "/" in model:
+        bare = model.split("/", 1)[1]
+        if bare and bare not in suffix_bases:
+            suffix_bases.append(bare)
 
-    # Suffix-aware fallback: some providers (e.g. ollama-cloud) store
-    # model IDs with :cloud / -cloud suffixes in models.dev while the
-    # live API returns bare names.  Without this, kimi-k2.6 misses the
-    # kimi-k2.6:cloud entry and falls through to stale OpenRouter metadata
-    # reporting 32768 — tripping the 64k minimum-context guard.
-    # The suffix-stripping in fetch_ollama_cloud_models() handles the
-    # model-picker UX; this handles the context-length lookup path.
-    for suffix in (":cloud", "-cloud"):
-        suffixed_key = model + suffix
-        entry = models.get(suffixed_key)
-        if entry:
-            ctx = _extract_context(entry)
-            if ctx:
-                return ctx
-        # Also try case-insensitive
-        suffixed_lower = model_lower + suffix
-        for mid, mdata in models.items():
-            if mid.lower() == suffixed_lower:
-                ctx = _extract_context(mdata)
+    for base in suffix_bases:
+        base_lower = base.lower()
+        for suffix in (":cloud", "-cloud"):
+            suffixed_key = base + suffix
+            entry = models.get(suffixed_key)
+            if entry:
+                ctx = _extract_context(entry)
                 if ctx:
                     return ctx
+            suffixed_lower = base_lower + suffix
+            for mid, mdata in models.items():
+                if mid.lower() == suffixed_lower:
+                    ctx = _extract_context(mdata)
+                    if ctx:
+                        return ctx
 
     return None
 
@@ -601,16 +595,30 @@ def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
 
 
 def _find_model_entry(models: Dict[str, Any], model: str) -> Optional[Dict[str, Any]]:
-    """Find a model entry by exact match, then case-insensitive fallback."""
-    # Exact match
-    entry = models.get(model)
-    if isinstance(entry, dict):
-        return entry
+    """Find a model entry by exact match, vendor-prefix strip, or
+    case-insensitive fallback.
 
-    # Case-insensitive match
-    model_lower = model.lower()
+    The prefix-strip fallback accepts inputs like ``openai-codex/gpt-5.5`` or
+    ``xiaomi/mimo-v2.5`` against a provider whose cache is keyed by bare names
+    (``gpt-5.5``, ``mimo-v2.5``). Aggregator caches are keyed by full
+    ``vendor/model`` slugs and matched by the exact path first — prefix-strip
+    is only tried on a complete miss. Callers pre-constrain the search to one
+    provider's catalog, so a non-matching prefix simply falls through to None.
+    """
+    candidates = [model]
+    if "/" in model:
+        bare = model.split("/", 1)[1]
+        if bare and bare not in candidates:
+            candidates.append(bare)
+
+    for candidate in candidates:
+        entry = models.get(candidate)
+        if isinstance(entry, dict):
+            return entry
+
+    candidates_lower = {c.lower() for c in candidates}
     for mid, mdata in models.items():
-        if mid.lower() == model_lower and isinstance(mdata, dict):
+        if mid.lower() in candidates_lower and isinstance(mdata, dict):
             return mdata
 
     return None

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -157,6 +157,23 @@ class TestLookupSupportsVisionOverride:
         with patch("agent.models_dev.get_model_capabilities", return_value=None):
             assert _lookup_supports_vision("openrouter", "x", None) is None
 
+    def test_provider_prefixed_model_slug_resolves_via_models_dev(self):
+        """Prefixed runtime slugs resolve via the shared models.dev lookup.
+
+        Prefix-on-miss lives in ``_find_model_entry`` (covered in
+        test_models_dev); image routing must not retry locally — it just
+        asks ``get_model_capabilities`` once with the raw slug.
+        """
+        fake_caps = type("Caps", (), {"supports_vision": True})()
+        with patch(
+            "agent.models_dev.get_model_capabilities",
+            return_value=fake_caps,
+        ) as mock_caps:
+            assert _lookup_supports_vision(
+                "openai-codex", "openai-codex/gpt-5.5", {}
+            ) is True
+            mock_caps.assert_called_once_with("openai-codex", "openai-codex/gpt-5.5")
+
 
 # ─── decide_image_input_mode with auto + override ────────────────────────────
 

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -127,10 +127,23 @@ class TestLookupModelsDevContext:
         mock_fetch.return_value = SAMPLE_REGISTRY
         assert lookup_models_dev_context("anthropic", "claude-opus-4-6") == 1000000
 
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_vendor_prefix_stripped_for_direct_provider(self, mock_fetch):
+        """Users sometimes copy aggregator-style ``vendor/model`` slugs into
+        a direct provider's config (e.g. ``openai-codex/gpt-5.5`` against a
+        provider whose cache is keyed by bare names). The lookup must strip a
+        leading ``vendor/`` prefix on miss so context-length auto-detection
+        still works."""
+        mock_fetch.return_value = SAMPLE_REGISTRY
+        assert lookup_models_dev_context("anthropic", "anthropic/claude-opus-4-6") == 1000000
 
-
-
-
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_aggregator_slug_match_unchanged(self, mock_fetch):
+        """Aggregator caches (e.g. kilocode→kilo) are keyed by the full
+        ``vendor/model`` slug. Exact match must still win — prefix-strip
+        is only a fallback."""
+        mock_fetch.return_value = SAMPLE_REGISTRY
+        assert lookup_models_dev_context("kilocode", "anthropic/claude-sonnet-4.6") == 1000000
 
     @patch("agent.models_dev.fetch_models_dev")
     def test_zero_context_filtered(self, mock_fetch):
@@ -371,8 +384,27 @@ class TestGetModelCapabilities:
         assert caps is not None
         assert caps.supports_vision is True
 
+    def test_vendor_prefix_stripped_for_direct_provider(self):
+        """Capability lookup must accept ``vendor/model`` form against direct
+        providers whose cache is keyed by bare names. Without this fallback,
+        a prefixed runtime slug (e.g. ``openai-codex/gpt-5.5``) silently loses
+        vision/tools detection on gateway and web paths that bypass in-memory
+        normalization."""
+        with patch("agent.models_dev.fetch_models_dev", return_value=CAPS_REGISTRY):
+            caps = get_model_capabilities("anthropic", "anthropic/claude-sonnet-4")
+        assert caps is not None
+        assert caps.supports_vision is True
+        assert caps.supports_tools is True
 
-
+    def test_prefix_strip_does_not_cross_providers(self):
+        """The strip is harmless even when the prefix names another vendor —
+        because ``_get_provider_models`` has already scoped the search to a
+        single provider's catalog, a non-existent bare name still returns
+        None. The strip only succeeds when the bare name happens to exist
+        in the configured provider's catalog."""
+        with patch("agent.models_dev.fetch_models_dev", return_value=CAPS_REGISTRY):
+            caps = get_model_capabilities("anthropic", "openai/gpt-5")
+        assert caps is None
 
     def test_modalities_non_dict_handled(self):
         """Non-dict modalities field should not crash."""


### PR DESCRIPTION
## Summary
- Resolve vision/capability lookup for provider-prefixed model slugs (e.g. `openai-codex/gpt-5.5`) by stripping the vendor prefix on miss inside `agent/models_dev.py:_find_model_entry`.
- Exact provider-scoped matches still win first; aggregator `vendor/model` keys are unchanged.
- `lookup_models_dev_context` shares the same helper so dashboard/context paths get the fallback too (no routing-local retry).

## Verification
- `pytest tests/agent/test_models_dev.py tests/agent/test_image_routing.py` — 61 passed

Closes SCA-257