### PR TITLE
fix(status): list configured plugin platforms

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -458,11 +458,51 @@ def show_status(args):
         
         print(f"  {name:<12}  {check_mark(has_token)} {status}")
 
-    # Plugin-registered platforms
+    # Plugin-registered platforms.  Status is often run as a standalone CLI
+    # command, so force plugin discovery before reading the registry; otherwise
+    # plugin channels such as Photon/iMessage can be configured and working but
+    # absent from `hermes status --all`.
     try:
+        try:
+            from hermes_cli.plugins import discover_plugins
+            discover_plugins()
+        except Exception:
+            pass
+        from gateway.config import Platform, _BUILTIN_PLATFORM_VALUES, load_gateway_config
         from gateway.platform_registry import platform_registry
+
+        try:
+            gateway_config = load_gateway_config()
+        except Exception:
+            gateway_config = None
+
         for entry in platform_registry.plugin_entries():
-            configured = entry.check_fn()
+            # Built-in platforms can also be backed by plugins during the
+            # migration period; the fixed table above is the authoritative
+            # status row for those names.  Avoid duplicate Telegram/Slack/etc.
+            # rows here and reserve this section for plugin-only channels.
+            if entry.name in _BUILTIN_PLATFORM_VALUES:
+                continue
+
+            platform_config = None
+            configured = False
+            if gateway_config is not None:
+                try:
+                    platform = Platform(entry.name)
+                    platform_config = gateway_config.platforms.get(platform)
+                    configured = bool(
+                        platform_config
+                        and platform_config.enabled
+                        and gateway_config._is_platform_connected(platform, platform_config)
+                    )
+                except Exception:
+                    configured = False
+
+            # Keep the status view concise: show configured plugin platforms,
+            # plus explicitly-present but disabled/misconfigured plugin blocks.
+            if not configured and platform_config is None:
+                continue
+
             status_str = "configured" if configured else "not configured"
             label = entry.label
             print(f"  {label:<12}  {check_mark(configured)} {status_str} (plugin)")

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -14,6 +14,49 @@ def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     assert "tvly...cdef" in output
 
 
+def test_show_status_discovers_plugin_platforms_before_listing(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    from gateway.platform_registry import PlatformEntry, platform_registry
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+    import hermes_cli.plugins as plugins_mod
+
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_minimax_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
+
+    def _discover_registers_plugin():
+        platform_registry.register(
+            PlatformEntry(
+                name="test_photon_status",
+                label="iMessage via Photon",
+                adapter_factory=lambda cfg: object(),
+                check_fn=lambda: True,
+                source="plugin",
+                plugin_name="photon-platform",
+            )
+        )
+
+    monkeypatch.setattr(plugins_mod, "discover_plugins", _discover_registers_plugin, raising=False)
+    try:
+        status_mod.show_status(SimpleNamespace(all=False, deep=False))
+    finally:
+        platform_registry.unregister("test_photon_status")
+
+    output = capsys.readouterr().out
+    assert "iMessage via Photon" in output
+    assert "configured (plugin)" in output
+
+
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
     import hermes_cli.auth as auth_mod


### PR DESCRIPTION
## Summary
- Load plugin registrations before rendering `hermes status --all`
- Report configured plugin-only messaging platforms, including Photon/iMessage
- Avoid duplicate rows for built-in platforms during plugin migration

## Test Plan
- `uv run --with pytest --with pytest-xdist pytest tests/hermes_cli/test_status.py -q -n 0`
- Verified `hermes status --all` lists `iMessage via Photon  ✓ configured (plugin)` on a configured local setup

This fixes a real troubleshooting gap where Photon/iMessage was configured and receiving messages, but was absent from the status output.