### PR TITLE
fix(agent): resolve MoA preset to its aggregator for auxiliary tasks

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3548,6 +3548,55 @@ def _resolve_auto(
     if not runtime_api_mode and _RUNTIME_MAIN_API_MODE:
         runtime_api_mode = _RUNTIME_MAIN_API_MODE
 
+    # ── MoA preset → aggregator resolution ──────────────────────────────
+    # When the main "provider" is the MoA virtual provider, the main
+    # "model" is a *preset name* (e.g. "local-moa-minimal"), NOT a model ID
+    # any real endpoint accepts. Auxiliary tasks (title generation,
+    # compression, vision, …) issue a single ordinary chat call and cannot
+    # run a MoA reference→aggregator loop, so passing the preset name through
+    # Step 1 yields HTTP 400 "<preset> is not a valid model ID". Resolve the
+    # preset to its aggregator's real (provider, model) — the aggregator is
+    # the callable backend that writes the final response in a MoA turn, so
+    # routing aux calls there keeps behavior (and locality/sovereignty)
+    # aligned with the active preset instead of falling back to a cloud
+    # default.
+    _main_prov_lc = str(runtime_provider or _read_main_provider() or "").strip().lower()
+    if _main_prov_lc == "moa":
+        try:
+            from hermes_cli.config import load_config
+            from hermes_cli.moa_config import resolve_moa_preset
+
+            _preset_name = runtime_model or _read_main_model() or ""
+            _moa_cfg = (load_config() or {}).get("moa") or {}
+            _preset = resolve_moa_preset(_moa_cfg, _preset_name or None)
+            _agg = _preset.get("aggregator") if isinstance(_preset, dict) else None
+            _agg_provider = str((_agg or {}).get("provider") or "").strip()
+            _agg_model = str((_agg or {}).get("model") or "").strip()
+            if _agg_provider and _agg_model:
+                logger.info(
+                    "Auxiliary auto-detect: MoA preset %r → aggregator %s (%s)",
+                    _preset_name or "default", _agg_provider, _agg_model,
+                )
+                runtime_provider = _agg_provider
+                runtime_model = _agg_model
+                # The aggregator's provider carries its own base_url/api_key
+                # resolution (named custom: providers included), so drop any
+                # MoA-level runtime credentials that don't apply to it.
+                runtime_base_url = ""
+                runtime_api_key = ""
+                runtime_api_mode = ""
+            else:
+                # Preset has no usable aggregator slot — skip Step 1 entirely
+                # rather than 400 on the preset name. Fall through to the
+                # configured fallback / aggregator chain below.
+                runtime_provider = "auto"
+                runtime_model = ""
+        except Exception as exc:
+            logger.debug("Auxiliary client: MoA preset resolution failed (%s); "
+                         "skipping main-provider Step 1", exc)
+            runtime_provider = "auto"
+            runtime_model = ""
+
     # ── Warn once if OPENAI_BASE_URL is set but config.yaml uses a named
     #    provider (not 'custom').  This catches the common "env poisoning"
     #    scenario where a user switches providers via `hermes model` but the

--- a/tests/agent/test_aux_moa_preset_resolution.py
+++ b/tests/agent/test_aux_moa_preset_resolution.py
@@ -1,0 +1,117 @@
+"""Regression: auxiliary client must resolve a MoA preset to its aggregator.
+
+Bug: when the active main model is a MoA preset (provider="moa",
+model="<preset-name>"), auxiliary side-tasks (title generation, compression,
+vision) passed the *preset name* straight through as a model ID, producing
+HTTP 400 "<preset> is not a valid model ID".
+
+Fix lives in agent.auxiliary_client._resolve_auto: a "moa" main provider is
+rewritten to the preset's aggregator (provider, model) before Step-1 builds a
+client. These tests exercise the real _resolve_auto with resolve_provider_client
+stubbed, asserting the (provider, model) actually handed to the router.
+"""
+
+import pytest
+
+import agent.auxiliary_client as ac
+
+
+@pytest.fixture(autouse=True)
+def _clear_runtime():
+    ac.clear_runtime_main()
+    yield
+    ac.clear_runtime_main()
+
+
+def _capture_resolver(monkeypatch):
+    """Stub resolve_provider_client; record the (provider, model) it receives."""
+    calls = []
+
+    def fake_resolve(provider, model, **kwargs):
+        calls.append({"provider": provider, "model": model, "kwargs": kwargs})
+        # Return a truthy sentinel client so Step-1 "wins" and returns.
+        return object(), model
+
+    monkeypatch.setattr(ac, "resolve_provider_client", fake_resolve)
+    # Neutralize the unhealthy-cache short-circuit so Step-1 always runs.
+    monkeypatch.setattr(ac, "_is_provider_unhealthy", lambda *_a, **_k: False)
+    return calls
+
+
+def _fake_config(monkeypatch, cfg):
+    # Patch load_config in BOTH the config module and the auxiliary_client's
+    # late-imported reference path. _resolve_auto does
+    # `from hermes_cli.config import load_config` at call time, so patching the
+    # source attribute is what matters.
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+
+
+def test_moa_preset_resolves_to_aggregator(monkeypatch):
+    calls = _capture_resolver(monkeypatch)
+    cfg = {
+        "model": {"provider": "moa", "default": "local-moa-minimal"},
+        "moa": {
+            "default_preset": "local-moa-minimal",
+            "presets": {
+                "local-moa-minimal": {
+                    "reference_models": [
+                        {"provider": "custom:ollama-local", "model": "qwen2.5:7b-instruct"}
+                    ],
+                    "aggregator": {
+                        "provider": "custom:qwen3.6-35b-nvfp4",
+                        "model": "nvidia/Qwen3.6-35B-A3B-NVFP4",
+                    },
+                }
+            },
+        },
+    }
+    _fake_config(monkeypatch, cfg)
+    ac.set_runtime_main("moa", "local-moa-minimal")
+
+    client, model = ac._resolve_auto(task="title_generation")
+
+    assert client is not None
+    # The preset name must NOT be used as a model id.
+    assert model != "local-moa-minimal"
+    assert model == "nvidia/Qwen3.6-35B-A3B-NVFP4"
+    assert calls, "resolve_provider_client was never called"
+    assert calls[0]["provider"] == "custom:qwen3.6-35b-nvfp4"
+    assert calls[0]["model"] == "nvidia/Qwen3.6-35B-A3B-NVFP4"
+    # No call should ever carry the bare preset name as the model id.
+    assert all(c["model"] != "local-moa-minimal" for c in calls)
+
+
+def test_moa_preset_without_aggregator_skips_step1(monkeypatch):
+    """A preset whose aggregator slot is empty must fall through, not 400."""
+    calls = _capture_resolver(monkeypatch)
+    # Force the fallback chain to yield nothing so we can assert Step-1 was
+    # skipped (no resolver call carrying the preset name).
+    monkeypatch.setattr(ac, "_try_configured_fallback_chain",
+                        lambda *_a, **_k: (None, None, None))
+    monkeypatch.setattr(ac, "_try_main_fallback_chain",
+                        lambda *_a, **_k: (None, None, None))
+    monkeypatch.setattr(ac, "_get_provider_chain", lambda: [])
+
+    cfg = {
+        "model": {"provider": "moa", "default": "broken-preset"},
+        "moa": {
+            "default_preset": "broken-preset",
+            "presets": {
+                "broken-preset": {
+                    "reference_models": [
+                        {"provider": "custom:ollama-local", "model": "qwen2.5:7b-instruct"}
+                    ],
+                    # aggregator missing → normalize fills DEFAULT_MOA_AGGREGATOR,
+                    # so to truly test "no aggregator" we blank it post-resolve.
+                    "aggregator": {"provider": "", "model": ""},
+                }
+            },
+        },
+    }
+    _fake_config(monkeypatch, cfg)
+    ac.set_runtime_main("moa", "broken-preset")
+
+    client, model = ac._resolve_auto(task="title_generation")
+
+    # Either way, the bare preset name must never reach the router as a model.
+    assert all(c["model"] != "broken-preset" for c in calls)


### PR DESCRIPTION
## Summary

When the active main model is a **Mixture-of-Agents preset**, auxiliary
side-tasks (title generation, context compression, vision) fail with:

```
HTTP 400: <preset-name> is not a valid model ID
```

The visible symptom is `⚠ Auxiliary title generation failed`, but the same
code path backs compression and vision, so they fail identically while a MoA
preset is active.

## Root cause

For a MoA preset the main "provider" is the virtual `moa` provider and the
main "model" is a **preset name** (e.g. `local-moa-minimal`), not a model ID
any real endpoint accepts.

`agent/auxiliary_client.py::_resolve_auto` Step 1 reuses the main
provider+model for side tasks. Auxiliary tasks issue a single ordinary chat
completion — they cannot run a MoA reference→aggregator loop — so the preset
name was passed straight through as the model ID and the upstream API
rejected it with a 400.

## Fix

In `_resolve_auto`, when the main provider is `moa`, resolve the preset to its
**aggregator's** real `(provider, model)` via
`hermes_cli.moa_config.resolve_moa_preset`, and route the auxiliary call to the
aggregator. The aggregator is the callable backend that writes the final
response in a MoA turn, so auxiliary tasks stay aligned with the active preset
(including locality, when the aggregator is a local/custom provider) instead of
silently falling back to a cloud default.

If the preset has no usable aggregator slot, or resolution raises, Step 1 is
skipped so the normal fallback chain runs — rather than 400-ing on the preset
name.

One implementation note worth flagging for reviewers: `resolve_moa_preset()`
expects the `moa` **sub-dict**, not the whole config object. Passing the whole
config makes `normalize_moa_config` find no top-level `presets` key and
synthesize a single legacy `default` preset.

## Tests

Adds `tests/agent/test_aux_moa_preset_resolution.py`:

- `test_moa_preset_resolves_to_aggregator` — asserts the resolver receives the
  aggregator's real model ID and never the bare preset name.
- `test_moa_preset_without_aggregator_skips_step1` — asserts the preset name is
  never handed to the router as a model id when no aggregator is usable.

### Verification

Run via the canonical runner:

```
scripts/run_tests.sh tests/agent/test_aux_moa_preset_resolution.py   # 2 passed
scripts/run_tests.sh tests/agent/                                    # 193 files, 4641 passed, 0 failed
```

The full `tests/agent/` suite (which includes `test_auxiliary_client.py`) stays
green with the change.

## Scope / caching

Single chokepoint in `_resolve_auto`, so the fix covers every auxiliary task
(title, compression, vision) at once. No change to main-loop behavior, prompt
caching, message alternation, or system-prompt stability — the change only
affects how the auxiliary client selects a backend when the main provider is
`moa`.
