### PR TITLE
fix(desktop): prioritize unpacked app icon to bypass asar nativeImage limitation

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -413,9 +413,10 @@ const WINDOW_BUTTON_POSITION = {
 // It's only the pre-layout fallback — the renderer measures the exact overlay
 // width live via the Window Controls Overlay API.
 const APP_ICON_PATHS = [
+  // nativeImage.createFromPath can't read from inside asar — unpacked first
+  path.join(unpackedPathFor(APP_ROOT), 'dist', 'apple-touch-icon.png'),
   path.join(APP_ROOT, 'public', 'apple-touch-icon.png'),
-  path.join(APP_ROOT, 'dist', 'apple-touch-icon.png'),
-  path.join(unpackedPathFor(APP_ROOT), 'dist', 'apple-touch-icon.png')
+  path.join(APP_ROOT, 'dist', 'apple-touch-icon.png')
 ]
 
 let rendererTitleBarTheme = null


### PR DESCRIPTION
## Problem

`nativeImage.createFromPath()` cannot load images from inside asar archives. The `APP_ICON_PATHS` array in `electron/main.cjs` had the asar-internal paths listed first. `fileExists()` returns true for files inside the asar, but when Electron tries to load it as a native image, it throws:

```
Uncaught Exception:
Error: Failed to load image from path '.../app.asar/public/apple-touch-icon.png'
at createWindow (.../app.asar/electron/main.cjs:5559:17)
```

This crashes the desktop app immediately on startup.

## Root Cause

The `dist/` directory is configured in `asarUnpack` (electron-builder config), so `app.asar.unpacked/dist/apple-touch-icon.png` exists and is loadable. But `getAppIconPath()` uses `APP_ICON_PATHS.find(fileExists)`, which picks the first path that exists — the asar-internal one — and feeds it to `nativeImage`.

## Fix

Reorder `APP_ICON_PATHS` so the unpacked path is tried first:

```js
const APP_ICON_PATHS = [
  // nativeImage.createFromPath can't read from inside asar — unpacked first
  path.join(unpackedPathFor(APP_ROOT), 'dist', 'apple-touch-icon.png'),
  path.join(APP_ROOT, 'public', 'apple-touch-icon.png'),
  path.join(APP_ROOT, 'dist', 'apple-touch-icon.png')
]
```

The asar paths remain as fallbacks (e.g. for dev mode where there's no packed asar).