### PR TITLE
Discover entry-point plugins in plugin CLI

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -199,6 +199,42 @@ ENTRY_POINTS_GROUP = "hermes_agent.plugins"
 _NS_PARENT = "hermes_plugins"
 
 
+def discover_entry_point_plugin_manifests() -> List["PluginManifest"]:
+    """Return metadata-only manifests for pip-installed plugin entry points.
+
+    This intentionally does not call ``EntryPoint.load()``. Listing available
+    plugins should not import third-party plugin code; loading remains gated by
+    ``PluginManager`` and ``plugins.enabled``.
+    """
+    manifests: List[PluginManifest] = []
+    try:
+        eps = importlib.metadata.entry_points()
+        # Python 3.12+ returns a SelectableGroups; earlier returns dict
+        if hasattr(eps, "select"):
+            group_eps = eps.select(group=ENTRY_POINTS_GROUP)
+        elif isinstance(eps, dict):
+            group_eps = eps.get(ENTRY_POINTS_GROUP, [])
+        else:
+            group_eps = [ep for ep in eps if ep.group == ENTRY_POINTS_GROUP]
+    except Exception as exc:
+        logger.debug("Entry-point scan failed: %s", exc)
+        return manifests
+
+    for ep in group_eps:
+        try:
+            manifests.append(
+                PluginManifest(
+                    name=ep.name,
+                    source="entrypoint",
+                    path=ep.value,
+                    key=ep.name,
+                )
+            )
+        except Exception as exc:
+            logger.debug("Skipping invalid plugin entry point %r: %s", ep, exc)
+    return manifests
+
+
 def _env_enabled(name: str) -> bool:
     """Return True when an env var is set to a truthy opt-in value."""
     return env_var_enabled(name)
@@ -1536,29 +1572,7 @@ class PluginManager:
 
     def _scan_entry_points(self) -> List[PluginManifest]:
         """Check ``importlib.metadata`` for pip-installed plugins."""
-        manifests: List[PluginManifest] = []
-        try:
-            eps = importlib.metadata.entry_points()
-            # Python 3.12+ returns a SelectableGroups; earlier returns dict
-            if hasattr(eps, "select"):
-                group_eps = eps.select(group=ENTRY_POINTS_GROUP)
-            elif isinstance(eps, dict):
-                group_eps = eps.get(ENTRY_POINTS_GROUP, [])
-            else:
-                group_eps = [ep for ep in eps if ep.group == ENTRY_POINTS_GROUP]
-
-            for ep in group_eps:
-                manifest = PluginManifest(
-                    name=ep.name,
-                    source="entrypoint",
-                    path=ep.value,
-                    key=ep.name,
-                )
-                manifests.append(manifest)
-        except Exception as exc:
-            logger.debug("Entry-point scan failed: %s", exc)
-
-        return manifests
+        return discover_entry_point_plugin_manifests()
 
     # -----------------------------------------------------------------------
     # Loading

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -915,13 +915,26 @@ def _discover_all_plugins() -> list:
     seen: dict = {}  # key -> (name, version, description, source, path, key)
 
     # Bundled (<repo>/plugins/<name>/), excluding memory/ and context_engine/
-    from hermes_cli.plugins import get_bundled_plugins_dir
+    from hermes_cli.plugins import (
+        discover_entry_point_plugin_manifests,
+        get_bundled_plugins_dir,
+    )
     repo_plugins = get_bundled_plugins_dir()
     for base, source, skip in (
         (repo_plugins, "bundled", {"memory", "context_engine"}),
         (_plugins_dir(), "user", set()),
     ):
         _scan_level(base, source, skip, "", 0, seen)
+    for manifest in discover_entry_point_plugin_manifests():
+        key = manifest.key or manifest.name
+        seen[key] = (
+            manifest.name,
+            manifest.version,
+            manifest.description,
+            "entry_point",
+            manifest.path or "",
+            key,
+        )
     return list(seen.values())
 
 

--- a/hermes_cli/subcommands/plugins.py
+++ b/hermes_cli/subcommands/plugins.py
@@ -14,7 +14,11 @@ def build_plugins_parser(subparsers, *, cmd_plugins: Callable) -> None:
     plugins_parser = subparsers.add_parser(
         "plugins",
         help="Manage plugins — install, update, remove, list",
-        description="Install plugins from Git repositories, update, remove, or list them.",
+        description=(
+            "Install plugins from Git repositories, update, remove, list, or enable "
+            "installed Python package plugins exposed via the hermes_agent.plugins "
+            "entry-point group."
+        ),
     )
     plugins_subparsers = plugins_parser.add_subparsers(dest="plugins_action")
 
@@ -54,7 +58,7 @@ def build_plugins_parser(subparsers, *, cmd_plugins: Callable) -> None:
     plugins_remove.add_argument("name", help="Plugin directory name to remove")
 
     plugins_list = plugins_subparsers.add_parser(
-        "list", aliases=["ls"], help="List installed plugins"
+        "list", aliases=["ls"], help="List available plugins"
     )
     plugins_list.add_argument(
         "--enabled",
@@ -83,7 +87,7 @@ def build_plugins_parser(subparsers, *, cmd_plugins: Callable) -> None:
     )
 
     plugins_enable = plugins_subparsers.add_parser(
-        "enable", help="Enable a disabled plugin"
+        "enable", help="Enable an available plugin"
     )
     plugins_enable.add_argument("name", help="Plugin name to enable")
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -15,6 +15,7 @@ from hermes_cli.plugins import (
     PluginContext,
     PluginManager,
     PluginManifest,
+    discover_entry_point_plugin_manifests,
     get_plugin_command_handler,
     get_plugin_commands,
     get_pre_tool_call_block_message,
@@ -30,6 +31,22 @@ from hermes_cli.middleware import (
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────
+
+
+class _FakeEntryPoints:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def select(self, *, group):
+        return [entry for entry in self._entries if entry.group == group]
+
+
+@pytest.fixture(autouse=True)
+def _no_entry_point_plugins(monkeypatch):
+    monkeypatch.setattr(
+        "importlib.metadata.entry_points",
+        lambda: _FakeEntryPoints([]),
+    )
 
 
 def _make_plugin_dir(base: Path, name: str, *, register_body: str = "pass",
@@ -391,6 +408,10 @@ class TestPluginDiscovery:
         # A later call (with discovery healthy again) must do the real scan.
         monkeypatch.undo()
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+        monkeypatch.setattr(
+            "importlib.metadata.entry_points",
+            lambda: _FakeEntryPoints([]),
+        )
         mgr.discover_and_load()
         assert mgr._discovered is True
         non_bundled = {
@@ -438,6 +459,58 @@ class TestPluginDiscovery:
             mgr.discover_and_load()
 
         assert "ep_plugin" in mgr._plugins
+
+    def test_entry_point_manifest_discovery_is_metadata_only(self):
+        """Entry-point discovery lists package plugins without importing them."""
+        fake_ep = MagicMock()
+        fake_ep.name = "fake-plugin"
+        fake_ep.value = "fake_plugin_package"
+        fake_ep.group = ENTRY_POINTS_GROUP
+        fake_ep.load.side_effect = AssertionError("entry point should not load")
+
+        def fake_entry_points():
+            result = MagicMock()
+            result.select = MagicMock(return_value=[fake_ep])
+            return result
+
+        with patch("importlib.metadata.entry_points", fake_entry_points):
+            manifests = discover_entry_point_plugin_manifests()
+
+        assert [manifest.name for manifest in manifests] == ["fake-plugin"]
+        assert manifests[0].source == "entrypoint"
+        assert manifests[0].path == "fake_plugin_package"
+        fake_ep.load.assert_not_called()
+
+    def test_enabled_entry_point_plugin_loads(self, tmp_path, monkeypatch):
+        """An entry-point plugin named in plugins.enabled is imported and loaded."""
+        hermes_home = tmp_path / "hermes_test"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["ep_plugin"]}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        fake_module = types.ModuleType("fake_ep_plugin")
+        fake_module.register = lambda ctx: ctx.register_hook("pre_llm_call", lambda **kw: None)  # type: ignore[attr-defined]
+
+        fake_ep = MagicMock()
+        fake_ep.name = "ep_plugin"
+        fake_ep.value = "fake_ep_plugin"
+        fake_ep.group = ENTRY_POINTS_GROUP
+        fake_ep.load.return_value = fake_module
+
+        def fake_entry_points():
+            result = MagicMock()
+            result.select = MagicMock(return_value=[fake_ep])
+            return result
+
+        with patch("importlib.metadata.entry_points", fake_entry_points):
+            mgr = PluginManager()
+            mgr.discover_and_load()
+
+        assert mgr._plugins["ep_plugin"].enabled is True
+        fake_ep.load.assert_called_once()
 
     def test_force_rediscover_clears_all_plugin_registries(self, monkeypatch):
         """force=True must clear every plugin-populated registry.

--- a/tests/hermes_cli/test_plugins_cmd_category_discovery.py
+++ b/tests/hermes_cli/test_plugins_cmd_category_discovery.py
@@ -13,6 +13,22 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+class _FakeEntryPoints:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def select(self, *, group):
+        return [entry for entry in self._entries if entry.group == group]
+
+
+@pytest.fixture(autouse=True)
+def _no_entry_point_plugins(monkeypatch):
+    monkeypatch.setattr(
+        "importlib.metadata.entry_points",
+        lambda: _FakeEntryPoints([]),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -92,6 +108,54 @@ class TestReadManifestInfo:
 
 
 class TestDiscoverAllPlugins:
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_entry_point_plugins_discovered(self, mock_user_dir, mock_bundled_dir, tmp_path, monkeypatch):
+        from importlib.metadata import EntryPoint
+
+        from hermes_cli.plugins import ENTRY_POINTS_GROUP
+        from hermes_cli.plugins_cmd import _discover_all_plugins
+
+        fake_ep = EntryPoint(
+            name="fake-plugin",
+            value="fake_plugin_package",
+            group=ENTRY_POINTS_GROUP,
+        )
+        monkeypatch.setattr(
+            "importlib.metadata.entry_points",
+            lambda: _FakeEntryPoints([fake_ep]),
+        )
+        mock_user_dir.return_value = tmp_path
+        mock_bundled_dir.return_value = tmp_path / "nonexistent"
+
+        entries = _discover_all_plugins()
+        entry = [e for e in entries if e[5] == "fake-plugin"][0]
+        assert entry[:4] == ("fake-plugin", "", "", "entry_point")
+        assert entry[4] == "fake_plugin_package"
+
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_invalid_entry_point_metadata_does_not_crash(self, mock_user_dir, mock_bundled_dir, tmp_path, monkeypatch):
+        from hermes_cli.plugins import ENTRY_POINTS_GROUP
+        from hermes_cli.plugins_cmd import _discover_all_plugins
+
+        class BrokenEntryPoint:
+            name = "broken-plugin"
+            group = ENTRY_POINTS_GROUP
+
+            @property
+            def value(self):
+                raise RuntimeError("bad metadata")
+
+        monkeypatch.setattr(
+            "importlib.metadata.entry_points",
+            lambda: _FakeEntryPoints([BrokenEntryPoint()]),
+        )
+        mock_user_dir.return_value = tmp_path
+        mock_bundled_dir.return_value = tmp_path / "nonexistent"
+
+        assert _discover_all_plugins() == []
+
     @patch("hermes_cli.plugins.get_bundled_plugins_dir")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
     def test_flat_plugins_still_discovered(self, mock_user_dir, mock_bundled_dir, tmp_path):
@@ -300,6 +364,79 @@ class TestFilterPluginEntries:
 
 
 class TestCmdListJson:
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_json_output_includes_entry_point_plugin(self, mock_user_dir, mock_bundled_dir, tmp_path, monkeypatch, capsys):
+        from importlib.metadata import EntryPoint
+
+        from hermes_cli.plugins import ENTRY_POINTS_GROUP
+        from hermes_cli.plugins_cmd import cmd_list
+
+        fake_ep = EntryPoint(
+            name="fake-plugin",
+            value="fake_plugin_package",
+            group=ENTRY_POINTS_GROUP,
+        )
+        monkeypatch.setattr(
+            "importlib.metadata.entry_points",
+            lambda: _FakeEntryPoints([fake_ep]),
+        )
+        mock_user_dir.return_value = tmp_path
+        mock_bundled_dir.return_value = tmp_path / "nonexistent"
+
+        args = MagicMock()
+        args.json = True
+        args.plain = False
+        args.no_bundled = False
+        args.user = False
+        args.enabled = False
+
+        cmd_list(args)
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+        assert payload == [
+            {
+                "name": "fake-plugin",
+                "status": "not enabled",
+                "version": "",
+                "description": "",
+                "source": "entry_point",
+            }
+        ]
+
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_json_output_marks_enabled_entry_point_plugin(self, mock_user_dir, mock_bundled_dir, tmp_path, monkeypatch, capsys):
+        from importlib.metadata import EntryPoint
+
+        from hermes_cli.plugins import ENTRY_POINTS_GROUP
+        from hermes_cli.plugins_cmd import cmd_list
+
+        fake_ep = EntryPoint(
+            name="fake-plugin",
+            value="fake_plugin_package",
+            group=ENTRY_POINTS_GROUP,
+        )
+        monkeypatch.setattr(
+            "importlib.metadata.entry_points",
+            lambda: _FakeEntryPoints([fake_ep]),
+        )
+        mock_user_dir.return_value = tmp_path
+        mock_bundled_dir.return_value = tmp_path / "nonexistent"
+
+        with patch("hermes_cli.plugins_cmd._get_enabled_set", return_value={"fake-plugin"}):
+            args = MagicMock()
+            args.json = True
+            args.plain = False
+            args.no_bundled = False
+            args.user = False
+            args.enabled = False
+
+            cmd_list(args)
+            captured = capsys.readouterr()
+            payload = json.loads(captured.out)
+            assert payload[0]["status"] == "enabled"
+
     @patch("hermes_cli.plugins.get_bundled_plugins_dir")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
     def test_json_output_includes_category_plugins(self, mock_user_dir, mock_bundled_dir, tmp_path, capsys):

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -15,6 +15,22 @@ from unittest.mock import patch
 import pytest
 
 
+class _FakeEntryPoints:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def select(self, *, group):
+        return [entry for entry in self._entries if entry.group == group]
+
+
+@pytest.fixture(autouse=True)
+def _no_entry_point_plugins(monkeypatch):
+    monkeypatch.setattr(
+        "importlib.metadata.entry_points",
+        lambda: _FakeEntryPoints([]),
+    )
+
+
 def _make_plugin_dir(parent: Path, name: str, manifest: dict) -> Path:
     d = parent / name
     d.mkdir(parents=True, exist_ok=True)
@@ -47,6 +63,29 @@ def nested_plugin_env(tmp_path):
 
 
 class TestResolvePluginKey:
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_entry_point_name_resolves_to_itself(self, mock_user, mock_bundled, tmp_path, monkeypatch):
+        from importlib.metadata import EntryPoint
+
+        from hermes_cli.plugins import ENTRY_POINTS_GROUP
+        from hermes_cli.plugins_cmd import _resolve_plugin_key
+
+        monkeypatch.setattr(
+            "importlib.metadata.entry_points",
+            lambda: _FakeEntryPoints([
+                EntryPoint(
+                    name="fake-plugin",
+                    value="fake_plugin_package",
+                    group=ENTRY_POINTS_GROUP,
+                )
+            ]),
+        )
+        mock_user.return_value = tmp_path
+        mock_bundled.return_value = tmp_path / "nonexistent"
+
+        assert _resolve_plugin_key("fake-plugin") == "fake-plugin"
+
     @patch("hermes_cli.plugins.get_bundled_plugins_dir")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
     def test_full_key_resolves_to_itself(self, mock_user, mock_bundled, nested_plugin_env):
@@ -100,6 +139,115 @@ class TestResolvePluginKey:
 
 
 class TestEnableDisableNested:
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    @patch("hermes_cli.plugins_cmd._save_disabled_set")
+    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set())
+    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set())
+    def test_enable_entry_point_writes_name(
+        self, mock_en, mock_dis, mock_save_en, mock_save_dis,
+        mock_user, mock_bundled, tmp_path, monkeypatch,
+    ):
+        from importlib.metadata import EntryPoint
+
+        from hermes_cli.plugins import ENTRY_POINTS_GROUP
+        from hermes_cli.plugins_cmd import cmd_enable
+
+        monkeypatch.setattr(
+            "importlib.metadata.entry_points",
+            lambda: _FakeEntryPoints([
+                EntryPoint(
+                    name="fake-plugin",
+                    value="fake_plugin_package",
+                    group=ENTRY_POINTS_GROUP,
+                )
+            ]),
+        )
+        mock_user.return_value = tmp_path
+        mock_bundled.return_value = tmp_path / "nonexistent"
+
+        cmd_enable("fake-plugin")
+
+        saved = mock_save_en.call_args[0][0]
+        assert saved == {"fake-plugin"}
+
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    @patch("hermes_cli.plugins_cmd._save_disabled_set")
+    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set())
+    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value={"fake-plugin"})
+    def test_enable_already_enabled_entry_point_is_idempotent(
+        self, mock_en, mock_dis, mock_save_en, mock_save_dis,
+        mock_user, mock_bundled, tmp_path, monkeypatch,
+    ):
+        from importlib.metadata import EntryPoint
+
+        from hermes_cli.plugins import ENTRY_POINTS_GROUP
+        from hermes_cli.plugins_cmd import cmd_enable
+
+        monkeypatch.setattr(
+            "importlib.metadata.entry_points",
+            lambda: _FakeEntryPoints([
+                EntryPoint(
+                    name="fake-plugin",
+                    value="fake_plugin_package",
+                    group=ENTRY_POINTS_GROUP,
+                )
+            ]),
+        )
+        mock_user.return_value = tmp_path
+        mock_bundled.return_value = tmp_path / "nonexistent"
+
+        cmd_enable("fake-plugin")
+
+        mock_save_en.assert_not_called()
+        mock_save_dis.assert_not_called()
+
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_enable_missing_entry_point_exits(self, mock_user, mock_bundled, tmp_path):
+        from hermes_cli.plugins_cmd import cmd_enable
+
+        mock_user.return_value = tmp_path
+        mock_bundled.return_value = tmp_path / "nonexistent"
+
+        with pytest.raises(SystemExit):
+            cmd_enable("missing-entry-point")
+
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_enable_entry_point_writes_isolated_config(
+        self, mock_user, mock_bundled, tmp_path, monkeypatch,
+    ):
+        from importlib.metadata import EntryPoint
+
+        import yaml
+
+        from hermes_cli.plugins import ENTRY_POINTS_GROUP
+        from hermes_cli.plugins_cmd import cmd_enable
+
+        hermes_home = tmp_path / "hermes_home"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(
+            "importlib.metadata.entry_points",
+            lambda: _FakeEntryPoints([
+                EntryPoint(
+                    name="fake-plugin",
+                    value="fake_plugin_package",
+                    group=ENTRY_POINTS_GROUP,
+                )
+            ]),
+        )
+        mock_user.return_value = hermes_home / "plugins"
+        mock_bundled.return_value = tmp_path / "nonexistent"
+
+        cmd_enable("fake-plugin")
+
+        config = yaml.safe_load((hermes_home / "config.yaml").read_text(encoding="utf-8"))
+        assert config["plugins"]["enabled"] == ["fake-plugin"]
+
     @patch("hermes_cli.plugins.get_bundled_plugins_dir")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
     @patch("hermes_cli.plugins_cmd._save_disabled_set")


### PR DESCRIPTION
## Summary
- add metadata-only discovery for Python package plugins registered under `hermes_agent.plugins`
- include entry-point plugins in `hermes plugins list`
- allow `hermes plugins enable <name>` to enable installed entry-point plugins
- keep existing runtime loading behavior and bundled/local plugin discovery intact

## Why
Runtime plugin loading already supports entry-point plugins when their names are manually present in `plugins.enabled`, but the plugin management CLI did not surface those installed plugins. This makes package-installed plugins harder to discover and enable.

## Validation
- `python -m compileall -q hermes_cli tests` — clean (no errors)
- targeted plugin suite: **132 passed, 0 failed**
- broad plugin suite: **378 passed, 3 failed, 7 skipped**
  - 3 failures all pre-existing on upstream/main (verified):
    - `test_rejects_symlink_escape` — Windows symlink privilege (WinError 1314)
    - `test_keyboard_interrupt_returns_cancel_value` — missing `_curses` on Windows
    - `test_depth_cap_two` — `a2a-bridge` entry-point plugin installed in venv, same failure on upstream/main
- isolated `HERMES_HOME` CLI smoke: skipped — live `hermes` binary uses installed Hermes, not dev checkout; unit tests provide equivalent coverage (entry-point discovery, listing, enable, JSON output)

## Notes
Full Windows-local validation is limited by existing environment issues:
- `scripts/run_tests.sh` blocked because Windows `bash` resolves to a WSL shim with no `/bin/bash`
- full pytest collection blocked by `which rg` not found
- unrelated Windows-local failures observed around symlink privilege, missing `_curses`, and cp1252 file reading
- Ruff unavailable in the managed venv

This PR does not modify `hermes-a2a-bridge`.
