### PR TITLE
fix(mcp): let OAuth discovery run before HTML preflight

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1830,6 +1830,47 @@ class TestReconnection:
 
         asyncio.run(_test())
 
+    def test_preflight_probe_skipped_for_initial_oauth_http_connect(self):
+        """OAuth HTTP servers must reach OAuth discovery before HTML preflight.
+
+        Some valid OAuth MCP endpoints return unauthenticated 302/HTML until
+        the OAuth auth provider performs protected-resource discovery. The
+        generic non-MCP HTML preflight must not reject those endpoints before
+        _run_http() has a chance to build the OAuth provider.
+        """
+        from tools.mcp_tool import MCPServerTask
+
+        target_server = None
+        probe = AsyncMock()
+
+        original_run_http = MCPServerTask._run_http
+
+        async def patched_run_http(self_srv, config):
+            if target_server is not self_srv:
+                return await original_run_http(self_srv, config)
+            self_srv.session = MagicMock()
+            self_srv._tools = []
+            self_srv._ready.set()
+            self_srv._shutdown_event.set()
+            await self_srv._shutdown_event.wait()
+
+        async def _test():
+            nonlocal target_server
+            server = MCPServerTask("oauth_http_srv")
+            target_server = server
+
+            with patch.object(MCPServerTask, "_run_http", patched_run_http), \
+                 patch.object(MCPServerTask, "_preflight_content_type", probe), \
+                 patch("asyncio.sleep", new_callable=AsyncMock):
+                await server.run({
+                    "url": "https://example.com/mcp",
+                    "auth": "oauth",
+                })
+
+            assert probe.await_count == 0
+
+        asyncio.run(_test())
+
     def test_preflight_probe_skipped_when_already_ready(self):
         """The probe must NOT re-run on reconnect (_ready already set).
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2307,12 +2307,23 @@ class MCPServerTask:
             # before surfacing an opaque CancelledError. Probing here — once,
             # outside the SDK task group — fails fast and non-retryably with
             # an actionable message, mirroring the URL-validation path above.
+            #
+            # OAuth MCP servers are the exception: some valid endpoints return
+            # pre-auth redirects/HTML until the OAuth auth provider performs
+            # protected-resource discovery and starts the login flow. Running
+            # this unauthenticated HTML probe first rejects those servers before
+            # OAuth gets a chance to run.
+            #
             # Skip the probe when _ready is already set: that only happens
             # after a prior successful connect, so this run() invocation is a
             # reconnect (OAuth recovery / manual refresh). The endpoint was
             # already validated once; re-probing burns a redundant network
             # round-trip against a known-good server on every reconnect.
-            if config.get("transport") != "sse" and not self._ready.is_set():
+            if (
+                config.get("transport") != "sse"
+                and self._auth_type != "oauth"
+                and not self._ready.is_set()
+            ):
                 try:
                     _probe_headers = dict(config.get("headers") or {})
                     await self._preflight_content_type(


### PR DESCRIPTION
## What does this PR do?

Allows OAuth MCP servers to reach the OAuth provider/discovery path before the generic HTTP content-type preflight can reject unauthenticated HTML redirects. Some valid OAuth MCP endpoints, including Akiflow, return pre-auth 302/HTML instead of a clean 401; Hermes previously rejected those as non-MCP before protected-resource discovery could run.

## Related Issue

Support thread: https://discord.com/channels/1053877538025386074/1520625672324648970

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Skip the generic Streamable HTTP content-type preflight for `auth: oauth` MCP servers so `_run_http()` can build the OAuth provider first.
- Keep URL validation and the preflight behavior unchanged for non-OAuth HTTP MCP servers.
- Add a regression test for initial OAuth HTTP connects.

## How to Test

1. Configure an OAuth HTTP MCP server whose unauthenticated endpoint redirects to HTML, such as Akiflow.
2. Run `hermes mcp login <name>`.
3. Confirm Hermes reaches OAuth discovery/login instead of failing immediately with `Content-Type text/html, not an MCP response`.

Focused local test run:

` .venv/bin/python -m pytest tests/tools/test_mcp_tool.py -q `

Result: `201 passed in 16.59s`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux focused unit test

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before this change, `hermes mcp login akiflow` can fail before OAuth starts with:

`Authentication failed: server returned Content-Type text/html, not an MCP response`

The failing ordering was: generic unauthenticated content-type preflight -> followed redirect to HTML -> hard failure -> OAuth provider/discovery path never ran.
