### PR TITLE
fix(projects): retry shared write_txn on transient SQLITE_BUSY

### DIFF
--- a/hermes_cli/projects_db.py
+++ b/hermes_cli/projects_db.py
@@ -162,7 +162,7 @@ def connect(db_path: Optional[Path] = None) -> sqlite3.Connection:
     path = db_path if db_path is not None else projects_db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     resolved = str(path.resolve())
-    conn = sqlite3.connect(str(path))
+    conn = sqlite3.connect(str(path), timeout=30)
     try:
         conn.row_factory = sqlite3.Row
         from hermes_state import apply_wal_with_fallback

--- a/hermes_cli/sqlite_util.py
+++ b/hermes_cli/sqlite_util.py
@@ -8,7 +8,9 @@ transaction. One definition here keeps the two stores from drifting.
 from __future__ import annotations
 
 import contextlib
+import random
 import sqlite3
+import time
 
 
 def add_column_if_missing(conn: sqlite3.Connection, table: str, column: str, ddl: str) -> bool:
@@ -28,6 +30,37 @@ def add_column_if_missing(conn: sqlite3.Connection, table: str, column: str, ddl
         raise
 
 
+_BUSY_MAX_RETRIES = 5
+_BUSY_RETRY_MIN_S = 0.020  # 20ms
+_BUSY_RETRY_MAX_S = 0.150  # 150ms
+
+
+def _is_busy_error(exc: BaseException) -> bool:
+    return isinstance(exc, sqlite3.OperationalError) and (
+        "database is locked" in str(exc).lower()
+        or "database is busy" in str(exc).lower()
+    )
+
+
+def _execute_boundary_with_retry(conn: sqlite3.Connection, sql: str) -> None:
+    """Retry BEGIN IMMEDIATE / COMMIT on transient SQLITE_BUSY.
+
+    SQLite's own busy_timeout uses a near-deterministic backoff, so
+    concurrent writers re-collide in lockstep under a stampede.  A jittered
+    retry on the transaction boundary breaks that convoy.  Only BEGIN
+    IMMEDIATE and COMMIT are retried — both are idempotent re-issues that
+    touch no transaction body, so a CAS inside write_txn is never replayed.
+    """
+    for attempt in range(_BUSY_MAX_RETRIES + 1):
+        try:
+            conn.execute(sql)
+            return
+        except sqlite3.OperationalError as exc:
+            if not _is_busy_error(exc) or attempt == _BUSY_MAX_RETRIES:
+                raise
+            time.sleep(random.uniform(_BUSY_RETRY_MIN_S, _BUSY_RETRY_MAX_S))
+
+
 @contextlib.contextmanager
 def write_txn(conn: sqlite3.Connection):
     """An IMMEDIATE write transaction: at most one concurrent writer wins.
@@ -35,8 +68,12 @@ def write_txn(conn: sqlite3.Connection):
     The explicit ROLLBACK is guarded so a SQLite auto-rollback (no active
     transaction left under EIO / lock contention / corruption) cannot shadow
     the original exception with a spurious rollback error.
+
+    BEGIN IMMEDIATE and COMMIT are retried with jitter on transient
+    SQLITE_BUSY to break convoy collisions that SQLite's deterministic
+    busy_timeout cannot resolve.
     """
-    conn.execute("BEGIN IMMEDIATE")
+    _execute_boundary_with_retry(conn, "BEGIN IMMEDIATE")
     try:
         yield conn
     except Exception:
@@ -46,4 +83,11 @@ def write_txn(conn: sqlite3.Connection):
             pass
         raise
     else:
-        conn.execute("COMMIT")
+        try:
+            _execute_boundary_with_retry(conn, "COMMIT")
+        except Exception:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.OperationalError:
+                pass
+            raise

--- a/tests/hermes_cli/test_sqlite_util_write_txn_busy_retry.py
+++ b/tests/hermes_cli/test_sqlite_util_write_txn_busy_retry.py
@@ -1,0 +1,108 @@
+"""write_txn BUSY-retry behaviour for the shared sqlite_util helper.
+
+Mirrors the kanban_db-specific tests but targets the shared primitive that
+projects_db (and any future consumer) imports.  No real DB is touched: a
+fake connection records and replays scripted boundary outcomes.
+"""
+
+import sqlite3
+
+import pytest
+
+from hermes_cli import sqlite_util
+
+
+class _FakeConn:
+    """Records execute() calls and replays a scripted result per SQL statement."""
+
+    def __init__(self, script):
+        self._script = {k: list(v) for k, v in script.items()}
+        self.calls = []
+
+    def execute(self, sql, *args):
+        self.calls.append(sql)
+        key = sql.strip().split()[0].upper()
+        outcomes = self._script.get(key)
+        if outcomes:
+            outcome = outcomes.pop(0)
+            if isinstance(outcome, Exception):
+                raise outcome
+        return None
+
+    def count(self, prefix):
+        prefix = prefix.upper()
+        return sum(1 for c in self.calls if c.strip().upper().startswith(prefix))
+
+
+def _busy():
+    return sqlite3.OperationalError("database is locked")
+
+
+def _other():
+    return sqlite3.OperationalError("no such table: projects")
+
+
+def test_transient_busy_at_begin_is_absorbed():
+    conn = _FakeConn({"BEGIN": [_busy(), None]})
+    with sqlite_util.write_txn(conn):
+        pass
+    assert conn.count("BEGIN") == 2
+    assert conn.count("COMMIT") == 1
+
+
+def test_transient_busy_at_commit_is_absorbed():
+    conn = _FakeConn({"COMMIT": [_busy(), None]})
+    with sqlite_util.write_txn(conn):
+        pass
+    assert conn.count("COMMIT") == 2
+
+
+def test_non_busy_error_is_not_retried():
+    conn = _FakeConn({"BEGIN": [_other()]})
+    with pytest.raises(sqlite3.OperationalError, match="no such table"):
+        with sqlite_util.write_txn(conn):
+            pass
+    assert conn.count("BEGIN") == 1
+
+
+def test_persistent_busy_is_bounded():
+    conn = _FakeConn({"BEGIN": [_busy()] * 50})
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        with sqlite_util.write_txn(conn):
+            pass
+    assert conn.count("BEGIN") <= sqlite_util._BUSY_MAX_RETRIES + 1
+
+
+def test_body_is_not_replayed_on_commit_retry():
+    conn = _FakeConn({"COMMIT": [_busy(), None]})
+    body_runs = 0
+    with sqlite_util.write_txn(conn):
+        body_runs += 1
+    assert body_runs == 1
+
+
+def test_persistent_busy_at_commit_rolls_back():
+    conn = _FakeConn({"COMMIT": [_busy()] * 50})
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        with sqlite_util.write_txn(conn):
+            pass
+    assert conn.count("ROLLBACK") == 1
+
+
+def test_retry_sleep_respects_jitter_bounds(monkeypatch):
+    slept = []
+    monkeypatch.setattr(sqlite_util.time, "sleep", lambda s: slept.append(s))
+    conn = _FakeConn({"BEGIN": [_busy(), _busy(), None]})
+    with sqlite_util.write_txn(conn):
+        pass
+    assert slept
+    assert all(s >= sqlite_util._BUSY_RETRY_MIN_S for s in slept)
+    assert all(s <= sqlite_util._BUSY_RETRY_MAX_S for s in slept)
+
+
+def test_clean_path_commits_once():
+    conn = _FakeConn({})
+    with sqlite_util.write_txn(conn):
+        pass
+    assert conn.count("BEGIN") == 1
+    assert conn.count("COMMIT") == 1


### PR DESCRIPTION
## Summary

The kanban BUSY-retry fix (204a67f0c, PR #54137) added jittered retry logic to kanban_db's **local** `write_txn`, but the **shared** `sqlite_util.write_txn` — which `projects_db` imports — was left unprotected.

`projects_db` is written concurrently by 3+ independent processes:
- **TUI/Dashboard gateway** (`tui_gateway/server.py` — 5 call sites)
- **Agent tools** (`tools/project_tools.py` — 4 call sites)
- **CLI** (`hermes_cli/projects_cmd.py`)

Its `sqlite3.connect()` call also lacked an explicit `timeout`, defaulting to 5 s vs kanban's 120 s — making it strictly more exposed to BUSY collisions under concurrent writes.

## Changes

- **`hermes_cli/sqlite_util.py`**: Add `_execute_boundary_with_retry` (5 attempts, 20–150 ms jitter band) to the shared `write_txn`, mirroring the kanban fix. BEGIN IMMEDIATE and COMMIT are the only statements retried — both are idempotent boundary re-issues, so transaction body / CAS logic is never replayed.
- **`hermes_cli/projects_db.py`**: Raise `sqlite3.connect` timeout from default 5 s to 30 s so the built-in busy handler absorbs bulk contention before the application-level retry fires.

## Test plan

- [x] 8 new tests (`test_sqlite_util_write_txn_busy_retry.py`) — mirrors the kanban BUSY-retry suite against the shared helper
- [x] Existing kanban BUSY-retry tests pass (8/8)
- [x] Existing projects_db tests pass (15/15)