### PR TITLE
fix(cli): suppress PseudoConsoleWindow flash from gh subprocess calls on Windows

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -27,6 +27,8 @@ import time
 from pathlib import Path
 from typing import Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 # OAuth device code flow constants (same client ID as opencode/Copilot CLI)
@@ -141,6 +143,7 @@ def _try_gh_cli_token() -> Optional[str]:
                 text=True,
                 timeout=5,
                 env=clean_env,
+                creationflags=windows_hide_flags(),
             )
         except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
             logger.debug("gh CLI token lookup failed (%s): %s", gh_path, exc)

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -10,6 +10,7 @@ import subprocess
 import shutil
 from pathlib import Path
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
 from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_constants import display_hermes_home
@@ -2196,6 +2197,7 @@ def run_doctor(args):
             result = subprocess.run(
                 ["gh", "auth", "status", "--json", "authenticated"],
                 capture_output=True, timeout=10,
+                creationflags=windows_hide_flags(),
             )
             return result.returncode == 0
         except (FileNotFoundError, subprocess.TimeoutExpired):

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -107,6 +107,30 @@ class TestResolveToken:
         assert source == ""
 
 
+class TestGhCliCreationFlags:
+    """_try_gh_cli_token passes CREATE_NO_WINDOW on Windows."""
+
+    def test_subprocess_run_receives_creationflags(self, monkeypatch):
+        """subprocess.run must receive creationflags to suppress console flash."""
+        import subprocess
+        from unittest.mock import MagicMock
+        from hermes_cli.copilot_auth import _try_gh_cli_token
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
+        monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        fake_result = MagicMock(returncode=0, stdout="gho_test_token\n")
+        with patch("hermes_cli.copilot_auth.subprocess.run", return_value=fake_result) as mock_run:
+            with patch("hermes_cli.copilot_auth._gh_cli_candidates", return_value=["/usr/bin/gh"]):
+                _try_gh_cli_token()
+
+        _, kwargs = mock_run.call_args
+        assert "creationflags" in kwargs
+        assert kwargs["creationflags"] == windows_hide_flags()
+
+
 class TestRequestHeaders:
     """Copilot API header generation."""
 


### PR DESCRIPTION
## What does this PR do?

Suppresses visible `PseudoConsoleWindow` console window flashes on Windows by adding `CREATE_NO_WINDOW` creation flags to `subprocess.run` calls that invoke the `gh` CLI. Without this flag, every `gh auth token` and `gh auth status` invocation spawns a brief console window that flashes on screen.

## Related Issue

Fixes #53957

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/copilot_auth.py`: Added `creationflags=windows_hide_flags()` to the `subprocess.run` call in `_try_gh_cli_token()` so `gh auth token` runs without a visible console window on Windows.
- `hermes_cli/doctor.py`: Added `creationflags=windows_hide_flags()` to the `subprocess.run` call in `_gh_authenticated()` so `gh auth status` runs without a visible console window on Windows.
- `tests/hermes_cli/test_copilot_auth.py`: Added `TestGhCliCreationFlags` regression test verifying `creationflags` is passed to `subprocess.run`.

## How to Test

1. Run `pytest tests/hermes_cli/test_copilot_auth.py::TestGhCliCreationFlags -v` — should pass
2. Run `pytest tests/hermes_cli/test_copilot_auth.py -v` — all 26 tests should pass
3. On Windows: launch Hermes Desktop with auxiliary providers set to `provider: auto` and verify no `PseudoConsoleWindow` flashes appear in the taskbar over a 45-second observation period

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses existing `windows_hide_flags()` helper which returns 0 on non-Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
