### PR TITLE
fix(mcp): handle JSON string headers config without crashing

### DIFF
--- a/tests/tools/test_mcp_normalize_headers.py
+++ b/tests/tools/test_mcp_normalize_headers.py
@@ -1,0 +1,95 @@
+"""Tests for _normalize_headers — MCP headers config normalization (#53915).
+
+When MCP server ``headers`` in config.yaml is written as a single-quoted JSON
+string (common for Cloudflare/GitHub MCP servers), ``dict(str)`` crashes with
+``ValueError: dictionary update sequence element #0 has length 1; 2 is required``.
+
+_normalize_headers handles dict, JSON string, None, and invalid inputs.
+"""
+
+import json
+import pytest
+
+from tools.mcp_tool import _normalize_headers
+
+
+class TestNormalizeHeadersDict:
+    """Proper dict input (YAML mapping) — the fast path."""
+
+    def test_empty_dict(self):
+        assert _normalize_headers({}) == {}
+
+    def test_simple_dict(self):
+        headers = {"Authorization": "Bearer token123"}
+        assert _normalize_headers(headers) == headers
+
+    def test_multiple_headers(self):
+        headers = {
+            "Authorization": "Bearer token123",
+            "X-Custom-Header": "value",
+            "Content-Type": "application/json",
+        }
+        assert _normalize_headers(headers) == headers
+
+    def test_returns_copy_not_same_object(self):
+        """_normalize_headers must return a new dict, not the input reference."""
+        original = {"Authorization": "Bearer token"}
+        result = _normalize_headers(original)
+        assert result == original
+        assert result is not original
+
+
+class TestNormalizeHeadersJsonString:
+    """JSON string input — the bug from #53915."""
+
+    def test_valid_json_string(self):
+        headers_str = '{"Authorization": "Bearer token123"}'
+        assert _normalize_headers(headers_str) == {"Authorization": "Bearer token123"}
+
+    def test_json_string_multiple_headers(self):
+        headers_str = '{"Authorization": "Bearer token", "X-Custom": "value"}'
+        assert _normalize_headers(headers_str) == {
+            "Authorization": "Bearer token",
+            "X-Custom": "value",
+        }
+
+    def test_json_string_with_cfut_token(self):
+        """The exact use case from the bug report — Cloudflare MCP server."""
+        headers_str = '{"Authorization": "Bearer cfut_xxx"}'
+        assert _normalize_headers(headers_str) == {"Authorization": "Bearer cfut_xxx"}
+
+    def test_json_string_empty_object(self):
+        assert _normalize_headers("{}") == {}
+
+    def test_invalid_json_string(self):
+        """Invalid JSON string should not crash — return empty dict with warning."""
+        assert _normalize_headers("not json at all") == {}
+
+    def test_json_string_not_a_dict(self):
+        """JSON string that parses to a list/int should return empty dict."""
+        assert _normalize_headers("[1, 2, 3]") == {}
+        assert _normalize_headers("42") == {}
+
+
+class TestNormalizeHeadersNone:
+    """None / absent input."""
+
+    def test_none(self):
+        assert _normalize_headers(None) == {}
+
+    def test_empty_string(self):
+        assert _normalize_headers("") == {}
+
+
+class TestNormalizeHeadersRegression:
+    """The exact crash from #53915 must not happen."""
+
+    def test_dict_on_json_string_does_not_crash(self):
+        """Before the fix, dict('{"Authorization": ...}') would crash with
+        ValueError: dictionary update sequence element #0 has length 1."""
+        # This is what the old code did: dict(config.get("headers") or {})
+        headers_str = '{"Authorization": "Bearer cfut_xxx"}'
+        # Old code: dict(headers_str) → ValueError
+        # New code: _normalize_headers(headers_str) → parsed dict
+        result = _normalize_headers(headers_str)
+        assert result == {"Authorization": "Bearer cfut_xxx"}

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -853,6 +853,42 @@ def _safe_numeric(value, default, coerce=int, minimum=1):
         return default
 
 
+def _normalize_headers(value: Any) -> dict:
+    """Normalize MCP server ``headers`` config to a ``dict``.
+
+    Handles three YAML shapes:
+
+    1. Proper mapping → returned as-is (fast path).
+    2. Single-quoted JSON string (common for Cloudflare/GitHub MCP servers
+       where the user copies a JSON blob into ``config.yaml``) → parsed via
+       ``json.loads``.
+    3. ``None`` / absent → empty dict.
+
+    Without this, ``dict(config.get("headers") or {})`` crashes with
+    ``ValueError: dictionary update sequence element #0 has length 1; 2 is
+    required`` when ``headers`` is a JSON string, because ``dict(str)`` iterates
+    per-character (#53915).
+    """
+    if not value:
+        return {}
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, dict):
+                return parsed
+        except (json.JSONDecodeError, TypeError):
+            pass
+        logger.warning(
+            "MCP headers config is a string but not valid JSON — ignoring. "
+            "Use a YAML mapping or a single-quoted JSON string."
+        )
+        return {}
+    logger.warning("MCP headers config has unexpected type %s — ignoring.", type(value).__name__)
+    return {}
+
+
 class SamplingHandler:
     """Handles sampling/createMessage requests for a single MCP server.
 
@@ -1984,7 +2020,7 @@ class MCPServerTask:
         if client_cert is not None:
             client_kwargs["cert"] = client_cert
 
-        probe_headers = dict(headers) if headers else {}
+        probe_headers = _normalize_headers(headers) if headers else {}
         try:
             async with _httpx.AsyncClient(**client_kwargs) as client:
                 # HEAD is cheapest; fall back to GET if the server doesn't
@@ -2025,7 +2061,7 @@ class MCPServerTask:
             )
 
         url = config["url"]
-        headers = dict(config.get("headers") or {})
+        headers = _normalize_headers(config.get("headers"))
         # Some MCP servers require MCP-Protocol-Version on the initial
         # initialize request and reject session-less POSTs otherwise.
         # Seed it as a client-level default, but treat user overrides as
@@ -2314,7 +2350,7 @@ class MCPServerTask:
             # round-trip against a known-good server on every reconnect.
             if config.get("transport") != "sse" and not self._ready.is_set():
                 try:
-                    _probe_headers = dict(config.get("headers") or {})
+                    _probe_headers = _normalize_headers(config.get("headers"))
                     await self._preflight_content_type(
                         config["url"],
                         headers=_probe_headers,


### PR DESCRIPTION
## Summary

When MCP server `headers` in config.yaml is a single-quoted JSON string, `dict(headers)` crashes with `ValueError: dictionary update sequence element #0 has length 1`.

Fix: add `_normalize_headers()` that handles dict, JSON string, and None. 13 regression tests.

Closes #53915