### PR TITLE
test(docker): wait for cont-init to finish before privilege-drop shim tests (fixes flaky build-arm64)

### DIFF
--- a/tests/docker/test_docker_exec_privilege_drop.py
+++ b/tests/docker/test_docker_exec_privilege_drop.py
@@ -32,21 +32,52 @@ import pytest
 
 
 # How long to give a `docker run -d` container before declaring it not ready.
-_RUN_READY_TIMEOUT_S = 20
+# Generous because under arm64 QEMU emulation cont-init (a Python config
+# migration + chowns) runs several times slower than on native amd64.
+_RUN_READY_TIMEOUT_S = 60
 
 
-def _wait_for_init(container: str) -> None:
-    """Block until /init is up enough that `docker exec` is responsive."""
+def _wait_for_cont_init(container: str) -> None:
+    """Block until s6 cont-init has fully finished, not merely until
+    ``docker exec`` is responsive.
+
+    The earlier ``_wait_for_init`` only polled ``docker exec <c> true``,
+    which succeeds almost immediately on s6-overlay — long before the
+    ``01-hermes-setup`` cont-init hook (docker/stage2-hook.sh) has
+    finished seeding + ``chown hermes:hermes`` config.yaml and running the
+    Python config migration. A test that wipes config.yaml and then writes
+    it as root would then race that boot-time chown: on native amd64
+    stage2-hook wins in a blink and the test always passed, but under arm64
+    QEMU emulation the slow Python migration was still in flight and
+    clobbered the root-written file's ownership back to hermes:hermes,
+    failing ``test_shim_opt_out_keeps_root`` non-deterministically.
+
+    The reliable "cont-init is done" signal is
+    ``$HERMES_HOME/logs/container-boot.log``: it is written by
+    ``02-reconcile-profiles`` (hermes_cli.container_boot), which s6 runs
+    *strictly after* ``01-hermes-setup`` in lexicographic order. The
+    reconciler always logs at least one ``profile=default`` line even for a
+    bare ``sleep infinity`` container, so once that marker appears every
+    stage2-hook side effect (seed, chown, migrate) is guaranteed complete.
+    Mirrors the readiness pattern in test_container_restart.py.
+    """
     deadline = time.monotonic() + _RUN_READY_TIMEOUT_S
+    last = ""
     while time.monotonic() < deadline:
         r = subprocess.run(
-            ["docker", "exec", container, "true"],
-            capture_output=True, timeout=5,
+            ["docker", "exec", container,
+             "cat", "/opt/data/logs/container-boot.log"],
+            capture_output=True, text=True, timeout=5,
         )
         if r.returncode == 0:
-            return
+            last = r.stdout
+            if "profile=default" in last:
+                return
         time.sleep(0.2)
-    pytest.fail(f"container {container} not responsive to docker exec within {_RUN_READY_TIMEOUT_S}s")
+    pytest.fail(
+        f"container {container} did not finish cont-init within "
+        f"{_RUN_READY_TIMEOUT_S}s (container-boot.log so far: {last!r})"
+    )
 
 
 @pytest.fixture
@@ -63,7 +94,7 @@ def sleep_container(built_image: str, container_name: str) -> Iterator[str]:
     )
     assert r.returncode == 0, f"docker run failed: {r.stderr}"
     try:
-        _wait_for_init(container_name)
+        _wait_for_cont_init(container_name)
         yield container_name
     finally:
         subprocess.run(


### PR DESCRIPTION
## Summary

Fixes the non-deterministic **`build-arm64`** failure in the Docker CI job where `tests/docker/test_docker_exec_privilege_drop.py::test_shim_opt_out_keeps_root` intermittently fails with:

```
AssertionError: With HERMES_DOCKER_EXEC_AS_ROOT=1, expected root:root, got 'hermes:hermes'
```

`build-amd64` is unaffected. This is a **test-only timing race** — no production code changes.

## Root cause

The `sleep_container` fixture released the test as soon as `docker exec <c> true` returned `0`. On s6-overlay that succeeds **almost immediately** — measured at **~0.05s** — long before the `01-hermes-setup` cont-init hook (`docker/stage2-hook.sh`) has finished:

- seeding `config.yaml`,
- **`chown hermes:hermes config.yaml`** (unconditional, every boot — `stage2-hook.sh:328`),
- running the Python config migration (`docker_config_migrate.py`).

Measured on emulated arm64, cont-init only **fully settles at ~9.8s**, leaving a **~10s window** in which the fixture had already handed control to the test.

`test_shim_opt_out_keeps_root` does: wipe `config.yaml` → write it **as root** (`HERMES_DOCKER_EXEC_AS_ROOT=1`) → assert `root:root`. When the test runs inside that ~10s window, stage2-hook's boot-time `chown hermes:hermes` lands on top of the root-written file and resets it to `hermes:hermes` → assertion fails.

The window is invisible on native amd64 (stage2-hook completes in a blink) but wide open under the arm64 image's **QEMU emulation**, which is exactly why only `build-arm64` flaked.

### Evidence (emulated arm64, this host)

| Signal | When |
|---|---|
| old wait (`docker exec true` returns 0) | **~0.05s** |
| cont-init actually finished (`container-boot.log` written) | **~9.8s** |
| **race window** | **~9.8s** |

## Fix

Replace the responsiveness poll with a wait on the canonical **"cont-init finished"** signal: `$HERMES_HOME/logs/container-boot.log` gaining a `profile=default` line. That log is written by `02-reconcile-profiles` (`hermes_cli.container_boot`), which s6 runs **strictly after** `01-hermes-setup` in lexicographic order — so once it appears, every stage2-hook side effect (seed, chown, migrate) is guaranteed complete. The reconciler always logs at least the `profile=default` line, even for a bare `sleep infinity` container.

This mirrors the readiness pattern already used in `tests/docker/test_container_restart.py`. Readiness timeout bumped 20s → 60s to cover slow emulation.

## Validation

- All 11 tests in `test_docker_exec_privilege_drop.py` pass against the amd64 harness image.
- `test_shim_opt_out_keeps_root` passes against the **emulated arm64** image with the new wait.
- Gap probe (above) proves the old wait released the test ~9.8s before cont-init finished — the exact window the fix now closes.

## Infographic

> Decorative — details are illustrative, not exact (the 52%/100% pass-rate figures are made up for the visual).

![arm64-ci-race-fixed](https://v3b.fal.media/files/b/0aa013b9/q7RX3hDtLWLvxudXpVAbS_bp27BAcv.png)
