### PR TITLE
fix(ssl): tolerate truststore's unsupported get_ca_certs() in CA bundle guard

### DIFF
--- a/agent/ssl_guard.py
+++ b/agent/ssl_guard.py
@@ -54,7 +54,16 @@ def _validate_bundle_path(label: str, value: str, *, require_substantial: bool =
         ctx = ssl.create_default_context(cafile=str(path))
     except Exception as exc:
         raise _ssl_err(f"{label} CA bundle at {value} cannot be loaded: {exc}") from exc
-    if not ctx.get_ca_certs():
+    # truststore (e.g. injected by pip-system-certs) replaces ssl.SSLContext
+    # with an implementation that routes trust to the OS keystore and leaves
+    # get_ca_certs() as NotImplementedError. That is a working TLS config, not
+    # a broken bundle, so treat the unsupported method as "cannot inspect" and
+    # skip the emptiness assertion rather than failing startup.
+    try:
+        loaded_certs = ctx.get_ca_certs()
+    except NotImplementedError:
+        return
+    if not loaded_certs:
         raise _ssl_err(f"{label} CA bundle at {value} did not load any certificates")
 
 

--- a/tests/agent/test_ssl_ca_guard.py
+++ b/tests/agent/test_ssl_ca_guard.py
@@ -80,3 +80,27 @@ def test_skip_env_var_bypasses_guard(monkeypatch, tmp_path, value):
     monkeypatch.setenv("SSL_CERT_FILE", str(fake))
     verify_ca_bundle()
     verify_ca_bundle_with_fallback()
+
+
+def test_truststore_get_ca_certs_not_implemented_passes(monkeypatch):
+    """truststore (pip-system-certs) leaves get_ca_certs() as NotImplementedError.
+
+    Routing trust to the OS keystore is a working config, not a broken bundle,
+    so the guard must treat the unsupported method as "cannot inspect" and pass
+    instead of raising an empty-message NotImplementedError on startup.
+    """
+    import ssl as _ssl
+
+    for key in ("HERMES_CA_BUNDLE", "SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"):
+        monkeypatch.delenv(key, raising=False)
+
+    real_create = _ssl.create_default_context
+
+    def _truststore_like(*args, **kwargs):
+        ctx = real_create(*args, **kwargs)
+        ctx.get_ca_certs = lambda *a, **k: (_ for _ in ()).throw(NotImplementedError())
+        return ctx
+
+    monkeypatch.setattr("agent.ssl_guard.ssl.create_default_context", _truststore_like)
+    verify_ca_bundle()
+    verify_ca_bundle_with_fallback()


### PR DESCRIPTION
## What does this PR do?

Fixes a startup crash with an empty error message — `Failed to initialize OpenAI client:` (blank after the colon) — that occurs whenever `truststore` is active in the environment (commonly injected by the `pip-system-certs` package, which monkey-patches `ssl.SSLContext` at interpreter startup via a `.pth` file).

The SSL preflight guard in `agent/ssl_guard.py` calls `ctx.get_ca_certs()` to assert that certificates loaded. `truststore`'s `SSLContext` implements that method as `raise NotImplementedError()` because it routes trust to the OS keystore instead of holding an in-memory cert list. That `NotImplementedError` has an empty string representation, so when it propagates to `agent_init.py` and is wrapped as `RuntimeError(f"Failed to initialize OpenAI client: {e}")`, the user sees nothing after the colon.

The underlying TLS is fully functional — this is purely the guard misclassifying a working, legitimate trust configuration as a broken CA bundle and aborting startup. The fix treats an unsupported `get_ca_certs()` as "cannot introspect → pass" while still rejecting genuinely missing/corrupt bundles (those checks run earlier in the function).

## Related Issue

Fixes #53967

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/ssl_guard.py` — in `_validate_bundle_path()`, wrap `ctx.get_ca_certs()` in a `try/except NotImplementedError` that returns (passes) instead of crashing. The empty-bundle assertion still runs when the method is supported.
- `tests/agent/test_ssl_ca_guard.py` — add `test_truststore_get_ca_certs_not_implemented_passes`, which patches `create_default_context` to return a context whose `get_ca_certs()` raises `NotImplementedError` (mimicking truststore) and asserts the guard passes.

## How to Test

1. Reproduce on `main`: in an env where `pip-system-certs` is installed, run `hermes -z "hi"` → fails with blank `Failed to initialize OpenAI client:`. Confirm the patch is active with `python -c "import ssl; print(ssl.SSLContext.__module__)"` → `pip._vendor.truststore._api`.
2. Apply this PR, run `hermes -z "hi"` again → agent initializes and the model responds. `hermes doctor` SSL section reports `✓ SSL CA certificate bundle is valid` instead of being skipped.
3. Regression: `pytest tests/agent/test_ssl_ca_guard.py -q` → all pass (15, incl. the new case). Genuinely broken bundles still error: `SSL_CERT_FILE=/tmp/nope.pem python -c "from agent.ssl_guard import verify_ca_bundle; verify_ca_bundle()"` still raises a clear `SSLConfigurationError`.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`fix(ssl):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the affected test module and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.1, Python 3.11.14

### Documentation & Housekeeping

- [x] Documentation — N/A (behavior aligns with existing `docs/rca-ssl-cacert-post-git-pull.md`; no new config keys)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — the fix is platform-agnostic; truststore injection is most common on macOS/Windows corporate setups, and `NotImplementedError` handling is OS-independent
- [x] Tool descriptions/schemas — N/A
