### PR TITLE
fix: QQAdapter.connect() missing is_reconnect parameter causing reconnect loop

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
## Description

`QQAdapter.connect()` was missing the `is_reconnect` keyword argument, causing the gateway reconnection logic to fail with:

```
QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

This triggered an infinite reconnect-retry loop (55+ attempts observed) where the QQ bot never re-established its WebSocket connection.

## Fix

Added `*, is_reconnect: bool = False` to match the `BasePlatformAdapter` base class signature.

```diff
- async def connect(self) -> bool:
+ async def connect(self, *, is_reconnect: bool = False) -> bool:
```

## Verification

- ✅ 161/161 tests pass (QQ bot test suite)
- ✅ Gateway logs confirm successful connection: `✓ qqbot connected`, `Ready, session_id=...`
- ✅ Syntax check passed

## Related

This is a known recurring issue — the same fix was applied before but got overwritten during code updates. The base class at `gateway/platforms/base.py:2637` already has the correct signature.

```
async def connect(self, *, is_reconnect: bool = False) -> bool:
```