### PR TITLE
feat(system-prompt): add config-gated system prompt repeat for recency bias

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1233,6 +1233,12 @@ def init_agent(
     # are noisy.
     agent._environment_probe = bool(_agent_section.get("environment_probe", True))
 
+    # System prompt repeat toggle. Default False. When True, the entire
+    # system prompt is appended a second time at the end so the model
+    # benefits from recency bias (Prompt Repetition Improves Non-Reasoning
+    # LLMs, arXiv 2512.14982, Google 2025). Byte-stable once deployed.
+    agent._repeat_system_prompt = bool(_agent_section.get("repeat_system_prompt", False))
+
     # App-level API retry count (wraps each model API call).  Default 3,
     # overridable via agent.api_max_retries in config.yaml.  See #11616.
     try:

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -420,6 +420,15 @@ def build_system_prompt(agent: Any, system_message: Optional[str] = None) -> str
     for warning in drain_truncation_warnings():
         agent._emit_status(warning)
 
+    # System prompt repeat: append the entire prompt a second time so the
+    # model benefits from recency bias (arXiv 2512.14982, Google 2025).
+    # Controlled by config.yaml agent.repeat_system_prompt (default False).
+    # Byte-stable — the separator and repetition are constant, so cached
+    # system prompts are identical across turns.
+    if getattr(agent, "_repeat_system_prompt", False):
+        _REPEAT_SEP = "\n\n══════════════════════════════════════════════════════════════════\n\n"
+        joined = joined + _REPEAT_SEP + joined
+
     return joined
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1098,6 +1098,13 @@ class TestBuildSystemPrompt:
         prompt = agent._build_system_prompt(system_message="Custom instruction")
         assert "Custom instruction" in prompt
 
+    def test_repeat_system_prompt_doubles_length(self, agent):
+        prompt_normal = agent._build_system_prompt()
+        agent._repeat_system_prompt = True
+        prompt_repeated = agent._build_system_prompt()
+        assert len(prompt_repeated) > len(prompt_normal) * 1.9
+        assert prompt_repeated.endswith(prompt_normal)
+
     def test_memory_guidance_when_memory_tool_loaded(self, agent_with_memory_tool):
         from agent.prompt_builder import MEMORY_GUIDANCE
 


### PR DESCRIPTION
## Summary

Add `agent.repeat_system_prompt` config option (default `false`). When enabled, the entire system prompt is appended a second time so the model benefits from recency bias alongside the existing primacy advantage.

## Motivation

The system prompt sits at the start of the context window (primacy position). LLMs recall information at the beginning and end of long contexts best, while middle content suffers from the "Lost in the Middle" effect (Liu et al., 2023). Simply repeating the prompt gives the model a second chance to process the same instructions at recency position.

## Evidence

**Prompt Repetition Improves Non-Reasoning LLMs** (arXiv 2512.14982, Google Research, Dec 2025 — Leviathan, Kalman, Matias):
- Repeating the input prompt improves accuracy across Gemini, GPT, Claude, **DeepSeek**
- **47/70 tests win, 0 losses**
- No increase in output token length or latency
- Mitigates order and position bias

## Changes

3 files, +22 lines:

| File | Change |
|------|--------|
| `agent/agent_init.py` | Read `repeat_system_prompt` (bool) from config → `agent._repeat_system_prompt` |
| `agent/system_prompt.py` | `build_system_prompt()`: if `_repeat_system_prompt` is True, `joined + separator + joined` |
| `tests/run_agent/test_run_agent.py` | Two invariants: length >1.9x, suffix match |

## Config

```yaml
agent:
  repeat_system_prompt: true   # default: false
```

## Cache Impact

Byte-stable once deployed — the separator and repetition are constant strings, so cached system prompts are identical across turns. Prompt caching is unaffected.
