### PR TITLE
fix: hide gh subprocess windows on Windows

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -27,6 +27,8 @@ import time
 from pathlib import Path
 from typing import Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 # OAuth device code flow constants (same client ID as opencode/Copilot CLI)
@@ -135,13 +137,16 @@ def _try_gh_cli_token() -> Optional[str]:
         if hostname:
             cmd += ["--hostname", hostname]
         try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=5,
-                env=clean_env,
-            )
+            run_kwargs = {
+                "capture_output": True,
+                "text": True,
+                "timeout": 5,
+                "env": clean_env,
+            }
+            hide_flags = windows_hide_flags()
+            if hide_flags:
+                run_kwargs["creationflags"] = hide_flags
+            result = subprocess.run(cmd, **run_kwargs)
         except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
             logger.debug("gh CLI token lookup failed (%s): %s", gh_path, exc)
             continue

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -25,6 +25,7 @@ load_hermes_dotenv(hermes_home=_env_path.parent, project_env=PROJECT_ROOT / ".en
 
 from hermes_cli.colors import Colors, color
 from hermes_cli.models import _HERMES_USER_AGENT
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_constants import OPENROUTER_MODELS_URL
 from utils import base_url_host_matches
 
@@ -2193,9 +2194,14 @@ def run_doctor(args):
     def _gh_authenticated() -> bool:
         """Check if gh CLI is authenticated via token file or device flow."""
         try:
+            run_kwargs = {"capture_output": True}
+            hide_flags = windows_hide_flags()
+            if hide_flags:
+                run_kwargs["creationflags"] = hide_flags
             result = subprocess.run(
                 ["gh", "auth", "status", "--json", "authenticated"],
-                capture_output=True, timeout=10,
+                timeout=10,
+                **run_kwargs,
             )
             return result.returncode == 0
         except (FileNotFoundError, subprocess.TimeoutExpired):

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -106,6 +106,23 @@ class TestResolveToken:
         assert token == ""
         assert source == ""
 
+    def test_gh_cli_fallback_hides_windows_console(self, monkeypatch):
+        from hermes_cli import copilot_auth
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return type("Result", (), {"returncode": 0, "stdout": "gho_from_cli\n"})()
+
+        monkeypatch.setattr(copilot_auth, "_gh_cli_candidates", lambda: ["gh"])
+        monkeypatch.setattr(copilot_auth, "windows_hide_flags", lambda: 0x08000000)
+        monkeypatch.setattr(copilot_auth.subprocess, "run", fake_run)
+
+        assert copilot_auth._try_gh_cli_token() == "gho_from_cli"
+        assert calls[0][0] == ["gh", "auth", "token"]
+        assert calls[0][1]["creationflags"] == 0x08000000
+
 
 class TestRequestHeaders:
     """Copilot API header generation."""

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -906,6 +906,40 @@ class TestGitHubTokenCheck:
         assert "gh auth" in str(call_log) or any(c[0] == "gh" for c in call_log), f"gh not called: {call_log}"
         assert "GitHub authenticated via gh CLI" in out or "token configured" in out
 
+    def test_gh_authenticated_hides_windows_console(self, monkeypatch, tmp_path):
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        project = tmp_path / "project"
+        project.mkdir()
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.setattr(doctor_mod, "windows_hide_flags", lambda: 0x08000000)
+
+        calls = []
+
+        def mock_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            if cmd[:3] == ["gh", "auth", "status"]:
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+        monkeypatch.setattr(doctor_mod.subprocess, "run", mock_run)
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+
+        gh_calls = [
+            kwargs
+            for cmd, kwargs in calls
+            if cmd[:3] == ["gh", "auth", "status"]
+        ]
+        assert gh_calls
+        assert gh_calls[0]["creationflags"] == 0x08000000
+
 
 def _run_doctor_with_healthy_oauth_fallback(
     monkeypatch,


### PR DESCRIPTION
Summary
- Apply the existing Windows hidden-window subprocess flag when reading `gh auth token` for Copilot credentials.
- Apply the same flag to the on-demand `gh auth status` doctor check.
- Add focused tests for the subprocess kwargs.

Problem
On Windows, Hermes Desktop could repeatedly spawn visible console windows while background credential resolution called the GitHub CLI. The short-lived `gh` subprocesses did not pass the hidden-window creation flag.

Validation
- $HOME/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/hermes_cli/test_copilot_auth.py::TestResolveToken::test_gh_cli_fallback_hides_windows_console tests/hermes_cli/test_copilot_auth.py::TestResolveToken::test_gh_cli_fallback tests/hermes_cli/test_doctor.py::TestGitHubTokenCheck::test_gh_authenticated_hides_windows_console tests/hermes_cli/test_doctor.py::TestGitHubTokenCheck::test_gh_authenticated_without_env_token_shows_ok
- $HOME/.hermes/hermes-agent/venv/bin/ruff check hermes_cli/copilot_auth.py hermes_cli/doctor.py tests/hermes_cli/test_copilot_auth.py tests/hermes_cli/test_doctor.py
- git diff --check
- added-line attribution scan clean

Fixes #53957