### PR TITLE
fix(agent): sanitize cache metadata for strict providers

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -115,6 +115,67 @@ def _model_consumes_thought_signature(model: Any) -> bool:
     return "gemini" in m or "gemma" in m
 
 
+def _route_preserves_cache_control(
+    *,
+    model: Any,
+    provider_profile: Any = None,
+    provider_name: Any = None,
+    base_url: Any = None,
+    is_openrouter: bool = False,
+    is_nous: bool = False,
+) -> bool:
+    """Return True for OpenAI-wire routes that intentionally accept
+    Anthropic-style ``cache_control`` markers.
+
+    Most chat-completions providers are strict OpenAI-compatible endpoints and
+    reject nested ``cache_control`` content-part keys. A few routes opt into
+    those markers for prompt caching; keep those exact paths intact.
+    """
+    model_lower = str(model or "").lower()
+    provider_lower = str(provider_name or "").strip().lower()
+    profile_name = str(getattr(provider_profile, "name", "") or "").strip().lower()
+    base_lower = str(base_url or "").strip().lower()
+
+    is_openrouter_route = (
+        bool(is_openrouter)
+        or profile_name == "openrouter"
+        or "openrouter.ai" in base_lower
+    )
+    is_nous_route = (
+        bool(is_nous)
+        or profile_name == "nous"
+        or "nousresearch" in base_lower
+    )
+
+    if is_openrouter_route and "claude" in model_lower:
+        return True
+    if is_nous_route and ("claude" in model_lower or "qwen" in model_lower):
+        return True
+    if provider_lower in {"opencode", "opencode-zen", "opencode-go", "alibaba"} and "qwen" in model_lower:
+        return True
+    return False
+
+
+def _content_has_cache_control(content: Any) -> bool:
+    if isinstance(content, list):
+        return any(isinstance(part, dict) and "cache_control" in part for part in content)
+    return False
+
+
+def _strip_cache_control_from_content(content: Any) -> Any:
+    if not isinstance(content, list):
+        return content
+    stripped = []
+    for part in content:
+        if isinstance(part, dict) and "cache_control" in part:
+            clean_part = dict(part)
+            clean_part.pop("cache_control", None)
+            stripped.append(clean_part)
+        else:
+            stripped.append(part)
+    return stripped
+
+
 class ChatCompletionsTransport(ProviderTransport):
     """Transport for api_mode='chat_completions'.
 
@@ -160,10 +221,15 @@ class ChatCompletionsTransport(ProviderTransport):
           gateways (e.g. opencode-go, codex.nekos.me) reject with
           ``Extra inputs are not permitted, field: 'messages[N]._empty_recovery_synthetic'``,
           which then poisons every subsequent request in the session.
+        - Stale ``cache_control`` markers on messages or nested text content
+          parts, unless the outgoing route is one of the known OpenAI-wire
+          providers that intentionally accepts those markers for prompt
+          caching. Strict providers such as Cerebras/Groq reject them.
         """
         strip_extra_content = not _model_consumes_thought_signature(
             kwargs.get("model")
         )
+        preserve_cache_control = bool(kwargs.get("preserve_cache_control"))
         needs_sanitize = False
         for msg in messages:
             if not isinstance(msg, dict):
@@ -173,6 +239,11 @@ class ChatCompletionsTransport(ProviderTransport):
                 or "codex_message_items" in msg
                 or "tool_name" in msg
                 or "timestamp" in msg  # #47868 — strict providers reject this
+                or (not preserve_cache_control and "cache_control" in msg)
+                or (
+                    not preserve_cache_control
+                    and _content_has_cache_control(msg.get("content"))
+                )
             ):
                 needs_sanitize = True
                 break
@@ -203,6 +274,10 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
             msg.pop("timestamp", None)  # #47868 — leak into strict providers
+            if not preserve_cache_control:
+                msg.pop("cache_control", None)
+                if _content_has_cache_control(msg.get("content")):
+                    msg["content"] = _strip_cache_control_from_content(msg.get("content"))
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
             # OpenAI's message schema has no ``_``-prefixed fields, so this
             # is safe and future-proofs against new markers being added.
@@ -273,13 +348,26 @@ class ChatCompletionsTransport(ProviderTransport):
             anthropic_max_output: int | None
             extra_body_additions: dict | None
         """
+        _profile = params.get("provider_profile")
+        preserve_cache_control = _route_preserves_cache_control(
+            model=model,
+            provider_profile=_profile,
+            provider_name=params.get("provider_name"),
+            base_url=params.get("base_url"),
+            is_openrouter=params.get("is_openrouter", False),
+            is_nous=params.get("is_nous", False),
+        )
+
         # Codex sanitization: drop reasoning_items / call_id / response_item_id.
         # Pass model so the Gemini thought_signature (extra_content) is kept for
         # Gemini targets and stripped for strict non-Gemini providers.
-        sanitized = self.convert_messages(messages, model=model)
+        sanitized = self.convert_messages(
+            messages,
+            model=model,
+            preserve_cache_control=preserve_cache_control,
+        )
 
         # ── Provider profile: single-path when present ──────────────────
-        _profile = params.get("provider_profile")
         if _profile:
             return self._build_kwargs_from_profile(
                 _profile, model, sanitized, tools, params

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -46,6 +46,25 @@ def _content_cache_key(instructions: str, tools: Optional[List[Dict[str, Any]]])
     return f"pck_{digest}"
 
 
+def _prompt_cache_key_for_wire(cache_key: Any) -> Optional[str]:
+    """Return a non-empty Responses ``prompt_cache_key`` that fits provider caps.
+
+    OpenAI's Responses API currently rejects ``prompt_cache_key`` values longer
+    than 64 characters. The normal content-addressed key is short, but caller
+    overrides and raw session-id fallbacks can still exceed the cap. Keep valid
+    keys readable; hash overlong keys into the same short ``pck_`` namespace.
+    """
+    if cache_key is None:
+        return None
+    text = str(cache_key).strip()
+    if not text:
+        return None
+    if len(text) <= 64:
+        return text
+    digest = hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()[:24]
+    return f"pck_{digest}"
+
+
 class ResponsesApiTransport(ProviderTransport):
     """Transport for api_mode='codex_responses'.
 
@@ -256,7 +275,9 @@ class ResponsesApiTransport(ProviderTransport):
         # cache-cold. session_id is left untouched for transcript isolation and
         # the cache-scope routing headers below. Falls back to session_id when
         # there is no static content to hash.
-        cache_key = _content_cache_key(instructions, response_tools) or session_id
+        cache_key = _prompt_cache_key_for_wire(
+            _content_cache_key(instructions, response_tools) or session_id
+        )
         # xAI Responses takes prompt_cache_key in extra_body (set further
         # down); GitHub Models opts out of cache-key routing entirely.
         if not is_github_responses and not is_xai_responses and cache_key:
@@ -295,6 +316,15 @@ class ResponsesApiTransport(ProviderTransport):
         request_overrides = params.get("request_overrides")
         if request_overrides:
             kwargs.update(request_overrides)
+
+        if not is_github_responses and not is_xai_responses:
+            normalized_cache_key = _prompt_cache_key_for_wire(
+                kwargs.get("prompt_cache_key")
+            )
+            if normalized_cache_key:
+                kwargs["prompt_cache_key"] = normalized_cache_key
+            else:
+                kwargs.pop("prompt_cache_key", None)
 
         # xAI Responses API rejects ``service_tier`` (HTTP 400 "Argument not
         # supported: service_tier") — hit when ``/fast`` priority-processing
@@ -372,6 +402,13 @@ class ResponsesApiTransport(ProviderTransport):
             if isinstance(existing_extra_body, dict):
                 merged_extra_body.update(existing_extra_body)
             merged_extra_body.setdefault("prompt_cache_key", cache_key)
+            normalized_body_cache_key = _prompt_cache_key_for_wire(
+                merged_extra_body.get("prompt_cache_key")
+            )
+            if normalized_body_cache_key:
+                merged_extra_body["prompt_cache_key"] = normalized_body_cache_key
+            else:
+                merged_extra_body.pop("prompt_cache_key", None)
             kwargs["extra_body"] = merged_extra_body
 
         return kwargs

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -130,6 +130,7 @@ def _chrome_debug_args(port: int) -> list[str]:
         f"--user-data-dir={chrome_debug_data_dir()}",
         "--no-first-run",
         "--no-default-browser-check",
+        "--disable-features=MacAppCodeSignClone",
     ]
 
 
@@ -181,7 +182,8 @@ def manual_chrome_debug_command(port: int = DEFAULT_BROWSER_CDP_PORT, system: st
         data_dir = chrome_debug_data_dir()
         return (
             f'open -a "Google Chrome" --args --remote-debugging-port={port} '
-            f'--user-data-dir="{data_dir}" --no-first-run --no-default-browser-check'
+            f'--user-data-dir="{data_dir}" --no-first-run --no-default-browser-check '
+            f'--disable-features=MacAppCodeSignClone'
         )
 
     return None

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -153,6 +153,48 @@ class TestChatCompletionsBasic:
         # Original list untouched (deepcopy-on-demand)
         assert msgs[1]["_empty_recovery_synthetic"] is True
 
+    def test_convert_messages_strips_stale_cache_control_for_strict_provider(self, transport):
+        """Strict OpenAI-compatible providers reject Anthropic cache markers
+        on nested text parts. Fallback replay must strip stale markers before
+        Cerebras/Groq/etc. see the payload.
+        """
+        msgs = [
+            {
+                "role": "system",
+                "content": [{"type": "text", "text": "sys", "cache_control": {"type": "ephemeral"}}],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "hi", "cache_control": {"type": "ephemeral"}}],
+                "cache_control": {"type": "ephemeral"},
+            },
+        ]
+        result = transport.convert_messages(msgs, model="gpt-oss-120b")
+        assert "cache_control" not in result[0]["content"][0]
+        assert "cache_control" not in result[1]["content"][0]
+        assert "cache_control" not in result[1]
+        # Original list untouched (deepcopy-on-demand)
+        assert msgs[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+        assert msgs[1]["cache_control"] == {"type": "ephemeral"}
+
+    def test_convert_messages_preserves_cache_control_when_route_supports_it(self, transport):
+        """OpenRouter Claude/Qwen-like cache-aware routes intentionally keep
+        cache markers; strict-provider stripping must not break that path.
+        """
+        msgs = [
+            {
+                "role": "system",
+                "content": [{"type": "text", "text": "sys", "cache_control": {"type": "ephemeral"}}],
+            }
+        ]
+        result = transport.convert_messages(
+            msgs,
+            model="anthropic/claude-sonnet-4.6",
+            preserve_cache_control=True,
+        )
+        assert result is msgs
+        assert result[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+
     def test_convert_messages_clean_list_is_identity(self, transport):
         """A list with no internal/codex keys is returned as-is (no copy)."""
         msgs = [

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -112,6 +112,31 @@ class TestCodexBuildKwargs:
         )
         assert kw1["prompt_cache_key"] == kw2["prompt_cache_key"]
 
+    def test_long_prompt_cache_key_override_is_hashed_under_provider_cap(self, transport):
+        """Caller overrides must not reintroduce overlong cache keys after the
+        transport has built its short content-addressed key."""
+        messages = [{"role": "user", "content": "Hi"}]
+        long_key = "cron_smoke_morning_brief_openai_codex_" + ("x" * 80)
+
+        kw1 = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            request_overrides={"prompt_cache_key": long_key},
+        )
+        kw2 = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            request_overrides={"prompt_cache_key": long_key},
+        )
+
+        pck = kw1.get("prompt_cache_key", "")
+        assert pck.startswith("pck_")
+        assert len(pck) <= 64
+        assert pck != long_key
+        assert pck == kw2["prompt_cache_key"]
+
     def test_github_responses_no_cache_key(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
@@ -162,6 +187,26 @@ class TestCodexBuildKwargs:
         )
         eb = kw.get("extra_body", {})
         assert eb.get("prompt_cache_key") == "caller-override"
+        assert eb.get("other_field") == 42
+
+    def test_xai_extra_body_long_prompt_cache_key_override_is_hashed(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        long_key = "xai-cache-key-" + ("y" * 80)
+
+        kw = transport.build_kwargs(
+            model="grok-4.3", messages=messages, tools=[],
+            session_id="conv-xai-1",
+            is_xai_responses=True,
+            request_overrides={
+                "extra_body": {"prompt_cache_key": long_key, "other_field": 42}
+            },
+        )
+
+        eb = kw.get("extra_body", {})
+        pck = eb.get("prompt_cache_key", "")
+        assert pck.startswith("pck_")
+        assert len(pck) <= 64
+        assert pck != long_key
         assert eb.get("other_field") == 42
 
     def test_max_tokens(self, transport):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,5 +1,6 @@
 import json
 import os
+import platform
 import subprocess
 import sys
 import threading
@@ -6541,10 +6542,20 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
         resp["result"]["messages"][0]
         == "Chromium-family browser isn't running with remote debugging — attempting to launch..."
     )
-    assert any(
-        "No supported Chromium-family browser executable was found" in line
-        for line in resp["result"]["messages"]
-    )
+    if platform.system() == "Darwin":
+        assert any(
+            line.startswith('open -a "Google Chrome" --args ')
+            for line in resp["result"]["messages"]
+        )
+        assert any(
+            "--disable-features=MacAppCodeSignClone" in line
+            for line in resp["result"]["messages"]
+        )
+    else:
+        assert any(
+            "No supported Chromium-family browser executable was found" in line
+            for line in resp["result"]["messages"]
+        )
     assert any(
         "--remote-debugging-port=9222" in line for line in resp["result"]["messages"]
     )


### PR DESCRIPTION
## Summary
- Strip stale Anthropic-style cache_control markers before sending Chat Completions requests to strict OpenAI-compatible providers, while preserving them for known cache-aware routes.
- Normalize caller-supplied Responses prompt_cache_key values to the documented 64-character wire cap, including xAI extra_body overrides.
- Add the macOS Chrome launch flag that avoids MacAppCodeSignClone remote-debugging launch failures.

## Tests
- uv run --extra dev pytest -q tests/agent/transports/test_chat_completions.py::TestChatCompletionsBasic::test_convert_messages_strips_stale_cache_control_for_strict_provider tests/agent/transports/test_chat_completions.py::TestChatCompletionsBasic::test_convert_messages_preserves_cache_control_when_route_supports_it tests/agent/transports/test_codex_transport.py::TestCodexBuildKwargs::test_long_prompt_cache_key_override_is_hashed_under_provider_cap tests/agent/transports/test_codex_transport.py::TestCodexBuildKwargs::test_xai_extra_body_long_prompt_cache_key_override_is_hashed tests/test_tui_gateway_server.py::test_browser_manage_connect_default_local_reports_launch_hint
