### PR TITLE
fix(credential-pool): unify retry-delay regex with extract_api_error_context

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -288,26 +288,63 @@ def _parse_absolute_timestamp(value: Any) -> Optional[float]:
 
 
 def _extract_retry_delay_seconds(message: str) -> Optional[float]:
+
     if not message:
+
         return None
+
     delay_match = re.search(r"quotaResetDelay[:\s\"]+(\d+(?:\.\d+)?)(ms|s)", message, re.IGNORECASE)
+
     if delay_match:
+
         value = float(delay_match.group(1))
+
         return value / 1000.0 if delay_match.group(2).lower() == "ms" else value
+
+    # "Resets in Xh Ym Zs" — unified pattern matching the same formats
+
+    # as extract_api_error_context in agent_runtime_helpers.py.  Supports
+
+    # h/hr/hrs/hour/hours, m/min/mins/minute/minutes, s/sec/secs/second/seconds
+
+    # in any combination (hours-only, minutes-only, seconds-only, or mixed).
+
+    resets_in_match = re.search(
+
+        r"resets?\s+in\s+"
+
+        r"(?:(\d+(?:\.\d+)?)\s*(?:h|hr|hrs|hour|hours)\b\s*)?"
+
+        r"(?:(\d+(?:\.\d+)?)\s*(?:m|min|mins|minute|minutes)\b\s*)?"
+
+        r"(?:(\d+(?:\.\d+)?)\s*(?:s|sec|secs|second|seconds)\b)?",
+
+        message,
+
+        re.IGNORECASE,
+
+    )
+
+    if resets_in_match and any(resets_in_match.groups()):
+
+        hours = float(resets_in_match.group(1) or 0)
+
+        minutes = float(resets_in_match.group(2) or 0)
+
+        seconds = float(resets_in_match.group(3) or 0)
+
+        return (hours * 3600) + (minutes * 60) + seconds
+
     sec_match = re.search(r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)", message, re.IGNORECASE)
+
     if sec_match:
+
         return float(sec_match.group(1))
-    # "Resets in 4hr 5min" format used by OpenCode Go weekly usage limits
-    hr_min_match = re.search(r"resets?\s+in\s+(\d+)\s*hr\s+(\d+)\s*min", message, re.IGNORECASE)
-    if hr_min_match:
-        return int(hr_min_match.group(1)) * 3600 + int(hr_min_match.group(2)) * 60
-    hr_only_match = re.search(r"resets?\s+in\s+(\d+)\s*hr\b", message, re.IGNORECASE)
-    if hr_only_match:
-        return int(hr_only_match.group(1)) * 3600
-    min_only_match = re.search(r"resets?\s+in\s+(\d+)\s*min\b", message, re.IGNORECASE)
-    if min_only_match:
-        return int(min_only_match.group(1)) * 60
+
     return None
+
+
+
 
 
 def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[str, Any]:

--- a/tests/agent/test_credential_pool_retry_delay.py
+++ b/tests/agent/test_credential_pool_retry_delay.py
@@ -1,0 +1,130 @@
+"""Tests for _extract_retry_delay_seconds in credential_pool.
+
+This function is the fallback retry-delay parser used by
+_normalize_error_context when the upstream error_context does not
+already carry a ``reset_at`` timestamp.  The regex must be at least as
+broad as the one in ``extract_api_error_context`` (agent_runtime_helpers)
+so that the fallback path never silently degrades to the default 1-hour
+cooldown when the message contains a parseable duration.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.credential_pool import _extract_retry_delay_seconds
+
+
+# ── quotaResetDelay format ──────────────────────────────────────────
+
+class TestQuotaResetDelay:
+    def test_ms_suffix(self):
+        assert _extract_retry_delay_seconds("quotaResetDelay: 5000ms") == 5.0
+
+    def test_s_suffix(self):
+        assert _extract_retry_delay_seconds("quotaResetDelay: 30s") == 30.0
+
+    def test_decimal_ms(self):
+        assert _extract_retry_delay_seconds("quotaResetDelay: 1500ms") == 1.5
+
+
+# ── "retry after N seconds" format ────────────────────────────────
+
+class TestRetryAfterSeconds:
+    def test_retry_after_seconds(self):
+        assert _extract_retry_delay_seconds("retry after 60 seconds") == 60.0
+
+    def test_retry_after_s(self):
+        assert _extract_retry_delay_seconds("retry after 90s") == 90.0
+
+    def test_retry_s_no_after(self):
+        assert _extract_retry_delay_seconds("retry 30s") == 30.0
+
+    def test_retry_uppercase(self):
+        assert _extract_retry_delay_seconds("Retry After 120 Seconds") == 120.0
+
+
+# ── "Resets in Xhr Ymin" — OpenCode Go format (original coverage) ─
+
+class TestResetsInOriginal:
+    def test_hr_min(self):
+        assert _extract_retry_delay_seconds("Resets in 4hr 5min") == 14700.0
+
+    def test_hr_min_spaced(self):
+        assert _extract_retry_delay_seconds("resets in 4 hr 5 min") == 14700.0
+
+    def test_hr_only(self):
+        assert _extract_retry_delay_seconds("Resets in 4hr") == 14400.0
+
+    def test_min_only(self):
+        assert _extract_retry_delay_seconds("Resets in 5min") == 300.0
+
+
+# ── "Resets in" with broader unit aliases (previously unparseable) ─
+
+class TestResetsInBroadened:
+    """These formats were NOT parsed by the old regex but ARE parsed by
+    extract_api_error_context.  The fallback must match the upstream
+    coverage to avoid silent 1-hour default cooldown."""
+
+    def test_single_letter_h_m(self):
+        assert _extract_retry_delay_seconds("Resets in 4h 5m") == 14700.0
+
+    def test_sec_only(self):
+        assert _extract_retry_delay_seconds("Resets in 90 sec") == 90.0
+
+    def test_s_only(self):
+        assert _extract_retry_delay_seconds("Resets in 90s") == 90.0
+
+    def test_full_words_hr_min(self):
+        assert _extract_retry_delay_seconds("Resets in 2 hours 30 minutes") == 9000.0
+
+    def test_hour_full_only(self):
+        assert _extract_retry_delay_seconds("Resets in 1 hour") == 3600.0
+
+    def test_minutes_full_only(self):
+        assert _extract_retry_delay_seconds("Resets in 45 minutes") == 2700.0
+
+    def test_seconds_full_only(self):
+        assert _extract_retry_delay_seconds("Resets in 30 seconds") == 30.0
+
+    def test_h_m_single_letter(self):
+        assert _extract_retry_delay_seconds("Resets in 5h 30m") == 19800.0
+
+    def test_hrs_mins(self):
+        assert _extract_retry_delay_seconds("Resets in 2hrs 15mins") == 8100.0
+
+    def test_all_three_components(self):
+        assert _extract_retry_delay_seconds("Resets in 1h 30m 15s") == 5415.0
+
+
+# ── Embedded in longer messages ────────────────────────────────────
+
+class TestEmbeddedInMessage:
+    def test_rate_limit_prefix(self):
+        msg = "rate limit exceeded. Resets in 2hr 30min"
+        assert _extract_retry_delay_seconds(msg) == 9000.0
+
+    def test_429_prefix(self):
+        msg = "429: Resets in 1hr 0min"
+        assert _extract_retry_delay_seconds(msg) == 3600.0
+
+    def test_quota_exceeded_prefix(self):
+        msg = "Quota exceeded for generate_content_free_tier_requests. Resets in 24 hours"
+        assert _extract_retry_delay_seconds(msg) == 86400.0
+
+
+# ── Negative cases ──────────────────────────────────────────────────
+
+class TestNoMatch:
+    def test_empty_string(self):
+        assert _extract_retry_delay_seconds("") is None
+
+    def test_none_relevant(self):
+        assert _extract_retry_delay_seconds("no relevant message") is None
+
+    def test_random_numbers(self):
+        assert _extract_retry_delay_seconds("error 12345 occurred") is None
+
+    def test_resets_without_duration(self):
+        assert _extract_retry_delay_seconds("resets in") is None


### PR DESCRIPTION
## Problem

The fallback retry-delay parser in `credential_pool.py` had a narrower regex than the upstream `extract_api_error_context`, causing silent degradation to default 1h cooldown for parseable messages.

## Specific gaps

- `Resets in 4h 5m` (single-letter) -> unparseable
- `Resets in 90 sec` / `Resets in 90s` (seconds-only) -> unparseable
- `Resets in 2 hours 30 minutes` (full words) -> unparseable
- `Resets in 1 hour` / `Resets in 45 minutes` (full-word only) -> unparseable
- `Resets in 2hrs 15mins` (plural variants) -> unparseable

## Fix

Replace three narrow regexes with a unified pattern matching `extract_api_error_context` in `agent_runtime_helpers.py`.

## Tests

28 new tests (previously zero coverage). All 78 existing tests pass.
