### PR TITLE
fix(webhook): recognize Forgejo event headers

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -533,6 +533,8 @@ class WebhookAdapter(BasePlatformAdapter):
         event_type = (
             request.headers.get("X-GitHub-Event", "")
             or request.headers.get("X-GitLab-Event", "")
+            or request.headers.get("X-Forgejo-Event", "")
+            or request.headers.get("X-Gitea-Event", "")
             or payload.get("event_type", "")
             or payload.get("type", "")
             or "unknown"

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -403,6 +403,30 @@ class TestEventFilter:
             assert resp.status == 202
 
     @pytest.mark.asyncio
+    async def test_event_filter_accepts_forgejo_and_gitea_headers(self):
+        """Forgejo/Gitea event headers are recognized for route filtering."""
+        for header_name in ("X-Forgejo-Event", "X-Gitea-Event"):
+            routes = {
+                "forge": {
+                    "secret": _INSECURE_NO_AUTH,
+                    "events": ["issues"],
+                    "prompt": "Issue: {action}",
+                }
+            }
+            adapter = _make_adapter(routes=routes)
+            adapter.handle_message = AsyncMock()
+
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/webhooks/forge",
+                    json={"action": "opened"},
+                    headers={header_name: "issues"},
+                )
+                assert resp.status == 202
+                adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_event_filter_rejects_non_matching(self):
         """Non-matching event type returns 200 with status=ignored."""
         routes = {


### PR DESCRIPTION
## Summary

- Recognize Forgejo/Gitea webhook event headers (`X-Forgejo-Event`, `X-Gitea-Event`) in the generic webhook adapter event filter.
- Add a focused regression test showing Forgejo/Gitea `issues` events pass route filtering.

## Why

Forgejo/Gitea webhooks commonly send event names in `X-Forgejo-Event` / `X-Gitea-Event`. Hermes previously checked GitHub/GitLab headers and payload fields, so a route configured with `events: ["issues"]` could see a real Forgejo/Gitea request as `unknown` and ignore it.

## Test plan

RED evidence before the production change:

```text
X-Forgejo-Event -> status 200 {"status":"ignored","event":"unknown"}
AssertionError: X-Forgejo-Event should be accepted
```

Focused GREEN checks run after the change:

```text
PYTHONPATH=/root/work/hermes-agent-forgejo-webhook-headers /usr/local/lib/hermes-agent/venv/bin/python <focused aiohttp adapter check>
```

Verified accepted event headers:

```text
X-GitHub-Event  -> 202 accepted event=issues
X-GitLab-Event  -> 202 accepted event=issues
X-Forgejo-Event -> 202 accepted event=issues
X-Gitea-Event   -> 202 accepted event=issues
```

Syntax/diff checks:

```text
/usr/local/lib/hermes-agent/venv/bin/python -m py_compile gateway/platforms/webhook.py tests/gateway/test_webhook_adapter.py
git diff --check
```

Note: the local Hermes install path is read-only in this LXC, so no production hotpatch or gateway restart was performed as part of this PR.
