### PR TITLE
fix(debug): show correct URL and API key in request dumps for all api_modes

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1235,11 +1235,34 @@ def dump_api_request_debug(
         body.pop("timeout", None)
         body = {k: v for k, v in body.items() if v is not None}
 
+        # Resolve the effective API key from the active transport.
+        # For anthropic_messages mode agent.client is None (the Anthropic
+        # SDK client lives at agent._anthropic_client); for bedrock_converse
+        # there is no OpenAI-compatible client either.  Fall back to the
+        # stored key when the primary client is absent.
         api_key = None
         try:
             api_key = getattr(agent.client, "api_key", None)
         except Exception as e:
             _ra().logger.debug("Could not extract API key for debug dump: %s", e)
+        if not api_key:
+            if agent.api_mode == "anthropic_messages":
+                api_key = getattr(agent, "_anthropic_api_key", None)
+            elif agent.api_mode == "bedrock_converse":
+                api_key = "aws-sdk"
+            else:
+                api_key = getattr(agent, "api_key", None)
+
+        # Build the request URL that matches the actual transport path.
+        _base = agent.base_url.rstrip("/")
+        if agent.api_mode == "codex_responses":
+            _url = f"{_base}/responses"
+        elif agent.api_mode == "anthropic_messages":
+            _url = f"{_base}/v1/messages"
+        elif agent.api_mode == "bedrock_converse":
+            _url = f"{_base}/converse"
+        else:
+            _url = f"{_base}/chat/completions"
 
         dump_payload: Dict[str, Any] = {
             "timestamp": datetime.now().isoformat(),
@@ -1247,12 +1270,13 @@ def dump_api_request_debug(
             "reason": reason,
             "request": {
                 "method": "POST",
-                "url": f"{agent.base_url.rstrip('/')}{'/responses' if agent.api_mode == 'codex_responses' else '/chat/completions'}",
+                "url": _url,
                 "headers": {
                     "Authorization": f"Bearer {agent._mask_api_key_for_logs(api_key)}",
                     "Content-Type": "application/json",
                 },
                 "body": body,
+                "api_mode": agent.api_mode,
             },
         }
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1913,6 +1913,66 @@ def test_dump_api_request_debug_uses_chat_completions_url(monkeypatch, tmp_path)
     assert payload["request"]["url"] == "http://127.0.0.1:9208/v1/chat/completions"
 
 
+def test_dump_api_request_debug_uses_anthropic_messages_url(monkeypatch, tmp_path):
+    """Debug dumps should show /v1/messages URL when in anthropic_messages mode."""
+    import json
+    _patch_agent_bootstrap(monkeypatch)
+    agent = run_agent.AIAgent(
+        model="claude-sonnet-4-20250514",
+        base_url="https://api.anthropic.com",
+        api_key="sk-ant-api03-test12345678",
+        provider="anthropic",
+        api_mode="anthropic_messages",
+        quiet_mode=True,
+        max_iterations=1,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.logs_dir = tmp_path
+    # Simulate the anthropic_messages init path: agent.client is None
+    # and the key lives at agent._anthropic_api_key.
+    agent.client = None
+    agent._anthropic_api_key = "sk-ant-api03-test12345678"
+
+    dump_file = agent._dump_api_request_debug(
+        {"model": "claude-sonnet-4-20250514", "messages": [{"role": "user", "content": "hi"}]},
+        reason="non_retryable_client_error",
+    )
+
+    payload = json.loads(dump_file.read_text())
+    assert payload["request"]["url"] == "https://api.anthropic.com/v1/messages"
+    assert payload["request"]["api_mode"] == "anthropic_messages"
+    # The Authorization header should show a masked key, not "Bearer None".
+    auth = payload["request"]["headers"]["Authorization"]
+    assert auth.startswith("Bearer ")
+    assert "None" not in auth
+
+
+def test_dump_api_request_debug_includes_api_mode(monkeypatch, tmp_path):
+    """Debug dumps should include the api_mode field for all transports."""
+    import json
+    _patch_agent_bootstrap(monkeypatch)
+    agent = run_agent.AIAgent(
+        model="gpt-4o",
+        base_url="http://127.0.0.1:9208/v1",
+        api_key="test-key-12345678901234",
+        quiet_mode=True,
+        max_iterations=1,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.logs_dir = tmp_path
+
+    dump_file = agent._dump_api_request_debug(
+        {"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]},
+        reason="preflight",
+    )
+
+    payload = json.loads(dump_file.read_text())
+    assert "api_mode" in payload["request"]
+    assert payload["request"]["api_mode"] == "chat_completions"
+
+
 def test_dump_api_request_debug_redacts_request_and_error_secrets(monkeypatch, tmp_path, capsys):
     """Request debug dumps should redact secrets before disk/stdout output."""
     import json


### PR DESCRIPTION
## What does this PR do?

Fixes the `dump_api_request_debug` function so that request dumps show the correct URL and API key for all `api_mode` values (`anthropic_messages`, `bedrock_converse`, `codex_responses`, `chat_completions`).

Previously, the dump function had two bugs:

1. **URL**: Only `codex_responses` got `/responses`; everything else got `/chat/completions` — even `anthropic_messages` (which actually hits `/v1/messages`) and `bedrock_converse` (`/converse`).

2. **API key**: Always read from `agent.client.api_key`. In `anthropic_messages` mode `agent.client` is `None` (the Anthropic SDK client lives at `agent._anthropic_client`), so the dump showed `Bearer None` even when a valid key was present.

This made debugging provider-side errors extremely confusing — issue #54206 reports a `hermes -z` user seeing `POST https://api.anthropic.com/chat/completions` with `Bearer None` in the dump and concluding the request was misrouted, when in fact the Anthropic SDK was sending to `/v1/messages` with the correct key.

## Related Issue

Fixes #54206

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_runtime_helpers.py`: Dispatch URL construction on `api_mode` (`/v1/messages` for anthropic, `/converse` for bedrock, `/responses` for codex, `/chat/completions` default). Fall back to `agent._anthropic_api_key` or `agent.api_key` when `agent.client` is absent. Add `api_mode` field to dump payload.
- `tests/run_agent/test_run_agent_codex_responses.py`: Add `test_dump_api_request_debug_uses_anthropic_messages_url` (verifies URL and key for anthropic_messages mode) and `test_dump_api_request_debug_includes_api_mode` (verifies api_mode field in dump payload).

## How to Test

1. `python -m pytest tests/run_agent/test_run_agent_codex_responses.py::test_dump_api_request_debug_uses_anthropic_messages_url tests/run_agent/test_run_agent_codex_responses.py::test_dump_api_request_debug_includes_api_mode tests/run_agent/test_run_agent_codex_responses.py::test_dump_api_request_debug_uses_responses_url tests/run_agent/test_run_agent_codex_responses.py::test_dump_api_request_debug_uses_chat_completions_url tests/run_agent/test_run_agent_codex_responses.py::test_dump_api_request_debug_redacts_request_and_error_secrets -q` — should pass
2. Observe that the Anthropic test verifies `url == "https://api.anthropic.com/v1/messages"` and `Authorization` does not contain "None".

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
