### PR TITLE
Hide kanban worker sessions from Desktop recents

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -170,7 +170,7 @@ const CRON_POLL_INTERVAL_MS = 30_000
 // self-managed sidebar section (refreshMessagingSessions). Excluding both here
 // keeps "Load more" paging through interactive local chats instead of
 // interleaving gateway threads that bury them.
-const SIDEBAR_EXCLUDED_SOURCES = ['cron', 'subagent', 'tool', ...MESSAGING_SESSION_SOURCE_IDS]
+const SIDEBAR_EXCLUDED_SOURCES = ['cron', 'subagent', 'tool', 'kanban', ...MESSAGING_SESSION_SOURCE_IDS]
 // The messaging slice is the inverse: drop cron + every local source so only
 // external-platform conversations remain, then split per platform in the UI.
 const MESSAGING_EXCLUDED_SOURCES = ['cron', ...LOCAL_SESSION_SOURCE_IDS]

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7709,6 +7709,7 @@ def _default_spawn(
     if task.tenant:
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id
+    env["HERMES_SESSION_SOURCE"] = "kanban"
     env["HERMES_KANBAN_WORKSPACE"] = workspace
     # Pin TERMINAL_CWD to the task's workspace so the worker's file tools and
     # context-file loader anchor on the workspace, not whatever cwd the

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2950,6 +2950,7 @@ class TestSharedBoardPaths:
             default_home / "kanban" / "workspaces"
         )
         assert env["HERMES_KANBAN_TASK"] == "t_dispatch_env"
+        assert env["HERMES_SESSION_SOURCE"] == "kanban"
         assert env["HERMES_KANBAN_BRANCH"] == "wt/t_dispatch_env"
 
 


### PR DESCRIPTION
Fixes #49991.

Kanban workers were still creating normal `cli` sessions, so Desktop had no way to tell `work kanban task t_...` transcripts apart from real chats. After a few dispatched tasks, the sidebar gets noisy fast.

This tags dispatcher-spawned workers with `HERMES_SESSION_SOURCE=kanban` and excludes that source from the Desktop recents list, the same way cron/subagent/tool sessions are already filtered. The transcripts still exist for debugging; they just stop showing up in the main conversation list.

Tested:
- `uv run --with pytest pytest tests/hermes_cli/test_kanban_db.py::TestSharedBoardPaths::test_dispatcher_spawn_injects_kanban_db_and_workspaces_root`
- `git diff --check`

I also tried `npm run typecheck --workspace apps/desktop`, but this local checkout is missing several CodeMirror packages/types (`@codemirror/language`, `@codemirror/state`, `@codemirror/view`, etc.), so it fails before this change is relevant.