### PR TITLE
fix(qqbot): accept is_reconnect kwarg in QQAdapter.connect

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
## Summary

The gateway reconnection logic in `run.py` passes `is_reconnect=True` when reconnecting platform adapters, but `QQAdapter.connect()` did not accept this keyword argument, causing a `TypeError` on reconnect attempts.

```
TypeError: QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

## Root Cause

`BasePlatformAdapter` (base class, line 2637) defines:
```python
async def connect(self, *, is_reconnect: bool = False) -> bool:
```

But `QQAdapter` (line 281) overrides it as:
```python
async def connect(self) -> bool:
```

The missing `is_reconnect` parameter causes the gateway\'s reconnection watcher to fail every time it tries to reconnect QQ Bot.

## Fix

Added the missing keyword-only parameter to `QQAdapter.connect()`, matching the base class signature. A one-line change.