### PR TITLE
feat(cli): add app.nz OpenAI/Anthropic-compatible gateway provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,15 @@
 # OLLAMA_BASE_URL=https://ollama.com/v1
 
 # =============================================================================
+# LLM PROVIDER (app.nz)
+# =============================================================================
+# app.nz is an OpenAI- and Anthropic-compatible LLM gateway/aggregator.
+# Use app/auto for prompt-aware routing, or pin upstream as provider/model.
+# Get your key (app_live_...) at: https://app.nz/docs
+# APPNZ_API_KEY=
+# APPNZ_BASE_URL=https://app.nz/v1  # Override default base URL
+
+# =============================================================================
 # LLM PROVIDER (z.ai / GLM)
 # =============================================================================
 # z.ai provides access to ZhipuAI GLM models (GLM-4-Plus, etc.)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -190,6 +190,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("OPENAI_API_KEY",),
         base_url_env_var="OPENAI_BASE_URL",
     ),
+    "appnz": ProviderConfig(
+        id="appnz",
+        name="app.nz",
+        auth_type="api_key",
+        inference_base_url="https://app.nz/v1",
+        api_key_env_vars=("APPNZ_API_KEY",),
+        base_url_env_var="APPNZ_BASE_URL",
+    ),
     "xai-oauth": ProviderConfig(
         id="xai-oauth",
         name="xAI Grok OAuth (SuperGrok / Premium+)",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -237,6 +237,14 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gpt-4o",
         "gpt-4o-mini",
     ],
+    "appnz": [
+        "app/auto",
+        "app/auto-code",
+        "app/auto-reasoning",
+        "app/auto-fast",
+        "app/auto-cheap",
+        "app/auto-vision",
+    ],
     "openai-codex": _codex_curated_models(),
     "xai-oauth": _xai_curated_models(),
     "copilot-acp": [
@@ -1023,6 +1031,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("anthropic",      "Anthropic",                "Anthropic (Claude models via API key or Claude Code)"),
     ProviderEntry("openai-codex",   "OpenAI Codex",             "OpenAI Codex (Codex CLI via ChatGPT subscription or API key)"),
     ProviderEntry("openai-api",     "OpenAI API",               "OpenAI API (api.openai.com, API key)"),
+    ProviderEntry("appnz",          "app.nz",                   "app.nz (OpenAI/Anthropic-compatible gateway, app/auto routing)"),
     ProviderEntry("alibaba",        "Qwen Cloud",               "Qwen Cloud / DashScope (Qwen + multi-provider)"),
     ProviderEntry("xai-oauth",      "xAI Grok OAuth (SuperGrok / Premium+)", "xAI Grok OAuth (SuperGrok / Premium+ subscription)"),
     ProviderEntry("xiaomi",         "Xiaomi MiMo",              "Xiaomi MiMo (MiMo-V2.5 and V2 models: pro, omni, flash)"),

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -69,6 +69,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://api.openai.com/v1",
         base_url_env_var="OPENAI_BASE_URL",
     ),
+    "appnz": HermesOverlay(
+        transport="openai_chat",
+        base_url_override="https://app.nz/v1",
+        base_url_env_var="APPNZ_BASE_URL",
+    ),
     "xai-oauth": HermesOverlay(
         transport="codex_responses",
         auth_type="oauth_external",
@@ -238,6 +243,11 @@ class ProviderDef:
 # Uses models.dev IDs where possible.
 
 ALIASES: Dict[str, str] = {
+    # appnz
+    "app": "appnz",
+    "app.nz": "appnz",
+    "app-nz": "appnz",
+
     # openrouter
     "openai": "openrouter",     # bare "openai" → route through aggregator
 


### PR DESCRIPTION
## What

Adds `appnz` (app.nz) as a first-class `api_key` provider.

app.nz is a hosted OpenAI- and Anthropic-compatible LLM gateway/aggregator. Base URL `https://app.nz/v1`, keys `app_live_...`, with `app/auto` prompt-aware routing (plus `-code` / `-reasoning` / `-fast` / `-cheap` / `-vision` variants) and the ability to pin upstreams as `provider/model`.

## Why

Lets users select app.nz from `hermes model`, the setup wizard, and the desktop Providers tab, configuring it via `APPNZ_API_KEY` (optional `APPNZ_BASE_URL` override).

## How it follows the existing pattern

Wired exactly like the curated hosted gateways `openai-api` / `zai`:
- `PROVIDER_REGISTRY` entry in `hermes_cli/auth.py` (auth_type `api_key`)
- `CANONICAL_PROVIDERS` entry + curated model list in `hermes_cli/models.py`
- `HERMES_OVERLAYS` transport/base-url metadata + name aliases in `hermes_cli/providers.py`
- `.env.example` commented block

Curated model list (no live-fetch/aggregator flag), matching the `openai-api`/`zai` approach.

## Tests

The provider parity contract passes:
`tests/hermes_cli/test_provider_catalog.py`, `test_provider_groups.py`, `test_provider_parity.py` -> 26 passed. `test_api_key_providers.py` + `test_list_picker_providers.py` -> 176 passed.
