### PR TITLE
docs: fix incorrect web search searxng instructions

### DIFF
--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -158,17 +158,33 @@ SearXNG ships with JSON output disabled by default. Copy the generated config an
 docker cp searxng:/etc/searxng/settings.yml ~/searxng/searxng/settings.yml
 ```
 
-Open `~/searxng/searxng/settings.yml` and find the `formats` block (around line 84):
+Open `~/searxng/searxng/settings.yml`.
+If `use_default_settings: true` is present, the file only contains your overrides. All other settings are inherited from the built-in defaults.
+To enable JSON responses for Hermes, add the following override:
 
 ```yaml
-# Before (default — JSON disabled):
-formats:
-  - html
+search:
+  formats:
+    - html
+    - json
+```
 
-# After (enable JSON for Hermes):
-formats:
-  - html
-  - json
+Your `settings.yml` should look similar to:
+
+```yaml
+# Read the documentation before extending the defaults:
+# https://docs.searxng.org/admin/settings/
+
+use_default_settings: true
+
+server:
+  secret_key: "abcdef12345678"
+  image_proxy: true
+
+search:
+  formats:
+    - html
+    - json
 ```
 
 **5. Restart to apply:**


### PR DESCRIPTION
## What does this PR do?

Recent version of SearXNG uses `use_default_settings: true`, so settings.yml only contains configuration overrides rather than the full default configuration. As a result, there is no existing formats block to edit. To enable JSON responses, users need to add the search.formats override instead of modifying a non-existent top-level formats section.


## Related Issue

(https://github.com/NousResearch/hermes-agent/issues/54117)

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ x ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)


## Changes Made

- Only change: website/docs/user-guide/features/web-search.md


### Documentation & Housekeeping

- [ x ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ N/A ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ N/A ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ N/A ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ N/A ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
