### PR TITLE
fix(telegram): repair model-collapsed/pre-escaped pipe tables (#53632)

### DIFF
--- a/agent/markdown_tables.py
+++ b/agent/markdown_tables.py
@@ -63,14 +63,40 @@ def _pad_to_width(s: str, target: int) -> str:
 
 
 def split_table_row(row: str) -> List[str]:
-    """Split ``| a | b | c |`` into ``["a", "b", "c"]`` with trims."""
+    """Split a GFM table row without treating escaped pipes as delimiters."""
 
-    s = row.strip()
-    if s.startswith("|"):
-        s = s[1:]
-    if s.endswith("|"):
-        s = s[:-1]
-    return [c.strip() for c in s.split("|")]
+    stripped = row.strip()
+    cells: List[str] = []
+    cell: List[str] = []
+    ended_with_delimiter = False
+
+    for char in stripped:
+        if char != "|":
+            cell.append(char)
+            ended_with_delimiter = False
+            continue
+
+        backslashes = 0
+        for previous in reversed(cell):
+            if previous != "\\":
+                break
+            backslashes += 1
+        if backslashes % 2:
+            cell.pop()
+            cell.append("|")
+            ended_with_delimiter = False
+            continue
+
+        cells.append("".join(cell).strip())
+        cell = []
+        ended_with_delimiter = True
+
+    cells.append("".join(cell).strip())
+    if stripped.startswith("|"):
+        cells.pop(0)
+    if ended_with_delimiter:
+        cells.pop()
+    return cells
 
 
 def is_table_divider(row: str) -> bool:
@@ -115,9 +141,13 @@ def _render_block(rows: List[List[str]], available_width: int | None = None) -> 
 
     ncols = max(len(r) for r in rows)
     rows = [r + [""] * (ncols - len(r)) for r in rows]
+    horizontal_rows = [
+        [cell.replace("|", r"\|") for cell in row]
+        for row in rows
+    ]
 
     widths = [
-        max(_MIN_COL_WIDTH, *(_disp_width(r[c]) for r in rows))
+        max(_MIN_COL_WIDTH, *(_disp_width(r[c]) for r in horizontal_rows))
         for c in range(ncols)
     ]
 
@@ -135,9 +165,9 @@ def _render_block(rows: List[List[str]], available_width: int | None = None) -> 
             + " |"
         )
 
-    out = [_row(rows[0])]
+    out = [_row(horizontal_rows[0])]
     out.append("|" + "|".join("-" * (w + 2) for w in widths) + "|")
-    for r in rows[1:]:
+    for r in horizontal_rows[1:]:
         out.append(_row(r))
     return out
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -509,7 +509,190 @@ from gateway.platforms.helpers import (
     TABLE_SEPARATOR_RE as _TABLE_SEPARATOR_RE,
     compile_mention_patterns,
     convert_table_to_bullets as _wrap_markdown_tables,
+    split_markdown_table_row as _split_markdown_table_row,
 )
+
+
+# A run of >= 2 GFM separator cells (``|:---|:---|``) — the fingerprint of a
+# pipe table whose rows the model collapsed onto a single physical line.
+_TABLE_SEP_RUN_RE = re.compile(r'\|(?:\s*:?-+:?\s*\|){2,}')
+_MARKDOWN_FENCE_RE = re.compile(r'^( {0,3})(`{3,}|~{3,})(.*)$')
+_INDENTED_CODE_RE = re.compile(r'^(?: {4}| {0,3}\t)')
+
+
+def _is_bounded_table_row_candidate(line: str) -> bool:
+    """Return whether a line has outer pipes, optionally escaped."""
+    stripped = line.strip()
+    first_pipe = stripped.find('|')
+    return (
+        first_pipe >= 0
+        and all(char == '\\' for char in stripped[:first_pipe])
+        and stripped.endswith('|')
+    )
+
+
+def _is_fully_preescaped_table_row(line: str) -> bool:
+    """Return whether every pipe in a bounded row has one escape."""
+    if not _is_bounded_table_row_candidate(line):
+        return False
+
+    for index, char in enumerate(line):
+        if char != '|':
+            continue
+        backslashes = 0
+        cursor = index - 1
+        while cursor >= 0 and line[cursor] == '\\':
+            backslashes += 1
+            cursor -= 1
+        # Only a single ``\|`` is unambiguously the model's pre-escaped
+        # structural delimiter. Longer runs can encode a literal backslash or
+        # an escaped pipe inside a cell, so normalizing them would guess at the
+        # row's column boundaries.
+        if backslashes != 1:
+            return False
+    return True
+
+
+def _split_collapsed_table(clean: str, n_cols: int) -> Optional[List[str]]:
+    """Re-split a single-line GFM table into ``n_cols``-wide rows.
+
+    ``clean`` is one physical line holding a whole table whose row breaks were
+    lost (``| h | h | |:--|:--| | a | b |``). Outer pipes give a leading and
+    trailing empty token and a single empty token between rows, so the cells
+    regroup deterministically even when a real cell is empty. Returns ``None``
+    (caller leaves the line alone) if the shape doesn't line up exactly.
+    """
+    parts = clean.split('|')
+    if not (parts and parts[0].strip() == '' and parts[-1].strip() == ''):
+        return None  # require outer pipes on the collapsed run
+    parts = parts[1:-1]
+    rows: List[List[str]] = []
+    i = 0
+    while i < len(parts):
+        row = parts[i:i + n_cols]
+        if len(row) != n_cols:
+            return None
+        rows.append([cell.strip() for cell in row])
+        i += n_cols
+        if i < len(parts):  # the empty token separating two rows
+            if parts[i].strip() != '':
+                return None
+            i += 1
+    if len(rows) < 3:  # header + separator + at least one data row
+        return None
+    rendered = ['| ' + ' | '.join(row) + ' |' for row in rows]
+    separators = [
+        index for index, row in enumerate(rendered)
+        if _TABLE_SEPARATOR_RE.match(row.strip())
+    ]
+    if separators != [1]:
+        return None
+    return rendered
+
+
+def _normalize_pipe_table_markdown(text: str) -> str:
+    r"""Repair pipe tables an LLM mangled before they reach Telegram.
+
+    Two model-side defects defeat GFM table detection downstream (#53632):
+
+    * **Pre-escaped bars** — a prompt that says "use Telegram MarkdownV2"
+      makes the model emit ``\| Date \| Event \|``. ``format_message`` then
+      escapes again, so Telegram shows the literal ``\|`` instead of a table.
+    * **Collapsed rows** — the model emits the whole table on one physical
+      line, so the GFM separator never sits on its own line and neither the
+      rich-render router nor the table→bullets helper recognises it.
+
+    A pre-escaped table is repaired only when every pipe is escaped exactly
+    once and its rows agree with the separator's column count. Ambiguous shapes,
+    valid GFM literal-pipe cells, prose, and code fences stay untouched.
+    Collapsed tables are additionally re-split into proper rows. The repaired
+    text then feeds the existing rich or legacy table machinery.
+    """
+    if '|' not in text:
+        return text
+
+    lines = text.split('\n')
+    out: List[str] = []
+    fence_char: Optional[str] = None
+    fence_width = 0
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        fence = _MARKDOWN_FENCE_RE.match(line)
+        if fence_char is not None:
+            out.append(line)
+            marker = fence.group(2) if fence else ''
+            if (
+                marker.startswith(fence_char)
+                and len(marker) >= fence_width
+                and not fence.group(3).strip()
+            ):
+                fence_char = None
+                fence_width = 0
+            i += 1
+            continue
+        if fence:
+            marker = fence.group(2)
+            fence_char = marker[0]
+            fence_width = len(marker)
+            out.append(line)
+            i += 1
+            continue
+        if (
+            _INDENTED_CODE_RE.match(line)
+            or not _is_bounded_table_row_candidate(line)
+        ):
+            out.append(line)
+            i += 1
+            continue
+
+        end = i + 1
+        while (
+            end < len(lines)
+            and not _INDENTED_CODE_RE.match(lines[end])
+            and _is_bounded_table_row_candidate(lines[end])
+        ):
+            end += 1
+
+        raw_candidate = lines[i:end]
+        if not all(_is_fully_preescaped_table_row(row) for row in raw_candidate):
+            out.extend(raw_candidate)
+            i = end
+            continue
+
+        if end == i + 1:
+            clean = line.replace(r'\|', '|')
+            stripped = clean.strip()
+            sep = _TABLE_SEP_RUN_RE.search(clean)
+            if sep and not _TABLE_SEPARATOR_RE.match(stripped):
+                # A separator run sharing its line with header/data cells means
+                # the rows were collapsed; re-split using its column count.
+                n_cols = len([c for c in sep.group(0).split('|') if c.strip()])
+                rows = _split_collapsed_table(clean, n_cols)
+                if rows:
+                    out.extend(rows)
+                    i = end
+                    continue
+
+        candidate = [row.replace(r'\|', '|') for row in raw_candidate]
+        separators = [
+            index for index, row in enumerate(candidate)
+            if _TABLE_SEPARATOR_RE.match(row.strip())
+        ]
+        if len(candidate) >= 3 and separators == [1]:
+            n_cols = len(_split_markdown_table_row(candidate[1]))
+            if n_cols >= 2 and all(
+                len(_split_markdown_table_row(row)) == n_cols
+                for row in candidate
+            ):
+                out.extend(candidate)
+                i = end
+                continue
+
+        out.extend(raw_candidate)
+        i = end
+
+    return '\n'.join(out)
 
 
 # ---------------------------------------------------------------------------
@@ -4447,7 +4630,12 @@ class TelegramAdapter(BasePlatformAdapter):
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
-        
+
+        # Repair pipe tables the model pre-escaped (``\|``) or collapsed onto a
+        # single line before the rich/legacy split, so both paths detect the
+        # table instead of emitting literal backslash-pipes (#53632).
+        content = _normalize_pipe_table_markdown(content)
+
         try:
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
             # sendRichMessage so tables/task lists/etc. render natively. Falls
@@ -4811,6 +4999,9 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+
+        if finalize:
+            content = _normalize_pipe_table_markdown(content)
 
         # Rich finalize (Bot API 10.1): when the completed content has
         # constructs the legacy MarkdownV2 edit degrades (tables → bullet

--- a/tests/agent/test_markdown_tables.py
+++ b/tests/agent/test_markdown_tables.py
@@ -43,6 +43,40 @@ def test_split_strips_outer_pipes_and_trims():
     assert split_table_row("a | b | c") == ["a", "b", "c"]
 
 
+def test_split_preserves_escaped_pipe_in_cell():
+    assert split_table_row(r"| a \| b | true |") == ["a | b", "true"]
+
+
+def test_split_even_backslashes_do_not_escape_separator():
+    assert split_table_row(r"| path \\| result |") == ["path \\\\", "result"]
+
+
+def test_split_uses_backslash_parity_for_pipes():
+    for count in range(1, 7):
+        backslashes = "\\" * count
+        cells = split_table_row(f"| left {backslashes}| right |")
+
+        if count % 2:
+            expected = "left " + ("\\" * (count - 1)) + "| right"
+            assert cells == [expected]
+        else:
+            assert cells == ["left " + backslashes, "right"]
+
+
+def test_realign_preserves_escaped_pipe_as_one_cell():
+    src = (
+        "| Expression | Result |\n"
+        "|------------|--------|\n"
+        r"| a \| b | true |"
+    )
+
+    out = realign_markdown_tables(src)
+
+    body = out.splitlines()[2]
+    assert r"a \| b" in body
+    assert split_table_row(body) == ["a | b", "true"]
+
+
 
 
 def test_looks_like_table_row():

--- a/tests/gateway/test_discord_format.py
+++ b/tests/gateway/test_discord_format.py
@@ -43,6 +43,16 @@ class TestDiscordFormatMessage:
         assert out.rstrip().endswith("Done.")
         assert "|---" not in out
 
+    def test_table_preserves_literal_pipe_cell(self):
+        adapter = _make_discord_adapter()
+        text = (
+            "| Expression | Result |\n"
+            "|------------|--------|\n"
+            "| a \\| b    | true   |"
+        )
+        out = adapter.format_message(text)
+        assert "**a | b**" in out
+        assert "• Result: true" in out
 
 class TestDiscordToolPreviewFormatting:
     def test_truncated_url_keeps_full_click_target(self):

--- a/tests/gateway/test_table_helpers.py
+++ b/tests/gateway/test_table_helpers.py
@@ -68,3 +68,12 @@ class TestConvertTableToBullets:
         assert "• head2: b" in out
 
 
+    def test_escaped_pipe_stays_in_one_cell(self):
+        text = (
+            "| Expression | Result |\n"
+            "|------------|--------|\n"
+            "| a \\| b    | true   |"
+        )
+        out = convert_table_to_bullets(text)
+        assert "**a | b**" in out
+        assert "• Result: true" in out

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -37,7 +37,9 @@ _ensure_telegram_mock()
 
 from plugins.platforms.telegram.adapter import (  # noqa: E402
     TelegramAdapter,
+    _TABLE_SEPARATOR_RE,
     _escape_mdv2,
+    _normalize_pipe_table_markdown,
     _strip_mdv2,
     _wrap_markdown_tables,
 )
@@ -675,3 +677,343 @@ class TestTelegramGuestMentionGating:
         message.caption_entities = [_guest_mention_entity(text)]
 
         assert adapter._should_process_message(message) is True
+
+
+# =========================================================================
+# _normalize_pipe_table_markdown — repair model-mangled pipe tables (#53632)
+# =========================================================================
+
+# The reporter's canonical payload: heading + a pipe table whose rows the model
+# both pre-escaped (``\|``) and collapsed onto a single physical line.
+_BROKEN_REPORTER_TABLE = (
+    "**\U0001f4c5 2-Week Forward Calendar (key dates only)**\n"
+    "\\| Date \\| Event \\| Category \\| Expected Impact \\| "
+    "\\|:-----\\|:------\\|:---------\\|:----------------\\| "
+    "\\| 2026-07-15 \\| Fed Beige Book \\| Macro \\| Regional growth signals \\| "
+    "\\| 2026-07-30 \\| ECB Meeting \\| Policy \\| Rate path clarification \\|"
+)
+
+_LITERAL_PIPE_TABLE = (
+    "| Expression | Result |\n"
+    "|------------|--------|\n"
+    "| a \\| b    | true   |"
+)
+
+
+class TestNormalizePipeTableMarkdown:
+    def test_collapsed_preescaped_table_is_relined(self):
+        """The reporter's single-line escaped table becomes proper GFM rows."""
+        out = _normalize_pipe_table_markdown(_BROKEN_REPORTER_TABLE)
+        lines = out.splitlines()
+        # Heading preserved verbatim.
+        assert lines[0] == "**\U0001f4c5 2-Week Forward Calendar (key dates only)**"
+        # No backslash-escaped bars survive.
+        assert "\\|" not in out
+        # Header, separator and both data rows now sit on their own lines.
+        assert "| Date | Event | Category | Expected Impact |" in lines
+        assert any(_TABLE_SEPARATOR_RE.match(line) for line in lines)
+        assert "| 2026-07-15 | Fed Beige Book | Macro | Regional growth signals |" in lines
+        assert "| 2026-07-30 | ECB Meeting | Policy | Rate path clarification |" in lines
+
+    def test_relined_table_routes_to_rich_renderer(self, adapter):
+        """Before: rich router can't see the table; after: it can."""
+        assert adapter._needs_rich_rendering(_BROKEN_REPORTER_TABLE) is False
+        repaired = _normalize_pipe_table_markdown(_BROKEN_REPORTER_TABLE)
+        assert adapter._needs_rich_rendering(repaired) is True
+
+    def test_relined_table_converts_to_bullets_on_legacy_path(self):
+        """The repaired table feeds the existing table→bullets helper cleanly."""
+        bullets = _wrap_markdown_tables(_normalize_pipe_table_markdown(_BROKEN_REPORTER_TABLE))
+        assert "\\|" not in bullets
+        assert "• Event: Fed Beige Book" in bullets
+        assert "• Category: Macro" in bullets
+
+    def test_multiline_preescaped_table_is_unescaped(self):
+        """A pre-escaped table that kept its newlines just loses the backslashes."""
+        src = (
+            "\\| Date \\| Event \\| Category \\|\n"
+            "\\|:-----\\|:------\\|:---------\\|\n"
+            "\\| 2026-07-15 \\| Fed \\| Macro \\|\n"
+            "\\| 2026-07-30 \\| ECB \\| Policy \\|"
+        )
+        out = _normalize_pipe_table_markdown(src)
+        assert "\\|" not in out
+        assert any(_TABLE_SEPARATOR_RE.match(line) for line in out.splitlines())
+
+    def test_well_formed_table_preserves_literal_pipe_escape(self):
+        assert _normalize_pipe_table_markdown(_LITERAL_PIPE_TABLE) == _LITERAL_PIPE_TABLE
+
+    def test_ambiguous_preescaped_table_is_left_untouched(self):
+        src = (
+            "\\| Expression \\| Result \\|\n"
+            "\\|------------\\|--------\\|\n"
+            "\\| a \\| b \\| true \\|"
+        )
+        assert _normalize_pipe_table_markdown(src) == src
+
+    def test_multiply_escaped_pipes_are_not_treated_as_structural(self):
+        literal_pipe = "\\" * 3 + "|"
+        src = (
+            "\\| A \\| B \\| C \\|\n"
+            "\\|---\\|---\\|---\\|\n"
+            f"\\| a {literal_pipe} b \\| true \\|"
+        )
+        assert _normalize_pipe_table_markdown(src) == src
+
+    @pytest.mark.parametrize("escape_count", [0, 2, 3, 4])
+    @pytest.mark.parametrize("ambiguous_first", [False, True])
+    def test_ambiguous_row_preserves_entire_contiguous_candidate(
+        self, ambiguous_first, escape_count
+    ):
+        literal_pipe = "\\" * escape_count + "|"
+        valid_rows = [
+            r"\| A \| B \| C \|",
+            r"\|---\|---\|---\|",
+            r"\| x \| y \| z \|",
+        ]
+        ambiguous = f"\\| a {literal_pipe} b \\| true \\|"
+        rows = [ambiguous, *valid_rows] if ambiguous_first else [*valid_rows, ambiguous]
+        src = "\n".join(rows)
+        assert _normalize_pipe_table_markdown(src) == src
+
+    @pytest.mark.parametrize("boundary_escape_count", [0, 2, 3])
+    @pytest.mark.parametrize("ambiguous_first", [False, True])
+    def test_ambiguous_outer_pipe_preserves_entire_contiguous_candidate(
+        self, ambiguous_first, boundary_escape_count
+    ):
+        boundary = "\\" * boundary_escape_count + "|"
+        valid_rows = [
+            r"\| A \| B \| C \|",
+            r"\|---\|---\|---\|",
+            r"\| x \| y \| z \|",
+        ]
+        ambiguous = f"{boundary} a \\| b \\| true {boundary}"
+        rows = [ambiguous, *valid_rows] if ambiguous_first else [*valid_rows, ambiguous]
+        src = "\n".join(rows)
+        assert _normalize_pipe_table_markdown(src) == src
+
+    @pytest.mark.parametrize(
+        ("rows", "should_normalize"),
+        [
+            (("header", "separator", "data"), True),
+            (("header", "data", "separator"), False),
+            (("separator", "header", "data"), False),
+            (("separator", "data", "header"), False),
+            (("data", "header", "separator"), False),
+            (("data", "separator", "header"), True),
+        ],
+    )
+    def test_multiline_separator_position_contract(self, rows, should_normalize):
+        escaped = {
+            "header": r"\| A \| B \|",
+            "separator": r"\|---\|---\|",
+            "data": r"\| x \| y \|",
+        }
+        src = "\n".join(escaped[row] for row in rows)
+        out = _normalize_pipe_table_markdown(src)
+
+        if should_normalize:
+            assert out == src.replace(r"\|", "|")
+        else:
+            assert out == src
+
+    def test_valid_table_shape_matrix(self):
+        for column_count in range(2, 6):
+            header = [f"H{index}" for index in range(column_count)]
+            separator = ["---"] * column_count
+            data = ["value", *([""] * (column_count - 1))]
+            clean_rows = [
+                "| " + " | ".join(row) + " |"
+                for row in (header, separator, data)
+            ]
+            escaped_rows = [row.replace("|", r"\|") for row in clean_rows]
+
+            multiline = "\n".join(escaped_rows)
+            collapsed = " ".join(escaped_rows)
+            expected = "\n".join(clean_rows)
+
+            assert _normalize_pipe_table_markdown(multiline) == expected
+            assert _normalize_pipe_table_markdown(collapsed) == expected
+            assert _normalize_pipe_table_markdown(expected) == expected
+
+    def test_invalid_row_width_preserves_entire_candidate(self):
+        valid_rows = [
+            r"\| A \| B \| C \|",
+            r"\|---\|---\|---\|",
+            r"\| x \| y \| z \|",
+        ]
+        for index, invalid_row in (
+            (0, r"\| A \| B \|"),
+            (2, r"\| x \| y \|"),
+        ):
+            rows = valid_rows.copy()
+            rows[index] = invalid_row
+            src = "\n".join(rows)
+            assert _normalize_pipe_table_markdown(src) == src
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            (
+                "~~~text\n"
+                "\\| A \\| B \\|\n"
+                "\\|---\\|---\\|\n"
+                "\\| x \\| y \\|\n"
+                "~~~"
+            ),
+            (
+                "    \\| A \\| B \\|\n"
+                "    \\|---\\|---\\|\n"
+                "    \\| x \\| y \\|"
+            ),
+            (
+                "\t\\| A \\| B \\|\n"
+                "\t\\|---\\|---\\|\n"
+                "\t\\| x \\| y \\|"
+            ),
+        ],
+    )
+    def test_preescaped_table_in_code_block_is_left_untouched(self, src):
+        assert _normalize_pipe_table_markdown(src) == src
+
+    @pytest.mark.parametrize(
+        ("opening", "closing"),
+        [
+            ("```python", "```"),
+            ("````", "`````"),
+            ("~~~text", "~~~"),
+            ("~~~~", "~~~~~   "),
+            ("````", "```"),
+            ("~~~", "```"),
+            ("```", None),
+        ],
+    )
+    def test_fence_boundaries_protect_preescaped_rows(self, opening, closing):
+        table = "\\| A \\| B \\|\n\\|---\\|---\\|\n\\| x \\| y \\|"
+        src = f"{opening}\n{table}"
+        if closing is not None:
+            src += f"\n{closing}"
+        assert _normalize_pipe_table_markdown(src) == src
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            r"\| A \| B \| \| x \| y \| \|---\|---\|",
+            r"\|---\|---\| \| A \| B \| \| x \| y \|",
+        ],
+    )
+    def test_collapsed_separator_must_be_second_row(self, src):
+        assert _normalize_pipe_table_markdown(src) == src
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            (
+                "\\| A \\| B \\|\n"
+                "\\| x \\| y \\|\n"
+                "\\|---\\|---\\|\n"
+                "\\| z \\| w \\|"
+            ),
+            (
+                "\\| A \\| B \\|\n"
+                "\\|---\\|---\\|\n"
+                "\\| x \\| y \\|\n"
+                "\\| C \\| D \\|\n"
+                "\\|---\\|---\\|\n"
+                "\\| z \\| w \\|"
+            ),
+        ],
+    )
+    def test_invalid_multiline_candidate_is_preserved_as_a_whole(self, src):
+        assert _normalize_pipe_table_markdown(src) == src
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            (
+                "\\| A \\| B \\|\n"
+                "    \\|---\\|---\\|\n"
+                "    \\| x \\| y \\|"
+            ),
+            (
+                "\\| A \\| B \\|\n"
+                "\\|---\\|---\\|\n"
+                "    \\| x \\| y \\|"
+            ),
+        ],
+    )
+    def test_candidate_scan_does_not_cross_into_indented_code(self, src):
+        assert _normalize_pipe_table_markdown(src) == src
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            (
+                "\\| A \\| B \\| \\|---\\|---\\| \\| x \\| y \\|\n"
+                "\\| C \\| D \\|\n"
+                "\\| z \\| w \\|\n"
+                "\\|---\\|---\\|"
+            ),
+            (
+                "\\| C \\| D \\|\n"
+                "\\| z \\| w \\|\n"
+                "\\|---\\|---\\|\n"
+                "\\| A \\| B \\| \\|---\\|---\\| \\| x \\| y \\|"
+            ),
+        ],
+    )
+    def test_mixed_collapsed_multiline_candidate_is_preserved_as_a_whole(self, src):
+        assert _normalize_pipe_table_markdown(src) == src
+
+    def test_idempotent(self):
+        once = _normalize_pipe_table_markdown(_BROKEN_REPORTER_TABLE)
+        twice = _normalize_pipe_table_markdown(once)
+        assert once == twice
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Today's news digest. No tables in here at all.",
+            "Compute a \\| b \\| c then compare the totals.",  # arithmetic, not a row
+            "Use the A \\| B fallback operator when needed.",  # lone inline pipe
+            "| A | B |\n|:--|:--|\n| 1 | 2 |",  # already-clean table
+            "```\n| a \\| b |\n```",  # escaped pipe inside a code fence
+            "- first\n- second\n- third",  # bullet list
+        ],
+    )
+    def test_non_table_content_is_left_untouched(self, text):
+        assert _normalize_pipe_table_markdown(text) == text
+
+
+@pytest.mark.asyncio
+async def test_legacy_send_repairs_collapsed_escaped_table(adapter):
+    """End-to-end: a cron-style broken table no longer reaches Telegram as
+    literal ``\\|`` text; the legacy path renders it as bullet groups (#53632)."""
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+    adapter._bot.send_chat_action = AsyncMock()
+    adapter._rich_send_disabled = True  # force the legacy MarkdownV2 path
+
+    result = await adapter.send("12345", _BROKEN_REPORTER_TABLE, metadata={"job_id": "daily-news"})
+
+    assert result.success is True
+    sent = "".join(call.kwargs["text"] for call in adapter._bot.send_message.await_args_list)
+    # The user-visible symptom (escaped bars) is gone; bullets render instead.
+    assert "\\|" not in _strip_mdv2(sent)
+    assert "Fed Beige Book" in _strip_mdv2(sent)
+
+
+@pytest.mark.asyncio
+async def test_legacy_send_preserves_literal_pipe_cell(adapter):
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+    adapter._bot.send_chat_action = AsyncMock()
+    adapter._rich_send_disabled = True
+
+    result = await adapter.send("12345", _LITERAL_PIPE_TABLE)
+
+    assert result.success is True
+    sent = "".join(call.kwargs["text"] for call in adapter._bot.send_message.await_args_list)
+    rendered = _strip_mdv2(sent)
+    assert "a | b" in rendered
+    assert "• Result: true" in rendered

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -33,6 +33,16 @@ TABLE_ONLY_CONTENT = (
     "| Red Sox | 36 | 34 | 6.0 |\n"
     "| Dodgers | 40 | 30 | 2.0 |"
 )
+LITERAL_PIPE_TABLE = (
+    "| Expression | Result |\n"
+    "|------------|--------|\n"
+    "| a \\| b    | true   |"
+)
+COLLAPSED_PREESCAPED_TABLE = (
+    "\\| Name \\| Status \\| "
+    "\\|------\\|--------\\| "
+    "\\| Hermes \\| Ready \\|"
+)
 DANGEROUS_DETAILS_MATH = (
     "<details><summary>Complex proof</summary>\n\n"
     "$$\\sum_{i=1}^{n} i = \\frac{n(n+1)}{2}$$\n\n"
@@ -81,6 +91,18 @@ def _rich_api_kwargs(adapter):
     call = adapter._bot.do_api_request.call_args
     assert call.args[0] == "sendRichMessage"
     return call.kwargs["api_kwargs"]
+
+
+@pytest.mark.asyncio
+async def test_rich_table_preserves_literal_pipe_escape():
+    adapter = _make_adapter()
+
+    result = await adapter.send("12345", LITERAL_PIPE_TABLE)
+
+    assert result.success is True
+    api_kwargs = _rich_api_kwargs(adapter)
+    assert api_kwargs["rich_message"]["markdown"] == LITERAL_PIPE_TABLE
+    adapter._bot.send_message.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -434,6 +456,36 @@ async def test_finalize_edit_uses_rich_for_table_content():
 
 
 @pytest.mark.asyncio
+async def test_finalize_edit_repairs_collapsed_preescaped_table():
+    adapter = _make_adapter()
+
+    result = await adapter.edit_message(
+        "12345", "555", COLLAPSED_PREESCAPED_TABLE, finalize=True,
+    )
+
+    assert result.success is True
+    api_kwargs = _rich_edit_kwargs(adapter)
+    assert api_kwargs["rich_message"]["markdown"] == (
+        "| Name | Status |\n"
+        "| ------ | -------- |\n"
+        "| Hermes | Ready |"
+    )
+
+
+@pytest.mark.asyncio
+async def test_finalize_edit_preserves_literal_pipe_escape():
+    adapter = _make_adapter()
+
+    result = await adapter.edit_message(
+        "12345", "555", LITERAL_PIPE_TABLE, finalize=True,
+    )
+
+    assert result.success is True
+    api_kwargs = _rich_edit_kwargs(adapter)
+    assert api_kwargs["rich_message"]["markdown"] == LITERAL_PIPE_TABLE
+
+
+@pytest.mark.asyncio
 async def test_legacy_edit_error_logs_redacted_bot_token_without_traceback(monkeypatch, caplog):
     import agent.redact as redact
 
@@ -553,5 +605,3 @@ async def test_rich_reply_records_and_recovers_text(monkeypatch, tmp_path):
     )
     assert event.reply_to_message_id == "678"
     assert event.reply_to_text == "Your morning briefing: CI is green."
-
-


### PR DESCRIPTION
## Summary

Repairs Telegram pipe tables that arrive with both of these model-generated defects:

- structural pipes are pre-escaped (`\| Date \| Event \|`); and
- multiple table rows are collapsed onto one physical line.

The repair runs before Telegram chooses the rich or legacy delivery path, and also runs when a streaming edit is finalized. Well-formed GFM tables, literal escaped pipes inside cells, prose, and code blocks remain unchanged.

This revision is rebased directly onto current `main` at `9712b8f0c`. It keeps the adapter-local normalization boundary and preserves main's newer shared link-formatting extraction.

## Issue status

Addresses #53632.

The reporter closed that issue after confirming the documented workaround—requesting plain GFM with one row per line and no pre-escaped structural pipes. The underlying adapter defect was not fixed by that workaround, and a later comment confirmed the same reproduction in a regular Telegram DM outside cron delivery. This PR provides the product-level fix.

## Root cause

The existing Telegram paths only recognize a GFM table when the separator is on its own line. A collapsed payload therefore bypasses both rich-table routing and the legacy table-to-bullets converter. Generic MarkdownV2 escaping then escapes the already escaped bars again, exposing literal `\|` text to the recipient.

A separate but related problem exists in the shared table realigner: `split_table_row()` uses plain `str.split("|")`, which treats a legal escaped pipe inside a cell as a column boundary.

## Fix

- Detect a contiguous, outer-pipe-bounded candidate block before deciding whether to transform it.
- Normalize only when every pipe is unambiguously escaped exactly once, the separator is uniquely in row two, and all rows have the same column count.
- Transform the whole candidate block or leave it byte-for-byte unchanged; mixed or multiply escaped shapes are never partially rewritten.
- Reconstruct collapsed rows using the separator's column count, including empty cells.
- Make `agent.markdown_tables.split_table_row()` respect Markdown backslash parity: an odd run escapes a literal pipe, while an even run leaves a structural delimiter.
- Re-escape literal pipe cell content when rendering a horizontal table.
- Protect backtick fences, tilde fences, unclosed fences, and indented code.
- Apply normalization in `TelegramAdapter.send()` and finalized `edit_message()` delivery, while leaving intermediate plain-text previews unchanged.

The repaired table feeds the existing rich renderer or legacy bullet conversion; this does not add another rendering path.

## Review feedback addressed

The original implementation unconditionally changed every `\|` inside a bounded row. In response to review, this revision separates pre-escaped structure recognition from legal escaped-pipe cell parsing and adds rich, legacy, Discord, final-edit, ambiguity, atomicity, protected-code, and backslash-parity regressions.

## Files changed

- `agent/markdown_tables.py` — escaped-pipe-aware row splitting and safe horizontal re-rendering.
- `plugins/platforms/telegram/adapter.py` — conservative table normalization before rich/legacy routing and on finalized edits.
- `tests/agent/test_markdown_tables.py` — shared parser and realigner contracts.
- `tests/gateway/test_table_helpers.py` — legacy table conversion coverage.
- `tests/gateway/test_telegram_format.py` — normalization, legacy delivery, final-edit, protected-region, ambiguity, and atomicity coverage.
- `tests/gateway/test_telegram_rich_messages.py` — rich delivery regressions.
- `tests/gateway/test_discord_format.py` — downstream escaped-pipe regression coverage.

## Validation

```text
6 focused files: 155 passed, 0 failed
ruff check: passed
git diff --check: passed
```

The focused run covers Telegram formatting and delivery, Telegram rich messages and rich-newline handling, shared markdown-table behavior, legacy table helpers, and Discord formatting.

## Risk

The normalizer is deliberately conservative. It requires a complete, structurally consistent table and performs an atomic whole-block conversion. Ambiguous escaping, inconsistent widths, misplaced or duplicate separators, valid literal-pipe cells, prose, and protected code regions are preserved unchanged.