### PR TITLE
fix(tui): split IME backspace text keypresses

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
@@ -40,6 +40,37 @@ describe('parseMultipleKeypresses bracketed paste recovery', () => {
   })
 })
 
+describe('parseMultipleKeypresses text control splitting', () => {
+  it('keeps an IME backspace plus composed character in the same read', () => {
+    const [keys, state] = parseMultipleKeypresses(INITIAL_STATE, '\x7fô')
+
+    expect(keys).toEqual([
+      expect.objectContaining({ name: 'backspace', raw: '\x7f' }),
+      expect.objectContaining({ name: '', raw: 'ô' })
+    ])
+    expect(state.mode).toBe('NORMAL')
+  })
+
+  it('keeps trailing IME text after a backspace in the same read', () => {
+    const [keys] = parseMultipleKeypresses(INITIAL_STATE, '\x7fôi')
+
+    expect(keys).toEqual([
+      expect.objectContaining({ name: 'backspace', raw: '\x7f' }),
+      expect.objectContaining({ name: '', raw: 'ôi' })
+    ])
+  })
+
+  it('splits embedded backspace control bytes without splitting surrounding text', () => {
+    const [keys] = parseMultipleKeypresses(INITIAL_STATE, 'ab\bç')
+
+    expect(keys).toEqual([
+      expect.objectContaining({ name: '', raw: 'ab' }),
+      expect.objectContaining({ name: 'backspace', raw: '\b' }),
+      expect.objectContaining({ name: '', raw: 'ç' })
+    ])
+  })
+})
+
 describe('mouse wheel modifier decoding', () => {
   // SGR mouse format: ESC [ < button ; col ; row M
   // Wheel up = 64 (0x40), wheel down = 65 (0x41).

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -184,6 +184,32 @@ function splitNumericParams(params: string): number[] {
   return params.split(';').map(p => parseInt(p, 10))
 }
 
+function parseTextKeypresses(text: string): ParsedKey[] {
+  const keys: ParsedKey[] = []
+  let textStart = 0
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+
+    if (ch !== '\x7f' && ch !== '\b') {
+      continue
+    }
+
+    if (i > textStart) {
+      keys.push(parseKeypress(text.slice(textStart, i)))
+    }
+
+    keys.push(parseKeypress(ch))
+    textStart = i + 1
+  }
+
+  if (textStart < text.length) {
+    keys.push(parseKeypress(text.slice(textStart)))
+  }
+
+  return keys
+}
+
 export type KeyParseState = {
   mode: 'NORMAL' | 'IN_PASTE'
   incomplete: string
@@ -278,7 +304,7 @@ export function parseMultipleKeypresses(
         const resynthesized = '\x1b' + token.value
         keys.push(parseKeypress(resynthesized))
       } else {
-        keys.push(parseKeypress(token.value))
+        keys.push(...parseTextKeypresses(token.value))
       }
     }
   }

--- a/ui-tui/src/__tests__/textInputImeBoundary.test.tsx
+++ b/ui-tui/src/__tests__/textInputImeBoundary.test.tsx
@@ -1,0 +1,86 @@
+import { EventEmitter } from 'events'
+
+import { renderSync } from '@hermes/ink'
+import React, { useState } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { TextInput } from '../components/textInput.js'
+
+class FakeTty extends EventEmitter {
+  chunks: string[] = []
+  columns = 80
+  rows = 24
+  isTTY = true
+  isRaw = false
+  private pendingReads: string[] = []
+
+  ref(): void {}
+  unref(): void {}
+
+  read(): string | null {
+    return this.pendingReads.shift() ?? null
+  }
+
+  send(chunk: string): void {
+    this.pendingReads.push(chunk)
+    this.emit('readable')
+  }
+
+  setEncoding(): this {
+    return this
+  }
+
+  setRawMode(mode: boolean): this {
+    this.isRaw = mode
+
+    return this
+  }
+
+  write(chunk: string | Uint8Array, cb?: (err?: Error | null) => void): boolean {
+    this.chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'))
+    cb?.()
+
+    return true
+  }
+}
+
+const tick = () => new Promise<void>(resolve => setImmediate(resolve))
+
+function Harness({ onValue }: { onValue: (value: string) => void }) {
+  const [value, setValue] = useState('o')
+
+  return React.createElement(TextInput, {
+    onChange: next => {
+      setValue(next)
+      onValue(next)
+    },
+    value
+  })
+}
+
+describe('TextInput IME recomposition boundary', () => {
+  it('applies a parser-split backspace plus composed character through useInput', async () => {
+    const stdout = new FakeTty()
+    const stdin = new FakeTty()
+    const stderr = new FakeTty()
+    const values: string[] = []
+
+    const instance = renderSync(React.createElement(Harness, { onValue: value => values.push(value) }), {
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream
+    })
+
+    try {
+      await tick()
+      stdin.send('\x7fô')
+      await tick()
+
+      expect(values.at(-1)).toBe('ô')
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Fixes a TUI keypress parser bug where an IME recomposition chunk such as `\x7fô` was parsed as one unnamed text key and then discarded by the composer. The parser now splits text tokens on embedded Backspace/DEL control bytes outside bracketed paste mode, preserving the control key and the following composed text.

## Related Issue

Fixes #53982

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts`: split plain text tokens around `\b` and `\x7f` before passing each segment to `parseKeypress()`.
- `ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts`: added regressions for `\x7fô`, `\x7fôi`, and embedded backspace text chunks.

## How to Test

1. Run `npm run test --workspace ui-tui -- packages/hermes-ink/src/ink/parse-keypress.test.ts`.
2. Run `npm run test --workspace ui-tui -- packages/hermes-ink/src/ink/parse-keypress.test.ts src/__tests__/textInputBurstInput.test.ts src/__tests__/textInputFastEcho.test.ts`.
3. Run `npm run typecheck --workspace ui-tui`.
4. Run `npm run lint --workspace ui-tui -- packages/hermes-ink/src/ink/parse-keypress.ts packages/hermes-ink/src/ink/parse-keypress.test.ts`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass; N/A, this is a TUI TypeScript parser change, so targeted Vitest/typecheck/lint were run instead
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, targeted parser/composer tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, no docs change needed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — parser-only TUI change, covered by unit tests
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Validation run locally:

```text
npm run test --workspace ui-tui -- packages/hermes-ink/src/ink/parse-keypress.test.ts
Test Files  1 passed (1)
Tests  17 passed (17)

npm run test --workspace ui-tui -- packages/hermes-ink/src/ink/parse-keypress.test.ts src/__tests__/textInputBurstInput.test.ts src/__tests__/textInputFastEcho.test.ts
Test Files  3 passed (3)
Tests  55 passed (55)

npm run typecheck --workspace ui-tui
passed

npm run lint --workspace ui-tui -- packages/hermes-ink/src/ink/parse-keypress.ts packages/hermes-ink/src/ink/parse-keypress.test.ts
0 errors; 5 existing warnings in unrelated useSessionLifecycle files
```