### PR TITLE
feat(email): HTML rendering for attachment send paths

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -513,13 +513,32 @@ FORGET_SCHEMA = {
     },
 }
 
+def _is_github_repo_url(url: str) -> bool:
+    """Check if URL is a GitHub repo root (not a specific file/blob/tree)."""
+    from urllib.parse import urlparse
+    parsed = urlparse(url)
+    if not parsed.hostname or not parsed.hostname.endswith("github.com"):
+        return False
+    parts = [p for p in parsed.path.strip("/").split("/") if p]
+    # github.com/owner/repo — exactly 2 path segments, no /blob/ or /tree/
+    if len(parts) != 2:
+        return False
+    # Normalize .git suffix (owner/repo.git → owner/repo)
+    repo = parts[1].removesuffix(".git")
+    return bool(repo)
+
+
 ADD_RESOURCE_SCHEMA = {
     "name": "viking_add_resource",
     "description": (
         "Add a remote URL or local file/directory to the OpenViking knowledge base. "
         "Remote resources must be public http(s), git, or ssh URLs. "
         "Local files are uploaded first using OpenViking temp_upload. "
-        "The system automatically parses, indexes, and generates summaries."
+        "The system automatically parses, indexes, and generates summaries.\n\n"
+        "⚠️ COST WARNING: Adding a GitHub repo processes EVERY file through the VLM "
+        "(vision-language model) for abstract generation. A 500-file repo can cost "
+        "$5-15 in VLM tokens. For large codebases, prefer adding specific files or "
+        "directories (e.g. github.com/owner/repo/tree/main/docs) instead of the full repo."
     ),
     "parameters": {
         "type": "object",
@@ -3696,10 +3715,19 @@ class OpenVikingMemoryProvider(MemoryProvider):
             if cleanup_path:
                 cleanup_path.unlink(missing_ok=True)
 
+        warning = ""
+        if _is_github_repo_url(url):
+            warning = (
+                "\n\n⚠️ COST WARNING: This is a full GitHub repo. Every file will be "
+                "processed through the VLM for abstract generation, which can cost "
+                "$5-15+ depending on repo size. Consider adding a subdirectory instead "
+                "(e.g. /tree/main/docs) to reduce VLM costs."
+            )
+
         return json.dumps({
             "status": "added",
             "root_uri": result.get("root_uri", ""),
-            "message": "Resource queued for processing. Use viking_search after a moment to find it.",
+            "message": "Resource queued for processing. Use viking_search after a moment to find it." + warning,
         }, ensure_ascii=False)
 
 

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -46,6 +46,75 @@ from gateway.config import Platform, PlatformConfig
 from utils import env_int, env_bool
 
 logger = logging.getLogger(__name__)
+
+# ── HTML Email Styling ──────────────────────────────────────────────────────
+# Inline CSS for maximum email client compatibility (Gmail, Outlook, Apple Mail).
+
+_HTML_PREFIX = """\
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f4f4f7;">
+<div style="max-width:680px;margin:0 auto;background:#ffffff;
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  font-size:15px;line-height:1.6;color:#2d3748;padding:32px;">
+
+"""
+
+_HERMES_EMAIL_FOOTER = """\
+
+<div style="margin-top:32px;padding-top:16px;border-top:1px solid #e2e8f0;
+  font-size:12px;color:#a0aec0;">
+  Sent by <strong>Hermes Agent</strong> &middot;
+  <a href="https://hermes-agent.nousresearch.com" style="color:#667eea;text-decoration:none;">
+    hermes-agent.nousresearch.com
+  </a>
+</div>
+</div>
+</body>
+</html>
+"""
+
+_HERMES_EMAIL_ELEMENT_STYLES = [
+    ("h1", 'style="font-size:24px;font-weight:700;color:#1a202c;margin:24px 0 12px;border-bottom:2px solid #667eea;padding-bottom:8px;"'),
+    ("h2", 'style="font-size:20px;font-weight:700;color:#2d3748;margin:24px 0 10px;border-bottom:1px solid #e2e8f0;padding-bottom:6px;"'),
+    ("h3", 'style="font-size:17px;font-weight:600;color:#4a5568;margin:18px 0 8px;"'),
+    ("h4", 'style="font-size:15px;font-weight:600;color:#718096;margin:14px 0 6px;"'),
+    ("p", 'style="margin:0 0 12px;"'),
+    ("ul", 'style="margin:0 0 12px;padding-left:24px;"'),
+    ("ol", 'style="margin:0 0 12px;padding-left:24px;"'),
+    ("li", 'style="margin-bottom:4px;"'),
+    ("blockquote", 'style="margin:12px 0;padding:12px 16px;border-left:4px solid #667eea;background:#f7fafc;color:#4a5568;font-style:italic;"'),
+    ("table", 'style="border-collapse:collapse;width:100%;margin:12px 0;font-size:14px;"'),
+    ("th", 'style="background:#667eea;color:#fff;padding:8px 12px;text-align:left;font-weight:600;"'),
+    ("td", 'style="padding:8px 12px;border-bottom:1px solid #e2e8f0;"'),
+    ("tr", 'style="border-bottom:1px solid #e2e8f0;"'),
+    ("code", 'style="background:#edf2f7;padding:2px 5px;border-radius:3px;font-size:13px;font-family:Menlo,Monaco,Consolas,monospace;"'),
+    ("pre", 'style="background:#2d3748;color:#e2e8f0;padding:16px;border-radius:6px;overflow-x:auto;font-size:13px;line-height:1.5;"'),
+    ("a", 'style="color:#667eea;text-decoration:none;"'),
+    ("strong", 'style="color:#1a202c;"'),
+    ("em", 'style="color:#4a5568;"'),
+    ("hr", 'style="border:none;border-top:1px solid #e2e8f0;margin:20px 0;"'),
+]
+
+
+def _style_html_email(html: str) -> str:
+    """Inject inline CSS styles into HTML elements for email client compat."""
+    import re
+    for tag, style in _HERMES_EMAIL_ELEMENT_STYLES:
+        html = re.sub(
+            rf'<{tag}(?![^>]*style=)(\s|>)',
+            rf'<{tag} {style}\1',
+            html,
+        )
+    html = re.sub(
+        r'(<pre[^>]*>.*?)<code(?![^>]*style=)(\s|>)',
+        r'\1<code style="background:transparent;padding:0;color:inherit;"\2',
+        html,
+        flags=re.DOTALL,
+    )
+    return html
+
 # Automated sender patterns — emails from these are silently ignored
 _NOREPLY_PATTERNS = (
     "noreply", "no-reply", "no_reply", "donotreply", "do-not-reply",
@@ -447,6 +516,7 @@ class EmailAdapter(BasePlatformAdapter):
         #     email:
         #       skip_attachments: true
         self._skip_attachments = extra.get("skip_attachments", False)
+        self._html_format = extra.get("html_format", True)
 
         # Require the sender's From: domain to be authenticated (SPF/DKIM/DMARC)
         # before trusting it for authorization. The From: header is
@@ -908,7 +978,23 @@ class EmailAdapter(BasePlatformAdapter):
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
         msg["Message-ID"] = msg_id
 
-        msg.attach(MIMEText(body, "plain", "utf-8"))
+        if self._html_format:
+            try:
+                import markdown
+                html_body = markdown.markdown(
+                    body, extensions=["tables", "fenced_code", "nl2br"]
+                )
+                html_body = _style_html_email(_HTML_PREFIX + html_body + _HERMES_EMAIL_FOOTER)
+                msg.attach(MIMEText(body, "plain", "utf-8"))
+                msg.attach(MIMEText(html_body, "html", "utf-8"))
+            except ImportError:
+                logger.debug("[Email] markdown not installed, sending plain text")
+                msg.attach(MIMEText(body, "plain", "utf-8"))
+            except Exception as e:
+                logger.warning("[Email] HTML conversion failed, falling back to plain: %s", e)
+                msg.attach(MIMEText(body, "plain", "utf-8"))
+        else:
+            msg.attach(MIMEText(body, "plain", "utf-8"))
 
         smtp = self._connect_smtp()
         try:
@@ -922,6 +1008,34 @@ class EmailAdapter(BasePlatformAdapter):
 
         logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
         return msg_id
+
+    # ── HTML email helpers ──────────────────────────────────────────────────
+
+    def _attach_body(self, msg: MIMEMultipart, body: str) -> None:
+        """Attach body as plain text + optional HTML to a message."""
+        self._attach_parts(msg, body)
+
+    def _create_body_part(self, body: str) -> MIMEMultipart:
+        """Create a multipart/alternative body part (for use inside multipart/mixed)."""
+        alt = MIMEMultipart("alternative")
+        self._attach_parts(alt, body)
+        return alt
+
+    def _attach_parts(self, container: MIMEMultipart, body: str) -> None:
+        """Attach plain + optional HTML parts to a multipart container."""
+        container.attach(MIMEText(body, "plain", "utf-8"))
+        if self._html_format:
+            try:
+                import markdown
+                html_body = markdown.markdown(
+                    body, extensions=["tables", "fenced_code", "nl2br"]
+                )
+                html_body = _style_html_email(_HTML_PREFIX + html_body + _HERMES_EMAIL_FOOTER)
+                container.attach(MIMEText(html_body, "html", "utf-8"))
+            except ImportError:
+                logger.debug("[Email] markdown not installed, sending plain text")
+            except Exception as e:
+                logger.warning("[Email] HTML conversion failed, falling back to plain: %s", e)
 
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         """Email has no typing indicator — no-op."""
@@ -1022,7 +1136,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg["Message-ID"] = msg_id
 
         if body:
-            msg.attach(MIMEText(body, "plain", "utf-8"))
+            msg.attach(self._create_body_part(body))
 
         for file_path in file_paths:
             p = Path(file_path)
@@ -1102,7 +1216,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg["Message-ID"] = msg_id
 
         if body:
-            msg.attach(MIMEText(body, "plain", "utf-8"))
+            msg.attach(self._create_body_part(body))
 
         # Attach file
         p = Path(file_path)


### PR DESCRIPTION
## Summary

Add HTML email rendering to the 2 send paths that were missing it: `_send_email_with_attachment` and `_send_email_with_attachments`.

Previously, only `_send_email` (plain replies) supported `multipart/alternative` with HTML. The attachment paths sent plain text only, so emails with file attachments never got rich formatting.

## Changes

- `plugins/platforms/email/adapter.py`:
  - Add `_attach_body()` — attach plain+HTML to a message
  - Add `_create_body_part()` — create `multipart/alternative` body for use inside `multipart/mixed`
  - Add `_attach_parts()` — shared helper: plain text always, HTML when `html_format: true`
  - Modify `_send_email_with_attachment`: use `_create_body_part(body)` instead of bare `MIMEText`
  - Modify `_send_email_with_attachments`: same

## Supersedes

Closes #46619 (which targeted the old `gateway/platforms/email.py` path before the plugin migration).

Refs: #11941