### PR TITLE
fix(cli): pass target_model to resolve_runtime_provider in _ensure_runtime_credentials

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -38,10 +38,17 @@ class CLIAgentSetupMixin:
         _primary_exc = None
         runtime = None
         try:
+            # Pass the active model so the resolver can derive the correct
+            # api_mode / base_url for it (e.g. opencode-go needs to pick
+            # ``chat_completions`` for non-MiniMax models even when the config
+            # default is a MiniMax model that would imply ``anthropic_messages``
+            # and strip ``/v1`` from the endpoint).
+            _target_model = getattr(self, "model", None) or None
             runtime = resolve_runtime_provider(
                 requested=self.requested_provider,
                 explicit_api_key=self._explicit_api_key,
                 explicit_base_url=self._explicit_base_url,
+                target_model=_target_model,
             )
         except Exception as exc:
             _primary_exc = exc

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -882,3 +882,57 @@ def test_save_custom_provider_uses_provided_name(monkeypatch, tmp_path):
     entries = saved.get("custom_providers", [])
     assert len(entries) == 1
     assert entries[0]["name"] == "Ollama"
+
+
+def test_ensure_runtime_credentials_passes_target_model_to_resolver(monkeypatch):
+    """Regression: ``_ensure_runtime_credentials`` must pass the active
+    ``self.model`` as ``target_model`` to ``resolve_runtime_provider`` so
+    the api_mode / base_url are derived for the model actually being used,
+    not the config default.
+
+    Before the fix, the resolver used ``model_cfg.default`` (e.g.
+    ``minimax-m3`` → ``anthropic_messages``) and so the resulting
+    ``self.api_mode`` was wrong for any chat invoked with ``-m <other>``.
+    """
+    cli = _import_cli()
+    captured_kwargs = {}
+
+    def _runtime_resolve(**kwargs):
+        captured_kwargs.update(kwargs)
+        return {
+            "provider": "opencode-go",
+            "api_mode": "chat_completions",
+            "base_url": "https://opencode.ai/zen/go/v1",
+            "api_key": "test-key",
+            "source": "env/config",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.format_runtime_provider_error",
+        lambda exc: str(exc),
+    )
+
+    # User runs: hermes chat -m qwen3.7-plus
+    shell = cli.HermesCLI(
+        model="qwen3.7-plus", provider="opencode-go", compact=True, max_turns=1
+    )
+
+    assert shell.model == "qwen3.7-plus"
+    assert shell.requested_provider == "opencode-go"
+
+    assert shell._ensure_runtime_credentials() is True
+
+    # The fix: resolver must receive the active model so it can pick the
+    # right api_mode (chat_completions for qwen3.7-plus, not
+    # anthropic_messages that the minimax-m3 default would imply).
+    assert captured_kwargs.get("target_model") == "qwen3.7-plus", (
+        f"_ensure_runtime_credentials must pass self.model as target_model; "
+        f"got kwargs={captured_kwargs!r}"
+    )
+    # And the resulting CLI state should reflect the chat_completions
+    # resolution, not whatever the config default would have implied.
+    assert shell.api_mode == "chat_completions"
+    assert shell.base_url == "https://opencode.ai/zen/go/v1"


### PR DESCRIPTION
## Summary

`_ensure_runtime_credentials()` called `resolve_runtime_provider()` without passing `target_model`, so the resolver derived `api_mode` and `base_url` from `model_cfg.default` instead of the active model. When the config default uses `anthropic_messages` (e.g. `minimax-m3` on `opencode-go`) and the user runs `hermes chat -m <chat_completions_model>`, the stale `anthropic_messages` mode strips `/v1` from the base URL and every non-MiniMax model 404s.

## Root cause

`hermes_cli/cli_agent_setup_mixin.py:_ensure_runtime_credentials` (line 41-45) called `resolve_runtime_provider(requested=..., explicit_api_key=..., explicit_base_url=...)` without `target_model`. The resolver then fell back to `model_cfg.get("default")` to derive `api_mode`, picking the wrong mode for any model that differs from the config default.

`resolve_runtime_provider` already accepts a `target_model` kwarg (added in #16878 / PR #16890 for the `/model` switch path) — it just wasn't being passed here.

## Fix

Pass `self.model` as `target_model` so the resolver derives `api_mode` and `base_url` for the model actually being used.

```diff
         _primary_exc = None
         runtime = None
         try:
+            # Pass the active model so the resolver can derive the correct
+            # api_mode / base_url for it (e.g. opencode-go needs to pick
+            # ``chat_completions`` for non-MiniMax models even when the config
+            # default is a MiniMax model that would imply ``anthropic_messages``
+            # and strip ``/v1`` from the endpoint).
+            _target_model = getattr(self, "model", None) or None
             runtime = resolve_runtime_provider(
                 requested=self.requested_provider,
                 explicit_api_key=self._explicit_api_key,
                 explicit_base_url=self._explicit_base_url,
+                target_model=_target_model,
             )
         except Exception as exc:
             _primary_exc = exc
```

## Why it's safe

- `target_model` is already an optional kwarg of `resolve_runtime_provider` (since #16878 / PR #16890, merged in v2026.4.30).
- `getattr(self, "model", None) or None` is defensive: if `self.model` is missing or empty, it passes `None` and the resolver uses the default (previous behavior).
- Does not touch `resolve_runtime_provider` or `runtime_provider.py`.
- Does not touch the `self.api_mode = "chat_completions"` initialization in `cli.py:3600`.
- Backward-compatible: for `minimax-m3` as default, the resolver now explicitly receives `target_model="minimax-m3"` and returns `anthropic_messages` — same result as before, but deterministic instead of by coincidence.

## Verification

- New regression test `test_ensure_runtime_credentials_passes_target_model_to_resolver` fails on pre-fix code, passes with the fix.
- 24/24 tests in `test_cli_provider_resolution.py` pass.
- 1118/1119 in `tests/cli/` + related `tests/hermes_cli/` suites pass (1 pre-existing flaky failure in `test_resume_quiet_stderr.py`, unrelated — passes in isolation).
- E2E: `hermes chat -m qwen3.7-plus -q "ok"` goes from HTTP 404 to a valid response; `minimax-m3` continues to work.

```
# Before fix:
hermes chat -m qwen3.7-plus -q "ok"    → HTTP 404
hermes chat -m kimi-k2.7-code -q "ok"  → HTTP 404
hermes chat -m deepseek-v4-pro -q "ok"  → HTTP 404

# After fix:
hermes chat -m qwen3.7-plus -q "ok"    → valid response ✅
hermes chat -m kimi-k2.7-code -q "ok"  → valid response ✅
hermes chat -m deepseek-v4-pro -q "ok"  → valid response ✅
hermes chat -m minimax-m3 -q "ok"      → valid response ✅ (unchanged)
```

## Related

- Fixes #54147
- #16878 — same bug family, fixed the `/model` switch path but not the CLI single-query path.
- #15319 — same root cause in `delegate_tool.py` (missing `target_model`), fixed with the same one-line pattern.
- #53251 — complementary fix for `runtime_override` staleness in `_init_agent` (openai-codex); compatible with this change.