### PR TITLE
feat(desktop): add file-backed session pins bridge

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -363,6 +363,10 @@ const DESKTOP_WINDOW_STATE_PATH = path.join(app.getPath('userData'), 'window-sta
 // ~/.hermes/active_profile file. Unset (null) preserves the legacy behavior:
 // no --profile flag, so the backend honors active_profile / default.
 const DESKTOP_PROFILE_CONFIG_PATH = path.join(app.getPath('userData'), 'active-profile.json')
+// File-backed session pins bridge. The renderer still owns the visible sidebar
+// state/localStorage, but external automation can update this JSON file and the
+// running Desktop process will push the new ids into the renderer immediately.
+const DESKTOP_PINNED_SESSIONS_PATH = path.join(app.getPath('userData'), 'pinned-sessions.json')
 // Mirrors hermes_cli.profiles._PROFILE_ID_RE so we never hand the backend a
 // value its profile resolver would reject and exit on.
 const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
@@ -4714,6 +4718,76 @@ function writeActiveDesktopProfile(name) {
   return value || null
 }
 
+function sanitizePinnedSessionIds(value) {
+  const rawIds = Array.isArray(value)
+    ? value
+    : Array.isArray(value?.ids)
+      ? value.ids
+      : []
+  const seen = new Set()
+  const ids = []
+
+  for (const item of rawIds) {
+    const id = typeof item === 'string' ? item.trim() : ''
+
+    if (id && !seen.has(id)) {
+      seen.add(id)
+      ids.push(id)
+    }
+  }
+
+  return ids
+}
+
+function readDesktopPinnedSessions() {
+  try {
+    const raw = fs.readFileSync(DESKTOP_PINNED_SESSIONS_PATH, 'utf8')
+    return { exists: true, ids: sanitizePinnedSessionIds(JSON.parse(raw)), path: DESKTOP_PINNED_SESSIONS_PATH }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      rememberLog(`[pins] failed to read ${DESKTOP_PINNED_SESSIONS_PATH}: ${error?.message || error}`)
+    }
+
+    return { exists: false, ids: [], path: DESKTOP_PINNED_SESSIONS_PATH }
+  }
+}
+
+function writeDesktopPinnedSessions(ids) {
+  const nextIds = sanitizePinnedSessionIds(ids)
+
+  fs.mkdirSync(path.dirname(DESKTOP_PINNED_SESSIONS_PATH), { recursive: true })
+  writeFileAtomic(
+    DESKTOP_PINNED_SESSIONS_PATH,
+    JSON.stringify({ ids: nextIds, updated_at: new Date().toISOString(), source: 'desktop' }, null, 2)
+  )
+
+  return { exists: true, ids: nextIds, path: DESKTOP_PINNED_SESSIONS_PATH }
+}
+
+function broadcastPinnedSessionsChanged() {
+  const payload = readDesktopPinnedSessions()
+
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) {
+      window.webContents.send('hermes:pinnedSessions:changed', payload)
+    }
+  }
+}
+
+let pinnedSessionsWatcherStarted = false
+
+function ensurePinnedSessionsWatcher() {
+  if (pinnedSessionsWatcherStarted) return
+
+  pinnedSessionsWatcherStarted = true
+  fs.mkdirSync(path.dirname(DESKTOP_PINNED_SESSIONS_PATH), { recursive: true })
+  fs.watchFile(DESKTOP_PINNED_SESSIONS_PATH, { interval: 750 }, (curr, prev) => {
+    if (curr.mtimeMs !== prev.mtimeMs || curr.size !== prev.size) {
+      broadcastPinnedSessionsChanged()
+    }
+  })
+}
+
 // Sanitize a connection config into the renderer-facing shape. With no
 // `profile` this describes the global/default connection (the existing
 // behavior); with a `profile` it describes that profile's per-profile remote
@@ -6273,6 +6347,16 @@ ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
 })
 
 ipcMain.handle('hermes:profile:get', async () => ({ profile: readActiveDesktopProfile() }))
+ipcMain.handle('hermes:pinnedSessions:get', async () => {
+  ensurePinnedSessionsWatcher()
+  return readDesktopPinnedSessions()
+})
+ipcMain.handle('hermes:pinnedSessions:set', async (_event, ids) => {
+  ensurePinnedSessionsWatcher()
+  const result = writeDesktopPinnedSessions(ids)
+  broadcastPinnedSessionsChanged()
+  return result
+})
 ipcMain.handle('hermes:profile:set', async (_event, name) => {
   const next = writeActiveDesktopProfile(name)
 

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -45,6 +45,15 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     get: () => ipcRenderer.invoke('hermes:profile:get'),
     set: name => ipcRenderer.invoke('hermes:profile:set', name)
   },
+  pinnedSessions: {
+    get: () => ipcRenderer.invoke('hermes:pinnedSessions:get'),
+    set: ids => ipcRenderer.invoke('hermes:pinnedSessions:set', ids),
+    onChanged: callback => {
+      const listener = (_event, payload) => callback(payload)
+      ipcRenderer.on('hermes:pinnedSessions:changed', listener)
+      return () => ipcRenderer.removeListener('hermes:pinnedSessions:changed', listener)
+    }
+  },
   api: request => ipcRenderer.invoke('hermes:api', request),
   notify: payload => ipcRenderer.invoke('hermes:notify', payload),
   requestMicrophoneAccess: () => ipcRenderer.invoke('hermes:requestMicrophoneAccess'),

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -110,7 +110,8 @@ import {
   $sessionsTotal,
   $workingSessionIds,
   sessionPinId,
-  setCurrentCwd
+  setCurrentCwd,
+  sortSessionsByNumber
 } from '@/store/session'
 
 import { type AppView, ARTIFACTS_ROUTE, MESSAGING_ROUTE, SKILLS_ROUTE } from '../../routes'
@@ -476,13 +477,9 @@ export function ChatSidebar({
     [sessions, showAllProfiles, profileScope]
   )
 
-  // Agent session order is pinned to creation time (started_at), NOT activity —
-  // a new message must never float a session to the top. Position only changes
-  // for a brand-new session or an explicit manual drag (agentOrderIds).
-  const sortedSessions = useMemo(
-    () => [...visibleSessions].sort((a, b) => (b.started_at || 0) - (a.started_at || 0)),
-    [visibleSessions]
-  )
+  // Keep #number-prefixed HQ sessions in stable numeric order. Unnumbered
+  // sessions retain the shared recency fallback used by other session pickers.
+  const sortedSessions = useMemo(() => sortSessionsByNumber(visibleSessions), [visibleSessions])
 
   const workingSessionIdSet = useMemo(() => new Set(workingSessionIds), [workingSessionIds])
 

--- a/apps/desktop/src/app/command-center/index.tsx
+++ b/apps/desktop/src/app/command-center/index.tsx
@@ -14,7 +14,7 @@ import { exportSession } from '@/lib/session-export'
 import { cn } from '@/lib/utils'
 import { upsertDesktopActionTask } from '@/store/activity'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
-import { $sessions, sessionPinId } from '@/store/session'
+import { $sessions, sessionPinId, sortSessionsByNumber } from '@/store/session'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { useRouteEnumParam } from '../hooks/use-route-enum-param'
@@ -128,12 +128,7 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
   const debouncedQuery = useDebouncedValue(query.trim(), 180)
 
   const filteredSessions = useMemo(() => {
-    const sorted = [...sessions].sort((a, b) => {
-      const left = a.last_active || a.started_at || 0
-      const right = b.last_active || b.started_at || 0
-
-      return right - left
-    })
+    const sorted = sortSessionsByNumber(sessions)
 
     const needle = debouncedQuery.toLowerCase()
 

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -53,6 +53,7 @@ import {
 import { $bindings } from '@/store/keybinds'
 import { openPetGenerate } from '@/store/pet-generate'
 import { requestStartWorkSession } from '@/store/projects'
+import { sortSessionsByNumber } from '@/store/session'
 import { runGatewayRestart } from '@/store/system-actions'
 import { luminance } from '@/themes/color'
 import { type ThemeMode, useTheme } from '@/themes/context'
@@ -256,8 +257,15 @@ export function CommandPalette() {
       : []
   }, [configQuery.data])
 
-  const sessions = useMemo(() => (sessionsQuery.data?.sessions ?? []).map(toSessionEntry), [sessionsQuery.data])
-  const archivedSessions = useMemo(() => (archivedQuery.data?.sessions ?? []).map(toSessionEntry), [archivedQuery.data])
+  const sessions = useMemo(
+    () => sortSessionsByNumber(sessionsQuery.data?.sessions ?? []).map(toSessionEntry),
+    [sessionsQuery.data]
+  )
+
+  const archivedSessions = useMemo(
+    () => sortSessionsByNumber(archivedQuery.data?.sessions ?? []).map(toSessionEntry),
+    [archivedQuery.data]
+  )
 
   // Reset the query/sub-page on close so it reopens clean.
   useEffect(() => {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -62,6 +62,11 @@ declare global {
         // clear the preference.
         set: (name: string | null) => Promise<DesktopActiveProfile>
       }
+      pinnedSessions: {
+        get: () => Promise<DesktopPinnedSessions>
+        set: (ids: string[]) => Promise<DesktopPinnedSessions>
+        onChanged: (callback: (payload: DesktopPinnedSessions) => void) => () => void
+      }
       api: <T>(request: HermesApiRequest) => Promise<T>
       notify: (payload: HermesNotification) => Promise<boolean>
       requestMicrophoneAccess: () => Promise<boolean>
@@ -382,6 +387,12 @@ export interface DesktopActiveProfile {
   // The desktop's stored profile preference, or null when unset (legacy launch
   // that defers to the sticky active_profile / default).
   profile: string | null
+}
+
+export interface DesktopPinnedSessions {
+  exists: boolean
+  ids: string[]
+  path: string
 }
 
 export interface DesktopConnectionConfig {

--- a/apps/desktop/src/store/layout.test.ts
+++ b/apps/desktop/src/store/layout.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const PIN_STORAGE_KEY = 'hermes.desktop.pinnedSessions'
+
+type PinnedPayload = { exists: boolean; ids: string[]; path: string }
+
+function flushMicrotasks() {
+  return new Promise(resolve => setTimeout(resolve, 0))
+}
+
+async function loadLayoutWithPinnedBridge(snapshot: PinnedPayload = { exists: false, ids: [], path: '/tmp/pins.json' }) {
+  vi.resetModules()
+  window.localStorage.clear()
+
+  let onChanged: ((payload: PinnedPayload) => void) | null = null
+
+  const bridge = {
+    get: vi.fn().mockResolvedValue(snapshot),
+    set: vi.fn().mockResolvedValue(snapshot),
+    onChanged: vi.fn((callback: (payload: PinnedPayload) => void) => {
+      onChanged = callback
+
+      return () => {
+        onChanged = null
+      }
+    })
+  }
+
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: { pinnedSessions: bridge }
+  })
+
+  const layout = await import('./layout')
+  await flushMicrotasks()
+
+  return {
+    bridge,
+    emitPinnedSessionsChanged: (payload: PinnedPayload) => onChanged?.(payload),
+    layout
+  }
+}
+
+afterEach(() => {
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: undefined
+  })
+  window.localStorage.clear()
+  vi.resetModules()
+})
+
+describe('external pinned sessions bridge', () => {
+  it('imports an existing external pin snapshot and sanitizes duplicate ids', async () => {
+    const { bridge, layout } = await loadLayoutWithPinnedBridge({
+      exists: true,
+      ids: ['alpha', 'beta', 'alpha', '', '  gamma  '],
+      path: '/tmp/pins.json'
+    })
+
+    expect(bridge.get).toHaveBeenCalledTimes(1)
+    expect(bridge.onChanged).toHaveBeenCalledTimes(1)
+    expect(layout.$pinnedSessionIds.get()).toEqual(['alpha', 'beta', 'gamma'])
+    expect(JSON.parse(window.localStorage.getItem(PIN_STORAGE_KEY) || '[]')).toEqual(['alpha', 'beta', 'gamma'])
+    expect(bridge.set).not.toHaveBeenCalled()
+  })
+
+  it('mirrors local pin changes back to the external bridge after initial sync', async () => {
+    const { bridge, layout } = await loadLayoutWithPinnedBridge({
+      exists: true,
+      ids: ['alpha'],
+      path: '/tmp/pins.json'
+    })
+
+    bridge.set.mockClear()
+    layout.pinSession('beta')
+
+    expect(layout.$pinnedSessionIds.get()).toEqual(['alpha', 'beta'])
+    expect(bridge.set).toHaveBeenCalledWith(['alpha', 'beta'])
+  })
+
+  it('applies external change events without writing them back in a loop', async () => {
+    const { bridge, emitPinnedSessionsChanged, layout } = await loadLayoutWithPinnedBridge({
+      exists: true,
+      ids: ['alpha'],
+      path: '/tmp/pins.json'
+    })
+
+    bridge.set.mockClear()
+    emitPinnedSessionsChanged({ exists: true, ids: ['delta', 'delta', 'epsilon'], path: '/tmp/pins.json' })
+
+    expect(layout.$pinnedSessionIds.get()).toEqual(['delta', 'epsilon'])
+    expect(bridge.set).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -178,6 +178,92 @@ export function restoreWorktree(id: string): void {
   }
 }
 
+let applyingExternalPinnedSessions = false
+let externalPinnedSessionsReady = false
+let externalPinnedSessionsUnsubscribe: (() => void) | null = null
+
+function externalPinnedSessionsBridge() {
+  if (typeof window === 'undefined') {
+    return undefined
+  }
+
+  return window.hermesDesktop?.pinnedSessions
+}
+
+function normalizePinnedSessionIds(ids: unknown): string[] {
+  if (!Array.isArray(ids)) {
+    return []
+  }
+
+  const seen = new Set<string>()
+  const out: string[] = []
+
+  for (const item of ids) {
+    const id = typeof item === 'string' ? item.trim() : ''
+
+    if (id && !seen.has(id)) {
+      seen.add(id)
+      out.push(id)
+    }
+  }
+
+  return out
+}
+
+function applyExternalPinnedSessions(ids: unknown) {
+  const next = normalizePinnedSessionIds(ids)
+
+  if (arraysEqual($pinnedSessionIds.get(), next)) {
+    return
+  }
+
+  applyingExternalPinnedSessions = true
+
+  try {
+    $pinnedSessionIds.set(next)
+  } finally {
+    applyingExternalPinnedSessions = false
+  }
+}
+
+export async function syncExternalPinnedSessions(): Promise<void> {
+  const bridge = externalPinnedSessionsBridge()
+
+  if (!bridge || externalPinnedSessionsUnsubscribe) {
+    return
+  }
+
+  try {
+    const snapshot = await bridge.get()
+    externalPinnedSessionsReady = true
+
+    if (snapshot?.exists) {
+      applyExternalPinnedSessions(snapshot.ids)
+    }
+
+    externalPinnedSessionsUnsubscribe = bridge.onChanged(payload => {
+      if (payload?.exists) {
+        applyExternalPinnedSessions(payload.ids)
+      }
+    })
+  } catch {
+    // External pin sync is optional. localStorage remains the fallback.
+  }
+}
+
+$pinnedSessionIds.subscribe(ids => {
+  if (applyingExternalPinnedSessions || !externalPinnedSessionsReady) {
+    return
+  }
+
+  const bridge = externalPinnedSessionsBridge()
+
+  if (bridge) {
+    void bridge.set([...ids]).catch(() => undefined)
+  }
+})
+void syncExternalPinnedSessions()
+
 export function setSidebarWidth(width: number) {
   const bounded = Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_DEFAULT_WIDTH, width))
   setPaneWidthOverride(CHAT_SIDEBAR_PANE_ID, bounded)

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -15,6 +15,7 @@ import {
   setCurrentCwd,
   setSessionAttention,
   setSessionWorking,
+  sortSessionsByNumber,
   workspaceCwdForNewSession
 } from './session'
 
@@ -74,6 +75,19 @@ describe('sessionPinId', () => {
     // After auto-compression the entry surfaces under a fresh tip id but keeps
     // the original root — pinning on the root keeps the pin stable.
     expect(sessionPinId(session({ id: 'tip', _lineage_root_id: 'root' }))).toBe('root')
+  })
+})
+
+describe('sortSessionsByNumber', () => {
+  it('sorts #number-prefixed sessions numerically before unnumbered recents', () => {
+    const rows = [
+      session({ id: 'recent', title: '최근', last_active: 30, started_at: 30 }),
+      session({ id: 'n10', title: '#0010 열번째', last_active: 10, started_at: 10 }),
+      session({ id: 'n2', title: '#0002 두번째', last_active: 20, started_at: 20 }),
+      session({ id: 'old', title: '오래됨', last_active: 1, started_at: 1 })
+    ]
+
+    expect(sortSessionsByNumber(rows).map(s => s.id)).toEqual(['n2', 'n10', 'recent', 'old'])
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -9,6 +9,46 @@ import type { SessionInfo, UsageStats } from '@/types/hermes'
 
 type Updater<T> = T | ((current: T) => T)
 
+const SESSION_NUMBER_RE = /^#(\d+)\b/
+
+function sessionSortActivity(session: SessionInfo): number {
+  return session.last_active || session.started_at || 0
+}
+
+export function sessionTitleNumber(session: SessionInfo): number | null {
+  const title = session.title?.trim() || ''
+  const match = SESSION_NUMBER_RE.exec(title)
+
+  if (!match) {
+    return null
+  }
+
+  const parsed = Number.parseInt(match[1], 10)
+
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+export function sortSessionsByNumber(sessions: SessionInfo[]): SessionInfo[] {
+  return [...sessions].sort((a, b) => {
+    const an = sessionTitleNumber(a)
+    const bn = sessionTitleNumber(b)
+
+    if (an !== null && bn !== null && an !== bn) {
+      return an - bn
+    }
+
+    if (an !== null && bn === null) {
+      return -1
+    }
+
+    if (an === null && bn !== null) {
+      return 1
+    }
+
+    return sessionSortActivity(b) - sessionSortActivity(a)
+  })
+}
+
 const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
 
 // The composer's model/effort/fast is sticky UI state, NOT the profile default

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5439,21 +5439,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # On Windows there's no bash/setsid chain — spawn a tiny Python
         # watcher directly via sys.executable instead.  The watcher polls
-        # current_pid, waits for our exit, then runs `hermes gateway
-        # restart` with detach flags so the respawn survives the CLI
-        # that triggered the /restart command closing its console.
+        # current_pid, waits for our exit, then runs the HQ Admin Helper
+        # gateway_restart action when available.  That path cooperates with
+        # the durable Windows Scheduled Task owner and avoids the generic
+        # `hermes gateway restart` race.  Non-HQ installs fall back to the
+        # stock CLI restart command.
         if sys.platform == "win32":
             import textwrap
             from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
 
-            cmd_argv = [*hermes_cmd, "gateway", "restart"]
+            admin_invoker = _hermes_home / "scripts" / "invoke_hermes_admin_helper.ps1"
+            use_admin_helper = admin_invoker.exists()
+            if use_admin_helper:
+                cmd_argv = [
+                    "powershell.exe",
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                    str(admin_invoker),
+                    "-Action",
+                    "gateway_restart",
+                    "-TimeoutSeconds",
+                    "120",
+                ]
+            else:
+                cmd_argv = [*hermes_cmd, "gateway", "restart"]
+            fallback_argv = [*hermes_cmd, "gateway", "restart"]
             watcher = textwrap.dedent(
                 """
                 import os, subprocess, sys, time
                 from hermes_cli._subprocess_compat import windows_detach_flags_without_breakaway
                 pid = int(sys.argv[1])
                 restart_after_s = float(sys.argv[2])
-                cmd = sys.argv[3:]
+                use_admin_helper = sys.argv[3] == '1'
+                raw_args = sys.argv[4:]
+                try:
+                    split_at = raw_args.index('--fallback--')
+                    cmd = raw_args[:split_at]
+                    fallback_cmd = raw_args[split_at + 1:]
+                except ValueError:
+                    cmd = raw_args
+                    fallback_cmd = []
                 deadline = time.monotonic() + restart_after_s
 
                 def _alive(p):
@@ -5487,12 +5514,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if not _alive(pid):
                         break
                     time.sleep(0.2)
-                subprocess.Popen(
-                    cmd,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    creationflags=windows_detach_flags_without_breakaway(),
-                )
+                flags = windows_detach_flags_without_breakaway()
+
+                def _launch(command):
+                    subprocess.Popen(
+                        command,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        creationflags=flags,
+                    )
+
+                if use_admin_helper:
+                    try:
+                        completed = subprocess.run(
+                            cmd,
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL,
+                            creationflags=flags,
+                            timeout=150,
+                        )
+                        if completed.returncode == 0:
+                            sys.exit(0)
+                    except Exception:
+                        pass
+                    if fallback_cmd:
+                        _launch(fallback_cmd)
+                else:
+                    _launch(cmd)
                 """
             ).strip()
             watcher_env = os.environ.copy()
@@ -5510,7 +5558,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     pythonpath.append(watcher_env["PYTHONPATH"])
                 watcher_env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath))
             subprocess.Popen(
-                [sys.executable, "-c", watcher, str(current_pid), str(restart_after_s), *cmd_argv],
+                [
+                    sys.executable,
+                    "-c",
+                    watcher,
+                    str(current_pid),
+                    str(restart_after_s),
+                    "1" if use_admin_helper else "0",
+                    *cmd_argv,
+                    "--fallback--",
+                    *fallback_argv,
+                ],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 env=watcher_env,
@@ -5640,7 +5698,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     await self._launch_detached_restart_command()
                 except Exception as e:
                     logger.error("Failed to launch detached gateway restart helper: %s", e)
-            await asyncio.sleep(0.05)
+            await asyncio.sleep(1.5)
             await self.stop(restart=True, detached_restart=detached, service_restart=via_service)
 
         # _run_restart is a short-lived self-terminating task (calls stop()

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -177,10 +177,12 @@ def test_load_restart_drain_timeout_prefers_env_then_config_then_default(
 
 
 @pytest.mark.asyncio
-async def test_request_restart_is_idempotent():
+async def test_request_restart_is_idempotent(monkeypatch):
     runner, _adapter = make_restart_runner()
     runner.stop = AsyncMock()
     runner._launch_detached_restart_command = AsyncMock()
+    sleep = AsyncMock()
+    monkeypatch.setattr(gateway_run.asyncio, "sleep", sleep)
 
     # _run_restart is held on self._restart_task and is intentionally NOT in
     # _background_tasks, so _stop_impl's cancel loop can't abort it mid-await
@@ -193,6 +195,7 @@ async def test_request_restart_is_idempotent():
     await runner._restart_task
 
     runner._launch_detached_restart_command.assert_awaited_once_with()
+    sleep.assert_awaited_once_with(1.5)
     runner.stop.assert_awaited_once_with(
         restart=True, detached_restart=True, service_restart=False
     )
@@ -323,6 +326,7 @@ async def test_windows_detached_restart_scrubs_gateway_marker(monkeypatch, tmp_p
 
     monkeypatch.setattr(gateway_run.sys, "platform", "win32")
     monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["hermes"])
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
     monkeypatch.setenv("_HERMES_GATEWAY", "1")
     monkeypatch.setenv("VIRTUAL_ENV", str(venv_dir))
@@ -346,9 +350,55 @@ async def test_windows_detached_restart_scrubs_gateway_marker(monkeypatch, tmp_p
     assert len(popen_calls) == 1
     cmd, kwargs = popen_calls[0]
     assert cmd[-3:] == ["hermes", "gateway", "restart"]
+    assert "--fallback--" in cmd
     assert kwargs["env"].get("_HERMES_GATEWAY") is None
     assert kwargs["env"]["VIRTUAL_ENV"] == str(venv_dir)
     assert str(site_packages) in kwargs["env"]["PYTHONPATH"].split(gateway_run.os.pathsep)
+    assert kwargs["stdout"] is subprocess.DEVNULL
+    assert kwargs["stderr"] is subprocess.DEVNULL
+
+
+@pytest.mark.asyncio
+async def test_windows_detached_restart_prefers_hq_admin_helper(monkeypatch, tmp_path):
+    runner, _adapter = make_restart_runner()
+    popen_calls = []
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    admin_invoker = scripts_dir / "invoke_hermes_admin_helper.ps1"
+    admin_invoker.write_text("# test helper", encoding="utf-8")
+
+    monkeypatch.setattr(gateway_run.sys, "platform", "win32")
+    monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["hermes"])
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
+    monkeypatch.setenv("_HERMES_GATEWAY", "1")
+
+    import hermes_cli._subprocess_compat as subprocess_compat
+
+    monkeypatch.setattr(
+        subprocess_compat,
+        "windows_detach_popen_kwargs",
+        lambda: {},
+    )
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append((cmd, kwargs))
+        return MagicMock()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    await runner._launch_detached_restart_command()
+
+    assert len(popen_calls) == 1
+    cmd, kwargs = popen_calls[0]
+    assert cmd[5] == "1"
+    assert "powershell.exe" in cmd
+    assert str(admin_invoker) in cmd
+    assert cmd[cmd.index("-Action") + 1] == "gateway_restart"
+    assert cmd[cmd.index("-TimeoutSeconds") + 1] == "120"
+    fallback_at = cmd.index("--fallback--")
+    assert cmd[fallback_at + 1 : fallback_at + 4] == ["hermes", "gateway", "restart"]
+    assert kwargs["env"].get("_HERMES_GATEWAY") is None
     assert kwargs["stdout"] is subprocess.DEVNULL
     assert kwargs["stderr"] is subprocess.DEVNULL
 


### PR DESCRIPTION
## Summary

- Harden Windows detached gateway restart so HQ Admin Helper is preferred when available, with CLI fallback and preserved upstream restart timeout behavior.
- Sort numbered Desktop sessions consistently across sidebar, command center, and command palette.
- Add a file-backed Desktop pinned sessions bridge so external automation can sync pinned session IDs with the renderer/localStorage state.

## Test plan

Fresh local verification was run on the PR-ready clean worktree and active local main.

Clean worktree (`C:/Users/82109/AppData/Local/hermes/worktrees/hq-upstream-verify-20260628-222651`):

- `python -m pytest tests/gateway/test_restart_drain.py -q -n 0` → 22 passed, 2 warnings
- `python -m py_compile gateway/run.py tests/gateway/test_restart_drain.py` → passed
- `git diff --check origin/main..HEAD -- gateway/run.py tests/gateway/test_restart_drain.py` → passed
- conflict-marker check for gateway restart files → passed
- added-line security scan for gateway restart files → passed
- full `git diff --check origin/main..HEAD` → passed

Active local main (`C:/Users/82109/AppData/Local/hermes/hermes-agent`):

- `python -m pytest tests/gateway/test_restart_drain.py -q -n 0` → 21 passed, 2 warnings
- `npm --workspace apps/desktop run test:ui -- src/store/session.test.ts src/store/layout.test.ts` → 23 passed
- `npm --workspace apps/desktop run typecheck` → passed
- focused ESLint for changed Desktop files → passed
- `python -m py_compile gateway/run.py gateway/session.py tests/gateway/test_restart_drain.py` → passed
- `node --check apps/desktop/electron/main.cjs` → passed
- `node --check apps/desktop/electron/preload.cjs` → passed
- targeted `git diff --check` / conflict marker checks / added-line security scan → passed
- full `git diff --check origin/main..HEAD` → passed

## Notes

This branch was built from a clean `origin/main` worktree and keeps the recovery stack separate from the divergent local `main` state.
