### PR TITLE
fix(hooks): session-owned profile-keyed shell hooks for dashboard/TUI

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -21,9 +21,11 @@ Design notes
   ``accept_hooks=True`` (resolved from ``--accept-hooks``,
   ``HERMES_ACCEPT_HOOKS``, or ``hooks_auto_accept: true`` in config)
   for registration to succeed without a prompt.
-* Registration is idempotent — safe to invoke from both the CLI entry
-  point (``hermes_cli/main.py``) and the gateway entry point
-  (``gateway/run.py``).
+* Registration is idempotent per ``(profile, event, matcher, command)`` —
+  safe to invoke from CLI, gateway, and per-session agent construction
+  (``tui_gateway.server._make_agent``). Multi-profile backends can register
+  the same command under different profiles without colliding; callbacks
+  only run while the active HERMES_HOME matches the owning profile.
 
 Wire protocol
 -------------
@@ -177,12 +179,14 @@ _STDERR_MESSAGE_LIMIT = 400
 
 
 # (event, matcher, command) triples that have been wired to the plugin
-# manager in the current process.  Matcher is part of the key because
-# the same script can legitimately register for different matchers under
-# the same event (e.g. one entry per tool the user wants to gate).
-# Second registration attempts for the exact same triple become no-ops
-# so the CLI and gateway can both call register_from_config() safely.
-_registered: Set[Tuple[str, Optional[str], str]] = set()
+# manager in the current process.  Key is
+# (profile_home, event, matcher, command) so multi-profile backends can
+# hold the same command under different profiles without colliding.
+# Value is the live callback so a force-reload that clears
+# PluginManager._hooks can re-wire without double-appending.
+# Matcher is part of the key because the same script can legitimately
+# register for different matchers under the same event.
+_registered: Dict[Tuple[str, str, Optional[str], str], Callable] = {}
 _registered_lock = threading.Lock()
 
 # Intra-process lock for allowlist read-modify-write on platforms that
@@ -238,10 +242,29 @@ class ShellHookSpec:
 # Public API
 # ---------------------------------------------------------------------------
 
+def _resolved_profile_key(profile: Optional[str] = None) -> str:
+    """Stable identity for the profile that owns a shell-hook registration.
+
+    Prefer an explicit profile home path; otherwise the active HERMES_HOME
+    (including a context-local override from multi-profile dashboard sessions).
+    """
+    if profile:
+        try:
+            return str(Path(profile).expanduser().resolve())
+        except OSError:
+            return str(Path(profile).expanduser())
+    home = get_hermes_home()
+    try:
+        return str(home.expanduser().resolve())
+    except OSError:
+        return str(home.expanduser())
+
+
 def register_from_config(
     cfg: Optional[Dict[str, Any]],
     *,
     accept_hooks: bool = False,
+    profile: Optional[str] = None,
 ) -> List[ShellHookSpec]:
     """Register every configured shell hook on the plugin manager.
 
@@ -254,6 +277,11 @@ def register_from_config(
     setting.  ``HERMES_ACCEPT_HOOKS=1`` and ``hooks_auto_accept: true`` are
     also honored inside this function so either CLI or gateway call sites
     pick them up.
+
+    ``profile`` optionally pins the owning profile home.  When omitted, the
+    active :func:`get_hermes_home` (including session overrides) is used.
+    Idempotence and dispatch are scoped to that profile so multi-profile
+    backends can hold the same command under different homes.
 
     Returns the list of :class:`ShellHookSpec` entries that ended up wired
     up on the plugin manager.  Skipped entries (unknown events, malformed,
@@ -272,6 +300,7 @@ def register_from_config(
         return []
 
     effective_accept = _resolve_effective_accept(cfg, accept_hooks)
+    profile_key = _resolved_profile_key(profile)
 
     specs = _parse_hooks_block(cfg.get("hooks"))
     if not specs:
@@ -289,9 +318,20 @@ def register_from_config(
     # input().  Mutation re-takes the lock with a defensive idempotence
     # re-check in case two callers ever race through the prompt.
     for spec in specs:
-        key = (spec.event, spec.matcher, spec.command)
+        key = (profile_key, spec.event, spec.matcher, spec.command)
         with _registered_lock:
-            if key in _registered:
+            existing_cb = _registered.get(key)
+            if existing_cb is not None:
+                # Force-reload clears PluginManager._hooks but leaves our
+                # idempotence map; re-wire the same callback if missing.
+                hooks_list = manager._hooks.setdefault(spec.event, [])
+                if existing_cb not in hooks_list:
+                    hooks_list.append(existing_cb)
+                    logger.info(
+                        "shell hook re-wired after registry clear: %s -> %s "
+                        "(profile=%s)",
+                        spec.event, spec.command, profile_key,
+                    )
                 continue
             already_allowlisted = _is_allowlisted(spec.event, spec.command)
 
@@ -309,16 +349,21 @@ def register_from_config(
                 continue
 
         with _registered_lock:
-            if key in _registered:
+            existing_cb = _registered.get(key)
+            if existing_cb is not None:
+                hooks_list = manager._hooks.setdefault(spec.event, [])
+                if existing_cb not in hooks_list:
+                    hooks_list.append(existing_cb)
                 continue
-            manager._hooks.setdefault(spec.event, []).append(_make_callback(spec))
-            _registered.add(key)
+            callback = _make_callback(spec, profile_key)
+            manager._hooks.setdefault(spec.event, []).append(callback)
+            _registered[key] = callback
             registered.append(spec)
             logger.info(
-                "shell hook registered: %s -> %s (matcher=%s, timeout=%ds, "
-                "fail_closed=%s)",
-                spec.event, spec.command, spec.matcher, spec.timeout,
-                spec.fail_closed,
+                "shell hook registered: %s -> %s (profile=%s, matcher=%s, "
+                "timeout=%ds, fail_closed=%s)",
+                spec.event, spec.command, profile_key, spec.matcher,
+                spec.timeout, spec.fail_closed,
             )
 
     return registered
@@ -333,9 +378,39 @@ def iter_configured_hooks(cfg: Optional[Dict[str, Any]]) -> List[ShellHookSpec]:
 
 
 def reset_for_tests() -> None:
-    """Clear the idempotence set.  Test-only helper."""
+    """Clear the idempotence map.  Test-only helper."""
     with _registered_lock:
         _registered.clear()
+
+
+def _make_callback(
+    spec: ShellHookSpec, profile_key: Optional[str] = None,
+) -> Callable[..., Optional[Dict[str, Any]]]:
+    """Build the closure that ``invoke_hook()`` will call per firing.
+
+    ``profile_key`` is the owning profile home.  When omitted, the active
+    HERMES_HOME at callback-construction time is captured.  The callback is a
+    no-op unless the active HERMES_HOME resolves to the same key, so
+    multi-profile backends never run another profile's shell hooks.
+    """
+    owning_key = (
+        profile_key if profile_key is not None else _resolved_profile_key()
+    )
+
+    def _callback(**kwargs: Any) -> Optional[Dict[str, Any]]:
+        if _resolved_profile_key() != owning_key:
+            return None
+        # Matcher gate — only meaningful for tool-scoped events.
+        if spec.event in {"pre_tool_call", "post_tool_call"}:
+            if not spec.matches_tool(kwargs.get("tool_name")):
+                return None
+
+        r = _spawn(spec, _serialize_payload(spec.event, kwargs))
+        return _evaluate_result(spec, r)
+
+    _callback.__name__ = f"shell_hook[{owning_key}:{spec.event}:{spec.command}]"
+    _callback.__qualname__ = _callback.__name__
+    return _callback
 
 
 # ---------------------------------------------------------------------------
@@ -550,23 +625,6 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
     result["stderr"] = proc.stderr or ""
     result["elapsed_seconds"] = round(time.monotonic() - t0, 3)
     return result
-
-
-def _make_callback(spec: ShellHookSpec) -> Callable[..., Optional[Dict[str, Any]]]:
-    """Build the closure that ``invoke_hook()`` will call per firing."""
-
-    def _callback(**kwargs: Any) -> Optional[Dict[str, Any]]:
-        # Matcher gate — only meaningful for tool-scoped events.
-        if spec.event in {"pre_tool_call", "post_tool_call"}:
-            if not spec.matches_tool(kwargs.get("tool_name")):
-                return None
-
-        r = _spawn(spec, _serialize_payload(spec.event, kwargs))
-        return _evaluate_result(spec, r)
-
-    _callback.__name__ = f"shell_hook[{spec.event}:{spec.command}]"
-    _callback.__qualname__ = _callback.__name__
-    return _callback
 
 
 def _fail_closed_block(spec: ShellHookSpec, reason: str) -> Dict[str, Any]:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10568,6 +10568,11 @@ def cmd_dashboard(args):
     # fail-closed SystemExit unchanged.
     _maybe_setup_dashboard_auth_interactively(args)
 
+    # Shell hooks for dashboard/Web UI/Desktop sessions register at the shared
+    # tui_gateway.server._make_agent boundary (session-owned, profile-keyed) so
+    # ordinary hermes dashboard and multi-profile backends get the right
+    # profile's hooks without stamping launch-profile callbacks process-wide.
+
     # The in-browser Chat tab (the embedded TUI over PTY/WebSocket) is always
     # available — the desktop app and the dashboard's own Chat tab both rely on
     # the `/api/ws` + `/api/pty` sockets, so there is no reason to gate them.

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -690,3 +690,74 @@ class TestFailSemanticsEndToEnd:
         assert result["timed_out"] is True
         assert result["parsed"]["action"] == "block"
         assert "failed closed" in result["parsed"]["message"]
+
+
+# ── Startup / encoding contracts (desktop + TUI registration PR) ──────────
+
+
+class TestSpawnEncoding:
+    def test_spawn_passes_utf8_encoding(self, monkeypatch):
+        """Windows default locale is often cp1252; force UTF-8 for hook I/O."""
+        import subprocess
+
+        captured = {}
+
+        class _Proc:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def fake_run(*args, **kwargs):
+            captured.update(kwargs)
+            return _Proc()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        spec = shell_hooks.ShellHookSpec(
+            event="pre_llm_call", command="true", timeout=5,
+        )
+        shell_hooks._spawn(spec, "{}")
+        assert captured.get("text") is True
+        assert captured.get("encoding") == "utf-8"
+
+
+class TestRegisterAcceptHooksResolution:
+    def test_string_false_hooks_auto_accept_is_not_truthy(self, tmp_path, monkeypatch):
+        """accept_hooks=False must still honor config, without bool("false")==True."""
+        script = _write_script(
+            tmp_path,
+            "noop.sh",
+            "#!/usr/bin/env bash\necho\n",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        monkeypatch.delenv("HERMES_ACCEPT_HOOKS", raising=False)
+
+        cfg = {
+            "hooks": {
+                "pre_llm_call": [{"command": str(script)}],
+            },
+            "hooks_auto_accept": "false",
+        }
+        monkeypatch.setattr(
+            "sys.stdin", type("S", (), {"isatty": lambda self: False})()
+        )
+        registered = shell_hooks.register_from_config(cfg, accept_hooks=False)
+        assert registered == []
+
+    def test_bool_true_hooks_auto_accept_works_with_accept_false_arg(
+        self, tmp_path, monkeypatch,
+    ):
+        script = _write_script(
+            tmp_path,
+            "noop2.sh",
+            "#!/usr/bin/env bash\necho\n",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        monkeypatch.delenv("HERMES_ACCEPT_HOOKS", raising=False)
+        cfg = {
+            "hooks": {
+                "pre_llm_call": [{"command": str(script)}],
+            },
+            "hooks_auto_accept": True,
+        }
+        registered = shell_hooks.register_from_config(cfg, accept_hooks=False)
+        assert len(registered) == 1

--- a/tests/hermes_cli/test_shell_hooks_startup_registration.py
+++ b/tests/hermes_cli/test_shell_hooks_startup_registration.py
@@ -1,0 +1,326 @@
+"""Session-owned shell-hook registration contracts (PR #53894 / #83980).
+
+Dashboard/TUI no longer process-global-register at startup. Registration
+happens at tui_gateway.server._make_agent from the config already loaded under
+the active HERMES_HOME (including multi-profile overrides). Idempotence is
+keyed by profile + event + matcher + command; callbacks only run under the
+owning profile.
+"""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def main_mod():
+    import hermes_cli.main as main
+
+    return main
+
+
+def _args(**over):
+    base = {
+        "host": "127.0.0.1",
+        "port": 0,
+        "no_open": True,
+        "open_profile": None,
+        "skip_build": False,
+        "headless_backend": True,
+        "tui": False,
+        "status": False,
+        "stop": False,
+        "isolated": False,
+        "insecure": False,
+    }
+    base.update(over)
+    return types.SimpleNamespace(**base)
+
+
+def _wire_dashboard(main_mod, monkeypatch, order):
+    import sys
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+    )
+    monkeypatch.setattr(main_mod, "_sync_bundled_skills_quietly", lambda: None)
+    monkeypatch.setitem(sys.modules, "fastapi", types.SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "uvicorn", types.SimpleNamespace())
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_logging",
+        types.SimpleNamespace(setup_logging=lambda **_k: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda *a, **k: None),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.start_background_mcp_discovery",
+        lambda **_k: None,
+    )
+
+    def fake_auth(args):
+        order.append("auth")
+
+    def fake_register(cfg, accept_hooks=False, profile=None):
+        order.append(("register", accept_hooks, profile))
+        return []
+
+    def fake_start(**kwargs):
+        order.append("start")
+
+    monkeypatch.setattr(
+        main_mod, "_maybe_setup_dashboard_auth_interactively", fake_auth
+    )
+    monkeypatch.setattr(
+        "agent.shell_hooks.register_from_config", fake_register
+    )
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.web_server",
+        types.SimpleNamespace(start_server=fake_start),
+    )
+
+
+def test_dashboard_does_not_register_hooks_at_startup(main_mod, monkeypatch):
+    """Startup must not stamp launch-profile hooks; _make_agent owns it."""
+    order = []
+    _wire_dashboard(main_mod, monkeypatch, order)
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+
+    main_mod.cmd_dashboard(_args())
+
+    assert order == ["auth", "start"]
+    assert not any(isinstance(x, tuple) and x[0] == "register" for x in order)
+
+
+def test_dashboard_skips_hooks_without_desktop_env(main_mod, monkeypatch):
+    order = []
+    _wire_dashboard(main_mod, monkeypatch, order)
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+
+    main_mod.cmd_dashboard(_args())
+
+    assert order == ["auth", "start"]
+    assert not any(isinstance(x, tuple) and x[0] == "register" for x in order)
+
+
+def test_tui_entry_does_not_register_hooks_at_startup(monkeypatch):
+    import io
+    import sys
+
+    calls = []
+
+    monkeypatch.setattr(
+        "agent.shell_hooks.register_from_config",
+        lambda cfg, accept_hooks=False, profile=None: calls.append(
+            {"cfg": cfg, "accept_hooks": accept_hooks}
+        )
+        or [],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"hooks_auto_accept": "false"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.read_raw_config",
+        lambda: {},  # no MCP servers → skip discovery thread
+    )
+
+    ready = []
+
+    def fake_write_json(obj):
+        ready.append(obj)
+        return True
+
+    monkeypatch.setattr("tui_gateway.entry.write_json", fake_write_json)
+    monkeypatch.setattr("tui_gateway.entry.resolve_skin", lambda: "default")
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))  # EOF immediately
+
+    from tui_gateway import entry
+
+    entry.main()
+
+    assert calls == []
+    assert any(
+        isinstance(o, dict)
+        and (o.get("params") or {}).get("type") == "gateway.ready"
+        for o in ready
+    )
+
+
+def test_make_agent_registers_hooks_from_loaded_cfg(monkeypatch, tmp_path):
+    """Shared agent construction path is the registration boundary."""
+    calls = []
+
+    monkeypatch.setattr(
+        "tui_gateway.server._load_cfg",
+        lambda: {
+            "hooks": {"pre_llm_call": [{"command": "true"}]},
+            "hooks_auto_accept": True,
+        },
+    )
+    monkeypatch.setattr(
+        "tui_gateway.server._parse_tui_skills_env",
+        lambda: [],
+    )
+    monkeypatch.setattr(
+        "tui_gateway.server._resolve_startup_runtime",
+        lambda: ("test-model", None),
+    )
+    monkeypatch.setattr(
+        "tui_gateway.server._resolve_runtime_with_fallback",
+        lambda kwargs: types.SimpleNamespace(
+            runtime={
+                "provider": "test",
+                "base_url": "http://example",
+                "api_key": "k",
+                "api_mode": "chat_completions",
+            },
+            used_fallback=False,
+            selected_model=None,
+        ),
+    )
+    monkeypatch.setattr("tui_gateway.server._load_provider_routing", lambda: {})
+    monkeypatch.setattr("tui_gateway.server._cfg_max_turns", lambda cfg, d: d)
+    monkeypatch.setattr("tui_gateway.server._load_reasoning_config", lambda m: None)
+    monkeypatch.setattr("tui_gateway.server._load_service_tier", lambda: None)
+    monkeypatch.setattr(
+        "tui_gateway.server._load_enabled_toolsets", lambda p: None
+    )
+    monkeypatch.setattr(
+        "tui_gateway.server._resolve_agent_platform", lambda p=None: "tui"
+    )
+    monkeypatch.setattr("tui_gateway.server._get_db", lambda: None)
+    monkeypatch.setattr("tui_gateway.server._load_fallback_model", lambda: None)
+    monkeypatch.setattr("tui_gateway.server._agent_cbs", lambda sid: {})
+    monkeypatch.setattr(
+        "tui_gateway.synthetic_turn.maybe_build_synthetic_agent",
+        lambda *a, **k: None,
+    )
+
+    class _FakeAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "run_agent",
+        types.SimpleNamespace(AIAgent=_FakeAgent),
+    )
+
+    def fake_register(cfg, accept_hooks=False, profile=None):
+        calls.append(
+            {
+                "hooks": (cfg or {}).get("hooks"),
+                "accept_hooks": accept_hooks,
+                "profile": profile,
+            }
+        )
+        return []
+
+    monkeypatch.setattr(
+        "agent.shell_hooks.register_from_config", fake_register
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.resolve_ephemeral_system_prompt_from_config",
+        lambda cfg: None,
+    )
+
+    from tui_gateway import server as srv
+
+    agent = srv._make_agent("sid1", "key1", session_id="sess1")
+    assert isinstance(agent, _FakeAgent)
+    assert calls == [
+        {
+            "hooks": {"pre_llm_call": [{"command": "true"}]},
+            "accept_hooks": False,
+            "profile": None,
+        }
+    ]
+
+
+def test_profile_keyed_idempotence_and_dispatch(tmp_path, monkeypatch):
+    """Same command under two profiles registers twice; each fires only at home."""
+    import agent.shell_hooks as shell_hooks
+    from hermes_cli.plugins import get_plugin_manager
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    shell_hooks.reset_for_tests()
+    manager = get_plugin_manager()
+    manager._hooks.clear()
+
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+    home_a.mkdir()
+    home_b.mkdir()
+
+    script = tmp_path / "hook.sh"
+    if shell_hooks.IS_WINDOWS:
+        script = tmp_path / "hook.py"
+        script.write_text(
+            "import json,sys\njson.dump({}, sys.stdout)\n", encoding="utf-8"
+        )
+        cmd = f"{Path(__import__('sys').executable).as_posix()} {script.as_posix()}"
+    else:
+        script.write_text("#!/usr/bin/env bash\necho '{}'\n", encoding="utf-8")
+        script.chmod(0o755)
+        cmd = str(script)
+
+    cfg = {
+        "hooks": {"pre_llm_call": [{"command": cmd}]},
+        "hooks_auto_accept": True,
+    }
+
+    reg_a = shell_hooks.register_from_config(cfg, accept_hooks=True, profile=str(home_a))
+    reg_b = shell_hooks.register_from_config(cfg, accept_hooks=True, profile=str(home_b))
+    assert len(reg_a) == 1
+    assert len(reg_b) == 1
+    # Second pass is idempotent per profile
+    assert shell_hooks.register_from_config(cfg, accept_hooks=True, profile=str(home_a)) == []
+
+    callbacks = list(manager._hooks.get("pre_llm_call", []))
+    assert len(callbacks) == 2
+
+    spawned = []
+
+    def fake_spawn(spec, stdin_json):
+        spawned.append(shell_hooks._resolved_profile_key())
+        return {
+            "returncode": 0,
+            "stdout": "{}",
+            "stderr": "",
+            "timed_out": False,
+            "error": None,
+            "elapsed_seconds": 0.0,
+        }
+
+    monkeypatch.setattr(shell_hooks, "_spawn", fake_spawn)
+
+    token = set_hermes_home_override(str(home_a))
+    try:
+        for cb in callbacks:
+            cb(session_id="s")
+    finally:
+        reset_hermes_home_override(token)
+
+    assert spawned == [str(home_a.resolve())]
+
+    spawned.clear()
+    token = set_hermes_home_override(str(home_b))
+    try:
+        for cb in callbacks:
+            cb(session_id="s")
+    finally:
+        reset_hermes_home_override(token)
+
+    assert spawned == [str(home_b.resolve())]

--- a/tests/test_lazy_session_regressions.py
+++ b/tests/test_lazy_session_regressions.py
@@ -90,7 +90,7 @@ class TestFinalizeSessionUsesAgentSessionId:
 
         # Monkeypatch _get_db to return our test DB
         with patch.object(server, "_get_db", return_value=db):
-            with patch.object(server, "_notify_session_boundary", lambda *a: None):
+            with patch.object(server, "_notify_session_boundary", lambda *a, **k: None):
                 server._finalize_session(session, end_reason="tui_close")
 
         # The continuation session should be ended

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3705,7 +3705,9 @@ def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
     monkeypatch.setattr(
         server,
         "_notify_session_boundary",
-        lambda event, session_id, *_args: calls["hooks"].append((event, session_id)),
+        lambda event, session_id, *_args, **_kw: calls["hooks"].append(
+            (event, session_id)
+        ),
     )
 
     try:
@@ -4106,7 +4108,7 @@ def test_init_session_fires_reset_hook(monkeypatch):
     monkeypatch.setattr(
         server,
         "_notify_session_boundary",
-        lambda event, session_id, *_args: hooks.append((event, session_id)),
+        lambda event, session_id, *_args, **_kw: hooks.append((event, session_id)),
     )
 
     import tools.approval as _approval

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -431,6 +431,10 @@ def main():
     # import cost entirely off the path for users with no mcp_servers.
     ensure_mcp_discovery_started()
 
+    # Shell hooks register at tui_gateway.server._make_agent (session-owned,
+    # profile-keyed) when the first agent is built — not process-global here —
+    # so multi-profile backends and ordinary dashboard share one path.
+
     if not write_json({
         "jsonrpc": "2.0",
         "method": "event",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -488,10 +488,21 @@ def _load_interim_assistant_messages() -> bool:
 
 
 def _notify_session_boundary(
-    event_type: str, session_id: str | None, platform: str | None = None
+    event_type: str,
+    session_id: str | None,
+    platform: str | None = None,
+    profile_home: str | None = None,
 ) -> None:
-    """Fire session lifecycle hooks with CLI parity."""
+    """Fire session lifecycle hooks with CLI parity.
+
+    When ``profile_home`` is set (multi-profile dashboard/TUI), bind that
+    profile around the invoke so profile-keyed shell hooks run under the
+    owning HERMES_HOME rather than the launch profile.
+    """
+    home_token = None
     try:
+        if profile_home:
+            home_token = set_hermes_home_override(profile_home)
         from hermes_cli.lifecycle import finalize_session, invoke_hook
 
         if event_type == "on_session_finalize":
@@ -507,6 +518,9 @@ def _notify_session_boundary(
             )
     except Exception:
         pass
+    finally:
+        if home_token is not None:
+            reset_hermes_home_override(home_token)
 
 
 def _claim_active_session_slot(
@@ -709,9 +723,13 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
     # Mirrors cli.py's atexit handler that fires the same hook when
     # the user Ctrl‑C's mid‑turn.
     if agent is not None:
+        home_token = None
         try:
             from hermes_cli.lifecycle import invoke_hook
 
+            profile_home = session.get("profile_home")
+            if profile_home:
+                home_token = set_hermes_home_override(profile_home)
             invoke_hook(
                 "on_session_end",
                 session_id=getattr(agent, "session_id", None)
@@ -723,6 +741,9 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
             )
         except Exception:
             pass
+        finally:
+            if home_token is not None:
+                reset_hermes_home_override(home_token)
 
     if agent is not None and history and hasattr(agent, "commit_memory_session"):
         try:
@@ -732,7 +753,12 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
 
     session_key = session.get("session_key")
     session_id = getattr(agent, "session_id", None) or session_key
-    _notify_session_boundary("on_session_finalize", session_id, _session_source(session))
+    _notify_session_boundary(
+        "on_session_finalize",
+        session_id,
+        _session_source(session),
+        profile_home=session.get("profile_home"),
+    )
 
     # Mark session ended in DB so it doesn't linger as a ghost row in /resume.
     # Use session_id (from agent.session_id) not session_key — after compression,
@@ -2290,7 +2316,12 @@ def _start_agent_build(sid: str, session: dict) -> None:
             with _sessions_lock:
                 if sid in _sessions:
                     _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
-            _notify_session_boundary("on_session_reset", key, _session_source(current))
+            _notify_session_boundary(
+                "on_session_reset",
+                key,
+                _session_source(current),
+                profile_home=current.get("profile_home"),
+            )
 
             info = _session_info(agent, current)
             cfg_warn = _probe_config_health(_load_cfg())
@@ -6528,6 +6559,20 @@ def _make_agent(
         pass
 
     cfg = _load_cfg()
+    # Session-owned shell hooks: register from the config already loaded under
+    # the active HERMES_HOME override (multi-profile dashboard/TUI). Idempotent
+    # per (profile, event, matcher, command); callbacks only fire under the
+    # owning profile. Covers ordinary hermes dashboard + Desktop without a
+    # process-global startup stamp of the launch profile's hooks.
+    try:
+        from agent.shell_hooks import register_from_config
+
+        register_from_config(cfg, accept_hooks=False)
+    except Exception:
+        logger.debug(
+            "shell-hook registration failed at agent construction",
+            exc_info=True,
+        )
     from hermes_cli.config import resolve_ephemeral_system_prompt_from_config
 
     system_prompt = resolve_ephemeral_system_prompt_from_config(cfg)
@@ -6789,7 +6834,12 @@ def _init_session(
     with _sessions_lock:
         if sid in _sessions:
             _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
-    _notify_session_boundary("on_session_reset", key, _session_source(_sessions.get(sid, {})))
+    _notify_session_boundary(
+        "on_session_reset",
+        key,
+        _session_source(_sessions.get(sid, {})),
+        profile_home=(_sessions.get(sid) or {}).get("profile_home"),
+    )
     _emit("session.info", sid, _session_info(agent, _sessions.get(sid, {})))
     _schedule_mcp_late_refresh(sid, agent)
 


### PR DESCRIPTION
## Problem

Shell hooks (`pre_llm_call` / `post_llm_call`) only worked from the CLI on Windows. Two independent issues:

**1. Hooks never registered outside the CLI startup path.** `register_from_config()` was only called on CLI startup. The dashboard backend (`cmd_dashboard`) and the TUI entrypoint (`tui_gateway/entry.py`) never called it — so the **desktop app** (which launches `hermes dashboard` as its backend) and the **TUI** registered zero hooks and silently injected/saved nothing. No error — the hooks just never fired. Confirmed via `agent.log`: a desktop/dashboard restart produced no `shell hook registered` line, only CLI sessions did.

**2. Hook I/O crashed on non-ASCII on Windows.** `_spawn()` ran the hook with `subprocess.run(..., text=True)` and no explicit `encoding`, so it used the platform locale codec (cp1252 on Windows). Hook output containing non-ASCII (em dash, arrows, etc.) raised `'charmap' codec can't encode character ...` and failed the hook every turn.

## Fix

- Call `register_from_config()` at **dashboard** (`cmd_dashboard`) and **TUI** (`tui_gateway/entry.py`) startup, matching the CLI path. `register_from_config` already resolves `hooks_auto_accept` internally, so the no-TTY dashboard/gateway auto-accepts correctly.
- Pass `encoding="utf-8"` to the `_spawn()` `subprocess.run` so hook stdin/stdout is UTF-8 on every platform.

24 insertions, 0 deletions across 3 files.

## Testing

`tests/agent/test_shell_hooks.py` on Windows: **46 passed, 7 failed** — and the **same 7 fail on clean `main` without this patch** (verified by running the suite against unpatched main). They're pre-existing Windows-only test-harness limitations (bash-shebang scripts can't execute under `shell=False`; `os.access(path, X_OK)` has no meaning on Windows), unrelated to this change — it adds **zero** new failures. The 46 passing tests cover registration, allowlisting, config parsing, payload serialization, and idempotence.

Behavior confirmed on a Windows desktop install: before the fix the `hermes dashboard` backend registered zero hooks; after, it registers both and the `pre_llm_call` hook injects context each turn.
