### PR TITLE
fix(gateway): suppress 'Session compressed N times' noise on chat gateways (#39293)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -70,7 +70,7 @@ _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
-    r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
+    r"("  # transient/auxiliary status that should stay in logs, not gateway chats
     r"auxiliary\s+.+\s+failed"
     r"|compression\s+summary\s+failed"
     r"|fallback\s+context\s+marker"
@@ -79,6 +79,7 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|auto-lowered\s+compression\s+threshold"
     r"|compacting\s+context\s+[—-]\s+summarizing\s+earlier\s+conversation"
     r"|preflight\s+compression"
+    r"|session\s+compressed\s+\d+\s+times"
     r"|rate\s+limited\.\s+waiting\s+\d"
     r"|retrying\s+in\s+\d"
     r"|max\s+retries\s+\(\d+\).*(?:trying\s+fallback|exhausted|invalid\s+responses)"
@@ -429,7 +430,11 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
 
 
 def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:
-    """Filter/sanitize agent status callbacks before platform delivery."""
+    """Filter/sanitize agent status callbacks before platform delivery.
+
+    Local/CLI sessions keep the raw diagnostic stream. Messaging gateway
+    surfaces should not receive transient auxiliary/compression chatter.
+    """
     text = str(message or "").strip()
     if not text:
         return None

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -31,6 +31,7 @@ CHAT_PLATFORMS = [
 NOISY_STATUS_MESSAGES = [
     "🗜️ Preflight compression check before sending...",
     "🗜️ Compacting context — summarizing earlier conversation so I can continue...",
+    "⚠️  Session compressed 12 times — accuracy may degrade. Consider /new to start fresh.",
     "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",
     "⏱️ Rate limited. Waiting 30.0s (attempt 2/3)...",
     "⏳ Retrying in 4.2s (attempt 1/3)...",


### PR DESCRIPTION
## Summary
Compression status noise still leaks to Discord/Slack and other chat gateways. PR #53316 widened the noisy-status filter from Telegram-only to all chat surfaces and added the `compacting context — summarizing earlier conversation` pattern, but it **missed the sibling warning emitted ~15 lines away** in `agent/conversation_compression.py`:

```
⚠️  Session compressed N times — accuracy may degrade. Consider /new to start fresh.
```

On a long session that compresses repeatedly, this fires once per compression pass (the reporter saw it 8→15 times in a single Discord thread). It routes through `_emit_status` → `_prepare_gateway_status_message`, but `_TELEGRAM_NOISY_STATUS_RE` had no pattern matching it, so it passed straight through to chat.

## Fix
- `gateway/run.py`: add `session\s+compressed\s+\d+\s+times` to `_TELEGRAM_NOISY_STATUS_RE` (inside the existing alternation; `re.IGNORECASE | re.DOTALL` already apply). Tightened so it matches the real emitted line (with/without `log_prefix`, double-space after the emoji) without over-matching arbitrary "compressed N" text. Docstring on `_prepare_gateway_status_message` clarified.
- `tests/gateway/test_telegram_noise_filter.py`: add the exact `Session compressed 12 times …` string to `NOISY_STATUS_MESSAGES`, exercised by the existing parametrized suppression test across all 15 chat platforms.

Programmatic/local surfaces (`local` CLI/TUI, `api_server`, `webhook`, `msgraph_webhook`) keep raw diagnostics unchanged — the raw-text short-circuit runs before the regex.

## Verification
- `pytest tests/gateway/test_telegram_noise_filter.py` → 195 passed; full file + `test_compression_count_warning_36908.py` → 197 passed.
- E2E (programmatic): the exact production string for cc=2/8/12/15 (with `log_prefix` + double space) → suppressed on Discord, raw-kept on `local`. Guardrails confirmed: a normal agent reply and benign "I compressed the image to 12 KB" are NOT suppressed.

## Credit
Salvage of #54075 by @HexLab98, cherry-picked onto current `main` with authorship preserved. Closes #54075.
