### PR TITLE
fix(telegram): gate channel posts like groups

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5938,7 +5938,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if not chat:
             return False
         chat_type = str(getattr(chat, "type", "")).split(".")[-1].lower()
-        return chat_type in {"group", "supergroup"}
+        return chat_type in {"channel", "group", "supergroup"}
 
     def _is_reply_to_bot(self, message: Message) -> bool:
         if not self._bot or not getattr(message, "reply_to_message", None):

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -89,6 +89,7 @@ def _group_message(
     text="hello",
     *,
     chat_id=-100,
+    chat_type="group",
     from_user_id=111,
     from_user_name="Alice Example",
     thread_id=None,
@@ -108,7 +109,7 @@ def _group_message(
         caption_entities=caption_entities or [],
         message_thread_id=thread_id,
         is_topic_message=thread_id is not None,
-        chat=SimpleNamespace(id=chat_id, type="group", title="Test Group", is_forum=thread_id is not None),
+        chat=SimpleNamespace(id=chat_id, type=chat_type, title="Test Group", is_forum=thread_id is not None),
         from_user=SimpleNamespace(id=from_user_id, full_name=from_user_name, first_name=from_user_name.split()[0]),
         reply_to_message=reply_to_message,
         date=None,
@@ -571,6 +572,17 @@ def test_guest_mode_defaults_to_false_for_allowed_chat_bypass():
         entities=[_mention_entity("hi @hermes_bot")],
     )
     assert adapter._should_process_message(mentioned) is False
+
+
+def test_channel_posts_respect_allowed_chats_gate():
+    adapter = _make_adapter(require_mention=False, allowed_chats=["-200"])
+
+    assert adapter._should_process_message(
+        _group_message("public broadcast", chat_id=-201, chat_type="channel")
+    ) is False
+    assert adapter._should_process_message(
+        _group_message("approved broadcast", chat_id=-200, chat_type="channel")
+    ) is True
 
 
 def test_guest_mode_mention_dropped_in_ignored_thread():


### PR DESCRIPTION
Summary
- Treat Telegram channel posts as group-like for trigger/routing gates.
- Add a regression test that drops a channel outside `allowed_chats` and allows an approved channel.

Root Cause
- `_is_group_chat()` only recognized `group` and `supergroup`, so `chat.type == "channel"` took the unrestricted DM fast path in `_should_process_message()` before `allowed_chats` or mention gates ran.

Tests
- `python -m pytest tests/gateway/test_telegram_group_gating.py -q`
- `python -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_group_gating.py`

Fixes #53674
