### PR TITLE
fix(dashboard): exclude compression children from session stats (#54298)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7708,9 +7708,9 @@ async def get_session_stats(profile: Optional[str] = None):
     """
     db = _open_session_db_for_profile(profile)
     try:
-        total = db.session_count(include_archived=True)
-        active_store = db.session_count(include_archived=False)
-        archived = db.session_count(archived_only=True)
+        total = db.session_count(include_archived=True, exclude_children=True)
+        active_store = db.session_count(include_archived=False, exclude_children=True)
+        archived = db.session_count(archived_only=True, exclude_children=True)
         messages = db.message_count()
         by_source: Dict[str, int] = {}
         try:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -782,6 +782,52 @@ class TestWebServerEndpoints:
         messages = self.client.get("/api/sessions/worker-only/messages?profile=worker").json()
         assert [m["content"] for m in messages["messages"]] == ["worker"]
 
+    def test_session_stats_excludes_compression_children(self):
+        """Stats endpoint must exclude compression-continuation children so
+        the total matches the session list count (#54298)."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            # Build a compression chain: root → child1 → child2 → tip
+            db.create_session(session_id="comp-root", source="cli")
+            db.append_message("comp-root", role="user", content="root")
+            db.end_session("comp-root", end_reason="compression")
+
+            db.create_session(
+                session_id="comp-child1", source="cli",
+                parent_session_id="comp-root",
+            )
+            db.append_message("comp-child1", role="user", content="child1")
+            db.end_session("comp-child1", end_reason="compression")
+
+            db.create_session(
+                session_id="comp-child2", source="cli",
+                parent_session_id="comp-child1",
+            )
+            db.append_message("comp-child2", role="user", content="child2")
+            db.end_session("comp-child2", end_reason="compression")
+
+            # Live tip — the only session the list should surface
+            db.create_session(
+                session_id="comp-tip", source="cli",
+                parent_session_id="comp-child2",
+            )
+            db.append_message("comp-tip", role="user", content="tip")
+
+            # An unrelated standalone session
+            db.create_session(session_id="standalone", source="cli")
+            db.append_message("standalone", role="user", content="solo")
+        finally:
+            db.close()
+
+        stats = self.client.get("/api/sessions/stats").json()
+        # 5 rows in DB but only 2 listable: comp-tip (chain collapsed) + standalone
+        assert stats["total"] == 2, (
+            f"Expected 2 listable sessions, got {stats['total']} "
+            "(compression children not excluded)"
+        )
+
     def test_analytics_endpoints_read_requested_profile(self):
         from hermes_state import SessionDB
         from hermes_cli import profiles as profiles_mod


### PR DESCRIPTION
## What does this PR do?

The dashboard's `GET /api/sessions/stats` endpoint reported inflated `total`, `active_store`, and `archived` counts because its `session_count()` calls omitted `exclude_children=True`.  Compression-continuation child sessions were counted even though the session **list** endpoint correctly hides them via `list_sessions_rich(include_children=False)`.  The result: the Sessions page showed N rows but the "Total" stat showed N + (chain length − 1).

## Related Issue

Fixes #54298

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: Added `exclude_children=True` to all three `session_count()` calls in `get_session_stats()` (total, active_store, archived) so the stats match the session list.
- `tests/hermes_cli/test_web_server.py`: Added `test_session_stats_excludes_compression_children` — builds a 4-node compression chain (root → child1 → child2 → tip) plus a standalone session, then asserts the stats endpoint returns `total == 2` (tip + standalone), not 5.

## How to Test

1. Run `pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_session_stats_excludes_compression_children -xvs` — should pass.
2. Run the full web server test suite: `pytest tests/hermes_cli/test_web_server.py -q` — all 332+ tests should pass (verified locally).
3. Manual: create a long conversation that triggers context compression, open `hermes dashboard`, and confirm the Sessions page "Total" stat matches the number of visible session rows.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
