### PR TITLE
feat(desktop): add Ctrl+F / Cmd+F find-in-page

### DIFF
--- a/apps/desktop/electron/find-in-page.test.ts
+++ b/apps/desktop/electron/find-in-page.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for the pure find-in-page helpers. The IPC handlers in
+ * main.ts are the only consumer — the helpers below must keep the wire
+ * shape stable (match counter shape, defaults, no-throw-on-destroyed).
+ */
+
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+
+import { describe, test } from 'vitest'
+
+import {
+  formatFoundInPage,
+  installFoundInPageForwarder,
+  performFind,
+  stopFind
+} from './find-in-page'
+
+// Minimal webContents stub. The Electron.WebContents type is huge, so we
+// model just the slice the helpers touch (`isDestroyed`, `findInPage`,
+// `stopFindInPage`, `on`/`off`, `send`, `destroyed`, `emit`) and cast through
+// `asWC()` at call sites.
+interface FakeWebContents {
+  calls: {
+    find: Array<{ query: string; options: { forward: boolean; findNext: boolean } }>
+    stop: Array<'clearSelection' | 'keepSelection' | 'activateSelection'>
+    send: Array<{ channel: string; payload: unknown }>
+  }
+  isDestroyed: () => boolean
+  destroy: () => void
+  findInPage: (query: string, options: { forward: boolean; findNext: boolean }) => void
+  stopFindInPage: (action: 'clearSelection' | 'keepSelection' | 'activateSelection') => void
+  send: (channel: string, payload: unknown) => void
+  on: typeof EventEmitter.prototype.on
+  off: typeof EventEmitter.prototype.off
+  emit: (event: string | symbol, ...args: unknown[]) => boolean
+}
+
+function makeFakeWebContents(): FakeWebContents {
+  const emitter = new EventEmitter()
+
+  const calls = {
+    find: [] as Array<{ query: string; options: { forward: boolean; findNext: boolean } }>,
+    stop: [] as Array<'clearSelection' | 'keepSelection' | 'activateSelection'>,
+    send: [] as Array<{ channel: string; payload: unknown }>
+  }
+
+  let destroyed = false
+
+  return {
+    calls,
+    isDestroyed: () => destroyed,
+    destroy() {
+      destroyed = true
+      emitter.emit('destroyed')
+    },
+    findInPage(query: string, options: { forward: boolean; findNext: boolean }) {
+      calls.find.push({ query, options })
+    },
+    stopFindInPage(action: 'clearSelection' | 'keepSelection' | 'activateSelection') {
+      calls.stop.push(action)
+    },
+    send(channel: string, payload: unknown) {
+      calls.send.push({ channel, payload })
+    },
+    on: emitter.on.bind(emitter),
+    off: emitter.off.bind(emitter),
+    emit: emitter.emit.bind(emitter)
+  }
+}
+
+function asWC(fake: FakeWebContents): Electron.WebContents {
+  return fake as unknown as Electron.WebContents
+}
+
+describe('formatFoundInPage', () => {
+  test('maps activeMatchOrdinal + matches onto the wire payload', () => {
+    assert.deepEqual(formatFoundInPage({ activeMatchOrdinal: 3, matches: 12 }), {
+      activeMatchOrdinal: 3,
+      count: 12
+    })
+  })
+
+  test('coerces missing fields to zero so the renderer never sees NaN', () => {
+    assert.deepEqual(formatFoundInPage({}), { activeMatchOrdinal: 0, count: 0 })
+    assert.deepEqual(formatFoundInPage({ activeMatchOrdinal: 0, matches: 0 }), {
+      activeMatchOrdinal: 0,
+      count: 0
+    })
+  })
+
+  test('null / undefined inputs still produce a well-formed payload', () => {
+    assert.deepEqual(
+      formatFoundInPage(null as unknown as { activeMatchOrdinal?: number; matches?: number }),
+      { activeMatchOrdinal: 0, count: 0 }
+    )
+    assert.deepEqual(formatFoundInPage(undefined), { activeMatchOrdinal: 0, count: 0 })
+  })
+})
+
+describe('performFind', () => {
+  test('forwards the query and options to webContents.findInPage', () => {
+    const wc = makeFakeWebContents()
+    performFind(asWC(wc), 'hello', { forward: true, findNext: false })
+    assert.deepEqual(wc.calls.find, [
+      { query: 'hello', options: { forward: true, findNext: false } }
+    ])
+  })
+
+  test('defaults forward to true when omitted', () => {
+    const wc = makeFakeWebContents()
+    performFind(asWC(wc), 'x', { findNext: true })
+    assert.deepEqual(wc.calls.find, [
+      { query: 'x', options: { forward: true, findNext: true } }
+    ])
+  })
+
+  test('defaults findNext to false when omitted', () => {
+    const wc = makeFakeWebContents()
+    performFind(asWC(wc), 'x', { forward: false })
+    assert.deepEqual(wc.calls.find, [
+      { query: 'x', options: { forward: false, findNext: false } }
+    ])
+  })
+
+  test('treats null / non-object options as "all defaults"', () => {
+    const wc = makeFakeWebContents()
+    performFind(asWC(wc), 'x', null)
+    assert.deepEqual(wc.calls.find, [
+      { query: 'x', options: { forward: true, findNext: false } }
+    ])
+  })
+
+  test('coerces a non-string query to string (defensive against bad renderer payloads)', () => {
+    const wc = makeFakeWebContents()
+    performFind(asWC(wc), 42 as unknown as string, null)
+    assert.equal(wc.calls.find[0].query, '42')
+  })
+
+  test('is a no-op when webContents is null', () => {
+    assert.doesNotThrow(() => performFind(null, 'q', null))
+  })
+
+  test('is a no-op when webContents is destroyed (does not throw across IPC)', () => {
+    const wc = makeFakeWebContents()
+    wc.destroy()
+    performFind(asWC(wc), 'q', null)
+    assert.equal(wc.calls.find.length, 0)
+  })
+})
+
+describe('stopFind', () => {
+  test('calls stopFindInPage with the default action (clearSelection)', () => {
+    const wc = makeFakeWebContents()
+    stopFind(asWC(wc))
+    assert.deepEqual(wc.calls.stop, ['clearSelection'])
+  })
+
+  test('honors an explicit action argument', () => {
+    const wc = makeFakeWebContents()
+    stopFind(asWC(wc), 'keepSelection')
+    assert.deepEqual(wc.calls.stop, ['keepSelection'])
+  })
+
+  test('is a no-op when webContents is null or destroyed', () => {
+    assert.doesNotThrow(() => stopFind(null))
+    const wc = makeFakeWebContents()
+    wc.destroy()
+    stopFind(asWC(wc))
+    assert.equal(wc.calls.stop.length, 0)
+  })
+})
+
+describe('installFoundInPageForwarder', () => {
+  test('forwards found-in-page to the sender as a formatted payload', () => {
+    const wc = makeFakeWebContents()
+    installFoundInPageForwarder(asWC(wc))
+    // Drive the fake's emit directly — this exercises the same code path
+    // as Electron's actual `webContents.emit('found-in-page', …)`.
+    wc.emit('found-in-page', {}, { activeMatchOrdinal: 2, matches: 5 })
+    assert.deepEqual(wc.calls.send, [
+      { channel: 'hermes:found-in-page', payload: { activeMatchOrdinal: 2, count: 5 } }
+    ])
+  })
+
+  test('handles missing fields without throwing', () => {
+    const wc = makeFakeWebContents()
+    installFoundInPageForwarder(asWC(wc))
+    wc.emit('found-in-page', {}, {})
+    assert.deepEqual(wc.calls.send, [
+      { channel: 'hermes:found-in-page', payload: { activeMatchOrdinal: 0, count: 0 } }
+    ])
+  })
+
+  test('skips send when webContents is destroyed at fire time', () => {
+    const wc = makeFakeWebContents()
+    installFoundInPageForwarder(asWC(wc))
+    wc.destroy()
+    wc.emit('found-in-page', {}, { activeMatchOrdinal: 1, matches: 1 })
+    assert.equal(wc.calls.send.length, 0, 'destroyed webContents must not be sent to')
+  })
+
+  test('returned uninstall removes the listener', () => {
+    const wc = makeFakeWebContents()
+    const uninstall = installFoundInPageForwarder(asWC(wc))
+    uninstall()
+    wc.emit('found-in-page', {}, { activeMatchOrdinal: 9, matches: 9 })
+    assert.equal(wc.calls.send.length, 0, 'uninstalled listener must not fire')
+  })
+
+  test('returned uninstall on a null webContents is a safe no-op', () => {
+    const uninstall = installFoundInPageForwarder(null)
+    assert.doesNotThrow(() => uninstall())
+  })
+
+  test('returned uninstall on a destroyed webContents is a safe no-op', () => {
+    const wc = makeFakeWebContents()
+    wc.destroy()
+    const uninstall = installFoundInPageForwarder(asWC(wc))
+    assert.doesNotThrow(() => uninstall())
+  })
+
+  // Regression: the original PR scoped the forwarder to the global mainWindow,
+  // so Cmd+F pressed in a secondary session window routed results back to the
+  // primary. Pin that the helper does NOT close over any window other than the
+  // webContents it was given — two forwarders installed on two distinct fakes
+  // must each send only to their own sender.
+  test('two forwarders installed on distinct webContents do not cross-fire', () => {
+    const wcA = makeFakeWebContents()
+    const wcB = makeFakeWebContents()
+    installFoundInPageForwarder(asWC(wcA))
+    installFoundInPageForwarder(asWC(wcB))
+    wcA.emit('found-in-page', {}, { activeMatchOrdinal: 1, matches: 1 })
+    assert.deepEqual(wcA.calls.send, [
+      { channel: 'hermes:found-in-page', payload: { activeMatchOrdinal: 1, count: 1 } }
+    ])
+    assert.equal(wcB.calls.send.length, 0, 'wcB must not receive wcA results')
+  })
+})

--- a/apps/desktop/electron/find-in-page.ts
+++ b/apps/desktop/electron/find-in-page.ts
@@ -1,0 +1,125 @@
+/**
+ * Pure helpers for the desktop find-in-page bridge (Ctrl/Cmd+F).
+ *
+ * The renderer drives an Electron `webContents.findInPage` over IPC so it can
+ * reuse the native "find-in-page" experience (incremental search, match
+ * highlight, Enter to step, Shift+Enter to step backwards, Escape to clear)
+ * across chat transcripts and editor panels. Everything in this module is
+ * pure with respect to its inputs so the routing + payload shaping can be
+ * unit-tested without booting a BrowserWindow.
+ *
+ * Multi-window correctness: the IPC handlers in main.ts resolve the
+ * requesting window via `BrowserWindow.fromWebContents(event.sender)` so a
+ * Cmd+F pressed in a secondary session window searches THAT window, not the
+ * primary. The `found-in-page` results are forwarded back to the same sender
+ * — see {@link installFoundInPageForwarder}.
+ */
+
+/** Match options accepted by the renderer's `findInPage` bridge call. */
+export interface FindInPageOptions {
+  /** Step direction. Defaults to `true` (forward). */
+  forward?: boolean
+  /**
+   * `true` to advance to the next/previous match using the previous query;
+   * `false` to (re)search the current `query` from scratch. The renderer
+   * passes `false` on a fresh query and `true` on Enter / Shift+Enter.
+   */
+  findNext?: boolean
+}
+
+/** Payload shape sent back to the renderer on every `found-in-page` event. */
+export interface FoundInPagePayload {
+  /** 1-indexed ordinal of the active match, or 0 when none. */
+  activeMatchOrdinal: number
+  /** Total matches in the document for the current query. */
+  count: number
+}
+
+/**
+ * Defensive projection of Electron's `found-in-page` event result. Electron
+ * exposes more fields (finalUpdate, selectionArea, etc.) that we don't need;
+ * keeping the projection explicit makes the wire shape auditable and keeps
+ * tests independent of the runtime type.
+ */
+export function formatFoundInPage(result: {
+  activeMatchOrdinal?: number
+  matches?: number
+}): FoundInPagePayload {
+  return {
+    activeMatchOrdinal: Number(result?.activeMatchOrdinal ?? 0),
+    count: Number(result?.matches ?? 0)
+  }
+}
+
+/**
+ * Issue a `findInPage` against the given `webContents`. No-op when the
+ * webContents is missing or destroyed — surfaces as a silent miss rather
+ * than throwing across the IPC boundary, matching Electron's own semantics
+ * for a destroyed renderer.
+ */
+export function performFind(
+  webContents: Electron.WebContents | null | undefined,
+  query: string,
+  options: FindInPageOptions | null | undefined
+): void {
+  if (!webContents || webContents.isDestroyed()) {
+    return
+  }
+
+  const opts = options && typeof options === 'object' ? options : {}
+
+  webContents.findInPage(String(query ?? ''), {
+    forward: opts.forward !== false,
+    findNext: Boolean(opts.findNext)
+  })
+}
+
+/**
+ * Stop the current find and clear highlights. The default `action` matches
+ * what the renderer sends on Escape / close.
+ */
+export function stopFind(
+  webContents: Electron.WebContents | null | undefined,
+  action: 'clearSelection' | 'keepSelection' | 'activateSelection' = 'clearSelection'
+): void {
+  if (!webContents || webContents.isDestroyed()) {
+    return
+  }
+
+  webContents.stopFindInPage(action)
+}
+
+/**
+ * Install a `found-in-page` listener on the given sender `webContents` and
+ * forward each result back to the SAME renderer (via `webContents.send`).
+ *
+ * Returns an uninstall function. Call it from `webContents.on('destroyed', …)`
+ * to avoid leaking the listener when the window goes away — Electron does
+ * not auto-detach webContents listeners on close.
+ *
+ * The forwarder is intentionally bound to a single sender rather than the
+ * primary window: a Cmd+F pressed in a secondary session window must
+ * highlight matches in THAT window, and the match counter must reflect
+ * THAT window's DOM, not the primary's.
+ */
+export function installFoundInPageForwarder(
+  webContents: Electron.WebContents | null | undefined
+): () => void {
+  if (!webContents || webContents.isDestroyed()) {
+    return () => {}
+  }
+
+  const handler = (_event: Electron.Event, result: Parameters<typeof formatFoundInPage>[0]) => {
+    if (webContents.isDestroyed()) {
+      return
+    }
+
+    webContents.send('hermes:found-in-page', formatFoundInPage(result))
+  }
+
+  webContents.on('found-in-page', handler)
+
+  return () => {
+    webContents.off('found-in-page', handler)
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -65,6 +65,7 @@ import {
   uninstallArgsForMode
 } from './desktop-uninstall'
 import { installEmbedReferer } from './embed-referer'
+import { installFoundInPageForwarder, performFind, stopFind } from './find-in-page'
 import { readDirForIpc } from './fs-read-dir'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
 import { scanGitRepos } from './git-repo-scan'
@@ -8208,6 +8209,61 @@ ipcMain.handle('hermes:openExternal', (_event, url) => {
   if (!openExternalUrl(url)) {
     throw new Error('Invalid external URL')
   }
+})
+
+// ── Find-in-page (Ctrl/Cmd+F) ─────────────────────────────────────────────
+// The desktop supports multiple BrowserWindows (one primary plus any
+// per-session secondary windows spawned via `hermes:window:openSession`).
+// Find must run against the requesting window, not a global — otherwise
+// Cmd+F pressed in a secondary session window would search the primary
+// and the match counter would report matches the user can't see. Resolve
+// the sender through `BrowserWindow.fromWebContents(event.sender)` and
+// forward `found-in-page` results back to that same sender.
+
+// Lazily-installed forwarder per sender webContents. We track one
+// uninstall fn per webContents id and prune entries when the sender goes
+// away — Electron does not auto-detach webContents listeners on close,
+// so the map is the cleanup path.
+const foundInPageForwarders = new Map<number, () => void>()
+
+function ensureFoundInPageForwarder(sender: Electron.WebContents): void {
+  if (foundInPageForwarders.has(sender.id)) {
+    return
+  }
+
+  const uninstall = installFoundInPageForwarder(sender)
+  foundInPageForwarders.set(sender.id, uninstall)
+
+  sender.once('destroyed', () => {
+    foundInPageForwarders.get(sender.id)?.()
+    foundInPageForwarders.delete(sender.id)
+  })
+}
+
+ipcMain.handle('hermes:find-in-page', (event, query, options) => {
+  const win = BrowserWindow.fromWebContents(event.sender)
+
+  if (!win || win.isDestroyed()) {
+    return { count: 0 }
+  }
+
+  ensureFoundInPageForwarder(event.sender)
+  performFind(win.webContents, query, options)
+
+  // The match count arrives asynchronously via `found-in-page`; the
+  // synchronous return value is intentionally `{ count: 0 }` to mirror
+  // Electron's own `findInPage` return semantics (an opaque request id).
+  return { count: 0 }
+})
+
+ipcMain.handle('hermes:stop-find-in-page', event => {
+  const win = BrowserWindow.fromWebContents(event.sender)
+
+  if (!win || win.isDestroyed()) {
+    return
+  }
+
+  stopFind(win.webContents)
 })
 
 ipcMain.handle('hermes:openPreviewInBrowser', async (_event, url) => {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -263,5 +263,19 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   themes: {
     fetchMarketplace: id => ipcRenderer.invoke('hermes:vscode-theme:fetch', id),
     searchMarketplace: query => ipcRenderer.invoke('hermes:vscode-theme:search', query)
+  },
+  // Find-in-page (Ctrl/Cmd+F): delegates to Electron's
+  // webContents.findInPage on the IPC sender's window so a Cmd+F pressed
+  // in a secondary session window searches THAT window, not the primary.
+  // `onFoundInPage` returns the unsubscribe fn; the renderer wires it via
+  // `initFindInPageListener` in store/find-in-page.ts and tears it down
+  // when the FindBar unmounts.
+  findInPage: (query, options) => ipcRenderer.invoke('hermes:find-in-page', query, options),
+  stopFindInPage: () => ipcRenderer.invoke('hermes:stop-find-in-page'),
+  onFoundInPage: callback => {
+    const listener = (_event, result) => callback(result)
+    ipcRenderer.on('hermes:found-in-page', listener)
+
+    return () => ipcRenderer.removeListener('hermes:found-in-page', listener)
   }
 })

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -16,6 +16,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { formatRefValue } from '@/components/assistant-ui/directive-text'
 import { BootFailureOverlay } from '@/components/boot-failure-overlay'
 import { DesktopInstallOverlay } from '@/components/desktop-install-overlay'
+import { FindBar } from '@/components/find-bar'
 import { GatewayConnectingOverlay } from '@/components/gateway-connecting-overlay'
 import { NotificationStack } from '@/components/notifications'
 import { DesktopOnboardingOverlay } from '@/components/onboarding'
@@ -900,6 +901,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       <SessionSwitcher />
       <FileActionDialogs />
       <RemoteFolderPicker />
+      <FindBar />
 
       {settingsOpen && (
         <Suspense fallback={null}>

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -9,6 +9,7 @@ import { contributedKeybindHandler, PROFILE_SLOT_COUNT, SESSION_SLOT_COUNT } fro
 import { comboAllowedInInput, comboFromEvent, isEditableTarget } from '@/lib/keybinds/combo'
 import { $repoStatus } from '@/store/coding-status'
 import { toggleCommandPalette } from '@/store/command-palette'
+import { openFindBar } from '@/store/find-in-page'
 import { $capture, $comboIndex, endCapture, setBinding } from '@/store/keybinds'
 import {
   requestSessionSearchFocus,
@@ -185,6 +186,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     // the Win/Linux path where ⌘W reaches the renderer directly.
     'view.closeTab': () => void closeActiveTab(),
     'view.reopenTab': reopenLastClosedTile,
+    'view.findInPage': openFindBar,
 
     'appearance.toggleMode': () => setMode(resolvedMode === 'dark' ? 'light' : 'dark'),
 

--- a/apps/desktop/src/components/find-bar.tsx
+++ b/apps/desktop/src/components/find-bar.tsx
@@ -1,0 +1,193 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useRef, useState } from 'react'
+
+import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+import {
+  $findInPage,
+  closeFindBar,
+  findNext,
+  findPrevious,
+  initFindInPageListener,
+  setFindQuery
+} from '@/store/find-in-page'
+
+/**
+ * Find-in-page overlay (Ctrl/Cmd+F).
+ *
+ * Drives Electron's `webContents.findInPage` via the preload bridge so the
+ * user gets the native browser-like incremental search (highlight, Enter to
+ * step, Shift+Enter to step backwards, Escape to close) over the rendered
+ * chat transcript + editor panels. Multi-window routing is handled in the
+ * main process — see apps/desktop/electron/find-in-page.ts.
+ */
+export function FindBar() {
+  const { t } = useI18n()
+  const { active, query, matchOrdinal, matchCount } = useStore($findInPage)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [localQuery, setLocalQuery] = useState('')
+
+  // Focus input when find bar opens.
+  useEffect(() => {
+    if (active) {
+      setLocalQuery('')
+      // Small delay so the DOM paints the input before we focus.
+      const id = requestAnimationFrame(() => inputRef.current?.focus())
+
+      return () => cancelAnimationFrame(id)
+    }
+
+    return undefined
+  }, [active])
+
+  // Subscribe to found-in-page results from the main process.
+  useEffect(() => {
+    const unsub = initFindInPageListener()
+
+    return unsub
+  }, [])
+
+  // Debounce search — fire findInPage 200ms after the user stops typing.
+  // The ref lets us cancel the pending timeout when the bar closes.
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (!active || !localQuery) {
+      return undefined
+    }
+
+    const id = setTimeout(() => setFindQuery(localQuery), 200)
+    debounceRef.current = id
+
+    return () => {
+      clearTimeout(id)
+      debounceRef.current = null
+    }
+  }, [active, localQuery])
+
+  // Cancel pending debounce + close highlights when the bar closes.
+  useEffect(() => {
+    if (!active && debounceRef.current) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
+  }, [active])
+
+  // Global Escape listener — works even when focus is outside the input.
+  // Captured so the find bar can always close regardless of which element
+  // inside the shell owns focus (composer textarea, side panel button, etc).
+  useEffect(() => {
+    if (!active) {
+      return undefined
+    }
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        closeFindBar()
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown, { capture: true })
+
+    return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
+  }, [active])
+
+  if (!active) {
+    return null
+  }
+
+  const onInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value
+    setLocalQuery(val)
+
+    // Empty query: clear highlights.
+    if (!val) {
+      setFindQuery('')
+    }
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      closeFindBar()
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+
+      if (e.shiftKey) {
+        findPrevious()
+      } else {
+        findNext()
+      }
+    }
+  }
+
+  const matchLabel =
+    query && matchCount > 0
+      ? `${matchOrdinal}/${matchCount}`
+      : query && matchCount === 0
+        ? '0/0'
+        : ''
+
+  return (
+    <div
+      className={cn(
+        'pointer-events-auto fixed right-4 top-[calc(var(--titlebar-height,0px)+0.5rem)] z-50',
+        'flex items-center gap-1 rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-surface-background) px-2 py-1 shadow-md'
+      )}
+    >
+      <input
+        className="h-6 w-40 bg-transparent text-xs text-(--ui-text-primary) outline-none placeholder:text-(--ui-text-tertiary)"
+        onChange={onInput}
+        onKeyDown={onKeyDown}
+        placeholder={t.keybinds.actions['view.findInPage'] ?? 'Find'}
+        ref={inputRef}
+        type="text"
+        value={localQuery}
+      />
+
+      {matchLabel && (
+        <span className="min-w-[3rem] text-center text-[0.6875rem] text-(--ui-text-tertiary)">
+          {matchLabel}
+        </span>
+      )}
+
+      <Tip label="Previous">
+        <button
+          className="flex h-5 w-5 items-center justify-center rounded text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background)"
+          onClick={findPrevious}
+          type="button"
+        >
+          <svg height="12" viewBox="0 0 16 16" width="12">
+            <path d="M4 10l4-4 4 4" fill="none" stroke="currentColor" strokeWidth="1.5" />
+          </svg>
+        </button>
+      </Tip>
+
+      <Tip label="Next">
+        <button
+          className="flex h-5 w-5 items-center justify-center rounded text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background)"
+          onClick={findNext}
+          type="button"
+        >
+          <svg height="12" viewBox="0 0 16 16" width="12">
+            <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" strokeWidth="1.5" />
+          </svg>
+        </button>
+      </Tip>
+
+      <Tip label="Close">
+        <button
+          className="flex h-5 w-5 items-center justify-center rounded text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background)"
+          onClick={closeFindBar}
+          type="button"
+        >
+          <svg height="10" viewBox="0 0 12 12" width="10">
+            <path d="M1 1l10 10M11 1L1 11" stroke="currentColor" strokeWidth="1.5" />
+          </svg>
+        </button>
+      </Tip>
+    </div>
+  )
+}

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -222,6 +222,19 @@ declare global {
         // returns the most-installed themes.
         searchMarketplace: (query: string) => Promise<DesktopMarketplaceSearchItem[]>
       }
+      // Find-in-page: delegates to Electron's webContents.findInPage on the
+      // IPC sender's window so Cmd+F from a secondary session window
+      // searches that window (not the primary). `onFoundInPage` returns the
+      // unsubscribe fn; the renderer wires it via `initFindInPageListener`
+      // in store/find-in-page.ts and tears it down when the FindBar unmounts.
+      findInPage: (
+        query: string,
+        options?: { forward?: boolean; findNext?: boolean }
+      ) => Promise<{ count: number }>
+      stopFindInPage: () => Promise<void>
+      onFoundInPage: (
+        callback: (result: { activeMatchOrdinal: number; count: number }) => void
+      ) => () => void
     }
   }
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -256,6 +256,7 @@ export const en: Translations = {
       'view.closeTab': 'Close tab',
       'view.reopenTab': 'Reopen closed tab',
       'view.flipPanes': 'Swap sidebar sides',
+      'view.findInPage': 'Find in page',
       'appearance.toggleMode': 'Toggle light / dark',
       'profile.default': 'Switch to default profile',
       'profile.switch.1': 'Switch to profile 1',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -247,6 +247,7 @@ export const zh: Translations = {
       'view.closeTab': '关闭标签',
       'view.reopenTab': '重新打开已关闭的标签',
       'view.flipPanes': '交换侧边栏位置',
+      'view.findInPage': '页面内查找',
       'appearance.toggleMode': '切换浅色/深色',
       'profile.default': '切换到默认配置',
       'profile.switch.1': '切换到配置 1',

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -121,6 +121,10 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   // is a no-op. ⌘⇧T reopens the last closed tab where it was.
   { id: 'view.closeTab', category: 'view', defaults: ['mod+w'] },
   { id: 'view.reopenTab', category: 'view', defaults: ['mod+shift+t'] },
+  // ⌘F — open the find-in-page bar. `comboAllowedInInput` lets the combo
+  // fire from inside a textarea / contenteditable (matches browser behavior
+  // so typing in the composer and pressing ⌘F focuses find, not 'f').
+  { id: 'view.findInPage', category: 'view', defaults: ['mod+f'] },
   { id: 'appearance.toggleMode', category: 'view', defaults: ['shift+x'] },
   { id: 'keybinds.openPanel', category: 'view', defaults: ['mod+/'] }
 ]

--- a/apps/desktop/src/store/find-in-page.ts
+++ b/apps/desktop/src/store/find-in-page.ts
@@ -1,0 +1,66 @@
+import { atom } from 'nanostores'
+
+export interface FindInPageState {
+  active: boolean
+  query: string
+  matchOrdinal: number
+  matchCount: number
+}
+
+export const $findInPage = atom<FindInPageState>({
+  active: false,
+  query: '',
+  matchOrdinal: 0,
+  matchCount: 0
+})
+
+export function openFindBar(): void {
+  $findInPage.set({ active: true, query: '', matchOrdinal: 0, matchCount: 0 })
+}
+
+export function closeFindBar(): void {
+  $findInPage.set({ active: false, query: '', matchOrdinal: 0, matchCount: 0 })
+  void window.hermesDesktop?.stopFindInPage()
+}
+
+export function setFindQuery(query: string): void {
+  const prev = $findInPage.get()
+  $findInPage.set({ ...prev, query })
+
+  if (!query) {
+    void window.hermesDesktop?.stopFindInPage()
+    $findInPage.set({ ...prev, query: '', matchOrdinal: 0, matchCount: 0 })
+
+    return
+  }
+
+  void window.hermesDesktop?.findInPage(query, { forward: true, findNext: false })
+}
+
+export function findNext(): void {
+  const { query } = $findInPage.get()
+
+  if (query) {
+    void window.hermesDesktop?.findInPage(query, { forward: true, findNext: true })
+  }
+}
+
+export function findPrevious(): void {
+  const { query } = $findInPage.get()
+
+  if (query) {
+    void window.hermesDesktop?.findInPage(query, { forward: false, findNext: true })
+  }
+}
+
+/** Called by the preload bridge when `found-in-page` fires on webContents. */
+export function updateFindResults(activeMatch: number, count: number): void {
+  const prev = $findInPage.get()
+  $findInPage.set({ ...prev, matchOrdinal: activeMatch, matchCount: count })
+}
+
+export function initFindInPageListener(): (() => void) | undefined {
+  return window.hermesDesktop?.onFoundInPage?.((result: { activeMatchOrdinal: number; count: number }) => {
+    updateFindResults(result.activeMatchOrdinal, result.count)
+  })
+}


### PR DESCRIPTION
## Summary

Adds Electron-native find-in-page (`Ctrl+F` / `Cmd+F`) to the Hermes Desktop app, providing a standard browser-like search experience across chat transcripts and editor panels. The desktop already supports secondary session windows (one per chat, spawned via `hermes:window:openSession`), so the bridge routes through `event.sender` so `Cmd+F` from a secondary window searches that window, not the primary.

Fixes #46169

## Maintainer review addressed

This update addresses the three concerns @teknium1 raised on the previous revision (comment IDs 3585030710, 4701578544):

1. **CJS→TS port** — the original PR targeted `electron/main.cjs` and `electron/preload.cjs`, but commit `39d09453f` ("feat(desktop): ts-ify everything") renamed them to `.ts` on `main` after the PR opened. Ported to `apps/desktop/electron/{main,preload}.ts` and extracted the IPC bridge into a focused pure-helpers module at `apps/desktop/electron/find-in-page.ts`.

2. **Multi-window routing** — the previous handlers always searched the global `mainWindow`, so `Cmd+F` from a secondary session window searched the primary. Resolved via `BrowserWindow.fromWebContents(event.sender)` in both handlers, with a per-sender lazy forwarder registry (`Map<webContentsId, () => void>`) that installs `installFoundInPageForwarder` on first `findInPage` call and self-cleans via `webContents.once('destroyed', …)`. The `'found-in-page'` results are sent back to the same renderer that initiated the search.

3. **Tests** — added `apps/desktop/electron/find-in-page.test.ts` (vitest) covering the four helpers (`performFind`, `stopFind`, `formatFoundInPage`, `installFoundInPageForwarder`) plus a regression test pinning the multi-window bug: two forwarders installed on distinct `webContents` do not cross-fire.

## What changed

| File | Change |
|------|--------|
| `electron/find-in-page.ts` | **New** — pure helpers (`performFind`, `stopFind`, `formatFoundInPage`, `installFoundInPageForwarder`) |
| `electron/find-in-page.test.ts` | **New** — 20 vitest cases including a multi-window regression test |
| `electron/main.ts` | `ipcMain.handle('hermes:find-in-page'\|'hermes:stop-find-in-page', …)` route through `event.sender`; per-sender forwarder registry |
| `electron/preload.ts` | Bridge methods: `findInPage`, `stopFindInPage`, `onFoundInPage` |
| `src/global.d.ts` | Type declarations for the three new bridge methods |
| `src/store/find-in-page.ts` | **New** — nanostores atom + actions (`openFindBar`, `closeFindBar`, `setFindQuery`, `findNext`, `findPrevious`) |
| `src/components/find-bar.tsx` | **New** — FindBar React component (input, prev/next nav, match counter, Escape to close) |
| `src/lib/keybinds/actions.ts` | Added `view.findInPage` action with default `mod+f` |
| `src/app/hooks/use-keybinds.ts` | Wired `view.findInPage` → `openFindBar()` |
| `src/app/contrib/wiring.tsx` | Mounted `<FindBar />` next to the other global overlays (`app-shell.tsx` no longer exists on main — replaced by the contrib wiring) |
| `src/i18n/en.ts` | `'view.findInPage': 'Find in page'` |
| `src/i18n/zh.ts` | `'view.findInPage': '页面内查找'` |

## How it works

1. `Cmd+F` / `Ctrl+F` opens the find bar overlay (top-right, below titlebar). The keybind runtime's `comboAllowedInInput` already accepts any `mod+…` combo from inside textareas (see `lib/keybinds/combo.ts:193`), so `⌘F` focuses the find bar instead of typing `f` into the composer — matches browser behavior.
2. User types a query — debounced 200ms, then `webContents.findInPage()` highlights all matches in the rendered DOM of the requesting window.
3. `Enter` cycles forward, `Shift+Enter` cycles backward.
4. Match counter shows `3/12` via the per-sender `found-in-page` forwarder.
5. `Escape` or clicking ✕ calls `stopFindInPage('clearSelection')` and hides the bar.

## Design rationale

The chat thread uses a **render budget** (`RENDER_BUDGET = 300` parts), not virtualization — all rendered messages are in the DOM. This means Electron's native `webContents.findInPage` works correctly on all visible content. A custom data-level search was considered but is unnecessary given the non-virtualized rendering.

The bridge is split into pure helpers (`find-in-page.ts`) so the routing logic and payload shape can be unit-tested without booting a BrowserWindow. The IPC handlers in `main.ts` are the only Electron-side consumer — three lines each, plus a one-shot `ensureFoundInPageForwarder(event.sender)` that wires the `'found-in-page'` listener to the sender's webContents and registers a `webContents.once('destroyed', …)` cleanup.

## Verification

- ✅ `tsc -p . --noEmit` (renderer) — zero errors
- ✅ `tsc -p tsconfig.electron.json --noEmit` (Electron) — zero errors
- ✅ `eslint` (changed files) — zero errors / warnings
- ✅ `npx vitest run electron/find-in-page.test.ts --project electron` — 20/20 passing
- ✅ Multi-window regression test pins the original bug: two forwarders on distinct `webContents` do not cross-fire.

Closes #46169
