### PR TITLE
feat: add BVCC Agent Wallet to optional-mcps 

### DIFF
--- a/optional-mcps/bvcc-agent-wallet/manifest.yaml
+++ b/optional-mcps/bvcc-agent-wallet/manifest.yaml
@@ -23,7 +23,7 @@ manifest_version: 1
         required: true
         secret: false
       - name: CHAIN_ID
-        prompt: "Default chain id: 42161 Arbitrum · 56 BNB · 1 Ethereum · 8453 Base · 421614 Arb Sepolia"
+        prompt: "Default chain id: 42161 Arbitrum · 56 BNB · 1 Ethereum · 8453 Base · 137 Polygon · 421614 Arb Sepolia"
         default: "42161"
         required: true
         secret: false

--- a/optional-mcps/bvcc-agent-wallet/manifest.yaml
+++ b/optional-mcps/bvcc-agent-wallet/manifest.yaml
@@ -1,0 +1,62 @@
+manifest_version: 1
+
+  name: bvcc-agent-wallet
+  description: Operate a non-custodial BVCC Agent Wallet on-chain — check balances, simulate, send native/tokens, approve, and swap (Uniswap v3/v4) within the agent's authorized on-chain limits.
+  source: https://github.com/blockventurechaincapital-crypto/bvcc-agent-mcp
+
+  transport:
+    type: stdio
+    command: npx
+    args:
+      - "-y"
+      - "@bvcc/agent-mcp"
+
+  auth:
+    type: api_key
+    env:
+      - name: AGENT_PRIVATE_KEY
+        prompt: "Agent EOA private key (0x + 64 hex). Used locally to sign; never transmitted."
+        required: true
+        secret: true
+      - name: WALLET_ADDRESS
+        prompt: "The BVCC Agent Wallet address this agent operates (0x...)."
+        required: true
+        secret: false
+      - name: CHAIN_ID
+        prompt: "Default chain id: 42161 Arbitrum · 56 BNB · 1 Ethereum · 8453 Base · 421614 Arb Sepolia"
+        default: "42161"
+        required: true
+        secret: false
+
+  tools:
+    default_enabled:
+      - getAgentStatus
+      - getCapabilities
+      - getNativeBalance
+      - getTokenBalances
+      - getRemaining
+      - needsApproval
+      - buildSwapPlan
+      - dryRunSendNative
+      - dryRunSendToken
+      - dryRunSwapV3
+      - dryRunSwapV4
+
+  post_install: |
+    This server operates a non-custodial BVCC Agent Wallet. The agent's private key
+    is read from the environment and used locally to sign only — it is never
+    transmitted. Every limit (spend caps, allowed tokens/recipients, expiry) is
+    enforced on-chain by the wallet contract; a blocked action reverts.
+
+    By default only read/simulate tools are enabled above. To let the agent move
+    funds, enable the write tools during the checklist (sendNative, sendToken,
+    approve, swapV3, swapV4), or set env BVCC_MCP_READONLY=true to hard-lock to
+    read-only regardless of selection.
+
+    This server is multi-network: every tool takes an optional `network` arg
+    (chain id or name), so the same agent works across chains without restarting.
+    The wallet address is the same on every chain (CREATE2); the agent must be
+    authorized on each chain it uses.
+
+    Re-run the tool checklist any time with:
+      hermes mcp configure bvcc-agent-wallet

--- a/optional-mcps/bvcc-agent-wallet/manifest.yaml
+++ b/optional-mcps/bvcc-agent-wallet/manifest.yaml
@@ -1,62 +1,82 @@
 manifest_version: 1
 
-  name: bvcc-agent-wallet
-  description: Operate a non-custodial BVCC Agent Wallet on-chain — check balances, simulate, send native/tokens, approve, and swap (Uniswap v3/v4) within the agent's authorized on-chain limits.
-  source: https://github.com/blockventurechaincapital-crypto/bvcc-agent-mcp
+name: bvcc-agent-wallet
+description: Operate a non-custodial BVCC Agent Wallet on-chain — check balances, simulate, send native/tokens, approve, swap (Uniswap v3/v4), provide liquidity (Uniswap v3/v4), and lend on Aave v3, all
+within the agent's authorized on-chain limits.
+source: https://github.com/blockventurechaincapital-crypto/bvcc-agent-mcp
 
-  transport:
-    type: stdio
-    command: npx
-    args:
-      - "-y"
-      - "@bvcc/agent-mcp"
+transport:
+  type: stdio
+  command: npx
+  args:
+    - "-y"
+    - "@bvcc/agent-mcp"
 
-  auth:
-    type: api_key
-    env:
-      - name: AGENT_PRIVATE_KEY
-        prompt: "Agent EOA private key (0x + 64 hex). Used locally to sign; never transmitted."
-        required: true
-        secret: true
-      - name: WALLET_ADDRESS
-        prompt: "The BVCC Agent Wallet address this agent operates (0x...)."
-        required: true
-        secret: false
-      - name: CHAIN_ID
-        prompt: "Default chain id: 42161 Arbitrum · 56 BNB · 1 Ethereum · 8453 Base · 137 Polygon · 421614 Arb Sepolia"
-        default: "42161"
-        required: true
-        secret: false
+auth:
+  type: api_key
+  env:
+    - name: AGENT_PRIVATE_KEY
+      prompt: "Agent EOA private key (0x + 64 hex). Used locally to sign; never transmitted."
+      required: true
+      secret: true
+    - name: WALLET_ADDRESS
+      prompt: "The BVCC Agent Wallet address this agent operates (0x...)."
+      required: true
+      secret: false
+    - name: CHAIN_ID
+      prompt: "Default chain id: 42161 Arbitrum · 56 BNB · 1 Ethereum · 8453 Base · 137 Polygon · 421614 Arb Sepolia"
+      default: "42161"
+      required: true
+      secret: false
 
-  tools:
-    default_enabled:
-      - getAgentStatus
-      - getCapabilities
-      - getNativeBalance
-      - getTokenBalances
-      - getRemaining
-      - needsApproval
-      - buildSwapPlan
-      - dryRunSendNative
-      - dryRunSendToken
-      - dryRunSwapV3
-      - dryRunSwapV4
+tools:
+  default_enabled:
+    - listGuides
+    - getGuide
+    - getAgentStatus
+    - getCapabilities
+    - getNativeBalance
+    - getTokenBalances
+    - getRemaining
+    - needsApproval
+    - getAavePositions
+    - getAaveMarket
+    - getV3Position
+    - getV4Position
+    - buildSwapPlan
+    - dryRunSendNative
+    - dryRunSendToken
+    - dryRunSwapV3
+    - dryRunSwapV4
+    - dryRunAaveSupply
+    - dryRunAaveBorrow
+    - aavePlanClosePosition
+    - aavePlanDeleverage
+    - aavePlanCollateralSwap
+    - aavePlanDebtSwap
+    - dryRunAddLiquidityV3
+    - dryRunRemoveLiquidityV3
+    - dryRunAddLiquidityV4
+    - dryRunRemoveLiquidityV4
 
-  post_install: |
-    This server operates a non-custodial BVCC Agent Wallet. The agent's private key
-    is read from the environment and used locally to sign only — it is never
-    transmitted. Every limit (spend caps, allowed tokens/recipients, expiry) is
-    enforced on-chain by the wallet contract; a blocked action reverts.
+post_install: |
+  This server operates a non-custodial BVCC Agent Wallet. The agent's private key
+  is read from the environment and used locally to sign only — it is never
+  transmitted. Every limit (spend caps, allowed tokens/recipients, expiry) is
+  enforced on-chain by the wallet contract; a blocked action reverts.
 
-    By default only read/simulate tools are enabled above. To let the agent move
-    funds, enable the write tools during the checklist (sendNative, sendToken,
-    approve, swapV3, swapV4), or set env BVCC_MCP_READONLY=true to hard-lock to
-    read-only regardless of selection.
+  By default only read/simulate tools are enabled above. To let the agent move
+  funds, enable the write tools during the checklist (e.g. sendNative, sendToken,
+  approve, swapV3/swapV4, aaveSupply/aaveBorrow/aaveRepay/aaveWithdraw,
+  addLiquidityV3/V4), or set env BVCC_MCP_READONLY=true to hard-lock to read-only.
 
-    This server is multi-network: every tool takes an optional `network` arg
-    (chain id or name), so the same agent works across chains without restarting.
-    The wallet address is the same on every chain (CREATE2); the agent must be
-    authorized on each chain it uses.
+  New to it? The agent can call listGuides / getGuide (getting-started, swaps,
+  lending, liquidity) for the recommended workflow and gotchas of each area.
 
-    Re-run the tool checklist any time with:
-      hermes mcp configure bvcc-agent-wallet
+  This server is multi-network: every tool takes an optional `network` arg
+  (chain id or name), so the same agent works across chains without restarting.
+  The wallet address is the same on every chain (CREATE2); the agent must be
+  authorized on each chain it uses.
+
+  Re-run the tool checklist any time with:
+    hermes mcp configure bvcc-agent-wallet

--- a/optional-mcps/bvcc-agent-wallet/manifest.yaml
+++ b/optional-mcps/bvcc-agent-wallet/manifest.yaml
@@ -1,8 +1,7 @@
 manifest_version: 1
 
 name: bvcc-agent-wallet
-description: Operate a non-custodial BVCC Agent Wallet on-chain — check balances, simulate, send native/tokens, approve, swap (Uniswap v3/v4), provide liquidity (Uniswap v3/v4), and lend on Aave v3, all
-within the agent's authorized on-chain limits.
+description: Operate a non-custodial BVCC Agent Wallet on-chain — check balances, simulate, send native/tokens, approve, swap (Uniswap v3/v4), provide liquidity (Uniswap v3/v4), and lend on Aave v3, all within the agent's authorized on-chain limits.
 source: https://github.com/blockventurechaincapital-crypto/bvcc-agent-mcp
 
 transport:


### PR DESCRIPTION
## What does this PR do?
  Adds a catalog entry (`optional-mcps/bvcc-agent-wallet/manifest.yaml`) for **BVCC Agent Wallet**, a stdio MCP server published on npm as `@bvcc/agent-mcp`. It lets a Hermes agent operate a **non-custodial** smart wallet on-chain —
  check balances, simulate, send native/ERC-20, approve, and swap on Uniswap v3/v4 — with every limit enforced on-chain by the wallet contract.

  ## Related Issue
  N/A — new catalog entry, no prior issue.

  ### Type of Change
  - [x] ✨  New feature (non-breaking change that adds functionality)

  ## Changes Made
  - Added `optional-mcps/bvcc-agent-wallet/manifest.yaml` (new catalog entry, no other files touched).
    - `transport: stdio` via `npx -y @bvcc/agent-mcp`
    - `auth: api_key` env prompts: `AGENT_PRIVATE_KEY` (secret), `WALLET_ADDRESS`, `CHAIN_ID` (default `42161`)
    - `tools.default_enabled` limited to read/simulate tools; write tools are opt-in during the checklist

  ## How to Test
  1. `hermes mcp add` the entry from the catalog (or run directly: `npx -y @bvcc/agent-mcp`).
  2. Provide `AGENT_PRIVATE_KEY`, `WALLET_ADDRESS`, `CHAIN_ID` when prompted.
  3. Call `getAgentStatus` / `getCapabilities` — returns the agent's on-chain authorization and limits, confirming the server starts and connects over stdio.

  ## Checklist
  ### Code
  - [x] I've read the Contributing Guide
  - [x] My commit messages follow Conventional Commits
  - [x] I searched for existing PRs to make sure this isn't a duplicate
  - [x] My PR contains only changes related to this feature (single file)
  - [ ] I've run `pytest tests/ -q` and all tests pass — N/A (catalog manifest only, no Python code changed)
  - [ ] I've added tests for my changes — N/A (declarative manifest)
  - [x] I've tested on my platform: Ubuntu (WSL2) + npx stdio

  ### Documentation & Housekeeping
  - [x] I've updated relevant documentation — or N/A (manifest is self-documenting via `post_install`)
  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact — or N/A (npx, cross-platform)
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A