### PR TITLE
fix(whatsapp): lazy-install aiohttp on connect (#54217)

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -417,6 +417,21 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         
         This launches the Node.js bridge process and waits for it to be ready.
         """
+        # aiohttp isn't a core dependency — it only ships with another platform
+        # extra (discord/slack/messaging), so a WhatsApp-only install reaches the
+        # bare `import aiohttp` below with nothing to import and crashes connect
+        # (#54217). Lazy-install it on first connect, mirroring platform.slack /
+        # platform.teams. ensure() is a no-op when aiohttp is already present.
+        try:
+            from tools.lazy_deps import ensure as _lazy_ensure
+            _lazy_ensure("platform.whatsapp", prompt=False)
+        except Exception as exc:
+            logger.warning(
+                "[%s] Could not lazy-install aiohttp (%s); WhatsApp may fail to "
+                "connect. Install it manually with `pip install hermes-agent[whatsapp]`.",
+                self.name, exc,
+            )
+
         if not check_whatsapp_requirements():
             logger.warning("[%s] Node.js not found. WhatsApp requires Node.js.", self.name)
             self._set_fatal_error(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,10 @@ messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", 
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.27.0", "slack-sdk==3.40.1", "aiohttp==3.13.4"]
 matrix = ["mautrix[encryption]==0.21.0", "aiosqlite==0.22.1", "asyncpg==0.31.0", "aiohttp-socks==0.11.0"]
+# WhatsApp's Node.js Baileys bridge is reached over HTTP via aiohttp. Lazy-
+# installed on first connect via tools/lazy_deps.py; this extra lets packagers
+# and `pip install hermes-agent[whatsapp]` users pull it ahead of time.
+whatsapp = ["aiohttp==3.13.4"]  # aiohttp: CVE-2026-34513/34518/34519/34520/34525
 # WeCom callback-mode adapter — parses untrusted XML POST bodies from
 # WeCom-controlled callback endpoints, so we use defusedxml (drop-in
 # replacement for stdlib xml.etree.ElementTree) to block billion-laughs

--- a/tests/gateway/test_whatsapp_lazy_aiohttp.py
+++ b/tests/gateway/test_whatsapp_lazy_aiohttp.py
@@ -1,0 +1,131 @@
+"""Regression tests for issue #54217.
+
+WhatsApp talks to its Node.js Baileys bridge over HTTP via ``aiohttp``, but
+``aiohttp`` is not a core dependency — it only arrives through another platform
+extra (discord/slack/messaging). A WhatsApp-only install therefore reached the
+bare ``import aiohttp`` inside ``WhatsAppAdapter.connect()`` with nothing to
+import and crashed with ``ModuleNotFoundError: No module named 'aiohttp'``.
+
+The fix registers ``platform.whatsapp`` in ``tools/lazy_deps.py`` (and a
+``whatsapp`` extra in ``pyproject.toml``) and calls ``ensure("platform.whatsapp",
+prompt=False)`` at the top of ``connect()`` so aiohttp auto-installs on first
+connect — mirroring ``platform.slack`` / ``platform.teams``.
+"""
+
+import asyncio
+import tomllib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _make_adapter():
+    """Create a WhatsAppAdapter with test attributes (bypass __init__).
+
+    Mirrors the helper in tests/gateway/test_whatsapp_connect.py.
+    """
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = MagicMock()
+    adapter._bridge_port = 19876
+    adapter._bridge_script = "/tmp/test-bridge.js"
+    adapter._session_path = Path("/tmp/test-wa-session")
+    adapter._bridge_log_fh = None
+    adapter._bridge_log = None
+    adapter._bridge_process = None
+    adapter._reply_prefix = None
+    adapter._running = False
+    adapter._message_handler = None
+    adapter._fatal_error_code = None
+    adapter._fatal_error_message = None
+    adapter._fatal_error_retryable = True
+    adapter._fatal_error_handler = None
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    adapter._background_tasks = set()
+    adapter._auto_tts_disabled_chats = set()
+    adapter._message_queue = asyncio.Queue()
+    adapter._http_session = None
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Wiring: registry + pyproject extra
+# ---------------------------------------------------------------------------
+
+def test_platform_whatsapp_registered_in_lazy_deps():
+    from tools.lazy_deps import LAZY_DEPS
+
+    assert "platform.whatsapp" in LAZY_DEPS, (
+        "platform.whatsapp missing from LAZY_DEPS — connect() can't lazy-install aiohttp"
+    )
+    specs = LAZY_DEPS["platform.whatsapp"]
+    assert any(s.startswith("aiohttp==") for s in specs), specs
+
+
+def test_whatsapp_extra_declared_in_pyproject():
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    extras = data["project"]["optional-dependencies"]
+    assert "whatsapp" in extras, "missing [project.optional-dependencies] whatsapp extra"
+    assert any(dep.startswith("aiohttp==") for dep in extras["whatsapp"]), extras["whatsapp"]
+
+
+# ---------------------------------------------------------------------------
+# connect() lazy-installs aiohttp before it is used
+# ---------------------------------------------------------------------------
+
+class TestConnectEnsuresAiohttp:
+
+    @pytest.mark.asyncio
+    async def test_connect_calls_ensure_before_using_aiohttp(self):
+        """connect() must call ensure("platform.whatsapp", prompt=False) up front.
+
+        The ensure() call sits above every other step in connect() — including
+        the Node.js requirements check and, crucially, the bare ``import
+        aiohttp`` further down. We stop connect() right after ensure() (Node.js
+        check returns False) and assert ensure() ran with the expected args; this
+        is what makes a WhatsApp-only install auto-install aiohttp instead of
+        crashing (#54217).
+        """
+        adapter = _make_adapter()
+        captured = {}
+
+        def fake_ensure(feature, *, prompt=True):
+            captured["feature"] = feature
+            captured["prompt"] = prompt
+
+        with patch("tools.lazy_deps.ensure", side_effect=fake_ensure) as mock_ensure, \
+             patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=False):
+            result = await adapter.connect()
+
+        mock_ensure.assert_called_once()
+        assert captured == {"feature": "platform.whatsapp", "prompt": False}
+        assert result is False  # stopped at the (mocked) Node.js requirements check
+
+    @pytest.mark.asyncio
+    async def test_connect_does_not_crash_when_ensure_fails(self):
+        """A failed lazy-install is swallowed — connect() returns False, not raises.
+
+        ensure() raises FeatureUnavailable (e.g. lazy installs disabled or pip
+        offline). The try/except around it must absorb that so connect() exits
+        cleanly via its normal failure paths instead of propagating.
+        """
+        from tools.lazy_deps import FeatureUnavailable
+
+        adapter = _make_adapter()
+
+        with patch("tools.lazy_deps.ensure",
+                   side_effect=FeatureUnavailable("platform.whatsapp", (), "disabled")) as mock_ensure, \
+             patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=False):
+            result = await adapter.connect()  # must not raise
+
+        mock_ensure.assert_called_once()
+        assert result is False

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -175,6 +175,13 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # installed on demand like every other messaging platform; also exposed
     # as the `teams` extra in pyproject for packagers / explicit installs.
     "platform.teams": ("microsoft-teams-apps==2.0.13.4", "aiohttp==3.13.4"),
+    # WhatsApp talks to its Node.js Baileys bridge over HTTP via aiohttp.
+    # aiohttp isn't a core dependency and otherwise only arrives through
+    # another platform extra (discord/slack/messaging), so a WhatsApp-only
+    # install had no aiohttp and crashed at connect with ModuleNotFoundError
+    # (#54217). Lazy-installed on demand like every other messaging platform;
+    # also exposed as the `whatsapp` extra in pyproject for explicit installs.
+    "platform.whatsapp": ("aiohttp==3.13.4",),  # CVE-2026-34513/34518/34519/34520/34525
 
     # ─── Terminal backends ─────────────────────────────────────────────────
     "terminal.modal": ("modal==1.3.4",),

--- a/uv.lock
+++ b/uv.lock
@@ -1623,6 +1623,9 @@ web = [
 wecom = [
     { name = "defusedxml" },
 ]
+whatsapp = [
+    { name = "aiohttp" },
+]
 youtube = [
     { name = "youtube-transcript-api" },
 ]
@@ -1635,6 +1638,7 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'slack'", specifier = "==3.13.4" },
     { name = "aiohttp", marker = "extra == 'sms'", specifier = "==3.13.4" },
     { name = "aiohttp", marker = "extra == 'teams'", specifier = "==3.13.4" },
+    { name = "aiohttp", marker = "extra == 'whatsapp'", specifier = "==3.13.4" },
     { name = "aiohttp-socks", marker = "extra == 'matrix'", specifier = "==0.11.0" },
     { name = "aiosqlite", marker = "extra == 'matrix'", specifier = "==0.22.1" },
     { name = "alibabacloud-dingtalk", marker = "extra == 'dingtalk'", specifier = "==2.2.42" },
@@ -1745,7 +1749,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "whatsapp", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"


### PR DESCRIPTION
## What does this PR do?

WhatsApp talks to its Node.js Baileys bridge over HTTP via `aiohttp`, but `aiohttp` is **not** a core dependency — it only arrives through another platform extra (`discord`/`slack`/`messaging`). A WhatsApp-only install therefore reaches the bare `import aiohttp` in `WhatsAppAdapter.connect()` with nothing to import and crashes with `ModuleNotFoundError: No module named 'aiohttp'`, so the gateway falls back to cron-only mode — exactly as reported.

The fix mirrors the existing `platform.slack` / `platform.teams` pattern: register the feature in `LAZY_DEPS`, expose a `whatsapp` extra, **and call `ensure("platform.whatsapp", prompt=False)` at the top of `connect()`** so aiohttp auto-installs on first connect.

> Note on overlap with #54237: that PR adds the `LAZY_DEPS` entry and the `pyproject` extra only. Those are *passive* — nothing calls `ensure()`, and the adapter still does a bare `import aiohttp` in `connect()`, so the `ModuleNotFoundError` crash persists with that change alone. Every other platform adapter (slack/teams/telegram/discord/matrix/dingtalk/feishu) explicitly calls `ensure("platform.X")` / `ensure_and_bind(...)` in its own code; there is no generic auto-install hook and `plugin.yaml` declares no pip deps. This PR adds that missing `connect()` call (plus `uv.lock` and tests) so the auto-install-on-connect behavior the issue asks for actually happens.

## Related Issue

Fixes #54217

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/whatsapp/adapter.py` — call `ensure("platform.whatsapp", prompt=False)` at the top of `connect()` (the actual runtime fix). `ensure()` is a no-op when aiohttp is already present; a failed install is logged, not raised, so `connect()` still degrades via its normal failure paths.
- `tools/lazy_deps.py` — register `"platform.whatsapp": ("aiohttp==3.13.4",)` (same CVE-patched pin as `platform.slack` / `platform.teams`).
- `pyproject.toml` — add a `whatsapp = ["aiohttp==3.13.4"]` extra for packagers / explicit `pip install hermes-agent[whatsapp]`.
- `uv.lock` — regenerated with `uv lock`; only the new `whatsapp` extra is added.
- `tests/gateway/test_whatsapp_lazy_aiohttp.py` — new regression tests.

## How to Test

Repro (before the fix): in an environment without `aiohttp`, configure a WhatsApp platform and run `hermes gateway` → `connect()` raises `ModuleNotFoundError: No module named 'aiohttp'` ~30s after start during bridge connect, and the gateway drops to cron-only mode.

After the fix:

1. `python -c "from tools.lazy_deps import LAZY_DEPS; assert 'platform.whatsapp' in LAZY_DEPS; print('ok')"`
2. `pytest tests/gateway/test_whatsapp_lazy_aiohttp.py tests/gateway/test_whatsapp_connect.py tests/tools/test_lazy_deps.py -q` — verifies `ensure()` is invoked before aiohttp is used, a failed install is swallowed (connect returns False, doesn't raise), and existing connect tests still pass.
3. On a clean WhatsApp-only install: `hermes gateway` → aiohttp auto-installs on first connect and WhatsApp connects.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(whatsapp): …`)
- [x] I searched for existing PRs — this completes #54237 (registry-only); see the note above
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin), Python 3.11

Ran the WhatsApp + `lazy_deps` suites locally — **195 passed**, `ruff check` clean, `uv.lock` in sync. (The full `pytest tests/ -q` needs every optional extra installed, which CI provides.)

### Documentation & Housekeeping

- [x] Docs (README, `docs/`, docstrings) — N/A
- [x] `cli-config.yaml.example` — N/A (no config keys added)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — change is platform-agnostic (aiohttp is cross-platform)
- [x] Tool descriptions/schemas — N/A
