### PR TITLE
fix: inline Signal attachments for RPC sends

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -144,7 +144,7 @@ def _path_to_data_uri(path: str) -> str:
     return f"data:{mime};base64,{encoded}"
 
 
-def _inline_send_attachments(params: dict) -> dict:
+async def _inline_send_attachments(params: dict) -> dict:
     """Inline local send attachments for signal-cli daemons without shared filesystems.
 
     ``signal-cli`` accepts attachments either as filesystem paths or as ``data:``
@@ -152,6 +152,11 @@ def _inline_send_attachments(params: dict) -> dict:
     signal-cli container cannot dereference raw paths. Convert existing local
     files to data URIs at the RPC boundary while preserving already-inlined,
     remote, or missing attachments unchanged.
+
+    The blocking file read + base64 encode runs off the gateway event loop via
+    :func:`asyncio.to_thread`. An unreadable local path raises ``OSError`` so
+    the caller can surface a controlled failed send instead of the error
+    escaping from the RPC boundary.
     """
     attachments = params.get("attachments")
     if not attachments:
@@ -165,7 +170,7 @@ def _inline_send_attachments(params: dict) -> dict:
             and not attachment.startswith("data:")
             and Path(attachment).is_file()
         ):
-            converted.append(_path_to_data_uri(attachment))
+            converted.append(await asyncio.to_thread(_path_to_data_uri, attachment))
             changed = True
         else:
             converted.append(attachment)
@@ -993,7 +998,17 @@ class SignalAdapter(BasePlatformAdapter):
             return None
 
         if method == "send" and isinstance(params, dict):
-            params = _inline_send_attachments(params)
+            try:
+                params = await _inline_send_attachments(params)
+            except OSError as _read_err:
+                # A local attachment became unreadable or was deleted between
+                # the is_file() check and the read. Fail the send in a controlled
+                # way rather than letting the error escape the RPC boundary.
+                logger.warning(
+                    "Signal send dropped: could not read attachment for inline send: %s",
+                    _read_err,
+                )
+                return None
 
         if rpc_id is None:
             rpc_id = f"{method}_{int(time.time() * 1000)}"

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -136,6 +136,45 @@ def _ext_to_mime(ext: str) -> str:
     return mime_for_ext(ext, fallback="application/octet-stream")
 
 
+def _path_to_data_uri(path: str) -> str:
+    """Read a local attachment path and return a Signal-compatible data URI."""
+    data = Path(path).read_bytes()
+    mime = _ext_to_mime(Path(path).suffix)
+    encoded = base64.b64encode(data).decode("ascii")
+    return f"data:{mime};base64,{encoded}"
+
+
+def _inline_send_attachments(params: dict) -> dict:
+    """Inline local send attachments for signal-cli daemons without shared filesystems.
+
+    ``signal-cli`` accepts attachments either as filesystem paths or as ``data:``
+    URIs. Hermes-generated files live in the Hermes container, so a separate
+    signal-cli container cannot dereference raw paths. Convert existing local
+    files to data URIs at the RPC boundary while preserving already-inlined,
+    remote, or missing attachments unchanged.
+    """
+    attachments = params.get("attachments")
+    if not attachments:
+        return params
+
+    converted = []
+    changed = False
+    for attachment in attachments:
+        if (
+            isinstance(attachment, str)
+            and not attachment.startswith("data:")
+            and Path(attachment).is_file()
+        ):
+            converted.append(_path_to_data_uri(attachment))
+            changed = True
+        else:
+            converted.append(attachment)
+
+    if not changed:
+        return params
+    return dict(params, attachments=converted)
+
+
 def _remux_aac_to_m4a(aac_data: bytes) -> Optional[Tuple[bytes, str]]:
     """Losslessly remux raw ADTS AAC bytes into an MP4 (.m4a) container.
 
@@ -952,6 +991,9 @@ class SignalAdapter(BasePlatformAdapter):
         if not self.client:
             logger.warning("Signal: RPC called but client not connected")
             return None
+
+        if method == "send" and isinstance(params, dict):
+            params = _inline_send_attachments(params)
 
         if rpc_id is None:
             rpc_id = f"{method}_{int(time.time() * 1000)}"

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -48,6 +48,11 @@ def _stub_rpc(return_value):
     return mock_rpc, captured
 
 
+async def _raise_oserror(params: dict) -> dict:
+    """Async stand-in for _inline_send_attachments that simulates a read failure."""
+    raise OSError("simulated unreadable attachment")
+
+
 # ---------------------------------------------------------------------------
 # Platform & Config
 # ---------------------------------------------------------------------------
@@ -122,7 +127,8 @@ class TestSignalHelpers:
         assert _parse_comma_list("") == []
         assert _parse_comma_list("  ,  ,  ") == []
 
-    def test_inline_send_attachments_converts_local_paths(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_inline_send_attachments_converts_local_paths(self, tmp_path):
         from gateway.platforms.signal import _inline_send_attachments
 
         attachment = tmp_path / "voice.ogg"
@@ -133,7 +139,7 @@ class TestSignalHelpers:
             "attachments": [str(attachment), "data:image/png;base64,AAAA", "/missing.jpg"],
         }
 
-        converted = _inline_send_attachments(params)
+        converted = await _inline_send_attachments(params)
 
         expected_data = base64.b64encode(b"OggS test audio").decode("ascii")
         assert converted is not params
@@ -141,12 +147,48 @@ class TestSignalHelpers:
         assert converted["attachments"][1:] == ["data:image/png;base64,AAAA", "/missing.jpg"]
         assert params["attachments"][0] == str(attachment)
 
-    def test_inline_send_attachments_leaves_no_local_files_unchanged(self):
+    @pytest.mark.asyncio
+    async def test_inline_send_attachments_leaves_no_local_files_unchanged(self):
         from gateway.platforms.signal import _inline_send_attachments
 
         params = {"recipient": ["+155****4567"], "attachments": ["data:text/plain;base64,SGk="]}
 
-        assert _inline_send_attachments(params) is params
+        assert await _inline_send_attachments(params) is params
+
+    @pytest.mark.asyncio
+    async def test_inline_send_attachments_unreadable_path_raises_oserror(self, tmp_path):
+        """An unreadable local attachment must raise OSError, not escape silently."""
+        from gateway.platforms.signal import _inline_send_attachments
+
+        unreadable = tmp_path / "locked.ogg"
+        unreadable.write_bytes(b"OggS test audio")
+        unreadable.chmod(0)
+
+        params = {
+            "recipient": ["+155****4567"],
+            "attachments": [str(unreadable)],
+        }
+
+        with pytest.raises(OSError):
+            await _inline_send_attachments(params)
+
+    @pytest.mark.asyncio
+    async def test_rpc_send_dropped_on_unreadable_attachment(self, monkeypatch):
+        """An unreadable send attachment must fail the RPC controlled, not escape."""
+        from gateway.platforms.signal import SignalAdapter
+
+        adapter = SignalAdapter.__new__(SignalAdapter)
+        adapter.client = MagicMock()
+        adapter.http_url = "http://localhost:8080"
+
+        monkeypatch.setattr(
+            "gateway.platforms.signal._inline_send_attachments",
+            _raise_oserror,
+        )
+
+        result = await adapter._rpc("send", {"recipient": ["+155****4567"], "attachments": ["/nope.ogg"]})
+        assert result is None
+        adapter.client.post.assert_not_called()
 
     def test_guess_extension_png(self):
         from gateway.platforms.signal import _guess_extension

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -122,6 +122,35 @@ class TestSignalHelpers:
         assert _parse_comma_list("") == []
         assert _parse_comma_list("  ,  ,  ") == []
 
+    def test_inline_send_attachments_converts_local_paths(self, tmp_path):
+        from gateway.platforms.signal import _inline_send_attachments
+
+        attachment = tmp_path / "voice.ogg"
+        attachment.write_bytes(b"OggS test audio")
+
+        params = {
+            "recipient": ["+155****4567"],
+            "attachments": [str(attachment), "data:image/png;base64,AAAA", "/missing.jpg"],
+        }
+
+        converted = _inline_send_attachments(params)
+
+        expected_data = base64.b64encode(b"OggS test audio").decode("ascii")
+        assert converted is not params
+        assert converted["attachments"][0] == f"data:audio/ogg;base64,{expected_data}"
+        assert converted["attachments"][1:] == ["data:image/png;base64,AAAA", "/missing.jpg"]
+        assert params["attachments"][0] == str(attachment)
+
+    def test_inline_send_attachments_leaves_no_local_files_unchanged(self):
+        from gateway.platforms.signal import _inline_send_attachments
+
+        params = {"recipient": ["+155****4567"], "attachments": ["data:text/plain;base64,SGk="]}
+
+        assert _inline_send_attachments(params) is params
+
+    def test_guess_extension_png(self):
+        from gateway.platforms.signal import _guess_extension
+        assert _guess_extension(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100) == ".png"
 
     def test_guess_extension_wav_routes_to_audio_cache(self):
         """A detected WAV must route to the audio cache, not the document cache.
@@ -709,6 +738,58 @@ class TestSignalSendResultValidation:
         assert result.success is False
         assert result.error == "Some connection error"
 
+    @pytest.mark.asyncio
+    async def test_rpc_inlines_local_send_attachments(self, monkeypatch, tmp_path):
+        adapter = _make_signal_adapter(monkeypatch)
+        attachment = tmp_path / "photo.png"
+        attachment.write_bytes(b"\x89PNG image bytes")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"jsonrpc": "2.0", "result": {"timestamp": 123}, "id": "1"}
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        adapter.client = mock_client
+
+        result = await adapter._rpc(
+            "send",
+            {"recipient": ["+155****4567"], "attachments": [str(attachment)]},
+            rpc_id="1",
+        )
+
+        assert result == {"timestamp": 123}
+        payload = mock_client.post.await_args.kwargs["json"]
+        expected_data = base64.b64encode(b"\x89PNG image bytes").decode("ascii")
+        assert payload["params"]["attachments"] == [f"data:image/png;base64,{expected_data}"]
+
+    @pytest.mark.asyncio
+    async def test_rpc_raises_rate_limit_on_results_failure(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "jsonrpc": "2.0",
+            "result": {
+                "timestamp": 1712345678000,
+                "results": [
+                    {
+                        "recipientAddress": {"number": "+155****4567"},
+                        "type": "RATE_LIMIT_FAILURE",
+                        "retryAfterSeconds": 15
+                    }
+                ]
+            },
+            "id": "1"
+        }
+        mock_client.post = AsyncMock(return_value=mock_response)
+        adapter.client = mock_client
+
+        from gateway.platforms.signal_rate_limit import SignalRateLimitError
+        with pytest.raises(SignalRateLimitError) as exc_info:
+            await adapter._rpc("send", {"recipient": ["+155****4567"]}, raise_on_rate_limit=True)
+
+        assert "Rate limit exceeded for recipient" in str(exc_info.value)
+        assert exc_info.value.retry_after == 15
 
 # ---------------------------------------------------------------------------
 # stop_typing() delegates to _stop_typing_indicator (#4647)


### PR DESCRIPTION
Fixes #53988

## Description
Inline local Signal attachment paths as data URIs at the JSON-RPC send boundary so a separate signal-cli container receives outbound media by value instead of trying to read Hermes-local paths. Existing data URI and missing/non-local attachments are preserved unchanged.

## Verification
- scripts/run_tests.sh tests/gateway/test_signal.py
- Scoped S1/S2 scans on changed files: clean
- Conventional commit subject check: clean
- Focused diff: gateway/platforms/signal.py and tests/gateway/test_signal.py only