### PR TITLE
fix(test): repair install.sh browser-install tests after run_with_timeout extraction

### DIFF
--- a/tests/test_install_sh_browser_install.py
+++ b/tests/test_install_sh_browser_install.py
@@ -136,11 +136,13 @@ def test_browser_install_timeout_stays_interruptible() -> None:
     """
     text = INSTALL_SH.read_text()
 
-    # GNU-flag probe + the guarded invocation must both be present.
-    assert "timeout --foreground -k 10 1 true" in text
-    assert 'timeout --foreground -k 10 "$timeout_seconds" "$@"' in text
+    # GNU-flag probe + the guarded invocation must both be present. The binary
+    # is resolved into $timeout_bin (timeout on Linux, gtimeout on macOS) before
+    # use, so the assertions match the variable form.
+    assert '"$timeout_bin" --foreground -k 10 1 true' in text
+    assert '"$timeout_bin" --foreground -k 10 "$timeout_seconds" "$@"' in text
     # Plain-timeout fallback preserved for BusyBox/non-GNU.
-    assert 'timeout "$timeout_seconds" "$@"' in text
+    assert '"$timeout_bin" "$timeout_seconds" "$@"' in text
 
 
 # ---------------------------------------------------------------------------
@@ -162,6 +164,7 @@ def _run_install_fn(distro: str, version: str, *, native_fails: bool,
     """
     # Extract the functions we need so we don't execute the whole installer.
     fn_names = [
+        "run_with_timeout",
         "run_browser_install_with_timeout",
         "playwright_host_unrecognized",
         "playwright_fallback_platform",


### PR DESCRIPTION
## Summary
Restores CI test slice 3/8 to green. `tests/test_install_sh_browser_install.py` was failing on `main` (8 tests) because #39219 refactored the timeout wrapper but the test's function-extraction harness wasn't updated to match.

Root cause: #39219 made `run_browser_install_with_timeout()` delegate to a new `run_with_timeout()` helper. The test harness sources a fixed list of functions out of `install.sh` to drive `run_playwright_install` in a stubbed shell — but that list still named only the old four functions. With `run_with_timeout` missing from the sourced shell, the call chain died before reaching the stubbed `npx`, so the run log was empty and all seven behavioral `assert len(runs) == N` checks failed with `AssertionError: []`. Separately, the same commit renamed the timeout binary to a `$timeout_bin` variable, which three stale literal-source assertions in `test_browser_install_timeout_stays_interruptible` no longer matched.

## Changes
- `tests/test_install_sh_browser_install.py`:
  - Add `run_with_timeout` to the extracted `fn_names` so the harness sources the helper the wrapper now delegates to.
  - Update the three GNU-flag source assertions to the `$timeout_bin` variable form (`timeout` on Linux, `gtimeout` on macOS).

## Validation
| | Before | After |
|---|---|---|
| `tests/test_install_sh_browser_install.py` | 8 failed, 7 passed | 15 passed, 0 failed |
| CI slice 3/8 | red | green |

Test-only change; no `install.sh` behavior touched. Confirmed the 8 failures reproduce on clean `origin/main` (pre-existing, not introduced by any open PR).

## Infographic

![the-helper-that-wasnt-sourced](https://v3b.fal.media/files/b/0aa0185f/_tC1Yz7USab4L4tQZQwl8_laL0uuRO.png)
