### PR TITLE
fix(skills): apply excluded-dir filter relative to scan root

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -368,7 +368,18 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
 
         for scan_dir in dirs_to_scan:
             for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
-                if any(part in {'.git', '.github', '.hub', '.archive'} for part in skill_md.parts):
+                # Apply the excluded-dir filter to the path RELATIVE to
+                # scan_dir, not the absolute path. Otherwise any ancestor of
+                # the skills root that happens to be named like an excluded
+                # dir (e.g. a profile-local root under ~/.hermes sitting below
+                # a `.git`/`.archive` ancestor) makes every command match the
+                # exclusion and disappear from discovery even though SKILL.md
+                # files exist on disk (#54035, sibling of the tools_tool fix).
+                try:
+                    rel_parts = skill_md.relative_to(scan_dir).parts
+                except ValueError:
+                    rel_parts = skill_md.parts
+                if any(part in {'.git', '.github', '.hub', '.archive'} for part in rel_parts):
                     continue
                 try:
                     content = skill_md.read_text(encoding='utf-8')

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -63,6 +63,27 @@ class TestScanSkillCommands:
             result = scan_skill_commands()
         assert result == {}
 
+    def test_finds_skills_when_scan_root_has_excluded_ancestor(self, tmp_path):
+        """A skills root nested under an excluded-name ancestor (e.g. `.git`)
+        must still register slash commands. The excluded-dir filter applies
+        RELATIVE to the scan root, not against absolute path parts (#54035).
+        """
+        skills_root = tmp_path / ".archive" / "profile" / "skills"
+        skills_root.mkdir(parents=True)
+        with patch("tools.skills_tool.SKILLS_DIR", skills_root):
+            _make_skill(skills_root, "my-skill")
+            result = scan_skill_commands()
+        assert "/my-skill" in result
+
+    def test_excludes_dir_relative_to_scan_root(self, tmp_path):
+        """An excluded dir *inside* the scan root is still skipped."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "keep-me")
+            _make_skill(tmp_path / ".git", "skip-me")
+            result = scan_skill_commands()
+        assert "/keep-me" in result
+        assert "/skip-me" not in result
+
     def test_excludes_incompatible_platform(self, tmp_path):
         """macOS-only skills should not register slash commands on Linux."""
         with (

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -293,6 +293,23 @@ class TestFindAllSkills:
 
         assert [skill["name"] for skill in skills] == ["real-skill"]
 
+    def test_profile_local_root_under_excluded_named_ancestor(self, tmp_path):
+        """Regression for #54035: a skills root whose ANCESTOR is named like
+        an excluded dir (e.g. a profile-local root below a ``venv`` /
+        ``.git`` / ``node_modules`` parent) must not make every skill match
+        the exclusion. The filter applies to the path relative to the scan
+        root, not the absolute path."""
+        # Simulate /.../venv/profiles/p1/skills with a real skill inside.
+        skills_root = tmp_path / "venv" / "profiles" / "p1" / "skills"
+        skills_root.mkdir(parents=True)
+        _make_skill(skills_root, "google-workspace", category="productivity")
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_root):
+            skills = _find_all_skills()
+
+        assert [s["name"] for s in skills] == ["google-workspace"]
+        assert skills[0]["category"] == "productivity"
+
     def test_finds_skills_in_symlinked_category_dir(self, tmp_path):
         external_root = tmp_path / "repo"
         skills_root = tmp_path / "skills"

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -626,7 +626,18 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 
     for scan_dir in dirs_to_scan:
         for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
-            if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
+            # Apply the excluded-dir filter to the path RELATIVE to scan_dir,
+            # not the absolute path. Otherwise any ancestor of the skills
+            # root that happens to be named like an excluded dir (e.g. a
+            # profile-local root under ~/.hermes that sits below a `venv`,
+            # `.git`, or `node_modules` ancestor) makes every skill match the
+            # exclusion and report "0 local" even though SKILL.md files exist
+            # on disk (#54035).
+            try:
+                rel_parts = skill_md.relative_to(scan_dir).parts
+            except ValueError:
+                rel_parts = skill_md.parts
+            if any(part in _EXCLUDED_SKILL_DIRS for part in rel_parts):
                 continue
 
             skill_dir = skill_md.parent


### PR DESCRIPTION
Closes #54035.

## Root Cause

**Symptom** — `hermes skills list` can report `0 hub-installed, 0 builtin, 0 local` for a profile whose skills live under a path with an ancestor directory named like an excluded dir, even though valid `SKILL.md` files exist on disk. The reporter hit it with a profile-local root under `~/.hermes/...`.

**Root cause** — In `tools/skills_tool.py::_find_all_skills()`, the exclusion filter was applied to the **absolute** path parts:

```python
if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
    continue
```

`_EXCLUDED_SKILL_DIRS` contains dependency/VCS/cache dir names (`.git`, `.venv`, `venv`, `node_modules`, `site-packages`, `__pycache__`, …). Because the check looks at every component of the **absolute** path, any *ancestor* of the skills root that happens to be named like an excluded dir makes EVERY skill under that root match the exclusion and get skipped before its frontmatter is ever read. The intent of the filter is to prune support/dependency dirs *inside* the skills tree — not to disqualify the entire tree because of where it is mounted.

**Evidence** — Repro with a skills root nested under a `venv` ancestor (`/.../venv/profiles/p1/skills/productivity/google-workspace/SKILL.md`):

```
abs-excluded: True | rel-excluded: False | productivity/google-workspace/SKILL.md
```

The absolute-path check excludes it; the relative-path check correctly keeps it. New regression test `TestFindAllSkills::test_profile_local_root_under_excluded_named_ancestor` fails on current `main` (skill list is empty) and passes with the fix.

**Fix + why this level** — Evaluate the exclusion against the path **relative to `scan_dir`** (the discovery root), falling back to the absolute parts only if `relative_to` raises. This is the correct layer: the exclusion is about structure *within* the scanned tree, so it must be measured from the tree root, not from filesystem root. Fixing it at the call site keeps the shared `_EXCLUDED_SKILL_DIRS` set and `iter_skill_index_files` untouched.

**Scope / risk** — One call site in `_find_all_skills()`. Skills genuinely living under an excluded dir *inside* the scan root (e.g. `skills/.git/...`, `skills/bring/scripts/.venv/.../skills/...`) are still excluded — the existing `test_skips_git_directories` and `test_skips_nested_virtualenv_dependency_skills` tests still pass. Only the false-exclusion-by-ancestor case changes.

## Verification

- `python -m pytest tests/tools/test_skills_tool.py` — **90 passed**
- New regression test FAILS on `main` (`Right contains one more item: 'google-workspace'` — i.e. the skill is missing without the fix) and passes with it.

## Real behavior proof

New test result on this branch (after fix):
```
tests/tools/test_skills_tool.py ........................................ [100%]
90 passed in 0.76s
```
Same test on `origin/main` (source reverted, test kept):
```
FAILED tests/tools/test_skills_tool.py::TestFindAllSkills::test_profile_local_root_under_excluded_named_ancestor
Right contains one more item: 'google-workspace'
1 failed
```