### PR TITLE
fix(gateway): call _cleanup_agent_resources before idle-TTL eviction (#11205)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14133,6 +14133,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "Agent cache idle-TTL evict: session=%s (idle=%.0fs)",
                 key, now - getattr(agent, "_last_activity_ts", now),
             )
+            # Idle TTL eviction is a session boundary for long-idle agents.
+            # Memory providers' on_session_end must fire here, otherwise the
+            # agent is gone by the time the session expiry watcher runs hours
+            # later (see #11205).
+            self._cleanup_agent_resources(agent)
             threading.Thread(
                 target=self._release_evicted_agent_soft,
                 args=(agent,),


### PR DESCRIPTION
## Summary

Fixes a race condition where gateway sessions expire silently without ever calling `MemoryProvider.on_session_end()`, causing all memory providers (Supermemory, OpenViking, Hindsight, etc.) to lose the entire conversation.

## The Bug

The gateway has two idle timers:

| Timer | Duration | What it does |
|-------|----------|--------------|
| `_AGENT_CACHE_IDLE_TTL_SECS` | 1 hour | Evicts the cached `AIAgent` from `_agent_cache` |
| Session expiry watcher | 24 hours | Finalizes the session in the DB |

**The problem:** `_sweep_idle_cached_agents()` evicts the agent via `_release_evicted_agent_soft()` at T+1h. At T+24h, `_session_expiry_watcher()` looks for the agent in `_agent_cache` to call `_cleanup_agent_resources()` → `shutdown_memory_provider()` → `on_session_end()`. **The agent is already gone.** The hook fires zero times. The conversation is never ingested into any memory provider.

This is the root cause of #11205, #15165, #7759, #53625.

## The Fix

In `_sweep_idle_cached_agents()`, call `_cleanup_agent_resources(agent)` **before** `_release_evicted_agent_soft()`. This treats idle-TTL eviction as a true session boundary, identical to CLI exit or gateway shutdown.

## Why this is correct

- `_cleanup_agent_resources` already calls `agent.shutdown_memory_provider(session_messages)` (#15165 fix)
- `shutdown_memory_provider` propagates to `MemoryManager.on_session_end()` → all providers
- No new code path — reuses existing battle-tested shutdown logic
- Keeps `_release_evicted_agent_soft` for client cleanup afterward

## Related

- Fixes #11205
- Fixes #15165  
- Fixes #7759
- Fixes #53625