### PR TITLE
fix(stt): wire stt.local.initial_prompt through to faster-whisper

### DIFF
--- a/tests/tools/test_stt_initial_prompt.py
+++ b/tests/tools/test_stt_initial_prompt.py
@@ -1,0 +1,110 @@
+"""Tests for stt.local.initial_prompt wiring in transcription_tools._transcribe_local.
+
+The `initial_prompt` parameter biases faster-whisper's vocabulary toward
+domain-specific terms (product names, technical jargon, etc.). This test
+asserts the config-driven wiring:
+
+  - stt.local.initial_prompt set in config.yaml  -> passed to transcribe()
+  - stt.local.initial_prompt unset               -> omitted (not None)
+
+We don't run a real model — we monkeypatch the WhisperModel on
+``tools.transcription_tools`` so we can capture the kwargs dict and
+assert on it. Faster-whisper is the heavy lift; the wiring is the
+lightweight contract this test guards.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def _reload_with_config(tmp_path, monkeypatch, stt_local_cfg):
+    """Spin up a hermes_home with a given stt.local config, import the module."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.dump({"stt": {"enabled": True, "local": stt_local_cfg}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    # Drop any cached import so _load_stt_config re-reads from disk.
+    for mod in list(sys.modules):
+        if mod == "tools.transcription_tools" or mod.startswith("tools.transcription_tools."):
+            del sys.modules[mod]
+
+    import tools.transcription_tools as tt  # noqa: WPS433 - intentional import after sys.path setup
+    return tt
+
+
+def test_initial_prompt_passed_when_set(tmp_path, monkeypatch):
+    tt = _reload_with_config(
+        tmp_path,
+        monkeypatch,
+        {"model": "base", "language": "de", "initial_prompt": "DeepSeek, MiMo, MiniMax"},
+    )
+
+    # Stub the slower bits: model load + transcribe call.
+    fake_model = MagicMock()
+    fake_model.transcribe.return_value = ([MagicMock(text="ok")], MagicMock(language="de", language_probability=1.0))
+    tt._local_model = fake_model
+    tt._local_model_name = "base"
+
+    result = tt._transcribe_local("/tmp/fake.ogg", model_name="base")
+    assert result["success"] is True
+
+    # The decisive assertion: transcribe() was called with initial_prompt kwarg.
+    fake_model.transcribe.assert_called_once()
+    _args, kwargs = fake_model.transcribe.call_args
+    assert kwargs.get("initial_prompt") == "DeepSeek, MiMo, MiniMax"
+    assert kwargs.get("language") == "de"
+
+
+def test_initial_prompt_omitted_when_unset(tmp_path, monkeypatch):
+    tt = _reload_with_config(
+        tmp_path,
+        monkeypatch,
+        {"model": "base", "language": "de"},
+    )
+
+    fake_model = MagicMock()
+    fake_model.transcribe.return_value = ([MagicMock(text="ok")], MagicMock(language="de", language_probability=1.0))
+    tt._local_model = fake_model
+    tt._local_model_name = "base"
+
+    result = tt._transcribe_local("/tmp/fake.ogg", model_name="base")
+    assert result["success"] is True
+
+    fake_model.transcribe.assert_called_once()
+    _args, kwargs = fake_model.transcribe.call_args
+    # No initial_prompt key when config doesn't set it.
+    assert "initial_prompt" not in kwargs
+    assert kwargs.get("language") == "de"
+
+
+def test_initial_prompt_omitted_when_empty_string(tmp_path, monkeypatch):
+    """Empty string is treated as 'unset' (whisper's own None == empty contract)."""
+    tt = _reload_with_config(
+        tmp_path,
+        monkeypatch,
+        {"model": "base", "initial_prompt": ""},
+    )
+
+    fake_model = MagicMock()
+    fake_model.transcribe.return_value = ([MagicMock(text="ok")], MagicMock(language="de", language_probability=1.0))
+    tt._local_model = fake_model
+    tt._local_model_name = "base"
+
+    tt._transcribe_local("/tmp/fake.ogg", model_name="base")
+
+    fake_model.transcribe.assert_called_once()
+    _args, kwargs = fake_model.transcribe.call_args
+    assert "initial_prompt" not in kwargs

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1128,14 +1128,21 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
             _local_model_name = model_name
 
         # Language: config.yaml (stt.local.language) > env var > auto-detect.
+        # Initial-prompt: config.yaml (stt.local.initial_prompt) — biases faster-whisper
+        # vocabulary toward domain-specific terms (product names, technical jargon, etc.).
+        # See: https://github.com/SYSTRAN/faster-whisper#initial_prompt
+        stt_local_cfg = _load_stt_config().get("local", {})
         _forced_lang = (
-            _load_stt_config().get("local", {}).get("language")
+            stt_local_cfg.get("language")
             or os.getenv(LOCAL_STT_LANGUAGE_ENV)
             or None
         )
+        _initial_prompt = stt_local_cfg.get("initial_prompt") or None
         transcribe_kwargs = {"beam_size": 5}
         if _forced_lang:
             transcribe_kwargs["language"] = _forced_lang
+        if _initial_prompt:
+            transcribe_kwargs["initial_prompt"] = _initial_prompt
 
         try:
             segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)


### PR DESCRIPTION
## Summary

`faster-whisper` exposes an `initial_prompt` kwarg that biases the model's
vocabulary toward domain-specific terms — useful for transcribing voice notes
that contain product names, technical jargon, or other words the default model
rarely sees in training (e.g. "DeepSeek", "MiMo", "Kicktipp", "Cronjobs").

Before this change, only `stt.local.language` was wired through from
`config.yaml` to the `transcribe()` call. `initial_prompt` was silently
ignored even when set, forcing users to either patch the code or accept
garbled transcripts of technical vocabulary.

This commit reads `stt.local.initial_prompt` from `config.yaml` and passes
it as the `initial_prompt` kwarg to faster-whisper's `transcribe()`. The
setting is optional and defaults to absent — existing configs are unaffected.

## Reproduction (before)

```yaml
# config.yaml
stt:
  provider: local
  local:
    model: large-v3
    language: de
    initial_prompt: "DeepSeek, MiMo, MiniMax, Kicktipp, Cronjobs"
```

User sends a voice note saying "schick mir den DeepSeek V4 Pro Tipp".
Transcribed result: "schick mir den **Debsig** V4 Pro Tipp".
The `initial_prompt` line in config is silently ignored.

After this fix, the same voice note transcribes correctly: "schick mir den
**DeepSeek** V4 Pro Tipp".

## Why this should merge

1. **Minimal blast radius** — 8 lines of core code, all additive.
2. **Backwards compatible** — `initial_prompt` defaults to absent; existing
   configs behave identically.
3. **Solves a real reported problem** — voice-to-text for technical vocab
   (model names, product names, internal jargon) is a recurring pain point.
4. **Mirrors existing `language` plumbing** — same config-yml pattern,
   same read order, same opt-in shape.
5. **Tests included** — three contracts: prompt set / unset / empty string.

## Test plan

- [x] `tests/tools/test_stt_initial_prompt.py` — 3 tests, all passing
- [x] Existing `tests/tools/test_transcription.py` — unchanged behavior
- [x] Manual E2E with `large-v3` and a domain-specific voice note:
  - Before: "Debsig", "Kick-Tip", "Conjobs"
  - After: "DeepSeek", "Kicktipp", "Cronjobs"

## AGENTS.md alignment

This change follows the project's "narrow waist" guidance:

- **No new core tool.** Uses existing `stt.local` config namespace.
- **No new `HERMES_*` env var.** All wiring is `config.yaml`-only, per the
  "reject PRs that tell users to set X in your .env" rule.
- **Extend, don't duplicate.** Reuses the existing `_load_stt_config()` /
  `_forced_lang` / `transcribe_kwargs` plumbing — no parallel code path.
- **Behavior contract tests, not snapshots.** Tests assert the kwarg-dict
  invariant (`initial_prompt` is present iff config sets it), not frozen
  model output.

Happy to address review feedback or split this into smaller commits if
preferred.