### PR TITLE
fix(auth): redact credential pool refresh errors

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -42,13 +42,20 @@ from hermes_cli.auth import (
 logger = logging.getLogger(__name__)
 
 
+_AUTH_ERROR_SECRET_ASSIGNMENT_RE = re.compile(
+    r"\b((?:access|refresh|id)?_?token|api_?key|client_secret|secret|password)\s*=\s*([^\s,;]+)",
+    re.IGNORECASE,
+)
+
+
 def _redact_exception_message(exc: Exception) -> str:
     """Return a redacted string representation of *exc* for safe storage."""
     try:
         from agent.redact import redact_sensitive_text
-        return redact_sensitive_text(str(exc), force=True)
+        redacted = redact_sensitive_text(str(exc), force=True)
+        return _AUTH_ERROR_SECRET_ASSIGNMENT_RE.sub(r"\1=***", redacted)
     except Exception:
-        return str(exc)
+        return "credential refresh failed"
 
 
 def _load_config_safe() -> Optional[dict]:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -42,6 +42,15 @@ from hermes_cli.auth import (
 logger = logging.getLogger(__name__)
 
 
+def _redact_exception_message(exc: Exception) -> str:
+    """Return a redacted string representation of *exc* for safe storage."""
+    try:
+        from agent.redact import redact_sensitive_text
+        return redact_sensitive_text(str(exc), force=True)
+    except Exception:
+        return str(exc)
+
+
 def _load_config_safe() -> Optional[dict]:
     """Load config.yaml, returning None on any error."""
     try:
@@ -1114,7 +1123,7 @@ class CredentialPool:
                                         state["last_auth_error"] = {
                                             "provider": "xai-oauth",
                                             "code": getattr(exc, "code", "unknown"),
-                                            "message": str(exc),
+                                            "message": _redact_exception_message(exc),
                                             "reason": "credential_pool_refresh_failure",
                                             "relogin_required": True,
                                             "at": datetime.now(timezone.utc).isoformat(),
@@ -1184,7 +1193,7 @@ class CredentialPool:
                                         state["last_auth_error"] = {
                                             "provider": "openai-codex",
                                             "code": getattr(exc, "code", "unknown"),
-                                            "message": str(exc),
+                                            "message": _redact_exception_message(exc),
                                             "reason": "credential_pool_refresh_failure",
                                             "relogin_required": True,
                                             "at": datetime.now(timezone.utc).isoformat(),

--- a/tests/agent/test_credential_pool_error_redact.py
+++ b/tests/agent/test_credential_pool_error_redact.py
@@ -1,0 +1,33 @@
+"""Credential-pool auth error messages must be safe to persist."""
+
+from __future__ import annotations
+
+
+def test_redact_exception_message_masks_refresh_token_value():
+    from agent.credential_pool import _redact_exception_message
+
+    exc = RuntimeError("refresh failed: refresh_token=rt-secret-value")
+
+    message = _redact_exception_message(exc)
+
+    assert "rt-secret-value" not in message
+    assert "refresh_token=***" in message
+
+
+def test_redact_exception_message_fails_closed(monkeypatch):
+    from agent import credential_pool
+
+    def broken_redactor(*_args, **_kwargs):
+        raise RuntimeError("redactor unavailable")
+
+    monkeypatch.setattr(
+        "agent.redact.redact_sensitive_text",
+        broken_redactor,
+    )
+
+    message = credential_pool._redact_exception_message(
+        RuntimeError("refresh failed: access_token=at-secret-value")
+    )
+
+    assert message == "credential refresh failed"
+    assert "at-secret-value" not in message


### PR DESCRIPTION
## Summary

Credential-pool refresh failures now redact sensitive exception text before persisting `last_auth_error.message` into auth state.

## Why

Terminal OAuth refresh failures for `xai-oauth` and `openai-codex` persist the exception message into provider auth state. If the upstream error includes values such as `access_token=...`, `refresh_token=...`, `api_key=...`, or similar credential-bearing fields, those values can be written into local auth state.

## Changes

- Add a helper for safe credential-pool exception messages.
- Run the shared redactor and additionally mask credential-style key/value assignments in persisted auth errors.
- Fail closed with a generic message if redaction itself fails.
- Add regression tests for both normal redaction and redactor failure.

## Tests

```text
python -m pytest tests\agent\test_credential_pool_error_redact.py -q
2 passed