### PR TITLE
fix(gateway): resolve profile override conflict under systemd double-load

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -335,6 +335,8 @@ sys.path.insert(0, str(PROJECT_ROOT))
 # ---------------------------------------------------------------------------
 def _apply_profile_override() -> None:
     """Pre-parse --profile/-p and set HERMES_HOME before imports."""
+    if os.environ.get("_HERMES_PROFILE_PROCESSED") == "1":
+        return
     argv = sys.argv[1:]
     profile_name = None
     consume = 0
@@ -503,6 +505,8 @@ def _apply_profile_override() -> None:
         if consume > 0 and profile_index is not None:
             start = profile_index + 1  # +1 because argv is sys.argv[1:]
             sys.argv = sys.argv[:start] + sys.argv[start + consume :]
+
+    os.environ["_HERMES_PROFILE_PROCESSED"] = "1"
 
 
 _apply_profile_override()


### PR DESCRIPTION
### Problem
When the Hermes agent is run under systemd using the `python -m hermes_cli.main` entrypoint (e.g. `python -m hermes_cli.main --profile default gateway run`), Python loads the module twice: once as the module `hermes_cli.main` and once as `__main__`.

During the first load, `_apply_profile_override()` parses and consumes the `--profile default` argument, setting `HERMES_HOME` correctly to the default root and stripping the flag from `sys.argv`. On the second load, since the flag is no longer present in `sys.argv`, the script falls back to the sticky active profile (e.g. `galyarder`) by reading `active_profile`. This overwrites `HERMES_HOME` to the wrong profile directory, leading to duplicate gateway/PID conflicts with other running profiles.

### Solution
Added an idempotency guard using a temporary environment variable (`_HERMES_PROFILE_PROCESSED`) to ensure `_apply_profile_override()` executes only once per process, preventing `HERMES_HOME` from being overwritten on subsequent imports.