### PR TITLE
Wrap launchd gateway Python when venv lives on external volumes

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2152,6 +2152,20 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
         filtered.append(msg)
     messages = filtered
 
+    metadata_fields = ("turn_id", "compression_generation")
+    if any(
+        isinstance(msg, dict) and any(field in msg for field in metadata_fields)
+        for msg in messages
+    ):
+        cleaned = []
+        for msg in messages:
+            if isinstance(msg, dict) and any(field in msg for field in metadata_fields):
+                msg = dict(msg)
+                for field in metadata_fields:
+                    msg.pop(field, None)
+            cleaned.append(msg)
+        messages = cleaned
+
     surviving_call_ids: set = set()
     for msg in messages:
         if msg.get("role") == "assistant":

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -923,6 +923,10 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
         "content": _san_content,
         "reasoning": reasoning_text,
         "finish_reason": finish_reason,
+        "turn_id": getattr(agent, "_current_turn_id", "") or "",
+        "compression_generation": int(
+            getattr(agent, "_current_compression_generation", 0) or 0
+        ),
     }
 
     raw_reasoning_content = getattr(assistant_message, "reasoning_content", None)

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -601,6 +601,72 @@ def compress_context(
     # session has logically ended), and let auto-compress callers detect
     # the no-op via len(returned) == len(input).
     if getattr(agent.context_compressor, "_last_compress_aborted", False):
+        _err = getattr(agent.context_compressor, "_last_summary_error", None) or "unknown error"
+        if getattr(agent, "_last_compression_summary_warning", None) != _err:
+            agent._last_compression_summary_warning = _err
+            agent._emit_warning(
+                f"⚠ Compression aborted: {_err}. "
+                "No messages were dropped — conversation continues unchanged. "
+                "Run /compress to retry, or /new to start a fresh session."
+            )
+        _existing_sp = getattr(agent, "_cached_system_prompt", None)
+        if not _existing_sp:
+            _existing_sp = agent._build_system_prompt(system_message)
+        _release_lock()  # compression aborted — no rotation will happen
+        return messages, _existing_sp
+
+    summary_error = getattr(agent.context_compressor, "_last_summary_error", None)
+    if summary_error:
+        if getattr(agent, "_last_compression_summary_warning", None) != summary_error:
+            agent._last_compression_summary_warning = summary_error
+            agent._emit_warning(
+                f"⚠ Compression summary failed: {summary_error}. "
+                "Inserted a fallback context marker."
+            )
+    else:
+        # No hard failure — but did the configured aux model error out
+        # and get recovered by retrying on main?  Surface that so users
+        # know their auxiliary.compression.model setting is broken even
+        # though compression succeeded.
+        _aux_fail_model = getattr(agent.context_compressor, "_last_aux_model_failure_model", None)
+        _aux_fail_err = getattr(agent.context_compressor, "_last_aux_model_failure_error", None)
+        if _aux_fail_model:
+            # Dedup on (model, error) so we don't spam on every compaction
+            _aux_key = (_aux_fail_model, _aux_fail_err)
+            if getattr(agent, "_last_aux_fallback_warning_key", None) != _aux_key:
+                agent._last_aux_fallback_warning_key = _aux_key
+                agent._emit_warning(
+                    f"ℹ Configured compression model '{_aux_fail_model}' failed "
+                    f"({_aux_fail_err or 'unknown error'}). Recovered using main model — "
+                    "check auxiliary.compression.model in config.yaml."
+                )
+
+    todo_snapshot = agent._todo_store.format_for_injection()
+    if todo_snapshot:
+        compressed.append({"role": "user", "content": todo_snapshot})
+
+    try:
+        next_generation = (
+            max(
+                int(m.get("compression_generation") or 0)
+                for m in messages
+                if isinstance(m, dict)
+            )
+            + 1
+        )
+    except (TypeError, ValueError):
+        next_generation = int(getattr(agent, "_current_compression_generation", 0) or 0) + 1
+    for msg in compressed:
+        if isinstance(msg, dict):
+            msg.setdefault("compression_generation", next_generation)
+            msg.setdefault("turn_id", f"compression:{next_generation}")
+    agent._current_compression_generation = next_generation
+
+    agent._invalidate_system_prompt()
+    new_system_prompt = agent._build_system_prompt(system_message)
+    agent._cached_system_prompt = new_system_prompt
+
+    if agent._session_db:
         try:
             _err = getattr(agent.context_compressor, "_last_summary_error", None) or "unknown error"
             if getattr(agent, "_last_compression_summary_warning", None) != _err:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -793,6 +793,10 @@ def run_conversation(
                 api_msg.pop("finish_reason")
             # Strip internal thinking-prefill marker
             api_msg.pop("_thinking_prefill", None)
+            # SessionDB-only message metadata is useful for replay and
+            # compaction bookkeeping but is not part of any provider schema.
+            api_msg.pop("turn_id", None)
+            api_msg.pop("compression_generation", None)
             # Strip Codex Responses API fields (call_id, response_item_id) for
             # strict providers like Mistral, Fireworks, etc. that reject unknown fields.
             # Uses new dicts so the internal messages list retains the fields

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -347,7 +347,14 @@ def _trajectory_normalize_msg(msg: Dict[str, Any]) -> Dict[str, Any]:
     return msg
 
 
-def make_tool_result_message(name: str, content: Any, tool_call_id: str) -> dict:
+def make_tool_result_message(
+    name: str,
+    content: Any,
+    tool_call_id: str,
+    *,
+    turn_id: str = "",
+    compression_generation: int = 0,
+) -> dict:
     """Build a tool-result message dict with both the OpenAI-format ``name``
     field (required by the wire format and provider adapters) and the internal
     ``tool_name`` field (written to the session DB messages table).
@@ -364,13 +371,20 @@ def make_tool_result_message(name: str, content: Any, tool_call_id: str) -> dict
     list structure stays valid for vision-capable adapters.
     """
     wrapped = _maybe_wrap_untrusted(name, content)
-    return {
+    msg = {
         "role": "tool",
         "name": name,
         "tool_name": name,
         "content": wrapped,
         "tool_call_id": tool_call_id,
     }
+    if turn_id:
+        msg["turn_id"] = turn_id
+    try:
+        msg["compression_generation"] = int(compression_generation or 0)
+    except (TypeError, ValueError):
+        msg["compression_generation"] = 0
+    return msg
 
 
 # Tools whose results carry attacker-controllable content.  Wrapping their

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -71,6 +71,16 @@ def _budget_for_agent(agent) -> BudgetConfig:
 _MAX_TOOL_WORKERS = 8
 
 
+def _make_turn_tool_result_message(agent, name: str, content: Any, tool_call_id: str) -> dict:
+    return make_tool_result_message(
+        name,
+        content,
+        tool_call_id,
+        turn_id=getattr(agent, "_current_turn_id", "") or "",
+        compression_generation=getattr(agent, "_current_compression_generation", 0) or 0,
+    )
+
+
 def _flush_session_db_after_tool_progress(
     agent,
     messages: list,
@@ -299,7 +309,8 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     if agent._interrupt_requested:
         print(f"{agent.log_prefix}⚡ Interrupt: skipping {num_tools} tool call(s)")
         for tc in tool_calls:
-            messages.append(make_tool_result_message(
+            messages.append(_make_turn_tool_result_message(
+                agent,
                 tc.function.name,
                 f"[Tool execution cancelled — {tc.function.name} was skipped due to user interrupt]",
                 tc.id,
@@ -828,7 +839,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # image tool result never poisons canonical session history.
         # String results pass through unchanged.
         _tool_content = agent._tool_result_content_for_active_model(name, function_result)
-        messages.append(make_tool_result_message(name, _tool_content, tc.id))
+        messages.append(_make_turn_tool_result_message(agent, name, _tool_content, tc.id))
         _flush_session_db_after_tool_progress(
             agent,
             messages,
@@ -869,7 +880,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 agent._vprint(f"{agent.log_prefix}⚡ Interrupt: skipping {len(remaining_calls)} tool call(s)", force=True)
             for skipped_tc in remaining_calls:
                 skipped_name = skipped_tc.function.name
-                messages.append(make_tool_result_message(
+                messages.append(_make_turn_tool_result_message(
+                    agent,
                     skipped_name,
                     f"[Tool execution cancelled — {skipped_name} was skipped due to user interrupt]",
                     skipped_tc.id,
@@ -1477,7 +1489,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Unwrap _multimodal dicts to an OpenAI-style content list
         # (see parallel path for rationale). String results pass through.
         _tool_content = agent._tool_result_content_for_active_model(function_name, function_result)
-        messages.append(make_tool_result_message(function_name, _tool_content, tool_call.id))
+        messages.append(_make_turn_tool_result_message(agent, function_name, _tool_content, tool_call.id))
         _flush_session_db_after_tool_progress(
             agent,
             messages,
@@ -1504,7 +1516,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             agent._vprint(f"{agent.log_prefix}⚡ Interrupt: skipping {remaining} remaining tool call(s)", force=True)
             for skipped_tc in assistant_message.tool_calls[i:]:
                 skipped_name = skipped_tc.function.name
-                messages.append(make_tool_result_message(
+                messages.append(_make_turn_tool_result_message(
+                    agent,
                     skipped_name,
                     f"[Tool execution skipped — {skipped_name} was not started. User sent a new message]",
                     skipped_tc.id,

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -150,6 +150,9 @@ class ChatCompletionsTransport(ProviderTransport):
           ``Extra inputs are not permitted, field: 'messages[N].tool_name'``.
           Permissive providers (OpenRouter, MiniMax) silently ignore the
           field, which masked the bug for months.
+        - SessionDB-only message metadata (``turn_id`` and
+          ``compression_generation``), which is useful for durable replay but
+          unknown to provider schemas.
         - Hermes-internal scaffolding markers — any top-level message key
           starting with ``_`` (e.g. ``_empty_recovery_synthetic``,
           ``_empty_terminal_sentinel``, ``_thinking_prefill``). These are
@@ -173,6 +176,8 @@ class ChatCompletionsTransport(ProviderTransport):
                 or "codex_message_items" in msg
                 or "tool_name" in msg
                 or "timestamp" in msg  # #47868 — strict providers reject this
+                or "turn_id" in msg
+                or "compression_generation" in msg
             ):
                 needs_sanitize = True
                 break
@@ -203,6 +208,8 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
             msg.pop("timestamp", None)  # #47868 — leak into strict providers
+            msg.pop("turn_id", None)
+            msg.pop("compression_generation", None)
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
             # OpenAI's message schema has no ``_``-prefixed fields, so this
             # is safe and future-proofs against new markers being added.

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -297,8 +297,23 @@ def build_turn_context(
             should_review_memory = True
             agent._turns_since_memory = 0
 
+    try:
+        current_generation = max(
+            int(m.get("compression_generation") or 0)
+            for m in messages
+            if isinstance(m, dict)
+        )
+    except (TypeError, ValueError):
+        current_generation = 0
+    agent._current_compression_generation = current_generation
+
     # Add user message.
-    user_msg = {"role": "user", "content": user_message}
+    user_msg = {
+        "role": "user",
+        "content": user_message,
+        "turn_id": turn_id,
+        "compression_generation": current_generation,
+    }
     messages.append(user_msg)
     current_turn_user_idx = len(messages) - 1
     agent._persist_user_message_idx = current_turn_user_idx

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -701,7 +701,9 @@ CREATE TABLE IF NOT EXISTS messages (
     platform_message_id TEXT,
     observed INTEGER DEFAULT 0,
     active INTEGER NOT NULL DEFAULT 1,
-    compacted INTEGER NOT NULL DEFAULT 0
+    compacted INTEGER NOT NULL DEFAULT 0,
+    turn_id TEXT,
+    compression_generation INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS state_meta (
@@ -735,6 +737,8 @@ CREATE INDEX IF NOT EXISTS idx_sessions_session_key
     ON sessions(session_key, started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_gateway_peer
     ON sessions(source, user_id, chat_id, chat_type, thread_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_messages_turn_id
+    ON messages(session_id, turn_id);
 """
 
 FTS_SQL = """
@@ -3014,6 +3018,8 @@ class SessionDB:
         platform_message_id: str = None,
         observed: bool = False,
         timestamp: Any = None,
+        turn_id: str = None,
+        compression_generation: int = 0,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -3059,14 +3065,19 @@ class SessionDB:
         num_tool_calls = 0
         if tool_calls is not None:
             num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
+        try:
+            comp_generation = int(compression_generation or 0)
+        except (TypeError, ValueError):
+            comp_generation = 0
 
         def _do(conn):
             cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, turn_id,
+                   compression_generation)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -3084,6 +3095,8 @@ class SessionDB:
                     codex_message_items_json,
                     platform_message_id,
                     1 if observed else 0,
+                    turn_id,
+                    comp_generation,
                 ),
             )
             msg_id = cursor.lastrowid
@@ -3104,7 +3117,14 @@ class SessionDB:
 
         return self._execute_write(_do)
 
-    def _insert_message_rows(self, conn, session_id: str, messages: List[Dict[str, Any]]) -> tuple[int, int]:
+    def _insert_message_rows(
+        self,
+        conn,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        *,
+        default_compression_generation: int = 0,
+    ) -> tuple[int, int]:
         """Insert *messages* as fresh active rows for *session_id*.
 
         Shared by :meth:`replace_messages` (delete-then-insert) and
@@ -3151,13 +3171,20 @@ class SessionDB:
             platform_msg_id = (
                 msg.get("platform_message_id") or msg.get("message_id")
             )
+            try:
+                comp_generation = int(
+                    msg.get("compression_generation", default_compression_generation) or 0
+                )
+            except (TypeError, ValueError):
+                comp_generation = int(default_compression_generation or 0)
 
             conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, turn_id,
+                   compression_generation)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -3175,6 +3202,8 @@ class SessionDB:
                     codex_message_items_json,
                     platform_msg_id,
                     1 if msg.get("observed") else 0,
+                    msg.get("turn_id"),
+                    comp_generation,
                 ),
             )
             inserted += 1
@@ -3254,8 +3283,20 @@ class SessionDB:
                 "WHERE session_id = ? AND active = 1",
                 (session_id,),
             )
+            row = conn.execute(
+                "SELECT COALESCE(MAX(compression_generation), 0) AS generation "
+                "FROM messages WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+            current_generation = (
+                row["generation"] if hasattr(row, "keys") else row[0]
+            )
+            next_generation = int(current_generation or 0) + 1
             inserted, tool_calls_total = self._insert_message_rows(
-                conn, session_id, compacted_messages
+                conn,
+                session_id,
+                compacted_messages,
+                default_compression_generation=next_generation,
             )
             # message_count / tool_call_count reflect the LIVE (active) set —
             # the archived rows are still on disk but not part of the live count.
@@ -3614,7 +3655,8 @@ class SessionDB:
             rows = self._conn.execute(
                 "SELECT role, content, tool_call_id, tool_calls, tool_name, "
                 "finish_reason, reasoning, reasoning_content, reasoning_details, "
-                "codex_reasoning_items, codex_message_items, platform_message_id, observed, timestamp "
+                "codex_reasoning_items, codex_message_items, platform_message_id, "
+                "observed, timestamp, turn_id, compression_generation "
                 f"FROM messages WHERE session_id IN ({placeholders})"
                 f"{active_clause} ORDER BY timestamp, id",
                 tuple(session_ids),
@@ -3628,6 +3670,9 @@ class SessionDB:
             msg = {"role": row["role"], "content": content}
             if row["timestamp"]:
                 msg["timestamp"] = row["timestamp"]
+            if row["turn_id"]:
+                msg["turn_id"] = row["turn_id"]
+            msg["compression_generation"] = int(row["compression_generation"] or 0)
             if row["tool_call_id"]:
                 msg["tool_call_id"] = row["tool_call_id"]
             if row["tool_name"]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1738,6 +1738,11 @@ class AIAgent:
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
                     timestamp=msg.get("timestamp"),
+                    turn_id=msg.get("turn_id") or getattr(self, "_current_turn_id", "") or None,
+                    compression_generation=msg.get(
+                        "compression_generation",
+                        getattr(self, "_current_compression_generation", 0) or 0,
+                    ),
                 )
                 flushed_ids.add(msg_id)
             self._last_flushed_db_idx = len(messages)

--- a/tests/agent/test_message_metadata_pipeline.py
+++ b/tests/agent/test_message_metadata_pipeline.py
@@ -1,0 +1,138 @@
+from types import SimpleNamespace
+
+from agent.agent_runtime_helpers import sanitize_api_messages
+from agent.chat_completion_helpers import build_assistant_message
+from agent.tool_dispatch_helpers import make_tool_result_message
+from agent.transports.chat_completions import ChatCompletionsTransport
+from hermes_state import SessionDB
+
+
+def test_session_db_persists_and_replays_message_metadata(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("s1", source="cli")
+
+    db.append_message(
+        "s1",
+        role="user",
+        content="hello",
+        turn_id="turn-1",
+        compression_generation=2,
+    )
+    db.append_message(
+        "s1",
+        role="assistant",
+        content="hi",
+        turn_id="turn-1",
+        compression_generation=2,
+    )
+    db.append_message(
+        "s1",
+        role="tool",
+        content="ok",
+        tool_call_id="call-1",
+        tool_name="read_file",
+        turn_id="turn-1",
+        compression_generation=2,
+    )
+
+    rows = db.get_messages("s1")
+    assert [row["turn_id"] for row in rows] == ["turn-1", "turn-1", "turn-1"]
+    assert [row["compression_generation"] for row in rows] == [2, 2, 2]
+
+    replay = db.get_messages_as_conversation("s1")
+    assert [msg["turn_id"] for msg in replay] == ["turn-1", "turn-1", "turn-1"]
+    assert [msg["compression_generation"] for msg in replay] == [2, 2, 2]
+
+
+def test_archive_and_compact_stamps_next_compression_generation(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("s1", source="cli")
+    db.append_message(
+        "s1",
+        role="user",
+        content="before",
+        turn_id="turn-1",
+        compression_generation=0,
+    )
+
+    db.archive_and_compact(
+        "s1",
+        [{"role": "assistant", "content": "summary", "turn_id": "compression:1"}],
+    )
+
+    active = db.get_messages("s1")
+    archived = db.get_messages("s1", include_inactive=True)
+    assert active[0]["compression_generation"] == 1
+    assert active[0]["turn_id"] == "compression:1"
+    assert any(row["content"] == "before" and row["compression_generation"] == 0 for row in archived)
+
+
+def test_runtime_assistant_and_tool_messages_carry_metadata():
+    agent = SimpleNamespace(
+        _current_turn_id="turn-1",
+        _current_compression_generation=3,
+        verbose_logging=False,
+        reasoning_callback=None,
+        stream_delta_callback=None,
+        _stream_callback=None,
+        _extract_reasoning=lambda _msg: None,
+        _strip_think_blocks=lambda text: text,
+        _needs_thinking_reasoning_pad=lambda: False,
+    )
+
+    assistant = build_assistant_message(
+        agent,
+        SimpleNamespace(content="done", tool_calls=[]),
+        "stop",
+    )
+    assert assistant["turn_id"] == "turn-1"
+    assert assistant["compression_generation"] == 3
+
+    tool = make_tool_result_message(
+        "read_file",
+        "ok",
+        "call-1",
+        turn_id="turn-1",
+        compression_generation=3,
+    )
+    assert tool["turn_id"] == "turn-1"
+    assert tool["compression_generation"] == 3
+
+
+def test_api_sanitizers_strip_local_message_metadata():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call-1", "function": {"name": "read_file", "arguments": "{}"}}],
+            "turn_id": "turn-1",
+            "compression_generation": 4,
+        },
+        {
+            "role": "tool",
+            "content": "ok",
+            "tool_call_id": "call-1",
+            "turn_id": "turn-1",
+            "compression_generation": 4,
+        },
+    ]
+
+    sanitized = sanitize_api_messages(messages)
+    assert all("turn_id" not in msg for msg in sanitized)
+    assert all("compression_generation" not in msg for msg in sanitized)
+    assert messages[0]["turn_id"] == "turn-1"
+
+    transport = ChatCompletionsTransport()
+    converted = transport.convert_messages(
+        [
+            {
+                "role": "user",
+                "content": "hello",
+                "timestamp": 123.0,
+                "turn_id": "turn-2",
+                "compression_generation": 5,
+            }
+        ],
+        model="test-model",
+    )
+    assert converted == [{"role": "user", "content": "hello"}]

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -170,7 +170,10 @@ def test_returns_turn_context_with_user_message_appended():
     assert isinstance(ctx, TurnContext)
     assert ctx.user_message == "hello"
     # The user turn was appended and indexed.
-    assert ctx.messages[-1] == {"role": "user", "content": "hello"}
+    assert ctx.messages[-1]["role"] == "user"
+    assert ctx.messages[-1]["content"] == "hello"
+    assert ctx.messages[-1]["turn_id"] == agent._current_turn_id
+    assert ctx.messages[-1]["compression_generation"] == 0
     assert ctx.current_turn_user_idx == len(ctx.messages) - 1
     assert ctx.active_system_prompt == "SYSTEM"
 
@@ -363,4 +366,3 @@ def test_expired_cooldown_allows_preflight(tmp_path):
     assert isinstance(ctx, TurnContext)
     agent._emit_status.assert_called_once()
     agent._compress_context.assert_called()
-


### PR DESCRIPTION
## Summary
- use a profile-scoped launchd wrapper when the configured Python path or its resolved target lives under `/Volumes/`
- keep the wrapper on the boot volume and make launchd execute it through `/bin/zsh`
- bake plugin `.env` values into the wrapper with `shlex.quote` instead of raw `export KEY=VALUE` lines
- keep the normal launchd plist path unchanged for non-external Python paths

## Tests
- `python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
- `python -m pytest tests/hermes_cli/test_gateway_service.py -q -k "launchd"`
- `python -m pytest tests/hermes_cli/test_gateway_service.py::TestProfileArg tests/hermes_cli/test_gateway_service.py::TestServiceWorkingDirIsStable -q`