### PR TITLE
fix(auxiliary): fall back to OPENROUTER_API_KEY when credential pool exhausted

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1669,13 +1669,14 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
     pool_present, entry = _select_pool_entry("openrouter")
     if pool_present:
         or_key = explicit_api_key or _pool_runtime_api_key(entry)
-        if not or_key:
-            _mark_provider_unhealthy("openrouter", ttl=60)
-            return None, None
-        base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
-        logger.debug("Auxiliary client: OpenRouter via pool")
-        return OpenAI(api_key=or_key, base_url=base_url,
-                       default_headers=build_or_headers()), model or _OPENROUTER_MODEL
+        if or_key:
+            base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
+            logger.debug("Auxiliary client: OpenRouter via pool")
+            return OpenAI(api_key=or_key, base_url=base_url,
+                           default_headers=build_or_headers()), model or _OPENROUTER_MODEL
+        # Pool exists but is exhausted (no usable runtime key) — fall through to
+        # the OPENROUTER_API_KEY env-var path rather than failing outright.
+        logger.debug("Auxiliary client: OpenRouter pool exhausted, trying OPENROUTER_API_KEY")
 
     or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
     if not or_key:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -27,6 +27,9 @@ from agent.auxiliary_client import (
     _refresh_nous_recommended_model,
     _normalize_aux_provider,
     _try_payment_fallback,
+    _try_openrouter,
+    _OPENROUTER_MODEL,
+    OPENROUTER_BASE_URL,
     _resolve_auto,
     _resolve_xai_oauth_for_aux,
     _CodexCompletionsAdapter,
@@ -918,6 +921,35 @@ class TestExplicitProviderRouting:
             "OPENROUTER_API_KEY not set" in record.message
             for record in caplog.records
         )
+
+    def test_try_openrouter_pool_exhausted_falls_back_to_env(self, monkeypatch):
+        """Pool present but exhausted → fall through to OPENROUTER_API_KEY env var."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-env-fallback")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_client = MagicMock(name="openrouter_client")
+            mock_openai.return_value = mock_client
+
+            client, model = _try_openrouter()
+
+        assert client is mock_client
+        assert model == _OPENROUTER_MODEL
+        mock_openai.assert_called_once()
+        assert mock_openai.call_args.kwargs["api_key"] == "sk-or-env-fallback"
+        assert mock_openai.call_args.kwargs["base_url"] == OPENROUTER_BASE_URL
+
+    def test_try_openrouter_pool_exhausted_no_env_marks_unhealthy(self, monkeypatch):
+        """Pool exhausted AND no env var → final failure marks provider unhealthy."""
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)), \
+             patch("agent.auxiliary_client._mark_provider_unhealthy") as mock_mark, \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = _try_openrouter()
+
+        assert client is None
+        assert model is None
+        mock_openai.assert_not_called()
+        mock_mark.assert_called_once_with("openrouter", ttl=60)
 
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""


### PR DESCRIPTION
## Summary
OpenRouter auxiliary tasks now fall back to `OPENROUTER_API_KEY` when the credential pool is exhausted, instead of failing outright.

Root cause: `_try_openrouter()` (`agent/auxiliary_client.py`) entered the `if pool_present:` branch and, when the pool existed but was exhausted (`_select_pool_entry` returns `(True, None)`), hit `return None, None` — making the env-var fallback path below it unreachable whenever any OpenRouter pool existed. Auxiliary tasks (compression, vision, web_extract) silently broke even with a valid `OPENROUTER_API_KEY` set.

The merged #52661 fallback-chain work does not cover this case — it explicitly excludes openrouter (`_explicit not in {"auto","openrouter","custom"}`), so the gap was still live on `main`.

## Changes
- `agent/auxiliary_client.py`: pool-present branch only returns early when it successfully builds a client; an exhausted pool now falls through to the `OPENROUTER_API_KEY` env-var path. `_mark_provider_unhealthy` still fires only on the final failure (pool exhausted AND env var absent).
- `tests/agent/test_auxiliary_client.py`: added two tests — exhausted-pool-falls-back-to-env, and exhausted-pool-no-env-still-marks-unhealthy.

## Validation
| Scenario (pool exhausted) | Before | After |
|---|---|---|
| `OPENROUTER_API_KEY` set | `(None, None)` — aux broken | builds OpenRouter client from env key |
| no env key | `(None, None)`, marks unhealthy | `(None, None)`, marks unhealthy (unchanged) |

- 14/14 openrouter tests in `tests/agent/test_auxiliary_client.py` pass.
- E2E against the real `resolve_provider_client("openrouter")` chain (temp HERMES_HOME, real imports, exhausted pool, env key set): client is built with `api_key=sk-or-e2e-realfallback`.

## Credit
Salvage of #23495 by @LeonSGP43 (earliest of the duplicate cluster, with a test), reworked onto current `main` to preserve the `_mark_provider_unhealthy` breaker marking and the `model=` param. Same fix also submitted independently by @ambition0802 (#24720) and @chronikion (#34190). Closes #23452.

## Infographic

![openrouter-fallback-fixed](https://v3b.fal.media/files/b/0aa00cb5/rrcxhpn3eIaWkUzHYF33X_sFxw8iRx.png)
