### PR TITLE
fix(moa): preserve Nous provider identity for references

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -86,9 +86,10 @@ def _slot_runtime(slot: dict[str, str]) -> dict[str, Any]:
         resolved_provider = str(rt.get("provider") or provider).strip().lower()
         # call_llm treats an explicit base_url as a custom endpoint. That is
         # correct for ordinary OpenAI-compatible targets, but wrong for OAuth /
-        # adapter-backed providers whose provider branch adds auth headers and
-        # request-shape adapters. Keep those providers identified by name.
-        if resolved_provider in {"openai-codex", "xai-oauth"}:
+        # provider-backed targets whose provider branch adds auth refresh,
+        # request metadata, or request-shape adapters. Keep those providers
+        # identified by name.
+        if resolved_provider in {"nous", "openai-codex", "xai-oauth"}:
             return out
         # Pass the resolved endpoint through so call_llm builds the request for
         # the provider's actual API surface instead of auto-detecting. base_url


### PR DESCRIPTION
## Summary
MoA Nous reference slots now run through the canonical `nous` provider path — preserving Nous Portal attribution tags, auth refresh, and accurate logs — instead of being pre-resolved into a bare `custom` endpoint.

Root cause: `_slot_runtime()` passed the resolved Nous `base_url`/`api_key` into `call_llm()`. Because `_resolve_task_provider_model()` forces `provider == "custom"` whenever a `base_url` is given, the call skipped the `provider == "nous"` branch in `_build_call_kwargs()` (which appends the portal tags) and logged `moa_reference custom ...` instead of `moa_reference nous ...`.

## Changes
- `agent/moa_loop.py`: add `nous` to the provider-identity preservation set alongside `openai-codex` and `xai-oauth`, so the slot is called by provider name and `call_llm` re-resolves the Nous runtime itself. Comment updated to reflect that these providers also carry auth refresh / request metadata, not just request-shape adapters.

## Validation
| | Before | After |
|---|---|---|
| `call_llm` sees provider | `custom` | `nous` |
| Nous Portal tags | dropped | present |
| Log line | `moa_reference custom …` | `moa_reference nous …` |
| OpenRouter / MiniMax slots | base_url passthrough | unchanged |

E2E: confirmed a Nous slot reaches `call_llm` as `provider="nous"` (portal tags fire), while OpenRouter/MiniMax slots still pass their base_url through unaffected. `py_compile` clean. Salvaged from #54002 (@helix4u) with authorship preserved.

## Infographic

![moa-nous-provider-identity](https://v3b.fal.media/files/b/0aa0119c/67usbCV66At0NELwfwb2__tfRDeRHW.png)
