### PR TITLE
test(run_agent): deflake fallback-exhaustion cooldown assertion on loaded CI

### DIFF
--- a/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
+++ b/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
@@ -70,7 +70,11 @@ class TestExhaustionArmsCooldown:
         cooldown = getattr(agent, "_rate_limited_until", 0)
         assert cooldown > before
         # Cooldown is the short exhaustion window, not the 60s rate-limit one.
-        assert cooldown <= before + _FALLBACK_EXHAUSTED_COOLDOWN_S + 1.0
+        # Allow generous scheduling slack: on a loaded CI box the wall-clock
+        # gap between capturing ``before`` and reading ``cooldown`` can exceed
+        # 1s. 10s still proves the short window (5s) was armed rather than the
+        # 60s rate-limit window.
+        assert cooldown <= before + _FALLBACK_EXHAUSTED_COOLDOWN_S + 10.0
 
     def test_no_chain_does_not_arm_cooldown(self):
         """An empty chain (no fallback configured) must not arm a cooldown —


### PR DESCRIPTION
## Summary

`tests/run_agent/test_24996_fallback_exhaustion_cooldown.py::test_non_retryable_exhaustion_arms_cooldown` is a wall-clock flake on loaded CI. Widening the assertion's scheduling slack from `+1.0s` to `+10.0s` deflakes it while preserving the behavioral contract.

**Why it flakes:** the test asserts the exhaustion cooldown stamp lands within `before + _FALLBACK_EXHAUSTED_COOLDOWN_S (5.0) + 1.0`. On a loaded 8-worker CI box the wall-clock gap between capturing `before` and reading `_rate_limited_until` drifts past 1s. Observed on two consecutive runs: `222.84 <= 222.73` (off 0.11s) and `231.14 <= 230.86` (off 0.28s).

**Why the fix is safe:** the assertion's real purpose (per its own comment) is to prove the *short* 5s exhaustion window was armed rather than the *60s* rate-limit window. A 10s ceiling still sits far below 60s, so the contract is intact — only the incidental scheduling slack changed. Test-only; no production code touched.

## Changes

- `tests/run_agent/test_24996_fallback_exhaustion_cooldown.py`: assertion ceiling `+1.0s` → `+10.0s`, with a comment explaining the loaded-CI scheduling drift.

## Validation

| | Before | After |
|---|---|---|
| `test_non_retryable_exhaustion_arms_cooldown` on loaded CI | flakes (gap ~6.1s vs 6.0s ceiling) | passes (10s slack) |
| Distinguishes 5s window from 60s | yes | yes (still far below 60s) |
| Local run | — | passes |

## Infographic

![deflake-fallback-exhaustion-cooldown](https://v3b.fal.media/files/b/0aa00e2b/keUZSnenWw2-pceu_jU65_vaKs2zsK.png)
