### PR TITLE
fix(teams): reject unauthorized users before attachment side effects

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -124,6 +124,57 @@ def _coerce_port(value: Any, *, default: int = _DEFAULT_PORT) -> int:
         return default
 
 
+def _is_truthy_env(value: str) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _teams_user_authorized(activity: Any) -> bool:
+    """Mirror the gateway's Teams allowlist gate before side effects occur.
+
+    The gateway's canonical authorization check runs after adapter dispatch, but
+    the Teams adapter downloads and caches attachments before calling
+    ``handle_message``. That let unauthorized senders force remote downloads and
+    local cache writes even though the gateway would reject them later.
+
+    Teams has no pairing path here, so the pre-dispatch mirror only needs the
+    explicit env-based gates the operator can configure:
+
+    1. ``TEAMS_ALLOW_ALL_USERS``
+    2. ``TEAMS_ALLOWED_USERS``
+    3. ``GATEWAY_ALLOW_ALL_USERS``
+    4. ``GATEWAY_ALLOWED_USERS``
+
+    With none configured, defer to the gateway runner's canonical authz path.
+    The adapter-side precheck exists only to prevent side effects before the
+    runner rejects a sender under an explicit allowlist policy.
+    """
+    if _is_truthy_env(os.getenv("TEAMS_ALLOW_ALL_USERS")):
+        return True
+    if _is_truthy_env(os.getenv("GATEWAY_ALLOW_ALL_USERS")):
+        return True
+
+    from_account = getattr(activity, "from_", None)
+    user_id = (
+        getattr(from_account, "aad_object_id", None)
+        or getattr(from_account, "id", None)
+        or ""
+    )
+    user_id = str(user_id).strip()
+
+    def _parse_csv(name: str) -> set[str]:
+        raw = os.getenv(name, "")
+        return {part.strip() for part in raw.split(",") if part.strip()}
+
+    saw_explicit_policy = False
+    for env_name in ("TEAMS_ALLOWED_USERS", "GATEWAY_ALLOWED_USERS"):
+        allowed = _parse_csv(env_name)
+        if allowed:
+            saw_explicit_policy = True
+            return bool(user_id) and ("*" in allowed or user_id in allowed)
+
+    return not saw_explicit_policy
+
+
 class _StaticAccessTokenProvider:
     """Minimal token-provider shim so outbound Graph delivery can reuse the shared client."""
 
@@ -843,6 +894,16 @@ class TeamsAdapter(BasePlatformAdapter):
         conv_id = getattr(activity.conversation, "id", None)
         if conv_id:
             self._conv_refs[conv_id] = ctx.conversation_ref
+
+        if not _teams_user_authorized(activity):
+            logger.warning(
+                "[teams] Unauthorized inbound dropped before event construction: user=%s conversation=%s",
+                getattr(getattr(activity, "from_", None), "aad_object_id", None)
+                or getattr(getattr(activity, "from_", None), "id", None)
+                or "",
+                conv_id or "",
+            )
+            return
 
         # Extract text — strip bot @mentions
         text = ""

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -749,6 +749,49 @@ class TestTeamsMessageHandling:
 
         assert adapter.handle_message.await_count == 1
 
+    @pytest.mark.anyio
+    async def test_unauthorized_user_dropped_before_event_dispatch(self, monkeypatch):
+        monkeypatch.setenv("TEAMS_ALLOWED_USERS", "aad-allowed")
+        monkeypatch.delenv("TEAMS_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+
+        activity = self._make_activity(from_aad_id="aad-denied", from_id="teams-id")
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_unauthorized_user_dropped_before_attachment_download(self, monkeypatch):
+        monkeypatch.setenv("TEAMS_ALLOWED_USERS", "aad-allowed")
+        monkeypatch.delenv("TEAMS_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+        adapter._fetch_attachment_bytes = AsyncMock(return_value=b"%PDF-1.4 fake")
+
+        activity = self._make_activity(
+            from_aad_id="aad-denied",
+            attachments=[TestTeamsAttachmentClassification()._file_download_attachment()],
+        )
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter._fetch_attachment_bytes.assert_not_awaited()
+        adapter.handle_message.assert_not_awaited()
+
 
 class TestTeamsAttachmentClassification:
     """Document attachments must set MessageType.DOCUMENT so run.py's


### PR DESCRIPTION
## Summary

This hardens the Teams adapter so explicit user-allowlist policies are enforced before any inbound message side effects occur. When a Teams sender is not allowed by `TEAMS_ALLOWED_USERS` or `GATEWAY_ALLOWED_USERS`, the adapter now drops the message before attachment downloads, cache writes, and event dispatch.

## Why

`plugins/platforms/teams/adapter.py` currently performs substantial work inside `_on_message()` before the gateway's canonical authorization check runs:

- caches the conversation reference
- normalizes message text
- downloads Teams file attachments
- caches downloaded files/images locally
- constructs and dispatches the `MessageEvent`

That means a sender who would ultimately be rejected by the gateway can still trigger remote attachment fetches and local cache writes first, as long as the operator configured an explicit allowlist policy.

This is especially relevant for Teams file attachments (`application/vnd.microsoft.teams.file.download.info`), where `_on_message()` downloads the pre-authenticated `downloadUrl` before `handle_message()` hands control to the gateway runner.

## Changes

- Add a lightweight Teams-specific pre-dispatch auth check for the explicit env-based gates:
  - `TEAMS_ALLOW_ALL_USERS`
  - `TEAMS_ALLOWED_USERS`
  - `GATEWAY_ALLOW_ALL_USERS`
  - `GATEWAY_ALLOWED_USERS`
- Run that check in `_on_message()` before text extraction, attachment download, cache writes, and event dispatch.
- Preserve existing behavior when no explicit allowlist/allow-all policy is configured by deferring to the gateway runner as before.
- Add regression tests proving unauthorized senders are dropped before:
  - `handle_message()` dispatch
  - attachment download execution

## Tests

```text
python -m pytest tests\gateway\test_teams.py -k "unauthorized_user_dropped_before_event_dispatch or unauthorized_user_dropped_before_attachment_download" -q
2 passed, 57 deselected in 1.16s