### PR TITLE
fix(relay,osv): guard json.loads against JSONDecodeError

### DIFF
--- a/gateway/relay/descriptor.py
+++ b/gateway/relay/descriptor.py
@@ -71,7 +71,12 @@ class CapabilityDescriptor:
         fields this gateway does not know yet); missing optional keys fall back
         to dataclass defaults.
         """
-        raw = json.loads(data)
+        try:
+            raw = json.loads(data)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise ValueError(f"Invalid handshake JSON: {exc}") from exc
+        if not isinstance(raw, dict):
+            raise ValueError(f"Expected JSON object, got {type(raw).__name__}")
         known = {f for f in cls.__dataclass_fields__}  # type: ignore[attr-defined]
         filtered = {k: v for k, v in raw.items() if k in known}
         return cls(**filtered)

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -162,7 +162,12 @@ def _query_osv(
     )
 
     with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
-        result = json.loads(resp.read())
+        raw = resp.read()
+    try:
+        result = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        logger.warning("Non-JSON response from OSV API")
+        return []
 
     vulns = result.get("vulns", [])
     # Only malware advisories — ignore regular CVEs


### PR DESCRIPTION
## Problem

Two locations call `json.loads()` on external input without catching `JSONDecodeError`:

### `gateway/relay/descriptor.py:74` — `CapabilityDescriptor.from_json()`

```python
raw = json.loads(data)           # crashes on malformed JSON
filtered = {k: v for k, v in raw.items() if k in known}  # crashes if raw is not a dict
```

A malformed handshake message (e.g. JSON array, truncated JSON, or non-JSON payload) causes either `JSONDecodeError` or `AttributeError` on `.items()`.

### `tools/osv_check.py:165` — `_query_osv_batch()`

```python
with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
    result = json.loads(resp.read())  # crashes on non-JSON response
```

The OSV API can return HTML error pages (rate limit, 502 gateway error), causing the entire vulnerability check to crash instead of gracefully returning no results.

## Fix

- `descriptor.py`: Wrap `json.loads()` in `try/except (json.JSONDecodeError, TypeError)`, raise `ValueError` with clear message. Add `isinstance(raw, dict)` guard before `.items()`.
- `osv_check.py`: Wrap `json.loads()` in `try/except (json.JSONDecodeError, UnicodeDecodeError)`, log warning, return empty list.

## Impact

- **Severity**: P1 — crash on malformed external input
- **Scope**: 2 files, 12 lines added
- **Risk**: Minimal — only adds error handling
