### PR TITLE
fix: eliminate race condition in OpenAI client replacement (#32846)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3685,16 +3685,28 @@ class AIAgent:
             client = getattr(self, "client", None)
             if client is not None and not self._is_openai_client_closed(client):
                 return client
+            old_client = client
+            try:
+                new_client = self._create_openai_client(
+                    self._client_kwargs, reason=reason, shared=True
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to recreate closed OpenAI client (%s) %s error=%s",
+                    reason,
+                    self._client_log_context(),
+                    exc,
+                )
+                raise RuntimeError("Failed to recreate closed OpenAI client") from exc
+            self.client = new_client
 
         logger.warning(
-            "Detected closed shared OpenAI client; recreating before use (%s) %s",
+            "Detected closed shared OpenAI client; recreated before use (%s) %s",
             reason,
             self._client_log_context(),
         )
-        if not self._replace_primary_openai_client(reason=f"recreate_closed:{reason}"):
-            raise RuntimeError("Failed to recreate closed OpenAI client")
-        with self._openai_client_lock():
-            return self.client
+        self._close_openai_client(old_client, reason=f"replace:{reason}", shared=True)
+        return new_client
 
     def _cleanup_dead_connections(self) -> bool:
         """Forwarder — see ``agent.agent_runtime_helpers.cleanup_dead_connections``."""

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -82,6 +82,7 @@ AUTHOR_MAP = {
     "w.a.t.s.o.n.mk10@gmail.com": "natehale",  # PR #48678 salvage (typing indicator lingers after final reply)
     "0x0sec@gmail.com": "kn8-codes",  # PR #48422 salvage (rich messages opt-in default off)
     "liaoshiwu@gmail.com": "de1tydev",  # PR #10158 salvage (poll read-only for notify_on_complete watcher; #10156)
+    "kurlyk@kurlyks-Mac-mini.local": "skabartem",  # PR #32867 salvage (atomic check-and-replace in _ensure_primary_openai_client; #32846)
     "szzhoujiarui@gmail.com": "szzhoujiarui-sketch",  # cron model.default salvage co-author (#45550)
     "rayjun0412@gmail.com": "rayjun",  # cron model.default salvage co-author (#43952)
     "96944678+sweetcornna@users.noreply.github.com": "sweetcornna",  # cron ticker-liveness salvage co-author (#33849)


### PR DESCRIPTION
## Summary
A closed shared OpenAI client is now recreated atomically — two concurrent threads can no longer race to replace it and close each other's freshly-created client mid-request.

Root cause: `_ensure_primary_openai_client` had a TOCTOU window. It checked "is the client closed?" under the lock, **released the lock**, then called `_replace_primary_openai_client`. Two gateway threads could both pass the check, both replace, and the second thread would close the first thread's just-installed client — failing the first thread's in-flight requests with closed-client errors. Fixes #32846.

## Changes
- `run_agent.py`: `_ensure_primary_openai_client` now does check + create + swap `self.client` entirely inside the lock; the displaced client is closed outside the lock (safe — no thread can re-select it). Removes the lock-release gap between detect and replace.

## Validation
| | Before | After |
|---|---|---|
| Concurrent close-detect → replace | two threads both replace; thread B closes thread A's live client | single atomic swap under lock; old client closed only after swap |
| Targeted client-lifecycle tests | — | 20/20 pass (`test_create_openai_client_reuse`, `test_restore_primary_pool_reselect`, `test_fallback_credential_isolation`, `test_28161_anthropic_stream_pool_cleanup`) |

Salvaged from #32867 — only the race-fix commit was cherry-picked (the PR's unrelated `batch_runner` rename and `trajectory_compressor` change were dropped). Contributor authorship preserved via cherry-pick.

## Infographic
![PR 32867 infographic](https://v3b.fal.media/files/b/0aa0150d/4zsC2h6l6KAhUpQhCZsFV_FJ5w7Lx7.png)
