### PR TITLE
fix(test): pin monotonic clock in spinner-elapsed test to fix CI flake

### DIFF
--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -400,13 +400,20 @@ class TestCLIStatusBar:
         cli_obj = _make_cli()
         cli_obj._spinner_text = "running tool"
 
-        # <60s path
-        cli_obj._tool_start_time = time.monotonic() - 9.2
-        short = cli_obj._render_spinner_text()
+        # Pin the clock: time.monotonic()'s epoch is arbitrary (often near
+        # boot), so deriving _tool_start_time from the real monotonic clock
+        # made the test fail on hosts where monotonic() < 65.2 — the start
+        # time went negative, the (t0 > 0) guard in _render_spinner_text
+        # dropped the "(elapsed)" suffix entirely, and the split below hit an
+        # IndexError. A fixed clock keeps both elapsed paths deterministic.
+        with patch.object(cli_mod.time, "monotonic", return_value=1000.0):
+            # <60s path
+            cli_obj._tool_start_time = 1000.0 - 9.2
+            short = cli_obj._render_spinner_text()
 
-        # >=60s path
-        cli_obj._tool_start_time = time.monotonic() - 65.2
-        long = cli_obj._render_spinner_text()
+            # >=60s path
+            cli_obj._tool_start_time = 1000.0 - 65.2
+            long = cli_obj._render_spinner_text()
 
         short_elapsed = short.split("(", 1)[1].rstrip(")")
         long_elapsed = long.split("(", 1)[1].rstrip(")")


### PR DESCRIPTION
## Summary
Makes `test_spinner_elapsed_format_is_fixed_width_to_reduce_wrap_jitter` deterministic, fixing an intermittent CI failure (`IndexError: list index out of range`) in the Python test slices.

Root cause: the test derived `_tool_start_time` from the live clock (`time.monotonic() - 65.2` / `- 9.2`). `monotonic()`'s epoch is arbitrary — on a host where `monotonic()` returns less than 65.2 (a fresh test subprocess on a freshly-booted CI runner), the start time goes negative, the `t0 > 0` guard in `_render_spinner_text()` drops the `(elapsed)` suffix entirely, and `short.split("(", 1)[1]` raises `IndexError`. It's deterministic given a small clock, so it recurs rather than clearing on rerun.

## Changes
- `tests/cli/test_cli_status_bar.py`: pin `cli.time.monotonic` to a fixed `1000.0` via `patch.object` and offset `_tool_start_time` from it, so both the `<60s` and `>=60s` paths always render the elapsed suffix regardless of the runner's monotonic epoch.

## Validation
| | Before | After |
|---|---|---|
| `monotonic()` epoch < 65.2 | `t0` negative → no `(elapsed)` → IndexError | `t0 = 934.8`, always positive → suffix rendered |
| `tests/cli/test_cli_status_bar.py` | flaky (1 fail under loaded shard) | 45 passed, 0 failed |

Test-only change; no production code touched. Verified the failing condition reproduces under a small mocked monotonic clock and that the pinned clock eliminates it.

## Infographic

![the-clock-with-no-epoch](https://v3b.fal.media/files/b/0aa019bb/BxWhs5bzKrvLp5dBJVwpm_CvpP9y9g.png)
