### PR TITLE
fix(gateway): bound adapter disconnect in fatal-error handler

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3633,7 +3633,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         existing = self.adapters.get(adapter.platform)
         if existing is adapter:
             try:
-                await adapter.disconnect()
+                await self._safe_adapter_disconnect(adapter, adapter.platform)
             finally:
                 self.adapters.pop(adapter.platform, None)
                 self.delivery_router.adapters = self.adapters

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -691,6 +691,29 @@ class TestRuntimeDisconnectQueuing:
 
         runner.stop.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_fatal_error_bounds_wedged_disconnect(self, monkeypatch):
+        """A wedged disconnect() in the fatal-error handler must not hang."""
+        monkeypatch.setenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "0.01")
+        runner = _make_runner()
+        runner.stop = AsyncMock()
+
+        class WedgedAdapter(StubAdapter):
+            async def disconnect(self):
+                await asyncio.sleep(60)
+
+        adapter = WedgedAdapter(succeed=True)
+        adapter._set_fatal_error("ws_wedge", "WebSocket hung", retryable=True)
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        await asyncio.wait_for(
+            runner._handle_adapter_fatal_error(adapter),
+            timeout=5.0,
+        )
+
+        assert Platform.TELEGRAM not in runner.adapters
+        assert Platform.TELEGRAM in runner._failed_platforms
+
 
 # --- Pause / resume circuit breaker ---
 


### PR DESCRIPTION
## Summary

- `_handle_adapter_fatal_error()` called raw `adapter.disconnect()` with no timeout — a half-dead adapter (e.g. a wedged Feishu/Lark WebSocket) blocked the handler indefinitely, preventing the platform from being popped and queued for reconnection
- Replace with `_safe_adapter_disconnect()`, which wraps the call in `HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT` — the same bounded-teardown pattern applied to `_stop_impl()` in #14128
- Add a regression test: a wedged adapter's fatal-error handler must complete within the timeout budget

## Test plan

- [x] `test_fatal_error_bounds_wedged_disconnect` — wedged `disconnect()` times out, adapter is removed, platform is queued for reconnection
- [x] All 13 existing `TestRuntimeDisconnectQueuing` + `test_bounded_adapter_teardown` tests pass