### PR TITLE
fix(moa): preserve Nous provider identity for references

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -58,9 +58,10 @@ def _slot_runtime(slot: dict[str, str]) -> dict[str, Any]:
         resolved_provider = str(rt.get("provider") or provider).strip().lower()
         # call_llm treats an explicit base_url as a custom endpoint. That is
         # correct for ordinary OpenAI-compatible targets, but wrong for OAuth /
-        # adapter-backed providers whose provider branch adds auth headers and
-        # request-shape adapters. Keep those providers identified by name.
-        if resolved_provider in {"openai-codex", "xai-oauth"}:
+        # provider-backed targets whose provider branch adds auth refresh,
+        # request metadata, or request-shape adapters. Keep those providers
+        # identified by name.
+        if resolved_provider in {"nous", "openai-codex", "xai-oauth"}:
             return out
         # Pass the resolved endpoint through so call_llm builds the request for
         # the provider's actual API surface instead of auto-detecting. base_url


### PR DESCRIPTION
## What does this PR do?

Preserves the `nous` provider identity for Mixture-of-Agents reference slots instead of pre-resolving the slot into a bare `custom` endpoint before `call_llm()`.

MoA already keeps `openai-codex` and `xai-oauth` identified by provider name because their provider branches carry auth/request-shape behavior. Nous needs the same treatment: when MoA passes the resolved Nous `base_url` and `api_key` into `call_llm()`, `_resolve_task_provider_model()` treats the call as `custom`, which makes logs show `moa_reference custom ...` and skips Nous-specific request metadata such as portal tags.

With this change, Nous reference models continue through the normal `provider == "nous"` path, preserving auth refresh behavior, request metadata, and accurate logs.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/moa_loop.py`: include `nous` in the provider-identity preservation path for MoA slot runtime resolution.
- Updated the nearby comment from adapter-only language to provider-backed behavior, since the preserved providers also carry auth refresh/request metadata.

## How to Test

1. No-network routing check for a Nous MoA reference slot:
   - Before: `_resolve_task_provider_model(...)` returned `custom`, and `_build_call_kwargs(...)` had no Nous portal tags.
   - After: `_resolve_task_provider_model(...)` returns `nous`, and `_build_call_kwargs(...)` includes Nous portal tags.
2. `python -m py_compile agent\moa_loop.py`
3. Live Windows desktop/AppData gateway test with Thing1/MoA:
   - Started a fresh desktop session and sent `tell me about you`.
   - `desktop.log` showed `moa_reference nous anthropic/claude-opus-4.7`, `moa_reference nous anthropic/claude-opus-4.8`, and `moa_reference nous z-ai/glm-5.2`.
   - Before this fix, the same reference slots logged as `moa_reference custom ...` against the Nous inference URL.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / AppData desktop install

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification output:

```text
slot_runtime: {'provider': 'nous', 'model': 'anthropic/claude-opus-4.8'}
resolve_task_provider_model: ('nous', 'anthropic/claude-opus-4.8', None, '', None)
kwargs_model: anthropic/claude-opus-4.8
kwargs_extra_body_has_tags: True
```

Live desktop log after restarting the AppData gateway with this patch:

```text
moa_reference openai-codex gpt-5.5
moa_reference openai-codex gpt-5.3-codex-spark
moa_reference xai-oauth grok-composer-2.5-fast
moa_reference nous anthropic/claude-opus-4.7
moa_reference nous anthropic/claude-opus-4.8
moa_reference xai-oauth grok-build-0.1
moa_reference nous z-ai/glm-5.2
moa_aggregator openai-codex gpt-5.5
```