### PR TITLE
feat(learn): support /learn --update for editing existing skills

### DIFF
--- a/agent/learn_prompt.py
+++ b/agent/learn_prompt.py
@@ -96,18 +96,115 @@ Quality bar:
   templates in `templates/`."""
 
 
+def parse_learn_request(user_request: str) -> tuple[str | None, str]:
+    """Split a ``/learn`` argument into ``(update_target, remaining_text)``.
+
+    ``/learn`` accepts exactly one flag — ``--update <skill>`` — and only when
+    it leads the argument. This is the single source of truth for that parsing
+    so the CLI, gateway, and TUI surfaces never re-implement it.
+
+    Returns:
+        ``(None, stripped_request)`` for an ordinary create-mode request, so
+        the create path stays byte-identical to the pre-``--update`` behavior.
+        ``(skill_name, notes)`` when ``--update`` leads the argument;
+        ``skill_name`` is ``""`` when the user typed ``--update`` without
+        naming a skill (still update mode — never create).
+    """
+    req = (user_request or "").strip()
+    if not req:
+        return None, ""
+
+    tokens = req.split(None, 1)
+    first = tokens[0]
+    rest = tokens[1].strip() if len(tokens) > 1 else ""
+
+    if first == "--update":
+        if not rest:
+            return "", ""
+        name_parts = rest.split(None, 1)
+        target = name_parts[0]
+        notes = name_parts[1].strip() if len(name_parts) > 1 else ""
+        return target, notes
+
+    return None, req
+
+
+def _build_update_prompt(skill_name: str, notes: str) -> str:
+    """Build the agent prompt for ``/learn --update <skill> [notes]``.
+
+    Update mode edits an EXISTING skill in place: read it with ``skill_view``,
+    then apply ``skill_manage`` ``patch`` (small fixes) or ``edit`` (major
+    rewrite). It never authors a new skill. Carries the same authoring
+    standards so an edited skill still matches house style.
+    """
+    name = (skill_name or "").strip()
+    notes = (notes or "").strip()
+
+    if name:
+        target_line = f"SKILL TO UPDATE: {name}\n\n"
+        read_step = (
+            f"1. Read the current skill first with `skill_view(\"{name}\")` so "
+            "you edit the real content rather than a guess. If no skill by "
+            "that name exists, say so and use `skills_list` to help the user "
+            "pick the right one — do not author a brand-new skill.\n"
+        )
+    else:
+        target_line = "SKILL TO UPDATE: (the user did not name one)\n\n"
+        read_step = (
+            "1. The user ran `/learn --update` without naming a skill. Use "
+            "`skills_list` to find the one they mean (ask if it is ambiguous), "
+            "then read it with `skill_view` — do not author a brand-new "
+            "skill.\n"
+        )
+
+    if notes:
+        change_line = f"WHAT TO CHANGE:\n{notes}\n\n"
+    else:
+        change_line = (
+            "WHAT TO CHANGE:\nThe user did not spell out the change — infer the "
+            "stale, missing, or incorrect parts from the current skill and the "
+            "conversation so far (errors hit, steps that were wrong or "
+            "missing) and improve those.\n\n"
+        )
+
+    return (
+        "[/learn --update] The user wants you to update an EXISTING skill in "
+        "place, not author a new one.\n\n"
+        f"{target_line}"
+        f"{change_line}"
+        "Do this:\n"
+        f"{read_step}"
+        "2. Apply the change with the `skill_manage` tool. Prefer "
+        "action=\"patch\" (old_string/new_string) for small, targeted fixes — "
+        "a typo, an added pitfall, a corrected command, a tightened trigger. "
+        "Use action=\"edit\" (full SKILL.md rewrite) ONLY for a major "
+        "overhaul. Never author a brand-new skill in update mode, and do not "
+        "change the skill's name or directory.\n\n"
+        f"{_AUTHORING_STANDARDS}\n\n"
+        "When done, tell the user the skill name and a one-line summary of "
+        "what you changed."
+    )
+
+
 def build_learn_prompt(user_request: str) -> str:
     """Build the agent prompt for an open-ended ``/learn`` request.
 
     Args:
         user_request: the free-text the user gave after ``/learn`` — a
             description of the workflow, paths, URLs, or "what I just did".
+            A leading ``--update <skill>`` switches to in-place update mode
+            (edit an existing skill via ``skill_manage`` patch/edit) instead
+            of authoring a new one.
 
     Returns:
         A complete instruction the agent runs as a normal turn. The agent
         gathers the described sources with its existing tools and authors the
         skill via ``skill_manage``.
     """
+    update_target, notes = parse_learn_request(user_request)
+    if update_target is not None:
+        return _build_update_prompt(update_target, notes)
+
     req = (user_request or "").strip()
     if not req:
         req = (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8626,14 +8626,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # web_extract, this conversation, pasted text) and authors the skill
             # via skill_manage. Mirrors the /blueprint fall-through so role
             # alternation is preserved. No engine, works on any backend.
-            from agent.learn_prompt import build_learn_prompt
+            from agent.learn_prompt import build_learn_prompt, parse_learn_request
 
             _learn_req = event.get_command_args().strip()
-            _ack = (
-                "Learning a skill from what you described…"
-                if _learn_req
-                else "Learning a skill from this conversation…"
-            )
+            _update_target, _ = parse_learn_request(_learn_req)
+            if _update_target is not None:
+                _ack = (
+                    f"Updating the skill '{_update_target}'…"
+                    if _update_target
+                    else "Updating an existing skill…"
+                )
+            else:
+                _ack = (
+                    "Learning a skill from what you described…"
+                    if _learn_req
+                    else "Learning a skill from this conversation…"
+                )
             try:
                 adapter = self.adapters.get(source.platform)
                 if adapter:

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1490,14 +1490,20 @@ class CLICommandsMixin:
         authors the skill via ``skill_manage``. No engine, no model-tool
         footprint, works on any terminal backend.
         """
-        from agent.learn_prompt import build_learn_prompt
+        from agent.learn_prompt import build_learn_prompt, parse_learn_request
 
         # Everything after the command word is the open-ended request.
         parts = cmd.strip().split(None, 1)
         user_request = parts[1].strip() if len(parts) > 1 else ""
 
         msg = build_learn_prompt(user_request)
-        if user_request:
+        update_target, _ = parse_learn_request(user_request)
+        if update_target is not None:
+            if update_target:
+                print(f"\n⚡ Updating the skill '{update_target}'...")
+            else:
+                print("\n⚡ Updating an existing skill...")
+        elif user_request:
             print("\n⚡ Learning a skill from what you described...")
         else:
             print("\n⚡ Learning a skill from this conversation...")

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -186,7 +186,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("hatch", "Generate a new petdex pet from a description",
                "Tools & Skills", cli_only=True, aliases=("generate-pet",), args_hint="[description]"),
     CommandDef("learn", "Learn a reusable skill from anything you describe (dirs, URLs, this chat, notes)",
-               "Tools & Skills", args_hint="<what to learn from>"),
+               "Tools & Skills", args_hint="[--update <skill>] <what to learn from>", subcommands=("--update",)),
     CommandDef("cron", "Manage scheduled tasks", "Tools & Skills",
                cli_only=True, args_hint="[subcommand]",
                subcommands=("list", "add", "create", "edit", "pause", "resume", "run", "remove")),
@@ -1863,6 +1863,54 @@ class SlashCommandCompleter(Completer):
         except Exception:
             pass
 
+    @staticmethod
+    def _learn_completions(sub_text: str, sub_lower: str):
+        """Yield completions for /learn — subcommand (--update) and skill name.
+
+        Handles:
+        - ``/learn <tab>`` -> suggests ``--update``
+        - ``/learn --update <tab>`` -> suggests available skill names from local skills catalog.
+        """
+        parts = sub_text.split()
+        trailing_space = sub_text.endswith(" ")
+
+        # Subcommand stage: zero words typed, or completing the first word.
+        if len(parts) == 0 or (len(parts) == 1 and not trailing_space):
+            partial = sub_text if not trailing_space else ""
+            if "--update".startswith(partial.lower()) and "--update" != partial.lower():
+                yield Completion(
+                    "--update",
+                    start_position=-len(partial),
+                    display="--update",
+                    display_meta="update an existing skill",
+                )
+            return
+
+        subcommand = parts[0].lower()
+        if subcommand != "--update":
+            return
+
+        partial = "" if trailing_space else parts[-1]
+        partial_lower = partial.lower()
+        already = set(parts[1:] if trailing_space else parts[1:-1])
+
+        # Suggest skill names
+        try:
+            from tools.skills_tool import _find_all_skills
+            skills = _find_all_skills()
+            for s in skills:
+                name = s["name"]
+                if name in already or not name.startswith(partial_lower):
+                    continue
+                yield Completion(
+                    name,
+                    start_position=-len(partial),
+                    display=name,
+                    display_meta=s.get("description", "") or "skill name",
+                )
+        except Exception:
+            return
+
     def get_completions(self, document, complete_event):
         text = document.text_before_cursor
         if not text.startswith("/"):
@@ -1902,6 +1950,10 @@ class SlashCommandCompleter(Completer):
 
             if base_cmd == "/handoff":
                 yield from self._handoff_completions(sub_text, sub_lower)
+                return
+
+            if base_cmd == "/learn":
+                yield from self._learn_completions(sub_text, sub_lower)
                 return
 
             # Static subcommand completions

--- a/tests/agent/test_learn_prompt.py
+++ b/tests/agent/test_learn_prompt.py
@@ -6,7 +6,11 @@ builds a standards-guided prompt that the live agent runs as a normal turn, so
 these are the load-bearing behavior contracts.
 """
 
-from agent.learn_prompt import build_learn_prompt, _AUTHORING_STANDARDS
+from agent.learn_prompt import (
+    build_learn_prompt,
+    parse_learn_request,
+    _AUTHORING_STANDARDS,
+)
 
 
 class TestBuildLearnPrompt:
@@ -65,6 +69,82 @@ class TestBuildLearnPrompt:
         assert "scripts/" in _AUTHORING_STANDARDS
 
 
+class TestParseLearnRequest:
+    def test_plain_request_is_not_update_mode(self):
+        # No --update flag → (None, stripped_request); create path untouched.
+        assert parse_learn_request("the REST client in ~/proj") == (
+            None,
+            "the REST client in ~/proj",
+        )
+
+    def test_empty_is_not_update_mode(self):
+        assert parse_learn_request("") == (None, "")
+        assert parse_learn_request("   \n ") == (None, "")
+
+    def test_update_with_skill_and_notes(self):
+        assert parse_learn_request("--update arxiv-search add the ID lookup") == (
+            "arxiv-search",
+            "add the ID lookup",
+        )
+
+    def test_update_with_skill_only(self):
+        assert parse_learn_request("--update arxiv-search") == ("arxiv-search", "")
+
+    def test_update_without_skill_is_still_update_mode(self):
+        # Bare --update routes to update mode with an empty target — it must
+        # never fall through to create.
+        assert parse_learn_request("--update") == ("", "")
+
+    def test_update_only_when_flag_leads(self):
+        # --update mid-string is ordinary free text, not the flag.
+        assert parse_learn_request("learn how --update works") == (
+            None,
+            "learn how --update works",
+        )
+
+
+class TestBuildUpdatePrompt:
+    def test_targets_the_named_skill(self):
+        prompt = build_learn_prompt("--update arxiv-search")
+        assert "arxiv-search" in prompt
+        assert "skill_view" in prompt
+
+    def test_uses_patch_and_edit_not_create(self):
+        prompt = build_learn_prompt("--update arxiv-search fix a flag")
+        assert 'action="patch"' in prompt
+        assert 'action="edit"' in prompt
+        # Update mode must never instruct the create action.
+        assert 'action="create"' not in prompt
+        # And must not carry the create-path's authoring instruction.
+        assert "Author ONE SKILL.md" not in prompt
+
+    def test_carries_the_authoring_standards(self):
+        # An edited skill must still match house style.
+        assert _AUTHORING_STANDARDS in build_learn_prompt("--update arxiv-search")
+
+    def test_embeds_the_change_notes_verbatim(self):
+        prompt = build_learn_prompt("--update arxiv-search add ID lookup section")
+        assert "add ID lookup section" in prompt
+
+    def test_bare_update_does_not_create(self):
+        prompt = build_learn_prompt("--update")
+        assert 'action="create"' not in prompt
+        assert "Author ONE SKILL.md" not in prompt
+        assert "skills_list" in prompt
+
+
+class TestCreatePathUnchanged:
+    def test_plain_request_still_uses_create(self):
+        prompt = build_learn_prompt("the REST client in ~/projects/acme-sdk")
+        assert 'action="create"' in prompt
+        assert "Author ONE SKILL.md" in prompt
+
+    def test_empty_request_still_falls_back_to_conversation(self):
+        prompt = build_learn_prompt("")
+        assert "conversation" in prompt.lower()
+        assert 'action="create"' in prompt
+
+
 class TestLearnRegistryWiring:
     def test_learn_is_registered_and_resolves(self):
         from hermes_cli.commands import resolve_command
@@ -89,3 +169,46 @@ class TestLearnRegistryWiring:
         from hermes_cli.commands import resolve_command
 
         assert not resolve_command("learn").cli_only
+
+    def test_learn_args_hint_and_subcommands(self):
+        from hermes_cli.commands import resolve_command
+
+        cmd = resolve_command("learn")
+        assert "--update" in cmd.args_hint
+        assert "--update" in cmd.subcommands
+
+
+class TestLearnCommandCompleter:
+    def test_learn_autocomplete_suggests_update_flag(self):
+        from hermes_cli.commands import SlashCommandCompleter
+        from prompt_toolkit.document import Document
+
+        completer = SlashCommandCompleter()
+        doc = Document("/learn ", cursor_position=len("/learn "))
+        completions = list(completer.get_completions(doc, None))
+        assert any(c.text == "--update" for c in completions)
+
+    def test_learn_autocomplete_suggests_skills(self, monkeypatch):
+        from hermes_cli.commands import SlashCommandCompleter
+        from prompt_toolkit.document import Document
+
+        monkeypatch.setattr(
+            "tools.skills_tool._find_all_skills",
+            lambda *args, **kwargs: [
+                {"name": "test-skill-one", "description": "Desc 1"},
+                {"name": "other-skill", "description": "Desc 2"},
+            ]
+        )
+
+        completer = SlashCommandCompleter()
+        doc = Document("/learn --update ", cursor_position=len("/learn --update "))
+        completions = list(completer.get_completions(doc, None))
+        suggested = [c.text for c in completions]
+        assert "test-skill-one" in suggested
+        assert "other-skill" in suggested
+
+        doc = Document("/learn --update test-s", cursor_position=len("/learn --update test-s"))
+        completions = list(completer.get_completions(doc, None))
+        suggested = [c.text for c in completions]
+        assert "test-skill-one" in suggested
+        assert "other-skill" not in suggested

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -861,6 +861,26 @@ class TestSubcommandCompletion:
         assert "none" in texts
         assert len(texts) > 1
 
+    def test_learn_completes_update_flag(self):
+        texts = {c.text for c in _completions(SlashCommandCompleter(), "/learn ")}
+        assert "--update" in texts
+
+    def test_learn_completes_skills_after_update(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.skills_tool._find_all_skills",
+            lambda *args, **kwargs: [
+                {"name": "test-skill-one", "description": "Desc 1"},
+                {"name": "other-skill", "description": "Desc 2"},
+            ]
+        )
+        texts = {c.text for c in _completions(SlashCommandCompleter(), "/learn --update ")}
+        assert "test-skill-one" in texts
+        assert "other-skill" in texts
+
+        texts = {c.text for c in _completions(SlashCommandCompleter(), "/learn --update test-s")}
+        assert "test-skill-one" in texts
+        assert "other-skill" not in texts
+
 
 # ── Ghost text (SlashCommandAutoSuggest) ────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds support for updating existing skills using:

/learn --update <skill>

Highlights

- parse --update inside build_learn_prompt()
- preserve existing /learn behavior
- reuse existing skill_view + skill_manage
- CLI autocomplete for --update
- update-aware CLI/Gateway messaging
- add parser and autocomplete tests

## Verification

- learn prompt tests passed
- CLI command tests passed
- TUI protocol tests passed