### PR TITLE
fix(cli): show alias name in --help instead of hardcoded hermes (#15698)

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -11,6 +11,70 @@ because its dispatch is tightly coupled to module-level ``cmd_*`` functions.
 """
 
 import argparse
+import os
+import sys
+from pathlib import Path
+
+
+def _cli_prog() -> str:
+    """Return the display name for the CLI binary.
+
+    When Hermes is invoked through a profile-alias wrapper (e.g. ``june``),
+    the wrapper sets ``HERMES_CLI_NAME`` so help text shows the alias name
+    instead of the hardcoded ``hermes``. Falls back to the basename of
+    ``sys.argv[0]`` and then to ``hermes``.
+    """
+    return (
+        os.environ.get("HERMES_CLI_NAME")
+        or Path(sys.argv[0]).name
+        or "hermes"
+    )
+
+
+def _build_epilogue(prog: str) -> str:
+    """Build the help epilog, interpolating *prog* into every example line."""
+    return f"""
+Examples:
+    {prog}                        Start interactive chat
+    {prog} chat -q "Hello"        Single query mode
+    {prog} --tui                  Launch the modern TUI (or set display.interface: tui)
+    {prog} --cli                  Force the classic REPL (overrides display.interface: tui)
+    {prog} -c                     Resume the most recent session
+    {prog} -c "my project"        Resume a session by name (latest in lineage)
+    {prog} --resume <session_id>  Resume a specific session by ID
+    {prog} setup                  Run setup wizard
+    {prog} logout                 Clear stored authentication
+    {prog} auth add <provider>    Add a pooled credential
+    {prog} auth list              List pooled credentials
+    {prog} auth remove <p> <t>    Remove pooled credential by index, id, or label
+    {prog} auth reset <provider>  Clear exhaustion status for a provider
+    {prog} model                  Select default model
+    {prog} fallback [list]        Show fallback provider chain
+    {prog} fallback add           Add a fallback provider (same picker as `{prog} model`)
+    {prog} fallback remove        Remove a fallback provider from the chain
+    {prog} config                 View configuration
+    {prog} config edit            Edit config in $EDITOR
+    {prog} config set model gpt-4 Set a config value
+    {prog} gateway                Run messaging gateway
+    {prog} -s hermes-agent-dev,github-auth
+    {prog} -w                     Start in isolated git worktree
+    {prog} gateway install        Install gateway background service
+    {prog} sessions list          List past sessions
+    {prog} sessions browse        Interactive session picker
+    {prog} sessions rename ID T   Rename/title a session
+    {prog} logs                   View agent.log (last 50 lines)
+    {prog} logs -f                Follow agent.log in real time
+    {prog} logs errors            View errors.log
+    {prog} logs --since 1h        Lines from the last hour
+    {prog} debug share             Upload debug report for support
+    {prog} update                 Update to latest version
+    {prog} dashboard              Start web UI dashboard (port 9119)
+    {prog} dashboard --stop       Stop running dashboard processes
+    {prog} dashboard --status     List running dashboard processes
+
+For more help on a command:
+    {prog} <command> --help
+"""
 
 
 # `--profile` / `-p` is consumed by ``main._apply_profile_override`` before
@@ -37,50 +101,6 @@ def _inherited_flag(parser, *args, **kwargs):
     return action
 
 
-_EPILOGUE = """
-Examples:
-    hermes                        Start interactive chat
-    hermes chat -q "Hello"        Single query mode
-    hermes --tui                  Launch the modern TUI (or set display.interface: tui)
-    hermes --cli                  Force the classic REPL (overrides display.interface: tui)
-    hermes -c                     Resume the most recent session
-    hermes -c "my project"        Resume a session by name (latest in lineage)
-    hermes --resume <session_id>  Resume a specific session by ID
-    hermes setup                  Run setup wizard
-    hermes logout                 Clear stored authentication
-    hermes auth add <provider>    Add a pooled credential
-    hermes auth list              List pooled credentials
-    hermes auth remove <p> <t>    Remove pooled credential by index, id, or label
-    hermes auth reset <provider>  Clear exhaustion status for a provider
-    hermes model                  Select default model
-    hermes fallback [list]        Show fallback provider chain
-    hermes fallback add           Add a fallback provider (same picker as `hermes model`)
-    hermes fallback remove        Remove a fallback provider from the chain
-    hermes config                 View configuration
-    hermes config edit            Edit config in $EDITOR
-    hermes config set model gpt-4 Set a config value
-    hermes gateway                Run messaging gateway
-    hermes -s hermes-agent-dev,github-auth
-    hermes -w                     Start in isolated git worktree
-    hermes gateway install        Install gateway background service
-    hermes sessions list          List past sessions
-    hermes sessions browse        Interactive session picker
-    hermes sessions rename ID T   Rename/title a session
-    hermes logs                   View agent.log (last 50 lines)
-    hermes logs -f                Follow agent.log in real time
-    hermes logs errors            View errors.log
-    hermes logs --since 1h        Lines from the last hour
-    hermes debug share             Upload debug report for support
-    hermes update                 Update to latest version
-    hermes dashboard              Start web UI dashboard (port 9119)
-    hermes dashboard --stop       Stop running dashboard processes
-    hermes dashboard --status     List running dashboard processes
-
-For more help on a command:
-    hermes <command> --help
-"""
-
-
 def build_top_level_parser():
     """Build the top-level parser, the subparsers action, and the ``chat`` subparser.
 
@@ -89,10 +109,10 @@ def build_top_level_parser():
     other subparsers via ``subparsers.add_parser(...)``.
     """
     parser = argparse.ArgumentParser(
-        prog="hermes",
+        prog=_cli_prog(),
         description="Hermes Agent - AI assistant with tool-calling capabilities",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=_EPILOGUE,
+        epilog=_build_epilogue(_cli_prog()),
     )
 
     parser.add_argument(

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -414,7 +414,11 @@ def create_wrapper_script(name: str, target: Optional[str] = None) -> Optional[P
     if is_windows:
         wrapper_path = wrapper_dir / f"{canon}.bat"
         try:
-            wrapper_path.write_text(f"@echo off\r\nhermes -p {profile} %*\r\n")
+            wrapper_path.write_text(
+                f"@echo off\r\n"
+                f'set HERMES_CLI_NAME={canon}\r\n'
+                f"hermes -p {profile} %*\r\n"
+            )
             return wrapper_path
         except OSError as e:
             print(f"⚠ Could not create wrapper at {wrapper_path}: {e}")
@@ -423,7 +427,10 @@ def create_wrapper_script(name: str, target: Optional[str] = None) -> Optional[P
         wrapper_path = wrapper_dir / canon
         try:
             hermes_exe = shutil.which("hermes") or "hermes"
-            wrapper_path.write_text(f'#!/bin/sh\nexec {shlex.quote(hermes_exe)} -p {profile} "$@"\n')
+            wrapper_path.write_text(
+                f'#!/bin/sh\n'
+                f'HERMES_CLI_NAME="{canon}" exec {shlex.quote(hermes_exe)} -p {profile} "$@"\n'
+            )
             wrapper_path.chmod(wrapper_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
             return wrapper_path
         except OSError as e:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -786,6 +786,7 @@ class TestWrapperScript:
         assert wrapper.name == "mybot"
         content = wrapper.read_text()
         assert content.startswith("#!/bin/sh")
+        assert "HERMES_CLI_NAME=\"mybot\"" in content
         assert "exec /opt/hermes/bin/hermes -p mybot" in content
 
     def test_creates_bat_on_windows(self, profile_env, monkeypatch):
@@ -795,7 +796,8 @@ class TestWrapperScript:
         assert wrapper is not None
         assert wrapper.name == "mybot.bat"
         content = wrapper.read_text()
-        assert "@echo off" in content
+        assert "echo off" in content
+        assert "HERMES_CLI_NAME=mybot" in content
         assert "hermes -p mybot" in content
         assert "%*" in content
 
@@ -844,10 +846,61 @@ class TestWrapperScript:
         assert wrapper is not None
         assert wrapper.name == "rq.bat"
         content = wrapper.read_text()
-        assert "@echo off" in content
+        assert "echo off" in content
+        assert "HERMES_CLI_NAME=rq" in content
         assert "hermes -p redqueen" in content
         assert "%*" in content
         assert "#!/bin/sh" not in content
+
+
+# ---------------------------------------------------------------------------
+# _cli_prog / _build_epilogue — dynamic CLI display name (Issue #15698)
+# ---------------------------------------------------------------------------
+
+
+class TestCliProgName:
+    """Tests for _cli_prog() — the dynamic CLI display name.
+
+    When invoked through a profile-alias wrapper, the wrapper sets
+    HERMES_CLI_NAME so --help shows the alias name instead of "hermes".
+    """
+
+    def test_returns_env_var_when_set(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CLI_NAME", "june")
+        monkeypatch.setattr("sys.argv", ["/usr/local/bin/hermes"])
+        from hermes_cli._parser import _cli_prog
+        assert _cli_prog() == "june"
+
+    def test_falls_back_to_argv0_when_no_env(self, monkeypatch):
+        monkeypatch.delenv("HERMES_CLI_NAME", raising=False)
+        monkeypatch.setattr("sys.argv", ["/opt/bin/mybot"])
+        from hermes_cli._parser import _cli_prog
+        assert _cli_prog() == "mybot"
+
+    def test_falls_back_to_hermes_when_nothing(self, monkeypatch):
+        monkeypatch.delenv("HERMES_CLI_NAME", raising=False)
+        monkeypatch.setattr("sys.argv", [""])
+        from hermes_cli._parser import _cli_prog
+        assert _cli_prog() == "hermes"
+
+
+class TestBuildEpilogue:
+    """Tests for _build_epilogue() — the dynamic help epilog."""
+
+    def test_epilogue_uses_custom_prog(self):
+        from hermes_cli._parser import _build_epilogue
+        epilog = _build_epilogue("june")
+        assert "june chat -q" in epilog
+        assert "june --tui" in epilog
+        assert "june <command> --help" in epilog
+        # The hardcoded name should NOT appear in the examples
+        assert "hermes chat -q" not in epilog
+
+    def test_epilogue_uses_hermes_by_default(self):
+        from hermes_cli._parser import _build_epilogue
+        epilog = _build_epilogue("hermes")
+        assert "hermes chat -q" in epilog
+        assert "hermes <command> --help" in epilog
 
 
 # ===================================================================


### PR DESCRIPTION
 Summary

    Fixes #15698

    When using profile-alias wrappers (e.g. june, cid, luna), june --help still showed prog=hermes and all examples used hermes instead of the alias name. The command worked fine, but the help text was wrong.

    Changes

    - hermes_cli/_parser.py:
      - Added _cli_prog() — reads HERMES_CLI_NAME env var (set by wrapper scripts), falls back to basename(sys.argv[0]), then to hermes
      - Replaced static _EPILOGUE with _build_epilogue(prog) that interpolates the display name into every example line
      - Updated build_top_level_parser() to use prog=_cli_prog() and epilog=_build_epilogue(_cli_prog())

    - hermes_cli/profiles.py:
      - Wrapper scripts now set HERMES_CLI_NAME=<alias> before exec, both in sh (posix) and bat (windows) variants

    - tests/hermes_cli/test_profiles.py:
      - Updated existing wrapper tests to assert HERMES_CLI_NAME is present
      - Added TestCliProgName — 3 tests for _cli_prog() (env var, argv[0] fallback, hermes default)
      - Added TestBuildEpilogue — 2 tests for _build_epilogue() (custom name, default hermes)

    Verification

    All 12 tests pass:

    tests/hermes_cli/test_profiles.py::TestWrapperScript::test_creates_sh_on_posix PASSED
    tests/hermes_cli/test_profiles.py::TestWrapperScript::test_creates_bat_on_windows PASSED
    tests/hermes_cli/test_profiles.py::TestWrapperScript::test_remove_finds_bat_on_windows PASSED
    tests/hermes_cli/test_profiles.py::TestWrapperScript::test_remove_finds_sh_on_posix PASSED
    tests/hermes_cli/test_profiles.py::TestWrapperScript::test_remove_returns_false_when_absent PASSED
    tests/hermes_cli/test_profiles.py::TestWrapperScript::test_custom_alias_target_on_posix PASSED
    tests/hermes_cli/test_profiles.py::TestWrapperScript::test_custom_alias_target_on_windows PASSED
    tests/hermes_cli/test_profiles.py::TestCliProgName::test_returns_env_var_when_set PASSED
    tests/hermes_cli/test_profiles.py::TestCliProgName::test_falls_back_to_argv0_when_no_env PASSED
    tests/hermes_cli/test_profiles.py::TestCliProgName::test_falls_back_to_hermes_when_nothing PASSED
    tests/hermes_cli/test_profiles.py::TestBuildEpilogue::test_epilogue_uses_custom_prog PASSED
    tests/hermes_cli/test_profiles.py::TestBuildEpilogue::test_epilogue_uses_hermes_by_default PASSED