### PR TITLE
fix(desktop): keep projects profile-scoped in app-global remote mode

### DIFF
--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -1,18 +1,50 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesGateway } from '@/hermes'
+
+const { fakeGateway, request } = vi.hoisted(() => {
+  const request = vi.fn(async () => ({ projects: [], active_id: null, scoped_session_ids: [] }))
+  const fakeGateway = {
+    connectionState: 'open',
+    request
+  } as unknown as HermesGateway
+
+  return {
+    fakeGateway,
+    request
+  }
+})
+
+vi.mock('@/store/gateway', () => ({
+  activeGateway: () => fakeGateway,
+  ensureActiveGatewayOpen: vi.fn(async () => fakeGateway)
+}))
 
 import {
+  $activeProjectId,
   $projectScope,
+  $projects,
+  $projectTree,
   $worktreeRefreshToken,
   ALL_PROJECTS,
   enterProject,
   exitProjectScope,
+  fetchProjectSessions,
+  refreshProjects,
+  refreshProjectTree,
   refreshWorktrees
 } from './projects'
+import { $activeGatewayProfile } from './profile'
 
 describe('project scope', () => {
   beforeEach(() => {
     window.localStorage.clear()
+    request.mockClear()
     $projectScope.set(ALL_PROJECTS)
+    $projects.set([])
+    $projectTree.set([])
+    $activeProjectId.set(null)
+    $activeGatewayProfile.set('default')
   })
 
   it('defaults to ALL_PROJECTS', () => {
@@ -40,6 +72,21 @@ describe('project scope', () => {
   it('persists the scope to localStorage', () => {
     enterProject('p_abc')
     expect(window.localStorage.getItem('hermes.desktop.projectScope')).toBe('p_abc')
+  })
+
+  it('forwards the active profile to projects RPCs', async () => {
+    $activeGatewayProfile.set('coder')
+
+    await refreshProjects()
+    await refreshProjectTree()
+    await fetchProjectSessions('p_123')
+
+    expect(request).toHaveBeenNthCalledWith(1, 'projects.list', { profile: 'coder' })
+    expect(request).toHaveBeenNthCalledWith(2, 'projects.tree', { preview_limit: 3, profile: 'coder' })
+    expect(request).toHaveBeenNthCalledWith(3, 'projects.project_sessions', {
+      project_id: 'p_123',
+      profile: 'coder'
+    })
   })
 })
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -5,7 +5,7 @@ import type { HermesGitBranch } from '@/global'
 import { persistentAtom } from '@/lib/persisted'
 import { activeGateway, ensureActiveGatewayOpen } from '@/store/gateway'
 import { setSidebarAgentsGrouped } from '@/store/layout'
-import { requestFreshSession } from '@/store/profile'
+import { $activeGatewayProfile, normalizeProfileKey, requestFreshSession } from '@/store/profile'
 import { $selectedStoredSessionId, $sessions, workspaceCwdForNewSession } from '@/store/session'
 import type { ProjectInfo, ProjectsPayload } from '@/types/hermes'
 
@@ -204,6 +204,14 @@ async function gatewayRequest<T>(method: string, params: Record<string, unknown>
   return gateway.request<T>(method, params)
 }
 
+function projectProfile(): string {
+  return normalizeProfileKey($activeGatewayProfile.get())
+}
+
+function projectParams(params: Record<string, unknown> = {}): Record<string, unknown> {
+  return { ...params, profile: projectProfile() }
+}
+
 function applyPayload(payload: ProjectsPayload): void {
   $projects.set(payload.projects ?? [])
   $activeProjectId.set(payload.active_id ?? null)
@@ -213,7 +221,7 @@ function applyPayload(payload: ProjectsPayload): void {
 // not up yet) leaves the cached atoms intact so the sidebar doesn't flicker.
 export async function refreshProjects(): Promise<void> {
   try {
-    applyPayload(await gatewayRequest<ProjectsPayload>('projects.list'))
+    applyPayload(await gatewayRequest<ProjectsPayload>('projects.list', projectParams()))
   } catch {
     // Backend may not be ready; keep the last known list.
   }
@@ -232,7 +240,7 @@ export async function refreshProjectTree(): Promise<void> {
   $projectTreeLoading.set(true)
 
   try {
-    const res = await gatewayRequest<ProjectTreePayload>('projects.tree', { preview_limit: 3 })
+    const res = await gatewayRequest<ProjectTreePayload>('projects.tree', projectParams({ preview_limit: 3 }))
     // The flat Sessions list shows everything; scoped ids are only used here to
     // reconcile the optimistic eviction layer against what the server still lists.
     const scoped = new Set(res.scoped_session_ids ?? [])
@@ -264,9 +272,10 @@ export async function refreshProjectTree(): Promise<void> {
 // membership match exactly.
 export async function fetchProjectSessions(projectId: string): Promise<SidebarProjectTree | null> {
   try {
-    const res = await gatewayRequest<{ project: SidebarProjectTree | null }>('projects.project_sessions', {
-      project_id: projectId
-    })
+    const res = await gatewayRequest<{ project: SidebarProjectTree | null }>(
+      'projects.project_sessions',
+      projectParams({ project_id: projectId })
+    )
 
     return res.project ?? null
   } catch {
@@ -291,7 +300,7 @@ export async function scanAndRecordRepos(force = false): Promise<void> {
 
   try {
     const repos = await scan([])
-    await gatewayRequest('projects.record_repos', { repos })
+    await gatewayRequest('projects.record_repos', projectParams({ repos }))
     // The disk scan may surface new zero-session repos; refold them into the tree.
     await refreshProjectTree()
   } catch {
@@ -409,17 +418,20 @@ function projectInfoToTreeNode(project: ProjectInfo): SidebarProjectTree {
 }
 
 export async function createProject(input: CreateProjectInput): Promise<ProjectInfo | null> {
-  const res = await gatewayRequest<{ project: ProjectInfo | null }>('projects.create', {
-    name: input.name,
-    folders: input.folders ?? [],
-    primary_path: input.primaryPath,
-    slug: input.slug,
-    description: input.description,
-    icon: input.icon,
-    color: input.color,
-    board_slug: input.boardSlug,
-    use: input.use ?? false
-  })
+  const res = await gatewayRequest<{ project: ProjectInfo | null }>(
+    'projects.create',
+    projectParams({
+      name: input.name,
+      folders: input.folders ?? [],
+      primary_path: input.primaryPath,
+      slug: input.slug,
+      description: input.description,
+      icon: input.icon,
+      color: input.color,
+      board_slug: input.boardSlug,
+      use: input.use ?? false
+    })
+  )
 
   // Not optimistic (the create awaits the RPC first, so there's nothing to roll
   // back): apply the server's row into the cached list + tree at once, so it
@@ -480,12 +492,15 @@ export async function updateProject(
   // Backend treats null/undefined as "leave unchanged"; "" clears (stores NULL).
   // Map explicit null → "" so "no color"/"no icon" actually clear.
   await persistOrRollback(snap, () =>
-    gatewayRequest('projects.update', {
-      id,
-      ...patch,
-      ...(patch.color === null && { color: '' }),
-      ...(patch.icon === null && { icon: '' })
-    })
+    gatewayRequest(
+      'projects.update',
+      projectParams({
+        id,
+        ...patch,
+        ...(patch.color === null && { color: '' }),
+        ...(patch.icon === null && { icon: '' })
+      })
+    )
   )
 }
 
@@ -524,7 +539,10 @@ export async function addProjectFolder(
   }
 
   await persistOrRollback(snap, () =>
-    gatewayRequest('projects.add_folder', { id, path, label: opts.label, is_primary: opts.isPrimary ?? false })
+    gatewayRequest(
+      'projects.add_folder',
+      projectParams({ id, path, label: opts.label, is_primary: opts.isPrimary ?? false })
+    )
   )
   reconcileProjects()
 }
@@ -567,13 +585,13 @@ export async function deleteProject(id: string): Promise<void> {
   }
 
   await persistOrRollback(snap, async () => {
-    applyPayload(await gatewayRequest<ProjectsPayload>('projects.delete', { id }))
+    applyPayload(await gatewayRequest<ProjectsPayload>('projects.delete', projectParams({ id })))
   })
   void refreshProjectTree()
 }
 
 export async function setActiveProject(id: null | string): Promise<void> {
-  const res = await gatewayRequest<{ active_id: null | string }>('projects.set_active', { id })
+  const res = await gatewayRequest<{ active_id: null | string }>('projects.set_active', projectParams({ id }))
   $activeProjectId.set(res.active_id ?? null)
 }
 

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import os
 import subprocess
+from pathlib import Path
 
 import pytest
 
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 import tui_gateway.server as server
 
 
@@ -235,3 +237,116 @@ def test_discover_repos_from_full_history(tmp_path):
 
     # The probe is persisted back onto the session rows (membership at the source).
     assert os.path.realpath(db.get_session("s1")["git_repo_root"]) == os.path.realpath(str(repo))
+
+
+def _profile_home(tmp_path: Path, name: str) -> Path:
+    home = tmp_path / name
+    home.mkdir(parents=True, exist_ok=True)
+    return home
+
+
+def _create_project(home: Path, name: str, folder: Path, *, use: bool = False) -> dict:
+    token = set_hermes_home_override(home)
+    server._db = None
+    server._db_error = None
+    try:
+        return _call("projects.create", {"name": name, "folders": [str(folder)], "use": use})["project"]
+    finally:
+        server._db = None
+        server._db_error = None
+        reset_hermes_home_override(token)
+
+
+def _create_session(home: Path, session_id: str, cwd: Path) -> None:
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=home / "state.db")
+    try:
+        db.create_session(session_id, "cli", cwd=str(cwd))
+        db.append_message(session_id, "user", f"hello from {session_id}")
+    finally:
+        db.close()
+
+
+def test_projects_rpc_profile_scope_isolates_projects_and_sessions(monkeypatch, tmp_path):
+    launch_home = _profile_home(tmp_path, "launch")
+    coder_home = _profile_home(tmp_path, "coder")
+    launch_repo = tmp_path / "launch-repo"
+    coder_repo = tmp_path / "coder-repo"
+    launch_repo.mkdir()
+    coder_repo.mkdir()
+
+    launch_project = _create_project(launch_home, "Launch", launch_repo, use=True)
+    coder_project = _create_project(coder_home, "Coder", coder_repo, use=True)
+    _create_session(launch_home, "launch-session", launch_repo)
+    _create_session(coder_home, "coder-session", coder_repo)
+
+    token = set_hermes_home_override(launch_home)
+    server._db = None
+    server._db_error = None
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir",
+        lambda name: coder_home if name == "coder" else launch_home if name == "default" else tmp_path / name,
+    )
+    try:
+        from hermes_state import SessionDB
+
+        server._db = SessionDB(db_path=launch_home / "state.db")
+        launch_listing = _call("projects.list")
+        coder_listing = _call("projects.list", {"profile": "coder"})
+        launch_tree = _call("projects.tree")
+        coder_tree = _call("projects.tree", {"profile": "coder"})
+        coder_sessions = _call("projects.project_sessions", {"profile": "coder", "project_id": coder_project["id"]})
+    finally:
+        if server._db is not None:
+            server._db.close()
+        server._db = None
+        server._db_error = None
+        reset_hermes_home_override(token)
+
+    assert [p["name"] for p in launch_listing["projects"]] == ["Launch"]
+    assert [p["name"] for p in coder_listing["projects"]] == ["Coder"]
+    assert launch_listing["active_id"] == launch_project["id"]
+    assert coder_listing["active_id"] == coder_project["id"]
+    assert [p["label"] for p in launch_tree["projects"]] == ["Launch"]
+    assert [p["label"] for p in coder_tree["projects"]] == ["Coder"]
+    assert launch_tree["projects"][0]["sessionCount"] == 1
+    assert coder_tree["projects"][0]["sessionCount"] == 1
+    assert coder_sessions["project"]["id"] == coder_project["id"]
+    assert coder_sessions["project"]["sessionCount"] == 1
+    assert coder_sessions["project"]["repos"][0]["groups"][0]["sessions"][0]["id"] == "coder-session"
+
+
+def test_projects_record_repos_writes_to_target_profile(monkeypatch, tmp_path):
+    launch_home = _profile_home(tmp_path, "launch")
+    coder_home = _profile_home(tmp_path, "coder")
+    launch_repo = tmp_path / "launch-scan"
+    coder_repo = tmp_path / "coder-scan"
+    launch_repo.mkdir()
+    coder_repo.mkdir()
+
+    token = set_hermes_home_override(launch_home)
+    server._db = None
+    server._db_error = None
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir",
+        lambda name: coder_home if name == "coder" else launch_home if name == "default" else tmp_path / name,
+    )
+    try:
+        from hermes_state import SessionDB
+
+        server._db = SessionDB(db_path=launch_home / "state.db")
+        _call("projects.record_repos", {"repos": [{"root": str(launch_repo), "label": "launch"}]})
+        _call("projects.record_repos", {"profile": "coder", "repos": [{"root": str(coder_repo), "label": "coder"}]})
+
+        launch_repos = _call("projects.discover_repos")["repos"]
+        coder_repos = _call("projects.discover_repos", {"profile": "coder"})["repos"]
+    finally:
+        if server._db is not None:
+            server._db.close()
+        server._db = None
+        server._db_error = None
+        reset_hermes_home_override(token)
+
+    assert [repo["label"] for repo in launch_repos] == ["launch"]
+    assert [repo["label"] for repo in coder_repos] == ["coder"]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -923,6 +923,40 @@ def _profile_scoped(handler):
     return wrapper
 
 
+@contextlib.contextmanager
+def _projects_profile_home(params: dict | None):
+    """Bind ``params['profile']``'s HERMES_HOME for profile-scoped projects RPCs."""
+    home = _profile_home(params.get("profile") if isinstance(params, dict) else None)
+    if home is None:
+        yield None
+        return
+    token = set_hermes_home_override(home)
+    try:
+        yield home
+    finally:
+        reset_hermes_home_override(token)
+
+
+@contextlib.contextmanager
+def _projects_session_db(params: dict | None):
+    """Yield the session db that matches a projects RPC's target profile."""
+    profile_home = _profile_home(params.get("profile") if isinstance(params, dict) else None)
+    if profile_home is None:
+        yield _get_db()
+        return
+
+    from hermes_state import SessionDB
+
+    db = None
+    try:
+        db = SessionDB(db_path=profile_home / "state.db")
+        yield db
+    finally:
+        if db is not None:
+            with contextlib.suppress(Exception):
+                db.close()
+
+
 # Placeholder ``terminal.cwd`` values that don't name a real directory — the
 # gateway resolves these to the home dir at runtime, so they must NOT be treated
 # as an explicit workspace (mirrors gateway/run.py's config bridge).
@@ -10191,8 +10225,9 @@ def _projects_method(name: str):
             try:
                 from hermes_cli import projects_db as pdb
 
-                with pdb.connect_closing() as conn:
-                    return fn(rid, params, pdb, conn)
+                with _projects_profile_home(params):
+                    with pdb.connect_closing() as conn:
+                        return fn(rid, params, pdb, conn)
             except _NoProject:
                 return _err(rid, _E_NO_PROJECT, "no such project")
             except ValueError as e:
@@ -10404,10 +10439,11 @@ def _discover_repos_payload(db, *, conn=None, backfill: bool = True) -> list[dic
 def _(rid, params: dict) -> dict:
     """Repos for the desktop overview: scanned-from-disk (cached) ∪ session-derived."""
     try:
-        db = _get_db()
-        if db is None:
-            return _ok(rid, {"repos": []})
-        return _ok(rid, {"repos": _discover_repos_payload(db)})
+        with _projects_profile_home(params):
+            with _projects_session_db(params) as db:
+                if db is None:
+                    return _ok(rid, {"repos": []})
+                return _ok(rid, {"repos": _discover_repos_payload(db)})
     except Exception as e:
         return _err(rid, 5061, str(e))
 
@@ -10427,11 +10463,12 @@ def _(rid, params: dict) -> dict:
             elif isinstance(item, dict) and item.get("root"):
                 pairs.append((str(item["root"]), item.get("label")))
 
-        with pdb.connect_closing() as conn:
-            pdb.record_discovered_repos(conn, pairs, replace=True)
+        with _projects_profile_home(params):
+            with pdb.connect_closing() as conn:
+                pdb.record_discovered_repos(conn, pairs, replace=True)
 
-        db = _get_db()
-        return _ok(rid, {"repos": _discover_repos_payload(db) if db is not None else []})
+            with _projects_session_db(params) as db:
+                return _ok(rid, {"repos": _discover_repos_payload(db) if db is not None else []})
     except Exception as e:
         return _err(rid, 5061, str(e))
 
@@ -10476,7 +10513,7 @@ def _project_tree_row(r: dict) -> dict:
 
 
 def _project_tree_inputs(
-    db, session_limit: int, *, include_discovered: bool
+    db, session_limit: int, *, include_discovered: bool, params: dict | None = None
 ) -> tuple[list[dict], list[dict], list[dict], str | None]:
     """Gather (sessions, projects, discovered_repos, active_id) for build_tree.
 
@@ -10502,23 +10539,24 @@ def _project_tree_inputs(
 
     from hermes_cli import projects_db as pdb
 
-    with pdb.connect_closing() as conn:
-        projects = [p.to_dict() for p in pdb.list_projects(conn)]
-        active_id = pdb.get_active_id(conn)
-        # backfill stays off the hot tree path — grouping uses the live resolver.
-        discovered = _discover_repos_payload(db, conn=conn, backfill=False) if include_discovered else []
+    with _projects_profile_home(params):
+        with pdb.connect_closing() as conn:
+            projects = [p.to_dict() for p in pdb.list_projects(conn)]
+            active_id = pdb.get_active_id(conn)
+            # backfill stays off the hot tree path — grouping uses the live resolver.
+            discovered = _discover_repos_payload(db, conn=conn, backfill=False) if include_discovered else []
 
     return sessions, projects, discovered, active_id
 
 
 def _build_project_tree(
-    db, *, preview_limit: int, hydrate: bool, session_limit: int, include_discovered: bool
+    db, *, preview_limit: int, hydrate: bool, session_limit: int, include_discovered: bool, params: dict | None = None
 ) -> tuple[dict, str | None]:
     """Gather inputs and run the one authoritative builder. Returns (tree, active_id)."""
     from tui_gateway import project_tree
 
     sessions, projects, discovered, active_id = _project_tree_inputs(
-        db, session_limit, include_discovered=include_discovered
+        db, session_limit, include_discovered=include_discovered, params=params
     )
     tree = project_tree.build_tree(
         projects,
@@ -10540,21 +10578,27 @@ def _(rid, params: dict) -> dict:
     Lanes carry no session rows here; drill-in uses ``projects.project_sessions``.
     """
     try:
-        db = _get_db()
-        if db is None:
-            return _ok(rid, {"projects": [], "active_id": None, "scoped_session_ids": []})
+        with _projects_profile_home(params):
+            with _projects_session_db(params) as db:
+                if db is None:
+                    return _ok(rid, {"projects": [], "active_id": None, "scoped_session_ids": []})
 
-        tree, active_id = _build_project_tree(
-            db,
-            preview_limit=int(params.get("preview_limit") or 3),
-            hydrate=False,
-            session_limit=int(params.get("session_limit") or 2000),
-            include_discovered=True,
-        )
-        return _ok(
-            rid,
-            {"projects": tree["projects"], "active_id": active_id, "scoped_session_ids": tree["scoped_session_ids"]},
-        )
+                tree, active_id = _build_project_tree(
+                    db,
+                    preview_limit=int(params.get("preview_limit") or 3),
+                    hydrate=False,
+                    session_limit=int(params.get("session_limit") or 2000),
+                    include_discovered=True,
+                    params=params,
+                )
+                return _ok(
+                    rid,
+                    {
+                        "projects": tree["projects"],
+                        "active_id": active_id,
+                        "scoped_session_ids": tree["scoped_session_ids"],
+                    },
+                )
     except Exception as e:
         return _err(rid, 5061, str(e))
 
@@ -10569,18 +10613,23 @@ def _(rid, params: dict) -> dict:
         if not project_id:
             return _err(rid, 5063, "project_id required")
 
-        db = _get_db()
-        if db is None:
-            return _ok(rid, {"project": None})
+        with _projects_profile_home(params):
+            with _projects_session_db(params) as db:
+                if db is None:
+                    return _ok(rid, {"project": None})
 
-        # Drill-in only needs the entered project (which has sessions), so skip
-        # the zero-session discovery tier entirely.
-        tree, _active = _build_project_tree(
-            db, preview_limit=0, hydrate=True, session_limit=int(params.get("session_limit") or 5000),
-            include_discovered=False,
-        )
-        proj = next((p for p in tree["projects"] if p["id"] == project_id), None)
-        return _ok(rid, {"project": proj})
+                # Drill-in only needs the entered project (which has sessions), so skip
+                # the zero-session discovery tier entirely.
+                tree, _active = _build_project_tree(
+                    db,
+                    preview_limit=0,
+                    hydrate=True,
+                    session_limit=int(params.get("session_limit") or 5000),
+                    include_discovered=False,
+                    params=params,
+                )
+                proj = next((p for p in tree["projects"] if p["id"] == project_id), None)
+                return _ok(rid, {"project": proj})
     except Exception as e:
         return _err(rid, 5061, str(e))
 


### PR DESCRIPTION
## What does this PR do?

Fixes desktop projects leaking across profiles in app-global remote mode by forwarding the active profile on `projects.*` RPCs and scoping gateway project handlers to the requested profile's `projects.db` and `state.db`.

This keeps the fix narrow to the confirmed bug: the desktop app and gateway were both defaulting to the dashboard process profile, so switching profiles could still read and write the wrong project/session metadata.

## Related Issue

Fixes #54278

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Forward the active profile from [apps/desktop/src/store/projects.ts](apps/desktop/src/store/projects.ts) for `projects.tree`, `projects.record_repos`, and related desktop RPCs
- Scope the projects RPC handlers in [tui_gateway/server.py](tui_gateway/server.py) to the requested profile's Hermes home and matching `state.db`
- Add desktop regression coverage in [apps/desktop/src/store/projects.test.ts](apps/desktop/src/store/projects.test.ts)
- Add gateway regression coverage in [tests/tui_gateway/test_projects_rpc.py](tests/tui_gateway/test_projects_rpc.py) for cross-profile isolation

## How to Test

1. Run `pytest tests/tui_gateway/test_projects_rpc.py`
2. Run `npx vitest run --config apps/desktop/vite.config.ts --environment jsdom apps/desktop/src/store/projects.test.ts`
3. In app-global remote mode, switch profiles and confirm the desktop sidebar only shows the active profile's projects

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (local dev environment; targeted desktop + gateway regression tests)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation completed:
- `pytest tests/tui_gateway/test_projects_rpc.py`
- `npx vitest run --config apps/desktop/vite.config.ts --environment jsdom apps/desktop/src/store/projects.test.ts`
