### PR TITLE
feat: add STT transcript echo toggle

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -536,6 +536,7 @@ class GatewayConfig:
 
     # STT settings
     stt_enabled: bool = True  # Whether to auto-transcribe inbound voice messages
+    stt_echo_transcripts: bool = True  # Whether to echo raw STT transcripts back to the user
 
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
@@ -659,6 +660,7 @@ class GatewayConfig:
             "always_log_local": self.always_log_local,
             "filter_silence_narration": self.filter_silence_narration,
             "stt_enabled": self.stt_enabled,
+            "stt_echo_transcripts": self.stt_echo_transcripts,
             "group_sessions_per_user": self.group_sessions_per_user,
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "max_concurrent_sessions": self.max_concurrent_sessions,
@@ -705,6 +707,13 @@ class GatewayConfig:
         stt_enabled = data.get("stt_enabled")
         if stt_enabled is None:
             stt_enabled = data.get("stt", {}).get("enabled") if isinstance(data.get("stt"), dict) else None
+        stt_echo_transcripts = data.get("stt_echo_transcripts")
+        if stt_echo_transcripts is None:
+            stt_echo_transcripts = (
+                data.get("stt", {}).get("echo_transcripts")
+                if isinstance(data.get("stt"), dict)
+                else None
+            )
 
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
@@ -748,6 +757,7 @@ class GatewayConfig:
                 data.get("filter_silence_narration"), True
             ),
             stt_enabled=_coerce_bool(stt_enabled, True),
+            stt_echo_transcripts=_coerce_bool(stt_echo_transcripts, True),
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17253,7 +17253,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 # real transcript instead of an empty string
                                 # (or file-path placeholder). Matches the UX
                                 # of fresh voice messages including the
-                                # 🎙️ echo back to the user.
+                                # optional 🎙️ echo back to the user.
                                 _media_urls = getattr(_peek_event, "media_urls", None) or []
                                 _media_types = getattr(_peek_event, "media_types", None) or []
                                 _audio_paths = []
@@ -17271,7 +17271,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             pending_text, _audio_paths,
                                         )
                                         pending_text = _enriched
-                                        if _transcripts:
+                                        if _transcripts and self._should_echo_stt_transcripts():
                                             _echo_meta = {"thread_id": source.thread_id} if source.thread_id else None
                                             for _tx in _transcripts:
                                                 try:
@@ -17632,9 +17632,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Transcribe audio media on the dequeued event BEFORE it is
                     # handed back as the next user turn, so queued/interrupting
                     # voice messages drain with the real transcript instead of
-                    # a file-path placeholder. Echo each transcript back to the
-                    # user (same 🎙️ format as fresh voice messages) so voice
-                    # interrupts feel identical to text interrupts.
+                    # a file-path placeholder. When configured, echo each
+                    # transcript back to the user in the same 🎙️ format as
+                    # fresh voice messages.
                     _pending_text = pending_event.text or ""
                     _media_urls = getattr(pending_event, "media_urls", None) or []
                     _media_types = getattr(pending_event, "media_types", None) or []
@@ -17653,7 +17653,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 _pending_text, _audio_paths,
                             )
                             pending = _enriched or None
-                            if _transcripts:
+                            if _transcripts and self._should_echo_stt_transcripts():
                                 _echo_meta = {"thread_id": source.thread_id} if source.thread_id else None
                                 for _tx in _transcripts:
                                     try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9329,10 +9329,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     message_text,
                     audio_paths,
                 )
-                # Echo each successful transcript back to the user immediately,
-                # before the agent loop runs. Lets the user verify STT quality
-                # in real-time and see the raw whisper output verbatim.
-                if _successful_transcripts:
+                # Echo each successful transcript back to the user immediately
+                # when configured. Lets users verify STT quality in real-time,
+                # while allowing quiet STT for users who only want the agent to
+                # receive the transcription.
+                if _successful_transcripts and self._should_echo_stt_transcripts():
                     _echo_adapter = self.adapters.get(source.platform)
                     _echo_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
                     if _echo_adapter:
@@ -11739,6 +11740,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return True
 
+    def _should_echo_stt_transcripts(self) -> bool:
+        """Return whether inbound voice/STT transcripts should be echoed to chat."""
+        return bool(getattr(self.config, "stt_echo_transcripts", True))
+
     async def _send_voice_reply(self, event: MessageEvent, text: str) -> None:
         """Generate TTS audio and send as a voice message before the text reply."""
         import uuid as _uuid
@@ -13814,9 +13819,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             enriched_text, successful_transcripts = await self._enrich_message_with_transcription(
                 text, audio_paths,
             )
-            # Echo raw transcripts back to the user so voice interrupts
-            # feel identical to fresh voice messages.
-            if successful_transcripts:
+            # Echo raw transcripts back to the user when configured so voice
+            # interrupts feel identical to fresh voice messages.
+            if successful_transcripts and self._should_echo_stt_transcripts():
                 echo_adapter = self.adapters.get(source.platform)
                 echo_meta = {"thread_id": source.thread_id} if source.thread_id else None
                 if echo_adapter:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1974,6 +1974,10 @@ DEFAULT_CONFIG = {
     
     "stt": {
         "enabled": True,
+        # When true, gateway voice messages are transcribed for the agent and
+        # the raw transcript is also echoed back to the user as a 🎙️ message.
+        # Set false to keep STT for the agent while suppressing that user-facing echo.
+        "echo_transcripts": True,
         "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe)
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3

--- a/tests/gateway/test_stt_transcript_echo_config.py
+++ b/tests/gateway/test_stt_transcript_echo_config.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from types import SimpleNamespace
 
 from gateway.config import GatewayConfig
@@ -39,3 +40,19 @@ def test_gateway_runner_uses_stt_echo_transcripts_flag():
 
     runner.config = SimpleNamespace()
     assert runner._should_echo_stt_transcripts() is True
+
+
+def test_all_gateway_transcript_echo_sends_are_gated():
+    source = Path(__file__).resolve().parents[2] / "gateway" / "run.py"
+    lines = source.read_text().splitlines()
+
+    echo_send_lines = [
+        index
+        for index, line in enumerate(lines)
+        if "f'🎙️" in line or 'f"🎙️' in line
+    ]
+
+    assert echo_send_lines
+    for index in echo_send_lines:
+        context = "\n".join(lines[max(0, index - 12): index + 1])
+        assert "_should_echo_stt_transcripts()" in context

--- a/tests/gateway/test_stt_transcript_echo_config.py
+++ b/tests/gateway/test_stt_transcript_echo_config.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+
+from gateway.config import GatewayConfig
+from gateway.run import GatewayRunner
+
+
+def test_stt_echo_transcripts_defaults_on_for_backwards_compatibility():
+    cfg = GatewayConfig.from_dict({})
+
+    assert cfg.stt_enabled is True
+    assert cfg.stt_echo_transcripts is True
+    assert cfg.to_dict()["stt_echo_transcripts"] is True
+
+
+def test_stt_echo_transcripts_can_be_disabled_in_stt_section():
+    cfg = GatewayConfig.from_dict({"stt": {"enabled": True, "echo_transcripts": False}})
+
+    assert cfg.stt_enabled is True
+    assert cfg.stt_echo_transcripts is False
+
+
+def test_top_level_stt_echo_transcripts_takes_precedence():
+    cfg = GatewayConfig.from_dict({
+        "stt_echo_transcripts": False,
+        "stt": {"echo_transcripts": True},
+    })
+
+    assert cfg.stt_echo_transcripts is False
+
+
+def test_gateway_runner_uses_stt_echo_transcripts_flag():
+    runner = GatewayRunner.__new__(GatewayRunner)
+
+    runner.config = SimpleNamespace(stt_echo_transcripts=False)
+    assert runner._should_echo_stt_transcripts() is False
+
+    runner.config = SimpleNamespace(stt_echo_transcripts=True)
+    assert runner._should_echo_stt_transcripts() is True
+
+    runner.config = SimpleNamespace()
+    assert runner._should_echo_stt_transcripts() is True


### PR DESCRIPTION
## Summary
- add `stt.echo_transcripts` config to keep voice-message STT enabled while suppressing the user-facing 🎙️ transcript echo
- preserve current behavior by defaulting the new flag to true
- gate both fresh voice-message and queued voice-interrupt transcript echo paths

## Test Plan
- `scripts/run_tests.sh tests/gateway/test_stt_transcript_echo_config.py tests/test_gateway_streaming_nested_config.py`
