### PR TITLE
feat(gateway): add mesh_session contract for stateful multi-turn over HTTP

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1883,6 +1883,22 @@ class APIServerAdapter(BasePlatformAdapter):
         if key_err is not None:
             return key_err
 
+        # --- Session contract for stateful multi-turn over HTTP ---
+        # Accept a conversation id under two alternate names:
+        #   X-Mesh-Session header, OR
+        #   "session" key in the JSON body (fallback for callers that
+        #   cannot easily set headers, e.g. some HTTP proxies).
+        # When either is present we RESUME that conversation with full
+        # context (prior turns + tool actions), persisted in SessionDB.
+        # When neither is present we start a fresh conversation.
+        # The resolved id is echoed back as the top-level JSON field
+        # "mesh_session" on non-stream responses, and inside the
+        # finish_reason="stop" chunk on streaming responses.
+        mesh_session_id = (
+            request.headers.get("X-Mesh-Session", "").strip()
+            or str((body or {}).get("session") or "").strip()
+        )
+
         # Allow caller to continue an existing session by passing X-Hermes-Session-Id.
         # When provided, history is loaded from state.db instead of from the request body.
         #
@@ -1890,7 +1906,10 @@ class APIServerAdapter(BasePlatformAdapter):
         # only allowed when the API key is configured and the request is
         # authenticated.  Without this gate, any unauthenticated client could
         # read arbitrary session history by guessing/enumerating session IDs.
-        provided_session_id = request.headers.get("X-Hermes-Session-Id", "").strip()
+        provided_session_id = (
+            request.headers.get("X-Hermes-Session-Id", "").strip()
+            or mesh_session_id
+        )
         if provided_session_id:
             if not self._api_key:
                 logger.warning(
@@ -1931,6 +1950,15 @@ class APIServerAdapter(BasePlatformAdapter):
                     break
             session_id = _derive_chat_session_id(system_prompt, first_user)
             # history already set from request body above
+
+        # When the caller sent no session id, expose the server-side id we
+        # actually used so the caller can persist and resend it to RESUME
+        # context on the next call. Without this, every sessionless call
+        # starts cold. We do NOT mint a random uuid here: the derived id is
+        # stable across turns for OpenAI-style clients that resend full
+        # history, and once returned it is fixed for that conversation.
+        if not mesh_session_id:
+            mesh_session_id = session_id
 
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
         model_name = body.get("model", self._model_name)
@@ -2027,6 +2055,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 request, completion_id, model_name, created, _stream_q,
                 agent_task, agent_ref, session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                mesh_session_id=mesh_session_id,
             )
 
         # Non-streaming: run the agent (with optional Idempotency-Key)
@@ -2109,6 +2138,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "object": "chat.completion",
             "created": created,
             "model": model_name,
+            "mesh_session": mesh_session_id,
             "choices": [
                 {
                     "index": 0,
@@ -2143,7 +2173,7 @@ class APIServerAdapter(BasePlatformAdapter):
     async def _write_sse_chat_completion(
         self, request: "web.Request", completion_id: str, model: str,
         created: int, stream_q, agent_task, agent_ref=None, session_id: str = None,
-        gateway_session_key: str = None,
+        gateway_session_key: str = None, mesh_session_id: str = None,
     ) -> "web.StreamResponse":
         """Write real streaming SSE from agent's stream_delta_callback queue.
 
@@ -2277,6 +2307,10 @@ class APIServerAdapter(BasePlatformAdapter):
             finish_chunk = {
                 "id": completion_id, "object": "chat.completion.chunk",
                 "created": created, "model": model,
+                # Echo the mesh session id (server-minted when the caller
+                # sent none) so streaming clients can persist + resume, same
+                # as the non-stream mesh_session field.
+                "mesh_session": mesh_session_id or session_id,
                 "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}],
                 "usage": {
                     "prompt_tokens": usage.get("input_tokens", 0),

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1648,6 +1648,164 @@ class TestDeriveChatSessionId:
 
 
 # ---------------------------------------------------------------------------
+# mesh_session contract — X-Mesh-Session / "session" body key for stateful
+# multi-turn over the OpenAI-compatible HTTP endpoint.
+# ---------------------------------------------------------------------------
+
+
+class TestMeshSessionContract:
+    """Tests for the mesh_session field contract.
+
+    The OpenAI-compatible chat completions endpoint now supports an explicit
+    session id via X-Mesh-Session header (or "session" body key). When
+    provided, the server resumes that conversation. When omitted, a fresh
+    session is started and the server-minted id is echoed back as
+    "mesh_session" in the response so callers can persist and resend it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_sessionless_response_includes_mesh_session(self, adapter):
+        """A call with no session id still gets a server-minted mesh_session back."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                assert "mesh_session" in data
+                assert data["mesh_session"], "mesh_session should be a non-empty server-minted id"
+                assert data["mesh_session"].startswith("api-")
+
+    @pytest.mark.asyncio
+    async def test_x_mesh_session_header_resumes_session(self, auth_adapter):
+        """Providing X-Mesh-Session header resumes that conversation id."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        session_id_sent = "resume-me-123"
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Mesh-Session": session_id_sent,
+                    },
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "continue"}],
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                # The echoed mesh_session should be the id the caller sent.
+                assert data["mesh_session"] == session_id_sent
+                # And the agent should have been invoked with that session_id.
+                assert mock_run.call_args.kwargs["session_id"] == session_id_sent
+
+    @pytest.mark.asyncio
+    async def test_session_body_key_fallback(self, auth_adapter):
+        """The "session" body key works as a fallback when no header is set."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        session_id_sent = "from-body-456"
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "continue"}],
+                        "session": session_id_sent,
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["mesh_session"] == session_id_sent
+                assert mock_run.call_args.kwargs["session_id"] == session_id_sent
+
+    @pytest.mark.asyncio
+    async def test_header_takes_precedence_over_body_key(self, auth_adapter):
+        """When both header and body key are present, the header wins."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Mesh-Session": "from-header",
+                    },
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "session": "from-body",
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["mesh_session"] == "from-header"
+
+    @pytest.mark.asyncio
+    async def test_streaming_finish_chunk_includes_mesh_session(self, adapter):
+        """The final SSE chunk includes mesh_session for streaming responses."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    cb("Hello!")
+                    cb(None)
+                return (
+                    {"final_response": "Hello!", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                assert "[DONE]" in body
+                # The finish chunk should contain a mesh_session field.
+                assert '"mesh_session"' in body
+
+
+# ---------------------------------------------------------------------------
 # /v1/responses endpoint
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Adds a lightweight session contract to the OpenAI-compatible `/v1/chat/completions` endpoint, enabling **stateful multi-turn conversations over HTTP** without requiring clients to resend full message history each turn.

### The problem

The chat completions endpoint is stateless by default — each call is a fresh conversation. The existing `X-Hermes-Session-Id` header allows resuming a session, but:

1. It returns **no session id** for the caller to persist, so the caller has no way to continue a conversation it didn't explicitly seed.
2. Thin HTTP clients — proxies, peer agents, Open WebUI-style frontends — are left unable to maintain multi-turn context, because they never learn which session id the server used.

### The fix

An opt-in session contract with two simple rules:

- **Inbound:** accept a conversation id via the `X-Mesh-Session` header, or a `"session"` key in the JSON body (fallback for callers that cannot easily set headers). When provided, the conversation is resumed with full prior context (same mechanism and API-key gate as `X-Hermes-Session-Id`).
- **Outbound:** echo the resolved session id back as a top-level `"mesh_session"` field on non-stream JSON responses, and inside the finish-chunk on streaming SSE responses. Callers capture this id and resend it on the next turn to continue the thread.

The server-minted id (when the caller sends none) is the same derived session id the endpoint already produces (`_derive_chat_session_id`), not a random uuid — so OpenAI-style clients that resend full message history get a stable id automatically.

### Backward compatibility

Fully backward-compatible. Omitting both the header and body key yields **identical behavior to today** — a fresh stateless call — with the only addition being the `mesh_session` field echoed in the response (which existing clients ignore without issue).

## Related Issue

No existing issue — this enables a class of thin-client / peer-agent use cases over the HTTP gateway.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/api_server.py` — 7 focused hunks:
  1. Extract `mesh_session_id` from `X-Mesh-Session` header or `"session"` body key
  2. Wire it into `provided_session_id` (resumes conversation under existing API-key gate)
  3. Mint from derived `session_id` when caller sent none (so echo is always non-empty)
  4. Pass `mesh_session_id` to the streaming SSE writer
  5. Add `mesh_session` field to non-streaming response JSON
  6. Add `mesh_session_id` parameter to `_write_sse_chat_completion`
  7. Add `mesh_session` to the streaming finish-chunk
- `tests/gateway/test_api_server.py` — 5 new tests in `TestMeshSessionContract`

## How to Test

1. **Sessionless echo:** `POST /v1/chat/completions` with no session header → response includes a server-minted `mesh_session` field
2. **Header resume:** `POST` with `X-Mesh-Session: <id>` → conversation resumes; echoed `mesh_session` matches
3. **Body key fallback:** `POST` with `"session": "<id>"` in JSON body → same resume behavior
4. **Precedence:** both header and body present → header wins
5. **Streaming:** `POST` with `stream: true` → finish-chunk includes `"mesh_session"`
6. **Backward compat:** omit everything → fresh call, same as before, plus `mesh_session` echo

```bash
pytest tests/gateway/test_api_server.py::TestMeshSessionContract -v
pytest tests/gateway/test_api_server.py::TestChatCompletionsEndpoint -v
```

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(gateway): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature (no unrelated commits)
- [x] I've run tests and all pass (24/24 chat-completion tests: 19 existing + 5 new)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.7

### Documentation & Housekeeping
- [x] N/A — no new config keys, no tool schema changes, no architecture changes (inline docstrings document the contract at the code site)