### PR TITLE
fix(desktop): report session override provider in session info

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4537,6 +4537,51 @@ def test_session_info_includes_session_title(monkeypatch):
     assert info["title"] == "Dashboard title"
 
 
+def test_session_info_prefers_session_model_override_provider_for_custom_runtime():
+    agent = types.SimpleNamespace(
+        tools=[],
+        model="shared-model",
+        provider="custom",
+        base_url="https://provider-a.example/v1",
+        api_mode="codex_responses",
+    )
+    session = {
+        "session_key": "session-key",
+        "history": [],
+        "model_override": {
+            "model": "shared-model",
+            "provider": "custom-provider-a",
+            "base_url": "https://provider-a.example/v1",
+            "api_mode": "codex_responses",
+        },
+    }
+
+    info = server._session_info(agent, session)
+
+    assert info["model"] == "shared-model"
+    assert info["provider"] == "custom-provider-a"
+
+
+def test_session_info_ignores_stale_model_override_provider():
+    agent = types.SimpleNamespace(
+        tools=[],
+        model="current-model",
+        provider="openai-codex",
+    )
+    session = {
+        "session_key": "session-key",
+        "history": [],
+        "model_override": {
+            "model": "old-model",
+            "provider": "custom-provider-a",
+        },
+    }
+
+    info = server._session_info(agent, session)
+
+    assert info["provider"] == "openai-codex"
+
+
 # ---------------------------------------------------------------------------
 # History-mutating commands must reject while session.running is True.
 # Without these guards, prompt.submit's post-run history write either

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3028,6 +3028,31 @@ def _current_profile_name() -> str:
 DESKTOP_BACKEND_CONTRACT = 2
 
 
+def _session_info_provider(agent, session: dict | None = None) -> str:
+    """Return the user-facing provider identity for ``session.info``.
+
+    ``agent.provider`` is the resolved runtime/billing class. For named custom
+    providers that value can be the literal ``custom`` even though the user chose
+    a routable provider slug from the desktop picker. If Desktop persists that
+    internal value into its sticky composer state, the next ``session.create``
+    can pair the right model with the wrong provider group.
+
+    The per-session ``model_override`` is the source of truth for picker and
+    live ``/model`` switches, so prefer it while it still describes the agent's
+    current model. Fall back to the runtime provider for older sessions and
+    built-in providers.
+    """
+    provider = str(getattr(agent, "provider", "") or "").strip()
+    override = (session or {}).get("model_override") if isinstance(session, dict) else None
+    if isinstance(override, dict):
+        override_provider = str(override.get("provider") or "").strip()
+        override_model = str(override.get("model") or "").strip()
+        agent_model = str(getattr(agent, "model", "") or "").strip()
+        if override_provider and (not override_model or override_model == agent_model):
+            return override_provider
+    return provider
+
+
 def _session_info(agent, session: dict | None = None) -> dict:
     if session is None:
         for candidate in _sessions.values():
@@ -3070,7 +3095,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         yolo = False
     info: dict = {
         "model": getattr(agent, "model", ""),
-        "provider": getattr(agent, "provider", ""),
+        "provider": _session_info_provider(agent, session),
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
         "fast": service_tier == "priority",


### PR DESCRIPTION
## Summary

Fix Desktop/TUI `session.info` so it reports the user-facing per-session provider override instead of the internal resolved runtime provider when a session was created or switched through a named custom provider.

For named custom providers, the live agent may expose `agent.provider == "custom"` because that is the resolved runtime/billing class. Desktop treats `session.info.provider` as sticky composer state. If it stores the internal `"custom"` value, a later session can pair the selected model with the wrong provider group and fail with provider-side model-not-supported errors.

This change makes `session.info` prefer `session["model_override"]["provider"]` when it still matches the live agent model, falling back to `agent.provider` for normal/built-in providers and older sessions.

## Why

Desktop model selection sends both model and provider. However, after the live agent is built, `session.info` can overwrite the Desktop provider state with the runtime provider class instead of the original provider slug.

This is especially visible when multiple named custom providers expose overlapping model IDs. The model name remains correct, but the next request can be routed to a different provider group.

## Changes

- Add `_session_info_provider()` helper in `tui_gateway/server.py`.
- Prefer the current session's `model_override.provider` when it describes the live model.
- Keep the previous fallback to `agent.provider`.
- Add regression coverage for:
  - named custom provider override survives `agent.provider == "custom"`
  - stale overrides are ignored when the live model no longer matches

## Related

Refs #50151

This is complementary to #50151. That PR guards Desktop against unsafe provider payloads. This PR fixes the backend payload source so `session.info` sends the user-facing session provider when available.

## Testing

```bash
./.venv/Scripts/python.exe -m pytest tests/test_tui_gateway_server.py -k "session_info_prefers_session_model_override_provider_for_custom_runtime or session_info_ignores_stale_model_override_provider" -q
# 2 passed, 299 deselected

./.venv/Scripts/python.exe -m pytest tests/test_tui_gateway_server.py -k "session_info" -q
# 4 passed, 297 deselected

git diff --check
./.venv/Scripts/python.exe -m py_compile tui_gateway/server.py tests/test_tui_gateway_server.py
```

Note: `scripts/run_tests.sh` was not used on this Windows checkout because it expects a POSIX-style `.venv/bin` or `venv/bin` virtualenv, while this local venv is Windows-style `.venv/Scripts`.
