### PR TITLE
fix(lazy_deps): only mark a backend active when its signature package is present

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1728,6 +1728,7 @@ AUTHOR_MAP = {
     "steveonjava@gmail.com": "steveonjava",  # PR #29669 (redact secrets in kanban tool payloads)
     "afnlegion01@gmail.com": "Afnath-max",  # PR #49129 salvage (opencode-zen catalog refresh + uncapped/live-first picker)
     "sharma.priyanshu96@gmail.com": "ipriyaaanshu",  # PR #51488 salvage (clear stale base_url on gateway model switches; #25107)
+    "spiky02plateau@users.noreply.github.com": "spiky02plateau",  # PR #54178 (lazy_deps: signature-gate active_features so a shared transitive dep no longer false-positives matrix refresh)
 }
 
 

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -404,3 +404,41 @@ class TestRefreshActiveFeatures:
         result = ld.refresh_active_features()
         assert result["a.ok"] == "current"
         assert result["b.fail"].startswith("failed:")
+
+
+class TestActiveFeaturesSignatureGating:
+    """active_features() keys on the signature (first) spec only.
+
+    Regression for the false-positive that made ``hermes update`` try to
+    refresh ``platform.matrix`` — and fail building ``mautrix[encryption]``
+    → ``python-olm`` — on any host that merely had a shared transitive dep
+    like ``asyncpg`` installed for an unrelated reason.
+    """
+
+    def test_shared_dep_present_does_not_flag_feature(self, monkeypatch):
+        # Signature package absent, only a trailing shared lib present.
+        monkeypatch.setattr(ld, "LAZY_DEPS", {
+            "platform.faux": ("signature-pkg==1.0", "asyncpg==0.31.0"),
+        })
+        present = {"asyncpg"}
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) in present,
+        )
+        assert ld.active_features() == []
+
+    def test_signature_present_flags_feature(self, monkeypatch):
+        monkeypatch.setattr(ld, "LAZY_DEPS", {
+            "platform.faux": ("signature-pkg==1.0", "asyncpg==0.31.0"),
+        })
+        present = {"signature-pkg"}
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) in present,
+        )
+        assert ld.active_features() == ["platform.faux"]
+
+    def test_empty_specs_never_flagged(self, monkeypatch):
+        monkeypatch.setattr(ld, "LAZY_DEPS", {"weird.empty": ()})
+        monkeypatch.setattr(ld, "_is_present", lambda spec: True)
+        assert ld.active_features() == []

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -811,16 +811,28 @@ def feature_install_command(feature: str) -> Optional[str]:
 def active_features() -> list[str]:
     """Return the list of features the user has ever lazy-installed.
 
-    A feature counts as "active" if at least one of its declared packages
-    is currently installed in the venv (presence check, ignoring version).
-    Features the user has never enabled stay quiet.
+    A feature counts as "active" only when its *signature* package — the
+    first spec in the feature's tuple — is installed (presence check,
+    ignoring version). Every entry in :data:`LAZY_DEPS` leads with its
+    defining package and lists shared libraries afterwards.
+
+    We deliberately do NOT key on "any spec present": trailing specs are
+    often generic libraries (``asyncpg``, ``aiosqlite``, ``aiohttp``,
+    ``qrcode``, ``numpy`` …) that get pulled in transitively by unrelated
+    features. Keying on those produced false positives — e.g. a host that
+    has ``asyncpg`` (for some other reason) but no ``mautrix`` would be
+    flagged as having ``platform.matrix`` active, then ``hermes update``
+    would try to refresh it and fail building ``mautrix[encryption]`` →
+    ``python-olm`` on every run. Gating on the signature package keeps the
+    behaviour aligned with the intent: detect backends the user actually
+    enabled.
 
     Used by ``hermes update`` to figure out which lazy backends need a
     refresh pass when pins move in :data:`LAZY_DEPS`.
     """
     active = []
     for feature, specs in LAZY_DEPS.items():
-        if any(_is_present(s) for s in specs):
+        if specs and _is_present(specs[0]):
             active.append(feature)
     return active
 


### PR DESCRIPTION
## Problem

`tools/lazy_deps.py::active_features()` flags a backend as "active" if **any** of its declared specs is installed:

```python
if any(_is_present(s) for s in specs):
    active.append(feature)
```

Several `LAZY_DEPS` entries list a defining package followed by generic shared libraries, e.g.:

```python
"platform.matrix": ("mautrix[encryption]==0.21.0", "aiosqlite==0.22.1",
                    "asyncpg==0.31.0", "aiohttp-socks==0.11.0"),
```

When one of those shared libs (`asyncpg`, `aiosqlite`, `aiohttp`, …) happens to be installed transitively for an unrelated reason, the backend is **falsely** flagged active. `hermes update` → `_refresh_active_lazy_features()` then tries to refresh it and fails building `mautrix[encryption]` → `python-olm` (bundled libolm `make static`):

```
⚠ platform.matrix failed to refresh: pip install failed: ...
```

This surfaces on **every** `hermes update` for users who never enabled Matrix but have `asyncpg`/`aiosqlite` present — a common situation, so the noisy "failed to refresh" warning is widespread.

## Root cause

The implementation contradicts the function's own docstring, which states active means *"backends the user has previously activated."* Keying on *any* spec means an incidental shared transitive dep is enough to mark a backend active.

## Fix

Gate on the **signature package** — the first spec in each feature tuple. Every `LAZY_DEPS` entry already leads with its defining package and lists shared libs afterwards, so this matches both the data convention and the documented intent:

```python
if specs and _is_present(specs[0]):
    active.append(feature)
```

Real users of a backend still have its signature package installed, so genuine refreshes (the reason this function exists — picking up moved version pins) are unaffected. Only false positives are removed.

## Tests

Adds `TestActiveFeaturesSignatureGating` in `tests/tools/test_lazy_deps.py`:
- shared dep present + signature absent ⇒ **not** active (the regression)
- signature present ⇒ active
- empty specs ⇒ never active

Full `tests/tools/test_lazy_deps.py` suite passes locally.

## Alternative considered

An explicit shared-dep denylist instead of positional `specs[0]`. The positional approach is smaller and self-maintaining (no list to keep in sync as backends are added), but happy to switch to a denylist if you prefer that shape.
