### PR TITLE
fix(skills,cron): guard shutil.rmtree calls against OSError

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1219,7 +1219,10 @@ def remove_job(job_id: str) -> bool:
             save_jobs(jobs)
             # Clean up output directory to prevent orphaned dirs accumulating
             if job_output_dir.exists():
-                shutil.rmtree(job_output_dir)
+                try:
+                    shutil.rmtree(job_output_dir)
+                except OSError as exc:
+                    logger.warning("Failed to remove job output dir %s: %s", job_output_dir, exc)
             return True
     return False
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1006,7 +1006,10 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
             message += f" Content absorbed into '{absorbed_target}'."
         return {"success": True, "message": message, "_archived": True}
 
-    shutil.rmtree(skill_dir)
+    try:
+        shutil.rmtree(skill_dir)
+    except OSError as exc:
+        logger.warning("Failed to remove skill dir %s: %s", skill_dir, exc)
 
     # Clean up empty category directories (don't remove the skills root itself)
     parent = skill_dir.parent

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3365,7 +3365,10 @@ def quarantine_bundle(bundle: SkillBundle) -> Path:
 
     dest = QUARANTINE_DIR / skill_name
     if dest.exists():
-        shutil.rmtree(dest)
+        try:
+            shutil.rmtree(dest)
+        except OSError as exc:
+            logger.warning("Failed to remove quarantine dir %s: %s", dest, exc)
     dest.mkdir(parents=True)
 
     for rel_path, file_content in validated_files:
@@ -3405,7 +3408,10 @@ def install_from_quarantine(
     install_dir = _resolve_lock_install_path(install_rel_path, safe_skill_name)
 
     if install_dir.exists():
-        shutil.rmtree(install_dir)
+        try:
+            shutil.rmtree(install_dir)
+        except OSError as exc:
+            logger.warning("Failed to remove install dir %s: %s", install_dir, exc)
 
     # Warn (but don't block) if SKILL.md is very large
     skill_md = quarantine_path / "SKILL.md"
@@ -3486,7 +3492,10 @@ def uninstall_skill(skill_name: str) -> Tuple[bool, str]:
         return False, f"Refusing to uninstall '{skill_name}': {exc}"
 
     if install_path.exists():
-        shutil.rmtree(install_path)
+        try:
+            shutil.rmtree(install_path)
+        except OSError as exc:
+            logger.warning("Failed to remove skill path %s: %s", install_path, exc)
 
     lock.record_uninstall(skill_name)
     append_audit_log("UNINSTALL", skill_name, entry["source"], entry["trust_level"], "n/a", "user_request")


### PR DESCRIPTION
## Problem

Multiple `shutil.rmtree()` calls in skill management and cron job cleanup are unprotected against `OSError`. These can fail due to:
- Permission denied (locked files on Windows, SELinux)
- Race conditions with concurrent skill operations
- Files opened by other processes

When these fail, the entire calling operation crashes instead of logging a warning and continuing.

## Affected Locations

| File | Function | Context |
|------|----------|---------|
| `tools/skill_manager_tool.py:1009` | `_delete_skill()` | Skill directory removal |
| `tools/skills_hub.py:3368` | Quarantine cleanup | Pre-install quarantine dir |
| `tools/skills_hub.py:3408` | Install path cleanup | Existing skill reinstall |
| `tools/skills_hub.py:3489` | Uninstall | Skill uninstall path removal |
| `cron/jobs.py:1222` | Job removal | Output directory cleanup |

## Fix

Wrap each `shutil.rmtree()` in `try/except OSError` with a `logger.warning()`, following the existing pattern used in:
- `tools/checkpoint_manager.py:1315` (archive cleanup)
- `tools/checkpoint_manager.py:1641` (checkpoint base cleanup)
- `hermes_cli/main.py:6275` (update temp dir cleanup)

```python
# Before
shutil.rmtree(skill_dir)

# After
try:
    shutil.rmtree(skill_dir)
except OSError as exc:
    logger.warning("Failed to remove skill dir %s: %s", skill_dir, exc)
```

## Impact

- **Severity**: P2 — graceful degradation on file system errors
- **Scope**: 3 files, 20 lines added
- **Risk**: Minimal — only adds error handling, no behavior change on success
