### PR TITLE
fix(platforms,gateway,tools): add encoding='utf-8' to write_text() calls

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -278,7 +278,7 @@ class DeliveryRouter:
         lines.append("")
         lines.append(content)
         
-        output_path.write_text("\n".join(lines))
+        output_path.write_text("\n".join(lines), encoding="utf-8")
         
         return {
             "path": str(output_path),
@@ -291,7 +291,7 @@ class DeliveryRouter:
         out_dir = get_hermes_home() / "cron" / "output"
         out_dir.mkdir(parents=True, exist_ok=True)
         path = out_dir / f"{job_id}_{timestamp}.txt"
-        path.write_text(content)
+        path.write_text(content, encoding="utf-8")
         return path
 
     def _filter_silence_narration_enabled(self) -> bool:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8001,7 +8001,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 prompt_path = _hermes_home / ".update_prompt.json"
                 try:
                     tmp = response_path.with_suffix(".tmp")
-                    tmp.write_text(response_text)
+                    tmp.write_text(response_text, encoding="utf-8")
                     tmp.replace(response_path)
                     prompt_path.unlink(missing_ok=True)
                 except OSError as e:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6206,7 +6206,7 @@ def _define_discord_view_classes() -> None:
                 home = get_hermes_home()
                 response_path = home / ".update_response"
                 tmp = response_path.with_suffix(".tmp")
-                tmp.write_text(answer)
+                tmp.write_text(answer, encoding="utf-8")
                 tmp.replace(response_path)
                 logger.info(
                     "Discord update prompt answered '%s' by %s",

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2100,7 +2100,7 @@ class FeishuAdapter(BasePlatformAdapter):
     def _write_update_prompt_response(answer: str) -> None:
         response_path = get_hermes_home() / ".update_response"
         tmp_path = response_path.with_suffix(".tmp")
-        tmp_path.write_text(answer)
+        tmp_path.write_text(answer, encoding="utf-8")
         tmp_path.replace(response_path)
 
     async def send_voice(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4805,7 +4805,7 @@ class TelegramAdapter(BasePlatformAdapter):
             home = get_hermes_home()
             response_path = home / ".update_response"
             tmp = response_path.with_suffix(".tmp")
-            tmp.write_text(answer)
+            tmp.write_text(answer, encoding="utf-8")
             tmp.replace(response_path)
             logger.info("Telegram update prompt answered '%s' by user %s",
                         answer, getattr(query.from_user, "id", "unknown"))

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -987,7 +987,7 @@ class GitHubSource(SkillSource):
         INDEX_CACHE_DIR.mkdir(parents=True, exist_ok=True)
         cache_file = INDEX_CACHE_DIR / f"{key}.json"
         try:
-            cache_file.write_text(json.dumps(data, ensure_ascii=False))
+            cache_file.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
         except OSError as e:
             logger.debug("Could not write cache: %s", e)
 
@@ -3180,7 +3180,7 @@ def _write_index_cache(key: str, data: Any) -> None:
             pass
     cache_file = INDEX_CACHE_DIR / f"{key}.json"
     try:
-        cache_file.write_text(json.dumps(data, ensure_ascii=False, default=str))
+        cache_file.write_text(json.dumps(data, ensure_ascii=False, default=str), encoding="utf-8")
     except OSError as e:
         logger.debug("Could not write cache: %s", e)
 
@@ -3220,7 +3220,7 @@ class HubLockFile:
 
     def save(self, data: dict) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
     def record_install(
         self,


### PR DESCRIPTION
## Problem

`Path.write_text()` without an explicit `encoding` parameter uses the platform's default encoding. On Windows this is typically `cp1252` or `mbcs`, which corrupts non-ASCII characters (emoji, CJK text, accented characters) in user-facing content.

This is a **cross-platform data corruption bug** — content written on Windows with non-ASCII characters will be silently corrupted, and reading it back with `read_text(encoding="utf-8")` (which the codebase consistently uses) will produce garbled output or raise `UnicodeDecodeError`.

## Affected Locations

| File | Context | Content Type |
|------|---------|-------------|
| `plugins/platforms/discord/adapter.py:6209` | Temp file for reply | User/agent response text |
| `plugins/platforms/telegram/adapter.py:4808` | Temp file for reply | User/agent response text |
| `plugins/platforms/feishu/adapter.py:2103` | Temp file for reply | User/agent response text |
| `gateway/run.py:8004` | Response temp file | Agent response text |
| `gateway/delivery.py:281,294` | Message output files | Message content |
| `tools/skills_hub.py` (3 locations) | Skill cache files | JSON with `ensure_ascii=False` |

## Fix

Add `encoding="utf-8"` to each `write_text()` call:

```python
# Before
tmp.write_text(answer)

# After
tmp.write_text(answer, encoding="utf-8")
```

This follows the existing pattern where `read_text()` calls consistently specify `encoding="utf-8"` throughout the codebase.

## Impact

- **Severity**: P1 — data corruption on Windows for non-ASCII content
- **Scope**: 6 files, 9 lines changed
- **Risk**: Minimal — explicit encoding matches what Linux already defaults to
