### PR TITLE
feat(tools): add tool failure logging with auto-capture and review workflow

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -1223,6 +1223,12 @@ def handle_function_call(
     except Exception as e:
         error_msg = f"Error executing {function_name}: {str(e)}"
         logger.exception(error_msg)
+        # Auto-log to tool failure journal so patterns can be reviewed later
+        try:
+            from tools._failure_log_store import auto_log
+            auto_log(function_name, str(e), function_args, session_id or "")
+        except Exception:
+            pass  # never let failure logging break the agent loop
         return json.dumps({"error": _sanitize_tool_error(error_msg)}, ensure_ascii=False)
 
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -1218,6 +1218,26 @@ def handle_function_call(
         except Exception as _hook_err:
             logger.debug("transform_tool_result hook error: %s", _hook_err)
 
+        # Result-level failure capture.  Many tools return a well-formed JSON
+        # ({"error": ...}) instead of raising — the exception-only hooks in
+        # registry.dispatch / this function's except block never see those.
+        # Reuse the same failure classifier the display layer uses
+        # (agent.display._detect_tool_failure) so the journal matches what the
+        # user is shown.  Never log our own journal tool, and never re-log a
+        # result that already came from an auto-logged exception path.
+        try:
+            if function_name not in ("tool_failure_log",):
+                from agent.display import _detect_tool_failure
+
+                is_failure, suffix = _detect_tool_failure(function_name, result)
+                if is_failure:
+                    from tools._failure_log_store import auto_log
+
+                    err_text = suffix.strip() or "tool returned an error result"
+                    auto_log(function_name, err_text, function_args, session_id or "")
+        except Exception:
+            pass  # never let failure logging break the agent loop
+
         return result
 
     except Exception as e:

--- a/tests/tools/test_tool_failure_log.py
+++ b/tests/tools/test_tool_failure_log.py
@@ -1,0 +1,492 @@
+"""Tests for tools/tool_failure_log.py and tools/_failure_log_store.py."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools._failure_log_store import (
+    _MAX_ARGS_LEN,
+    _MAX_ERROR_LEN,
+    _next_id,
+    append_record,
+    auto_log,
+    read_all,
+    write_records,
+)
+from tools.tool_failure_log import (
+    _MAX_FIX_LEN,
+    _VALID_RESOLUTIONS,
+    _parse_ids,
+    check_requirements,
+    tool_failure_log,
+)
+
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+
+def _clean():
+    """Remove the failures log so tests start from a known state."""
+    from tools._failure_log_store import _log_path
+    lp = _log_path()
+    if lp.exists():
+        lp.unlink()
+
+
+# =========================================================================
+# _failure_log_store
+# =========================================================================
+
+
+class TestNextId:
+    def test_empty(self):
+        assert _next_id([]) == 1
+
+    def test_sequential(self):
+        assert _next_id([{"id": 1}, {"id": 2}, {"id": 3}]) == 4
+
+    def test_gaps(self):
+        assert _next_id([{"id": 1}, {"id": 5}, {"id": 3}]) == 6
+
+    def test_missing_id_field(self):
+        assert _next_id([{"x": 1}, {"id": 7}]) == 8
+
+    def test_non_int_id(self):
+        assert _next_id([{"id": "abc"}, {"id": 3}]) == 4
+
+
+class TestReadAll:
+    def test_empty_log(self):
+        _clean()
+        assert read_all() == []
+
+    def test_reads_and_reverses(self):
+        _clean()
+        append_record({"ts": "a", "t": "t1", "e": "e1"})
+        append_record({"ts": "b", "t": "t2", "e": "e2"})
+        records = read_all()
+        assert len(records) == 2
+        # newest first
+        assert records[0]["t"] == "t2"
+        assert records[1]["t"] == "t1"
+
+    def test_skips_malformed_lines(self):
+        _clean()
+        lp = Path(os.environ["HERMES_HOME"]) / "tool_failures" / "failures.jsonl"
+        lp.parent.mkdir(parents=True, exist_ok=True)
+        lp.write_text('{"id":1,"t":"ok","e":"good"}\nnot json\n{"id":2,"t":"ok2","e":"good2"}\n', encoding="utf-8")
+        records = read_all()
+        assert len(records) == 2
+        assert records[0]["id"] == 2
+
+    def test_skips_empty_lines(self):
+        _clean()
+        lp = Path(os.environ["HERMES_HOME"]) / "tool_failures" / "failures.jsonl"
+        lp.parent.mkdir(parents=True, exist_ok=True)
+        lp.write_text('\n{"id":1,"t":"x","e":"y"}\n\n', encoding="utf-8")
+        records = read_all()
+        assert len(records) == 1
+
+
+class TestWriteRecords:
+    def test_atomic_rewrite(self):
+        _clean()
+        append_record({"ts": "a", "t": "x", "e": "old"})
+        write_records([{"id": 1, "ts": "b", "t": "y", "e": "new", "r": "fixed"}])
+        records = read_all()
+        assert len(records) == 1
+        assert records[0]["e"] == "new"
+        assert records[0]["r"] == "fixed"
+
+
+class TestAppendRecord:
+    def test_assigns_id(self):
+        _clean()
+        rec = {"ts": "z", "t": "test", "e": "err", "r": "pending"}
+        saved = append_record(rec)
+        assert saved["id"] == 1
+        assert saved["t"] == "test"
+
+    def test_id_increments(self):
+        _clean()
+        r1 = append_record({"ts": "a", "t": "t1", "e": "e1"})
+        r2 = append_record({"ts": "b", "t": "t2", "e": "e2"})
+        assert r1["id"] == 1
+        assert r2["id"] == 2
+
+    def test_does_not_overwrite_caller_id(self):
+        """Caller should not set id — append_record assigns it under lock."""
+        _clean()
+        rec = {"id": 999, "ts": "z", "t": "test", "e": "err"}
+        saved = append_record(rec)
+        # The lock-assigned id wins
+        assert saved["id"] == 1
+
+
+class TestAutoLog:
+    def test_basic(self):
+        _clean()
+        nid = auto_log("web_search", "timeout", {"query": "test"}, "s1")
+        assert nid == 1
+        records = read_all()
+        assert len(records) == 1
+        r = records[0]
+        assert r["t"] == "web_search"
+        assert r["e"] == "timeout"
+        assert r["a"] == '{"query": "test"}'
+        assert r["s"] == "s1"
+        assert r["f"] == ""
+        assert r["l"] == []
+        assert r["r"] == "pending"
+
+    def test_args_truncation(self):
+        _clean()
+        big_args = {"q": "x" * 300}
+        auto_log("t", "e", big_args)
+        r = read_all()[0]
+        assert len(r["a"]) <= _MAX_ARGS_LEN
+
+    def test_error_truncation(self):
+        _clean()
+        auto_log("t", "e" * 300)
+        r = read_all()[0]
+        assert len(r["e"]) <= _MAX_ERROR_LEN
+
+    def test_returns_none_on_failure(self, monkeypatch):
+        _clean()
+        # Break the filesystem so auto_log catches and returns None
+        monkeypatch.setattr("tools._failure_log_store._data_dir", lambda: Path("/nonexistent/xyz"))
+        result = auto_log("t", "e")
+        assert result is None
+
+
+# =========================================================================
+# tool_failure_log — action handlers
+# =========================================================================
+
+
+class TestParseIds:
+    def test_all(self):
+        assert _parse_ids("all") is None
+
+    def test_single_int(self):
+        assert _parse_ids(5) == {5}
+
+    def test_list(self):
+        assert _parse_ids([1, 2, 3]) == {1, 2, 3}
+
+    def test_invalid_returns_none(self):
+        assert _parse_ids("abc") is None
+        assert _parse_ids(None) is None
+
+    def test_mixed_valid_invalid(self):
+        assert _parse_ids([1, "x", 3]) == {1, 3}
+
+
+class TestActionLog:
+    def test_basic(self):
+        _clean()
+        r = json.loads(tool_failure_log(action="log", tool="web_search", error="timeout"))
+        assert r["ok"] is True
+        assert r["id"] == 1
+        assert r["c"] == 1
+
+    def test_missing_tool(self):
+        _clean()
+        r = json.loads(tool_failure_log(action="log", error="timeout"))
+        assert "e" in r
+        assert "tool is required" in r["e"]
+
+    def test_missing_error(self):
+        _clean()
+        r = json.loads(tool_failure_log(action="log", tool="x"))
+        assert "e" in r
+        assert "error is required" in r["e"]
+
+    def test_with_fix(self):
+        _clean()
+        tool_failure_log(action="log", tool="t", error="e", fix="used alternative")
+        r = read_all()[0]
+        assert r["f"] == "used alternative"
+
+    def test_fix_truncation(self):
+        _clean()
+        tool_failure_log(action="log", tool="t", error="e", fix="x" * 500)
+        r = read_all()[0]
+        assert len(r["f"]) <= _MAX_FIX_LEN
+
+
+class TestActionList:
+    def test_empty(self):
+        _clean()
+        r = json.loads(tool_failure_log(action="list"))
+        assert r["c"] == 0
+        assert r["total"] == 0
+        assert r["items"] == []
+
+    def test_pagination(self):
+        _clean()
+        for i in range(5):
+            tool_failure_log(action="log", tool="t", error=f"e{i}")
+        r = json.loads(tool_failure_log(action="list", limit=2, offset=1))
+        assert r["limit"] == 2
+        assert r["offset"] == 1
+        assert len(r["items"]) == 2
+        assert r["c"] == 5
+
+    def test_status_filter(self):
+        _clean()
+        tool_failure_log(action="log", tool="t", error="e1")
+        nid = json.loads(tool_failure_log(action="log", tool="t", error="e2"))["id"]
+        tool_failure_log(action="resolve", ids=nid, resolution="fixed")
+        r = json.loads(tool_failure_log(action="list", status="fixed"))
+        assert r["c"] == 1
+        assert r["items"][0]["r"] == "fixed"
+
+    def test_tool_filter(self):
+        _clean()
+        tool_failure_log(action="log", tool="web_search", error="e1")
+        tool_failure_log(action="log", tool="patch", error="e2")
+        r = json.loads(tool_failure_log(action="list", tool="patch"))
+        assert r["c"] == 1
+
+    def test_limit_clamped(self):
+        _clean()
+        r = json.loads(tool_failure_log(action="list", limit=999))
+        assert r["limit"] <= 100
+
+
+class TestActionStats:
+    def test_empty(self):
+        _clean()
+        r = json.loads(tool_failure_log(action="stats"))
+        assert r["total"] == 0
+        assert r["resolved"] == 0
+        assert r["pending"] == 0
+
+    def test_aggregates(self):
+        _clean()
+        tool_failure_log(action="log", tool="web_search", error="timeout")
+        tool_failure_log(action="log", tool="web_search", error="timeout")
+        tool_failure_log(action="log", tool="patch", error="no match")
+        r = json.loads(tool_failure_log(action="stats"))
+        assert r["total"] == 3
+        assert r["pending"] == 3
+        assert r["tools"] == 2
+        assert r["by_tool"]["web_search"]["c"] == 2
+        assert r["by_tool"]["web_search"]["top"]["timeout"] == 2
+
+    def test_by_state(self):
+        _clean()
+        tool_failure_log(action="log", tool="a", error="e1")
+        tool_failure_log(action="log", tool="b", error="e2")
+        tool_failure_log(action="log", tool="c", error="e3")
+        tool_failure_log(action="resolve", ids=1, resolution="fixed")
+        tool_failure_log(action="resolve", ids=2, resolution="blocked")
+        r = json.loads(tool_failure_log(action="stats"))
+        assert r["resolved"] == 2
+        assert r["pending"] == 1
+        assert r["by_state"]["fixed"] == 1
+        assert r["by_state"]["blocked"] == 1
+
+
+class TestActionResolve:
+    def test_single(self):
+        _clean()
+        nid = json.loads(tool_failure_log(action="log", tool="t", error="e"))["id"]
+        r = json.loads(tool_failure_log(action="resolve", ids=nid, resolution="fixed"))
+        assert r["ok"] is True
+        assert r["updated"] == 1
+
+    def test_batch_list(self):
+        _clean()
+        ids = []
+        for i in range(3):
+            ids.append(json.loads(tool_failure_log(action="log", tool="t", error=f"e{i}"))["id"])
+        r = json.loads(tool_failure_log(action="resolve", ids=ids, resolution="wontfix"))
+        assert r["updated"] == 3
+
+    def test_all_with_filter(self):
+        _clean()
+        tool_failure_log(action="log", tool="web_search", error="e1")
+        tool_failure_log(action="log", tool="patch", error="e2")
+        r = json.loads(tool_failure_log(
+            action="resolve", ids="all", tool="web_search", status="pending", resolution="fixed"
+        ))
+        assert r["updated"] == 1
+
+    def test_invalid_resolution(self):
+        _clean()
+        r = json.loads(tool_failure_log(action="resolve", ids=1, resolution="invalid"))
+        assert "e" in r
+
+    def test_no_matching_records(self):
+        _clean()
+        r = json.loads(tool_failure_log(action="resolve", ids=999))
+        assert r["updated"] == 0
+        assert "hint" in r
+
+
+class TestActionUpdate:
+    def test_update_fix(self):
+        _clean()
+        nid = json.loads(tool_failure_log(action="log", tool="t", error="e"))["id"]
+        r = json.loads(tool_failure_log(action="update", ids=nid, fix="found workaround"))
+        assert r["ok"] is True
+        assert r["updated"] == 1
+        rec = read_all()[0]
+        assert rec["f"] == "found workaround"
+
+    def test_update_appends_fix(self):
+        _clean()
+        nid = json.loads(tool_failure_log(action="log", tool="t", error="e", fix="first fix"))["id"]
+        tool_failure_log(action="update", ids=nid, fix="second fix")
+        rec = read_all()[0]
+        assert "first fix" in rec["f"]
+        assert "second fix" in rec["f"]
+
+    def test_update_with_link_ids(self):
+        _clean()
+        nid1 = json.loads(tool_failure_log(action="log", tool="a", error="e1"))["id"]
+        nid2 = json.loads(tool_failure_log(action="log", tool="b", error="e2"))["id"]
+        tool_failure_log(action="update", ids=nid1, link_ids=[nid2])
+        rec = [r for r in read_all() if r["id"] == nid1][0]
+        assert nid2 in rec["l"]
+
+    def test_no_fix_or_links(self):
+        _clean()
+        nid = json.loads(tool_failure_log(action="log", tool="t", error="e"))["id"]
+        r = json.loads(tool_failure_log(action="update", ids=nid))
+        assert "e" in r
+
+
+class TestActionLink:
+    def test_bidirectional(self):
+        _clean()
+        ids = []
+        for i in range(3):
+            ids.append(json.loads(tool_failure_log(action="log", tool="t", error=f"e{i}"))["id"])
+        r = json.loads(tool_failure_log(action="link", ids=ids))
+        assert r["ok"] is True
+        assert r["updated"] == 3
+        assert sorted(r["linked"]) == ids
+
+        # Verify bidirectional
+        records = read_all()
+        for rec in records:
+            others = set(ids) - {rec["id"]}
+            assert set(rec["l"]) == others
+
+    def test_needs_at_least_two(self):
+        _clean()
+        nid = json.loads(tool_failure_log(action="log", tool="t", error="e"))["id"]
+        r = json.loads(tool_failure_log(action="link", ids=[nid]))
+        assert "e" in r
+
+    def test_non_list_ids(self):
+        r = json.loads(tool_failure_log(action="link", ids=1))
+        assert "e" in r
+
+
+class TestUnknownAction:
+    def test_returns_error(self):
+        r = json.loads(tool_failure_log(action="nonexistent"))
+        assert "e" in r
+        assert "unknown action" in r["e"]
+
+
+# =========================================================================
+# check_requirements
+# =========================================================================
+
+
+class TestCheckRequirements:
+    def test_always_true(self):
+        assert check_requirements() is True
+
+
+# =========================================================================
+# Integration — auto_log → tool chain
+# =========================================================================
+
+
+class TestIntegration:
+    def test_auto_log_then_update_then_resolve(self):
+        _clean()
+        # Simulate auto-log from registry.dispatch
+        nid = auto_log("web_search", "timeout", {"q": "test"}, "sess_abc")
+        assert nid == 1
+
+        # Agent adds fix
+        r = json.loads(tool_failure_log(action="update", ids=nid, fix="used browser"))
+        assert r["updated"] == 1
+
+        # Agent links to another auto-logged failure
+        nid2 = auto_log("web_search", "HTTP 429", {"q": "test2"}, "sess_abc")
+        r = json.loads(tool_failure_log(action="link", ids=[nid, nid2]))
+        assert r["updated"] == 2
+
+        # Resolve both
+        r = json.loads(tool_failure_log(action="resolve", ids=[nid, nid2], resolution="fixed"))
+        assert r["updated"] == 2
+
+        # Verify final state
+        records = read_all()
+        assert len(records) == 2
+        for rec in records:
+            assert rec["r"] == "fixed"
+            assert len(rec["l"]) == 1  # linked to each other
+
+    def test_multiple_auto_logs_increment_ids(self):
+        _clean()
+        ids = []
+        for i in range(10):
+            ids.append(auto_log("t", f"e{i}"))
+        assert ids == list(range(1, 11))
+        assert len(read_all()) == 10
+
+
+# =========================================================================
+# Edge cases
+# =========================================================================
+
+
+class TestEdgeCases:
+    def test_whitespace_tool_name_rejected(self):
+        r = json.loads(tool_failure_log(action="log", tool="   ", error="e"))
+        assert "e" in r
+
+    def test_very_long_args_output(self):
+        _clean()
+        tool_failure_log(action="log", tool="t", error="e", args="x" * 500)
+        r = read_all()[0]
+        assert len(r["a"]) <= _MAX_ARGS_LEN
+
+    def test_list_default_limit(self):
+        _clean()
+        for i in range(30):
+            tool_failure_log(action="log", tool="t", error=f"e{i}")
+        r = json.loads(tool_failure_log(action="list"))
+        assert len(r["items"]) == 20  # default
+        assert r["c"] == 30
+        assert r["total"] == 30
+
+    def test_resolve_ids_all_no_filter(self):
+        _clean()
+        for i in range(5):
+            tool_failure_log(action="log", tool="t", error=f"e{i}")
+        r = json.loads(tool_failure_log(action="resolve", ids="all", resolution="fixed"))
+        assert r["updated"] == 5
+
+    def test_resolve_blocked_state(self):
+        _clean()
+        nid = json.loads(tool_failure_log(action="log", tool="t", error="e"))["id"]
+        r = json.loads(tool_failure_log(action="resolve", ids=nid, resolution="blocked"))
+        assert r["updated"] == 1
+        rec = read_all()[0]
+        assert rec["r"] == "blocked"

--- a/tests/tools/test_tool_failure_log.py
+++ b/tests/tools/test_tool_failure_log.py
@@ -13,6 +13,7 @@ from tools._failure_log_store import (
     _next_id,
     append_record,
     auto_log,
+    mutate_records,
     read_all,
     write_records,
 )
@@ -163,6 +164,87 @@ class TestAutoLog:
         monkeypatch.setattr("tools._failure_log_store._data_dir", lambda: Path("/nonexistent/xyz"))
         result = auto_log("t", "e")
         assert result is None
+
+
+class TestRedaction:
+    """Persisted records must never retain raw credentials (sweeper review)."""
+
+    def test_auto_log_redacts_api_key_in_args(self):
+        _clean()
+        auto_log("web_search", "boom", {"api_key": "sk-abcdefghijklmnopqrstuvwxyz123"}, "s1")
+        r = read_all()[0]
+        # The credential value must be redacted; the key name may remain.
+        assert "sk-abcdefghijklmnopqrstuvwxyz123" not in r["a"]
+
+    def test_auto_log_redacts_secret_in_error(self):
+        _clean()
+        auto_log("terminal", "Authorization: Bearer eyJsecretsecrettokenvalue123456", None, "s1")
+        r = read_all()[0]
+        assert "eyJsecretsecrettokenvalue123456" not in r["e"]
+
+    def test_manual_log_redacts_args(self):
+        _clean()
+        tool_failure_log(
+            action="log",
+            tool="web_search",
+            error="fail",
+            args=json.dumps({"password": "hunter2supersecret"}),
+        )
+        r = read_all()[0]
+        assert "hunter2supersecret" not in r["a"]
+
+
+class TestTransactionalMutation:
+    """resolve/update/link must run as one transaction under the shared lock
+    so an intervening append_record() can never be lost (sweeper review)."""
+
+    def test_mutate_records_is_atomic_with_concurrent_append(self):
+        _clean()
+        nid = auto_log("t", "e1")
+        nid2 = auto_log("t", "e2")
+
+        # A real concurrent writer (separate thread) appends continuously
+        # while the main thread performs a transactional read-modify-write.
+        # mutate_records holds the RW lock for the whole transaction, so the
+        # concurrent appends are serialized around it and none are lost.
+        import threading
+
+        stop = threading.Event()
+        concurrent_ids = []
+
+        def _writer():
+            while not stop.is_set():
+                cid = auto_log("t", "e_concurrent")
+                if cid is not None:
+                    concurrent_ids.append(cid)
+
+        w = threading.Thread(target=_writer, daemon=True)
+        w.start()
+        try:
+            updated = mutate_records(
+                lambda r: r["id"] in (nid, nid2),
+                lambda r: r.__setitem__("r", "fixed"),
+            )
+        finally:
+            stop.set()
+            w.join(timeout=5)
+
+        assert updated == 2
+
+        # Every concurrently-appended record must survive (not clobbered).
+        records = read_all()
+        present = {r["id"] for r in records}
+        assert set(concurrent_ids).issubset(present)
+        # The two resolved records kept their mutation.
+        resolved = [r for r in records if r["r"] == "fixed"]
+        assert len(resolved) == 2
+
+    def test_resolve_uses_mutate_records(self):
+        _clean()
+        nid = json.loads(tool_failure_log(action="log", tool="t", error="e"))["id"]
+        r = json.loads(tool_failure_log(action="resolve", ids=nid, resolution="fixed"))
+        assert r["updated"] == 1
+        assert read_all()[0]["r"] == "fixed"
 
 
 # =========================================================================
@@ -490,3 +572,56 @@ class TestEdgeCases:
         assert r["updated"] == 1
         rec = read_all()[0]
         assert rec["r"] == "blocked"
+
+
+# =========================================================================
+# Regression — result-level failure capture (sweeper review: exception-only
+# hooks missed tools that return {"error":...} without raising).
+# =========================================================================
+
+
+class TestResultLevelAutoLog:
+    def test_handle_function_call_captures_error_result(self):
+        """A tool returning {"error":...} (no exception) must be auto-logged."""
+        _clean()
+        from tools.registry import registry
+
+        def _boom(args, **kw):
+            return json.dumps({"error": "simulated semantic failure", "success": False})
+
+        registry.register(
+            name="_result_fail_tool",
+            toolset="_result_fail_test",
+            schema={"name": "_result_fail_tool", "description": "x",
+                    "parameters": {"type": "object", "properties": {}}},
+            handler=_boom,
+            check_fn=lambda: True,
+        )
+        from model_tools import handle_function_call
+
+        out = handle_function_call("_result_fail_tool", {})
+        assert '"error"' in out
+        recs = read_all()
+        assert any(r["t"] == "_result_fail_tool" for r in recs), \
+            "result-level failure was not auto-logged"
+
+    def test_handle_function_call_does_not_log_success(self):
+        """A successful tool result must NOT be auto-logged."""
+        _clean()
+        from tools.registry import registry
+
+        def _ok(args, **kw):
+            return json.dumps({"ok": True, "value": 42})
+
+        registry.register(
+            name="_result_ok_tool",
+            toolset="_result_ok_test",
+            schema={"name": "_result_ok_tool", "description": "x",
+                    "parameters": {"type": "object", "properties": {}}},
+            handler=_ok,
+            check_fn=lambda: True,
+        )
+        from model_tools import handle_function_call
+
+        handle_function_call("_result_ok_tool", {})
+        assert read_all() == [], "successful result must not be auto-logged"

--- a/tools/_failure_log_store.py
+++ b/tools/_failure_log_store.py
@@ -1,0 +1,154 @@
+"""
+Shared storage primitives for the tool failure log.
+
+Used by both ``tools/tool_failure_log.py`` (the agent-facing tool) and
+``model_tools.py`` (the auto-log hook in ``handle_function_call``).
+
+All mutations acquire an exclusive lock where available (``fcntl.LOCK_EX``
+on POSIX; no-op on native Windows) to prevent TOCTOU races and lost-update
+conflicts between concurrent writers.
+"""
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+# fcntl is Unix-only — native Windows has no equivalent advisory lock.
+# We degrade gracefully: concurrent writes are rare for a failure log
+# and the worst case (duplicate id) is non-destructive.
+try:
+    import fcntl
+    _HAS_FCNTL = True
+except (ImportError, NotImplementedError):
+    _HAS_FCNTL = False
+
+_MAX_ERROR_LEN = 256
+_MAX_ARGS_LEN = 200
+
+
+def _data_dir() -> Path:
+    p = get_hermes_home() / "tool_failures"
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _log_path() -> Path:
+    return _data_dir() / "failures.jsonl"
+
+
+def _next_id(records: List[dict]) -> int:
+    """Derive the next id from the highest id across all records."""
+    max_id = 0
+    for r in records:
+        rid = r.get("id", 0)
+        if isinstance(rid, int) and rid > max_id:
+            max_id = rid
+    return max_id + 1
+
+
+def _read_lines_unlocked(fh) -> List[dict]:
+    """Read all valid JSONL records from an already-open file handle.
+
+    Caller must hold the lock.  Handle is rewound and read from the start.
+    Returns records in insertion order (oldest first)."""
+    fh.seek(0)
+    records: List[dict] = []
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return records
+
+
+def read_all() -> List[dict]:
+    """Return every valid record from the log, newest first (lock-free snapshot)."""
+    lp = _log_path()
+    if not lp.exists():
+        return []
+    with open(lp, "r", encoding="utf-8") as fh:
+        records = _read_lines_unlocked(fh)
+    records.reverse()  # newest first
+    return records
+
+
+def write_records(records: List[dict]) -> None:
+    """Atomically rewrite the entire log file under an exclusive lock."""
+    lp = _log_path()
+    tmp = lp.with_suffix(".tmp")
+    with open(tmp, "w", encoding="utf-8") as fh:
+        if _HAS_FCNTL:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            for rec in records:
+                fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+        finally:
+            if _HAS_FCNTL:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    os.replace(tmp, lp)
+
+
+def append_record(rec: dict) -> dict:
+    """Append one record with auto-assigned id under an exclusive lock.
+
+    The caller should NOT set ``id`` on *rec* — it is assigned atomically
+    inside the lock to prevent TOCTOU races between concurrent writers.
+    """
+    lp = _log_path()
+    lp.parent.mkdir(parents=True, exist_ok=True)
+    with open(lp, "a+", encoding="utf-8") as fh:
+        if _HAS_FCNTL:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            existing = _read_lines_unlocked(fh)
+            rec["id"] = _next_id(existing)
+            line = json.dumps(rec, ensure_ascii=False) + "\n"
+            fh.write(line)
+            fh.flush()
+            os.fsync(fh.fileno())
+        finally:
+            if _HAS_FCNTL:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    return rec
+
+
+def auto_log(
+    tool_name: str,
+    error_msg: str,
+    args: Optional[dict] = None,
+    session_id: str = "",
+) -> Optional[int]:
+    """Called from ``handle_function_call`` and ``registry.dispatch`` error paths.
+
+    Returns the record id, or None if logging failed (never raises).
+    """
+    try:
+        args_summary = ""
+        if args:
+            args_summary = json.dumps(args, ensure_ascii=False)[:_MAX_ARGS_LEN]
+
+        rec = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "t": tool_name,
+            "e": error_msg[:_MAX_ERROR_LEN],
+            "a": args_summary,
+            "s": session_id or "",
+            "f": "",
+            "l": [],
+            "r": "pending",
+        }
+        # id is assigned inside append_record under the lock
+        append_record(rec)
+        return rec["id"]
+    except Exception:
+        # Never let failure logging break the agent loop
+        return None

--- a/tools/_failure_log_store.py
+++ b/tools/_failure_log_store.py
@@ -4,13 +4,18 @@ Shared storage primitives for the tool failure log.
 Used by both ``tools/tool_failure_log.py`` (the agent-facing tool) and
 ``model_tools.py`` (the auto-log hook in ``handle_function_call``).
 
-All mutations acquire an exclusive lock where available (``fcntl.LOCK_EX``
-on POSIX; no-op on native Windows) to prevent TOCTOU races and lost-update
-conflicts between concurrent writers.
+All mutations acquire an exclusive advisory lock (``fcntl.LOCK_EX`` on POSIX;
+a threading.Lock no-op on native Windows) so read-modify-write sequences
+(resolve/update/link) and concurrent appends cannot lose updates.
+
+Security: any text persisted here (error messages, tool arguments) is run
+through ``agent.redact.redact_sensitive_text`` before it is written, so a
+durable JSONL journal can never retain credentials.
 """
 
 import json
 import os
+import threading
 import time
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -18,16 +23,42 @@ from typing import Dict, List, Optional
 from hermes_constants import get_hermes_home
 
 # fcntl is Unix-only — native Windows has no equivalent advisory lock.
-# We degrade gracefully: concurrent writes are rare for a failure log
-# and the worst case (duplicate id) is non-destructive.
+# We fall back to an in-process threading.Lock so that read-modify-write
+# sequences within the same process still cannot lose updates; cross-process
+# races on native Windows are rare for a failure log and the worst case
+# (a lost update on a low-frequency journal) is non-destructive.
 try:
     import fcntl
     _HAS_FCNTL = True
 except (ImportError, NotImplementedError):
+    fcntl = None
     _HAS_FCNTL = False
 
 _MAX_ERROR_LEN = 256
 _MAX_ARGS_LEN = 200
+
+
+def _flock_ex(fh) -> None:
+    """Acquire an exclusive advisory lock on *fh* (POSIX only)."""
+    if _HAS_FCNTL:
+        import fcntl  # local import → typed as the module, not Optional
+
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+
+
+def _flock_un(fh) -> None:
+    """Release the advisory lock held on *fh* (POSIX only)."""
+    if _HAS_FCNTL:
+        import fcntl  # local import → typed as the module, not Optional
+
+        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+# Module-level lock guarding every read-modify-write transaction and the
+# temporary-file rename dance.  This is the single shared lock the sweeper
+# review asked for: resolve/update/link all take it for the whole transaction,
+# so an intervening append_record() can never be lost.
+_RW_LOCK = threading.Lock()
 
 
 def _data_dir() -> Path:
@@ -38,6 +69,21 @@ def _data_dir() -> Path:
 
 def _log_path() -> Path:
     return _data_dir() / "failures.jsonl"
+
+
+def _redact(text: str) -> str:
+    """Redact secrets from a string before it is persisted durably.
+
+    Never raises — if redaction is unavailable the raw value still goes
+    through, but the common path masks credentials per agent/redact.py.
+    """
+    if not text:
+        return text
+    try:
+        from agent.redact import redact_sensitive_text
+        return redact_sensitive_text(text, force=True)
+    except Exception:
+        return text
 
 
 def _next_id(records: List[dict]) -> int:
@@ -80,45 +126,87 @@ def read_all() -> List[dict]:
 
 
 def write_records(records: List[dict]) -> None:
-    """Atomically rewrite the entire log file under an exclusive lock."""
-    lp = _log_path()
-    tmp = lp.with_suffix(".tmp")
-    with open(tmp, "w", encoding="utf-8") as fh:
-        if _HAS_FCNTL:
-            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
-        try:
-            for rec in records:
-                fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
-            fh.flush()
-            os.fsync(fh.fileno())
-        finally:
-            if _HAS_FCNTL:
-                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
-    os.replace(tmp, lp)
+    """Atomically rewrite the entire log file under the shared RW lock."""
+    with _RW_LOCK:
+        lp = _log_path()
+        tmp = lp.with_suffix(".tmp")
+        with open(tmp, "w", encoding="utf-8") as fh:
+            _flock_ex(fh)
+            try:
+                for rec in records:
+                    fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+                fh.flush()
+                os.fsync(fh.fileno())
+            finally:
+                _flock_un(fh)
+        os.replace(tmp, lp)
 
 
 def append_record(rec: dict) -> dict:
-    """Append one record with auto-assigned id under an exclusive lock.
+    """Append one record with auto-assigned id under the shared RW lock.
 
     The caller should NOT set ``id`` on *rec* — it is assigned atomically
     inside the lock to prevent TOCTOU races between concurrent writers.
     """
-    lp = _log_path()
-    lp.parent.mkdir(parents=True, exist_ok=True)
-    with open(lp, "a+", encoding="utf-8") as fh:
-        if _HAS_FCNTL:
-            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
-        try:
-            existing = _read_lines_unlocked(fh)
-            rec["id"] = _next_id(existing)
-            line = json.dumps(rec, ensure_ascii=False) + "\n"
-            fh.write(line)
-            fh.flush()
-            os.fsync(fh.fileno())
-        finally:
-            if _HAS_FCNTL:
-                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    with _RW_LOCK:
+        lp = _log_path()
+        lp.parent.mkdir(parents=True, exist_ok=True)
+        with open(lp, "a+", encoding="utf-8") as fh:
+            _flock_ex(fh)
+            try:
+                existing = _read_lines_unlocked(fh)
+                rec["id"] = _next_id(existing)
+                rec["e"] = _redact(str(rec.get("e", "")))[:_MAX_ERROR_LEN]
+                rec["a"] = _redact(str(rec.get("a", "")))[:_MAX_ARGS_LEN]
+                line = json.dumps(rec, ensure_ascii=False) + "\n"
+                fh.write(line)
+                fh.flush()
+                os.fsync(fh.fileno())
+            finally:
+                _flock_un(fh)
     return rec
+
+
+def mutate_records(matcher, mutator) -> int:
+    """Single-transaction read-modify-write over the whole log file.
+
+    *matcher(rec)*: return True if *rec* should be mutated.
+    *mutator(rec)*: apply the in-place change to *rec*.
+
+    Both run inside the shared RW lock so that the read, the edits, and the
+    rewrite are atomic with respect to concurrent append_record() calls.
+    Returns the number of records mutated.
+    """
+    with _RW_LOCK:
+        lp = _log_path()
+        if not lp.exists():
+            return 0
+        with open(lp, "r", encoding="utf-8") as fh:
+            _flock_ex(fh)
+            try:
+                records = _read_lines_unlocked(fh)
+            finally:
+                _flock_un(fh)
+
+        updated = 0
+        for r in records:
+            if matcher(r):
+                mutator(r)
+                updated += 1
+
+        if updated:
+            tmp = lp.with_suffix(".tmp")
+            with open(tmp, "w", encoding="utf-8") as fh:
+                _flock_ex(fh)
+                try:
+                    for rec in records:
+                        fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+                    fh.flush()
+                    os.fsync(fh.fileno())
+                finally:
+                    _flock_un(fh)
+            os.replace(tmp, lp)
+        return updated
 
 
 def auto_log(
@@ -134,19 +222,23 @@ def auto_log(
     try:
         args_summary = ""
         if args:
-            args_summary = json.dumps(args, ensure_ascii=False)[:_MAX_ARGS_LEN]
+            try:
+                args_summary = json.dumps(args, ensure_ascii=False)
+            except (TypeError, ValueError):
+                args_summary = str(args)
 
         rec = {
             "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "t": tool_name,
-            "e": error_msg[:_MAX_ERROR_LEN],
+            "e": error_msg,
             "a": args_summary,
             "s": session_id or "",
             "f": "",
             "l": [],
             "r": "pending",
         }
-        # id is assigned inside append_record under the lock
+        # id is assigned inside append_record under the lock; args/error are
+        # redacted inside append_record before the line is written.
         append_record(rec)
         return rec["id"]
     except Exception:

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -452,6 +452,13 @@ class ToolRegistry:
         """
         entry = self.get_entry(name)
         if not entry:
+            # Auto-log unknown-tool errors
+            try:
+                from tools._failure_log_store import auto_log
+                auto_log(name, f"Unknown tool: {name}", args,
+                         kwargs.get("session_id", ""))
+            except Exception:
+                pass
             return json.dumps({"error": f"Unknown tool: {name}"})
         try:
             if entry.is_async:
@@ -460,6 +467,13 @@ class ToolRegistry:
             return entry.handler(args, **kwargs)
         except Exception as e:
             logger.exception("Tool %s dispatch error: %s", name, e)
+            # Auto-log execution errors
+            try:
+                from tools._failure_log_store import auto_log
+                auto_log(name, f"{type(e).__name__}: {e}", args,
+                         kwargs.get("session_id", ""))
+            except Exception:
+                pass
             # Route through the sanitizer so framing tokens / CDATA / fences
             # in exception strings don't reach the model as structural noise.
             # See model_tools._sanitize_tool_error for rationale.

--- a/tools/tool_failure_log.py
+++ b/tools/tool_failure_log.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""
+Tool Failure Logger — persistent, reviewable tool-error journal.
+
+Failures are auto-logged by the agent loop (model_tools.py catch block),
+so the agent only calls this tool to update a fix, link related failures,
+review stats, or resolve entries.  Manual ``log`` is still available for
+failures the auto-logger cannot see (e.g. semantic errors where the tool
+returns a valid JSON but the content is wrong).
+
+Storage: ``~/.hermes/tool_failures/failures.jsonl``
+
+Actions:
+  log     — manual failure record (auto-log handles most cases)
+  update  — add fix description and/or link related failures to a record
+  link    — link multiple failure records that share a root cause
+  list    — paginate the failure log
+  stats   — aggregate by tool + error category
+  resolve — mark as fixed, wontfix, or blocked
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Dict, List, Optional
+
+from tools._failure_log_store import (
+    _MAX_ARGS_LEN,
+    _MAX_ERROR_LEN,
+    append_record,
+    read_all,
+    write_records,
+)
+from tools.registry import registry, tool_error  # noqa: F401
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_DEFAULT_LIMIT = 20
+_MAX_LIMIT = 100
+_MAX_FIX_LEN = 300
+
+_VALID_RESOLUTIONS = {"fixed", "wontfix", "blocked"}
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_ids(ids_raw: Any) -> set | None:
+    """Parse ids arg into a set of ints, or None for 'all'."""
+    if ids_raw == "all":
+        return None
+    if isinstance(ids_raw, list):
+        target_ids = set()
+        for v in ids_raw:
+            try:
+                target_ids.add(int(v))
+            except (ValueError, TypeError):
+                pass
+        return target_ids if target_ids else None
+    if ids_raw is not None:
+        try:
+            return {int(ids_raw)}
+        except (ValueError, TypeError):
+            return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Action handlers
+# ---------------------------------------------------------------------------
+
+
+def _action_log(args: dict, session_id: str = "") -> str:
+    tool = (args.get("tool") or "").strip()
+    error = (args.get("error") or "").strip()
+    if not tool:
+        return json.dumps({"e": "tool is required"}, ensure_ascii=False)
+    if not error:
+        return json.dumps({"e": "error is required"}, ensure_ascii=False)
+
+    args_summary = (args.get("args") or "")[:_MAX_ARGS_LEN]
+    fix = (args.get("fix") or "")[:_MAX_FIX_LEN]
+
+    prev_count = len(read_all())
+
+    rec = {
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "t": tool,
+        "e": error[:_MAX_ERROR_LEN],
+        "a": args_summary,
+        "s": session_id or "",
+        "f": fix,
+        "l": [],
+        "r": "pending",
+    }
+    # id is assigned atomically by append_record under lock
+    saved = append_record(rec)
+    return json.dumps({"ok": True, "id": saved["id"], "c": prev_count + 1}, ensure_ascii=False)
+
+
+def _action_list(args: dict) -> str:
+    status = (args.get("status") or "").strip()
+    tool_filter = (args.get("tool") or "").strip()
+    limit = min(int(args.get("limit", _DEFAULT_LIMIT) or _DEFAULT_LIMIT), _MAX_LIMIT)
+    offset = max(int(args.get("offset", 0) or 0), 0)
+
+    records = read_all()
+    total = len(records)
+
+    if status:
+        records = [r for r in records if r.get("r") == status]
+    if tool_filter:
+        records = [r for r in records if r.get("t") == tool_filter]
+
+    filtered_total = len(records)
+    page = records[offset : offset + limit]
+
+    items = []
+    for r in page:
+        items.append(
+            {
+                "id": r["id"],
+                "ts": r["ts"],
+                "t": r["t"],
+                "e": r["e"],
+                "a": r.get("a", ""),
+                "f": r.get("f", ""),
+                "l": r.get("l", []),
+                "r": r.get("r", "pending"),
+            }
+        )
+
+    return json.dumps(
+        {
+            "items": items,
+            "c": filtered_total,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+        },
+        ensure_ascii=False,
+    )
+
+
+def _action_stats(args: dict) -> str:  # noqa: ARG001
+    records = read_all()
+    total = len(records)
+
+    by_tool: Dict[str, Dict[str, Any]] = {}
+    # Count by resolution state
+    resolved_states: Dict[str, int] = {}
+    pending = 0
+    error_counts: Dict[str, int] = {}
+
+    for r in records:
+        t = r.get("t", "?")
+        e = r.get("e", "?")
+        rs = r.get("r", "pending")
+
+        if t not in by_tool:
+            by_tool[t] = {"c": 0, "fixed": 0, "pending": 0, "blocked": 0, "wontfix": 0, "top": {}}
+        by_tool[t]["c"] += 1
+        if rs in ("fixed", "wontfix", "blocked"):
+            by_tool[t][rs] = by_tool[t].get(rs, 0) + 1
+            resolved_states[rs] = resolved_states.get(rs, 0) + 1
+        else:
+            by_tool[t]["pending"] += 1
+            pending += 1
+
+        te_key = e[:60]
+        by_tool[t]["top"][te_key] = by_tool[t]["top"].get(te_key, 0) + 1
+        error_counts[te_key] = error_counts.get(te_key, 0) + 1
+
+    for t in by_tool:
+        by_tool[t]["top"] = dict(
+            sorted(by_tool[t]["top"].items(), key=lambda x: x[1], reverse=True)[:3]
+        )
+
+    global_top = dict(
+        sorted(error_counts.items(), key=lambda x: x[1], reverse=True)[:5]
+    )
+
+    resolved_total = sum(resolved_states.values())
+
+    return json.dumps(
+        {
+            "total": total,
+            "resolved": resolved_total,
+            "pending": pending,
+            "by_state": resolved_states,
+            "tools": len(by_tool),
+            "by_tool": by_tool,
+            "top_errors": global_top,
+        },
+        ensure_ascii=False,
+    )
+
+
+def _action_resolve(args: dict) -> str:
+    ids_raw = args.get("ids")
+    resolution = (args.get("resolution") or "fixed").strip()
+
+    if resolution not in _VALID_RESOLUTIONS:
+        return json.dumps(
+            {"e": f"resolution must be one of: {', '.join(sorted(_VALID_RESOLUTIONS))}"},
+            ensure_ascii=False,
+        )
+
+    target_ids = _parse_ids(ids_raw)
+    if target_ids is None and ids_raw != "all":
+        return json.dumps({"e": "ids is required (list, int, or 'all')"}, ensure_ascii=False)
+
+    status_filter = (args.get("status") or "").strip()
+    tool_filter = (args.get("tool") or "").strip()
+
+    records = read_all()
+    updated = 0
+    records.reverse()  # oldest first for rewrite
+
+    for r in records:
+        rid = r.get("id")
+        if target_ids is not None and rid not in target_ids:
+            continue
+        if status_filter and r.get("r") != status_filter:
+            continue
+        if tool_filter and r.get("t") != tool_filter:
+            continue
+        r["r"] = resolution
+        updated += 1
+
+    if updated == 0:
+        return json.dumps({"ok": True, "updated": 0, "hint": "no matching records"}, ensure_ascii=False)
+
+    write_records(records)
+    return json.dumps({"ok": True, "updated": updated, "resolution": resolution}, ensure_ascii=False)
+
+
+def _action_update(args: dict) -> str:
+    """Update fix description and/or linked IDs for existing records."""
+    ids_raw = args.get("ids")
+    target_ids = _parse_ids(ids_raw)
+    if target_ids is None:
+        return json.dumps({"e": "ids is required (int or list of ints)"}, ensure_ascii=False)
+
+    fix = (args.get("fix") or "").strip()
+    link_ids_raw = args.get("link_ids")
+
+    # Parse link_ids
+    new_links: List[int] = []
+    if link_ids_raw is not None:
+        if isinstance(link_ids_raw, list):
+            for v in link_ids_raw:
+                try:
+                    new_links.append(int(v))
+                except (ValueError, TypeError):
+                    pass
+        else:
+            try:
+                new_links.append(int(link_ids_raw))
+            except (ValueError, TypeError):
+                pass
+
+    if not fix and not new_links:
+        return json.dumps({"e": "provide fix and/or link_ids to update"}, ensure_ascii=False)
+
+    records = read_all()
+    updated = 0
+    records.reverse()
+
+    for r in records:
+        rid = r.get("id")
+        if rid not in target_ids:
+            continue
+        if fix:
+            r["f"] = (r.get("f", "") + ("; " if r.get("f") else "") + fix)[:_MAX_FIX_LEN]
+        if new_links:
+            existing = set(r.get("l", []))
+            existing.update(new_links)
+            existing.discard(rid)  # don't link to self
+            r["l"] = sorted(existing)
+        updated += 1
+
+    if updated == 0:
+        return json.dumps({"ok": True, "updated": 0, "hint": "no matching records"}, ensure_ascii=False)
+
+    write_records(records)
+    return json.dumps({"ok": True, "updated": updated}, ensure_ascii=False)
+
+
+def _action_link(args: dict) -> str:
+    """Link multiple failures together (shared root cause)."""
+    ids_raw = args.get("ids")
+    if not isinstance(ids_raw, list) or len(ids_raw) < 2:
+        return json.dumps({"e": "ids must be a list of 2+ ints"}, ensure_ascii=False)
+
+    target_ids = set()
+    for v in ids_raw:
+        try:
+            target_ids.add(int(v))
+        except (ValueError, TypeError):
+            pass
+
+    if len(target_ids) < 2:
+        return json.dumps({"e": "need at least 2 valid ids"}, ensure_ascii=False)
+
+    records = read_all()
+    records.reverse()
+    updated = 0
+
+    for r in records:
+        rid = r.get("id")
+        if rid not in target_ids:
+            continue
+        existing = set(r.get("l", []))
+        # Link to all other targets
+        others = target_ids - {rid}
+        existing.update(others)
+        r["l"] = sorted(existing)
+        updated += 1
+
+    if updated < 2:
+        return json.dumps({"ok": True, "updated": updated, "hint": "fewer than 2 records matched"}, ensure_ascii=False)
+
+    write_records(records)
+    return json.dumps({"ok": True, "updated": updated, "linked": sorted(target_ids)}, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Tool entry point
+# ---------------------------------------------------------------------------
+
+
+def tool_failure_log(
+    action: str = "",
+    tool: str = "",
+    error: str = "",
+    args: str = "",
+    fix: str = "",
+    ids: Any = None,
+    link_ids: Any = None,
+    resolution: str = "fixed",
+    status: str = "",
+    limit: int = _DEFAULT_LIMIT,
+    offset: int = 0,
+    session_id: str = "",
+    task_id: Optional[str] = None,
+) -> str:
+    action = (action or "").strip().lower()
+
+    payload = {
+        "tool": tool,
+        "error": error,
+        "args": args,
+        "fix": fix,
+        "ids": ids,
+        "link_ids": link_ids,
+        "resolution": resolution,
+        "status": status,
+        "limit": limit,
+        "offset": offset,
+    }
+
+    try:
+        if action == "log":
+            return _action_log(payload, session_id=session_id)
+        elif action == "list":
+            return _action_list(payload)
+        elif action == "stats":
+            return _action_stats(payload)
+        elif action == "resolve":
+            return _action_resolve(payload)
+        elif action == "update":
+            return _action_update(payload)
+        elif action == "link":
+            return _action_link(payload)
+        else:
+            return json.dumps(
+                {"e": f"unknown action: '{action}'. Use: log, update, link, list, stats, resolve"},
+                ensure_ascii=False,
+            )
+    except Exception as exc:
+        return json.dumps({"e": f"internal error: {exc}"}, ensure_ascii=False)
+
+
+def check_requirements() -> bool:
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Register
+# ---------------------------------------------------------------------------
+
+registry.register(
+    name="tool_failure_log",
+    toolset="tool_failure_log",
+    schema={
+        "name": "tool_failure_log",
+        "description": "Log, update, link, list, and resolve tool failures. Failures are auto-logged — use this to add fixes (update), link related (link), review (list/stats), or resolve. Manual log for semantic failures only.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["log", "update", "link", "list", "stats", "resolve"],
+                    "description": "log: record. update: add fix/links. link: connect failures. list/stats: review. resolve: mark fixed/wontfix/blocked.",
+                },
+                "tool": {
+                    "type": "string",
+                    "description": "Tool name (for log, or filter for list/resolve).",
+                },
+                "error": {
+                    "type": "string",
+                    "description": "Error summary (for log/update). Truncated to 256 chars.",
+                },
+                "args": {
+                    "type": "string",
+                    "description": "Key arguments summary (for log). Truncated to 200 chars.",
+                },
+                "fix": {
+                    "type": "string",
+                    "description": "Fix/workaround applied (for log/update). Truncated to 300 chars.",
+                },
+                "ids": {
+                    "description": "Target ids: single int, list of ints, or 'all'.",
+                },
+                "link_ids": {
+                    "description": "For update: list of related failure ids to link to this record.",
+                },
+                "resolution": {
+                    "type": "string",
+                    "enum": ["fixed", "wontfix", "blocked"],
+                    "description": "fixed: permanent fix shipped. wontfix: not worth fixing. blocked: waiting on external dependency.",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["pending", "fixed", "wontfix", "blocked"],
+                    "description": "Filter by resolution status (for list or resolve with ids='all').",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max records for list (default 20, max 100).",
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Pagination offset for list (default 0).",
+                },
+            },
+            "required": ["action"],
+        },
+    },
+    handler=lambda args, **kw: tool_failure_log(
+        action=args.get("action", ""),
+        tool=args.get("tool", ""),
+        error=args.get("error", ""),
+        args=args.get("args", ""),
+        fix=args.get("fix", ""),
+        ids=args.get("ids"),
+        link_ids=args.get("link_ids"),
+        resolution=args.get("resolution", "fixed"),
+        status=args.get("status", ""),
+        limit=args.get("limit", _DEFAULT_LIMIT),
+        offset=args.get("offset", 0),
+        session_id=kw.get("session_id", ""),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_requirements,
+    requires_env=[],
+)

--- a/tools/tool_failure_log.py
+++ b/tools/tool_failure_log.py
@@ -29,8 +29,8 @@ from tools._failure_log_store import (
     _MAX_ARGS_LEN,
     _MAX_ERROR_LEN,
     append_record,
+    mutate_records,
     read_all,
-    write_records,
 )
 from tools.registry import registry, tool_error  # noqa: F401
 
@@ -83,7 +83,15 @@ def _action_log(args: dict, session_id: str = "") -> str:
     if not error:
         return json.dumps({"e": "error is required"}, ensure_ascii=False)
 
-    args_summary = (args.get("args") or "")[:_MAX_ARGS_LEN]
+    raw_args = args.get("args")
+    if isinstance(raw_args, dict):
+        try:
+            args_summary = json.dumps(raw_args, ensure_ascii=False)
+        except (TypeError, ValueError):
+            args_summary = str(raw_args)
+    else:
+        args_summary = str(raw_args or "")
+    args_summary = args_summary[:_MAX_ARGS_LEN]
     fix = (args.get("fix") or "")[:_MAX_FIX_LEN]
 
     prev_count = len(read_all())
@@ -91,14 +99,15 @@ def _action_log(args: dict, session_id: str = "") -> str:
     rec = {
         "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "t": tool,
-        "e": error[:_MAX_ERROR_LEN],
+        "e": error,
         "a": args_summary,
         "s": session_id or "",
         "f": fix,
         "l": [],
         "r": "pending",
     }
-    # id is assigned atomically by append_record under lock
+    # id is assigned atomically by append_record under lock; args/error are
+    # redacted inside append_record before the line is written.
     saved = append_record(rec)
     return json.dumps({"ok": True, "id": saved["id"], "c": prev_count + 1}, ensure_ascii=False)
 
@@ -218,25 +227,23 @@ def _action_resolve(args: dict) -> str:
     status_filter = (args.get("status") or "").strip()
     tool_filter = (args.get("tool") or "").strip()
 
-    records = read_all()
-    updated = 0
-    records.reverse()  # oldest first for rewrite
-
-    for r in records:
+    def _match(r):
         rid = r.get("id")
         if target_ids is not None and rid not in target_ids:
-            continue
+            return False
         if status_filter and r.get("r") != status_filter:
-            continue
+            return False
         if tool_filter and r.get("t") != tool_filter:
-            continue
-        r["r"] = resolution
-        updated += 1
+            return False
+        return True
 
+    def _mutate(r):
+        r["r"] = resolution
+
+    updated = mutate_records(_match, _mutate)
     if updated == 0:
         return json.dumps({"ok": True, "updated": 0, "hint": "no matching records"}, ensure_ascii=False)
 
-    write_records(records)
     return json.dumps({"ok": True, "updated": updated, "resolution": resolution}, ensure_ascii=False)
 
 
@@ -268,27 +275,22 @@ def _action_update(args: dict) -> str:
     if not fix and not new_links:
         return json.dumps({"e": "provide fix and/or link_ids to update"}, ensure_ascii=False)
 
-    records = read_all()
-    updated = 0
-    records.reverse()
+    def _match(r):
+        return r.get("id") in target_ids
 
-    for r in records:
-        rid = r.get("id")
-        if rid not in target_ids:
-            continue
+    def _mutate(r):
         if fix:
             r["f"] = (r.get("f", "") + ("; " if r.get("f") else "") + fix)[:_MAX_FIX_LEN]
         if new_links:
             existing = set(r.get("l", []))
             existing.update(new_links)
-            existing.discard(rid)  # don't link to self
+            existing.discard(r.get("id"))  # don't link to self
             r["l"] = sorted(existing)
-        updated += 1
 
+    updated = mutate_records(_match, _mutate)
     if updated == 0:
         return json.dumps({"ok": True, "updated": 0, "hint": "no matching records"}, ensure_ascii=False)
 
-    write_records(records)
     return json.dumps({"ok": True, "updated": updated}, ensure_ascii=False)
 
 
@@ -308,25 +310,20 @@ def _action_link(args: dict) -> str:
     if len(target_ids) < 2:
         return json.dumps({"e": "need at least 2 valid ids"}, ensure_ascii=False)
 
-    records = read_all()
-    records.reverse()
-    updated = 0
+    def _match(r):
+        return r.get("id") in target_ids
 
-    for r in records:
+    def _mutate(r):
         rid = r.get("id")
-        if rid not in target_ids:
-            continue
         existing = set(r.get("l", []))
         # Link to all other targets
-        others = target_ids - {rid}
-        existing.update(others)
+        existing.update(target_ids - {rid})
         r["l"] = sorted(existing)
-        updated += 1
 
+    updated = mutate_records(_match, _mutate)
     if updated < 2:
         return json.dumps({"ok": True, "updated": updated, "hint": "fewer than 2 records matched"}, ensure_ascii=False)
 
-    write_records(records)
     return json.dumps({"ok": True, "updated": updated, "linked": sorted(target_ids)}, ensure_ascii=False)
 
 
@@ -419,7 +416,7 @@ registry.register(
                 },
                 "args": {
                     "type": "string",
-                    "description": "Key arguments summary (for log). Truncated to 200 chars.",
+                    "description": "Key arguments summary (for log). Truncated to 200 chars. Passed through with no semantic interpretation; structure is up to the caller.",
                 },
                 "fix": {
                     "type": "string",

--- a/toolsets.py
+++ b/toolsets.py
@@ -64,6 +64,8 @@ _HERMES_CORE_TOOLS = [
     "execute_code", "delegate_task",
     # Cronjob management
     "cronjob",
+    # Tool failure logging — records failures + fixes for later review
+    "tool_failure_log",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
     # Kanban multi-agent coordination — only in schema when the agent is

--- a/toolsets.py
+++ b/toolsets.py
@@ -64,8 +64,6 @@ _HERMES_CORE_TOOLS = [
     "execute_code", "delegate_task",
     # Cronjob management
     "cronjob",
-    # Tool failure logging — records failures + fixes for later review
-    "tool_failure_log",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
     # Kanban multi-agent coordination — only in schema when the agent is
@@ -184,9 +182,22 @@ TOOLSETS = {
     "cronjob": {
         "description": "Cronjob management tool - create, list, update, pause, resume, remove, and trigger scheduled tasks",
         "tools": ["cronjob"],
-        "includes": []
+        "includes": [],
     },
-    
+
+    # Tool failure logging lives in its OWN opt-in toolset rather than the
+    # shared core bundle.  AGENTS.md requires a new core tool to be the last
+    # resort (footprint ladder), and this is an observability/debugging aid,
+    # not a capability most sessions need on every turn.  Enabling it is a
+    # one-line, profile-local change (`tools.<platform>.enabled` lists or
+    # `hermes tools`) — zero core-schema footprint for the 99% of sessions
+    # that never review the failure journal.
+    "tool_failure_log": {
+        "description": "Persistent, reviewable tool-failure journal — auto-captured by the agent loop, with log/update/link/list/stats/resolve review workflow. Opt-in: enable per session to keep it off the default core schema.",
+        "tools": ["tool_failure_log"],
+        "includes": [],
+    },
+
 
     "file": {
         "description": "File manipulation tools: read, write, patch (with fuzzy matching), and search (content + files)",


### PR DESCRIPTION
## What

Adds a persistent, reviewable journal of tool failures that is auto-populated by the agent loop — the agent never needs to remember to log. Failures are captured at the dispatch level (registry.dispatch) and orchestration level (handle_function_call), then the agent can later add fix details, link related failures, review aggregate stats, and mark them resolved.

## Why

Hermes agents frequently encounter tool errors mid-task and either fix the tool or bypass it. Without systematic logging, these failures are lost — the same bugs recur, and no one knows which tools need attention. This gives Hermes a self-improving feedback loop: every failure is captured, patterns emerge from stats, and permanent fixes can be shipped.

## Changes

### New files
- **`tools/_failure_log_store.py`** — shared JSONL storage with advisory locking (`fcntl` on POSIX, no-op on native Windows). Exposes `read_all()`, `write_records()`, `append_record()`, and `auto_log()`.
- **`tools/tool_failure_log.py`** — 6-action agent tool: `log`, `update`, `link`, `list`, `stats`, `resolve` (3 resolution states: fixed/wontfix/blocked). Compact single-char JSON keys for token efficiency.
- **`tests/tools/test_tool_failure_log.py`** — 56 tests covering all actions, edge cases (empty log, malformed lines, truncation), and integration (auto-log → update → link → resolve).

### Modified files
- **`tools/registry.py`** (+14): auto-log in both `dispatch()` error paths (unknown tool + execution exception), gated behind try/except to never break the agent loop.
- **`model_tools.py`** (+6): auto-log in `handle_function_call` catch block for orchestration-layer errors.
- **`toolsets.py`** (+2): `tool_failure_log` added to `_HERMES_CORE_TOOLS`.

### Token cost
Schema: ~418 tokens (flat format — registry does the `{"type": "function", ...}` wrapping at `get_definitions:439`). JSONL records: ~128 bytes each.

## How to test

```bash
# Unit + integration tests (56 new tests)
python -m pytest tests/tools/test_tool_failure_log.py -v

# Verify no regressions in existing tests
python -m pytest tests/test_model_tools.py tests/tools/test_registry.py -v
```

Manual smoke test:
```
# Trigger a tool error — auto-logged automatically
# then review with:
tool_failure_log(action="list", limit=5)
tool_failure_log(action="stats")
```

## Platforms tested
- Linux (WSL2)