### PR TITLE
fix(qqbot): accept is_reconnect kwarg in connect() to fix reconnection loop

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
## Problem

The gateway reconnection watcher calls `adapter.connect(is_reconnect=True)` on failed platforms (gateway/run.py L3176), but `QQAdapter.connect()` does not accept this keyword argument. This causes every reconnect attempt to fail with:

```
QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

The watcher retries with exponential backoff (60s → 120s → 240s → 300s) indefinitely, filling the log with errors.

## Root Cause

`QQAdapter.connect()` (line 281) has signature `async def connect(self) -> bool:` — missing the `is_reconnect` parameter that `BasePlatformAdapter.connect()` defines and all other platform adapters implement:

| Adapter | `is_reconnect` |
|---------|:---:|
| base.py | ✅ |
| weixin.py | ✅ |
| signal.py | ✅ |
| api_server.py | ✅ |
| bluebubbles.py | ✅ |
| webhook.py | ✅ |
| whatsapp_cloud.py | ✅ |
| yuanbao.py | ✅ |
| msgraph_webhook.py | ✅ |
| **qqbot** | ❌ |

## Fix

One-line change: add `*, is_reconnect: bool = False` to match the base class contract.

```python
# Before
async def connect(self) -> bool:

# After  
async def connect(self, *, is_reconnect: bool = False) -> bool:
```

## Verification

```
✓ qqbot connected
Gateway running with 3 platform(s)
[QQBot:1903051698] Ready, session_id=...
```

No more reconnection loop in gateway.log.