### PR TITLE
fix: pass video reference inputs to providers

### DIFF
--- a/agent/video_gen_provider.py
+++ b/agent/video_gen_provider.py
@@ -149,6 +149,10 @@ class VideoGenProvider(abc.ABC):
                 "supports_audio": True,
                 "supports_negative_prompt": True,
                 "max_reference_images": 7,
+                "max_reference_videos": 3,
+                "max_reference_audios": 3,
+                "supports_first_frame": True,
+                "supports_last_frame": True,
             }
 
         Used by the tool layer for soft validation and by ``hermes tools``
@@ -163,6 +167,10 @@ class VideoGenProvider(abc.ABC):
             "supports_audio": False,
             "supports_negative_prompt": False,
             "max_reference_images": 0,
+            "max_reference_videos": 0,
+            "max_reference_audios": 0,
+            "supports_first_frame": False,
+            "supports_last_frame": False,
         }
 
     @abc.abstractmethod

--- a/plugins/video_gen/fal/__init__.py
+++ b/plugins/video_gen/fal/__init__.py
@@ -120,6 +120,7 @@ FAL_FAMILIES: Dict[str, Dict[str, Any]] = {
         "tier": "premium",
         "text_endpoint": "bytedance/seedance-2.0/text-to-video",
         "image_endpoint": "bytedance/seedance-2.0/image-to-video",
+        "reference_endpoint": "bytedance/seedance-2.0/reference-to-video",
         # Seedance accepts "auto" too — we omit it from the enum so the
         # agent can't pass it; the endpoint defaults handle the rest.
         "aspect_ratios": ("21:9", "16:9", "4:3", "1:1", "3:4", "9:16"),
@@ -127,6 +128,11 @@ FAL_FAMILIES: Dict[str, Dict[str, Any]] = {
         "durations": (4, 15),
         "audio": True,
         "negative": False,
+        "max_reference_images": 9,
+        "max_reference_videos": 3,
+        "max_reference_audios": 3,
+        "supports_first_frame": True,
+        "supports_last_frame": True,
     },
     "kling-v3-4k": {
         "display": "Kling v3 4K",
@@ -245,18 +251,35 @@ def _build_payload(
     negative_prompt: Optional[str],
     audio: Optional[bool],
     seed: Optional[int],
+    reference_image_urls: Optional[List[str]] = None,
+    reference_video_urls: Optional[List[str]] = None,
+    reference_audio_urls: Optional[List[str]] = None,
+    last_frame_url: Optional[str] = None,
+    reference_mode: bool = False,
 ) -> Dict[str, Any]:
     """Build a family-specific payload, dropping keys the family doesn't declare."""
     payload: Dict[str, Any] = {}
 
     if prompt:
         payload["prompt"] = prompt
-    if image_url:
+    if reference_mode:
+        image_urls = list(reference_image_urls or [])
+        if image_url and image_url not in image_urls:
+            image_urls.insert(0, image_url)
+        if image_urls:
+            payload["image_urls"] = image_urls
+        if reference_video_urls:
+            payload["video_urls"] = list(reference_video_urls)
+        if reference_audio_urls:
+            payload["audio_urls"] = list(reference_audio_urls)
+    elif image_url:
         # Some endpoints (e.g. Kling v3 4K image-to-video) expect
         # `start_image_url` instead of `image_url`. The family entry can
         # declare an override.
         key = family.get("image_param_key") or "image_url"
         payload[key] = image_url
+        if last_frame_url:
+            payload["end_image_url"] = last_frame_url
     if seed is not None:
         payload["seed"] = seed
 
@@ -442,6 +465,11 @@ class FALVideoGenProvider(VideoGenProvider):
                 "price": meta["price"],
                 "tier": meta.get("tier", "premium"),
                 "modalities": modalities,
+                "max_reference_images": meta.get("max_reference_images", 0),
+                "max_reference_videos": meta.get("max_reference_videos", 0),
+                "max_reference_audios": meta.get("max_reference_audios", 0),
+                "supports_first_frame": meta.get("supports_first_frame", False),
+                "supports_last_frame": meta.get("supports_last_frame", False),
             })
         return out
 
@@ -463,6 +491,7 @@ class FALVideoGenProvider(VideoGenProvider):
         }
 
     def capabilities(self) -> Dict[str, Any]:
+        _, family = _resolve_family(None)
         return {
             "modalities": ["text", "image"],
             "aspect_ratios": ["16:9", "9:16", "1:1"],
@@ -471,7 +500,11 @@ class FALVideoGenProvider(VideoGenProvider):
             "min_duration": 1,
             "supports_audio": True,
             "supports_negative_prompt": True,
-            "max_reference_images": 0,
+            "max_reference_images": family.get("max_reference_images", 0),
+            "max_reference_videos": family.get("max_reference_videos", 0),
+            "max_reference_audios": family.get("max_reference_audios", 0),
+            "supports_first_frame": family.get("supports_first_frame", False),
+            "supports_last_frame": family.get("supports_last_frame", False),
         }
 
     def generate(
@@ -481,6 +514,10 @@ class FALVideoGenProvider(VideoGenProvider):
         model: Optional[str] = None,
         image_url: Optional[str] = None,
         reference_image_urls: Optional[List[str]] = None,
+        reference_video_urls: Optional[List[str]] = None,
+        reference_audio_urls: Optional[List[str]] = None,
+        first_frame_url: Optional[str] = None,
+        last_frame_url: Optional[str] = None,
         duration: Optional[int] = None,
         aspect_ratio: str = "16:9",
         resolution: str = "720p",
@@ -514,9 +551,30 @@ class FALVideoGenProvider(VideoGenProvider):
         prompt = (prompt or "").strip()
         family_id, family = _resolve_family(model)
 
-        # Route: image_url → image-to-video endpoint; else → text-to-video.
-        image_url_norm = (image_url or "").strip() or None
-        if image_url_norm:
+        image_url_norm = (first_frame_url or image_url or "").strip() or None
+        reference_mode = bool(
+            reference_image_urls or reference_video_urls or reference_audio_urls
+        )
+        if reference_mode and (first_frame_url or last_frame_url):
+            return error_response(
+                error=(
+                    "Seedance reference media cannot be combined with explicit "
+                    "first/last frame controls in one request."
+                ),
+                error_type="unsupported_combination",
+                provider="fal", model=family_id, prompt=prompt,
+            )
+
+        if reference_mode:
+            endpoint = family.get("reference_endpoint")
+            modality_used = "reference"
+            if not endpoint:
+                return error_response(
+                    error=f"FAL family {family_id} has no reference-to-video endpoint.",
+                    error_type="modality_unsupported",
+                    provider="fal", model=family_id, prompt=prompt,
+                )
+        elif image_url_norm:
             endpoint = family.get("image_endpoint")
             modality_used = "image"
             if not endpoint:
@@ -543,6 +601,13 @@ class FALVideoGenProvider(VideoGenProvider):
                     provider="fal", model=family_id, prompt=prompt,
                 )
 
+        if last_frame_url and not image_url_norm:
+            return error_response(
+                error="last_frame_url requires image_url or first_frame_url.",
+                error_type="missing_first_frame",
+                provider="fal", model=family_id, prompt=prompt,
+            )
+
         if not prompt:
             return error_response(
                 error="prompt is required.",
@@ -560,6 +625,11 @@ class FALVideoGenProvider(VideoGenProvider):
             negative_prompt=negative_prompt,
             audio=audio,
             seed=seed,
+            reference_image_urls=reference_image_urls,
+            reference_video_urls=reference_video_urls,
+            reference_audio_urls=reference_audio_urls,
+            last_frame_url=last_frame_url,
+            reference_mode=reference_mode,
         )
 
         try:

--- a/tests/plugins/video_gen/test_fal_plugin.py
+++ b/tests/plugins/video_gen/test_fal_plugin.py
@@ -83,6 +83,20 @@ def test_fal_list_models_advertises_both_modalities():
         )
 
 
+def test_seedance_model_advertises_reference_capabilities():
+    from plugins.video_gen.fal import FALVideoGenProvider
+
+    seedance = next(
+        model
+        for model in FALVideoGenProvider().list_models()
+        if model["id"] == "seedance-2.0"
+    )
+    assert seedance["max_reference_videos"] == 3
+    assert seedance["max_reference_audios"] == 3
+    assert seedance["supports_first_frame"] is True
+    assert seedance["supports_last_frame"] is True
+
+
 def test_fal_unavailable_without_key(monkeypatch):
     from plugins.video_gen.fal import FALVideoGenProvider
     from plugins.video_gen import fal as fal_plugin
@@ -223,6 +237,52 @@ class TestFamilyRouting:
         assert with_fake_fal["endpoint"] == "bytedance/seedance-2.0/image-to-video"
         # Seedance uses regular image_url (not start_image_url)
         assert with_fake_fal["arguments"]["image_url"] == "https://example.com/dog.png"
+
+    def test_seedance_reference_media_routes_to_reference_endpoint(self, with_fake_fal):
+        from plugins.video_gen.fal import FALVideoGenProvider
+
+        result = FALVideoGenProvider().generate(
+            "follow @Video1 with the rhythm from @Audio1",
+            model="seedance-2.0",
+            reference_image_urls=["https://example.com/style.png"],
+            reference_video_urls=["https://example.com/motion.mp4"],
+            reference_audio_urls=["https://example.com/rhythm.wav"],
+        )
+
+        assert result["success"] is True
+        assert result["modality"] == "reference"
+        assert (
+            with_fake_fal["endpoint"]
+            == "bytedance/seedance-2.0/reference-to-video"
+        )
+        assert with_fake_fal["arguments"]["image_urls"] == [
+            "https://example.com/style.png"
+        ]
+        assert with_fake_fal["arguments"]["video_urls"] == [
+            "https://example.com/motion.mp4"
+        ]
+        assert with_fake_fal["arguments"]["audio_urls"] == [
+            "https://example.com/rhythm.wav"
+        ]
+
+    def test_seedance_first_last_frames_reach_image_payload(self, with_fake_fal):
+        from plugins.video_gen.fal import FALVideoGenProvider
+
+        result = FALVideoGenProvider().generate(
+            "transition between these frames",
+            model="seedance-2.0",
+            first_frame_url="https://example.com/start.png",
+            last_frame_url="https://example.com/end.png",
+        )
+
+        assert result["success"] is True
+        assert with_fake_fal["endpoint"] == "bytedance/seedance-2.0/image-to-video"
+        assert with_fake_fal["arguments"]["image_url"] == (
+            "https://example.com/start.png"
+        )
+        assert with_fake_fal["arguments"]["end_image_url"] == (
+            "https://example.com/end.png"
+        )
 
     def test_kling_4k_remaps_image_param(self, with_fake_fal):
         """Kling v3 4K image-to-video receives start_image_url, not image_url."""

--- a/tests/tools/test_video_generation_dispatch.py
+++ b/tests/tools/test_video_generation_dispatch.py
@@ -21,8 +21,9 @@ def _reset_registry():
 class _RecordingProvider(VideoGenProvider):
     """Captures the kwargs the tool layer hands it."""
 
-    def __init__(self, name: str = "fake"):
+    def __init__(self, name: str = "fake", capabilities: Optional[Dict[str, Any]] = None):
         self._name = name
+        self._capabilities = capabilities or {"modalities": ["text", "image"]}
         self.last_kwargs: Dict[str, Any] = {}
 
     @property
@@ -36,7 +37,7 @@ class _RecordingProvider(VideoGenProvider):
         return "model-a"
 
     def capabilities(self) -> Dict[str, Any]:
-        return {"modalities": ["text", "image"]}
+        return self._capabilities
 
     def generate(self, prompt, **kwargs):
         self.last_kwargs = {"prompt": prompt, **kwargs}
@@ -109,6 +110,44 @@ class TestUnifiedDispatch:
         assert result["modality"] == "image"
         assert provider.last_kwargs["image_url"] == "https://example.com/img.png"
 
+    def test_reference_media_inputs_reach_provider(self):
+        provider = _RecordingProvider(
+            "rec",
+            {
+                "modalities": ["text", "image"],
+                "max_reference_videos": 3,
+                "max_reference_audios": 3,
+                "supports_first_frame": True,
+                "supports_last_frame": True,
+            },
+        )
+        video_gen_registry.register_provider(provider)
+        result = self._run({
+            "prompt": "match the references",
+            "reference_video_urls": [" https://example.com/ref.mp4 ", ""],
+            "reference_audio_urls": "https://example.com/ref.wav",
+            "first_frame_url": " https://example.com/first.png ",
+            "last_frame_url": "https://example.com/last.png",
+        })
+
+        assert result["success"] is True
+        assert provider.last_kwargs["reference_video_urls"] == ["https://example.com/ref.mp4"]
+        assert provider.last_kwargs["reference_audio_urls"] == ["https://example.com/ref.wav"]
+        assert provider.last_kwargs["first_frame_url"] == "https://example.com/first.png"
+        assert provider.last_kwargs["last_frame_url"] == "https://example.com/last.png"
+
+    def test_reference_media_inputs_rejected_when_model_lacks_capability(self):
+        provider = _RecordingProvider("rec")
+        video_gen_registry.register_provider(provider)
+
+        result = self._run({
+            "prompt": "match the reference",
+            "reference_video_urls": ["https://example.com/ref.mp4"],
+        })
+
+        assert "error" in result
+        assert "does not support" in result["error"]
+
     def test_prompt_required(self):
         provider = _RecordingProvider("rec")
         video_gen_registry.register_provider(provider)
@@ -135,6 +174,67 @@ class TestUnifiedDispatch:
 
     def test_edit_extend_fields_not_in_schema(self):
         from tools.video_generation_tool import VIDEO_GENERATE_SCHEMA
-        props = VIDEO_GENERATE_SCHEMA["parameters"]["properties"]
-        assert "operation" not in props
-        assert "video_url" not in props
+        properties = VIDEO_GENERATE_SCHEMA["parameters"]["properties"]
+        assert "operation" not in properties
+        assert "video_url" not in properties
+
+    def test_reference_media_fields_are_capability_gated(self, monkeypatch):
+        from tools import video_generation_tool
+
+        provider = _RecordingProvider(
+            "rec",
+            {
+                "modalities": ["text", "image"],
+                "max_reference_videos": 2,
+                "max_reference_audios": 1,
+                "supports_first_frame": True,
+                "supports_last_frame": True,
+            },
+        )
+        video_gen_registry.register_provider(provider)
+        monkeypatch.setattr(
+            video_generation_tool,
+            "_read_configured_video_provider",
+            lambda: "rec",
+        )
+        monkeypatch.setattr(
+            video_generation_tool,
+            "_read_configured_video_model",
+            lambda: "model-a",
+        )
+
+        properties = video_generation_tool._build_dynamic_video_schema()[
+            "parameters"
+        ]["properties"]
+        assert properties["reference_video_urls"]["items"]["type"] == "string"
+        assert properties["reference_video_urls"]["maxItems"] == 2
+        assert properties["reference_audio_urls"]["items"]["type"] == "string"
+        assert properties["first_frame_url"]["type"] == "string"
+        assert properties["last_frame_url"]["type"] == "string"
+
+    def test_reference_media_fields_hidden_for_unsupported_model(self, monkeypatch):
+        from tools import video_generation_tool
+
+        provider = _RecordingProvider("rec")
+        video_gen_registry.register_provider(provider)
+        monkeypatch.setattr(
+            video_generation_tool,
+            "_read_configured_video_provider",
+            lambda: "rec",
+        )
+        monkeypatch.setattr(
+            video_generation_tool,
+            "_read_configured_video_model",
+            lambda: "model-a",
+        )
+
+        properties = video_generation_tool._build_dynamic_video_schema()[
+            "parameters"
+        ]["properties"]
+        for field in (
+            "reference_video_urls",
+            "reference_audio_urls",
+            "first_frame_url",
+            "last_frame_url",
+        ):
+            assert field not in properties

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -24,6 +24,10 @@ reference-to-video - with a compact schema:
     prompt                   text instruction (required)
     image_url                drives image-to-video
     reference_image_urls     list, up to provider-declared cap
+    reference_video_urls     reference videos for motion/camera/style guidance
+    reference_audio_urls     reference audio for rhythm/music/voice guidance
+    first_frame_url          image URL to pin the video's first frame
+    last_frame_url           image URL to pin the video's last frame
     duration                 seconds (provider clamps)
     aspect_ratio             "16:9" | "9:16" | "1:1" | ...
     resolution               "480p" | "540p" | "720p" | "1080p"
@@ -45,6 +49,7 @@ from __future__ import annotations
 
 import json
 import logging
+from copy import deepcopy
 from typing import Any, Dict, List, Optional
 
 from agent.video_gen_provider import (
@@ -57,6 +62,32 @@ from agent.video_gen_provider import (
 from tools.registry import registry, tool_error
 
 logger = logging.getLogger(__name__)
+
+
+_REFERENCE_INPUT_PROPERTIES: Dict[str, Dict[str, Any]] = {
+    "reference_video_urls": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": (
+            "Optional reference video URLs for motion, camera, or style guidance."
+        ),
+    },
+    "reference_audio_urls": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": (
+            "Optional reference audio URLs for rhythm, music, or voice guidance."
+        ),
+    },
+    "first_frame_url": {
+        "type": "string",
+        "description": "Optional image URL to pin the video's first frame.",
+    },
+    "last_frame_url": {
+        "type": "string",
+        "description": "Optional image URL to pin the video's last frame.",
+    },
+}
 
 
 VIDEO_GENERATE_SCHEMA: Dict[str, Any] = {
@@ -293,7 +324,7 @@ def _coerce_bool(value: Any) -> Optional[bool]:
     return None
 
 
-def _normalize_reference_images(value: Any) -> Optional[List[str]]:
+def _normalize_url_list(value: Any) -> Optional[List[str]]:
     if value is None:
         return None
     if isinstance(value, str):
@@ -307,10 +338,74 @@ def _normalize_reference_images(value: Any) -> Optional[List[str]]:
     return out or None
 
 
+_REFERENCE_CAPABILITY_KEYS = {
+    "reference_video_urls": "max_reference_videos",
+    "reference_audio_urls": "max_reference_audios",
+    "first_frame_url": "supports_first_frame",
+    "last_frame_url": "supports_last_frame",
+}
+
+
+def _capabilities_for_model(provider: Any, model: Optional[str]) -> Dict[str, Any]:
+    """Return provider capabilities with model-specific metadata applied."""
+    try:
+        capabilities = dict(provider.capabilities() or {})
+    except Exception:
+        capabilities = {}
+
+    try:
+        models = provider.list_models() or []
+    except Exception:
+        models = []
+    model_meta = next(
+        (
+            item
+            for item in models
+            if isinstance(item, dict) and item.get("id") == model
+        ),
+        {},
+    )
+    model_capabilities = {
+        "max_reference_images",
+        *_REFERENCE_CAPABILITY_KEYS.values(),
+    }
+    for capability in model_capabilities:
+        if capability in model_meta:
+            capabilities[capability] = model_meta[capability]
+    return capabilities
+
+
+def _supports_reference_input(capabilities: Dict[str, Any], field: str) -> bool:
+    value = capabilities.get(_REFERENCE_CAPABILITY_KEYS[field])
+    if field in {"reference_video_urls", "reference_audio_urls"}:
+        return isinstance(value, int) and not isinstance(value, bool) and value > 0
+    return value is True
+
+
+def _schema_parameters_for_capabilities(
+    capabilities: Dict[str, Any],
+) -> Dict[str, Any]:
+    parameters = deepcopy(VIDEO_GENERATE_SCHEMA["parameters"])
+    properties = parameters["properties"]
+    for field, capability in _REFERENCE_CAPABILITY_KEYS.items():
+        if not _supports_reference_input(capabilities, field):
+            continue
+        definition = deepcopy(_REFERENCE_INPUT_PROPERTIES[field])
+        limit = capabilities.get(capability)
+        if definition.get("type") == "array" and isinstance(limit, int):
+            definition["maxItems"] = limit
+        properties[field] = definition
+    return parameters
+
+
 def _handle_video_generate(args: Dict[str, Any], **_kw: Any) -> str:
     prompt = (args.get("prompt") or "").strip()
     image_url = (args.get("image_url") or "").strip() or None
-    reference_image_urls = _normalize_reference_images(args.get("reference_image_urls"))
+    reference_image_urls = _normalize_url_list(args.get("reference_image_urls"))
+    reference_video_urls = _normalize_url_list(args.get("reference_video_urls"))
+    reference_audio_urls = _normalize_url_list(args.get("reference_audio_urls"))
+    first_frame_url = (args.get("first_frame_url") or "").strip() or None
+    last_frame_url = (args.get("last_frame_url") or "").strip() or None
     duration = _coerce_int(args.get("duration"))
     aspect_ratio = (args.get("aspect_ratio") or DEFAULT_ASPECT_RATIO).strip() or DEFAULT_ASPECT_RATIO
     resolution = (args.get("resolution") or DEFAULT_RESOLUTION).strip() or DEFAULT_RESOLUTION
@@ -339,11 +434,33 @@ def _handle_video_generate(args: Dict[str, Any], **_kw: Any) -> str:
     # Resolve model: explicit arg wins, then config, then provider default.
     model = model_override or _read_configured_video_model() or provider.default_model()
 
+    capabilities = _capabilities_for_model(provider, model)
+    reference_inputs = {
+        "reference_video_urls": reference_video_urls,
+        "reference_audio_urls": reference_audio_urls,
+        "first_frame_url": first_frame_url,
+        "last_frame_url": last_frame_url,
+    }
+    unsupported = [
+        field
+        for field, value in reference_inputs.items()
+        if value and not _supports_reference_input(capabilities, field)
+    ]
+    if unsupported:
+        return tool_error(
+            f"Provider '{getattr(provider, 'name', '?')}' model "
+            f"'{model or 'default'}' does not support: {', '.join(unsupported)}"
+        )
+
     kwargs: Dict[str, Any] = {
         "model": model,
         "_model_override_explicit": bool(model_override),
         "image_url": image_url,
         "reference_image_urls": reference_image_urls,
+        "reference_video_urls": reference_video_urls,
+        "reference_audio_urls": reference_audio_urls,
+        "first_frame_url": first_frame_url,
+        "last_frame_url": last_frame_url,
         "duration": duration,
         "aspect_ratio": aspect_ratio,
         "resolution": resolution,
@@ -486,12 +603,11 @@ def _build_dynamic_video_schema() -> Dict[str, Any]:
             "\nNo video backend is available. Calls will return an error "
             "until the user picks one via `hermes tools` → Video Generation."
         )
-        return {"description": "\n".join(parts)}
+        return {
+            "description": "\n".join(parts),
+            "parameters": _schema_parameters_for_capabilities({}),
+        }
 
-    try:
-        caps = provider.capabilities() or {}
-    except Exception:
-        caps = {}
     try:
         models = provider.list_models() or []
     except Exception:
@@ -502,6 +618,7 @@ def _build_dynamic_video_schema() -> Dict[str, Any]:
         (m for m in models if isinstance(m, dict) and m.get("id") == active_model),
         {},
     )
+    caps = _capabilities_for_model(provider, active_model)
 
     backend_label = provider.display_name
     line = f"\nActive backend: {backend_label}"
@@ -538,6 +655,22 @@ def _build_dynamic_video_schema() -> Dict[str, Any]:
     max_refs = caps.get("max_reference_images") or 0
     if max_refs:
         parts.append(f"- reference_image_urls: up to {max_refs} images")
+    max_reference_videos = caps.get("max_reference_videos") or 0
+    if max_reference_videos:
+        parts.append(
+            f"- reference_video_urls: up to {max_reference_videos} videos"
+        )
+    max_reference_audios = caps.get("max_reference_audios") or 0
+    if max_reference_audios:
+        parts.append(
+            f"- reference_audio_urls: up to {max_reference_audios} audio files"
+        )
+    if caps.get("supports_first_frame") and caps.get("supports_last_frame"):
+        parts.append(
+            "- first_frame_url / last_frame_url: start/end frame control supported"
+        )
+    elif caps.get("supports_first_frame"):
+        parts.append("- first_frame_url: start-frame control supported")
     if provider.name == "xai":
         parts.append(
             "- chaining: for edit/extend pass the public HTTPS MP4 in `video` "
@@ -554,7 +687,10 @@ def _build_dynamic_video_schema() -> Dict[str, Any]:
         if notice:
             parts.append(f"- storage: {notice}")
 
-    return {"description": "\n".join(parts)}
+    return {
+        "description": "\n".join(parts),
+        "parameters": _schema_parameters_for_capabilities(caps),
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary
- Add provider and model capability metadata for reference video, reference audio, first-frame, and last-frame inputs.
- Expose those fields only when the selected video model supports them, including provider limits in the generated schema.
- Implement the inputs for FAL Seedance 2.0 by routing reference media and first/last frames to the appropriate endpoints.
- Add dispatch, schema-gating, capability, and concrete provider-payload tests.

Problem
The unified video tool could forward reference fields, but no provider consumed them. The fields were also advertised for every backend even when unsupported, so calls could appear valid while having no effect.

Validation
- 53 focused video-generation tests passed
- Ruff passed for all changed Python files
- git diff --check passed
- attribution and wording scans passed

Fixes #53952