### PR TITLE
fix(qqbot): accept is_reconnect kwarg in QQAdapter.connect

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,8 +278,14 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
-        """Authenticate, obtain gateway URL, and open the WebSocket."""
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """Authenticate, obtain gateway URL, and open the WebSocket.
+
+        ``is_reconnect`` is part of the BasePlatformAdapter.connect contract:
+        the gateway's reconnect loop calls ``connect(is_reconnect=True)``. The
+        QQ adapter establishes a fresh WebSocket session either way, so the
+        flag is accepted for signature compatibility but not otherwise used.
+        """
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
             self._set_fatal_error("qq_missing_dependency", message, retryable=True)

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -190,6 +190,31 @@ class TestVoiceAttachmentSSRFProtection:
         assert kwargs.get("follow_redirects") is True
         assert kwargs.get("event_hooks", {}).get("response") == [_ssrf_redirect_guard]
 
+    def test_connect_accepts_is_reconnect_kwarg(self):
+        """The gateway reconnect loop calls ``connect(is_reconnect=True)``.
+
+        BasePlatformAdapter.connect declares ``is_reconnect`` as a keyword
+        argument and gateway.run forwards it on every reconnect attempt, so
+        every adapter must accept it. Regression test for a TypeError
+        ("unexpected keyword argument 'is_reconnect'") that broke QQ
+        reconnection entirely.
+        """
+        import inspect
+        from gateway.platforms.qqbot import QQAdapter
+
+        sig = inspect.signature(QQAdapter.connect)
+        assert "is_reconnect" in sig.parameters
+
+        client = mock.AsyncMock()
+        with mock.patch("gateway.platforms.qqbot.adapter.httpx.AsyncClient", return_value=client):
+            adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+            adapter._ensure_token = mock.AsyncMock(side_effect=RuntimeError("stop after client creation"))
+
+            # Must not raise TypeError on the reconnect call path.
+            connected = asyncio.run(adapter.connect(is_reconnect=True))
+
+        assert connected is False
+
 
 # ---------------------------------------------------------------------------
 # WebSocket proxy handling


### PR DESCRIPTION
## Summary

The gateway reconnect loop calls `adapter.connect(is_reconnect=True)` (`gateway/run.py` forwards the flag on every retry via `_connect_adapter`), and the `BasePlatformAdapter.connect` contract declares `is_reconnect` as a keyword argument. Every other adapter (telegram, slack, signal, discord, …) accepts it — but `QQAdapter.connect` omitted it.

As a result, the first reconnect attempt after a dropped QQ connection raised:

```
QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

and QQ never recovered — the gateway kept retrying with exponential backoff (60s → 120s → 240s → 300s) and the bot stayed offline. Observed in the wild on a live QQ bot deployment.

## Fix

Add `*, is_reconnect: bool = False` to `QQAdapter.connect` to match the base-class contract. The QQ adapter establishes a fresh WebSocket session on both cold start and reconnect, so the flag is accepted for signature compatibility but not otherwise used (documented in the docstring).

## Test

Adds `test_connect_accepts_is_reconnect_kwarg` which asserts the signature exposes `is_reconnect` and that `connect(is_reconnect=True)` does not raise `TypeError` on the reconnect path.

```
tests/gateway/test_qqbot.py::TestVoiceAttachmentSSRFProtection::test_connect_uses_redirect_guard_hook PASSED
tests/gateway/test_qqbot.py::TestVoiceAttachmentSSRFProtection::test_connect_accepts_is_reconnect_kwarg PASSED
```