### PR TITLE
fix(gateway): polish background process notifications

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2257,6 +2257,59 @@ def _resolve_hermes_bin() -> Optional[list[str]]:
     return None
 
 
+def _background_output_tail(output: str, command: str = "", *, limit: int = 1000) -> str:
+    """Return a sanitized, bounded output tail for public background notifications."""
+    if not output:
+        return ""
+    try:
+        from tools.ansi_strip import strip_ansi
+        output = strip_ansi(output)
+    except Exception:
+        pass
+    try:
+        from agent.redact import redact_terminal_output
+        output = redact_terminal_output(output, command or "")
+    except Exception:
+        pass
+    output = re.sub(r"proc_[A-Za-z0-9_-]+", "background process", output)
+    if "Traceback (most recent call last):" in output:
+        lines = [line.strip() for line in output.splitlines() if line.strip()]
+        if lines:
+            return f"Final error: {lines[-1]}"
+        return ""
+    if len(output) <= limit:
+        return output.strip()
+    tail = output[-limit:]
+    newline = tail.find("\n")
+    if newline != -1:
+        tail = tail[newline + 1:]
+    return f"[… output truncated — showing last {len(tail)} chars]\n{tail.strip()}"
+
+
+def _format_background_process_chat_notification(
+    *,
+    exited: bool,
+    exit_code: Optional[int],
+    output: str = "",
+    command: str = "",
+) -> str:
+    """Format a background process watcher notification for human chat surfaces."""
+    if exited:
+        if exit_code in {0, None}:
+            status = "✅ Background task completed."
+        else:
+            status = f"⚠️ Background task failed (exit code {exit_code})."
+        label = "Final output"
+    else:
+        status = "⏳ Background task is still running."
+        label = "Recent output"
+
+    tail = _background_output_tail(output, command)
+    if not tail:
+        return status
+    return f"{status}\n\n{label}:\n{tail}"
+
+
 def _parse_session_key(session_key: str) -> "dict | None":
     """Parse a session key into its component parts.
 
@@ -14150,15 +14203,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     or (notify_mode == "error" and session.exit_code not in {0, None})
                 )
                 if should_notify:
-                    new_output = session.output_buffer[-1000:] if session.output_buffer else ""
-                    if new_output:
-                        from agent.redact import redact_terminal_output
-                        new_output = redact_terminal_output(
-                            new_output, getattr(session, "command", "") or ""
-                        )
-                    message_text = (
-                        f"[Background process {session_id} finished with exit code {session.exit_code}~ "
-                        f"Here's the final output:\n{new_output}]"
+                    message_text = _format_background_process_chat_notification(
+                        exited=True,
+                        exit_code=session.exit_code,
+                        output=session.output_buffer or "",
+                        command=getattr(session, "command", "") or "",
                     )
                     adapter = None
                     for p, a in self.adapters.items():
@@ -14180,15 +14229,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             elif has_new_output and notify_mode == "all" and not agent_notify:
                 # New output available -- deliver status update (only in "all" mode)
                 # Skip periodic updates for agent_notify watchers (they only care about completion)
-                new_output = session.output_buffer[-500:] if session.output_buffer else ""
-                if new_output:
-                    from agent.redact import redact_terminal_output
-                    new_output = redact_terminal_output(
-                        new_output, getattr(session, "command", "") or ""
-                    )
-                message_text = (
-                    f"[Background process {session_id} is still running~ "
-                    f"New output:\n{new_output}]"
+                message_text = _format_background_process_chat_notification(
+                    exited=False,
+                    exit_code=None,
+                    output=session.output_buffer or "",
+                    command=getattr(session, "command", "") or "",
                 )
                 adapter = None
                 for p, a in self.adapters.items():

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -154,7 +154,7 @@ class TestLoadBackgroundNotificationsMode:
             "result",
             [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0)],
             1,
-            "finished with exit code 0",
+            "Background task completed",
         ),
         # error mode: exit 0 → no notification
         (
@@ -168,14 +168,14 @@ class TestLoadBackgroundNotificationsMode:
             "error",
             [SimpleNamespace(output_buffer="traceback\n", exited=True, exit_code=1)],
             1,
-            "finished with exit code 1",
+            "Background task failed (exit code 1)",
         ),
         # all mode: exited → notifies
         (
             "all",
             [SimpleNamespace(output_buffer="ok\n", exited=True, exit_code=0)],
             1,
-            "finished with exit code 0",
+            "Background task completed",
         ),
     ],
 )
@@ -202,6 +202,72 @@ async def test_run_process_watcher_respects_notification_mode(
     if expected_fragment is not None:
         sent_message = adapter.send.await_args.args[1]
         assert expected_fragment in sent_message
+
+    if adapter.send.await_count:
+        sent_message = adapter.send.await_args.args[1]
+        assert "[Background process" not in sent_message
+        assert "proc_test" not in sent_message
+
+
+@pytest.mark.asyncio
+async def test_background_notification_strips_ansi_and_hides_process_id(monkeypatch, tmp_path):
+    """Public watcher notifications should not expose terminal styling or proc ids."""
+    import tools.process_registry as pr_module
+
+    sessions = [
+        SimpleNamespace(
+            output_buffer="\x1b[31mfailed proc_secret123\x1b[0m\n",
+            exited=True,
+            exit_code=1,
+            command="run secret",
+        )
+    ]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "error")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    await runner._run_process_watcher(_watcher_dict(session_id="proc_secret123"))
+
+    sent_message = adapter.send.await_args.args[1]
+    assert "Background task failed (exit code 1)" in sent_message
+    assert "\x1b[" not in sent_message
+    assert "proc_secret123" not in sent_message
+    assert "[Background process" not in sent_message
+
+
+@pytest.mark.asyncio
+async def test_background_notification_summarizes_traceback(monkeypatch, tmp_path):
+    """Tracebacks are summarized to the final exception line for chat delivery."""
+    import tools.process_registry as pr_module
+
+    output = (
+        "Traceback (most recent call last):\n"
+        "  File \"job.py\", line 1, in <module>\n"
+        "RuntimeError: final failure\n"
+    )
+    sessions = [SimpleNamespace(output_buffer=output, exited=True, exit_code=1, command="python job.py")]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "error")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    await runner._run_process_watcher(_watcher_dict())
+
+    sent_message = adapter.send.await_args.args[1]
+    assert "Background task failed (exit code 1)" in sent_message
+    assert "Final error: RuntimeError: final failure" in sent_message
+    assert "Traceback (most recent call last)" not in sent_message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Replace raw background process watcher chat messages with compact human-facing notifications.
- Hide internal `proc_*` identifiers and bracketed `[Background process ...]` debug wrappers from public chat notifications.
- Strip ANSI terminal styling, keep output bounded, and summarize Python tracebacks to the final exception line.

## Why
The process watcher can deliver standalone chat notifications when a background terminal process emits output or exits. Those messages should be status updates for users, not internal observability/debug strings.

## Tests
- `python -m compileall -q gateway/run.py tests/gateway/test_background_process_notifications.py`
- `ruff check gateway/run.py tests/gateway/test_background_process_notifications.py`
- `python -m pytest tests/gateway/test_background_process_notifications.py -q -o 'addopts='`
- `python -m pytest tests/gateway/test_internal_event_bypass_pairing.py tests/tools/test_notify_on_complete.py -q -o 'addopts='`
- Local `git merge-tree` against `upstream/main`: clean
