### PR TITLE
fix(title-gen): strip <think> blocks from reasoning-model title output

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -5,6 +5,7 @@ adds latency to the user-facing reply.
 """
 
 import logging
+import re
 import threading
 from typing import Callable, Optional
 
@@ -88,6 +89,8 @@ def generate_title(
             main_runtime=main_runtime,
         )
         title = (response.choices[0].message.content or "").strip()
+        # Strip <think>...</think> blocks from reasoning-model outputs
+        title = re.sub(r'<think>.*?</think>\s*', '', title, flags=re.DOTALL).strip()
         # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
         title = title.strip('"\'')
         if title.lower().startswith("title:"):


### PR DESCRIPTION
When title generation uses a reasoning model (DeepSeek, QwQ, etc.), the model may emit \ blocks before the actual title text. These blocks leak into the session title and produce broken titles like \.

This fix strips think blocks before the existing quote/prefix cleanup so they never reach the session DB.

**Tested:** `23/23 tests passed` in `tests/agent/test_title_generator.py`