### PR TITLE
fix(anthropic): use platform.claude.com for OAuth token exchange

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1251,7 +1251,13 @@ def run_oauth_setup_token() -> Optional[str]:
 # Stores credentials in ~/.hermes/.anthropic_oauth.json (our own file).
 
 _OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-_OAUTH_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
+# Anthropic migrated the OAuth token endpoint from console.anthropic.com to
+# platform.claude.com. Try the new host first, fall back to the old one (kept
+# in sync with refresh_anthropic_oauth_pure). The console host now 404s.
+_OAUTH_TOKEN_URLS = [
+    "https://platform.claude.com/v1/oauth/token",
+    "https://console.anthropic.com/v1/oauth/token",
+]
 _OAUTH_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
 _OAUTH_SCOPES = "org:create_api_key user:profile user:inference"
 _HERMES_OAUTH_FILE = get_hermes_home() / ".anthropic_oauth.json"
@@ -1337,20 +1343,22 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
         logger.warning("OAuth state mismatch — possible CSRF, aborting")
         return None
 
-    try:
-        import urllib.request
+    import urllib.request
 
-        exchange_data = json.dumps({
-            "grant_type": "authorization_code",
-            "client_id": _OAUTH_CLIENT_ID,
-            "code": code,
-            "state": received_state,
-            "redirect_uri": _OAUTH_REDIRECT_URI,
-            "code_verifier": verifier,
-        }).encode()
+    exchange_data = json.dumps({
+        "grant_type": "authorization_code",
+        "client_id": _OAUTH_CLIENT_ID,
+        "code": code,
+        "state": received_state,
+        "redirect_uri": _OAUTH_REDIRECT_URI,
+        "code_verifier": verifier,
+    }).encode()
 
+    result = None
+    last_error = None
+    for endpoint in _OAUTH_TOKEN_URLS:
         req = urllib.request.Request(
-            _OAUTH_TOKEN_URL,
+            endpoint,
             data=exchange_data,
             headers={
                 "Content-Type": "application/json",
@@ -1358,11 +1366,17 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             },
             method="POST",
         )
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                result = json.loads(resp.read().decode())
+            break
+        except Exception as e:
+            last_error = e
+            logger.debug("Anthropic OAuth token exchange failed at %s: %s", endpoint, e)
+            continue
 
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            result = json.loads(resp.read().decode())
-    except Exception as e:
-        print(f"Token exchange failed: {e}")
+    if result is None:
+        print(f"Token exchange failed: {last_error}")
         return None
 
     access_token = result.get("access_token", "")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5431,7 +5431,7 @@ _oauth_sessions_lock = threading.Lock()
 try:
     from agent.anthropic_adapter import (
         _OAUTH_CLIENT_ID as _ANTHROPIC_OAUTH_CLIENT_ID,
-        _OAUTH_TOKEN_URL as _ANTHROPIC_OAUTH_TOKEN_URL,
+        _OAUTH_TOKEN_URLS as _ANTHROPIC_OAUTH_TOKEN_URLS,
         _OAUTH_REDIRECT_URI as _ANTHROPIC_OAUTH_REDIRECT_URI,
         _OAUTH_SCOPES as _ANTHROPIC_OAUTH_SCOPES,
         _generate_pkce as _generate_pkce_pair,
@@ -5620,22 +5620,29 @@ def _submit_anthropic_pkce(
         "redirect_uri": _ANTHROPIC_OAUTH_REDIRECT_URI,
         "code_verifier": sess["verifier"],
     }).encode()
-    req = urllib.request.Request(
-        _ANTHROPIC_OAUTH_TOKEN_URL,
-        data=exchange_data,
-        headers={
-            "Content-Type": "application/json",
-            "User-Agent": "hermes-dashboard/1.0",
-        },
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=20) as resp:
-            result = json.loads(resp.read().decode())
-    except Exception as e:
+    result = None
+    last_error = None
+    for _endpoint in _ANTHROPIC_OAUTH_TOKEN_URLS:
+        req = urllib.request.Request(
+            _endpoint,
+            data=exchange_data,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "hermes-dashboard/1.0",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=20) as resp:
+                result = json.loads(resp.read().decode())
+            break
+        except Exception as e:
+            last_error = e
+            continue
+    if result is None:
         with _oauth_sessions_lock:
             sess["status"] = "error"
-            sess["error_message"] = f"Token exchange failed: {e}"
+            sess["error_message"] = f"Token exchange failed: {last_error}"
         return {"ok": False, "status": "error", "message": sess["error_message"]}
 
     access_token = result.get("access_token", "")


### PR DESCRIPTION
## Problem

`hermes auth add anthropic --type oauth` (and the dashboard's web OAuth flow) fail at the token-exchange step with:

```
Token exchange failed: HTTP Error 404: Not Found
Anthropic OAuth login did not return credentials.
```

Anthropic migrated its OAuth token endpoint from `console.anthropic.com` to `platform.claude.com`. The old host now returns **404**.

The repo was already half-migrated: `refresh_anthropic_oauth_pure` tries `platform.claude.com/v1/oauth/token` first and falls back to `console.anthropic.com/v1/oauth/token`. But the two **login** paths still POSTed only to the dead `console.anthropic.com` endpoint, so every fresh login failed.

## Fix

- `agent/anthropic_adapter.py`: replace the single `_OAUTH_TOKEN_URL` constant with a `_OAUTH_TOKEN_URLS` list (`platform.claude.com` first, `console.anthropic.com` fallback) and have `run_hermes_oauth_login_pure()` iterate over it — mirroring the existing refresh logic.
- `hermes_cli/web_server.py`: update the import and the dashboard's exchange loop to use the same fallback list.

The fallback keeps the old host working should Anthropic ever revert.

## Testing

- `python -m py_compile` passes on both files.
- Endpoint order and request shape match the already-working `refresh_anthropic_oauth_pure` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)