### PR TITLE
feat(cron): add [FAILURE: reason] marker for content-level failure escalation

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -329,6 +329,40 @@ def _is_cron_silence_response(text: str) -> bool:
         return True
     return False
 
+
+# ---------------------------------------------------------------------------
+# Content-level failure marker — the symmetric counterpart to [SILENT].
+#
+# When a cron agent's task fails at the content level (skill not found, tool
+# errors, can't complete) but the agent process itself succeeds, the agent
+# can signal this with [FAILURE: reason].  The scheduler marks the run as
+# failed and optionally routes a copy of the response to a configured
+# escalation channel (cron.failure_escalation_channel in config.yaml).
+# ---------------------------------------------------------------------------
+_FAILURE_RE = re.compile(r"\[FAILURE(?::\s*(.+?))?\]", re.IGNORECASE)
+
+
+def _parse_cron_failure_marker(text: str) -> Optional[str]:
+    """Extract a failure reason from a ``[FAILURE: reason]`` marker.
+
+    Returns the reason string if a marker is found, ``None`` otherwise.
+    Only recognizes the bracketed form — no loose matching (unlike silence
+    tokens).  The marker must appear as a prefix or on its own first line
+    so genuine content that quotes ``[FAILURE]`` mid-sentence is not
+    misclassified.
+    """
+    if not isinstance(text, str):
+        return None
+    stripped = text.strip()
+    if not stripped:
+        return None
+    # Check the full response or its first non-empty line.
+    first_line = stripped.splitlines()[0].strip()
+    m = _FAILURE_RE.match(first_line)
+    if m:
+        return m.group(1) or "agent reported task failure"
+    return None
+
 # ---------------------------------------------------------------------------
 # Persistent thread pool for parallel cron jobs.
 # The tick function submits jobs here and returns immediately so the ticker
@@ -2445,7 +2479,13 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         "SILENT: If there is genuinely nothing new to report, respond "
         "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
         "Never combine [SILENT] with content — either report your "
-        "findings normally, or say [SILENT] and nothing more.]\n\n"
+        "findings normally, or say [SILENT] and nothing more. "
+        "FAILURE: If this task actually failed — a skill isn't found, "
+        "a tool keeps erroring, or you genuinely cannot complete it — "
+        "start your response with [FAILURE: brief reason] "
+        "(e.g. \"[FAILURE: skill not found]\"). The scheduler will mark "
+        "the run as failed and route the report to the operator. "
+        "Do not use send_message for failure reporting.]\n\n"
     )
     prompt = cron_hint + prompt
     if skills is None:
@@ -3828,6 +3868,25 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             if should_deliver and success and _is_cron_silence_response(deliver_content):
                 logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                 should_deliver = False
+
+            # Content-level failure escalation — see _parse_cron_failure_marker.
+            # When the agent signals [FAILURE: reason], mark the run as failed
+            # and optionally route a copy to cron.failure_escalation_channel.
+            failure_reason = _parse_cron_failure_marker(deliver_content) if should_deliver and success else None
+            if failure_reason:
+                logger.info("Job '%s': agent returned [FAILURE: %s]", job["id"], failure_reason)
+                success = False
+                error = f"Agent-reported failure: {failure_reason}"
+                try:
+                    esc_channel = (load_config() or {}).get("cron", {}).get("failure_escalation_channel")
+                except Exception:
+                    esc_channel = None
+                if esc_channel:
+                    esc_job = {**job, "deliver": esc_channel}
+                    try:
+                        _deliver_result(esc_job, deliver_content, adapters=adapters, loop=loop)
+                    except Exception as esc_err:
+                        logger.error("Failure escalation delivery failed for job %s: %s", job["id"], esc_err)
 
             if should_deliver:
                 try:

--- a/tests/cron/test_cron_failure_marker.py
+++ b/tests/cron/test_cron_failure_marker.py
@@ -1,0 +1,176 @@
+"""Tests for the [FAILURE: reason] content-level failure marker.
+
+Covers the parser contract (_parse_cron_failure_marker) and the
+run_one_job integration: status flip, escalation delivery, and
+escalation-failure resilience.
+"""
+import cron.scheduler as s
+
+
+# ---------------------------------------------------------------------------
+# Parser contract
+# ---------------------------------------------------------------------------
+
+def test_parse_failure_marker_with_reason():
+    parse = s._parse_cron_failure_marker
+    assert parse("[FAILURE: skill not found]") == "skill not found"
+
+
+def test_parse_failure_marker_without_reason():
+    parse = s._parse_cron_failure_marker
+    assert parse("[FAILURE]") == "agent reported task failure"
+
+
+def test_parse_failure_marker_case_insensitive():
+    parse = s._parse_cron_failure_marker
+    assert parse("[failure: timeout]") == "timeout"
+    assert parse("[Failure: API error]") == "API error"
+
+
+def test_parse_failure_marker_first_line_only():
+    parse = s._parse_cron_failure_marker
+    assert parse("[FAILURE: oops]\nSome detail follows") == "oops"
+
+
+def test_parse_failure_marker_rejects_mid_sentence():
+    """A [FAILURE] mention mid-sentence must not trigger — only prefix."""
+    parse = s._parse_cron_failure_marker
+    assert parse("The task said [FAILURE: x] in its log") is None
+
+
+def test_parse_failure_marker_rejects_normal_response():
+    parse = s._parse_cron_failure_marker
+    assert parse("Everything went fine, report attached.") is None
+
+
+def test_parse_failure_marker_rejects_empty_and_none():
+    parse = s._parse_cron_failure_marker
+    assert parse("") is None
+    assert parse("   ") is None
+    assert parse(None) is None
+
+
+def test_parse_failure_marker_rejects_silent():
+    """[SILENT] must not be confused with [FAILURE]."""
+    parse = s._parse_cron_failure_marker
+    assert parse("[SILENT]") is None
+
+
+# ---------------------------------------------------------------------------
+# Pipeline integration (run_one_job)
+# ---------------------------------------------------------------------------
+
+def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final response",
+                    error=None, config=None):
+    """Patch the job pipeline primitives and record calls.
+
+    ``config`` is the return value of ``load_config()`` — set it to
+    ``{"cron": {"failure_escalation_channel": "..."}}`` to enable escalation.
+    """
+    calls = []
+
+    def fake_run_job(job, *, defer_agent_teardown=None):
+        calls.append(("run_job", job["id"]))
+        return (success, output, final, error)
+
+    def fake_save(jid, out):
+        calls.append(("save", jid))
+        return f"/tmp/{jid}.txt"
+
+    def fake_deliver(job, content, adapters=None, loop=None):
+        calls.append(("deliver", job.get("deliver", "default"), content))
+        return None
+
+    def fake_mark(jid, ok, err=None, delivery_error=None):
+        calls.append(("mark", jid, ok, err))
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", fake_save)
+    monkeypatch.setattr(s, "_deliver_result", fake_deliver)
+    monkeypatch.setattr(s, "mark_job_run", fake_mark)
+    monkeypatch.setattr(s, "load_config", lambda: config)
+    return calls
+
+
+def test_failure_marker_flips_status_to_failed(monkeypatch):
+    """[FAILURE: reason] must flip success→False and record the reason."""
+    calls = _patch_pipeline(monkeypatch, final="[FAILURE: skill not found]\nDetails here")
+
+    ok = s.run_one_job({"id": "f1", "name": "t"})
+
+    assert ok is True  # run_one_job returns True (job processed, not crashed)
+    mark = [c for c in calls if c[0] == "mark"][0]
+    assert mark[2] is False  # success=False
+    assert "skill not found" in mark[3]  # error contains reason
+
+
+def test_failure_marker_escalation_delivery(monkeypatch):
+    """When failure_escalation_channel is configured, the response is also
+    delivered to the escalation channel."""
+    calls = _patch_pipeline(
+        monkeypatch,
+        final="[FAILURE: tool error]\nCould not run",
+        config={"cron": {"failure_escalation_channel": "discord:escalation-room"}},
+    )
+
+    s.run_one_job({"id": "f2", "name": "t"})
+
+    delivers = [c for c in calls if c[0] == "deliver"]
+    # Two deliveries: escalation channel + main channel
+    assert len(delivers) == 2
+    esc = [d for d in delivers if d[1] == "discord:escalation-room"]
+    assert len(esc) == 1
+    assert "[FAILURE: tool error]" in esc[0][2]
+
+
+def test_failure_marker_no_escalation_without_config(monkeypatch):
+    """Without failure_escalation_channel, only the main delivery fires."""
+    calls = _patch_pipeline(monkeypatch, final="[FAILURE: oops]", config={})
+
+    s.run_one_job({"id": "f3", "name": "t"})
+
+    delivers = [c for c in calls if c[0] == "deliver"]
+    assert len(delivers) == 1  # main delivery only
+
+
+def test_failure_marker_escalation_error_does_not_crash(monkeypatch):
+    """If escalation delivery raises, the main pipeline still completes."""
+    calls = []
+
+    def fake_run_job(job, *, defer_agent_teardown=None):
+        calls.append(("run_job",))
+        return (True, "out", "[FAILURE: boom]", None)
+
+    deliver_count = {"n": 0}
+
+    def fake_deliver(job, content, adapters=None, loop=None):
+        deliver_count["n"] += 1
+        if job.get("deliver") == "discord:esc":
+            raise RuntimeError("escalation channel down")
+        calls.append(("deliver-main",))
+        return None
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "_deliver_result", fake_deliver)
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: calls.append(("mark",)))
+    monkeypatch.setattr(s, "load_config",
+                        lambda: {"cron": {"failure_escalation_channel": "discord:esc"}})
+
+    ok = s.run_one_job({"id": "f4", "name": "t"})
+
+    assert ok is True
+    assert ("deliver-main",) in calls
+    assert ("mark",) in calls
+    assert deliver_count["n"] == 2  # escalation attempted + main delivered
+
+
+def test_normal_response_not_affected_by_failure_marker(monkeypatch):
+    """A normal (non-failure) response must not trigger failure logic."""
+    calls = _patch_pipeline(monkeypatch, final="All tasks completed successfully.")
+
+    s.run_one_job({"id": "f5", "name": "t"})
+
+    mark = [c for c in calls if c[0] == "mark"][0]
+    assert mark[2] is True  # success=True
+    assert mark[3] is None  # no error

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -267,6 +267,25 @@ By default (`cron.wrap_response: true`), cron deliveries are wrapped with:
 
 The `[SILENT]` prefix in a cron response suppresses delivery entirely — useful for jobs that only need to write to files or perform side effects.
 
+### Failure Escalation
+
+When a cron agent's task fails at the content level — a skill is not found, a tool keeps erroring, or the agent cannot complete the task — but the agent process itself succeeds, the agent can signal this by starting its response with `[FAILURE: reason]` (e.g., `[FAILURE: skill not found]`).
+
+The scheduler will:
+
+1. Mark the run as **failed** (even though the agent process succeeded).
+2. Deliver the agent's full response to the original target channel as usual.
+3. Optionally route a copy to a configured **escalation channel** for operator visibility.
+
+To enable escalation delivery, set `cron.failure_escalation_channel` in `config.yaml`:
+
+```yaml
+cron:
+  failure_escalation_channel: "discord:channel:123456789"
+```
+
+The marker must appear at the **start of the first line** — a `[FAILURE]` mention mid-sentence is ignored to avoid false positives. This is symmetric with `[SILENT]`: both are prefix-only markers that control post-run behavior.
+
 ### Session Isolation
 
 Cron deliveries are NOT mirrored into gateway session conversation history. They exist only in the cron job's own session. This prevents message alternation violations in the target chat's conversation.


### PR DESCRIPTION
## Summary

Cron jobs can fail at the **content level** — the agent completes normally (`success=True`) but the task itself failed (skill not found, tool keeps erroring, external API down). Today the scheduler has no way to distinguish this from a successful run, making these failures invisible unless someone manually reads cron output logs.

`[SILENT]` lets agents signal "nothing to report"; `[FAILURE: reason]` is the symmetric counterpart for "I ran but couldn't do the job."

## Changes

- `cron/scheduler.py`
  - `_FAILURE_RE` + `_parse_cron_failure_marker()`: extracts reason from `[FAILURE: reason]` marker. Bracketed-prefix only (no loose matching) so genuine content quoting `[FAILURE]` mid-sentence is not misclassified.
  - Cron prompt hint: adds `FAILURE:` section instructing agents to use `[FAILURE: brief reason]` instead of `send_message` for failure reporting.
  - `run_one_job()`: after `[SILENT]` check, detects `[FAILURE]` marker → flips `success=False` → optionally routes a copy to `cron.failure_escalation_channel`.

## Config (opt-in)

```yaml
cron:
  failure_escalation_channel: "discord:123456789"
```

When configured, the scheduler delivers a copy of the agent's failure report to the escalation channel **in addition to** the regular delivery target. Without the config, `[FAILURE]` still marks the run as failed (visible in `cron list --all`) but no extra delivery happens.

## Design rationale

- **Symmetric with `[SILENT]`**: same pattern (agent emits marker → scheduler acts), opposite direction (suppress vs. escalate)
- **Scheduler-level routing**: no contradiction with the "do NOT use send_message" cron rule — the scheduler handles delivery, not the agent
- **Platform-agnostic**: escalation uses the existing `_deliver_result()` routing which supports `platform:channel_id` format (Discord, Telegram, Slack, etc.)
- **Opt-in**: no behavior change without `failure_escalation_channel` configured, except `[FAILURE]` responses now correctly mark `last_status` as failed instead of ok

## Test plan

- [x] Created a one-shot cron job with prompt "respond with [FAILURE: test]"
- [x] Verified scheduler detected marker and logged `agent returned [FAILURE: test]`
- [x] Verified `success` flipped to `False` (`last_status` shows failed)
- [x] Verified escalation delivery routed to configured Discord channel
- [x] Verified regular delivery still works alongside escalation
- [ ] Unit tests for `_parse_cron_failure_marker()` edge cases