### PR TITLE
fix(tui): drop cross-session events during null-sid switch window (#51058)

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -1758,6 +1758,69 @@ describe('createGatewayEventHandler', () => {
       // Turn continues without finalizing or throwing
       expect(getUiState().busy).toBe(true)
       expect(appended).toHaveLength(0)
+  describe('cross-session event filtering', () => {
+    it('drops events from a different session_id', () => {
+      const appended: Msg[] = []
+      const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+      patchUiState({ sid: 'sess-active' })
+      onEvent({ payload: { text: 'other session' }, session_id: 'sess-other', type: 'message.delta' } as any)
+
+      expect(appended.filter(m => m.role === 'assistant')).toHaveLength(0)
+    })
+
+    it('drops session-scoped events with empty-string session_id', () => {
+      const appended: Msg[] = []
+      const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+      patchUiState({ sid: 'sess-active' })
+      onEvent({ payload: { text: 'orphan' }, session_id: '', type: 'message.delta' } as any)
+
+      expect(appended.filter(m => m.role === 'assistant')).toHaveLength(0)
+    })
+
+    it('drops all non-gateway events when sid is null (switch window)', () => {
+      const appended: Msg[] = []
+      const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+      // sid is null during session switch/reset
+      patchUiState({ sid: null as any })
+      onEvent({ payload: { text: 'leaked' }, session_id: 'sess-other', type: 'message.delta' } as any)
+
+      expect(appended.filter(m => m.role === 'assistant')).toHaveLength(0)
+    })
+
+    it('passes gateway.* events through even when sid is null', () => {
+      const appended: Msg[] = []
+      const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+      patchUiState({ sid: null as any })
+      onEvent({ payload: {}, type: 'gateway.ready' } as any)
+
+      // gateway.ready should not throw and should be processed
+      expect(appended.length).toBeGreaterThanOrEqual(0)
+    })
+
+    it('passes pet.* and skin.* global events through with empty session_id', () => {
+      const appended: Msg[] = []
+      const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+      patchUiState({ sid: 'sess-active' })
+      onEvent({ payload: {}, session_id: '', type: 'skin.changed' } as any)
+
+      // Should not throw — global event passes through
+      expect(appended.length).toBeGreaterThanOrEqual(0)
+    })
+
+    it('accepts events matching the active session_id', () => {
+      const appended: Msg[] = []
+      const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+      patchUiState({ sid: 'sess-active' })
+      onEvent({ payload: { text: 'hello' }, session_id: 'sess-active', type: 'message.delta' } as any)
+      onEvent({ payload: { text: 'hello' }, session_id: 'sess-active', type: 'message.complete' } as any)
+
+      expect(appended.filter(m => m.role === 'assistant')).toHaveLength(1)
     })
   })
 })

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -5,6 +5,7 @@ import { getOverlayState, patchOverlayState, resetOverlayState } from '../app/ov
 import { turnController } from '../app/turnController.js'
 import { getTurnState, resetTurnState } from '../app/turnStore.js'
 import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
+import type { GatewayEvent } from '../gatewayTypes.js'
 import { estimateTokensRough } from '../lib/text.js'
 import type { Msg } from '../types.js'
 
@@ -1758,69 +1759,69 @@ describe('createGatewayEventHandler', () => {
       // Turn continues without finalizing or throwing
       expect(getUiState().busy).toBe(true)
       expect(appended).toHaveLength(0)
+    })
+  })
   describe('cross-session event filtering', () => {
-    it('drops events from a different session_id', () => {
+    it.each([
+      ['foreign session', 'sess-active', 'sess-other'],
+      ['foreign session during the null-sid switch window', null, 'sess-other'],
+      ['explicit empty session id', 'sess-active', '']
+    ])('drops the %s transcript sequence', (_case, activeSid, eventSid) => {
+      const appended: Msg[] = []
+      const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+      patchUiState({ sid: activeSid })
+      onEvent({ payload: { text: 'leaked delta' }, session_id: eventSid, type: 'message.delta' } satisfies GatewayEvent)
+      onEvent({
+        payload: { text: 'leaked answer' },
+        session_id: eventSid,
+        type: 'message.complete'
+      } satisfies GatewayEvent)
+
+      expect(appended).toEqual([])
+    })
+
+    it('accepts the transcript sequence matching the active session', () => {
       const appended: Msg[] = []
       const onEvent = createGatewayEventHandler(buildCtx(appended))
 
       patchUiState({ sid: 'sess-active' })
-      onEvent({ payload: { text: 'other session' }, session_id: 'sess-other', type: 'message.delta' } as any)
+      onEvent({
+        payload: { text: 'current delta' },
+        session_id: 'sess-active',
+        type: 'message.delta'
+      } satisfies GatewayEvent)
+      onEvent({
+        payload: { text: 'current answer' },
+        session_id: 'sess-active',
+        type: 'message.complete'
+      } satisfies GatewayEvent)
 
-      expect(appended.filter(m => m.role === 'assistant')).toHaveLength(0)
+      expect(appended).toEqual([{ role: 'assistant', text: 'current answer' }])
     })
 
-    it('drops session-scoped events with empty-string session_id', () => {
+    it('accepts a truly unscoped transcript sequence', () => {
       const appended: Msg[] = []
       const onEvent = createGatewayEventHandler(buildCtx(appended))
 
       patchUiState({ sid: 'sess-active' })
-      onEvent({ payload: { text: 'orphan' }, session_id: '', type: 'message.delta' } as any)
+      onEvent({ payload: { text: 'unscoped delta' }, type: 'message.delta' } satisfies GatewayEvent)
+      onEvent({ payload: { text: 'unscoped answer' }, type: 'message.complete' } satisfies GatewayEvent)
 
-      expect(appended.filter(m => m.role === 'assistant')).toHaveLength(0)
+      expect(appended).toEqual([{ role: 'assistant', text: 'unscoped answer' }])
     })
 
-    it('drops all non-gateway events when sid is null (switch window)', () => {
-      const appended: Msg[] = []
-      const onEvent = createGatewayEventHandler(buildCtx(appended))
-
-      // sid is null during session switch/reset
-      patchUiState({ sid: null as any })
-      onEvent({ payload: { text: 'leaked' }, session_id: 'sess-other', type: 'message.delta' } as any)
-
-      expect(appended.filter(m => m.role === 'assistant')).toHaveLength(0)
-    })
-
-    it('passes gateway.* events through even when sid is null', () => {
-      const appended: Msg[] = []
-      const onEvent = createGatewayEventHandler(buildCtx(appended))
-
-      patchUiState({ sid: null as any })
-      onEvent({ payload: {}, type: 'gateway.ready' } as any)
-
-      // gateway.ready should not throw and should be processed
-      expect(appended.length).toBeGreaterThanOrEqual(0)
-    })
-
-    it('passes pet.* and skin.* global events through with empty session_id', () => {
-      const appended: Msg[] = []
-      const onEvent = createGatewayEventHandler(buildCtx(appended))
+    it('accepts an explicit empty session id for a global skin event', () => {
+      const onEvent = createGatewayEventHandler(buildCtx([]))
 
       patchUiState({ sid: 'sess-active' })
-      onEvent({ payload: {}, session_id: '', type: 'skin.changed' } as any)
+      onEvent({
+        payload: { branding: { agent_name: 'Event Contract Skin' } },
+        session_id: '',
+        type: 'skin.changed'
+      } satisfies GatewayEvent)
 
-      // Should not throw — global event passes through
-      expect(appended.length).toBeGreaterThanOrEqual(0)
-    })
-
-    it('accepts events matching the active session_id', () => {
-      const appended: Msg[] = []
-      const onEvent = createGatewayEventHandler(buildCtx(appended))
-
-      patchUiState({ sid: 'sess-active' })
-      onEvent({ payload: { text: 'hello' }, session_id: 'sess-active', type: 'message.delta' } as any)
-      onEvent({ payload: { text: 'hello' }, session_id: 'sess-active', type: 'message.complete' } as any)
-
-      expect(appended.filter(m => m.role === 'assistant')).toHaveLength(1)
+      expect(getUiState().theme.brand.name).toBe('Event Contract Skin')
     })
   })
 })

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -6,6 +6,7 @@ import { turnController } from '../app/turnController.js'
 import { getTurnState, resetTurnState } from '../app/turnStore.js'
 import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import { ZERO } from '../domain/usage.js'
+import type { GatewayEvent } from '../gatewayTypes.js'
 import { estimateTokensRough } from '../lib/text.js'
 import type { Msg } from '../types.js'
 
@@ -2054,69 +2055,69 @@ describe('createGatewayEventHandler', () => {
       // Turn continues without finalizing or throwing
       expect(getUiState().busy).toBe(true)
       expect(appended).toHaveLength(0)
+    })
+  })
   describe('cross-session event filtering', () => {
-    it('drops events from a different session_id', () => {
+    it.each([
+      ['foreign session', 'sess-active', 'sess-other'],
+      ['foreign session during the null-sid switch window', null, 'sess-other'],
+      ['explicit empty session id', 'sess-active', '']
+    ])('drops the %s transcript sequence', (_case, activeSid, eventSid) => {
+      const appended: Msg[] = []
+      const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+      patchUiState({ sid: activeSid })
+      onEvent({ payload: { text: 'leaked delta' }, session_id: eventSid, type: 'message.delta' } satisfies GatewayEvent)
+      onEvent({
+        payload: { text: 'leaked answer' },
+        session_id: eventSid,
+        type: 'message.complete'
+      } satisfies GatewayEvent)
+
+      expect(appended).toEqual([])
+    })
+
+    it('accepts the transcript sequence matching the active session', () => {
       const appended: Msg[] = []
       const onEvent = createGatewayEventHandler(buildCtx(appended))
 
       patchUiState({ sid: 'sess-active' })
-      onEvent({ payload: { text: 'other session' }, session_id: 'sess-other', type: 'message.delta' } as any)
+      onEvent({
+        payload: { text: 'current delta' },
+        session_id: 'sess-active',
+        type: 'message.delta'
+      } satisfies GatewayEvent)
+      onEvent({
+        payload: { text: 'current answer' },
+        session_id: 'sess-active',
+        type: 'message.complete'
+      } satisfies GatewayEvent)
 
-      expect(appended.filter(m => m.role === 'assistant')).toHaveLength(0)
+      expect(appended).toEqual([{ role: 'assistant', text: 'current answer' }])
     })
 
-    it('drops session-scoped events with empty-string session_id', () => {
+    it('accepts a truly unscoped transcript sequence', () => {
       const appended: Msg[] = []
       const onEvent = createGatewayEventHandler(buildCtx(appended))
 
       patchUiState({ sid: 'sess-active' })
-      onEvent({ payload: { text: 'orphan' }, session_id: '', type: 'message.delta' } as any)
+      onEvent({ payload: { text: 'unscoped delta' }, type: 'message.delta' } satisfies GatewayEvent)
+      onEvent({ payload: { text: 'unscoped answer' }, type: 'message.complete' } satisfies GatewayEvent)
 
-      expect(appended.filter(m => m.role === 'assistant')).toHaveLength(0)
+      expect(appended).toEqual([{ role: 'assistant', text: 'unscoped answer' }])
     })
 
-    it('drops all non-gateway events when sid is null (switch window)', () => {
-      const appended: Msg[] = []
-      const onEvent = createGatewayEventHandler(buildCtx(appended))
-
-      // sid is null during session switch/reset
-      patchUiState({ sid: null as any })
-      onEvent({ payload: { text: 'leaked' }, session_id: 'sess-other', type: 'message.delta' } as any)
-
-      expect(appended.filter(m => m.role === 'assistant')).toHaveLength(0)
-    })
-
-    it('passes gateway.* events through even when sid is null', () => {
-      const appended: Msg[] = []
-      const onEvent = createGatewayEventHandler(buildCtx(appended))
-
-      patchUiState({ sid: null as any })
-      onEvent({ payload: {}, type: 'gateway.ready' } as any)
-
-      // gateway.ready should not throw and should be processed
-      expect(appended.length).toBeGreaterThanOrEqual(0)
-    })
-
-    it('passes pet.* and skin.* global events through with empty session_id', () => {
-      const appended: Msg[] = []
-      const onEvent = createGatewayEventHandler(buildCtx(appended))
+    it('accepts an explicit empty session id for a global skin event', () => {
+      const onEvent = createGatewayEventHandler(buildCtx([]))
 
       patchUiState({ sid: 'sess-active' })
-      onEvent({ payload: {}, session_id: '', type: 'skin.changed' } as any)
+      onEvent({
+        payload: { branding: { agent_name: 'Event Contract Skin' } },
+        session_id: '',
+        type: 'skin.changed'
+      } satisfies GatewayEvent)
 
-      // Should not throw — global event passes through
-      expect(appended.length).toBeGreaterThanOrEqual(0)
-    })
-
-    it('accepts events matching the active session_id', () => {
-      const appended: Msg[] = []
-      const onEvent = createGatewayEventHandler(buildCtx(appended))
-
-      patchUiState({ sid: 'sess-active' })
-      onEvent({ payload: { text: 'hello' }, session_id: 'sess-active', type: 'message.delta' } as any)
-      onEvent({ payload: { text: 'hello' }, session_id: 'sess-active', type: 'message.complete' } as any)
-
-      expect(appended.filter(m => m.role === 'assistant')).toHaveLength(1)
+      expect(getUiState().theme.brand.name).toBe('Event Contract Skin')
     })
   })
 })

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -2054,6 +2054,69 @@ describe('createGatewayEventHandler', () => {
       // Turn continues without finalizing or throwing
       expect(getUiState().busy).toBe(true)
       expect(appended).toHaveLength(0)
+  describe('cross-session event filtering', () => {
+    it('drops events from a different session_id', () => {
+      const appended: Msg[] = []
+      const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+      patchUiState({ sid: 'sess-active' })
+      onEvent({ payload: { text: 'other session' }, session_id: 'sess-other', type: 'message.delta' } as any)
+
+      expect(appended.filter(m => m.role === 'assistant')).toHaveLength(0)
+    })
+
+    it('drops session-scoped events with empty-string session_id', () => {
+      const appended: Msg[] = []
+      const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+      patchUiState({ sid: 'sess-active' })
+      onEvent({ payload: { text: 'orphan' }, session_id: '', type: 'message.delta' } as any)
+
+      expect(appended.filter(m => m.role === 'assistant')).toHaveLength(0)
+    })
+
+    it('drops all non-gateway events when sid is null (switch window)', () => {
+      const appended: Msg[] = []
+      const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+      // sid is null during session switch/reset
+      patchUiState({ sid: null as any })
+      onEvent({ payload: { text: 'leaked' }, session_id: 'sess-other', type: 'message.delta' } as any)
+
+      expect(appended.filter(m => m.role === 'assistant')).toHaveLength(0)
+    })
+
+    it('passes gateway.* events through even when sid is null', () => {
+      const appended: Msg[] = []
+      const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+      patchUiState({ sid: null as any })
+      onEvent({ payload: {}, type: 'gateway.ready' } as any)
+
+      // gateway.ready should not throw and should be processed
+      expect(appended.length).toBeGreaterThanOrEqual(0)
+    })
+
+    it('passes pet.* and skin.* global events through with empty session_id', () => {
+      const appended: Msg[] = []
+      const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+      patchUiState({ sid: 'sess-active' })
+      onEvent({ payload: {}, session_id: '', type: 'skin.changed' } as any)
+
+      // Should not throw — global event passes through
+      expect(appended.length).toBeGreaterThanOrEqual(0)
+    })
+
+    it('accepts events matching the active session_id', () => {
+      const appended: Msg[] = []
+      const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+      patchUiState({ sid: 'sess-active' })
+      onEvent({ payload: { text: 'hello' }, session_id: 'sess-active', type: 'message.delta' } as any)
+      onEvent({ payload: { text: 'hello' }, session_id: 'sess-active', type: 'message.complete' } as any)
+
+      expect(appended.filter(m => m.role === 'assistant')).toHaveLength(1)
     })
   })
 })

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -402,9 +402,20 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
   }
 
   return (ev: GatewayEvent) => {
+    // During session switch/reset, `sid` is momentarily null. The old
+    // `sid &&` guard short-circuited to false, letting events from other live
+    // sessions bleed into the active view (#51058). When sid is null, drop ALL
+    // non-gateway session events instead.
+    //
+    // Also filter empty-string session_id: _emit() can set session_id to ""
+    // when callers omit it (session.set_cwd, config.set, session.title). These
+    // session-scoped events would bleed into whichever session is active.
     const sid = getUiState().sid
+    const evSid = ev.session_id ?? ''
+    const GLOBAL_PREFIXES = ['gateway.', 'pet.', 'skin.', 'billing.']
+    const isGlobal = GLOBAL_PREFIXES.some((p) => ev.type.startsWith(p))
 
-    if (ev.session_id && sid && ev.session_id !== sid && !ev.type.startsWith('gateway.')) {
+    if (evSid && (!sid || evSid !== sid) && !isGlobal) {
       return
     }
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -411,11 +411,12 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
     // when callers omit it (session.set_cwd, config.set, session.title). These
     // session-scoped events would bleed into whichever session is active.
     const sid = getUiState().sid
-    const evSid = ev.session_id ?? ''
+    const hasSessionId = Object.prototype.hasOwnProperty.call(ev, 'session_id')
+    const evSid = ev.session_id
     const GLOBAL_PREFIXES = ['gateway.', 'pet.', 'skin.', 'billing.']
-    const isGlobal = GLOBAL_PREFIXES.some((p) => ev.type.startsWith(p))
+    const isGlobal = GLOBAL_PREFIXES.some(p => ev.type.startsWith(p))
 
-    if (evSid && (!sid || evSid !== sid) && !isGlobal) {
+    if (hasSessionId && (!sid || !evSid || evSid !== sid) && !isGlobal) {
       return
     }
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -749,9 +749,20 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
   }
 
   return (ev: GatewayEvent) => {
+    // During session switch/reset, `sid` is momentarily null. The old
+    // `sid &&` guard short-circuited to false, letting events from other live
+    // sessions bleed into the active view (#51058). When sid is null, drop ALL
+    // non-gateway session events instead.
+    //
+    // Also filter empty-string session_id: _emit() can set session_id to ""
+    // when callers omit it (session.set_cwd, config.set, session.title). These
+    // session-scoped events would bleed into whichever session is active.
     const sid = getUiState().sid
+    const evSid = ev.session_id ?? ''
+    const GLOBAL_PREFIXES = ['gateway.', 'pet.', 'skin.', 'billing.']
+    const isGlobal = GLOBAL_PREFIXES.some((p) => ev.type.startsWith(p))
 
-    if (ev.session_id && sid && ev.session_id !== sid && !ev.type.startsWith('gateway.')) {
+    if (evSid && (!sid || evSid !== sid) && !isGlobal) {
       return
     }
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -758,11 +758,12 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
     // when callers omit it (session.set_cwd, config.set, session.title). These
     // session-scoped events would bleed into whichever session is active.
     const sid = getUiState().sid
-    const evSid = ev.session_id ?? ''
+    const hasSessionId = Object.prototype.hasOwnProperty.call(ev, 'session_id')
+    const evSid = ev.session_id
     const GLOBAL_PREFIXES = ['gateway.', 'pet.', 'skin.', 'billing.']
-    const isGlobal = GLOBAL_PREFIXES.some((p) => ev.type.startsWith(p))
+    const isGlobal = GLOBAL_PREFIXES.some(p => ev.type.startsWith(p))
 
-    if (evSid && (!sid || evSid !== sid) && !isGlobal) {
+    if (hasSessionId && (!sid || !evSid || evSid !== sid) && !isGlobal) {
       return
     }
 


### PR DESCRIPTION
## Problem

During session switch/reset, `getUiState().sid` is momentarily `null`. The old event filter `ev.session_id && sid && ev.session_id !== sid` short-circuits to `false` when `sid` is null, so events from **any** live session bleed into the view — the cross-session bleed reported in #51058.

## Fix

Change the condition so that when `sid` is null, **all** non-gateway session events are dropped:

```diff
- if (ev.session_id && sid && ev.session_id !== sid && !ev.type.startsWith('gateway.')) {
+ if (ev.session_id && (!sid || ev.session_id !== sid) && !ev.type.startsWith('gateway.')) {
```

`(!sid || ev.session_id !== sid)` means: drop the event if there is no active session **or** the event belongs to a different session. Gateway-meta events (`gateway.*`) are still always allowed through.

## Scope

1 file, 1 condition change. Supersedes #53928 which was opened from a `main` branch and accidentally bundled 3 unrelated fixes.

Closes #51058