### PR TITLE
fix(gateway): headless systemd install — honor --start flags + non-TTY defaults (#42065)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3044,6 +3044,7 @@ def systemd_install(
     system: bool = False,
     run_as_user: str | None = None,
     enable_on_startup: bool = True,
+    non_interactive: bool = False,
 ):
     if system:
         _require_root_for_system_service("install")
@@ -3057,7 +3058,7 @@ def systemd_install(
         print()
         print_legacy_unit_warning()
         print()
-        if prompt_yes_no("Remove the legacy unit(s) before installing?", True):
+        if non_interactive or prompt_yes_no("Remove the legacy unit(s) before installing?", True):
             remove_legacy_hermes_units(interactive=False)
             print()
 
@@ -6271,10 +6272,11 @@ def _gateway_command_inner(args):
             # Honor CLI flags (--start-now / --no-start-now, --start-on-login /
             # --no-start-on-login).  When not provided, prompt interactively or
             # fall back to True for non-TTY / headless contexts (SSH, CI, pipes).
+            non_interactive = not (hasattr(sys.stdin, "isatty") and sys.stdin.isatty())
             _sn = getattr(args, "start_now", None)
             if _sn is not None:
                 start_now = _sn
-            elif sys.stdin.isatty():
+            elif not non_interactive:
                 start_now = prompt_yes_no("Start the gateway now after installing the service?", True)
             else:
                 start_now = True
@@ -6282,7 +6284,7 @@ def _gateway_command_inner(args):
             _sol = getattr(args, "start_on_login", None)
             if _sol is not None:
                 start_on_login = _sol
-            elif sys.stdin.isatty():
+            elif not non_interactive:
                 start_on_login = prompt_yes_no("Start the gateway automatically on login/boot with systemd?", True)
             else:
                 start_on_login = True
@@ -6291,6 +6293,7 @@ def _gateway_command_inner(args):
                 system=system,
                 run_as_user=run_as_user,
                 enable_on_startup=start_on_login,
+                non_interactive=non_interactive,
             )
             if start_now:
                 systemd_start(system=system)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6268,8 +6268,24 @@ def _gateway_command_inner(args):
                     "  Or use tmux/screen for persistence: tmux new -s hermes 'hermes gateway run'"
                 )
                 print()
-            start_now = prompt_yes_no("Start the gateway now after installing the service?", True)
-            start_on_login = prompt_yes_no("Start the gateway automatically on login/boot with systemd?", True)
+            # Honor CLI flags (--start-now / --no-start-now, --start-on-login /
+            # --no-start-on-login).  When not provided, prompt interactively or
+            # fall back to True for non-TTY / headless contexts (SSH, CI, pipes).
+            _sn = getattr(args, "start_now", None)
+            if _sn is not None:
+                start_now = _sn
+            elif sys.stdin.isatty():
+                start_now = prompt_yes_no("Start the gateway now after installing the service?", True)
+            else:
+                start_now = True
+
+            _sol = getattr(args, "start_on_login", None)
+            if _sol is not None:
+                start_on_login = _sol
+            elif sys.stdin.isatty():
+                start_on_login = prompt_yes_no("Start the gateway automatically on login/boot with systemd?", True)
+            else:
+                start_on_login = True
             systemd_install(
                 force=force,
                 system=system,

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -169,26 +169,26 @@ def build_gateway_parser(
         dest="start_now",
         action="store_true",
         default=None,
-        help=argparse.SUPPRESS,
+        help="Start the gateway service immediately after installing",
     )
     gateway_install.add_argument(
         "--no-start-now",
         dest="start_now",
         action="store_false",
-        help=argparse.SUPPRESS,
+        help="Do not start the gateway service after installing",
     )
     gateway_install.add_argument(
         "--start-on-login",
         dest="start_on_login",
         action="store_true",
         default=None,
-        help=argparse.SUPPRESS,
+        help="Enable the service to start automatically on login/boot",
     )
     gateway_install.add_argument(
         "--no-start-on-login",
         dest="start_on_login",
         action="store_false",
-        help=argparse.SUPPRESS,
+        help="Do not enable the service to start on login/boot",
     )
     gateway_install.add_argument(
         "--elevated-handoff",

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -451,7 +451,7 @@ def test_gateway_install_in_container_with_operational_systemd_uses_systemd(monk
     monkeypatch.setattr(
         gateway,
         "systemd_install",
-        lambda force=False, system=False, run_as_user=None, enable_on_startup=True: calls.append(("install", force, system, run_as_user, enable_on_startup)),
+        lambda force=False, system=False, run_as_user=None, enable_on_startup=True, **kw: calls.append(("install", force, system, run_as_user, enable_on_startup)),
     )
     monkeypatch.setattr(gateway, "systemd_start", lambda system=False: calls.append(("start", system)))
 
@@ -767,7 +767,7 @@ def test_install_linux_gateway_from_setup_system_choice_as_root_installs(monkeyp
     monkeypatch.setattr(
         gateway,
         "systemd_install",
-        lambda force=False, system=False, run_as_user=None, enable_on_startup=True: calls.append((force, system, run_as_user, enable_on_startup)),
+        lambda force=False, system=False, run_as_user=None, enable_on_startup=True, **kw: calls.append((force, system, run_as_user, enable_on_startup)),
     )
 
     scope, did_install = gateway.install_linux_gateway_from_setup(force=True)
@@ -783,7 +783,7 @@ def test_install_linux_gateway_from_setup_passes_startup_choice(monkeypatch):
     monkeypatch.setattr(
         gateway,
         "systemd_install",
-        lambda force=False, system=False, run_as_user=None, enable_on_startup=True: calls.append((force, system, run_as_user, enable_on_startup)),
+        lambda force=False, system=False, run_as_user=None, enable_on_startup=True, **kw: calls.append((force, system, run_as_user, enable_on_startup)),
     )
 
     scope, did_install = gateway.install_linux_gateway_from_setup(force=False, enable_on_startup=False)
@@ -805,7 +805,7 @@ def test_gateway_install_can_decline_start_now_and_startup(monkeypatch):
     monkeypatch.setattr(
         gateway,
         "systemd_install",
-        lambda force=False, system=False, run_as_user=None, enable_on_startup=True: calls.append(("install", force, system, run_as_user, enable_on_startup)),
+        lambda force=False, system=False, run_as_user=None, enable_on_startup=True, **kw: calls.append(("install", force, system, run_as_user, enable_on_startup)),
     )
     monkeypatch.setattr(gateway, "systemd_start", lambda system=False: calls.append(("start", system)))
 
@@ -831,7 +831,7 @@ def test_gateway_install_systemd_honors_start_now_flag(monkeypatch):
     monkeypatch.setattr(
         gateway,
         "systemd_install",
-        lambda force=False, system=False, run_as_user=None, enable_on_startup=True: calls.append(("install", enable_on_startup)),
+        lambda force=False, system=False, run_as_user=None, enable_on_startup=True, **kw: calls.append(("install", enable_on_startup)),
     )
     monkeypatch.setattr(gateway, "systemd_start", lambda system=False: calls.append(("start",)))
 
@@ -859,7 +859,7 @@ def test_gateway_install_systemd_non_tty_uses_defaults(monkeypatch):
     monkeypatch.setattr(
         gateway,
         "systemd_install",
-        lambda force=False, system=False, run_as_user=None, enable_on_startup=True: calls.append(("install", enable_on_startup)),
+        lambda force=False, system=False, run_as_user=None, enable_on_startup=True, **kw: calls.append(("install", enable_on_startup)),
     )
     monkeypatch.setattr(gateway, "systemd_start", lambda system=False: calls.append(("start",)))
 
@@ -885,7 +885,7 @@ def test_gateway_install_systemd_no_start_now_flag_non_tty(monkeypatch):
     monkeypatch.setattr(
         gateway,
         "systemd_install",
-        lambda force=False, system=False, run_as_user=None, enable_on_startup=True: calls.append(("install", enable_on_startup)),
+        lambda force=False, system=False, run_as_user=None, enable_on_startup=True, **kw: calls.append(("install", enable_on_startup)),
     )
     monkeypatch.setattr(gateway, "systemd_start", lambda system=False: calls.append(("start",)))
 
@@ -898,6 +898,38 @@ def test_gateway_install_systemd_no_start_now_flag_non_tty(monkeypatch):
     assert all(c[0] != "prompt" for c in calls)
     assert ("install", True) in calls
     assert ("start",) not in calls
+
+
+def test_gateway_install_noninteractive_skips_legacy_unit_prompt(monkeypatch, tmp_path):
+    """In non-TTY, the legacy-unit removal prompt in systemd_install is skipped.
+
+    Covers the second hidden prompt that --start-now/--start-on-login do not
+    guard. Originally contributed via PR #42124 (kyssta-exe).
+    """
+    monkeypatch.setattr(gateway, "has_legacy_hermes_units", lambda: True)
+
+    calls = []
+    monkeypatch.setattr(
+        gateway,
+        "prompt_yes_no",
+        lambda question, default=True: calls.append(("prompt", question)) or True,
+    )
+    monkeypatch.setattr(gateway, "remove_legacy_hermes_units", lambda interactive=False: calls.append(("remove_legacy",)))
+    monkeypatch.setattr(gateway, "print_legacy_unit_warning", lambda: None)
+
+    fake_path = tmp_path / "hermes-gateway.service"
+    monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: fake_path)
+    monkeypatch.setattr(gateway, "generate_systemd_unit", lambda system=False, run_as_user=None: "[Service]")
+    monkeypatch.setattr(gateway, "_run_systemctl", lambda *a, **kw: None)
+    monkeypatch.setattr(gateway, "_ensure_linger_enabled", lambda: None)
+    monkeypatch.setattr(gateway, "print_systemd_scope_conflict_warning", lambda: None)
+    monkeypatch.setattr(gateway, "_service_scope_label", lambda system=False: "user")
+
+    gateway.systemd_install(non_interactive=True)
+
+    # Legacy units removed without prompting.
+    assert ("remove_legacy",) in calls
+    assert all(c[0] != "prompt" for c in calls)
 
 
 def test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails(monkeypatch):

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -444,6 +444,7 @@ def test_gateway_install_in_container_with_operational_systemd_uses_systemd(monk
     monkeypatch.setattr(gateway, "is_wsl", lambda: False)
     monkeypatch.setattr(gateway, "is_macos", lambda: False)
     monkeypatch.setattr(gateway, "is_managed", lambda: False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
 
     calls = []
     monkeypatch.setattr(gateway, "prompt_yes_no", lambda question, default=True: calls.append(("prompt", question, default)) or True)
@@ -796,6 +797,7 @@ def test_gateway_install_can_decline_start_now_and_startup(monkeypatch):
     monkeypatch.setattr(gateway, "is_wsl", lambda: False)
     monkeypatch.setattr(gateway, "is_macos", lambda: False)
     monkeypatch.setattr(gateway, "is_managed", lambda: False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
 
     answers = iter([False, False])
     calls = []
@@ -815,6 +817,87 @@ def test_gateway_install_can_decline_start_now_and_startup(monkeypatch):
         ("prompt", "Start the gateway automatically on login/boot with systemd?", True),
         ("install", True, False, None, False),
     ]
+
+
+def test_gateway_install_systemd_honors_start_now_flag(monkeypatch):
+    """--start-now / --no-start-now should bypass the interactive prompt."""
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "is_wsl", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "is_managed", lambda: False)
+
+    calls = []
+    monkeypatch.setattr(gateway, "prompt_yes_no", lambda question, default=True: calls.append(("prompt", question)))
+    monkeypatch.setattr(
+        gateway,
+        "systemd_install",
+        lambda force=False, system=False, run_as_user=None, enable_on_startup=True: calls.append(("install", enable_on_startup)),
+    )
+    monkeypatch.setattr(gateway, "systemd_start", lambda system=False: calls.append(("start",)))
+
+    args = SimpleNamespace(
+        gateway_command="install", force=False, system=False,
+        run_as_user=None, start_now=True, start_on_login=False,
+    )
+    gateway.gateway_command(args)
+
+    assert ("prompt", "Start the gateway now after installing the service?") not in calls
+    assert ("start",) in calls
+    assert ("install", False) in calls
+
+
+def test_gateway_install_systemd_non_tty_uses_defaults(monkeypatch):
+    """Non-TTY stdin (headless/CI) should use True defaults without prompting."""
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "is_wsl", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "is_managed", lambda: False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    calls = []
+    monkeypatch.setattr(gateway, "prompt_yes_no", lambda question, default=True: calls.append(("prompt", question)))
+    monkeypatch.setattr(
+        gateway,
+        "systemd_install",
+        lambda force=False, system=False, run_as_user=None, enable_on_startup=True: calls.append(("install", enable_on_startup)),
+    )
+    monkeypatch.setattr(gateway, "systemd_start", lambda system=False: calls.append(("start",)))
+
+    args = SimpleNamespace(gateway_command="install", force=False, system=False, run_as_user=None)
+    gateway.gateway_command(args)
+
+    # No prompts — defaults used (start_now=True, start_on_login=True)
+    assert all(c[0] != "prompt" for c in calls)
+    assert ("install", True) in calls
+    assert ("start",) in calls
+
+
+def test_gateway_install_systemd_no_start_now_flag_non_tty(monkeypatch):
+    """--no-start-now in non-TTY should skip starting the service."""
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "is_wsl", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "is_managed", lambda: False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    calls = []
+    monkeypatch.setattr(gateway, "prompt_yes_no", lambda question, default=True: calls.append(("prompt", question)))
+    monkeypatch.setattr(
+        gateway,
+        "systemd_install",
+        lambda force=False, system=False, run_as_user=None, enable_on_startup=True: calls.append(("install", enable_on_startup)),
+    )
+    monkeypatch.setattr(gateway, "systemd_start", lambda system=False: calls.append(("start",)))
+
+    args = SimpleNamespace(
+        gateway_command="install", force=False, system=False,
+        run_as_user=None, start_now=False, start_on_login=True,
+    )
+    gateway.gateway_command(args)
+
+    assert all(c[0] != "prompt" for c in calls)
+    assert ("install", True) in calls
+    assert ("start",) not in calls
 
 
 def test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails(monkeypatch):


### PR DESCRIPTION
## Summary

`hermes gateway install` now works headlessly on Linux/systemd — non-TTY contexts (provisioning, CI, `ssh host 'hermes gateway install'`, `</dev/null`) install with sensible defaults instead of reading EOF and aborting with no service installed.

Root cause: PR #28874 (Windows idempotency) changed the *shared* systemd branch in `hermes_cli/gateway.py` to call `prompt_yes_no` unconditionally. The Windows branch honored `args.start_now`/`start_on_login`; the systemd branch ignored them and prompted every time. `prompt_yes_no` reads stdin and aborts on EOF, so any non-TTY invocation hung/failed.

Fixes #42065.

## Changes

- `hermes_cli/gateway.py`: systemd install branch honors `--start-now`/`--start-on-login` (mirrors the Windows path); when flags are absent it prompts only on a TTY, else falls back to `True` defaults. `systemd_install()` gained a `non_interactive` flag so the second hidden prompt — *"Remove the legacy unit(s) before installing?"* — is also bypassed in headless contexts.
- `hermes_cli/subcommands/gateway.py`: promoted the four `--start-*` flags from `argparse.SUPPRESS` to visible `--help` text.
- `tests/hermes_cli/test_gateway.py`: flag-bypass, non-TTY-defaults, and legacy-unit-skip coverage; existing `systemd_install` mocks accept the new kwarg.

## Validation

| Scenario | Before | After |
|---|---|---|
| `install </dev/null` (non-TTY) | hangs on EOF / exits ≠0, no unit | installs with defaults, starts, no prompt |
| `install` (TTY, no flags) | prompts ×2 | prompts ×2 (unchanged) |
| `install --no-start-now` | prompted anyway | flag honored, service not started |
| legacy units present, non-TTY | prompt could still hang | removed without prompting |

53/53 tests in `tests/hermes_cli/test_gateway.py` pass. E2E-verified all four paths with a real non-TTY stdin and real `gateway_command()` calls.

## Credit

Salvage of @liuhao1024's PR #42071 (flag-honoring + non-TTY, submitted first) with @kyssta-exe's PR #42124 legacy-unit-prompt fix folded in. Both authorships preserved.

## Infographic

![headless-gateway-install-fixed](https://v3b.fal.media/files/b/0aa017ed/Mu7Kkzbizt2ynjbo894If_zDjqb8cr.png)
