### PR TITLE
fix(state): opt-in logical lineage for JSON/JSONL session export

### DIFF
--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -877,7 +877,7 @@ class HermesConsoleEngine:
         )
         self.register(
             ("sessions", "export"),
-            "sessions export <output> [--source SOURCE] [--session-id ID]",
+            "sessions export <output> [--source SOURCE] [--session-id ID] [--lineage single|logical]",
             "Export sessions to JSONL.",
             _sessions_export,
             mutating=True,
@@ -1422,6 +1422,11 @@ def _sessions_export(_engine: HermesConsoleEngine, args: list[str]) -> str:
     parser.add_argument("output")
     parser.add_argument("--source")
     parser.add_argument("--session-id")
+    parser.add_argument(
+        "--lineage",
+        choices=["single", "logical"],
+        default="single",
+    )
     ns = parser.parse_args(args)
 
     def _run() -> None:
@@ -1458,7 +1463,11 @@ def _sessions_export(_engine: HermesConsoleEngine, args: list[str]) -> str:
                 if not resolved_session_id:
                     raise ConsoleCommandError(f"Session '{ns.session_id}' not found.")
                 _guard_exports([resolved_session_id])
-                data = db.export_session(resolved_session_id)
+                data = (
+                    db.export_session_lineage(resolved_session_id)
+                    if ns.lineage == "logical"
+                    else db.export_session(resolved_session_id)
+                )
                 if not data:
                     raise ConsoleCommandError(f"Session '{ns.session_id}' not found.")
                 rows = [data]
@@ -1468,7 +1477,7 @@ def _sessions_export(_engine: HermesConsoleEngine, args: list[str]) -> str:
                     for session in db.search_sessions(source=ns.source, limit=100000)
                 ]
                 _guard_exports(session_ids)
-                rows = db.export_all(source=ns.source)
+                rows = db.export_all(source=ns.source, lineage=ns.lineage)
 
             lines = [json.dumps(row, ensure_ascii=False) for row in rows]
             text = "\n".join(lines)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13426,7 +13426,10 @@ def main():
         "--lineage",
         choices=["single", "logical"],
         default="single",
-        help="md/qmd only: export one row or its compression lineage",
+        help=(
+            "export one physical row (single) or stitch its compression "
+            "lineage (logical). Applies to json/jsonl and md/qmd"
+        ),
     )
     sessions_export.add_argument(
         "--delete-after-verified",

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -434,12 +434,44 @@ def cmd_sessions(args, sessions_parser=None):
 
             return redact_session_data(data)
 
+        lineage_mode = getattr(args, "lineage", "single")
+        lineage_is_logical = lineage_mode == "logical"
+
+        def _export_json_one(session_id):
+            if lineage_is_logical:
+                return db.export_session_lineage(session_id)
+            return db.export_session(session_id)
+
+        def _export_json_many(session_ids):
+            if not lineage_is_logical:
+                return [
+                    session
+                    for session in (
+                        db.export_session(session_id) for session_id in session_ids
+                    )
+                    if session
+                ]
+            seen_roots = set()
+            exported = []
+            for session_id in session_ids:
+                chain = db.get_compression_lineage(session_id)
+                if not chain:
+                    continue
+                root = chain[0]
+                if root in seen_roots:
+                    continue
+                seen_roots.add(root)
+                data = db.export_session_lineage(session_id)
+                if data:
+                    exported.append(data)
+            return exported
+
         def _collect_sessions():
             """Resolve --session-id / filters / bare export into a list
             of redacted session dicts, or None after printing an error."""
             if args.session_id:
                 resolved = db.resolve_session_id(args.session_id)
-                data = _redact(db.export_session(resolved)) if resolved else None
+                data = _redact(_export_json_one(resolved)) if resolved else None
                 if not data:
                     print(f"Session '{args.session_id}' not found.")
                     return None
@@ -457,16 +489,16 @@ def cmd_sessions(args, sessions_parser=None):
                         print(f"  ... {len(candidates) - 100} more")
                     return None
                 return [
-                    s
-                    for s in (
-                        _redact(db.export_session(row["id"])) for row in candidates
-                    )
-                    if s
+                    _redact(session)
+                    for session in _export_json_many(row["id"] for row in candidates)
                 ]
             if args.dry_run:
                 print("--dry-run requires at least one filter.")
                 return None
-            return [_redact(s) for s in db.export_all(source=None)]
+            return [
+                _redact(session)
+                for session in db.export_all(source=None, lineage=lineage_mode)
+            ]
 
         # Prompt-only export (--only user-prompts): one prompt record per
         # line (jsonl) or headed sections (md). Delegates rendering to
@@ -652,7 +684,7 @@ def cmd_sessions(args, sessions_parser=None):
                 if not resolved_session_id:
                     print(f"Session '{args.session_id}' not found.")
                     return
-                data = _redact(db.export_session(resolved_session_id))
+                data = _redact(_export_json_one(resolved_session_id))
                 if not data:
                     print(f"Session '{args.session_id}' not found.")
                     return
@@ -677,18 +709,12 @@ def cmd_sessions(args, sessions_parser=None):
                         if len(candidates) > 100:
                             print(f"  ... {len(candidates) - 100} more")
                         return
-                    sessions = [
-                        s
-                        for s in (
-                            db.export_session(row["id"]) for row in candidates
-                        )
-                        if s
-                    ]
+                    sessions = _export_json_many(row["id"] for row in candidates)
                 else:
                     if args.dry_run:
                         print("--dry-run requires at least one filter.")
                         return
-                    sessions = db.export_all(source=None)
+                    sessions = db.export_all(source=None, lineage=lineage_mode)
                 if args.output == "-":
 
                     for s in sessions:
@@ -743,8 +769,6 @@ def cmd_sessions(args, sessions_parser=None):
             print("--delete-after-verified is only supported with --session-id.")
             db.close()
             return
-
-        lineage_is_logical = getattr(args, "lineage", "single") == "logical"
 
         if args.session_id:
             resolved_session_id = db.resolve_session_id(args.session_id)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4187,24 +4187,190 @@ class SessionDB:
     # Export and cleanup
     # =========================================================================
 
-    def export_session(self, session_id: str) -> Optional[Dict[str, Any]]:
-        """Export a single session with all its messages as a dict."""
-        session = self.get_session(session_id)
-        if not session:
-            return None
-        messages = self.get_messages(session_id)
-        return {**session, "messages": messages}
+    def _compression_chain_root_id(self, session_id: str) -> str:
+        """Climb compression-continuation edges to the chain root.
+
+        Context compression ends a session (``end_reason='compression'``) and
+        forks a continuation child linked by ``parent_session_id``. A long
+        conversation therefore becomes a chain of physical session rows. This
+        walks *up* that chain — following ONLY compression edges, never branch
+        (``_branched_from``) / delegate (``_delegate_from``) / tool children —
+        and returns the root (the first session the user actually started).
+
+        Returns ``session_id`` unchanged when it is already a root or not part
+        of a compression chain. Bounded at 100 hops defensively.
+        """
+        if not session_id:
+            return session_id
+        current = session_id
+        seen = {current}
+        for _ in range(100):
+            with self._lock:
+                row = self._conn.execute(
+                    """
+                    SELECT parent.id
+                    FROM sessions child
+                    JOIN sessions parent ON parent.id = child.parent_session_id
+                    WHERE child.id = ?
+                      AND parent.end_reason = 'compression'
+                      AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL
+                      AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL
+                      AND COALESCE(child.source, '') != 'tool'
+                    LIMIT 1
+                    """,
+                    (current,),
+                ).fetchone()
+            if row is None:
+                return current
+            parent_id = row["id"] if hasattr(row, "keys") else row[0]
+            if not parent_id or parent_id in seen:
+                return current
+            seen.add(parent_id)
+            current = parent_id
+        return current
+
+    def _compression_chain_ids(self, session_id: str) -> List[str]:
+        """Full compression chain, root -> tip, for any member session.
+
+        Normalizes *session_id* to its chain root, then walks forward following
+        the same compression-only edge definition as :meth:`get_compression_tip`
+        (preferring the continuing/live child over stale closed siblings). The
+        returned list is the ordered set of physical session rows whose messages
+        together form one logical conversation. For a non-chained session it is
+        ``[session_id]``.
+        """
+        if not session_id:
+            return [session_id]
+        root = self._compression_chain_root_id(session_id)
+        chain = [root]
+        seen = {root}
+        current = root
+        for _ in range(100):
+            with self._lock:
+                row = self._conn.execute(
+                    """
+                    SELECT child.id
+                    FROM sessions parent
+                    JOIN sessions child ON child.parent_session_id = parent.id
+                    WHERE parent.id = ?
+                      AND parent.end_reason = 'compression'
+                      AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL
+                      AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL
+                      AND COALESCE(child.source, '') != 'tool'
+                    ORDER BY
+                      CASE
+                        WHEN child.end_reason = 'compression' THEN 0
+                        WHEN child.ended_at IS NULL THEN 1
+                        ELSE 2
+                      END,
+                      COALESCE(
+                        (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = child.id),
+                        child.started_at
+                      ) DESC,
+                      child.started_at DESC,
+                      child.id DESC
+                    LIMIT 1
+                    """,
+                    (current,),
+                ).fetchone()
+            if row is None:
+                break
+            child_id = row["id"] if hasattr(row, "keys") else row[0]
+            if not child_id or child_id in seen:
+                break
+            seen.add(child_id)
+            chain.append(child_id)
+            current = child_id
+        return chain
+
+    def _is_compression_continuation(self, session_id: str) -> bool:
+        """True when *session_id* is a compression continuation child.
+
+        i.e. its parent ended with ``end_reason='compression'`` and it is not a
+        branch / delegate / tool child. Such rows are folded into their chain
+        root by :meth:`export_all` so a single conversation is exported once,
+        not as N fragments.
+        """
+        if not session_id:
+            return False
+        with self._lock:
+            row = self._conn.execute(
+                """
+                SELECT 1
+                FROM sessions child
+                JOIN sessions parent ON parent.id = child.parent_session_id
+                WHERE child.id = ?
+                  AND parent.end_reason = 'compression'
+                  AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL
+                  AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL
+                  AND COALESCE(child.source, '') != 'tool'
+                LIMIT 1
+                """,
+                (session_id,),
+            ).fetchone()
+        return row is not None
+
+    def export_session(
+        self, session_id: str, stitch_lineage: bool = True
+    ) -> Optional[Dict[str, Any]]:
+        """Export a session with all its messages as a dict.
+
+        By default (``stitch_lineage=True``) the full compression chain is
+        reassembled: *session_id* is normalized to its chain root and the
+        messages from every continuation segment are concatenated in chain
+        order (each segment ordered by insertion id, matching
+        :meth:`get_messages`). The returned dict carries the ROOT session's
+        metadata plus the stitched ``messages`` and a ``_lineage_session_ids``
+        list naming every segment. This fixes long conversations exporting as a
+        single fragment when context compression had split them across rows.
+
+        Pass ``stitch_lineage=False`` for the legacy single-row behavior.
+        """
+        if not stitch_lineage:
+            session = self.get_session(session_id)
+            if not session:
+                return None
+            messages = self.get_messages(session_id)
+            return {**session, "messages": messages}
+
+        chain = self._compression_chain_ids(session_id)
+        root = self.get_session(chain[0])
+        if not root:
+            # Fall back to the requested id if the root row vanished.
+            session = self.get_session(session_id)
+            if not session:
+                return None
+            return {**session, "messages": self.get_messages(session_id)}
+        messages: List[Dict[str, Any]] = []
+        for sid in chain:
+            messages.extend(self.get_messages(sid))
+        result = {**root, "messages": messages}
+        if len(chain) > 1:
+            result["_lineage_session_ids"] = chain
+        return result
 
     def export_all(self, source: str = None) -> List[Dict[str, Any]]:
         """
-        Export all sessions (with messages) as a list of dicts.
+        Export all conversations (with messages) as a list of dicts.
         Suitable for writing to a JSONL file for backup/analysis.
+
+        Compression continuations are folded into their chain root via
+        :meth:`export_session`, so a conversation that was split across N
+        physical session rows is exported ONCE as a single stitched record
+        rather than N fragments. Branch / delegate / tool children remain their
+        own entries (they are distinct conversations, not continuations).
         """
         sessions = self.search_sessions(source=source, limit=100000)
         results = []
         for session in sessions:
-            messages = self.get_messages(session["id"])
-            results.append({**session, "messages": messages})
+            sid = session["id"]
+            # Skip rows that are mid-chain continuations — they are emitted as
+            # part of their root's stitched export, not on their own.
+            if self._is_compression_continuation(sid):
+                continue
+            exported = self.export_session(sid, stitch_lineage=True)
+            if exported is not None:
+                results.append(exported)
         return results
 
     def clear_messages(self, session_id: str) -> None:

--- a/hermes_state_portability.py
+++ b/hermes_state_portability.py
@@ -291,16 +291,40 @@ class SessionPortabilityMixin:
         base["messages"] = [msg for seg in segments for msg in (seg.get("messages") or [])]
         return base
 
-    def export_all(self, source: str = None) -> List[Dict[str, Any]]:
+    def export_all(
+        self, source: str = None, lineage: str = "single"
+    ) -> List[Dict[str, Any]]:
         """
         Export all sessions (with messages) as a list of dicts.
         Suitable for writing to a JSONL file for backup/analysis.
+
+        ``lineage='single'`` (default) emits one record per physical session
+        row. ``lineage='logical'`` folds compression continuations into one
+        record per conversation via :meth:`export_session_lineage`; branch,
+        delegate, and tool children remain their own entries.
         """
         sessions = self.search_sessions(source=source, limit=100000)
+        if lineage != "logical":
+            results = []
+            for session in sessions:
+                messages = self.get_messages(session["id"])
+                results.append({**session, "messages": messages})
+            return results
+
         results = []
+        seen_roots = set()
         for session in sessions:
-            messages = self.get_messages(session["id"])
-            results.append({**session, "messages": messages})
+            sid = session["id"]
+            lineage_ids = self.get_compression_lineage(sid)
+            if not lineage_ids:
+                continue
+            root = lineage_ids[0]
+            if root in seen_roots:
+                continue
+            seen_roots.add(root)
+            exported = self.export_session_lineage(sid)
+            if exported is not None:
+                results.append(exported)
         return results
 
     @staticmethod

--- a/tests/test_export_lineage_stitch.py
+++ b/tests/test_export_lineage_stitch.py
@@ -1,0 +1,99 @@
+"""E2E: export reassembles compression-split conversations.
+
+Drives the REAL SessionDB against a temp HERMES_HOME. Builds an actual
+compression chain (parent end_reason='compression' -> continuation child)
+and asserts export_session stitches it and export_all folds continuations
+into their root instead of emitting fragments.
+"""
+import importlib, os, tempfile, unittest, json
+from pathlib import Path
+
+
+class ExportLineageStitchTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        os.environ["HERMES_HOME"] = self.tmp.name
+        import hermes_state
+        importlib.reload(hermes_state)
+        self.hs = hermes_state
+        self.db = hermes_state.SessionDB(db_path=Path(self.tmp.name) / "state.db")
+
+    def tearDown(self):
+        try:
+            self.db.close()
+        except Exception:
+            pass
+        self.tmp.cleanup()
+        os.environ.pop("HERMES_HOME", None)
+
+    def _chain(self):
+        """root -[compression]-> mid -[compression]-> tip ; 2 msgs each."""
+        self.db.create_session("root", source="cli"); self.db.set_session_title("root", "Long Convo")
+        self.db.append_message("root", "user", "u1")
+        self.db.append_message("root", "assistant", "a1")
+        self.db.end_session("root", "compression")
+
+        self.db.create_session("mid", source="cli", parent_session_id="root")
+        self.db.append_message("mid", "user", "u2")
+        self.db.append_message("mid", "assistant", "a2")
+        self.db.end_session("mid", "compression")
+
+        self.db.create_session("tip", source="cli", parent_session_id="mid")
+        self.db.append_message("tip", "user", "u3")
+        self.db.append_message("tip", "assistant", "a3")
+
+    def test_export_session_stitches_full_chain_from_any_member(self):
+        self._chain()
+        for entry in ("root", "mid", "tip"):
+            exported = self.db.export_session(entry)
+            self.assertIsNotNone(exported, entry)
+            self.assertEqual(exported["id"], "root", f"{entry}: root metadata expected")
+            contents = [m["content"] for m in exported["messages"]]
+            self.assertEqual(contents, ["u1", "a1", "u2", "a2", "u3", "a3"],
+                             f"{entry}: chain not stitched in order")
+            self.assertEqual(exported["_lineage_session_ids"], ["root", "mid", "tip"])
+
+    def test_legacy_flag_returns_single_segment(self):
+        self._chain()
+        exported = self.db.export_session("mid", stitch_lineage=False)
+        self.assertEqual([m["content"] for m in exported["messages"]], ["u2", "a2"])
+        self.assertNotIn("_lineage_session_ids", exported)
+
+    def test_export_all_folds_continuations_into_root(self):
+        self._chain()
+        # standalone unrelated session
+        self.db.create_session("solo", source="cli"); self.db.set_session_title("solo", "Solo")
+        self.db.append_message("solo", "user", "s1")
+        rows = self.db.export_all()
+        ids = sorted(r["id"] for r in rows)
+        self.assertEqual(ids, ["root", "solo"],
+                         "continuations must not appear as their own export rows")
+        root_row = next(r for r in rows if r["id"] == "root")
+        self.assertEqual([m["content"] for m in root_row["messages"]],
+                         ["u1", "a1", "u2", "a2", "u3", "a3"])
+
+    def test_branch_and_delegate_children_are_not_folded(self):
+        """A branch/delegate child is a distinct conversation, not a continuation."""
+        self.db.create_session("p", source="cli"); self.db.set_session_title("p", "Parent")
+        self.db.append_message("p", "user", "p1")
+        self.db.end_session("p", "compression")
+        # real continuation
+        self.db.create_session("cont", source="cli", parent_session_id="p")
+        self.db.append_message("cont", "user", "c1")
+        # branch child of p (NOT a continuation) — carries _branched_from marker
+        self.db.create_session("br", source="cli", parent_session_id="p",
+                               model_config={"_branched_from": "p"})
+        self.db.append_message("br", "user", "b1")
+
+        rows = self.db.export_all()
+        ids = sorted(r["id"] for r in rows)
+        # p folds cont; br stands alone
+        self.assertIn("br", ids)
+        self.assertIn("p", ids)
+        self.assertNotIn("cont", ids)
+        p_row = next(r for r in rows if r["id"] == "p")
+        self.assertEqual([m["content"] for m in p_row["messages"]], ["p1", "c1"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_export_lineage_stitch.py
+++ b/tests/test_export_lineage_stitch.py
@@ -1,0 +1,307 @@
+"""JSON export stitches compression lineages only when lineage=logical.
+
+Covers the salvage of lineage-aware JSON/JSONL export:
+- export_session stays a single physical row
+- export_session_lineage stitches root->tip from any member
+- branch/delegate/tool children are not folded into the chain
+- export_all(lineage='logical') folds continuations; default/single keeps fragments
+- CLI JSON/JSONL and console export honor --lineage
+"""
+
+from __future__ import annotations
+
+import json
+
+from hermes_state import SessionDB
+
+
+def _build_chain(db: SessionDB) -> None:
+    db.create_session("root", source="cli")
+    db.append_message("root", "user", "u1")
+    db.append_message("root", "assistant", "a1")
+    db.end_session("root", "compression")
+
+    db.create_session("mid", source="cli", parent_session_id="root")
+    db.append_message("mid", "user", "u2")
+    db.append_message("mid", "assistant", "a2")
+    db.end_session("mid", "compression")
+
+    db.create_session("tip", source="cli", parent_session_id="mid")
+    db.append_message("tip", "user", "u3")
+    db.append_message("tip", "assistant", "a3")
+
+
+def _contents(exported) -> list:
+    return [message.get("content") for message in (exported.get("messages") or [])]
+
+
+def test_export_session_stays_single_row(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        _build_chain(db)
+        exported = db.export_session("mid")
+        assert exported is not None
+        assert exported["id"] == "mid"
+        assert _contents(exported) == ["u2", "a2"]
+        assert "lineage_session_ids" not in exported
+        assert "segments" not in exported
+    finally:
+        db.close()
+
+
+def test_export_session_lineage_stitches_from_any_member(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        _build_chain(db)
+        for member in ("root", "mid", "tip"):
+            exported = db.export_session_lineage(member)
+            assert exported is not None, member
+            assert exported["lineage_session_ids"] == ["root", "mid", "tip"], member
+            assert _contents(exported) == ["u1", "a1", "u2", "a2", "u3", "a3"], member
+    finally:
+        db.close()
+
+
+def test_export_session_lineage_excludes_branch_delegate_tool(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        _build_chain(db)
+        db.create_session(
+            "branch",
+            source="cli",
+            parent_session_id="root",
+            model_config={"_branched_from": "root"},
+        )
+        db.append_message("branch", "user", "b1")
+        db.create_session(
+            "delegate",
+            source="delegate",
+            parent_session_id="mid",
+            model_config={"_delegate_from": "mid"},
+        )
+        db.append_message("delegate", "user", "d1")
+        db.create_session("tool", source="tool", parent_session_id="mid")
+        db.append_message("tool", "user", "t1")
+
+        for member in ("root", "mid", "tip"):
+            exported = db.export_session_lineage(member)
+            assert exported["lineage_session_ids"] == ["root", "mid", "tip"]
+            assert _contents(exported) == ["u1", "a1", "u2", "a2", "u3", "a3"]
+
+        for child, content in (
+            ("branch", "b1"),
+            ("delegate", "d1"),
+            ("tool", "t1"),
+        ):
+            exported = db.export_session_lineage(child)
+            assert exported["lineage_session_ids"] == [child]
+            assert _contents(exported) == [content]
+    finally:
+        db.close()
+
+
+def test_export_all_logical_folds_continuations(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        _build_chain(db)
+        db.create_session("solo", source="cli")
+        db.append_message("solo", "user", "s1")
+
+        rows = db.export_all(lineage="logical")
+        conversation = [
+            row
+            for row in rows
+            if row.get("lineage_session_ids") == ["root", "mid", "tip"]
+        ]
+        assert len(conversation) == 1
+        assert _contents(conversation[0]) == ["u1", "a1", "u2", "a2", "u3", "a3"]
+        ids = {row["id"] for row in rows}
+        assert "solo" in ids
+        assert "mid" not in ids
+        assert "root" not in ids
+    finally:
+        db.close()
+
+
+def test_export_all_single_keeps_fragments(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        _build_chain(db)
+        db.create_session("solo", source="cli")
+        db.append_message("solo", "user", "s1")
+
+        for rows in (db.export_all(), db.export_all(lineage="single")):
+            ids = sorted(row["id"] for row in rows)
+            assert ids == ["mid", "root", "solo", "tip"]
+            mid = next(row for row in rows if row["id"] == "mid")
+            assert _contents(mid) == ["u2", "a2"]
+            assert "lineage_session_ids" not in mid
+    finally:
+        db.close()
+
+
+def test_export_all_logical_keeps_branch_delegate_tool(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("parent", source="cli")
+        db.append_message("parent", "user", "p1")
+        db.end_session("parent", "compression")
+        db.create_session("cont", source="cli", parent_session_id="parent")
+        db.append_message("cont", "user", "c1")
+        db.create_session(
+            "branch",
+            source="cli",
+            parent_session_id="parent",
+            model_config={"_branched_from": "parent"},
+        )
+        db.append_message("branch", "user", "b1")
+        db.create_session(
+            "delegate",
+            source="delegate",
+            parent_session_id="parent",
+            model_config={"_delegate_from": "parent"},
+        )
+        db.append_message("delegate", "user", "d1")
+        db.create_session("tool", source="tool", parent_session_id="parent")
+        db.append_message("tool", "user", "t1")
+
+        rows = db.export_all(lineage="logical")
+        ids = {row["id"] for row in rows}
+        assert "branch" in ids
+        assert "delegate" in ids
+        assert "tool" in ids
+        conversation = next(
+            row
+            for row in rows
+            if row.get("lineage_session_ids") == ["parent", "cont"]
+        )
+        assert _contents(conversation) == ["p1", "c1"]
+        assert "parent" not in ids
+    finally:
+        db.close()
+
+
+def _jsonl_export_args(**overrides):
+    from argparse import Namespace
+
+    defaults = dict(
+        sessions_action="export",
+        format="jsonl",
+        output="-",
+        session_id=None,
+        lineage="single",
+        redact=False,
+        only=None,
+        dry_run=False,
+        yes=False,
+        source=None,
+        older_than=None,
+        newer_than=None,
+        before=None,
+        after=None,
+        title=None,
+        end_reason=None,
+        cwd=None,
+        min_messages=None,
+        max_messages=None,
+        model=None,
+        provider=None,
+        user=None,
+        chat_id=None,
+        chat_type=None,
+        branch=None,
+        min_tokens=None,
+        max_tokens=None,
+        min_cost=None,
+        max_cost=None,
+        min_tool_calls=None,
+        max_tool_calls=None,
+    )
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+def test_cli_jsonl_honors_lineage(capsys):
+    from hermes_cli.sessions_cmd import cmd_sessions
+
+    db = SessionDB()
+    try:
+        _build_chain(db)
+    finally:
+        db.close()
+
+    cmd_sessions(_jsonl_export_args(session_id="mid"))
+    single = json.loads(capsys.readouterr().out.strip())
+    assert single["id"] == "mid"
+    assert _contents(single) == ["u2", "a2"]
+    assert "lineage_session_ids" not in single
+
+    cmd_sessions(_jsonl_export_args(session_id="mid", lineage="logical"))
+    logical = json.loads(capsys.readouterr().out.strip())
+    assert logical["lineage_session_ids"] == ["root", "mid", "tip"]
+    assert _contents(logical) == ["u1", "a1", "u2", "a2", "u3", "a3"]
+
+
+def test_cli_jsonl_export_all_folds_when_logical(capsys):
+    from hermes_cli.sessions_cmd import cmd_sessions
+
+    db = SessionDB()
+    try:
+        _build_chain(db)
+        db.create_session("solo", source="cli")
+        db.append_message("solo", "user", "s1")
+    finally:
+        db.close()
+
+    cmd_sessions(_jsonl_export_args())
+    single_rows = [
+        json.loads(line)
+        for line in capsys.readouterr().out.splitlines()
+        if line.strip()
+    ]
+    assert sorted(row["id"] for row in single_rows) == ["mid", "root", "solo", "tip"]
+
+    cmd_sessions(_jsonl_export_args(lineage="logical"))
+    logical_rows = [
+        json.loads(line)
+        for line in capsys.readouterr().out.splitlines()
+        if line.strip()
+    ]
+    ids = {row["id"] for row in logical_rows}
+    assert "solo" in ids
+    assert "mid" not in ids
+    conversation = next(
+        row
+        for row in logical_rows
+        if row.get("lineage_session_ids") == ["root", "mid", "tip"]
+    )
+    assert _contents(conversation) == ["u1", "a1", "u2", "a2", "u3", "a3"]
+
+
+def test_console_json_honors_lineage():
+    from hermes_cli.console_engine import HermesConsoleEngine
+
+    db = SessionDB()
+    try:
+        _build_chain(db)
+    finally:
+        db.close()
+
+    engine = HermesConsoleEngine()
+    single = engine.execute(
+        "sessions export - --session-id mid",
+        confirmed=True,
+    )
+    assert single.status == "ok"
+    single_row = json.loads(single.output.strip())
+    assert single_row["id"] == "mid"
+    assert _contents(single_row) == ["u2", "a2"]
+
+    logical = engine.execute(
+        "sessions export - --session-id mid --lineage logical",
+        confirmed=True,
+    )
+    assert logical.status == "ok"
+    logical_row = json.loads(logical.output.strip())
+    assert logical_row["lineage_session_ids"] == ["root", "mid", "tip"]
+    assert _contents(logical_row) == ["u1", "a1", "u2", "a2", "u3", "a3"]


### PR DESCRIPTION
## Problem

Context compression ends a session (`end_reason='compression'`) and forks a continuation child linked by `parent_session_id`. JSON / JSONL export still read one physical row, so a marathon conversation exported as a fragment (or as N disconnected JSONL records). Markdown/QMD already had an explicit `--lineage logical` opt-in via `export_session_lineage()`.

## Salvage

Reuse the existing lineage helpers instead of adding parallel walkers, and make the JSON contract match Markdown:

- `export_session()` stays a single physical row (no default stitch)
- `export_session_lineage()` / `get_compression_lineage()` remain the stitch path
- `export_all(..., lineage='single'|'logical')` — `logical` folds compression continuations into the root; `single` keeps fragments
- `--lineage` now applies to JSON/JSONL as well as md/qmd (default still `single`)
- Branch / delegate / tool children stay their own entries (same compression-only edges as `get_compression_tip`)
- `session_search` / #91312 untouched (COEXIST)

## Test plan

- [x] `tests/test_export_lineage_stitch.py`: single-row default, stitch root→tip from any member, fold vs fragments, branch/delegate/tool exclusion, CLI `--lineage`
- [x] Existing md export / compression lineage tests