### PR TITLE
feet: add Hermes agents dashboard

### DIFF
--- a/hermes_cli/agents.py
+++ b/hermes_cli/agents.py
@@ -1,0 +1,443 @@
+"""Agents Dashboard core module.
+
+Loads an agent registry from ``$HERMES_HOME/agents.yaml`` (with sensible
+defaults derived from existing Hermes profiles when the registry is
+missing), renders a manager-friendly team table, emits JSON, creates a
+starter registry, and prepares an orchestrated handoff card for the
+``orch`` profile via the existing Kanban backend.
+
+This is CLI/edge functionality — it does not touch the core agent loop
+or add new model tools.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from hermes_constants import get_hermes_home
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AgentSpec:
+    """Normalized agent record shown in the dashboard."""
+
+    name: str
+    profile: str
+    role: str
+    description: str = ""
+    can_edit_files: Any = False  # bool | "limited"
+    escalates_to: str = "orch"
+    skills: list[str] = field(default_factory=list)
+    model: str = ""
+    provider: str = ""
+    base_url: str = ""
+    status: str = "ready"
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# Default registry / profile discovery
+# ---------------------------------------------------------------------------
+
+# Role defaults keyed by profile name. Allows an agent name to differ
+# from a profile name while still providing a sensible default role.
+_DEFAULT_ROLES: dict[str, str] = {
+    "orch": "orchestrator",
+    "coding": "implementer",
+    "search": "researcher",
+    "strong": "architect_reviewer",
+    "fast": "quick_worker",
+    "default": "default",
+}
+
+_DEFAULT_DESCRIPTIONS: dict[str, str] = {
+    "orch": "Planeja, delega, acompanha e consolida trabalho do time de IAs.",
+    "coding": "Implementa código, roda testes, depura e entrega evidências reais.",
+    "search": "Pesquisa documentação, fatos atuais e fontes externas.",
+    "strong": "Analisa arquitetura, trade-offs, riscos e decisões difíceis.",
+    "fast": "Executa tarefas rápidas, simples e de baixo risco.",
+}
+
+# Starter registry content (from the plan). Used by ``agents init``.
+STARTER_AGENTS_YAML = """\
+version: 1
+agents:
+  orch:
+    profile: orch
+    role: orchestrator
+    description: Planeja, delega, acompanha e consolida trabalho do time de IAs.
+    can_edit_files: false
+    escalates_to: user
+    skills:
+      - kanban-orchestrator
+
+  coding:
+    profile: coding
+    role: implementer
+    description: Implementa código, roda testes, depura e entrega evidências reais.
+    can_edit_files: true
+    escalates_to: orch
+    skills:
+      - systematic-debugging
+      - test-driven-development
+      - requesting-code-review
+
+  fast:
+    profile: fast
+    role: quick_worker
+    description: Executa tarefas rápidas, simples e de baixo risco.
+    can_edit_files: limited
+    escalates_to: orch
+    skills: []
+
+  strong:
+    profile: strong
+    role: architect_reviewer
+    description: Analisa arquitetura, trade-offs, riscos e decisões difíceis.
+    can_edit_files: false
+    escalates_to: orch
+    skills: []
+
+  search:
+    profile: search
+    role: researcher
+    description: Pesquisa documentação, fatos atuais e fontes externas.
+    can_edit_files: false
+    escalates_to: orch
+    skills: []
+"""
+
+
+def _registry_path() -> Path:
+    """Return the path to ``$HERMES_HOME/agents.yaml``."""
+    return get_hermes_home() / "agents.yaml"
+
+
+def _discover_profiles() -> list[tuple[str, str, str]]:
+    """Discover real profiles on disk.
+
+    Returns a list of ``(name, model, provider)`` tuples. Uses the existing
+    ``hermes_cli.profiles`` helpers so we stay consistent with the rest of
+    the CLI. Failures are swallowed — a broken profile should never crash
+    the agents dashboard.
+    """
+    try:
+        from hermes_cli.profiles import list_profiles
+    except Exception:
+        return []
+    found: list[tuple[str, str, str]] = []
+    try:
+        for info in list_profiles():
+            found.append((
+                info.name,
+                info.model or "",
+                info.provider or "",
+            ))
+    except Exception:
+        pass
+    return found
+
+
+def _build_default_agents() -> list[AgentSpec]:
+    """Build a default agent list from discovered profiles.
+
+    When no explicit registry exists, we derive agents from the real
+    profiles on disk so the dashboard is useful out of the box.
+    """
+    agents: list[AgentSpec] = []
+    seen: set[str] = set()
+    for name, model, provider in _discover_profiles():
+        if name in seen:
+            continue
+        seen.add(name)
+        agents.append(AgentSpec(
+            name=name,
+            profile=name,
+            role=_DEFAULT_ROLES.get(name, "agent"),
+            description=_DEFAULT_DESCRIPTIONS.get(name, ""),
+            model=model,
+            provider=provider,
+            status="ready",
+        ))
+    return agents
+
+
+def _merge_registry_into_agents(
+    registry_agents: dict[str, Any],
+    discovered: list[AgentSpec],
+) -> list[AgentSpec]:
+    """Merge explicit registry entries with discovered profile data.
+
+    Registry entries take precedence for role/description/skills/etc.
+    Discovered profile model/provider data is merged in when the registry
+    entry does not carry its own. Profiles discovered on disk that are
+    not in the registry are appended as defaults.
+    """
+    by_profile: dict[str, AgentSpec] = {}
+    for spec in discovered:
+        by_profile[spec.profile] = spec
+
+    result: list[AgentSpec] = []
+    registry_profiles: set[str] = set()
+    for agent_name, raw in (registry_agents or {}).items():
+        if not isinstance(raw, dict):
+            continue
+        profile = raw.get("profile") or agent_name
+        registry_profiles.add(profile)
+        discovered_spec = by_profile.get(profile)
+        spec = AgentSpec(
+            name=agent_name,
+            profile=profile,
+            role=raw.get("role", _DEFAULT_ROLES.get(profile, "agent")),
+            description=raw.get("description", ""),
+            can_edit_files=raw.get("can_edit_files", False),
+            escalates_to=raw.get("escalates_to", "orch"),
+            skills=list(raw.get("skills", []) or []),
+            model=raw.get("model") or (discovered_spec.model if discovered_spec else ""),
+            provider=raw.get("provider") or (discovered_spec.provider if discovered_spec else ""),
+            base_url=raw.get("base_url", ""),
+            status=raw.get("status", "ready"),
+        )
+        result.append(spec)
+
+    # Append discovered profiles not present in the registry.
+    for spec in discovered:
+        if spec.profile not in registry_profiles:
+            result.append(spec)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def load_agents() -> list[AgentSpec]:
+    """Load the agent registry and return normalized agent records.
+
+    If ``$HERMES_HOME/agents.yaml`` is missing, derives sensible defaults
+    from the real profiles on disk. Missing profiles are marked
+    ``missing_profile`` rather than crashing.
+    """
+    path = _registry_path()
+    if not path.is_file():
+        return _build_default_agents()
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except Exception:
+        return _build_default_agents()
+
+    registry_agents = data.get("agents", {}) if isinstance(data, dict) else {}
+    discovered = _build_default_agents()
+    agents = _merge_registry_into_agents(registry_agents, discovered)
+
+    # Mark agents whose profile dir does not exist.
+    try:
+        from hermes_cli.profiles import list_profiles
+        known_profiles = {info.name for info in list_profiles()}
+    except Exception:
+        known_profiles = set()
+    if known_profiles:
+        for spec in agents:
+            if spec.profile not in known_profiles:
+                spec.status = "missing_profile"
+
+    return agents
+
+
+def render_table(agents: list[AgentSpec]) -> str:
+    """Render a manager-friendly team dashboard as plain text."""
+    home = str(get_hermes_home())
+    header = f"Hermes AI Team\nHERMES_HOME: {home}\n"
+    cols = ["Agent", "Profile", "Model", "Provider", "Role", "Status"]
+    rows = [[a.name, a.profile, a.model or "-", a.provider or "-", a.role, a.status] for a in agents]
+    widths = [len(c) for c in cols]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+    sep = "  "
+    lines = [sep.join(c.ljust(widths[i]) for i, c in enumerate(cols))]
+    lines.append(sep.join("-" * widths[i] for i in range(len(cols))))
+    for row in rows:
+        lines.append(sep.join(str(cell).ljust(widths[i]) for i, cell in enumerate(row)))
+    actions = (
+        "\nActions:\n"
+        '  hermes agents orchestrate "<task>"   Send a task to orch for planning\n'
+        "  hermes kanban list                    View team task board\n"
+        "  hermes profile list                   Inspect profile configs\n"
+    )
+    return header + "\n" + "\n".join(lines) + "\n" + actions
+
+
+def to_json(agents: list[AgentSpec]) -> str:
+    """Return a JSON string of normalized agent records."""
+    return json.dumps([a.to_dict() for a in agents], indent=2, ensure_ascii=False)
+
+
+def init_registry(force: bool = False) -> Path:
+    """Write the starter registry to ``$HERMES_HOME/agents.yaml``.
+
+    Refuses to overwrite an existing file unless ``force=True``. Returns
+    the path written. Raises ``FileExistsError`` when the file exists and
+    ``force`` is False.
+    """
+    path = _registry_path()
+    if path.exists() and not force:
+        raise FileExistsError(
+            f"{path} already exists. Use --force to overwrite."
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(STARTER_AGENTS_YAML)
+    return path
+
+
+def orchestrate(task: str, *, create_card: bool = True) -> dict:
+    """Prepare a planning handoff for the ``orch`` profile.
+
+    Creates a Kanban card assigned to ``orch`` when the backend is
+    available, and always returns a dict describing the handoff (including
+    the exact CLI command to start processing). Does NOT execute the task
+    itself — that is ``orch``'s job once it picks up the card.
+
+    Returns a dict with keys:
+        - ``task``: the user task text
+        - ``card_id``: created Kanban card id, or None
+        - ``command``: the exact ``hermes kanban create ...`` command
+        - ``dispatcher_running``: bool
+        - ``dispatcher_message``: human guidance when not running
+        - ``body``: the card body handed to orch
+    """
+    safe_title = task.strip()
+    if not safe_title:
+        raise ValueError("task text is required")
+    title = f"orchestrate: {safe_title}"
+    body = _build_orchestrate_body(safe_title)
+    assignee = "orch"
+    command = _build_kanban_create_command(title, body, assignee)
+
+    result: dict = {
+        "task": safe_title,
+        "card_id": None,
+        "command": command,
+        "dispatcher_running": True,
+        "dispatcher_message": "",
+        "body": body,
+    }
+
+    if not create_card:
+        return result
+
+    # Attempt to create a Kanban card via the Python API.
+    # We use initial_status="running" (the same default as `hermes kanban
+    # create`) so the card is immediately visible; the dispatcher/orch
+    # picks it up from there. "ready" is not a valid initial_status — it
+    # is derived automatically by kanban_db when a task has no pending
+    # parents.
+    try:
+        from hermes_cli import kanban_db as kb
+        kb.init_db()
+        with kb.connect_closing() as conn:
+            card_id = kb.create_task(
+                conn,
+                title=title,
+                body=body,
+                assignee=assignee,
+                initial_status="running",
+            )
+        result["card_id"] = card_id
+    except Exception as exc:
+        # Kanban unavailable — still return the handoff command so the
+        # user can run it manually.
+        result["dispatcher_message"] = (
+            f"Could not create Kanban card automatically: {exc}\n"
+            f"Run the command below manually to create the card."
+        )
+
+    # Check dispatcher presence so we can warn if the card will sit idle.
+    try:
+        from hermes_cli.kanban import _check_dispatcher_presence
+        running, message = _check_dispatcher_presence()
+        result["dispatcher_running"] = running
+        if not running and message:
+            result["dispatcher_message"] = message
+    except Exception:
+        pass
+
+    return result
+
+
+def _build_orchestrate_body(task: str) -> str:
+    """Build the card body that instructs orch to plan the work."""
+    return (
+        f"User task: {task}\n\n"
+        "You are the orch profile. Load kanban-orchestrator. "
+        "Discover available profiles. Produce a task graph. "
+        "Create concrete Kanban cards for coding/search/strong/fast as appropriate. "
+        "Do not implement code yourself. "
+        "Ask the user only if ambiguity changes scope/architecture/security/cost/UX."
+    )
+
+
+def _build_kanban_create_command(title: str, body: str, assignee: str) -> str:
+    """Build a shell-safe ``hermes kanban create`` command string.
+
+    Uses ``shlex.quote`` so the result is safely copiável/colável even
+    when the task text contains quotes, ``$`` expansions, backticks, or
+    other shell metacharacters.
+    """
+    return (
+        f"hermes kanban create {shlex.quote(title)} "
+        f"--assignee {shlex.quote(assignee)} "
+        f"--body {shlex.quote(body)}"
+    )
+
+
+def render_orchestrate_summary(result: dict) -> str:
+    """Render the orchestrate result as human-friendly text for the CLI.
+
+    When a Kanban card was created (``card_id`` present), we do NOT print
+    the ``hermes kanban create ...`` command again — that would invite the
+    user to create a duplicate card. Instead we point them to the board /
+    gateway as appropriate. When no card was created, we print the exact
+    manual command (shell-quoted) so the user can run it themselves.
+    """
+    lines = [f"Orchestration handoff prepared for: {result['task']}"]
+    card_id = result.get("card_id")
+    if card_id:
+        lines.append(f"Created Kanban card: {card_id}")
+    else:
+        lines.append("Kanban card was not created automatically.")
+    if result.get("dispatcher_message"):
+        lines.append("")
+        lines.append("⚠  " + result["dispatcher_message"])
+    lines.append("")
+    if card_id:
+        # Card already exists — don't suggest creating another one.
+        lines.append("Next step — the card is ready for orch to pick up.")
+        running = result.get("dispatcher_running", True)
+        if not running:
+            lines.append("  Start the gateway so the dispatcher can claim it:")
+            lines.append("    hermes gateway start")
+        lines.append("  View the board with:")
+        lines.append("    hermes kanban list")
+    else:
+        # No card created — the user needs to run the command manually.
+        lines.append("Next step — create the card manually, then orch picks it up:")
+        lines.append(f"  {result['command']}")
+    return "\n".join(lines)

--- a/hermes_cli/agents_dashboard.py
+++ b/hermes_cli/agents_dashboard.py
@@ -1,0 +1,380 @@
+"""Agents Dashboard TUI module.
+
+Provides a navigable terminal dashboard for the Hermes AI team. Uses
+``rich`` for rendering (table, panels, syntax highlighting) when
+available, with a plain-text fallback for non-interactive environments.
+
+The dashboard:
+- Reuses ``hermes_cli.agents.load_agents()`` (no duplicated registry parsing).
+- Shows all agents with profile, model, provider, role, status,
+  can_edit_files, escalates_to, and skills.
+- Marks the ``default`` profile as fallback/legacy (not a primary worker).
+- Supports interactive numeric selection to inspect a single agent's details.
+- Exits cleanly on ``q``, Esc, or Ctrl-C.
+- Falls back to a non-interactive table dump when stdin is not a TTY.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+from hermes_cli.agents import AgentSpec, load_agents
+
+# Escape character as delivered by most terminals when the user presses Esc.
+# In a cooked-mode terminal, a bare Esc often arrives as ``\x1b`` (sometimes
+# followed by a sequence), so we check for a leading ``\x1b``.
+ESC = "\x1b"
+
+# Sentinel values that mean "quit the dashboard" in any prompt.
+_QUIT_KEYS = ("q", "Q", "quit", "exit", ESC)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _is_interactive() -> bool:
+    """Return True if stdin appears to be a real TTY."""
+    try:
+        return sys.stdin.isatty()
+    except Exception:
+        return False
+
+
+def _skills_str(skills: list[str]) -> str:
+    if not skills:
+        return "-"
+    return ", ".join(skills)
+
+
+def _edit_label(spec: AgentSpec) -> str:
+    val = spec.can_edit_files
+    if val is True:
+        return "yes"
+    if val == "limited":
+        return "limited"
+    return "no"
+
+
+def _status_label(spec: AgentSpec) -> str:
+    if spec.profile == "default":
+        return f"{spec.status} (fallback)"
+    return spec.status
+
+
+def _is_fallback(spec: AgentSpec) -> bool:
+    return spec.profile == "default" or spec.role == "fallback"
+
+
+# ---------------------------------------------------------------------------
+# Rich-based rendering
+# ---------------------------------------------------------------------------
+
+def _render_rich_table(agents: list[AgentSpec]) -> str:
+    """Render the agent team as a rich table and return the string output."""
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console(file=sys.stdout, force_terminal=False, width=120)
+    table = Table(title="Hermes AI Team", show_lines=False)
+    table.add_column("#", style="dim", width=3)
+    table.add_column("Agent", style="bold")
+    table.add_column("Profile")
+    table.add_column("Model")
+    table.add_column("Provider")
+    table.add_column("Role")
+    table.add_column("Status")
+    table.add_column("Edit")
+    table.add_column("Escalates")
+
+    for idx, agent in enumerate(agents, 1):
+        fallback = _is_fallback(agent)
+        style = "dim" if fallback else ""
+        table.add_row(
+            str(idx),
+            agent.name,
+            agent.profile,
+            agent.model or "-",
+            agent.provider or "-",
+            agent.role,
+            _status_label(agent),
+            _edit_label(agent),
+            agent.escalates_to,
+            style=style,
+        )
+    console.print(table)
+    # Capture: rich Console writes to stdout; we need the string.
+    return ""  # Actually printed to stdout already
+
+
+def _render_rich_table_str(agents: list[AgentSpec]) -> str:
+    """Render the agent team as a rich table and return it as a string."""
+    from rich.console import Console
+    from rich.table import Table
+    import io
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=120)
+    table = Table(title="Hermes AI Team", show_lines=False)
+    table.add_column("#", style="dim", width=3)
+    table.add_column("Agent", style="bold")
+    table.add_column("Profile")
+    table.add_column("Model")
+    table.add_column("Provider")
+    table.add_column("Role")
+    table.add_column("Status")
+    table.add_column("Edit")
+    table.add_column("Escalates")
+
+    for idx, agent in enumerate(agents, 1):
+        fallback = _is_fallback(agent)
+        style = "dim" if fallback else ""
+        table.add_row(
+            str(idx),
+            agent.name,
+            agent.profile,
+            agent.model or "-",
+            agent.provider or "-",
+            agent.role,
+            _status_label(agent),
+            _edit_label(agent),
+            agent.escalates_to,
+            style=style,
+        )
+    console.print(table)
+    return buf.getvalue()
+
+
+def _render_agent_detail_str(agent: AgentSpec) -> str:
+    """Render a single agent's full details as a string."""
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.table import Table
+    import io
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=100)
+
+    # Build a detail table
+    detail = Table(show_header=False, box=None, show_lines=False)
+    detail.add_column("Field", style="bold", width=16)
+    detail.add_column("Value")
+
+    detail.add_row("Agent", agent.name)
+    detail.add_row("Profile", agent.profile)
+    detail.add_row("Model", agent.model or "-")
+    detail.add_row("Provider", agent.provider or "-")
+    detail.add_row("Base URL", agent.base_url or "-")
+    detail.add_row("Role", agent.role)
+    detail.add_row("Description", agent.description or "-")
+    detail.add_row("Can edit files", _edit_label(agent))
+    detail.add_row("Escalates to", agent.escalates_to)
+    detail.add_row("Skills", _skills_str(agent.skills))
+    detail.add_row("Status", _status_label(agent))
+
+    title = f"Agent: {agent.name}"
+    if _is_fallback(agent):
+        title += "  [fallback/legacy]"
+
+    console.print(Panel(detail, title=title, border_style="cyan"))
+    return buf.getvalue()
+
+
+def _render_actions_str(interactive: bool = True) -> str:
+    """Render the actions/help panel as a string.
+
+    When ``interactive`` is False (non-TTY / --no-detail), the hint about
+    pressing keys is replaced with guidance to run in a TTY.
+    """
+    from rich.console import Console
+    from rich.panel import Panel
+    import io
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=100)
+    if interactive:
+        hint = "[dim]Press a number to inspect an agent, q/Esc to quit.[/dim]"
+    else:
+        hint = "[dim]Run 'hermes agents dashboard' in a TTY to inspect agent details interactively.[/dim]"
+    actions = (
+        "[bold]Actions:[/bold]\n"
+        "  hermes agents orchestrate \"<task>\"   Send a task to orch for planning\n"
+        "  hermes kanban list                     View team task board\n"
+        "  hermes profile list                    Inspect profile configs\n"
+        "\n"
+        + hint
+    )
+    console.print(Panel(actions, title="Actions", border_style="blue"))
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Plain-text fallback (no rich)
+# ---------------------------------------------------------------------------
+
+def _render_plain_table(agents: list[AgentSpec]) -> str:
+    """Render the agent team as a plain text table (no rich dependency)."""
+    cols = ["#", "Agent", "Profile", "Model", "Provider", "Role", "Status", "Edit", "Escalates"]
+    rows = []
+    for idx, a in enumerate(agents, 1):
+        rows.append([
+            str(idx),
+            a.name,
+            a.profile,
+            a.model or "-",
+            a.provider or "-",
+            a.role,
+            _status_label(a),
+            _edit_label(a),
+            a.escalates_to,
+        ])
+    widths = [len(c) for c in cols]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(str(cell)))
+    sep = "  "
+    lines = ["Hermes AI Team", ""]
+    lines.append(sep.join(c.ljust(widths[i]) for i, c in enumerate(cols)))
+    lines.append(sep.join("-" * widths[i] for i in range(len(cols))))
+    for row in rows:
+        lines.append(sep.join(str(cell).ljust(widths[i]) for i, cell in enumerate(row)))
+    lines.append("")
+    lines.append("Actions:")
+    lines.append('  hermes agents orchestrate "<task>"   Send a task to orch for planning')
+    lines.append("  hermes kanban list                     View team task board")
+    lines.append("  hermes profile list                    Inspect profile configs")
+    return "\n".join(lines)
+
+
+def _render_plain_detail(agent: AgentSpec) -> str:
+    """Render a single agent's details as plain text (no rich)."""
+    lines = [f"Agent: {agent.name}"]
+    if _is_fallback(agent):
+        lines.append("  [fallback/legacy]")
+    lines.append(f"  Profile:       {agent.profile}")
+    lines.append(f"  Model:         {agent.model or '-'}")
+    lines.append(f"  Provider:      {agent.provider or '-'}")
+    lines.append(f"  Base URL:      {agent.base_url or '-'}")
+    lines.append(f"  Role:          {agent.role}")
+    lines.append(f"  Description:   {agent.description or '-'}")
+    lines.append(f"  Can edit:      {_edit_label(agent)}")
+    lines.append(f"  Escalates to:  {agent.escalates_to}")
+    lines.append(f"  Skills:        {_skills_str(agent.skills)}")
+    lines.append(f"  Status:        {_status_label(agent)}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def render_dashboard_str(agents: list[AgentSpec] | None = None) -> str:
+    """Render the dashboard as a string (non-interactive mode).
+
+    Uses rich when available, plain text otherwise. Returns the full
+    dashboard output (table + actions panel).
+    """
+    resolved = agents if agents is not None else load_agents()
+    try:
+        table = _render_rich_table_str(resolved)
+        actions = _render_actions_str(interactive=False)
+        return table + actions
+    except ImportError:
+        return _render_plain_table(resolved)
+
+
+def render_agent_detail_str(agent: AgentSpec) -> str:
+    """Render a single agent detail as a string."""
+    try:
+        return _render_agent_detail_str(agent)
+    except ImportError:
+        return _render_plain_detail(agent)
+
+
+def run_dashboard(agents: list[AgentSpec] | None = None) -> int:
+    """Run the interactive or fallback dashboard.
+
+    In an interactive TTY: shows the table, prompts for a number to
+    inspect an agent detail, or q/Esc to quit. Loops until quit.
+
+    In a non-TTY: prints the table + actions and exits 0.
+
+    Returns 0 on clean exit, non-zero on error.
+    """
+    resolved = agents if agents is not None else load_agents()
+
+    if not resolved:
+        print("No agents found. Run 'hermes agents init' to create a starter registry.")
+        return 0
+
+    # Non-interactive: dump table and exit.
+    if not _is_interactive():
+        print(render_dashboard_str(resolved))
+        return 0
+
+    # Interactive: show table + actions, loop for selection.
+    return _interactive_loop(resolved)
+
+
+def _interactive_loop(agents: list[AgentSpec]) -> int:
+    """Interactive selection loop using rich + input().
+
+    Quit keys: ``q``, ``Q``, ``quit``, ``exit``, or Esc (``\\x1b``).
+    In the detail prompt, Esc goes back to the dashboard (not quit), so
+    the user can Esc out of a detail view without accidentally exiting.
+    """
+    try:
+        from rich.console import Console
+        console: Any = Console()
+        use_rich = True
+    except ImportError:
+        console = None
+        use_rich = False
+
+    while True:
+        # Render the dashboard
+        if use_rich:
+            console.print(_render_rich_table_str(agents))
+            console.print(_render_actions_str(interactive=True))
+        else:
+            print(_render_plain_table(agents))
+
+        # Prompt — q/Esc quit, number selects an agent.
+        try:
+            choice = input("\nSelect agent # (or q/Esc to quit): ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return 0
+
+        if choice in _QUIT_KEYS or choice.startswith(ESC):
+            return 0
+
+        # Try to parse as a number
+        try:
+            idx = int(choice)
+        except ValueError:
+            print("Invalid input. Enter a number, or q/Esc to quit.")
+            continue
+
+        if idx < 1 or idx > len(agents):
+            print(f"Number out of range (1-{len(agents)}).")
+            continue
+
+        agent = agents[idx - 1]
+        detail = render_agent_detail_str(agent)
+        if use_rich:
+            console.print(detail)
+        else:
+            print(detail)
+
+        # Wait for user to go back or quit.
+        # Enter = back to dashboard, q = quit, Esc = back to dashboard.
+        try:
+            back = input("\nPress Enter/Esc to go back, q to quit: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return 0
+        if back in ("q", "Q"):
+            return 0
+        # Esc or Enter or anything else: loop and re-render the dashboard.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -300,6 +300,7 @@ from hermes_cli.subcommands.pairing import build_pairing_parser
 from hermes_cli.subcommands.plugins import build_plugins_parser
 from hermes_cli.subcommands.mcp import build_mcp_parser
 from hermes_cli.subcommands.claw import build_claw_parser
+from hermes_cli.subcommands.agents import build_agents_parser
 
 
 def _require_tty(command_name: str) -> None:
@@ -4247,6 +4248,66 @@ def cmd_kanban(args):
     from hermes_cli.kanban import kanban_command
 
     return kanban_command(args)
+
+
+def cmd_agents(args):
+    """AI team dashboard — bare ``hermes agents`` behaves like ``agents list``."""
+    from hermes_cli.agents import load_agents, render_table
+
+    agents = load_agents()
+    print(render_table(agents))
+    return 0
+
+
+def cmd_agents_list(args):
+    """List agents as a table or JSON."""
+    from hermes_cli.agents import load_agents, render_table, to_json
+
+    agents = load_agents()
+    if getattr(args, "json", False):
+        print(to_json(agents))
+    else:
+        print(render_table(agents))
+    return 0
+
+
+def cmd_agents_init(args):
+    """Create a starter agents.yaml registry."""
+    from hermes_cli.agents import init_registry
+
+    try:
+        path = init_registry(force=getattr(args, "force", False))
+    except FileExistsError as exc:
+        print(f"agents init: {exc}", file=sys.stderr)
+        return 1
+    print(f"Wrote starter registry to {path}")
+    return 0
+
+
+def cmd_agents_orchestrate(args):
+    """Prepare a planning handoff for orch via Kanban."""
+    from hermes_cli.agents import orchestrate, render_orchestrate_summary
+
+    create_card = not getattr(args, "no_create", False)
+    try:
+        result = orchestrate(args.task, create_card=create_card)
+    except ValueError as exc:
+        print(f"agents orchestrate: {exc}", file=sys.stderr)
+        return 2
+    print(render_orchestrate_summary(result))
+    return 0
+
+
+def cmd_agents_dashboard(args):
+    """Open the navigable agents dashboard."""
+    from hermes_cli.agents_dashboard import run_dashboard, render_dashboard_str, load_agents
+
+    # --no-detail forces non-interactive output even in a TTY.
+    if getattr(args, "no_detail", False):
+        agents = load_agents()
+        print(render_dashboard_str(agents))
+        return 0
+    return run_dashboard()
 
 
 def cmd_project(args):
@@ -12340,6 +12401,18 @@ def main():
 
     kanban_parser = _build_kanban_parser(subparsers)
     kanban_parser.set_defaults(func=cmd_kanban)
+
+    # =========================================================================
+    # agents command — AI team dashboard
+    # =========================================================================
+    build_agents_parser(
+        subparsers,
+        cmd_agents=cmd_agents,
+        cmd_agents_list=cmd_agents_list,
+        cmd_agents_init=cmd_agents_init,
+        cmd_agents_orchestrate=cmd_agents_orchestrate,
+        cmd_agents_dashboard=cmd_agents_dashboard,
+    )
 
     # =========================================================================
     # project command — named, multi-folder workspaces

--- a/hermes_cli/subcommands/agents.py
+++ b/hermes_cli/subcommands/agents.py
@@ -1,0 +1,114 @@
+"""``hermes agents`` subcommand parser.
+
+Builds the argparse tree for the agents dashboard command. The handler
+functions live in ``hermes_cli.main`` (injected) so this module stays
+import-light and mirrors the pattern of ``hermes_cli/subcommands/dashboard.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Callable
+
+
+def build_agents_parser(
+    subparsers,
+    *,
+    cmd_agents: Callable,
+    cmd_agents_list: Callable,
+    cmd_agents_init: Callable,
+    cmd_agents_orchestrate: Callable,
+    cmd_agents_dashboard: Callable,
+) -> None:
+    """Attach the ``agents`` subcommand tree."""
+    # =========================================================================
+    # agents command
+    # =========================================================================
+    agents_parser = subparsers.add_parser(
+        "agents",
+        help="Show the AI team dashboard (agents, profiles, models)",
+        description=(
+            "Display a manager-friendly dashboard of Hermes AI agents: "
+            "profile, model, provider, role and status. Use subcommands "
+            "to list as JSON, create a starter registry, or send a task "
+            "to orch for planning."
+        ),
+    )
+    agents_parser.set_defaults(func=cmd_agents)
+
+    agents_subparsers = agents_parser.add_subparsers(dest="agents_action")
+
+    # agents list [--json]
+    list_parser = agents_subparsers.add_parser(
+        "list",
+        help="List agents as a table (default) or JSON",
+        description="Print the agent team as a table, or as JSON with --json.",
+    )
+    list_parser.add_argument(
+        "--json",
+        dest="json",
+        action="store_true",
+        help="Output normalized JSON instead of a table",
+    )
+    list_parser.set_defaults(func=cmd_agents_list)
+
+    # agents init [--force]
+    init_parser = agents_subparsers.add_parser(
+        "init",
+        help="Create a starter agents.yaml registry",
+        description=(
+            "Write a starter agent registry to $HERMES_HOME/agents.yaml. "
+            "Refuses to overwrite an existing file unless --force is passed."
+        ),
+    )
+    init_parser.add_argument(
+        "--force",
+        dest="force",
+        action="store_true",
+        help="Overwrite an existing agents.yaml",
+    )
+    init_parser.set_defaults(func=cmd_agents_init)
+
+    # agents orchestrate "<task>"
+    orchestrate_parser = agents_subparsers.add_parser(
+        "orchestrate",
+        help="Send a task to orch for planning (creates a Kanban card)",
+        description=(
+            "Prepare a planning handoff for the orch profile. Creates a "
+            "Kanban card assigned to orch when the backend is available, "
+            "and prints the exact next command to start processing. "
+            "Does NOT execute the task itself."
+        ),
+    )
+    orchestrate_parser.add_argument(
+        "task",
+        help='The task text to hand to orch, e.g. "Melhorar upload do app".',
+    )
+    orchestrate_parser.add_argument(
+        "--no-create",
+        dest="no_create",
+        action="store_true",
+        help="Do not create a Kanban card; only print the handoff command.",
+    )
+    orchestrate_parser.set_defaults(func=cmd_agents_orchestrate)
+
+    # agents dashboard
+    dashboard_parser = agents_subparsers.add_parser(
+        "dashboard",
+        help="Open a navigable terminal dashboard of the AI team",
+        description=(
+            "Display a navigable terminal dashboard of Hermes AI agents. "
+            "Shows profile, model, provider, role, status, edit permissions, "
+            "escalation and skills. In a TTY, supports numeric selection to "
+            "inspect individual agent details. In non-interactive mode, "
+            "prints a table and exits. Uses rich when available, falls back "
+            "to plain text otherwise."
+        ),
+    )
+    dashboard_parser.add_argument(
+        "--no-detail",
+        dest="no_detail",
+        action="store_true",
+        help="Non-interactive mode: print table without prompting for selection.",
+    )
+    dashboard_parser.set_defaults(func=cmd_agents_dashboard)

--- a/tests/hermes_cli/test_agents_cli.py
+++ b/tests/hermes_cli/test_agents_cli.py
@@ -1,0 +1,442 @@
+"""Tests for the ``hermes agents`` CLI command.
+
+Uses a temporary HERMES_HOME with fake profile dirs/configs so the real
+user config is never touched. Exercises registry loading, default
+creation, table output, JSON output, init, and orchestrate handoff.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Ensure the repo root is on sys.path so `hermes_cli` / `hermes_constants`
+# import correctly regardless of pytest invocation cwd.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from hermes_cli import agents as agents_mod
+
+
+@pytest.fixture
+def temp_hermes_home(tmp_path, monkeypatch):
+    """Point HERMES_HOME at a temp dir and patch get_hermes_home accordingly."""
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # Patch the get_hermes_home used inside hermes_cli.agents so it
+    # reflects the temp home regardless of any cached imports.
+    monkeypatch.setattr(
+        agents_mod, "get_hermes_home", lambda: Path(os.environ["HERMES_HOME"])
+    )
+    return home
+
+
+def _write_fake_profile(home: Path, name: str, model: str, provider: str) -> None:
+    """Create a fake profile directory with a config.yaml."""
+    if name == "default":
+        profile_dir = home
+    else:
+        profile_dir = home / "profiles" / name
+        profile_dir.mkdir(parents=True, exist_ok=True)
+    cfg = {"model": {"default": model, "provider": provider}}
+    (profile_dir / "config.yaml").write_text(yaml.safe_dump(cfg), encoding="utf-8")
+
+
+def _write_registry(home: Path, registry: dict) -> None:
+    (home / "agents.yaml").write_text(yaml.safe_dump(registry), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# load_agents
+# ---------------------------------------------------------------------------
+
+class TestLoadAgents:
+    def test_missing_registry_uses_discovered_profiles(self, temp_hermes_home, monkeypatch):
+        _write_fake_profile(temp_hermes_home, "default", "gpt-5.5", "openai-codex")
+        # Force discovery to see our fake profiles. We patch
+        # _discover_profiles directly so the test is hermetic.
+        monkeypatch.setattr(
+            agents_mod,
+            "_discover_profiles",
+            lambda: [("default", "gpt-5.5", "openai-codex")],
+        )
+        agents = agents_mod.load_agents()
+        assert len(agents) >= 1
+        assert any(a.profile == "default" for a in agents)
+        assert any(a.model == "gpt-5.5" for a in agents)
+
+    def test_explicit_registry_is_loaded(self, temp_hermes_home, monkeypatch):
+        _write_fake_profile(temp_hermes_home, "default", "gpt-5.5", "openai-codex")
+        _write_registry(temp_hermes_home, {
+            "version": 1,
+            "agents": {
+                "lead": {
+                    "profile": "default",
+                    "role": "orchestrator",
+                    "description": "Team lead",
+                    "can_edit_files": False,
+                    "skills": ["kanban-orchestrator"],
+                },
+            },
+        })
+        monkeypatch.setattr(
+            agents_mod,
+            "_discover_profiles",
+            lambda: [("default", "gpt-5.5", "openai-codex")],
+        )
+        agents = agents_mod.load_agents()
+        lead = next(a for a in agents if a.name == "lead")
+        assert lead.profile == "default"
+        assert lead.role == "orchestrator"
+        assert lead.model == "gpt-5.5"
+        assert lead.skills == ["kanban-orchestrator"]
+
+    def test_missing_profile_marked(self, temp_hermes_home, monkeypatch):
+        _write_fake_profile(temp_hermes_home, "default", "gpt-5.5", "openai-codex")
+        _write_registry(temp_hermes_home, {
+            "version": 1,
+            "agents": {
+                "ghost": {
+                    "profile": "nonexistent_profile",
+                    "role": "agent",
+                },
+            },
+        })
+        # Discovery only finds 'default'; 'nonexistent_profile' won't exist.
+        from hermes_cli.profiles import list_profiles
+        monkeypatch.setattr(
+            agents_mod,
+            "_discover_profiles",
+            lambda: [(p.name, p.model or "", p.provider or "") for p in list_profiles()],
+        )
+        agents = agents_mod.load_agents()
+        ghost = next(a for a in agents if a.name == "ghost")
+        assert ghost.status == "missing_profile"
+
+    def test_registry_agent_without_model_inherits_discovered(self, temp_hermes_home, monkeypatch):
+        _write_fake_profile(temp_hermes_home, "default", "gpt-5.5", "openai-codex")
+        _write_registry(temp_hermes_home, {
+            "version": 1,
+            "agents": {
+                "lead": {"profile": "default", "role": "orchestrator"},
+            },
+        })
+        monkeypatch.setattr(
+            agents_mod,
+            "_discover_profiles",
+            lambda: [("default", "gpt-5.5", "openai-codex")],
+        )
+        agents = agents_mod.load_agents()
+        lead = next(a for a in agents if a.name == "lead")
+        assert lead.model == "gpt-5.5"
+        assert lead.provider == "openai-codex"
+
+
+# ---------------------------------------------------------------------------
+# render_table / to_json
+# ---------------------------------------------------------------------------
+
+class TestRender:
+    def test_table_contains_expected_columns_and_model(self, temp_hermes_home, monkeypatch):
+        monkeypatch.setattr(
+            agents_mod,
+            "_discover_profiles",
+            lambda: [("coding", "glm-5.2:cloud", "custom")],
+        )
+        agents = agents_mod.load_agents()
+        out = agents_mod.render_table(agents)
+        assert "Agent" in out
+        assert "Model" in out
+        assert "Provider" in out
+        assert "Role" in out
+        assert "Status" in out
+        assert "glm-5.2:cloud" in out
+
+    def test_json_is_valid(self, temp_hermes_home, monkeypatch):
+        monkeypatch.setattr(
+            agents_mod,
+            "_discover_profiles",
+            lambda: [("coding", "glm-5.2:cloud", "custom")],
+        )
+        agents = agents_mod.load_agents()
+        raw = agents_mod.to_json(agents)
+        data = json.loads(raw)
+        assert isinstance(data, list)
+        assert any(entry["profile"] == "coding" for entry in data)
+        assert any(entry["model"] == "glm-5.2:cloud" for entry in data)
+
+
+# ---------------------------------------------------------------------------
+# init_registry
+# ---------------------------------------------------------------------------
+
+class TestInit:
+    def test_init_creates_file(self, temp_hermes_home):
+        path = agents_mod.init_registry(force=False)
+        assert path == temp_hermes_home / "agents.yaml"
+        assert path.is_file()
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        assert "agents" in data
+        assert "orch" in data["agents"]
+
+    def test_init_refuses_overwrite_without_force(self, temp_hermes_home):
+        agents_mod.init_registry(force=False)
+        with pytest.raises(FileExistsError):
+            agents_mod.init_registry(force=False)
+
+    def test_init_force_overwrites(self, temp_hermes_home):
+        agents_mod.init_registry(force=False)
+        # Overwrite manually with different content to prove --force replaces.
+        path = temp_hermes_home / "agents.yaml"
+        path.write_text("version: 99\nagents: {}\n", encoding="utf-8")
+        agents_mod.init_registry(force=True)
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        assert "orch" in data["agents"]
+
+
+# ---------------------------------------------------------------------------
+# orchestrate
+# ---------------------------------------------------------------------------
+
+class TestOrchestrate:
+    def test_orchestrate_builds_handoff_body(self, temp_hermes_home):
+        result = agents_mod.orchestrate("Test task", create_card=False)
+        assert result["task"] == "Test task"
+        assert "hermes kanban create" in result["command"]
+        assert "orch" in result["command"]
+        assert "Test task" in result["body"]
+
+    def test_orchestrate_empty_task_raises(self, temp_hermes_home):
+        with pytest.raises(ValueError):
+            agents_mod.orchestrate("   ", create_card=False)
+
+    def test_orchestrate_no_create_has_no_card_id(self, temp_hermes_home):
+        result = agents_mod.orchestrate("Some task", create_card=False)
+        assert result["card_id"] is None
+
+    def test_render_summary_contains_command(self, temp_hermes_home):
+        result = agents_mod.orchestrate("Do something", create_card=False)
+        summary = agents_mod.render_orchestrate_summary(result)
+        assert "hermes kanban create" in summary
+
+    def test_orchestrate_quoting_safe_with_quotes_and_dollar(self, temp_hermes_home):
+        """The printed command must survive shell metacharacters: quotes, $, backticks."""
+        tricky = 'tarefa com "aspas" e $HOME e `cmd`'
+        result = agents_mod.orchestrate(tricky, create_card=False)
+        cmd = result["command"]
+        # The command must be safe to copy/paste into a shell: shlex.quote
+        # wraps the args in single quotes, so $ and `` are literal.
+        # Verify by parsing the command back with shlex.
+        import shlex as _shlex
+        parts = _shlex.split(cmd)
+        assert parts[0] == "hermes"
+        assert parts[1] == "kanban"
+        assert parts[2] == "create"
+        # The title arg must reconstruct to the exact title (not a mangled one).
+        assert "orchestrate: " + tricky in parts[3]
+        # $HOME must appear literally (not expanded), and aspas must be intact.
+        assert "$HOME" in parts[3]
+        assert '"aspas"' in parts[3]
+        # The --body arg must contain the original task text too.
+        assert any("$HOME" in p for p in parts)
+
+    def test_render_summary_no_duplicate_command_when_card_created(self, temp_hermes_home):
+        """When card_id exists, summary must NOT print the kanban create command."""
+        result = agents_mod.orchestrate("Some task", create_card=False)
+        # Simulate a card having been created.
+        result["card_id"] = "t_fake123"
+        summary = agents_mod.render_orchestrate_summary(result)
+        assert "Created Kanban card: t_fake123" in summary
+        # Must NOT contain the create command (would invite duplicates).
+        assert "hermes kanban create" not in summary
+        assert "hermes kanban list" in summary  # points to board instead
+
+    def test_render_summary_shows_command_when_no_card(self, temp_hermes_home):
+        """When card_id is None, summary MUST print the manual create command."""
+        result = agents_mod.orchestrate("Some task", create_card=False)
+        summary = agents_mod.render_orchestrate_summary(result)
+        assert "hermes kanban create" in summary
+        assert "Kanban card was not created" in summary
+
+    def test_render_summary_suggests_gateway_when_dispatcher_down(self, temp_hermes_home):
+        """When card exists but dispatcher is down, suggest `hermes gateway start`."""
+        result = agents_mod.orchestrate("Some task", create_card=False)
+        result["card_id"] = "t_fake456"
+        result["dispatcher_running"] = False
+        result["dispatcher_message"] = "No gateway is running"
+        summary = agents_mod.render_orchestrate_summary(result)
+        assert "hermes gateway start" in summary
+        assert "hermes kanban list" in summary
+        # Still must not suggest creating a duplicate card.
+        assert "hermes kanban create" not in summary
+
+
+# ---------------------------------------------------------------------------
+# Dashboard
+# ---------------------------------------------------------------------------
+
+class TestDashboard:
+    """Tests for the ``hermes agents dashboard`` subcommand and rendering."""
+
+    def _make_agents(self) -> list:
+        """Build a small set of fake agents for rendering tests."""
+        from hermes_cli.agents import AgentSpec
+        return [
+            AgentSpec(
+                name="orch", profile="orch", role="orchestrator",
+                description="Team lead", can_edit_files=False,
+                escalates_to="user", skills=["kanban-orchestrator"],
+                model="gpt-5.5", provider="openai-codex", status="ready",
+            ),
+            AgentSpec(
+                name="coding", profile="coding", role="implementer",
+                description="Writes code", can_edit_files=True,
+                escalates_to="orch", skills=["test-driven-development"],
+                model="glm-5.2:cloud", provider="custom", status="ready",
+            ),
+            AgentSpec(
+                name="default", profile="default", role="fallback",
+                description="Legacy base", can_edit_files=False,
+                escalates_to="orch", skills=[],
+                model="glm-5.2", provider="ollama-cloud", status="ready",
+            ),
+        ]
+
+    def test_render_dashboard_str_contains_agents(self):
+        from hermes_cli.agents_dashboard import render_dashboard_str
+        agents = self._make_agents()
+        out = render_dashboard_str(agents)
+        assert "orch" in out
+        assert "coding" in out
+        assert "default" in out
+        assert "gpt-5.5" in out
+        assert "glm-5.2:cloud" in out
+
+    def test_render_dashboard_str_contains_actions(self):
+        from hermes_cli.agents_dashboard import render_dashboard_str
+        agents = self._make_agents()
+        out = render_dashboard_str(agents)
+        assert "hermes agents orchestrate" in out
+        assert "hermes kanban list" in out
+
+    def test_render_dashboard_str_marks_fallback(self):
+        from hermes_cli.agents_dashboard import render_dashboard_str
+        agents = self._make_agents()
+        out = render_dashboard_str(agents)
+        # The default profile should be marked as fallback.
+        assert "fallback" in out
+
+    def test_render_agent_detail_contains_all_fields(self):
+        from hermes_cli.agents_dashboard import render_agent_detail_str
+        agents = self._make_agents()
+        coding = agents[1]
+        detail = render_agent_detail_str(coding)
+        assert "coding" in detail
+        assert "implementer" in detail
+        assert "glm-5.2:cloud" in detail
+        assert "custom" in detail
+        assert "test-driven-development" in detail
+        assert "orch" in detail  # escalates_to
+
+    def test_render_agent_detail_marks_fallback(self):
+        from hermes_cli.agents_dashboard import render_agent_detail_str
+        agents = self._make_agents()
+        default_agent = agents[2]
+        detail = render_agent_detail_str(default_agent)
+        assert "fallback" in detail
+
+    def test_run_dashboard_non_interactive_prints_and_exits(self, temp_hermes_home, monkeypatch):
+        """In a non-TTY, run_dashboard should print the table and return 0."""
+        from hermes_cli import agents_dashboard as dash_mod
+        agents = self._make_agents()
+        # Force non-interactive
+        monkeypatch.setattr(dash_mod, "_is_interactive", lambda: False)
+        result = dash_mod.run_dashboard(agents=agents)
+        assert result == 0
+
+    def test_run_dashboard_no_agents_prints_message(self, temp_hermes_home, monkeypatch):
+        """When there are no agents, run_dashboard prints a helpful message."""
+        from hermes_cli import agents_dashboard as dash_mod
+        result = dash_mod.run_dashboard(agents=[])
+        assert result == 0
+
+    def test_dashboard_no_detail_flag_renders_non_interactive(self, temp_hermes_home, monkeypatch):
+        """``--no-detail`` should force non-interactive rendering."""
+        from hermes_cli import agents_dashboard as dash_mod
+        agents = self._make_agents()
+        out = dash_mod.render_dashboard_str(agents)
+        assert "orch" in out
+        assert "coding" in out
+
+    def test_plain_table_fallback_has_columns(self, monkeypatch):
+        """The plain-text fallback table should have the expected columns."""
+        from hermes_cli import agents_dashboard as dash_mod
+        agents = self._make_agents()
+        # Force plain rendering by making rich import fail.
+        import builtins
+        real_import = builtins.__import__
+        def fake_import(name, *args, **kwargs):
+            if name.startswith("rich"):
+                raise ImportError("no rich")
+            return real_import(name, *args, **kwargs)
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        out = dash_mod._render_plain_table(agents)
+        assert "Agent" in out
+        assert "Model" in out
+        assert "Provider" in out
+        assert "Role" in out
+        assert "Status" in out
+        assert "orch" in out
+
+    def test_esc_quits_main_prompt(self, temp_hermes_home, monkeypatch):
+        """Pressing Esc (\\x1b) at the main prompt should exit with 0."""
+        from hermes_cli import agents_dashboard as dash_mod
+        agents = self._make_agents()
+        # Force interactive mode so the loop runs.
+        monkeypatch.setattr(dash_mod, "_is_interactive", lambda: True)
+        # Simulate Esc at the first prompt.
+        monkeypatch.setattr("builtins.input", lambda prompt="": "\x1b")
+        result = dash_mod.run_dashboard(agents=agents)
+        assert result == 0
+
+    def test_q_quits_main_prompt(self, temp_hermes_home, monkeypatch):
+        """Pressing q at the main prompt should exit with 0."""
+        from hermes_cli import agents_dashboard as dash_mod
+        agents = self._make_agents()
+        monkeypatch.setattr(dash_mod, "_is_interactive", lambda: True)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "q")
+        result = dash_mod.run_dashboard(agents=agents)
+        assert result == 0
+
+    def test_esc_in_detail_goes_back_not_quit(self, temp_hermes_home, monkeypatch):
+        """Esc at the detail prompt should go back, not quit.
+
+        The sequence: select agent 1, then Esc at the detail prompt
+        (goes back), then q at the main prompt (quits).
+        """
+        from hermes_cli import agents_dashboard as dash_mod
+        agents = self._make_agents()
+        monkeypatch.setattr(dash_mod, "_is_interactive", lambda: True)
+        # First input: "1" (select agent 1)
+        # Second input: "\x1b" (Esc at detail → goes back)
+        # Third input: "q" (quit at main prompt)
+        inputs = iter(["1", "\x1b", "q"])
+        monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+        result = dash_mod.run_dashboard(agents=agents)
+        assert result == 0
+
+    def test_non_interactive_actions_hint_mentions_tty(self, temp_hermes_home, monkeypatch):
+        """The non-interactive actions panel should not say 'Press a number'."""
+        from hermes_cli import agents_dashboard as dash_mod
+        agents = self._make_agents()
+        monkeypatch.setattr(dash_mod, "_is_interactive", lambda: False)
+        out = dash_mod.render_dashboard_str(agents)
+        assert "Press a number" not in out
+        assert "TTY" in out


### PR DESCRIPTION
This PR adds the first Hermes Agents dashboard/CLI MVP for viewing and coordinating profile-based AI teams.

    It introduces:

    - hermes agents — manager-friendly table of configured AI agents
    - hermes agents list --json — machine-readable agent registry output
    - hermes agents init — starter agents.yaml registry creation
    - hermes agents orchestrate "<task>" — Kanban handoff preparation for the orch profile
    - hermes agents dashboard — terminal dashboard with Rich rendering and plain-text fallback

    The dashboard displays:

    - agent name
    - profile
    - model
    - provider
    - role
    - status
    - edit capability
    - escalation target
    - fallback/legacy marker for the default profile

    It also supports:

    - numeric selection in TTY mode to inspect agent details
    - clean exit with q or Esc
    - non-interactive output with --no-detail
    - safe shell quoting for generated hermes kanban create ... commands

    Why

    Hermes profiles can already represent different specialized agents, but there was no simple command surface for viewing the configured AI team or preparing orchestration handoffs.

    This PR creates a small CLI/dashboard layer without changing the core agent loop or adding model tools.

    Implementation Notes

    - Adds hermes_cli/agents.py for:
      - AgentSpec
      - registry loading from $HERMES_HOME/agents.yaml
      - profile/model discovery
      - table/JSON rendering
      - orchestration handoff generation
      - safe shell quoting via shlex.quote

    - Adds hermes_cli/agents_dashboard.py for:
      - Rich-based dashboard rendering
      - plain-text fallback when Rich is unavailable
      - non-interactive mode
      - simple TTY interaction via numeric selection
      - Esc/q behavior

    - Adds hermes_cli/subcommands/agents.py for argparse wiring.

    - Wires the new command into hermes_cli/main.py.

    - Adds CLI and dashboard tests in tests/hermes_cli/test_agents_cli.py.

    Test Plan

    Automated tests:

    bash
    venv/bin/python -m pytest tests/hermes_cli/test_agents_cli.py tests/hermes_cli/test_kanban_core_functionality.py -q -o 'addopts='


    Result:

    text
    197 passed


    Manual smoke tests:

    bash
    hermes agents --help
    hermes agents
    hermes agents list --json
    hermes agents dashboard --help
    hermes agents dashboard --no-detail
    hermes agents orchestrate 'teste final com "aspas" e $HOME' --no-create


    Verified:

    - hermes agents --help lists list, init, orchestrate, and dashboard
    - hermes agents shows configured agents
    - hermes agents list --json returns valid JSON
    - hermes agents dashboard --no-detail renders the dashboard table
    - default is marked as fallback
    - generated Kanban command preserves quotes and $HOME literally
    - dashboard exits cleanly with q and Esc
    - Esc in detail view goes back to the dashboard
    - existing Kanban tests still pass

    Scope

    This PR intentionally does not:

    - change the core agent loop
    - add new model tools
    - require the gateway to be running
    - implement a full-screen Textual/curses UI
    - change Kanban internals
    - implement autonomous worker execution

    Future follow-ups may add:

    - Kanban task status summary in the dashboard
    - an interactive action to trigger orchestrate
    - a fuller Textual-based TUI with arrow-key navigation


    Se quiser uma versão mais curta, use esta:

    markdown
    Summary

    Adds the first hermes agents CLI/dashboard MVP for viewing profile-based AI teams and preparing orchestration handoffs.

    Includes:

    - hermes agents
    - hermes agents list --json
    - hermes agents init
    - hermes agents orchestrate "<task>"
    - hermes agents dashboard

    The dashboard shows agent/profile/model/provider/role/status/edit/escalation info, marks default as fallback, supports non-interactive output, and allows simple TTY inspection with clean q/Esc behavior.

    Test Plan

    bash
    venv/bin/python -m pytest tests/hermes_cli/test_agents_cli.py tests/hermes_cli/test_kanban_core_functionality.py -q -o 'addopts='


    Result:

    text
    197 passed


    Manual checks:

    bash
    hermes agents --help
    hermes agents
    hermes agents list --json
    hermes agents dashboard --help
    hermes agents dashboard --no-detail
    hermes agents orchestrate 'teste final com "aspas" e $HOME' --no-create


    Verified that the dashboard renders correctly, JSON output is valid, existing commands still work, Esc/q behavior works, and generated shell commands use safe quoting.

    Scope

    No core agent-loop changes, no new model tools, no Kanban internals changed, and no gateway requirement.