### PR TITLE
fix(skills): keep profile-local skills visible

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -328,7 +328,11 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     _skill_commands = {}
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
-        from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+        from agent.skill_utils import (
+            get_external_skills_dirs,
+            has_excluded_skill_path_part,
+            iter_skill_index_files,
+        )
         from hermes_cli.commands import resolve_command
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
@@ -341,7 +345,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
 
         for scan_dir in dirs_to_scan:
             for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
-                if any(part in {'.git', '.github', '.hub', '.archive'} for part in skill_md.parts):
+                if has_excluded_skill_path_part(skill_md, scan_dir):
                     continue
                 try:
                     content = skill_md.read_text(encoding='utf-8')

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -807,6 +807,15 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
         yield Path(path)
 
 
+def has_excluded_skill_path_part(path: Path, scan_dir: Path) -> bool:
+    """Return whether *path* contains an excluded component within *scan_dir*."""
+    try:
+        parts = path.relative_to(scan_dir).parts
+    except ValueError:
+        parts = path.parts
+    return any(part in EXCLUDED_SKILL_DIRS for part in parts)
+
+
 # ── Namespace helpers for plugin-provided skills ───────────────────────────
 
 _NAMESPACE_RE = re.compile(r"^[a-zA-Z0-9_-]+$")

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -127,6 +127,18 @@ class TestScanSkillCommands:
         assert "/knowledge-brain" in result
         assert result["/knowledge-brain"]["name"] == "knowledge-brain"
 
+    def test_finds_commands_under_excluded_ancestor(self, tmp_path):
+        skills_root = tmp_path / ".git" / "profiles" / "parul" / "skills"
+        skills_root.mkdir(parents=True)
+        _make_skill(skills_root, "google-workspace")
+        _make_skill(skills_root / ".hub", "quarantined-skill")
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_root):
+            result = scan_skill_commands()
+
+        assert "/google-workspace" in result
+        assert "/quarantined-skill" not in result
+
     def test_loads_skill_invocation_from_symlinked_skill_dir(self, tmp_path):
         """Slash commands should load skills symlinked under the local skills dir."""
         external_root = tmp_path / "external"

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -307,8 +307,8 @@ class TestFindAllSkills:
         assert [s["name"] for s in skills] == ["knowledge-brain"]
         assert skills[0]["category"] == "linked"
 
-    def test_profile_local_skills_under_dot_hermes_are_not_hidden(self, tmp_path):
-        skills_root = tmp_path / ".hermes" / "profiles" / "parul" / "skills"
+    def test_skills_under_excluded_ancestor_are_not_hidden(self, tmp_path):
+        skills_root = tmp_path / ".venv" / "profiles" / "parul" / "skills"
         skills_root.mkdir(parents=True)
         _make_skill(skills_root, "google-workspace", category="productivity")
 

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -307,6 +307,25 @@ class TestFindAllSkills:
         assert [s["name"] for s in skills] == ["knowledge-brain"]
         assert skills[0]["category"] == "linked"
 
+    def test_profile_local_skills_under_dot_hermes_are_not_hidden(self, tmp_path):
+        skills_root = tmp_path / ".hermes" / "profiles" / "parul" / "skills"
+        skills_root.mkdir(parents=True)
+        _make_skill(skills_root, "google-workspace", category="productivity")
+
+        hidden_skill = skills_root / ".hub" / "quarantined-skill"
+        hidden_skill.mkdir(parents=True)
+        (hidden_skill / "SKILL.md").write_text(
+            "---\nname: quarantined-skill\ndescription: hidden\n---\n",
+            encoding="utf-8",
+        )
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_root):
+            skills = _find_all_skills()
+
+        names = {skill["name"] for skill in skills}
+        assert "google-workspace" in names
+        assert "quarantined-skill" not in names
+
 
 # ---------------------------------------------------------------------------
 # skills_list

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -81,7 +81,7 @@ from tools.registry import registry, tool_error
 from hermes_cli.config import cfg_get
 from utils import env_var_enabled
 from agent.skill_utils import (
-    EXCLUDED_SKILL_DIRS as _EXCLUDED_SKILL_DIRS,
+    has_excluded_skill_path_part as _has_excluded_skill_path_part,
     is_skill_support_path as _is_skill_support_path,
 )
 
@@ -719,11 +719,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     # dirs_to_scan already resolved above for the signature.
     for scan_dir in dirs_to_scan:
         for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
-            try:
-                skill_parts = skill_md.relative_to(scan_dir).parts
-            except ValueError:
-                skill_parts = skill_md.parts
-            if any(part in _EXCLUDED_SKILL_DIRS for part in skill_parts):
+            if _has_excluded_skill_path_part(skill_md, scan_dir):
                 continue
 
             skill_dir = skill_md.parent

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -719,7 +719,11 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     # dirs_to_scan already resolved above for the signature.
     for scan_dir in dirs_to_scan:
         for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
-            if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
+            try:
+                skill_parts = skill_md.relative_to(scan_dir).parts
+            except ValueError:
+                skill_parts = skill_md.parts
+            if any(part in _EXCLUDED_SKILL_DIRS for part in skill_parts):
                 continue
 
             skill_dir = skill_md.parent


### PR DESCRIPTION
Fixes #54035

Profile-local skills under `~/.hermes/profiles/<profile>/skills/...` were being skipped because `_find_all_skills()` applied hidden-directory exclusions against absolute path parts. Since those absolute paths include `.hermes`, valid profile-local skills could be filtered out before frontmatter was read.

This patch applies the exclusion check relative to the current scan root instead. That keeps normal profile-local skills visible while still excluding hidden/quarantined directories such as `.hub`.

It also adds a regression test covering both cases:
- a valid skill under `.hermes/profiles/<profile>/skills/...` is discovered
- a hidden skill under `skills/.hub/...` remains excluded

Validation:
uv run --extra dev pytest tests/tools/test_skills_tool.py -q -k 'profile_local_skills_under_dot_hermes_are_not_hidden or skips_git_directories or finds_skills'
uv run --extra dev pytest tests/tools/test_skills_tool.py tests/agent/test_external_skills.py -q

Result:
101 passed