### PR TITLE
fix(tui): force UTF-8 output when reading clipboard via PowerShell

### DIFF
--- a/ui-tui/src/__tests__/clipboard.test.ts
+++ b/ui-tui/src/__tests__/clipboard.test.ts
@@ -20,9 +20,22 @@ describe('readClipboardText', () => {
     await expect(readClipboardText('win32', run)).resolves.toBe('from windows\r\n')
     expect(run).toHaveBeenCalledWith(
       'powershell',
-      ['-NoProfile', '-NonInteractive', '-Command', 'Get-Clipboard -Raw'],
+      ['-NoProfile', '-NonInteractive', '-Command', '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Get-Clipboard -Raw'],
       expect.objectContaining({ encoding: 'utf8', maxBuffer: 4 * 1024 * 1024, windowsHide: true })
     )
+  })
+
+  it('forces UTF-8 output encoding in the PowerShell read command (CJK fix)', async () => {
+    // Regression for the ??? on CJK/emoji paste bug: without the
+    // [Console]::OutputEncoding = UTF8 prefix, PowerShell emits the ANSI
+    // code page and non-ASCII chars are decoded as `?`.
+    const run = vi.fn().mockResolvedValue({ stdout: '你好世界，测试中文' })
+
+    await expect(readClipboardText('win32', run)).resolves.toBe('你好世界，测试中文')
+    const [, args] = run.mock.calls[0]
+    const command = (args as string[])[args.length - 1]
+    expect(command).toContain('[System.Text.Encoding]::UTF8')
+    expect(command).toContain('Get-Clipboard -Raw')
   })
 
   it('tries powershell.exe first on WSL', async () => {
@@ -33,7 +46,7 @@ describe('readClipboardText', () => {
     )
     expect(run).toHaveBeenCalledWith(
       'powershell.exe',
-      ['-NoProfile', '-NonInteractive', '-Command', 'Get-Clipboard -Raw'],
+      ['-NoProfile', '-NonInteractive', '-Command', '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Get-Clipboard -Raw'],
       expect.objectContaining({ encoding: 'utf8', maxBuffer: 4 * 1024 * 1024, windowsHide: true })
     )
   })

--- a/ui-tui/src/lib/clipboard.ts
+++ b/ui-tui/src/lib/clipboard.ts
@@ -3,7 +3,18 @@ import { promisify } from 'node:util'
 
 const execFileAsync = promisify(execFile)
 const CLIPBOARD_MAX_BUFFER = 4 * 1024 * 1024
-const POWERSHELL_ARGS = ['-NoProfile', '-NonInteractive', '-Command', 'Get-Clipboard -Raw'] as const
+// PowerShell emits Get-Clipboard output using the system ANSI code page
+// (e.g. CP936 on Chinese Windows), not UTF-8. Reading that stdout as UTF-8
+// turns every non-ASCII char (CJK, emoji, accented, Cyrillic) into `?`.
+// Force stdout to UTF-8 first so the bytes we decode actually are UTF-8 —
+// mirroring the base64+UTF8.GetString approach already used on the write
+// path (Set-Clipboard).
+const POWERSHELL_ARGS = [
+  '-NoProfile',
+  '-NonInteractive',
+  '-Command',
+  '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Get-Clipboard -Raw'
+] as const
 
 type ClipboardRun = typeof execFileAsync
 


### PR DESCRIPTION
Closes #53963.

## Root Cause

**Symptom** — Pasting Chinese/CJK (or emoji, accented, Cyrillic) text into the Web Dashboard / Desktop app on Windows/WSL produces literal `?` per character. Example: `你好世界，测试中文` → `????????????`. Affects all non-ASCII text on non-UTF-8 Windows locales.

**Root cause** — `ui-tui/src/lib/clipboard.ts` reads the clipboard with `powershell(.exe) -NoProfile -NonInteractive -Command Get-Clipboard -Raw`. PowerShell writes that stdout using the system ANSI code page (e.g. CP936 on Chinese Windows), **not** UTF-8. Hermes then reads the child process stdout with `encoding: 'utf8'`, so ANSI-coded bytes that aren't valid UTF-8 get replaced with `?` / U+FFFD.

**Evidence** — `POWERSHELL_ARGS` at `clipboard.ts:6`. Notably the **write** path in the same file already solved the identical encoding problem (base64 + `[System.Text.Encoding]::UTF8.GetString(...)` for `Set-Clipboard`), but the read path was never given the matching treatment. New regression test feeds `你好世界，测试中文` through a mocked `run` and asserts the emitted command carries the UTF-8 directive; it fails on current `main`.

**Fix + why this level** — Prepend `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8;` to the `Get-Clipboard -Raw` command so PowerShell emits UTF-8 stdout, which then matches the `encoding: 'utf8'` read. This is the correct layer: fixing the producer's output encoding removes the mismatch at the source, rather than guessing the ANSI code page on the Node side (which varies by locale and is unreliable). It mirrors the existing write-path solution for symmetry.

**Scope / risk** — Single constant change in `clipboard.ts` (shared by both the `win32` and WSL `powershell.exe` read attempts). ASCII-only clipboards are unaffected (UTF-8 is a superset of ASCII). No change to the macOS/Wayland/X11 backends or the write path.

## Verification

- `npx vitest run src/__tests__/clipboard.test.ts` (in `ui-tui/`) — **20 passed**
- Updated the two existing PowerShell-args assertions and added `forces UTF-8 output encoding in the PowerShell read command (CJK fix)`, which round-trips `你好世界，测试中文` and asserts the command contains `[System.Text.Encoding]::UTF8`. It FAILS on `main` (3 tests fail without the fix) and passes with it.

## Real behavior proof

New + updated tests on this branch (after fix):
```
✓ src/__tests__/clipboard.test.ts (20 tests) 8ms
Test Files  1 passed (1)
     Tests  20 passed (20)
```
On `origin/main` (source reverted, tests kept):
```
Test Files  1 failed (1)
     Tests  3 failed | 17 passed (20)
```

## Related

- #35107 (/copy garbled CJK in TUI), #38077 (emoji → ??) — same ANSI-code-page root cause on the clipboard paths.