### PR TITLE
fix(telegram): preserve reply and forwarded context

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9469,7 +9469,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # is referencing. History can contain the same or similar text
             # multiple times, and without an explicit pointer the agent has to
             # guess (or answer for both subjects). Token overhead is minimal.
-            reply_snippet = event.reply_to_text[:500]
+            reply_snippet = event.reply_to_text
             if getattr(event, "reply_to_is_own_message", False):
                 message_text = (
                     f'[Replying to your previous message: "{reply_snippet}"]\n\n'

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6575,6 +6575,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
+        self._apply_forwarded_context(event, msg)
         await self._cache_replied_media(msg, event)
         event = self._apply_telegram_group_observe_attribution(event)
         self._enqueue_text_event(event)
@@ -6803,10 +6804,12 @@ class TelegramAdapter(BasePlatformAdapter):
         # Add caption as text
         if msg.caption:
             event.text = self._clean_bot_trigger_text(msg.caption)
+        self._apply_forwarded_context(event, msg)
         
         # Handle stickers: describe via vision tool with caching
         if msg.sticker:
             await self._handle_sticker(msg, event)
+            self._apply_forwarded_context(event, msg)
             event = self._apply_telegram_group_observe_attribution(event)
             await self.handle_message(event)
             return
@@ -7323,6 +7326,74 @@ class TelegramAdapter(BasePlatformAdapter):
             return text or None
         except Exception:
             return None
+
+    @staticmethod
+    def _telegram_context_value(value: Any) -> Optional[str]:
+        """Return a real string value, ignoring test/mock placeholders."""
+        if value is None:
+            return None
+        # MagicMock creates truthy child attributes for anything. Treat those
+        # as absent so tests/mocks do not look like forwarded Telegram payloads.
+        if type(value).__module__.startswith("unittest.mock"):
+            return None
+        text = str(value).strip()
+        return text or None
+
+    @classmethod
+    def _telegram_user_display_name(cls, user: Any) -> Optional[str]:
+        """Best-effort human label for Telegram users/chats in context notes."""
+        if user is None or type(user).__module__.startswith("unittest.mock"):
+            return None
+        for attr in ("full_name", "title", "username", "first_name", "name"):
+            value = cls._telegram_context_value(getattr(user, attr, None))
+            if value:
+                return value
+        return cls._telegram_context_value(getattr(user, "id", None))
+
+    @classmethod
+    def _telegram_forward_context(cls, message: Any) -> Optional[str]:
+        """Return a compact context marker when a Telegram message is forwarded."""
+        origin = getattr(message, "forward_origin", None)
+        if origin is not None and type(origin).__module__.startswith("unittest.mock"):
+            origin = None
+        sender: Optional[str] = None
+
+        if origin is not None:
+            sender = (
+                cls._telegram_user_display_name(getattr(origin, "sender_user", None))
+                or cls._telegram_context_value(getattr(origin, "sender_user_name", None))
+                or cls._telegram_user_display_name(getattr(origin, "chat", None))
+                or cls._telegram_context_value(getattr(origin, "author_signature", None))
+            )
+
+        if not sender:
+            sender = (
+                cls._telegram_user_display_name(getattr(message, "forward_from", None))
+                or cls._telegram_context_value(getattr(message, "forward_sender_name", None))
+                or cls._telegram_user_display_name(getattr(message, "forward_from_chat", None))
+                or cls._telegram_context_value(getattr(message, "forward_signature", None))
+            )
+
+        is_forwarded = bool(
+            origin is not None
+            or sender
+            or cls._telegram_context_value(getattr(message, "forward_date", None)) is not None
+        )
+        if not is_forwarded:
+            return None
+
+        if sender:
+            return f"[Forwarded Telegram message from {sender}.]"
+        return "[Forwarded Telegram message.]"
+
+    def _apply_forwarded_context(self, event: MessageEvent, message: Any) -> MessageEvent:
+        """Prefix forwarded Telegram content so the agent does not treat it as authored text."""
+        context = self._telegram_forward_context(message)
+        if not context:
+            return event
+        text = (event.text or "").strip()
+        event.text = f"{context}\n\n{text}" if text else context
+        return event
 
     def _build_message_event(
         self,

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -499,6 +499,30 @@ class TestSenderPrefixWithBackfill:
         assert "[Alice] [Charlie" not in result
         assert "[Alice] [Recent" not in result
 
+    @pytest.mark.asyncio
+    async def test_reply_context_preserves_full_replied_text(self, runner):
+        """Reply context is a pointer, so do not truncate long replied-to text."""
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+        )
+        long_reply = "section-" + ("A" * 700) + "-tail"
+        event = MessageEvent(
+            text="what about this?",
+            source=source,
+            reply_to_message_id="99",
+            reply_to_text=long_reply,
+        )
+
+        result = await runner._prepare_inbound_message_text(
+            event=event, source=source, history=[],
+        )
+
+        assert long_reply in result
+        assert "-tail" in result
+        assert "[Replying to:" in result
+
 
 class TestSessionStoreRewriteTranscript:
     """Regression: /retry and /undo must persist truncated history to DB."""

--- a/tests/gateway/test_telegram_reply_quote.py
+++ b/tests/gateway/test_telegram_reply_quote.py
@@ -46,6 +46,9 @@ def _make_message(
     reply_to_caption=None,
     reply_to_id=42,
     quote_text=None,
+    forward_origin=None,
+    forward_sender_name=None,
+    forward_date=None,
 ):
     chat = SimpleNamespace(id=111, type="private", title=None, full_name="Alice")
     user = SimpleNamespace(id=42, full_name="Alice")
@@ -72,6 +75,9 @@ def _make_message(
         quote=quote,
         date=None,
         forum_topic_created=None,
+        forward_origin=forward_origin,
+        forward_sender_name=forward_sender_name,
+        forward_date=forward_date,
     )
 
 
@@ -142,3 +148,49 @@ def test_empty_quote_text_falls_back_to_full_reply():
     event = adapter._build_message_event(msg, MessageType.TEXT)
 
     assert event.reply_to_text == "Prior message body"
+
+
+def test_forwarded_text_gets_explicit_context_prefix():
+    """Forwarded text should be marked as forwarded before it reaches the agent."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    msg = _make_message(
+        text="Please review this proposal",
+        forward_origin=SimpleNamespace(
+            sender_user=SimpleNamespace(full_name="Bob Example", username="bob", id=7)
+        ),
+    )
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+    adapter._apply_forwarded_context(event, msg)
+
+    assert event.text == (
+        "[Forwarded Telegram message from Bob Example.]\n\n"
+        "Please review this proposal"
+    )
+
+
+def test_forwarded_caption_gets_context_prefix():
+    """Forwarded media captions should keep the forwarded marker too."""
+    adapter = _make_adapter()
+    event = SimpleNamespace(text="diagram caption")
+    msg = _make_message(
+        text="",
+        forward_sender_name="Hidden Sender",
+    )
+
+    adapter._apply_forwarded_context(event, msg)
+
+    assert event.text == "[Forwarded Telegram message from Hidden Sender.]\n\ndiagram caption"
+
+
+def test_forwarded_without_sender_still_marked():
+    """Some Telegram forwards hide sender details but still expose forward_date."""
+    adapter = _make_adapter()
+    event = SimpleNamespace(text="anonymous forwarded text")
+    msg = _make_message(text="", forward_date=object())
+
+    adapter._apply_forwarded_context(event, msg)
+
+    assert event.text == "[Forwarded Telegram message.]\n\nanonymous forwarded text"


### PR DESCRIPTION
## Summary
- Preserve the full replied-to Telegram text when building the agent-facing reply pointer instead of truncating it to 500 characters.
- Add an explicit forwarded-message context prefix for Telegram forwarded text and forwarded media captions/stickers.
- Handle hidden-sender forwards with a generic forwarded marker.

## Why
Replies and forwards are intent/context pointers. If the gateway truncates replied-to text or passes forwarded content as if it were authored directly by the user, the agent can answer with incomplete or misattributed context.

## Tests
- `python -m compileall -q plugins/platforms/telegram/adapter.py gateway/run.py tests/gateway/test_telegram_reply_quote.py tests/gateway/test_session.py`
- `ruff check plugins/platforms/telegram/adapter.py gateway/run.py tests/gateway/test_telegram_reply_quote.py tests/gateway/test_session.py`
- `python -m pytest tests/gateway/test_telegram_reply_quote.py tests/gateway/test_session.py::TestSenderPrefixWithBackfill tests/gateway/test_telegram_documents.py::TestMediaGroups tests/gateway/test_video_context_note.py -q -o 'addopts='`
- Local `git merge-tree` against `upstream/main`: clean
