### PR TITLE
fix(mcp): normalize bare array schemas missing items

### DIFF
--- a/tests/test_mcp_tool.py
+++ b/tests/test_mcp_tool.py
@@ -1,0 +1,49 @@
+"""Tests for MCP tool input schema normalization."""
+
+import pytest
+from tools.mcp_tool import _normalize_mcp_input_schema
+
+
+class TestNormalizeArrayItems:
+    """OpenAI rejects JSON Schema arrays without 'items' — ensure we patch them."""
+
+    def test_bare_array_gets_empty_items(self):
+        result = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {"tags": {"type": "array"}},
+        })
+        assert result["properties"]["tags"]["items"] == {}
+
+    def test_typed_array_preserved(self):
+        result = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {"tags": {"type": "array", "items": {"type": "string"}}},
+        })
+        assert result["properties"]["tags"]["items"] == {"type": "string"}
+
+    def test_nested_bare_array_fixed(self):
+        result = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {
+                "nested": {
+                    "type": "object",
+                    "properties": {"values": {"type": "array"}},
+                }
+            },
+        })
+        assert result["properties"]["nested"]["properties"]["values"]["items"] == {}
+
+    def test_non_array_untouched(self):
+        result = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+        })
+        assert "items" not in result["properties"]["name"]
+
+    def test_none_returns_default_object(self):
+        result = _normalize_mcp_input_schema(None)
+        assert result == {"type": "object", "properties": {}}
+
+    def test_top_level_array_fixed(self):
+        result = _normalize_mcp_input_schema({"type": "array"})
+        assert result["items"] == {}

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3793,6 +3793,10 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
                     else:
                         repaired.pop("required", None)
 
+        # Ensure arrays have items (OpenAI rejects arrays without items).
+        if repaired.get("type") == "array" and "items" not in repaired:
+            repaired["items"] = {}
+
         return repaired
 
     normalized = _rewrite_local_refs(schema)


### PR DESCRIPTION
## What this fixes

If you connect an MCP server whose tools declare an array parameter without specifying what goes in it, Hermes silently breaks when using the OpenAI provider. The tool fails with a 400 and no helpful message.

## The actual bug

OpenAI strictly requires every array schema to have items. Some MCP servers skip it when they mean array of anything. Without items, OpenAI rejects the whole request.

## What changed

4 lines in tools/mcp_tool.py. When the normalizer sees a bare array with no items, it adds items: {} — which means any type is fine. Arrays with items already declared are untouched.

## Real-world trigger

Any MCP server whose tool input schema has a bare array field. Before: tool silently fails. After: works.