### PR TITLE
fix(image-routing): unblock message queue on OpenRouter 'no endpoints' image 404 (#21160)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2259,6 +2259,15 @@ def run_conversation(
                     # "unknown variant `image_url`, expected `text`".
                     "unknown variant `image_url`, expected `text`",
                     "unknown variant image_url, expected text",
+                    # OpenRouter routes a request to upstream endpoints and,
+                    # when none of the candidate endpoints for the model accept
+                    # image input, returns HTTP 404 "No endpoints found that
+                    # support image input". Without this phrase the agent never
+                    # strips the images, the retry loop re-sends the same
+                    # rejected request until exhaustion, and the gateway leaves
+                    # every subsequent message queued behind the stuck turn —
+                    # the P1 in issue #21160. The 404 passes the 4xx gate below.
+                    "no endpoints found that support image input",
                 )
                 _err_lower = _err_body.lower()
                 _looks_like_image_rejection = any(

--- a/tests/run_agent/test_image_rejection_fallback.py
+++ b/tests/run_agent/test_image_rejection_fallback.py
@@ -195,6 +195,7 @@ class TestImageRejectionPhraseIsolation:
         "does not support vision",
         "model does not support image",
         "image_url'. expected",
+        "no endpoints found that support image input",
     )
 
     def _matches(self, body: str) -> bool:
@@ -244,9 +245,27 @@ class TestImageRejectionPhraseIsolation:
             # match the agent cascaded into compression / context-too-large
             # recovery instead of just stripping the images.
             "Invalid 'input[56].content[1].image_url'. Expected a valid URL, but got a value with an invalid format.",
+            # OpenRouter 404 when no upstream endpoint for the model accepts
+            # image input — issue #21160. The exact wording from the report.
+            "HTTP 404: No endpoints found that support image input",
         ]
         for body in bodies:
             assert self._matches(body) is True, f"false negative on: {body}"
+
+    def test_openrouter_data_policy_no_endpoints_does_not_trip(self):
+        """OpenRouter has several 'no endpoints ...' 404 bodies. Only the
+        image-input one is an image rejection — the guardrail / data-policy
+        variants (agent/error_classifier.py) are about routing restrictions,
+        not vision, and must route to their own handler, not get their images
+        stripped.
+        """
+        bodies = [
+            "No endpoints available matching your guardrail restrictions",
+            "No endpoints available matching your data policy",
+            "No endpoints found matching your data policy",
+        ]
+        for body in bodies:
+            assert self._matches(body) is False, f"false positive on: {body}"
 
     def test_codex_data_url_rejection_does_not_false_match_other_url_errors(self):
         """The narrow 'image_url'. expected' phrase (keyed on the


### PR DESCRIPTION
## Summary

Sending an image to a non-vision model routed through OpenRouter no longer locks the gateway's message queue.

The agent already strips images and retries text-only when a provider rejects image content — that retry is what lets the gateway drain queued messages. But the fallback only fires on a hardcoded phrase list, and the OpenRouter wording (`HTTP 404: No endpoints found that support image input`) was missing. For OpenRouter-routed non-vision models the fallback never fired, the retry loop re-sent the same rejected request until exhaustion, and every subsequent message — including plain text — stayed queued behind the stuck turn. That's the P1 in #21160.

## Changes

- `agent/conversation_loop.py`: add `"no endpoints found that support image input"` to `_IMAGE_REJECTION_PHRASES`. The 404 already passes the existing `400 ≤ status < 500` gate, so the phrase is all that was needed — the strip-images / retry-text-only path then fires and the queue drains.
- `tests/run_agent/test_image_rejection_fallback.py`: positive case for the OpenRouter 404 wording, plus a guard test asserting the sibling OpenRouter `no endpoints … data policy / guardrail` 404s do **not** trip image-stripping (those are routing restrictions, not vision rejections, and route to their own handler).

## Validation

| | Before | After |
|---|---|---|
| OpenRouter image-input 404 | retries exhaust, queue locks | images stripped, retried text-only, queue drains |
| Guardrail / data-policy 404s | n/a | unchanged (not treated as image rejection) |
| Targeted tests | — | 16/16 pass |

## Credit

Reported by @liu14goal14-ux (#21160). PR #21198 by @ygd58 proposed a config-override layer for the same issue; that override already exists on `main` in a richer form (`model.supports_vision` / `providers.<p>.models.<m>.supports_vision`), and it does not address the actual P1 (the missing 404 phrase), so #21198 is closed as superseded.

## Infographic

![image-queue-unlocked](https://v3b.fal.media/files/b/0aa00c99/iYvxajQPxR1BgP1ytbcte_kQyGQ6IC.png)
