### PR TITLE
fix(win32): add CREATE_NO_WINDOW to all background subprocess calls

### DIFF
--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -653,6 +653,7 @@ def _git(cwd: Path, *args: str) -> str:
             capture_output=True,
             text=True,
             timeout=_GIT_TIMEOUT,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
         )
     except (OSError, subprocess.SubprocessError):
         return ""

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -330,6 +330,7 @@ def _run_git(
             env=env,
             cwd=str(normalized_working_dir),
             stdin=subprocess.DEVNULL,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
         )
         ok = result.returncode == 0
         stdout = result.stdout.strip()
@@ -450,6 +451,7 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
             capture_output=True, text=True,
             env=init_env, timeout=_GIT_TIMEOUT,
             stdin=subprocess.DEVNULL,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
         )
         if result.returncode != 0:
             return f"Shadow store init failed: {result.stderr.strip()}"

--- a/tui_gateway/git_probe.py
+++ b/tui_gateway/git_probe.py
@@ -26,12 +26,16 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 import threading
 import time
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 
 _GIT_TIMEOUT = 1.5
+
+# Windows: suppress conhost.exe window flashes from git subprocess calls
+_CREATE_NO_WINDOW = 0x08000000 if sys.platform == "win32" else 0
 _WARM_WORKERS = 8
 
 # How long a "not a git repo" answer stays cached before it's re-probed. Short
@@ -53,6 +57,7 @@ def run_git(cwd: str, *args: str) -> str:
             timeout=_GIT_TIMEOUT,
             check=False,
             stdin=subprocess.DEVNULL,
+            creationflags=_CREATE_NO_WINDOW,
         )
         return result.stdout.strip() if result.returncode == 0 else ""
     except Exception:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -289,6 +289,7 @@ class _SlashWorker:
             # slash_worker runs the Hermes agent → needs provider credentials.
             # Tier-1 secrets (gateway/GitHub/infra) are still stripped (#29157).
             env=hermes_subprocess_env(inherit_credentials=True),
+            creationflags=git_probe._CREATE_NO_WINDOW,
         )
         threading.Thread(target=self._drain_stdout, daemon=True).start()
         threading.Thread(target=self._drain_stderr, daemon=True).start()
@@ -9124,7 +9125,7 @@ def _(rid, params: dict) -> dict:
             str(pdf_path), str(out_prefix),
         ]
         try:
-            res = subprocess.run(argv, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL)
+            res = subprocess.run(argv, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL, creationflags=git_probe._CREATE_NO_WINDOW)
         except subprocess.TimeoutExpired:
             return _err(rid, 5028, "pdftoppm timed out (>120s)")
         if res.returncode != 0:
@@ -11155,6 +11156,7 @@ def _(rid, params: dict) -> dict:
             # needs provider credentials. Tier-1 secrets still stripped (#29157).
             env=hermes_subprocess_env(inherit_credentials=True),
             stdin=subprocess.DEVNULL,
+            creationflags=git_probe._CREATE_NO_WINDOW,
         )
         parts = [r.stdout or "", r.stderr or ""]
         out = "\n".join(p for p in parts if p).strip() or "(no output)"
@@ -11216,6 +11218,7 @@ def _(rid, params: dict) -> dict:
                 text=True,
                 timeout=30,
                 stdin=subprocess.DEVNULL,
+                creationflags=git_probe._CREATE_NO_WINDOW,
             )
             output = (
                 (r.stdout or "")
@@ -11675,6 +11678,7 @@ def _list_repo_files(root: str) -> list[str]:
             timeout=2.0,
             check=False,
             stdin=subprocess.DEVNULL,
+            creationflags=git_probe._CREATE_NO_WINDOW,
         )
         if top_result.returncode == 0:
             top = top_result.stdout.decode("utf-8", "replace").strip()
@@ -11693,6 +11697,7 @@ def _list_repo_files(root: str) -> list[str]:
                 timeout=2.0,
                 check=False,
                 stdin=subprocess.DEVNULL,
+                creationflags=git_probe._CREATE_NO_WINDOW,
             )
             if list_result.returncode == 0:
                 for p in list_result.stdout.decode("utf-8", "replace").split("\0"):
@@ -13552,6 +13557,7 @@ def _(rid, params: dict) -> dict:
         r = subprocess.run(
             cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd(),
             stdin=subprocess.DEVNULL,
+            creationflags=git_probe._CREATE_NO_WINDOW,
         )
         return _ok(
             rid,


### PR DESCRIPTION
## fix(win32): add CREATE_NO_WINDOW to all background subprocess calls

Fixes #53424

### Problem

On Windows, every `subprocess.run([git, ...])` or `subprocess.Popen(...)` call without `creationflags=CREATE_NO_WINDOW` causes a brief `conhost.exe` console window to flash on screen. While `hermes_cli/web_server.py` and `hermes_cli/banner.py` already handle this correctly via `windows_hide_flags()`, several other modules missed the flag — most critically `tui_gateway/git_probe.py`, which is the central hub for all gateway git probing and can spawn dozens of git processes per second during sidebar refreshes.

**User-visible symptom:** Rapid, continuous console window flashing when the Hermes Desktop app is running on Windows, especially on machines with multiple sessions across different working directories.

### Root Cause

`pythonw.exe` (the dashboard process) is windowless by design, but its child processes (`git.exe`, `pdftoppm`, `python -m hermes_cli.main`) are console executables. Without `CREATE_NO_WINDOW` (`0x08000000`), Windows allocates a new `conhost.exe` for each child, producing a visible flash even though the process completes in milliseconds.

The `hermes_cli/_subprocess_compat.py` module already documents this exact issue and provides `windows_hide_flags()` — but it was only consumed by `web_server.py` and `banner.py`. The gateway, agent, and checkpoint code paths were missed.

### Fix

Add `creationflags` to every `subprocess.run` / `subprocess.Popen` call that spawns a console executable:

| File | Call sites fixed | Context |
|---|---|---|
| `tui_gateway/git_probe.py` | 1 | `run_git()` — central hub for all gateway git probes |
| `tui_gateway/server.py` | 7 | `_SlashWorker` Popen, pdftoppm, `hermes_cli.main`, quick_commands, `git rev-parse`, `git ls-files`, `shell.exec` |
| `agent/coding_context.py` | 1 | `_git()` — git context probe per coding session |
| `tools/checkpoint_manager.py` | 2 | `_run_git()` hub + `_init_store()` |

Two styles used to match existing conventions in each file:
- **tui_gateway/ files:** `git_probe._CREATE_NO_WINDOW` (module-level constant, `sys.platform`-guarded)
- **Standalone modules (agent/, tools/):** `getattr(subprocess, CREATE_NO_WINDOW, 0)` — zero-import, safe on all platforms

Both approaches resolve to `0x08000000` on Windows and `0` elsewhere — no behavioral change on Linux/macOS.

### Testing
- All 4 modified files pass `py_compile` syntax check (Python 3.11).
- Manually tested on Windows 10 (build 26200): after patching and clearing `__pycache__`, the rapid conhost.exe flashing stopped completely. Process monitoring confirmed `git.exe` calls still succeed (stdout captured correctly).
- No impact on non-Windows: `creationflags` parameter is ignored on POSIX, and the flag values resolve to `0`.

### Notes
`hermes_cli/main.py` (~43 git calls) and `cli.py` (~17 git calls) also lack `creationflags`, but these are CLI-only code paths where the user already has a terminal open, so the flash is not visible. This PR focuses on the background/daemon paths that run headless.

Consider a follow-up to centralize the flag via `_subprocess_compat.windows_hide_flags()` across all modules for consistency.