### PR TITLE
fix(desktop): remove the voice mic re-arm delay

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/speech-chunking.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/speech-chunking.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractChunk } from './use-voice-conversation'
+
+const take = (text: string, force = false) => extractChunk(text, force)
+
+// The loop never hands the splitter a finished reply: it appends stream deltas
+// to a buffer and drains whole sentences as they become available, then forces
+// the remainder once the response completes. Testing a complete string hides
+// every bug that only exists while the text is still arriving, so these feed the
+// text in one character at a time and collect what would actually be spoken.
+function speakStreamed(reply: string): string[] {
+  let buffer = ''
+  const spoken: string[] = []
+
+  for (const character of reply) {
+    buffer += character
+
+    let chunk = take(buffer)
+
+    while (chunk !== null) {
+      spoken.push(chunk[0])
+      buffer = chunk[1]
+      chunk = take(buffer)
+    }
+  }
+
+  const forced = take(buffer, true)
+
+  if (forced && forced[0]) {
+    spoken.push(forced[0])
+  }
+
+  return spoken
+}
+
+describe('extractChunk while the reply is still streaming', () => {
+  // A '.' after a digit is ambiguous until the next character arrives: "1." is
+  // either a finished sentence or the head of "1.2". Splitting on the buffer end
+  // speaks "one" and then "two billion".
+  it('keeps a decimal whole when the buffer ends mid-number', () => {
+    expect(speakStreamed('Revenue grew to 1.2 billion. Margins held.')).toEqual([
+      'Revenue grew to 1.2 billion.',
+      'Margins held.'
+    ])
+    expect(speakStreamed('Version 2.0 shipped today. More below.')).toEqual([
+      'Version 2.0 shipped today.',
+      'More below.'
+    ])
+  })
+
+  // The other half of the same trade: a sentence ending in a number still ends,
+  // as soon as the space after it proves the number is finished.
+  it('ends a sentence that finishes on a number', () => {
+    expect(speakStreamed('It closed at 187.5. Volume was up today.')).toEqual([
+      'It closed at 187.5.',
+      'Volume was up today.'
+    ])
+    expect(speakStreamed('The answer is 42. Next question please.')).toEqual([
+      'The answer is 42.',
+      'Next question please.'
+    ])
+  })
+
+  it('speaks a plain reply sentence by sentence', () => {
+    expect(speakStreamed('This is a full sentence. And another one.')).toEqual([
+      'This is a full sentence.',
+      'And another one.'
+    ])
+  })
+
+  it('keeps a list marker attached to its item', () => {
+    expect(speakStreamed('1. First take the lid off. 2. Then pour.')).toEqual([
+      '1. First take the lid off.',
+      '2. Then pour.'
+    ])
+  })
+
+  // The accepted cost of treating "42." and "2." as the same token: when every
+  // item is shorter than the minimum, the next marker rides out on the previous
+  // chunk. Audible only as an early boundary.
+  it('glues a trailing marker when every list item is shorter than the minimum', () => {
+    expect(speakStreamed('1. Yes. 2. No.')).toEqual(['1. Yes. 2.', 'No.'])
+  })
+
+  it('voices the tail once the response completes', () => {
+    expect(speakStreamed('All done. No trailing stop')).toEqual(['All done.', 'No trailing stop'])
+  })
+
+  it('loses nothing across a whole reply', () => {
+    const reply = 'First one here. Then 3.5 percent. 1. A point. Finally, the end.'
+
+    expect(speakStreamed(reply).join(' ')).toBe(reply)
+  })
+})
+
+describe('extractChunk', () => {
+  it('waits rather than voicing a fragment with no boundary', () => {
+    expect(take('a partial sentence with no end yet')).toBeNull()
+  })
+
+  it('voices what is left when forced', () => {
+    expect(take('a partial sentence with no end yet', true)).toEqual([
+      'a partial sentence with no end yet',
+      ''
+    ])
+  })
+
+  it('soft-wraps a long boundary-free run at a clause break', () => {
+    const runOn = `${'x'.repeat(120)}, ${'y'.repeat(120)}`
+    const result = take(runOn)
+
+    expect(result).not.toBeNull()
+    expect(result?.[0].length).toBeLessThan(runOn.length)
+    expect(`${result?.[0]} ${result?.[1]}`).toBe(runOn)
+  })
+
+  // `。！？` end a sentence the same way `.` does. The boundary still needs
+  // whitespace or the buffer end after it, so unspaced CJK runs stay whole, as
+  // they did before this splitter, and MIN_SPEAK_CHARS counts characters, so
+  // short CJK sentences merge.
+  it('ends a sentence on CJK punctuation', () => {
+    expect(take('これは長い日本語の文です。 次の文もあります。')).toEqual([
+      'これは長い日本語の文です。',
+      '次の文もあります。'
+    ])
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.tsx
@@ -1,0 +1,176 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { type MicRecorderErrorCopy, useMicRecorder } from './use-mic-recorder'
+
+const copy: MicRecorderErrorCopy = {
+  microphoneAccessDenied: 'access denied',
+  microphoneConstraintsUnsupported: 'constraints unsupported',
+  microphoneInUse: 'in use',
+  microphonePermissionDenied: 'permission denied',
+  microphoneStartFailed: 'start failed',
+  microphoneUnsupported: 'unsupported',
+  noMicrophone: 'no microphone'
+}
+
+function fakeTrack() {
+  const track = {
+    readyState: 'live' as MediaStreamTrack['readyState'],
+    stop: vi.fn(() => {
+      track.readyState = 'ended'
+    })
+  }
+
+  return track
+}
+
+// One entry per getUserMedia call, each with its own track, so a test can end
+// the first stream's track without touching the replacement.
+let streamTracks: ReturnType<typeof fakeTrack>[] = []
+let getUserMedia: ReturnType<typeof vi.fn>
+let recorderInstances: FakeRecorder[] = []
+
+// Minimal MediaRecorder stand-in: jsdom has none. Only the surface the hook
+// touches (state, start/stop, ondataavailable/onstop/onerror) is modelled.
+class FakeRecorder {
+  state: 'inactive' | 'recording' = 'inactive'
+  ondataavailable: ((event: { data: Blob }) => void) | null = null
+  onstop: (() => void) | null = null
+  onerror: ((event: unknown) => void) | null = null
+  start = vi.fn(() => {
+    this.state = 'recording'
+  })
+
+  stop = vi.fn(() => {
+    this.state = 'inactive'
+    this.ondataavailable?.({ data: new Blob(['audio'], { type: 'audio/webm' }) })
+    this.onstop?.()
+  })
+
+  constructor() {
+    recorderInstances.push(this)
+  }
+
+  static isTypeSupported() {
+    return true
+  }
+}
+
+beforeEach(() => {
+  streamTracks = []
+  recorderInstances = []
+  getUserMedia = vi.fn(async () => {
+    const track = fakeTrack()
+    streamTracks.push(track)
+
+    return { getTracks: () => [track] } as unknown as MediaStream
+  })
+
+  vi.stubGlobal('MediaRecorder', FakeRecorder)
+  vi.stubGlobal('navigator', {
+    ...navigator,
+    mediaDevices: { getUserMedia }
+  })
+  vi.stubGlobal('AudioContext', undefined)
+  ;(window as unknown as { hermesDesktop?: unknown }).hermesDesktop = {
+    requestMicrophoneAccess: vi.fn(async () => true)
+  }
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+const started = () => waitFor(() => expect(recorderInstances.length).toBeGreaterThan(0))
+
+describe('useMicRecorder stream lifecycle', () => {
+  // The mic re-arm fix rests on this: a normal stop between turns keeps the
+  // MediaStream open, so the next turn skips the getUserMedia round-trip that
+  // was costing seconds after the assistant finished speaking.
+  it('keeps the stream open across a normal stop and reuses it on the next start', async () => {
+    const { result } = renderHook(() => useMicRecorder(copy))
+
+    await act(async () => {
+      await result.current.handle.start()
+    })
+    await started()
+
+    await act(async () => {
+      await result.current.handle.stop()
+    })
+
+    expect(streamTracks[0].stop).not.toHaveBeenCalled()
+    expect(getUserMedia).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await result.current.handle.start()
+    })
+
+    // Second turn re-arms off the retained stream.
+    expect(getUserMedia).toHaveBeenCalledTimes(1)
+    expect(streamTracks[0].stop).not.toHaveBeenCalled()
+  })
+
+  it('releases the stream on cancel', async () => {
+    const { result } = renderHook(() => useMicRecorder(copy))
+
+    await act(async () => {
+      await result.current.handle.start()
+    })
+    await started()
+
+    act(() => result.current.handle.cancel())
+
+    expect(streamTracks[0].stop).toHaveBeenCalled()
+  })
+
+  it('releases the stream on unmount', async () => {
+    const { result, unmount } = renderHook(() => useMicRecorder(copy))
+
+    await act(async () => {
+      await result.current.handle.start()
+    })
+    await started()
+
+    unmount()
+
+    expect(streamTracks[0].stop).toHaveBeenCalled()
+  })
+
+  it('releases the stream when the recorder errors', async () => {
+    const onError = vi.fn()
+    const { result } = renderHook(() => useMicRecorder(copy))
+
+    await act(async () => {
+      await result.current.handle.start({ onError })
+    })
+    await started()
+
+    act(() => recorderInstances[0].onerror?.(new Event('error')))
+
+    expect(streamTracks[0].stop).toHaveBeenCalled()
+    expect(onError).toHaveBeenCalled()
+  })
+
+  // A stream whose track died while idle (device unplugged, OS revoked it) must
+  // not be reused: the hook re-requests rather than arming a dead recorder.
+  it('re-requests the stream when the retained tracks are no longer live', async () => {
+    const { result } = renderHook(() => useMicRecorder(copy))
+
+    await act(async () => {
+      await result.current.handle.start()
+    })
+    await started()
+    await act(async () => {
+      await result.current.handle.stop()
+    })
+
+    streamTracks[0].readyState = 'ended'
+
+    await act(async () => {
+      await result.current.handle.start()
+    })
+
+    expect(getUserMedia).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 type BrowserAudioContext = typeof AudioContext
 
@@ -71,6 +71,8 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
   const streamRef = useRef<MediaStream | null>(null)
   const chunksRef = useRef<Blob[]>([])
   const audioContextRef = useRef<AudioContext | null>(null)
+  const analyserRef = useRef<AnalyserNode | null>(null)
+  const sourceRef = useRef<MediaStreamAudioSourceNode | null>(null)
   const animationRef = useRef<number | null>(null)
   const startedAtRef = useRef(0)
   const heardSpeechRef = useRef(false)
@@ -78,23 +80,48 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
   const silenceStartedAtRef = useRef<number | null>(null)
   const stopResolverRef = useRef<((recording: MicRecording | null) => void) | null>(null)
 
-  const cleanup = () => {
+  const stopMeter = useCallback(() => {
     if (animationRef.current) {
       window.cancelAnimationFrame(animationRef.current)
       animationRef.current = null
     }
 
+    setLevel(0)
+  }, [])
+
+  // Tear down the per-turn audio graph (meter loop, analyser, AudioContext).
+  // The AudioContext is intentionally NOT kept alive between turns: the browser
+  // can suspend an idle context, after which the analyser reads silence and
+  // speech detection silently stops (the turn then idles out after ~12s). It's
+  // cheap to recreate, so we rebuild it fresh on every re-arm.
+  const teardownAudioGraph = useCallback(() => {
+    stopMeter()
+    sourceRef.current?.disconnect()
+    sourceRef.current = null
+    analyserRef.current = null
     void audioContextRef.current?.close()
     audioContextRef.current = null
-    streamRef.current?.getTracks().forEach(track => track.stop())
-    streamRef.current = null
+  }, [stopMeter])
+
+  // Soft stop between turns: drop the per-turn MediaRecorder + audio graph but
+  // KEEP the mic STREAM alive, so the next turn re-arms without a fresh
+  // getUserMedia (that round-trip was the multi-second post-TTS mic delay).
+  const softCleanup = useCallback(() => {
+    teardownAudioGraph()
     recorderRef.current = null
-    setLevel(0)
     setRecording(false)
     silenceTriggeredRef.current = false
-  }
+  }, [teardownAudioGraph])
 
-  useEffect(() => () => cleanup(), [])
+  // Full release: also stop the mic tracks. Used when the conversation
+  // ends/cancels, on a recorder error, or on unmount.
+  const releaseStream = useCallback(() => {
+    softCleanup()
+    streamRef.current?.getTracks().forEach(track => track.stop())
+    streamRef.current = null
+  }, [softCleanup])
+
+  useEffect(() => () => releaseStream(), [releaseStream])
 
   const startMeter = (stream: MediaStream, options: MicRecorderOptions) => {
     const audioWindow = window as Window & { webkitAudioContext?: BrowserAudioContext }
@@ -105,15 +132,20 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
     }
 
     try {
+      // Fresh AudioContext per turn (see teardownAudioGraph) — built on the
+      // kept-alive stream, so this is cheap and always starts in 'running'.
       const audioContext = new AudioContextCtor()
       const analyser = audioContext.createAnalyser()
-      const source = audioContext.createMediaStreamSource(stream)
-
       analyser.fftSize = 256
-      const data = new Uint8Array(analyser.fftSize)
 
+      const source = audioContext.createMediaStreamSource(stream)
       source.connect(analyser)
+
       audioContextRef.current = audioContext
+      analyserRef.current = analyser
+      sourceRef.current = source
+
+      const data = new Uint8Array(analyser.fftSize)
 
       const tick = () => {
         analyser.getByteTimeDomainData(data)
@@ -175,20 +207,33 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
       throw new Error(copy.microphoneUnsupported)
     }
 
-    const permitted = await window.hermesDesktop?.requestMicrophoneAccess?.()
+    // Reuse a still-live stream from a previous turn so we skip the costly
+    // requestMicrophoneAccess + getUserMedia round-trip — that round-trip was
+    // the seconds-long re-arm delay after the assistant finished speaking.
+    let stream = streamRef.current
 
-    if (permitted === false) {
-      throw new Error(copy.microphoneAccessDenied)
-    }
+    if (!stream || !stream.getTracks().some(track => track.readyState === 'live')) {
+      const permitted = await window.hermesDesktop?.requestMicrophoneAccess?.()
 
-    let stream: MediaStream
+      if (permitted === false) {
+        throw new Error(copy.microphoneAccessDenied)
+      }
 
-    try {
-      stream = await navigator.mediaDevices.getUserMedia({
-        audio: { echoCancellation: true, noiseSuppression: true }
-      })
-    } catch (error) {
-      throw micError(error, copy)
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: { echoCancellation: true, noiseSuppression: true }
+        })
+      } catch (error) {
+        throw micError(error, copy)
+      }
+
+      // A brand-new stream invalidates any analyser graph wired to the old one.
+      sourceRef.current?.disconnect()
+      sourceRef.current = null
+      analyserRef.current = null
+      void audioContextRef.current?.close()
+      audioContextRef.current = null
+      streamRef.current = stream
     }
 
     const mimeType =
@@ -226,7 +271,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
       const heardSpeech = heardSpeechRef.current
 
       chunksRef.current = []
-      cleanup()
+      softCleanup()
 
       const resolver = stopResolverRef.current
       stopResolverRef.current = null
@@ -248,7 +293,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
       const error = micError((event as Event & { error?: unknown }).error, copy)
       const resolver = stopResolverRef.current
       stopResolverRef.current = null
-      cleanup()
+      releaseStream()
       options.onError?.(error)
       resolver?.(null)
     }
@@ -263,7 +308,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
       const recorder = recorderRef.current
 
       if (!recorder || recorder.state === 'inactive') {
-        cleanup()
+        softCleanup()
         resolve(null)
 
         return
@@ -285,7 +330,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
       recorder.stop()
     }
 
-    cleanup()
+    releaseStream()
     resolver?.(null)
   }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
@@ -1,0 +1,176 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { useState } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useVoiceConversation } from './use-voice-conversation'
+
+interface PendingVoiceResponse {
+  id: string
+  pending: boolean
+  text: string
+}
+
+const recorder = vi.hoisted(() => ({
+  cancel: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn()
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      notifications: {
+        voice: {
+          configureSpeechToText: 'Configure speech-to-text',
+          couldNotStartSession: 'Could not start voice session',
+          microphoneFailed: 'Microphone failed',
+          playbackFailed: 'Playback failed',
+          transcriptionFailed: 'Transcription failed',
+          unavailable: 'Voice unavailable'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+vi.mock('@/lib/voice-playback', () => ({
+  playSpeechText: vi.fn(async () => true),
+  prefetchSpeechText: vi.fn(),
+  clearSpeechPrefetch: vi.fn(),
+  stopVoicePlayback: vi.fn()
+}))
+
+vi.mock('./use-mic-recorder', () => ({
+  useMicRecorder: () => ({ handle: recorder, level: 0 })
+}))
+
+// Drives the hook the way the composer does: `pendingResponse` is a live getter,
+// and `busy` is host React state that flips true on submit and false when the
+// assistant finishes — so it lands in the same commit as the hook's own
+// setStatus('thinking'), as it does in the app.
+function setup() {
+  const state: { response: PendingVoiceResponse | null } = { response: null }
+
+  const consumePendingResponse = vi.fn(() => {
+    state.response = null
+  })
+
+  let onSilence: (() => void) | undefined
+  recorder.start.mockImplementation(async (options: { onSilence?: () => void }) => {
+    onSilence = options?.onSilence
+  })
+  recorder.stop.mockResolvedValue({
+    audio: new Blob(['voice'], { type: 'audio/webm' }),
+    durationMs: 1200,
+    heardSpeech: true
+  })
+
+  const view = renderHook(() => {
+    const [busy, setBusy] = useState(false)
+
+    const conversation = useVoiceConversation({
+      busy,
+      consumePendingResponse,
+      enabled: true,
+      onSubmit: () => setBusy(true),
+      onTranscribeAudio: async () => 'hello',
+      pendingResponse: () => state.response
+    })
+
+    return { conversation, setBusy }
+  })
+
+  const status = () => view.result.current.conversation.status
+
+  // Puts the hook in the post-submit state: awaiting a spoken response, status
+  // 'thinking'. Mirrors the real path (start -> listen -> silence -> transcribe
+  // -> submit) rather than reaching into refs, so the invariants hold for the
+  // transitions the loop actually performs.
+  const submitATurn = async () => {
+    await act(async () => {
+      await view.result.current.conversation.start()
+    })
+    await waitFor(() => expect(recorder.start).toHaveBeenCalled())
+
+    await act(async () => {
+      onSilence?.()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(status()).toBe('thinking'))
+    recorder.start.mockClear()
+  }
+
+  // The assistant's turn ends: host clears `busy`.
+  const finishTurn = async () => {
+    await act(async () => view.result.current.setBusy(false))
+  }
+
+  return { consumePendingResponse, finishTurn, state, status, submitATurn, view }
+}
+
+describe('useVoiceConversation mic re-arm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    recorder.start.mockResolvedValue(undefined)
+  })
+
+  // The bug in #54067: when the reply is fully spoken, `status` is already
+  // 'idle' (speak()'s finally set it), so the completion path's setStatus('idle')
+  // is a no-op -> React bails out -> no re-render -> the effect never re-runs to
+  // reach startListening(). The mic must re-arm from the completion itself, not
+  // from an incidental later re-render.
+  it('re-arms the mic when a spoken reply completes and status is already idle', async () => {
+    const h = setup()
+    await h.submitATurn()
+
+    // The assistant streams one sentence, which gets spoken -> status returns to
+    // 'idle' via speak()'s finally.
+    await act(async () => {
+      h.state.response = { id: 'r1', pending: true, text: 'This is a full sentence.' }
+    })
+    await act(async () => h.view.rerender())
+    await waitFor(() => expect(h.status()).toBe('idle'))
+
+    recorder.start.mockClear()
+
+    // The reply completes with nothing further to speak.
+    h.state.response = { id: 'r1', pending: false, text: 'This is a full sentence.' }
+    await h.finishTurn()
+
+    await waitFor(() => expect(recorder.start).toHaveBeenCalledTimes(1))
+  })
+
+  // The sibling early-return path (`!busy && status === 'thinking'`): the turn
+  // ends without ever producing a spoken response. The loop must still recover
+  // to a listening mic rather than stranding the UI in 'thinking'.
+  it('re-arms the mic when a turn ends without a spoken response', async () => {
+    const h = setup()
+    await h.submitATurn()
+
+    // Turn finishes; no pending response was ever published.
+    h.state.response = null
+    await h.finishTurn()
+
+    await waitFor(() => expect(recorder.start).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(h.status()).toBe('listening'))
+  })
+
+  // The completion path can also be reached while status is still 'thinking' —
+  // a reply with no speakable text (tool-only / empty). Same invariant.
+  it('re-arms the mic when a reply completes with no speakable text', async () => {
+    const h = setup()
+    await h.submitATurn()
+
+    h.state.response = { id: 'r1', pending: false, text: '' }
+    await h.finishTurn()
+
+    await waitFor(() => expect(recorder.start).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(h.status()).toBe('listening'))
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -24,6 +24,66 @@ interface VoiceConversationOptions {
   consumePendingResponse: () => void
 }
 
+// Minimum length for a chunk to be voiced on its own. Shorter leading
+// fragments — list markers like "One.", "1.", "A." — are merged with the
+// sentence that follows, so TTS never has to speak a clipped one-word chunk
+// (which sounds like it's "running out of air", pauses, and isn't prefetched).
+const MIN_SPEAK_CHARS = 8
+
+// Pure sentence splitter. Walks boundaries and accumulates until the chunk is
+// at least MIN_SPEAK_CHARS, so a short marker stays attached to the text it
+// introduces. Returns [chunk, rest], or null when there is no usable chunk yet
+// and the caller isn't forcing.
+//
+// `!?。！？` end a sentence. A `.` does too, but the buffer here is still
+// growing, so its end proves nothing: `1.` may be a finished sentence or the
+// head of `1.2`. A `.` after a digit therefore waits for whitespace to confirm
+// it, while every other `.` may also end at the buffer end. That costs one
+// character of latency on "grew 12." and keeps "1.2 billion" from being spoken
+// as "one" then "two billion".
+export const extractChunk = (raw: string, force: boolean): [string, string] | null => {
+  const buffer = raw.replace(/\s+/g, ' ').trim()
+
+  if (!buffer) {
+    return null
+  }
+
+  const boundary = /(?:[!?。！？](?:\s+|$)|(?<![0-9])\.(?:\s+|$)|(?<=[0-9])\.\s+)/g
+  let match: RegExpExecArray | null
+  let end = -1
+
+  while ((match = boundary.exec(buffer)) !== null) {
+    end = match.index + match[0].trimEnd().length
+
+    if (end >= MIN_SPEAK_CHARS) {
+      break
+    }
+  }
+
+  if (end >= 0 && (end >= MIN_SPEAK_CHARS || force)) {
+    return [buffer.slice(0, end).trim(), buffer.slice(end).trim()]
+  }
+
+  // No usable sentence boundary yet: soft-wrap a very long buffer, else wait.
+  if (!force && buffer.length > 220) {
+    const softBoundary = Math.max(
+      buffer.lastIndexOf(', ', 180),
+      buffer.lastIndexOf('; ', 180),
+      buffer.lastIndexOf(': ', 180)
+    )
+
+    if (softBoundary > 80) {
+      return [buffer.slice(0, softBoundary + 1).trim(), buffer.slice(softBoundary + 1).trim()]
+    }
+  }
+
+  if (!force) {
+    return null
+  }
+
+  return [buffer, '']
+}
+
 export function useVoiceConversation({
   busy,
   enabled,
@@ -89,45 +149,15 @@ export function useVoiceConversation({
   }
 
   const takeSpeechChunk = (force = false): string | null => {
-    const buffer = speechBufferRef.current.replace(/\s+/g, ' ').trim()
+    const result = extractChunk(speechBufferRef.current, force)
 
-    if (!buffer) {
-      speechBufferRef.current = ''
-
+    if (!result) {
       return null
     }
 
-    const sentence = buffer.match(/^(.+?[.!?。！？])(?:\s+|$)/)
+    speechBufferRef.current = result[1]
 
-    if (sentence?.[1] && (sentence[1].length >= 8 || force)) {
-      const chunk = sentence[1].trim()
-      speechBufferRef.current = buffer.slice(sentence[1].length).trim()
-
-      return chunk
-    }
-
-    if (!force && buffer.length > 220) {
-      const softBoundary = Math.max(
-        buffer.lastIndexOf(', ', 180),
-        buffer.lastIndexOf('; ', 180),
-        buffer.lastIndexOf(': ', 180)
-      )
-
-      if (softBoundary > 80) {
-        const chunk = buffer.slice(0, softBoundary + 1).trim()
-        speechBufferRef.current = buffer.slice(softBoundary + 1).trim()
-
-        return chunk
-      }
-    }
-
-    if (!force) {
-      return null
-    }
-
-    speechBufferRef.current = ''
-
-    return buffer
+    return result[0] || null
   }
 
   const handleTurn = useCallback(

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -355,13 +355,18 @@ export function useVoiceConversation({
         }
 
         if (!response.pending && !busy) {
+          // Whole reply spoken. Fall through to the restart guard at the bottom
+          // instead of returning: `status` is already 'idle' here, because the
+          // last speak() set it, so setStatus('idle') changes nothing, React
+          // bails out, and no re-render arrives to run this effect again. The
+          // mic then waited for an unrelated render, which was the variable 4-8s
+          // delay before recording resumed. Reaching startListening() in this
+          // same pass is the whole fix.
           awaitingSpokenResponseRef.current = false
           consumePendingResponse()
           resetSpeechBuffer()
           pendingStartRef.current = true
           setStatus('idle')
-
-          return
         }
       }
 


### PR DESCRIPTION
## What

Three fixes to the desktop voice loop, all on the microphone side.

- The mic re-arms as soon as the assistant finishes speaking, instead of waiting for an unrelated re-render.
- The MediaStream stays open between turns, so a turn no longer re-runs `getUserMedia`.
- The sentence splitter stops handing TTS a clipped fragment or half a number.

## Why

Two separate delays after the assistant stopped talking, both measured on macOS with a local
Kokoro + Whisper backend.

**The effect never re-ran.** Once the reply was fully spoken, the loop set `pendingStartRef`, called
`setStatus('idle')` and returned. `status` is already `'idle'` at that point, because the last `speak()` set
it in its `finally`, so the setState is a no-op, React bails out, and the re-render that would run the effect
again never arrives. The restart guard is three lines below the return. Nothing reaches it until some other
component happens to render, which is where the 4-8s wait and its variance came from.

**Every turn re-acquired the microphone.** Cleanup stopped the stream tracks on every normal stop, so the
next turn paid `requestMicrophoneAccess` + `getUserMedia` again.

**The splitter mishandled short fragments and numbers.** A bare list marker like `1.` was voiced as its own
synth call, which sounds clipped and pauses before the item it introduces. And because the splitter runs on a
buffer that is still growing, a `.` at the end of the buffer doesn't mean the sentence ended: `Revenue grew
to 1.` matched, so the reply was spoken as "Revenue grew to one" followed by "2 billion."

## Notes

The AudioContext is still rebuilt every turn on purpose. The browser suspends an idle context, after which
the analyser reads silence and speech detection stops without any error.

Keeping the stream open has two visible consequences: the OS microphone indicator stays lit for the whole
conversation rather than flickering off between turns, and a microphone device change takes effect on the
next release instead of the next turn. Cancel, unmount, mute and recorder errors all still release the
tracks.

#38411 diagnosed the re-arm first and independently. Its fix removes the same early return, and also removes
the `setStatus('idle')` calls; the sibling paths rely on those, so removing them strands the hook in
`'thinking'` with a dead microphone. This keeps both and drops only the one return that can't be reached
usefully. Evidence and a correction are on that PR. If it merges first, the re-arm commit here comes out.

`voice-playback.ts` is deliberately untouched. #44308 has been rewriting `playSpeechText` for the same
latency goal since 11 June; the prefetch work that used to be in this PR is offered there instead.

## Testing

19 contracts. `use-voice-conversation.test.tsx` (3) and `use-mic-recorder.test.tsx` (5) run against current
`main` unchanged: 2 fail there (the already-idle re-arm, and stream retention across a normal stop) and 6
pass, holding the existing teardown and sibling behaviour still. `speech-chunking.test.ts` (11) imports
`extractChunk`, which this PR adds, and streams the reply in a character at a time, since passing a finished
string hides the decimal case.

Desktop UI suite green apart from `markdown-text.test.ts`, which fails the same way on unmodified `main`
here. eslint clean on the touched files. tsc shows the same errors as `main`, none in these files. Verified
on macOS with local Kokoro + Whisper. Not tested on Windows; @wen0531 tested an earlier revision on Linux
(comment below).

Fixes #51265.
