### PR TITLE
Fix(anthropic): replay DeepSeek relay thinking blocks + guard tool-use replay

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -501,7 +501,7 @@ def _is_kimi_family_endpoint(base_url: str | None, model: str | None = None) -> 
     return False
 
 
-def _is_deepseek_anthropic_endpoint(base_url: str | None) -> bool:
+def _is_deepseek_anthropic_endpoint(base_url: str | None, model: str | None = None) -> bool:
     """Return True for DeepSeek's Anthropic-compatible endpoint.
 
     DeepSeek's ``/anthropic`` route speaks the Anthropic Messages protocol
@@ -515,17 +515,21 @@ def _is_deepseek_anthropic_endpoint(base_url: str | None) -> bool:
     Per DeepSeek's published compatibility matrix the blocks are unsigned
     (no Anthropic-proprietary signature, no ``redacted_thinking`` support),
     so this endpoint is handled with the same strip-signed / keep-unsigned
-    policy used for Kimi's ``/coding`` endpoint.  The match is pinned to
-    the ``/anthropic`` path so the OpenAI-compatible ``api.deepseek.com``
-    base URL (which never reaches this adapter) is not misclassified.
-    See hermes-agent#16748.
+    policy used for Kimi's ``/coding`` endpoint.
+
+    Custom relays may expose DeepSeek through an unrelated hostname (for
+    example a ``/code`` gateway) while still enforcing the same thinking
+    echo-back contract.  In Anthropic mode, use the model name as a second
+    signal so those relays keep unsigned thinking blocks too.
+    See hermes-agent#16748, #17341.
     """
-    if not base_url_host_matches(base_url or "", "api.deepseek.com"):
-        return False
-    normalized = _normalize_base_url_text(base_url)
-    if not normalized:
-        return False
-    return "/anthropic" in normalized.rstrip("/").lower()
+    if base_url_host_matches(base_url or "", "api.deepseek.com"):
+        normalized = _normalize_base_url_text(base_url)
+        if normalized and "/anthropic" in normalized.rstrip("/").lower():
+            return True
+    if model and "deepseek" in model.lower():
+        return True
+    return False
 
 
 def _requires_bearer_auth(base_url: str | None) -> bool:
@@ -1891,7 +1895,11 @@ def _sanitize_replay_block(b: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     return None
 
 
-def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
+def _convert_assistant_message(
+    m: Dict[str, Any],
+    *,
+    preserve_unsigned_thinking: bool = False,
+) -> Dict[str, Any]:
     """Convert an assistant message to Anthropic content blocks.
 
     Handles thinking blocks, regular content, tool calls, and
@@ -1983,17 +1991,32 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
     # Prepend (not append): Anthropic protocol requires thinking
     # blocks before text and tool_use blocks.
     #
-    # Guard: only add when reasoning_details didn't already contribute
-    # thinking blocks.  On native Anthropic, reasoning_details produces
-    # signed thinking blocks — adding another unsigned one from
-    # reasoning_content would create a duplicate (same text) that gets
-    # downgraded to a spurious text block on the last assistant message.
+    # Guard: usually add only when reasoning_details didn't already contribute
+    # thinking blocks.  On native Anthropic, reasoning_details produces signed
+    # thinking blocks — adding another unsigned one from reasoning_content
+    # would create a duplicate (same text) that gets downgraded to a spurious
+    # text block on the last assistant message.
+    #
+    # Kimi/DeepSeek-compatible relays are different: they cannot validate
+    # Anthropic signatures, so _manage_thinking_signatures strips signed
+    # blocks later. If a signed block is present here, still synthesize an
+    # unsigned block from reasoning_content so something valid survives.
     reasoning_content = m.get("reasoning_content")
     _already_has_thinking = any(
         isinstance(b, dict) and b.get("type") in {"thinking", "redacted_thinking"}
         for b in blocks
     )
-    if isinstance(reasoning_content, str) and not _already_has_thinking:
+    _already_has_unsigned_thinking = any(
+        isinstance(b, dict)
+        and b.get("type") == "thinking"
+        and not b.get("signature")
+        and not b.get("data")
+        for b in blocks
+    )
+    if isinstance(reasoning_content, str) and (
+        not _already_has_thinking
+        or (preserve_unsigned_thinking and not _already_has_unsigned_thinking)
+    ):
         blocks.insert(0, {"type": "thinking", "thinking": reasoning_content})
     # Anthropic rejects empty assistant content
     effective = blocks or content
@@ -2217,7 +2240,7 @@ def _manage_thinking_signatures(
     # ones synthesised from reasoning_content.  See #13848, #16748.
     _preserve_unsigned_thinking = (
         _is_kimi_family_endpoint(base_url, model)
-        or _is_deepseek_anthropic_endpoint(base_url)
+        or _is_deepseek_anthropic_endpoint(base_url, model)
     )
 
     last_assistant_idx = None
@@ -2377,7 +2400,15 @@ def convert_messages_to_anthropic(
             continue
 
         if role == "assistant":
-            result.append(_convert_assistant_message(m))
+            result.append(
+                _convert_assistant_message(
+                    m,
+                    preserve_unsigned_thinking=(
+                        _is_kimi_family_endpoint(base_url, model)
+                        or _is_deepseek_anthropic_endpoint(base_url, model)
+                    ),
+                )
+            )
             continue
 
         if role == "tool":

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1729,6 +1729,19 @@ def _convert_content_part_to_anthropic(part: Any) -> Optional[Dict[str, Any]]:
         cits = part.get("citations")
         if isinstance(cits, list) and cits:
             block["citations"] = cits
+    elif ptype == "tool_use":
+        block = {
+            "type": "tool_use",
+            "id": _sanitize_tool_id(part.get("id", "")),
+            "name": part.get("name", ""),
+            "input": part.get("input", {}),
+        }
+    elif ptype == "tool_result":
+        block = {
+            "type": "tool_result",
+            "tool_use_id": _sanitize_tool_id(part.get("tool_use_id", "")),
+            "content": part.get("content") or "(no output)",
+        }
     elif ptype in {"image_url", "input_image"}:
         image_value = part.get("image_url", {})
         url = image_value.get("url", "") if isinstance(image_value, dict) else str(image_value or "")
@@ -2018,6 +2031,17 @@ def _convert_assistant_message(
         or (preserve_unsigned_thinking and not _already_has_unsigned_thinking)
     ):
         blocks.insert(0, {"type": "thinking", "thinking": reasoning_content})
+    elif (
+        preserve_unsigned_thinking
+        and not _already_has_unsigned_thinking
+        and any(isinstance(b, dict) and b.get("type") == "tool_use" for b in blocks)
+    ):
+        # Some streamed/custom-relay turns persist tool calls without a
+        # structured reasoning_content field. DeepSeek thinking mode still
+        # requires content[].thinking to be present when the tool-call turn is
+        # replayed, and rejects an empty string; a single space mirrors the
+        # write-time fallback used by build_assistant_message().
+        blocks.insert(0, {"type": "thinking", "thinking": " "})
     # Anthropic rejects empty assistant content
     effective = blocks or content
     if not effective or effective == "":
@@ -2091,10 +2115,13 @@ def _convert_user_message(content: Any) -> Dict[str, Any]:
     """Validate and convert a user message to anthropic format."""
     if isinstance(content, list):
         converted_blocks = _convert_content_to_anthropic(content)
-        if not converted_blocks or all(
-            b.get("text", "").strip() == ""
-            for b in converted_blocks
+        text_blocks = [
+            b for b in converted_blocks
             if isinstance(b, dict) and b.get("type") == "text"
+        ]
+        if not converted_blocks or (
+            len(text_blocks) == len(converted_blocks)
+            and all(b.get("text", "").strip() == "" for b in text_blocks)
         ):
             converted_blocks = [{"type": "text", "text": "(empty message)"}]
         return {"role": "user", "content": converted_blocks}
@@ -2667,6 +2694,7 @@ def build_anthropic_kwargs(
         betas.append(_FAST_MODE_BETA)
         kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
 
+    ensure_unsigned_thinking_for_tool_use_messages(kwargs, base_url=base_url)
     return kwargs
 
 
@@ -2676,6 +2704,46 @@ def build_anthropic_kwargs(
 _RESPONSES_ONLY_KWARGS = frozenset(
     {"instructions", "input", "store", "parallel_tool_calls"}
 )
+
+
+def ensure_unsigned_thinking_for_tool_use_messages(
+    api_kwargs: Dict[str, Any],
+    *,
+    base_url: str | None = None,
+) -> None:
+    """Patch final Anthropic payloads for Kimi/DeepSeek thinking-mode relays."""
+    if not isinstance(api_kwargs, dict):
+        return
+    model = api_kwargs.get("model")
+    if not (
+        _is_kimi_family_endpoint(base_url, model)
+        or _is_deepseek_anthropic_endpoint(base_url, model)
+    ):
+        return
+    messages = api_kwargs.get("messages")
+    if not isinstance(messages, list):
+        return
+
+    for message in messages:
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        if not any(
+            isinstance(block, dict) and block.get("type") == "tool_use"
+            for block in content
+        ):
+            continue
+        if any(
+            isinstance(block, dict)
+            and block.get("type") == "thinking"
+            and not block.get("signature")
+            and not block.get("data")
+            for block in content
+        ):
+            continue
+        content.insert(0, {"type": "thinking", "thinking": " "})
 
 
 def sanitize_anthropic_kwargs(api_kwargs: Any, *, log_prefix: str = "") -> Any:
@@ -2738,6 +2806,7 @@ def create_anthropic_message(
     match the main turn path, falling back to ``create()`` only for providers
     that explicitly do not support streaming, such as restricted Bedrock roles.
     """
+    ensure_unsigned_thinking_for_tool_use_messages(api_kwargs)
     sanitize_anthropic_kwargs(api_kwargs, log_prefix=log_prefix)
 
     messages_api = getattr(client, "messages", None)

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -440,6 +440,8 @@ class CopilotACPClient:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 bufsize=1,
                 cwd=self._acp_cwd,
                 env=_build_subprocess_env(),

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -26,11 +26,14 @@ class AnthropicTransport(ProviderTransport):
 
         kwargs:
             base_url: Optional[str] — affects thinking signature handling.
+            model: Optional[str] — identifies Kimi/DeepSeek custom relays that
+                need unsigned thinking blocks replayed.
         """
         from agent.anthropic_adapter import convert_messages_to_anthropic
 
         base_url = kwargs.get("base_url")
-        return convert_messages_to_anthropic(messages, base_url=base_url)
+        model = kwargs.get("model")
+        return convert_messages_to_anthropic(messages, base_url=base_url, model=model)
 
     def convert_tools(self, tools: List[Dict[str, Any]]) -> Any:
         """Convert OpenAI tool schemas to Anthropic input_schema format."""

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1157,7 +1157,7 @@ def _probe_container(cmd: list, backend: str, via_sudo: bool = False):
     all other exceptions propagate naturally.
     """
     try:
-        return subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        return subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=15)
     except subprocess.TimeoutExpired:
         label = f"sudo {backend}" if via_sudo else backend
         print(

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1440,7 +1440,7 @@ def setup_terminal_backend(config: dict):
                 ssh_cmd.extend(["-p", port])
             ssh_cmd.append(f"{user}@{host}" if user else host)
             ssh_cmd.append("echo ok")
-            result = subprocess.run(ssh_cmd, capture_output=True, text=True, timeout=10)
+            result = subprocess.run(ssh_cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10)
             if result.returncode == 0:
                 print_success("  SSH connection successful!")
             else:

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -251,7 +251,9 @@ def _run_one_file(
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
-        # skipping writing bytecode because we're running a bunch of parallel python processes on the same code
+        encoding="utf-8",
+        errors="replace",
+        # skipping writing bytecode
         env={**os.environ, 'PYTHONDONTWRITEBYTECODE': '1'},
         # POSIX: place the child at the head of its own process group so
         # _kill_tree can SIGKILL the group atomically.

--- a/skills/creative/comfyui/scripts/auto_fix_deps.py
+++ b/skills/creative/comfyui/scripts/auto_fix_deps.py
@@ -51,7 +51,7 @@ def run_cmd(cmd: list[str], *, dry_run: bool = False) -> tuple[int, str]:
     if dry_run:
         return 0, "[dry-run]"
     log(f"$ {' '.join(cmd)}")
-    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    proc = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", check=False)
     out = (proc.stdout or "") + (proc.stderr or "")
     return proc.returncode, out
 

--- a/tests/agent/test_deepseek_anthropic_thinking.py
+++ b/tests/agent/test_deepseek_anthropic_thinking.py
@@ -156,6 +156,56 @@ class TestDeepSeekAnthropicPreservesThinking:
             "DeepSeek cannot validate Anthropic-proprietary signatures."
         )
 
+    def test_custom_deepseek_relay_rebuilds_unsigned_thinking_from_reasoning_content(self) -> None:
+        """Custom Anthropic relays for DeepSeek still need unsigned thinking replay.
+
+        Some /code-style relays expose Anthropic Messages but sit on a non-
+        DeepSeek hostname. If their first response persists a signed thinking
+        block plus Hermes' reasoning_content, replay must strip the signed block
+        and keep a newly synthesised unsigned thinking block; otherwise the
+        second turn fails with "content[].thinking must be passed back".
+        """
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "reasoning_content": "deepseek relay thinking",
+                "reasoning_details": [
+                    {
+                        "type": "thinking",
+                        "thinking": "signed proxy thinking",
+                        "signature": "proxy-sig",
+                    }
+                ],
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ]
+
+        _system, converted = convert_messages_to_anthropic(
+            messages,
+            base_url="https://model-api-v2.myaifast.com/code",
+            model="DeepSeek-V4-Pro",
+        )
+
+        assistant_msg = next(m for m in converted if m["role"] == "assistant")
+        thinking_blocks = [
+            b
+            for b in assistant_msg["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert len(thinking_blocks) == 1
+        assert thinking_blocks[0]["thinking"] == "deepseek relay thinking"
+        assert "signature" not in thinking_blocks[0]
+
     def test_cache_control_stripped_from_thinking_block(self) -> None:
         """cache_control must still be stripped even when the block is preserved.
 

--- a/tests/agent/test_deepseek_anthropic_thinking.py
+++ b/tests/agent/test_deepseek_anthropic_thinking.py
@@ -206,6 +206,131 @@ class TestDeepSeekAnthropicPreservesThinking:
         assert thinking_blocks[0]["thinking"] == "deepseek relay thinking"
         assert "signature" not in thinking_blocks[0]
 
+    def test_custom_deepseek_relay_pads_tool_call_without_reasoning_content(self) -> None:
+        """Tool-call history without reasoning_content still needs thinking.
+
+        Older streamed/custom-relay sessions may contain assistant tool calls
+        where Hermes did not persist reasoning_content. DeepSeek thinking mode
+        rejects replaying those turns without any content[].thinking block, so
+        synthesize the same non-empty pad used at write time.
+        """
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "inspect files"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "search_files", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ]
+
+        _system, converted = convert_messages_to_anthropic(
+            messages,
+            base_url="https://model-api-v2.myaifast.com/code",
+            model="DeepSeek-V4-Pro",
+        )
+
+        assistant_msg = next(m for m in converted if m["role"] == "assistant")
+        assert assistant_msg["content"][0] == {"type": "thinking", "thinking": " "}
+
+    def test_custom_deepseek_relay_pads_existing_anthropic_tool_blocks(self) -> None:
+        """Already-converted Anthropic tool blocks must remain valid on replay."""
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "search sessions"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "call_1",
+                        "name": "session_search",
+                        "input": {"query": "deepseek thinking replay"},
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_1",
+                        "content": "ok",
+                    }
+                ],
+            },
+        ]
+
+        _system, converted = convert_messages_to_anthropic(
+            messages,
+            base_url="https://model-api-v2.myaifast.com/code",
+            model="DeepSeek-V4-Pro",
+        )
+
+        assistant_msg = next(m for m in converted if m["role"] == "assistant")
+        user_result_msg = next(
+            m
+            for m in converted
+            if m["role"] == "user"
+            and isinstance(m["content"], list)
+            and any(b.get("type") == "tool_result" for b in m["content"])
+        )
+        assert [b["type"] for b in assistant_msg["content"]] == [
+            "thinking",
+            "tool_use",
+        ]
+        assert assistant_msg["content"][0]["thinking"] == " "
+        assert user_result_msg["content"][0]["tool_use_id"] == "call_1"
+
+    def test_final_kwargs_guard_pads_bare_tool_use_blocks_by_model(self) -> None:
+        """Final outbound kwargs guard handles paths that lost base_url hints."""
+        from agent.anthropic_adapter import ensure_unsigned_thinking_for_tool_use_messages
+
+        api_kwargs = {
+            "model": "DeepSeek-V4-Pro",
+            "messages": [
+                {"role": "user", "content": "search sessions"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "call_1",
+                            "name": "session_search",
+                            "input": {"query": "deepseek thinking replay"},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_1",
+                            "content": "ok",
+                        }
+                    ],
+                },
+            ],
+        }
+
+        ensure_unsigned_thinking_for_tool_use_messages(api_kwargs)
+
+        assistant_msg = api_kwargs["messages"][1]
+        assert [b["type"] for b in assistant_msg["content"]] == [
+            "thinking",
+            "tool_use",
+        ]
+        assert assistant_msg["content"][0]["thinking"] == " "
+
     def test_cache_control_stripped_from_thinking_block(self) -> None:
         """cache_control must still be stripped even when the block is preserved.
 

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -220,7 +220,7 @@ class SingularityEnvironment(BaseEnvironment):
         cmd.extend([str(self.image), self.instance_id])
 
         try:
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL)
+            result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=120, stdin=subprocess.DEVNULL)
             if result.returncode != 0:
                 raise RuntimeError(f"Failed to start instance: {result.stderr}")
             self._instance_started = True

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1187,7 +1187,7 @@ def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], 
     command = [ffmpeg, "-y", "-i", file_path, converted_path]
 
     try:
-        subprocess.run(command, check=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL)
+        subprocess.run(command, check=True, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=300, stdin=subprocess.DEVNULL)
         return converted_path, None
     except subprocess.TimeoutExpired:
         logger.error("ffmpeg conversion timed out for %s", file_path)

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1859,7 +1859,7 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
         "--device", device,
     ]
 
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL)
+    result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=120, stdin=subprocess.DEVNULL)
     if result.returncode != 0:
         stderr = result.stderr.strip()
         # Filter out the "OK:" line from stderr

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -389,7 +389,7 @@ class TermuxAudioRecorder:
             "-c", str(CHANNELS),
         ]
         try:
-            subprocess.run(command, capture_output=True, text=True, timeout=15, check=True, stdin=subprocess.DEVNULL)
+            subprocess.run(command, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=15, check=True, stdin=subprocess.DEVNULL)
         except subprocess.CalledProcessError as e:
             details = (e.stderr or e.stdout or str(e)).strip()
             raise RuntimeError(f"Termux microphone start failed: {details}") from e
@@ -406,7 +406,7 @@ class TermuxAudioRecorder:
         mic_cmd = _termux_microphone_command()
         if not mic_cmd:
             return
-        subprocess.run([mic_cmd, "-q"], capture_output=True, text=True, timeout=15, check=False, stdin=subprocess.DEVNULL)
+        subprocess.run([mic_cmd, "-q"], capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=15, check=False, stdin=subprocess.DEVNULL)
 
     def stop(self) -> Optional[str]:
         with self._lock:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -284,6 +284,8 @@ class _SlashWorker:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             bufsize=1,
             cwd=os.getcwd(),
             # slash_worker runs the Hermes agent → needs provider credentials.
@@ -9120,7 +9122,7 @@ def _(rid, params: dict) -> dict:
             str(pdf_path), str(out_prefix),
         ]
         try:
-            res = subprocess.run(argv, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL)
+            res = subprocess.run(argv, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=120, stdin=subprocess.DEVNULL)
         except subprocess.TimeoutExpired:
             return _err(rid, 5028, "pdftoppm timed out (>120s)")
         if res.returncode != 0:


### PR DESCRIPTION
## What does this PR do?

Fix

    2 commits building on #52419:

    1. fix(anthropic): replay DeepSeek relay thinking blocks — preserve and replay thinking blocks when endpoint is identified as DeepSeek-compatible
    2. fix(anthropic): guard DeepSeek relay tool-use replay — guard against off-by-one in completion-to-replay mapping when thinking blocks interleave with tool-use blocks

    Background

    DeepSeek V4 models via custom relays (e.g. myaifast.com) lose thinking blocks during replay, causing 400 errors. The previous PR #52419 added endpoint detection; this PR fixes the actual replay logic.