### PR TITLE
fix(gateway): bound uploaded archive intake

### DIFF
--- a/archive_inspector.py
+++ b/archive_inspector.py
@@ -1,0 +1,238 @@
+"""Bounded ZIP/OOXML archive inspection helpers.
+
+The helpers in this module validate ZIP central-directory metadata before any
+CRC pass or member extraction happens.  Callers can then read individual members
+through :func:`read_zip_member`, which enforces the same per-member bounds while
+streaming so malformed archives cannot expand unbounded data into memory.
+"""
+
+from __future__ import annotations
+
+import re
+import zipfile
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Iterable
+
+
+_DEFAULT_MAX_ENTRIES = 2_000
+_DEFAULT_MAX_COMPRESSED_BYTES = 512 * 1024 * 1024
+_DEFAULT_MAX_UNCOMPRESSED_BYTES = 512 * 1024 * 1024
+_DEFAULT_MAX_MEMBER_BYTES = 64 * 1024 * 1024
+_DEFAULT_MAX_XML_MEMBER_BYTES = 16 * 1024 * 1024
+_DEFAULT_MAX_COMPRESSION_RATIO = 100.0
+_READ_CHUNK_BYTES = 1024 * 1024
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+
+
+class ZipInspectionError(ValueError):
+    """Raised when a ZIP archive violates configured safety limits."""
+
+
+@dataclass(frozen=True)
+class ZipInspectionLimits:
+    max_entries: int = _DEFAULT_MAX_ENTRIES
+    max_compressed_bytes: int = _DEFAULT_MAX_COMPRESSED_BYTES
+    max_uncompressed_bytes: int = _DEFAULT_MAX_UNCOMPRESSED_BYTES
+    max_member_bytes: int = _DEFAULT_MAX_MEMBER_BYTES
+    max_xml_member_bytes: int = _DEFAULT_MAX_XML_MEMBER_BYTES
+    max_compression_ratio: float | None = _DEFAULT_MAX_COMPRESSION_RATIO
+
+
+@dataclass(frozen=True)
+class ZipMemberInfo:
+    name: str
+    file_size: int
+    compress_size: int
+    is_dir: bool
+
+
+@dataclass(frozen=True)
+class ZipInspectionReport:
+    members: tuple[ZipMemberInfo, ...]
+    total_compressed_bytes: int
+    total_uncompressed_bytes: int
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        return tuple(member.name for member in self.members)
+
+    def has_member(self, name: str) -> bool:
+        return any(member.name == name for member in self.members)
+
+
+def _config_int(config: dict[str, object], key: str, default: int) -> int:
+    raw = config.get(key, default)
+    try:
+        value = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ZipInspectionError(f"invalid integer archive limit gateway.file_intake.{key}={raw!r}") from exc
+    if value <= 0:
+        raise ZipInspectionError(f"archive limit gateway.file_intake.{key} must be positive")
+    return value
+
+
+def _config_float(config: dict[str, object], key: str, default: float | None) -> float | None:
+    raw = config.get(key, default)
+    if raw is None:
+        return None
+    if isinstance(raw, str) and raw.lower() in {"0", "off", "false", "none", "disabled"}:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError) as exc:
+        raise ZipInspectionError(f"invalid numeric archive limit gateway.file_intake.{key}={raw!r}") from exc
+    if value <= 0:
+        raise ZipInspectionError(f"archive limit gateway.file_intake.{key} must be positive")
+    return value
+
+
+def _load_file_intake_config() -> dict[str, object]:
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        cfg = load_config() or {}
+        section = cfg_get(cfg, "gateway", "file_intake", default={}) or {}
+        return section if isinstance(section, dict) else {}
+    except Exception:
+        return {}
+
+
+def file_intake_zip_limits_from_config() -> ZipInspectionLimits:
+    """Return ZIP limits used by gateway intake and lightweight OOXML readers."""
+
+    config = _load_file_intake_config()
+    return ZipInspectionLimits(
+        max_entries=_config_int(config, "max_archive_entries", _DEFAULT_MAX_ENTRIES),
+        max_compressed_bytes=_config_int(
+            config,
+            "max_archive_compressed_bytes",
+            _DEFAULT_MAX_COMPRESSED_BYTES,
+        ),
+        max_uncompressed_bytes=_config_int(
+            config,
+            "max_archive_uncompressed_bytes",
+            _DEFAULT_MAX_UNCOMPRESSED_BYTES,
+        ),
+        max_member_bytes=_config_int(
+            config,
+            "max_archive_member_bytes",
+            _DEFAULT_MAX_MEMBER_BYTES,
+        ),
+        max_xml_member_bytes=_config_int(
+            config,
+            "max_ooxml_xml_member_bytes",
+            _DEFAULT_MAX_XML_MEMBER_BYTES,
+        ),
+        max_compression_ratio=_config_float(
+            config,
+            "max_compression_ratio",
+            _DEFAULT_MAX_COMPRESSION_RATIO,
+        ),
+    )
+
+
+def _safe_member_name(name: str) -> str:
+    normalized = name.replace("\\", "/")
+    if not normalized or normalized.startswith("/") or _WINDOWS_DRIVE_RE.match(normalized):
+        raise ZipInspectionError(f"unsafe archive member path: {name}")
+    parts = PurePosixPath(normalized).parts
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ZipInspectionError(f"unsafe archive member path: {name}")
+    return normalized
+
+
+def inspect_zip(zf: zipfile.ZipFile, limits: ZipInspectionLimits | None = None) -> ZipInspectionReport:
+    """Validate central-directory metadata without reading member bodies."""
+
+    limits = limits or ZipInspectionLimits()
+    try:
+        infos = zf.infolist()
+    except zipfile.BadZipFile as exc:
+        raise ZipInspectionError(f"not a valid zip archive: {exc}") from exc
+
+    if len(infos) > limits.max_entries:
+        raise ZipInspectionError(f"archive has too many entries: {len(infos)} > {limits.max_entries}")
+
+    members: list[ZipMemberInfo] = []
+    total_compressed = 0
+    total_uncompressed = 0
+    for info in infos:
+        name = _safe_member_name(info.filename)
+        file_size = int(info.file_size)
+        compress_size = int(info.compress_size)
+        total_compressed += compress_size
+        total_uncompressed += file_size
+
+        if total_compressed > limits.max_compressed_bytes:
+            raise ZipInspectionError(
+                f"archive compressed size exceeds limit: {total_compressed} > {limits.max_compressed_bytes}"
+            )
+        if total_uncompressed > limits.max_uncompressed_bytes:
+            raise ZipInspectionError(
+                f"archive uncompressed size exceeds limit: {total_uncompressed} > {limits.max_uncompressed_bytes}"
+            )
+        if not info.is_dir() and file_size > limits.max_member_bytes:
+            raise ZipInspectionError(
+                f"archive member exceeds limit: {name} is {file_size} bytes > {limits.max_member_bytes}"
+            )
+        if name.lower().endswith(".xml") and file_size > limits.max_xml_member_bytes:
+            raise ZipInspectionError(
+                f"XML member exceeds limit: {name} is {file_size} bytes > {limits.max_xml_member_bytes}"
+            )
+        if limits.max_compression_ratio is not None and file_size > 0:
+            ratio = float("inf") if compress_size == 0 else file_size / max(compress_size, 1)
+            if ratio > limits.max_compression_ratio:
+                raise ZipInspectionError(
+                    f"archive member compression ratio exceeds limit: {name} ratio {ratio:.1f} > {limits.max_compression_ratio:g}"
+                )
+        members.append(ZipMemberInfo(name=name, file_size=file_size, compress_size=compress_size, is_dir=info.is_dir()))
+
+    return ZipInspectionReport(
+        members=tuple(members),
+        total_compressed_bytes=total_compressed,
+        total_uncompressed_bytes=total_uncompressed,
+    )
+
+
+def ensure_zip_crc(zf: zipfile.ZipFile, _report: ZipInspectionReport | None = None) -> None:
+    """Run stdlib CRC validation after callers have already inspected bounds."""
+
+    bad = zf.testzip()
+    if bad:
+        raise ZipInspectionError(f"corrupt zip member: {bad}")
+
+
+def read_zip_member(zf: zipfile.ZipFile, name: str, *, max_bytes: int) -> bytes:
+    """Read one ZIP member with an explicit decompressed-byte ceiling."""
+
+    try:
+        info = zf.getinfo(name)
+    except KeyError as exc:
+        raise ZipInspectionError(f"missing archive member: {name}") from exc
+    safe_name = _safe_member_name(info.filename)
+    if int(info.file_size) > max_bytes:
+        raise ZipInspectionError(f"archive member exceeds read limit: {safe_name} is {info.file_size} bytes > {max_bytes}")
+
+    chunks: list[bytes] = []
+    total = 0
+    try:
+        with zf.open(info, "r") as fh:
+            while True:
+                chunk = fh.read(min(_READ_CHUNK_BYTES, max_bytes + 1 - total))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                total += len(chunk)
+                if total > max_bytes:
+                    raise ZipInspectionError(f"archive member exceeds read limit: {safe_name} > {max_bytes} bytes")
+    except zipfile.BadZipFile as exc:
+        raise ZipInspectionError(f"corrupt zip member: {safe_name}") from exc
+    except RuntimeError as exc:
+        raise ZipInspectionError(f"cannot read zip member {safe_name}: {exc}") from exc
+    return b"".join(chunks)
+
+
+def existing_members(names: Iterable[str], report: ZipInspectionReport) -> list[str]:
+    available = set(report.names)
+    return [name for name in names if name in available]

--- a/gateway/file_intake.py
+++ b/gateway/file_intake.py
@@ -1,0 +1,628 @@
+"""Durable file-intake manifest and lightweight extractors.
+
+This module sits below platform adapters: adapters cache bytes first, then record
+what arrived here.  The manifest is intentionally profile-local and boring
+(SQLite + files under HERMES_HOME/file_intake) so uploads survive context
+compression/restarts without requiring another service.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import json
+import re
+import sqlite3
+import time
+import zipfile
+from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version as _package_version
+from pathlib import Path
+from typing import Any, Mapping
+
+from packaging.version import InvalidVersion, Version
+
+from archive_inspector import (
+    ensure_zip_crc,
+    file_intake_zip_limits_from_config,
+    inspect_zip,
+    read_zip_member,
+)
+from hermes_constants import get_hermes_dir
+
+
+SCHEMA_VERSION = 1
+_MIN_SAFE_PYPDF_VERSION = Version("6.13.3")
+_MAX_SAFE_PYPDF_VERSION = Version("7")
+
+
+@dataclass(frozen=True)
+class IntakeRecord:
+    sha256: str
+    source_id: int
+    duplicate: bool
+    cache_path: str
+    artifact_dir: str
+    status: str
+    extracted_text_path: str | None = None
+    structure_path: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "sha256": self.sha256,
+            "source_id": self.source_id,
+            "duplicate": self.duplicate,
+            "cache_path": self.cache_path,
+            "artifact_dir": self.artifact_dir,
+            "status": self.status,
+            "extracted_text_path": self.extracted_text_path,
+            "structure_path": self.structure_path,
+        }
+
+
+def get_file_intake_dir() -> Path:
+    root = get_hermes_dir("file_intake", "file_intake")
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def get_artifacts_dir() -> Path:
+    root = get_file_intake_dir() / "artifacts"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def get_intake_db_path() -> Path:
+    return get_file_intake_dir() / "intake.sqlite"
+
+
+def _connect(db_path: Path | None = None) -> sqlite3.Connection:
+    path = db_path or get_intake_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    _ensure_schema(conn)
+    return conn
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS file_intake_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS intake_files (
+            sha256 TEXT PRIMARY KEY,
+            original_filename TEXT NOT NULL,
+            mime_type TEXT NOT NULL,
+            size_bytes INTEGER NOT NULL,
+            first_cache_path TEXT NOT NULL,
+            artifact_dir TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'received',
+            retention_policy TEXT NOT NULL DEFAULT 'transient',
+            first_seen_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            extracted_text_path TEXT,
+            structure_path TEXT,
+            error TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS intake_sources (
+            source_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            sha256 TEXT NOT NULL REFERENCES intake_files(sha256) ON DELETE CASCADE,
+            source_platform TEXT NOT NULL,
+            chat_id TEXT,
+            thread_id TEXT,
+            message_id TEXT,
+            user_id TEXT,
+            username TEXT,
+            platform_file_id TEXT,
+            platform_unique_id TEXT,
+            cache_path TEXT NOT NULL,
+            received_at REAL NOT NULL,
+            metadata_json TEXT NOT NULL DEFAULT '{}'
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_intake_sources_sha256 ON intake_sources(sha256);
+        CREATE INDEX IF NOT EXISTS idx_intake_sources_message ON intake_sources(source_platform, chat_id, thread_id, message_id);
+        CREATE INDEX IF NOT EXISTS idx_intake_files_status ON intake_files(status);
+        """
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO file_intake_meta(key, value) VALUES('schema_version', ?)",
+        (str(SCHEMA_VERSION),),
+    )
+    conn.commit()
+
+
+def sha256_file(path: str | Path) -> tuple[str, int]:
+    h = hashlib.sha256()
+    total = 0
+    with Path(path).open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+            total += len(chunk)
+    return h.hexdigest(), total
+
+
+def _artifact_dir_for(sha256: str) -> Path:
+    # Two-level prefix keeps future directories from becoming huge.
+    return get_artifacts_dir() / sha256[:2] / sha256
+
+
+def record_incoming_file(
+    *,
+    cache_path: str | Path,
+    original_filename: str | None = None,
+    mime_type: str | None = None,
+    size_bytes: int | None = None,
+    source_platform: str,
+    chat_id: str | int | None = None,
+    thread_id: str | int | None = None,
+    message_id: str | int | None = None,
+    user_id: str | int | None = None,
+    username: str | None = None,
+    platform_file_id: str | None = None,
+    platform_unique_id: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> IntakeRecord:
+    """Record one inbound cached file and its platform provenance.
+
+    Content identity is keyed by sha256.  Every Telegram/Slack/etc. message gets
+    a provenance row even when the bytes are a duplicate, so follow-up prompts can
+    resolve "the file I just sent" without re-extracting the same content.
+    """
+
+    path = Path(cache_path)
+    digest, actual_size = sha256_file(path)
+    size = int(size_bytes) if size_bytes is not None else actual_size
+    now = time.time()
+    artifact_dir = _artifact_dir_for(digest)
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    filename = Path(original_filename or path.name or "document").name
+    mime = (mime_type or "application/octet-stream").strip() or "application/octet-stream"
+    metadata_json = json.dumps(dict(metadata or {}), ensure_ascii=False, sort_keys=True)
+
+    with _connect() as conn:
+        existing = conn.execute(
+            "SELECT sha256, status, extracted_text_path, structure_path FROM intake_files WHERE sha256=?",
+            (digest,),
+        ).fetchone()
+        duplicate = existing is not None
+        if duplicate:
+            conn.execute(
+                "UPDATE intake_files SET updated_at=? WHERE sha256=?",
+                (now, digest),
+            )
+        else:
+            conn.execute(
+                """
+                INSERT INTO intake_files(
+                    sha256, original_filename, mime_type, size_bytes,
+                    first_cache_path, artifact_dir, status, first_seen_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, 'received', ?, ?)
+                """,
+                (digest, filename, mime, size, str(path), str(artifact_dir), now, now),
+            )
+        cur = conn.execute(
+            """
+            INSERT INTO intake_sources(
+                sha256, source_platform, chat_id, thread_id, message_id, user_id,
+                username, platform_file_id, platform_unique_id, cache_path,
+                received_at, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                digest,
+                source_platform,
+                _str_or_none(chat_id),
+                _str_or_none(thread_id),
+                _str_or_none(message_id),
+                _str_or_none(user_id),
+                username,
+                platform_file_id,
+                platform_unique_id,
+                str(path),
+                now,
+                metadata_json,
+            ),
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT status, extracted_text_path, structure_path FROM intake_files WHERE sha256=?",
+            (digest,),
+        ).fetchone()
+        return IntakeRecord(
+            sha256=digest,
+            source_id=int(cur.lastrowid),
+            duplicate=duplicate,
+            cache_path=str(path),
+            artifact_dir=str(artifact_dir),
+            status=row["status"],
+            extracted_text_path=row["extracted_text_path"],
+            structure_path=row["structure_path"],
+        )
+
+
+def _str_or_none(value: str | int | None) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+
+
+def should_keep_cache_path(path: str | Path) -> bool:
+    """Return True when manifest retention says cleanup must keep this blob."""
+    raw = str(Path(path))
+    with _connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT f.status, f.retention_policy
+            FROM intake_sources s
+            JOIN intake_files f ON f.sha256 = s.sha256
+            WHERE s.cache_path=? OR f.first_cache_path=?
+            """,
+            (raw, raw),
+        ).fetchall()
+    for row in rows:
+        if row["retention_policy"] in {"keep", "linked", "project", "current_session"}:
+            return True
+        if row["status"] in {"extracted", "routed", "archived"}:
+            return True
+    return False
+
+
+def update_file_status(
+    sha256: str,
+    status: str,
+    *,
+    extracted_text_path: str | None = None,
+    structure_path: str | None = None,
+    error: str | None = None,
+) -> None:
+    with _connect() as conn:
+        conn.execute(
+            """
+            UPDATE intake_files
+            SET status=?, updated_at=?,
+                extracted_text_path=COALESCE(?, extracted_text_path),
+                structure_path=COALESCE(?, structure_path),
+                error=?
+            WHERE sha256=?
+            """,
+            (status, time.time(), extracted_text_path, structure_path, error, sha256),
+        )
+        conn.commit()
+
+
+def get_file_record(sha256: str) -> dict[str, Any] | None:
+    with _connect() as conn:
+        row = conn.execute("SELECT * FROM intake_files WHERE sha256=?", (sha256,)).fetchone()
+        return dict(row) if row else None
+
+
+
+
+def get_file_record_by_cache_path(path: str | Path) -> dict[str, Any] | None:
+    raw = str(Path(path))
+    with _connect() as conn:
+        row = conn.execute(
+            """
+            SELECT f.*
+            FROM intake_sources s
+            JOIN intake_files f ON f.sha256 = s.sha256
+            WHERE s.cache_path=? OR f.first_cache_path=?
+            ORDER BY s.source_id DESC
+            LIMIT 1
+            """,
+            (raw, raw),
+        ).fetchone()
+        return dict(row) if row else None
+
+
+def list_recent_files(
+    *,
+    limit: int = 10,
+    source_platform: str | None = None,
+    chat_id: str | int | None = None,
+    thread_id: str | int | None = None,
+) -> list[dict[str, Any]]:
+    clauses: list[str] = []
+    params: list[Any] = []
+    if source_platform is not None:
+        clauses.append("s.source_platform=?")
+        params.append(source_platform)
+    if chat_id is not None:
+        clauses.append("s.chat_id=?")
+        params.append(str(chat_id))
+    if thread_id is not None:
+        clauses.append("s.thread_id=?")
+        params.append(str(thread_id))
+    where = "WHERE " + " AND ".join(clauses) if clauses else ""
+    sql = f"""
+        SELECT
+            s.source_id, s.source_platform, s.chat_id, s.thread_id, s.message_id,
+            s.received_at, s.cache_path,
+            f.sha256, f.original_filename, f.mime_type, f.size_bytes, f.status,
+            f.extracted_text_path, f.structure_path, f.artifact_dir, f.retention_policy
+        FROM intake_sources s
+        JOIN intake_files f ON f.sha256 = s.sha256
+        {where}
+        ORDER BY s.received_at DESC, s.source_id DESC
+        LIMIT ?
+    """
+    params.append(max(1, min(int(limit), 100)))
+    with _connect() as conn:
+        return [dict(r) for r in conn.execute(sql, params).fetchall()]
+
+
+def build_intake_context_note(path: str | Path) -> str | None:
+    row = get_file_record_by_cache_path(path)
+    if not row:
+        return None
+    parts = [
+        f"intake sha256={row['sha256']}",
+        f"status={row['status']}",
+        f"size={row['size_bytes']} bytes",
+        f"artifact_dir={row['artifact_dir']}",
+    ]
+    if row.get("extracted_text_path"):
+        parts.append(f"extracted_text={row['extracted_text_path']}")
+    if row.get("structure_path"):
+        parts.append(f"structure={row['structure_path']}")
+    return "; ".join(parts)
+
+
+def build_semantic_file_card(sha256: str, *, summary: str | None = None) -> str:
+    row = get_file_record(sha256)
+    if not row:
+        raise KeyError(f"unknown intake file sha256: {sha256}")
+    sources = list_sources(sha256)
+    lines = [
+        f"# File intake: {row['original_filename']}",
+        "",
+        "## Identity",
+        f"- sha256: `{row['sha256']}`",
+        f"- mime_type: `{row['mime_type']}`",
+        f"- size_bytes: `{row['size_bytes']}`",
+        f"- status: `{row['status']}`",
+        f"- retention_policy: `{row['retention_policy']}`",
+        f"- artifact_dir: `{row['artifact_dir']}`",
+    ]
+    if row.get("extracted_text_path"):
+        lines.append(f"- extracted_text_path: `{row['extracted_text_path']}`")
+    if row.get("structure_path"):
+        lines.append(f"- structure_path: `{row['structure_path']}`")
+    if summary:
+        lines.extend(["", "## Summary", summary.strip()])
+    lines.extend(["", "## Sources"])
+    for src in sources[:20]:
+        lines.append(
+            f"- {src['source_platform']} chat={src.get('chat_id')} thread={src.get('thread_id')} "
+            f"message={src.get('message_id')} cache_path=`{src.get('cache_path')}`"
+        )
+    lines.extend(["", "## Routing note", "No automatic Gbrain/Notion writeback was performed. Use this card only when the user explicitly routes the file."])
+    return "\n".join(lines)
+
+
+def list_sources(sha256: str) -> list[dict[str, Any]]:
+    with _connect() as conn:
+        rows = conn.execute(
+            "SELECT * FROM intake_sources WHERE sha256=? ORDER BY source_id",
+            (sha256,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+
+def extract_if_supported(record: IntakeRecord, *, filename: str = "", mime_type: str = "") -> IntakeRecord:
+    """Run the v1 extractor when the file type is supported.
+
+    Currently full extraction is implemented for PPTX because it directly
+    supports Tim's current presentation workflow. Unsupported files stay in the
+    manifest as `received` rather than failing noisy.
+    """
+
+    ext = Path(filename or record.cache_path).suffix.lower()
+    try:
+        extractor = None
+        if ext == ".pptx" or mime_type == "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+            extractor = extract_pptx
+        elif ext == ".docx" or mime_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+            extractor = extract_docx
+        elif ext == ".xlsx" or mime_type == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+            extractor = extract_xlsx
+        elif ext == ".zip" or mime_type in {"application/zip", "application/x-zip-compressed"}:
+            extractor = inspect_zip_archive
+        elif ext == ".pdf" or mime_type == "application/pdf":
+            extractor = extract_pdf
+
+        if extractor is not None:
+            text_path, structure_path = extractor(record.cache_path, record.artifact_dir)
+            update_file_status(
+                record.sha256,
+                "extracted",
+                extracted_text_path=str(text_path),
+                structure_path=str(structure_path),
+                error=None,
+            )
+            return IntakeRecord(
+                sha256=record.sha256,
+                source_id=record.source_id,
+                duplicate=record.duplicate,
+                cache_path=record.cache_path,
+                artifact_dir=record.artifact_dir,
+                status="extracted",
+                extracted_text_path=str(text_path),
+                structure_path=str(structure_path),
+            )
+    except Exception as exc:
+        update_file_status(record.sha256, "failed_extract", error=str(exc))
+    return record
+
+
+def extract_pptx(path: str | Path, artifact_dir: str | Path) -> tuple[Path, Path]:
+    """Extract slide text from a PPTX without depending on python-pptx."""
+
+    pptx_path = Path(path)
+    out_dir = Path(artifact_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    slides: list[dict[str, Any]] = []
+    limits = file_intake_zip_limits_from_config()
+    with zipfile.ZipFile(pptx_path) as zf:
+        report = inspect_zip(zf, limits)
+        slide_names = sorted(
+            (n for n in report.names if re.fullmatch(r"ppt/slides/slide\d+\.xml", n)),
+            key=lambda n: int(re.search(r"slide(\d+)\.xml", n).group(1)),
+        )
+        for idx, name in enumerate(slide_names, start=1):
+            xml = read_zip_member(zf, name, max_bytes=limits.max_xml_member_bytes).decode("utf-8", errors="ignore")
+            parts = [html.unescape(x) for x in re.findall(r"<a:t>(.*?)</a:t>", xml, flags=re.S)]
+            text = " ".join(_clean_xml_text(p) for p in parts if p).strip()
+            slides.append({"index": idx, "source": name, "text": text})
+
+    structure = {
+        "type": "pptx",
+        "source_path": str(pptx_path),
+        "slide_count": len(slides),
+        "slides": slides,
+    }
+    structure_path = out_dir / "structure.json"
+    text_path = out_dir / "extracted.md"
+    structure_path.write_text(json.dumps(structure, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    lines = [f"# Extracted PPTX: {pptx_path.name}", "", f"Slides: {len(slides)}", ""]
+    for slide in slides:
+        lines.append(f"## Slide {slide['index']}")
+        lines.append(slide["text"] or "[no text extracted]")
+        lines.append("")
+    text_path.write_text("\n".join(lines), encoding="utf-8")
+    return text_path, structure_path
+
+
+def extract_docx(path: str | Path, artifact_dir: str | Path) -> tuple[Path, Path]:
+    docx_path = Path(path)
+    out_dir = Path(artifact_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    limits = file_intake_zip_limits_from_config()
+    with zipfile.ZipFile(docx_path) as zf:
+        inspect_zip(zf, limits)
+        xml = read_zip_member(zf, "word/document.xml", max_bytes=limits.max_xml_member_bytes).decode("utf-8", errors="ignore")
+    paragraphs = []
+    for para_xml in re.findall(r"<w:p[\s>].*?</w:p>", xml, flags=re.S):
+        parts = [html.unescape(x) for x in re.findall(r"<w:t[^>]*>(.*?)</w:t>", para_xml, flags=re.S)]
+        text = "".join(_clean_xml_text(p) for p in parts).strip()
+        if text:
+            paragraphs.append(text)
+    structure = {"type": "docx", "source_path": str(docx_path), "paragraph_count": len(paragraphs), "paragraphs": paragraphs}
+    return _write_text_structure(out_dir, f"Extracted DOCX: {docx_path.name}", paragraphs, structure)
+
+
+def extract_xlsx(path: str | Path, artifact_dir: str | Path) -> tuple[Path, Path]:
+    xlsx_path = Path(path)
+    out_dir = Path(artifact_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    limits = file_intake_zip_limits_from_config()
+    with zipfile.ZipFile(xlsx_path) as zf:
+        report = inspect_zip(zf, limits)
+        shared_strings = []
+        if "xl/sharedStrings.xml" in report.names:
+            ss = read_zip_member(zf, "xl/sharedStrings.xml", max_bytes=limits.max_xml_member_bytes).decode("utf-8", errors="ignore")
+            for item in re.findall(r"<si[\s>].*?</si>", ss, flags=re.S):
+                parts = [html.unescape(x) for x in re.findall(r"<t[^>]*>(.*?)</t>", item, flags=re.S)]
+                shared_strings.append("".join(_clean_xml_text(p) for p in parts))
+        sheet_names = sorted(n for n in report.names if re.fullmatch(r"xl/worksheets/sheet\d+\.xml", n))
+        sheets = []
+        lines = []
+        for idx, name in enumerate(sheet_names, start=1):
+            xml = read_zip_member(zf, name, max_bytes=limits.max_xml_member_bytes).decode("utf-8", errors="ignore")
+            cells = re.findall(r"<c[^>]*(?:t=\"s\")?[^>]*>.*?<v>(.*?)</v>.*?</c>", xml, flags=re.S)
+            values = []
+            for raw in cells[:200]:
+                value = html.unescape(raw.strip())
+                try:
+                    si = int(value)
+                    if 0 <= si < len(shared_strings):
+                        value = shared_strings[si]
+                except ValueError:
+                    pass
+                if value:
+                    values.append(value)
+            sheets.append({"index": idx, "source": name, "sample_values": values[:50]})
+            lines.append(f"Sheet {idx}: " + (", ".join(values[:20]) if values else "[no text extracted]"))
+    structure = {"type": "xlsx", "source_path": str(xlsx_path), "sheet_count": len(sheets), "sheets": sheets}
+    return _write_text_structure(out_dir, f"Extracted XLSX: {xlsx_path.name}", lines, structure)
+
+
+def inspect_zip_archive(path: str | Path, artifact_dir: str | Path) -> tuple[Path, Path]:
+    zip_path = Path(path)
+    out_dir = Path(artifact_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    limits = file_intake_zip_limits_from_config()
+    entries = []
+    with zipfile.ZipFile(zip_path) as zf:
+        report = inspect_zip(zf, limits)
+        ensure_zip_crc(zf, report)
+        for info in report.members:
+            entries.append({"name": info.name, "size": info.file_size, "compressed_size": info.compress_size, "is_dir": info.is_dir})
+    structure = {"type": "zip", "source_path": str(zip_path), "entry_count": len(entries), "total_compressed_bytes": report.total_compressed_bytes, "total_uncompressed_bytes": report.total_uncompressed_bytes, "entries": entries}
+    lines = [f"{e['name']} ({e['size']} bytes)" for e in entries[:500]]
+    return _write_text_structure(out_dir, f"Inspected ZIP: {zip_path.name}", lines, structure)
+
+
+def extract_pdf(path: str | Path, artifact_dir: str | Path) -> tuple[Path, Path]:
+    pdf_path = Path(path)
+    out_dir = Path(artifact_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    pages = []
+    error = None
+    _ensure_safe_pypdf_version()
+    try:
+        from pypdf import PdfReader  # type: ignore
+        reader = PdfReader(str(pdf_path))
+        for idx, page in enumerate(reader.pages, start=1):
+            try:
+                pages.append({"index": idx, "text": (page.extract_text() or "").strip()})
+            except Exception as exc:  # pragma: no cover - depends on PDF internals
+                pages.append({"index": idx, "text": "", "error": str(exc)})
+    except Exception as exc:
+        error = f"PDF text extraction unavailable or failed: {exc}"
+    lines = [p.get("text", "") or "[no text extracted]" for p in pages] if pages else [error or "[no text extracted]"]
+    structure = {"type": "pdf", "source_path": str(pdf_path), "page_count": len(pages), "pages": pages, "error": error}
+    return _write_text_structure(out_dir, f"Extracted PDF: {pdf_path.name}", lines, structure)
+
+
+def _ensure_safe_pypdf_version() -> None:
+    try:
+        installed = _package_version("pypdf")
+    except PackageNotFoundError as exc:
+        raise RuntimeError("PDF text extraction requires pypdf>=6.13.3,<7") from exc
+    try:
+        parsed = Version(installed)
+    except InvalidVersion as exc:
+        raise RuntimeError(f"PDF text extraction disabled: invalid pypdf version {installed!r}") from exc
+    if not (_MIN_SAFE_PYPDF_VERSION <= parsed < _MAX_SAFE_PYPDF_VERSION):
+        raise RuntimeError(
+            f"PDF text extraction disabled: pypdf {installed} is outside the supported security window >=6.13.3,<7"
+        )
+
+
+def _write_text_structure(out_dir: Path, title: str, blocks: list[str], structure: dict[str, Any]) -> tuple[Path, Path]:
+    structure_path = out_dir / "structure.json"
+    text_path = out_dir / "extracted.md"
+    structure_path.write_text(json.dumps(structure, ensure_ascii=False, indent=2), encoding="utf-8")
+    lines = [f"# {title}", ""]
+    for i, block in enumerate(blocks, start=1):
+        lines.append(f"## Item {i}")
+        lines.append(block or "[no text extracted]")
+        lines.append("")
+    text_path.write_text("\n".join(lines), encoding="utf-8")
+    return text_path, structure_path
+
+
+def _clean_xml_text(text: str) -> str:
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1495,6 +1495,13 @@ def cleanup_document_cache(max_age_hours: int = 24) -> int:
     for f in cache_dir.iterdir():
         if f.is_file() and f.stat().st_mtime < cutoff:
             try:
+                from gateway.file_intake import should_keep_cache_path
+
+                if should_keep_cache_path(f):
+                    continue
+            except Exception:
+                pass
+            try:
                 f.unlink()
                 removed += 1
             except OSError:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9458,6 +9458,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 agent_path = to_agent_visible_cache_path(path)
 
                 context_note = _build_document_context_note(display_name, agent_path, mtype)
+                try:
+                    from gateway.file_intake import build_intake_context_note
+
+                    intake_note = build_intake_context_note(path)
+                    if intake_note:
+                        context_note = f"{context_note} Intake: {intake_note}."
+                except Exception:
+                    pass
                 message_text = f"{context_note}\n\n{message_text}"
 
         if getattr(event, "reply_to_text", None) and event.reply_to_message_id:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2681,6 +2681,19 @@ DEFAULT_CONFIG = {
         # adapter. ``0`` disables the cap. Default 128 MiB.
         "max_inbound_media_bytes": 134217728,
 
+        # Bounded archive/document intake for user-uploaded ZIP/OOXML files.
+        # These limits are checked before CRC validation or member extraction
+        # so malformed archives cannot expand unbounded data into memory.
+        "file_intake": {
+            "max_archive_entries": 2000,
+            "max_archive_compressed_bytes": 536870912,
+            "max_archive_uncompressed_bytes": 536870912,
+            "max_archive_member_bytes": 67108864,
+            "max_ooxml_xml_member_bytes": 16777216,
+            # Set to null/0/false to disable ratio enforcement.
+            "max_compression_ratio": 100.0,
+        },
+
         # When false (default), any file path the agent emits is delivered
         # as a native attachment as long as it isn't under the credential /
         # system-path denylist (/etc, /proc, ~/.ssh, ~/.aws, ~/.hermes/.env,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -65,6 +65,7 @@ from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
+from gateway.file_intake import extract_if_supported, record_incoming_file
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -7014,6 +7015,24 @@ class TelegramAdapter(BasePlatformAdapter):
                 event.media_urls = [cached_path]
                 event.media_types = [mime_type]
                 logger.info("[Telegram] Cached user document at %s (%s)", cached_path, mime_type)
+                try:
+                    intake_record = record_incoming_file(
+                        cache_path=cached_path,
+                        original_filename=original_filename or f"document{ext or '.bin'}",
+                        mime_type=mime_type,
+                        size_bytes=len(raw_bytes),
+                        source_platform="telegram",
+                        chat_id=getattr(msg.chat, "id", None),
+                        thread_id=getattr(msg, "message_thread_id", None),
+                        message_id=getattr(msg, "message_id", None),
+                        user_id=getattr(msg.from_user, "id", None) if getattr(msg, "from_user", None) else None,
+                        username=getattr(msg.from_user, "username", None) if getattr(msg, "from_user", None) else None,
+                        platform_file_id=getattr(doc, "file_id", None),
+                        platform_unique_id=getattr(doc, "file_unique_id", None),
+                    )
+                    extract_if_supported(intake_record, filename=original_filename, mime_type=mime_type)
+                except Exception as intake_exc:
+                    logger.info("[Telegram] File intake skipped for %s: %s", cached_path, intake_exc)
 
                 # For text-readable files, inject content into event.text (capped
                 # at 100 KB). Gate on a text-like extension/MIME — NOT a blind

--- a/tests/gateway/test_file_intake.py
+++ b/tests/gateway/test_file_intake.py
@@ -1,0 +1,247 @@
+import json
+import zipfile
+from pathlib import Path
+
+from gateway.file_intake import (
+    extract_if_supported,
+    get_file_record,
+    list_sources,
+    record_incoming_file,
+)
+
+
+def test_record_incoming_file_creates_manifest_and_source(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = tmp_path / "report.pdf"
+    payload.write_bytes(b"%PDF-1.4 fake")
+
+    rec = record_incoming_file(
+        cache_path=payload,
+        original_filename="report.pdf",
+        mime_type="application/pdf",
+        source_platform="telegram",
+        chat_id=100,
+        thread_id=200,
+        message_id=300,
+        user_id=400,
+        platform_file_id="file-id",
+        platform_unique_id="unique-id",
+    )
+
+    assert rec.sha256
+    assert rec.duplicate is False
+    assert rec.status == "received"
+    row = get_file_record(rec.sha256)
+    assert row["original_filename"] == "report.pdf"
+    assert row["mime_type"] == "application/pdf"
+    assert row["size_bytes"] == payload.stat().st_size
+    assert Path(row["artifact_dir"]).is_dir()
+    sources = list_sources(rec.sha256)
+    assert len(sources) == 1
+    assert sources[0]["source_platform"] == "telegram"
+    assert sources[0]["chat_id"] == "100"
+    assert sources[0]["message_id"] == "300"
+
+
+def test_record_incoming_file_dedups_content_but_keeps_provenance(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    p1 = tmp_path / "a.txt"
+    p2 = tmp_path / "b.txt"
+    p1.write_bytes(b"same bytes")
+    p2.write_bytes(b"same bytes")
+
+    first = record_incoming_file(cache_path=p1, original_filename="a.txt", source_platform="telegram", message_id=1)
+    second = record_incoming_file(cache_path=p2, original_filename="b.txt", source_platform="telegram", message_id=2)
+
+    assert first.sha256 == second.sha256
+    assert first.duplicate is False
+    assert second.duplicate is True
+    sources = list_sources(first.sha256)
+    assert [s["message_id"] for s in sources] == ["1", "2"]
+
+
+def _write_pptx(path: Path):
+    slide_xml = """
+    <p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+           xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+      <p:cSld><p:spTree><p:sp><p:txBody>
+        <a:p><a:r><a:t>Hello</a:t></a:r><a:r><a:t>world</a:t></a:r></a:p>
+      </p:txBody></p:sp></p:spTree></p:cSld>
+    </p:sld>
+    """
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("ppt/slides/slide1.xml", slide_xml)
+        zf.writestr("ppt/slides/slide2.xml", slide_xml.replace("Hello", "Second"))
+
+
+def test_extract_if_supported_writes_pptx_artifacts(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    pptx = tmp_path / "deck.pptx"
+    _write_pptx(pptx)
+
+    rec = record_incoming_file(
+        cache_path=pptx,
+        original_filename="deck.pptx",
+        mime_type="application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        source_platform="telegram",
+    )
+    extracted = extract_if_supported(rec, filename="deck.pptx", mime_type="application/vnd.openxmlformats-officedocument.presentationml.presentation")
+
+    assert extracted.status == "extracted"
+    text = Path(extracted.extracted_text_path).read_text(encoding="utf-8")
+    assert "Slides: 2" in text
+    assert "Hello world" in text
+    structure = json.loads(Path(extracted.structure_path).read_text(encoding="utf-8"))
+    assert structure["slide_count"] == 2
+    row = get_file_record(rec.sha256)
+    assert row["status"] == "extracted"
+    assert row["extracted_text_path"] == extracted.extracted_text_path
+
+
+def test_cleanup_keeps_extracted_manifest_file(tmp_path, monkeypatch):
+    import os
+    import time
+    from gateway.platforms.base import cleanup_document_cache, get_document_cache_dir
+    from gateway.file_intake import update_file_status
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "doc_cache")
+    cache_dir = get_document_cache_dir()
+    keep = cache_dir / "keep.pdf"
+    old = cache_dir / "old.pdf"
+    keep.write_bytes(b"keep")
+    old.write_bytes(b"old")
+
+    rec = record_incoming_file(cache_path=keep, original_filename="keep.pdf", source_platform="telegram")
+    update_file_status(rec.sha256, "extracted")
+
+    old_time = time.time() - 48 * 3600
+    os.utime(keep, (old_time, old_time))
+    os.utime(old, (old_time, old_time))
+
+    removed = cleanup_document_cache(max_age_hours=24)
+    assert removed == 1
+    assert keep.exists()
+    assert not old.exists()
+
+
+def _record_and_extract(tmp_path, filename, mime, writer, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    path = tmp_path / filename
+    writer(path)
+    rec = record_incoming_file(cache_path=path, original_filename=filename, mime_type=mime, source_platform="telegram")
+    return extract_if_supported(rec, filename=filename, mime_type=mime)
+
+
+def test_docx_extractor_writes_text(tmp_path, monkeypatch):
+    def writer(path):
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("word/document.xml", '<w:document xmlns:w="w"><w:body><w:p><w:r><w:t>Hello docx</w:t></w:r></w:p></w:body></w:document>')
+
+    rec = _record_and_extract(tmp_path, "doc.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", writer, monkeypatch)
+    assert rec.status == "extracted"
+    assert "Hello docx" in Path(rec.extracted_text_path).read_text(encoding="utf-8")
+
+
+def test_xlsx_extractor_writes_sheet_sample(tmp_path, monkeypatch):
+    def writer(path):
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("xl/sharedStrings.xml", '<sst xmlns="x"><si><t>Hello xlsx</t></si></sst>')
+            zf.writestr("xl/worksheets/sheet1.xml", '<worksheet xmlns="x"><sheetData><row><c t="s"><v>0</v></c></row></sheetData></worksheet>')
+
+    rec = _record_and_extract(tmp_path, "book.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", writer, monkeypatch)
+    assert rec.status == "extracted"
+    structure = json.loads(Path(rec.structure_path).read_text(encoding="utf-8"))
+    assert structure["sheet_count"] == 1
+    assert "Hello xlsx" in Path(rec.extracted_text_path).read_text(encoding="utf-8")
+
+
+def test_pdf_extractor_rejects_vulnerable_pypdf_before_import(tmp_path, monkeypatch):
+    from gateway import file_intake
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(file_intake, "_package_version", lambda name: "5.9.0")
+    path = tmp_path / "unsafe.pdf"
+    path.write_bytes(b"%PDF-1.4 fake")
+    rec = record_incoming_file(
+        cache_path=path,
+        original_filename="unsafe.pdf",
+        mime_type="application/pdf",
+        source_platform="telegram",
+    )
+
+    extracted = extract_if_supported(rec, filename="unsafe.pdf", mime_type="application/pdf")
+
+    assert extracted.status == "received"
+    row = get_file_record(rec.sha256)
+    assert row is not None
+    assert row["status"] == "failed_extract"
+    assert "pypdf 5.9.0" in row["error"]
+    assert ">=6.13.3,<7" in row["error"]
+
+
+def test_zip_inspector_rejects_zip_slip(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    path = tmp_path / "evil.zip"
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("../evil.txt", "bad")
+    rec = record_incoming_file(cache_path=path, original_filename="evil.zip", mime_type="application/zip", source_platform="telegram")
+
+    extracted = extract_if_supported(rec, filename="evil.zip", mime_type="application/zip")
+
+    assert extracted.status == "received"
+    row = get_file_record(rec.sha256)
+    assert row is not None
+    assert row["status"] == "failed_extract"
+    assert "unsafe archive member" in row["error"]
+
+
+def test_zip_inspector_writes_safe_manifest(tmp_path, monkeypatch):
+    def writer(path):
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("folder/file.txt", "hello")
+
+    rec = _record_and_extract(tmp_path, "safe.zip", "application/zip", writer, monkeypatch)
+    assert rec.status == "extracted"
+    structure = json.loads(Path(rec.structure_path).read_text(encoding="utf-8"))
+    assert structure["entry_count"] == 1
+    assert structure["entries"][0]["name"] == "folder/file.txt"
+
+
+def test_recent_files_and_context_note_and_semantic_card(tmp_path, monkeypatch):
+    from gateway.file_intake import (
+        build_intake_context_note,
+        build_semantic_file_card,
+        list_recent_files,
+        update_file_status,
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = tmp_path / "brief.txt"
+    payload.write_text("hello", encoding="utf-8")
+    rec = record_incoming_file(
+        cache_path=payload,
+        original_filename="brief.txt",
+        mime_type="text/plain",
+        source_platform="telegram",
+        chat_id="chat-1",
+        thread_id="thread-1",
+        message_id="msg-1",
+    )
+    extracted = Path(rec.artifact_dir) / "extracted.md"
+    extracted.write_text("# Brief\nhello", encoding="utf-8")
+    update_file_status(rec.sha256, "extracted", extracted_text_path=str(extracted))
+
+    recent = list_recent_files(source_platform="telegram", chat_id="chat-1", limit=5)
+    assert recent[0]["sha256"] == rec.sha256
+    assert recent[0]["message_id"] == "msg-1"
+
+    note = build_intake_context_note(payload)
+    assert rec.sha256 in note
+    assert "status=extracted" in note
+    assert str(extracted) in note
+
+    card = build_semantic_file_card(rec.sha256, summary="Short summary")
+    assert "# File intake: brief.txt" in card
+    assert "Short summary" in card
+    assert "No automatic Gbrain/Notion writeback" in card


### PR DESCRIPTION
## Summary

Adds bounded intake for user-uploaded archive-backed documents so Telegram attachments can be recorded, lightly extracted, and surfaced to the agent without unbounded ZIP/OOXML reads.

This PR keeps the capability at the gateway edge:

- records inbound document provenance in a profile-local SQLite manifest
- extracts lightweight text/structure artifacts for `.pptx`, `.docx`, `.xlsx`, `.zip`, and safe `pypdf` PDFs
- validates ZIP central-directory metadata before CRC checks or member reads
- enforces archive entry, compressed-byte, uncompressed-byte, member-byte, XML-member, and compression-ratio limits from `config.yaml`
- preserves extracted cached documents during document-cache cleanup
- adds document context metadata so the agent can see extraction artifact paths instead of asking users to paste the file contents

## Why

Incoming binary documents currently reach the agent as cached paths, but ZIP/OOXML formats need safe bounded handling before any extraction path can be trusted. Malformed or intentionally compressed archives can otherwise force unbounded decompression/memory use when an agent tries to inspect them.

## Safety notes

- ZIP member names are rejected if they are absolute paths, Windows-drive paths, or contain `.` / `..` path components.
- Archive bodies are only read through `read_zip_member()`, which streams with an explicit byte ceiling.
- Limits are in `gateway.file_intake` config, not new user-facing env vars.
- PDF extraction is disabled unless `pypdf` is in the known-safe `>=6.13.3,<7` window.
- Failed extraction records `failed_extract` and leaves the original cached file available; it does not break message delivery.

## Tests

- `python -m compileall -q archive_inspector.py gateway/file_intake.py hermes_cli/config.py plugins/platforms/telegram/adapter.py gateway/run.py gateway/platforms/base.py`
- `python -m pytest tests/gateway/test_file_intake.py tests/gateway/test_document_cache.py tests/gateway/test_telegram_group_gating.py -q -o 'addopts='`
- `python -m ruff check archive_inspector.py gateway/file_intake.py tests/gateway/test_file_intake.py gateway/platforms/base.py gateway/run.py plugins/platforms/telegram/adapter.py hermes_cli/config.py`
