### PR TITLE
fix(tools): preserve CWD across environment recreation in execute_code

### DIFF
--- a/tests/tools/test_code_execution_cwd_preservation.py
+++ b/tests/tools/test_code_execution_cwd_preservation.py
@@ -1,0 +1,87 @@
+"""Regression: execute_code must preserve CWD across environment recreation.
+
+When the terminal environment is cleaned up mid-conversation and
+``_get_or_create_env`` rebuilds it, the new environment must use the
+last-known CWD — not the config default.  This is the execute_code
+sibling of the file-tools fix in #26211.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _force_local(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+
+@patch("tools.terminal_tool._active_environments", new_callable=dict)
+@patch("tools.terminal_tool._get_env_config")
+@patch("tools.terminal_tool._create_environment")
+def test_get_or_create_env_uses_last_known_cwd(
+    mock_create_env, mock_config, mock_active
+):
+    from tools.code_execution_tool import _get_or_create_env
+    from tools.file_tools import _last_known_cwd
+
+    mock_env = MagicMock()
+    mock_create_env.return_value = mock_env
+    mock_config.return_value = {
+        "env_type": "local",
+        "cwd": "/default/config/path",
+        "timeout": 30,
+    }
+
+    task_id = "default"
+    _last_known_cwd[task_id] = "/Users/user/project"
+
+    try:
+        _get_or_create_env(task_id)
+
+        create_call = mock_create_env.call_args
+        assert create_call is not None
+        args = create_call.args if create_call.args else ()
+        kwargs = create_call.kwargs if create_call.kwargs else {}
+        cwd_passed = kwargs.get("cwd", args[2] if len(args) >= 3 else None)
+        assert cwd_passed == "/Users/user/project", (
+            f"Expected last-known CWD '/Users/user/project', got {cwd_passed!r}"
+        )
+    finally:
+        _last_known_cwd.pop(task_id, None)
+        mock_active.pop(task_id, None)
+
+
+@patch("tools.terminal_tool._active_environments", new_callable=dict)
+@patch("tools.terminal_tool._get_env_config")
+@patch("tools.terminal_tool._create_environment")
+def test_get_or_create_env_falls_back_to_config_when_no_last_known(
+    mock_create_env, mock_config, mock_active
+):
+    from tools.code_execution_tool import _get_or_create_env
+    from tools.file_tools import _last_known_cwd
+
+    mock_env = MagicMock()
+    mock_create_env.return_value = mock_env
+    mock_config.return_value = {
+        "env_type": "local",
+        "cwd": "/default/config/path",
+        "timeout": 30,
+    }
+
+    task_id = "default"
+    _last_known_cwd.pop(task_id, None)
+
+    try:
+        _get_or_create_env(task_id)
+
+        create_call = mock_create_env.call_args
+        assert create_call is not None
+        args = create_call.args if create_call.args else ()
+        kwargs = create_call.kwargs if create_call.kwargs else {}
+        cwd_passed = kwargs.get("cwd", args[2] if len(args) >= 3 else None)
+        assert cwd_passed == "/default/config/path", (
+            f"Expected config default '/default/config/path', got {cwd_passed!r}"
+        )
+    finally:
+        mock_active.pop(task_id, None)

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -646,7 +646,8 @@ def _get_or_create_env(task_id: str):
         else:
             image = ""
 
-        cwd = overrides.get("cwd") or config["cwd"]
+        from tools.file_tools import _last_known_cwd_for
+        cwd = overrides.get("cwd") or _last_known_cwd_for(effective_task_id) or config["cwd"]
 
         container_config = None
         if env_type in {"docker", "singularity", "modal", "daytona"}:


### PR DESCRIPTION
## Summary

- `_get_or_create_env()` rebuilt the terminal environment with the config default CWD after cleanup eviction — execute_code scripts silently ran in the Hermes install root instead of the user's working directory
- The sibling `file_tools._get_file_ops()` was fixed in #26211 to consult `_last_known_cwd` before falling back to the config default, but `_get_or_create_env()` — whose own comment says "same pattern as file_tools._get_file_ops" — was not updated
- Add the same `_last_known_cwd_for()` fallback so execute_code preserves the user's last-known directory across env recreation

## Test plan

- [x] `test_get_or_create_env_uses_last_known_cwd` — env recreation uses preserved CWD
- [x] `test_get_or_create_env_falls_back_to_config_when_no_last_known` — config default used when no prior CWD
- [x] All 4 existing `TestLastKnownCwd` file-tools tests pass