### PR TITLE
fix: guard session state from malformed responses

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -489,6 +489,19 @@ def repair_message_sequence_with_cursor(agent, messages: List[Dict]) -> int:
                 agent._last_flushed_db_idx, len(messages)
             )
 
+    if repairs > 0:
+        db = getattr(agent, "_session_db", None)
+        session_id = getattr(agent, "session_id", None)
+        if db is not None and session_id and hasattr(db, "apply_repaired_active_messages"):
+            try:
+                db.apply_repaired_active_messages(session_id, messages)
+            except Exception:
+                logging.getLogger(__name__).warning(
+                    "Failed to persist message-sequence repair for session=%s",
+                    session_id,
+                    exc_info=True,
+                )
+
     return repairs
 
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -36,6 +36,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional, Tuple
 
+from agent.message_quarantine import live_context_messages
 from agent.model_metadata import estimate_request_tokens_rough
 
 logger = logging.getLogger(__name__)
@@ -344,6 +345,7 @@ def compress_context(
         prompt — the session is NOT rotated.  Callers should detect the
         no-op via ``len(returned) == len(input)`` and stop the retry loop.
     """
+    messages = live_context_messages(messages)
     # Lazy feasibility check — run the auxiliary-provider probe + context
     # length lookup just-in-time on the first compression attempt instead of
     # at AIAgent.__init__. Saves ~400ms cold off every short session that

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2028,7 +2028,14 @@ def run_conversation(
                     getattr(agent, "_current_streamed_assistant_text", "") or ""
                 ).strip()
                 if _partial:
-                    messages.append({"role": "assistant", "content": _partial})
+                    messages.append({
+                        "role": "assistant",
+                        "content": _partial,
+                        "finish_reason": "interrupted_during_api_call",
+                        "active": False,
+                        "compacted": False,
+                        "_quarantine_reason": "interrupted_during_api_call",
+                    })
                     final_response = _partial
                 else:
                     final_response = f"{INTERRUPT_WAITING_FOR_MODEL_PREFIX}{api_elapsed:.1f}s elapsed)."

--- a/agent/message_quarantine.py
+++ b/agent/message_quarantine.py
@@ -1,0 +1,22 @@
+"""Helpers for keeping forensic/quarantined rows out of live model context."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+def is_live_context_message(message: Mapping[str, Any]) -> bool:
+    """Return True when *message* may be replayed to the model.
+
+    ``active=False`` / ``active=0`` rows are forensic records (rewind tails,
+    interrupted partial assistant output, malformed provider responses).  They
+    must remain queryable with include_inactive=True, but must not be sent back
+    to providers or summarized into compression output.
+    """
+    return message.get("active", True) not in (False, 0)
+
+
+def live_context_messages(messages: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    if not messages:
+        return []
+    return [m for m in messages if isinstance(m, dict) and is_live_context_message(m)]

--- a/agent/tool_call_validation.py
+++ b/agent/tool_call_validation.py
@@ -1,0 +1,176 @@
+"""Pre-dispatch validation for model-emitted tool calls.
+
+Provider/tool-call glitches can emit syntactically valid tool calls with empty
+argument objects (for example ``terminal {}`` or ``write_file {}``).  Letting
+those reach real handlers turns a provider-side malformed response into
+side-effect-bearing tool errors that poison the active session history.  These
+helpers validate the already-parsed argument dict against the registered tool
+schema before any handler, checkpoint, approval prompt, or guardrail execution
+runs.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+
+def _schema_for_tool(function_name: str) -> dict[str, Any] | None:
+    try:
+        from tools.registry import registry
+
+        entry = registry.get_entry(function_name)
+    except Exception:
+        return None
+    if entry is None or not isinstance(getattr(entry, "schema", None), dict):
+        return None
+    return entry.schema
+
+
+def _parameter_schema(schema: Mapping[str, Any]) -> Mapping[str, Any]:
+    params = schema.get("parameters")
+    return params if isinstance(params, Mapping) else {}
+
+
+def _properties(params: Mapping[str, Any]) -> Mapping[str, Any]:
+    props = params.get("properties")
+    return props if isinstance(props, Mapping) else {}
+
+
+def _required(params: Mapping[str, Any]) -> list[str]:
+    req = params.get("required")
+    return [str(item) for item in req] if isinstance(req, list) else []
+
+
+def _json_type_matches(value: Any, expected: str) -> bool:
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "number":
+        return (isinstance(value, int | float) and not isinstance(value, bool))
+    if expected == "boolean":
+        return isinstance(value, bool)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "object":
+        return isinstance(value, dict)
+    return True
+
+
+def _field_type(properties: Mapping[str, Any], field: str) -> str | None:
+    spec = properties.get(field)
+    if not isinstance(spec, Mapping):
+        return None
+    raw = spec.get("type")
+    return raw if isinstance(raw, str) else None
+
+
+def _field_missing_or_empty(args: Mapping[str, Any], properties: Mapping[str, Any], field: str) -> bool:
+    if field not in args or args.get(field) is None:
+        return True
+    expected = _field_type(properties, field)
+    # Empty content is a valid write_file payload, but empty command/path/mode/etc.
+    # are provider malformed-output symptoms, not meaningful calls.
+    if expected == "string" and field != "content" and isinstance(args.get(field), str) and not args[field].strip():
+        return True
+    return False
+
+
+def _conditional_required(function_name: str, args: Mapping[str, Any]) -> list[str]:
+    """Return required fields that are conditional and not expressible in the
+    current lightweight schemas.
+    """
+    missing: list[str] = []
+    if function_name == "patch":
+        mode = args.get("mode", "replace")
+        if mode == "patch":
+            if _field_missing_or_empty(args, {"patch": {"type": "string"}}, "patch"):
+                missing.append("patch")
+        else:
+            for field in ("path", "old_string", "new_string"):
+                if field not in args or args.get(field) is None:
+                    missing.append(field)
+                elif field != "new_string" and isinstance(args.get(field), str) and not args[field].strip():
+                    missing.append(field)
+    elif function_name == "cronjob":
+        action = str(args.get("action") or "").strip()
+        if action in {"update", "pause", "resume", "remove", "run"}:
+            if _field_missing_or_empty(args, {"job_id": {"type": "string"}}, "job_id"):
+                missing.append("job_id")
+        if action == "create":
+            for field in ("schedule", "prompt"):
+                if _field_missing_or_empty(args, {field: {"type": "string"}}, field):
+                    missing.append(field)
+        if args.get("no_agent") is True and _field_missing_or_empty(args, {"script": {"type": "string"}}, "script"):
+            missing.append("script")
+    return missing
+
+
+def validate_tool_call_arguments(function_name: str, function_args: Any) -> str | None:
+    """Return a JSON error result when *function_args* must not dispatch.
+
+    ``None`` means the call is safe to continue to the normal tool path.  The
+    validator is intentionally conservative: tools not registered in the normal
+    registry (agent-loop/context/memory tools) are allowed unless their own
+    special-case checks below apply.
+    """
+    if not isinstance(function_args, dict):
+        return json.dumps(
+            {
+                "error": "invalid_tool_arguments: tool arguments must be a JSON object",
+                "code": "invalid_tool_arguments",
+                "tool": function_name,
+                "invalid_fields": ["arguments"],
+            },
+            ensure_ascii=False,
+        )
+
+    schema = _schema_for_tool(function_name)
+    if schema is None:
+        return None
+
+    params = _parameter_schema(schema)
+    props = _properties(params)
+    missing: list[str] = []
+    invalid: list[str] = []
+
+    for field in _required(params):
+        if _field_missing_or_empty(function_args, props, field):
+            missing.append(field)
+            continue
+        expected = _field_type(props, field)
+        if expected and not _json_type_matches(function_args.get(field), expected):
+            invalid.append(field)
+
+    for field, spec in props.items():
+        if field not in function_args or function_args.get(field) is None:
+            continue
+        if not isinstance(spec, Mapping):
+            continue
+        expected = spec.get("type")
+        if isinstance(expected, str) and not _json_type_matches(function_args[field], expected):
+            invalid.append(str(field))
+
+    for field in _conditional_required(function_name, function_args):
+        if field not in missing:
+            missing.append(field)
+
+    if not missing and not invalid:
+        return None
+
+    parts: list[str] = []
+    if missing:
+        parts.append("missing required field(s): " + ", ".join(missing))
+    if invalid:
+        parts.append("invalid field type(s): " + ", ".join(invalid))
+    return json.dumps(
+        {
+            "error": f"invalid_tool_arguments: {function_name} " + "; ".join(parts),
+            "code": "invalid_tool_arguments",
+            "tool": function_name,
+            "missing_required": missing,
+            "invalid_fields": invalid,
+        },
+        ensure_ascii=False,
+    )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -37,6 +37,7 @@ from agent.tool_dispatch_helpers import (
     _append_subdir_hint_to_multimodal,
     make_tool_result_message,
 )
+from agent.tool_call_validation import validate_tool_call_arguments
 from tools.terminal_tool import (
     get_active_env,
 )
@@ -373,10 +374,25 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
         # ── Block evaluation (BEFORE checkpoint preflight) ───────────
         # We must know whether the tool will execute before touching
-        # checkpoint state (dedup slot, real snapshots).
-        block_result = None
+        # checkpoint state (dedup slot, real snapshots).  Validate malformed
+        # provider-emitted arguments here so required-arg drops like
+        # ``terminal {}`` never reach side-effect-bearing handlers.
+        block_result = validate_tool_call_arguments(function_name, function_args)
         blocked_by_guardrail = False
-        if _ts_scope_block is not None:
+        if block_result is not None:
+            _emit_terminal_post_tool_call(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                result=block_result,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                status="blocked",
+                error_type="invalid_tool_arguments",
+                error_message=block_result,
+                middleware_trace=list(middleware_trace),
+            )
+        elif _ts_scope_block is not None:
             # Out-of-scope tool_call: reject before hooks/guardrails/dispatch.
             block_result = _ts_scope_block
             _emit_terminal_post_tool_call(
@@ -918,13 +934,15 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_call_id=getattr(tool_call, "id", "") or "",
         )
 
-        # Check plugin hooks for a block directive before executing.
-        _block_msg: Optional[str] = None
-        _block_error_type = "plugin_block"
-        if _ts_scope_block is not None:
+        # Check plugin hooks for a block directive before executing.  First,
+        # reject malformed provider-emitted argument objects so calls like
+        # ``terminal {}`` or ``write_file {}`` never reach real handlers.
+        _block_msg: Optional[str] = validate_tool_call_arguments(function_name, function_args)
+        _block_error_type = "invalid_tool_arguments" if _block_msg is not None else "plugin_block"
+        if _block_msg is None and _ts_scope_block is not None:
             _block_msg = _ts_scope_block
             _block_error_type = "tool_scope_block"
-        else:
+        elif _block_msg is None:
             try:
                 from hermes_cli.plugins import get_pre_tool_call_block_message
                 _block_msg = get_pre_tool_call_block_message(
@@ -1024,8 +1042,14 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         tool_start_time = time.time()
 
         if _block_msg is not None:
-            # Tool blocked by plugin policy — return error without executing.
-            function_result = json.dumps({"error": _block_msg}, ensure_ascii=False)
+            # Tool blocked by plugin/guardrail/preflight policy — return error
+            # without executing.  Preflight validation already returns a
+            # structured JSON tool result; plugin/tool-scope blocks are plain
+            # strings and get wrapped here.
+            if _block_error_type == "invalid_tool_arguments":
+                function_result = _block_msg
+            else:
+                function_result = json.dumps({"error": _block_msg}, ensure_ascii=False)
             tool_duration = 0.0
             _emit_terminal_post_tool_call(
                 agent,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -30,6 +30,7 @@ from typing import Any, Dict, List, Optional
 
 from agent.conversation_compression import conversation_history_after_compression
 from agent.iteration_budget import IterationBudget
+from agent.message_quarantine import live_context_messages
 from agent.model_metadata import (
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
@@ -255,7 +256,11 @@ def build_turn_context(
         _msg_preview,
     )
 
-    # Initialize conversation (copy to avoid mutating the caller's list).
+    # Initialize conversation (copy to avoid mutating the caller's list).  Treat
+    # inactive rows as forensic-only: they remain in state.db/search with
+    # include_inactive=True but must not be replayed, compressed, or passed to
+    # plugins as live context.
+    conversation_history = live_context_messages(conversation_history)
     messages = list(conversation_history) if conversation_history else []
 
     # Hydrate todo store from conversation history.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2724,6 +2724,8 @@ class SessionDB:
         platform_message_id: str = None,
         observed: bool = False,
         timestamp: Any = None,
+        active: bool = True,
+        compacted: bool = False,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -2775,8 +2777,8 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, active, compacted)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -2794,22 +2796,27 @@ class SessionDB:
                     codex_message_items_json,
                     platform_message_id,
                     1 if observed else 0,
+                    1 if active else 0,
+                    1 if compacted else 0,
                 ),
             )
             msg_id = cursor.lastrowid
 
-            # Update counters
-            if num_tool_calls > 0:
-                conn.execute(
-                    """UPDATE sessions SET message_count = message_count + 1,
-                       tool_call_count = tool_call_count + ? WHERE id = ?""",
-                    (num_tool_calls, session_id),
-                )
-            else:
-                conn.execute(
-                    "UPDATE sessions SET message_count = message_count + 1 WHERE id = ?",
-                    (session_id,),
-                )
+            # Update live-context counters.  Forensic inactive rows (quarantine,
+            # rewind tails) remain queryable via include_inactive=True but must
+            # not inflate the session's active message/tool counts.
+            if active:
+                if num_tool_calls > 0:
+                    conn.execute(
+                        """UPDATE sessions SET message_count = message_count + 1,
+                           tool_call_count = tool_call_count + ? WHERE id = ?""",
+                        (num_tool_calls, session_id),
+                    )
+                else:
+                    conn.execute(
+                        "UPDATE sessions SET message_count = message_count + 1 WHERE id = ?",
+                        (session_id,),
+                    )
             return msg_id
 
         return self._execute_write(_do)
@@ -2824,7 +2831,7 @@ class SessionDB:
         — the caller owns that, since the two flows reconcile counts differently.
         """
         now_ts = time.time()
-        inserted = 0
+        active_inserted = 0
         tool_calls_total = 0
         for msg in messages:
             role = msg.get("role", "unknown")
@@ -2866,8 +2873,8 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, active, compacted)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -2885,15 +2892,18 @@ class SessionDB:
                     codex_message_items_json,
                     platform_msg_id,
                     1 if msg.get("observed") else 0,
+                    1 if msg.get("active", True) else 0,
+                    1 if msg.get("compacted", False) else 0,
                 ),
             )
-            inserted += 1
-            if tool_calls is not None:
-                tool_calls_total += (
-                    len(tool_calls) if isinstance(tool_calls, list) else 1
-                )
+            if msg.get("active", True):
+                active_inserted += 1
+                if tool_calls is not None:
+                    tool_calls_total += (
+                        len(tool_calls) if isinstance(tool_calls, list) else 1
+                    )
             now_ts = max(now_ts + 1e-6, message_timestamp + 1e-6)
-        return inserted, tool_calls_total
+        return active_inserted, tool_calls_total
 
     def replace_messages(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         """Atomically replace every message for a session.
@@ -3516,6 +3526,91 @@ class SessionDB:
             "target_message": target_row,
             "new_head_id": new_head_id,
         }
+
+    def apply_repaired_active_messages(
+        self, session_id: str, repaired_messages: List[Dict[str, Any]]
+    ) -> int:
+        """Persist an in-memory message-sequence repair to active rows.
+
+        ``repair_message_sequence`` may merge adjacent user messages or drop
+        stray tool rows right before a provider request.  Without this method,
+        the DB still contains the unrepaired active rows, so every future turn
+        repeats the same in-memory repair.  This method keeps forensic rows on
+        disk while making the repaired active view durable:
+
+        * rows absent from ``repaired_messages`` become ``active=0``;
+        * surviving rows keep ``active=1`` and get updated content/finish_reason.
+        """
+        surviving: Dict[int, Dict[str, Any]] = {}
+        for msg in repaired_messages or []:
+            if not isinstance(msg, dict):
+                continue
+            msg_id = msg.get("id")
+            if msg_id is None:
+                continue
+            try:
+                msg_id_int = int(msg_id)
+            except (TypeError, ValueError):
+                continue
+            surviving[msg_id_int] = msg
+        if not surviving:
+            return 0
+
+        def _do(conn):
+            rows = conn.execute(
+                "SELECT id FROM messages WHERE session_id = ? AND active = 1",
+                (session_id,),
+            ).fetchall()
+            active_ids = {int(r[0]) for r in rows}
+            changed = 0
+            drop_ids = sorted(active_ids - set(surviving))
+            if drop_ids:
+                placeholders = ",".join("?" for _ in drop_ids)
+                conn.execute(
+                    f"UPDATE messages SET active = 0, compacted = 0 "
+                    f"WHERE id IN ({placeholders})",
+                    drop_ids,
+                )
+                changed += len(drop_ids)
+
+            for msg_id, msg in surviving.items():
+                if msg_id not in active_ids:
+                    continue
+                role = msg.get("role")
+                content = self._encode_content(msg.get("content"))
+                finish_reason = msg.get("finish_reason")
+                cur = conn.execute(
+                    "UPDATE messages SET content = ?, finish_reason = ?, active = 1 "
+                    "WHERE id = ? AND session_id = ?",
+                    (content, finish_reason, msg_id, session_id),
+                )
+                changed += cur.rowcount or 0
+
+            active_count = conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE session_id = ? AND active = 1",
+                (session_id,),
+            ).fetchone()[0]
+            tool_rows = conn.execute(
+                "SELECT role, tool_calls FROM messages WHERE session_id = ? AND active = 1",
+                (session_id,),
+            ).fetchall()
+            tool_count = 0
+            for role, tool_calls_json in tool_rows:
+                if role == "tool":
+                    tool_count += 1
+                elif tool_calls_json:
+                    try:
+                        parsed = json.loads(tool_calls_json)
+                        tool_count += len(parsed) if isinstance(parsed, list) else 1
+                    except (TypeError, ValueError, json.JSONDecodeError):
+                        tool_count += 1
+            conn.execute(
+                "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
+                (active_count, tool_count, session_id),
+            )
+            return changed
+
+        return self._execute_write(_do)
 
     def restore_rewound(self, session_id: str, since_message_id: int) -> int:
         """Mark inactive messages with id >= *since_message_id* active again.

--- a/run_agent.py
+++ b/run_agent.py
@@ -1695,6 +1695,8 @@ class AIAgent:
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
                     timestamp=msg.get("timestamp"),
+                    active=msg.get("active", True),
+                    compacted=msg.get("compacted", False),
                 )
                 flushed_ids.add(msg_id)
             self._last_flushed_db_idx = len(messages)

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -10,6 +10,8 @@ recovery every turn.
 """
 
 from run_agent import AIAgent
+from hermes_state import SessionDB
+from agent.agent_runtime_helpers import repair_message_sequence_with_cursor
 
 
 def _bare_agent():
@@ -298,3 +300,59 @@ def test_flush_guard_clamps_overshooting_cursor():
 
     # min(5, 2) = 2 → nothing skipped below start_idx, cursor settles at 2
     assert agent._last_flushed_db_idx == 2
+
+def test_repair_persists_consecutive_user_merge_to_session_db(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("s1", source="test")
+    db.append_message("s1", role="user", content="first")
+    db.append_message("s1", role="user", content="second")
+
+    messages = db.get_messages("s1")
+    agent = _bare_agent()
+    agent._session_db = db
+    agent.session_id = "s1"
+    agent._last_flushed_db_idx = len(messages)
+
+    repairs = repair_message_sequence_with_cursor(agent, messages)
+
+    assert repairs == 1
+    assert messages == [
+        {**messages[0], "content": "first\n\nsecond"},
+    ]
+
+    live = db.get_messages("s1")
+    all_rows = db.get_messages("s1", include_inactive=True)
+
+    assert [m["content"] for m in live] == ["first\n\nsecond"]
+    assert len(all_rows) == 2
+    assert all_rows[0]["active"] == 1
+    assert all_rows[0]["content"] == "first\n\nsecond"
+    assert all_rows[1]["active"] == 0
+    assert all_rows[1]["content"] == "second"
+
+
+def test_repair_persists_stray_tool_drop_to_session_db(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("s1", source="test")
+    db.append_message("s1", role="tool", content="orphan", tool_call_id="missing")
+    db.append_message("s1", role="user", content="real")
+
+    messages = db.get_messages("s1")
+    agent = _bare_agent()
+    agent._session_db = db
+    agent.session_id = "s1"
+    agent._last_flushed_db_idx = len(messages)
+
+    repairs = repair_message_sequence_with_cursor(agent, messages)
+
+    assert repairs == 1
+    assert [m["role"] for m in messages] == ["user"]
+
+    live = db.get_messages("s1")
+    all_rows = db.get_messages("s1", include_inactive=True)
+
+    assert [m["content"] for m in live] == ["real"]
+    assert all_rows[0]["role"] == "tool"
+    assert all_rows[0]["active"] == 0
+    assert all_rows[1]["role"] == "user"
+    assert all_rows[1]["active"] == 1

--- a/tests/run_agent/test_session_quarantine_guards.py
+++ b/tests/run_agent/test_session_quarantine_guards.py
@@ -1,0 +1,154 @@
+"""Session-integrity guards for malformed/interrupted assistant output.
+
+These contracts pin the failure mode that can poison a live session: provider
+transport/interruption glitches may produce assistant text that should remain in
+forensics, but must not be replayed to the next model call.
+"""
+
+from pathlib import Path
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from hermes_state import SessionDB
+from run_agent import AIAgent
+from agent.conversation_compression import compress_context
+from agent.message_quarantine import live_context_messages
+
+
+def _make_agent_with_db(tmp_path):
+    hermes_home = Path(tempfile.mkdtemp(prefix="hermes-test-home-"))
+    (hermes_home / "logs").mkdir(parents=True, exist_ok=True)
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("run_agent._hermes_home", hermes_home),
+        patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("s1", source="test")
+    agent._session_db = db
+    setattr(agent, "session_id", "s1")
+    agent._session_db_created = True
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = "s1"
+    agent._last_flushed_db_idx = 0
+    agent.client = MagicMock()
+    return agent, db
+
+
+def test_inactive_quarantined_message_is_preserved_but_not_live_context(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("s1", source="test")
+    db.append_message("s1", role="user", content="safe user")
+    db.append_message(
+        "s1",
+        role="assistant",
+        content="garbled partial assistant text",
+        finish_reason="interrupted_during_api_call",
+        active=False,
+        compacted=False,
+    )
+
+    live = db.get_messages("s1")
+    all_rows = db.get_messages("s1", include_inactive=True)
+
+    assert [m["content"] for m in live] == ["safe user"]
+    assert [m["content"] for m in all_rows] == [
+        "safe user",
+        "garbled partial assistant text",
+    ]
+    assert all_rows[1]["active"] == 0
+    assert all_rows[1]["compacted"] == 0
+    assert all_rows[1]["finish_reason"] == "interrupted_during_api_call"
+
+
+def test_agent_flush_persists_quarantined_partial_as_inactive(tmp_path):
+    agent, db = _make_agent_with_db(tmp_path)
+    messages = [
+        {"role": "user", "content": "continue"},
+        {
+            "role": "assistant",
+            "content": "partial bytes from interrupted provider response",
+            "finish_reason": "interrupted_during_api_call",
+            "active": False,
+            "compacted": False,
+            "_quarantine_reason": "interrupted_during_api_call",
+        },
+    ]
+
+    agent._flush_messages_to_session_db(messages, conversation_history=[])
+
+    live = db.get_messages("s1")
+    all_rows = db.get_messages("s1", include_inactive=True)
+
+    assert [m["content"] for m in live] == ["continue"]
+    assert [m["content"] for m in all_rows] == [
+        "continue",
+        "partial bytes from interrupted provider response",
+    ]
+    assert all_rows[1]["active"] == 0
+    assert all_rows[1]["finish_reason"] == "interrupted_during_api_call"
+
+
+def test_live_context_filter_drops_inactive_forensic_rows():
+    history = [
+        {"role": "user", "content": "safe"},
+        {"role": "assistant", "content": "poison", "active": False},
+        {"role": "assistant", "content": "also poison", "active": 0},
+        {"role": "assistant", "content": "safe reply", "active": True},
+    ]
+
+    assert [m["content"] for m in live_context_messages(history)] == [
+        "safe",
+        "safe reply",
+    ]
+
+
+def test_compression_entry_excludes_quarantined_messages():
+    captured = {}
+
+    class _Compressor:
+        _last_compress_aborted = True
+        _last_summary_error = "test abort"
+
+        def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+            captured["messages"] = list(messages)
+            return list(messages)
+
+    class _Agent:
+        _compression_feasibility_checked = True
+        _session_db = None
+        _memory_manager = None
+        _cached_system_prompt = "system"
+        _last_compression_summary_warning = None
+        context_compressor = _Compressor()
+        session_id = "s1"
+        model = "test/model"
+
+        def _emit_status(self, _msg):
+            pass
+
+        def _emit_warning(self, _msg):
+            pass
+
+        def _build_system_prompt(self, _system_message):
+            return "system"
+
+    messages = [
+        {"role": "user", "content": "safe"},
+        {"role": "assistant", "content": "poison", "active": False},
+        {"role": "assistant", "content": "safe reply"},
+    ]
+
+    returned, _ = compress_context(_Agent(), messages, "system", approx_tokens=123)
+
+    assert [m["content"] for m in captured["messages"]] == ["safe", "safe reply"]
+    assert [m["content"] for m in returned] == ["safe", "safe reply"]

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -75,7 +75,7 @@ def _make_agent():
     return agent
 
 
-def _mock_tool_call(name="web_search", arguments="{}", call_id="call_1"):
+def _mock_tool_call(name="web_search", arguments='{"query":"test"}', call_id="call_1"):
     return SimpleNamespace(
         id=call_id,
         type="function",
@@ -250,3 +250,64 @@ def test_execute_tool_calls_concurrent_flushes_each_tool_result_in_order():
     # production flush call breaks one of these assertions.
     assert flushed_tool_ids == ["c1", "c2"]
     assert flush_lengths == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# Contract 4: malformed/empty tool-call arguments are rejected BEFORE the real
+# tool dispatch surface. A provider glitch that emits terminal/write_file/etc.
+# with {} must not call handlers with None-valued required parameters or create
+# side-effect-bearing tool errors in the active context.
+# ---------------------------------------------------------------------------
+def test_execute_tool_calls_sequential_rejects_missing_required_args_before_dispatch():
+    agent = _make_agent()
+    tool_call = _mock_tool_call(name="terminal", arguments="{}", call_id="bad-terminal")
+    messages: list = []
+    assistant_message = SimpleNamespace(content="", tool_calls=[tool_call])
+
+    agent._flush_messages_to_session_db = MagicMock()
+
+    with (
+        patch("run_agent.handle_function_call", return_value="SHOULD_NOT_DISPATCH") as disp,
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        agent._execute_tool_calls_sequential(assistant_message, messages, "task-1")
+
+    disp.assert_not_called()
+    assert len(messages) == 1
+    assert messages[0]["role"] == "tool"
+    assert messages[0]["tool_call_id"] == "bad-terminal"
+    assert "invalid_tool_arguments" in messages[0]["content"]
+    assert "terminal" in messages[0]["content"]
+    assert "command" in messages[0]["content"]
+    agent._flush_messages_to_session_db.assert_called_once()
+
+
+def test_execute_tool_calls_concurrent_rejects_missing_required_args_before_dispatch():
+    agent = _make_agent()
+    tool_call = _mock_tool_call(name="write_file", arguments="{}", call_id="bad-write")
+    messages: list = []
+    assistant_message = SimpleNamespace(content="", tool_calls=[tool_call])
+
+    agent._flush_messages_to_session_db = MagicMock()
+
+    with (
+        patch.object(agent, "_invoke_tool", return_value="SHOULD_NOT_DISPATCH") as inv,
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        agent._execute_tool_calls_concurrent(assistant_message, messages, "task-1")
+
+    inv.assert_not_called()
+    assert len(messages) == 1
+    assert messages[0]["role"] == "tool"
+    assert messages[0]["tool_call_id"] == "bad-write"
+    assert "invalid_tool_arguments" in messages[0]["content"]
+    assert "write_file" in messages[0]["content"]
+    assert "path" in messages[0]["content"]
+    assert "content" in messages[0]["content"]
+    agent._flush_messages_to_session_db.assert_called_once()

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8464,3 +8464,28 @@ class TestResolveRuntimeWithFallback:
 
         assert agent.model == "gpt-5.5"
         assert captured["provider"] == "deepseek"
+
+def test_async_delegation_notification_queues_internal_context_not_user_turn():
+    session = {"history_lock": threading.RLock()}
+    text = "[ASYNC DELEGATION COMPLETE — deleg_test]\n--- RESULT ---\ndone"
+
+    server._queue_async_delegation_context(session, text)
+    server._queue_async_delegation_context(session, text)
+
+    assert session["_pending_async_delegation_context"] == [text]
+
+
+def test_async_delegation_context_is_merged_into_next_prompt_and_cleared():
+    session = {
+        "history_lock": threading.RLock(),
+        "_pending_async_delegation_context": [
+            "[ASYNC DELEGATION COMPLETE — deleg_test]\n--- RESULT ---\ndone"
+        ],
+    }
+
+    prompt = server._consume_async_delegation_context(session, "what should I do next?")
+
+    assert "_pending_async_delegation_context" not in session
+    assert prompt.startswith("[INTERNAL ASYNC DELEGATION RESULTS")
+    assert "deleg_test" in prompt
+    assert prompt.endswith("what should I do next?")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8187,6 +8187,43 @@ def _notification_event_dedup_key(evt: dict) -> tuple:
     return (evt_sid, evt_type)
 
 
+def _queue_async_delegation_context(session: dict, text: str) -> None:
+    """Queue async delegation completion text for the next real user turn.
+
+    Background subagent completions are internal events, not ordinary user
+    messages.  Replaying them via _run_prompt_submit immediately can persist a
+    standalone user row and, if the provider turn is interrupted, leave a
+    user→user alternation violation.  Keep them as pending context and merge
+    into the next user prompt instead.
+    """
+    if not text:
+        return
+    pending = session.setdefault("_pending_async_delegation_context", [])
+    if text not in pending:
+        pending.append(text)
+
+
+def _consume_async_delegation_context(session: dict, prompt: Any) -> Any:
+    pending = session.pop("_pending_async_delegation_context", None)
+    if not pending:
+        return prompt
+    block = "\n\n".join(str(p) for p in pending if p)
+    if not block:
+        return prompt
+    prefix = (
+        "[INTERNAL ASYNC DELEGATION RESULTS — context for this turn]\n"
+        f"{block}\n"
+        "[/INTERNAL ASYNC DELEGATION RESULTS]"
+    )
+    if isinstance(prompt, str):
+        return f"{prefix}\n\n{prompt}"
+    # Multimodal/native content: preserve the original payload and add the
+    # internal event as a text prefix part where possible.
+    if isinstance(prompt, list):
+        return [{"type": "text", "text": prefix}, *prompt]
+    return f"{prefix}\n\n{prompt}"
+
+
 def _notification_poller_loop(
     stop_event: threading.Event, sid: str, session: dict
 ) -> None:
@@ -8237,6 +8274,11 @@ def _notification_poller_loop(
             _emit("status.update", sid, {"kind": "process", "text": text})
             _emitted.add(_dedup_key)
 
+        if evt.get("type") == "async_delegation":
+            with session["history_lock"]:
+                _queue_async_delegation_context(session, text)
+            continue
+
         with session["history_lock"]:
             if session.get("running"):
                 process_registry.completion_queue.put(evt)
@@ -8279,6 +8321,11 @@ def _notification_poller_loop(
         if _dedup_key not in _emitted:
             _emit("status.update", sid, {"kind": "process", "text": text})
             _emitted.add(_dedup_key)
+
+        if evt.get("type") == "async_delegation":
+            with session["history_lock"]:
+                _queue_async_delegation_context(session, text)
+            continue
 
         with session["history_lock"]:
             if session.get("running"):
@@ -8360,7 +8407,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             _register_session_cwd(session)
             cols = session.get("cols", 80)
             streamer = make_stream_renderer(cols)
-            prompt = text
+            prompt = _consume_async_delegation_context(session, text)
 
             if isinstance(prompt, str) and "@" in prompt:
                 from agent.context_references import preprocess_context_references


### PR DESCRIPTION
## Summary

Fixes a session-integrity failure mode where malformed/interrupted provider output can poison active conversation history:

- reject malformed tool calls before dispatch (for example `terminal {}` / `write_file {}`)
- persist interrupted partial assistant output as forensic inactive rows instead of live context
- exclude inactive/quarantined rows from replay and compression inputs
- queue async delegation completions as internal context for the next real user turn in TUI instead of immediately injecting them as standalone user turns
- persist message-sequence repair back to `state.db` so repeated `user -> user` / stray-tool repair does not recur every request

## Why

A provider/transport glitch can produce partial assistant text or tool calls with empty argument objects. Previously Hermes could:

1. execute invalid tool calls far enough to create tool errors in the active transcript,
2. persist interrupted/garbled assistant partials as live assistant messages,
3. replay/compress those forensic rows later,
4. inject async delegation completion text as ordinary user messages, and
5. repair message alternation only in memory before each request while leaving the DB active view dirty.

Together those behaviors let one bad provider response contaminate future turns.

## Changes

- Added `agent/tool_call_validation.py` and wired it into sequential + concurrent tool execution before real handler dispatch.
- Added `agent/message_quarantine.py` and used it in turn setup + compression entry.
- Extended `SessionDB.append_message()` / insert helpers to accept `active` and `compacted` flags.
- Marked interrupted streamed assistant partials as `active=False`, `finish_reason='interrupted_during_api_call'`.
- Added `SessionDB.apply_repaired_active_messages()` and call it from `repair_message_sequence_with_cursor()`.
- Changed TUI async delegation completion handling to status-notify + queue internal context for the next real user prompt.

## Tests

```bash
python -m pytest \
  tests/test_hermes_state.py \
  tests/run_agent/test_tool_call_incremental_persistence.py \
  tests/run_agent/test_session_quarantine_guards.py \
  tests/run_agent/test_message_sequence_repair.py \
  tests/test_tui_gateway_server.py::test_async_delegation_notification_queues_internal_context_not_user_turn \
  tests/test_tui_gateway_server.py::test_async_delegation_context_is_merged_into_next_prompt_and_cleared \
  -o 'addopts=' -q
# 317 passed

python -m py_compile agent/tool_call_validation.py agent/tool_executor.py hermes_state.py agent/conversation_loop.py agent/message_quarantine.py agent/turn_context.py agent/conversation_compression.py agent/agent_runtime_helpers.py tui_gateway/server.py

git diff --check
```
