### PR TITLE
fix(mcp): let OAuth servers reach discovery before HTML preflight

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "ha-agent@homelab.4410.us": "oreoluwa",  # PR #49845 salvage (skip preflight content-type probe for OAuth MCP servers so OAuth discovery runs; Akiflow/Hospitable)
     "prathamesh290504@gmail.com": "PRATHAMESH75",  # PR #37550 salvage (ExecStopPost cgroup-orphan reaper to unblock systemd restart; #37454)
     "der@konsi.org": "konsisumer",  # PR #19608 salvage (read-modify-write merge in write_credential_pool to preserve concurrently-added credentials; #19566)
     "linyubin@users.noreply.github.com": "linyubin",  # PR #50228 salvage (eager fallback on persistent transport timeout/overloaded; #22277)

--- a/tests/tools/test_mcp_preflight_content_type.py
+++ b/tests/tools/test_mcp_preflight_content_type.py
@@ -7,6 +7,16 @@ production probe must run on its own httpx client outside the MCP SDK's anyio
 task group, and a faithful test must exercise that actual method so the
 content-type allow-list, HEAD->GET fallback, and best-effort pass-through are
 all covered as shipped.
+
+OAuth note
+----------
+``MCPServerTask.run()`` skips the preflight entirely when ``auth_type=="oauth"``
+(see ``test_run_skips_preflight_for_oauth``).  OAuth-protected MCP servers
+return ``200 text/html`` (a login/landing page) on an unauthenticated probe,
+which ``_preflight_content_type`` correctly rejects — the probe cannot tell
+whether the page is a valid OAuth endpoint or a misconfigured URL.  The right
+validator for OAuth servers is ``.well-known/oauth-protected-resource``, which
+the OAuth handshake consults automatically.
 """
 
 from __future__ import annotations
@@ -205,6 +215,74 @@ def test_head_501_falls_back_to_get_and_passes_json():
 # ---------------------------------------------------------------------------
 # ssl_verify / client_cert forwarding to the probe client
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# OAuth server: why the run() guard is needed
+# ---------------------------------------------------------------------------
+
+def test_oauth_server_html_response_raises_without_skip():
+    """_preflight_content_type raises NonMcpEndpointError for 200 text/html.
+
+    This documents the failure mode that the ``self._auth_type != "oauth"``
+    guard in ``MCPServerTask.run()`` prevents.  An OAuth-protected MCP server
+    returns a login/landing page on an unauthenticated HEAD probe — identical
+    to a misconfigured URL from the preflight's point of view — because it
+    cannot serve a meaningful MCP response without a Bearer token.
+
+    Real-world example: Hospitable's MCP server
+    (``https://mcp.hospitable.com/mcp``) returns ``200 text/html`` to an
+    unauthenticated httpx HEAD request.  With the guard removed, connecting
+    via ``hermes mcp add/login`` raises ``NonMcpEndpointError`` before the
+    OAuth browser flow can begin.  With the guard in place, 63 tools are
+    discovered and the server connects successfully.
+    """
+    task = _make_task("hospitable")
+    # HEAD returns 200 text/html — what Hospitable sends without a token.
+    with _serve(_handler(status=200, content_type="text/html; charset=UTF-8")) as base:
+        with pytest.raises(NonMcpEndpointError) as exc_info:
+            asyncio.run(task._preflight_content_type(f"{base}/mcp", timeout=5.0))
+    assert "hospitable" in str(exc_info.value)
+
+
+def test_run_skips_preflight_for_oauth(monkeypatch):
+    """MCPServerTask.run() must not call _preflight_content_type for OAuth servers.
+
+    The ``self._auth_type != "oauth"`` guard in the preflight condition ensures
+    that OAuth-protected servers never hit ``NonMcpEndpointError`` from the
+    unauthenticated GET probe.  The probe is inapplicable to OAuth servers:
+    their identity is established by the OAuth metadata discovery
+    (``.well-known/oauth-protected-resource``), not by a GET content-type check.
+    """
+    import tools.mcp_tool as _mcp
+
+    preflight_calls: list[str] = []
+
+    async def _inner():
+        # Patch at the class level: replacement receives (self, url, **kwargs).
+        async def _fake_preflight(self, url, **kwargs):
+            preflight_calls.append(url)
+
+        async def _fake_run_http(self, config):
+            # Abort immediately after the preflight gate — we only want to
+            # verify the gate, not exercise the real transport.
+            raise asyncio.CancelledError()
+
+        # Bypass URL validation so the test doesn't need a live network.
+        monkeypatch.setattr(_mcp, "_validate_remote_mcp_url", lambda n, u: None)
+        monkeypatch.setattr(_mcp.MCPServerTask, "_preflight_content_type", _fake_preflight)
+        monkeypatch.setattr(_mcp.MCPServerTask, "_run_http", _fake_run_http)
+
+        task = _mcp.MCPServerTask("hospitable-test")
+        with pytest.raises(asyncio.CancelledError):
+            await task.run({"url": "https://mcp.hospitable.com/mcp", "auth": "oauth"})
+
+    asyncio.run(_inner())
+    assert preflight_calls == [], (
+        "_preflight_content_type must not be called for OAuth servers; "
+        "without the guard the OAuth flow is blocked by the 200 text/html "
+        "landing page the server returns to an unauthenticated probe"
+    )
+
 
 def test_ssl_verify_and_cert_forwarded(monkeypatch):
     captured: dict = {}

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2307,12 +2307,12 @@ class MCPServerTask:
             # before surfacing an opaque CancelledError. Probing here — once,
             # outside the SDK task group — fails fast and non-retryably with
             # an actionable message, mirroring the URL-validation path above.
-            # Skip the probe when _ready is already set: that only happens
-            # after a prior successful connect, so this run() invocation is a
-            # reconnect (OAuth recovery / manual refresh). The endpoint was
-            # already validated once; re-probing burns a redundant network
-            # round-trip against a known-good server on every reconnect.
-            if config.get("transport") != "sse" and not self._ready.is_set():
+            # Skip the probe when _ready is already set (reconnect after a
+            # prior successful connect) — the endpoint was validated once,
+            # re-probing is a redundant round-trip. Also skip for OAuth servers:
+            # without a cached token the endpoint returns HTML or 401, which
+            # would incorrectly block the OAuth flow before it can run.
+            if config.get("transport") != "sse" and not self._ready.is_set() and self._auth_type != "oauth":
                 try:
                     _probe_headers = dict(config.get("headers") or {})
                     await self._preflight_content_type(


### PR DESCRIPTION
## Summary

OAuth MCP servers now reach OAuth discovery instead of being rejected by the unauthenticated content-type preflight. Some valid OAuth endpoints (Akiflow, Hospitable) return a pre-auth `302`/`text/html` redirect rather than a clean `401`; Hermes was rejecting those as non-MCP before the OAuth provider could run protected-resource discovery (RFC 9728).

Root cause: `MCPServerTask.run()` runs a generic Streamable-HTTP content-type probe before the OAuth path starts. For OAuth servers the probe is inapplicable — their identity is established by `.well-known/oauth-protected-resource`, not a GET content-type check — so the HTML it sees on an unauthenticated request is indistinguishable from a misconfigured URL, and it aborts.

## Changes

- `tools/mcp_tool.py`: skip the preflight probe when `auth_type == "oauth"` (one-line guard added to the existing gate). `_auth_type` is assigned before the gate, so the guard is reachable. Non-OAuth HTTP servers and the reconnect path are unchanged.
- `tests/tools/test_mcp_preflight_content_type.py`: regression tests documenting the OAuth-HTML failure mode and asserting the run() gate skips the probe for OAuth servers (real-world Hospitable example).

## Validation

| | Before | After |
|---|---|---|
| OAuth server returns 302/HTML unauthenticated | rejected as non-MCP, OAuth never starts | preflight skipped, OAuth discovery + login run |
| Non-OAuth HTTP server | preflight runs | preflight runs (unchanged) |
| OAuth reconnect | (skipped via `_ready`) | (skipped, unchanged) |

`scripts/run_tests.sh tests/tools/test_mcp_preflight_content_type.py` → 23 passed. E2E with real imports confirmed `_auth_type` is set before the gate and the guard skips the probe only for fresh OAuth connects.

## Credit

Salvaged from #49845 by @oreoluwa (earliest PR with this mechanism; cherry-picked with authorship preserved). Same fix was independently submitted as #53968 by @helix4u — both contributors credited; #53968 closed as duplicate.

## Infographic

![mcp-oauth-preflight-skip](https://v3b.fal.media/files/b/0aa01a48/FWs9PaSKOx1cqU2Q3DHZP_hp4mfNJN.png)
