### PR TITLE
fix(gateway): gate quick_commands through slash access policy (#44727)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8874,6 +8874,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not isinstance(quick_commands, dict):
                 quick_commands = {}
             if command in quick_commands:
+                # Quick commands are slash capabilities too — and type:exec
+                # ones run a shell command in the gateway process. The early
+                # gate above only fires for registry-known commands, so quick
+                # commands (never in the registry) would otherwise reach this
+                # dispatch sink unchecked. Apply the same admin/user policy to
+                # the raw typed name here so non-admins can't invoke admin-only
+                # quick commands. (#44727)
+                _denied = self._check_slash_access(source, command)
+                if _denied is not None:
+                    return _denied
                 qcmd = quick_commands[command]
                 if qcmd.get("type") == "exec":
                     exec_cmd = qcmd.get("command", "")

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -315,6 +315,74 @@ async def test_plugin_registered_command_is_gated(monkeypatch):
     assert "/myplugin is admin-only here" in result
 
 
+@pytest.mark.asyncio
+async def test_non_admin_denied_for_unlisted_quick_command_exec():
+    """A non-admin must not reach the quick_commands exec sink for a command
+    that isn't in user_allowed_commands. Regression for #44727 — quick
+    commands are never in the gateway registry, so the early gate skips them;
+    the sink gate must catch them."""
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": [],
+        }
+    )
+    runner.config.quick_commands = {
+        "limits": {"type": "exec", "command": "printf quick-command-bypass-confirmed"}
+    }
+
+    result = await runner._handle_message(
+        _make_event("/limits", _make_source(user_id="999"))
+    )
+
+    assert result is not None
+    assert "⛔" in result
+    assert "/limits is admin-only here" in result
+    assert "quick-command-bypass-confirmed" not in result
+
+
+@pytest.mark.asyncio
+async def test_listed_quick_command_runs_for_non_admin():
+    """When the operator lists the quick command in user_allowed_commands, a
+    non-admin can run it — the gate must allow, not blanket-deny."""
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": ["limits"],
+        }
+    )
+    runner.config.quick_commands = {
+        "limits": {"type": "exec", "command": "printf quick-command-allowed"}
+    }
+
+    result = await runner._handle_message(
+        _make_event("/limits", _make_source(user_id="999"))
+    )
+
+    assert result == "quick-command-allowed"
+
+
+@pytest.mark.asyncio
+async def test_admin_runs_quick_command_when_gating_enabled():
+    """An admin runs the quick command even under an enabled gate with an
+    empty user_allowed_commands list."""
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": [],
+        }
+    )
+    runner.config.quick_commands = {
+        "limits": {"type": "exec", "command": "printf quick-command-admin"}
+    }
+
+    result = await runner._handle_message(
+        _make_event("/limits", _make_source(user_id="111"))
+    )
+
+    assert result == "quick-command-admin"
+
+
 # ---------------------------------------------------------------------------
 # Running-agent fast-path gating — admin/user split must hold even when an
 # agent is already running. The fast-path block in _handle_message dispatches


### PR DESCRIPTION
## Summary
Config-backed `quick_commands` are now gated through the gateway's admin/user slash-access policy, closing an authorization bypass: a non-admin allowlisted gateway user could invoke admin-only quick commands — including `type: exec` shell commands that run in the gateway process — even when the operator set `allow_admin_from` / `user_allowed_commands` to lock them out.

Root cause: the early slash gate in `_handle_message` only fires for registry-known commands (`is_gateway_known_command(canonical)`). `quick_commands` are never in the gateway command registry, so they slipped straight past the gate to the `type: exec` dispatch sink unchecked.

Fixes #44727.

## Changes
- `gateway/run.py`: call `_check_slash_access(source, command)` at the `quick_commands` dispatch site (the single exec chokepoint, cold-path only), using the raw typed command name, before resolving/running `qcmd`.
- `tests/gateway/test_slash_access_dispatch.py`: 3 integration tests driving the real `_handle_message` — non-admin denied for an unlisted exec quick command (the PoC), admin runs it, non-admin runs it when it's in `user_allowed_commands`.

## Validation
Targeted suite: `tests/gateway/test_slash_access_dispatch.py` — 21/21 passing.

E2E against the real `GatewayRunner._handle_message`:

| Case | Result |
|---|---|
| Non-admin (999), empty `user_allowed_commands` (the PoC) | ⛔ DENIED — bypass closed |
| Admin (111) | RUNS — admin unaffected |
| Non-admin (999), command in `user_allowed_commands` | RUNS — opt-in works |
| No policy set (`allow_admin_from` unset) | RUNS — backward-compat intact |

## Credit
Same fix independently submitted in #44791 (@maxpetrusenko, earliest) and #45536 (@zapabob). This salvage uses the sink-gate approach; both contributors co-authored.

## Infographic

![quick-command-auth-bypass-sealed](https://v3b.fal.media/files/b/0aa01728/9m8RXEaVWaxjUEseH8Tje_EgsEypvf.png)
