### PR TITLE
feat(cli): add cli_queue_drained plugin hook

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -44,6 +44,7 @@ import contextlib
 import json
 import logging
 import os
+import re
 import threading
 import time
 from pathlib import Path  # noqa: F401 — used by test mocks
@@ -3353,6 +3354,10 @@ def _try_configured_fallback_chain(
 
     task_config = _get_auxiliary_task_config(task)
     chain = task_config.get("fallback_chain")
+    if not chain:
+        alias = _task_model_alias(task_config)
+        if alias is not None:
+            chain = alias.get("fallback_chain")
     if not chain or not isinstance(chain, list):
         return None, None, ""
 
@@ -4284,7 +4289,26 @@ def resolve_provider_client(
             final_model = _normalize_resolved_model(model or default_model, provider)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode else (client, final_model))
 
-        creds = resolve_api_key_provider_credentials(provider)
+        if explicit_base_url:
+            creds = {"api_key": "", "base_url": explicit_base_url, "source": "explicit_base_url"}
+            if explicit_api_key:
+                creds["api_key"] = explicit_api_key.strip()
+            else:
+                try:
+                    from hermes_cli.config import get_env_value
+                except Exception:
+                    get_env_value = None  # type: ignore[assignment]
+                for env_name in pconfig.api_key_env_vars:
+                    candidate = ""
+                    if get_env_value is not None:
+                        candidate = str(get_env_value(env_name) or "").strip()
+                    candidate = candidate or os.getenv(env_name, "").strip()
+                    if candidate:
+                        creds["api_key"] = candidate
+                        creds["source"] = f"env:{env_name}"
+                        break
+        else:
+            creds = resolve_api_key_provider_credentials(provider)
         api_key = str(creds.get("api_key", "")).strip()
         # Honour an explicit api_key override (e.g. from a fallback_model entry
         # or a custom_providers entry) so callers that pass an explicit
@@ -4848,7 +4872,7 @@ def _client_cache_key(
     # so the task participates in the cache key. Non-auto providers keep the
     # old cache shape because the explicit provider/model tuple is sufficient.
     task_key = (task or "") if provider == "auto" else ""
-    pool_hint = _pool_cache_hint(provider, main_runtime=main_runtime)
+    pool_hint = "" if (base_url or api_key) else _pool_cache_hint(provider, main_runtime=main_runtime)
     return (provider, async_mode, base_url or "", api_key or "", api_mode or "", runtime_key, is_vision, task_key, pool_hint)
 
 
@@ -5110,7 +5134,7 @@ def _get_cached_client(
     # after key #1 is marked exhausted the retry would still get key #1 from
     # the env var and fail again, causing the retry2_err handler to mark key #2.
     effective_api_key = api_key
-    if not effective_api_key:
+    if not effective_api_key and not base_url:
         _pe = _peek_pool_entry(_normalize_aux_provider(provider))
         if _pe is not None:
             _pk = _pool_runtime_api_key(_pe)
@@ -5162,6 +5186,55 @@ _AUX_DIRECT_API_BASE_URLS: Dict[str, str] = {
 }
 
 
+def _model_alias_entry(alias_name: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Return config.yaml model_aliases.<alias_name> when it is usable.
+
+    Auxiliary task configs historically accepted only concrete provider/model
+    pairs. Adam's cheap-worker aliases carry the same pair plus a fallback_chain;
+    resolving them here lets auxiliary.<task>.model: smart-cheap inherit that
+    routing without copying fallback blocks into every task/profile.
+    """
+    key = str(alias_name or "").strip().lower()
+    if not key:
+        return None
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+    except Exception:
+        return None
+    aliases = config.get("model_aliases") if isinstance(config, dict) else None
+    if not isinstance(aliases, dict):
+        return None
+    for name, entry in aliases.items():
+        if str(name or "").strip().lower() != key or not isinstance(entry, dict):
+            continue
+        provider = str(entry.get("provider") or "").strip()
+        model = str(entry.get("model") or "").strip()
+        if not provider or not model:
+            return None
+        return dict(entry)
+    return None
+
+
+def _alias_api_mode(alias: Dict[str, Any]) -> Optional[str]:
+    raw = str(alias.get("api_mode") or alias.get("transport") or "").strip()
+    if raw:
+        return raw
+    api_format = str(alias.get("api_format") or "").strip().lower()
+    if api_format in {"anthropic", "anthropic_messages"}:
+        return "anthropic_messages"
+    if api_format in {"openai", "chat_completions", "openai_chat"}:
+        return "chat_completions"
+    if api_format == "codex_responses":
+        return "codex_responses"
+    return None
+
+
+def _task_model_alias(task_config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    alias_name = task_config.get("model_alias") or task_config.get("model")
+    return _model_alias_entry(str(alias_name or "").strip())
+
+
 def _resolve_task_provider_model(
     task: str = None,
     provider: str = None,
@@ -5194,6 +5267,21 @@ def _resolve_task_provider_model(
         cfg_base_url = str(task_config.get("base_url", "")).strip() or None
         cfg_api_key = str(task_config.get("api_key", "")).strip() or None
         cfg_api_mode = str(task_config.get("api_mode", "")).strip() or None
+        # If auxiliary.<task>.model names a configured model_alias, treat the
+        # alias as the task's concrete provider/model and inherit its fallback
+        # chain. Explicit call-time provider/model args still win below. A
+        # base_url/api_mode is inherited only when the alias uses base_url;
+        # legacy alias endpoint fields can point at transport-specific final
+        # paths and are not safe to blindly reuse for auxiliary clients.
+        if not model:
+            alias = _task_model_alias(task_config)
+            if alias is not None:
+                cfg_provider = str(alias.get("provider") or cfg_provider or "").strip() or cfg_provider
+                cfg_model = str(alias.get("model") or cfg_model or "").strip() or cfg_model
+                alias_base_url = str(alias.get("base_url") or "").strip() or None
+                if alias_base_url:
+                    cfg_base_url = cfg_base_url or alias_base_url
+                    cfg_api_mode = cfg_api_mode or _alias_api_mode(alias)
 
     resolved_model = model or cfg_model
     resolved_api_mode = cfg_api_mode
@@ -5218,6 +5306,9 @@ def _resolve_task_provider_model(
         cfg_provider, cfg_base_url = _expand_direct_api_alias(cfg_provider, cfg_base_url)
 
     if base_url:
+        provider_norm = _normalize_aux_provider(provider) if provider else ""
+        if provider_norm and provider_norm != "custom":
+            return provider, resolved_model, base_url, api_key, resolved_api_mode
         return "custom", resolved_model, base_url, api_key, resolved_api_mode
     if provider:
         return provider, resolved_model, base_url, api_key, resolved_api_mode
@@ -5329,6 +5420,14 @@ def _is_anthropic_compat_endpoint(provider: str, base_url: str) -> bool:
         return True
     url_lower = (base_url or "").lower()
     return "/anthropic" in url_lower
+
+
+
+def _is_zai_vision_model(model: str) -> bool:
+    """Return True for GLM vision/multimodal model IDs that reject max_tokens."""
+    model_l = (model or "").lower()
+    return bool(re.search(r"(?:^|[/])glm-[\w.]*v(?:-|$)", model_l))
+
 
 
 def _convert_openai_images_to_anthropic(messages: list) -> list:
@@ -5453,23 +5552,18 @@ def _build_call_kwargs(
         kwargs["temperature"] = temperature
 
     if max_tokens is not None:
-        # We do NOT cap output by default. Most chat-completions providers treat
-        # an omitted max_tokens as "use the model's max output", which is what we
-        # want for auxiliary tasks (compression summaries, titles, vision, etc.) —
-        # an explicit cap only risks truncating a summary or 400-ing on providers
-        # that reject the parameter outright (e.g. GitHub Copilot / newer OpenAI
-        # GPT-5 models require max_completion_tokens, not max_tokens; ZAI vision
-        # models reject it entirely with error 1210). Omitting it sidesteps all of
-        # those wire-format quirks at once.
-        #
-        # The one exception is the Anthropic Messages wire (MiniMax and any
-        # ``/anthropic`` endpoint reached through the OpenAI SDK wrapper), where
-        # max_tokens is a MANDATORY field — omitting it is a hard 400. Keep it only
-        # there.
+        # Most chat-completions providers can omit max_tokens safely, which is
+        # useful for long auxiliary tasks. ZAI text models are the exception in
+        # practice for micro-label/classifier calls: when uncapped they can burn
+        # seconds producing hidden reasoning even for tiny prompts. Keep the cap
+        # for ZAI text models, but still omit it for ZAI vision models, which
+        # reject max_tokens with error 1210.
         _effective_base = base_url or (
             _current_custom_base_url() if provider == "custom" else ""
         )
-        if _is_anthropic_compat_endpoint(provider, _effective_base):
+        if _is_anthropic_compat_endpoint(provider, _effective_base) or (
+            provider == "zai" and not _is_zai_vision_model(model)
+        ):
             kwargs["max_tokens"] = max_tokens
 
     if tools:
@@ -5610,6 +5704,7 @@ def call_llm(
     tools: list = None,
     timeout: float = None,
     extra_body: dict = None,
+    allow_fallback: bool = True,
 ) -> Any:
     """Centralized synchronous LLM call.
 
@@ -5628,6 +5723,10 @@ def call_llm(
         tools: Tool definitions (for function calling).
         timeout: Request timeout in seconds (None = read from auxiliary.{task}.timeout config).
         extra_body: Additional request body fields.
+        allow_fallback: When False, provider/model capacity failures are raised
+            to the caller instead of falling through Hermes' auxiliary fallback
+            layers. Internal orchestrators use this when they own a narrower
+            ordered fallback chain (for example model_aliases.fast-cheap).
 
     Returns:
         Response object with .choices[0].message.content
@@ -6023,7 +6122,7 @@ def call_llm(
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
-        if should_fallback and (is_auto or is_capacity_error):
+        if allow_fallback and should_fallback and (is_auto or is_capacity_error):
             if _is_payment_error(first_err):
                 reason = "payment error"
                 # Resolve the actual provider label (resolved_provider may be

--- a/cli.py
+++ b/cli.py
@@ -3474,8 +3474,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self.tool_progress_mode = "off" if _raw_tp is False else str(_raw_tp)
         # resume_display: "full" (show history) | "minimal" (one-liner only)
         self.resume_display = CLI_CONFIG["display"].get("resume_display", "full")
-        # bell_on_complete: play terminal bell (\a) when agent finishes a response
+        # bell_on_complete: play terminal bell (\a) when the interactive input
+        # queue drains after a response. In direct/non-interactive chat() calls,
+        # it still fires at the end of that single turn.
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
+        self._defer_completion_cues_to_queue_drain = False
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", False)
         # reasoning_full: when reasoning display is on, print the post-response
@@ -10922,6 +10925,82 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         finally:
             self._voice_tts_done.set()
 
+    def _queue_has_pending_work(self) -> bool:
+        """Return True when follow-up work is already queued for this CLI session."""
+        for attr in ("_pending_input", "_interrupt_queue"):
+            q = getattr(self, attr, None)
+            if q is None:
+                continue
+            try:
+                if not q.empty():
+                    return True
+            except Exception:
+                # Be conservative: if queue state cannot be inspected, do not
+                # emit a completion cue that might claim a batch is finished.
+                return True
+        return False
+
+    def _emit_cli_queue_drained_hook(
+        self,
+        *,
+        user_input: Any = None,
+        response: Optional[str] = None,
+        bell_emitted: bool = False,
+    ) -> bool:
+        """Emit the generic classic-CLI queue-drained lifecycle hook.
+
+        This is intentionally generic: core only detects that the interactive CLI
+        has finished a successful turn and both user-input queues are empty.
+        Plugins own concrete side effects such as desktop alerts, telemetry,
+        shell notifications, or other post-turn integrations.
+        """
+        try:
+            from hermes_cli.plugins import _ensure_plugins_discovered, has_hook, invoke_hook
+
+            _ensure_plugins_discovered()
+            if not has_hook("cli_queue_drained"):
+                return False
+            invoke_hook(
+                "cli_queue_drained",
+                cli=self,
+                agent=getattr(self, "agent", None),
+                session_id=getattr(self, "session_id", None),
+                platform=getattr(self, "platform", None) or "cli",
+                user_input=user_input,
+                response=response,
+                queued_work_drained=True,
+                bell_emitted=bool(bell_emitted),
+                interrupted=bool(getattr(self, "_last_turn_interrupted", False)),
+                timestamp=time.time(),
+            )
+            return True
+        except Exception as exc:
+            logger.debug("cli_queue_drained hook dispatch failed: %s", exc)
+            return False
+
+    def _emit_completion_cues_if_idle(self, *, user_input: Any = None, response: Optional[str] = None) -> bool:
+        """Emit terminal bell and cli_queue_drained hook only after queued work drains."""
+        if self._queue_has_pending_work():
+            return False
+        if getattr(self, "_last_turn_interrupted", False):
+            return False
+        if not response or (isinstance(response, str) and response.strip().lower().startswith("error:")):
+            return False
+
+        emitted = False
+        bell_emitted = False
+        if getattr(self, "bell_on_complete", False):
+            sys.stdout.write("\a")
+            sys.stdout.flush()
+            emitted = True
+            bell_emitted = True
+
+        hook_emitted = self._emit_cli_queue_drained_hook(
+            user_input=user_input,
+            response=response,
+            bell_emitted=bell_emitted,
+        )
+        return emitted or hook_emitted
 
     def _voice_beeps_enabled(self) -> bool:
         """Return whether CLI voice mode should play record start/stop beeps."""
@@ -12116,12 +12195,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     ))
 
 
-            # Play terminal bell when agent finishes (if enabled).
-            # Works over SSH — the bell propagates to the user's terminal.
-            if self.bell_on_complete:
-                sys.stdout.write("\a")
-                sys.stdout.flush()
-
             # Notify when iteration budget was hit
             if result and not result.get("completed") and not result.get("interrupted"):
                 _api_calls = result.get("api_calls", 0)
@@ -12169,6 +12242,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 preview = _leftover_steer[:60] + ("..." if len(_leftover_steer) > 60 else "")
                 print(f"\n⏩ Delivering leftover /steer as next turn: '{preview}'")
                 self._pending_input.put(_leftover_steer)
+
+            if not getattr(self, "_defer_completion_cues_to_queue_drain", False):
+                self._emit_completion_cues_if_idle(user_input=message, response=response)
 
             return response
             
@@ -14689,8 +14765,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     self._pet_reasoning = False
                     app.invalidate()  # Refresh status line
 
+                    response = None
+                    self._defer_completion_cues_to_queue_drain = True
                     try:
-                        self.chat(user_input, images=submit_images or None)
+                        response = self.chat(user_input, images=submit_images or None)
                     finally:
                         self._agent_running = False
                         self._spinner_text = ""
@@ -14737,6 +14815,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                                 self._pending_input.put(_synth)
                         except Exception:
                             pass  # Non-fatal — don't break the main loop
+
+                        self._defer_completion_cues_to_queue_drain = False
+                        self._emit_completion_cues_if_idle(user_input=user_input, response=response)
 
                 except Exception as e:
                     logger.warning("process_loop unhandled error (msg may be lost): %s", e)

--- a/cli.py
+++ b/cli.py
@@ -15338,6 +15338,11 @@ def main(
     
     # Handle query shorthand
     query = query or q
+    # Non-interactive one-shot runs are auxiliary/subagent-like evidence. They
+    # should be distinguishable from human main sessions in state.db so commit
+    # synthesis/capsule systems can exclude them without title heuristics.
+    if query is not None and not os.environ.get("HERMES_SESSION_SOURCE"):
+        os.environ["HERMES_SESSION_SOURCE"] = "cli_oneshot"
     
     # Parse toolsets - handle both string and tuple/list inputs
     # Default to hermes-cli toolset which includes cronjob management tools

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4245,17 +4245,57 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return []
 
     @staticmethod
+    def _load_gateway_context_files() -> str:
+        """Load gateway-only context files as ephemeral system context.
+
+        These files are the gateway analogue of SOUL.md/MEMORY.md: they apply
+        only to messaging gateway sessions and must never be appended to the
+        user's message.  Keeping them on the ephemeral-system rail prevents
+        short gateway turns like "." or "ok" from being semantically dominated
+        by operational policy text.
+        """
+        blocks: list[str] = []
+        gateway_context_dir = _hermes_home / "gateway"
+        for filename in ("SOUL.gateway.md", "MEMORY.gateway.md"):
+            path = gateway_context_dir / filename
+            try:
+                if not path.exists() or not path.is_file():
+                    continue
+                content = path.read_text(encoding="utf-8").strip()
+            except Exception as exc:
+                logger.warning("Failed to load gateway context file %s: %s", path, exc)
+                continue
+            if content:
+                blocks.append(f"## {filename}\n{content}")
+
+        if not blocks:
+            return ""
+
+        header = (
+            "[Gateway-only context files - system context for messaging gateway "
+            "turns, not the user's current request. Do not acknowledge these "
+            "files unless Adam asks about them.]"
+        )
+        return f"{header}\n\n" + "\n\n".join(blocks)
+
+    @staticmethod
     def _load_ephemeral_system_prompt() -> str:
-        """Load ephemeral system prompt from config or env var.
+        """Load ephemeral system prompt from config/env plus gateway context files.
         
-        Checks HERMES_EPHEMERAL_SYSTEM_PROMPT env var first, then falls back to
-        agent.system_prompt in ~/.hermes/config.yaml.
+        HERMES_EPHEMERAL_SYSTEM_PROMPT still overrides agent.system_prompt from
+        config.yaml, preserving the existing user-configured prompt precedence.
+        Gateway context files are additive and remain on the system/context rail.
         """
         prompt = os.getenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "")
-        if prompt:
-            return prompt
-        cfg = _load_gateway_runtime_config()
-        return str(cfg_get(cfg, "agent", "system_prompt", default="") or "").strip()
+        if not prompt:
+            cfg = _load_gateway_runtime_config()
+            prompt = str(cfg_get(cfg, "agent", "system_prompt", default="") or "")
+
+        parts = [prompt.strip()] if str(prompt or "").strip() else []
+        gateway_context = GatewayRunner._load_gateway_context_files()
+        if gateway_context:
+            parts.append(gateway_context)
+        return "\n\n".join(parts).strip()
 
     @staticmethod
     def _load_reasoning_config() -> dict | None:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1633,6 +1633,28 @@ DEFAULT_CONFIG = {
         # dashboard. Set false to suppress the hint.
         "tui_agents_nudge": True,
         "bell_on_complete": False,
+        # Optional classic-CLI voice cue emitted only after the input queue is
+        # fully drained.  Disabled by default.  `source=llm` may use a configured
+        # cheap/fast model alias for a semantic task-locator label, then route
+        # the cue through completion-specific TTS modes without changing global
+        # `tts.provider`.
+        "completion_voice": {
+            "enabled": False,
+            "source": "prompt",       # prompt | session_title | fixed | llm
+            "label": "",              # Exact text when source=fixed, or override when set
+            "suffix": "",
+            "max_words": 7,
+            "fallback_source": "prompt",
+            "model_alias": "",
+            "llm_timeout": 4,
+            "llm_max_input_chars": 4000,
+            "llm_extra_body": {},
+            "telemetry": True,
+            "suppress_when_voice_tts": True,
+            "tts_mode": "",           # active key under tts_modes; empty = global tts.provider
+            "tts_provider": "",       # optional direct provider override when not using tts_modes
+            "tts_modes": {},
+        },
         "show_reasoning": False,
         # When reasoning display is on, the post-response "Reasoning" recap box
         # collapses long thinking to the first 10 lines. Set true to print the

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -145,6 +145,14 @@ VALID_HOOKS: Set[str] = {
     "on_session_reset",
     "subagent_start",
     "subagent_stop",
+    # Classic CLI queue-drained lifecycle hook. Fired after a CLI turn finishes
+    # successfully AND both the pending-input and interrupt queues are empty.
+    # Observer plugins can use this for local desktop notifications, telemetry,
+    # shell integrations, or other post-turn side effects without coupling
+    # user-specific behavior to cli.py. Common kwargs: cli, agent, session_id,
+    # platform="cli", user_input, response, queued_work_drained=True,
+    # bell_emitted, interrupted, timestamp.
+    "cli_queue_drained",
     # Gateway pre-dispatch hook. Fired once per incoming MessageEvent
     # after the internal-event guard but BEFORE auth/pairing and agent
     # dispatch. Plugins may return a dict to influence flow:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1898,7 +1898,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1915,7 +1914,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1932,7 +1930,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1949,7 +1946,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1966,7 +1962,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1983,7 +1978,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2000,7 +1994,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2017,7 +2010,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2034,7 +2026,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2051,7 +2042,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2068,7 +2058,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2085,7 +2074,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2102,7 +2090,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2119,7 +2106,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2136,7 +2122,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2153,7 +2138,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2170,7 +2154,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2187,7 +2170,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2204,7 +2186,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2221,7 +2202,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2238,7 +2218,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2255,7 +2234,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2272,7 +2250,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2289,7 +2266,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2306,7 +2282,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2323,7 +2298,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -24,6 +24,7 @@ import hashlib
 import hmac
 import logging
 import os
+import re
 import urllib.parse
 from typing import Any, Dict, Optional
 

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -288,6 +288,7 @@ def _file_content_hash(path: Path) -> str:
         return ""
 
 
+
 def check_whatsapp_requirements() -> bool:
     """
     Check if WhatsApp dependencies are available.
@@ -1067,6 +1068,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         for msg_data in messages:
                             event = await self._build_message_event(msg_data)
                             if event:
+                                if msg_data.get("agentDispatchAllowed") is False:
+                                    await self._handle_ingest_only_event(event)
+                                    continue
                                 if event.message_type == MessageType.TEXT:
                                     self._enqueue_text_event(event)
                                 else:
@@ -1082,6 +1086,43 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 await asyncio.sleep(5)
             
             await asyncio.sleep(1)  # Poll interval
+
+    async def _handle_ingest_only_event(self, event: MessageEvent) -> None:
+        """Expose a WhatsApp event to plugins, then drop it fail-closed.
+
+        The Node bridge marks non-allowlisted bot-mode senders with
+        ``agentDispatchAllowed=false`` when
+        ``WHATSAPP_FORWARD_UNAUTHORIZED_EVENTS`` is enabled. Those events are
+        useful for business inbox ingestion, but must never enter normal agent
+        dispatch if the business plugin is disabled or buggy.
+        """
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+
+            results = _invoke_hook(
+                "pre_gateway_dispatch",
+                event=event,
+                gateway=None,
+                session_store=None,
+            )
+            handled = any(
+                isinstance(result, dict) and result.get("action") == "skip"
+                for result in results
+            )
+            if not handled:
+                logger.info(
+                    "[%s] Dropped WhatsApp ingest-only event without plugin handler: chat=%s user=%s",
+                    self.name,
+                    getattr(event.source, "chat_id", None),
+                    getattr(event.source, "user_id", None),
+                )
+        except Exception as exc:
+            logger.warning(
+                "[%s] WhatsApp ingest-only plugin hook failed; dropping event fail-closed: %s",
+                self.name,
+                exc,
+                exc_info=True,
+            )
 
     # ── Text debounce batching ──────────────────────────────────────
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -44,6 +44,12 @@ const WHATSAPP_DEBUG =
   typeof process.env.WHATSAPP_DEBUG === 'string' &&
   ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_DEBUG.toLowerCase());
 
+function envFlag(name, defaultVal = false) {
+  const raw = process.env[name];
+  if (raw === undefined || raw === null || String(raw).trim() === '') return defaultVal;
+  return ['1', 'true', 'yes', 'on'].includes(String(raw).trim().toLowerCase());
+}
+
 const PORT = parseInt(getArg('port', '3000'), 10);
 const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session'));
 // Cache directories: the Python gateway passes the profile-aware paths via
@@ -71,6 +77,7 @@ try {
 const PAIR_ONLY = args.includes('--pair-only');
 const WHATSAPP_MODE = getArg('mode', process.env.WHATSAPP_MODE || 'self-chat'); // "bot" or "self-chat"
 const ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_ALLOWED_USERS || '');
+const FORWARD_UNAUTHORIZED_EVENTS = envFlag('WHATSAPP_FORWARD_UNAUTHORIZED_EVENTS', false);
 const DEFAULT_REPLY_PREFIX = '⚕ *Hermes Agent*\n────────────\n';
 const REPLY_PREFIX = process.env.WHATSAPP_REPLY_PREFIX === undefined
   ? DEFAULT_REPLY_PREFIX
@@ -304,11 +311,17 @@ async function startSocket() {
         if (!isSelfChat) continue;
       }
 
+      let agentDispatchAllowed = true;
+      let ingestReason = null;
+
       // Handle !fromMe messages (from other people) based on mode.
       // Self-chat mode only responds to the user's own messages to
       // themselves — stranger DMs / group pings must never reach the
       // Python gateway, otherwise a pairing-code reply fires in response
-      // to arbitrary incoming messages (#8389).
+      // to arbitrary incoming messages (#8389).  Bot mode may optionally
+      // forward unauthorized messages as read-only business-ingest events;
+      // those events carry agentDispatchAllowed=false and must be dropped
+      // before normal agent dispatch by the Python adapter.
       if (!msg.key.fromMe) {
         if (WHATSAPP_MODE === 'self-chat') {
           try {
@@ -322,15 +335,28 @@ async function startSocket() {
           continue;
         }
         if (!matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
-          try {
-            console.log(JSON.stringify({
-              event: 'ignored',
-              reason: 'allowlist_mismatch',
-              chatId,
-              senderId,
-            }));
-          } catch {}
-          continue;
+          if (WHATSAPP_MODE === 'bot' && FORWARD_UNAUTHORIZED_EVENTS) {
+            agentDispatchAllowed = false;
+            ingestReason = 'allowlist_mismatch';
+            try {
+              console.log(JSON.stringify({
+                event: 'business_ingest_only',
+                reason: ingestReason,
+                chatId,
+                senderId,
+              }));
+            } catch {}
+          } else {
+            try {
+              console.log(JSON.stringify({
+                event: 'ignored',
+                reason: 'allowlist_mismatch',
+                chatId,
+                senderId,
+              }));
+            } catch {}
+            continue;
+          }
         }
       }
 
@@ -458,6 +484,8 @@ async function startSocket() {
         hasQuotedMessage,
         botIds,
         timestamp: msg.messageTimestamp,
+        agentDispatchAllowed,
+        ingestReason,
       };
 
       messageQueue.push(event);
@@ -743,6 +771,9 @@ if (PAIR_ONLY) {
       console.log(`🔒 No WHATSAPP_ALLOWED_USERS set — incoming messages are rejected.`);
       console.log(`   Set WHATSAPP_ALLOWED_USERS=<phone> to authorize specific users,`);
       console.log(`   or WHATSAPP_ALLOWED_USERS=* for an explicit open bot.`);
+    }
+    if (WHATSAPP_MODE === 'bot' && FORWARD_UNAUTHORIZED_EVENTS) {
+      console.log(`📥 Unauthorized inbound messages are forwarded as ingest-only events.`);
     }
     console.log();
     startSocket();

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -111,8 +111,9 @@ class TestBuildCallKwargsMaxTokens:
     Most chat-completions providers treat an omitted max_tokens as "use the
     model max", which is what we want for auxiliary tasks. An explicit cap only
     risks truncation or a wire-format 400 (GitHub Copilot / GPT-5 reject
-    max_tokens; ZAI vision rejects it entirely). The Anthropic Messages wire is
-    the one exception — max_tokens is a mandatory field there.
+    max_tokens; ZAI vision rejects it entirely). Exceptions: the Anthropic
+    Messages wire requires max_tokens, and ZAI text models need the cap for
+    low-latency micro-label/classifier calls.
     """
 
     @pytest.mark.parametrize(
@@ -159,6 +160,134 @@ class TestBuildCallKwargsMaxTokens:
         )
         assert kwargs["max_tokens"] == 1234
         assert "max_completion_tokens" not in kwargs
+
+    def test_keeps_max_tokens_on_zai_text_models_for_fast_micro_calls(self):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="zai",
+            model="glm-5.1",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=1234,
+            base_url="https://api.z.ai/api/coding/paas/v4",
+        )
+        assert kwargs["max_tokens"] == 1234
+        assert "max_completion_tokens" not in kwargs
+
+    def test_omits_max_tokens_on_zai_vision_models(self):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="zai",
+            model="glm-5v-turbo",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=1234,
+            base_url="https://api.z.ai/api/paas/v4",
+        )
+        assert "max_tokens" not in kwargs
+        assert "max_completion_tokens" not in kwargs
+
+    def test_task_model_alias_resolves_for_auxiliary_and_supplies_fallback_chain(self, monkeypatch):
+        import agent.auxiliary_client as aux
+
+        cfg = {
+            "auxiliary": {
+                "title_generation": {
+                    "provider": "zai",
+                    "model": "smart-cheap",
+                }
+            },
+            "model_aliases": {
+                "smart-cheap": {
+                    "provider": "zai",
+                    "model": "glm-5.2",
+                    "fallback_chain": [
+                        {
+                            "provider": "openai-codex",
+                            "model": "gpt-5.4",
+                            "api_mode": "codex_responses",
+                        }
+                    ],
+                }
+            },
+        }
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+        provider, model, base_url, api_key, api_mode = aux._resolve_task_provider_model("title_generation")
+        assert provider == "zai"
+        assert model == "glm-5.2"
+        assert base_url is None
+        assert api_key is None
+        assert api_mode is None
+
+        sentinel = object()
+        monkeypatch.setattr(aux, "_resolve_fallback_entry", lambda entry: (sentinel, entry["model"]))
+        client, resolved_model, label = aux._try_configured_fallback_chain(
+            "title_generation",
+            "zai",
+            reason="rate limit",
+        )
+        assert client is sentinel
+        assert resolved_model == "gpt-5.4"
+        assert label == "fallback_chain[0](openai-codex)"
+
+    def test_explicit_known_provider_base_url_preserves_provider_identity(self):
+        from agent.auxiliary_client import _resolve_task_provider_model
+
+        provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            provider="zai",
+            model="glm-5.1",
+            base_url="https://api.z.ai/api/coding/paas/v4",
+        )
+
+        assert provider == "zai"
+        assert model == "glm-5.1"
+        assert base_url == "https://api.z.ai/api/coding/paas/v4"
+        assert api_key is None
+        assert api_mode is None
+
+    def test_explicit_provider_base_url_skips_pool_endpoint_probe(self, monkeypatch):
+        import agent.auxiliary_client as aux
+
+        with aux._client_cache_lock:
+            aux._client_cache.clear()
+
+        sentinel_client = SimpleNamespace(base_url="https://api.z.ai/api/coding/paas/v4")
+
+        def fail_pool_peek(provider):
+            raise AssertionError("explicit base_url should not peek credential pool")
+
+        def fake_resolve_provider_client(
+            provider,
+            model=None,
+            async_mode=False,
+            raw_codex=False,
+            explicit_base_url=None,
+            explicit_api_key=None,
+            api_mode=None,
+            main_runtime=None,
+            is_vision=False,
+            task=None,
+        ):
+            assert provider == "zai"
+            assert model == "glm-5.1"
+            assert explicit_base_url == "https://api.z.ai/api/coding/paas/v4"
+            assert explicit_api_key is None
+            return sentinel_client, "glm-5.1"
+
+        monkeypatch.setattr(aux, "_peek_pool_entry", fail_pool_peek)
+        monkeypatch.setattr(aux, "resolve_provider_client", fake_resolve_provider_client)
+
+        try:
+            client, model = aux._get_cached_client(
+                "zai",
+                "glm-5.1",
+                base_url="https://api.z.ai/api/coding/paas/v4",
+            )
+            assert client is sentinel_client
+            assert model == "glm-5.1"
+        finally:
+            with aux._client_cache_lock:
+                aux._client_cache.clear()
 
 
 class TestNousTagsScoping:

--- a/tests/cli/test_cli_queue_drained_hook.py
+++ b/tests/cli/test_cli_queue_drained_hook.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import io
+import queue
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from hermes_cli.plugins import VALID_HOOKS
+
+
+def _make_cli_for_queue_drained():
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._pending_input = queue.Queue()
+    cli._interrupt_queue = queue.Queue()
+    cli._last_turn_interrupted = False
+    cli.bell_on_complete = False
+    cli.agent = SimpleNamespace(session_id="agent-session")
+    cli.session_id = "cli-session"
+    cli.platform = "cli"
+    return cli
+
+
+def test_cli_queue_drained_hook_is_registered():
+    assert "cli_queue_drained" in VALID_HOOKS
+
+
+def test_queue_drained_hook_waits_for_pending_queue(monkeypatch):
+    cli = _make_cli_for_queue_drained()
+    cli.bell_on_complete = True
+    cli._pending_input.put("next queued turn")
+
+    stdout = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stdout)
+
+    with patch.object(cli, "_emit_cli_queue_drained_hook") as emit_hook:
+        emitted = cli._emit_completion_cues_if_idle(
+            user_input="first turn",
+            response="finished",
+        )
+
+    assert emitted is False
+    assert stdout.getvalue() == ""
+    emit_hook.assert_not_called()
+
+
+def test_queue_drained_hook_emits_bell_and_payload_when_idle(monkeypatch):
+    cli = _make_cli_for_queue_drained()
+    cli.bell_on_complete = True
+
+    stdout = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stdout)
+
+    emitted_payloads = []
+
+    def fake_invoke_hook(name, **kwargs):
+        emitted_payloads.append((name, kwargs))
+        return [{"started": True}]
+
+    monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda *a, **kw: None)
+    monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: name == "cli_queue_drained")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+
+    emitted = cli._emit_completion_cues_if_idle(
+        user_input="Implement queue drained hook",
+        response="finished",
+    )
+
+    assert emitted is True
+    assert stdout.getvalue() == "\a"
+    assert len(emitted_payloads) == 1
+    name, payload = emitted_payloads[0]
+    assert name == "cli_queue_drained"
+    assert payload["cli"] is cli
+    assert payload["agent"] is cli.agent
+    assert payload["session_id"] == "cli-session"
+    assert payload["platform"] == "cli"
+    assert payload["user_input"] == "Implement queue drained hook"
+    assert payload["response"] == "finished"
+    assert payload["queued_work_drained"] is True
+    assert payload["bell_emitted"] is True
+    assert payload["interrupted"] is False
+    assert isinstance(payload["timestamp"], float)
+
+
+def test_queue_drained_hook_can_emit_without_bell(monkeypatch):
+    cli = _make_cli_for_queue_drained()
+    cli.bell_on_complete = False
+
+    stdout = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stdout)
+
+    monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda *a, **kw: None)
+    monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: name == "cli_queue_drained")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda name, **kwargs: [{"started": True}])
+
+    emitted = cli._emit_completion_cues_if_idle(
+        user_input="Run tests",
+        response="finished",
+    )
+
+    assert emitted is True
+    assert stdout.getvalue() == ""
+
+
+def test_queue_drained_hook_suppressed_for_interrupted_turn(monkeypatch):
+    cli = _make_cli_for_queue_drained()
+    cli._last_turn_interrupted = True
+
+    stdout = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stdout)
+
+    with patch.object(cli, "_emit_cli_queue_drained_hook") as emit_hook:
+        emitted = cli._emit_completion_cues_if_idle(
+            user_input="run tests",
+            response="finished",
+        )
+
+    assert emitted is False
+    assert stdout.getvalue() == ""
+    emit_hook.assert_not_called()
+
+
+def test_queue_drained_hook_suppressed_for_empty_or_error_response(monkeypatch):
+    cli = _make_cli_for_queue_drained()
+    stdout = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stdout)
+
+    with patch.object(cli, "_emit_cli_queue_drained_hook") as emit_hook:
+        assert cli._emit_completion_cues_if_idle(user_input="x", response="") is False
+        assert cli._emit_completion_cues_if_idle(user_input="x", response="Error: failed") is False
+
+    assert stdout.getvalue() == ""
+    emit_hook.assert_not_called()

--- a/tests/gateway/test_gateway_context_files.py
+++ b/tests/gateway/test_gateway_context_files.py
@@ -1,0 +1,76 @@
+"""Gateway-only context file loading.
+
+Regression coverage for Adam/NOVA gateway policies: durable gateway guidance must
+ride the ephemeral system/context rail, never the pre_llm_call user-message rail.
+"""
+
+
+def test_gateway_context_files_are_loaded_from_hermes_home(tmp_path, monkeypatch):
+    from gateway import run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    gateway_dir = tmp_path / "gateway"
+    gateway_dir.mkdir()
+    (gateway_dir / "SOUL.gateway.md").write_text("soul gateway rule", encoding="utf-8")
+    (gateway_dir / "MEMORY.gateway.md").write_text("gateway memory fact", encoding="utf-8")
+
+    prompt = gateway_run.GatewayRunner._load_gateway_context_files()
+
+    assert "Gateway-only context files" in prompt
+    assert "not the user's current request" in prompt
+    assert "## SOUL.gateway.md" in prompt
+    assert "soul gateway rule" in prompt
+    assert "## MEMORY.gateway.md" in prompt
+    assert "gateway memory fact" in prompt
+
+
+def test_gateway_context_files_ignore_missing_and_blank_files(tmp_path, monkeypatch):
+    from gateway import run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    gateway_dir = tmp_path / "gateway"
+    gateway_dir.mkdir()
+    (gateway_dir / "SOUL.gateway.md").write_text("   \n", encoding="utf-8")
+
+    assert gateway_run.GatewayRunner._load_gateway_context_files() == ""
+
+
+def test_ephemeral_prompt_appends_gateway_context_to_config_prompt(tmp_path, monkeypatch):
+    from gateway import run as gateway_run
+
+    monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_runtime_config",
+        lambda: {"agent": {"system_prompt": "base gateway prompt"}},
+    )
+    gateway_dir = tmp_path / "gateway"
+    gateway_dir.mkdir()
+    (gateway_dir / "SOUL.gateway.md").write_text("file-only gateway policy", encoding="utf-8")
+
+    prompt = gateway_run.GatewayRunner._load_ephemeral_system_prompt()
+
+    assert prompt.startswith("base gateway prompt")
+    assert "file-only gateway policy" in prompt
+
+
+def test_env_ephemeral_prompt_overrides_config_but_keeps_gateway_context(tmp_path, monkeypatch):
+    from gateway import run as gateway_run
+
+    monkeypatch.setenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "env gateway prompt")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_runtime_config",
+        lambda: {"agent": {"system_prompt": "config prompt should not appear"}},
+    )
+    gateway_dir = tmp_path / "gateway"
+    gateway_dir.mkdir()
+    (gateway_dir / "MEMORY.gateway.md").write_text("gateway memory rail", encoding="utf-8")
+
+    prompt = gateway_run.GatewayRunner._load_ephemeral_system_prompt()
+
+    assert prompt.startswith("env gateway prompt")
+    assert "config prompt should not appear" not in prompt
+    assert "gateway memory rail" in prompt

--- a/tests/gateway/test_whatsapp_business_ingest.py
+++ b/tests/gateway/test_whatsapp_business_ingest.py
@@ -1,0 +1,109 @@
+import asyncio
+from types import SimpleNamespace
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+
+def _event(
+    *,
+    text="hello",
+    message_type=MessageType.TEXT,
+    raw_message=None,
+    media_urls=None,
+    media_types=None,
+):
+    media_urls = list(media_urls or [])
+    media_types = list(media_types or [])
+    raw = {"agentDispatchAllowed": False}
+    if raw_message:
+        raw.update(raw_message)
+    source = SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id="48500111222@s.whatsapp.net",
+        chat_type="dm",
+        user_id="48500111222@s.whatsapp.net",
+        user_name="Customer",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=message_type,
+        source=source,
+        raw_message=raw,
+        message_id=raw.get("messageId", "MSG1"),
+        media_urls=media_urls,
+        media_types=media_types,
+    )
+
+
+def test_ingest_only_handler_invokes_pre_gateway_dispatch_and_drops(monkeypatch):
+    adapter = object.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    calls = []
+
+    def fake_invoke_hook(name, **kwargs):
+        calls.append((name, kwargs))
+        return [{"action": "skip", "reason": "whatsapp_business_ingested"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+
+    asyncio.run(adapter._handle_ingest_only_event(_event()))
+
+    assert len(calls) == 1
+    name, kwargs = calls[0]
+    assert name == "pre_gateway_dispatch"
+    assert kwargs["event"].raw_message["agentDispatchAllowed"] is False
+    assert kwargs["gateway"] is None
+    assert kwargs["session_store"] is None
+
+
+def test_ingest_only_media_event_passes_media_to_business_hook_and_drops(monkeypatch):
+    adapter = object.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    calls = []
+    media_path = "/home/adamf/.hermes/cache/images/customer.jpg"
+
+    def fake_invoke_hook(name, **kwargs):
+        calls.append((name, kwargs))
+        return [{"action": "skip", "reason": "whatsapp_business_ingested"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+
+    event = _event(
+        text="[image received]",
+        message_type=MessageType.PHOTO,
+        raw_message={
+            "agentDispatchAllowed": False,
+            "messageId": "MEDIA1",
+            "hasMedia": True,
+            "mediaType": "image",
+            "mediaUrls": [media_path],
+        },
+        media_urls=[media_path],
+        media_types=["image/jpeg"],
+    )
+    asyncio.run(adapter._handle_ingest_only_event(event))
+
+    assert len(calls) == 1
+    _, kwargs = calls[0]
+    observed = kwargs["event"]
+    assert observed.message_type == MessageType.PHOTO
+    assert observed.raw_message["agentDispatchAllowed"] is False
+    assert observed.raw_message["hasMedia"] is True
+    assert observed.media_urls == [media_path]
+    assert observed.media_types == ["image/jpeg"]
+
+
+def test_ingest_only_handler_fail_closed_when_hook_crashes(monkeypatch):
+    adapter = object.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+
+    def boom(name, **kwargs):
+        raise RuntimeError("hook exploded")
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", boom)
+
+    # No exception: ingest-only events are dropped even if the plugin fails.
+    asyncio.run(adapter._handle_ingest_only_event(_event()))

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -156,6 +156,7 @@ class TestValidateFilePath:
         assert _validate_file_path("templates/config.yaml") is None
         assert _validate_file_path("scripts/train.py") is None
         assert _validate_file_path("assets/image.png") is None
+        assert _validate_file_path("learnings/LEARNINGS.md") is None
 
     def test_empty_path(self):
         assert _validate_file_path("") == "file_path is required."
@@ -209,12 +210,17 @@ class TestCreateSkill:
             result = _create_skill("my-skill", VALID_SKILL_CONTENT)
         assert result["success"] is True
         assert (tmp_path / "my-skill" / "SKILL.md").exists()
+        learnings_md = tmp_path / "my-skill" / "learnings" / "LEARNINGS.md"
+        assert learnings_md.exists()
+        assert "my-skill Learnings" in learnings_md.read_text()
+        assert result["learnings_md"] == str(learnings_md)
 
     def test_create_with_category(self, tmp_path):
         with _skill_dir(tmp_path):
             result = _create_skill("my-skill", VALID_SKILL_CONTENT, category="devops")
         assert result["success"] is True
         assert (tmp_path / "devops" / "my-skill" / "SKILL.md").exists()
+        assert (tmp_path / "devops" / "my-skill" / "learnings" / "LEARNINGS.md").exists()
         assert result["category"] == "devops"
 
     def test_create_duplicate_blocked(self, tmp_path):
@@ -450,6 +456,17 @@ class TestWriteFile:
         assert result["success"] is True
         assert (tmp_path / "my-skill" / "references" / "api.md").exists()
 
+    def test_write_learning_file(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _write_file(
+                "my-skill",
+                "learnings/LEARNINGS.md",
+                "# Learnings\n\n2026-01-01 — Issue: test. Change: test. Guardrail: test.\n",
+            )
+        assert result["success"] is True
+        assert (tmp_path / "my-skill" / "learnings" / "LEARNINGS.md").exists()
+
     def test_write_to_nonexistent_skill(self, tmp_path):
         with _skill_dir(tmp_path):
             result = _write_file("nonexistent", "references/doc.md", "content")
@@ -489,6 +506,14 @@ class TestRemoveFile:
             result = _remove_file("my-skill", "references/api.md")
         assert result["success"] is True
         assert not (tmp_path / "my-skill" / "references" / "api.md").exists()
+
+    def test_remove_learning_file(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            _write_file("my-skill", "learnings/LEARNINGS.md", "content")
+            result = _remove_file("my-skill", "learnings/LEARNINGS.md")
+        assert result["success"] is True
+        assert not (tmp_path / "my-skill" / "learnings" / "LEARNINGS.md").exists()
 
     def test_remove_nonexistent_file(self, tmp_path):
         with _skill_dir(tmp_path):

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -477,6 +477,17 @@ class TestSkillView:
         assert result["success"] is True
         assert "Endpoint info" in result["content"]
 
+    def test_view_learning_file(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "my-skill")
+            learnings_dir = skill_dir / "learnings"
+            learnings_dir.mkdir()
+            (learnings_dir / "LEARNINGS.md").write_text("# Learnings\nDecision history.")
+            raw = skill_view("my-skill", file_path="learnings/LEARNINGS.md")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "Decision history" in result["content"]
+
     def test_view_nonexistent_file(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(tmp_path, "my-skill")
@@ -490,10 +501,14 @@ class TestSkillView:
             refs_dir = skill_dir / "references"
             refs_dir.mkdir()
             (refs_dir / "guide.md").write_text("guide content")
+            learnings_dir = skill_dir / "learnings"
+            learnings_dir.mkdir()
+            (learnings_dir / "LEARNINGS.md").write_text("decision history")
             raw = skill_view("my-skill")
         result = json.loads(raw)
         assert result["linked_files"] is not None
         assert "references" in result["linked_files"]
+        assert result["linked_files"]["learnings"] == ["learnings/LEARNINGS.md"]
 
     def test_view_tags_from_metadata(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -16,7 +16,7 @@ Actions:
   edit       -- Replace the SKILL.md content of a user skill (full rewrite)
   patch      -- Targeted find-and-replace within SKILL.md or any supporting file
   delete     -- Remove a user skill entirely
-  write_file -- Add/overwrite a supporting file (reference, template, script, asset)
+  write_file -- Add/overwrite a supporting file (reference, template, script, asset, learning)
   remove_file-- Remove a supporting file from a user skill
 
 Directory layout for user skills:
@@ -26,7 +26,8 @@ Directory layout for user skills:
     │   ├── references/
     │   ├── templates/
     │   ├── scripts/
-    │   └── assets/
+    │   ├── assets/
+    │   └── learnings/
     └── category-name/
         └── another-skill/
             └── SKILL.md
@@ -336,7 +337,7 @@ MAX_SKILL_FILE_BYTES = 1_048_576    # 1 MiB per supporting file
 VALID_NAME_RE = re.compile(r'^[a-z0-9][a-z0-9._-]*$')
 
 # Subdirectories allowed for write_file/remove_file
-ALLOWED_SUBDIRS = {"references", "templates", "scripts", "assets"}
+ALLOWED_SUBDIRS = {"references", "templates", "scripts", "assets", "learnings"}
 
 
 # =============================================================================
@@ -431,7 +432,7 @@ def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[st
             f"{label} content is {len(content):,} characters "
             f"(limit: {MAX_SKILL_CONTENT_CHARS:,}). "
             f"Consider splitting into a smaller SKILL.md with supporting files "
-            f"in references/ or templates/."
+            "under references/, templates/, or learnings/."
         )
     return None
 
@@ -686,6 +687,21 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     skill_md = skill_dir / "SKILL.md"
     _atomic_write_text(skill_md, content)
 
+    # Scaffold durable per-skill decision memory. New skills start with an
+    # empty-ish learning log so future production corrections and rejected
+    # alternatives have a canonical home from day one.
+    learnings_dir = skill_dir / "learnings"
+    learnings_dir.mkdir(parents=True, exist_ok=True)
+    learnings_md = learnings_dir / "LEARNINGS.md"
+    _atomic_write_text(
+        learnings_md,
+        (
+            f"# {name} Learnings\n\n"
+            "Purpose: preserve durable production lessons, decision history, "
+            "rejected alternatives, and guardrails for future edits.\n"
+        ),
+    )
+
     # Security scan — roll back on block
     scan_error = _security_scan_skill(skill_dir)
     if scan_error:
@@ -707,12 +723,13 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
         "message": f"Skill '{name}' created.",
         "path": str(skill_dir.relative_to(SKILLS_DIR)),
         "skill_md": str(skill_md),
+        "learnings_md": str(learnings_md),
         "_change": {"description": _desc},
     }
     if category:
         result["category"] = category
     result["hint"] = (
-        "To add reference files, templates, or scripts, use "
+        "learnings/LEARNINGS.md was scaffolded automatically. To add reference files, templates, scripts, assets, or additional learnings, use "
         "skill_manage(action='write_file', name='{}', file_path='references/example.md', file_content='...')".format(name)
     )
     return result
@@ -1234,8 +1251,9 @@ SKILL_MANAGE_SCHEMA = {
         "If you used a skill and hit issues not covered by it, patch it immediately.\n\n"
         "After difficult/iterative tasks, offer to save as a skill. "
         "Skip for simple one-offs. Confirm with user before creating/deleting.\n\n"
-        "Good skills: trigger conditions, numbered steps with exact commands, "
-        "pitfalls section, verification steps. Use skill_view() to see format examples.\n\n"
+        "Good skills: precise YAML descriptions, numbered steps with exact commands, "
+        "pitfalls section, verification steps, and learnings/ for durable correction history. "
+        "Use skill_view() to see format examples.\n\n"
         "Pinned skills are protected from deletion only — skill_manage(action='delete') "
         "will refuse with a message pointing the user to `hermes curator unpin <name>`. "
         "Patches and edits go through on pinned skills so you can still improve them as "
@@ -1296,7 +1314,7 @@ SKILL_MANAGE_SCHEMA = {
                 "description": (
                     "Path to a supporting file within the skill directory. "
                     "For 'write_file'/'remove_file': required, must be under references/, "
-                    "templates/, scripts/, or assets/. "
+                    "templates/, scripts/, assets/, or learnings/. "
                     "For 'patch': optional, defaults to SKILL.md if omitted."
                 )
             },

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -9,7 +9,7 @@ and optional supporting files like references, templates, and examples.
 Inspired by Anthropic's Claude Skills system with progressive disclosure architecture:
 - Metadata (name ≤64 chars, description ≤1024 chars) - shown in skills_list
 - Full Instructions - loaded via skill_view when needed
-- Linked Files (references, templates) - loaded on demand
+- Linked Files (references, templates, scripts, assets, learnings) - loaded on demand
 
 Directory Structure:
     skills/
@@ -1293,11 +1293,12 @@ def skill_view(
         # Reuse the parse from the platform check above
         frontmatter = parsed_frontmatter
 
-        # Get reference, template, asset, and script files if this is a directory-based skill
+        # Get reference, template, asset, script, and learning files if this is a directory-based skill
         reference_files = []
         template_files = []
         asset_files = []
         script_files = []
+        learning_files = []
 
         if skill_dir:
             references_dir = skill_dir / "references"
@@ -1338,6 +1339,14 @@ def skill_view(
                         [str(f.relative_to(skill_dir)) for f in scripts_dir.glob(ext)]
                     )
 
+            learnings_dir = skill_dir / "learnings"
+            if learnings_dir.exists():
+                learning_files = [
+                    str(f.relative_to(skill_dir))
+                    for f in learnings_dir.rglob("*.md")
+                    if f.is_file()
+                ]
+
         # Read tags/related_skills with backward compat:
         # Check metadata.hermes.* first (agentskills.io convention), fall back to top-level
         hermes_meta = {}
@@ -1360,6 +1369,8 @@ def skill_view(
             linked_files["assets"] = asset_files
         if script_files:
             linked_files["scripts"] = script_files
+        if learning_files:
+            linked_files["learnings"] = learning_files
 
         try:
             rel_path = str(skill_md.relative_to(SKILLS_DIR))
@@ -1460,7 +1471,7 @@ def skill_view(
             "path": rel_path,
             "skill_dir": str(skill_dir) if skill_dir else None,
             "linked_files": linked_files if linked_files else None,
-            "usage_hint": "To view linked files, call skill_view(name, file_path) where file_path is e.g. 'references/api.md' or 'assets/config.yaml'"
+            "usage_hint": "To view linked files, call skill_view(name, file_path) where file_path is e.g. 'references/api.md', 'assets/config.yaml', or 'learnings/LEARNINGS.md'"
             if linked_files
             else None,
             "required_environment_variables": required_env_vars,
@@ -1576,7 +1587,7 @@ SKILLS_LIST_SCHEMA = {
 
 SKILL_VIEW_SCHEMA = {
     "name": "skill_view",
-    "description": "Skills allow for loading information about specific tasks and workflows, as well as scripts and templates. Load a skill's full content or access its linked files (references, templates, scripts). First call returns SKILL.md content plus a 'linked_files' dict showing available references/templates/scripts. To access those, call again with file_path parameter.",
+    "description": "Skills allow for loading information about specific tasks and workflows, as well as scripts, templates, and learnings. Load a skill's full content or access its linked files (references, templates, scripts, assets, learnings). First call returns SKILL.md content plus a 'linked_files' dict showing available support files. To access those, call again with file_path parameter.",
     "parameters": {
         "type": "object",
         "properties": {

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2132,12 +2132,14 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
 def text_to_speech_tool(
     text: str,
     output_path: Optional[str] = None,
+    provider_override: Optional[str] = None,
 ) -> str:
     """
     Convert text to speech audio.
 
-    Reads provider/voice config from ~/.hermes/config.yaml (tts: section).
-    The model sends text; the user configures voice and provider.
+    Reads provider/voice config from ~/.hermes/config.yaml (tts: section)
+    unless an internal caller passes provider_override. The model sends text;
+    the user configures voice and provider.
 
     On messaging platforms, the returned MEDIA:<path> tag is intercepted
     by the send pipeline and delivered as a native voice message.
@@ -2146,6 +2148,8 @@ def text_to_speech_tool(
     Args:
         text: The text to convert to speech.
         output_path: Optional custom save path. Defaults to ~/voice-memos/<timestamp>.mp3
+        provider_override: Optional internal provider override for system-owned
+            call sites that must not mutate global tts.provider.
 
     Returns:
         str: JSON result with success, file_path, and optionally MEDIA tag.
@@ -2154,7 +2158,11 @@ def text_to_speech_tool(
         return tool_error("Text is required", success=False)
 
     tts_config = _load_tts_config()
-    provider = _get_provider(tts_config)
+    provider = (
+        str(provider_override).lower().strip()
+        if provider_override
+        else _get_provider(tts_config)
+    )
 
     # User-declared command provider (type: command under tts.providers.<name>)
     # resolves BEFORE the built-in dispatch. Built-in names short-circuit here


### PR DESCRIPTION
## Summary

Adds a generic `cli_queue_drained` lifecycle hook for the classic Hermes CLI.

The hook fires after a successful CLI turn only when both interactive input queues are drained. This gives plugins a stable post-turn integration point without duplicating CLI queue logic or monkeypatching CLI internals.

## Behavior

- Registers `cli_queue_drained` as a valid plugin hook.
- Emits the hook after a non-empty, non-error response.
- Suppresses hook emission while pending input or interrupt queues contain follow-up work.
- Suppresses hook emission for interrupted turns.
- Preserves terminal bell behavior on the same queue-drained boundary.
- Includes payload metadata for plugins: CLI instance, agent reference, session/platform metadata, user input, response, queue-drained state, bell state, interruption state, and timestamp.

## Test Plan

- `python -m py_compile cli.py hermes_cli/plugins.py tests/cli/test_cli_queue_drained_hook.py`
- `uv run --with pytest --with pyyaml python -m pytest tests/cli/test_cli_queue_drained_hook.py -q -o 'addopts='`
