### PR TITLE
fix: keep goal waits from parking on delegation ids

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -129,6 +129,9 @@ JUDGE_SYSTEM_PROMPT = (
     "watch_patterns trigger fires (use this for a long-lived watcher that "
     "signals mid-run and may never exit). Otherwise return its pid in "
     "``wait_on_pid`` (releases on exit only).\n"
+    "Never put delegate_task ids like ``deleg_abc123`` in ``wait_on_session``; "
+    "those are async delegation ids, not process sessions. If there is no listed "
+    "background process or fixed backoff to wait on, return CONTINUE.\n"
     "- The agent says it is rate-limited / backing off / must wait a fixed "
     "period — return seconds in ``wait_for_seconds``.\n"
     "Picking WAIT parks the loop without burning a turn; it resumes "
@@ -663,6 +666,18 @@ def _session_waiting(session_id: str) -> bool:
         return False
 
 
+def _looks_like_async_delegation_id(value: str) -> bool:
+    """Return True for delegate_task async ids (``deleg_...``).
+
+    ``wait_on_session`` is scoped to process_registry sessions. Async
+    delegation ids are not process sessions; parking a goal on one can strand
+    the loop when completion re-entry has already been missed. Treat them as
+    invalid wait-session targets so the goal continues instead of persisting a
+    stale barrier.
+    """
+    return str(value or "").strip().startswith("deleg_")
+
+
 _JSON_OBJECT_RE = re.compile(r"\{.*?\}", re.DOTALL)
 
 
@@ -776,7 +791,18 @@ def _parse_judge_response(raw: str) -> Tuple[str, str, bool, Optional[Dict[str, 
     # exit OR watch-pattern match), then pid (exit only), then seconds.
     sess = data.get("wait_on_session") or data.get("session_id") or data.get("wait_session")
     if isinstance(sess, str) and sess.strip():
-        return "wait", reason, False, {"session_id": sess.strip()}
+        sess = sess.strip()
+        if _looks_like_async_delegation_id(sess):
+            return (
+                "continue",
+                (
+                    f"{reason} (wait target {sess!r} is an async delegation id, "
+                    "not a process session — continuing)"
+                ),
+                False,
+                None,
+            )
+        return "wait", reason, False, {"session_id": sess}
     pid = _first_int("wait_on_pid", "pid", "wait_pid")
     if pid is not None:
         return "wait", reason, False, {"pid": pid}
@@ -1300,6 +1326,10 @@ class GoalManager:
         session_id = str(session_id or "").strip()
         if not session_id:
             raise ValueError("session_id must be a non-empty string")
+        if _looks_like_async_delegation_id(session_id):
+            raise ValueError(
+                "session_id must be a process_registry session id, not an async delegation id"
+            )
         self._state.waiting_on_session = session_id
         self._state.waiting_on_pid = None
         self._state.waiting_until = 0.0
@@ -1467,22 +1497,48 @@ class GoalManager:
         # the is_waiting() short-circuit once the barrier clears).
         if verdict == "wait" and wait_directive:
             if wait_directive.get("session_id"):
-                self.wait_on_session(str(wait_directive["session_id"]), reason=reason)
-                tgt = f"session {wait_directive['session_id']}"
+                session_target = str(wait_directive["session_id"])
+                if _looks_like_async_delegation_id(session_target):
+                    verdict = "continue"
+                    reason = (
+                        f"{reason} (wait target {session_target!r} is an async "
+                        "delegation id, not a process session — continuing)"
+                    )
+                    state.last_verdict = verdict
+                    state.last_reason = reason
+                else:
+                    self.wait_on_session(session_target, reason=reason)
+                    tgt = f"session {wait_directive['session_id']}"
+                    return {
+                        "status": "active",
+                        "should_continue": False,
+                        "continuation_prompt": None,
+                        "verdict": "wait",
+                        "reason": reason,
+                        "message": f"⏳ Goal parked (judge) — waiting on {tgt}: {reason}",
+                    }
             elif wait_directive.get("pid"):
                 self.wait_on(int(wait_directive["pid"]), reason=reason)
                 tgt = f"pid {wait_directive['pid']}"
+                return {
+                    "status": "active",
+                    "should_continue": False,
+                    "continuation_prompt": None,
+                    "verdict": "wait",
+                    "reason": reason,
+                    "message": f"⏳ Goal parked (judge) — waiting on {tgt}: {reason}",
+                }
             else:
                 self.wait_for_seconds(int(wait_directive["seconds"]), reason=reason)
                 tgt = f"{wait_directive['seconds']}s"
-            return {
-                "status": "active",
-                "should_continue": False,
-                "continuation_prompt": None,
-                "verdict": "wait",
-                "reason": reason,
-                "message": f"⏳ Goal parked (judge) — waiting on {tgt}: {reason}",
-            }
+                return {
+                    "status": "active",
+                    "should_continue": False,
+                    "continuation_prompt": None,
+                    "verdict": "wait",
+                    "reason": reason,
+                    "message": f"⏳ Goal parked (judge) — waiting on {tgt}: {reason}",
+                }
 
         if verdict == "done":
             state.status = "done"

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -119,6 +119,21 @@ class TestParseJudgeResponse:
         assert wait is None
         assert pf is False
 
+    def test_wait_verdict_with_delegation_id_downgrades_to_continue(self):
+        """delegate_task ids are not process sessions; never park /goal on them."""
+        from hermes_cli.goals import _parse_judge_response
+
+        raw = json.dumps({
+            "verdict": "wait",
+            "wait_on_session": "deleg_215a49d1",
+            "reason": "waiting for review",
+        })
+        v, reason, pf, wait = _parse_judge_response(raw)
+        assert v == "continue"
+        assert wait is None
+        assert pf is False
+        assert "async delegation id" in reason
+
     def test_unknown_verdict_falls_back_to_continue(self):
         from hermes_cli.goals import _parse_judge_response
 
@@ -334,6 +349,35 @@ class TestGoalManager:
         assert "a long goal" in decision["continuation_prompt"]
         assert mgr.state.status == "active"
         assert mgr.state.turns_used == 1
+
+    def test_evaluate_after_turn_does_not_wait_on_delegation_id(self, hermes_home):
+        """A bad judge/directive must not persist deleg_* as waiting_on_session."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="eval-deleg-wait", default_max_turns=5)
+        mgr.set("wait for subagent review")
+
+        with patch.object(
+            goals,
+            "judge_goal",
+            return_value=(
+                "wait",
+                "waiting for review",
+                False,
+                {"session_id": "deleg_215a49d1"},
+            ),
+        ):
+            decision = mgr.evaluate_after_turn("review pending")
+
+        assert decision["verdict"] == "continue"
+        assert decision["should_continue"] is True
+        state = mgr.state
+        assert state is not None
+        assert state.waiting_on_session is None
+        assert state.last_verdict == "continue"
+        assert state.last_reason is not None
+        assert "async delegation id" in state.last_reason
 
     def test_evaluate_after_turn_budget_exhausted(self, hermes_home):
         """When turn budget hits ceiling, auto-pause instead of continuing."""
@@ -1203,6 +1247,11 @@ class TestSessionTriggerBarrier:
             assert False, "expected ValueError"
         except ValueError:
             pass
+        try:
+            mgr.wait_on_session("deleg_215a49d1")
+            assert False, "expected ValueError"
+        except ValueError as exc:
+            assert "async delegation id" in str(exc)
 
     def test_session_directive_parsed_from_judge(self, hermes_home):
         from hermes_cli.goals import _parse_judge_response


### PR DESCRIPTION
## Summary
- reject async delegation ids (`deleg_*`) as `/goal` `wait_on_session` targets
- clarify the goal judge prompt so delegate_task ids are not emitted as process sessions
- defensively downgrade bad wait directives to continue instead of persisting stale barriers
- add regression coverage for parser, GoalManager validation, and evaluate_after_turn

## Tests
- `python -m pytest tests/hermes_cli/test_goals.py -q -o 'addopts='`\n- `python -m pytest tests/tui_gateway/test_goal_command.py tests/gateway/test_goal_verdict_send.py tests/gateway/test_goal_max_turns_config.py tests/gateway/test_goal_status_notice.py tests/test_tui_gateway_server.py -q -o 'addopts=' -k 'goal or notification_poller or active_subagents'`\n- `python -m py_compile hermes_cli/goals.py`\n- `git diff --check`\n\n## Bug\nA `/goal` judge can currently return `wait_on_session: deleg_xxx` after a background `delegate_task` review. `deleg_xxx` is an async delegation id, not a process_registry session id, so the goal state can persist a stale wait barrier and appear stuck even after the child session completed.