### PR TITLE
fix: escape unknown desktop markdown tags

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -94,6 +94,43 @@ describe('preprocessMarkdown', () => {
     expect(output).toContain('<https://www.getyourguide.com/culebra-island-l145468/from-fajardo-tour-t19894/>')
   })
 
+  it('escapes unknown html-like prose tokens before they reach the renderer', () => {
+    const output = preprocessMarkdown(
+      'The proxy uses <tool_call> and <observation> blocks. Keep the rest of the sentence visible.'
+    )
+
+    expect(output).toContain(
+      'The proxy uses &lt;tool_call&gt; and &lt;observation&gt; blocks. Keep the rest of the sentence visible.'
+    )
+    expect(output).not.toContain('<tool_call>')
+    expect(output).not.toContain('<observation>')
+  })
+
+  it('preserves known html tags and markdown autolinks', () => {
+    const output = preprocessMarkdown('Use <strong>bold</strong> and visit https://example.com/page.')
+
+    expect(output).toContain('<strong>bold</strong>')
+    expect(output).toContain('<https://example.com/page>')
+  })
+
+  it('does not escape html-like tokens inside code', () => {
+    const fence = '```'
+
+    const input = [
+      'Inline `return <tool_call>` stays code.',
+      '',
+      `${fence}xml`,
+      '<tool_call>',
+      fence
+    ].join('\n')
+
+    const output = preprocessMarkdown(input)
+
+    expect(output).toContain('`return <tool_call>`')
+    expect(output).toContain('<tool_call>')
+    expect(output).toContain(`${fence}xml`)
+  })
+
   it('strips orphan numeric citation markers outside code spans', () => {
     const output = preprocessMarkdown('This is the source[0], but keep `items[0]` untouched.')
 

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -20,6 +20,63 @@ const LOCAL_PREVIEW_URL_RE = /(^|\s)https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0
 const LOCAL_PREVIEW_ONLY_RE = /^https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?\/?$/i
 const URL_ONLY_LINE_RE = /^\s*https?:\/\/\S+\s*$/i
 const CITATION_MARKER_RE = /(?<=[\p{L}\p{N})\].,!?:;"'”’])\[(?:\d+(?:\s*,\s*\d+)*)\](?!\()/gu
+const HTML_TAG_RE = /<\/?([A-Za-z][A-Za-z0-9:_-]*)(?:\s+[^<>]*?)?\/?>/g
+
+const SAFE_HTML_TAG_NAMES = new Set([
+  'a',
+  'abbr',
+  'b',
+  'blockquote',
+  'br',
+  'cite',
+  'code',
+  'data',
+  'del',
+  'details',
+  'div',
+  'em',
+  'figcaption',
+  'figure',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'hr',
+  'i',
+  'img',
+  'ins',
+  'kbd',
+  'li',
+  'mark',
+  'ol',
+  'p',
+  'pre',
+  'q',
+  'rp',
+  'rt',
+  'ruby',
+  's',
+  'samp',
+  'small',
+  'span',
+  'strong',
+  'sub',
+  'summary',
+  'sup',
+  'table',
+  'tbody',
+  'td',
+  'tfoot',
+  'th',
+  'thead',
+  'tr',
+  'u',
+  'ul',
+  'var',
+  'wbr'
+])
 
 /**
  * Returns true when `body` contains a line that's exactly `marker` (modulo
@@ -138,6 +195,16 @@ function autoLinkRawUrls(text: string): string {
   })
 }
 
+function escapeUnknownHtmlLikeTags(text: string): string {
+  return text.replace(HTML_TAG_RE, (tag: string, name: string) => {
+    if (SAFE_HTML_TAG_NAMES.has(name.toLowerCase())) {
+      return tag
+    }
+
+    return tag.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  })
+}
+
 function normalizeVisibleProse(text: string): string {
   return text
     .split(INLINE_CODE_SPLIT_RE)
@@ -145,7 +212,9 @@ function normalizeVisibleProse(text: string): string {
       part.startsWith('`')
         ? part
         : autoLinkRawUrls(
-            part.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
+            escapeUnknownHtmlLikeTags(
+              part.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
+            )
           )
     )
     .join('')


### PR DESCRIPTION
Summary
- Escape unknown HTML-like tags in Desktop markdown prose before they reach the renderer.
- Preserve known HTML tags, markdown autolinks, inline code, and fenced code.
- Add regression tests for unknown tool/reasoning tag-shaped tokens.

Problem
The Desktop markdown renderer could parse bare unknown tag-shaped prose as raw HTML and hide the rest of the message until a matching closer or the end of the message. This made complete assistant responses look truncated in chat.

Validation
- npx vitest run --environment jsdom src/components/assistant-ui/markdown-text.test.ts
- npx eslint src/lib/markdown-preprocess.ts src/components/assistant-ui/markdown-text.test.ts
- git diff --check
- added-line attribution scan clean

Fixes #53953