### PR TITLE
fix: quiet expected optional tool check failures

### DIFF
--- a/tests/tools/test_terminal_tool_requirements.py
+++ b/tests/tools/test_terminal_tool_requirements.py
@@ -1,6 +1,7 @@
 """Tests for terminal/file tool availability in local dev environments."""
 
 import importlib
+import logging
 
 import pytest
 
@@ -132,6 +133,41 @@ class TestCheckFnTransientFailureSuppression:
         t = {"now": 1000.0}
         monkeypatch.setattr(reg.time, "monotonic", lambda: t["now"])
         assert reg._check_fn_cached(never) is False
+
+    def test_expected_false_check_fn_is_debug_not_warning(self, monkeypatch, caplog):
+        """Optional gated tools often return False by design.
+
+        That should hide the tool without producing scary WARNING noise on
+        every agent build; only exceptional probes and recent-success flakes
+        deserve warning-level logs.
+        """
+        import tools.registry as reg
+
+        def optional_unavailable():
+            return False
+
+        t = {"now": 1000.0}
+        monkeypatch.setattr(reg.time, "monotonic", lambda: t["now"])
+        with caplog.at_level(logging.DEBUG, logger="tools.registry"):
+            assert reg._check_fn_cached(optional_unavailable) is False
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("returned False" in msg for msg in messages)
+        assert not any(record.levelno >= logging.WARNING for record in caplog.records)
+
+    def test_raising_check_fn_still_warns(self, monkeypatch, caplog):
+        import tools.registry as reg
+
+        def broken():
+            raise RuntimeError("boom")
+
+        t = {"now": 1000.0}
+        monkeypatch.setattr(reg.time, "monotonic", lambda: t["now"])
+        with caplog.at_level(logging.WARNING, logger="tools.registry"):
+            assert reg._check_fn_cached(broken) is False
+
+        assert any(record.levelno == logging.WARNING for record in caplog.records)
+        assert any("raised" in record.getMessage() for record in caplog.records)
 
     def test_grace_expiry_lets_real_outage_through(self, monkeypatch):
         import tools.registry as reg

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -185,13 +185,28 @@ def _check_fn_cached(fn: Callable) -> bool:
             )
             return True
 
-        # No recent success (or grace expired) — honor the failure. Log it so
-        # silent tool loss in quiet mode (subagents) is diagnosable.
-        logger.warning(
-            "check_fn %s %s; dependent tools will be unavailable this turn",
-            getattr(fn, "__qualname__", fn),
-            "raised" if raised else "returned False",
-        )
+        # No recent success (or grace expired) — honor the failure.  A plain
+        # False is the normal/expected path for optional gated tools (browser,
+        # Spotify, X search, Yuanbao, etc.) and should not spam WARNING on
+        # every agent build.  Keep WARNING for exceptions and for tools that
+        # were recently available but now look persistently down.
+        fn_name = getattr(fn, "__qualname__", fn)
+        if raised:
+            logger.warning(
+                "check_fn %s raised; dependent tools will be unavailable this turn",
+                fn_name,
+            )
+        elif last_good is not None:
+            logger.warning(
+                "check_fn %s returned False after last-success grace expired; "
+                "dependent tools will be unavailable this turn",
+                fn_name,
+            )
+        else:
+            logger.debug(
+                "check_fn %s returned False; dependent tools will be unavailable this turn",
+                fn_name,
+            )
         _check_fn_cache[fn] = (now, False)
         return False
 


### PR DESCRIPTION
## Summary

Reduce noisy warning logs for expected optional tool unavailability:

- `check_fn` returning `False` with no recent successful availability is now logged at DEBUG
- exceptions from `check_fn` still log at WARNING
- a tool that was recently available but remains unavailable after the last-success grace window still logs at WARNING
- transient failures within the grace window still keep the existing WARNING + last-good behavior

## Why

Many optional/gated tools return `False` by design when their runtime is not configured or the current session mode does not apply, for example browser CDP/dialog tools, Kanban worker-only tools, Spotify, X search, Yuanbao, or video generation providers. These are normal availability decisions, not operational failures, but they currently appear as repeated WARNING lines during every agent/tool-definition build.

This keeps real warning signals while removing expected unavailable optional tools from warning-level noise.

## Tests

```bash
python -m pytest tests/tools/test_terminal_tool_requirements.py tests/tools/test_registry.py tests/test_model_tools.py -o 'addopts=' -q
# 72 passed, 1 warning

python -m py_compile tools/registry.py

git diff --check
```
