### PR TITLE
fix(install): normalize 8.3 short profile paths so Windows desktop stage doesn't abort (#43334)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -122,15 +122,29 @@ function ConvertTo-LongPath {
     return $Path
 }
 
-foreach ($tmpVar in @('TEMP', 'TMP')) {
-    $current = [Environment]::GetEnvironmentVariable($tmpVar)
+# Normalize every profile-derived location that can surface in 8.3 short form
+# when the user-profile folder name contains a space. %TEMP%/%TMP% were the
+# first observed offenders, but the same short alias (e.g. C:\Users\PPTAI~1)
+# also reaches provider cmdlets through %USERPROFILE%/%LOCALAPPDATA%/%APPDATA%
+# and the $HermesHome/$InstallDir defaults derived from them (params 26-27).
+# The desktop build streams its log to a path under $InstallDir via a provider
+# cmdlet, so a short-form $InstallDir aborts the desktop stage with
+# "An object at the specified path C:\Users\PPTAI~1 does not exist." (#43334).
+foreach ($pathVar in @('TEMP', 'TMP', 'USERPROFILE', 'LOCALAPPDATA', 'APPDATA')) {
+    $current = [Environment]::GetEnvironmentVariable($pathVar)
     if ($current) {
         $expanded = ConvertTo-LongPath $current
         if ($expanded -and $expanded -ne $current) {
-            Set-Item -Path "Env:$tmpVar" -Value $expanded
+            Set-Item -Path "Env:$pathVar" -Value $expanded
         }
     }
 }
+
+# $HermesHome/$InstallDir are bound from the (possibly short-form) env vars at
+# parameter-binding time, BEFORE the loop above runs, so re-expand them here in
+# case they captured a "~1" component. These feed the desktop build's log path.
+$HermesHome = ConvertTo-LongPath $HermesHome
+$InstallDir = ConvertTo-LongPath $InstallDir
 
 # ============================================================================
 # Configuration

--- a/scripts/tests/test-install-ps1-longpath.ps1
+++ b/scripts/tests/test-install-ps1-longpath.ps1
@@ -27,8 +27,8 @@ if (-not (Test-Path $installScript)) {
 
 $failures = 0
 function Assert-Equal {
-    param([Parameter(Mandatory = $true)] $Expected,
-          [Parameter(Mandatory = $true)] $Actual,
+    param([AllowNull()] $Expected,
+          [AllowNull()] $Actual,
           [Parameter(Mandatory = $true)] [string]$Label)
     if ($Expected -ne $Actual) {
         Write-Host "FAIL: $Label" -ForegroundColor Red
@@ -61,7 +61,9 @@ Write-Host ""
 Write-Host "-- ConvertTo-LongPath --"
 
 Assert-Equal -Expected "" -Actual (ConvertTo-LongPath "") -Label "empty string returns empty"
-Assert-Equal -Expected $null -Actual (ConvertTo-LongPath $null) -Label "null returns null"
+# The [string]$Path param coerces $null to "" before the body runs, so a $null
+# input surfaces as empty string (IsNullOrWhiteSpace short-circuit returns it).
+Assert-Equal -Expected "" -Actual (ConvertTo-LongPath $null) -Label "null coerces to empty string"
 
 # No 8.3 component -> returned verbatim (even with spaces).
 $longish = "C:\Users\First Last\AppData\Local\Temp"
@@ -74,6 +76,27 @@ Assert-Equal -Expected $noTilde -Actual (ConvertTo-LongPath $noTilde) -Label "ti
 # (FolderExists/FileExists both false, or COM unavailable on this host).
 $fakeShort = "C:\Users\FIRST~1.LAS\does\not\exist"
 Assert-Equal -Expected $fakeShort -Actual (ConvertTo-LongPath $fakeShort) -Label "nonexistent 8.3 path falls back to input"
+
+# --- Normalization coverage (issue #43334) ---
+# The %TEMP%-only fix missed the profile-root short form (C:\Users\PPTAI~1)
+# reached via %USERPROFILE%/%LOCALAPPDATA%/%APPDATA% and the $HermesHome /
+# $InstallDir defaults derived from them — which is what aborts the desktop
+# stage. Assert the installer normalizes all of these, not just TEMP/TMP.
+Write-Host ""
+Write-Host "-- short-path normalization coverage (#43334) --"
+
+$scriptText = Get-Content -Raw -Path $installScript
+foreach ($mustNormalize in @('USERPROFILE', 'LOCALAPPDATA', 'APPDATA')) {
+    Assert-Equal -Expected $true `
+        -Actual ($scriptText -match "(?m)^\s*foreach\s*\(\`$pathVar\s+in\s+@\([^)]*'$mustNormalize'") `
+        -Label "normalization loop covers %$mustNormalize%"
+}
+Assert-Equal -Expected $true `
+    -Actual ($scriptText -match '(?m)^\s*\$HermesHome\s*=\s*ConvertTo-LongPath\s+\$HermesHome') `
+    -Label "`$HermesHome is re-expanded after param binding"
+Assert-Equal -Expected $true `
+    -Actual ($scriptText -match '(?m)^\s*\$InstallDir\s*=\s*ConvertTo-LongPath\s+\$InstallDir') `
+    -Label "`$InstallDir is re-expanded after param binding"
 
 # --- Summary ---
 Write-Host ""


### PR DESCRIPTION
## Summary
The Windows installer now completes for users whose profile folder name contains a space (e.g. `C:\Users\PPT AI`) — it was aborting at the desktop stage with `An object at the specified path C:\Users\PPTAI~1 does not exist.`

**Root cause:** Windows generates an 8.3 short alias (`PPTAI~1`) for profile folders with spaces, and PowerShell's FileSystem provider mishandles the `~<digit>` component when the path reaches a provider cmdlet (`Tee-Object`/`Out-File`). The desktop build streams its log through such a cmdlet to a path under `$InstallDir`. PR #49838 added `ConvertTo-LongPath` and fixed this for `%TEMP%`/`%TMP%`, but the reporter's failure is the **profile-root** short form, reached via `%USERPROFILE%`/`%LOCALAPPDATA%`/`%APPDATA%` and the `$HermesHome`/`$InstallDir` defaults derived from `%LOCALAPPDATA%` (params bound *before* the normalization loop runs). Those were never normalized.

## Changes
- `scripts/install.ps1`: widen the 8.3 normalization loop to cover `USERPROFILE`/`LOCALAPPDATA`/`APPDATA` in addition to `TEMP`/`TMP`, and re-expand `$HermesHome`/`$InstallDir` after param binding (they may have captured a short-form default from the env).
- `scripts/tests/test-install-ps1-longpath.ps1`: 5 new coverage assertions (loop covers each profile var; `$HermesHome`/`$InstallDir` re-expanded). Also makes the existing test runnable on PowerShell 7+/pwsh — `Assert-Equal` now allows null args, and the null-input assertion matches the real contract (`[string]$Path` coerces null to empty). These two were latent pre-existing failures only masked by Windows PowerShell 5.1's lenient `Mandatory` binding.

## Validation
RED→GREEN verified with `pwsh` 7 on macOS:

| install.ps1 state | #43334 coverage assertions |
|---|---|
| TEMP/TMP only (before) | 5 FAIL |
| widened (this PR) | 10/10 OK, exit 0 |

`install.ps1` parses clean (13599 tokens, no syntax errors). The fix is additive and string-identity-guarded (`ConvertTo-LongPath` no-ops any path without a `~<digit>` component), so non-spaced profiles are unaffected.

Closes #43334
