### PR TITLE
fix(pool): re-select from credential pool on primary runtime restore

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1078,6 +1078,34 @@ def restore_primary_runtime(agent) -> bool:
             api_mode=rt.get("compressor_api_mode", ""),
         )
 
+        # ── Re-select from the credential pool if one is available ──
+        # The snapshot's api_key was captured at construction time.  Across
+        # turns the pool may have rotated (token revocation, billing/rate-limit
+        # exhaustion, cooldown), leaving the snapshot key stale.  Restoring it
+        # blindly re-fails on the first request and burns through the remaining
+        # pool entries before cross-provider fallback even gets a chance.  Ask
+        # the pool for its current best entry and swap the live credential in.
+        # When the pool is absent, empty, or the entry has no usable key, we
+        # keep the snapshot key (the existing behavior).  Fixes #25205.
+        pool = getattr(agent, "_credential_pool", None)
+        if pool is not None and pool.has_available():
+            entry = pool.select()
+            if entry is not None:
+                entry_key = (
+                    getattr(entry, "runtime_api_key", None)
+                    or getattr(entry, "access_token", "")
+                )
+                if entry_key:
+                    # ``_swap_credential`` rebuilds the OpenAI/Anthropic client,
+                    # reapplies base-url-scoped headers, and carries the
+                    # accumulated base_url / OAuth-detection fixes (#33163).
+                    agent._swap_credential(entry)
+                    logger.info(
+                        "Restore re-selected pool entry %s (%s)",
+                        getattr(entry, "id", "?"),
+                        getattr(entry, "label", "?"),
+                    )
+
         # ── Reset fallback chain for the new turn ──
         agent._fallback_activated = False
         agent._fallback_index = 0

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -48,6 +48,7 @@ AUTHOR_MAP = {
     "der@konsi.org": "konsisumer",  # PR #19608 salvage (read-modify-write merge in write_credential_pool to preserve concurrently-added credentials; #19566)
     "linyubin@users.noreply.github.com": "linyubin",  # PR #50228 salvage (eager fallback on persistent transport timeout/overloaded; #22277)
     "5261694+djstunami@users.noreply.github.com": "djstunami",  # PR #5316 salvage / co-author (suppress transient check_fn flakes so subagents keep file/terminal tools; #21658 / #5304)
+    "jmmaloney4@gmail.com": "jmmaloney4",  # PR #25206 salvage (re-select credential pool on primary runtime restore; #25205)
     "dale@dalenguyen.me": "dalenguyen",  # PR #53678 salvage (strip VIRTUAL_ENV/CONDA_PREFIX from terminal subprocess env; #23473)
     "blaryx@gmail.com": "Blaryxoff",  # PR #32602 salvage (deep-merge PUT /api/config to preserve unrelated sections; #13396)
     "diamondeyesfox@gmail.com": "DiamondEyesFox",  # PR #53351 salvage (rebaseline in-place compression flushes to prevent duplicate compacted rows; #9096)

--- a/tests/agent/test_restore_primary_pool_reselect.py
+++ b/tests/agent/test_restore_primary_pool_reselect.py
@@ -1,0 +1,222 @@
+# Copyright 2025 Nous Research (Licensed under the Apache License, Version 2.0)
+"""Test that _restore_primary_runtime re-selects from the credential pool
+instead of using a stale snapshot key.
+
+Bug: when a credential pool entry is revoked/marked-exhausted during a turn,
+_restore_primary_runtime restores the original (now-stale) api_key from the
+construction-time snapshot. The next turn immediately hits the same error,
+exhausting remaining entries and falling through to cross-provider fallback.
+"""
+
+import json
+import logging
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.credential_pool import (
+    AUTH_TYPE_OAUTH,
+    PooledCredential,
+)
+
+
+def _make_entry(
+    label: str,
+    access_token: str,
+    *,
+    source: str = "device_code",
+    priority: int = 0,
+    last_status: str | None = None,
+    last_status_at: float | None = None,
+) -> dict:
+    return {
+        "id": label,
+        "label": label,
+        "provider": "openai-codex",
+        "auth_type": AUTH_TYPE_OAUTH,
+        "source": source,
+        "priority": priority,
+        "access_token": access_token,
+        "refresh_token": f"rt-{label}",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "last_status": last_status,
+        "last_status_at": last_status_at,
+    }
+
+
+def _build_mock_pool(entries: list[dict], *, strategy: str = "round_robin"):
+    """Build a mock CredentialPool with the given entries."""
+    from agent.credential_pool import CredentialPool
+
+    pool = CredentialPool(
+        provider="openai-codex",
+        entries=[PooledCredential.from_dict("openai-codex", e) for e in entries],
+    )
+    pool._strategy = strategy
+    return pool
+
+
+class TestRestorePrimaryPoolReselect:
+    """_restore_primary_runtime should re-select from the credential pool."""
+
+    def _make_agent(self, pool):
+        """Create a minimal AIAgent with the given credential pool."""
+        from run_agent import AIAgent
+
+        agent = AIAgent.__new__(AIAgent)
+        agent.model = "gpt-5.5"
+        agent.provider = "openai-codex"
+        agent.base_url = "https://chatgpt.com/backend-api/codex"
+        agent.api_mode = "codex_responses"
+        agent.api_key = "original-key-entry-1"
+        agent._client_kwargs = {
+            "api_key": "original-key-entry-1",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        }
+        agent._credential_pool = pool
+        agent._fallback_activated = True
+        agent._fallback_index = 1
+        agent._rate_limited_until = 0
+        agent._use_prompt_caching = False
+        agent._use_native_cache_layout = False
+        agent.context_compressor = MagicMock()
+        agent.context_compressor.update_model = MagicMock()
+
+        # Snapshot the original state
+        agent._primary_runtime = {
+            "model": "gpt-5.5",
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_mode": "codex_responses",
+            "api_key": "original-key-entry-1",
+            "client_kwargs": {
+                "api_key": "original-key-entry-1",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+            },
+            "use_prompt_caching": False,
+            "use_native_cache_layout": False,
+            "compressor_model": "gpt-5.5",
+            "compressor_base_url": "https://chatgpt.com/backend-api/codex",
+            "compressor_api_key": "original-key-entry-1",
+            "compressor_provider": "openai-codex",
+            "compressor_context_length": 128000,
+            "compressor_threshold_tokens": 0.8,
+        }
+
+        # Mock client creation methods
+        agent._create_openai_client = MagicMock(return_value=MagicMock())
+        agent._apply_client_headers_for_base_url = MagicMock()
+        agent._replace_primary_openai_client = MagicMock(return_value=True)
+
+        return agent
+
+    def test_restore_reselects_from_pool_after_rotation(self):
+        """After pool rotation, restore should use the new entry, not the stale snapshot key."""
+        entries = [
+            _make_entry("entry-1", "original-key-entry-1", priority=0),
+            _make_entry("entry-2", "rotated-key-entry-2", priority=1),
+            _make_entry("entry-3", "fresh-key-entry-3", priority=2),
+        ]
+        pool = _build_mock_pool(entries)
+
+        # Simulate: entry-1 was exhausted, pool rotated to entry-2
+        exhausted = pool._entries[0]
+        pool._mark_exhausted(exhausted, 401)
+        pool._current_id = "entry-2"
+
+        agent = self._make_agent(pool)
+        result = agent._restore_primary_runtime()
+
+        assert result is True
+        # The agent should have the NEW key from entry-2, not the stale snapshot key
+        assert agent.api_key == "rotated-key-entry-2"
+        assert agent._client_kwargs["api_key"] == "rotated-key-entry-2"
+
+    def test_restore_uses_freshest_available_entry(self):
+        """When multiple entries are available, restore should select the pool's best pick."""
+        entries = [
+            _make_entry("entry-1", "key-1", priority=0,
+                         last_status="exhausted", last_status_at=time.time() + 3600),
+            _make_entry("entry-2", "key-2", priority=1),
+            _make_entry("entry-3", "key-3", priority=2),
+        ]
+        pool = _build_mock_pool(entries)
+
+        agent = self._make_agent(pool)
+        result = agent._restore_primary_runtime()
+
+        assert result is True
+        # entry-1 is exhausted, so pool should select entry-2
+        assert agent.api_key == "key-2"
+        assert agent._client_kwargs["api_key"] == "key-2"
+
+    def test_restore_without_pool_uses_snapshot(self):
+        """When no pool exists, restore should use the snapshot key (existing behavior)."""
+        agent = self._make_agent(pool=None)
+        result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert agent.api_key == "original-key-entry-1"
+
+    def test_restore_with_empty_pool_uses_snapshot(self):
+        """When pool exists but has no available entries, use snapshot key."""
+        entries = [
+            _make_entry("entry-1", "key-1", priority=0,
+                         last_status="exhausted", last_status_at=time.time() + 3600),
+        ]
+        pool = _build_mock_pool(entries)
+
+        agent = self._make_agent(pool)
+        result = agent._restore_primary_runtime()
+
+        assert result is True
+        # Pool has no available entries, so fall back to snapshot key
+        assert agent.api_key == "original-key-entry-1"
+
+    def test_restore_rebuilds_client_after_reselect(self):
+        """After re-selecting from pool, client should be rebuilt with new key."""
+        entries = [
+            _make_entry("entry-1", "key-1", priority=0),
+        ]
+        pool = _build_mock_pool(entries)
+
+        agent = self._make_agent(pool)
+        result = agent._restore_primary_runtime()
+
+        assert result is True
+        # _swap_credential rebuilds the live OpenAI client with the fresh key.
+        agent._replace_primary_openai_client.assert_called_once_with(
+            reason="credential_rotation",
+        )
+
+    def test_restore_skips_reselect_if_entry_has_no_key(self):
+        """If pool entry has an empty access token, fall back to snapshot key."""
+        entries = [
+            _make_entry("entry-1", "", priority=0),
+        ]
+        pool = _build_mock_pool(entries)
+
+        agent = self._make_agent(pool)
+        result = agent._restore_primary_runtime()
+
+        assert result is True
+        # Entry has no key, so use snapshot
+        assert agent.api_key == "original-key-entry-1"
+
+    def test_restore_updates_base_url_from_pool_entry(self):
+        """If pool entry has a different base_url, restore should update it."""
+        entries = [
+            {
+                **_make_entry("entry-1", "key-1", priority=0),
+                "base_url": "https://custom-endpoint.example.com/v1",
+            },
+        ]
+        pool = _build_mock_pool(entries)
+
+        agent = self._make_agent(pool)
+        result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert "custom-endpoint.example.com" in agent.base_url
+        assert "custom-endpoint.example.com" in agent._client_kwargs["base_url"]

--- a/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
+++ b/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
@@ -70,7 +70,12 @@ class TestExhaustionArmsCooldown:
         cooldown = getattr(agent, "_rate_limited_until", 0)
         assert cooldown > before
         # Cooldown is the short exhaustion window, not the 60s rate-limit one.
-        assert cooldown <= before + _FALLBACK_EXHAUSTED_COOLDOWN_S + 1.0
+        # Use a generous upper slack: the only thing this must distinguish is
+        # the ~5s short window from the 60s rate-limit window, so any margin
+        # well below 60s proves it. A tight +1.0s false-fails on a loaded CI
+        # runner when wall-clock jitter between `before` and the cooldown
+        # computation exceeds a second (GC pause, swap, scheduler contention).
+        assert cooldown <= before + _FALLBACK_EXHAUSTED_COOLDOWN_S + 30.0
 
     def test_no_chain_does_not_arm_cooldown(self):
         """An empty chain (no fallback configured) must not arm a cooldown —

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -982,10 +982,16 @@ def test_session_resume_follows_compression_tip(monkeypatch, tmp_path):
     db = SessionDB(db_path=tmp_path / "state.db")
     base = int(time.time()) - 10_000
     db.create_session("parent_root", source="tui")
-    db.append_message("parent_root", role="user", content="pre-compression turn")
+    db.append_message(
+        "parent_root", role="user", content="pre-compression turn",
+        timestamp=base + 10,
+    )
     db.end_session("parent_root", "compression")
     db.create_session("cont_tip", source="tui", parent_session_id="parent_root")
-    db.append_message("cont_tip", role="assistant", content="post-compression reply")
+    db.append_message(
+        "cont_tip", role="assistant", content="post-compression reply",
+        timestamp=base + 110,
+    )
     conn = db._conn
     assert conn is not None
     conn.execute(

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1568,14 +1568,31 @@ class TestSigkillEscalation:
         try:
             ProcessRegistry._terminate_host_pid(parent.pid)
 
-            def _all_dead():
-                return not any(
-                    psutil.pid_exists(p)
-                    and ProcessRegistry._proc_alive(psutil.Process(p))
-                    for p in all_pids
-                )
+            def _pid_dead(p: int) -> bool:
+                # A pid is "dead" for our purposes if it no longer exists OR
+                # exists only as an unreaped zombie (already terminated, just
+                # not reaped by its reparented parent yet). psutil can also
+                # raise mid-probe if the pid vanishes between the existence
+                # check and the status read — treat any such race as dead.
+                try:
+                    if not psutil.pid_exists(p):
+                        return True
+                    return not ProcessRegistry._proc_alive(psutil.Process(p))
+                except Exception:
+                    return True
 
-            assert _wait_until(_all_dead, timeout=4.0), (
+            def _all_dead():
+                return all(_pid_dead(p) for p in all_pids)
+
+            # _terminate_host_pid SIGKILLs synchronously before returning, so
+            # the kill signals are already delivered here. The only remaining
+            # wait is the kernel tearing down 3 processes and the reparented
+            # children transitioning to zombie — which can lag on a loaded CI
+            # runner. Give a generous budget (matches the wait() test's 10s)
+            # so this asserts the escalation BEHAVIOR, not the runner's
+            # scheduling latency. The assertion itself never weakens: every
+            # tree member must end up dead/zombie.
+            assert _wait_until(_all_dead, timeout=15.0, interval=0.02), (
                 "entire SIGTERM-ignoring tree (parent + children) must be SIGKILLed"
             )
         finally:


### PR DESCRIPTION
## Summary
Long-lived sessions now restore a **live** credential instead of a dead one. `_restore_primary_runtime` was restoring the construction-time `api_key` snapshot and never consulting `self._credential_pool` — so once the pool rotated away from a revoked/exhausted entry mid-session, every new turn restored the stale key, re-failed instantly, burned the remaining pool entries, and fell through to cross-provider fallback.

Root cause: the snapshot key (`rt["api_key"]`) is frozen at construction; the pool tracks which entries are currently usable, but restore ignored it entirely.

## Changes
- `agent/agent_runtime_helpers.py` (`restore_primary_runtime`): after restoring the snapshot, re-select the pool's current best entry (`pool.select()`) and swap the live credential in via `_swap_credential` — which already rebuilds the OpenAI/Anthropic client, reapplies base-url-scoped headers, and carries the accumulated base_url (#33163) / OAuth-detection fixes. Guarded on `pool.has_available()`; falls back to the snapshot key when the pool is absent, empty, or the entry has no usable key.
- `tests/agent/test_restore_primary_pool_reselect.py`: 7 tests covering reselect-after-rotation, freshest-available pick, no-pool / empty-pool / keyless-entry fallthrough, client rebuild, and base_url update.
- `scripts/release.py`: AUTHOR_MAP entry for the contributor.

## Validation
| | Before | After |
|---|---|---|
| Restore after pool rotated off a revoked entry | restores revoked snapshot key → instant 401 → fallback | re-selects live pool entry, no fail |
| No credential pool | snapshot key | snapshot key (unchanged) |
| Pool empty / entry keyless | — | snapshot key (graceful fallback) |
| Targeted tests | — | 7/7 new + 42/42 existing restore tests pass |

E2E verified on a real `AIAgent` + real `CredentialPool`: with entry e1 marked `token_revoked` and the pool rotated to e2, restore now yields `live-key-2` instead of the revoked snapshot key; the no-pool path still preserves the snapshot key.

## Credit
Salvaged from #25206 by @jmmaloney4 (who also reported #25205), rebased onto current `main`. The original targeted the pre-refactor monolithic method in `run_agent.py`; the logic now lives in `agent/agent_runtime_helpers.py` and is collapsed onto `_swap_credential` instead of re-inlining the client rebuild. Duplicate #25730 (@dusterbloom) closed in favor of this.

Fixes #25205

## Infographic

![stale-key-credential-pool-reselect](https://v3b.fal.media/files/b/0aa00cd6/JW-ONA83uiAGLDAM7j-BM_gv4Rp3MK.png)
