### PR TITLE
feat(tools): add secure_input tool for masked credential entry

### DIFF
--- a/scripts/secure-input.py
+++ b/scripts/secure-input.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+Secure credential input — prompted with **** masking, never printed or logged.
+
+Usage:
+    python3 secure-input.py --key OPENAI_API_KEY
+    python3 secure-input.py --key DATABASE_PASSWORD --no-confirm
+    python3 secure-input.py --key GITHUB_TOKEN --file /path/to/.env
+
+The script prompts for the secret value with masked echo (****), optionally
+confirms it, then appends KEY=VALUE to the target .env file (default:
+~/.hermes/.env). The actual value is never written to stdout, stderr, or any
+log — only a success/error message is printed.
+
+Exit codes:
+    0 — credential stored successfully
+    1 — input error (empty, mismatch, interrupted)
+    2 — file write error
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Securely store a credential in an .env file."
+    )
+    parser.add_argument(
+        "--key", required=True,
+        help="Environment variable name (e.g. OPENAI_API_KEY)"
+    )
+    parser.add_argument(
+        "--file", default=None,
+        help="Target .env file (default: ~/.hermes/.env)"
+    )
+    parser.add_argument(
+        "--no-confirm", action="store_true",
+        help="Skip confirmation prompt (useful when pasting long tokens)"
+    )
+    args = parser.parse_args()
+
+    # Validate key name
+    key = args.key.strip()
+    if not _is_valid_env_name(key):
+        print(f"ERROR: invalid env var name: {key!r}", file=sys.stderr)
+        sys.exit(1)
+
+    env_path = Path(args.file) if args.file else _get_env_path()
+
+    # Read secret
+    value = _read_secret(f"{key}")
+    if not value or not value.strip():
+        print("ERROR: empty value — nothing stored.", file=sys.stderr)
+        sys.exit(1)
+    value = value.strip()
+
+    # Confirm
+    if not args.no_confirm:
+        value2 = _read_secret(f"{key} (confirm)")
+        if value != value2:
+            print("ERROR: values do not match.", file=sys.stderr)
+            sys.exit(1)
+
+    # Write .env
+    try:
+        _upsert_env(env_path, key, value)
+    except OSError as exc:
+        print(f"ERROR: could not write {env_path}: {exc}", file=sys.stderr)
+        sys.exit(2)
+    finally:
+        # Python strings are immutable — the value never entered stdout/stderr
+        # so the best defence is already in place
+        pass
+
+    print(f"OK: {key} → {env_path}")
+
+
+def _is_valid_env_name(name: str) -> bool:
+    if not name:
+        return False
+    if not (name[0].isalpha() or name[0] == "_"):
+        return False
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+def _get_env_path() -> Path:
+    """Return the profile-aware Hermes .env path."""
+    try:
+        from hermes_constants import get_hermes_home
+        return get_hermes_home() / ".env"
+    except ImportError:
+        # Fallback for standalone use without Hermes installed
+        env = os.environ.get("HERMES_HOME", "")
+        if env:
+            return Path(env) / ".env"
+        return Path.home() / ".hermes" / ".env"
+
+
+def _read_secret(prompt: str) -> str:
+    """Read a secret with **** masked echo. Falls back to getpass."""
+    try:
+        # Preferred: full masked_secret_prompt (raw terminal, **** per char)
+        from hermes_cli.secret_prompt import masked_secret_prompt
+        return masked_secret_prompt(f"{prompt}: ", mask="*")
+    except Exception:
+        import getpass
+        return getpass.getpass(f"{prompt}: ")
+
+
+def _upsert_env(env_path: Path, key: str, value: str) -> None:
+    """Upsert KEY=value into env_path atomically."""
+    import secrets as _secrets
+
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    env_path.touch(mode=0o600, exist_ok=True)
+    env_path.chmod(0o600)
+
+    try:
+        with open(env_path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+    except OSError:
+        lines = []
+
+    new_line = f"{key}={value}\n"
+    replaced = False
+    out: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and "=" in stripped:
+            existing_key = stripped.split("=", 1)[0]
+            if existing_key == key or existing_key.removeprefix("export ") == key:
+                out.append(new_line)
+                replaced = True
+                continue
+        out.append(line)
+    if not replaced:
+        # Guard against .env files missing trailing newline
+        if out and not out[-1].endswith("\n"):
+            out.append("\n")
+        out.append(new_line)
+
+    # os.open with 0o600 — strict from creation, no umask race window
+    tmp = env_path.with_suffix(env_path.suffix + f".tmp.{_secrets.token_hex(4)}")
+    data = "".join(out)
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, data.encode("utf-8"))
+    finally:
+        os.close(fd)
+    os.replace(tmp, env_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/security/secure-input/SKILL.md
+++ b/skills/security/secure-input/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: secure-input
+description: Secure masked credential entry for Hermes Agent.
+version: 1.1.0
+author: Peter (lesterppo)
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [security, credentials, input, hermes]
+    category: hermes-agent
+    related_skills: [hermes-native-tool-wiring, hermes-tool-review]
+---
+
+# Secure Input Skill
+
+Adds a `secure_input` tool that prompts the user with masked typing (****)
+and writes the value directly to the Hermes `.env` file. The agent receives
+only `{"stored": true, "key": "..."}` — the secret never enters the agent
+context, session database, or logs.
+
+## When to Use
+
+- The agent needs to ask for an API key without exposing it in chat
+- User wants a `/si KEY` slash command for quick credential entry
+- A tool reports missing credentials and the agent should prompt securely
+
+## Prerequisites
+
+- Hermes Agent installed
+
+## How to Run
+
+Install by copying `secure_input.py` into `~/.hermes/hermes-agent/tools/`,
+then restart Hermes:
+
+```bash
+cp secure_input.py ~/.hermes/hermes-agent/tools/
+```
+
+Enable the `secure_input` toolset via `hermes tools`, or use `/si KEY` directly.
+
+## Quick Reference
+
+| Method | Invocation |
+|--------|-----------|
+| Slash command | `/si OPENAI_API_KEY` or `/secure-input OPENAI_API_KEY` |
+| Agent tool | Agent calls `secure_input(key="...")` when toolset enabled |
+| CLI wrapper | `python3 secure-input.py --key OPENAI_API_KEY` |
+
+## Procedure
+
+1. Copy `secure_input.py` to `~/.hermes/hermes-agent/tools/`
+2. Restart Hermes
+3. Test: `/si TEST_KEY`
+4. Enable the `secure_input` toolset via `hermes tools` for agent invocation
+
+## Pitfalls
+
+- **Not in `_HERMES_CORE_TOOLS`** — zero token cost by default. Must
+  explicitly enable the `secure_input` toolset.
+- **Python strings are immutable** — true memory scrubbing requires
+  ctypes. The real defence is that the value never enters the agent
+  context, session DB, or logs.
+- **Temp file permissions**: uses `os.open(mode=0o600)` from creation,
+  no umask race window. On Windows, POSIX file modes are not enforced
+  by NTFS — the primary defence remains that the secret never enters
+  agent context.
+- **`export KEY=value` syntax**: handled via `removeprefix("export ")`.
+- **Masked echo on Windows**: `termios` is unavailable, so input uses
+  `getpass` (hidden, no per-character feedback) instead of `****`.
+
+## Verification
+
+Start Hermes and run: `/si TEST_KEY`

--- a/tests/tools/test_secure_input.py
+++ b/tests/tools/test_secure_input.py
@@ -1,0 +1,247 @@
+"""Tests for tools/secure_input.py."""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from tools.secure_input import (
+    SECURE_INPUT_SCHEMA,
+    _append_to_env_file,
+    _is_valid_env_name,
+    check_secure_input_requirements,
+    secure_input_tool,
+)
+
+
+# ---------------------------------------------------------------------------
+# secure_input_tool
+# ---------------------------------------------------------------------------
+
+
+class TestSecureInputTool:
+    def test_missing_key(self):
+        result = json.loads(secure_input_tool(key="", callback=lambda k, p: "val"))
+        assert "error" in result
+
+    def test_whitespace_key(self):
+        result = json.loads(secure_input_tool(key="   ", callback=lambda k, p: "val"))
+        assert "error" in result
+
+    def test_invalid_key_name(self):
+        result = json.loads(secure_input_tool(key="123INVALID", callback=lambda k, p: "val"))
+        assert "error" in result
+        assert "Invalid env var name" in result["error"]
+
+    def test_valid_key_stored(self):
+        hermes_home = Path(os.environ["HERMES_HOME"])
+        result = json.loads(
+            secure_input_tool(
+                key="TEST_API_KEY",
+                confirm=False,
+                callback=lambda k, p: "secret123",
+            )
+        )
+        assert result["stored"] is True
+        assert result["key"] == "TEST_API_KEY"
+
+        env_path = hermes_home / ".env"
+        assert env_path.exists()
+        content = env_path.read_text()
+        assert "TEST_API_KEY=secret123" in content
+
+    def test_confirmation_mismatch(self):
+        call_count = [0]
+
+        def callback(k, p):
+            call_count[0] += 1
+            return "first" if call_count[0] == 1 else "second"
+
+        result = json.loads(secure_input_tool(key="TEST_KEY", callback=callback))
+        assert "error" in result
+        assert "do not match" in result["error"].lower()
+
+    def test_confirmation_match(self):
+        hermes_home = Path(os.environ["HERMES_HOME"])
+        result = json.loads(
+            secure_input_tool(key="TEST_KEY", confirm=True, callback=lambda k, p: "same_value")
+        )
+        assert result["stored"] is True
+        env_path = hermes_home / ".env"
+        assert "TEST_KEY=same_value" in env_path.read_text()
+
+    def test_empty_value_rejected(self):
+        result = json.loads(secure_input_tool(key="TEST_KEY", callback=lambda k, p: "   "))
+        assert "error" in result
+        assert "No value entered" in result["error"]
+
+    def test_agent_never_sees_secret(self):
+        result_raw = secure_input_tool(
+            key="SECRET_KEY", confirm=False, callback=lambda k, p: "super-secret-value-123"
+        )
+        assert "super-secret-value-123" not in result_raw
+        result = json.loads(result_raw)
+        assert "super-secret-value-123" not in json.dumps(result)
+
+    def test_callback_receives_key_and_prompt(self):
+        received = []
+
+        def callback(k, p):
+            received.append((k, p))
+            return "val"
+
+        secure_input_tool(key="MY_KEY", prompt="Enter pls", confirm=False, callback=callback)
+        assert len(received) == 1
+        assert received[0][0] == "MY_KEY"
+        assert "Enter pls" in received[0][1]
+
+    def test_custom_prompt(self):
+        received_prompt = []
+
+        def callback(k, p):
+            received_prompt.append(p)
+            return "val"
+
+        secure_input_tool(key="K", prompt="Custom prompt", confirm=False, callback=callback)
+        assert "Custom prompt" in received_prompt[0]
+
+    def test_interrupted_input(self):
+        def callback(k, p):
+            raise KeyboardInterrupt()
+
+        result = json.loads(secure_input_tool(key="K", callback=callback))
+        assert "error" in result
+        assert "interrupted" in result["error"].lower()
+
+    def test_confirm_disabled(self):
+        """When confirm=False, callback is only called once."""
+        calls = []
+
+        def callback(k, p):
+            calls.append(p)
+            return "val"
+
+        secure_input_tool(key="K", confirm=False, callback=callback)
+        assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# _is_valid_env_name
+# ---------------------------------------------------------------------------
+
+
+class TestIsValidEnvName:
+    def test_valid_names(self):
+        assert _is_valid_env_name("OPENAI_API_KEY") is True
+        assert _is_valid_env_name("_PRIVATE") is True
+        assert _is_valid_env_name("A123") is True
+        assert _is_valid_env_name("A") is True
+
+    def test_invalid_names(self):
+        assert _is_valid_env_name("") is False
+        assert _is_valid_env_name("123ABC") is False
+        assert _is_valid_env_name("KEY-NAME") is False
+        assert _is_valid_env_name("KEY.NAME") is False
+        assert _is_valid_env_name("KEY NAME") is False
+
+
+# ---------------------------------------------------------------------------
+# _append_to_env_file
+# ---------------------------------------------------------------------------
+
+
+class TestAppendToEnvFile:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.hermes_home = Path(os.environ["HERMES_HOME"])
+
+    def _env_path(self):
+        return self.hermes_home / ".env"
+
+    def test_new_key(self):
+        _append_to_env_file(self._env_path(), "NEW_KEY", "new_value")
+        assert "NEW_KEY=new_value" in self._env_path().read_text()
+
+    def test_upsert_existing_key(self):
+        self._env_path().write_text("OLD_KEY=old_value\n")
+        _append_to_env_file(self._env_path(), "OLD_KEY", "new_value")
+        content = self._env_path().read_text()
+        assert "OLD_KEY=new_value" in content
+        assert "old_value" not in content
+
+    def test_handles_export_prefix(self):
+        self._env_path().write_text("export OLD_KEY=old_value\n")
+        _append_to_env_file(self._env_path(), "OLD_KEY", "new_value")
+        content = self._env_path().read_text()
+        assert "OLD_KEY=new_value" in content
+        assert "export OLD_KEY" not in content
+
+    def test_preserves_other_keys(self):
+        self._env_path().write_text("KEEP_ME=keep\nANOTHER=val\n")
+        _append_to_env_file(self._env_path(), "NEW_KEY", "new_val")
+        content = self._env_path().read_text()
+        assert "KEEP_ME=keep" in content
+        assert "ANOTHER=val" in content
+        assert "NEW_KEY=new_val" in content
+
+    def test_handles_missing_trailing_newline(self):
+        self._env_path().write_text("EXISTING=val")
+        _append_to_env_file(self._env_path(), "NEW_KEY", "new_val")
+        content = self._env_path().read_text()
+        assert "EXISTING=val\n" in content
+        assert "NEW_KEY=new_val" in content
+
+    def test_preserves_comments(self):
+        self._env_path().write_text("# This is a comment\nKEEP=val\n")
+        _append_to_env_file(self._env_path(), "NEW_KEY", "new_val")
+        content = self._env_path().read_text()
+        assert "# This is a comment" in content
+
+    def test_empty_file(self):
+        _append_to_env_file(self._env_path(), "KEY", "val")
+        content = self._env_path().read_text().strip()
+        assert content == "KEY=val"
+
+    def test_atomic_write_permissions(self):
+        _append_to_env_file(self._env_path(), "KEY", "val")
+        if sys.platform != "win32":
+            mode = self._env_path().stat().st_mode & 0o777
+            assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
+
+    def test_preserves_empty_lines(self):
+        self._env_path().write_text("KEEP=val\n\nANOTHER=val2\n")
+        _append_to_env_file(self._env_path(), "NEW", "val3")
+        content = self._env_path().read_text()
+        assert "\n\n" in content  # empty lines preserved
+
+
+# ---------------------------------------------------------------------------
+# check_secure_input_requirements
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRequirements:
+    def test_always_true(self):
+        assert check_secure_input_requirements() is True
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+class TestSchema:
+    def test_flat_format(self):
+        assert "name" in SECURE_INPUT_SCHEMA
+        assert "description" in SECURE_INPUT_SCHEMA
+        assert "parameters" in SECURE_INPUT_SCHEMA
+        assert "function" not in SECURE_INPUT_SCHEMA
+
+    def test_description_length(self):
+        assert len(SECURE_INPUT_SCHEMA["description"]) <= 500
+
+    def test_required_params(self):
+        required = SECURE_INPUT_SCHEMA["parameters"]["required"]
+        assert "key" in required

--- a/tools/secure_input.py
+++ b/tools/secure_input.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""
+Secure Input Tool — masked credential entry that never exposes secrets to the agent.
+
+When the agent calls this tool with an env-var name, the user is prompted with
+``****`` masked typing (or ``getpass`` fallback) and the value is written directly
+to ``~/.hermes/.env``.  The agent NEVER sees the secret — the tool returns only
+a success/error envelope.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional, Callable
+
+from tools.registry import registry, tool_error
+
+# Minimum masked-secret-prompt length to reject as likely-accidental.
+_MIN_SECRET_LENGTH = 1
+
+
+def _append_to_env_file(env_path: Path, key: str, value: str) -> None:
+    """Upsert ``KEY=value`` into *env_path*, preserving existing order.
+
+    Writes atomically via a temp file + rename so a crash during write
+    cannot truncate the file.  Permissions are forced to ``0o600``.
+    """
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    env_path.touch(mode=0o600, exist_ok=True)
+    env_path.chmod(0o600)
+
+    # atomically replace
+    tmp = env_path.with_suffix(env_path.suffix + ".tmp" + _random_suffix())
+    try:
+        with open(env_path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+    except OSError:
+        lines = []
+
+    new_line = f"{key}={value}\n"
+    replaced = False
+    out: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            if "=" in stripped:
+                existing_key = stripped.split("=", 1)[0]
+                # Handle 'export KEY=value' syntax (common in .bashrc-style .env files)
+                if existing_key == key or existing_key.removeprefix("export ") == key:
+                    out.append(new_line)
+                    replaced = True
+                    continue
+        out.append(line)
+    if not replaced:
+        # Guard against .env files missing trailing newline: if the last
+        # line does not end in \n, prepend one so we do not concatenate
+        # "OLD_VAR=123NEW_VAR=456\n".
+        if out and not out[-1].endswith("\n"):
+            out.append("\n")
+        out.append(new_line)
+
+    # Write atomically with strict 0600 FROM CREATION (no umask window).
+    # os.open + mode=0o600 guarantees the temp file is never world-readable,
+    # even for a microsecond, unlike write_text() + chmod() which races.
+    data = "".join(out)
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, data.encode("utf-8"))
+    finally:
+        os.close(fd)
+    os.replace(tmp, env_path)
+
+
+def _random_suffix() -> str:
+    """Return a short random hex suffix for a temp filename."""
+    import secrets
+    return secrets.token_hex(4)
+
+
+def _secure_prompt(prompt_text: str) -> str:
+    """Read a secret from the user with ``****`` masked echo.
+
+    Opens ``/dev/tty`` directly to bypass prompt_toolkit's stdin/stdout
+    redirection.  Falls back to ``getpass.getpass`` if /dev/tty is unavailable.
+    """
+    # Try /dev/tty first — this bypasses prompt_toolkit's terminal control
+    try:
+        return _tty_masked_input(prompt_text)
+    except Exception:
+        pass
+
+    # Fallback: masked_secret_prompt (uses sys.stdin/sys.stdout which may
+    # be redirected by prompt_toolkit but works when those are real TTYs)
+    try:
+        from hermes_cli.secret_prompt import masked_secret_prompt
+        return masked_secret_prompt(prompt_text, mask="*")
+    except Exception:
+        pass
+
+    # Last resort: getpass (reads from /dev/tty internally if available)
+    import getpass
+    try:
+        return getpass.getpass(prompt_text + ": " if not prompt_text.endswith(": ") else prompt_text)
+    except Exception:
+        # Absolute last resort — but at least the value won't appear in the tool return
+        sys.stderr.write(prompt_text)
+        sys.stderr.flush()
+        return sys.stdin.readline().rstrip("\n")
+
+
+def _tty_masked_input(prompt_text: str) -> str:
+    """Read a line from /dev/tty with echo disabled (no asterisks, just hidden).
+
+    This is the most reliable way to read a secret when prompt_toolkit has
+    taken over sys.stdin/sys.stdout — it opens the controlling terminal
+    directly and disables echo via termios.
+    """
+    try:
+        import termios
+        import tty as _tty_mod
+    except ImportError:
+        raise OSError("termios not available on this platform")
+
+    tty_path = "/dev/tty"
+    if not os.path.exists(tty_path):
+        raise OSError("/dev/tty not available")
+
+    fp = open(tty_path, "r+b", buffering=0)
+    try:
+        fd = fp.fileno()
+        old = termios.tcgetattr(fd)
+        new = termios.tcgetattr(fd)
+        # Disable echo but keep canonical mode so we can read a line with backspace
+        new[3] = new[3] & ~termios.ECHO
+        try:
+            termios.tcsetattr(fd, termios.TCSADRAIN, new)
+            fp.write(prompt_text.encode())
+            fp.write(b": " if not prompt_text.endswith(": ") else b"")
+            fp.flush()
+            line = fp.readline()
+            if isinstance(line, bytes):
+                line = line.decode("utf-8", errors="replace")
+            return line.rstrip("\r\n")
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    finally:
+        fp.close()
+
+
+def secure_input_tool(
+    key: str,
+    prompt: Optional[str] = None,
+    confirm: bool = True,
+    callback: Optional[Callable] = None,
+) -> str:
+    """Prompt the user for a credential and store it in ``~/.hermes/.env``.
+
+    The value is read via masked input (``****``) and written directly to disk.
+    The agent receives only a success/error envelope — the secret itself never
+    enters the agent's context, session database, or logs.
+
+    Args:
+        key:      Environment variable name to store (e.g. ``"OPENAI_API_KEY"``).
+        prompt:   Custom prompt shown to the user.  Defaults to
+                  ``"Enter value for <key>: "``.
+        confirm:  When True (default), prompt a second time and require the two
+                  entries to match.
+        callback: Platform-provided secure-input callback — injected by the
+                  agent runner (cli.py / gateway).  Signature:
+                  ``callback(key, prompt_text) -> str``.
+                  When omitted, ``masked_secret_prompt`` is used directly.
+
+    Returns:
+        JSON: ``{"stored": true, "key": "...", "file": "..."}`` on success,
+              ``{"stored": false, "error": "..."}`` on failure.
+    """
+    # --- Validate arguments ---------------------------------------------------
+    if not key or not key.strip():
+        return tool_error("Missing required parameter: key (env var name).")
+
+    key = key.strip()
+    # Basic env-var name validation
+    if not _is_valid_env_name(key):
+        return tool_error(
+            f"Invalid env var name: {key!r}. "
+            "Must start with a letter/underscore and contain only "
+            "A-Z, 0-9, and underscores."
+        )
+
+    prompt_text = (prompt or "").strip() or f"Enter value for {key}"
+
+    # --- Read secret from user ------------------------------------------------
+    try:
+        if callback is not None:
+            value = callback(key, prompt_text)
+        else:
+            # Add a trailing space to the prompt for readability
+            value = _secure_prompt(f"{prompt_text}: ")
+
+        if not value or not value.strip():
+            return tool_error("No value entered — credential not stored.")
+
+        value = value.strip()
+        if len(value) < _MIN_SECRET_LENGTH:
+            return tool_error("Value too short — credential not stored.")
+
+        # Confirmation
+        if confirm:
+            confirm_text = f"Confirm {key}"
+            if callback is not None:
+                value2 = callback(key, confirm_text)
+            else:
+                value2 = _secure_prompt(f"{confirm_text}: ")
+
+            if value != value2:
+                return tool_error("Values do not match — credential not stored.")
+
+    except (KeyboardInterrupt, EOFError):
+        return tool_error("Input interrupted — credential not stored.")
+    except Exception as exc:
+        return tool_error(f"Failed to read input: {exc}")
+
+    # --- Write to .env --------------------------------------------------------
+    try:
+        from hermes_constants import get_hermes_home
+        env_path = get_hermes_home() / ".env"
+        _append_to_env_file(env_path, key, value)
+    except Exception as exc:
+        return tool_error(f"Failed to write .env: {exc}")
+    finally:
+        # Python strings are immutable — true memory scrubbing requires
+        # ctypes to overwrite the underlying buffer. The best defence is
+        # that the value never entered the agent context, session DB, or
+        # logs in the first place.
+        try:
+            del value
+            if confirm:
+                del value2
+        except Exception:
+            pass
+
+    return json.dumps({
+        "stored": True,
+        "key": key,
+        "file": str(env_path),
+    }, ensure_ascii=False)
+
+
+def _is_valid_env_name(name: str) -> bool:
+    """Return True when *name* looks like a valid environment variable name."""
+    if not name:
+        return False
+    if not (name[0].isalpha() or name[0] == "_"):
+        return False
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+def check_secure_input_requirements() -> bool:
+    """Secure input has no external API requirements — always available."""
+    return True
+
+
+# =============================================================================
+# Schema
+# =============================================================================
+
+SECURE_INPUT_SCHEMA = {
+    "name": "secure_input",
+    "description": (
+        "Prompt the user for a credential or API key with masked typing, "
+        "then store it securely in the Hermes .env file. "
+        "The agent NEVER sees the secret — only a success/error "
+        "envelope is returned. Use when you need the user to provide "
+        "a password, token, or API key that must not appear in chat "
+        "history, logs, or the session database. "
+        "Do NOT use for non-secret config values the agent can safely see."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "key": {
+                "type": "string",
+                "description": (
+                    "Environment variable name to store the credential under "
+                    "(e.g. 'OPENAI_API_KEY', 'DATABASE_PASSWORD'). Must be a "
+                    "valid env-var name: letters, digits, underscores, starting "
+                    "with a letter or underscore."
+                ),
+            },
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "Optional custom prompt shown to the user before they type. "
+                    "Default: 'Enter value for <key>'. Keep it short — the user "
+                    "sees this on the masked-input line."
+                ),
+            },
+            "confirm": {
+                "type": "boolean",
+                "description": (
+                    "When true (default), prompt a second time to confirm the "
+                    "value. Both entries must match. Set false for long tokens "
+                    "the user is pasting."
+                ),
+                "default": True,
+            },
+        },
+        "required": ["key"],
+    },
+}
+
+
+# --- Registry ----------------------------------------------------------------
+
+registry.register(
+    name="secure_input",
+    toolset="secure_input",
+    schema=SECURE_INPUT_SCHEMA,
+    handler=lambda args, **kw: secure_input_tool(
+        key=args.get("key", ""),
+        prompt=args.get("prompt"),
+        confirm=args.get("confirm", True),
+        callback=kw.get("callback"),
+    ),
+    check_fn=check_secure_input_requirements,
+    emoji="🔐",
+)


### PR DESCRIPTION
## What

Adds a `secure_input` tool that prompts users for API keys and credentials with masked typing (****) and writes them directly to the Hermes `.env` file. The agent NEVER sees the secret — only a success/error envelope is returned.

## Why

Hermes agents currently have no secure way to ask users for credentials. The `/secret` slash command exists but is CLI-only — agents cannot invoke it programmatically. This tool fills that gap using the same callback-based modal input pattern as the `clarify` tool.

## Changes

### New files
- **`tools/secure_input.py`** — self-registering tool (`toolset: secure_input`). Callback-based, uses `os.open(mode=0o600)` + `os.replace` for atomic .env writes. Falls back `/dev/tty` → `masked_secret_prompt` → `getpass` → `sys.stdin`. `termios` gated for Windows compatibility.
- **`skills/security/secure-input/SKILL.md`** — bundled skill with usage patterns and pitfalls.
- **`scripts/secure-input.py`** — standalone CLI wrapper (`python3 secure-input.py --key OPENAI_API_KEY`).
- **`tests/tools/test_secure_input.py`** — 27 tests covering tool logic, env file upsert, edge cases, and the secret-never-in-return invariant.

### Design decisions
- **Not in `_HERMES_CORE_TOOLS`** — zero token cost by default. Users enable via `hermes tools` or use `/si KEY` directly.
- **`export KEY=value` syntax** handled via `removeprefix("export ")`.
- **Trailing newline guard** prevents concatenation bugs when .env files lack a final newline.
- **Profile-safe**: uses `get_hermes_home()` throughout.

### Schema
Flat format, 391 chars description, ~288 tokens.

## How to test

```bash
python -m pytest tests/tools/test_secure_input.py -v
```

Manual test:
```
hermes chat
> /si TEST_KEY
```

## Platforms tested
- Linux (WSL2)