### PR TITLE
fix(send_message): reuse live gateway adapter for Matrix media sends (#46310)

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -913,6 +913,145 @@ class TestSendToPlatformChunking:
         ]
 
 
+class TestMatrixMediaLiveAdapterReuse:
+    """Verify _send_matrix_via_adapter reuses the live gateway adapter
+    when available, avoiding per-message E2EE re-init storms (#46310)."""
+
+    def test_live_adapter_skips_connect_disconnect(self, tmp_path):
+        """When a live gateway adapter exists, no connect() or disconnect()
+        should be called — the persistent E2EE session is reused."""
+        img_path = tmp_path / "photo.png"
+        img_path.write_bytes(b"\x89PNG\r\n")
+
+        calls = []
+
+        class LiveAdapter:
+            async def send(self, chat_id, message, metadata=None):
+                calls.append(("send", chat_id, message))
+                return SimpleNamespace(success=True, message_id="$text")
+
+            async def send_image_file(self, chat_id, path, metadata=None):
+                calls.append(("send_image_file", chat_id, path))
+                return SimpleNamespace(success=True, message_id="$img")
+
+        live_adapter = LiveAdapter()
+        fake_runner = SimpleNamespace(
+            adapters={Platform.MATRIX: live_adapter}
+        )
+
+        with patch(
+            "gateway.run._gateway_runner_ref",
+            return_value=fake_runner,
+        ), patch.dict(
+            sys.modules, {"gateway.platforms.matrix": SimpleNamespace()}
+        ):
+            result = asyncio.run(
+                _send_matrix_via_adapter(
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "!room:example.com",
+                    "here is an image",
+                    media_files=[(str(img_path), False)],
+                )
+            )
+
+        assert result["success"] is True
+        assert result["message_id"] == "$img"
+        # Only send + send_image_file; no connect / disconnect
+        assert calls == [
+            ("send", "!room:example.com", "here is an image"),
+            ("send_image_file", "!room:example.com", str(img_path)),
+        ]
+
+    def test_live_adapter_not_available_falls_back_to_ephemeral(self, tmp_path):
+        """When _gateway_runner_ref returns None, the ephemeral adapter
+        path (connect + disconnect) is used as before."""
+        doc_path = tmp_path / "doc.pdf"
+        doc_path.write_bytes(b"%PDF-1.4")
+
+        calls = []
+
+        class EphemeralAdapter:
+            def __init__(self, _config):
+                pass
+
+            async def connect(self):
+                calls.append(("connect",))
+                return True
+
+            async def send(self, chat_id, message, metadata=None):
+                calls.append(("send", chat_id, message))
+                return SimpleNamespace(success=True, message_id="$txt")
+
+            async def send_document(self, chat_id, path, metadata=None):
+                calls.append(("send_document", chat_id, path))
+                return SimpleNamespace(success=True, message_id="$doc")
+
+            async def disconnect(self):
+                calls.append(("disconnect",))
+
+        fake_module = SimpleNamespace(MatrixAdapter=EphemeralAdapter)
+
+        with patch(
+            "gateway.run._gateway_runner_ref", return_value=None
+        ), patch.dict(sys.modules, {"gateway.platforms.matrix": fake_module}):
+            result = asyncio.run(
+                _send_matrix_via_adapter(
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "!room:example.com",
+                    "report attached",
+                    media_files=[(str(doc_path), False)],
+                )
+            )
+
+        assert result["success"] is True
+        assert calls == [
+            ("connect",),
+            ("send", "!room:example.com", "report attached"),
+            ("send_document", "!room:example.com", str(doc_path)),
+            ("disconnect",),
+        ]
+
+    def test_live_adapter_no_matrix_adapter_falls_back(self):
+        """When the runner exists but has no Matrix adapter registered,
+        fall back to ephemeral."""
+        calls = []
+
+        class EphemeralAdapter:
+            def __init__(self, _config):
+                pass
+
+            async def connect(self):
+                calls.append(("connect",))
+                return True
+
+            async def send(self, chat_id, message, metadata=None):
+                calls.append(("send",))
+                return SimpleNamespace(success=True, message_id="$txt")
+
+            async def disconnect(self):
+                calls.append(("disconnect",))
+
+        # Runner exists but adapters dict has no MATRIX key
+        fake_runner = SimpleNamespace(adapters={})
+        fake_module = SimpleNamespace(MatrixAdapter=EphemeralAdapter)
+
+        with patch(
+            "gateway.run._gateway_runner_ref",
+            return_value=fake_runner,
+        ), patch.dict(sys.modules, {"gateway.platforms.matrix": fake_module}):
+            result = asyncio.run(
+                _send_matrix_via_adapter(
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "!room:example.com",
+                    "hello",
+                )
+            )
+
+        assert result["success"] is True
+        assert ("connect",) in calls
+        assert ("disconnect",) in calls
+
+
 # ---------------------------------------------------------------------------
 # HTML auto-detection in Telegram send
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -943,7 +943,7 @@ class TestMatrixMediaLiveAdapterReuse:
             "gateway.run._gateway_runner_ref",
             return_value=fake_runner,
         ), patch.dict(
-            sys.modules, {"gateway.platforms.matrix": SimpleNamespace()}
+            sys.modules, {"plugins.platforms.matrix.adapter": SimpleNamespace()}
         ):
             result = asyncio.run(
                 _send_matrix_via_adapter(
@@ -993,7 +993,7 @@ class TestMatrixMediaLiveAdapterReuse:
 
         with patch(
             "gateway.run._gateway_runner_ref", return_value=None
-        ), patch.dict(sys.modules, {"gateway.platforms.matrix": fake_module}):
+        ), patch.dict(sys.modules, {"plugins.platforms.matrix.adapter": fake_module}):
             result = asyncio.run(
                 _send_matrix_via_adapter(
                     SimpleNamespace(enabled=True, token="tok", extra={}),
@@ -1038,7 +1038,7 @@ class TestMatrixMediaLiveAdapterReuse:
         with patch(
             "gateway.run._gateway_runner_ref",
             return_value=fake_runner,
-        ), patch.dict(sys.modules, {"gateway.platforms.matrix": fake_module}):
+        ), patch.dict(sys.modules, {"plugins.platforms.matrix.adapter": fake_module}):
             result = asyncio.run(
                 _send_matrix_via_adapter(
                     SimpleNamespace(enabled=True, token="tok", extra={}),

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1468,56 +1468,50 @@ async def _send_signal(extra, chat_id, message, media_files=None):
 
 
 async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, thread_id=None):
-    """Send via the Matrix adapter so native Matrix media uploads are preserved."""
+    """Send via the Matrix adapter so native Matrix media uploads are preserved.
+
+    When a live gateway adapter is available (i.e. the tool runs inside a
+    running gateway), the persistent connection is reused — one olm/megolm
+    session for all sends.  This avoids per-message E2EE re-init storms
+    that exhaust recipient OTKs and silently drop messages (issue #46310).
+
+    Falls back to an ephemeral connect/disconnect cycle only when no gateway
+    is running (standalone cron, ``hermes send`` CLI).
+    """
+    media_files = media_files or []
+    metadata = {"thread_id": thread_id} if thread_id else None
+
+    # --- Try the live gateway adapter first (persistent E2EE session) ---
+    live_adapter = None
+    try:
+        from gateway.config import Platform
+        from gateway.run import _gateway_runner_ref
+
+        runner = _gateway_runner_ref()
+        if runner is not None:
+            live_adapter = runner.adapters.get(Platform.MATRIX)
+    except Exception:
+        live_adapter = None
+
+    if live_adapter is not None:
+        return await _send_via_matrix_adapter(
+            live_adapter, chat_id, message, media_files, metadata
+        )
+
+    # --- Fallback: ephemeral adapter (standalone / cron context) ---
     try:
         from plugins.platforms.matrix.adapter import MatrixAdapter
     except ImportError:
         return {"error": "Matrix dependencies not installed. Run: pip install 'mautrix[encryption]'"}
 
-    media_files = media_files or []
-
+    adapter = MatrixAdapter(pconfig)
     try:
-        adapter = MatrixAdapter(pconfig)
         connected = await adapter.connect()
         if not connected:
             return _error("Matrix connect failed")
-
-        metadata = {"thread_id": thread_id} if thread_id else None
-        last_result = None
-
-        if message.strip():
-            last_result = await adapter.send(chat_id, message, metadata=metadata)
-            if not last_result.success:
-                return _error(f"Matrix send failed: {last_result.error}")
-
-        for media_path, is_voice in media_files:
-            if not os.path.exists(media_path):
-                return _error(f"Media file not found: {media_path}")
-
-            ext = os.path.splitext(media_path)[1].lower()
-            if ext in _IMAGE_EXTS:
-                last_result = await adapter.send_image_file(chat_id, media_path, metadata=metadata)
-            elif ext in _VIDEO_EXTS:
-                last_result = await adapter.send_video(chat_id, media_path, metadata=metadata)
-            elif ext in _VOICE_EXTS and is_voice:
-                last_result = await adapter.send_voice(chat_id, media_path, metadata=metadata)
-            elif ext in _AUDIO_EXTS:
-                last_result = await adapter.send_voice(chat_id, media_path, metadata=metadata)
-            else:
-                last_result = await adapter.send_document(chat_id, media_path, metadata=metadata)
-
-            if not last_result.success:
-                return _error(f"Matrix media send failed: {last_result.error}")
-
-        if last_result is None:
-            return {"error": "No deliverable text or media remained after processing MEDIA tags"}
-
-        return {
-            "success": True,
-            "platform": "matrix",
-            "chat_id": chat_id,
-            "message_id": last_result.message_id,
-        }
+        return await _send_via_matrix_adapter(
+            adapter, chat_id, message, media_files, metadata
+        )
     except Exception as e:
         return _error(f"Matrix send failed: {e}")
     finally:
@@ -1525,6 +1519,45 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
             await adapter.disconnect()
         except Exception:
             pass
+
+
+async def _send_via_matrix_adapter(adapter, chat_id, message, media_files, metadata):
+    """Core send logic shared by live and ephemeral Matrix adapters."""
+    last_result = None
+
+    if message.strip():
+        last_result = await adapter.send(chat_id, message, metadata=metadata)
+        if not last_result.success:
+            return _error(f"Matrix send failed: {last_result.error}")
+
+    for media_path, is_voice in media_files:
+        if not os.path.exists(media_path):
+            return _error(f"Media file not found: {media_path}")
+
+        ext = os.path.splitext(media_path)[1].lower()
+        if ext in _IMAGE_EXTS:
+            last_result = await adapter.send_image_file(chat_id, media_path, metadata=metadata)
+        elif ext in _VIDEO_EXTS:
+            last_result = await adapter.send_video(chat_id, media_path, metadata=metadata)
+        elif ext in _VOICE_EXTS and is_voice:
+            last_result = await adapter.send_voice(chat_id, media_path, metadata=metadata)
+        elif ext in _AUDIO_EXTS:
+            last_result = await adapter.send_voice(chat_id, media_path, metadata=metadata)
+        else:
+            last_result = await adapter.send_document(chat_id, media_path, metadata=metadata)
+
+        if not last_result.success:
+            return _error(f"Matrix media send failed: {last_result.error}")
+
+    if last_result is None:
+        return {"error": "No deliverable text or media remained after processing MEDIA tags"}
+
+    return {
+        "success": True,
+        "platform": "matrix",
+        "chat_id": chat_id,
+        "message_id": last_result.message_id,
+    }
 
 
 # _send_dingtalk moved to plugins/platforms/dingtalk/adapter.py::_standalone_send,

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1482,19 +1482,39 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
     metadata = {"thread_id": thread_id} if thread_id else None
 
     # --- Try the live gateway adapter first (persistent E2EE session) ---
+    # Reusing the running gateway's already-connected adapter is the whole
+    # point of #46310: it avoids a per-send login + olm/megolm re-init + OTK
+    # claim that, under burst sends, exhausts recipient one-time keys and
+    # silently drops messages. The import is guarded narrowly (gateway code may
+    # be absent in some standalone contexts); a runner that *exists* but whose
+    # adapter lookup fails is logged rather than silently swallowed, because a
+    # silent fall-through here would re-introduce the exact reconnect storm
+    # this fix prevents.
     live_adapter = None
+    runner = None
     try:
-        from gateway.config import Platform
         from gateway.run import _gateway_runner_ref
-
         runner = _gateway_runner_ref()
-        if runner is not None:
-            live_adapter = runner.adapters.get(Platform.MATRIX)
     except Exception:
-        live_adapter = None
+        runner = None
+    if runner is not None:
+        try:
+            from gateway.config import Platform
+            live_adapter = runner.adapters.get(Platform.MATRIX)
+        except Exception:
+            logger.warning(
+                "Matrix: live gateway adapter lookup failed; falling back to an "
+                "ephemeral connect (may re-init E2EE per send, see #46310)",
+                exc_info=True,
+            )
+            live_adapter = None
 
     if live_adapter is not None:
-        return await _send_via_matrix_adapter(
+        # NOTE: the live adapter is owned by the gateway — we must NOT
+        # disconnect it. Correctness here depends on this branch returning
+        # before the ephemeral ``adapter`` is constructed below, so the
+        # ephemeral ``finally`` disconnect never touches the live session.
+        return await _matrix_send_core(
             live_adapter, chat_id, message, media_files, metadata
         )
 
@@ -1509,7 +1529,7 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
         connected = await adapter.connect()
         if not connected:
             return _error("Matrix connect failed")
-        return await _send_via_matrix_adapter(
+        return await _matrix_send_core(
             adapter, chat_id, message, media_files, metadata
         )
     except Exception as e:
@@ -1521,7 +1541,7 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
             pass
 
 
-async def _send_via_matrix_adapter(adapter, chat_id, message, media_files, metadata):
+async def _matrix_send_core(adapter, chat_id, message, media_files, metadata):
     """Core send logic shared by live and ephemeral Matrix adapters."""
     last_result = None
 


### PR DESCRIPTION
## Summary
`send_message`'s Matrix media path now reuses the running gateway's persistent adapter instead of doing a full login + olm/megolm E2EE re-init + one-time-key (OTK) claim on every send — which under burst proactive sends exhausted recipient OTKs and silently dropped messages while still returning `success: true` (#46310).

Salvage of #46365 (@liuhao1024) onto current `main`, with follow-up fixes.

## Changes
- `tools/send_message_tool.py` — `_send_matrix_via_adapter()` checks `_gateway_runner_ref()` for a live `Platform.MATRIX` adapter and reuses it (one persistent E2EE session for all sends). Ephemeral connect/disconnect is kept only as the standalone/cron fallback. Shared send body extracted into `_send_via_matrix_adapter()`.
- Follow-up (this salvage): the live-adapter lookup splits the gateway import guard from the adapter lookup and **logs** (instead of silently swallowing) when a runner exists but `adapters.get()` raises — a silent fall-through there would re-introduce the exact reconnect storm this fix prevents. Documented that the live adapter is gateway-owned and must not be disconnected.
- `tests/tools/test_send_message_tool.py` — 3 new tests (live reuse / no-gateway fallback / no-matrix-adapter fallback). Follow-up: the three `sys.modules` patches now target `plugins.platforms.matrix.adapter` (Matrix migrated to a plugin in #41112; the contributor's branch predated that and used the stale `gateway.platforms.matrix` path).

## Validation
| | Result |
|---|---|
| `pytest tests/tools/test_send_message_tool.py` | 149 passed |
| ruff (changed files) | clean |
| E2E (real imports, temp env) | live adapter → 0 connect/disconnect; runner-lookup-raises → logs + ephemeral fallback; no gateway → ephemeral connects once |

## Credit
Cherry-picked from #46365 by @liuhao1024 (authorship preserved via rebase merge). Closes #46310.

Also supersedes #46407 (@kyssta-exe), which implemented the same idea but referenced `Platform.MATRIX` without importing `Platform`, so its `NameError` was swallowed by the surrounding `try/except` and it always fell back to ephemeral — the fix was effectively dead. Both contributors thanked.
