### PR TITLE
fix(retry): stop SDK auto-retry double-firing inside the rate-limit loop (Anthropic + OpenAI), raise Retry-After cap to 600s

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1420,6 +1420,15 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
         keepalive_http = agent._build_keepalive_http_client(client_kwargs.get("base_url", ""))
         if keepalive_http is not None:
             client_kwargs["http_client"] = keepalive_http
+    # Delegate all rate-limit / 5xx retry to hermes's outer conversation loop,
+    # which honors Retry-After and applies adaptive/jittered backoff. The OpenAI
+    # SDK default (max_retries=2) uses its own 1-2s backoff that ignores
+    # Retry-After and double-retries inside our loop — the same deadlock the
+    # Anthropic clients hit (#26293). This is the single chokepoint every primary
+    # OpenAI/aggregator client passes through (init, switch_model, recovery,
+    # restore, request-scoped); auxiliary_client builds its own clients and keeps
+    # SDK retries because it is NOT wrapped by the conversation loop.
+    client_kwargs.setdefault("max_retries", 0)
     # Uses the module-level `OpenAI` name, resolved lazily on first
     # access via __getattr__ below. Tests patch via `run_agent.OpenAI`.
     client = _ra().OpenAI(**client_kwargs)

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -673,6 +673,9 @@ def _build_anthropic_client_with_bearer_hook(
     kwargs = {
         "timeout": timeout_obj,
         "http_client": http_client,
+        # Delegate retry to hermes's outer loop (honors Retry-After); the SDK
+        # default max_retries=2 ignores it and double-retries. (#26293)
+        "max_retries": 0,
         # The SDK requires *something* for api_key/auth_token. Our
         # event hook overrides Authorization per request so this value
         # is never sent. The sentinel string makes accidental leaks
@@ -757,6 +760,12 @@ def build_anthropic_client(
     _read_timeout = timeout if (isinstance(timeout, (int, float)) and timeout > 0) else 900.0
     kwargs = {
         "timeout": Timeout(timeout=float(_read_timeout), connect=10.0),
+        # Delegate all rate-limit / 5xx retry to hermes's outer conversation
+        # loop, which honors Retry-After. The SDK default (max_retries=2) uses
+        # its own 1-2s backoff that ignores Retry-After and double-retries
+        # inside our loop — burning request slots against a bucket that won't
+        # refill for minutes. (#26293)
+        "max_retries": 0,
     }
     if normalized_base_url:
         # Azure Anthropic endpoints require an ``api-version`` query parameter.
@@ -852,6 +861,9 @@ def build_anthropic_bedrock_client(region: str):
     return _anthropic_sdk.AnthropicBedrock(
         aws_region=region,
         timeout=Timeout(timeout=900.0, connect=10.0),
+        # Delegate retry to hermes's outer loop (honors Retry-After); the SDK
+        # default max_retries=2 ignores it and double-retries. (#26293)
+        max_retries=0,
         default_headers={"anthropic-beta": ",".join([*_COMMON_BETAS, _CONTEXT_1M_BETA])},
     )
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3658,7 +3658,12 @@ def run_conversation(
                         _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
                         if _ra_raw:
                             try:
-                                _retry_after = min(float(_ra_raw), 120)  # Cap at 2 minutes
+                                # Cap at 10 minutes. Anthropic Tier 1 input-token
+                                # buckets reset in ~171s, so a 120s cap caused us to
+                                # retry before the actual reset window and re-trip the
+                                # limit. 600s covers all realistic provider reset
+                                # windows while still rejecting pathological values. (#26293)
+                                _retry_after = min(float(_ra_raw), 600)
                             except (TypeError, ValueError):
                                 pass
                 wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -201,6 +201,28 @@ class TestBuildAnthropicClient:
             betas = kwargs["default_headers"]["anthropic-beta"]
             assert "context-1m-2025-08-07" in betas
 
+    def test_disables_sdk_retries_for_api_key(self):
+        """#26293: the SDK's default max_retries=2 ignores Retry-After and
+        double-retries inside hermes's outer loop. We delegate retry entirely
+        to the outer loop, so the client must be built with max_retries=0."""
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("sk-ant-api03-something")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["max_retries"] == 0
+
+    def test_disables_sdk_retries_for_oauth_token(self):
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("sk-ant-oat01-" + "x" * 60)
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["max_retries"] == 0
+
+    def test_bedrock_disables_sdk_retries(self):
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            mock_sdk.AnthropicBedrock = MagicMock()
+            build_anthropic_bedrock_client("us-east-1")
+            kwargs = mock_sdk.AnthropicBedrock.call_args[1]
+            assert kwargs["max_retries"] == 0
+
 
 class TestReadClaudeCodeCredentials:
     @pytest.fixture(autouse=True)

--- a/tests/run_agent/test_create_openai_client_disables_sdk_retries.py
+++ b/tests/run_agent/test_create_openai_client_disables_sdk_retries.py
@@ -1,0 +1,78 @@
+"""Regression guard: _create_openai_client must disable SDK-level retries.
+
+#26293: the OpenAI SDK default ``max_retries=2`` uses its own 1-2s backoff that
+ignores ``Retry-After`` and double-retries *inside* hermes's outer conversation
+loop — burning request slots against a rate-limited bucket that won't refill for
+minutes. The outer loop already owns rate-limit backoff (honors Retry-After,
+adaptive + jittered), so every primary OpenAI/aggregator client must be built
+with ``max_retries=0``. This is the OpenAI-path twin of the Anthropic adapter
+fix in tests/agent/test_anthropic_adapter.py.
+"""
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+@patch("run_agent.OpenAI")
+def test_create_openai_client_disables_sdk_retries(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    agent._create_openai_client(
+        {"api_key": "test-key", "base_url": "https://openrouter.ai/api/v1"},
+        reason="test",
+        shared=False,
+    )
+
+    # Find the construction call that carries our base_url (AIAgent() also
+    # builds a client during init; the assertion targets the explicit call).
+    matching = [
+        c for c in mock_openai.call_args_list
+        if c.kwargs.get("base_url") == "https://openrouter.ai/api/v1"
+    ]
+    assert matching, "OpenAI was never constructed with the expected base_url"
+    for call in matching:
+        assert call.kwargs.get("max_retries") == 0, (
+            "_create_openai_client must set max_retries=0 so the SDK does not "
+            "double-retry inside the outer rate-limit loop (#26293); got "
+            f"{call.kwargs.get('max_retries')!r}"
+        )
+
+
+@patch("run_agent.OpenAI")
+def test_create_openai_client_honors_explicit_max_retries(mock_openai):
+    """An explicit max_retries in client_kwargs is respected (setdefault, not
+    clobber) — future callers can opt back into SDK retries if needed."""
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    agent._create_openai_client(
+        {
+            "api_key": "test-key",
+            "base_url": "https://explicit.example.com/v1",
+            "max_retries": 5,
+        },
+        reason="test",
+        shared=False,
+    )
+
+    matching = [
+        c for c in mock_openai.call_args_list
+        if c.kwargs.get("base_url") == "https://explicit.example.com/v1"
+    ]
+    assert matching, "OpenAI was never constructed with the explicit base_url"
+    assert matching[-1].kwargs.get("max_retries") == 5

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2293,6 +2293,56 @@ class TestExecuteToolCalls:
         assert "Rate limit reached" not in output
 
 
+class TestRetryAfterCap:
+    """#26293: the conversation loop owns rate-limit backoff and honors the
+    Retry-After header up to a 600s ceiling (was 120s, which retried before
+    Tier-1 reset windows of ~171s and re-tripped the limit)."""
+
+    def _drive_once(self, agent, retry_after_value):
+        """Raise one 429 carrying ``Retry-After`` and capture the wait the loop
+        chose. Interrupt during the backoff sleep so the test doesn't actually
+        wait, and return the status string that reports the wait time."""
+
+        class _RateLimitError(Exception):
+            status_code = 429
+            response = SimpleNamespace(headers={"retry-after": str(retry_after_value)})
+
+            def __str__(self):
+                return "Error code: 429 - Rate limit exceeded."
+
+        def _fake_api_call(api_kwargs):
+            raise _RateLimitError()
+
+        agent._interruptible_api_call = _fake_api_call
+        agent._persist_session = lambda *args, **kwargs: None
+        agent._save_trajectory = lambda *args, **kwargs: None
+
+        captured = []
+        original_buffer = agent._buffer_status
+
+        def _capture_status(msg, *args, **kwargs):
+            captured.append(msg)
+            # Break out of the incremental backoff sleep immediately rather
+            # than blocking for the full Retry-After window.
+            if "Waiting" in msg:
+                agent._interrupt_requested = True
+            return original_buffer(msg, *args, **kwargs)
+
+        agent._buffer_status = _capture_status
+        agent.run_conversation("hello")
+        return next((m for m in captured if "Waiting" in m), "")
+
+    def test_retry_after_under_cap_is_honored(self, agent):
+        # 300s > old 120s cap but < new 600s cap → used verbatim.
+        status = self._drive_once(agent, 300)
+        assert "Waiting 300.0s" in status
+
+    def test_retry_after_above_cap_is_clamped_to_600s(self, agent):
+        # 900s exceeds the ceiling → clamped to 600s, not the old 120s.
+        status = self._drive_once(agent, 900)
+        assert "Waiting 600.0s" in status
+
+
 class TestConcurrentToolExecution:
     """Tests for _execute_tool_calls_concurrent and dispatch logic."""
 


### PR DESCRIPTION
## Summary
A rate-limited Anthropic (or OpenAI/aggregator) account no longer deadlocks: the inference SDK's built-in auto-retry no longer fights hermes's outer rate-limit loop, and the `Retry-After` cap now honors real Tier-1 reset windows.

Root cause (two interacting defaults): the SDK clients were built without `max_retries`, so the SDK default (`max_retries=2`) kicked in. The SDK's own 1-2s backoff **ignores `Retry-After`** and double-retries *inside* hermes's outer retry loop, burning request slots against a bucket that won't refill for minutes. The conversation loop also capped `Retry-After` at 120s, so on a Tier-1 account (input-token bucket resets in ~171s) it retried *before* the reset window and re-tripped the limit. Net effect: the agent appears hung.

Salvaged from @konsisumer's PR #35955 (Anthropic side), with a sibling fix for the same bug class on the OpenAI/aggregator path found during audit.

## Changes
- `agent/anthropic_adapter.py`: set `max_retries=0` on all three Anthropic SDK constructors (`Anthropic`, `AnthropicBedrock`, bearer-hook client). *(@konsisumer)*
- `agent/conversation_loop.py`: raise the `Retry-After` cap from 120s → 600s — covers all realistic provider reset windows while still rejecting pathological values. *(@konsisumer)*
- `agent/agent_runtime_helpers.py`: set `max_retries=0` at the single `create_openai_client` chokepoint — covers every primary OpenAI/aggregator client (init, switch_model, recovery, restore, request-scoped). Uses `setdefault` so a future caller can opt back in. *(sibling fix)*
- Tests: Anthropic adapter `max_retries=0` assertions + 600s-cap behavior test *(@konsisumer)*; new OpenAI-path regression tests (`max_retries=0` default + explicit-override honored).

**Not touched:** `auxiliary_client` builds its own clients for side-LLM tasks (compression, vision, etc.) and is **not** wrapped by the conversation loop, so it keeps SDK-level retries as its only retry layer. The chokepoint fix only affects the main conversation client.

## Validation
| | Before | After |
|---|---|---|
| Anthropic SDK retries | `max_retries=2` (ignores Retry-After) | `max_retries=0` (loop owns retry) |
| OpenAI/aggregator SDK retries | `max_retries=2` (ignores Retry-After) | `max_retries=0` (loop owns retry) |
| `Retry-After` cap | 120s (< 171s Tier-1 reset → re-trips) | 600s (honors real reset windows) |
| Targeted tests | — | 175 pass (Anthropic + OpenAI + isolation/reuse guards) |

E2E-verified the OpenAI chokepoint with real imports: default kwargs → `max_retries=0`; explicit `max_retries=5` → respected.

Fixes #26293.

## Infographic

![rate-limit-retry-deadlock-fixed](https://v3b.fal.media/files/b/0aa00cf6/Jo3ruX8yWIkcHAO7LDAr__XrniCOSH.png)
