### PR TITLE
test(install): fix stale test after #39219 run_with_timeout refactor

### DIFF
--- a/tests/test_install_sh_browser_install.py
+++ b/tests/test_install_sh_browser_install.py
@@ -136,11 +136,12 @@ def test_browser_install_timeout_stays_interruptible() -> None:
     """
     text = INSTALL_SH.read_text()
 
-    # GNU-flag probe + the guarded invocation must both be present.
-    assert "timeout --foreground -k 10 1 true" in text
-    assert 'timeout --foreground -k 10 "$timeout_seconds" "$@"' in text
+    # GNU-flag probe + the guarded invocation must both be present. The timeout
+    # binary is parameterized ($timeout_bin) so macOS gtimeout works too (#39219).
+    assert '"$timeout_bin" --foreground -k 10 1 true' in text
+    assert '"$timeout_bin" --foreground -k 10 "$timeout_seconds" "$@"' in text
     # Plain-timeout fallback preserved for BusyBox/non-GNU.
-    assert 'timeout "$timeout_seconds" "$@"' in text
+    assert '"$timeout_bin" "$timeout_seconds" "$@"' in text
 
 
 # ---------------------------------------------------------------------------
@@ -161,8 +162,11 @@ def _run_install_fn(distro: str, version: str, *, native_fails: bool,
     the install command ran, and the override value seen on each run.
     """
     # Extract the functions we need so we don't execute the whole installer.
+    # run_browser_install_with_timeout delegates to run_with_timeout (#39219),
+    # so the helper must be pulled in too or the install command never runs.
     fn_names = [
         "run_browser_install_with_timeout",
+        "run_with_timeout",
         "playwright_host_unrecognized",
         "playwright_fallback_platform",
         "run_playwright_install",


### PR DESCRIPTION
## Summary

`tests/test_install_sh_browser_install.py` is green again — the 8 behavioral failures (and 2 text-assertion failures) were stale-test fallout from PR #39219, not a behavior regression.

#39219 refactored `run_browser_install_with_timeout` into a thin wrapper that delegates to a new `run_with_timeout` helper, and parameterized the timeout binary as `$timeout_bin` (so macOS `gtimeout` works). The behavioral harness only extracted the now-empty wrapper, so the stubbed install command never ran (`runs == []`) and every behavioral case failed. Two text assertions still expected the old literal `timeout` invocation.

## Changes

- `tests/test_install_sh_browser_install.py`: extract `run_with_timeout` alongside the wrapper in the harness; update the two timeout-string assertions to match the `$timeout_bin`-parameterized form. No production code touched — `install.sh` behavior is unchanged.

## Validation

| | Before | After |
|---|---|---|
| `tests/test_install_sh_browser_install.py` | 7 passed / 8 failed | 15 passed / 0 failed |

Verified on current `origin/main`: the 8 failures reproduce, and this test-only change makes the file fully green via `scripts/run_tests.sh`.

## Infographic

![stale-test-green-again](https://v3b.fal.media/files/b/0aa018b8/A80W7stU7uQM5rjOgw9wg_eGv1lZTG.png)
