### PR TITLE
fix(gateway): wire memory monitor

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -69,6 +69,9 @@ _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
+_GATEWAY_MEMORY_MONITOR_DEFAULT_ENABLED = True
+_GATEWAY_MEMORY_MONITOR_DEFAULT_INTERVAL_SECONDS = 300.0
+_GATEWAY_MEMORY_MONITOR_MIN_INTERVAL_SECONDS = 1.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
@@ -100,6 +103,84 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
 _GATEWAY_RAW_TEXT_PLATFORMS = frozenset(
     {"local", "api_server", "webhook", "msgraph_webhook"}
 )
+
+
+def _coerce_gateway_memory_monitor_enabled(value: Any, default: bool) -> bool:
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"0", "false", "no", "off", "disabled"}:
+            return False
+        if normalized in {"1", "true", "yes", "on", "enabled"}:
+            return True
+        return default
+    if value is None:
+        return default
+    return bool(value)
+
+
+def _coerce_gateway_memory_monitor_interval(value: Any) -> float:
+    try:
+        interval = float(value)
+    except (TypeError, ValueError):
+        return _GATEWAY_MEMORY_MONITOR_DEFAULT_INTERVAL_SECONDS
+    if interval < _GATEWAY_MEMORY_MONITOR_MIN_INTERVAL_SECONDS:
+        return _GATEWAY_MEMORY_MONITOR_DEFAULT_INTERVAL_SECONDS
+    return interval
+
+
+def _resolve_gateway_memory_monitor_config(
+    config: Optional[dict] = None,
+) -> tuple[bool, float]:
+    cfg = config if isinstance(config, dict) else _load_gateway_runtime_config()
+    monitor_cfg = cfg_get(cfg, "logging", "memory_monitor", default=None)
+
+    enabled = _GATEWAY_MEMORY_MONITOR_DEFAULT_ENABLED
+    interval_seconds = _GATEWAY_MEMORY_MONITOR_DEFAULT_INTERVAL_SECONDS
+
+    if isinstance(monitor_cfg, dict):
+        enabled = _coerce_gateway_memory_monitor_enabled(
+            monitor_cfg.get("enabled"),
+            enabled,
+        )
+        interval_seconds = _coerce_gateway_memory_monitor_interval(
+            monitor_cfg.get("interval_seconds", interval_seconds),
+        )
+    elif monitor_cfg is not None:
+        enabled = _coerce_gateway_memory_monitor_enabled(monitor_cfg, enabled)
+
+    return enabled, interval_seconds
+
+
+def _start_gateway_memory_monitor(config: Optional[dict] = None) -> bool:
+    enabled, interval_seconds = _resolve_gateway_memory_monitor_config(config)
+    if not enabled:
+        logger.debug("Gateway memory monitoring disabled by config")
+        return False
+    try:
+        from gateway.memory_monitor import start_memory_monitoring
+
+        return start_memory_monitoring(interval_seconds=interval_seconds)
+    except Exception as exc:
+        logger.warning("[MEMORY] Periodic memory monitoring failed to start: %s", exc)
+        return False
+
+
+def _stop_gateway_memory_monitor() -> None:
+    try:
+        from gateway.memory_monitor import stop_memory_monitoring
+
+        stop_memory_monitoring()
+    except Exception as exc:
+        logger.debug("Gateway memory monitoring stop failed: %s", exc)
+
+
+async def _wait_with_gateway_memory_monitor(runner: Any) -> None:
+    memory_monitor_started = _start_gateway_memory_monitor()
+    try:
+        await runner.wait_for_shutdown()
+    finally:
+        if memory_monitor_started:
+            _stop_gateway_memory_monitor()
 
 
 def _gateway_surface_passes_raw_text(platform: Any) -> bool:
@@ -21139,8 +21220,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     )
     housekeeping_thread.start()
     
-    # Wait for shutdown
-    await runner.wait_for_shutdown()
+    # Monitor only a fully running gateway, and always stop the monitor when
+    # the runner leaves its active lifetime.
+    await _wait_with_gateway_memory_monitor(runner)
 
     try:
         from hermes_cli.nous_auth_keepalive import stop_nous_auth_keepalive

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2852,6 +2852,10 @@ DEFAULT_CONFIG = {
         "level": "INFO",       # Minimum level for agent.log: DEBUG, INFO, WARNING
         "max_size_mb": 5,      # Max size per log file before rotation
         "backup_count": 3,     # Number of rotated backup files to keep
+        "memory_monitor": {
+            "enabled": True,
+            "interval_seconds": 300,
+        },
     },
 
     # Remotely-hosted model catalog manifest.  When enabled, the CLI fetches

--- a/tests/gateway/test_memory_monitor.py
+++ b/tests/gateway/test_memory_monitor.py
@@ -120,3 +120,108 @@ def test_unavailable_rss_warns_and_does_not_start(caplog, monkeypatch):
     assert started is False
     assert mm.is_running() is False
     assert any("Memory monitoring unavailable" in r.getMessage() for r in caplog.records)
+
+
+def test_default_config_enables_gateway_memory_monitor():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    monitor_cfg = DEFAULT_CONFIG["logging"]["memory_monitor"]
+    assert monitor_cfg["enabled"] is True
+    assert monitor_cfg["interval_seconds"] == 300
+
+
+def test_gateway_memory_monitor_config_defaults_enabled():
+    from gateway.run import _resolve_gateway_memory_monitor_config
+
+    assert _resolve_gateway_memory_monitor_config({}) == (True, 300.0)
+
+
+def test_gateway_memory_monitor_config_can_disable():
+    from gateway.run import _resolve_gateway_memory_monitor_config
+
+    cfg = {"logging": {"memory_monitor": {"enabled": False, "interval_seconds": 30}}}
+    assert _resolve_gateway_memory_monitor_config(cfg) == (False, 30.0)
+
+
+def test_gateway_memory_monitor_config_falls_back_for_bad_interval():
+    from gateway.run import _resolve_gateway_memory_monitor_config
+
+    cfg = {"logging": {"memory_monitor": {"enabled": True, "interval_seconds": 0}}}
+    assert _resolve_gateway_memory_monitor_config(cfg) == (True, 300.0)
+
+
+def test_start_gateway_memory_monitor_passes_config_interval(monkeypatch):
+    from gateway.run import _start_gateway_memory_monitor
+
+    calls = []
+    monkeypatch.setattr(
+        mm,
+        "start_memory_monitoring",
+        lambda interval_seconds: calls.append(interval_seconds) or True,
+    )
+
+    cfg = {"logging": {"memory_monitor": {"enabled": True, "interval_seconds": 42}}}
+    assert _start_gateway_memory_monitor(cfg) is True
+    assert calls == [42.0]
+
+
+def test_start_gateway_memory_monitor_skips_disabled_config(monkeypatch):
+    from gateway.run import _start_gateway_memory_monitor
+
+    calls = []
+    monkeypatch.setattr(
+        mm,
+        "start_memory_monitoring",
+        lambda interval_seconds: calls.append(interval_seconds) or True,
+    )
+
+    cfg = {"logging": {"memory_monitor": {"enabled": False, "interval_seconds": 42}}}
+    assert _start_gateway_memory_monitor(cfg) is False
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_gateway_memory_monitor_tracks_running_lifetime(monkeypatch):
+    from gateway.run import _wait_with_gateway_memory_monitor
+
+    events = []
+
+    class Runner:
+        async def wait_for_shutdown(self):
+            events.append("wait")
+
+    monkeypatch.setattr(
+        "gateway.run._start_gateway_memory_monitor",
+        lambda: events.append("start") or True,
+    )
+    monkeypatch.setattr(
+        "gateway.run._stop_gateway_memory_monitor",
+        lambda: events.append("stop"),
+    )
+
+    await _wait_with_gateway_memory_monitor(Runner())
+
+    assert events == ["start", "wait", "stop"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_memory_monitor_stops_when_shutdown_wait_fails(monkeypatch):
+    from gateway.run import _wait_with_gateway_memory_monitor
+
+    stopped = False
+
+    class Runner:
+        async def wait_for_shutdown(self):
+            raise RuntimeError("shutdown wait failed")
+
+    def stop_monitor():
+        nonlocal stopped
+        stopped = True
+
+    monkeypatch.setattr("gateway.run._start_gateway_memory_monitor", lambda: True)
+    monkeypatch.setattr("gateway.run._stop_gateway_memory_monitor", stop_monitor)
+
+    with pytest.raises(RuntimeError, match="shutdown wait failed"):
+        await _wait_with_gateway_memory_monitor(Runner())
+
+    assert stopped is True

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -250,6 +250,7 @@ async def test_startup_aborts_after_registered_adapter_restart(tmp_path, monkeyp
 async def test_start_gateway_does_not_start_cron_after_aborted_startup(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     cron_started = False
+    memory_monitor_started = False
 
     class AbortedStartupRunner:
         def __init__(self, config):
@@ -271,6 +272,10 @@ async def test_start_gateway_does_not_start_cron_after_aborted_startup(tmp_path,
         nonlocal cron_started
         cron_started = True
 
+    def fail_if_memory_monitor_starts(*args, **kwargs):
+        nonlocal memory_monitor_started
+        memory_monitor_started = True
+
     monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
     monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
     monkeypatch.setattr("gateway.status.write_pid_file", lambda: None)
@@ -280,6 +285,10 @@ async def test_start_gateway_does_not_start_cron_after_aborted_startup(tmp_path,
     monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: None)
     monkeypatch.setattr("gateway.run.GatewayRunner", AbortedStartupRunner)
     monkeypatch.setattr("gateway.run._start_cron_ticker", fail_if_cron_starts)
+    monkeypatch.setattr(
+        "gateway.run._start_gateway_memory_monitor",
+        fail_if_memory_monitor_starts,
+    )
     monkeypatch.setattr("tools.mcp_tool.shutdown_mcp_servers", lambda: None)
 
     with pytest.raises(SystemExit) as exc:
@@ -287,3 +296,4 @@ async def test_start_gateway_does_not_start_cron_after_aborted_startup(tmp_path,
 
     assert exc.value.code == GATEWAY_SERVICE_RESTART_EXIT_CODE
     assert cron_started is False
+    assert memory_monitor_started is False


### PR DESCRIPTION
Summary
- Enable periodic gateway RSS, GC, and thread-count logging through logging.memory_monitor.
- Start monitoring only after the gateway runner reaches active mode.
- Stop monitoring in a guaranteed cleanup path when the runner leaves its active lifetime.
- Preserve current main's cooperative cron and housekeeping shutdown so in-flight delivery can finish without blocking the event loop.
- Add coverage for configuration, start/stop lifecycle, failure cleanup, and aborted startup.

Problem
The memory monitor module existed but the gateway never started it, so long-running processes had no baseline or periodic memory timeline. Lifecycle wiring also had to avoid starting background work for an aborted startup and avoid restoring synchronous thread joins that can drop in-flight delivery.

Validation
- 23 focused memory-monitor and startup-race tests passed
- Ruff passed for all changed Python files
- git diff --check passed
- attribution and wording scans passed

Refs #53995