### PR TITLE
fix(gateway): default restart_drain_timeout to 0 to kill systemd crash loop

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -626,10 +626,10 @@ agent:
   # gateway_timeout_warning: 900
 
   # Graceful drain timeout for gateway stop/restart (seconds).
-  # The gateway stops accepting new work, waits for in-flight agents to
-  # finish, then interrupts anything still running after this timeout.
-  # 0 = no drain, interrupt immediately.
-  # restart_drain_timeout: 60
+  # Default 0 = no drain: a restart interrupts in-flight agents immediately,
+  # cleans up, and exits. Set a positive value only if you want a grace
+  # window on /restart, and keep it well under systemd's TimeoutStopSec.
+  # restart_drain_timeout: 0
 
   # Max app-level retry attempts for API errors (connection drops, provider
   # timeouts, 5xx, etc.) before the agent surfaces the failure. Lower this

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5811,7 +5811,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.warning(
                     "Stale systemd unit detected: %s has TimeoutStopSec=%.0fs but "
                     "drain_timeout=%.0fs (expected >=%.0fs). systemd may SIGKILL the "
-                    "gateway mid-drain. Run `hermes gateway service install --replace` "
+                    "gateway mid-drain. Run `hermes gateway install --force` "
                     "to regenerate the unit, or shorten agent.restart_drain_timeout.",
                     _alignment.get("unit", "(unknown)"),
                     _alignment["timeout_stop_sec"],

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -916,13 +916,18 @@ DEFAULT_CONFIG = {
         # Graceful drain timeout for gateway stop/restart (seconds).
         # The gateway stops accepting new work, waits for running agents
         # to finish, then interrupts any remaining runs after the timeout.
-        # 0 = no drain, interrupt immediately.
+        # 0 = no drain, interrupt immediately (the default).
         #
-        # 180s is calibrated for realistic in-flight agent turns: a typical
-        # coding conversation mid-reasoning runs 60–150s per call, so a 60s
-        # budget routinely interrupted legitimate work on /restart. Raise
-        # further in config.yaml if you run very-long-reasoning models.
-        "restart_drain_timeout": 180,
+        # Contract: if you restart the gateway, in-flight work stops. We do
+        # not hold the restart open for a grace window — a drain timeout
+        # large enough to "save" a long agent turn would have to outlast an
+        # unbounded task (some runs take days), which is impossible, and a
+        # drain timeout shorter than systemd's TimeoutStopSec invites a
+        # SIGKILL-mid-cleanup race that leaves a stale lock and crash-loops
+        # the service. 0 sidesteps both: interrupt now, clean up, exit fast.
+        # Set a positive value in config.yaml only if you explicitly want a
+        # grace window on /restart (and keep it well under TimeoutStopSec).
+        "restart_drain_timeout": 0,
         # Max app-level retry attempts for API errors (connection drops,
         # provider timeouts, 5xx, etc.) before the agent surfaces the
         # failure.  The OpenAI SDK already does its own low-level retries

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -94,6 +94,10 @@ async def test_gateway_stop_interrupts_running_agents_and_cancels_adapter_tasks(
 @pytest.mark.asyncio
 async def test_gateway_stop_drains_running_agents_before_disconnect():
     runner, adapter = make_restart_runner()
+    # Opt into a grace window (the default is 0 = interrupt immediately).
+    # This exercises the path where an agent finishes within the drain
+    # window and must NOT be interrupted.
+    runner._restart_drain_timeout = 5.0
     disconnect_mock = AsyncMock()
     adapter.disconnect = disconnect_mock
 


### PR DESCRIPTION
## Summary
A gateway restart now interrupts in-flight agents immediately instead of holding the process open for a grace window, which kills the systemd crash-loop reported in #31981.

Root cause: `restart_drain_timeout` (the gateway's own drain timer) and systemd's `TimeoutStopSec` (the kill timer) were two independently-set values. On a stale unit where `TimeoutStopSec` < drain, systemd SIGKILLed the gateway **mid-cleanup**, before it could remove its PID/lock file. The next startup then saw the stale lock, exited with "another gateway instance is already running", and under `Restart=on-failure` looped forever (one reporter's diag log hit 63 MB over 13 days).

Setting the drain default to `0` makes the mismatch structurally impossible: with drain 0 the generated unit gets `TimeoutStopSec=90` against a near-instant drain, so systemd never kills mid-cleanup. The contract is now explicit — **restart the gateway, in-flight work stops.** A grace window large enough to "save" a long agent turn would have to outlast an unbounded task, which is impossible.

## Changes
- `hermes_cli/config.py`: `restart_drain_timeout` default `180 → 0`; comment rewritten to state the contract and the timer-coupling rationale.
- `cli-config.yaml.example`: doc comment updated to match (`60 → 0`).
- `gateway/run.py`: stale-unit warning suggested `hermes gateway service install --replace` — that subcommand does not exist. Corrected to `hermes gateway install --force`.
- `tests/gateway/test_gateway_shutdown.py`: the one test that depended on a positive default drain now sets an explicit `5.0` to cover the opt-in grace-window path.

Notes:
- `DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT` derives from `DEFAULT_CONFIG`, so it tracks the new default automatically — single source of truth.
- The unit-generation tests are invariant-based (`max(60, DEFAULT) + 30`), so they carried the change with no edits and now assert `TimeoutStopSec=90`.
- `parse_restart_drain_timeout("0")` returns `0.0` cleanly (no coercion-to-default edge with the new 0 default).

## Validation
| | Before | After |
|---|---|---|
| Default drain | 180s grace window on every restart | 0 — interrupt immediately |
| systemd kill-timer vs drain | could be SIGKILLed mid-cleanup (stale unit) | 90s ≫ near-instant drain; race impossible |
| Stale-unit warning command | `hermes gateway service install --replace` (invalid) | `hermes gateway install --force` |
| Crash loop on stale unit | infinite | cannot form |

Targeted suites green: `test_gateway_service` (175), `test_restart_drain` (21), `test_gateway_shutdown`, `test_shutdown_forensics` — 196 tests.

Closes #31981.

## Infographic

![gateway-restart-crash-loop](https://v3b.fal.media/files/b/0aa01536/2tHsYlpVXiC7txozn9dHv_b1guOZTb.png)
