### PR TITLE
fix(redact): non-reusable sentinel for prefix secrets in file reads (#35519)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -402,7 +402,40 @@ def _redact_form_body(text: str) -> str:
     return _redact_query_string(text.strip())
 
 
-def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = False) -> str:
+def _mask_token_nonreusable(token: str) -> str:
+    """Redact a prefix-matched credential to a NON-REUSABLE sentinel.
+
+    Unlike :func:`_mask_token` (which keeps head/tail chars — fine for logs
+    that are never fed back into a config), this emits a marker that:
+
+    * cannot be mistaken for a usable-but-truncated key, so an agent that
+      reads it from a config file and writes it back does NOT corrupt the
+      stored credential into a dead 13-char string (issue #35519); and
+    * still does not leak the secret material (no head/tail chars).
+
+    The vendor prefix label is preserved for debuggability so the agent can
+    still tell *which* credential is present (e.g. a GitHub PAT vs an OpenAI
+    key) without seeing any of its bytes.
+    """
+    if not token:
+        return "«redacted-secret»"
+    # Preserve only the recognizable vendor prefix label (e.g. "ghp_", "sk-"),
+    # never any of the random secret body.
+    label = ""
+    for sub in _PREFIX_SUBSTRINGS:
+        if token.startswith(sub):
+            label = sub
+            break
+    return f"«redacted:{label}…»" if label else "«redacted-secret»"
+
+
+def redact_sensitive_text(
+    text: str,
+    *,
+    force: bool = False,
+    code_file: bool = False,
+    file_read: bool = False,
+) -> str:
     """Apply all redaction patterns to a block of text.
 
     Safe to call on any string -- non-matching text passes through unchanged.
@@ -414,6 +447,17 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     patterns when the text is known to be source code (e.g. MAX_TOKENS=***
     constants, "apiKey": "test" fixtures). Prefix patterns, auth headers,
     private keys, DB connstrings, JWTs, and URL secrets are still redacted.
+
+    Set file_read=True for file *content* returned to the agent (read_file /
+    search_files / cat). Secrets are STILL redacted — they are never exposed —
+    but prefix-matched credentials are replaced with a non-reusable sentinel
+    (``«redacted:ghp_…»``) instead of a head/tail-preserving mask
+    (``ghp_S1...Pn2T``). The old mask looked like a real-but-truncated key, so
+    an agent reading it from config.yaml and writing it back silently corrupted
+    the stored credential into a dead 13-char value → 401 (issue #35519). The
+    sentinel is syntactically invalid as a token, so it can't be mistaken for a
+    usable key or written back as one. Implies code_file=True (config/data
+    files shouldn't trigger the source-code ENV/JSON false-positive paths).
 
     Performance: each regex pattern is gated behind a cheap substring
     pre-check (e.g. ``"=" in text`` for ENV assignments, ``"://" in text``
@@ -433,9 +477,15 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     if not (force or _REDACT_ENABLED):
         return text
 
+    # file_read content shouldn't hit the source-code ENV/JSON false-positive
+    # paths either (it's config/data, not log lines).
+    if file_read:
+        code_file = True
+
     # Known prefixes (sk-, ghp_, etc.) — gate on substring presence
     if _has_known_prefix_substring(text):
-        text = _PREFIX_RE.sub(lambda m: _mask_token(m.group(1)), text)
+        _prefix_sub = _mask_token_nonreusable if file_read else _mask_token
+        text = _PREFIX_RE.sub(lambda m: _prefix_sub(m.group(1)), text)
 
     # ENV assignments: OPENAI_API_KEY=***  (skip for code files — false positives)
     if not code_file:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -753,3 +753,60 @@ class TestTerminalOutputRedaction:
         out = "CUSTOM_TOKEN=zzzopaque1234567890abcdef"
         red = redact_terminal_output(out, "printenv")
         assert "zzzopaque1234567890abcdef" in red
+
+
+class TestFileReadNonReusableRedaction:
+    """#35519: prefix-matched credentials in FILE CONTENT (read_file /
+    search_files / cat) must be redacted to a NON-REUSABLE sentinel — not a
+    head/tail mask that looks like a real-but-truncated key and gets written
+    back to config (corrupting the credential -> 401)."""
+
+    GHP = "ghp_S1abcdefghijklmnopqrstuvwxyz0Pn2T"  # realistic GitHub PAT shape
+    SK = "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789"
+
+    def test_file_read_uses_nonreusable_sentinel(self):
+        out = redact_sensitive_text(f"token: {self.GHP}", force=True, file_read=True)
+        # The sentinel marker is present and obviously a redaction...
+        assert "«redacted:ghp_…»" in out, out
+        # ...and the head/tail-preserving mask shape is NOT produced.
+        assert "..." not in out
+        # The agent can still tell which vendor credential is present.
+        assert "ghp_" in out
+
+    def test_file_read_does_not_leak_secret_body(self):
+        """Crucial: file_read must NOT expose the real key (no un-redact)."""
+        out = redact_sensitive_text(f"token: {self.GHP}", force=True, file_read=True)
+        # No run of the secret body survives.
+        assert "S1abcdefghij" not in out
+        assert self.GHP not in out
+        assert "Pn2T" not in out  # not even the tail (the old mask kept it)
+
+    def test_file_read_sentinel_is_not_a_plausible_key(self):
+        """The sentinel can't be mistaken for / written back as a usable key:
+        the old mask was a 13-char `ghp_S1...Pn2T` that broke GitHub auth when
+        an agent re-saved it. The sentinel is syntactically invalid as a token
+        (contains « » … and ':'), so it can't round-trip into a dead key."""
+        out = redact_sensitive_text(f"GITHUB_PERSONAL_ACCESS_TOKEN: {self.GHP}",
+                                    force=True, file_read=True)
+        masked = out.split(": ", 1)[1].strip()
+        # Not a bare token: contains the sentinel delimiters.
+        assert masked.startswith("«") and masked.endswith("»")
+        assert "…" in masked
+
+    def test_default_mode_unchanged_keeps_headtail_mask(self):
+        """Regression guard: NON-file_read (logs/display) keeps the existing
+        head/tail mask shape — only file content gets the sentinel."""
+        out = redact_sensitive_text(f"token: {self.GHP}", force=True)
+        assert "«redacted" not in out          # no sentinel in log mode
+        assert "ghp_" in out and "..." in out   # head/tail mask preserved
+
+    def test_file_read_implies_code_file_no_env_falsepos(self):
+        """file_read should skip the source-code ENV/JSON false-positive paths
+        (it's config/data). A bare ``MAX_TOKENS=8000`` must pass through."""
+        out = redact_sensitive_text("MAX_TOKENS=8000", force=True, file_read=True)
+        assert out == "MAX_TOKENS=8000"
+
+    def test_sk_prefix_also_sentinelized(self):
+        out = redact_sensitive_text(f"key: {self.SK}", force=True, file_read=True)
+        assert "«redacted:sk-…»" in out
+        assert self.SK not in out

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -795,8 +795,11 @@ class TestFileReadNonReusableRedaction:
 
     def test_default_mode_unchanged_keeps_headtail_mask(self):
         """Regression guard: NON-file_read (logs/display) keeps the existing
-        head/tail mask shape — only file content gets the sentinel."""
-        out = redact_sensitive_text(f"token: {self.GHP}", force=True)
+        head/tail mask shape — only file content gets the sentinel. Uses a
+        bare-token context (no ``key:`` prefix) so this isolates the prefix
+        pass: a ``token: <key>`` line would additionally hit the YAML config
+        pass and collapse to ``***``, which is unrelated to this guard."""
+        out = redact_sensitive_text(f"see {self.GHP} here", force=True)
         assert "«redacted" not in out          # no sentinel in log mode
         assert "ghp_" in out and "..." in out   # head/tail mask preserved
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1021,7 +1021,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                         "file_size": result_dict["file_size"],
                     }, ensure_ascii=False)
                 if result_dict["content"]:
-                    result_dict["content"] = redact_sensitive_text(result_dict["content"], code_file=True)
+                    result_dict["content"] = redact_sensitive_text(result_dict["content"], file_read=True)
                 return json.dumps(result_dict, ensure_ascii=False)
 
         # ── Binary file guard ─────────────────────────────────────────
@@ -1137,7 +1137,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
 
         # ── Redact secrets (after guard check to skip oversized content) ──
         if result.content:
-            result.content = redact_sensitive_text(result.content, code_file=True)
+            result.content = redact_sensitive_text(result.content, file_read=True)
             result_dict["content"] = result.content
 
         # Large-file hint: if the file is big and the caller didn't ask
@@ -1697,7 +1697,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         if hasattr(result, 'matches'):
             for m in result.matches:
                 if hasattr(m, 'content') and m.content:
-                    m.content = redact_sensitive_text(m.content, code_file=True)
+                    m.content = redact_sensitive_text(m.content, file_read=True)
         result_dict = result.to_dict(densify=True)
 
         if count >= 3:


### PR DESCRIPTION
## Summary
A user's API keys are no longer corrupted (or exposed) when the agent reads a config/data file. Prefix-matched credentials in file content are redacted to a **non-reusable sentinel** (`«redacted:ghp_…»`) instead of a plausible-looking truncated key — so the agent can't write the masked value back and silently break auth.

## Root cause (#35519)
With `security.redact_secrets` on (the default), `read_file` / `search_files` / `cat` applied `redact_sensitive_text(code_file=True)` to file content. `code_file=True` skips the ENV/JSON patterns but **still runs prefix masking**, so an API key in `config.yaml` (`ghp_…`, `sk-…`, `xai-…`) came back as a head/tail mask like `ghp_S1...Pn2T` — a plausible-looking *truncated key*. When the agent read that value and wrote it back (re-configuring, building a curl), the mask replaced the real credential → 401. The issue cites a production `config.yaml` found containing exactly that 13-char masked PAT.

## Why not just stop redacting config files?
The two community PRs (#35529 `config_file=True`, #35534 `redact_prefixes=False`) fix corruption by **not** masking prefixes for config reads — but that returns the user's **real, unmasked keys** into the agent context, the model, and any logs. This PR keeps redacting while making the output non-destructive: zero secret bytes emitted, and the sentinel is syntactically invalid as a token so it can't round-trip into a dead key.

## Scope audit (the B in "salvage + widen")
Audited every `redact_sensitive_text(code_file=True)` call site. The read-config-then-write-back vector is **only** the three `file_tools.py` sites. `code_execution_tool.py` (sandbox stdout/stderr) and `process_registry.py` (command echo) are *program output / display*, not file content the agent re-saves — head/tail masking is correct there and switching them would gain nothing. Terminal `cat` display goes through `redact_terminal_output`, which the issue explicitly calls out as a separate, fine display path. **No widening needed — the 3-site scope is exactly right.**

## Changes
- `agent/redact.py`: new `_mask_token_nonreusable()` (prefix → `«redacted:<label>…»`, vendor prefix kept for debuggability, no secret bytes) + `redact_sensitive_text(file_read=True)` routes prefix matches through it (implies `code_file=True`). Log/display mode unchanged.
- `tools/file_tools.py`: 3 sites (`read_file`, `search_files`, `cat`) switched `code_file=True` → `file_read=True`.
- `tests/agent/test_redact.py`: 6 new tests (sentinel shape, no-leak, not-a-plausible-key, default mode unchanged, `file_read` implies `code_file`, `sk-` prefix).

## Validation
| | Before | After (file read) |
|---|---|---|
| `GITHUB_PERSONAL_ACCESS_TOKEN: ghp_…` | `ghp_S1...Pn2T` (looks real → 401) | `«redacted:ghp_…»` |
| `api_key: sk-proj-…` | `sk-pr...4321` | `«redacted:sk-…»` |
| `xai_key: xai-…` | `xai-A...XYZ` | `«redacted:xai-…»` |
| `max_tokens: 8000` | unchanged | unchanged |
| log/display mode | head/tail mask | head/tail mask (unchanged) |

- `tests/agent/test_redact.py` — **113 passed**. `tests/tools/test_file_tools.py` — **43 passed**.
- **E2E:** real `read_file_tool` against a temp `HERMES_HOME` config.yaml with real-shaped `ghp_`/`sk-`/`xai-` keys — confirmed no secret body/head/tail leaks, no `...` shape, sentinels present, non-secrets intact.

## Credit
Diagnosis and the config-read fix direction from @liuhao1024 (#35529) and @adammatski1972 (#35534). Salvage commit authored by @kshitijk4poor (#53146), which implements the safer redact-but-non-destructive variant. One follow-up commit fixes the regression-guard test (the salvaged test asserted stale default-mode behavior — on current `main` a `token: <key>` line additionally hits the YAML config pass and collapses to `***`; the guard now uses a bare-token context to isolate the prefix-mask shape).

Closes #35519. Supersedes #35529, #35534, #53146.

## Infographic

![secret-redaction-nondestructive](https://v3b.fal.media/files/b/0aa017fd/C8se5-pcoMpV8jROzH81R_UE4y3XJL.png)
