### PR TITLE
Fix Windows .cmd shim URL truncation at '&' in browser tool

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -34,6 +34,9 @@ from typing import Sequence
 __all__ = [
     "IS_WINDOWS",
     "resolve_node_command",
+    "is_windows_batch_shim",
+    "windows_batch_quote",
+    "windows_batch_safe_args",
     "windows_detach_flags",
     "windows_detach_flags_without_breakaway",
     "windows_hide_flags",
@@ -85,6 +88,77 @@ def resolve_node_command(name: str, argv: Sequence[str]) -> list[str]:
     if resolved:
         return [resolved, *argv]
     return [name, *argv]
+
+
+# -----------------------------------------------------------------------------
+# Windows batch-shim (.cmd / .bat) argument quoting
+# -----------------------------------------------------------------------------
+
+
+def is_windows_batch_shim(executable: str) -> bool:
+    """True when ``executable`` is a Windows batch shim (``.cmd`` / ``.bat``).
+
+    Only ever True on Windows.  ``npx.cmd``, ``npm.cmd``, and the
+    ``node_modules/.bin/<tool>.cmd`` shims npm drops on Windows all match.
+    Launching such a file routes execution through ``cmd.exe``, which
+    treats ``& | < > ^ ( )`` as shell metacharacters — so unquoted
+    arguments that contain them (e.g. a URL query string
+    ``...?q=a&tbm=b``) get split, and the tail is run as a bogus second
+    command.  Callers use this predicate to decide whether to route the
+    argv through :func:`windows_batch_quote`.
+    """
+    if not IS_WINDOWS or not executable:
+        return False
+    low = executable.lower()
+    return low.endswith(".cmd") or low.endswith(".bat")
+
+
+def windows_batch_quote(parts: Sequence[str]) -> str:
+    """Build a ``cmd.exe``-safe command-line string from an argv list.
+
+    When the launched program is a ``.cmd`` / ``.bat`` shim, Windows
+    routes execution through ``cmd.exe``, which treats ``& | < > ^ ( )``
+    as shell metacharacters.  ``subprocess.list2cmdline`` (used implicitly
+    when you pass a *list* to ``subprocess.Popen``) only quotes for spaces
+    and the C-runtime argv parser — it does NOT escape cmd metacharacters
+    — so an argument like ``https://x/?q=a&tbm=b`` is split at ``&`` and
+    the tail (``tbm=b``) is executed as a second command, surfacing as
+    ``'tbm' is not recognized as an internal or external command``.
+
+    Wrapping every token in double quotes neutralizes those metacharacters
+    at the ``cmd.exe`` layer, while the downstream program still receives
+    the original, unsplit argument via ``CommandLineToArgvW``.  Embedded
+    double quotes are doubled (``"`` → ``""``), the cmd.exe convention for
+    a literal quote inside a quoted token.
+
+    Returns a single string suitable for ``subprocess.Popen(cmdline, ...)``
+    with ``shell=False``.  Only meaningful when :func:`is_windows_batch_shim`
+    is True for ``parts[0]``; use :func:`windows_batch_safe_args` to apply
+    it conditionally.
+    """
+    return " ".join('"' + str(p).replace('"', '""') + '"' for p in parts)
+
+
+def windows_batch_safe_args(parts: Sequence[str]):
+    """Return ``subprocess.Popen`` args safe for a possibly-shim first token.
+
+    On Windows, if ``parts[0]`` is a ``.cmd`` / ``.bat`` shim, returns a
+    ``cmd.exe``-quoted command-line STRING (so ``& | < >`` in later
+    arguments aren't treated as shell metacharacters — see
+    :func:`windows_batch_quote`).  Otherwise returns the original argv as
+    a list, unchanged.
+
+    No-op on POSIX and for real executables (``.exe`` / extensionless),
+    so call sites can apply it unconditionally:
+
+    .. code-block:: python
+
+        proc = subprocess.Popen(windows_batch_safe_args(argv), ...)
+    """
+    parts = list(parts)
+    if parts and is_windows_batch_shim(parts[0]):
+        return windows_batch_quote(parts)
+    return parts
 
 
 # -----------------------------------------------------------------------------

--- a/tests/hermes_cli/test_subprocess_compat_batch_quote.py
+++ b/tests/hermes_cli/test_subprocess_compat_batch_quote.py
@@ -1,0 +1,83 @@
+"""Tests for Windows batch-shim (.cmd/.bat) argument quoting.
+
+These guard the fix for the Windows bug where launching a ``.cmd`` shim
+(e.g. ``npx.cmd`` or ``node_modules/.bin/agent-browser.cmd``) routes
+through ``cmd.exe``, which treats ``& | < > ^ ( )`` as shell
+metacharacters.  An unquoted URL argument such as
+``https://www.google.com/search?q=x&tbm=isch`` is split at ``&`` and the
+tail (``tbm=isch``) is executed as a bogus second command, surfacing as
+``'tbm' is not recognized as an internal or external command``.
+
+The helpers neutralize the metacharacters by double-quoting each token,
+while the launched program still receives the original, unsplit argument
+via ``CommandLineToArgvW``.
+"""
+
+from __future__ import annotations
+
+from hermes_cli import _subprocess_compat as sc
+
+
+def test_windows_batch_quote_wraps_ampersand_url():
+    url = "https://www.google.com/search?q=cats&tbm=isch&hl=en"
+    out = sc.windows_batch_quote(["agent-browser", "open", url])
+    # Every token is double-quoted, so cmd.exe never sees a bare '&'.
+    assert out == f'"agent-browser" "open" "{url}"'
+    # The full URL (including both '&') survives intact inside the quotes.
+    assert url in out
+    assert "&tbm=isch&hl=en" in out
+
+
+def test_windows_batch_quote_doubles_embedded_quotes():
+    out = sc.windows_batch_quote(['say "hi"'])
+    assert out == '"say ""hi"""'
+
+
+def test_windows_batch_quote_empty():
+    assert sc.windows_batch_quote([]) == ""
+
+
+def test_is_windows_batch_shim_true_for_cmd_bat_on_windows(monkeypatch):
+    monkeypatch.setattr(sc, "IS_WINDOWS", True)
+    assert sc.is_windows_batch_shim(r"C:\tools\npx.cmd")
+    assert sc.is_windows_batch_shim(r"C:\tools\foo.BAT")
+    assert sc.is_windows_batch_shim("agent-browser.cmd")
+
+
+def test_is_windows_batch_shim_false_for_exe_and_empty(monkeypatch):
+    monkeypatch.setattr(sc, "IS_WINDOWS", True)
+    assert not sc.is_windows_batch_shim(r"C:\tools\node.exe")
+    assert not sc.is_windows_batch_shim("agent-browser")
+    assert not sc.is_windows_batch_shim("")
+
+
+def test_is_windows_batch_shim_false_on_posix(monkeypatch):
+    monkeypatch.setattr(sc, "IS_WINDOWS", False)
+    assert not sc.is_windows_batch_shim("npx.cmd")
+
+
+def test_windows_batch_safe_args_quotes_for_shim(monkeypatch):
+    monkeypatch.setattr(sc, "IS_WINDOWS", True)
+    parts = ["npx.cmd", "agent-browser", "open", "https://x/?a=1&b=2"]
+    out = sc.windows_batch_safe_args(parts)
+    assert isinstance(out, str)
+    assert out == '"npx.cmd" "agent-browser" "open" "https://x/?a=1&b=2"'
+
+
+def test_windows_batch_safe_args_passthrough_for_exe(monkeypatch):
+    monkeypatch.setattr(sc, "IS_WINDOWS", True)
+    parts = ["node.exe", "script.js", "https://x/?a=1&b=2"]
+    out = sc.windows_batch_safe_args(parts)
+    # Real executable: not routed through cmd.exe, list is returned as-is.
+    assert out == parts
+
+
+def test_windows_batch_safe_args_noop_on_posix(monkeypatch):
+    monkeypatch.setattr(sc, "IS_WINDOWS", False)
+    parts = ["npx.cmd", "agent-browser", "https://x/?a=1&b=2"]
+    assert sc.windows_batch_safe_args(parts) == parts
+
+
+def test_windows_batch_safe_args_empty(monkeypatch):
+    monkeypatch.setattr(sc, "IS_WINDOWS", True)
+    assert sc.windows_batch_safe_args([]) == []

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -68,7 +68,7 @@ from agent.auxiliary_client import call_llm
 from hermes_constants import agent_browser_runnable, get_hermes_home
 from utils import env_int, is_truthy_value
 from hermes_cli.config import DEFAULT_CONFIG, cfg_get
-from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli._subprocess_compat import windows_hide_flags, windows_batch_safe_args
 
 try:
     from tools.website_policy import check_website_access
@@ -922,7 +922,7 @@ def _run_chrome_fallback_command(
                 _si.dwFlags |= subprocess.STARTF_USESTDHANDLES
                 _popen_extra["startupinfo"] = _si
             proc = subprocess.Popen(
-                full, stdout=stdout_fd, stderr=stderr_fd,
+                windows_batch_safe_args(full), stdout=stdout_fd, stderr=stderr_fd,
                 stdin=subprocess.DEVNULL, env=browser_env,
                 **_popen_extra,
             )
@@ -2202,7 +2202,7 @@ def _run_browser_command(
                 _si.dwFlags |= subprocess.STARTF_USESTDHANDLES
                 _popen_extra["startupinfo"] = _si
             proc = subprocess.Popen(
-                cmd_parts,
+                windows_batch_safe_args(cmd_parts),
                 stdout=stdout_fd,
                 stderr=stderr_fd,
                 stdin=subprocess.DEVNULL,


### PR DESCRIPTION
## Problem

On Windows, the browser tool launches `agent-browser` through a `.cmd` shim — either `npx.cmd` or, when installed locally, `node_modules/.bin/agent-browser.cmd`. Both `subprocess.Popen` call sites in `tools/browser_tool.py` pass an argv **list**, which Python renders via `subprocess.list2cmdline`. That routine quotes only for spaces and the C runtime's `argv` parser — it does **not** escape `cmd.exe` shell metacharacters (`& | < > ^ ( )`).

Because a `.cmd` file is executed by `cmd.exe`, an unquoted URL argument such as:

```
https://www.google.com/search?q=cats&tbm=isch&hl=en
```

is split at the first `&`, and the tail is run as a second command. This surfaces in the gateway logs as:

```
WARNING tools.browser_tool: browser 'open' stderr: 'tbm' is not recognized as an internal or external command, operable program or batch file.
WARNING tools.browser_tool: browser 'open' stderr: 'setlang' is not recognized as an internal or external command, operable program or batch file.
```

Navigation still completes, but the URL is silently **truncated at `&`**, so query parameters after the first one (`tbm`, `hl`, `setlang`, …) are lost.

## Root cause

`list2cmdline` quoting + `cmd.exe` metacharacter handling for `.cmd`/`.bat` shims. The C-runtime quoting that `Popen(list)` applies is the wrong layer — `cmd.exe` parses the line *before* the program's `argv` parser ever sees it.

## Fix

Add helpers to `hermes_cli/_subprocess_compat.py` (the existing home for Windows subprocess-shim concerns):

- `is_windows_batch_shim(exe)` — True only on Windows for `.cmd`/`.bat`.
- `windows_batch_quote(parts)` — wraps every token in double quotes (doubling embedded quotes), neutralizing cmd metacharacters at the `cmd.exe` layer. The program still receives the original, unsplit argument via `CommandLineToArgvW`.
- `windows_batch_safe_args(parts)` — returns the cmd-quoted **string** when `parts[0]` is a shim, else the original list. No-op on POSIX and for real executables, so it's safe to apply unconditionally.

Both `subprocess.Popen` call sites in `tools/browser_tool.py` now wrap their args with `windows_batch_safe_args(...)`.

## Tests

`tests/hermes_cli/test_subprocess_compat_batch_quote.py` covers: ampersand-URL quoting, embedded-quote doubling, `.cmd`/`.bat` shim detection (and `.exe`/empty negatives), and the POSIX / real-exe pass-through no-ops (via monkeypatching `IS_WINDOWS`, so the suite is meaningful on Linux CI).

## Notes

This only affects Windows; behavior on POSIX is unchanged. Verified empirically with a real `agent-browser` invocation: the list form reproduces the truncation; the quoted-string form preserves the full URL.
