### PR TITLE
fix(dashboard): redact oauth error responses

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6132,11 +6132,7 @@ def _resolve_provider_status(provider_id: str, status_fn) -> Dict[str, Any]:
         try:
             return status_fn()
         except Exception as e:
-            try:
-                from agent.redact import redact_sensitive_text
-                return {"logged_in": False, "error": redact_sensitive_text(str(e), force=True)}
-            except Exception:
-                return {"logged_in": False, "error": str(e)}
+            return {"logged_in": False, "error": _safe_oauth_error_message(e)}
     try:
         from hermes_cli import auth as hauth
         if provider_id == "nous":
@@ -6220,12 +6216,23 @@ def _resolve_provider_status(provider_id: str, status_fn) -> Dict[str, Any]:
                 "has_refresh_token": bool(raw.get("has_refresh_token")),
             }
     except Exception as e:
-        try:
-            from agent.redact import redact_sensitive_text
-            return {"logged_in": False, "error": redact_sensitive_text(str(e), force=True)}
-        except Exception:
-            return {"logged_in": False, "error": str(e)}
+        return {"logged_in": False, "error": _safe_oauth_error_message(e)}
     return {"logged_in": False}
+
+
+def _safe_oauth_error_message(exc: Exception) -> str:
+    """Return an OAuth error string that is safe for dashboard API responses."""
+    try:
+        from agent.redact import redact_sensitive_text
+        redacted = redact_sensitive_text(str(exc), force=True)
+        return re.sub(
+            r"\b((?:access|refresh|id)?_?token|api_?key|client_secret|secret|password|key)\s*=\s*([^\s,;]+)",
+            r"\1=***",
+            redacted,
+            flags=re.IGNORECASE,
+        )
+    except Exception:
+        return "OAuth provider error"
 
 
 def _oauth_provider_disconnect_command(provider: Dict[str, Any]) -> Optional[str]:
@@ -6423,13 +6430,7 @@ async def disconnect_oauth_provider(
             return {"ok": bool(cleared), "provider": provider_id}
         except Exception as e:
             _log.exception("disconnect %s failed", provider_id)
-            try:
-                from agent.redact import redact_sensitive_text
-                raise HTTPException(status_code=500, detail=redact_sensitive_text(str(e), force=True))
-            except HTTPException:
-                raise
-            except Exception:
-                raise HTTPException(status_code=500, detail=str(e))
+            raise HTTPException(status_code=500, detail=_safe_oauth_error_message(e))
 
 
 # ---------------------------------------------------------------------------
@@ -7184,11 +7185,7 @@ def _nous_poller(session_id: str) -> None:
         _log.warning("nous device-code poll failed (session=%s): %s", session_id, e)
         with _oauth_sessions_lock:
             sess["status"] = "error"
-            try:
-                from agent.redact import redact_sensitive_text
-                sess["error_message"] = redact_sensitive_text(str(e), force=True)
-            except Exception:
-                sess["error_message"] = str(e)
+            sess["error_message"] = _safe_oauth_error_message(e)
 
 
 def _minimax_poller(session_id: str) -> None:
@@ -7272,11 +7269,7 @@ def _minimax_poller(session_id: str) -> None:
         _log.warning("minimax device-code poll failed (session=%s): %s", session_id, e)
         with _oauth_sessions_lock:
             sess["status"] = "error"
-            try:
-                from agent.redact import redact_sensitive_text
-                sess["error_message"] = redact_sensitive_text(str(e), force=True)
-            except Exception:
-                sess["error_message"] = str(e)
+            sess["error_message"] = _safe_oauth_error_message(e)
 
 
 def _codex_full_login_worker(session_id: str) -> None:
@@ -7395,11 +7388,7 @@ def _codex_full_login_worker(session_id: str) -> None:
             s = _oauth_sessions.get(session_id)
             if s:
                 s["status"] = "error"
-                try:
-                    from agent.redact import redact_sensitive_text
-                    s["error_message"] = redact_sensitive_text(str(e), force=True)
-                except Exception:
-                    s["error_message"] = str(e)
+                s["error_message"] = _safe_oauth_error_message(e)
 
 
 @app.post("/api/providers/oauth/{provider_id}/start")
@@ -7440,13 +7429,7 @@ async def start_oauth_login(
         raise
     except Exception as e:
         _log.exception("oauth/start %s failed", provider_id)
-        try:
-            from agent.redact import redact_sensitive_text
-            raise HTTPException(status_code=500, detail=redact_sensitive_text(str(e), force=True))
-        except HTTPException:
-            raise
-        except Exception:
-            raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=_safe_oauth_error_message(e))
     raise HTTPException(status_code=400, detail="Unsupported flow")
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6132,7 +6132,11 @@ def _resolve_provider_status(provider_id: str, status_fn) -> Dict[str, Any]:
         try:
             return status_fn()
         except Exception as e:
-            return {"logged_in": False, "error": str(e)}
+            try:
+                from agent.redact import redact_sensitive_text
+                return {"logged_in": False, "error": redact_sensitive_text(str(e), force=True)}
+            except Exception:
+                return {"logged_in": False, "error": str(e)}
     try:
         from hermes_cli import auth as hauth
         if provider_id == "nous":
@@ -6216,7 +6220,11 @@ def _resolve_provider_status(provider_id: str, status_fn) -> Dict[str, Any]:
                 "has_refresh_token": bool(raw.get("has_refresh_token")),
             }
     except Exception as e:
-        return {"logged_in": False, "error": str(e)}
+        try:
+            from agent.redact import redact_sensitive_text
+            return {"logged_in": False, "error": redact_sensitive_text(str(e), force=True)}
+        except Exception:
+            return {"logged_in": False, "error": str(e)}
     return {"logged_in": False}
 
 
@@ -6415,7 +6423,13 @@ async def disconnect_oauth_provider(
             return {"ok": bool(cleared), "provider": provider_id}
         except Exception as e:
             _log.exception("disconnect %s failed", provider_id)
-            raise HTTPException(status_code=500, detail=str(e))
+            try:
+                from agent.redact import redact_sensitive_text
+                raise HTTPException(status_code=500, detail=redact_sensitive_text(str(e), force=True))
+            except HTTPException:
+                raise
+            except Exception:
+                raise HTTPException(status_code=500, detail=str(e))
 
 
 # ---------------------------------------------------------------------------
@@ -7170,7 +7184,11 @@ def _nous_poller(session_id: str) -> None:
         _log.warning("nous device-code poll failed (session=%s): %s", session_id, e)
         with _oauth_sessions_lock:
             sess["status"] = "error"
-            sess["error_message"] = str(e)
+            try:
+                from agent.redact import redact_sensitive_text
+                sess["error_message"] = redact_sensitive_text(str(e), force=True)
+            except Exception:
+                sess["error_message"] = str(e)
 
 
 def _minimax_poller(session_id: str) -> None:
@@ -7254,7 +7272,11 @@ def _minimax_poller(session_id: str) -> None:
         _log.warning("minimax device-code poll failed (session=%s): %s", session_id, e)
         with _oauth_sessions_lock:
             sess["status"] = "error"
-            sess["error_message"] = str(e)
+            try:
+                from agent.redact import redact_sensitive_text
+                sess["error_message"] = redact_sensitive_text(str(e), force=True)
+            except Exception:
+                sess["error_message"] = str(e)
 
 
 def _codex_full_login_worker(session_id: str) -> None:
@@ -7373,7 +7395,11 @@ def _codex_full_login_worker(session_id: str) -> None:
             s = _oauth_sessions.get(session_id)
             if s:
                 s["status"] = "error"
-                s["error_message"] = str(e)
+                try:
+                    from agent.redact import redact_sensitive_text
+                    s["error_message"] = redact_sensitive_text(str(e), force=True)
+                except Exception:
+                    s["error_message"] = str(e)
 
 
 @app.post("/api/providers/oauth/{provider_id}/start")
@@ -7414,7 +7440,13 @@ async def start_oauth_login(
         raise
     except Exception as e:
         _log.exception("oauth/start %s failed", provider_id)
-        raise HTTPException(status_code=500, detail=str(e))
+        try:
+            from agent.redact import redact_sensitive_text
+            raise HTTPException(status_code=500, detail=redact_sensitive_text(str(e), force=True))
+        except HTTPException:
+            raise
+        except Exception:
+            raise HTTPException(status_code=500, detail=str(e))
     raise HTTPException(status_code=400, detail="Unsupported flow")
 
 

--- a/tests/hermes_cli/test_web_server_oauth_error_redact.py
+++ b/tests/hermes_cli/test_web_server_oauth_error_redact.py
@@ -1,105 +1,126 @@
-"""Tests that web_server.py OAuth error handlers redact sensitive text."""
+"""Dashboard OAuth error handlers must not echo credentials."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+import time
 
 import pytest
-from unittest.mock import patch
+from fastapi import HTTPException
 
 
-def _redact_side_effect(text, force=False):
-    """Fake redact that brackets the text to prove it was called."""
-    return f"[REDACTED:{text}]"
+SECRET = "sk-oauthsecretvalue1234567890"
 
 
-class TestResolveProviderStatusRedact:
-    """_resolve_provider_status() must route errors through redact_sensitive_text."""
+def test_safe_oauth_error_message_redacts_credentials():
+    from hermes_cli.web_server import _safe_oauth_error_message
 
-    @patch("agent.redact.redact_sensitive_text", side_effect=_redact_side_effect)
-    def test_status_fn_exception_redacted(self, mock_redact):
-        from hermes_cli.web_server import _resolve_provider_status
+    message = _safe_oauth_error_message(
+        RuntimeError(f"provider failed: access_token={SECRET}")
+    )
 
-        def bad_status():
-            raise ValueError("token_expired: secret_abc123")
-
-        result = _resolve_provider_status("test", bad_status)
-        assert result["logged_in"] is False
-        assert "[REDACTED:" in result["error"]
-        mock_redact.assert_called()
-
-    @patch("agent.redact.redact_sensitive_text", side_effect=_redact_side_effect)
-    def test_outer_fallback_exception_redacted(self, mock_redact):
-        from hermes_cli.web_server import _resolve_provider_status
-
-        with patch("hermes_cli.web_server.hauth") as mock_hauth:
-            mock_hauth.get_nous_auth_status.side_effect = ValueError("key=sk-abc123")
-            result = _resolve_provider_status("nous", None)
-            assert result["logged_in"] is False
-            assert "[REDACTED:" in result["error"]
-            mock_redact.assert_called()
+    assert SECRET not in message
+    assert "access_token=***" in message
 
 
-class TestDeviceCodePollerRedact:
-    """Device-code pollers must redact error_message in session state."""
+def test_safe_oauth_error_message_fails_closed(monkeypatch):
+    from hermes_cli import web_server
 
-    @patch("agent.redact.redact_sensitive_text", side_effect=_redact_side_effect)
-    def test_nous_poller_error_redacted(self, mock_redact):
-        from hermes_cli.web_server import _oauth_sessions, _oauth_sessions_lock, _nous_poller
+    def broken_redactor(*_args, **_kwargs):
+        raise RuntimeError("redactor unavailable")
 
-        session_id = "test-redact-nous"
-        with _oauth_sessions_lock:
-            _oauth_sessions[session_id] = {
-                "status": "pending",
-                "provider": "nous",
-                "poll_fn": lambda: None,
-            }
+    monkeypatch.setattr("agent.redact.redact_sensitive_text", broken_redactor)
 
-        with patch("hermes_cli.web_server.nous_poll_device_code", side_effect=ValueError("device_code=dg_abc123")):
-            _nous_poller(session_id)
+    message = web_server._safe_oauth_error_message(
+        RuntimeError(f"provider failed: access_token={SECRET}")
+    )
 
-        with _oauth_sessions_lock:
-            sess = _oauth_sessions.get(session_id, {})
-        assert sess.get("status") == "error"
-        assert "dg_abc123" not in sess.get("error_message", "")
-        mock_redact.assert_called()
+    assert message == "OAuth provider error"
+    assert SECRET not in message
 
-    @patch("agent.redact.redact_sensitive_text", side_effect=_redact_side_effect)
-    def test_minimax_poller_error_redacted(self, mock_redact):
-        from hermes_cli.web_server import _oauth_sessions, _oauth_sessions_lock, _minimax_poller
 
-        session_id = "test-redact-minimax"
-        with _oauth_sessions_lock:
-            _oauth_sessions[session_id] = {
-                "status": "pending",
-                "provider": "minimax-oauth",
-                "code_verifier": "verifier123",
-                "user_code": "code123",
-                "region": "us",
-            }
+def test_resolve_provider_status_redacts_status_fn_exception():
+    from hermes_cli.web_server import _resolve_provider_status
 
-        with patch("hermes_cli.web_server._minimax_poll_token", side_effect=ValueError("api_key=minimax_key_abc")):
-            _minimax_poller(session_id)
+    def bad_status():
+        raise ValueError(f"token expired: api_key={SECRET}")
 
-        with _oauth_sessions_lock:
-            sess = _oauth_sessions.get(session_id, {})
-        assert sess.get("status") == "error"
-        assert "minimax_key_abc" not in sess.get("error_message", "")
-        mock_redact.assert_called()
+    result = _resolve_provider_status("test", bad_status)
 
-    @patch("agent.redact.redact_sensitive_text", side_effect=_redact_side_effect)
-    def test_codex_worker_error_redacted(self, mock_redact):
-        from hermes_cli.web_server import _oauth_sessions, _oauth_sessions_lock, _codex_full_login_worker
+    assert result["logged_in"] is False
+    assert SECRET not in result["error"]
+    assert "api_key=***" in result["error"]
 
-        session_id = "test-redact-codex"
-        with _oauth_sessions_lock:
-            _oauth_sessions[session_id] = {
-                "status": "pending",
-                "provider": "openai-codex",
-            }
 
-        with patch("hermes_cli.web_server.httpx") as mock_httpx:
-            mock_httpx.Client.side_effect = ValueError("bearer_token=sk-codex-abc")
-            _codex_full_login_worker(session_id)
+def test_resolve_provider_status_redacts_dispatch_exception(monkeypatch):
+    from hermes_cli.web_server import _resolve_provider_status
 
-        with _oauth_sessions_lock:
-            s = _oauth_sessions.get(session_id, {})
-        assert s.get("status") == "error"
-        assert "sk-codex-abc" not in s.get("error_message", "")
-        mock_redact.assert_called()
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_nous_auth_status",
+        lambda: (_ for _ in ()).throw(ValueError(f"key={SECRET}")),
+    )
+
+    result = _resolve_provider_status("nous", None)
+
+    assert result["logged_in"] is False
+    assert SECRET not in result["error"]
+    assert "key=***" in result["error"]
+
+
+def test_nous_poller_stores_redacted_error_message():
+    from hermes_cli.web_server import _oauth_sessions, _oauth_sessions_lock, _nous_poller
+
+    session_id = "test-redact-nous"
+    with _oauth_sessions_lock:
+        _oauth_sessions[session_id] = {
+            "status": "pending",
+            "provider": "nous",
+            "poll_fn": lambda: None,
+            "created_at": time.time(),
+            "portal_base_url": "https://portal.example.test",
+            "client_id": "client-id",
+            "device_code": "device-code",
+            "interval": 1,
+            "expires_at": time.time() + 600,
+        }
+
+    with patch(
+        "hermes_cli.auth._poll_for_token",
+        side_effect=ValueError(f"access_token={SECRET}"),
+    ):
+        _nous_poller(session_id)
+
+    with _oauth_sessions_lock:
+        sess = _oauth_sessions.pop(session_id, {})
+
+    assert sess.get("status") == "error"
+    assert SECRET not in sess.get("error_message", "")
+    assert "access_token=***" in sess.get("error_message", "")
+
+
+@pytest.mark.anyio
+async def test_start_oauth_login_redacts_http_exception_detail(monkeypatch):
+    from hermes_cli.web_server import start_oauth_login
+
+    monkeypatch.setattr(
+        "hermes_cli.web_server._require_token",
+        lambda request: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.web_server._gc_oauth_sessions",
+        lambda: None,
+    )
+    async def broken_start(*_args, **_kwargs):
+        raise ValueError(f"refresh_token={SECRET}")
+
+    monkeypatch.setattr(
+        "hermes_cli.web_server._start_device_code_flow",
+        broken_start,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await start_oauth_login("nous", request=None)
+
+    assert exc.value.status_code == 500
+    assert SECRET not in str(exc.value.detail)
+    assert "refresh_token=***" in str(exc.value.detail)

--- a/tests/hermes_cli/test_web_server_oauth_error_redact.py
+++ b/tests/hermes_cli/test_web_server_oauth_error_redact.py
@@ -1,0 +1,105 @@
+"""Tests that web_server.py OAuth error handlers redact sensitive text."""
+
+import pytest
+from unittest.mock import patch
+
+
+def _redact_side_effect(text, force=False):
+    """Fake redact that brackets the text to prove it was called."""
+    return f"[REDACTED:{text}]"
+
+
+class TestResolveProviderStatusRedact:
+    """_resolve_provider_status() must route errors through redact_sensitive_text."""
+
+    @patch("agent.redact.redact_sensitive_text", side_effect=_redact_side_effect)
+    def test_status_fn_exception_redacted(self, mock_redact):
+        from hermes_cli.web_server import _resolve_provider_status
+
+        def bad_status():
+            raise ValueError("token_expired: secret_abc123")
+
+        result = _resolve_provider_status("test", bad_status)
+        assert result["logged_in"] is False
+        assert "[REDACTED:" in result["error"]
+        mock_redact.assert_called()
+
+    @patch("agent.redact.redact_sensitive_text", side_effect=_redact_side_effect)
+    def test_outer_fallback_exception_redacted(self, mock_redact):
+        from hermes_cli.web_server import _resolve_provider_status
+
+        with patch("hermes_cli.web_server.hauth") as mock_hauth:
+            mock_hauth.get_nous_auth_status.side_effect = ValueError("key=sk-abc123")
+            result = _resolve_provider_status("nous", None)
+            assert result["logged_in"] is False
+            assert "[REDACTED:" in result["error"]
+            mock_redact.assert_called()
+
+
+class TestDeviceCodePollerRedact:
+    """Device-code pollers must redact error_message in session state."""
+
+    @patch("agent.redact.redact_sensitive_text", side_effect=_redact_side_effect)
+    def test_nous_poller_error_redacted(self, mock_redact):
+        from hermes_cli.web_server import _oauth_sessions, _oauth_sessions_lock, _nous_poller
+
+        session_id = "test-redact-nous"
+        with _oauth_sessions_lock:
+            _oauth_sessions[session_id] = {
+                "status": "pending",
+                "provider": "nous",
+                "poll_fn": lambda: None,
+            }
+
+        with patch("hermes_cli.web_server.nous_poll_device_code", side_effect=ValueError("device_code=dg_abc123")):
+            _nous_poller(session_id)
+
+        with _oauth_sessions_lock:
+            sess = _oauth_sessions.get(session_id, {})
+        assert sess.get("status") == "error"
+        assert "dg_abc123" not in sess.get("error_message", "")
+        mock_redact.assert_called()
+
+    @patch("agent.redact.redact_sensitive_text", side_effect=_redact_side_effect)
+    def test_minimax_poller_error_redacted(self, mock_redact):
+        from hermes_cli.web_server import _oauth_sessions, _oauth_sessions_lock, _minimax_poller
+
+        session_id = "test-redact-minimax"
+        with _oauth_sessions_lock:
+            _oauth_sessions[session_id] = {
+                "status": "pending",
+                "provider": "minimax-oauth",
+                "code_verifier": "verifier123",
+                "user_code": "code123",
+                "region": "us",
+            }
+
+        with patch("hermes_cli.web_server._minimax_poll_token", side_effect=ValueError("api_key=minimax_key_abc")):
+            _minimax_poller(session_id)
+
+        with _oauth_sessions_lock:
+            sess = _oauth_sessions.get(session_id, {})
+        assert sess.get("status") == "error"
+        assert "minimax_key_abc" not in sess.get("error_message", "")
+        mock_redact.assert_called()
+
+    @patch("agent.redact.redact_sensitive_text", side_effect=_redact_side_effect)
+    def test_codex_worker_error_redacted(self, mock_redact):
+        from hermes_cli.web_server import _oauth_sessions, _oauth_sessions_lock, _codex_full_login_worker
+
+        session_id = "test-redact-codex"
+        with _oauth_sessions_lock:
+            _oauth_sessions[session_id] = {
+                "status": "pending",
+                "provider": "openai-codex",
+            }
+
+        with patch("hermes_cli.web_server.httpx") as mock_httpx:
+            mock_httpx.Client.side_effect = ValueError("bearer_token=sk-codex-abc")
+            _codex_full_login_worker(session_id)
+
+        with _oauth_sessions_lock:
+            s = _oauth_sessions.get(session_id, {})
+        assert s.get("status") == "error"
+        assert "sk-codex-abc" not in s.get("error_message", "")
+        mock_redact.assert_called()


### PR DESCRIPTION
## Summary

Dashboard OAuth error paths now redact credential-bearing exception text before returning it through API responses or OAuth session state.

## Why

Several dashboard OAuth paths surfaced raw `str(exc)` values:

- provider status resolution
- OAuth start failures
- disconnect failures
- background device-code poller errors

These responses are authenticated, but they are still frontend/API-visible. Provider exceptions can include token, key, or refresh-token fields, so the dashboard should not echo them back verbatim.

## Changes

- Add a shared `_safe_oauth_error_message()` helper.
- Redact OAuth error strings and mask credential-style key/value assignments.
- Fail closed with a generic OAuth error if redaction fails.
- Apply the helper to status, start, disconnect, and device-code poller error paths.
- Add regression coverage for response detail and persisted OAuth session errors.

## Tests

```text
python -m pytest tests\hermes_cli\test_web_server_oauth_error_redact.py -q
6 passed