### PR TITLE
fix(gateway): treat null-start scoped locks as stale

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1031,17 +1031,18 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                     and current_start != existing.get("start_time")
                 ):
                     stale = True
-                # When start_time comparison is unavailable (macOS / Windows
-                # have no /proc, so both sides are None), fall back to
-                # checking the live process command line.  When cmdline is
-                # also unreadable (Windows has no ps), consult the lock
-                # record's own argv — the gateway writes it at startup and
-                # it's the only identity signal on platforms without ps.
+                # When start_time comparison is unavailable on either side,
+                # fall back to checking the live process command line.  When
+                # cmdline is also unreadable (Windows has no ps), consult the
+                # lock record's own argv — the gateway writes it at startup
+                # and it's the only identity signal on platforms without ps.
                 # Both oracles must indicate "not a gateway" to mark stale.
                 if (
                     not stale
-                    and existing.get("start_time") is None
-                    and current_start is None
+                    and (
+                        existing.get("start_time") is None
+                        or current_start is None
+                    )
                     and not _looks_like_gateway_process(existing_pid)
                 ):
                     live_cmdline = _read_process_cmdline(existing_pid)

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -843,6 +843,36 @@ class TestScopedLocks:
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "telegram"
 
+    def test_acquire_scoped_lock_replaces_reused_pid_when_record_lacks_start_time(
+        self, tmp_path, monkeypatch
+    ):
+        """A legacy/null-start lock must not block when the live PID is unrelated."""
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 873,
+            "start_time": None,
+            "kind": "hermes-gateway",
+            "argv": ["/Users/user/.hermes/hermes-agent/hermes_cli/main.py", "gateway", "run"],
+        }))
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 456)
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: False)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: "/usr/libexec/bluetoothuserd")
+
+        acquired, existing = status.acquire_scoped_lock(
+            "telegram-bot-token",
+            "secret",
+            metadata={"platform": "telegram"},
+        )
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["metadata"]["platform"] == "telegram"
+
     def test_acquire_scoped_lock_keeps_lock_when_cmdline_unreadable_but_record_is_gateway(self, tmp_path, monkeypatch):
         """Windows regression: ps unavailable so cmdline cannot be read.
 


### PR DESCRIPTION
Summary
- Treat a scoped lock as stale when either the recorded or live start time is unavailable and the live PID is confirmed not to be a gateway.
- Add a regression test for a null-start lock record whose recycled PID now has a live start time.

Root Cause
- The fallback stale-lock check only ran when both `existing.start_time` and `current_start` were `None`. On macOS, legacy/null lock records can coexist with a `psutil` live start time for an unrelated recycled PID, so the stale branch was skipped.

Tests
- `python -m pytest tests/gateway/test_status.py -q -k 'acquire_scoped_lock'`
- `python -m py_compile gateway/status.py tests/gateway/test_status.py`

Fixes #53763
