### PR TITLE
feat(moa): support reasoning effort presets

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from agent.auxiliary_client import call_llm
 from agent.transports import get_transport
+from hermes_constants import parse_reasoning_effort
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +124,14 @@ def _slot_label(slot: dict[str, str]) -> str:
     return f"{slot.get('provider', '').strip()}:{slot.get('model', '').strip()}"
 
 
+def _reasoning_extra_body(effort: str | None) -> dict[str, Any] | None:
+    """Return an OpenRouter/Codex-style reasoning extra_body, if configured."""
+    parsed = parse_reasoning_effort(str(effort or ""))
+    if parsed is None:
+        return None
+    return {"reasoning": parsed}
+
+
 def _slot_runtime(slot: dict[str, str]) -> dict[str, Any]:
     """Resolve a reference/aggregator slot to real runtime call kwargs.
 
@@ -223,6 +232,7 @@ def _run_reference(
     *,
     temperature: float | None = None,
     max_tokens: int | None = None,
+    reasoning_effort: str | None = None,
 ) -> tuple[str, str, Any]:
     """Call one reference model and return ``(label, text, usage)``.
 
@@ -275,6 +285,7 @@ def _run_reference(
             messages=messages,
             temperature=temperature,
             max_tokens=max_tokens,
+            extra_body=_reasoning_extra_body(reasoning_effort),
             **runtime,
         )
         usage = CanonicalUsage()
@@ -339,6 +350,7 @@ def _run_references_parallel(
     *,
     temperature: float | None = None,
     max_tokens: int | None = None,
+    reasoning_effort: str | None = None,
 ) -> list[tuple[str, str, Any]]:
     """Fan out all reference models in parallel, returning outputs in order.
 
@@ -375,6 +387,7 @@ def _run_references_parallel(
                     ref_messages,
                     temperature=temperature,
                     max_tokens=max_tokens,
+                    reasoning_effort=reasoning_effort,
                 )
             ] = idx
         # Collect every reference before returning — the aggregator needs the
@@ -832,6 +845,8 @@ class MoAChatCompletions:
             # The acting agent's own configured temperature (if any) still
             # applies to the aggregator, which IS the acting model.
             aggregator_temperature = api_kwargs.get("temperature")
+        reference_reasoning_effort = str(preset.get("reference_reasoning_effort") or "")
+        aggregator_reasoning_effort = str(preset.get("aggregator_reasoning_effort") or "")
 
         # When the preset is disabled, skip the reference fan-out and let the
         # configured aggregator act alone — it is the preset's acting model, so
@@ -902,6 +917,7 @@ class MoAChatCompletions:
                 ref_messages,
                 temperature=temperature,
                 max_tokens=reference_max_tokens,
+                reasoning_effort=reference_reasoning_effort,
             )
             self._ref_cache_key = _cache_key
             self._ref_cache_outputs = list(reference_outputs)
@@ -1010,13 +1026,18 @@ class MoAChatCompletions:
             # actually governs the aggregator stream, not just call_llm's default.
             if api_kwargs.get("timeout") is not None:
                 stream_kwargs["timeout"] = api_kwargs["timeout"]
+
+        extra_body = dict(agg_kwargs.get("extra_body") or {})
+        reasoning_extra = _reasoning_extra_body(aggregator_reasoning_effort)
+        if reasoning_extra:
+            extra_body.update(reasoning_extra)
         _agg_response = call_llm(
             task="moa_aggregator",
             messages=agg_messages,
             temperature=aggregator_temperature,
             max_tokens=agg_kwargs.get("max_tokens"),
             tools=agg_kwargs.get("tools"),
-            extra_body=agg_kwargs.get("extra_body"),
+            extra_body=extra_body or None,
             **stream_kwargs,
             **_slot_runtime(aggregator),
         )

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -863,17 +863,21 @@ export interface MoaConfigResponse {
     {
       aggregator: MoaModelSlot
       aggregator_temperature: number
+      aggregator_reasoning_effort: string
       enabled: boolean
       max_tokens: number
       reference_models: MoaModelSlot[]
+      reference_reasoning_effort: string
       reference_temperature: number
     }
   >
   aggregator: MoaModelSlot
   aggregator_temperature: number
+  aggregator_reasoning_effort: string
   enabled: boolean
   max_tokens: number
   reference_models: MoaModelSlot[]
+  reference_reasoning_effort: string
   reference_temperature: number
 }
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -177,6 +177,37 @@ model:
 #   response_cache_ttl: 300      # Cache TTL in seconds, 1-86400 (default: 300)
 
 # =============================================================================
+# Mixture of Agents (/moa)
+# =============================================================================
+# Named presets used by /moa. References provide private advisory context;
+# the aggregator is the acting model that answers or calls tools.
+#
+# reference_reasoning_effort / aggregator_reasoning_effort are optional MoA-
+# specific overrides. Empty string = provider/model default. Valid explicit
+# values mirror /reasoning: none, minimal, low, medium, high, xhigh.
+moa:
+  default_preset: "default"
+  active_preset: ""
+  presets:
+    default:
+      reference_models:
+        - provider: "openai-codex"
+          model: "gpt-5.5"
+        - provider: "openrouter"
+          model: "deepseek/deepseek-v4-pro"
+      aggregator:
+        provider: "openrouter"
+        model: "anthropic/claude-opus-4.8"
+      # Optional sampling overrides. null = omit temperature and use the
+      # provider/model default, matching normal single-model Hermes behavior.
+      reference_temperature: null
+      aggregator_temperature: null
+      reference_reasoning_effort: ""
+      aggregator_reasoning_effort: ""
+      max_tokens: 4096
+      enabled: true
+
+# =============================================================================
 # Git Worktree Isolation
 # =============================================================================
 # When enabled, each CLI session creates an isolated git worktree so multiple

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2194,6 +2194,8 @@ DEFAULT_CONFIG = {
                     {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"},
                 ],
                 "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+                "reference_reasoning_effort": "",
+                "aggregator_reasoning_effort": "",
                 "max_tokens": 4096,
                 "enabled": True,
             }

--- a/hermes_cli/moa_cmd.py
+++ b/hermes_cli/moa_cmd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from hermes_constants import VALID_REASONING_EFFORTS
 from hermes_cli.config import load_config, save_config
 from hermes_cli.inventory import build_models_payload, load_picker_context
 from hermes_cli.moa_config import DEFAULT_MOA_PRESET_NAME, normalize_moa_config
@@ -60,6 +61,21 @@ def _pick_slot(current: dict[str, str] | None = None) -> dict[str, str]:
     return {"provider": str(provider.get("slug") or ""), "model": str(model)}
 
 
+def _pick_reasoning_effort(title: str, current: str = "") -> str:
+    """Prompt for a MoA reasoning effort.
+
+    ``""`` means no MoA-specific override; providers/models use their normal
+    default. ``"none"`` is an explicit disable signal, mirroring /reasoning.
+    """
+    values = ["", "none", *VALID_REASONING_EFFORTS]
+    rows = ["Default (provider/model default)", "Disable reasoning (none)"] + [
+        str(effort) for effort in VALID_REASONING_EFFORTS
+    ]
+    clean = str(current or "").strip().lower()
+    default = values.index(clean) if clean in values else 0
+    return values[_prompt_choice(title, rows, default)]
+
+
 def _print_config(config: dict[str, Any]) -> None:
     cfg = normalize_moa_config(config.get("moa") if isinstance(config, dict) else {})
     print("Mixture of Agents presets")
@@ -74,6 +90,10 @@ def _print_config(config: dict[str, Any]) -> None:
             print(f"    {idx}. {slot['provider']}:{slot['model']}")
         agg = preset["aggregator"]
         print(f"  Aggregator: {agg['provider']}:{agg['model']}")
+        ref_reasoning = preset.get("reference_reasoning_effort") or "default"
+        agg_reasoning = preset.get("aggregator_reasoning_effort") or "default"
+        print(f"  Reference reasoning: {ref_reasoning}")
+        print(f"  Aggregator reasoning: {agg_reasoning}")
 
 
 def cmd_moa(args) -> None:
@@ -105,6 +125,14 @@ def cmd_moa(args) -> None:
         current = dict(current)
         current["reference_models"] = refs
         current["aggregator"] = _pick_slot(current.get("aggregator"))
+        current["reference_reasoning_effort"] = _pick_reasoning_effort(
+            "Select reference reasoning effort",
+            str(current.get("reference_reasoning_effort") or ""),
+        )
+        current["aggregator_reasoning_effort"] = _pick_reasoning_effort(
+            "Select aggregator reasoning effort",
+            str(current.get("aggregator_reasoning_effort") or ""),
+        )
         moa["presets"][preset_name] = current
         moa.setdefault("default_preset", preset_name)
         cfg["moa"] = normalize_moa_config(moa)

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -7,6 +7,8 @@ import json
 from copy import deepcopy
 from typing import Any
 
+from hermes_constants import parse_reasoning_effort
+
 MOA_MARKER_PREFIX = "__HERMES_MOA_TURN_V1__"
 DEFAULT_MOA_PRESET_NAME = "default"
 
@@ -73,6 +75,19 @@ def _coerce_fanout(value: Any) -> str:
     return mode if mode in {"per_iteration", "user_turn"} else "per_iteration"
 
 
+def _clean_reasoning_effort(value: Any) -> str:
+    """Return a supported reasoning effort string or ``""``.
+
+    MoA presets store the human-readable effort level, not the provider request
+    body. Runtime code converts the string through ``parse_reasoning_effort``
+    so it stays in lockstep with the regular ``/reasoning`` levels.
+    """
+    effort = str(value or "").strip().lower()
+    if not effort:
+        return ""
+    return effort if parse_reasoning_effort(effort) is not None else ""
+
+
 def _clean_slot(slot: Any) -> dict[str, str] | None:
     if not isinstance(slot, dict):
         return None
@@ -98,6 +113,8 @@ def _default_preset() -> dict[str, Any]:
         # matching single-model agent behavior.
         "reference_temperature": None,
         "aggregator_temperature": None,
+        "reference_reasoning_effort": "",
+        "aggregator_reasoning_effort": "",
         "max_tokens": 4096,
         "reference_max_tokens": None,
         "fanout": "per_iteration",
@@ -128,6 +145,8 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         "aggregator": aggregator,
         "reference_temperature": _coerce_float_or_none(raw.get("reference_temperature")),
         "aggregator_temperature": _coerce_float_or_none(raw.get("aggregator_temperature")),
+        "reference_reasoning_effort": _clean_reasoning_effort(raw.get("reference_reasoning_effort")),
+        "aggregator_reasoning_effort": _clean_reasoning_effort(raw.get("aggregator_reasoning_effort")),
         "max_tokens": _coerce_int(raw.get("max_tokens"), 4096),
         # Optional cap on how much each reference ADVISOR may generate per turn.
         # None (default) = uncapped: advisors write full-length advice, matching
@@ -189,6 +208,8 @@ def normalize_moa_config(raw: Any) -> dict[str, Any]:
         "aggregator": deepcopy(active["aggregator"]),
         "reference_temperature": active["reference_temperature"],
         "aggregator_temperature": active["aggregator_temperature"],
+        "reference_reasoning_effort": active["reference_reasoning_effort"],
+        "aggregator_reasoning_effort": active["aggregator_reasoning_effort"],
         "max_tokens": active["max_tokens"],
         "reference_max_tokens": active.get("reference_max_tokens"),
         "fanout": active.get("fanout", "per_iteration"),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -956,6 +956,8 @@ class MoaPresetPayload(BaseModel):
     # single-model agent behavior.
     reference_temperature: Optional[float] = None
     aggregator_temperature: Optional[float] = None
+    reference_reasoning_effort: str = ""
+    aggregator_reasoning_effort: str = ""
     max_tokens: int = 4096
     enabled: bool = True
 
@@ -970,6 +972,8 @@ class MoaConfigPayload(BaseModel):
     aggregator: MoaModelSlot = MoaModelSlot()
     reference_temperature: Optional[float] = None
     aggregator_temperature: Optional[float] = None
+    reference_reasoning_effort: str = ""
+    aggregator_reasoning_effort: str = ""
     max_tokens: int = 4096
     enabled: bool = True
     profile: Optional[str] = None
@@ -4470,6 +4474,8 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                             "aggregator": preset.aggregator.dict(),
                             "reference_temperature": preset.reference_temperature,
                             "aggregator_temperature": preset.aggregator_temperature,
+                            "reference_reasoning_effort": preset.reference_reasoning_effort,
+                            "aggregator_reasoning_effort": preset.aggregator_reasoning_effort,
                             "max_tokens": preset.max_tokens,
                             "enabled": preset.enabled,
                         }
@@ -4482,6 +4488,8 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                     "aggregator": body.aggregator.dict(),
                     "reference_temperature": body.reference_temperature,
                     "aggregator_temperature": body.aggregator_temperature,
+                    "reference_reasoning_effort": body.reference_reasoning_effort,
+                    "aggregator_reasoning_effort": body.aggregator_reasoning_effort,
                     "max_tokens": body.max_tokens,
                     "enabled": body.enabled,
                 }

--- a/tests/hermes_cli/test_moa_cmd.py
+++ b/tests/hermes_cli/test_moa_cmd.py
@@ -1,0 +1,25 @@
+from hermes_cli.moa_cmd import _print_config
+
+
+def test_print_config_includes_reasoning_efforts(capsys):
+    _print_config(
+        {
+            "moa": {
+                "default_preset": "review",
+                "presets": {
+                    "review": {
+                        "reference_models": [
+                            {"provider": "deepseek", "model": "deepseek-v4-pro"}
+                        ],
+                        "aggregator": {"provider": "openai-codex", "model": "gpt-5.5"},
+                        "reference_reasoning_effort": "low",
+                        "aggregator_reasoning_effort": "xhigh",
+                    }
+                },
+            }
+        }
+    )
+
+    out = capsys.readouterr().out
+    assert "Reference reasoning: low" in out
+    assert "Aggregator reasoning: xhigh" in out

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -115,6 +115,38 @@ def test_normalize_moa_config_coerces_float_max_tokens():
     assert cfg2["presets"][DEFAULT_MOA_PRESET_NAME]["max_tokens"] == 4096
 
 
+def test_normalize_moa_config_preserves_reasoning_efforts():
+    """MoA presets can opt reference and aggregator calls into reasoning.
+
+    The stored values mirror the regular /reasoning levels. Invalid hand-edited
+    values degrade to "" rather than being forwarded to providers.
+    """
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "review": {
+                    "reference_reasoning_effort": "HIGH",
+                    "aggregator_reasoning_effort": "xhigh",
+                },
+                "broken": {
+                    "reference_reasoning_effort": "turbo",
+                    "aggregator_reasoning_effort": 123,
+                },
+            }
+        }
+    )
+
+    review = cfg["presets"]["review"]
+    assert review["reference_reasoning_effort"] == "high"
+    assert review["aggregator_reasoning_effort"] == "xhigh"
+    assert cfg["reference_reasoning_effort"] == "high"
+    assert cfg["aggregator_reasoning_effort"] == "xhigh"
+
+    broken = cfg["presets"]["broken"]
+    assert broken["reference_reasoning_effort"] == ""
+    assert broken["aggregator_reasoning_effort"] == ""
+
+
 def test_exact_preset_matching_is_not_fuzzy():
     config = {"presets": {"coding": {}, "review": {}}}
 

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -140,6 +140,89 @@ moa:
     assert agg_call.get("max_tokens") is None
 
 
+def test_moa_reasoning_efforts_forwarded_to_reference_and_aggregator(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      reference_reasoning_effort: low
+      aggregator_reasoning_effort: xhigh
+      reference_models:
+        - provider: openai-codex
+          model: gpt-5.5
+      aggregator:
+        provider: openai-codex
+        model: gpt-5.5
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        if kwargs["task"] == "moa_reference":
+            return _response("reference advice")
+        return _response("aggregator acted")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    from agent.moa_loop import MoAChatCompletions
+
+    facade = MoAChatCompletions("review")
+    facade.create(messages=[{"role": "user", "content": "solve this"}], tools=[])
+
+    ref_call = next(c for c in calls if c["task"] == "moa_reference")
+    agg_call = next(c for c in calls if c["task"] == "moa_aggregator")
+    assert ref_call["extra_body"] == {"reasoning": {"enabled": True, "effort": "low"}}
+    assert agg_call["extra_body"] == {"reasoning": {"enabled": True, "effort": "xhigh"}}
+
+
+def test_moa_reasoning_effort_none_disables_reasoning(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      aggregator_reasoning_effort: none
+      reference_models:
+        - provider: openai-codex
+          model: gpt-5.5
+      aggregator:
+        provider: openai-codex
+        model: gpt-5.5
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        if kwargs["task"] == "moa_reference":
+            return _response("reference advice")
+        return _response("aggregator acted")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    from agent.moa_loop import MoAChatCompletions
+
+    facade = MoAChatCompletions("review")
+    facade.create(messages=[{"role": "user", "content": "solve this"}], tools=[])
+
+    ref_call = next(c for c in calls if c["task"] == "moa_reference")
+    agg_call = next(c for c in calls if c["task"] == "moa_aggregator")
+    assert ref_call["extra_body"] is None
+    assert agg_call["extra_body"] == {"reasoning": {"enabled": False}}
+
+
 def test_moa_slots_routed_through_resolve_runtime_provider(monkeypatch):
     """Reference + aggregator slots must be called via their provider's real
     runtime (resolve_runtime_provider), not a bare provider/model call.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2136,6 +2136,8 @@ export interface MoaConfigResponse {
     aggregator: MoaModelSlot;
     reference_temperature: number;
     aggregator_temperature: number;
+    reference_reasoning_effort: string;
+    aggregator_reasoning_effort: string;
     max_tokens: number;
     enabled: boolean;
   }>;
@@ -2143,6 +2145,8 @@ export interface MoaConfigResponse {
   aggregator: MoaModelSlot;
   reference_temperature: number;
   aggregator_temperature: number;
+  reference_reasoning_effort: string;
+  aggregator_reasoning_effort: string;
   max_tokens: number;
   enabled: boolean;
 }

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -747,6 +747,8 @@ function MoaModelsModal({
       aggregator: draft.aggregator,
       reference_temperature: draft.reference_temperature,
       aggregator_temperature: draft.aggregator_temperature,
+      reference_reasoning_effort: draft.reference_reasoning_effort,
+      aggregator_reasoning_effort: draft.aggregator_reasoning_effort,
       max_tokens: draft.max_tokens,
       enabled: draft.enabled,
     };


### PR DESCRIPTION
## What does this PR do?

Adds optional MoA preset-level reasoning-effort controls for both sides of the Mixture-of-Agents flow:

- `reference_reasoning_effort` controls reference/advisor model calls.
- `aggregator_reasoning_effort` controls the acting aggregator model call.

Empty string keeps the provider/model default. Explicit values reuse the existing Hermes `/reasoning` levels: `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`.

This keeps MoA reasoning configuration in the preset, preserves the values through CLI/dashboard/Web/Desktop config paths, and forwards the normalized settings to `call_llm()` as `extra_body.reasoning` without changing normal non-MoA model routing.

The branch has been rebased onto current `origin/main`. During conflict resolution, this PR keeps the current main behavior where unset MoA temperatures are omitted (`null` / `None`) so provider/model defaults apply; the new reasoning-effort fields are added without reintroducing hardcoded MoA temperature defaults.

## Related Issue

N/A. I searched open and closed PRs for `reference_reasoning_effort`, `aggregator_reasoning_effort`, and `MoA reasoning effort` and did not find a duplicate.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/moa_loop.py`
  - Parses MoA preset reasoning efforts through the existing Hermes reasoning parser.
  - Forwards `reference_reasoning_effort` into reference/advisor calls.
  - Merges `aggregator_reasoning_effort` into aggregator `extra_body` while preserving current streaming, reference usage/cost accounting, fan-out, and temperature behavior on `main`.
- `hermes_cli/moa_config.py`
  - Normalizes and preserves `reference_reasoning_effort` and `aggregator_reasoning_effort` per preset and in the active response shape.
  - Keeps the current `None`/unset temperature behavior from `main`.
- `hermes_cli/moa_cmd.py`
  - Adds CLI configuration prompts and list output for reference and aggregator reasoning efforts.
- `hermes_cli/web_server.py`
  - Preserves the new fields through MoA API payloads.
- `web/src/lib/api.ts`, `web/src/pages/ModelsPage.tsx`, `apps/desktop/src/types/hermes.ts`
  - Updates Web/Desktop MoA types and save payload handling so UI saves do not drop the new fields.
- `hermes_cli/config.py`, `cli-config.yaml.example`
  - Adds default/example MoA preset reasoning-effort fields.
  - Documents `null` temperatures in the YAML example to match current provider-default behavior.
- `tests/hermes_cli/test_moa_config.py`, `tests/hermes_cli/test_moa_cmd.py`, `tests/run_agent/test_moa_loop_mode.py`
  - Adds normalization, CLI display, and runtime forwarding coverage.

## How to Test

Commands run on WSL2/Ubuntu:

1. `python3 -m py_compile agent/moa_loop.py hermes_cli/config.py hermes_cli/moa_cmd.py hermes_cli/moa_config.py hermes_cli/web_server.py tests/hermes_cli/test_moa_config.py tests/hermes_cli/test_moa_cmd.py tests/run_agent/test_moa_loop_mode.py`
   - Result: passed.
2. `python3 -m pytest tests/hermes_cli/test_moa_config.py tests/hermes_cli/test_moa_cmd.py tests/run_agent/test_moa_loop_mode.py -q`
   - Result on rebased branch: `53 passed in 5.31s`.
3. `npm run --prefix web typecheck`
   - Result: passed.
4. `npm run --prefix apps/desktop typecheck`
   - Result: passed.
5. `python3 - <<'PY' ... yaml.safe_load(Path('cli-config.yaml.example').read_text()) ... PY`
   - Result: parsed successfully; default MoA example includes blank `reference_reasoning_effort` / `aggregator_reasoning_effort` and `null` temperatures.
6. `git diff --check origin/main...HEAD`
   - Result: passed.

Full suite note:

- I attempted `scripts/run_tests.sh` on the rebased branch, but the local full suite is not green outside this PR's MoA diff. I therefore left the full-suite checkbox unchecked.
- To check whether these failures were introduced here, I reran the non-MoA failing subset in a clean detached `origin/main` worktree; failures reproduced there as well. The failures are outside this PR's changed MoA files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Not checked: local full suite is not green for unrelated files outside this PR's MoA diff; targeted Python tests, Web typecheck, Desktop typecheck, `py_compile`, YAML parse, and `git diff --check` pass.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / Ubuntu on Windows

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - N/A for standalone docs; `cli-config.yaml.example` now documents the new MoA preset fields.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - N/A: no architecture or workflow rule changes.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - Config/type changes use existing YAML/JSON/TypeScript/Python paths and do not add platform-specific filesystem or process behavior.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
  - N/A: no model tool schema changes.

## Screenshots / Logs

N/A. This is a CLI/config/runtime plumbing change covered by targeted tests and typechecks.
