### PR TITLE
fix: harden Windows cron Telegram alerts

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1631,13 +1631,24 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         from tools.environments.local import _sanitize_subprocess_env
 
         popen_kwargs = {"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}
+        child_env = _sanitize_subprocess_env(os.environ.copy())
+        # Cron no_agent scripts often emit Telegram-ready Unicode (Korean,
+        # emoji, box-drawing bars).  On Windows services/GUI launches the
+        # locale default is commonly cp949, and subprocess.run(text=True)
+        # will decode stdout with that codec unless we pin it.  A decode
+        # failure in the reader thread can make a successful script look like
+        # empty stdout, which suppresses delivery.  Force UTF-8 on both sides.
+        child_env.setdefault("PYTHONIOENCODING", "utf-8")
+        child_env.setdefault("PYTHONUTF8", "1")
         result = subprocess.run(
             argv,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=script_timeout,
             cwd=str(path.parent),
-            env=_sanitize_subprocess_env(os.environ.copy()),
+            env=child_env,
             **popen_kwargs,
         )
         stdout = (result.stdout or "").strip()

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -99,6 +99,25 @@ class TestRunJobScript:
         assert success is True
         assert output == "hello from script"
 
+    def test_script_stdout_decodes_utf8_unicode(self, cron_env):
+        """No-agent cron scripts may emit Telegram-ready Korean/emoji text.
+
+        Windows GUI/service launches commonly default subprocess text decoding
+        to cp949. Pinning the scheduler's decode path to UTF-8 keeps those
+        successful scripts from being misread as empty/silent output.
+        """
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "unicode.py"
+        script.write_text(
+            'print("✅ 한글/이모지/막대문자 정상 출력: 📊 ███···")\n',
+            encoding="utf-8",
+        )
+
+        success, output = _run_job_script(str(script))
+        assert success is True
+        assert output == "✅ 한글/이모지/막대문자 정상 출력: 📊 ███···"
+
     def test_script_relative_path(self, cron_env):
         from cron.scheduler import _run_job_script
 

--- a/tests/tools/test_send_message_telegram_proxy.py
+++ b/tests/tools/test_send_message_telegram_proxy.py
@@ -15,6 +15,7 @@ the same way the gateway adapter (and the Discord standalone path) do.
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 from types import SimpleNamespace
 from typing import Any
@@ -155,3 +156,66 @@ class TestSendTelegramStandaloneProxy:
         assert "get_updates_request" not in call_kwargs
         httpx_request_factory.assert_not_called()
         bot.send_message.assert_awaited_once()
+
+    def test_text_only_timeout_falls_back_to_direct_bot_api(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If python-telegram-bot times out, text cron alerts should still
+        deliver through the plain Bot API endpoint when it is reachable.
+        """
+        from tools.send_message_tool import _send_telegram
+
+        for var in (
+            "TELEGRAM_PROXY",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "HTTP_PROXY",
+            "http_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+            "NO_PROXY",
+            "no_proxy",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+
+        bot = MagicMock()
+        bot.send_message = AsyncMock(side_effect=TimeoutError("Timed out"))
+        bot_factory = MagicMock(return_value=bot)
+        httpx_request_factory = MagicMock(side_effect=lambda **kw: MagicMock(_kw=kw))
+        _install_telegram_mock_with_request(monkeypatch, bot_factory, httpx_request_factory)
+
+        opened = []
+
+        class _FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return json.dumps(
+                    {"ok": True, "result": {"message_id": 777}}
+                ).encode("utf-8")
+
+        def fake_urlopen(url, *, data, timeout):
+            opened.append((url, data, timeout))
+            return _FakeResponse()
+
+        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+        result: dict[str, Any] = asyncio.run(
+            _send_telegram("tok", "-100123", "✅ 한글 alert")
+        )
+
+        assert result["success"] is True
+        assert result["message_id"] == "777"
+        assert "urllib Bot API fallback" in result["warnings"][0]
+        bot.send_message.assert_awaited_once()
+        assert opened
+        url, data, timeout = opened[0]
+        assert url == "https://api.telegram.org/bottok/sendMessage"
+        assert timeout == 30
+        assert b"chat_id=-100123" in data
+        assert "%E2%9C%85" in data.decode("utf-8")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1241,6 +1241,46 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
     except ImportError:
         return {"error": "python-telegram-bot not installed. Run: pip install python-telegram-bot"}
     except Exception as e:
+        # Windows desktop/gateway cron runs have occasionally hit python-telegram-bot
+        # HTTPX timeouts even while the plain Bot API endpoint is reachable.  For
+        # text-only Telegram sends, fall back to a minimal urllib sendMessage call
+        # so cron alerts are not dropped by a transport-specific timeout.
+        try:
+            import json as _json
+            import urllib.parse as _urlparse
+            import urllib.request as _urlrequest
+
+            if (not media_files) and str(message or "").strip():
+                payload = {
+                    "chat_id": str(chat_id),
+                    "text": str(message),
+                }
+                if thread_id is not None:
+                    payload["message_thread_id"] = str(thread_id)
+                data = _urlparse.urlencode(payload).encode("utf-8")
+                with _urlrequest.urlopen(
+                    f"https://api.telegram.org/bot{token}/sendMessage",
+                    data=data,
+                    timeout=30,
+                ) as resp:
+                    raw = resp.read().decode("utf-8", "replace")
+                obj = _json.loads(raw)
+                if obj.get("ok"):
+                    result = obj.get("result") or {}
+                    return {
+                        "success": True,
+                        "platform": "telegram",
+                        "chat_id": chat_id,
+                        "message_id": str(result.get("message_id", "")),
+                        "warnings": [
+                            "python-telegram-bot send failed; delivered via urllib Bot API fallback"
+                        ],
+                    }
+        except Exception as fallback_exc:
+            logger.warning(
+                "Telegram urllib fallback failed after python-telegram-bot error: %s",
+                _sanitize_error_text(fallback_exc),
+            )
         return _error(f"Telegram send failed: {e}")
 
 


### PR DESCRIPTION
## Summary
- force UTF-8 decoding/env for cron `no_agent` script stdout so Windows GUI/service launches do not misread Korean/emoji output as silent empty output
- add a text-only Telegram Bot API fallback when the python-telegram-bot send path times out or otherwise fails after formatting
- add regressions for UTF-8 cron output and text-only Telegram timeout fallback

## Why
On Windows Desktop/Gateway, `no_agent` cron jobs can emit Telegram-ready Korean/emoji/box-drawing text. If the scheduler decodes subprocess stdout via the default Windows locale (commonly cp949), successful scripts can hit `UnicodeDecodeError` and be treated as empty/silent output, suppressing alerts.

Separately, we observed Telegram direct Bot API `sendMessage` succeeding while the python-telegram-bot/HTTPX standalone path timed out. For text-only cron alerts, falling back to a minimal direct Bot API call prevents dropping notifications when the platform endpoint is reachable.

## Validation
- `python -m pytest tests/cron/test_cron_script.py::TestRunJobScript::test_script_stdout_decodes_utf8_unicode tests/tools/test_send_message_telegram_proxy.py::TestSendTelegramStandaloneProxy::test_text_only_timeout_falls_back_to_direct_bot_api -q -o 'addopts='`
- `python -m pytest tests/cron/test_cron_script.py tests/tools/test_send_message_telegram_proxy.py -q -o 'addopts='`
