### PR TITLE
fix(hermes_constants): guard int() cast on HERMES_NODE_TARGET_MAJOR env var

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -287,7 +287,10 @@ def _candidate_node_command_names(command: str) -> list[str]:
     return [f"{base}.cmd", f"{base}.exe", base]
 
 
-_HERMES_NODE_TARGET_MAJOR = int(os.environ.get("HERMES_NODE_TARGET_MAJOR", "22"))
+try:
+    _HERMES_NODE_TARGET_MAJOR = int(os.environ.get("HERMES_NODE_TARGET_MAJOR", "22"))
+except (ValueError, TypeError):
+    _HERMES_NODE_TARGET_MAJOR = 22
 _managed_node_heal_attempted = False
 _NODE_BOOTSTRAP_SCRIPT = Path(__file__).resolve().parent / "scripts" / "lib" / "node-bootstrap.sh"
 


### PR DESCRIPTION
## Problem

`hermes_constants.py:290` performs a module-level `int()` cast on the `HERMES_NODE_TARGET_MAJOR` environment variable without any error handling:

```python
_HERMES_NODE_TARGET_MAJOR = int(os.environ.get("HERMES_NODE_TARGET_MAJOR", "22"))
```

If a user sets `HERMES_NODE_TARGET_MAJOR=abc` (or any non-numeric value), the entire application crashes at **import time** with an unhandled `ValueError`.

## Fix

Wrap the `int()` cast in `try/except (ValueError, TypeError)` with a fallback to the default value of `22`:

```python
try:
    _HERMES_NODE_TARGET_MAJOR = int(os.environ.get("HERMES_NODE_TARGET_MAJOR", "22"))
except (ValueError, TypeError):
    _HERMES_NODE_TARGET_MAJOR = 22
```

This follows the same pattern already used elsewhere in the codebase (e.g., `tui_gateway/server.py:144`, `tui_gateway/server.py:223`, `plugins/browser/firecrawl/provider.py:82`).

## Impact

- **Severity**: P1 — application crash at import time on misconfigured env
- **Scope**: 1 file, 4 lines added
- **Risk**: Minimal — only adds a safety net, no behavior change for valid values
