### PR TITLE
fix(telegram): suppress quotes on internal status messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -218,12 +218,17 @@ def _non_conversational_metadata(
     *,
     platform: Any = None,
 ) -> Optional[Dict[str, Any]]:
-    """Mark Discord lifecycle/status sends without changing other platforms."""
-    if _gateway_platform_value(platform) != "discord":
-        return metadata
-    merged = dict(metadata or {})
-    merged["non_conversational"] = True
-    return merged
+    """Mark gateway-internal sends so adapters do not render them as user replies."""
+    platform_value = _gateway_platform_value(platform)
+    if platform_value == "discord":
+        merged = dict(metadata or {})
+        merged["non_conversational"] = True
+        return merged
+    if platform_value == "telegram" and metadata:
+        merged = dict(metadata)
+        merged["telegram_reply_to_mode"] = "off"
+        return merged
+    return metadata
 
 
 def _is_transient_network_error(exc: BaseException) -> bool:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -581,6 +581,13 @@ class TelegramAdapter(BasePlatformAdapter):
         return int(reply_to) if reply_to is not None else None
 
     @staticmethod
+    def _metadata_reply_to_mode(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+        if not metadata:
+            return None
+        value = metadata.get("telegram_reply_to_mode")
+        return str(value).strip().lower() if value is not None else None
+
+    @staticmethod
     def _looks_like_private_chat_id(chat_id: str) -> bool:
         try:
             return int(chat_id) > 0
@@ -1202,9 +1209,10 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         metadata_reply_to = self._metadata_reply_to_message_id(metadata)
         private_dm_topic_send = self._is_private_dm_topic_send(chat_id, thread_id, metadata)
+        effective_reply_to_mode = self._metadata_reply_to_mode(metadata) or self._reply_to_mode
         dm_topic_reply_to_off = (
             private_dm_topic_send
-            and self._reply_to_mode == "off"
+            and effective_reply_to_mode == "off"
             and bool(metadata and metadata.get("telegram_dm_topic_reply_fallback"))
         )
         reply_to_source = reply_to or (
@@ -1213,7 +1221,7 @@ class TelegramAdapter(BasePlatformAdapter):
             else None
         )
         if private_dm_topic_send:
-            should_thread = reply_to_source is not None and self._reply_to_mode != "off"
+            should_thread = reply_to_source is not None and effective_reply_to_mode != "off"
         else:
             should_thread = self._should_thread_reply(reply_to_source, 0)
         reply_to_id = int(reply_to_source) if should_thread and reply_to_source else None
@@ -1222,7 +1230,7 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_id,
             metadata,
             reply_to_message_id=reply_to_id,
-            reply_to_mode=self._reply_to_mode,
+            reply_to_mode=effective_reply_to_mode,
         )
         if private_dm_topic_send and reply_to_id is None and not dm_topic_reply_to_off:
             # Refusing to send outside the requested DM topic — defer to the
@@ -2887,9 +2895,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 # / commit 21a15b671). Honor it — don't fail loud just because the anchor was
                 # suppressed by config. The new fail-loud contract only applies when the caller
                 # didn't ask for the anchor to be dropped.
+                effective_reply_to_mode = self._metadata_reply_to_mode(metadata) or self._reply_to_mode
                 dm_topic_reply_to_off = (
                     private_dm_topic_send
-                    and self._reply_to_mode == "off"
+                    and effective_reply_to_mode == "off"
                     and bool(metadata and metadata.get("telegram_dm_topic_reply_fallback"))
                 )
                 reply_to_source = reply_to or (
@@ -2898,7 +2907,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 if private_dm_topic_send:
                     should_thread = (
                         reply_to_source is not None
-                        and self._reply_to_mode != "off"
+                        and effective_reply_to_mode != "off"
                     )
                 else:
                     should_thread = self._should_thread_reply(reply_to_source, i)
@@ -2914,7 +2923,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     thread_id,
                     metadata,
                     reply_to_message_id=reply_to_id,
-                    reply_to_mode=self._reply_to_mode,
+                    reply_to_mode=effective_reply_to_mode,
                 )
                 if used_thread_fallback and thread_kwargs.get("message_thread_id") is not None:
                     thread_kwargs = dict(thread_kwargs)

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -309,11 +309,14 @@ async def test_run_agent_progress_stays_in_originating_topic(monkeypatch, tmp_pa
             "chat_id": "-1001",
             "content": '💻 terminal: "pwd"',
             "reply_to": None,
-            "metadata": {"thread_id": "17585"},
+            "metadata": {"thread_id": "17585", "telegram_reply_to_mode": "off"},
         }
     ]
     assert adapter.edits
-    assert all(call["metadata"] == {"thread_id": "17585"} for call in adapter.typing)
+    assert all(
+        call["metadata"] == {"thread_id": "17585", "telegram_reply_to_mode": "off"}
+        for call in adapter.typing
+    )
 
 
 @pytest.mark.asyncio
@@ -351,7 +354,10 @@ async def test_run_agent_progress_edits_keep_originating_topic_metadata(monkeypa
 
     assert result["final_response"] == "done"
     assert adapter.edits
-    assert all(call["metadata"] == {"thread_id": "17585"} for call in adapter.edits)
+    assert all(
+        call["metadata"] == {"thread_id": "17585", "telegram_reply_to_mode": "off"}
+        for call in adapter.edits
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -458,6 +458,57 @@ async def test_send_private_dm_topic_uses_direct_messages_topic_id():
     assert call_log[0]["direct_messages_topic_id"] == 99999
 
 
+
+
+@pytest.mark.asyncio
+async def test_send_metadata_reply_to_mode_off_suppresses_dm_topic_quote():
+    """Gateway-internal Telegram sends can stay in a DM topic without quoting the user."""
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        return SimpleNamespace(message_id=42)
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="12345",
+        content="status update",
+        metadata={
+            "thread_id": "20197",
+            "telegram_dm_topic_reply_fallback": True,
+            "direct_messages_topic_id": "20197",
+            "telegram_reply_to_message_id": "462",
+            "telegram_reply_to_mode": "off",
+        },
+    )
+
+    assert result.success is True
+    assert len(call_log) == 1
+    assert call_log[0]["chat_id"] == 12345
+    assert call_log[0]["text"] == "status update"
+    assert call_log[0]["parse_mode"]
+    assert call_log[0]["reply_to_message_id"] is None
+    assert call_log[0]["message_thread_id"] == 20197
+
+
+def test_gateway_non_conversational_telegram_metadata_suppresses_reply_quote():
+    from gateway.run import _non_conversational_metadata
+
+    metadata = _non_conversational_metadata(
+        {
+            "thread_id": "20197",
+            "telegram_dm_topic_reply_fallback": True,
+            "telegram_reply_to_message_id": "462",
+        },
+        platform=Platform.TELEGRAM,
+    )
+
+    assert metadata["telegram_reply_to_mode"] == "off"
+    assert metadata["telegram_reply_to_message_id"] == "462"
+
+
 def test_base_gateway_metadata_marks_telegram_dm_topics_as_reply_fallback():
     source = SimpleNamespace(
         platform=Platform.TELEGRAM,


### PR DESCRIPTION
## Summary
- Let gateway-internal Telegram progress/status metadata request `telegram_reply_to_mode=off`.
- Teach the Telegram adapter to honor that per-send metadata override while preserving DM topic routing.
- Keep real user-facing replies anchored normally; only internal status/progress bubbles suppress the visible quoted prompt.

## Why
Hermes-created Telegram DM topic lanes can require a reply anchor for routing, but internal progress/status messages should not render as visible replies quoting the user's prompt. This keeps topic delivery while removing repeated quote clutter.

## Tests
- `python -m compileall -q plugins/platforms/telegram/adapter.py gateway/run.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_run_progress_topics.py`
- `ruff check plugins/platforms/telegram/adapter.py gateway/run.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_run_progress_topics.py`
- `python -m pytest tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_run_progress_topics.py -q -o 'addopts='`
- Local `git merge-tree` against `upstream/main`: clean
