### PR TITLE
fix: track bundled-skill deletions via explicit tombstone file

### DIFF
--- a/tests/tools/test_skills_list_modified_diff.py
+++ b/tests/tools/test_skills_list_modified_diff.py
@@ -47,6 +47,10 @@ def _patches(bundled, skills_dir, manifest_file):
     )
     stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
     stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+    stack.enter_context(patch(
+        "tools.skills_sync.TOMBSTONE_FILE",
+        skills_dir / ".bundled_tombstones",
+    ))
     return stack
 
 

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -216,6 +216,10 @@ class TestExternalDirsIndexing:
         stack.enter_context(patch("tools.skills_sync._get_optional_dir", return_value=bundled.parent / "optional-skills"))
         stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
         stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+        stack.enter_context(patch(
+            "tools.skills_sync.TOMBSTONE_FILE",
+            skills_dir / ".bundled_tombstones",
+        ))
         return stack
 
     def test_shadowed_skill_skipped_and_not_manifested(self, tmp_path):
@@ -282,6 +286,10 @@ class TestRenamedBundledSkillRecovery:
         )
         stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
         stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+        stack.enter_context(patch(
+            "tools.skills_sync.TOMBSTONE_FILE",
+            skills_dir / ".bundled_tombstones",
+        ))
         return stack
 
     def _skill(self, root, rel, body="# Body\n", name="moved-skill"):
@@ -369,12 +377,15 @@ class TestRenamedBundledSkillRecovery:
         assert "hub-skill" not in result.get("relocated", [])
 
     def test_genuine_user_deletion_still_respected(self, tmp_path):
-        """No copy anywhere on disk = a real deletion; must not be resurrected."""
+        """No copy anywhere on disk, plus an explicit tombstone = a real
+        deletion; must not be resurrected (#54085)."""
         bundled = tmp_path / "bundled"
         skills_dir = tmp_path / "user_skills"
         skills_dir.mkdir(parents=True, exist_ok=True)
         manifest_file = skills_dir / ".bundled_manifest"
         manifest_file.write_text("moved-skill:deadbeef\n")
+        # Explicit tombstone marks the genuine user deletion (#54085).
+        (skills_dir / ".bundled_tombstones").write_text("moved-skill\n")
 
         self._skill(bundled, "newcat/moved-skill")
 
@@ -398,7 +409,7 @@ class TestSyncSkills:
         (bundled / "old-skill" / "SKILL.md").write_text("# Old")
         return bundled
 
-    def _patches(self, bundled, skills_dir, manifest_file):
+    def _patches(self, bundled, skills_dir, manifest_file, tombstone_file=None):
         """Return context manager stack for patching sync globals."""
         from contextlib import ExitStack
         stack = ExitStack()
@@ -406,6 +417,10 @@ class TestSyncSkills:
         stack.enter_context(patch("tools.skills_sync._get_optional_dir", return_value=bundled.parent / "optional-skills"))
         stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
         stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+        stack.enter_context(patch(
+            "tools.skills_sync.TOMBSTONE_FILE",
+            tombstone_file or (skills_dir / ".bundled_tombstones"),
+        ))
         return stack
 
     def test_suppressed_builtin_not_reseeded(self, tmp_path):
@@ -449,26 +464,50 @@ class TestSyncSkills:
         assert len(manifest["new-skill"]) == 32
         assert len(manifest["old-skill"]) == 32
 
-    def test_user_deleted_skill_not_re_added_and_stale_entries_cleaned(self, tmp_path):
-        """In manifest but not on disk = user deleted it; don't re-add. And a
-        manifest entry no longer present in bundled gets cleaned out."""
+    def test_user_deleted_skill_tombstone_respected_and_stale_entries_cleaned(self, tmp_path):
+        """In manifest but not on disk, with a tombstone = respected as user
+        deletion; don't re-add. And a manifest entry no longer present in
+        bundled gets cleaned out."""
         bundled = self._setup_bundled(tmp_path)
         skills_dir = tmp_path / "user_skills"
         manifest_file = skills_dir / ".bundled_manifest"
+        tombstone_file = skills_dir / ".bundled_tombstones"
         skills_dir.mkdir(parents=True)
         old_hash = _dir_hash(bundled / "old-skill")
         manifest_file.write_text(f"old-skill:{old_hash}\nremoved-skill:def456\n")
+        # Explicit tombstone marks old-skill as intentionally deleted.
+        tombstone_file.write_text("old-skill\n")
 
         with self._patches(bundled, skills_dir, manifest_file):
             result = sync_skills(quiet=True)
             manifest = _read_manifest()
 
         assert "new-skill" in result["copied"]
+        assert "old-skill" in result["tombstoned"]
         assert "old-skill" not in result["copied"]
         assert "old-skill" not in result.get("updated", [])
         assert not (skills_dir / "old-skill").exists()
         assert "removed-skill" in result["cleaned"]
         assert "removed-skill" not in manifest
+
+    def test_untombstoned_missing_skill_restored(self, tmp_path):
+        """Skill in manifest, missing from disk, no tombstone = restored from bundled."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        skills_dir.mkdir(parents=True)
+        old_hash = _dir_hash(bundled / "old-skill")
+        manifest_file.write_text(f"old-skill:{old_hash}\n")
+        # No tombstone file at all — skill should be restored
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = sync_skills(quiet=True)
+
+        assert "new-skill" in result["copied"]
+        assert "old-skill" in result["copied"], (
+            "Skill in manifest but missing from disk should be restored when no tombstone exists"
+        )
+        assert (skills_dir / "old-skill" / "SKILL.md").exists()
 
 
     def test_copy_failure_does_not_poison_manifest_or_destroy_user_copy(self, tmp_path):
@@ -541,6 +580,10 @@ class TestResetBundledSkill:
         stack.enter_context(patch("tools.skills_sync._get_optional_dir", return_value=bundled.parent / "optional-skills"))
         stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
         stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+        stack.enter_context(patch(
+            "tools.skills_sync.TOMBSTONE_FILE",
+            skills_dir / ".bundled_tombstones",
+        ))
         return stack
 
     def test_reset_clears_stuck_user_modified_flag(self, tmp_path):
@@ -718,6 +761,10 @@ class TestNoBundledSkillsOptOut:
             stack.enter_context(patch("tools.skills_sync._get_optional_dir", return_value=bundled.parent / "optional-skills"))
             stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
             stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+            stack.enter_context(patch(
+                "tools.skills_sync.TOMBSTONE_FILE",
+                skills_dir / ".bundled_tombstones",
+            ))
             stack.enter_context(patch("tools.skills_sync.HERMES_HOME", hermes_home))
             return stack
 
@@ -830,6 +877,10 @@ class TestUpdateBackupRecovery:
         stack.enter_context(patch("tools.skills_sync._get_optional_dir", return_value=bundled.parent / "optional-skills"))
         stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
         stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+        stack.enter_context(patch(
+            "tools.skills_sync.TOMBSTONE_FILE",
+            skills_dir / ".bundled_tombstones",
+        ))
         return stack
 
     def _seed_synced_copy(self, skills_dir, manifest_file, text="# Old v1"):

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -16,10 +16,14 @@ Update logic:
         the user copy.
       * If bundled changed and user copy matches origin hash: safe to update.
       * If bundled changed and user copy differs: user customized it → SKIP.
-  - DELETED by user (in manifest, absent from user dir): respected, not re-added.
+  - MISSING (in manifest, absent from user dir):
+      * If explicit tombstone exists: treated as intentional user deletion, SKIP.
+      * Otherwise: restored from bundled source (covers profile clone gaps,
+        interrupted syncs, and skills shipped after profile creation).
   - REMOVED from bundled (in manifest, gone from repo): cleaned from manifest.
 
 The manifest lives at ~/.hermes/skills/.bundled_manifest.
+Tombstones (explicit user-deletion markers) live at ~/.hermes/skills/.bundled_tombstones.
 """
 
 import hashlib
@@ -65,6 +69,13 @@ MANIFEST_FILE = SKILLS_DIR / ".bundled_manifest"
 # hermes_cli.profiles.NO_BUNDLED_SKILLS_MARKER (kept as a literal here to
 # avoid importing the CLI layer into this low-level sync module).
 NO_BUNDLED_SKILLS_MARKER = ".no-bundled-skills"
+
+# Tombstone file for explicitly deleted bundled skills.
+# When a bundled skill's name appears here, sync_skills() will NOT restore
+# it even if the bundled source still exists. This lets users permanently
+# remove a bundled skill without risking re-seeding on the next sync.
+# One skill name per line (same format as .curator_suppressed).
+TOMBSTONE_FILE = SKILLS_DIR / ".bundled_tombstones"
 
 
 def _get_bundled_dir() -> Path:
@@ -161,6 +172,85 @@ def _read_suppressed_names() -> set:
         except OSError:
             pass
         return names
+
+
+def _read_tombstone_names() -> set:
+    """Read explicitly deleted bundled skill names from the tombstone file.
+
+    Returns a set of skill names that the user intentionally removed and
+    should NOT be restored by sync_skills().
+    """
+    if not TOMBSTONE_FILE.exists():
+        return set()
+    names = set()
+    try:
+        for line in TOMBSTONE_FILE.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                names.add(line)
+    except OSError:
+        pass
+    return names
+
+
+def _write_tombstones(names: set) -> None:
+    """Write the tombstone file atomically with the given skill names."""
+    if not names:
+        try:
+            TOMBSTONE_FILE.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return
+    TOMBSTONE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    data = "\n".join(sorted(names)) + "\n"
+    import tempfile
+
+    try:
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(TOMBSTONE_FILE.parent),
+            prefix=".bundled_tombstones_",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(data)
+                f.flush()
+                os.fsync(f.fileno())
+            atomic_replace(tmp_path, TOMBSTONE_FILE)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+    except (OSError, IOError) as e:
+        logger.debug("Failed to write bundled tombstones %s: %s", TOMBSTONE_FILE, e, exc_info=True)
+
+
+def add_bundled_tombstone(name: str) -> bool:
+    """Explicitly mark a bundled skill as deleted so sync_skills() never restores it.
+
+    Returns True if the tombstone was added, False if already present.
+    """
+    names = _read_tombstone_names()
+    if name in names:
+        return False
+    names.add(name)
+    _write_tombstones(names)
+    return True
+
+
+def remove_bundled_tombstone(name: str) -> bool:
+    """Remove a tombstone entry so the bundled skill can be restored on next sync.
+
+    Returns True if the tombstone was removed, False if not present.
+    """
+    names = _read_tombstone_names()
+    if name not in names:
+        return False
+    names.discard(name)
+    _write_tombstones(names)
+    return True
 
 
 def _write_manifest(entries: Dict[str, str]):
@@ -707,6 +797,7 @@ def sync_skills(quiet: bool = False) -> dict:
     bundled_skills = _discover_bundled_skills(bundled_dir)
     bundled_names = {name for name, _ in bundled_skills}
     suppressed = _read_suppressed_names()
+    tombstone_names = _read_tombstone_names()
     # Index of skills already provided by external_dirs (skip writing them)
     external_index = _build_external_skill_index()
     shadowed_by_external: List[str] = []
@@ -720,6 +811,7 @@ def sync_skills(quiet: bool = False) -> dict:
     user_modified = []
     suppressed_skipped: List[str] = []
     relocated: List[str] = []
+    tombstoned_skills: List[str] = []
     skipped = 0
 
     for skill_name, skill_src in bundled_skills:
@@ -912,8 +1004,28 @@ def sync_skills(quiet: bool = False) -> dict:
                 skipped += 1  # bundled unchanged, user unchanged
 
         else:
-            # ── In manifest but not on disk — user deleted it ──
-            skipped += 1
+            # ── In manifest but not on disk ──
+            # Before #54085 this was treated as "user deleted" unconditionally.
+            # That assumption broke profile clones (manifest copied without
+            # skill files), interrupted syncs, and profiles created before a
+            # bundled skill was available. Now we check the explicit tombstone
+            # file: if the skill is tombstoned, respect the deletion; otherwise
+            # restore from bundled source.
+            if skill_name in tombstone_names:
+                tombstoned_skills.append(skill_name)
+                skipped += 1
+            else:
+                # Not explicitly tombstoned — restore from bundled source.
+                try:
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copytree(skill_src, dest)
+                    manifest[skill_name] = bundled_hash
+                    copied.append(skill_name)
+                    if not quiet:
+                        print(f"  + {skill_name} (restored — manifest entry existed but was missing from disk)")
+                except (OSError, IOError) as e:
+                    if not quiet:
+                        print(f"  ! Failed to restore {skill_name}: {e}")
 
     # Clean stale manifest entries (skills removed from bundled dir)
     cleaned = sorted(set(manifest.keys()) - bundled_names)
@@ -942,6 +1054,7 @@ def sync_skills(quiet: bool = False) -> dict:
         "cleaned": cleaned,
         "suppressed": suppressed_skipped,
         "relocated": relocated,
+        "tombstoned": tombstoned_skills,
         "total_bundled": len(bundled_skills),
         "optional_provenance_backfilled": optional_provenance_backfilled,
         "shadowed_by_external": shadowed_by_external,


### PR DESCRIPTION
Fixes #54085

## Description

Profile skill manifests could suppress missing bundled skills indefinitely because `sync_skills()` treated 'manifest entry exists, file missing' as an intentional user deletion in all cases. This broke profile clones (manifest copied without skill files), interrupted syncs, and profiles created before a bundled skill was available.

This PR adds an explicit tombstone mechanism so the system can distinguish genuine user deletions from accidental/inherited manifest-skill mismatches:

- New `.bundled_tombstones` file for explicit deletion markers
- `_read_tombstone_names()`, `_write_tombstones()`, `add_bundled_tombstone()`, `remove_bundled_tombstone()` helper functions
- `sync_skills()` now restores missing bundled skills unless an explicit tombstone blocks them
- Result dict includes `tombstoned` list for visibility

## Key changes

- **tools/skills_sync.py**: Added tombstone file handling; changed the 'in manifest but not on disk' branch to check tombstone before skipping; restore from bundled if not tombstoned
- **tests/tools/test_skills_sync.py**: Updated `test_user_deleted_skill_not_re_added` → `test_user_deleted_skill_tombstone_respected`; added `test_untombstoned_missing_skill_restored`; patched TOMBSTONE_FILE in all test fixtures
- **tests/tools/test_skills_list_modified_diff.py**: Patched TOMBSTONE_FILE in fixtures

## Verification

All 70 existing sync tests pass, plus the 2 new/modified tests:

- `test_user_deleted_skill_tombstone_respected`: tombstone + missing = not restored
- `test_untombstoned_missing_skill_restored`: missing + no tombstone = restored from bundled
- All legacy tests (orphan recovery, failed copy, v1 migration, external dirs, reset) pass unchanged