### PR TITLE
fix: normalize MoA aggregator system messages

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -192,6 +192,45 @@ def _run_references_parallel(
     return [r for r in results if r is not None]
 
 
+def _normalize_system_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return provider-safe chat messages with system/developer content at head.
+
+    MoA forwards the normal Hermes transcript to the aggregator/acting model.
+    Long resumed sessions and compression can leave extra system/developer
+    guidance in the middle of the list. Anthropic-backed chat-completions
+    endpoints reject that shape (for example: ``messages.1: role 'system' must
+    precede an 'assistant' message or end the array``). Preserve the guidance,
+    but collapse all system/developer text into one leading system message.
+    """
+    system_parts: list[str] = []
+    out: list[dict[str, Any]] = []
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if role in {"system", "developer"}:
+            content = msg.get("content")
+            if isinstance(content, str):
+                text = content.strip()
+            elif isinstance(content, list):
+                chunks: list[str] = []
+                for part in content:
+                    if isinstance(part, str):
+                        chunks.append(part)
+                    elif isinstance(part, dict) and part.get("type") == "text":
+                        chunks.append(str(part.get("text") or ""))
+                text = "\n".join(chunk for chunk in chunks if chunk).strip()
+            else:
+                text = ""
+            if text:
+                system_parts.append(text)
+            continue
+        out.append(dict(msg))
+    if system_parts:
+        out.insert(0, {"role": "system", "content": "\n\n".join(system_parts)})
+    return out
+
+
 def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Build an advisory-safe view of the conversation for reference models.
 
@@ -374,7 +413,7 @@ class MoAChatCompletions:
         from hermes_cli.moa_config import resolve_moa_preset
 
         preset = resolve_moa_preset(load_config().get("moa") or {}, self.preset_name)
-        messages = list(api_kwargs.get("messages") or [])
+        messages = _normalize_system_messages(list(api_kwargs.get("messages") or []))
         reference_models = preset.get("reference_models") or []
         aggregator = preset.get("aggregator") or {}
         # MoA does not cap reference or aggregator output: each model uses its

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -79,6 +79,55 @@ def test_moa_runtime_provider_uses_virtual_endpoint():
     assert runtime["api_key"] == "moa-virtual-provider"
 
 
+def test_moa_actor_collapses_midstream_system_messages(monkeypatch, tmp_path):
+    """MoA aggregator/acting model must not receive system messages mid-list."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      reference_models: []
+      aggregator:
+        provider: openrouter
+        model: anthropic/claude-opus-4.8
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    captured = {}
+
+    def fake_call_llm(**kwargs):
+        captured["messages"] = kwargs["messages"]
+        return _response("aggregator acted")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    from agent.moa_loop import MoAClient
+
+    client = MoAClient("review")
+    response = getattr(client.chat, "completions").create(
+        messages=[
+            {"role": "system", "content": "base system"},
+            {"role": "system", "content": "compression summary"},
+            {"role": "user", "content": "say hello"},
+            {"role": "assistant", "content": "prior answer"},
+            {"role": "system", "content": "late repair note"},
+            {"role": "user", "content": "again"},
+        ]
+    )
+
+    assert response.choices[0].message.content == "aggregator acted"
+    roles = [m["role"] for m in captured["messages"]]
+    assert roles.count("system") == 1
+    assert roles[0] == "system"
+    assert "base system" in captured["messages"][0]["content"]
+    assert "compression summary" in captured["messages"][0]["content"]
+    assert "late repair note" in captured["messages"][0]["content"]
+
+
 def test_moa_does_not_cap_output_tokens(monkeypatch, tmp_path):
     """MoA must not inject an output cap on reference or aggregator calls.
 


### PR DESCRIPTION
## Summary
- normalize MoA aggregator/acting-model messages so `system`/`developer` content is collapsed into one leading system message
- preserve compressed/resumed-session guidance while avoiding Anthropic/OpenRouter 400s for mid-list system roles
- add regression coverage for MoA aggregator message normalization

## Test evidence
- `/Users/sitka/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/hermes_cli/test_moa_config.py tests/run_agent/test_moa_loop_mode.py`
- Result: `31 passed, 1 warning` (existing `discord/player.py` `audioop` deprecation)

## Risk / rollback
- Low risk: transformation is scoped to the MoA virtual client's aggregator/acting-model path.
- Reference-model advisory calls already use a trimmed user/assistant-only view; this makes the acting aggregator path provider-safe too.
