### PR TITLE
fix(desktop): stop repeated terminal redraws during pane settle

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.test.tsx
@@ -1,0 +1,285 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useTerminalSession } from './use-terminal-session'
+
+const testState = vi.hoisted(() => {
+  const fitSizes: Array<{ cols: number; rows: number }> = []
+
+  const resizeObservers = new Set<{
+    target: Element | null
+    trigger: () => void
+  }>()
+
+  class MockTerminal {
+    cols = 80
+    rows = 24
+    options: Record<string, unknown>
+    unicode = { activeVersion: '' }
+
+    constructor(options: Record<string, unknown>) {
+      this.options = options
+    }
+
+    clearSelection() {}
+
+    dispose() {}
+
+    focus() {}
+
+    getSelection() {
+      return ''
+    }
+
+    getSelectionPosition() {
+      return null
+    }
+
+    hasSelection() {
+      return false
+    }
+
+    loadAddon(addon: { __terminal?: MockTerminal }) {
+      addon.__terminal = this
+    }
+
+    onData(_cb: (data: string) => void) {
+      return { dispose() {} }
+    }
+
+    onSelectionChange(_cb: () => void) {
+      return { dispose() {} }
+    }
+
+    open(_host: HTMLElement) {}
+
+    write(_data: string) {}
+  }
+
+  class MockFitAddon {
+    __terminal?: MockTerminal
+
+    fit() {
+      const next = fitSizes.shift()
+
+      if (!next || !this.__terminal) {
+        return
+      }
+
+      this.__terminal.cols = next.cols
+      this.__terminal.rows = next.rows
+    }
+  }
+
+  class MockUnicode11Addon {}
+
+  class MockWebLinksAddon {}
+
+  class MockWebglAddon {
+    clearTextureAtlas() {}
+
+    dispose() {}
+
+    onContextLoss(_cb: () => void) {}
+  }
+
+  return {
+    MockFitAddon,
+    MockTerminal,
+    MockUnicode11Addon,
+    MockWebLinksAddon,
+    MockWebglAddon,
+    fitSizes,
+    resizeObservers
+  }
+})
+
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: () => undefined }))
+vi.mock('@/themes/context', () => ({
+  useTheme: () => ({
+    renderedMode: 'light',
+    theme: {},
+    themeName: 'test-skin'
+  })
+}))
+vi.mock('./buffer', () => ({
+  makeTerminalReader: () => () => null,
+  setActiveTerminalReader: () => undefined
+}))
+vi.mock('@xterm/addon-fit', () => ({ FitAddon: testState.MockFitAddon }))
+vi.mock('@xterm/addon-unicode11', () => ({ Unicode11Addon: testState.MockUnicode11Addon }))
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: testState.MockWebLinksAddon }))
+vi.mock('@xterm/addon-webgl', () => ({ WebglAddon: testState.MockWebglAddon }))
+vi.mock('@xterm/xterm', () => ({ Terminal: testState.MockTerminal }))
+
+class TestResizeObserver {
+  target: Element | null = null
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    testState.resizeObservers.add(this)
+  }
+
+  disconnect() {
+    testState.resizeObservers.delete(this)
+  }
+
+  observe(target: Element) {
+    this.target = target
+  }
+
+  trigger() {
+    if (!this.target) {
+      return
+    }
+
+    this.callback(
+      [
+        {
+          contentRect: { height: 320, width: 640 } as DOMRectReadOnly,
+          target: this.target
+        } as ResizeObserverEntry
+      ],
+      this as unknown as ResizeObserver
+    )
+  }
+}
+
+function Harness() {
+  const { hostRef } = useTerminalSession({ cwd: '/repo', onAddSelectionToChat: () => undefined })
+
+  return <div data-testid="host" ref={hostRef} />
+}
+
+describe('useTerminalSession', () => {
+  const dataListeners = new Map<string, (data: string) => void>()
+  const exitListeners = new Map<string, (payload: { code: null | number; signal: null | string }) => void>()
+  const start = vi.fn<() => Promise<{ id: string; shell: string }>>()
+  const resize = vi.fn<(id: string, size: { cols: number; rows: number }) => Promise<void>>()
+  const write = vi.fn<(id: string, data: string) => Promise<void>>()
+  const dispose = vi.fn<(id: string) => Promise<void>>()
+  let clientHeightDescriptor: PropertyDescriptor | undefined
+  let clientWidthDescriptor: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('ResizeObserver', TestResizeObserver)
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+      window.setTimeout(() => callback(performance.now()), 0)
+    )
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+    clientWidthDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth')
+    clientHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight')
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get() {
+        return 640
+      }
+    })
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get() {
+        return 320
+      }
+    })
+
+    testState.fitSizes.length = 0
+    testState.resizeObservers.clear()
+    dataListeners.clear()
+    exitListeners.clear()
+    start.mockReset()
+    resize.mockReset()
+    write.mockReset()
+    dispose.mockReset()
+    start.mockResolvedValue({ id: 'session-1', shell: 'zsh' })
+    resize.mockResolvedValue(undefined)
+    write.mockResolvedValue(undefined)
+    dispose.mockResolvedValue(undefined)
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        terminal: {
+          dispose,
+          onData: (id: string, cb: (data: string) => void) => {
+            dataListeners.set(id, cb)
+
+            return () => {
+              dataListeners.delete(id)
+            }
+          },
+          onExit: (id: string, cb: (payload: { code: null | number; signal: null | string }) => void) => {
+            exitListeners.set(id, cb)
+
+            return () => {
+              exitListeners.delete(id)
+            }
+          },
+          resize,
+          start,
+          write
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    Reflect.deleteProperty(window, 'hermesDesktop')
+
+    if (clientWidthDescriptor) {
+      Object.defineProperty(HTMLElement.prototype, 'clientWidth', clientWidthDescriptor)
+    }
+
+    if (clientHeightDescriptor) {
+      Object.defineProperty(HTMLElement.prototype, 'clientHeight', clientHeightDescriptor)
+    }
+  })
+
+  it('sends only one pristine Ctrl-L redraw across repeated launch-time resizes', async () => {
+    testState.fitSizes.push(
+      { cols: 80, rows: 24 },
+      { cols: 81, rows: 24 },
+      { cols: 82, rows: 24 },
+      { cols: 83, rows: 24 },
+      { cols: 84, rows: 24 }
+    )
+
+    render(<Harness />)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(0)
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(start).toHaveBeenCalledWith({ cols: 80, cwd: '/repo', rows: 24 })
+    expect(dataListeners.has('session-1')).toBe(true)
+
+    act(() => {
+      dataListeners.get('session-1')?.('\r\n\r\nprompt $ ')
+    })
+
+    for (let i = 0; i < 3; i += 1) {
+      await act(async () => {
+        for (const observer of [...testState.resizeObservers]) {
+          observer.trigger()
+        }
+
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(130)
+      })
+    }
+
+    expect(resize).toHaveBeenCalledTimes(4)
+    expect(write.mock.calls.filter(([, data]) => data === '\f')).toHaveLength(1)
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
@@ -418,6 +418,8 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
     // multi-line prompts (term.clear() would drop all but the cursor row) and we
     // stop the moment real output exists, so command scrollback is never wiped.
     let promptPristine = true
+    let promptPainted = false
+    let gapCleanupSent = false
     let gapCleanupTimer = 0
 
     // While armed, strip leading blank rows so the prompt lands at the very top
@@ -447,12 +449,17 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
         return
       }
 
+      promptPainted = true
       stripLeading = false
       term.write(next)
     }
 
     const scheduleGapCleanup = () => {
-      if (!promptPristine) {
+      // The first visible prompt already has its leading blank rows stripped in
+      // armedWrite(). Only ask the shell for one pristine redraw after that, so
+      // a pane whose geometry settles in several steps doesn't blink repeatedly
+      // on launch or session switch.
+      if (!promptPristine || !promptPainted || gapCleanupSent) {
         return
       }
 
@@ -464,10 +471,11 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
         gapCleanupTimer = 0
         const id = sessionIdRef.current
 
-        if (disposed || !id || !promptPristine) {
+        if (disposed || !id || !promptPristine || !promptPainted || gapCleanupSent) {
           return
         }
 
+        gapCleanupSent = true
         stripLeading = true
         void terminalApi.write(id, '\f')
         term.clearSelection()


### PR DESCRIPTION
## What does this PR do?

Fixes a desktop regression where the embedded terminal pane can visibly blink several times on launch and session switch.

The old flow could schedule multiple pristine `Ctrl-L` redraws while the pane geometry settled across the initial fit, post-start fit, and follow-up `ResizeObserver` resizes. This patch keeps the prompt-gap cleanup but limits it to a single redraw after the first real prompt paint, which preserves the original alignment fix without repeated flicker.

## Related Issue

Fixes #53433

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Gate pristine gap-cleanup redraws in `apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts` so launch-time/session-switch resize bursts only send one automatic `Ctrl-L`.
- Track whether the first real prompt has painted before allowing that redraw, so the original prompt-top gap cleanup still applies.
- Add `apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.test.tsx` to lock the regression: repeated launch-time resizes must not emit more than one `\f` write.

## How to Test

1. On current `main`, inspect the terminal launch/session-switch resize path in `use-terminal-session.ts`: the startup fit sequence can schedule repeated pristine `Ctrl-L` redraws during pane settle.
2. Apply this patch and run:
   - `npx vitest run --environment jsdom src/app/right-sidebar/terminal/use-terminal-session.test.tsx`
   - `npx eslint src/app/right-sidebar/terminal/use-terminal-session.ts src/app/right-sidebar/terminal/use-terminal-session.test.tsx`
3. Confirm the regression test passes and the hook now allows only one pristine redraw across repeated startup resizes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation:

- `npx vitest run --environment jsdom src/app/right-sidebar/terminal/use-terminal-session.test.tsx` -> passed
- `npx eslint src/app/right-sidebar/terminal/use-terminal-session.ts src/app/right-sidebar/terminal/use-terminal-session.test.tsx` -> passed
