### PR TITLE
fix(agent): recover pure-Latin search matches embedded in CJK text (#54242)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3726,6 +3726,97 @@ class SessionDB:
         """Count CJK characters in text."""
         return sum(1 for ch in text if cls._is_cjk_codepoint(ord(ch)))
 
+    @staticmethod
+    def _trigram_eligible_tokens(query: str) -> bool:
+        """True when every non-operator token is long enough for the trigram
+        tokenizer to match (>=3 chars).
+
+        The trigram tokenizer indexes overlapping 3-character sequences, so a
+        token shorter than 3 chars produces no trigrams and can never match.
+        With FTS5's implicit-AND between tokens, a single short token makes the
+        whole MATCH return nothing, so the trigram path is only worth taking
+        when every searchable token qualifies.
+        """
+        tokens = [
+            t for t in query.strip('"').strip().split()
+            if t.upper() not in {"AND", "OR", "NOT"}
+        ]
+        return bool(tokens) and all(len(t) >= 3 for t in tokens)
+
+    def _run_trigram_search(
+        self,
+        raw_query: str,
+        *,
+        order_by_sql: str,
+        include_inactive: bool,
+        source_filter: List[str] = None,
+        exclude_sources: List[str] = None,
+        role_filter: List[str] = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Run a search against the ``messages_fts_trigram`` table.
+
+        The trigram tokenizer indexes overlapping 3-byte sequences, so it
+        matches substrings regardless of word boundaries — both CJK phrases the
+        unicode61 tokenizer splits into single characters and Latin runs the
+        unicode61 tokenizer fuses onto adjacent CJK (e.g. ``修改youer服务端``).
+        Each non-operator token is quoted to neutralise FTS5 special characters
+        while boolean operators (AND/OR/NOT) are preserved.
+
+        Returns the matching rows, or ``None`` when the trigram query cannot be
+        executed (e.g. the trigram tokenizer is unavailable at runtime) so the
+        caller can fall back to another strategy.
+        """
+        tokens = raw_query.split()
+        parts = []
+        for tok in tokens:
+            if tok.upper() in {"AND", "OR", "NOT"}:
+                parts.append(tok)
+            else:
+                parts.append('"' + tok.replace('"', '""') + '"')
+        trigram_query = " ".join(parts)
+        tri_where = ["messages_fts_trigram MATCH ?"]
+        tri_params: list = [trigram_query]
+        if not include_inactive:
+            tri_where.append("(m.active = 1 OR m.compacted = 1)")
+        if source_filter is not None:
+            tri_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
+            tri_params.extend(source_filter)
+        if exclude_sources is not None:
+            tri_where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
+            tri_params.extend(exclude_sources)
+        if role_filter:
+            tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
+            tri_params.extend(role_filter)
+        tri_sql = f"""
+            SELECT
+                m.id,
+                m.session_id,
+                m.role,
+                snippet(messages_fts_trigram, 0, '>>>', '<<<', '...', 40) AS snippet,
+                m.content,
+                m.timestamp,
+                m.tool_name,
+                s.source,
+                s.model,
+                s.started_at AS session_started
+            FROM messages_fts_trigram
+            JOIN messages m ON m.id = messages_fts_trigram.rowid
+            JOIN sessions s ON s.id = m.session_id
+            WHERE {' AND '.join(tri_where)}
+            {order_by_sql}
+            LIMIT ? OFFSET ?
+        """
+        tri_params.extend([limit, offset])
+        with self._lock:
+            try:
+                tri_cursor = self._conn.execute(tri_sql, tri_params)
+            except sqlite3.OperationalError:
+                # Trigram query failed at runtime — let the caller fall back.
+                return None
+            return [dict(row) for row in tri_cursor.fetchall()]
+
     def search_messages(
         self,
         query: str,
@@ -3869,59 +3960,23 @@ class SessionDB:
 
             _trigram_succeeded = False
             if cjk_count >= 3 and not _any_short_cjk and self._trigram_available:
-                # Trigram FTS5 path — quote each non-operator token to handle
-                # FTS5 special chars (%, *, etc.) while preserving boolean
-                # operators (AND, OR, NOT) for multi-term queries.
-                tokens = raw_query.split()
-                parts = []
-                for tok in tokens:
-                    if tok.upper() in {"AND", "OR", "NOT"}:
-                        parts.append(tok)
-                    else:
-                        parts.append('"' + tok.replace('"', '""') + '"')
-                trigram_query = " ".join(parts)
-                tri_where = ["messages_fts_trigram MATCH ?"]
-                tri_params: list = [trigram_query]
-                if not include_inactive:
-                    tri_where.append("(m.active = 1 OR m.compacted = 1)")
-                if source_filter is not None:
-                    tri_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
-                    tri_params.extend(source_filter)
-                if exclude_sources is not None:
-                    tri_where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
-                    tri_params.extend(exclude_sources)
-                if role_filter:
-                    tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
-                    tri_params.extend(role_filter)
-                tri_sql = f"""
-                    SELECT
-                        m.id,
-                        m.session_id,
-                        m.role,
-                        snippet(messages_fts_trigram, 0, '>>>', '<<<', '...', 40) AS snippet,
-                        m.content,
-                        m.timestamp,
-                        m.tool_name,
-                        s.source,
-                        s.model,
-                        s.started_at AS session_started
-                    FROM messages_fts_trigram
-                    JOIN messages m ON m.id = messages_fts_trigram.rowid
-                    JOIN sessions s ON s.id = m.session_id
-                    WHERE {' AND '.join(tri_where)}
-                    {order_by_sql}
-                    LIMIT ? OFFSET ?
-                """
-                tri_params.extend([limit, offset])
-                with self._lock:
-                    try:
-                        tri_cursor = self._conn.execute(tri_sql, tri_params)
-                    except sqlite3.OperationalError:
-                        # Trigram query failed at runtime — fall through to LIKE.
-                        pass
-                    else:
-                        matches = [dict(row) for row in tri_cursor.fetchall()]
-                        _trigram_succeeded = True
+                # Trigram FTS5 path — indexed substring matching that handles
+                # multi-char CJK phrases the unicode61 tokenizer splits apart.
+                tri_matches = self._run_trigram_search(
+                    raw_query,
+                    order_by_sql=order_by_sql,
+                    include_inactive=include_inactive,
+                    source_filter=source_filter,
+                    exclude_sources=exclude_sources,
+                    role_filter=role_filter,
+                    limit=limit,
+                    offset=offset,
+                )
+                if tri_matches is not None:
+                    # ``None`` means the trigram query errored — fall through to
+                    # the LIKE substring path below.
+                    matches = tri_matches
+                    _trigram_succeeded = True
             if not _trigram_succeeded:
                 # Short / mixed CJK query, trigram unavailable, or trigram
                 # <3 CJK chars. Fall back to LIKE substring search.
@@ -3978,6 +4033,37 @@ class SessionDB:
                     return []
                 else:
                     matches = [dict(row) for row in cursor.fetchall()]
+
+            # Pure-Latin queries run against the unicode61 ``messages_fts`` table,
+            # whose tokenizer does not insert a boundary between Latin letters and
+            # adjacent CJK characters: "修改youer服务端" is indexed as one token,
+            # so MATCH "youer" finds nothing even though the substring is present
+            # (#54242). When the exact-token search returns nothing, retry on the
+            # trigram table, which matches Latin runs embedded in CJK. Gated on a
+            # zero-result miss so successful Latin searches keep their unicode61
+            # ranking, and on >=3-char tokens since trigram needs >=3 chars to
+            # match. Because it only fires on a zero-result miss this is strictly
+            # additive (it never reorders or removes existing hits); the trade-off
+            # is that any other zero-result Latin query also gains trigram
+            # *substring* semantics (e.g. "cat" can then match "concatenate").
+            # Genuinely absent terms still return [].
+            if (
+                not matches
+                and self._trigram_available
+                and self._trigram_eligible_tokens(query)
+            ):
+                tri_matches = self._run_trigram_search(
+                    query.strip('"').strip(),
+                    order_by_sql=order_by_sql,
+                    include_inactive=include_inactive,
+                    source_filter=source_filter,
+                    exclude_sources=exclude_sources,
+                    role_filter=role_filter,
+                    limit=limit,
+                    offset=offset,
+                )
+                if tri_matches:
+                    matches = tri_matches
 
         # Add surrounding context (1 message before + after each match).
         # Done outside the lock so we don't hold it across N sequential queries.

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1506,6 +1506,46 @@ class TestCJKSearchFallback:
         results = db.search_messages("Agent通信")
         assert len(results) == 1
 
+    def test_pure_latin_word_embedded_in_cjk_is_found(self, db):
+        """Regression for #54242.
+
+        A pure-Latin query (no CJK chars) routes to the unicode61 ``messages_fts``
+        table, whose tokenizer fuses a Latin run onto the adjacent CJK characters
+        ("修改youer服务端" is indexed as a single token), so MATCH "youer" returns
+        nothing. The zero-result trigram fallback must recover the match.
+        """
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="修改youer服务端的计划")
+        results = db.search_messages("youer")
+        assert len(results) == 1
+        assert results[0]["session_id"] == "s1"
+
+    def test_pure_latin_query_with_normal_match_is_unaffected(self, db):
+        """A normal space-delimited Latin query still resolves on the unicode61
+        path; the zero-result trigram fallback only fires when it misses."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="deploy the docker container")
+        results = db.search_messages("docker")
+        assert len(results) == 1
+        assert results[0]["session_id"] == "s1"
+
+    def test_pure_latin_query_absent_term_returns_empty(self, db):
+        """A Latin term that is genuinely absent must still return nothing,
+        even with the trigram fallback enabled."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="修改youer服务端的计划")
+        assert db.search_messages("kubernetes") == []
+
+    def test_pure_latin_embedded_fallback_preserves_source_filter(self, db):
+        """The embedded-Latin trigram fallback must honour source_filter."""
+        db.create_session(session_id="s1", source="cli")
+        db.create_session(session_id="s2", source="telegram")
+        db.append_message("s1", role="user", content="修改youer服务端cli")
+        db.append_message("s2", role="user", content="修改youer服务端telegram")
+        results = db.search_messages("youer", source_filter=["telegram"])
+        assert len(results) == 1
+        assert results[0]["source"] == "telegram"
+
     def test_cjk_partial_fts5_results_supplemented_by_like(self, db):
         """When FTS5 returns *some* CJK results, LIKE must still find all matches.
 


### PR DESCRIPTION
## What does this PR do?

`search_messages()` returned **zero results for a pure-Latin query when the matching word is embedded in CJK text with no whitespace boundary**.

Pure-Latin queries (no CJK characters) route to the unicode61 `messages_fts` table. The unicode61 tokenizer does not insert a token boundary between Latin letters and adjacent CJK characters, so a message containing `修改youer服务端的计划` is indexed as a single fused token. `search_messages("youer")` therefore matched nothing — even though the substring is plainly present — and the pure-Latin code path had no fallback (the trigram and LIKE fallbacks only existed on the CJK branch).

This is the core of #54242: an agent is effectively blind to past conversations where an English proper noun (project name, technical term) appears in a CJK context.

**Fix:** add a zero-result trigram fallback to the pure-Latin path. When the unicode61 search misses, retry against the existing `messages_fts_trigram` table, which indexes overlapping 3-char sequences and therefore matches substrings regardless of word boundaries.

The fallback is deliberately conservative:

- It only fires when the unicode61 search returns **zero** results, so successful Latin searches keep their unicode61 token ranking unchanged and pay no extra query.
- It is gated on `self._trigram_available` and on every non-operator token being ≥3 chars (the trigram minimum), via a small `_trigram_eligible_tokens()` helper.
- Trade-off (documented in-code): any *other* zero-result Latin query now also gains trigram substring semantics (e.g. `cat` can then match `concatenate`). Genuinely-absent terms still return `[]`.

The trigram query construction previously inlined in the CJK branch is extracted into a `_run_trigram_search()` helper and reused by both paths — a behavior-preserving refactor (identical SQL, params, and the `None`-on-error vs `[]`-on-empty distinction).

## Related Issue

Fixes #54242

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py`:
  - New `_run_trigram_search()` helper holding the trigram FTS5 query, extracted from the CJK branch of `search_messages()`.
  - New `_trigram_eligible_tokens()` helper (true when every non-operator token is ≥3 chars).
  - `search_messages()`: the pure-Latin `else` branch now retries on the trigram table when the unicode61 search returns no rows.
- `tests/test_hermes_state.py::TestCJKSearchFallback`: 4 regression tests — embedded-Latin word is found; a normal Latin match is unaffected; a genuinely-absent term still returns empty; `source_filter` is honoured on the fallback path.

## How to Test

Reproduction:

```python
db.create_session(session_id="s1", source="cli")
db.append_message("s1", role="user", content="修改youer服务端的计划")
db.search_messages("youer")   # before: []   after: 1 match
```

Tests:

```bash
python3 -m pytest tests/test_hermes_state.py -q
# 295 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected test module `pytest tests/test_hermes_state.py -q` and all 295 tests pass (full suite runs in CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin), Python 3.14 — logic is stdlib `sqlite3`/FTS5 only

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — added docstrings to the new helpers; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure SQLite FTS5, platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (internal search path; tool contract unchanged)
