### PR TITLE
fix(cli): scope TUI npm-install check to target workspace deps

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1447,6 +1447,69 @@ def _termux_workspace_install_context(
     return ws_root, tuple(workspace_args)
 
 
+def _ws_relevant_packages(
+    wanted: dict[str, object], ws_root: Path, root: Path
+) -> set[str] | None:
+    """Return the set of ``node_modules/…`` keys reachable from *root*'s workspace.
+
+    When *root* lives inside a workspace checkout (``ws_root != root``),
+    walks the transitive dependency closure starting from the workspace
+    entries for *root* (e.g. ``ui-tui``, ``ui-tui/packages/hermes-ink``).
+    Only ``node_modules/…`` keys in the returned set should be compared
+    by :func:`_tui_need_npm_install` -- packages that belong to other
+    workspaces (``apps/desktop``, ``web``, etc.) are intentionally not
+    installed by ``npm install --workspace ui-tui`` and must be ignored.
+
+    Returns ``None`` when *root* is standalone (no workspace scoping
+    needed), signalling the caller to compare all entries.
+    """
+    if ws_root == root:
+        return None  # standalone project -- compare everything
+
+    try:
+        ws_name = root.relative_to(ws_root).as_posix()
+    except ValueError:
+        return None
+
+    # Collect workspace entries: the target workspace + any child workspaces
+    # (e.g. ui-tui/packages/hermes-ink).  Ignore nested node_modules entries
+    # like apps/desktop/node_modules/electron -- those are workspace-local
+    # overrides, not workspace roots.
+    ws_entries: list[str] = []
+    for key in wanted:
+        if key == ws_name or (
+            key.startswith(ws_name + "/") and "/node_modules/" not in key
+        ):
+            ws_entries.append(key)
+
+    # BFS: collect all transitive dependencies reachable from the workspace.
+    closure: set[str] = set()
+    frontier: list[str] = []
+    for ws_key in ws_entries:
+        ws_pkg = wanted.get(ws_key)
+        if not isinstance(ws_pkg, dict):
+            continue
+        for grp in ("dependencies", "devDependencies"):
+            for dep_name in ws_pkg.get(grp, {}):  # type: ignore[union-attr]
+                nm_key = f"node_modules/{dep_name}"
+                if nm_key not in closure:
+                    closure.add(nm_key)
+                    frontier.append(nm_key)
+
+    while frontier:
+        nm_key = frontier.pop()
+        pkg = wanted.get(nm_key)
+        if not isinstance(pkg, dict):
+            continue
+        for dep_name in pkg.get("dependencies", {}):  # type: ignore[union-attr]
+            child_key = f"node_modules/{dep_name}"
+            if child_key not in closure:
+                closure.add(child_key)
+                frontier.append(child_key)
+
+    return closure
+
+
 def _tui_need_npm_install(root: Path) -> bool:
     """True when @hermes/ink is missing or node_modules is behind package-lock.json.
 
@@ -1461,13 +1524,20 @@ def _tui_need_npm_install(root: Path) -> bool:
     workspace root; only the prebuilt-bundle sentinel stays relative to
     *root* (``ui-tui/dist/entry.js``).
 
+    **Workspace scoping:** in a workspace checkout the root lockfile
+    contains entries for every workspace (``apps/desktop``, ``web``, etc.),
+    but ``npm install --workspace ui-tui`` only installs the TUI's own
+    dependency tree.  The content comparison is scoped to the transitive
+    closure of the target workspace's dependencies so that packages
+    belonging to other workspaces do not trigger a spurious reinstall.
+
     Compares ``package-lock.json`` against ``node_modules/.package-lock.json``
     (npm's hidden lockfile) by **content**, not mtime: git checkouts and npm
     rewrites can bump the root lockfile's timestamp even when installed deps
     already match, which used to trigger a spurious "Installing TUI
     dependencies" on every launch.
 
-    For each entry in the root lock's ``packages`` map:
+    For each entry in the (scoped) root lock's ``packages`` map:
       - missing from hidden lock → reinstall (unless the entry is marked
         ``optional`` or ``peer``, which npm may intentionally skip per platform)
       - present but with differing fields (excluding npm-written runtime
@@ -1505,6 +1575,11 @@ def _tui_need_npm_install(root: Path) -> bool:
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return lock.stat().st_mtime > marker.stat().st_mtime
 
+    # Workspace scoping: only compare packages in the target workspace's
+    # transitive dependency tree.  Packages from other workspaces are
+    # intentionally not installed by --workspace ui-tui.
+    relevant = _ws_relevant_packages(wanted, ws_root, root)
+
     def comparable(pkg: dict) -> dict:
         return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
 
@@ -1513,6 +1588,10 @@ def _tui_need_npm_install(root: Path) -> bool:
             continue
 
         if not isinstance(pkg, dict):
+            continue
+
+        # Skip packages outside the target workspace's dependency tree.
+        if relevant is not None and name not in relevant:
             continue
 
         if name not in installed:

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -499,6 +499,90 @@ def test_no_stray_lockfiles_in_workspace_subdirs(main_mod) -> None:
     )
 
 
+# ── _ws_relevant_packages + workspace-scoped _tui_need_npm_install ──
+
+
+def test_ws_relevant_packages_returns_none_for_standalone(
+    tmp_path: Path, main_mod
+) -> None:
+    """Standalone project (ws_root == root) returns None -- compare everything."""
+    wanted = {"node_modules/foo": {"version": "1.0.0"}}
+    assert main_mod._ws_relevant_packages(wanted, tmp_path, tmp_path) is None
+
+
+def test_ws_relevant_packages_collects_transitive_closure(
+    tmp_path: Path, main_mod
+) -> None:
+    """Walks direct + transitive deps of the target workspace."""
+    ws_root = tmp_path
+    root = tmp_path / "ui-tui"
+    root.mkdir()
+    wanted = {
+        "ui-tui": {"dependencies": {"react": "^18"}},
+        "ui-tui/packages/hermes-ink": {"dependencies": {"chalk": "^5"}},
+        "apps/desktop": {"dependencies": {"electron": "^30", "@codemirror/state": "^6"}},
+        "node_modules/react": {"version": "18.3.0", "dependencies": {"scheduler": "^0.24"}},
+        "node_modules/scheduler": {"version": "0.24.0"},
+        "node_modules/chalk": {"version": "5.4.0"},
+        "node_modules/electron": {"version": "30.0.0"},
+        "node_modules/@codemirror/state": {"version": "6.5.0"},
+    }
+    result = main_mod._ws_relevant_packages(wanted, ws_root, root)
+    assert result is not None
+    assert "node_modules/react" in result
+    assert "node_modules/scheduler" in result  # transitive via react
+    assert "node_modules/chalk" in result  # via hermes-ink child workspace
+    assert "node_modules/electron" not in result  # apps/desktop only
+    assert "node_modules/@codemirror/state" not in result  # apps/desktop only
+
+
+def test_no_install_when_missing_package_belongs_to_other_workspace(
+    tmp_path: Path, main_mod
+) -> None:
+    """Packages from other workspaces must not trigger reinstall."""
+    ws_root = tmp_path
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (ws_root / "package-lock.json").write_text(
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"ink":"^5"}},'
+        '"apps/desktop":{"dependencies":{"electron":"^30"}},'
+        '"node_modules/ink":{"version":"5.0.0"},'
+        '"node_modules/electron":{"version":"30.0.0"}'
+        "}}"
+    )
+    _touch_ink(ws_root)
+    (ws_root / "node_modules" / ".package-lock.json").write_text(
+        '{"packages":{"node_modules/ink":{"version":"5.0.0"}}}'
+    )
+    # electron is MISSING from hidden lock but belongs to apps/desktop, not ui-tui.
+    assert main_mod._tui_need_npm_install(tui_dir) is False
+
+
+def test_install_when_missing_package_belongs_to_target_workspace(
+    tmp_path: Path, main_mod
+) -> None:
+    """Packages in the target workspace's dep tree DO trigger reinstall."""
+    ws_root = tmp_path
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (ws_root / "package-lock.json").write_text(
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"ink":"^5","new-dep":"^1"}},'
+        '"node_modules/ink":{"version":"5.0.0"},'
+        '"node_modules/new-dep":{"version":"1.0.0"}'
+        "}}"
+    )
+    _touch_ink(ws_root)
+    (ws_root / "node_modules" / ".package-lock.json").write_text(
+        '{"packages":{"node_modules/ink":{"version":"5.0.0"}}}'
+    )
+    # new-dep is MISSING and is a direct dep of ui-tui -- must trigger install.
+    assert main_mod._tui_need_npm_install(tui_dir) is True
+
+
 def test_tui_launch_install_uses_workspace_scope(
     tmp_path: Path, main_mod, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Problem

Every TUI launch prints "Installing TUI dependencies..." and runs a redundant `npm install --workspace ui-tui`, even when all ui-tui deps are already installed.

Started after 699adc2ca ("regen package-lock for integrity checks") which added `apps/desktop` dependencies (`@codemirror/*`, `@radix-ui/*`, `@lezer/*`, etc.) to the root `package-lock.json` for the first time.

## Root Cause

`_tui_need_npm_install()` compares **all** ~1,375 packages in the root `package-lock.json` against the hidden lockfile (`node_modules/.package-lock.json`). But the actual install runs `npm install --workspace ui-tui`, which only installs the ~345 packages in ui-tui's dependency tree.

The ~90 packages belonging to `apps/desktop`, `web`, and other workspaces are never installed by that command, so the hidden lockfile never contains them. The content comparison sees them as "missing" every time and returns `True`, creating an infinite reinstall loop on every launch.

## Fix

Add `_ws_relevant_packages()` which builds the transitive dependency closure from the target workspace's entries in the lockfile (BFS over `dependencies` and `devDependencies`, starting from `ui-tui` and `ui-tui/packages/hermes-ink`).

`_tui_need_npm_install()` now skips packages outside that closure when comparing installed vs wanted state. Packages from `apps/desktop`, `web`, etc. are no longer considered.

Standalone (non-workspace) installs are unaffected -- the helper returns `None` and the full comparison runs as before.

### Per-file summary

- **`hermes_cli/main.py`**: Add `_ws_relevant_packages()` helper; call it from `_tui_need_npm_install()` to scope the content comparison to the target workspace's dep tree.
- **`tests/hermes_cli/test_tui_npm_install.py`**: Add 4 new tests covering standalone fallback, transitive closure correctness, cross-workspace exclusion, and same-workspace inclusion.

## Testing

All 33 tests pass (29 existing + 4 new):

```
tests/hermes_cli/test_tui_npm_install.py    33 passed in 0.43s
```

Manual verification against the live repo with `apps/desktop` deps in the lockfile:
- Before fix: `_tui_need_npm_install(ui-tui)` returns `True` (90 false-positive missing packages)
- After fix: `_tui_need_npm_install(ui-tui)` returns `False` (0 false positives, only real ui-tui deps compared)

**Platforms tested:** macOS 15.7, Hermes Agent v0.17.0-0c2e6c00 (Hermes TUI runtime, standard installer layout)

Signed-off-by: Chris van Hoof <vanhoof@ouwish.com>
