### PR TITLE
fix(memory): add routine-turn judgment test to MEMORY_GUIDANCE

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -161,7 +161,15 @@ MEMORY_GUIDANCE = (
     "'Project uses pytest with xdist' ✓ — 'Run tests with pytest -n 4' ✗. "
     "Imperative phrasing gets re-read as a directive in later sessions and can "
     "cause repeated work or override the user's current request. Procedures and "
-    "workflows belong in skills, not memory."
+    "workflows belong in skills, not memory.\n"
+    "Before saving anything to memory, apply this test: if a new session "
+    "started tomorrow and did not have this fact, would it make a mistake on "
+    "a routine turn that the user has to correct? If yes, it belongs in memory. "
+    "If the content already lives in a skill, project file, or external source, "
+    "do not duplicate it in memory — at most a one-line pointer. Memory holds "
+    "standing facts that change how you operate across all tasks, not arguments, "
+    "evidence, quotes, or lessons learned (those go in notes or skills). When "
+    "in doubt, leave it out; you can always add it later."
 )
 
 SESSION_SEARCH_GUIDANCE = (

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -50,6 +50,13 @@ class TestGuidanceConstants:
         assert "like a diary" not in MEMORY_GUIDANCE
         assert ">80%" not in MEMORY_GUIDANCE
 
+    def test_memory_guidance_includes_routine_turn_test(self):
+        """Memory guidance must tell the model to test whether a fact would
+        cause a mistake on a routine turn before saving it."""
+        assert "would it make a mistake" in MEMORY_GUIDANCE
+        assert "do not duplicate" in MEMORY_GUIDANCE
+        assert "When in doubt, leave it out" in MEMORY_GUIDANCE
+
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE


### PR DESCRIPTION
MEMORY_GUIDANCE tells the model what to save (durable facts) and what not to save (task progress, PR numbers, stale artifacts), but gives no test for the boundary between important and belongs-in-memory. The phrase "will still matter later" is easy to override with the stronger-feeling "this is important and durable."

**Observed failure mode:** an agent used up half the memory budget to record extensive details about one particular finding that would be relevant in maybe one out of a hundred turns, because it was a durable fact that might be used later. There is no constraint about how often it will be used or how important it is to every random session. Content that already lives in a skill or project file gets duplicated into memory, crowding out facts that are load-bearing on every turn.

**Fix:** add an explicit pre-save judgment test to `MEMORY_GUIDANCE`:

> Before saving anything to memory, apply this test: if a new session started tomorrow and did not have this fact, would it make a mistake on a routine turn that the user has to correct? If yes, it belongs in memory. If the content already lives in a skill, project file, or external source, do not duplicate it in memory — at most a one-line pointer. Memory holds standing facts that change how you operate across all tasks, not arguments, evidence, quotes, or lessons learned. When in doubt, leave it out; you can always add it later.

This makes the existing "prevents the user from having to correct or remind you again" principle actionable as a pre-save test, and explicitly tells the model not to duplicate content that lives elsewhere.

**Test:** adds `test_memory_guidance_includes_routine_turn_test` alongside the existing `test_memory_guidance_discourages_task_logs`. All existing assertions still pass.