### PR TITLE
fix(cron): add per-job allow_silent flag to control [SILENT] suppression

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1586,6 +1586,7 @@ def create_job(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    allow_silent: bool = True,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1643,6 +1644,12 @@ def create_job(
         monitor_url: Optional http(s) URL used as the monitor source instead
                 of a script — fetched with a bounded GET each tick. Same
                 hash-suppression semantics as ``monitor_script``.
+        allow_silent: When True (default), the scheduler prepends ``[SILENT]``
+                suppression guidance to the agent prompt, letting the agent
+                suppress delivery when there is nothing new to report. When
+                False, the suppression guidance is omitted and ``[SILENT]``
+                responses are still delivered — intended for recurring
+                briefing/report jobs that should always send an all-clear.
 
     Returns:
         The created job dict
@@ -1777,6 +1784,10 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        # When False, the scheduler omits [SILENT] suppression guidance and
+        # always delivers the agent's response. For recurring briefing/report
+        # jobs that should send an all-clear even when nothing changed (#53230).
+        "allow_silent": bool(allow_silent),
     }
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2717,17 +2717,26 @@ def _build_job_prompt(
         has_injected_data = True
 
     # Always prepend cron execution guidance so the agent knows how
-    # delivery works and can suppress delivery when appropriate.
+    # delivery works.  The [SILENT] suppression guidance is only injected
+    # when the job allows silent delivery (default).  Jobs with
+    # allow_silent=False (e.g. recurring briefings that should always send
+    # an all-clear) skip the suppression instruction entirely (#53230).
+    allow_silent = job.get("allow_silent", True)  # back-compat: absent = True
+    silent_hint = ""
+    if allow_silent:
+        silent_hint = (
+            "SILENT: If there is genuinely nothing new to report, respond "
+            "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
+            "Never combine [SILENT] with content — either report your "
+            "findings normally, or say [SILENT] and nothing more. "
+        )
     cron_hint = (
         "[IMPORTANT: You are running as a scheduled cron job. "
         "DELIVERY: Your final response will be automatically delivered "
         "to the user — do NOT use send_message or try to deliver "
         "the output yourself. Just produce your report/output as your "
         "final response and the system handles the rest. "
-        "SILENT: If there is genuinely nothing new to report, respond "
-        "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
-        "Never combine [SILENT] with content — either report your "
-        "findings normally, or say [SILENT] and nothing more.]\n\n"
+        f"{silent_hint}]\n\n"
     )
     prompt = cron_hint + prompt
     if skills is None:
@@ -4695,8 +4704,16 @@ def run_one_job(
             # #46917).  Keeps the intentional bracketed-prefix / trailing-line
             # tolerance the cron contract relies on.
             if should_deliver and success and _is_cron_silence_response(deliver_content):
-                logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
-                should_deliver = False
+                # Internal silence signals (no_agent empty output, wakeAgent=false)
+                # are always honored — they are not LLM responses. Only an
+                # explicit agent [SILENT] response respects allow_silent, so a
+                # job that set allow_silent=False still gets it delivered (useful
+                # for recurring briefing/report jobs that should send an all-clear
+                # even when nothing changed) while script-task internal silence is
+                # never leaked as a literal "[SILENT]" message.
+                if job.get("no_agent") or job.get("allow_silent", True):
+                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+                    should_deliver = False
 
             if should_deliver:
                 unresolved_origin = (

--- a/tests/tools/test_cron_allow_silent.py
+++ b/tests/tools/test_cron_allow_silent.py
@@ -1,0 +1,117 @@
+"""Tests for the per-job ``allow_silent`` flag (#53230).
+
+When ``allow_silent=False``:
+1. ``_build_job_prompt`` must NOT inject ``[SILENT]`` suppression guidance.
+2. The delivery path must NOT suppress a ``[SILENT]`` response.
+
+When ``allow_silent=True`` (default, including back-compat for jobs created
+before the field existed):
+1. ``_build_job_prompt`` still injects the suppression guidance.
+2. The delivery path still suppresses ``[SILENT]`` responses.
+"""
+
+import pytest
+
+from cron.jobs import create_job
+from cron.scheduler import _build_job_prompt, _is_cron_silence_response, SILENT_MARKER
+
+
+class TestAllowSilentPromptInjection:
+    """The ``allow_silent`` flag controls ``[SILENT]`` guidance injection."""
+
+    def test_default_job_injects_silent_guidance(self):
+        """Jobs created without specifying allow_silent get suppression guidance."""
+        job = create_job(
+            prompt="Daily report",
+            schedule="0 9 * * *",
+        )
+        prompt = _build_job_prompt(job)
+        assert SILENT_MARKER in prompt, (
+            "Default jobs (allow_silent=True) must have [SILENT] guidance"
+        )
+
+    def test_allow_silent_true_injects_guidance(self):
+        """Explicit allow_silent=True still injects suppression guidance."""
+        job = create_job(
+            prompt="Daily report",
+            schedule="0 9 * * *",
+            allow_silent=True,
+        )
+        prompt = _build_job_prompt(job)
+        assert SILENT_MARKER in prompt
+
+    def test_allow_silent_false_omits_silent_guidance(self):
+        """allow_silent=False must NOT inject [SILENT] suppression guidance."""
+        job = create_job(
+            prompt="Daily report — always send an all-clear",
+            schedule="0 9 * * *",
+            allow_silent=False,
+        )
+        prompt = _build_job_prompt(job)
+        assert SILENT_MARKER not in prompt, (
+            "allow_silent=False jobs must not have [SILENT] guidance injected"
+        )
+        # But the cron_hint (delivery instructions) should still be present
+        assert "scheduled cron job" in prompt
+
+    def test_back_compat_missing_key_defaults_to_true(self):
+        """Jobs created before allow_silent existed (no key in dict) default to True."""
+        job = create_job(
+            prompt="Legacy job",
+            schedule="0 9 * * *",
+        )
+        # Simulate a legacy job by deleting the key
+        job.pop("allow_silent", None)
+        prompt = _build_job_prompt(job)
+        assert SILENT_MARKER in prompt, (
+            "Legacy jobs without allow_silent key must default to True"
+        )
+
+    def test_cron_hint_delivery_instructions_always_present(self):
+        """Regardless of allow_silent, the DELIVERY instruction is always present."""
+        for allow_silent in (True, False):
+            job = create_job(
+                prompt="Test",
+                schedule="0 9 * * *",
+                allow_silent=allow_silent,
+            )
+            prompt = _build_job_prompt(job)
+            assert "DELIVERY:" in prompt
+            assert "scheduled cron job" in prompt
+
+
+class TestAllowSilentJobField:
+    """The ``allow_silent`` field is properly stored in the job dict."""
+
+    def test_field_defaults_to_true(self):
+        job = create_job(prompt="Test", schedule="0 9 * * *")
+        assert job.get("allow_silent") is True
+
+    def test_field_explicitly_true(self):
+        job = create_job(prompt="Test", schedule="0 9 * * *", allow_silent=True)
+        assert job.get("allow_silent") is True
+
+    def test_field_explicitly_false(self):
+        job = create_job(prompt="Test", schedule="0 9 * * *", allow_silent=False)
+        assert job.get("allow_silent") is False
+
+    def test_field_is_bool(self):
+        """Ensure the stored value is a proper bool, not truthy/falsy."""
+        job = create_job(prompt="Test", schedule="0 9 * * *", allow_silent=False)
+        assert isinstance(job.get("allow_silent"), bool)
+
+
+class TestSilenceDetectionStillWorks:
+    """_is_cron_silence_response is not affected by allow_silent — it's a
+    pure string check. The allow_silent flag gates whether the scheduler
+    *consults* it during delivery, not whether it can detect the marker."""
+
+    def test_detects_silent_marker(self):
+        assert _is_cron_silence_response("[SILENT]")
+
+    def test_detects_silent_with_newline(self):
+        assert _is_cron_silence_response("[SILENT]\n")
+
+    def test_does_not_detect_normal_text(self):
+        assert not _is_cron_silence_response("All systems normal")
+        assert not _is_cron_silence_response("Daily report: nothing changed.")

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1052,6 +1052,7 @@ def cronjob(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    allow_silent: Optional[bool] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1140,6 +1141,7 @@ def cronjob(
                     attach_to_session=attach_to_session,
                     monitor_script=_normalize_optional_job_value(monitor_script),
                     monitor_url=_normalize_optional_job_value(monitor_url),
+                    allow_silent=allow_silent if allow_silent is not None else True,
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
@@ -1395,6 +1397,8 @@ def cronjob(
                 updates["enabled_toolsets"] = enabled_toolsets or None
             if attach_to_session is not None:
                 updates["attach_to_session"] = bool(attach_to_session)
+            if allow_silent is not None:
+                updates["allow_silent"] = bool(allow_silent)
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1556,6 +1556,16 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "allow_silent": {
+                "type": "boolean",
+                "default": True,
+                "description": (
+                    "Default: True (the agent may suppress delivery by responding with [SILENT] when there's nothing new to report). "
+                    "Set False to opt out of [SILENT] suppression for AGENT-generated final responses — the job will ALWAYS deliver its response, even when the agent emits [SILENT]. "
+                    "Use this for recurring briefings / heartbeats that should always send an all-clear, never go quiet. "
+                    "Note: internal silences from no_agent script jobs (empty stdout or wakeAgent=false) remain silent regardless of this flag — the flag only controls whether an LLM agent's explicit [SILENT] response is honoured."
+                ),
+            },
         },
         "required": ["action"]
     }
@@ -1615,6 +1625,7 @@ registry.register(
         no_agent=args.get("no_agent"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),
+        allow_silent=args.get("allow_silent"),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id"),
     ),


### PR DESCRIPTION
## Summary

The generic `[SILENT]` suppression guidance is currently injected into **all** cron job prompts, including recurring briefing/report jobs that should always send an all-clear. This creates contradictory instructions at runtime:

- **Job-specific instruction:** "if everything looks normal, say so explicitly"
- **Scheduler-injected instruction:** "if there is genuinely nothing new to report, respond with exactly `[SILENT]`"

Because both are present, the same recurring report can sometimes deliver an all-clear and sometimes suppress delivery entirely — nondeterministic and trust-undermining for daily briefings.

## Root Cause

`_build_job_prompt()` in `cron/scheduler.py` unconditionally prepends `[SILENT]` suppression guidance to every agent-driven cron job prompt (since `89db3aeb2c`, 2026-04-05). There was no per-job opt-out mechanism.

## Fix

Add a first-class **`allow_silent`** boolean field to cron jobs (default `True` for full backward compatibility):

| `allow_silent` | Prompt injection | Delivery suppression |
|---|---|---|
| `True` (default) | `[SILENT]` guidance injected | `[SILENT]` responses suppress delivery |
| `False` | No `[SILENT]` guidance | Agent response always delivered, even if it contains `[SILENT]` |

When `allow_silent=False`:
1. **`_build_job_prompt()`** omits the `SILENT: If there is genuinely nothing new…` guidance from the cron hint — but keeps the `DELIVERY:` instructions (the agent still needs to know not to use `send_message`).
2. **Delivery path** (`execute_job`): the `_is_cron_silence_response()` check is gated on `job.get("allow_silent", True)` — so even if the model returns `[SILENT]`, the response is delivered.

Backward compatibility: jobs created before this change have no `allow_silent` key. Both code sites use `job.get("allow_silent", True)` so legacy jobs behave exactly as before.

## Usage

```python
# Create a recurring briefing that always delivers
cronjob(
    action="create",
    schedule="0 9 * * *",
    prompt="Give me a daily summary of overnight activity. Always send a brief all-clear if nothing happened.",
    allow_silent=False,
)

# Update an existing job to always deliver
cronjob(action="update", job_id="abc123", allow_silent=False)
```

## Changes

- **`cron/jobs.py`**: `allow_silent: bool = True` param on `create_job()`, stored as `bool` in job dict
- **`cron/scheduler.py`**: conditional `[SILENT]` hint injection in `_build_job_prompt()`, gated delivery suppression in `execute_job`
- **`tools/cronjob_tools.py`**: expose `allow_silent` in the `cronjob` tool (create + update actions)
- **`tests/tools/test_cron_allow_silent.py`**: 12 regression tests covering prompt injection, job dict field, back-compat, and silence detection

## Test Results

```
tests/tools/test_cron_allow_silent.py ..... 12 passed
tests/tools/test_cronjob_tools.py ......... 79 passed (no regression)
```

Closes #53230