### PR TITLE
fix: prevent broken run-in-terminal disconnect for claude-code on Windows

### DIFF
--- a/hermes_cli/web_routers/oauth.py
+++ b/hermes_cli/web_routers/oauth.py
@@ -514,10 +514,22 @@ def _oauth_provider_disconnect_command(provider: Dict[str, Any]) -> Optional[str
     """
     if provider.get("flow") != "external" or provider.get("id") != "claude-code":
         return None
-    rm_file = "rm -f ~/.claude/.credentials.json"
+    # macOS gets the keychain + POSIX rm combo (unchanged).
     if sys.platform == "darwin":
-        return f'security delete-generic-password -s "Claude Code-credentials" 2>/dev/null; {rm_file}'
-    return rm_file
+        return 'security delete-generic-password -s "Claude Code-credentials" 2>/dev/null; rm -f ~/.claude/.credentials.json'
+    # Windows: the embedded terminal cannot run `rm -f`, so we hand it
+    # PowerShell's Remove-Item with -Force (handles read-only files) and
+    # -ErrorAction SilentlyContinue (no-op when missing, mirroring `rm -f`
+    # semantics). $env:USERPROFILE is expanded by the child PowerShell
+    # process, not the parent shell, so the literal `$` must survive
+    # whatever quoting the embedded terminal applies.
+    if sys.platform == "win32":
+        return (
+            "powershell -NoProfile -Command "
+            "\"Remove-Item -LiteralPath \\\"$env:USERPROFILE\\.claude\\credentials.json\\\" "
+            "-Force -ErrorAction SilentlyContinue\""
+        )
+    return "rm -f ~/.claude/.credentials.json"
 
 
 def _oauth_provider_disconnect_hint(provider: Dict[str, Any], status: Dict[str, Any]) -> Optional[str]:

--- a/hermes_cli/web_routers/oauth.py
+++ b/hermes_cli/web_routers/oauth.py
@@ -526,7 +526,7 @@ def _oauth_provider_disconnect_command(provider: Dict[str, Any]) -> Optional[str
     if sys.platform == "win32":
         return (
             "powershell -NoProfile -Command "
-            "\"Remove-Item -LiteralPath \\\"$env:USERPROFILE\\.claude\\credentials.json\\\" "
+            "\"Remove-Item -LiteralPath \\\"$env:USERPROFILE\\.claude\\.credentials.json\\\" "
             "-Force -ErrorAction SilentlyContinue\""
         )
     return "rm -f ~/.claude/.credentials.json"

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6533,10 +6533,22 @@ def _oauth_provider_disconnect_command(provider: Dict[str, Any]) -> Optional[str
     if provider.get("flow") != "external":
         return None
     if provider.get("id") == "claude-code":
-        rm_file = "rm -f ~/.claude/.credentials.json"
+        # macOS gets the keychain + POSIX rm combo (unchanged).
         if sys.platform == "darwin":
-            return f'security delete-generic-password -s "Claude Code-credentials" 2>/dev/null; {rm_file}'
-        return rm_file
+            return 'security delete-generic-password -s "Claude Code-credentials" 2>/dev/null; rm -f ~/.claude/.credentials.json'
+        # Windows: the embedded terminal cannot run `rm -f`, so we hand it
+        # PowerShell's Remove-Item with -Force (handles read-only files) and
+        # -ErrorAction SilentlyContinue (no-op when missing, mirroring `rm -f`
+        # semantics). $env:USERPROFILE is expanded by the child PowerShell
+        # process, not the parent shell, so the literal `$` must survive
+        # whatever quoting the embedded terminal applies.
+        if sys.platform == "win32":
+            return (
+                "powershell -NoProfile -Command "
+                "\"Remove-Item -LiteralPath \\\"$env:USERPROFILE\\.claude\\credentials.json\\\" "
+                "-Force -ErrorAction SilentlyContinue\""
+            )
+        return "rm -f ~/.claude/.credentials.json"
     return None
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6545,7 +6545,7 @@ def _oauth_provider_disconnect_command(provider: Dict[str, Any]) -> Optional[str
         if sys.platform == "win32":
             return (
                 "powershell -NoProfile -Command "
-                "\"Remove-Item -LiteralPath \\\"$env:USERPROFILE\\.claude\\credentials.json\\\" "
+                "\"Remove-Item -LiteralPath \\\"$env:USERPROFILE\\.claude\\.credentials.json\\\" "
                 "-Force -ErrorAction SilentlyContinue\""
             )
         return "rm -f ~/.claude/.credentials.json"

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -522,7 +522,15 @@ def test_oauth_catalog_marks_external_providers_not_disconnectable():
     assert providers["claude-code"]["disconnectable"] is False
     assert providers["claude-code"]["disconnect_hint"]
     cmd = providers["claude-code"]["disconnect_command"]
-    assert cmd and ".claude/.credentials.json" in cmd
+    # Windows must surface a PowerShell-native delete; POSIX keeps the legacy
+    # form. Both forms should reference the .claude credentials path.
+    if sys.platform == "win32":
+        assert cmd is not None
+        assert "rm -f" not in cmd
+        assert "powershell" in cmd.lower()
+        assert ".claude" in cmd
+    else:
+        assert cmd and ".claude/.credentials.json" in cmd
 
 
 def test_external_oauth_disconnect_rejected_before_auth_mutation(monkeypatch):

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -20,6 +20,7 @@ The fix:
 These tests pin the corrected behavior.
 """
 import asyncio
+import sys
 import time
 from datetime import datetime, timezone
 from unittest.mock import patch
@@ -523,14 +524,36 @@ def test_oauth_catalog_marks_external_providers_not_disconnectable():
     assert providers["claude-code"]["disconnect_hint"]
     cmd = providers["claude-code"]["disconnect_command"]
     # Windows must surface a PowerShell-native delete; POSIX keeps the legacy
-    # form. Both forms should reference the .claude credentials path.
+    # form. Both forms should reference the exact .credentials.json path.
     if sys.platform == "win32":
         assert cmd is not None
         assert "rm -f" not in cmd
         assert "powershell" in cmd.lower()
-        assert ".claude" in cmd
+        assert r".claude\.credentials.json" in cmd
     else:
         assert cmd and ".claude/.credentials.json" in cmd
+
+
+def test_claude_code_disconnect_command_platform_matrix(monkeypatch):
+    """Verify claude-code disconnect command targets exact hidden file across platforms."""
+    from hermes_cli.web_server import _oauth_provider_disconnect_command
+
+    provider = {"id": "claude-code", "flow": "external"}
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    win_cmd = _oauth_provider_disconnect_command(provider)
+    assert win_cmd is not None
+    assert "rm -f" not in win_cmd
+    assert "powershell" in win_cmd.lower()
+    assert r"$env:USERPROFILE\.claude\.credentials.json" in win_cmd
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+    mac_cmd = _oauth_provider_disconnect_command(provider)
+    assert mac_cmd == 'security delete-generic-password -s "Claude Code-credentials" 2>/dev/null; rm -f ~/.claude/.credentials.json'
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    linux_cmd = _oauth_provider_disconnect_command(provider)
+    assert linux_cmd == "rm -f ~/.claude/.credentials.json"
 
 
 def test_external_oauth_disconnect_rejected_before_auth_mutation(monkeypatch):

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -23,6 +23,7 @@ These tests pin the corrected behavior.
 """
 import asyncio
 import json
+import sys
 import time
 from datetime import datetime, timezone
 from unittest.mock import patch
@@ -614,14 +615,36 @@ def test_oauth_catalog_marks_external_providers_not_disconnectable():
     assert providers["claude-code"]["disconnect_hint"]
     cmd = providers["claude-code"]["disconnect_command"]
     # Windows must surface a PowerShell-native delete; POSIX keeps the legacy
-    # form. Both forms should reference the .claude credentials path.
+    # form. Both forms should reference the exact .credentials.json path.
     if sys.platform == "win32":
         assert cmd is not None
         assert "rm -f" not in cmd
         assert "powershell" in cmd.lower()
-        assert ".claude" in cmd
+        assert r".claude\.credentials.json" in cmd
     else:
         assert cmd and ".claude/.credentials.json" in cmd
+
+
+def test_claude_code_disconnect_command_platform_matrix(monkeypatch):
+    """Verify claude-code disconnect command targets exact hidden file across platforms."""
+    from hermes_cli.web_routers.oauth import _oauth_provider_disconnect_command
+
+    provider = {"id": "claude-code", "flow": "external"}
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    win_cmd = _oauth_provider_disconnect_command(provider)
+    assert win_cmd is not None
+    assert "rm -f" not in win_cmd
+    assert "powershell" in win_cmd.lower()
+    assert r"$env:USERPROFILE\.claude\.credentials.json" in win_cmd
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+    mac_cmd = _oauth_provider_disconnect_command(provider)
+    assert mac_cmd == 'security delete-generic-password -s "Claude Code-credentials" 2>/dev/null; rm -f ~/.claude/.credentials.json'
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    linux_cmd = _oauth_provider_disconnect_command(provider)
+    assert linux_cmd == "rm -f ~/.claude/.credentials.json"
 
 
 def test_external_oauth_disconnect_rejected_before_auth_mutation(monkeypatch):

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -613,7 +613,15 @@ def test_oauth_catalog_marks_external_providers_not_disconnectable():
     assert providers["claude-code"]["disconnectable"] is False
     assert providers["claude-code"]["disconnect_hint"]
     cmd = providers["claude-code"]["disconnect_command"]
-    assert cmd and ".claude/.credentials.json" in cmd
+    # Windows must surface a PowerShell-native delete; POSIX keeps the legacy
+    # form. Both forms should reference the .claude credentials path.
+    if sys.platform == "win32":
+        assert cmd is not None
+        assert "rm -f" not in cmd
+        assert "powershell" in cmd.lower()
+        assert ".claude" in cmd
+    else:
+        assert cmd and ".claude/.credentials.json" in cmd
 
 
 def test_external_oauth_disconnect_rejected_before_auth_mutation(monkeypatch):


### PR DESCRIPTION
## Summary
On Windows, the desktop OAuth disconnect flow surfaced a Unix-only `rm -f ~/.claude/.credentials.json` command for the Claude Code provider, which the embedded Windows terminal cannot execute.

## Changes
- `hermes_cli/web_server.py`: stop returning a Unix rm command as the disconnect command for `claude-code` on Windows. Keep the existing keychain + `rm` path on macOS; other platforms preserve the prior behavior.
- `tests/hermes_cli/test_web_oauth_dispatch.py`: update the claude-code disconnect_command assertion so it validates Windows correctly (no Unix rm surfaced) while still pinning the legacy non-Windows behavior.

## Test Plan
On Windows, confirming disconnect for Claude Code no longer shows the Unix rm command. On macOS, the keychain + rm command remains.