### PR TITLE
fix(cli): guard json.loads against JSONDecodeError in API response parsing

### DIFF
--- a/hermes_cli/nous_account.py
+++ b/hermes_cli/nous_account.py
@@ -1,5 +1,8 @@
 """Normalized Nous Portal account entitlement helpers."""
 
+import logging
+
+logger = logging.getLogger(__name__)
 from __future__ import annotations
 
 import hashlib
@@ -572,7 +575,12 @@ def _fetch_nous_account_info(
     }
     req = urllib.request.Request(url, headers=headers)
     with urllib.request.urlopen(req, timeout=8) as resp:
-        payload = json.loads(resp.read().decode())
+        raw = resp.read()
+    try:
+        payload = json.loads(raw.decode())
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        logger.warning("Non-JSON response from %s", url)
+        return {}
     return payload if isinstance(payload, dict) else {}
 
 

--- a/hermes_cli/security_audit.py
+++ b/hermes_cli/security_audit.py
@@ -17,6 +17,9 @@ Out of scope on purpose: global pip/npm, editor/browser extensions,
 daily background scans, auto-blocking installs.
 """
 
+import logging
+
+logger = logging.getLogger(__name__)
 from __future__ import annotations
 
 import argparse
@@ -288,13 +291,23 @@ def _http_post_json(url: str, payload: dict) -> dict:
         url, data=data, headers={"Content-Type": "application/json"}, method="POST"
     )
     with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        raw = resp.read()
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        logger.warning("Non-JSON POST response from %s", url)
+        return {}
 
 
 def _http_get_json(url: str) -> dict:
     req = urllib.request.Request(url, method="GET")
     with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        raw = resp.read()
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        logger.warning("Non-JSON GET response from %s", url)
+        return {}
 
 
 def _osv_query_batch(components: list[Component]) -> dict[Component, list[str]]:


### PR DESCRIPTION
## Problem

`json.loads()` called on HTTP response bodies without catching `JSONDecodeError`. If the server returns an HTML error page, empty body, or malformed response, the application crashes with an unhandled exception.

### `hermes_cli/nous_account.py:575` — `_fetch_nous_account_info()`

```python
with urllib.request.urlopen(req, timeout=8) as resp:
    payload = json.loads(resp.read().decode())  # crashes on non-JSON
```

Caller at line 400 has **no** try/except guard, so a server error page causes a hard crash during account info fetch.

### `hermes_cli/security_audit.py:291,297` — `_http_post_json()`, `_http_get_json()`

```python
def _http_get_json(url: str) -> dict:
    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
        return json.loads(resp.read().decode("utf-8"))  # crashes on non-JSON
```

Callers currently have guards, but the helper functions should be self-contained to prevent future regressions when new callers are added.

## Fix

Wrap each `json.loads()` in `try/except (json.JSONDecodeError, UnicodeDecodeError)` with `logger.warning()` and return `{}` on failure. This follows the existing pattern in `model_catalog.py:137`:

```python
try:
    return json.loads(raw.decode("utf-8"))
except (json.JSONDecodeError, UnicodeDecodeError):
    logger.warning("Non-JSON response from %s", url)
    return {}
```

## Impact

- **Severity**: P1 — crash on malformed API response
- **Scope**: 2 files, 24 lines added
- **Risk**: Minimal — only adds error handling, no behavior change for valid JSON responses
