### PR TITLE
fix(mcp): handle JSON-string headers in config.yaml

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -101,6 +101,35 @@ from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
+def _normalize_headers(raw: Any) -> dict:
+    """Normalize MCP server headers config value into a dict.
+
+    Accepts a dict (proper YAML mapping) or a JSON string (common when
+    the whole header block is single-quoted in config.yaml). Returns
+    an empty dict for None/empty. Raises nothing on parse failure —
+    logs a warning and returns {} so a malformed header stanza doesn't
+    crash the MCP server task (which surfaces as an opaque CancelledError).
+    """
+    if not raw:
+        return {}
+    if isinstance(raw, dict):
+        return dict(raw)
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                return parsed
+            logger.warning(
+                "MCP headers JSON string did not parse to a dict (got %s); ignoring",
+                type(parsed).__name__,
+            )
+            return {}
+        except json.JSONDecodeError as exc:
+            logger.warning("MCP headers string is not valid JSON: %s; ignoring", exc)
+            return {}
+    logger.warning("MCP headers config has unexpected type %s; ignoring", type(raw).__name__)
+    return {}
+
 # Upper bound for the OSV malware preflight during stdio MCP startup. The
 # check makes a blocking urllib HTTPS call whose own timeout can fail to
 # interrupt a stalled SSL handshake, which froze the asyncio event loop and
@@ -2025,7 +2054,7 @@ class MCPServerTask:
             )
 
         url = config["url"]
-        headers = dict(config.get("headers") or {})
+        headers = _normalize_headers(config.get("headers"))
         # Some MCP servers require MCP-Protocol-Version on the initial
         # initialize request and reject session-less POSTs otherwise.
         # Seed it as a client-level default, but treat user overrides as
@@ -2314,7 +2343,7 @@ class MCPServerTask:
             # round-trip against a known-good server on every reconnect.
             if config.get("transport") != "sse" and not self._ready.is_set():
                 try:
-                    _probe_headers = dict(config.get("headers") or {})
+                    _probe_headers = _normalize_headers(config.get("headers"))
                     await self._preflight_content_type(
                         config["url"],
                         headers=_probe_headers,


### PR DESCRIPTION
## Summary

Fixes #53915

MCP HTTP transport servers crash on startup when `headers` is configured as a JSON string (single-quoted in YAML). `dict(config.get("headers") or {})` iterates a string per-character, causing `ValueError: dictionary update sequence element #0 has length 1; 2 is required`. This surfaces as `CancelledError` warnings in logs.

## Root Cause

`yaml.safe_load` returns a `str` when the entire header block is single-quoted in YAML:
```yaml
mcp_servers:
  cf-personal:
    headers: '{"Authorization":"Bearer cfut_xxx"}'
```

`dict()` on a string iterates character-by-character; each character must be a 2-tuple, so `{` (length 1) triggers `ValueError`. The crash happens before the SDK connection logic is reached, so `CancelledError` is the only visible symptom.

Two call sites affected:
- `MCPServerTask.run()` line ~2292 — preflight content-type probe
- `MCPServerTask._run_http()` line ~2018 — HTTP session headers

## Proposed Fix

Add `_normalize_headers()` helper that accepts dict, JSON string, or None and returns a proper dict:

```python
def _normalize_headers(raw: Any) -> dict:
    if not raw:
        return {}
    if isinstance(raw, dict):
        return dict(raw)
    if isinstance(raw, str):
        try:
            parsed = json.loads(raw)
            if isinstance(parsed, dict):
                return parsed
            logger.warning("MCP headers JSON string did not parse to a dict; ignoring")
            return {}
        except json.JSONDecodeError:
            logger.warning("MCP headers string is not valid JSON; ignoring")
            return {}
    logger.warning("MCP headers config has unexpected type; ignoring")
    return {}
```

Replaces both `dict(config.get("headers") or {})` call sites.

## Backward Compatibility

- Dict input: passes through unchanged
- JSON string: now works (previously crashed)
- None/empty: returns `{}` (same as before)
- Invalid input: logs warning + returns `{}` instead of crashing

## Testing

```bash
python3 -m pytest tests/tools/test_mcp_tool.py -o 'addopts=' -q --tb=short
# 200 passed in 17.53s
```

Live verification: both Cloudflare MCP servers (cf-personal, cf-hypajump) now connect successfully — 3 tools each (`docs`, `search`, `execute`), `error=None`.

## Environment

- OS: Ubuntu 24.04 (aarch64)
- Python: 3.12.3
- Hermes: 0.17.0