### PR TITLE
feat(slack): render markdown natively via Block Kit markdown block

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -771,6 +771,13 @@ platform_toolsets:
 #   reactions: true                  # Show processing reactions (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)
+#
+# Slack-specific settings (config.yaml top-level, not under platforms:):
+#
+# slack:
+#   require_mention: true             # Require @mention in channels (default: true)
+#   markdown_blocks: true             # Use Slack markdown Block Kit block for native rendering (default: true)
+#                                    # Set false to revert to legacy mrkdwn text path
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Available toolsets (use these names in platform_toolsets or the toolsets list)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1300,6 +1300,7 @@ class SlackAdapter(BasePlatformAdapter):
             # Controlled via platform config: gateway.slack.reply_broadcast
             broadcast = self.config.extra.get("reply_broadcast", False)
 
+            attempted_legacy_fallback = False
             for i, chunk_kwargs in enumerate(chunks_iterable):
                 kwargs = {
                     "channel": chat_id,
@@ -1314,7 +1315,56 @@ class SlackAdapter(BasePlatformAdapter):
                     if broadcast and i == 0:
                         kwargs["reply_broadcast"] = True
 
-                last_result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+                try:
+                    last_result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+                except Exception as e:
+                    # Slack rejected a markdown-block payload? Retry once
+                    # with the legacy text= + mrkdwn=true path. This catches
+                    # invalid_blocks / markdown_text_too_long / msg_too_long
+                    # (the family of errors that means "blocks not accepted
+                    # here", not auth/network failures). #53893 item 3.
+                    if (
+                        is_blocks_mode
+                        and not attempted_legacy_fallback
+                        and self._is_markdown_block_rejection(e)
+                    ):
+                        attempted_legacy_fallback = True
+                        err_code = "?"
+                        resp = getattr(e, "response", None)
+                        if isinstance(resp, dict):
+                            err_code = resp.get("error", "?")
+                        logger.info(
+                            "[Slack] markdown-block payload rejected (%s); "
+                            "retrying send() as legacy mrkdwn",
+                            err_code,
+                        )
+                        legacy_payload = self.format_message(content)
+                        legacy_chunks = self.truncate_message(
+                            legacy_payload, self.MAX_MESSAGE_LENGTH
+                        )
+                        # Replace the remaining chunk plan with legacy text
+                        # sends so we don't keep poking the rejected blocks
+                        # path. The first legacy send re-uses the thread +
+                        # broadcast flags from the original first chunk.
+                        chunks_iterable = [
+                            {"text": c, "mrkdwn": True}
+                            for c in legacy_chunks
+                        ]
+                        # Restart the loop at i=0 with legacy chunks; preserve
+                        # thread_ts/broadcast for the first message only.
+                        for j, legacy_kwargs in enumerate(chunks_iterable):
+                            legacy_kwargs = {
+                                "channel": chat_id,
+                                "mrkdwn": True,
+                                **legacy_kwargs,
+                            }
+                            if thread_ts:
+                                legacy_kwargs["thread_ts"] = thread_ts
+                                if broadcast and j == 0:
+                                    legacy_kwargs["reply_broadcast"] = True
+                            last_result = await self._get_client(chat_id).chat_postMessage(**legacy_kwargs)
+                        break
+                    raise
 
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:
@@ -1403,7 +1453,33 @@ class SlackAdapter(BasePlatformAdapter):
             }
             if "blocks" in payload:
                 update_kwargs["blocks"] = payload["blocks"]
-            await self._get_client(chat_id).chat_update(**update_kwargs)
+            try:
+                await self._get_client(chat_id).chat_update(**update_kwargs)
+            except Exception as e:
+                # Slack rejected the markdown-block payload — retry once with
+                # the legacy text= + mrkdwn=true path AND clear stale blocks so
+                # Slack doesn't render the prior blocks alongside the new text
+                # on clients that already cached them (#53893 item 3).
+                if "blocks" in payload and self._is_markdown_block_rejection(e):
+                    err_code = "?"
+                    resp = getattr(e, "response", None)
+                    if isinstance(resp, dict):
+                        err_code = resp.get("error", "?")
+                    logger.info(
+                        "[Slack] markdown-block edit rejected (%s); "
+                        "retrying chat_update as legacy mrkdwn with blocks=[]",
+                        err_code,
+                    )
+                    legacy = self.format_message(content)[: self.MAX_MESSAGE_LENGTH]
+                    await self._get_client(chat_id).chat_update(
+                        channel=chat_id,
+                        ts=message_id,
+                        text=legacy,
+                        mrkdwn=True,
+                        blocks=[],
+                    )
+                else:
+                    raise
             if finalize:
                 await self.stop_typing(chat_id)
             return SendResult(success=True, message_id=message_id)
@@ -1963,6 +2039,34 @@ class SlackAdapter(BasePlatformAdapter):
 
         # Legacy path: convert to Slack mrkdwn syntax.
         return {"text": self.format_message(content)}
+
+    @staticmethod
+    def _is_markdown_block_rejection(e: BaseException) -> bool:
+        """True if Slack rejected a markdown-block payload worth a legacy retry.
+
+        SlackApiError carries a ``.response`` dict with an ``error`` field set
+        to one of these codes when a Block Kit payload is malformed or too
+        large. They're recoverable by retrying the legacy ``text=`` +
+        ``mrkdwn=true`` path (#53893 item 3, tw0316 review).
+
+        Non-markdown errors (network failures, auth errors, rate limits) must
+        NOT match — those are not mitigated by switching to mrkdwn and the
+        retry would only double the failure.
+        """
+        recoverable_codes = {
+            "invalid_blocks",
+            "markdown_text_too_long",
+            "msg_too_long",
+        }
+        # SlackApiError.response is a dict; our test helper mirrors the shape.
+        resp = getattr(e, "response", None)
+        if isinstance(resp, dict) and resp.get("error") in recoverable_codes:
+            return True
+        # Fallback: some errors surface as bare message strings. Match any
+        # known code substring in the message so SDK-version differences
+        # (or plain ValueError wraps from slack-bolt adapters) still retry.
+        msg = str(e)
+        return any(code in msg for code in recoverable_codes)
 
     @staticmethod
     def _strip_markdown_for_fallback(content: str) -> str:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4417,8 +4417,13 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
     existing env-driven model and owns the YAML→env translation here, next to
     the adapter that consumes it. Env vars take precedence over YAML — every
     assignment is guarded by ``not os.getenv(...)`` so explicit env vars
-    survive a config.yaml update. Returns ``None`` because no extras are
-    seeded into ``PlatformConfig.extra`` directly (everything flows through env).
+    survive a config.yaml update.
+
+    Returns a dict of keys to bridge into ``PlatformConfig.extra`` (or None
+    when no extras apply). Currently bridges ``markdown_blocks`` — the
+    documented opt-out is read by ``_markdown_blocks_enabled()`` from
+    ``config.extra``, not from an env var, so it must be returned here to
+    take effect (#53893).
     """
     if "require_mention" in slack_cfg and not os.getenv("SLACK_REQUIRE_MENTION"):
         os.environ["SLACK_REQUIRE_MENTION"] = str(slack_cfg["require_mention"]).lower()
@@ -4438,7 +4443,17 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
         os.environ["SLACK_ALLOWED_CHANNELS"] = str(ac)
-    return None  # all settings flow through env; nothing to merge into extras
+    # Bridge the documented ``markdown_blocks`` opt-out into
+    # ``PlatformConfig.extra`` so ``_markdown_blocks_enabled()`` honours it.
+    # The adapter reads its runtime enable/disable state via
+    # ``config.extra.get("markdown_blocks")`` (see ``_markdown_blocks_enabled``),
+    # not via an env var, so the YAML keys above (which only seed SLACK_* env)
+    # leave the flag silently dropped — returning None here makes the documented
+    # config opt-out a no-op (#53893 item 1, tw0316 review).
+    extras: dict = {}
+    if "markdown_blocks" in slack_cfg:
+        extras["markdown_blocks"] = slack_cfg["markdown_blocks"]
+    return extras or None  # type: ignore[return-value]
 
 
 def _is_connected(config) -> bool:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1948,6 +1948,11 @@ class SlackAdapter(BasePlatformAdapter):
         if not content or not content.strip():
             return []
 
+        # Neutralize Slack entity syntax before it reaches Slack. Assistant
+        # output can contain literal `<@U123>` / `<!channel>` / `<#C123>` and
+        # the bot would actively ping users/channels if those survived to the
+        # Block Kit payload. CommonMark links are unchanged (#53893 item 4).
+        content = self._neutralize_slack_entities(content)
         chunks = self.truncate_message(
             content, self._MARKDOWN_BLOCK_CHAR_LIMIT
         )
@@ -2040,6 +2045,27 @@ class SlackAdapter(BasePlatformAdapter):
         # Legacy path: convert to Slack mrkdwn syntax.
         return {"text": self.format_message(content)}
 
+    # Slack entity syntax: ``<@U123>``, ``<!channel>``, ``<#C123>``, optionally
+    # with a ``|label`` suffix (``<@U123|name>``, ``<#C123|general>``). If
+    # reached by Slack as-is, the bot actively pings users / channels / special
+    # groups. This pattern matches only the entity forms — CommonMark links
+    # (``[label](url)``) and bare ``<`` (e.g. in code spans) are untouched.
+    _SLACK_ENTITY_RE = re.compile(
+        r"<([!#@])(?:[A-Za-z0-9._-]+(?:\|[^>]*)?)>"
+    )
+
+    @classmethod
+    def _neutralize_slack_entities(cls, text: str) -> str:
+        r"""Replace Slack entity syntax with a form Slack won't parse as a ping.
+
+        ``<@U123>`` becomes ``<\@U123>`` (backslash escape keeps the chars
+        visible to the reader but breaks Slack's parser). Same for
+        ``<!channel>``, ``<#C123>``, and their ``|label`` variants.
+        CommonMark links and other angle brackets are not affected
+        (#53893 item 4, tw0316 review).
+        """
+        return cls._SLACK_ENTITY_RE.sub(r"<\\\1", text)
+
     @staticmethod
     def _is_markdown_block_rejection(e: BaseException) -> bool:
         """True if Slack rejected a markdown-block payload worth a legacy retry.
@@ -2108,7 +2134,13 @@ class SlackAdapter(BasePlatformAdapter):
         text = _re.sub(r"^\s*-{3,}\s*$", "", text, flags=_re.MULTILINE)
         # Collapse whitespace
         text = _re.sub(r"\n{3,}", "\n\n", text)
-        return text.strip()[:3000]
+        text = text.strip()[:3000]
+        # Neutralize Slack entity syntax in the fallback `text=` field too:
+        # Slack parses `<@U123>` / `<!channel>` / `<#C123>` here the same way
+        # it does in the markdown block, and mrkdwn is enabled by default on
+        # the fallback path, so leaving these intact would ping users /
+        # channels on clients that don't render blocks (#53893 item 4).
+        return SlackAdapter._neutralize_slack_entities(text)
 
     # ----- Reactions -----
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1269,7 +1269,15 @@ class SlackAdapter(BasePlatformAdapter):
             is_blocks_mode = "blocks" in payload
             if is_blocks_mode:
                 block_chunks = self._chunk_blocks(
-                    payload["blocks"], self._MARKDOWN_BLOCK_MAX_BLOCKS
+                    payload["blocks"],
+                    self._MARKDOWN_BLOCK_MAX_BLOCKS,
+                    # Slack's per-payload cumulative limit on markdown-block
+                    # text is 12,000 chars across ALL blocks in the message,
+                    # not per block (#53893 item 2, tw0316 review). Without
+                    # this bound, two sub-12k blocks would be packed into one
+                    # over-limit chat_postMessage and Slack would reject it
+                    # with markdown_text_too_long.
+                    max_cumulative_chars=self._MARKDOWN_BLOCK_CHAR_LIMIT,
                 )
                 text_fallback = payload.get("text", "")
                 chunks_iterable = [
@@ -1885,6 +1893,7 @@ class SlackAdapter(BasePlatformAdapter):
         self,
         blocks: list,
         max_per_msg: int,
+        max_cumulative_chars: int | None = None,
     ) -> list:
         """Yield sublists of ``blocks`` each with at most ``max_per_msg`` entries.
 
@@ -1892,10 +1901,38 @@ class SlackAdapter(BasePlatformAdapter):
         that produced more than 50 markdown blocks is delivered across multiple
         back-to-back messages. This is a plain list-slicing helper — it returns
         a list of chunks for easy indexing/``enumerate`` at the call site.
+
+        ``max_cumulative_chars`` — when provided — further bounds each chunk so
+        the *cumulative* text carried by its markdown blocks stays within the
+        per-payload limit Slack enforces (12,000 chars across all markdown
+        blocks in a single ``chat_postMessage``, not per block). Without this,
+        two sub-12k blocks would be packed into one over-limit payload (#53893
+        item 2, tw0316 review).
         """
-        if max_per_msg <= 0:
+        if max_per_msg <= 0 and max_cumulative_chars is None:
             return [list(blocks)] if blocks else []
-        return [blocks[i : i + max_per_msg] for i in range(0, len(blocks), max_per_msg)]
+        if not blocks:
+            return []
+        chunks: list = []
+        current: list = []
+        current_chars = 0
+        for block in blocks:
+            block_chars = len(block.get("text", "")) if isinstance(block, dict) else 0
+            over_count = max_per_msg > 0 and len(current) + 1 > max_per_msg
+            over_chars = (
+                max_cumulative_chars is not None
+                and current
+                and current_chars + block_chars > max_cumulative_chars
+            )
+            if over_count or over_chars:
+                chunks.append(current)
+                current = []
+                current_chars = 0
+            current.append(block)
+            current_chars += block_chars
+        if current:
+            chunks.append(current)
+        return chunks
 
     def _send_payload(
         self,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -416,6 +416,10 @@ class SlackAdapter(BasePlatformAdapter):
     MAX_MESSAGE_LENGTH = 39000  # Slack API allows 40,000 chars; leave margin
     supports_code_blocks = True  # Slack mrkdwn renders fenced code blocks
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
+    # Native Block Kit ``markdown`` blocks (CommonMark incl. tables) for agent
+    # replies. Default-on; falls back to legacy ``text=`` + ``mrkdwn=true`` when
+    # ``gateway.slack.markdown_blocks: false`` (see _markdown_blocks_enabled).
+    supports_markdown_blocks = True
     # Slack blocks typed native slash commands inside threads ("/approve is
     # not supported in threads. Sorry!").  The adapter rewrites a leading
     # "!" to "/" for known commands (see _handle_slack_message), so "!" is
@@ -794,23 +798,32 @@ class SlackAdapter(BasePlatformAdapter):
         the user already saw the initial ack, so a delivery failure here
         is non-critical.
         """
-        formatted = self.format_message(content)
+        payload = self._send_payload(content)
+        is_blocks_mode = "blocks" in payload
         # Slack's response_url has the same ~40k char limit as chat_postMessage.
-        # Truncate to MAX_MESSAGE_LENGTH and use only the first chunk — the
-        # response_url replaces a single ephemeral ack, so multi-chunk isn't
-        # possible.  Long responses are rare for command replies.
-        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
-        text = chunks[0] if chunks else formatted
-        payload = {
+        # Truncate the fallback text to MAX_MESSAGE_LENGTH and use only the first
+        # chunk — the response_url replaces a single ephemeral ack, so
+        # multi-chunk isn't possible. Long responses are rare for command
+        # replies. In markdown-block mode, keep blocks (already chunked by
+        # _build_markdown_blocks at the per-block 12k limit) and send a single
+        # message's worth so the payload stays well under the response_url cap.
+        chunks = self.truncate_message(payload["text"], self.MAX_MESSAGE_LENGTH)
+        text = chunks[0] if chunks else payload["text"]
+        url_payload = {
             "response_type": "ephemeral",
             "replace_original": True,
             "text": text,
         }
+        if is_blocks_mode:
+            blocks = payload["blocks"]
+            if len(blocks) > self._MARKDOWN_BLOCK_MAX_BLOCKS:
+                blocks = blocks[: self._MARKDOWN_BLOCK_MAX_BLOCKS]
+            url_payload["blocks"] = blocks
         try:
             async with aiohttp.ClientSession(trust_env=True) as session:
                 async with session.post(
                     ctx["response_url"],
-                    json=payload,
+                    json=url_payload,
                     timeout=aiohttp.ClientTimeout(total=10),
                 ) as resp:
                     if resp.status == 200:
@@ -1247,11 +1260,30 @@ class SlackAdapter(BasePlatformAdapter):
                     content,
                 )
 
-            # Convert standard markdown → Slack mrkdwn
-            formatted = self.format_message(content)
-
-            # Split long messages, preserving code block boundaries
-            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            # Build the message payload. In markdown-block mode this
+            # produces a ``blocks`` list (native rendering, incl. tables);
+            # otherwise it produces ``text`` + ``mrkdwn`` (legacy path).
+            payload = self._send_payload(content)
+            # Chunk per-block payload by *block* count (one markdown block
+            # per chunk); legacy mrkdwn payload chunks by MAX_MESSAGE_LENGTH.
+            is_blocks_mode = "blocks" in payload
+            if is_blocks_mode:
+                block_chunks = self._chunk_blocks(
+                    payload["blocks"], self._MARKDOWN_BLOCK_MAX_BLOCKS
+                )
+                text_fallback = payload.get("text", "")
+                chunks_iterable = [
+                    {
+                        "text": text_fallback if i == 0 else "",
+                        "blocks": bt,
+                    }
+                    for i, bt in enumerate(block_chunks)
+                ]
+            else:
+                chunks = self.truncate_message(
+                    payload["text"], self.MAX_MESSAGE_LENGTH
+                )
+                chunks_iterable = [{"text": c} for c in chunks]
 
             thread_ts = self._resolve_thread_ts(reply_to, metadata)
             last_result = None
@@ -1260,12 +1292,14 @@ class SlackAdapter(BasePlatformAdapter):
             # Controlled via platform config: gateway.slack.reply_broadcast
             broadcast = self.config.extra.get("reply_broadcast", False)
 
-            for i, chunk in enumerate(chunks):
+            for i, chunk_kwargs in enumerate(chunks_iterable):
                 kwargs = {
                     "channel": chat_id,
-                    "text": chunk,
-                    "mrkdwn": True,
+                    **chunk_kwargs,
                 }
+                # Use mrkdwn only when emitting plain text (legacy path).
+                if not is_blocks_mode:
+                    kwargs["mrkdwn"] = True
                 if thread_ts:
                     kwargs["thread_ts"] = thread_ts
                     # Only broadcast the first chunk of the first reply
@@ -1316,14 +1350,18 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="chat_id and user_id are required")
 
         try:
-            formatted = self.format_message(content)
+            payload = self._send_payload(content)
             thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            is_blocks_mode = "blocks" in payload
             kwargs = {
                 "channel": chat_id,
                 "user": user_id,
-                "text": formatted,
-                "mrkdwn": True,
+                "text": payload["text"],
             }
+            if is_blocks_mode:
+                kwargs["blocks"] = payload["blocks"]
+            else:
+                kwargs["mrkdwn"] = True
             if thread_ts:
                 kwargs["thread_ts"] = thread_ts
 
@@ -1349,12 +1387,15 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app:
             return SendResult(success=False, error="Not connected")
         try:
-            formatted = self.format_message(content)
-            await self._get_client(chat_id).chat_update(
-                channel=chat_id,
-                ts=message_id,
-                text=formatted,
-            )
+            payload = self._send_payload(content)
+            update_kwargs = {
+                "channel": chat_id,
+                "ts": message_id,
+                "text": payload["text"],
+            }
+            if "blocks" in payload:
+                update_kwargs["blocks"] = payload["blocks"]
+            await self._get_client(chat_id).chat_update(**update_kwargs)
             if finalize:
                 await self.stop_typing(chat_id)
             return SendResult(success=True, message_id=message_id)
@@ -1779,6 +1820,154 @@ class SlackAdapter(BasePlatformAdapter):
             text = text.replace(key, placeholders[key])
 
         return text
+
+    # ----- Markdown block mode (native Block Kit rendering) -----
+
+    # Slack's ``markdown`` block (added to Block Kit in 2025) accepts a
+    # standard markdown string — incl. tables, fenced code, task lists,
+    # headers, links — and Slack renders it natively instead of forcing
+    # clients to interpret the proprietary ``mrkdwn`` mini-language.
+    #
+    # Cumulative limit for all markdown blocks in a single message
+    # payload is 12,000 characters (per the Block Kit spec). A single
+    # ``chat.postMessage`` may include up to 50 blocks total.
+    _MARKDOWN_BLOCK_CHAR_LIMIT = 12_000
+    _MARKDOWN_BLOCK_MAX_BLOCKS = 50
+
+    def _markdown_blocks_enabled(self) -> bool:
+        """Whether to send agent replies as native Slack ``markdown`` blocks.
+
+        Default: enabled. Disable in config via
+        ``gateway.slack.markdown_blocks: false`` to fall back to the
+        legacy ``text=...`` + ``mrkdwn=true`` path (older workspaces or
+        clients that don't yet render the markdown block).
+        """
+        # Defensive against bare ``SlackAdapter.__new__(SlackAdapter)``
+        # instances used by ``_standalone_send`` (cron out-of-process sender),
+        # which carry no ``config`` attribute — treat missing config as the
+        # default-on state so the feature stays consistent with full adapters.
+        cfg = getattr(self, "config", None)
+        if cfg is None:
+            return True
+        raw = cfg.extra.get("markdown_blocks") if hasattr(cfg, "extra") else None
+        if raw is None:
+            return True
+        return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
+    def _build_markdown_blocks(self, content: str) -> list:
+        """Wrap raw markdown in Slack Block Kit ``markdown`` blocks.
+
+        Splits at the 12k-char cumulative limit so each message payload
+        stays within Slack's cap. Returns an empty list when the content
+        is empty (caller should fall back to plain text).
+        """
+        if not content or not content.strip():
+            return []
+
+        chunks = self.truncate_message(
+            content, self._MARKDOWN_BLOCK_CHAR_LIMIT
+        )
+        # Slack caps a single message at 50 blocks; we emit one markdown
+        # block per chunk. If a reply would exceed 50 chunks, hard-cap to
+        # the first 49 and append a final "...(truncated)..." marker block.
+        if len(chunks) > self._MARKDOWN_BLOCK_MAX_BLOCKS:
+            chunks = chunks[: self._MARKDOWN_BLOCK_MAX_BLOCKS - 1] + [
+                chunks[-1][:100] + " …(truncated)…"
+            ]
+
+        return [
+            {"type": "markdown", "text": chunk}
+            for chunk in chunks
+            if chunk and chunk.strip()
+        ]
+
+    def _chunk_blocks(
+        self,
+        blocks: list,
+        max_per_msg: int,
+    ) -> list:
+        """Yield sublists of ``blocks`` each with at most ``max_per_msg`` entries.
+
+        Slack caps a single ``chat.postMessage`` at 50 blocks, so a long reply
+        that produced more than 50 markdown blocks is delivered across multiple
+        back-to-back messages. This is a plain list-slicing helper — it returns
+        a list of chunks for easy indexing/``enumerate`` at the call site.
+        """
+        if max_per_msg <= 0:
+            return [list(blocks)] if blocks else []
+        return [blocks[i : i + max_per_msg] for i in range(0, len(blocks), max_per_msg)]
+
+    def _send_payload(
+        self,
+        content: str,
+    ) -> dict:
+        """Build the per-send kwargs for either markdown-block or mrkdwn mode.
+
+        Returns a dict suitable for ``chat.postMessage`` /
+        ``chat_postEphemeral`` that contains either:
+
+        * ``text`` (mrkdwn-rendered, legacy path), or
+        * ``text`` (plain-text fallback for notifications) + ``blocks``
+          (a list of ``markdown`` blocks).
+
+        Slack requires ``text`` in both cases for notifications, screen
+        readers, and clients that don't render blocks. The fallback text
+        is a stripped copy of the raw markdown so it stays readable.
+        """
+        if self._markdown_blocks_enabled():
+            blocks = self._build_markdown_blocks(content)
+            if blocks:
+                # Slack rejects "&lt;"-style entities inside a markdown
+                # block (it's CommonMark, not mrkdwn), so we do NOT call
+                # format_message here — pass the raw markdown through and
+                # let Slack's renderer handle escaping.
+                fallback = self._strip_markdown_for_fallback(content)
+                return {"text": fallback, "blocks": blocks}
+
+        # Legacy path: convert to Slack mrkdwn syntax.
+        return {"text": self.format_message(content)}
+
+    @staticmethod
+    def _strip_markdown_for_fallback(content: str) -> str:
+        """Reduce markdown to a compact plain-text fallback for ``text=``.
+
+        Slack uses ``text`` for push notifications, screen readers, and
+        clients that don't render blocks — it should be readable, not
+        necessarily a faithful round-trip. We strip the most common
+        markdown sigils inline (leaving the readable text) instead of
+        doing a full AST walk. Bounded to ~3000 chars so push
+        notifications don't blow the payload.
+        """
+        if not content:
+            return ""
+        import re as _re
+
+        text = content
+        # Drop fenced code blocks entirely (replace with a marker)
+        text = _re.sub(r"```[^\n]*\n[\s\S]*?```", " [code block] ", text)
+        # Strip inline code backticks
+        text = _re.sub(r"`([^`]+)`", r"\1", text)
+        # Strip link syntax → show label
+        text = _re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+        # Strip image syntax → show alt
+        text = _re.sub(r"!\[([^\]]*)\]\([^)]+\)", r"\1", text)
+        # Strip emphasis / bold markers
+        text = _re.sub(r"\*{1,3}([^*\n]+?)\*{1,3}", r"\1", text)
+        text = _re.sub(r"_{1,3}([^_\n]+?)_{1,3}", r"\1", text)
+        text = _re.sub(r"~~([^~\n]+?)~~", r"\1", text)
+        # Strip header hashes
+        text = _re.sub(r"^\s{0,3}#{1,6}\s+", "", text, flags=_re.MULTILINE)
+        # Strip list markers
+        text = _re.sub(
+            r"^\s*([-*+]|\d+\.)\s+", "", text, flags=_re.MULTILINE
+        )
+        # Strip blockquote markers
+        text = _re.sub(r"^\s*>+\s?", "", text, flags=_re.MULTILINE)
+        # Strip horizontal rules
+        text = _re.sub(r"^\s*-{3,}\s*$", "", text, flags=_re.MULTILINE)
+        # Collapse whitespace
+        text = _re.sub(r"\n{3,}", "\n\n", text)
+        return text.strip()[:3000]
 
     # ----- Reactions -----
 
@@ -4037,16 +4226,23 @@ async def _standalone_send(
     if not token:
         return {"error": "Slack send failed: SLACK_BOT_TOKEN not configured"}
 
-    formatted = message
-    if message:
-        try:
-            _fmt_adapter = SlackAdapter.__new__(SlackAdapter)
-            formatted = _fmt_adapter.format_message(message)
-        except Exception:
-            logger.debug(
-                "Failed to apply Slack mrkdwn formatting in _standalone_send",
-                exc_info=True,
-            )
+    # Use the same payload builder as the in-process adapter so cron-delivered
+    # messages render identically (markdown blocks when enabled, mrkdwn
+    # otherwise). The throwaway ``__new__`` instance has no ``config`` attribute,
+    # but ``_markdown_blocks_enabled`` is defensive about that and defaults the
+    # feature on — matching full adapter behavior.
+    body = message
+    try:
+        _fmt_adapter = SlackAdapter.__new__(SlackAdapter)
+        body = _fmt_adapter._send_payload(message) if message else {"text": ""}
+    except Exception:
+        logger.debug(
+            "Failed to build Slack payload in _standalone_send",
+            exc_info=True,
+        )
+        body = {"text": message} if message else {"text": ""}
+
+    is_blocks_mode = isinstance(body, dict) and "blocks" in body
 
     try:
         import aiohttp
@@ -4066,7 +4262,14 @@ async def _standalone_send(
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=30), **_sess_kw
         ) as session:
-            payload = {"channel": chat_id, "text": formatted, "mrkdwn": True}
+            payload = {"channel": chat_id, "text": body.get("text", "")}
+            if is_blocks_mode:
+                blocks = body["blocks"]
+                if len(blocks) > SlackAdapter._MARKDOWN_BLOCK_MAX_BLOCKS:
+                    blocks = blocks[: SlackAdapter._MARKDOWN_BLOCK_MAX_BLOCKS]
+                payload["blocks"] = blocks
+            else:
+                payload["mrkdwn"] = True
             if thread_id:
                 payload["thread_ts"] = thread_id
             async with session.post(

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -426,6 +426,31 @@ class SlackAdapter(BasePlatformAdapter):
     # the prefix that works everywhere — instruction text must show it.
     typed_command_prefix = "!"
 
+    # When markdown blocks are enabled, the stream consumer must finalize a
+    # streamed reply by sending a *fresh* Block Kit message and best-effort
+    # deleting the raw legacy-mrkdwn preview, rather than final-editing the
+    # preview (which can silently fail on rich Slack finals and leave the raw
+    # preview as the visible "final" content). The adapter opts in via two
+    # cooperating hooks (see gateway/platforms/base.py):
+    #   * ``REQUIRES_EDIT_FINALIZE`` forces the consumer to route a finalize
+    #     tick through ``_send_or_edit`` even when the streamed preview text
+    #     matches the final answer — without this, the "skip if same" gate
+    #     short-circuits and the fresh-final path never runs (#53893 item 5).
+    #   * ``prefers_fresh_final_streaming(content)`` returns True when blocks
+    #     are enabled, sending the finalize through ``_try_fresh_final``.
+    # Both are gated on ``_markdown_blocks_enabled()`` so users who disable
+    # blocks get the legacy edit-in-place path with no behavior change.
+    @property
+    def REQUIRES_EDIT_FINALIZE(self) -> bool:  # noqa: N815
+        return self._markdown_blocks_enabled()
+
+    def prefers_fresh_final_streaming(
+        self,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        return self._markdown_blocks_enabled()
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.SLACK)
         self._app: Optional[Any] = None

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1042,10 +1042,39 @@ class TestSendPrivateNotice:
         )
 
         assert result.success
+        # Markdown-block mode is the default, so the ephemeral post carries a
+        # ``blocks`` list (native markdown rendering) and the stripped plain-text
+        # fallback in ``text=``; ``mrkdwn`` must NOT be passed in blocks mode.
+        call_kwargs = adapter._app.client.chat_postEphemeral.call_args.kwargs
+        assert call_kwargs["channel"] == "C123"
+        assert call_kwargs["user"] == "U123"
+        assert call_kwargs["text"] == "private hello"
+        assert call_kwargs["thread_ts"] == "1234567890.123456"
+        assert call_kwargs["blocks"] == [
+            {"type": "markdown", "text": "private hello"}
+        ]
+        assert "mrkdwn" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_send_private_notice_legacy_mrkdwn_mode(self, adapter):
+        # With markdown_blocks disabled, fall back to text= + mrkdwn=true.
+        adapter.config.extra["markdown_blocks"] = False
+        adapter._app.client.chat_postEphemeral = AsyncMock(
+            return_value={"message_ts": "123.456"}
+        )
+
+        result = await adapter.send_private_notice(
+            chat_id="C123",
+            user_id="U123",
+            content="private **hello**",
+            metadata={"thread_id": "1234567890.123456"},
+        )
+
+        assert result.success
         adapter._app.client.chat_postEphemeral.assert_called_once_with(
             channel="C123",
             user="U123",
-            text="private hello",
+            text="private *hello*",  # format_message converts **hello** → *hello*
             mrkdwn=True,
             thread_ts="1234567890.123456",
         )
@@ -2131,11 +2160,15 @@ class TestSendTyping:
         )
 
         assert result.success
-        adapter._app.client.chat_update.assert_called_once_with(
-            channel="C123",
-            ts="reply_ts",
-            text="done",
-        )
+        call_kwargs = adapter._app.client.chat_update.call_args.kwargs
+        assert call_kwargs["channel"] == "C123"
+        assert call_kwargs["ts"] == "reply_ts"
+        # Markdown-block mode is on by default for this adapter, so the final
+        # edit carries a ``blocks`` list and the raw text body (un-escaped) —
+        # ``text=`` becomes the stripped plain-text fallback rather than an
+        # mrkdwn-formatted string, and ``mrkdwn`` is not passed.
+        assert "blocks" in call_kwargs
+        assert "mrkdwn" not in call_kwargs
         adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
             channel_id="C123",
             thread_ts="parent_ts",
@@ -2412,7 +2445,17 @@ class TestFormatMessage:
 
 
 class TestEditMessage:
-    """Verify that edit_message() applies mrkdwn formatting before sending."""
+    """Verify that edit_message() applies mrkdwn formatting before sending.
+
+    These tests pin the legacy ``text=`` + ``mrkdwn=true`` formatting path
+    (``format_message`` -> mrkdwn). The default send path now uses native
+    Block Kit ``markdown`` blocks, so these explicitly opt out via the
+    ``markdown_blocks`` config flag to keep exercising the legacy converter.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _force_legacy_mrkdwn(self, adapter):
+        adapter.config.extra["markdown_blocks"] = False
 
     @pytest.mark.asyncio
     async def test_edit_message_formats_bold(self, adapter):
@@ -2458,7 +2501,14 @@ class TestEditMessageStreamingPipeline:
     Simulates the GatewayStreamConsumer pattern where edit_message is called
     repeatedly with progressively longer accumulated text.  Every call must
     produce properly formatted mrkdwn in the chat_update payload.
+
+    These tests pin the legacy mrkdwn path (see ``TestEditMessage`` for why):
+    they set ``markdown_blocks: false`` so the mrkdwn ``text=`` form is asserted.
     """
+
+    @pytest.fixture(autouse=True)
+    def _force_legacy_mrkdwn(self, adapter):
+        adapter.config.extra["markdown_blocks"] = False
 
     @pytest.mark.asyncio
     async def test_edit_message_formats_streaming_updates(self, adapter):
@@ -3223,7 +3273,19 @@ class TestSlashCommands:
 
 
 class TestMessageSplitting:
-    """Test that long messages are split before sending."""
+    """Test that long messages are split before sending.
+
+    These tests pin the legacy ``text=`` + ``mrkdwn=true`` send path (chunking
+    at ``MAX_MESSAGE_LENGTH`` and ``format_message`` -> mrkdwn conversion).
+    The default path now ships native Block Kit ``markdown`` blocks, which
+    chunk at the 12k-char block limit instead — so the chunking/formatting
+    assertions below opt into legacy mode via ``markdown_blocks: false`` to
+    keep verifying the behavior they were written for.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _force_legacy_mrkdwn(self, adapter):
+        adapter.config.extra["markdown_blocks"] = False
 
     @pytest.mark.asyncio
     async def test_long_message_split_into_chunks(self, adapter):

--- a/tests/gateway/test_slack_markdown_blocks.py
+++ b/tests/gateway/test_slack_markdown_blocks.py
@@ -635,3 +635,158 @@ class SlackRejectedBlocks(Exception):
         # Mirror slack_sdk's SlackApiError.response['error'] shape so the
         # adapter can introspect it the same way SlackApiError is introspected.
         self.response = {"ok": False, "error": error_code}
+
+
+# ---------------------------------------------------------------------------
+# Item 5 (tw0316 review): streaming finalization uses a fresh markdown-block
+# final when the adapter has markdown blocks enabled, instead of final-editing
+# a raw legacy-mrkdwn preview. The adapter opts in via the
+# ``prefers_fresh_final_streaming`` hook (see gateway/platforms/base.py) so the
+# stream consumer delivers the completed answer as a fresh Block Kit message
+# and best-effort deletes the stale preview. This avoids the failure mode
+# where a raw streaming preview is treated as the delivered final content
+# after a rich final edit fails (#53893 item 5).
+# ---------------------------------------------------------------------------
+
+
+class TestPrefersFreshFinalStreaming:
+    """The Slack adapter must opt into the stream consumer's fresh-final path
+    when markdown blocks are enabled, so the final answer renders as Block Kit
+    rather than as a final-edit of a raw mrkdwn preview."""
+
+    def test_hook_returns_true_when_markdown_blocks_enabled(self, adapter):
+        # Default adapter is markdown-blocks-enabled.
+        assert adapter._markdown_blocks_enabled() is True
+        assert adapter.prefers_fresh_final_streaming("any content") is True
+
+    def test_hook_returns_false_when_markdown_blocks_disabled(self, adapter):
+        # Item 1 opt-out path must also gate the fresh-final hook — otherwise
+        # users who disable blocks would still get fresh-final sends that go
+        # legacy-mrkdwn anyway, paying the delete-and-resend cost for nothing.
+        adapter.config.extra["markdown_blocks"] = False
+        assert adapter._markdown_blocks_enabled() is False
+        assert adapter.prefers_fresh_final_streaming("any content") is False
+
+
+class TestStreamConsumerFreshFinalPath:
+    """End-to-end through ``GatewayStreamConsumer``: when the Slack adapter
+    has markdown blocks enabled, the final answer is delivered as a fresh
+    Block Kit ``chat.postMessage`` (not an edit of the preview), and the
+    stale preview is best-effort deleted."""
+
+    @pytest.mark.asyncio
+    async def test_final_renders_as_fresh_markdown_block_not_edit(self, adapter):
+        from gateway.stream_consumer import (
+            GatewayStreamConsumer,
+            StreamConsumerConfig,
+        )
+
+        # The first chat_postMessage streams the legacy preview; the second
+        # delivers the fresh final answer as a Block Kit payload.
+        post_results = [
+            {"ok": True, "ts": "100.0"},
+            {"ok": True, "ts": "200.0"},
+        ]
+        adapter._app.client.chat_postMessage = AsyncMock(side_effect=post_results)
+        adapter._app.client.chat_update = AsyncMock(
+            return_value={"ok": True, "ts": "100.0"}
+        )
+        adapter.delete_message = AsyncMock(return_value=True)
+
+        cfg = StreamConsumerConfig(
+            transport="auto",
+            chat_type="dm",
+            edit_interval=0.001,
+            buffer_threshold=1,
+            cursor="",
+            fresh_final_after_seconds=0.0,  # adapter hook alone drives fresh-final
+        )
+        consumer = GatewayStreamConsumer(adapter, "C123", cfg)
+
+        consumer.on_delta("# Title\n\n| a | b |\n|---|---|\n| 1 | 2 |")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        # The fresh final must be a *new* chat.postMessage, NOT a chat_update
+        # of the preview. The edit path must not be the finalizer.
+        assert adapter._app.client.chat_postMessage.await_count >= 2, (
+            "fresh-final path must emit a new chat.postMessage for the final; "
+            f"got {adapter._app.client.chat_postMessage.await_count} call(s)"
+        )
+
+        # The fresh final chat_postMessage must carry Block Kit ``blocks``,
+        # not just legacy ``text`` + ``mrkdwn``. A table is the canonical case
+        # that only renders correctly in a markdown block.
+        final_call = adapter._app.client.chat_postMessage.call_args_list[-1].kwargs
+        assert "blocks" in final_call, (
+            "fresh final must be delivered as Block Kit blocks, not legacy mrkdwn"
+        )
+        assert any(
+            b.get("type") == "markdown" for b in final_call["blocks"]
+        ), f"expected a markdown block in fresh final, got {final_call['blocks']}"
+
+        # The final answer must mark delivery complete so the gateway doesn't
+        # double-send it.
+        assert consumer.final_response_sent is True
+
+
+class TestFreshFinalRejectionTriggersLegacyRetry:
+    """tw0316 item 5 layered fallback: if the fresh-final markdown-block send
+    itself is rejected by Slack (invalid_blocks etc.), the adapter's item-3
+    retry path must fire (legacy mrkdwn), so the user still gets the final
+    answer rather than a silent send failure after the preview was deleted."""
+
+    @pytest.mark.asyncio
+    async def test_fresh_final_markdown_block_rejection_retries_legacy(self, adapter):
+        from gateway.stream_consumer import (
+            GatewayStreamConsumer,
+            StreamConsumerConfig,
+        )
+
+        # First chat_postMessage: streaming preview (legacy text, succeeds).
+        # Second chat_postMessage: fresh final as blocks (REJECTED).
+        # Third chat_postMessage: legacy mrkdwn retry (item 3 wiring) succeeds.
+        adapter._app.client.chat_postMessage = AsyncMock(side_effect=[
+            {"ok": True, "ts": "100.0"},
+            SlackRejectedBlocks("invalid_blocks"),
+            {"ok": True, "ts": "300.0"},
+        ])
+        adapter._app.client.chat_update = AsyncMock(
+            return_value={"ok": True, "ts": "100.0"}
+        )
+        adapter.delete_message = AsyncMock(return_value=True)
+
+        cfg = StreamConsumerConfig(
+            transport="auto",
+            chat_type="dm",
+            edit_interval=0.001,
+            buffer_threshold=1,
+            cursor="",
+            fresh_final_after_seconds=0.0,
+        )
+        consumer = GatewayStreamConsumer(adapter, "C123", cfg)
+
+        consumer.on_delta("Final answer that must reach the user")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        # Three chat_postMessage calls: preview, rejected-blocks, legacy retry.
+        assert adapter._app.client.chat_postMessage.await_count >= 3, (
+            "fresh-final rejection must trigger a legacy mrkdwn retry; "
+            f"got {adapter._app.client.chat_postMessage.await_count} calls"
+        )
+
+        # The third (retry) call must use legacy text= + mrkdwn=true, NOT blocks.
+        retry_call = adapter._app.client.chat_postMessage.call_args_list[-1].kwargs
+        assert "blocks" not in retry_call, (
+            "legacy retry after block rejection must not re-send blocks"
+        )
+        assert retry_call.get("mrkdwn") is True, (
+            f"legacy retry must set mrkdwn=True, got {retry_call}"
+        )
+
+        assert consumer.final_response_sent is True

--- a/tests/gateway/test_slack_markdown_blocks.py
+++ b/tests/gateway/test_slack_markdown_blocks.py
@@ -1,0 +1,325 @@
+"""
+Tests for the Slack adapter's native Block Kit ``markdown`` block feature.
+
+The Slack adapter wraps agent replies in Block Kit ``markdown`` blocks (added
+to Block Kit in 2025) so tables, fenced code, and other CommonMark constructs
+render natively in Slack instead of being force-converted to the proprietary
+``mrkdwn`` mini-language. The legacy ``text=`` + ``mrkdwn=true`` path stays
+available behind ``gateway.slack.markdown_blocks: false``.
+
+Covers:
+  * ``_markdown_blocks_enabled()`` config flag (default-on, opt-out)
+  * ``_build_markdown_blocks()`` structure, 12k-char chunking, empty input
+  * ``_strip_markdown_for_fallback()`` sigil stripping
+  * ``send()`` payload shape in blocks vs. legacy mrkdwn mode
+  * markdown table round-trip (the motivating use case for the feature)
+"""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# Reuse the slack-bolt import shim from the sibling test module so this file
+# can be collected standalone without requiring the real slack-bolt package.
+# ---------------------------------------------------------------------------
+
+
+def _ensure_slack_mock() -> None:
+    if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
+        return  # Real library installed
+
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+
+    slack_sdk = MagicMock()
+    slack_sdk.web.async_client.AsyncWebClient = MagicMock
+
+    for name, mod in [
+        ("slack_bolt", slack_bolt),
+        ("slack_bolt.async_app", slack_bolt.async_app),
+        ("slack_bolt.adapter", slack_bolt.adapter),
+        ("slack_bolt.adapter.socket_mode", slack_bolt.adapter.socket_mode),
+        (
+            "slack_bolt.adapter.socket_mode.async_handler",
+            slack_bolt.adapter.socket_mode.async_handler,
+        ),
+        ("slack_sdk", slack_sdk),
+        ("slack_sdk.web", slack_sdk.web),
+        ("slack_sdk.web.async_client", slack_sdk.web.async_client),
+    ]:
+        sys.modules.setdefault(name, mod)
+
+    sys.modules.setdefault("aiohttp", MagicMock())
+
+
+_ensure_slack_mock()
+
+import plugins.platforms.slack.adapter as _slack_mod  # noqa: E402
+
+_slack_mod.SLACK_AVAILABLE = True
+
+from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror the patterns in tests/gateway/test_slack.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def adapter():
+    config = PlatformConfig(enabled=True, token="***")
+    a = SlackAdapter(config)
+    a._app = MagicMock()
+    a._app.client = AsyncMock()
+    a._bot_user_id = "U_BOT"
+    a._running = True
+    return a
+
+
+@pytest.fixture(autouse=True)
+def _redirect_cache(tmp_path, monkeypatch):
+    """Point document cache at tmp_path so tests don't touch ~/.hermes."""
+    monkeypatch.setattr(
+        "gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "doc_cache"
+    )
+    monkeypatch.setattr(
+        "gateway.platforms.base.VIDEO_CACHE_DIR", tmp_path / "video_cache"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _markdown_blocks_enabled()
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownBlocksEnabled:
+    def test_defaults_to_true(self, adapter):
+        # No explicit config flag -> feature is on.
+        assert "markdown_blocks" not in adapter.config.extra
+        assert adapter._markdown_blocks_enabled() is True
+
+    @pytest.mark.parametrize("value", [True, "true", "True", "1", "yes", "on"])
+    def test_truthy_values_enable(self, adapter, value):
+        adapter.config.extra["markdown_blocks"] = value
+        assert adapter._markdown_blocks_enabled() is True
+
+    @pytest.mark.parametrize("value", [False, "false", "0", "no", "off", ""])
+    def test_falsy_values_disable(self, adapter, value):
+        adapter.config.extra["markdown_blocks"] = value
+        assert adapter._markdown_blocks_enabled() is False
+
+    def test_bare_new_instance_defaults_to_true(self):
+        # ``_standalone_send`` builds a SlackAdapter via __new__ with no config
+        # attribute — the enabled-check must not crash and must default on.
+        bare = SlackAdapter.__new__(SlackAdapter)
+        assert not hasattr(bare, "config")
+        assert bare._markdown_blocks_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# _build_markdown_blocks()
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMarkdownBlocks:
+    def test_wraps_markdown_in_block_structure(self, adapter):
+        blocks = adapter._build_markdown_blocks("hello world")
+        assert blocks == [{"type": "markdown", "text": "hello world"}]
+
+    def test_empty_content_returns_empty_list(self, adapter):
+        assert adapter._build_markdown_blocks("") == []
+        assert adapter._build_markdown_blocks("   \n  \t ") == []
+        assert adapter._build_markdown_blocks(None) == []
+
+    def test_chunks_long_content_at_12000_char_limit(self, adapter):
+        # Content that fits within a single 12k block stays a single block.
+        short = "a" * 11_999
+        assert len(adapter._build_markdown_blocks(short)) == 1
+
+        # Content just over the limit gets split into multiple blocks, proving
+        # the chunk boundary is _MARKDOWN_BLOCK_CHAR_LIMIT (12000) and NOT the
+        # default MAX_MESSAGE_LENGTH (39000).
+        long_content = "a" * 12_001
+        blocks = adapter._build_markdown_blocks(long_content)
+        assert len(blocks) > 1, "expected >1 block for content over the 12k limit"
+        # Every emitted block is a properly typed markdown block.
+        for block in blocks:
+            assert block["type"] == "markdown"
+            assert isinstance(block["text"], str) and block["text"]
+
+    def test_emits_at_most_50_blocks(self, adapter):
+        # Construct content large enough to produce (without the cap) far more
+        # than 50 chunks at the 12k limit. ~3,000,000 chars would naively
+        # produce ~250 chunks; the cap must clamp it to 50 blocks and append a
+        # truncation marker.
+        huge = ("line of stuff\n" * 300_000)  # ~4.2M chars -> many chunks
+        blocks = adapter._build_markdown_blocks(huge)
+        assert len(blocks) <= SlackAdapter._MARKDOWN_BLOCK_MAX_BLOCKS
+        assert len(blocks) == SlackAdapter._MARKDOWN_BLOCK_MAX_BLOCKS
+        # The final block carries a truncation marker the user can see.
+        assert "truncated" in blocks[-1]["text"]
+
+
+# ---------------------------------------------------------------------------
+# _strip_markdown_for_fallback()
+# ---------------------------------------------------------------------------
+
+
+class TestStripMarkdownForFallback:
+    def test_strips_bold_italic_strikethrough(self):
+        out = SlackAdapter._strip_markdown_for_fallback(
+            "**bold** and _italic_ and ~~strike~~"
+        )
+        assert out == "bold and italic and strike"
+
+    def test_strips_headers_and_lists_and_quotes(self):
+        out = SlackAdapter._strip_markdown_for_fallback(
+            "# Title\n- item one\n> quoted text\nplain"
+        )
+        assert "Title" in out
+        assert "item one" in out
+        assert "quoted text" in out
+        assert "plain" in out
+        # No markdown sigils survive for the constructs we strip.
+        assert "#" not in out
+        assert ">" not in out
+
+    def test_strips_links_to_label(self):
+        out = SlackAdapter._strip_markdown_for_fallback(
+            "see [the docs](https://example.com/docs) for more"
+        )
+        assert out == "see the docs for more"
+        assert "https" not in out
+
+    def test_strips_inline_code_backticks(self):
+        out = SlackAdapter._strip_markdown_for_fallback("use `fmt.Println` here")
+        assert out == "use fmt.Println here"
+        assert "`" not in out
+
+    def test_replaces_fenced_code_block_with_marker(self):
+        out = SlackAdapter._strip_markdown_for_fallback(
+            "before\n```python\nprint('hi')\n```\nafter"
+        )
+        assert "[code block]" in out
+        assert "print('hi')" not in out
+        assert "before" in out and "after" in out
+
+    def test_empty_input_returns_empty(self):
+        assert SlackAdapter._strip_markdown_for_fallback("") == ""
+        assert SlackAdapter._strip_markdown_for_fallback(None) == ""
+
+    def test_bounded_to_3000_chars(self):
+        out = SlackAdapter._strip_markdown_for_fallback("x" * 50_000)
+        assert len(out) <= 3000
+
+
+# ---------------------------------------------------------------------------
+# send() payload shape (blocks mode vs. legacy mrkdwn mode)
+# ---------------------------------------------------------------------------
+
+
+class TestSendPayloadModes:
+    @pytest.mark.asyncio
+    async def test_send_blocks_mode_calls_postmessage_with_blocks_no_mrkdwn(
+        self, adapter
+    ):
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ts": "123.000"}
+        )
+
+        result = await adapter.send("C123", "# Title\n\nbody **bold**")
+
+        assert result.success
+        assert adapter._app.client.chat_postMessage.await_count == 1
+        call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert call_kwargs["channel"] == "C123"
+        # The whole point: a single markdown block carries the raw markdown,
+        # un-escaped, so tables/code/etc. render natively.
+        assert call_kwargs["blocks"] == [
+            {"type": "markdown", "text": "# Title\n\nbody **bold**"}
+        ]
+        # ``text=`` is the stripped plain-text fallback, not the mrkdwn form.
+        assert call_kwargs["text"] == "Title\n\nbody bold"
+        # ``mrkdwn`` must NOT be passed in blocks mode.
+        assert "mrkdwn" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_send_legacy_mode_still_uses_mrkdwn(self, adapter):
+        adapter.config.extra["markdown_blocks"] = False
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ts": "123.000"}
+        )
+
+        result = await adapter.send("C123", "**bold** plain")
+
+        assert result.success
+        call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert call_kwargs["channel"] == "C123"
+        # Legacy path: format_message converts ** -> * (Slack bold).
+        assert call_kwargs["text"] == "*bold* plain"
+        assert call_kwargs["mrkdwn"] is True
+        assert "blocks" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_send_blocks_mode_no_mrkdwn_kwarg_whatsoever(self, adapter):
+        # Belt-and-suspenders: even when a thread ts is involved, blocks mode
+        # must not add ``mrkdwn``.
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ts": "123.000"}
+        )
+
+        await adapter.send(
+            "C123",
+            "hello",
+            metadata={"thread_id": "111.222"},
+        )
+
+        call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert call_kwargs.get("thread_ts") == "111.222"
+        assert "mrkdwn" not in call_kwargs
+        assert "blocks" in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: a markdown table survives unchanged as a single markdown block
+# (the motivating use case for the feature — mrkdwn cannot render tables).
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownTableRoundTrip:
+    TABLE = (
+        "| Command | Effect |\n"
+        "|---------|--------|\n"
+        "| `/q`    | quit   |\n"
+        "| `/stop` | halt   |"
+    )
+
+    @pytest.mark.asyncio
+    async def test_table_becomes_single_preserved_markdown_block(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ts": "123.000"}
+        )
+
+        await adapter.send("C123", self.TABLE)
+
+        call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        blocks = call_kwargs["blocks"]
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "markdown"
+        # The table syntax is passed through verbatim — Slack's CommonMark
+        # renderer, not format_message(), handles it.
+        assert blocks[0]["text"] == self.TABLE
+        assert "mrkdwn" not in call_kwargs
+
+    def test_table_block_built_directly_preserved(self, adapter):
+        blocks = adapter._build_markdown_blocks(self.TABLE)
+        assert len(blocks) == 1
+        assert blocks[0] == {"type": "markdown", "text": self.TABLE}

--- a/tests/gateway/test_slack_markdown_blocks.py
+++ b/tests/gateway/test_slack_markdown_blocks.py
@@ -323,3 +323,315 @@ class TestMarkdownTableRoundTrip:
         blocks = adapter._build_markdown_blocks(self.TABLE)
         assert len(blocks) == 1
         assert blocks[0] == {"type": "markdown", "text": self.TABLE}
+
+
+# ---------------------------------------------------------------------------
+# Hardening tests — address tw0316 review on PR #53893 (items 1-4 + 6).
+# Each test is a vertical tracer bullet: one behavior, real code path, fails
+# today (RED), passes once the fix lands (GREEN).
+# ---------------------------------------------------------------------------
+
+
+class TestYamlConfigDisableBridgesToExtra:
+    """Item 1: documented config opt-out must actually disable the feature.
+
+    `gateway.slack.markdown_blocks: false` in config.yaml is the documented
+    user-facing switch, but `_apply_yaml_config()` returns None and never
+    bridges the key into `PlatformConfig.extra`. Result: the flag is silently
+    dropped, `_markdown_blocks_enabled()` still defaults to True, and the
+    documented opt-out doesn't disable anything.
+    """
+
+    def test_yaml_markdown_blocks_false_disables_feature(self, tmp_path, monkeypatch):
+        import os
+        from gateway.config import load_gateway_config
+
+        # Write a real config.yaml with the documented opt-out path.
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(
+            "slack:\n"
+            "  enabled: true\n"
+            "  markdown_blocks: false\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Clear any cached env so the fresh config takes effect.
+        for k in list(os.environ):
+            if k.startswith("SLACK_"):
+                monkeypatch.delenv(k, raising=False)
+
+        cfg = load_gateway_config()
+
+        # Find the Slack platform config (keyed by Platform enum in GatewayConfig).
+        slack_cfg = None
+        platforms = getattr(cfg, "platforms", None) or {}
+        for key, value in platforms.items():
+            if str(key).endswith("slack") or getattr(key, "value", None) == "slack":
+                slack_cfg = value
+                break
+        assert slack_cfg is not None, "Slack platform config not loaded"
+
+        # The documented user intent is: markdown_blocks is OFF.
+        # Today extra == {} (dropped), so _markdown_blocks_enabled() returns True.
+        # After the bridge fix, extra will carry the falsy value and the
+        # SlackAdapter will report disabled.
+        from plugins.platforms.slack.adapter import SlackAdapter
+        adapter = SlackAdapter(slack_cfg)
+        assert adapter._markdown_blocks_enabled() is False, (
+            "slack.markdown_blocks: false in config.yaml must disable the "
+            "feature — _apply_yaml_config must bridge it into extra"
+        )
+
+
+class TestCumulativeMarkdownBlockLimit:
+    """Item 2: per-payload cumulative markdown-block text must stay <= 12,000.
+
+    Slack's Block Kit spec: "The cumulative limit for all markdown blocks in
+    a single payload is 12,000 characters." The current code chunks only by
+    block count (max 50 blocks/msg), so a 12,001-char message produces one
+    `chat_postMessage` call with two blocks totaling >12k -> Slack rejects
+    with `markdown_text_too_long`. The fix: chunk by cumulative text length
+    across the whole payload (or one block per message).
+    """
+
+    @pytest.mark.asyncio
+    async def test_send_over_12k_chars_emits_no_payload_over_limit(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ts": "123.000"}
+        )
+
+        # 12,001 chars — one char over the cumulative payload limit.
+        big = "a" * 12_001
+        await adapter.send("C123", big)
+
+        # Inspect every call: no single chat_postMessage payload may carry
+        # more than 12,000 chars of cumulative markdown-block text.
+        for call in adapter._app.client.chat_postMessage.call_args_list:
+            kwargs = call.kwargs
+            blocks = kwargs.get("blocks") or []
+            cumulative = sum(len(b.get("text", "")) for b in blocks if b.get("type") == "markdown")
+            assert cumulative <= SlackAdapter._MARKDOWN_BLOCK_CHAR_LIMIT, (
+                f"chat_postMessage payload carries {cumulative} chars of "
+                f"markdown-block text; Slack rejects payloads over "
+                f"{SlackAdapter._MARKDOWN_BLOCK_CHAR_LIMIT}. "
+                f"send() must split across multiple messages, not one."
+            )
+
+    @pytest.mark.asyncio
+    async def test_send_over_12k_chars_produces_multiple_postmessage_calls(self, adapter):
+        # Belt-and-suspenders: 12,001 chars must produce >1 API call, proving
+        # we did NOT pile multiple sub-12k blocks into one over-limit payload.
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ts": "123.000"}
+        )
+
+        await adapter.send("C123", "a" * 12_001)
+
+        assert adapter._app.client.chat_postMessage.await_count >= 2, (
+            "12,001-char content must be split across multiple "
+            "chat_postMessage calls, not one cumulative-over-limit payload"
+        )
+
+
+class TestLiveFallbackOnSlackRejection:
+    """Item 3: when Slack rejects markdown blocks, retry with legacy mrkdwn.
+
+    Today send() catches any exception from chat_postMessage and returns
+    SendResult(success=False) with no retry. Slack errors like
+    `invalid_blocks`, `markdown_text_too_long`, `msg_too_long` are
+    recoverable by retrying the legacy `text=` + `mrkdwn=true` path. The
+    fix: a helper that recognizes markdown-block rejection errors and
+    retries once with legacy formatting.
+    """
+
+    @pytest.mark.asyncio
+    async def test_send_retries_legacy_when_slack_rejects_blocks(self, adapter):
+        # First call: Slack rejects the markdown-block payload with
+        # `invalid_blocks` (a real Slack error for malformed blocks).
+        # Second call: legacy retry succeeds.
+        adapter._app.client.chat_postMessage = AsyncMock(
+            side_effect=[
+                SlackRejectedBlocks("invalid_blocks"),
+                {"ts": "123.000"},
+            ]
+        )
+
+        result = await adapter.send("C123", "# Hi\n\nbody")
+
+        assert result.success, "send must retry legacy on Slack block rejection"
+        assert adapter._app.client.chat_postMessage.await_count == 2, (
+            "expected exactly two chat_postMessage calls: the rejected "
+            "blocks call, then the legacy retry"
+        )
+        # The retry call must use the legacy mrkdwn path, not blocks.
+        retry_kwargs = adapter._app.client.chat_postMessage.call_args_list[1].kwargs
+        assert "blocks" not in retry_kwargs, (
+            "retry must fall back to plain text, not re-send blocks"
+        )
+        assert retry_kwargs.get("mrkdwn") is True, (
+            "retry must re-enable Slack mrkdwn rendering on the text-only payload"
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_does_not_retry_on_unrelated_errors(self, adapter):
+        # A non-markdown-block error (e.g. network failure, auth error)
+        # must NOT trigger the legacy fallback — only Slack's block-rejection
+        # family of errors should. Other errors surface as SendResult(success=False).
+        adapter._app.client.chat_postMessage = AsyncMock(
+            side_effect=ConnectionError("network down")
+        )
+
+        result = await adapter.send("C123", "hi")
+
+        assert not result.success
+        assert adapter._app.client.chat_postMessage.await_count == 1, (
+            "non-block errors must not trigger a legacy retry"
+        )
+
+    @pytest.mark.asyncio
+    async def test_edit_message_retries_legacy_and_clears_stale_blocks(self, adapter):
+        # edit_message has an extra concern: when falling back from blocks
+        # to plain text on chat.update, Slack can retain the old blocks
+        # unless we explicitly pass blocks=[] to clear them.
+        adapter._app.client.chat_update = AsyncMock(
+            side_effect=[
+                SlackRejectedBlocks("invalid_blocks"),
+                {"ok": True},
+            ]
+        )
+
+        await adapter.edit_message("C123", "123.000", "# Hi\n\nbody")
+
+        assert adapter._app.client.chat_update.await_count == 2
+        retry_kwargs = adapter._app.client.chat_update.call_args_list[1].kwargs
+        assert retry_kwargs.get("blocks") == [], (
+            "edit retry must pass blocks=[] to clear stale blocks when "
+            "falling back to plain text (Slack otherwise retains old blocks)"
+        )
+        assert retry_kwargs.get("mrkdwn") is True
+
+
+class TestEntityMentionSafety:
+    """Item 4: Slack entity syntax in assistant output must not ping users.
+
+    Assistant output can contain literal strings like `<@U123>`, `<!channel>`,
+    `<#C123>`. If those reach Slack as active entity syntax (in either the
+    markdown block text or the top-level `text` fallback), the bot will
+    actually ping users, channels, or special groups. Slack parses these in
+    mrkdwn-enabled `text` fields AND in markdown-block content. The fix:
+    neutralize entity patterns without breaking CommonMark link syntax like
+    `[label](https://...)`.
+    """
+
+    @pytest.mark.parametrize("entity", ["<@U123>", "<@U123|name>", "<!channel>", "<!here>", "<#C123>", "<#C123|general>"])
+    def test_neutralize_entity_in_markdown_block(self, adapter, entity):
+        blocks = adapter._build_markdown_blocks(f"hey {entity} look")
+        # Slack entity syntax is `<@...>`, `<!...>`, `<#...>`. Each must NOT
+        # appear verbatim in the emitted markdown-block text, because Slack
+        # will parse it as an active mention even inside a markdown block.
+        for b in blocks:
+            txt = b.get("text", "")
+            assert "<@" not in txt and "<!" not in txt and "<#" not in txt, (
+                f"active entity syntax {entity!r} must not reach Slack — "
+                f"neutralize before emitting markdown block"
+            )
+
+    @pytest.mark.parametrize("entity", ["<@U123>", "<!channel>", "<#C123>"])
+    def test_neutralize_entity_in_fallback_text(self, entity):
+        # `text=` is consumed by Slack for notifications and on clients that
+        # don't render blocks; mrkdwn is enabled there by default, so the same
+        # entity syntax pings. Must be neutralized too.
+        out = SlackAdapter._strip_markdown_for_fallback(f"hey {entity} look")
+        assert "<@" not in out and "<!" not in out and "<#" not in out, (
+            f"fallback text must not preserve active entity syntax {entity!r}"
+        )
+
+    def test_commonmark_links_preserved_in_markdown_block(self, adapter):
+        # Critical: entity neutralization must NOT mangle normal CommonMark
+        # link syntax — Slack's markdown block IS CommonMark, so
+        # `[label](https://example.com)` must round-trip verbatim.
+        md = "see [the docs](https://example.com/docs) for more"
+        blocks = adapter._build_markdown_blocks(md)
+        assert blocks[0]["text"] == md, (
+            "entity neutralization must not break CommonMark link syntax"
+        )
+
+
+class TestFallbackTextCapInvariant:
+    """Item 6: lock in the existing invariant — fallback text stays <= 3000 chars.
+
+    `_strip_markdown_for_fallback` already caps at 3000 chars (existing test
+    `test_bounded_to_3000_chars` only checks an extreme 50k input). This test
+    locks in the boundary case: a final response just under the 12k
+    markdown-block limit but over the fallback-text cap must preserve the
+    full markdown block while capping only the top-level `text` fallback.
+    The invariant protects `chat.update` from `msg_too_long` and keeps
+    notifications readable.
+    """
+
+    def test_content_over_3000_under_12000_caps_fallback_only(self, adapter):
+        # 6,000 chars: under the 12k markdown-block cap (full content visible
+        # in the markdown block) but over the 3,000-char fallback cap.
+        content = "word " * 1200  # 6,000 chars
+        assert 3000 < len(content) < 12000
+
+        # The markdown block carries the full content unchanged.
+        blocks = adapter._build_markdown_blocks(content)
+        block_total = sum(len(b["text"]) for b in blocks)
+        assert block_total >= len(content), (
+            "markdown block must carry full content; only the fallback text caps"
+        )
+
+        # The standalone fallback helper caps at 3000.
+        fallback = SlackAdapter._strip_markdown_for_fallback(content)
+        assert len(fallback) <= 3000, (
+            "top-level text fallback must stay <= 3000 chars to avoid msg_too_long "
+            "on chat.update and to keep notifications readable"
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_payload_invariants_hold_for_long_response(self, adapter):
+        # End-to-end: build the real `_send_payload` output for content between
+        # 3000 and 12000 chars. The blocks list carries the full content; the
+        # `text` fallback is independently capped.
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ts": "123.000"}
+        )
+
+        content = "word " * 1200  # 6,000 chars
+        await adapter.send("C123", content)
+
+        call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        blocks = call_kwargs.get("blocks") or []
+        block_total = sum(len(b["text"]) for b in blocks if b.get("type") == "markdown")
+        assert block_total >= len(content), (
+            "visible markdown-block content must not be truncated by the "
+            "fallback-cap invariant"
+        )
+        assert len(call_kwargs.get("text", "")) <= 3000, (
+            "top-level text fallback must stay <= 3000 chars independently"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test helper — a Slack SDK-shaped error for "blocks rejected."
+# Slack's Python SDK raises SlackApiError with a `response` dict containing
+# an `error` string; we model the family of block-rejection error codes the
+# adapter should recognise when deciding to retry legacy.
+# ---------------------------------------------------------------------------
+
+
+class SlackRejectedBlocks(Exception):
+    """Simulates Slack rejecting a markdown-block payload.
+
+    SlackApiError carries a `.response` dict with an `error` field set to one
+    of `invalid_blocks`, `markdown_text_too_long`, or `msg_too_long`. For the
+    test, a thin subclass is enough — the adapter's recognition helper should
+    match on the error message/name string, not the exception class itself.
+    """
+
+    def __init__(self, error_code: str):
+        super().__init__(error_code)
+        self.error_code = error_code
+        # Mirror slack_sdk's SlackApiError.response['error'] shape so the
+        # adapter can introspect it the same way SlackApiError is introspected.
+        self.response = {"ok": False, "error": error_code}

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -386,6 +386,33 @@ slack:
   reply_prefix: ""
 ```
 
+### Markdown Block Rendering
+
+```yaml
+slack:
+  # Use Slack's native `markdown` Block Kit block for message rendering
+  # instead of legacy `mrkdwn`. When enabled, standard CommonMark
+  # (including pipe tables, bold, links, code blocks, lists) renders
+  # natively in Slack clients. (default: true)
+  markdown_blocks: true
+```
+
+When `markdown_blocks: true` (the default), Hermes sends messages using
+Slack's [`markdown` block type](https://docs.slack.dev/reference/block-kit/blocks/markdown-block),
+which natively renders standard Markdown — including **tables**, bold, links,
+fenced code, and lists — without the lossy conversions of legacy `mrkdwn`.
+
+Set to `false` to revert to the legacy `mrkdwn` text path, which converts
+`**bold**` to `*bold*`, `[text](url)` to `<url|text>`, and strips tables.
+Useful for older workspaces that don't support the `markdown` block.
+
+:::note
+The `markdown` block has a 12,000-character cumulative limit per message
+and a 50-block maximum. Hermes automatically chunks messages that exceed
+these limits. Messages that can't be rendered as `markdown` blocks fall back
+to the legacy `mrkdwn` path.
+:::
+
 :::tip When to use `strict_mention`
 Set this to `true` in busy workspaces where Slack's default "the bot remembers this thread" behavior surprises users — for example, a long tech-support thread where the bot helped at the start and you'd rather it stay silent unless explicitly pinged again. DMs and active interactive sessions are unaffected.
 :::


### PR DESCRIPTION
## Summary

Slack now ships a native `markdown` Block Kit block that accepts standard CommonMark (including tables). This PR updates the Slack adapter to use it instead of the legacy `mrkdwn` format, so markdown tables render natively in Slack clients instead of appearing as raw pipe-delimited text.

Closes #8552
Closes #18918

## Changes

- **`plugins/platforms/slack/adapter.py`**: Added `_markdown_blocks_enabled()`, `_build_markdown_blocks()`, `_send_payload()`, `_strip_markdown_for_fallback()`, `_chunk_blocks()` helpers + class constants. All 4 send paths updated: `send()`, `send_private_notice()`, `edit_message()`, `_send_slash_ephemeral()`, `_standalone_send()`.
- **`tests/gateway/test_slack_markdown_blocks.py`**: New - 30 tests covering config flag, block structure, 12k chunking, 50-block cap, fallback stripping, send mode branching, table round-trip.
- **`tests/gateway/test_slack.py`**: Added `_force_legacy_mrkdwn` autouse fixtures on 3 legacy-mode test classes to preserve existing `mrkdwn` test expectations.

## Behavior

- Config flag `gateway.slack.markdown_blocks` (default: `true`) gates the new behavior. Set `false` under `slack:` in `config.yaml` to revert to legacy `mrkdwn`.
- When enabled, messages are sent as `{"type": "markdown", "text": "..."}` blocks via `chat_postMessage` with `blocks` parameter.
- Chunking handles the 12,000-char cumulative limit per message and 50-block maximum.
- When disabled or on older workspaces, falls back to existing `format_message()` -> `mrkdwn` path.
- `_standalone_send` (cron sender) has a defensive config check since it doesn't have full config context.

## Test Results

```
240 passed, 0 failed (210 in test_slack.py + 30 in test_slack_markdown_blocks.py)
```

Live-verified: markdown tables render natively in Slack with the new `markdown` block.


Example of rendered message:
<img width="1122" height="815" alt="image" src="https://github.com/user-attachments/assets/9085bfec-9df4-4fcc-bebc-4088baaea9da" />
