### PR TITLE
fix(gateway): show usage limits before first turn

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3461,9 +3461,8 @@ class GatewaySlashCommandsMixin:
                         agent = cached[0]
 
         # Resolve provider/base_url/api_key for the account-usage fetch.
-        # Prefer the live agent; fall back to persisted billing data on the
-        # SessionDB row so `/usage` still returns account info between turns
-        # when no agent is resident.
+        # Prefer the live agent, then session/config/runtime defaults so `/usage`
+        # can show account limits before the first model-backed turn.
         provider = getattr(agent, "provider", None) if agent and agent is not _AGENT_PENDING_SENTINEL else None
         base_url = getattr(agent, "base_url", None) if agent and agent is not _AGENT_PENDING_SENTINEL else None
         api_key = getattr(agent, "api_key", None) if agent and agent is not _AGENT_PENDING_SENTINEL else None
@@ -3475,6 +3474,41 @@ class GatewaySlashCommandsMixin:
                 persisted = {}
             provider = provider or persisted.get("billing_provider")
             base_url = base_url or persisted.get("billing_base_url")
+
+        if not provider:
+            override = getattr(self, "_session_model_overrides", {}).get(session_key, {})
+            if isinstance(override, dict):
+                provider = provider or override.get("provider")
+                base_url = base_url or override.get("base_url")
+                api_key = api_key or override.get("api_key")
+
+        if not provider:
+            try:
+                from gateway.run import _load_gateway_config
+
+                cfg = _load_gateway_config() or {}
+            except Exception:
+                cfg = {}
+            model_cfg = cfg.get("model") if isinstance(cfg, dict) else None
+            if isinstance(model_cfg, dict):
+                provider = provider or model_cfg.get("provider")
+                base_url = base_url or model_cfg.get("base_url")
+                api_key = api_key or model_cfg.get("api_key")
+
+        if not provider:
+            try:
+                from gateway.run import _resolve_runtime_agent_kwargs
+
+                runtime = _resolve_runtime_agent_kwargs() or {}
+                provider = provider or runtime.get("provider")
+                base_url = base_url or runtime.get("base_url")
+                api_key = api_key or runtime.get("api_key")
+            except Exception:
+                pass
+
+        if not provider:
+            provider = "openai-codex"
+            base_url = base_url or "https://chatgpt.com/backend-api/codex"
 
         # Fetch account usage off the event loop so slow provider APIs don't
         # block the gateway. Failures are non-fatal -- account_lines stays [].

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -242,3 +242,93 @@ class TestUsageAccountSection:
         assert account_call["kwargs"]["base_url"] == "https://chatgpt.com/backend-api/codex"
         assert "📊 **Session Info**" in result
         assert "📈 **Account limits**" in result
+
+
+class TestUsageAccountFreshSessionFallback:
+    """Account limits should work before any model-backed gateway turn."""
+
+    @pytest.mark.asyncio
+    async def test_usage_command_uses_config_provider_before_first_turn(self, monkeypatch):
+        runner = _make_runner(SK)
+        runner._session_db = None
+        runner._session_model_overrides = {}
+        session_entry = MagicMock()
+        session_entry.session_id = "sess-fresh"
+        runner.session_store.get_or_create_session.return_value = session_entry
+        runner.session_store.load_transcript.return_value = []
+
+        calls = []
+
+        async def _fake_to_thread(fn, *args, **kwargs):
+            calls.append({"args": args, "kwargs": kwargs})
+            return fn(*args, **kwargs)
+
+        monkeypatch.setattr("gateway.run.asyncio.to_thread", _fake_to_thread)
+        monkeypatch.setattr(
+            "gateway.run._load_gateway_config",
+            lambda: {
+                "model": {
+                    "provider": "openai-codex",
+                    "base_url": "https://chatgpt.com/backend-api/codex",
+                }
+            },
+        )
+        monkeypatch.setattr(
+            "gateway.slash_commands.fetch_account_usage",
+            lambda provider, base_url=None, api_key=None: object(),
+        )
+        monkeypatch.setattr(
+            "gateway.slash_commands.render_account_usage_lines",
+            lambda snapshot, markdown=False: [
+                "📈 **Account limits**",
+                "Provider: openai-codex (Pro)",
+            ],
+        )
+        monkeypatch.setattr("agent.account_usage.nous_credits_lines", lambda markdown=False: [])
+
+        event = MagicMock()
+        result = await runner._handle_usage_command(event)
+
+        account_call = next(c for c in calls if c["args"] == ("openai-codex",))
+        assert account_call["kwargs"]["base_url"] == "https://chatgpt.com/backend-api/codex"
+        assert "📈 **Account limits**" in result
+        assert "model-backed message" not in result
+
+    @pytest.mark.asyncio
+    async def test_usage_command_falls_back_to_codex_when_context_is_unknown(self, monkeypatch):
+        runner = _make_runner(SK)
+        runner._session_db = None
+        runner._session_model_overrides = {}
+        session_entry = MagicMock()
+        session_entry.session_id = "sess-unknown"
+        runner.session_store.get_or_create_session.return_value = session_entry
+        runner.session_store.load_transcript.return_value = []
+
+        calls = []
+
+        async def _fake_to_thread(fn, *args, **kwargs):
+            calls.append({"args": args, "kwargs": kwargs})
+            return fn(*args, **kwargs)
+
+        monkeypatch.setattr("gateway.run.asyncio.to_thread", _fake_to_thread)
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: (_ for _ in ()).throw(RuntimeError("not configured")),
+        )
+        monkeypatch.setattr(
+            "gateway.slash_commands.fetch_account_usage",
+            lambda provider, base_url=None, api_key=None: object(),
+        )
+        monkeypatch.setattr(
+            "gateway.slash_commands.render_account_usage_lines",
+            lambda snapshot, markdown=False: ["📈 **Account limits**"],
+        )
+        monkeypatch.setattr("agent.account_usage.nous_credits_lines", lambda markdown=False: [])
+
+        event = MagicMock()
+        result = await runner._handle_usage_command(event)
+
+        account_call = next(c for c in calls if c["args"] == ("openai-codex",))
+        assert account_call["kwargs"]["base_url"] == "https://chatgpt.com/backend-api/codex"
+        assert "📈 **Account limits**" in result


### PR DESCRIPTION
## Summary
- Let gateway `/usage` resolve account-limit context before any model-backed turn exists.
- Resolve provider/base URL from the live/cached agent, persisted billing metadata, session model overrides, config, runtime defaults, then a final OpenAI Codex fallback.
- Keep account-limit fetching off the event loop and preserve existing session-token/history behavior.

## Why
Account/quota information should be available from gateway commands even in a fresh session. Requiring a prior model-backed message makes `/usage` less useful for account diagnostics after `/reset` or gateway startup.

## Tests
- `python -m compileall -q gateway/slash_commands.py tests/gateway/test_usage_command.py`
- `ruff check gateway/slash_commands.py tests/gateway/test_usage_command.py`
- `python -m pytest tests/gateway/test_usage_command.py -q -o 'addopts='`
- Local `git merge-tree` against `upstream/main`: clean
