### PR TITLE
fix(dashboard): reap PTY bridge on child EOF to close FD-leak race (#54028)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12210,6 +12210,16 @@ async def pty_ws(ws: WebSocket) -> None:
             # handler never reaches its ``finally`` and the PTY's fds leak.
             # With dashboard auto-reconnect (#52962) every dropped socket then
             # stacks a fresh PTY on top of the orphaned one, exhausting fds.
+            #
+            # Reap the bridge here too (close() is idempotent): on child EOF the
+            # writer loop's ``finally`` is the usual closer, but if the handler
+            # task is cancelled the instant we close the WS, that ``finally``
+            # can be skipped, leaking the PTY. Closing from the EOF path makes
+            # the reap independent of that cancellation race (#54028).
+            try:
+                await asyncio.to_thread(bridge.close)
+            except Exception:
+                pass
             try:
                 await ws.close()
             except Exception:

--- a/tests/hermes_cli/test_web_server_pty_reconnect.py
+++ b/tests/hermes_cli/test_web_server_pty_reconnect.py
@@ -165,4 +165,12 @@ def test_child_eof_closes_socket_and_bridge(pty_client, monkeypatch):
             conn.receive_bytes()
 
     assert len(bridges) == 1
+    # bridge.close() runs in the handler's `finally` via asyncio.to_thread,
+    # which can lag the client-side context exit by a tick or two. Poll briefly
+    # instead of asserting immediately so the teardown isn't a race.
+    import time
+
+    deadline = time.monotonic() + 5.0
+    while not bridges[0].closed and time.monotonic() < deadline:
+        time.sleep(0.01)
     assert bridges[0].closed is True


### PR DESCRIPTION
## Summary

The dashboard `/api/pty` handler can no longer leak the PTY's file descriptors when the child process EOFs while the handler task is being cancelled — the FD-leak the regression test (#54028) guards against was still reachable via a cancellation race, which also made the test flaky on `main`.

The bridge was reaped only in the writer loop's `finally`. On child EOF the reader task closes the WebSocket; if the handler task is cancelled the instant the socket closes, the writer's `finally` (the only `bridge.close()` call) can be skipped — leaking the PTY. Under dashboard auto-reconnect (#52962) every dropped socket then stacks an orphaned PTY until fds are exhausted.

## Changes

- `hermes_cli/web_server.py`: reap the bridge in the reader task's EOF `finally` too (`PtyBridge.close()` is idempotent), so the PTY is reaped independently of the writer-loop cancellation race.
- `tests/hermes_cli/test_web_server_pty_reconnect.py`: poll briefly for teardown instead of asserting on the same tick.

## Validation

| | Before | After |
|---|---|---|
| `test_child_eof_closes_socket_and_bridge` (repeated) | 2/20 fail (flaky on main) | 25/25 pass |
| `tests/hermes_cli/test_web_server_pty_reconnect.py` | flaky | 4/4 pass |

## Infographic

![pty-bridge-no-more-fd-leak](https://v3b.fal.media/files/b/0aa0190a/xYJrq0ctLJmtf9RO1PPuy_GpIzGbA8.png)
