### PR TITLE
fix(goals): fire goal judge after streamed turns (Ralph loop stuck at turns_used=0)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9167,20 +9167,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _final_text = str(_agent_result.get("final_response") or "")
                 elif isinstance(_agent_result, str):
                     _final_text = _agent_result
-                # Skip for empty responses (interrupted / errored) — the
-                # judge would almost always say "continue" and we'd loop
-                # on error. Let the user drive the next turn.
-                if _final_text.strip():
-                    try:
-                        session_entry = self.session_store.get_or_create_session(source)
-                    except Exception:
-                        session_entry = None
-                    if session_entry is not None:
-                        await self._post_turn_goal_continuation(
-                            session_entry=session_entry,
-                            source=source,
-                            final_response=_final_text,
-                        )
+                # NOTE: _final_text is often empty here even on a successful
+                # turn — when the reply was streamed (or the run was
+                # superseded) _handle_message_with_agent returns None / no
+                # final_response, because the text was already delivered
+                # out-of-band. Previously we skipped the goal hook on empty
+                # text, which silently stalled every streamed /goal at
+                # turns_used=0 (the judge never ran). Always invoke the hook
+                # when a session resolves; it recovers the real last response
+                # from the transcript when needed and is a cheap no-op when no
+                # goal is active.
+                try:
+                    session_entry = self.session_store.get_or_create_session(source)
+                except Exception:
+                    session_entry = None
+                if session_entry is not None:
+                    await self._post_turn_goal_continuation(
+                        session_entry=session_entry,
+                        source=source,
+                        final_response=_final_text,
+                    )
             except Exception as _goal_exc:
                 logger.debug("goal continuation hook failed: %s", _goal_exc)
             return _agent_result
@@ -11390,6 +11396,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         await _deliver()
 
+    def _recover_last_assistant_text(self, session_id: str) -> str:
+        """Most recent assistant message text for a session, or "".
+
+        The goal-continuation hook needs the turn's final reply, but streamed
+        turns return no final_response to the caller (it was delivered
+        out-of-band). Reading the persisted transcript recovers the real last
+        assistant turn so the judge can evaluate it instead of being skipped.
+        """
+        if not session_id:
+            return ""
+        try:
+            from hermes_cli.goals import _get_session_db
+            db = _get_session_db()
+            if db is None:
+                return ""
+            msgs = db.get_messages(session_id)
+        except Exception as exc:
+            logger.debug("goal continuation: transcript recovery failed: %s", exc)
+            return ""
+        for m in reversed(msgs or []):
+            if m.get("role") != "assistant":
+                continue
+            content = m.get("content")
+            if isinstance(content, str) and content.strip():
+                return content
+            # Multimodal turns store content as a list of parts.
+            if isinstance(content, list):
+                joined = " ".join(
+                    p.get("text", "")
+                    for p in content
+                    if isinstance(p, dict) and p.get("text")
+                ).strip()
+                if joined:
+                    return joined
+        return ""
+
     async def _post_turn_goal_continuation(
         self,
         *,
@@ -11421,6 +11463,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         mgr = GoalManager(session_id=sid, default_max_turns=max_turns)
         if not mgr.is_active():
+            return
+
+        # Streamed replies leave `final_response` empty (the inner handler
+        # returned None because the text was delivered out-of-band). Recover
+        # the turn's real last assistant message from the persisted transcript
+        # so the judge evaluates actual progress instead of being skipped —
+        # the skip is what stalled streamed /goal loops at turns_used=0.
+        if not (final_response or "").strip():
+            final_response = self._recover_last_assistant_text(sid)
+        if not (final_response or "").strip():
+            # Genuinely empty turn (interrupted / errored). Skip — judging an
+            # empty reply would just say "continue" and busy-loop.
             return
 
         try:


### PR DESCRIPTION
## Problem

When a `/goal` is set on a platform with **streaming enabled** (the default on Telegram), the Ralph loop never advances: the goal stays `active` at `turns_used=0`, the `goal_judge` model is never called, and no `[Continuing toward your standing goal]` continuation is ever enqueued. The agent does the work for the first turn, but the loop silently stalls.

This affects any streamed `/goal`, not an edge case.

## Root cause

The goal-continuation hook in `_handle_message` reads the turn's `final_response` from the return value of `_handle_message_with_agent`:

```python
if _final_text.strip():
    ...
    await self._post_turn_goal_continuation(..., final_response=_final_text)
```

When the reply is streamed, `_handle_message_with_agent` returns `None` (the text was already delivered out-of-band via the stream consumer; the dict it would otherwise return is `response`, which ends up `None` on that path). So `_final_text` is empty, the `if _final_text.strip():` gate is false, and `_post_turn_goal_continuation` — the only place that calls the judge and increments `turns_used` — is never reached.

## Fix

`gateway/run.py`:

1. **Always invoke the goal-continuation hook** when a session resolves, instead of gating on non-empty `final_response`. It is a cheap no-op when no goal is active (`_post_turn_goal_continuation` returns early on `not mgr.is_active()`).
2. In `_post_turn_goal_continuation`, when `final_response` is empty, **recover the turn's last assistant message from the persisted transcript** (`SessionDB.get_messages`) via a new `_recover_last_assistant_text()` helper before judging. Genuinely empty turns (interrupted / errored) are still skipped so the judge isn't asked to evaluate nothing.

No behavior change for non-streamed turns or for non-goal messages.

## Testing

Verified end-to-end over Telegram with a multi-turn `/goal`:

- `turns_used` advances (was stuck at `0`, now `0 → 4+`)
- the `goal_judge` model is loaded/called on every turn
- `[Continuing toward your standing goal]` continuations are enqueued between turns
- judge verdicts are correct (`continue` while incomplete, with sensible reasons)
- transcript recovery returns the exact streamed final response (confirmed against the logged `response_len`)

Non-goal messages and non-streamed goals are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)