### PR TITLE
fix(agent): keep same-provider+model fallback with a different base_url

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1164,7 +1164,20 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     current_model = (getattr(agent, "model", "") or "").strip()
     current_base_url = str(getattr(agent, "base_url", "") or "").rstrip("/").lower()
     fb_base_url_for_dedup = (fb.get("base_url") or "").strip().rstrip("/").lower()
-    if fb_provider == current_provider and fb_model == current_model:
+    # Two entries that share a (provider, model) but point at DIFFERENT
+    # base_urls resolve to distinct backend endpoints (e.g. two
+    # ``provider: custom`` entries at different URLs) and ARE valid fallbacks
+    # for each other — falling back to the other endpoint does NOT loop the
+    # failure. Only treat a same-(provider, model) entry as a self-fallback
+    # when its base_url is also the same, or when neither side carries a
+    # distinguishing base_url. See issue #54251.
+    same_provider_model = fb_provider == current_provider and fb_model == current_model
+    same_endpoint = (
+        fb_base_url_for_dedup == current_base_url
+        or not fb_base_url_for_dedup
+        or not current_base_url
+    )
+    if same_provider_model and same_endpoint:
         logger.warning(
             "Fallback skip: chain entry %s/%s matches current provider/model",
             fb_provider, fb_model,

--- a/hermes_cli/fallback_cmd.py
+++ b/hermes_cli/fallback_cmd.py
@@ -184,10 +184,21 @@ def cmd_fallback_add(args) -> None:
         return
 
     # Picker picked the same thing that's already the primary → nothing changed,
-    # and there's nothing useful to add as a fallback to itself.
+    # and there's nothing useful to add as a fallback to itself.  A same
+    # (provider, model) entry whose ``base_url`` DIFFERS points at a distinct
+    # backend endpoint, so it is a valid fallback and must NOT be rejected as
+    # a self-fallback (#54251).
+    def _norm_url(entry: Dict[str, Any]) -> str:
+        return (entry.get("base_url") or "").strip().rstrip("/").lower()
+
     primary_entry = _extract_fallback_from_model_cfg(model_before)
     if primary_entry and primary_entry["provider"] == new_entry["provider"] \
-            and primary_entry["model"] == new_entry["model"]:
+            and primary_entry["model"] == new_entry["model"] \
+            and (
+                _norm_url(primary_entry) == _norm_url(new_entry)
+                or not _norm_url(primary_entry)
+                or not _norm_url(new_entry)
+            ):
         _restore_model_cfg(model_before)
         _restore_auth_active_provider(active_provider_before)
         print()
@@ -205,10 +216,17 @@ def cmd_fallback_add(args) -> None:
     final_cfg = load_config()
     chain = _read_chain(final_cfg)
 
-    # Reject exact-duplicate fallback entries.
+    # Reject exact-duplicate fallback entries.  An entry that shares a
+    # (provider, model) with an existing one but uses a DIFFERENT base_url is
+    # a distinct endpoint and must be appended, not skipped (#54251).
     for existing in chain:
         if existing.get("provider") == new_entry["provider"] \
-                and existing.get("model") == new_entry["model"]:
+                and existing.get("model") == new_entry["model"] \
+                and (
+                    _norm_url(existing) == _norm_url(new_entry)
+                    or not _norm_url(existing)
+                    or not _norm_url(new_entry)
+                ):
             print()
             print(f"  {_format_entry(new_entry)} is already in the fallback chain — skipped.")
             return

--- a/tests/hermes_cli/test_custom_provider_model_switch.py
+++ b/tests/hermes_cli/test_custom_provider_model_switch.py
@@ -693,3 +693,76 @@ class TestCustomProviderDiscoverModels:
             _model_flow_named_custom({}, provider_info)
 
         mock_fetch.assert_not_called()
+
+
+class TestFallbackAddBaseUrlAware:
+    """`hermes fallback add` must accept a fallback entry that shares
+    (provider, model) with the primary but uses a DIFFERENT ``base_url`` —
+    those are distinct backend endpoints (#54251). An entry with the SAME
+    provider+model+base_url is still rejected as a self-fallback / duplicate.
+    """
+
+    def _run_add_with_pick(self, primary_model_cfg, picked_model_cfg):
+        """Drive ``cmd_fallback_add`` with the picker yielding ``picked_model_cfg``.
+
+        Returns the fallback chain persisted after the command runs.
+        """
+        from argparse import Namespace
+        from hermes_cli.config import load_config, save_config
+        import hermes_cli.fallback_cmd as fallback_cmd
+
+        # Seed the primary into config["model"] before the picker runs.
+        cfg = load_config()
+        cfg["model"] = dict(primary_model_cfg)
+        save_config(cfg)
+
+        def _fake_picker(args=None):
+            # The picker writes the user's selection to config["model"].
+            c = load_config()
+            c["model"] = dict(picked_model_cfg)
+            save_config(c)
+
+        with patch("hermes_cli.main._require_tty"), \
+             patch("hermes_cli.main.select_provider_and_model", side_effect=_fake_picker), \
+             patch("builtins.print"):
+            fallback_cmd.cmd_fallback_add(Namespace())
+
+        return fallback_cmd._read_chain(load_config())
+
+    def test_fallback_add_accepts_same_model_different_base_url(self, config_home):
+        chain = self._run_add_with_pick(
+            primary_model_cfg={
+                "provider": "custom",
+                "default": "my-model",
+                "base_url": "https://a.example/v1",
+            },
+            picked_model_cfg={
+                "provider": "custom",
+                "default": "my-model",
+                "base_url": "https://b.example/v1",
+            },
+        )
+        # Before the fix the differing-base_url entry is rejected as a
+        # self-fallback and never reaches the chain.
+        assert any(
+            e.get("provider") == "custom"
+            and e.get("model") == "my-model"
+            and (e.get("base_url") or "").rstrip("/") == "https://b.example/v1"
+            for e in chain
+        ), f"expected the differing-base_url entry to be appended, got {chain!r}"
+
+    def test_fallback_add_rejects_same_model_same_base_url(self, config_home):
+        chain = self._run_add_with_pick(
+            primary_model_cfg={
+                "provider": "custom",
+                "default": "my-model",
+                "base_url": "https://a.example/v1",
+            },
+            picked_model_cfg={
+                "provider": "custom",
+                "default": "my-model",
+                "base_url": "https://a.example/v1",
+            },
+        )
+        # Identical endpoint → self-fallback guard still fires → nothing added.
+        assert chain == [], f"expected no fallback added for a self-loop, got {chain!r}"

--- a/tests/run_agent/test_auth_provider_failover.py
+++ b/tests/run_agent/test_auth_provider_failover.py
@@ -124,3 +124,58 @@ class TestAuthFailoverActivation:
         err.status_code = 500
         classified = classify_api_error(err)
         assert self._should_failover(agent, classified, retry) is False
+
+
+class TestFallbackBaseUrlAwareSkip:
+    """A fallback entry that shares (provider, model) with the current backend
+    but points at a DIFFERENT ``base_url`` is a distinct endpoint and must be
+    activated, not skipped as a self-fallback (#54251). An entry with the SAME
+    base_url is still skipped (preserves the self-loop guard)."""
+
+    def test_failover_activates_for_same_provider_model_different_base_url(self):
+        agent = _make_agent(
+            fallback_model=[{
+                "provider": "custom",
+                "model": "my-model",
+                "base_url": "https://b.example/v1",
+                "api_key": "k",
+            }]
+        )
+        # Primary backend: same provider+model, but a DIFFERENT endpoint.
+        agent.provider = "custom"
+        agent.model = "my-model"
+        agent.base_url = "https://a.example/v1"
+        agent._fallback_index = 0
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(base_url="https://b.example/v1"), "my-model"),
+        ):
+            advanced = agent._try_activate_fallback(reason=FailoverReason.auth)
+        # Before the fix the entry is wrongly skipped as a self-fallback and,
+        # with no further entries, activation returns False without advancing.
+        assert advanced is True
+        assert agent._fallback_index == 1
+
+    def test_failover_skips_same_provider_model_same_base_url(self):
+        agent = _make_agent(
+            fallback_model=[{
+                "provider": "custom",
+                "model": "my-model",
+                "base_url": "https://a.example/v1",
+                "api_key": "k",
+            }]
+        )
+        # Primary backend: identical provider+model+base_url — a true self-loop.
+        agent.provider = "custom"
+        agent.model = "my-model"
+        agent.base_url = "https://a.example/v1"
+        agent._fallback_index = 0
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(base_url="https://a.example/v1"), "my-model"),
+        ):
+            advanced = agent._try_activate_fallback(reason=FailoverReason.auth)
+        # The lone entry is the same endpoint → skipped → chain exhausted.
+        assert advanced is False


### PR DESCRIPTION
## What does this PR do?

Fixes the fallback chain wrongly skipping an entry that shares a provider+model with the current backend but points at a DIFFERENT `base_url`. Different endpoints are different backends and must be eligible fallbacks. Covers both code sites the issue identifies — the runtime skip in `agent/chat_completion_helpers.py::_try_activate_fallback` and the CLI picker / chain-dedup in `hermes_cli/fallback_cmd.py`.

## Related Issue

Fixes #54251

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/chat_completion_helpers.py`: the same-(provider, model) self-fallback skip now also requires the same `base_url` (or that neither side carries a distinguishing base_url). The existing same-base_url/model dedup (#22548) is preserved for the cross-provider shim-URL case.
- `hermes_cli/fallback_cmd.py`: the "cannot be a fallback for itself" picker guard and the exact-duplicate chain rejection are now base_url-aware, so a same-provider+model entry with a different endpoint URL is accepted/appended.

Issue lists 2 affected code sites (1: runtime `_try_activate_fallback`, 2: CLI `fallback_cmd`). This PR covers both.

## How to Test

`uv run --with pytest --with pytest-asyncio python3 -m pytest tests/run_agent/test_auth_provider_failover.py tests/hermes_cli/test_custom_provider_model_switch.py -v`

Each new test fails before the fix (entry skipped/rejected) and passes after.

## Checklist
### Code
- [x] My commit messages follow Conventional Commits (`fix(agent):`)
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes (fail-before/pass-after at both sites)
- [x] I've tested on my platform: macOS 15
### Documentation & Housekeeping
- [x] N/A — no docs/config-key/architecture changes

> Audited siblings: the two sites named in the issue are the only places that dedup a fallback entry against the current backend by provider+model; both are fixed here. No further widening needed.