### PR TITLE
docs(gateway): warn against custom ExecStopPost kill drop-in (restart loop)

### DIFF
--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -435,6 +435,10 @@ journalctl -u hermes-gateway -f
 
 Use the user service on laptops and dev boxes. Use the system service on VPS or headless hosts that should come back at boot without relying on systemd linger.
 
+:::danger Don't add a custom `ExecStopPost` kill drop-in
+The unit Hermes installs already shuts the gateway down cleanly with `KillMode=mixed` + `KillSignal=SIGTERM`, and uses `Restart=always` with `RestartForceExitStatus` so updates and `/restart` respawn correctly. Do **not** add a systemd drop-in such as `ExecStopPost=/bin/kill -9 $MAINPID` — `ExecStopPost` fires on *every* stop, including clean restarts, so it `SIGKILL`s the freshly spawned instance before it stabilizes and `Restart=always` immediately respawns it. The result is an infinite restart loop (and, on Telegram, a flood of restart messages). If you've added such a drop-in, remove it: `systemctl --user edit hermes-gateway` (or `sudo systemctl edit hermes-gateway` for a system service) and delete the `ExecStopPost` line, then `systemctl --user daemon-reload`.
+:::
+
 :::tip Headless VMs: user service + linger avoids root prompts
 A system service needs root for every restart — including the automatic gateway restart at the end of `hermes update`. When `hermes update` runs as a non-root user, it tries passwordless `sudo systemctl`; if that's unavailable, it skips the restart and prints the manual `sudo systemctl restart hermes-gateway` command (it never blocks on an interactive password prompt).
 


### PR DESCRIPTION
## Summary
Documents that a user-added `ExecStopPost=/bin/kill -9 $MAINPID` systemd drop-in is what causes the gateway restart loop reported in #23272 — and tells users how to remove it.

The issue's two claimed root causes don't hold against current `main`: `--replace` is already a `store_true` flag (default `False`, truly opt-in) on the `gateway run` subparser, the generated systemd unit invokes `gateway run` with **no** `--replace`, and we ship no `ExecStopPost`. The loop only occurs when the operator adds their own `kill -9` drop-in that fires on every stop (including clean restarts) and races `Restart=always`. This PR adds a danger callout so the misconfiguration is documented.

## Changes
- `website/docs/user-guide/messaging/index.md`: add a `:::danger` callout under Service Management → Linux (systemd) explaining why a custom `ExecStopPost` kill drop-in creates an infinite restart loop, noting the unit already shuts down cleanly (`KillMode=mixed` + `KillSignal=SIGTERM`, `Restart=always` + `RestartForceExitStatus`), and giving the removal steps (`systemctl --user edit hermes-gateway` → delete the line → `daemon-reload`).

## Validation
| | Before | After |
|---|---|---|
| Restart-loop trigger documented | no | yes (danger callout) |
| MDX | — | admonitions balanced, no JSX-hostile constructs |

Closes #23272.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa00ca9/oagGAacfhKZK42Fava8AK_GqKBntRz.png)
