### PR TITLE
fix(gateway): show delegated subagent progress

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15506,6 +15506,55 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not tool_progress_enabled:
                 return
 
+            if str(event_type or "").startswith("subagent."):
+                if event_type == "subagent.thinking":
+                    return
+
+                def _short_subagent_text(value: Any, limit: int = 90) -> str:
+                    text = str(value or "").strip().replace("\n", " ")
+                    return text[: limit - 1] + "…" if len(text) > limit else text
+
+                task_index = kwargs.get("task_index")
+                try:
+                    agent_number = int(task_index) + 1
+                except Exception:
+                    agent_number = None
+                label = f"agent {agent_number}" if agent_number is not None else "agent"
+                goal = _short_subagent_text(kwargs.get("goal") or preview, 70)
+                if event_type == "subagent.start":
+                    msg = f"🤖 {label} started"
+                    if goal:
+                        msg += f': "{goal}"'
+                    progress_queue.put(msg)
+                    return
+                if event_type == "subagent.tool":
+                    from agent.display import get_tool_emoji
+
+                    child_tool = str(tool_name or "tool")
+                    child_preview = _short_subagent_text(preview, 70)
+                    emoji = get_tool_emoji(child_tool, default="⚙️")
+                    msg = f"  ↳ {emoji} {child_tool}"
+                    if child_preview:
+                        msg += f': "{child_preview}"'
+                    progress_queue.put(msg)
+                    return
+                if event_type == "subagent.progress":
+                    child_progress = _short_subagent_text(preview or tool_name, 100)
+                    if child_progress:
+                        progress_queue.put(f"  ↳ {child_progress}")
+                    return
+                if event_type == "subagent.complete":
+                    status = _short_subagent_text(kwargs.get("status") or "completed", 40)
+                    if status in {"completed", "success", "done"}:
+                        prefix = "✅"
+                    elif status in {"failed", "error", "timeout"}:
+                        prefix = "⚠️"
+                    else:
+                        prefix = "🏁"
+                    progress_queue.put(f"{prefix} {label} {status}")
+                    return
+                return
+
             # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
             if event_type not in {"tool.started",}:
                 return

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -186,6 +186,31 @@ class LongPreviewAgent:
         }
 
 
+class SubagentProgressAgent:
+    """Agent that emits delegated subagent progress events."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            cb("tool.started", "delegate_task", "2 agents", {})
+            time.sleep(0.35)
+            cb("subagent.start", preview="inspect gateway routing", task_index=0, goal="inspect gateway routing")
+            cb("subagent.tool", "read_file", "gateway/run.py", {}, task_index=0, goal="inspect gateway routing")
+            cb("subagent.progress", preview="🔀 read_file", task_index=0, goal="inspect gateway routing")
+            cb("subagent.thinking", preview="hidden internal reasoning", task_index=0, goal="inspect gateway routing")
+            cb("subagent.complete", preview="done", status="completed", task_index=0, goal="inspect gateway routing")
+            time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class DelayedProgressAgent:
     def __init__(self, **kwargs):
         self.tool_progress_callback = kwargs.get("tool_progress_callback")
@@ -314,6 +339,55 @@ async def test_run_agent_progress_stays_in_originating_topic(monkeypatch, tmp_pa
     ]
     assert adapter.edits
     assert all(call["metadata"] == {"thread_id": "17585"} for call in adapter.typing)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_progress_includes_delegated_subagent_events(monkeypatch, tmp_path):
+    """Gateway progress should surface delegated child-agent events compactly."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = SubagentProgressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.delegate_tool  # noqa: F401 - register delegate_task emoji
+    import tools.file_tools  # noqa: F401 - register read_file emoji
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-subagent-progress",
+        session_key="agent:main:telegram:group:-1001:17585",
+    )
+
+    assert result["final_response"] == "done"
+    rendered = "\n".join(
+        [entry["content"] for entry in adapter.sent]
+        + [entry["content"] for entry in adapter.edits]
+    )
+    assert "delegate_task" in rendered
+    assert "🤖 agent 1 started" in rendered
+    assert "inspect gateway routing" in rendered
+    assert "read_file" in rendered
+    assert "✅ agent 1 completed" in rendered
+    assert "hidden internal reasoning" not in rendered
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Render delegated subagent progress events in the gateway progress bubble.
- Show child start, child tool calls, batched child progress summaries, and child completion/failure status.
- Suppress `subagent.thinking` so internal child reasoning/self-talk is not exposed in chat progress.

## Why
`delegate_task` already relays structured `subagent.*` events from child agents, but the gateway progress callback only rendered top-level `tool.started` events. As a result, users saw the parent `delegate_task` call without any compact visibility into what child agents were doing.

## Tests
- `python -m compileall -q gateway/run.py tests/gateway/test_run_progress_topics.py`
- `ruff check gateway/run.py tests/gateway/test_run_progress_topics.py`
- `python -m pytest tests/gateway/test_run_progress_topics.py -q -o 'addopts='`
- Local `git merge-tree` against `upstream/main`: clean
