### PR TITLE
fix(install): override Playwright platform on too-new apt releases (#35166)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1891,6 +1891,69 @@ run_browser_install_with_timeout() {
     fi
 }
 
+# Export PLAYWRIGHT_HOST_PLATFORM_OVERRIDE only on apt-based releases that
+# Playwright's platform resolver does NOT yet recognize, where the Chromium/deps
+# download otherwise stalls indefinitely — the "Installing Playwright Chromium
+# with system dependencies" hang reported in #35166.
+#
+# Playwright resolves the host to a CDN build in hostPlatform.ts. For Ubuntu (and
+# pop/neon/tuxedo, which share Ubuntu versions) it maps:
+#     major < 20 -> ubuntu18.04 ; <22 -> ubuntu20.04 ; <24 -> ubuntu22.04 ;
+#     <26 -> ubuntu24.04 ; >=26 -> "ubuntu<major.minor>" (NO build -> HANG).
+# For Debian: 11/12/13 are recognized; >=14 has no build -> HANG.
+#
+# Critically, releases Playwright already maps correctly (Ubuntu <26, Debian <14)
+# MUST be left alone: forcing ubuntu24.04 onto e.g. 22.04 pulls a Chromium built
+# against a newer glibc and breaks it ("version `GLIBC_2.36' not found",
+# microsoft/playwright#35114). So we override ONLY the too-new releases, and pin
+# them to the newest build Playwright actually ships (ubuntu24.04), which runs on
+# 26.04/Debian 14. An operator-provided value is always respected.
+maybe_export_playwright_platform_override() {
+    # Respect an explicit operator-provided value.
+    if [ -n "${PLAYWRIGHT_HOST_PLATFORM_OVERRIDE:-}" ]; then
+        return 0
+    fi
+
+    # Map the host CPU to Playwright's platform-arch suffix. Playwright only
+    # ships x64/arm64 Linux builds; leave anything else to resolve natively.
+    local arch_suffix
+    case "$(uname -m)" in
+        x86_64|amd64) arch_suffix="x64" ;;
+        aarch64|arm64) arch_suffix="arm64" ;;
+        *) return 0 ;;
+    esac
+
+    # VERSION_ID is sourced from /etc/os-release in detect_os(). Without a numeric
+    # version we can't tell whether the release is too new, so don't risk it.
+    local major
+    major="$(printf '%s' "${VERSION_ID:-}" | cut -d. -f1)"
+    case "$major" in
+        ''|*[!0-9]*) return 0 ;;
+    esac
+
+    local too_new=false
+    case "$DISTRO" in
+        ubuntu|pop|neon|tuxedo)
+            # Playwright has a build through ubuntu24.04 (covers majors 24,25).
+            if [ "$major" -ge 26 ]; then too_new=true; fi
+            ;;
+        debian)
+            # Playwright has builds debian11/12/13.
+            if [ "$major" -ge 14 ]; then too_new=true; fi
+            ;;
+        *)
+            # Other apt derivatives (Mint, Kali, Raspbian, Zorin, ...) have their
+            # own Playwright mappings; don't second-guess them.
+            return 0
+            ;;
+    esac
+
+    [ "$too_new" = true ] || return 0
+
+    export PLAYWRIGHT_HOST_PLATFORM_OVERRIDE="ubuntu24.04-${arch_suffix}"
+    log_info "Set PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=$PLAYWRIGHT_HOST_PLATFORM_OVERRIDE ($DISTRO $VERSION_ID is newer than Playwright recognizes; avoids the Chromium download hang)"
+}
+
 configure_browser_env_from_system_browser() {
     local env_file="$HERMES_HOME/.env"
     local browser_path="${DETECTED_BROWSER_EXECUTABLE:-}"
@@ -1961,7 +2024,12 @@ install_node_deps() {
             log_info "Skipping bundled Chromium download (AGENT_BROWSER_EXECUTABLE_PATH is set)."
         else
             case "$DISTRO" in
-                ubuntu|debian|raspbian|pop|linuxmint|elementary|zorin|kali|parrot)
+                ubuntu|debian|raspbian|pop|neon|tuxedo|linuxmint|elementary|zorin|kali|parrot)
+                    # Newer apt releases (e.g. Ubuntu 26.04, Debian 14) aren't
+                    # recognized by Playwright's platform resolver yet, which
+                    # makes the Chromium/deps download stall indefinitely
+                    # (#35166). Point it at the newest build Playwright ships.
+                    maybe_export_playwright_platform_override
                     # Use --with-deps only when sudo is available non-interactively
                     # (root, or a user with passwordless sudo). Non-sudo users
                     # — typical for systemd service accounts and unprivileged

--- a/tests/test_install_sh_browser_install.py
+++ b/tests/test_install_sh_browser_install.py
@@ -86,3 +86,31 @@ def test_install_script_skips_with_deps_when_no_sudo() -> None:
     # service-user installs (systemd accounts, operator users, etc.).
     assert 'if [ "$(id -u)" -eq 0 ] || (command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null); then' in text
     assert "sudo npx playwright install-deps chromium" in text
+
+
+def test_install_script_overrides_playwright_platform_on_newer_apt() -> None:
+    """Releases newer than Playwright's resolver knows (Ubuntu >=26, Debian >=14)
+    hang at the Chromium download (#35166). The installer must set
+    PLAYWRIGHT_HOST_PLATFORM_OVERRIDE to the newest build Playwright ships
+    (ubuntu24.04) on exactly those releases — and MUST NOT touch releases
+    Playwright already maps correctly, since forcing ubuntu24.04 onto an older
+    release pulls a newer-glibc Chromium that breaks (playwright#35114).
+    """
+    text = INSTALL_SH.read_text()
+
+    # The helper exists and is invoked from the apt branch before the
+    # playwright install calls.
+    assert "maybe_export_playwright_platform_override()" in text
+    assert "maybe_export_playwright_platform_override\n" in text
+    # It exports the override pointing at ubuntu24.04 with an arch suffix.
+    assert 'export PLAYWRIGHT_HOST_PLATFORM_OVERRIDE="ubuntu24.04-${arch_suffix}"' in text
+    # It must respect an operator-provided value rather than clobbering it.
+    assert 'if [ -n "${PLAYWRIGHT_HOST_PLATFORM_OVERRIDE:-}" ]; then' in text
+    # It must be version-scoped to the releases that actually hang, NOT applied
+    # to every apt distro — the thresholds mirror Playwright's hostPlatform.ts.
+    assert 'if [ "$major" -ge 26 ]; then too_new=true; fi' in text  # Ubuntu/pop/neon/tuxedo
+    assert 'if [ "$major" -ge 14 ]; then too_new=true; fi' in text  # Debian
+    # Non-numeric / missing VERSION_ID must be left to native resolution.
+    assert "${VERSION_ID:-}" in text
+
+


### PR DESCRIPTION
## What does this PR do?

Fixes the installer hanging forever at `Installing Playwright Chromium with system dependencies` on **Ubuntu 26.04 and Debian 14+** (reported in #35166, 7+ confirmations across Ubuntu 24.04/26.04 and Debian 13). Ctrl+C can't interrupt it because the GNU `timeout` child runs in its own process group.

**Root cause:** Playwright maps the host OS to a CDN build of Chromium + its system deps in `hostPlatform.ts`. For releases its resolver doesn't recognize yet — Ubuntu major ≥26, Debian major ≥14 — there is no build, so `npx playwright install --with-deps chromium` stalls indefinitely. The previously-attempted PR #35304 addressed only the *interruptibility* symptom (and was closed unmerged); it never fixed the hang itself.

**Fix:** A new `maybe_export_playwright_platform_override()` helper exports `PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-<arch>` on exactly the too-new apt releases, pointing them at the newest build Playwright actually ships — which runs fine on 26.04 / Debian 14. This is the community-confirmed workaround (`PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64`), applied automatically and safely.

### Why version-scoped (the important part)

Releases Playwright **already** maps correctly (Ubuntu ≤25, Debian ≤13) are deliberately left untouched. Forcing `ubuntu24.04` onto e.g. 22.04 would pull a Chromium built against a newer glibc and break it (`version 'GLIBC_2.36' not found`, microsoft/playwright#35114). The helper mirrors Playwright's own `hostPlatform.ts` thresholds:

- Ubuntu / Pop!_OS / KDE Neon / TUXEDO OS: override only when major ≥ 26
- Debian: override only when major ≥ 14
- An operator-set `PLAYWRIGHT_HOST_PLATFORM_OVERRIDE` is always respected (never clobbered)
- Missing / non-numeric `VERSION_ID`, non-x64/arm64 arch, and non-ubuntu/debian apt derivatives all no-op (native resolution)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh`: add `maybe_export_playwright_platform_override()`, invoked at the top of the apt case branch before both the `--with-deps` and the no-sudo browser-only `playwright install` invocations. Added `neon`/`tuxedo` to the apt case label so KDE Neon / TUXEDO OS (Ubuntu-based) get the same handling.
- `tests/test_install_sh_browser_install.py`: regression test asserting the helper exists, is version-scoped (Ubuntu ≥26 / Debian ≥14), points at `ubuntu24.04-${arch_suffix}`, and respects an operator-provided value.

## How to Test

1. `pytest tests/test_install_sh_browser_install.py -q` — 7 passed.
2. `bash -n scripts/install.sh` — syntax OK.
3. Behavioral: extract the helper and exercise it under controlled `DISTRO`/`VERSION_ID`/`uname -m`. Ubuntu ≥26 / Debian ≥14 → `ubuntu24.04-<arch>`; Ubuntu ≤25 / Debian ≤13 → unset; operator preset preserved; bad/missing version and non-x64/arm64 arch → unset.

## Related Issue

Refs #35166

## Checklist

- [x] I've read the Contributing Guide
- [x] Conventional Commit message (`fix(install):`)
- [x] Searched existing PRs for duplicates (none address the root cause)
- [x] Only changes related to this fix
- [x] `pytest` passes
- [x] Added a regression test
- [x] Considered cross-platform impact (Linux apt distros; no-ops elsewhere)
