### PR TITLE
fix(anthropic): use env-only proxy policy for Anthropic SDK clients

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -752,6 +752,7 @@ def build_anthropic_client(
     normalize_proxy_env_vars()
 
     from httpx import Timeout
+    from agent.process_bootstrap import build_keepalive_http_client
 
     normalized_base_url = _normalize_base_url_text(base_url)
     if normalized_base_url:
@@ -767,6 +768,9 @@ def build_anthropic_client(
         # refill for minutes. (#26293)
         "max_retries": 0,
     }
+    _http_client = build_keepalive_http_client(normalized_base_url or "")
+    if _http_client is not None:
+        kwargs["http_client"] = _http_client
     if normalized_base_url:
         # Azure Anthropic endpoints require an ``api-version`` query parameter.
         # Pass it via default_query so the SDK appends it to every request URL

--- a/tests/agent/test_anthropic_client_proxy_env.py
+++ b/tests/agent/test_anthropic_client_proxy_env.py
@@ -1,0 +1,76 @@
+"""Regression guard: Anthropic clients must use env-only proxy policy.
+
+On macOS, httpx with default ``trust_env=True`` reads system proxy settings
+via ``urllib.request.getproxies()`` but not the macOS proxy exception list.
+Anthropic clients (main agent + auxiliary) must mirror the OpenAI fix in
+#53702: explicit ``HTTPS_PROXY`` / ``NO_PROXY`` env vars only, via a custom
+keepalive transport that suppresses automatic system-proxy detection.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+
+def _pool_types(http_client) -> list:
+    return [
+        type(mount._pool).__name__
+        for mount in http_client._mounts.values()
+        if mount is not None and hasattr(mount, "_pool")
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _clean_proxy_env(monkeypatch):
+    for key in (
+        "HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+        "https_proxy", "http_proxy", "all_proxy",
+        "NO_PROXY", "no_proxy",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_anthropic_client_routes_via_env_proxy(monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+
+    mock_sdk = MagicMock()
+    with patch("agent.anthropic_adapter._get_anthropic_sdk", return_value=mock_sdk):
+        from agent.anthropic_adapter import build_anthropic_client
+        build_anthropic_client("sk-ant-test-key", base_url="https://api.anthropic.com")
+
+    http_client = mock_sdk.Anthropic.call_args.kwargs.get("http_client")
+    assert http_client is not None, "http_client must be injected"
+    assert isinstance(http_client, httpx.Client)
+    assert "HTTPProxy" in _pool_types(http_client)
+    http_client.close()
+
+
+def test_anthropic_client_no_proxy_when_env_unset():
+    mock_sdk = MagicMock()
+    with patch("agent.anthropic_adapter._get_anthropic_sdk", return_value=mock_sdk):
+        from agent.anthropic_adapter import build_anthropic_client
+        build_anthropic_client("sk-ant-test-key", base_url="https://api.anthropic.com")
+
+    http_client = mock_sdk.Anthropic.call_args.kwargs.get("http_client")
+    assert http_client is not None, "http_client must be injected"
+    assert isinstance(http_client, httpx.Client)
+    assert "HTTPProxy" not in _pool_types(http_client)
+    http_client.close()
+
+
+def test_anthropic_client_ignores_macos_system_proxy():
+    mock_sdk = MagicMock()
+    with patch("agent.anthropic_adapter._get_anthropic_sdk", return_value=mock_sdk):
+        with patch(
+            "urllib.request.getproxies",
+            return_value={"http": "http://127.0.0.1:7897", "https": "http://127.0.0.1:7897"},
+        ):
+            from agent.anthropic_adapter import build_anthropic_client
+            build_anthropic_client("sk-ant-test-key", base_url="https://api.anthropic.com")
+
+    http_client = mock_sdk.Anthropic.call_args.kwargs.get("http_client")
+    assert http_client is not None, "http_client must be injected"
+    assert isinstance(http_client, httpx.Client)
+    assert "HTTPProxy" not in _pool_types(http_client)
+    http_client.close()


### PR DESCRIPTION
## Summary

- `build_anthropic_client()` passed no `http_client` to the Anthropic SDK, so the SDK built its default httpx client with `trust_env=True` — on macOS this reads system proxy settings via `getproxies()` which omit the ExceptionsList, breaking calls to internal/custom Anthropic endpoints behind a proxy
- Inject `build_keepalive_http_client()` — the same helper #53702 applied to OpenAI clients — so Anthropic clients use explicit `HTTPS_PROXY` / `NO_PROXY` env vars only
- Single chokepoint fix: covers main agent, all auxiliary Anthropic clients, and OAuth paths

## Test plan

- [x] `test_anthropic_client_routes_via_env_proxy` — HTTPS_PROXY set → proxy applied
- [x] `test_anthropic_client_no_proxy_when_env_unset` — no env vars → no proxy, no system proxy
- [x] `test_anthropic_client_ignores_macos_system_proxy` — getproxies() returns proxy but env unset → not applied
- [x] All 5 existing OpenAI proxy policy tests pass (no regression)