### PR TITLE
fix(verification): route verification_evidence.db through apply_wal_with_fallback for the macOS F_FULLFSYNC barrier (follow-up to #54045)

### DIFF
--- a/agent/verification_evidence.py
+++ b/agent/verification_evidence.py
@@ -63,7 +63,14 @@ def _connect() -> sqlite3.Connection:
     path = _db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path)
-    conn.execute("PRAGMA journal_mode=WAL")
+    # Route through the shared helper so verification_evidence.db gets the same
+    # WAL-with-DELETE-fallback behavior and the macOS F_FULLFSYNC checkpoint
+    # barrier (#54045) that every other production DB already uses; it was the
+    # last one still setting journal_mode=WAL with a bare PRAGMA. Lazy import
+    # mirrors hermes_cli.projects_db / kanban_db to avoid an import cycle.
+    from hermes_state import apply_wal_with_fallback
+
+    apply_wal_with_fallback(conn, db_label="verification_evidence.db")
     conn.execute("PRAGMA busy_timeout=5000")
     conn.row_factory = sqlite3.Row
     _ensure_schema(conn)

--- a/tests/agent/test_verification_evidence.py
+++ b/tests/agent/test_verification_evidence.py
@@ -4,12 +4,32 @@ import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from agent import verification_evidence as verification_evidence_module
 from agent.verification_evidence import (
     classify_verification_command,
     mark_workspace_edited,
     record_terminal_result,
     verification_status,
 )
+
+
+def test_connect_uses_shared_wal_fallback(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    calls = []
+
+    def apply_wal_with_fallback(conn, *, db_label):
+        calls.append((conn, db_label))
+
+    monkeypatch.setattr(
+        "hermes_state.apply_wal_with_fallback",
+        apply_wal_with_fallback,
+    )
+
+    conn = verification_evidence_module._connect()
+    try:
+        assert calls == [(conn, "verification_evidence.db")]
+    finally:
+        conn.close()
 
 
 def _node_project(root: Path) -> None:


### PR DESCRIPTION
Follow-up to #54045 (F_FULLFSYNC barrier at WAL checkpoints on macOS).

#54045 added the macOS `PRAGMA checkpoint_fullfsync=1` barrier inside `hermes_state.apply_wal_with_fallback`, and every production SQLite DB routes through that helper — `state.db`, `hermes_cli/projects_db.py` (projects.db), `hermes_cli/kanban_db.py` (kanban.db), `plugins/memory/holographic/store.py` (memory_store.db), and `gateway/platforms/api_server.py` (response_store.db).

`agent/verification_evidence.py` was the one straggler: `_connect()` set `PRAGMA journal_mode=WAL` with a bare execute and never imported the helper, so `verification_evidence.db` missed both:

- the macOS `F_FULLFSYNC` checkpoint barrier #54045 just established (the silent on-disk corruption window on a launchd SIGTERM landing during a checkpoint), and
- the NFS/SMB `WAL`→`DELETE` fallback that keeps the DB usable on WAL-incompatible mounts.

This routes it through `apply_wal_with_fallback(conn, db_label="verification_evidence.db")`, using the same function-local lazy import as `hermes_cli/projects_db.py` to avoid an import cycle. Behavior is unchanged on a normal local filesystem (still WAL) and is now consistent with every other production DB. The helper's behavior is covered by the existing `tests/test_hermes_state_wal_fallback.py`.
