### PR TITLE
fix(tui): redact gateway error messages

### DIFF
--- a/tests/tui_gateway/test_server_error_redact.py
+++ b/tests/tui_gateway/test_server_error_redact.py
@@ -1,56 +1,75 @@
-"""Tests that tui_gateway/server.py error responses redact sensitive text."""
+"""TUI gateway transport errors must not echo credentials."""
 
-import json
-import pytest
-from unittest.mock import patch
+from __future__ import annotations
 
-
-def _redact_side_effect(text, force=False):
-    """Fake redact that brackets the text to prove it was called."""
-    return f"[REDACTED:{text}]"
+import threading
 
 
-class TestErrRedact:
-    """_err() must route error messages through redact_sensitive_text."""
-
-    @patch("agent.redact.redact_sensitive_text", side_effect=_redact_side_effect)
-    def test_err_redacts_message(self, mock_redact):
-        from tui_gateway.server import _err
-
-        result = _err("r1", -32000, "secret_token=abc123")
-        msg = result["error"]["message"]
-        assert "abc123" not in msg
-        assert "[REDACTED:" in msg
-        mock_redact.assert_called()
-
-    @patch("agent.redact.redact_sensitive_text", side_effect=_redact_side_effect)
-    def test_err_preserves_code_and_id(self, mock_redact):
-        from tui_gateway.server import _err
-
-        result = _err("r42", -32600, "invalid request with key=sk-xyz")
-        assert result["jsonrpc"] == "2.0"
-        assert result["id"] == "r42"
-        assert result["error"]["code"] == -32600
-
-    @patch("agent.redact.redact_sensitive_text", side_effect=Exception("redact broken"))
-    def test_err_falls_back_to_raw_on_redact_failure(self, mock_redact):
-        from tui_gateway.server import _err
-
-        result = _err("r2", -32000, "error with device_code=dg_abc")
-        msg = result["error"]["message"]
-        assert "dg_abc" in msg
-        mock_redact.assert_called()
+SECRET = "sk-tuisecretvalue1234567890"
 
 
-class TestAgentInitErrorRedact:
-    """Agent init error path must redact before emitting."""
+def test_err_redacts_secret_assignments():
+    from tui_gateway.server import _err
 
-    @patch("agent.redact.redact_sensitive_text", side_effect=_redact_side_effect)
-    def test_agent_init_error_emits_redacted(self, mock_redact):
-        from tui_gateway.server import _make_agent
-        from tui_gateway.server import _sessions
+    result = _err("r1", -32000, f"provider failed: access_token={SECRET}")
 
-        # _make_agent will fail because we pass garbage config
-        # We just verify that if it throws, the error path calls redact
-        # This is an integration-level check
-        mock_redact.assert_not_called()
+    msg = result["error"]["message"]
+    assert result["jsonrpc"] == "2.0"
+    assert result["id"] == "r1"
+    assert result["error"]["code"] == -32000
+    assert SECRET not in msg
+    assert "access_token=***" in msg
+
+
+def test_err_fails_closed_when_redactor_fails(monkeypatch):
+    from tui_gateway import server
+
+    def broken_redactor(*_args, **_kwargs):
+        raise RuntimeError("redactor unavailable")
+
+    monkeypatch.setattr("agent.redact.redact_sensitive_text", broken_redactor)
+
+    result = server._err("r2", -32000, f"provider failed: api_key={SECRET}")
+
+    assert result["error"]["message"] == "Gateway error"
+    assert SECRET not in result["error"]["message"]
+
+
+def test_start_agent_build_redacts_init_error(monkeypatch):
+    from tui_gateway import server
+
+    emitted = []
+
+    def fake_make_agent(*_args, **_kwargs):
+        raise RuntimeError(f"init failed: refresh_token={SECRET}")
+
+    monkeypatch.setattr(server, "_set_session_context", lambda target: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
+
+    sid = "redact-build-sid"
+    session = {
+        "agent": None,
+        "agent_ready": threading.Event(),
+        "session_key": "k1",
+        "profile_home": None,
+        "model_override": None,
+        "create_reasoning_override": None,
+        "create_service_tier_override": None,
+    }
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session)
+        assert session["agent_ready"].wait(timeout=3), "agent build did not finish"
+    finally:
+        server._sessions.clear()
+
+    assert SECRET not in session["agent_error"]
+    assert "refresh_token=***" in session["agent_error"]
+
+    error_events = [args for args in emitted if args and args[0] == "error"]
+    assert error_events
+    payload = error_events[-1][2]
+    assert SECRET not in payload["message"]
+    assert "refresh_token=***" in payload["message"]

--- a/tests/tui_gateway/test_server_error_redact.py
+++ b/tests/tui_gateway/test_server_error_redact.py
@@ -1,0 +1,56 @@
+"""Tests that tui_gateway/server.py error responses redact sensitive text."""
+
+import json
+import pytest
+from unittest.mock import patch
+
+
+def _redact_side_effect(text, force=False):
+    """Fake redact that brackets the text to prove it was called."""
+    return f"[REDACTED:{text}]"
+
+
+class TestErrRedact:
+    """_err() must route error messages through redact_sensitive_text."""
+
+    @patch("agent.redact.redact_sensitive_text", side_effect=_redact_side_effect)
+    def test_err_redacts_message(self, mock_redact):
+        from tui_gateway.server import _err
+
+        result = _err("r1", -32000, "secret_token=abc123")
+        msg = result["error"]["message"]
+        assert "abc123" not in msg
+        assert "[REDACTED:" in msg
+        mock_redact.assert_called()
+
+    @patch("agent.redact.redact_sensitive_text", side_effect=_redact_side_effect)
+    def test_err_preserves_code_and_id(self, mock_redact):
+        from tui_gateway.server import _err
+
+        result = _err("r42", -32600, "invalid request with key=sk-xyz")
+        assert result["jsonrpc"] == "2.0"
+        assert result["id"] == "r42"
+        assert result["error"]["code"] == -32600
+
+    @patch("agent.redact.redact_sensitive_text", side_effect=Exception("redact broken"))
+    def test_err_falls_back_to_raw_on_redact_failure(self, mock_redact):
+        from tui_gateway.server import _err
+
+        result = _err("r2", -32000, "error with device_code=dg_abc")
+        msg = result["error"]["message"]
+        assert "dg_abc" in msg
+        mock_redact.assert_called()
+
+
+class TestAgentInitErrorRedact:
+    """Agent init error path must redact before emitting."""
+
+    @patch("agent.redact.redact_sensitive_text", side_effect=_redact_side_effect)
+    def test_agent_init_error_emits_redacted(self, mock_redact):
+        from tui_gateway.server import _make_agent
+        from tui_gateway.server import _sessions
+
+        # _make_agent will fail because we pass garbage config
+        # We just verify that if it throws, the error path calls redact
+        # This is an integration-level check
+        mock_redact.assert_not_called()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import queue
+import re
 import subprocess
 import sys
 import threading
@@ -1046,12 +1047,23 @@ def _ok(rid, result: dict) -> dict:
     return {"jsonrpc": "2.0", "id": rid, "result": result}
 
 
-def _err(rid, code: int, msg: str) -> dict:
+def _safe_error_message(msg: Any, *, fallback: str = "Gateway error") -> str:
+    """Return a JSON-RPC/event error message safe for frontend transport."""
     try:
         from agent.redact import redact_sensitive_text
-        msg = redact_sensitive_text(str(msg), force=True)
+        redacted = redact_sensitive_text(str(msg), force=True)
+        return re.sub(
+            r"\b((?:access|refresh|id)?_?token|api_?key|client_secret|secret|password|key)\s*=\s*([^\s,;]+)",
+            r"\1=***",
+            redacted,
+            flags=re.IGNORECASE,
+        )
     except Exception:
-        pass
+        return fallback
+
+
+def _err(rid, code: int, msg: str) -> dict:
+    msg = _safe_error_message(msg)
     return {"jsonrpc": "2.0", "id": rid, "error": {"code": code, "message": msg}}
 
 
@@ -1295,16 +1307,8 @@ def _start_agent_build(sid: str, session: dict) -> None:
             # _schedule_mcp_late_refresh. Cache-safe (pre-first-turn only).
             _schedule_mcp_late_refresh(sid, agent)
         except Exception as e:
-            try:
-                from agent.redact import redact_sensitive_text
-                current["agent_error"] = redact_sensitive_text(str(e), force=True)
-            except Exception:
-                current["agent_error"] = str(e)
-            try:
-                from agent.redact import redact_sensitive_text
-                _emit("error", sid, {"message": redact_sensitive_text(f"agent init failed: {e}", force=True)})
-            except Exception:
-                _emit("error", sid, {"message": f"agent init failed: {e}"})
+            current["agent_error"] = _safe_error_message(e)
+            _emit("error", sid, {"message": _safe_error_message(f"agent init failed: {e}")})
         finally:
             if home_token is not None:
                 reset_hermes_home_override(home_token)
@@ -8732,13 +8736,11 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             except Exception:
                 pass
             print(
-                f"[gateway-turn] {type(e).__name__}: {e}", file=sys.stderr, flush=True
+                f"[gateway-turn] {type(e).__name__}: {_safe_error_message(e)}",
+                file=sys.stderr,
+                flush=True,
             )
-            try:
-                from agent.redact import redact_sensitive_text
-                _emit("error", sid, {"message": redact_sensitive_text(str(e), force=True)})
-            except Exception:
-                _emit("error", sid, {"message": str(e)})
+            _emit("error", sid, {"message": _safe_error_message(e)})
         finally:
             try:
                 if approval_token is not None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1047,6 +1047,11 @@ def _ok(rid, result: dict) -> dict:
 
 
 def _err(rid, code: int, msg: str) -> dict:
+    try:
+        from agent.redact import redact_sensitive_text
+        msg = redact_sensitive_text(str(msg), force=True)
+    except Exception:
+        pass
     return {"jsonrpc": "2.0", "id": rid, "error": {"code": code, "message": msg}}
 
 
@@ -1290,8 +1295,16 @@ def _start_agent_build(sid: str, session: dict) -> None:
             # _schedule_mcp_late_refresh. Cache-safe (pre-first-turn only).
             _schedule_mcp_late_refresh(sid, agent)
         except Exception as e:
-            current["agent_error"] = str(e)
-            _emit("error", sid, {"message": f"agent init failed: {e}"})
+            try:
+                from agent.redact import redact_sensitive_text
+                current["agent_error"] = redact_sensitive_text(str(e), force=True)
+            except Exception:
+                current["agent_error"] = str(e)
+            try:
+                from agent.redact import redact_sensitive_text
+                _emit("error", sid, {"message": redact_sensitive_text(f"agent init failed: {e}", force=True)})
+            except Exception:
+                _emit("error", sid, {"message": f"agent init failed: {e}"})
         finally:
             if home_token is not None:
                 reset_hermes_home_override(home_token)
@@ -8721,7 +8734,11 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             print(
                 f"[gateway-turn] {type(e).__name__}: {e}", file=sys.stderr, flush=True
             )
-            _emit("error", sid, {"message": str(e)})
+            try:
+                from agent.redact import redact_sensitive_text
+                _emit("error", sid, {"message": redact_sensitive_text(str(e), force=True)})
+            except Exception:
+                _emit("error", sid, {"message": str(e)})
         finally:
             try:
                 if approval_token is not None:


### PR DESCRIPTION
## Summary

TUI gateway error messages now redact credential-bearing exception text before sending it over JSON-RPC/events or printing turn-dispatch errors.

## Why

The TUI gateway has several frontend-visible error paths that previously surfaced raw exception strings. If provider/auth setup failures include values like `access_token=...`, `refresh_token=...`, `api_key=...`, or similar fields, those values could be echoed into the TUI/Desktop transport.

## Changes

- Add a shared `_safe_error_message()` helper for gateway error text.
- Redact JSON-RPC `_err()` messages.
- Redact agent initialization errors stored on the session and emitted to the frontend.
- Redact prompt-submit turn errors emitted to the frontend and stderr.
- Fail closed with a generic gateway error if redaction fails.
- Add regression tests for JSON-RPC errors and agent-init error emission.

## Tests

```text
python -m pytest tests\tui_gateway\test_server_error_redact.py -q
3 passed