### PR TITLE
fix(agent): activate fallback chain on repeated stale-stream kills (#25689)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -25,7 +25,11 @@ import uuid
 from types import SimpleNamespace
 from typing import Any, Dict, Optional
 
-from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
+from hermes_cli.timeouts import (
+    get_provider_request_timeout,
+    get_provider_stale_fallback_threshold,
+    get_provider_stale_timeout,
+)
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
 from agent.model_metadata import is_local_endpoint
@@ -1844,6 +1848,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # resolved, so the builder degrades to its plain default if it ever runs
     # first.
     _stream_stale_timeout = None
+    stale_forced_close = {"pending": False}
+    stale_fallback_pending = {"pending": False}
 
     def _fire_first_delta():
         if not first_delta_fired["done"] and on_first_delta:
@@ -1852,6 +1858,70 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 on_first_delta()
             except Exception:
                 pass
+
+    def _current_stream_runtime_key() -> tuple[str, str, str]:
+        """Identify the active backend for turn-scoped stale tracking."""
+        return (
+            (getattr(agent, "provider", "") or "").strip().lower(),
+            (getattr(agent, "model", "") or "").strip(),
+            str(getattr(agent, "base_url", "") or "").rstrip("/").lower(),
+        )
+
+    def _get_turn_stale_stream_state() -> dict:
+        """Return the current turn's stale-stream state for this runtime."""
+        state = getattr(agent, "_turn_stale_stream_state", None)
+        if not isinstance(state, dict):
+            state = {}
+            agent._turn_stale_stream_state = state
+        runtime_key = _current_stream_runtime_key()
+        if state.get("runtime_key") != runtime_key:
+            state["runtime_key"] = runtime_key
+            state["count"] = 0
+        elif not isinstance(state.get("count"), int):
+            state["count"] = 0
+        return state
+
+    def _reset_stream_retry_state() -> None:
+        """Clear per-attempt delivery state before retrying a stream."""
+        try:
+            agent._reset_stream_delivery_tracking()
+        except Exception:
+            pass
+        result["partial_tool_names"] = []
+        deltas_were_sent["yes"] = False
+        first_delta_fired["done"] = False
+
+    def _try_stream_fallback_after_repeated_stale(
+        error: Exception, *, mid_tool_call: bool,
+    ) -> bool:
+        """Switch to the configured fallback provider after repeated stale kills."""
+        if not stale_fallback_pending["pending"] or not agent._has_pending_fallback():
+            return False
+
+        stale_fallback_pending["pending"] = False
+        stale_forced_close["pending"] = False
+
+        if mid_tool_call:
+            try:
+                agent._fire_stream_delta(
+                    "\n\n⚠ Repeated stale stream errors; switching to fallback provider…\n\n"
+                )
+            except Exception:
+                pass
+
+        agent._buffer_status(
+            "⚠️ Repeated stale stream errors — switching to fallback provider..."
+        )
+        _reset_stream_retry_state()
+
+        from agent.error_classifier import FailoverReason
+
+        if agent._try_activate_fallback(reason=FailoverReason.timeout):
+            _get_turn_stale_stream_state()["count"] = 0
+            return True
+
+        result["error"] = error
+        return False
 
     def _call_chat_completions():
         """Stream a chat completions response."""
@@ -2355,9 +2425,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             type(e).__name__,
                         )
                         return
+                    _forced_stale_error = stale_forced_close["pending"]
+                    if _forced_stale_error:
+                        stale_forced_close["pending"] = False
                     _is_timeout = isinstance(
                         e, (_httpx.ReadTimeout, _httpx.ConnectTimeout, _httpx.PoolTimeout)
-                    )
+                    ) or _forced_stale_error
                     _is_conn_err = isinstance(
                         e, (_httpx.ConnectError, _httpx.RemoteProtocolError, ConnectionError)
                     )
@@ -2406,6 +2479,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             or _is_sse_conn_err_preview
                             or _is_stream_parse_err
                         )
+                        if (
+                            _forced_stale_error
+                            and stale_fallback_pending["pending"]
+                            and _partial_tool_in_flight
+                        ):
+                            if _try_stream_fallback_after_repeated_stale(
+                                e, mid_tool_call=True,
+                            ):
+                                continue
+                            if result["error"] is not None:
+                                return
                         _can_silent_retry = (
                             _partial_tool_in_flight
                             and _is_transient
@@ -2441,16 +2525,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         # fresh preamble doesn't get double-recorded in
                         # _current_streamed_assistant_text (which would
                         # pollute the interim-visible-text comparison).
-                        try:
-                            agent._reset_stream_delivery_tracking()
-                        except Exception:
-                            pass
-                        # Reset in-memory accumulators so the next
-                        # attempt's chunks don't concat onto the dead
-                        # stream's partial JSON.
-                        result["partial_tool_names"] = []
-                        deltas_were_sent["yes"] = False
-                        first_delta_fired["done"] = False
+                        _reset_stream_retry_state()
                         agent._emit_stream_drop(
                             error=e,
                             attempt=_stream_attempt + 2,
@@ -2498,6 +2573,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             )
 
                     if _is_timeout or _is_conn_err or _is_sse_conn_err or _is_stream_parse_err:
+                        if _forced_stale_error and stale_fallback_pending["pending"]:
+                            if _try_stream_fallback_after_repeated_stale(
+                                e, mid_tool_call=False,
+                            ):
+                                continue
+                            if result["error"] is not None:
+                                return
                         # Transient network / timeout error. Retry the
                         # streaming request with a fresh connection first.
                         if _stream_attempt < _max_stream_retries:
@@ -2610,6 +2692,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         _stream_stale_timeout_base = _cfg_stale
     else:
         _stream_stale_timeout_base = env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
+    # Number of consecutive stale-stream kills (within one turn, per runtime)
+    # before escalating to the configured fallback chain.  Config-driven:
+    # model.stale_fallback_threshold (or per-provider/per-model override),
+    # resolved in hermes_cli/timeouts.py.  0 disables fallback escalation.
+    _stale_fallback_threshold = get_provider_stale_fallback_threshold(
+        agent.provider, agent.model
+    )
     # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
     # for prefill on large contexts.  Disable the stale detector unless
     # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.
@@ -2682,16 +2771,26 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 f"context: ~{_est_ctx:,} tokens). "
                 f"Reconnecting..."
             )
+            _turn_stale_state = _get_turn_stale_stream_state()
+            _turn_stale_state["count"] += 1
+            stale_forced_close["pending"] = True
+            if (
+                _stale_fallback_threshold > 0
+                and _turn_stale_state["count"] >= _stale_fallback_threshold
+                and agent._has_pending_fallback()
+            ):
+                stale_fallback_pending["pending"] = True
             try:
                 _close_request_client_once("stale_stream_kill")
             except Exception:
                 pass
             # Rebuild the primary client too — its connection pool
             # may hold dead sockets from the same provider outage.
-            try:
-                agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
-            except Exception:
-                pass
+            if not stale_fallback_pending["pending"]:
+                try:
+                    agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
+                except Exception:
+                    pass
             # Reset the timer so we don't kill repeatedly while
             # the inner thread processes the closure.
             last_chunk_time["t"] = time.time()

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -220,6 +220,7 @@ def build_turn_context(
     agent._last_content_with_tools = None
     agent._last_content_tools_all_housekeeping = False
     agent._mute_post_response = False
+    agent._turn_stale_stream_state = {"runtime_key": None, "count": 0}
     agent._unicode_sanitization_passes = 0
     agent._tool_guardrails.reset_for_turn()
     agent._tool_guardrail_halt_decision = None

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -102,6 +102,14 @@ model:
 # implicit non-stream stale detector is auto-disabled for local endpoints
 # and can scale upward for very large contexts.
 #
+# ``stale_fallback_threshold`` controls how many consecutive stale-stream
+# kills (within one turn, for the same provider/model) are tolerated before
+# Hermes escalates to the next entry in ``fallback_providers``. A provider
+# that holds the connection open but delivers no tokens is otherwise retried
+# on the same endpoint forever. Default is 2; set 0 to disable escalation and
+# keep retrying the primary. Resolution order: per-model override ->
+# per-provider -> top-level ``stale_fallback_threshold`` -> default.
+#
 # Not currently wired for AWS Bedrock (bedrock_converse + AnthropicBedrock
 # SDK paths) — those use boto3 with its own timeout configuration.
 #
@@ -118,6 +126,8 @@ model:
 #     models:
 #       gpt-5.4:
 #         stale_timeout_seconds: 1800  # Longer non-stream stale timeout for slow large-context turns
+#   zai:
+#     stale_fallback_threshold: 1    # Escalate to fallback after a single stale-stream kill
 
 # =============================================================================
 # OpenRouter Provider Routing (only applies when using OpenRouter)

--- a/hermes_cli/timeouts.py
+++ b/hermes_cli/timeouts.py
@@ -69,6 +69,61 @@ def get_provider_stale_timeout(
     return _coerce_timeout(provider_config.get("stale_timeout_seconds"))
 
 
+def get_provider_stale_fallback_threshold(
+    provider_id: str, model: str | None = None
+) -> int:
+    """Return the consecutive stale-stream kill count that triggers fallback.
+
+    Resolution order (first match wins):
+      1. providers.<id>.models.<model>.stale_fallback_threshold
+      2. providers.<id>.stale_fallback_threshold
+      3. top-level stale_fallback_threshold
+      4. default of 2
+
+    Returns 0 to disable stale-stream fallback escalation entirely.
+    Negative or non-integer values are clamped/ignored and fall through
+    to the next source.
+    """
+    default = 2
+
+    try:
+        from hermes_cli.config import load_config_readonly
+        config = load_config_readonly()
+    except Exception:
+        return default
+
+    if not isinstance(config, dict):
+        return default
+
+    def _coerce(raw: object) -> int | None:
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            return None
+        return value if value >= 0 else None
+
+    if provider_id:
+        providers = config.get("providers", {})
+        provider_config = (
+            providers.get(provider_id, {}) if isinstance(providers, dict) else {}
+        )
+        if isinstance(provider_config, dict):
+            model_config = _get_model_config(provider_config, model)
+            if model_config is not None:
+                threshold = _coerce(model_config.get("stale_fallback_threshold"))
+                if threshold is not None:
+                    return threshold
+            threshold = _coerce(provider_config.get("stale_fallback_threshold"))
+            if threshold is not None:
+                return threshold
+
+    threshold = _coerce(config.get("stale_fallback_threshold"))
+    if threshold is not None:
+        return threshold
+
+    return default
+
+
 def _get_model_config(
     provider_config: dict[str, object], model: str | None
 ) -> dict[str, object] | None:

--- a/tests/hermes_cli/test_timeouts.py
+++ b/tests/hermes_cli/test_timeouts.py
@@ -4,12 +4,84 @@ import textwrap
 
 from hermes_cli.timeouts import (
     get_provider_request_timeout,
+    get_provider_stale_fallback_threshold,
     get_provider_stale_timeout,
 )
 
 
 def _write_config(tmp_path, body: str) -> None:
     (tmp_path / "config.yaml").write_text(textwrap.dedent(body), encoding="utf-8")
+
+
+def test_stale_fallback_threshold_defaults_to_two(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path, "providers: {}\n")
+
+    assert get_provider_stale_fallback_threshold("zai", "glm-5-turbo") == 2
+
+
+def test_stale_fallback_threshold_model_override_wins(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        stale_fallback_threshold: 4
+        providers:
+          zai:
+            stale_fallback_threshold: 3
+            models:
+              glm-5-turbo:
+                stale_fallback_threshold: 1
+        """,
+    )
+
+    assert get_provider_stale_fallback_threshold("zai", "glm-5-turbo") == 1
+
+
+def test_stale_fallback_threshold_provider_over_top_level(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        stale_fallback_threshold: 4
+        providers:
+          zai:
+            stale_fallback_threshold: 3
+        """,
+    )
+
+    # No model override → provider value wins over the top-level default.
+    assert get_provider_stale_fallback_threshold("zai", "glm-5-turbo") == 3
+    # Unknown provider → top-level value wins.
+    assert get_provider_stale_fallback_threshold("openrouter", "x") == 4
+
+
+def test_stale_fallback_threshold_zero_disables(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path, "stale_fallback_threshold: 0\n")
+
+    # 0 is a valid, explicit "disable escalation" value — not coerced to default.
+    assert get_provider_stale_fallback_threshold("zai", "glm-5-turbo") == 0
+
+
+def test_stale_fallback_threshold_invalid_falls_through(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        stale_fallback_threshold: 5
+        providers:
+          zai:
+            stale_fallback_threshold: "not-a-number"
+            models:
+              glm-5-turbo:
+                stale_fallback_threshold: -3
+        """,
+    )
+
+    # Negative model value and non-numeric provider value are both ignored,
+    # falling through to the valid top-level value.
+    assert get_provider_stale_fallback_threshold("zai", "glm-5-turbo") == 5
 
 
 def test_model_timeout_override_wins(monkeypatch, tmp_path):

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -1519,7 +1519,14 @@ class TestRepeatedStaleStreamFallback:
 
         monkeypatch.setenv("HERMES_STREAM_RETRIES", "3")
         monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "0.05")
-        monkeypatch.setenv("HERMES_STREAM_STALE_FALLBACK_THRESHOLD", "2")
+        # Threshold is config-driven (model.stale_fallback_threshold), resolved
+        # via hermes_cli.timeouts.get_provider_stale_fallback_threshold. Patch
+        # the import site in chat_completion_helpers to drive the escalation
+        # path deterministically at threshold=2.
+        monkeypatch.setattr(
+            "agent.chat_completion_helpers.get_provider_stale_fallback_threshold",
+            lambda *a, **k: 2,
+        )
 
         first_response = agent._interruptible_streaming_api_call(
             {"model": "deepseek-v4-flash", "messages": []}

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -3,6 +3,7 @@
 Tests the unified streaming API call, delta callbacks, tool-call
 suppression, provider fallback, and CLI streaming display.
 """
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -1422,6 +1423,124 @@ class TestSilentRetryMidToolCall:
         )
         assert "Stream stalled" not in content, (
             f"Text-only stall should not emit tool-call warning: {content!r}"
+        )
+
+
+class TestRepeatedStaleStreamFallback:
+    """Repeated stale kills within one turn should escalate to runtime fallback."""
+
+    @patch("run_agent.AIAgent._abort_request_openai_client")
+    @patch("run_agent.AIAgent._replace_primary_openai_client")
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_second_stale_in_same_turn_switches_to_fallback_provider(
+        self, mock_close, mock_create, mock_replace, mock_abort, monkeypatch,
+    ):
+        from run_agent import AIAgent
+
+        try:
+            import httpx as _httpx
+        except Exception:  # pragma: no cover - dependency is present in test env
+            pytest.skip("httpx unavailable")
+
+        current_close_event = {"event": None}
+        switched_to_fallback = {"yes": False}
+        stream_attempts = {"n": 0}
+        status_lines = []
+        stream_plan = iter([
+            "stale",
+            "primary_recovered",
+            "stale",
+            "fallback_recovered",
+        ])
+
+        def _stalled_stream(close_event):
+            if False:
+                yield None
+            while not close_event.wait(0.01):
+                pass
+            raise _httpx.ReadError("[Errno 9] Bad file descriptor")
+
+        def _healthy_stream(text):
+            yield _make_stream_chunk(content=text)
+            yield _make_stream_chunk(finish_reason="stop")
+
+        def _make_client():
+            client = MagicMock()
+
+            def _create_stream(*_args, **_kwargs):
+                stream_attempts["n"] += 1
+                behavior = next(stream_plan)
+                if behavior == "primary_recovered":
+                    return _healthy_stream("Primary recovered once")
+                if behavior == "fallback_recovered":
+                    assert switched_to_fallback["yes"] is True
+                    return _healthy_stream("Fallback recovered")
+                close_event = threading.Event()
+                current_close_event["event"] = close_event
+                return _stalled_stream(close_event)
+
+            client.chat.completions.create.side_effect = _create_stream
+            return client
+
+        mock_create.side_effect = lambda *_args, **_kwargs: _make_client()
+
+        def _close_client(_client, *_args, **_kwargs):
+            close_event = current_close_event.get("event")
+            if close_event is not None:
+                close_event.set()
+
+        mock_close.side_effect = _close_client
+        mock_abort.side_effect = _close_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            provider="deepseek",
+            model="deepseek-v4-flash",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+        agent._fallback_chain = [{"provider": "openrouter", "model": "kimi-k2"}]
+        agent._fallback_index = 0
+        agent._buffer_status = lambda text: status_lines.append(text)
+
+        def _activate_fallback(reason=None):
+            switched_to_fallback["yes"] = True
+            agent.provider = "openrouter"
+            agent.model = "kimi-k2"
+            agent._fallback_index = 1
+            return True
+
+        agent._try_activate_fallback = MagicMock(side_effect=_activate_fallback)
+
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "3")
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "0.05")
+        monkeypatch.setenv("HERMES_STREAM_STALE_FALLBACK_THRESHOLD", "2")
+
+        first_response = agent._interruptible_streaming_api_call(
+            {"model": "deepseek-v4-flash", "messages": []}
+        )
+        assert first_response.choices[0].message.content == "Primary recovered once"
+        assert agent._try_activate_fallback.call_count == 0
+
+        second_response = agent._interruptible_streaming_api_call(
+            {"model": "deepseek-v4-flash", "messages": []}
+        )
+
+        assert second_response.choices[0].message.content == "Fallback recovered"
+        assert stream_attempts["n"] == 4, (
+            "Expected 1 stale + recovery on primary, then 1 stale + fallback recovery; "
+            f"got {stream_attempts['n']} attempts"
+        )
+        assert agent._try_activate_fallback.call_count == 1
+        assert switched_to_fallback["yes"] is True
+        assert agent._turn_stale_stream_state["count"] == 0
+        assert any("fallback" in line.lower() for line in status_lines), (
+            f"Expected a fallback status message, got {status_lines!r}"
         )
 
 

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -105,6 +105,11 @@ The fallback activates automatically when the primary model fails with:
 - **Auth failures** (HTTP 401, 403) — immediately (no point retrying)
 - **Not found** (HTTP 404) — immediately
 - **Invalid responses** — when the API returns malformed or empty responses repeatedly
+- **Stale streams** — when the provider holds the connection open (SSE keep-alives) but delivers no tokens. After `stale_fallback_threshold` consecutive stale-stream kills within a turn (default 2), Hermes escalates to the next provider instead of retrying the same unresponsive endpoint forever.
+
+:::tip Tuning stale-stream fallback
+A provider can be alive (not returning 429/500) yet stop delivering stream chunks. By default Hermes kills the stalled connection and reconnects to the same provider, escalating to `fallback_providers` after 2 such kills in one turn. Tune this with `stale_fallback_threshold` in `config.yaml` — set it to `1` to fail over after the first stale kill, or `0` to disable escalation and keep retrying the primary. It resolves per-model, then per-provider, then top-level: `providers.<id>.models.<model>.stale_fallback_threshold` → `providers.<id>.stale_fallback_threshold` → top-level `stale_fallback_threshold`.
+:::
 
 When triggered, Hermes:
 


### PR DESCRIPTION
## Summary
A primary provider that holds the stream open but stops delivering tokens now fails over to `fallback_providers` instead of being retried forever. After `stale_fallback_threshold` consecutive stale-stream kills within a turn (default 2), Hermes escalates to the next provider via the existing timeout-failover path.

Root cause: the streaming stale-kill block (`agent/chat_completion_helpers.py`) closed the connection, rebuilt the pool, reset the timer, and re-looped on the **same** provider — it never called `_try_activate_fallback()`. Empty/malformed responses already triggered eager fallback; stale streams did not. Fixes #25689 (and dup #43211).

## Changes
- `agent/chat_completion_helpers.py`: turn-scoped, per-runtime stale-kill counter; on reaching the threshold, route the next forced-close through the existing timeout fallback path (`_try_activate_fallback(reason=FailoverReason.timeout)`), gated on `_has_pending_fallback()`; skip the primary-client pool rebuild when escalating.
- `agent/turn_context.py`: reset turn-scoped stale-stream state at the start of each turn.
- `hermes_cli/timeouts.py`: `get_provider_stale_fallback_threshold()` — config-driven threshold, resolved per-model → per-provider → top-level `stale_fallback_threshold` → default 2; `0` disables escalation.
- `cli-config.yaml.example`, `website/docs/user-guide/features/fallback-providers.md`: document the key.
- Tests: turn-level regression in `test_streaming.py`; 5 resolution-order tests in `test_timeouts.py`.

Salvaged from @izumi0uu's #43231. The contributor's original used a `HERMES_STREAM_STALE_FALLBACK_THRESHOLD` env var; per the .env-secrets-only policy, behavioral thresholds belong in `config.yaml`, so we swapped it for the config helper above and kept their turn-scoped escalation design (which matches the report: a provider that recovers, then goes stale again later in the same turn).

## Validation
| | Behavior |
|---|---|
| Before | Stale stream → kill + reconnect same provider → repeats until `max_retries`, fallback never fires |
| After | 2nd stale kill in a turn → `_try_activate_fallback(timeout)` → fallback provider serves the turn |

- Targeted: `test_streaming.py` + `test_timeouts.py` + `test_provider_fallback.py` → 78 passed.
- E2E (real config.yaml + real `AIAgent` + real streaming helper, stalling stream): turn 1 stale→recover (no fallback), turn 2 stale→escalate exactly once with `reason=timeout`, fallback delivers. Config resolution verified through the real `get_provider_stale_fallback_threshold` (no helper mock).

## Infographic

![stale-stream-fallback-escalation](https://v3b.fal.media/files/b/0aa00d10/qsGwS2aX8_ErGiKHyMzKz_ok2A7FRy.png)
