### PR TITLE
fix(file-ops): preserve CWD across terminal env re-creation (#26211)

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -513,3 +513,105 @@ class TestPatchSchemaShape:
         params = PATCH_SCHEMA["parameters"]
         assert params["required"] == ["mode"]
         assert "anyOf" not in params and "oneOf" not in params
+
+
+# ---------------------------------------------------------------------------
+# _last_known_cwd tests (#26211: silent file creation failure in long conversations)
+# ---------------------------------------------------------------------------
+
+class TestLastKnownCwd:
+    """
+    When the terminal environment is cleaned up and re-created during a long
+    conversation, _last_known_cwd preserves the old environment's CWD so
+    subsequent file writes with relative paths land in the right directory.
+
+    Regression guard for issue #26211.
+    """
+
+    @patch("tools.terminal_tool._active_environments", new_callable=dict)
+    @patch("tools.file_tools._file_ops_cache", new_callable=dict)
+    @patch("tools.terminal_tool._get_env_config")
+    @patch("tools.terminal_tool._create_environment")
+    def test_last_known_cwd_preserved_across_env_recreation(
+        self, mock_create_env, mock_config, mock_cache, mock_active
+    ):
+        from tools.file_tools import _get_file_ops, _last_known_cwd
+
+        # Setup: create a mock env with a known CWD
+        mock_env = MagicMock()
+        mock_env.cwd = "/Users/user/project"
+        mock_create_env.return_value = mock_env
+        mock_config.return_value = {
+            "env_type": "local",
+            "cwd": "/default/path",
+            "timeout": 30,
+        }
+
+        task_id = "default"
+
+        # Preset _last_known_cwd to simulate a previous env's CWD
+        _last_known_cwd[task_id] = "/Users/user/project"
+
+        # Call _get_file_ops - should use _last_known_cwd for the new env
+        result = _get_file_ops(task_id)
+
+        # Verify the env was created with the saved CWD, not the default
+        create_call = mock_create_env.call_args
+        assert create_call is not None, "_create_environment was not called"
+        
+        # Find cwd in the kwargs
+        kwargs = create_call.kwargs if create_call.kwargs else {}
+        # cwd is passed as positional or keyword
+        cwd_passed = kwargs.get("cwd", None)
+        if cwd_passed is None:
+            # Try positional args
+            args = create_call.args if create_call.args else []
+            # Position: (env_type, image, cwd, timeout, ...)
+            if len(args) >= 3:
+                cwd_passed = args[2]
+        
+        assert cwd_passed == "/Users/user/project", \
+            f"Expected cwd='/Users/user/project', got {cwd_passed!r}"
+        
+        # Cleanup
+        _last_known_cwd.pop(task_id, None)
+        
+    @patch("tools.terminal_tool._active_environments", new_callable=dict)
+    @patch("tools.file_tools._file_ops_cache", new_callable=dict)
+    @patch("tools.terminal_tool._get_env_config")
+    @patch("tools.terminal_tool._create_environment")
+    def test_last_known_cwd_falls_back_to_config_default_when_not_set(
+        self, mock_create_env, mock_config, mock_cache, mock_active
+    ):
+        from tools.file_tools import _get_file_ops, _last_known_cwd
+
+        mock_env = MagicMock()
+        mock_env.cwd = "/default/path"
+        mock_create_env.return_value = mock_env
+        mock_config.return_value = {
+            "env_type": "local",
+            "cwd": "/config/default/path",
+            "timeout": 30,
+        }
+
+        # _get_file_ops resolves to "default"
+        task_id = "default"
+        
+        # Ensure _last_known_cwd is empty for this task
+        _last_known_cwd.pop(task_id, None)
+
+        result = _get_file_ops(task_id)
+        
+        create_call = mock_create_env.call_args
+        assert create_call is not None, "_create_environment was not called"
+        
+        kwargs = create_call.kwargs if create_call.kwargs else {}
+        cwd_passed = kwargs.get("cwd", None)
+        if cwd_passed is None:
+            args = create_call.args if create_call.args else []
+            if len(args) >= 3:
+                cwd_passed = args[2]
+        
+        # Should fall back to config default
+        assert cwd_passed == "/config/default/path", \
+            f"Expected cwd='/config/default/path', got {cwd_passed!r}"

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -615,3 +615,141 @@ class TestLastKnownCwd:
         # Should fall back to config default
         assert cwd_passed == "/config/default/path", \
             f"Expected cwd='/config/default/path', got {cwd_passed!r}"
+
+    @patch("tools.terminal_tool._active_environments", new_callable=dict)
+    @patch("tools.file_tools._file_ops_cache", new_callable=dict)
+    def test_live_cwd_read_mirrors_into_last_known_cwd(self, mock_cache, mock_active):
+        """Belt-and-suspenders (#26211): every successful live-cwd read records
+        the cwd in _last_known_cwd, so the durable anchor doesn't depend on the
+        cleanup-detection branch of _get_file_ops firing."""
+        from tools.file_tools import _get_live_tracking_cwd, _last_known_cwd
+
+        task_id = "default"
+        _last_known_cwd.pop(task_id, None)
+
+        cached = MagicMock()
+        cached.env = MagicMock()
+        cached.env.cwd = "/Users/user/project"
+        cached.env.cwd_owner = "default"
+        mock_cache[task_id] = cached
+
+        live = _get_live_tracking_cwd(task_id)
+
+        assert live == "/Users/user/project"
+        # The read mirrored the live cwd into the durable registry.
+        assert _last_known_cwd.get(task_id) == "/Users/user/project"
+        _last_known_cwd.pop(task_id, None)
+
+    @patch("tools.terminal_tool._active_environments", new_callable=dict)
+    @patch("tools.file_tools._file_ops_cache", new_callable=dict)
+    @patch("tools.terminal_tool._get_env_config")
+    @patch("tools.terminal_tool._create_environment")
+    def test_mirrored_cwd_survives_when_cache_already_cleared(
+        self, mock_create_env, mock_config, mock_cache, mock_active
+    ):
+        """The original save-old-cwd path only fires when _file_ops_cache still
+        holds the stale entry. If the cleanup thread popped BOTH dicts first,
+        _get_file_ops sees cached=None and never saves — but the proactive
+        mirror from an earlier live read already populated _last_known_cwd, so
+        the rebuilt env still restores the user's directory."""
+        from tools.file_tools import (
+            _get_file_ops, _get_live_tracking_cwd, _last_known_cwd,
+        )
+
+        task_id = "default"
+        _last_known_cwd.pop(task_id, None)
+
+        # 1) Env is alive and the agent has cd'd into the project. A live read
+        #    (happens on every relative-path resolution) mirrors the cwd.
+        cached = MagicMock()
+        cached.env = MagicMock()
+        cached.env.cwd = "/Users/user/project"
+        cached.env.cwd_owner = "default"
+        mock_cache[task_id] = cached
+        assert _get_live_tracking_cwd(task_id) == "/Users/user/project"
+        assert _last_known_cwd.get(task_id) == "/Users/user/project"
+
+        # 2) Cleanup thread kills the env AND clears the cache before the next
+        #    file write — so _get_file_ops' save-old-cwd branch never runs.
+        mock_cache.pop(task_id, None)
+        mock_active.clear()
+
+        mock_env = MagicMock()
+        mock_env.cwd = "/Users/user/project"
+        mock_create_env.return_value = mock_env
+        mock_config.return_value = {
+            "env_type": "local",
+            "cwd": "/config/default/path",
+            "timeout": 30,
+        }
+
+        _get_file_ops(task_id)
+
+        create_call = mock_create_env.call_args
+        assert create_call is not None, "_create_environment was not called"
+        kwargs = create_call.kwargs if create_call.kwargs else {}
+        cwd_passed = kwargs.get("cwd", None)
+        if cwd_passed is None:
+            args = create_call.args if create_call.args else []
+            if len(args) >= 3:
+                cwd_passed = args[2]
+
+        # Rebuilt env restored the mirrored cwd, NOT the config default.
+        assert cwd_passed == "/Users/user/project", \
+            f"Expected restored cwd='/Users/user/project', got {cwd_passed!r}"
+        _last_known_cwd.pop(task_id, None)
+
+
+class TestSilentFileMisplacementE2E:
+    """Real-IO regression for #26211.
+
+    Exercises the actual write_file_tool path against a temp filesystem: an
+    agent cd's into a project, the cleanup thread kills the env, and a later
+    relative-path write must land in the project dir (not the config default).
+    Mocks miss this because resolution (_resolve_path_for_task) runs BEFORE
+    _get_file_ops rebuilds the env — only the durable _last_known_cwd fallback
+    in _authoritative_workspace_root makes the resolved path correct.
+    """
+
+    def test_relative_write_after_env_cleanup_lands_in_user_cwd(self, tmp_path, monkeypatch):
+        import tools.terminal_tool as tt
+        import tools.file_tools as ft
+
+        project = tmp_path / "project"
+        config_default = tmp_path / "config_default"
+        project.mkdir()
+        config_default.mkdir()
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+        _orig = tt._get_env_config
+        monkeypatch.setattr(
+            tt, "_get_env_config",
+            lambda: {**_orig(), "env_type": "local", "cwd": str(config_default)},
+        )
+
+        task_id = "default"
+        ft._last_known_cwd.pop(task_id, None)
+
+        # 1) Env alive; agent has cd'd into the project. A relative write
+        #    while alive mirrors the live cwd into the durable registry.
+        fo = ft._get_file_ops(task_id)
+        fo.env.cwd = str(project)
+        fo.env.cwd_owner = "default"
+        ft.write_file_tool("alive.txt", "1\n", task_id)
+        assert (project / "alive.txt").exists()
+
+        # 2) Cleanup thread kills the env AND clears the file_ops cache.
+        with tt._env_lock:
+            tt._active_environments.pop(task_id, None)
+            tt._last_activity.pop(task_id, None)
+        with ft._file_ops_lock:
+            ft._file_ops_cache.pop(task_id, None)
+
+        # 3) The next relative write must still land in the project dir.
+        res = json.loads(ft.write_file_tool("report.txt", "hello\n", task_id))
+        assert res.get("resolved_path") == str(project / "report.txt"), res
+        assert (project / "report.txt").exists(), "file should be in the user's cwd"
+        assert not (config_default / "report.txt").exists(), \
+            "file silently misplaced into config default (the #26211 bug)"
+
+        ft._last_known_cwd.pop(task_id, None)

--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -394,3 +394,27 @@ def test_unknown_owner_keeps_prior_single_session_behavior(tmp_path, monkeypatch
     )
     assert ft._get_live_tracking_cwd("default") == str(ws)
     assert ft._get_live_tracking_cwd("any-session") == str(ws)
+
+
+def test_preserved_cwd_does_not_override_non_owning_sessions_worktree(
+    _two_worktree_sessions, monkeypatch
+):
+    """#26211 belt-and-suspenders must not break worktree isolation.
+
+    The owner (session B) doing an owned live read mirrors wt_b into the shared
+    _last_known_cwd['default'] registry. Session A — which does NOT own the env
+    but HAS its own registered worktree (wt_a) — must still resolve into wt_a,
+    not inherit B's preserved cwd through the shared-container key. The
+    session-specific registered override must beat the durable shared anchor.
+    """
+    wt_a, wt_b, _main = _two_worktree_sessions
+    monkeypatch.setattr(ft, "_last_known_cwd", {})
+
+    # Owner B resolves first — this mirrors wt_b into _last_known_cwd['default'].
+    assert ft._resolve_path_for_task("target.py", task_id="sess-b") == (wt_b / "target.py")
+    assert ft._last_known_cwd.get("default") == str(wt_b)
+
+    # A still routes to its own registered worktree despite the shared anchor.
+    resolved_a = ft._resolve_path_for_task("target.py", task_id="sess-a")
+    assert resolved_a == (wt_a / "target.py")
+    assert not str(resolved_a).startswith(str(wt_b))

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -204,10 +204,13 @@ def _get_live_tracking_cwd(task_id: str = "default") -> str | None:
         env = getattr(cached, "env", None)
         live_cwd = _live_cwd_if_owned(env, task_id)
         if live_cwd:
+            _remember_last_known_cwd(container_key, live_cwd)
             return live_cwd
         # Legacy: a cache entry carrying its own cwd with no env to own it.
         if env is None and getattr(cached, "cwd", None):
-            return getattr(cached, "cwd", None)
+            legacy_cwd = getattr(cached, "cwd", None)
+            _remember_last_known_cwd(container_key, legacy_cwd)
+            return legacy_cwd
 
     try:
         from tools.terminal_tool import _active_environments, _env_lock
@@ -216,6 +219,7 @@ def _get_live_tracking_cwd(task_id: str = "default") -> str | None:
             env = _active_environments.get(container_key) or _active_environments.get(task_id)
         live_cwd = _live_cwd_if_owned(env, task_id)
         if live_cwd:
+            _remember_last_known_cwd(container_key, live_cwd)
             return live_cwd
     except Exception:
         pass
@@ -240,6 +244,16 @@ def _authoritative_workspace_root(task_id: str = "default") -> str | None:
     live = _get_live_tracking_cwd(task_id)
     if live:
         return live
+    # When the terminal env was cleaned up mid-conversation, the live cwd is
+    # gone but the directory the agent navigated to is still recorded in the
+    # durable _last_known_cwd registry. Prefer it over the config/process
+    # fallback so a relative-path write resolved BEFORE the env is rebuilt
+    # still lands in the user's directory (root cause of #26211: write happens
+    # via _resolve_path_for_task -> here, which runs before _get_file_ops
+    # rebuilds the env). Keyed by the resolved container id, same as the save.
+    preserved = _last_known_cwd_for(task_id)
+    if preserved:
+        return preserved
     registered = _registered_task_cwd_override(task_id)
     if registered:
         return registered
@@ -559,6 +573,41 @@ _file_ops_cache: dict = {}
 # relative-path file writes land in the right directory after the
 # terminal environment is cleaned up and rebuilt (root cause of #26211).
 _last_known_cwd: dict = {}
+
+
+def _remember_last_known_cwd(task_id: str, cwd: str | None) -> None:
+    """Mirror a live terminal cwd into the durable ``_last_known_cwd`` registry.
+
+    Belt-and-suspenders for #26211: the cleanup thread can pop BOTH
+    ``_file_ops_cache`` and ``_active_environments`` before ``_get_file_ops``
+    reaches its stale-cache detection branch, in which case the old cwd is
+    never saved and the rebuilt env falls back to the config default — exactly
+    the silent-misplacement bug. By recording the cwd on every successful live
+    read (which happens on every relative-path file resolution while the env is
+    alive), the durable anchor no longer depends on the cleanup-detection
+    branch firing, so it survives recreation regardless of pop ordering.
+    """
+    if not cwd:
+        return
+    with _file_ops_lock:
+        if _last_known_cwd.get(task_id) != cwd:
+            _last_known_cwd[task_id] = cwd
+
+
+def _last_known_cwd_for(task_id: str = "default") -> str | None:
+    """Read the durable last-known cwd for *task_id*, container-key aware.
+
+    The registry is keyed by the resolved container id (the same key used by
+    the save sites in ``_get_file_ops`` / ``_get_live_tracking_cwd``), so look
+    up the resolved key first and fall back to the raw task id.
+    """
+    try:
+        from tools.terminal_tool import _resolve_container_task_id
+        container_key = _resolve_container_task_id(task_id)
+    except Exception:
+        container_key = task_id
+    with _file_ops_lock:
+        return _last_known_cwd.get(container_key) or _last_known_cwd.get(task_id)
 
 # Track files read per task to detect re-read loops and deduplicate reads.
 # Per task_id we store:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -555,6 +555,10 @@ def _is_expected_write_exception(exc: Exception) -> bool:
 
 _file_ops_lock = threading.Lock()
 _file_ops_cache: dict = {}
+# Per-task last-known CWD — preserved across env re-creation so
+# relative-path file writes land in the right directory after the
+# terminal environment is cleaned up and rebuilt (root cause of #26211).
+_last_known_cwd: dict = {}
 
 # Track files read per task to detect re-read loops and deduplicate reads.
 # Per task_id we store:
@@ -789,7 +793,13 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 _last_activity[task_id] = time.time()
                 return cached
             else:
-                # Environment was cleaned up -- invalidate stale cache entry
+                # Environment was cleaned up -- preserve the old cwd before
+                # invalidating the stale cache entry (fixes #26211: silent
+                # file-creation failures in long-running conversations).
+                old_cwd = getattr(cached, "cwd", None)
+                if old_cwd:
+                    with _file_ops_lock:
+                        _last_known_cwd[task_id] = old_cwd
                 with _file_ops_lock:
                     _file_ops_cache.pop(task_id, None)
 
@@ -827,7 +837,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
             else:
                 image = ""
 
-            cwd = overrides.get("cwd") or config["cwd"]
+            cwd = overrides.get("cwd") or _last_known_cwd.get(task_id) or config["cwd"]
             logger.info("Creating new %s environment for task %s...", env_type, task_id[:8])
 
             container_config = None

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -244,6 +244,15 @@ def _authoritative_workspace_root(task_id: str = "default") -> str | None:
     live = _get_live_tracking_cwd(task_id)
     if live:
         return live
+    # A session-specific registered override (TUI/Desktop/ACP workspace cwd)
+    # is more authoritative than the shared last-known anchor: it is keyed by
+    # the raw session id, so when two worktree sessions share the single
+    # "default" terminal env, a NON-owning session must resolve against its OWN
+    # registered worktree — never the other session's leftover cwd. (Checked
+    # before _last_known_cwd, which is keyed by the shared container id.)
+    registered = _registered_task_cwd_override(task_id)
+    if registered:
+        return registered
     # When the terminal env was cleaned up mid-conversation, the live cwd is
     # gone but the directory the agent navigated to is still recorded in the
     # durable _last_known_cwd registry. Prefer it over the config/process
@@ -254,9 +263,6 @@ def _authoritative_workspace_root(task_id: str = "default") -> str | None:
     preserved = _last_known_cwd_for(task_id)
     if preserved:
         return preserved
-    registered = _registered_task_cwd_override(task_id)
-    if registered:
-        return registered
     return _configured_terminal_cwd()
 
 


### PR DESCRIPTION
## Summary

Relative-path file writes in long-running conversations now land in the directory the user navigated to, instead of silently going to the config default. Closes #26211.

Root cause: the terminal-env cleanup thread (300s idle) kills the env mid-conversation. On the next write the env is rebuilt with `config["cwd"]`, discarding the user's `cd`'d directory — so the agent reports "File created (N bytes)" while the file lands somewhere the user can't see with `ls`/Finder.

## Changes

- `tools/file_tools.py`:
  - **(cherry-picked, @zccyman / PR #26251)** `_last_known_cwd` registry — save the old env's cwd before invalidating the stale cache entry, and restore it when rebuilding the env (`overrides.get("cwd") or _last_known_cwd.get(task_id) or config["cwd"]`).
  - **(follow-up)** Proactively mirror every live cwd read into `_last_known_cwd`, so the durable anchor survives even when the cleanup thread pops both `_file_ops_cache` **and** `_active_environments` before `_get_file_ops`' save branch can fire.
  - **(follow-up)** Fall back to `_last_known_cwd` in `_authoritative_workspace_root`. `write_file_tool` resolves the path (via `_resolve_path_for_task`) **before** `_get_file_ops` rebuilds the env, so restoring only the rebuilt env's cwd was insufficient — the resolution that decides where the file lands runs first. This closes that gap.
- `tests/tools/test_file_tools.py`: the cherry-picked `TestLastKnownCwd` cases, two new mock cases for the proactive mirror, and a real-IO E2E regression (`TestSilentFileMisplacementE2E`) exercising the actual `write_file_tool` path after env cleanup.

Note: the local env's persisted `_cwd_file` can't serve as the anchor — it's keyed by a random per-session uuid and deleted on cleanup (the same cleanup that triggers the bug). The in-memory `_last_known_cwd` registry is the durable anchor instead.

## Validation

| | Before | After |
|---|---|---|
| Relative write after idle env cleanup | lands in `config["cwd"]`, reported as success | lands in the user's `cd`'d dir |
| `tests/tools/test_file_tools.py` | — | 43 pass |
| `test_file_operations.py` + edge cases | — | 168 pass total |
| Real-IO E2E (write after cleanup) | file in wrong dir | file in `project/`, not `config_default/` |

Salvage of #26251 by @zccyman — original cwd-preservation commit cherry-picked with authorship preserved; the resolution-time gap and E2E regression added on top. Supersedes #26336 (warning-only, symptom not root cause), already closed.

## Infographic

![Preserve CWD across terminal restarts — fix #26211](https://v3b.fal.media/files/b/0aa00d02/6ppK0B6jSajgs9xhw7nMx_2xnVV67Y.png)
