### PR TITLE
feat(agent): add iteration budget pressure warnings

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -72,6 +72,36 @@ logger = logging.getLogger(__name__)
 # to treat it as cancellation metadata rather than assistant prose.
 INTERRUPT_WAITING_FOR_MODEL_PREFIX = "Operation interrupted: waiting for model response ("
 
+ITERATION_BUDGET_CAUTION_THRESHOLD = 0.7
+ITERATION_BUDGET_WARNING_THRESHOLD = 0.9
+
+
+def _iteration_budget_pressure_message(api_call_count: int, max_iterations: int) -> Optional[str]:
+    """Return an ephemeral max-iteration pressure warning for the model.
+
+    The returned text is injected only into the API-call message copy. It must
+    never be appended to the persistent transcript/session history.
+    """
+    if max_iterations <= 0 or api_call_count <= 0:
+        return None
+
+    used_fraction = api_call_count / max_iterations
+    remaining = max(max_iterations - api_call_count, 0)
+    if used_fraction >= ITERATION_BUDGET_WARNING_THRESHOLD:
+        return (
+            f"[SYSTEM: Iteration budget warning: API call {api_call_count}/{max_iterations}; "
+            f"{remaining} iterations remain before the hard limit. You MUST prepare the final "
+            "answer now. Avoid further tool calls unless they are absolutely critical to avoid "
+            "an incorrect response.]"
+        )
+    if used_fraction >= ITERATION_BUDGET_CAUTION_THRESHOLD:
+        return (
+            f"[SYSTEM: Iteration budget caution: API call {api_call_count}/{max_iterations}; "
+            f"{remaining} iterations remain before the hard limit. Start consolidating findings "
+            "and plan to provide a final response soon.]"
+        )
+    return None
+
 
 def _image_error_max_dimension(error: Exception) -> Optional[int]:
     """Extract a provider-reported image dimension ceiling, if present."""
@@ -821,6 +851,9 @@ def run_conversation(
         effective_system = active_system_prompt or ""
         if agent.ephemeral_system_prompt:
             effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+        budget_pressure = _iteration_budget_pressure_message(api_call_count, agent.max_iterations)
+        if budget_pressure:
+            effective_system = (effective_system + "\n\n" + budget_pressure).strip()
         if effective_system:
             api_messages = [{"role": "system", "content": effective_system}] + api_messages
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -22,6 +22,7 @@ from agent.codex_responses_adapter import _normalize_codex_response
 
 import run_agent
 from run_agent import AIAgent
+from agent.conversation_loop import _iteration_budget_pressure_message
 from agent.error_classifier import FailoverReason
 from agent.memory_manager import MemoryManager
 from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
@@ -53,6 +54,26 @@ def test_is_destructive_command_treats_cp_as_mutating():
 
 def test_is_destructive_command_treats_install_as_mutating():
     assert run_agent._is_destructive_command("install template.env .env") is True
+
+
+def test_iteration_budget_pressure_message_thresholds():
+    assert _iteration_budget_pressure_message(6, 10) is None
+
+    caution = _iteration_budget_pressure_message(7, 10)
+    assert caution is not None
+    assert "budget caution" in caution
+    assert "API call 7/10" in caution
+    assert "3 iterations remain" in caution
+
+    warning = _iteration_budget_pressure_message(9, 10)
+    assert warning is not None
+    assert "budget warning" in warning
+    assert "MUST prepare the final answer now" in warning
+
+
+def test_iteration_budget_pressure_message_ignores_invalid_counts():
+    assert _iteration_budget_pressure_message(0, 10) is None
+    assert _iteration_budget_pressure_message(1, 0) is None
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

Adds iteration budget pressure warnings to the agent loop.

When Hermes approaches `max_iterations`, the model currently receives no advance signal and can keep making tool calls until the hard max-iteration fallback asks for a tool-less summary. This PR injects ephemeral system guidance into the API-call message copy so the model can start wrapping up before that hard cutoff.

## Behavior

- At 70% of `max_iterations`: add a caution message asking the model to consolidate and prepare a final response.
- At 90% of `max_iterations`: add a stronger warning asking the model to prepare the final answer and avoid non-critical tool calls.
- At 100%: existing max-iteration fallback behavior remains unchanged.

The pressure message is added only to `api_messages`; it is not appended to the persistent transcript/session history.

## Compatibility

- No new dependencies.
- No config/schema changes.
- Existing behavior is unchanged until the configured iteration budget reaches the caution/warning thresholds.
- Existing max-iteration handling remains the final fallback.

Fixes #414.

## Tests

- `pytest tests/run_agent/test_run_agent.py -q`
- `ruff check agent/conversation_loop.py tests/run_agent/test_run_agent.py`
