### PR TITLE
fix(test): repair install.sh browser tests after run_with_timeout refactor (#39219)

### DIFF
--- a/tests/test_install_sh_browser_install.py
+++ b/tests/test_install_sh_browser_install.py
@@ -137,10 +137,13 @@ def test_browser_install_timeout_stays_interruptible() -> None:
     text = INSTALL_SH.read_text()
 
     # GNU-flag probe + the guarded invocation must both be present.
-    assert "timeout --foreground -k 10 1 true" in text
-    assert 'timeout --foreground -k 10 "$timeout_seconds" "$@"' in text
+    # GNU-flag probe + the guarded invocation must both be present. The binary
+    # is resolved into $timeout_bin (GNU `timeout` on Linux, `gtimeout` on
+    # macOS-Homebrew) so the probe + call are parameterized rather than literal.
+    assert '"$timeout_bin" --foreground -k 10 1 true' in text
+    assert '"$timeout_bin" --foreground -k 10 "$timeout_seconds" "$@"' in text
     # Plain-timeout fallback preserved for BusyBox/non-GNU.
-    assert 'timeout "$timeout_seconds" "$@"' in text
+    assert '"$timeout_bin" "$timeout_seconds" "$@"' in text
 
 
 # ---------------------------------------------------------------------------
@@ -162,6 +165,7 @@ def _run_install_fn(distro: str, version: str, *, native_fails: bool,
     """
     # Extract the functions we need so we don't execute the whole installer.
     fn_names = [
+        "run_with_timeout",
         "run_browser_install_with_timeout",
         "playwright_host_unrecognized",
         "playwright_fallback_platform",


### PR DESCRIPTION
## Summary
Main is red on `tests/test_install_sh_browser_install.py` (8 failures) — this restores it.

PR #54096 generalized `run_browser_install_with_timeout` into a shared `run_with_timeout` helper (adds `gtimeout` + a pure-shell macOS fallback). The test update was pushed seconds after the install.sh change merged, so it missed the merge train and main went red.

## Root cause
- Behavioral tests extracted `run_browser_install_with_timeout` but not the `run_with_timeout` it now delegates to → empty run log → 8 failures.
- `test_browser_install_timeout_stays_interruptible` asserted the literal `timeout --foreground ...`, but the helper now resolves the binary into `$timeout_bin` (`timeout` on Linux, `gtimeout` on macOS-Homebrew).

## Changes
- Add `run_with_timeout` to the extracted function set.
- Update the interruptible-test assertions to the `$timeout_bin` form.

## Validation
`pytest tests/test_install_sh_browser_install.py` → 15/15 pass (was 7 pass / 8 fail on main).