### PR TITLE
fix: add file-backed knowledge base plugin

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2209,6 +2209,12 @@ DEFAULT_CONFIG = {
         "engine": "compressor",
     },
 
+    # File-backed declarative knowledge notes. Relative paths are resolved
+    # against the active profile's HERMES_HOME.
+    "knowledge_base": {
+        "path": "knowledge-base",
+    },
+
     # Persistent memory -- bounded curated memory injected into system prompt
     "memory": {
         "memory_enabled": True,

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -115,7 +115,16 @@ def gui_toolset_label(label: str) -> str:
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+_DEFAULT_OFF_TOOLSETS = {
+    "homeassistant",
+    "spotify",
+    "discord",
+    "discord_admin",
+    "video",
+    "video_gen",
+    "x_search",
+    "knowledge_base",
+}
 
 
 def _xai_credentials_present() -> bool:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -750,6 +750,9 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
 _CATEGORY_MERGE: Dict[str, str] = {
     "privacy": "security",
     "context": "agent",
+    # The knowledge-base plugin has one path setting; keep it beside the
+    # related persistent-memory settings instead of creating a one-field tab.
+    "knowledge_base": "memory",
     "skills": "agent",
     "cron": "agent",
     "network": "agent",

--- a/plugins/knowledge_base/__init__.py
+++ b/plugins/knowledge_base/__init__.py
@@ -1,0 +1,266 @@
+"""File-backed knowledge-base plugin."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from hermes_constants import get_hermes_home
+from tools.registry import tool_error
+
+_TOOLSET = "knowledge_base"
+_DEFAULT_DIR = "knowledge-base"
+_MAX_CONTENT_BYTES = 1_000_000
+_MAX_SEARCH_RESULTS = 50
+
+
+def _tool_result(**payload: Any) -> str:
+    return json.dumps({"success": True, **payload}, ensure_ascii=False, indent=2)
+
+
+def _load_kb_config() -> dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        data = load_config()
+    except Exception:
+        return {}
+    cfg = data.get("knowledge_base") if isinstance(data, dict) else None
+    return cfg if isinstance(cfg, dict) else {}
+
+
+def _root() -> Path:
+    cfg = _load_kb_config()
+    raw = str(cfg.get("path") or "").strip()
+    if not raw:
+        return get_hermes_home() / _DEFAULT_DIR
+    expanded = Path(raw).expanduser()
+    if expanded.is_absolute():
+        return expanded
+    return get_hermes_home() / expanded
+
+
+def _clean_parts(raw_path: str, *, allow_empty: bool) -> tuple[str, ...]:
+    cleaned = str(raw_path or "").strip().replace("\\", "/")
+    if not cleaned:
+        if allow_empty:
+            return ()
+        raise ValueError("path is required")
+    parsed = PurePosixPath(cleaned)
+    if parsed.is_absolute():
+        raise ValueError("path must be relative to the knowledge base")
+    parts = parsed.parts
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ValueError("path must not contain empty, '.', or '..' segments")
+    return parts
+
+
+def _resolve_path(raw_path: str, *, note: bool, allow_empty: bool = False) -> tuple[Path, str]:
+    root = _root().resolve(strict=False)
+    parts = _clean_parts(raw_path, allow_empty=allow_empty)
+    rel = Path(*parts) if parts else Path()
+    if note:
+        if not rel.suffix:
+            rel = rel.with_suffix(".md")
+        elif rel.suffix.lower() != ".md":
+            raise ValueError("knowledge-base notes must be markdown files")
+    candidate = (root / rel).resolve(strict=False)
+    try:
+        relative = candidate.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("path escapes the knowledge base") from exc
+    return candidate, relative.as_posix()
+
+
+def _configured_root() -> tuple[Path, str]:
+    root = _root().resolve(strict=False)
+    return root, root.as_posix()
+
+
+def _kb_read(args: dict[str, Any], **_: Any) -> str:
+    try:
+        note_path, rel = _resolve_path(args.get("path", ""), note=True)
+        if not note_path.exists():
+            return tool_error(f"knowledge note not found: {rel}", success=False)
+        if not note_path.is_file():
+            return tool_error(f"knowledge path is not a file: {rel}", success=False)
+        content = note_path.read_text(encoding="utf-8")
+        return _tool_result(path=rel, content=content)
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def _kb_write(args: dict[str, Any], **_: Any) -> str:
+    try:
+        content = args.get("content")
+        if not isinstance(content, str):
+            return tool_error("content is required", success=False)
+        encoded = content.encode("utf-8")
+        if len(encoded) > _MAX_CONTENT_BYTES:
+            return tool_error("content is too large for a single note", success=False)
+        mode = str(args.get("mode") or "overwrite").strip().lower()
+        if mode not in {"overwrite", "append"}:
+            return tool_error("mode must be 'overwrite' or 'append'", success=False)
+        note_path, rel = _resolve_path(args.get("path", ""), note=True)
+        note_path.parent.mkdir(parents=True, exist_ok=True)
+        if mode == "append" and note_path.exists():
+            existing = note_path.read_text(encoding="utf-8")
+            separator = "" if existing.endswith("\n") or not existing else "\n"
+            note_path.write_text(f"{existing}{separator}{content}", encoding="utf-8")
+        else:
+            note_path.write_text(content, encoding="utf-8")
+        return _tool_result(path=rel, bytes=len(encoded), mode=mode)
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def _iter_notes(base: Path):
+    if not base.exists():
+        return
+    for path in sorted(base.rglob("*")):
+        if path.is_file() and path.suffix.lower() == ".md":
+            yield path
+
+
+def _snippet(text: str, needle: str) -> str:
+    lower = text.lower()
+    index = lower.find(needle)
+    if index < 0:
+        return text[:240].strip()
+    start = max(0, index - 90)
+    end = min(len(text), index + len(needle) + 150)
+    return text[start:end].strip()
+
+
+def _title_for(path: Path, text: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            return stripped.lstrip("#").strip() or path.stem
+    return path.stem
+
+
+def _kb_search(args: dict[str, Any], **_: Any) -> str:
+    try:
+        query = str(args.get("query") or "").strip()
+        if not query:
+            return tool_error("query is required", success=False)
+        raw_limit = args.get("limit", 10)
+        try:
+            limit = int(raw_limit)
+        except (TypeError, ValueError):
+            return tool_error("limit must be an integer", success=False)
+        limit = max(1, min(limit, _MAX_SEARCH_RESULTS))
+        base, _ = _resolve_path(args.get("path", ""), note=False, allow_empty=True)
+        root, root_display = _configured_root()
+        needle = query.lower()
+        results: list[dict[str, Any]] = []
+        for note_path in _iter_notes(base):
+            text = note_path.read_text(encoding="utf-8", errors="replace")
+            haystack = text.lower()
+            score = haystack.count(needle)
+            if score <= 0:
+                continue
+            rel = note_path.resolve(strict=False).relative_to(root).as_posix()
+            results.append({
+                "path": rel,
+                "title": _title_for(note_path, text),
+                "score": score,
+                "snippet": _snippet(text, needle),
+            })
+        results.sort(key=lambda item: (-item["score"], item["path"]))
+        return _tool_result(root=root_display, query=query, results=results[:limit])
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def _kb_list(args: dict[str, Any], **_: Any) -> str:
+    try:
+        folder, rel = _resolve_path(args.get("path", ""), note=False, allow_empty=True)
+        root, root_display = _configured_root()
+        if not folder.exists():
+            return _tool_result(root=root_display, path=rel, directories=[], notes=[])
+        if not folder.is_dir():
+            return tool_error(f"knowledge path is not a directory: {rel}", success=False)
+        directories = []
+        notes = []
+        for child in sorted(folder.iterdir(), key=lambda item: item.name.lower()):
+            child_rel = child.resolve(strict=False).relative_to(root).as_posix()
+            if child.is_dir():
+                directories.append(child_rel)
+            elif child.is_file() and child.suffix.lower() == ".md":
+                notes.append(child_rel)
+        return _tool_result(root=root_display, path=rel, directories=directories, notes=notes)
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+KB_READ_SCHEMA = {
+    "name": "kb_read",
+    "description": "Read a markdown note from the configured knowledge base.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Relative note path. .md is appended when omitted."},
+        },
+        "required": ["path"],
+    },
+}
+
+KB_WRITE_SCHEMA = {
+    "name": "kb_write",
+    "description": "Create, replace, or append to a markdown note in the configured knowledge base.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Relative note path. .md is appended when omitted."},
+            "content": {"type": "string", "description": "Markdown content to write."},
+            "mode": {"type": "string", "enum": ["overwrite", "append"], "description": "Write mode. Defaults to overwrite."},
+        },
+        "required": ["path", "content"],
+    },
+}
+
+KB_SEARCH_SCHEMA = {
+    "name": "kb_search",
+    "description": "Search markdown notes in the configured knowledge base.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Case-insensitive text to find in notes."},
+            "path": {"type": "string", "description": "Optional relative folder to search under."},
+            "limit": {"type": "integer", "description": "Maximum results. Defaults to 10, max 50."},
+        },
+        "required": ["query"],
+    },
+}
+
+KB_LIST_SCHEMA = {
+    "name": "kb_list",
+    "description": "List folders and markdown notes in the configured knowledge base.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Optional relative folder to list."},
+        },
+        "required": [],
+    },
+}
+
+_TOOLS = (
+    ("kb_read", KB_READ_SCHEMA, _kb_read),
+    ("kb_write", KB_WRITE_SCHEMA, _kb_write),
+    ("kb_search", KB_SEARCH_SCHEMA, _kb_search),
+    ("kb_list", KB_LIST_SCHEMA, _kb_list),
+)
+
+
+def register(ctx) -> None:
+    for name, schema, handler in _TOOLS:
+        ctx.register_tool(
+            name=name,
+            toolset=_TOOLSET,
+            schema=schema,
+            handler=handler,
+        )

--- a/plugins/knowledge_base/plugin.yaml
+++ b/plugins/knowledge_base/plugin.yaml
@@ -1,0 +1,4 @@
+name: knowledge_base
+version: 0.1.0
+kind: backend
+description: "File-backed knowledge-base tools for persistent declarative notes."

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3767,6 +3767,7 @@ class TestBuildSchemaFromConfig:
         # These should be merged away
         assert "privacy" not in categories  # merged into security
         assert "context" not in categories  # merged into agent
+        assert CONFIG_SCHEMA["knowledge_base.path"]["category"] == "memory"
 
     def test_no_single_field_categories(self):
         """After merging, no category should have just 1 field."""

--- a/tests/plugins/test_knowledge_base_plugin.py
+++ b/tests/plugins/test_knowledge_base_plugin.py
@@ -1,0 +1,91 @@
+import json
+
+from hermes_cli.config import DEFAULT_CONFIG
+from hermes_cli.tools_config import _DEFAULT_OFF_TOOLSETS
+from plugins import knowledge_base as kb
+
+
+def _use_home(monkeypatch, tmp_path):
+    monkeypatch.setattr(kb, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(kb, "_load_kb_config", lambda: {"path": "knowledge-base"})
+
+
+def test_knowledge_base_write_read_list_and_search(monkeypatch, tmp_path):
+    _use_home(monkeypatch, tmp_path)
+
+    written = json.loads(kb._kb_write({
+        "path": "domain/widgets",
+        "content": "# Widget Rules\n\nRoute premium widgets to the review queue.",
+    }))
+    assert written["success"] is True
+    assert written["path"] == "domain/widgets.md"
+
+    appended = json.loads(kb._kb_write({
+        "path": "domain/widgets.md",
+        "content": "Capture supplier notes separately.",
+        "mode": "append",
+    }))
+    assert appended["success"] is True
+
+    read = json.loads(kb._kb_read({"path": "domain/widgets"}))
+    assert read["path"] == "domain/widgets.md"
+    assert "review queue" in read["content"]
+    assert "supplier notes" in read["content"]
+
+    listed = json.loads(kb._kb_list({"path": "domain"}))
+    assert listed["notes"] == ["domain/widgets.md"]
+
+    searched = json.loads(kb._kb_search({"query": "premium widgets"}))
+    assert searched["results"][0]["path"] == "domain/widgets.md"
+    assert searched["results"][0]["title"] == "Widget Rules"
+
+
+def test_knowledge_base_uses_configured_path(monkeypatch, tmp_path):
+    configured = tmp_path / "vault"
+    monkeypatch.setattr(kb, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+        "knowledge_base": {"path": "vault"},
+    })
+
+    payload = json.loads(kb._kb_write({"path": "decisions/launch", "content": "Ship it."}))
+
+    assert payload["success"] is True
+    assert (configured / "decisions" / "launch.md").read_text(encoding="utf-8") == "Ship it."
+
+
+def test_knowledge_base_rejects_paths_outside_root(monkeypatch, tmp_path):
+    _use_home(monkeypatch, tmp_path)
+
+    payload = json.loads(kb._kb_read({"path": "../secrets"}))
+
+    assert payload["success"] is False
+    assert "must not contain" in payload["error"]
+
+
+def test_knowledge_base_search_accepts_uppercase_markdown_suffix(monkeypatch, tmp_path):
+    _use_home(monkeypatch, tmp_path)
+    root = tmp_path / "knowledge-base"
+    root.mkdir()
+    (root / "UPPER.MD").write_text("# Upper\n\nSearchable knowledge.", encoding="utf-8")
+
+    payload = json.loads(kb._kb_search({"query": "searchable"}))
+
+    assert [item["path"] for item in payload["results"]] == ["UPPER.MD"]
+
+
+def test_knowledge_base_config_is_registered():
+    assert DEFAULT_CONFIG["knowledge_base"] == {"path": "knowledge-base"}
+
+
+def test_knowledge_base_registers_opt_in_toolset():
+    calls = []
+
+    class Context:
+        def register_tool(self, **kwargs):
+            calls.append(kwargs)
+
+    kb.register(Context())
+
+    assert [call["name"] for call in calls] == ["kb_read", "kb_write", "kb_search", "kb_list"]
+    assert {call["toolset"] for call in calls} == {"knowledge_base"}
+    assert "knowledge_base" in _DEFAULT_OFF_TOOLSETS


### PR DESCRIPTION
Summary
- Add an opt-in file-backed knowledge-base plugin with kb_read, kb_write, kb_search, and kb_list.
- Register knowledge_base.path in DEFAULT_CONFIG and load it through Hermes' standard merged, profile-aware config path.
- Resolve the default relative to the active HERMES_HOME and keep the toolset disabled until explicitly enabled.
- Search Markdown suffixes case-insensitively so .md and .MD notes behave consistently.
- Place the single knowledge-base path setting in the existing Memory settings category instead of creating a one-field dashboard tab.
- Add focused config, uppercase-suffix, path-safety, toolset, schema, and note-operation tests.

Problem
Hermes had no structured on-demand store for declarative notes. The first implementation also parsed config.yaml privately, accepted uppercase Markdown notes for direct reads while omitting them from recursive search on Linux, and created a one-field dashboard settings category.

Validation
- 17 dashboard-schema and knowledge-base plugin tests passed
- focused toolset and config tests passed
- Ruff passed for all changed Python files
- git diff --check passed
- attribution and wording scans passed

Fixes #53950