### PR TITLE
tools/send_message: surface silent mirror-skip to caller + warn-log

### DIFF
--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -59,8 +59,17 @@ def mirror_to_session(
             user_id=user_id,
         )
         if not session_id:
-            logger.debug(
-                "Mirror: no session found for %s:%s:%s:%s",
+            # Bumped from debug to warning: silent loss of cross-channel
+            # continuity is a confusing failure mode for operators and agents.
+            # The mirror mechanism intentionally avoids creating sessions on
+            # outbound (see _find_session_id docstring), but the operator
+            # should be able to see in normal logs when an outbound landed
+            # without continuity backing.
+            logger.warning(
+                "Mirror: no session found for %s:%s:%s:%s — outbound "
+                "delivered but will not be reflected in destination "
+                "transcript. The recipient's next reply will lack context "
+                "about this message.",
                 platform,
                 chat_id,
                 thread_id,

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -446,22 +446,34 @@ def _handle_send(args):
         if used_home_channel and isinstance(result, dict) and result.get("success"):
             result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
 
-        # Mirror the sent message into the target's gateway session
+        # Mirror the sent message into the target's gateway session.
+        # Always surface mirror state to the caller (true OR false): the
+        # agent's next turn needs to know when its outbound landed without
+        # continuity backing so it can compensate (self-include context in
+        # the next message, choose another channel, etc.).
         if isinstance(result, dict) and result.get("success") and mirror_text:
             try:
                 from gateway.mirror import mirror_to_session
                 from gateway.session_context import get_session_env
                 source_label = get_session_env("HERMES_SESSION_PLATFORM", "cli")
                 user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
-                if mirror_to_session(
+                mirrored = mirror_to_session(
                     platform_name,
                     chat_id,
                     mirror_text,
                     source_label=source_label,
                     thread_id=thread_id,
                     user_id=user_id,
-                ):
-                    result["mirrored"] = True
+                )
+                result["mirrored"] = bool(mirrored)
+                if not mirrored:
+                    result["mirror_warning"] = (
+                        "Message delivered but NOT mirrored into the "
+                        "destination session (no matching session exists "
+                        "for this platform + chat_id). The recipient's "
+                        "next reply will reach the agent without context "
+                        "of this message."
+                    )
             except Exception:
                 pass
 


### PR DESCRIPTION
Fixes #54273


### Motivation

When `tools/send_message_tool._handle_send` delivers a message and then
calls `gateway.mirror.mirror_to_session` to write the outbound into the
destination session's transcript, the mirror can silently fail.
`_find_session_id` returns `None` if no existing gateway session matches
the target `(platform, chat_id, thread_id, user_id)` — and
`mirror_to_session` returns False without surfacing the skip anywhere the
caller can see.

That's by design for the mirror (avoids contaminating another
participant's session — see `_find_session_id` docstring), but the
silence creates a confusing failure mode: cross-platform sends (cron
deliveries, `hermes send` CLI, MCP server invocations, dashboard
notifications) succeed at the platform level while quietly losing
cross-channel continuity. The recipient's next reply reaches the agent
without context of the prior outbound, and the agent has no way to know
why.

### What this changes

Two tiny, behavior-preserving observability bumps:

#### `gateway/mirror.py`

Bump the no-session-found log level from `debug` to `warning`, with a
message that explains the operational consequence:

```python
# before
logger.debug("Mirror: no session found for %s:%s:%s:%s", ...)

# after
logger.warning(
    "Mirror: no session found for %s:%s:%s:%s — outbound delivered "
    "but will not be reflected in destination transcript. The "
    "recipient's next reply will lack context about this message.",
    ...
)
```

#### `tools/send_message_tool.py`

Always populate `result["mirrored"]` (true OR false) and add a
`mirror_warning` explanation string on the false path:

```python
# before
if mirror_to_session(...):
    result["mirrored"] = True

# after
mirrored = mirror_to_session(...)
result["mirrored"] = bool(mirrored)
if not mirrored:
    result["mirror_warning"] = (
        "Message delivered but NOT mirrored into the destination "
        "session (no matching session exists for this platform + "
        "chat_id). The recipient's next reply will reach the agent "
        "without context of this message."
    )
```

The underlying design decision (`mirror_to_session` does not create
sessions on outbound) is preserved. This change is **observability-only**.

### Why this matters

- Operators tailing logs see continuity gaps as they happen, not after
  a confused agent reply later
- Tool callers (cron, MCP, dashboard, CLI) get a structured
  `mirrored: false` + `mirror_warning` in their result envelope, so they
  can compensate (self-include context in the next outbound, choose a
  channel with an existing session, etc.)
- Especially useful for callers that are NOT the in-process agent —
  per the design comment in `send_message_tool.py` ("The agent should
  not decide on its own to fire off cross-platform messages or
  reactions"), the primary users of `_handle_send` are external/operator
  callers, who currently get zero signal about continuity gaps

### Repro (validated against Hermes 0.17.0)

```bash
$ hermes send --json --to discord:#some-channel "test message"
{
  "success": true,
  "platform": "discord",
  "chat_id": "1484235813834461287",
  "message_id": "1520734481114337412",
  "mirrored": false,
  "mirror_warning": "Message delivered but NOT mirrored into the destination session (no matching session exists for this platform + chat_id). The recipient's next reply will reach the agent without context of this message."
}
```

Without this patch, `mirrored` is absent from the result and there's no
signal to the caller about the continuity gap.

### Scope discipline

This PR deliberately does NOT:

- Add a `create_if_missing` mode for `mirror_to_session` (that's a
  separate, larger design conversation worth its own issue)
- Change the design of which session keys get mirrored — only surfaces
  the existing silent-skip behavior
- Change how `_find_session_id` resolves candidate sessions

Open to feedback on the warning text wording and on the `mirror_warning`
JSON field name if you'd prefer something more conventional (e.g.,
`mirror_note`, `continuity_warning`).

### Test plan

- [x] Live test against Hermes 0.17.0 confirms the new `mirrored` and
  `mirror_warning` fields appear in `hermes send --json` output when the
  destination has no prior session (validated on two production
  instances — Tieler and Breaker)
- [x] When the destination has an existing session, `mirrored: true`
  appears and `mirror_warning` is absent (unchanged behavior, just
  always-populated field)
- [x] No new code paths to test in mirror.py; the path was already there
  — only the log level changed

---

