### PR TITLE
fix(install): scope Playwright override to too-new apt releases + keep step interruptible (#35166)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -509,8 +509,13 @@ detect_os() {
                 if [ -f /etc/os-release ]; then
                     . /etc/os-release
                     DISTRO="$ID"
+                    # VERSION_ID (e.g. "26.04", "14") lets us tell whether the
+                    # apt release is newer than the newest one Playwright's
+                    # platform resolver recognizes — the #35166 hang condition.
+                    DISTRO_VERSION="${VERSION_ID:-}"
                 else
                     DISTRO="unknown"
+                    DISTRO_VERSION=""
                 fi
             fi
             ;;
@@ -1885,10 +1890,43 @@ run_browser_install_with_timeout() {
     shift
 
     if command -v timeout >/dev/null 2>&1; then
-        timeout "$timeout_seconds" "$@"
+        # GNU `timeout` runs the command in its own process group, so a terminal
+        # Ctrl+C is delivered to `timeout` but never reaches the child — the
+        # download looks frozen and ignores Ctrl+C (#35166). `--foreground`
+        # keeps the command in the shell's foreground group so Ctrl+C reaches
+        # it; `-k 10` sends SIGKILL 10s after the deadline so a wedged download
+        # can't outlive the timeout. Both flags are GNU-only — probe once and
+        # fall back to plain `timeout` on BusyBox (Alpine), and to direct exec
+        # when `timeout` is absent (stock macOS, where Ctrl+C works natively).
+        if timeout --foreground -k 10 1 true >/dev/null 2>&1; then
+            timeout --foreground -k 10 "$timeout_seconds" "$@"
+        else
+            timeout "$timeout_seconds" "$@"
+        fi
     else
         "$@"
     fi
+}
+
+# Return success only when the host is an apt release NEWER than the newest one
+# Playwright's platform resolver recognizes — the exact condition that makes
+# `playwright install` hang uninterruptibly (#35166). We scope the override
+# retry to this case rather than retrying on *any* failure, so a genuine
+# network/disk/permission failure doesn't get a mismatched-glibc build forced
+# onto it. Newest Playwright-known apt releases as of this writing: Ubuntu
+# 24.04, Debian 13. Anything above triggers the fallback; everything Playwright
+# already handles (and every non-apt distro) does not.
+playwright_host_unrecognized() {
+    # Compare dotted versions: returns 0 if $1 > $2.
+    _ver_gt() {
+        [ "$1" = "$2" ] && return 1
+        [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" = "$1" ]
+    }
+    case "$DISTRO" in
+        ubuntu) _ver_gt "${DISTRO_VERSION:-0}" "24.04" ;;
+        debian) _ver_gt "${DISTRO_VERSION:-0}" "13" ;;
+        *) return 1 ;;  # Non-apt or unknown — not the #35166 hang condition.
+    esac
 }
 
 # Compute the PLAYWRIGHT_HOST_PLATFORM_OVERRIDE value to retry an install with
@@ -1912,14 +1950,19 @@ playwright_fallback_platform() {
 # Debian 14, future distros — see #35166), retry it ONCE with
 # PLAYWRIGHT_HOST_PLATFORM_OVERRIDE pinned to the newest known build.
 #
-# This is deliberately try-native-first, override-only-on-failure rather than a
-# hardcoded distro/version table: when Playwright already supports the host
-# (e.g. Ubuntu 26.04 on Playwright >=1.61), the first attempt succeeds and the
-# override never runs — so we never force a mismatched-glibc build onto a
-# release Playwright handles correctly (microsoft/playwright#35114). It is also
-# self-correcting: new distro releases work the moment Playwright adds them,
-# with no change here. Playwright's maintainers bless this env var as the
-# supported escape hatch for unrecognized platforms (microsoft/playwright#33434).
+# The override retry is scoped to the actual hang condition: it fires only when
+# the host is an apt release NEWER than Playwright recognizes
+# (playwright_host_unrecognized). On every release Playwright already supports
+# (Ubuntu <=24.04, Debian <=13) and every non-apt distro, the first attempt is
+# authoritative and a failure is reported as-is — we never force a
+# mismatched-glibc build (microsoft/playwright#35114) onto a host Playwright
+# handles correctly. This is deliberately narrower than a retry-on-any-failure:
+# a network/disk/permission error on a supported host should surface, not get
+# papered over with a platform override. Playwright's maintainers bless this
+# env var as the supported escape hatch for unrecognized platforms
+# (microsoft/playwright#33434); a hardcoded full distro/version table was
+# rejected upstream (microsoft/playwright#33432), so we only need the
+# newest-known floor here.
 #
 # An operator-provided PLAYWRIGHT_HOST_PLATFORM_OVERRIDE is always respected:
 # it is inherited by the first attempt, and the retry is skipped.
@@ -1940,14 +1983,21 @@ run_playwright_install() {
         return 1
     fi
 
+    # Only retry with an override on the apt releases too new for Playwright to
+    # recognize (the #35166 hang). Any other failure is a real failure and is
+    # surfaced unchanged.
+    if ! playwright_host_unrecognized; then
+        return 1
+    fi
+
     local fallback
     fallback="$(playwright_fallback_platform)"
     if [ -z "$fallback" ]; then
         return 1  # No usable fallback build for this arch.
     fi
 
-    log_warn "Playwright didn't recognize this platform — retrying with PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=$fallback"
-    log_info "(common on apt releases newer than Playwright knows, e.g. Ubuntu 26.04 / Debian 14; see #35166)"
+    log_warn "Playwright doesn't recognize ${DISTRO} ${DISTRO_VERSION} yet — retrying with PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=$fallback"
+    log_info "(apt releases newer than Playwright knows hang at this step; see #35166)"
     PLAYWRIGHT_HOST_PLATFORM_OVERRIDE="$fallback" \
         run_browser_install_with_timeout "$timeout_seconds" "$@"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1891,6 +1891,67 @@ run_browser_install_with_timeout() {
     fi
 }
 
+# Compute the PLAYWRIGHT_HOST_PLATFORM_OVERRIDE value to retry an install with
+# when Playwright's platform resolver rejects the host. ubuntu24.04 is the
+# newest Linux build Playwright has shipped across recent releases and runs on
+# newer apt releases (its binaries are dynamically linked); we point too-new /
+# unrecognized hosts at it. Only x64/arm64 Linux have Playwright builds — emit
+# nothing for anything else so the caller skips the retry. Echoes the value
+# (e.g. "ubuntu24.04-x64") or nothing.
+playwright_fallback_platform() {
+    case "$(uname -m)" in
+        x86_64|amd64) echo "ubuntu24.04-x64" ;;
+        aarch64|arm64) echo "ubuntu24.04-arm64" ;;
+        *) : ;;  # No Playwright Linux build for this arch.
+    esac
+}
+
+# Run a `playwright install ...` command, and if it fails or hangs (the
+# uninterruptible "Installing Playwright Chromium with system dependencies"
+# stall on apt releases Playwright doesn't recognize yet — Ubuntu 26.04,
+# Debian 14, future distros — see #35166), retry it ONCE with
+# PLAYWRIGHT_HOST_PLATFORM_OVERRIDE pinned to the newest known build.
+#
+# This is deliberately try-native-first, override-only-on-failure rather than a
+# hardcoded distro/version table: when Playwright already supports the host
+# (e.g. Ubuntu 26.04 on Playwright >=1.61), the first attempt succeeds and the
+# override never runs — so we never force a mismatched-glibc build onto a
+# release Playwright handles correctly (microsoft/playwright#35114). It is also
+# self-correcting: new distro releases work the moment Playwright adds them,
+# with no change here. Playwright's maintainers bless this env var as the
+# supported escape hatch for unrecognized platforms (microsoft/playwright#33434).
+#
+# An operator-provided PLAYWRIGHT_HOST_PLATFORM_OVERRIDE is always respected:
+# it is inherited by the first attempt, and the retry is skipped.
+#
+# Usage: run_playwright_install <timeout_seconds> npx playwright install [args...]
+run_playwright_install() {
+    local timeout_seconds="$1"
+    shift
+
+    # First attempt: native platform resolution (inherits any operator override).
+    if run_browser_install_with_timeout "$timeout_seconds" "$@" 2>/dev/null; then
+        return 0
+    fi
+
+    # Operator already pinned the platform — their choice already applied to the
+    # attempt above; a second identical run won't help.
+    if [ -n "${PLAYWRIGHT_HOST_PLATFORM_OVERRIDE:-}" ]; then
+        return 1
+    fi
+
+    local fallback
+    fallback="$(playwright_fallback_platform)"
+    if [ -z "$fallback" ]; then
+        return 1  # No usable fallback build for this arch.
+    fi
+
+    log_warn "Playwright didn't recognize this platform — retrying with PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=$fallback"
+    log_info "(common on apt releases newer than Playwright knows, e.g. Ubuntu 26.04 / Debian 14; see #35166)"
+    PLAYWRIGHT_HOST_PLATFORM_OVERRIDE="$fallback" \
+        run_browser_install_with_timeout "$timeout_seconds" "$@"
+}
+
 configure_browser_env_from_system_browser() {
     local env_file="$HERMES_HOME/.env"
     local browser_path="${DETECTED_BROWSER_EXECUTABLE:-}"
@@ -1971,7 +2032,7 @@ install_node_deps() {
                     # exact command the admin needs to run separately.
                     if [ "$(id -u)" -eq 0 ] || (command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null); then
                         log_info "Installing Playwright Chromium with system dependencies..."
-                        cd "$INSTALL_DIR" && run_browser_install_with_timeout 600 npx playwright install --with-deps chromium 2>/dev/null || {
+                        cd "$INSTALL_DIR" && run_playwright_install 600 npx playwright install --with-deps chromium || {
                             log_warn "Playwright browser installation failed — browser tools will not work."
                             log_warn "Try running manually: cd $INSTALL_DIR && npx playwright install --with-deps chromium"
                         }
@@ -1981,7 +2042,7 @@ install_node_deps() {
                         log_info "  sudo npx playwright install-deps chromium"
                         log_info "  (from $INSTALL_DIR, after Node.js deps are installed)"
                         log_info "Installing Chromium binary into this user's Playwright cache..."
-                        cd "$INSTALL_DIR" && run_browser_install_with_timeout 600 npx playwright install chromium 2>/dev/null || {
+                        cd "$INSTALL_DIR" && run_playwright_install 600 npx playwright install chromium || {
                             log_warn "Playwright browser installation failed — browser tools will not work."
                             log_warn "Try running manually: cd $INSTALL_DIR && npx playwright install chromium"
                         }
@@ -2001,7 +2062,7 @@ install_node_deps() {
                             log_warn "  sudo pacman -S nss atk at-spi2-core cups libdrm libxkbcommon mesa pango cairo alsa-lib"
                         fi
                     fi
-                    cd "$INSTALL_DIR" && run_browser_install_with_timeout 600 npx playwright install chromium 2>/dev/null || {
+                    cd "$INSTALL_DIR" && run_playwright_install 600 npx playwright install chromium || {
                         log_warn "Playwright browser installation failed — browser tools will not work."
                     }
                     ;;
@@ -2009,7 +2070,7 @@ install_node_deps() {
                     log_warn "Playwright does not support automatic dependency installation on RPM-based systems."
                     log_info "Install Chromium system dependencies manually before using browser tools:"
                     log_info "  sudo dnf install nss atk at-spi2-core cups-libs libdrm libxkbcommon mesa-libgbm pango cairo alsa-lib"
-                    cd "$INSTALL_DIR" && run_browser_install_with_timeout 600 npx playwright install chromium 2>/dev/null || {
+                    cd "$INSTALL_DIR" && run_playwright_install 600 npx playwright install chromium || {
                         log_warn "Playwright browser installation failed — install dependencies above and retry."
                     }
                     ;;
@@ -2017,7 +2078,7 @@ install_node_deps() {
                     log_warn "Playwright does not support automatic dependency installation on zypper-based systems."
                     log_info "Install Chromium system dependencies manually before using browser tools:"
                     log_info "  sudo zypper install mozilla-nss libatk-1_0-0 at-spi2-core cups-libs libdrm2 libxkbcommon0 Mesa-libgbm1 pango cairo libasound2"
-                    cd "$INSTALL_DIR" && run_browser_install_with_timeout 600 npx playwright install chromium 2>/dev/null || {
+                    cd "$INSTALL_DIR" && run_playwright_install 600 npx playwright install chromium || {
                         log_warn "Playwright browser installation failed — install dependencies above and retry."
                     }
                     ;;
@@ -2026,7 +2087,7 @@ install_node_deps() {
                     log_info "Install Chromium/browser system dependencies for your distribution, then run:"
                     log_info "  cd $INSTALL_DIR && npx playwright install chromium"
                     log_info "Browser tools will not work until dependencies are installed."
-                    cd "$INSTALL_DIR" && run_browser_install_with_timeout 600 npx playwright install chromium 2>/dev/null || true
+                    cd "$INSTALL_DIR" && run_playwright_install 600 npx playwright install chromium || true
                     ;;
             esac
         fi

--- a/tests/test_install_sh_browser_install.py
+++ b/tests/test_install_sh_browser_install.py
@@ -58,13 +58,21 @@ def test_install_script_strips_stale_snap_browser_override() -> None:
 def test_playwright_installs_are_timeout_guarded() -> None:
     text = INSTALL_SH.read_text()
 
+    # The timeout wrapper still exists and is used internally by the install
+    # wrapper, so every Playwright download remains bounded.
     assert "run_browser_install_with_timeout()" in text
-    assert "run_browser_install_with_timeout 600 npx playwright install chromium" in text
+    # Playwright installs now go through run_playwright_install(), which wraps
+    # run_browser_install_with_timeout (timeout-guarded) and adds an
+    # unrecognized-platform fallback retry.
+    assert "run_playwright_install 600 npx playwright install chromium" in text
     # --with-deps is still invoked on apt-based systems, but only when sudo
     # is available non-interactively (root or passwordless sudo). Non-sudo
     # service users fall back to the browser-only install — see
     # install_node_deps() in install.sh.
-    assert "run_browser_install_with_timeout 600 npx playwright install --with-deps chromium" in text
+    assert "run_playwright_install 600 npx playwright install --with-deps chromium" in text
+    # The wrapper still bounds the download with the timeout helper.
+    assert 'run_browser_install_with_timeout "$timeout_seconds" "$@"' in text
+
 
 
 def test_install_script_supports_skip_browser_flag() -> None:
@@ -86,3 +94,29 @@ def test_install_script_skips_with_deps_when_no_sudo() -> None:
     # service-user installs (systemd accounts, operator users, etc.).
     assert 'if [ "$(id -u)" -eq 0 ] || (command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null); then' in text
     assert "sudo npx playwright install-deps chromium" in text
+
+
+def test_playwright_install_retries_with_platform_override_on_failure() -> None:
+    """Installer must self-correct when Playwright doesn't recognize the host.
+
+    On apt releases newer than Playwright knows (Ubuntu 26.04, Debian 14, future
+    distros) `playwright install` hangs/fails (#35166). run_playwright_install
+    must retry ONCE with PLAYWRIGHT_HOST_PLATFORM_OVERRIDE pinned to the newest
+    known build — but only on failure (try-native-first, so a host Playwright
+    already supports keeps its native build and avoids the glibc mismatch in
+    microsoft/playwright#35114), and never when the operator pinned the value.
+    """
+    text = INSTALL_SH.read_text()
+
+    assert "run_playwright_install()" in text
+    assert "playwright_fallback_platform()" in text
+    # Fallback target is the newest known build, arch-aware.
+    assert 'echo "ubuntu24.04-x64"' in text
+    assert 'echo "ubuntu24.04-arm64"' in text
+    # Try native first: only retry after the first attempt fails.
+    assert 'if run_browser_install_with_timeout "$timeout_seconds" "$@" 2>/dev/null; then' in text
+    # Operator-pinned override is respected (retry skipped).
+    assert 'if [ -n "${PLAYWRIGHT_HOST_PLATFORM_OVERRIDE:-}" ]; then' in text
+    # The retry actually sets the override for the child process.
+    assert 'PLAYWRIGHT_HOST_PLATFORM_OVERRIDE="$fallback" \\' in text
+

--- a/tests/test_install_sh_browser_install.py
+++ b/tests/test_install_sh_browser_install.py
@@ -102,14 +102,16 @@ def test_playwright_install_retries_with_platform_override_on_failure() -> None:
     On apt releases newer than Playwright knows (Ubuntu 26.04, Debian 14, future
     distros) `playwright install` hangs/fails (#35166). run_playwright_install
     must retry ONCE with PLAYWRIGHT_HOST_PLATFORM_OVERRIDE pinned to the newest
-    known build — but only on failure (try-native-first, so a host Playwright
-    already supports keeps its native build and avoids the glibc mismatch in
-    microsoft/playwright#35114), and never when the operator pinned the value.
+    known build — but only when the host is one of those too-new apt releases
+    (playwright_host_unrecognized), never on a host Playwright already supports
+    (which would force a glibc mismatch, microsoft/playwright#35114), and never
+    when the operator pinned the value.
     """
     text = INSTALL_SH.read_text()
 
     assert "run_playwright_install()" in text
     assert "playwright_fallback_platform()" in text
+    assert "playwright_host_unrecognized()" in text
     # Fallback target is the newest known build, arch-aware.
     assert 'echo "ubuntu24.04-x64"' in text
     assert 'echo "ubuntu24.04-arm64"' in text
@@ -117,6 +119,170 @@ def test_playwright_install_retries_with_platform_override_on_failure() -> None:
     assert 'if run_browser_install_with_timeout "$timeout_seconds" "$@" 2>/dev/null; then' in text
     # Operator-pinned override is respected (retry skipped).
     assert 'if [ -n "${PLAYWRIGHT_HOST_PLATFORM_OVERRIDE:-}" ]; then' in text
+    # The retry is gated on the unrecognized-apt-release check, not any failure.
+    assert "if ! playwright_host_unrecognized; then" in text
     # The retry actually sets the override for the child process.
     assert 'PLAYWRIGHT_HOST_PLATFORM_OVERRIDE="$fallback" \\' in text
+
+
+def test_browser_install_timeout_stays_interruptible() -> None:
+    """The Playwright download must stay Ctrl+C-able and force-kill if wedged.
+
+    GNU `timeout` runs the child in its own process group, so a terminal Ctrl+C
+    reaches `timeout` but never the download — it looks frozen and ignores
+    Ctrl+C (#35166). `--foreground` keeps it in the shell's foreground group;
+    `-k 10` guarantees a SIGKILL after the deadline. Both are GNU-only, so the
+    installer probes support once and falls back to plain `timeout`.
+    """
+    text = INSTALL_SH.read_text()
+
+    # GNU-flag probe + the guarded invocation must both be present.
+    assert "timeout --foreground -k 10 1 true" in text
+    assert 'timeout --foreground -k 10 "$timeout_seconds" "$@"' in text
+    # Plain-timeout fallback preserved for BusyBox/non-GNU.
+    assert 'timeout "$timeout_seconds" "$@"' in text
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests: source the install.sh helpers in a stubbed shell and assert
+# the override retry fires ONLY on a too-new apt release (#35166), and not on a
+# host Playwright already supports.
+# ---------------------------------------------------------------------------
+
+import subprocess
+
+
+def _run_install_fn(distro: str, version: str, *, native_fails: bool,
+                    arch: str = "x86_64", operator_override: str = "") -> dict:
+    """Source the relevant functions from install.sh and drive run_playwright_install.
+
+    Stubs `npx` (the install command) to fail/succeed, `uname -m` for arch, and
+    `log_warn`/`log_info` to no-ops. Returns parsed observations: how many times
+    the install command ran, and the override value seen on each run.
+    """
+    # Extract the functions we need so we don't execute the whole installer.
+    fn_names = [
+        "run_browser_install_with_timeout",
+        "playwright_host_unrecognized",
+        "playwright_fallback_platform",
+        "run_playwright_install",
+    ]
+    src = INSTALL_SH.read_text()
+    import re
+
+    extracted = []
+    for name in fn_names:
+        m = re.search(rf"^{re.escape(name)}\(\) \{{.*?^\}}", src, re.MULTILINE | re.DOTALL)
+        assert m, f"could not extract {name}() from install.sh"
+        extracted.append(m.group(0))
+    body = "\n\n".join(extracted)
+
+    native_rc = 1 if native_fails else 0
+    harness = f"""
+set -u
+DISTRO={distro!r}
+DISTRO_VERSION={version!r}
+export PLAYWRIGHT_HOST_PLATFORM_OVERRIDE={operator_override!r}
+[ -z "$PLAYWRIGHT_HOST_PLATFORM_OVERRIDE" ] && unset PLAYWRIGHT_HOST_PLATFORM_OVERRIDE
+
+log_warn() {{ :; }}
+log_info() {{ :; }}
+
+# Stub `uname -m` for arch control without touching the real binary.
+uname() {{ if [ "$1" = "-m" ]; then echo {arch!r}; else command uname "$@"; fi }}
+
+# Stub `timeout`: just run the command, ignoring flags/duration. We only care
+# about how the npx stub behaves, not real timeout semantics here.
+timeout() {{
+    while [ $# -gt 0 ]; do
+        case "$1" in -*|[0-9]*) shift ;; *) break ;; esac
+    done
+    "$@"
+}}
+
+# Stub the install command. Record each invocation + the override in effect.
+npx() {{
+    echo "RUN override=${{PLAYWRIGHT_HOST_PLATFORM_OVERRIDE:-<none>}}" >>"$RUNLOG"
+    # First run reflects native_fails; the override retry (if any) succeeds.
+    if [ -n "${{PLAYWRIGHT_HOST_PLATFORM_OVERRIDE:-}}" ]; then return 0; fi
+    return {native_rc}
+}}
+
+{body}
+
+run_playwright_install 600 npx playwright install --with-deps chromium
+echo "FINAL_RC=$?"
+"""
+    import tempfile, os
+    with tempfile.NamedTemporaryFile("w", suffix=".log", delete=False) as lf:
+        runlog = lf.name
+    try:
+        env = dict(os.environ, RUNLOG=runlog)
+        proc = subprocess.run(["bash", "-c", harness], capture_output=True,
+                              text=True, env=env)
+        runs = Path(runlog).read_text().strip().splitlines()
+        final_rc = None
+        for line in proc.stdout.splitlines():
+            if line.startswith("FINAL_RC="):
+                final_rc = int(line.split("=", 1)[1])
+        return {"runs": runs, "final_rc": final_rc, "stderr": proc.stderr}
+    finally:
+        Path(runlog).unlink(missing_ok=True)
+
+
+def test_override_retry_fires_on_ubuntu_26() -> None:
+    """Ubuntu 26.04 (too new) → native fails → retry with ubuntu24.04 override."""
+    r = _run_install_fn("ubuntu", "26.04", native_fails=True)
+    assert len(r["runs"]) == 2, r["runs"]
+    assert "override=<none>" in r["runs"][0]
+    assert "override=ubuntu24.04-x64" in r["runs"][1]
+    assert r["final_rc"] == 0
+
+
+def test_override_retry_does_not_fire_on_supported_ubuntu() -> None:
+    """Ubuntu 24.04 is recognized by Playwright → a failure is surfaced, no override."""
+    r = _run_install_fn("ubuntu", "24.04", native_fails=True)
+    assert len(r["runs"]) == 1, r["runs"]
+    assert "override=<none>" in r["runs"][0]
+    assert r["final_rc"] == 1
+
+
+def test_override_retry_does_not_fire_on_fedora() -> None:
+    """Non-apt distro never triggers the override retry, even on failure."""
+    r = _run_install_fn("fedora", "42", native_fails=True)
+    assert len(r["runs"]) == 1, r["runs"]
+    assert r["final_rc"] == 1
+
+
+def test_override_retry_fires_on_debian_14() -> None:
+    """Debian 14 (> 13) is the too-new apt case → retry with override."""
+    r = _run_install_fn("debian", "14", native_fails=True)
+    assert len(r["runs"]) == 2, r["runs"]
+    assert "override=ubuntu24.04-x64" in r["runs"][1]
+    assert r["final_rc"] == 0
+
+
+def test_no_retry_when_native_succeeds_on_ubuntu_26() -> None:
+    """Even on Ubuntu 26.04, a successful native install is never retried."""
+    r = _run_install_fn("ubuntu", "26.04", native_fails=False)
+    assert len(r["runs"]) == 1, r["runs"]
+    assert "override=<none>" in r["runs"][0]
+    assert r["final_rc"] == 0
+
+
+def test_operator_override_respected_no_second_run() -> None:
+    """An operator-pinned override applies to attempt 1; no second run on failure."""
+    r = _run_install_fn("ubuntu", "26.04", native_fails=True,
+                        operator_override="ubuntu22.04-x64")
+    # The override is set, so the npx stub returns 0 on the first run.
+    assert len(r["runs"]) == 1, r["runs"]
+    assert "override=ubuntu22.04-x64" in r["runs"][0]
+    assert r["final_rc"] == 0
+
+
+def test_override_retry_skipped_on_unsupported_arch() -> None:
+    """Ubuntu 26.04 on an arch with no Playwright build → no fallback retry."""
+    r = _run_install_fn("ubuntu", "26.04", native_fails=True, arch="riscv64")
+    assert len(r["runs"]) == 1, r["runs"]
+    assert r["final_rc"] == 1
 


### PR DESCRIPTION
## Summary

The installer no longer hangs uninterruptibly at "Installing Playwright Chromium" on Ubuntu 26.04 — and the platform-override escape hatch now fires *only* on the apt releases that actually trigger the hang, not on every install failure.

Root cause (#35166): on apt releases newer than Playwright's resolver recognizes (Ubuntu 26.04, Debian 14, future distros), Playwright returns a platform identifier with no CDN build, so `npx playwright install` stalls forever — and because GNU `timeout` runs the child in its own process group, a terminal Ctrl+C never reaches it.

This builds on @kshitijk4poor's #54032 (cherry-picked, authorship preserved) with two corrections.

## Changes

- `scripts/install.sh`
  - **Scope the override retry to the real hang condition.** New `playwright_host_unrecognized()` returns true only on apt releases newer than Playwright knows (Ubuntu > 24.04 / Debian > 13, version-sorted). `run_playwright_install()` now retries with `PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-<arch>` *only* in that case — instead of retrying on **any** failure. A network/disk/permission error on a supported host surfaces unchanged rather than getting a mismatched-glibc build forced onto it (microsoft/playwright#35114).
  - `detect_os()` now captures `DISTRO_VERSION` from `/etc/os-release`.
  - **Keep the step interruptible** (folds in the self-closed #35304): the download runs under `timeout --foreground -k 10` (probed once, plain-`timeout` fallback for BusyBox, direct exec where `timeout` is absent). `--foreground` lets a terminal Ctrl+C reach the child; `-k 10` force-kills a wedged download after the deadline.
- `tests/test_install_sh_browser_install.py`: 7 new behavioral tests that source the helpers in a stubbed shell and assert the retry fires on Ubuntu 26.04 / Debian 14 but **not** on supported Ubuntu, non-apt distros, native success, operator-pinned override, or unsupported arch — plus the interruptibility guard.

## Validation

| Scenario | Before | After |
|---|---|---|
| Ubuntu 26.04, install stalls | Hangs forever, Ctrl+C ignored | Retries with `ubuntu24.04` override; Ctrl+C works |
| Ubuntu 24.04, real network failure | n/a | Surfaces failure (no override forced) |
| Fedora / non-apt, failure | n/a | Surfaces failure (no override) |
| Native install succeeds | — | No retry, no override |
| Operator-pinned override | — | Respected, single attempt |

`scripts/run_tests.sh tests/test_install_sh_browser_install.py` → 15 passed. `bash -n scripts/install.sh` → OK. Version-gate verified across 10 distro/version edges (24.04/25.10/26.04, Debian 12/13/14, empty version, non-apt).

Closes #35166.

## Infographic

![install-hang-fixed-35166](https://v3b.fal.media/files/b/0aa015ef/D3aBsaWEWub_bPXkkzU3f_3a3A7bH0.png)
