### PR TITLE
fix: keep MCP reconnect retries alive after disconnect

### DIFF
--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -353,13 +353,13 @@ def test_circuit_breaker_cleared_on_reconnect(monkeypatch, tmp_path):
         _cleanup(mcp_tool, "srv")
 
 
-def test_run_loop_parks_instead_of_exiting_then_revives(monkeypatch, tmp_path):
-    """The run loop must NOT exit when the reconnect budget is exhausted.
+def test_run_loop_keeps_retrying_after_each_recovered_outage(monkeypatch, tmp_path):
+    """Each recovered outage gets a fresh reconnect threshold window.
 
-    It deregisters tools and parks as a dormant listener; a later
-    ``_reconnect_event`` revives it and re-enters the transport. This is the
-    structural fix for #16788 — without a live task, no half-open probe could
-    ever bring a dead stdio server back.
+    Once the reconnect budget is exhausted, stale tools are deregistered but
+    the background task continues retrying. If the server recovers and later
+    drops again, retry/backoff counters reset so stale tools are deregistered
+    again after the next threshold window.
     """
     import asyncio
 
@@ -379,7 +379,7 @@ def test_run_loop_parks_instead_of_exiting_then_revives(monkeypatch, tmp_path):
 
     monkeypatch.setattr(mcp_tool.asyncio, "sleep", _fast_sleep)
 
-    state = {"transport_calls": 0, "deregistered": 0, "revived": False}
+    state = {"transport_calls": 0, "deregistered": 0}
 
     async def _scenario():
         class _Task(MCPServerTask):
@@ -392,57 +392,47 @@ def test_run_loop_parks_instead_of_exiting_then_revives(monkeypatch, tmp_path):
 
             async def _run_stdio(self, config):
                 state["transport_calls"] += 1
-                # First connect succeeds (sets _ready) then immediately
-                # fails, as if the subprocess died — the post-ready failure
-                # path that counts toward the reconnect budget.
-                if state["transport_calls"] == 1:
+                call = state["transport_calls"]
+
+                if call == 1:
+                    # First connect succeeds, then immediately fails as if the
+                    # subprocess died. Marking connected lets the outer loop
+                    # reset any stale retry state for this new outage.
                     self.session = object()
                     self._ready.set()
+                    self._mark_connected()
                     self.session = None
                     raise RuntimeError("subprocess died")
-                # Keep failing until the budget is exhausted and the loop
-                # parks, UNLESS we've been revived after parking.
-                if state["revived"]:
+
+                if call < 5:
+                    raise RuntimeError("still down")
+
+                if call == 5:
+                    # The server recovered after the first threshold window,
+                    # tools were published again, then it dropped a second
+                    # time. The next outage must get its own threshold window.
                     self.session = object()
                     self._ready.set()
-                    await self._wait_for_lifecycle_event()
-                    return
-                raise RuntimeError("still down")
+                    self._registered_tool_names = ["srv__tool"]
+                    self._mark_connected()
+                    self.session = None
+                    raise RuntimeError("second outage")
+
+                if call < 8:
+                    raise RuntimeError("still down again")
+
+                self.session = object()
+                self._ready.set()
+                self._shutdown_event.set()
+                return
 
         task = _Task("srv")
         task._registered_tool_names = ["srv__tool"]
 
         run_task = asyncio.ensure_future(task.run({"command": "x"}))
 
-        # Wait until the loop has parked (it deregisters tools right before
-        # blocking on _wait_for_reconnect_or_shutdown).
-        for _ in range(500):
-            await _real_sleep(0)
-            if state["deregistered"] >= 1:
-                break
-        # Give the loop one more tick to settle into the park wait.
-        await _real_sleep(0)
-        assert not run_task.done(), "run loop exited instead of parking"
-        assert state["deregistered"] >= 1, "tools not deregistered on park"
-
-        # Revive it: a reconnect signal must wake the parked task.
-        state["revived"] = True
-        before = state["transport_calls"]
-        task._reconnect_event.set()
-        for _ in range(500):
-            await _real_sleep(0)
-            if state["transport_calls"] > before:
-                break
-        assert state["transport_calls"] > before, (
-            "parked task did not re-enter transport on reconnect signal"
-        )
-
-        # Clean shutdown.
-        task._shutdown_event.set()
-        task._reconnect_event.set()
-        try:
-            await asyncio.wait_for(run_task, timeout=2)
-        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
-            run_task.cancel()
+        await asyncio.wait_for(run_task, timeout=2)
+        assert state["transport_calls"] == 8
+        assert state["deregistered"] == 2
 
     asyncio.run(_scenario())

--- a/tests/tools/test_mcp_reconnect_signal.py
+++ b/tests/tools/test_mcp_reconnect_signal.py
@@ -7,6 +7,7 @@ reconnect with fresh credentials. This file exercises the signal plumbing
 in isolation from the full stdio/http transport machinery.
 """
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
@@ -55,3 +56,120 @@ async def test_wait_for_lifecycle_event_shutdown_wins_when_both_set():
     task._reconnect_event.set()
     reason = await task._wait_for_lifecycle_event()
     assert reason == "shutdown"
+
+
+@pytest.mark.asyncio
+async def test_post_ready_disconnect_retries_past_reconnect_cap(monkeypatch):
+    """After initial readiness, reconnect failures should not park the task."""
+    import tools.mcp_tool as mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    class FlakyPostReadyTask(MCPServerTask):
+        __slots__ = ("attempts", "shutdown_after")
+
+        def __init__(self, shutdown_after: int):
+            super().__init__("test")
+            self.attempts = 0
+            self.shutdown_after = shutdown_after
+
+        async def _run_stdio(self, config):
+            self.attempts += 1
+            if self.attempts >= self.shutdown_after:
+                self._shutdown_event.set()
+            raise ConnectionError("transient disconnect")
+
+    sleep_delays = []
+
+    async def fake_sleep(delay):
+        sleep_delays.append(delay)
+
+    async def fail_if_parked(self):
+        raise AssertionError("post-ready reconnects should keep retrying")
+
+    monkeypatch.setattr(mcp_tool.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(
+        MCPServerTask,
+        "_wait_for_reconnect_or_shutdown",
+        fail_if_parked,
+        raising=False,
+    )
+
+    shutdown_after = mcp_tool._MAX_RECONNECT_RETRIES + 2
+    task = FlakyPostReadyTask(shutdown_after=shutdown_after)
+    task._ready.set()  # Simulate a server that had connected successfully.
+
+    await task.run({"command": "fake-mcp-server"})
+
+    assert task.attempts == shutdown_after
+    assert len(sleep_delays) == mcp_tool._MAX_RECONNECT_RETRIES + 1
+    assert max(sleep_delays) <= mcp_tool._MAX_BACKOFF_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_initial_connection_failures_remain_bounded(monkeypatch):
+    """Bad initial configs/offline servers should still fail fast."""
+    import tools.mcp_tool as mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    class NeverReadyTask(MCPServerTask):
+        __slots__ = ("attempts",)
+
+        def __init__(self):
+            super().__init__("test")
+            self.attempts = 0
+
+        async def _run_stdio(self, config):
+            self.attempts += 1
+            raise ConnectionError("startup failure")
+
+    async def fake_sleep(delay):
+        return None
+
+    monkeypatch.setattr(mcp_tool.asyncio, "sleep", fake_sleep)
+
+    task = NeverReadyTask()
+    await task.run({"command": "fake-mcp-server"})
+
+    assert task.attempts == mcp_tool._MAX_INITIAL_CONNECT_RETRIES + 1
+    assert isinstance(task._error, ConnectionError)
+    assert task._ready.is_set()
+
+
+@pytest.mark.asyncio
+async def test_post_threshold_reconnect_reregisters_deregistered_tools(monkeypatch):
+    """Recovered servers must publish tools again after stale deregistration."""
+    from tools.registry import registry
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    server_name = "reconnect_regression_server"
+    tool_name = "mcp_reconnect_regression_server_echo"
+
+    class FakeSession:
+        async def list_tools(self):
+            return SimpleNamespace(
+                tools=[
+                    SimpleNamespace(
+                        name="echo",
+                        description="Echo input",
+                        inputSchema={"type": "object", "properties": {}},
+                    )
+                ]
+            )
+
+    task = MCPServerTask(server_name)
+    task._config = {}
+    task.session = FakeSession()
+    task._ready.set()  # Reconnect path: initial start already completed.
+
+    try:
+        task._deregister_tools()
+        assert registry.get_toolset_for_tool(tool_name) is None
+
+        await task._discover_tools()
+
+        assert task._registered_tool_names == [tool_name]
+        assert registry.get_toolset_for_tool(tool_name) == f"mcp-{server_name}"
+        assert mcp_tool._mcp_tool_server_names[tool_name] == server_name
+    finally:
+        task._deregister_tools()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1429,7 +1429,7 @@ class MCPServerTask:
         "_registered_tool_names", "_auth_type", "_refresh_lock",
         "_rpc_lock", "_pending_refresh_tasks",
         "_pending_call_context",
-        "initialize_result", "_ping_unsupported",
+        "initialize_result", "_ping_unsupported", "_connect_epoch",
     )
 
     def __init__(self, name: str):
@@ -1483,6 +1483,12 @@ class MCPServerTask:
         # back to ``list_tools`` (the pre-ping probe) so we neither spam pings
         # nor reconnect-loop. Reset on each fresh transport connection.
         self._ping_unsupported: bool = False
+        self._connect_epoch: int = 0
+
+    def _mark_connected(self) -> None:
+        """Record a successful transport+discovery cycle."""
+        self._connect_epoch += 1
+        _reset_server_error(self.name)
 
     def _is_http(self) -> bool:
         """Check if this server uses HTTP transport."""
@@ -1759,41 +1765,6 @@ class MCPServerTask:
         self._reconnect_event.clear()
         return "reconnect"
 
-    async def _wait_for_reconnect_or_shutdown(self) -> str:
-        """Block until a reconnect or shutdown is requested while parked.
-
-        Used by :meth:`run` after the reconnect budget is exhausted. The
-        task stays alive (so ``_reconnect_event`` always has a listener) but
-        does no work until something explicitly asks it to come back —
-        the circuit-breaker half-open probe, OAuth recovery, or a manual
-        ``/mcp`` refresh.
-
-        Returns:
-            ``"shutdown"`` if the server should exit the run loop entirely,
-            ``"reconnect"`` if it should rebuild the transport. The reconnect
-            event is cleared before returning so the next park cycle starts
-            from a fresh signal. Shutdown takes precedence.
-        """
-        shutdown_task = asyncio.ensure_future(self._shutdown_event.wait())
-        reconnect_task = asyncio.ensure_future(self._reconnect_event.wait())
-        try:
-            await asyncio.wait(
-                {shutdown_task, reconnect_task},
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-        finally:
-            for t in (shutdown_task, reconnect_task):
-                if not t.done():
-                    t.cancel()
-                    try:
-                        await t
-                    except (asyncio.CancelledError, Exception):
-                        pass
-        if self._shutdown_event.is_set():
-            return "shutdown"
-        self._reconnect_event.clear()
-        return "reconnect"
-
     async def _run_stdio(self, config: dict):
         """Run the server using stdio transport."""
         if not _MCP_AVAILABLE:
@@ -1895,7 +1866,7 @@ class MCPServerTask:
                     # Session is live again: clear any breaker state from a
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
-                    _reset_server_error(self.name)
+                    self._mark_connected()
                     # stdio transport does not use OAuth, but we still honor
                     # _reconnect_event (e.g. future manual /mcp refresh) for
                     # consistency with _run_http.
@@ -2130,7 +2101,7 @@ class MCPServerTask:
                     # Session is live again: clear any breaker state from a
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
-                    _reset_server_error(self.name)
+                    self._mark_connected()
                     reason = await self._wait_for_lifecycle_event()
                     if reason == "reconnect":
                         logger.info(
@@ -2183,7 +2154,7 @@ class MCPServerTask:
                         # Session is live again: clear any breaker state from
                         # a prior outage so the first call after recovery
                         # isn't gated on a stale failure count (#16788).
-                        _reset_server_error(self.name)
+                        self._mark_connected()
                         reason = await self._wait_for_lifecycle_event()
                         if reason == "reconnect":
                             logger.info(
@@ -2210,7 +2181,7 @@ class MCPServerTask:
                     # Session is live again: clear any breaker state from a
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
-                    _reset_server_error(self.name)
+                    self._mark_connected()
                     reason = await self._wait_for_lifecycle_event()
                     if reason == "reconnect":
                         logger.info(
@@ -2241,6 +2212,7 @@ class MCPServerTask:
                 self.name,
             )
             self._tools = []
+            self._register_discovered_tools_if_needed()
             return
         async with self._rpc_lock:
             tools_result = await self.session.list_tools()
@@ -2248,6 +2220,22 @@ class MCPServerTask:
             tools_result.tools
             if hasattr(tools_result, "tools")
             else []
+        )
+        self._register_discovered_tools_if_needed()
+
+    def _register_discovered_tools_if_needed(self) -> None:
+        """Re-register tools after a post-ready reconnect if needed.
+
+        Initial registration is performed by ``_discover_and_register_server``
+        after ``start()`` completes. During a later reconnect, however,
+        ``_ready`` remains set; if outage handling previously deregistered
+        stale tools, the successful reconnect must publish the freshly
+        discovered tools again.
+        """
+        if not self._ready.is_set() or self._registered_tool_names:
+            return
+        self._registered_tool_names = _register_server_tools(
+            self.name, self, self._config
         )
 
     async def run(self, config: dict):
@@ -2332,6 +2320,7 @@ class MCPServerTask:
         backoff = 1.0
 
         while True:
+            connected_epoch_before = self._connect_epoch
             try:
                 if self._is_http():
                     await self._run_http(config)
@@ -2340,8 +2329,8 @@ class MCPServerTask:
                 # Transport returned cleanly. Two cases:
                 #  - _shutdown_event was set: exit the run loop entirely.
                 #  - _reconnect_event was set (auth recovery): loop back and
-                #    rebuild the MCP session with fresh credentials. Do NOT
-                #    touch the retry counters — this is not a failure.
+                #    rebuild the MCP session with fresh credentials. This is
+                #    not a failure, so reset retry/backoff counters.
                 if self._shutdown_event.is_set():
                     break
                 logger.info(
@@ -2378,6 +2367,13 @@ class MCPServerTask:
                 self.session = None
                 raise
             except Exception as exc:
+                if self._ready.is_set() and self._connect_epoch > connected_epoch_before:
+                    # This attempt established a fresh session before it later
+                    # failed. Treat the following reconnect as a new outage so
+                    # stale retry/backoff state from an older outage does not
+                    # skip threshold handling.
+                    retries = 0
+                    backoff = 1.0
                 self.session = None
 
                 # If this is the first connection attempt, retry with backoff
@@ -2432,41 +2428,25 @@ class MCPServerTask:
 
                 retries += 1
                 if retries > _MAX_RECONNECT_RETRIES:
+                    if retries == _MAX_RECONNECT_RETRIES + 1:
+                        # Once the warning threshold is crossed, remove
+                        # stale tools from the live registry while the
+                        # background task keeps trying to reconnect and
+                        # rediscover them.
+                        self._deregister_tools()
                     logger.warning(
-                        "MCP server '%s' failed after %d reconnection attempts, "
-                        "parking until a reconnect is requested: %s",
-                        self.name, _MAX_RECONNECT_RETRIES, exc,
+                        "MCP server '%s' still disconnected after %d "
+                        "reconnection attempts; continuing background retries "
+                        "in %.0fs: %s",
+                        self.name, retries - 1, backoff, exc,
                     )
-                    # Do NOT return — exiting the task orphans the server:
-                    # nothing would ever listen for _reconnect_event again,
-                    # so a half-open circuit-breaker probe could never revive
-                    # it and the server would be permanently wedged for the
-                    # life of the process (#16788). Instead, drop the phantom
-                    # tools from the registry and park as a dormant listener.
-                    # A future _reconnect_event.set() — from the breaker's
-                    # half-open probe, OAuth recovery, or a manual /mcp
-                    # refresh — wakes us to rebuild the transport (respawning
-                    # a dead stdio subprocess in the process).
-                    self._deregister_tools()
-                    self._reconnect_event.clear()
-                    parked = await self._wait_for_reconnect_or_shutdown()
-                    if parked == "shutdown":
-                        return
-                    logger.info(
-                        "MCP server '%s': reconnect requested while parked; "
-                        "rebuilding transport.",
-                        self.name,
+                else:
+                    logger.warning(
+                        "MCP server '%s' connection lost (attempt %d/%d), "
+                        "reconnecting in %.0fs: %s",
+                        self.name, retries, _MAX_RECONNECT_RETRIES,
+                        backoff, exc,
                     )
-                    retries = 0
-                    backoff = 1.0
-                    continue
-
-                logger.warning(
-                    "MCP server '%s' connection lost (attempt %d/%d), "
-                    "reconnecting in %.0fs: %s",
-                    self.name, retries, _MAX_RECONNECT_RETRIES,
-                    backoff, exc,
-                )
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, _MAX_BACKOFF_SECONDS)
 


### PR DESCRIPTION
## Summary
- Keep post-ready MCP reconnect attempts alive with capped backoff after the warning threshold instead of parking indefinitely.
- Deregister stale MCP tools once the threshold is crossed, then re-register freshly discovered tools after recovery.
- Reset retry/backoff state after a recovered session so each later outage gets its own threshold window.
- Preserve bounded initial connection retries for bad config/offline servers.

## Test plan
- `python3 -m py_compile tools/mcp_tool.py tests/tools/test_mcp_reconnect_signal.py tests/tools/test_mcp_circuit_breaker.py`
- `pytest -q -o 'addopts=' tests/tools/test_mcp_reconnect_signal.py tests/tools/test_mcp_circuit_breaker.py`