### PR TITLE
perf: reduce request and tool prompt budget overhead

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1942,6 +1942,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     around_message_id=next_args.get("around_message_id"),
                     window=next_args.get("window", 5),
                     sort=next_args.get("sort"),
+                    max_content_chars=next_args.get("max_content_chars"),
                     db=session_db,
                     current_session_id=agent.session_id,
                 ),

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -902,13 +902,17 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
         logger.debug("Keychain: no entry found for 'Claude Code-credentials'")
         return None
 
-    raw = result.stdout.strip()
+    raw_stdout = result.stdout
+    if not isinstance(raw_stdout, str):
+        logger.debug("Keychain: credentials payload is not text")
+        return None
+    raw = raw_stdout.strip()
     if not raw:
         return None
 
     try:
         data = json.loads(raw)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, TypeError):
         logger.debug("Keychain: credentials payload is not valid JSON")
         return None
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -468,6 +468,32 @@ def compress_context(
                 _existing_sp = agent._build_system_prompt(system_message)
             return messages, _existing_sp
 
+        # A delayed stale path can acquire the lock after the real compressor
+        # already released it, while still holding the old parent session_id.
+        # In that case the parent has already been ended with reason
+        # "compression" and has a continuation child. Proceeding would create a
+        # second sibling child (the original transcript-fork incident), so no-op
+        # before invoking the compressor.
+        try:
+            _compression_tip = _lock_db.get_compression_tip(_lock_sid)
+        except Exception:
+            _compression_tip = _lock_sid
+        if _compression_tip and _compression_tip != _lock_sid:
+            logger.warning(
+                "compression skipped: session=%s already continued as %s — "
+                "returning messages unchanged to avoid session fork",
+                _lock_sid, _compression_tip,
+            )
+            try:
+                _lock_db.release_compression_lock(_lock_sid, _lock_holder)
+            except Exception as _rel_err:
+                logger.debug("compression lock release failed: %s", _rel_err)
+            _lock_holder = None
+            _existing_sp = getattr(agent, "_cached_system_prompt", None)
+            if not _existing_sp:
+                _existing_sp = agent._build_system_prompt(system_message)
+            return messages, _existing_sp
+
     def _release_lock() -> None:
         """Release the lock keyed on the OLD session_id (before rotation)."""
         if _lock_db is not None and _lock_sid and _lock_holder:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -67,6 +67,125 @@ from utils import base_url_host_matches, env_var_enabled
 
 logger = logging.getLogger(__name__)
 
+
+def _serialized_chars(value: Any) -> int:
+    """Return a stable JSON-ish character count for telemetry buckets."""
+    try:
+        return len(json.dumps(value, ensure_ascii=False, separators=(",", ":")))
+    except (TypeError, ValueError):
+        return len(str(value))
+
+
+def _rough_tokens_for_chars(chars: int) -> int:
+    return (max(0, int(chars)) + 3) // 4
+
+
+def _tool_schema_contributors(
+    tool_defs: List[Dict[str, Any]],
+    *,
+    limit: int = 5,
+) -> List[Dict[str, int | str]]:
+    """Return the largest individual tool schemas for budget diagnostics."""
+    contributors: List[Dict[str, int | str]] = []
+    for index, tool_def in enumerate(tool_defs):
+        fn = tool_def.get("function") if isinstance(tool_def, dict) else None
+        name = None
+        if isinstance(fn, dict):
+            raw_name = fn.get("name")
+            if raw_name:
+                name = str(raw_name)
+        if not name:
+            name = f"tool_{index}"
+        schema_chars = _serialized_chars(tool_def)
+        contributors.append({
+            "name": name,
+            "schema_chars": schema_chars,
+            "schema_tokens": _rough_tokens_for_chars(schema_chars),
+        })
+    contributors.sort(key=lambda item: int(item.get("schema_chars", 0)), reverse=True)
+    return contributors[: max(0, int(limit))]
+
+
+def _request_budget_snapshot(
+    api_messages: List[Dict[str, Any]],
+    tools: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """Break a pending provider request into prompt/schema budget buckets.
+
+    ``estimate_request_tokens_rough`` already gives the all-up number used by
+    compression gates; this helper exposes the buckets that explain *why* a
+    turn is heavy: system prompt, conversation messages, and tool schemas.
+    """
+    messages = api_messages if isinstance(api_messages, list) else []
+    tool_defs = tools if isinstance(tools, list) else []
+    system_messages = [m for m in messages if m.get("role") == "system"]
+    conversation_messages = [m for m in messages if m.get("role") != "system"]
+
+    system_prompt_chars = sum(_serialized_chars(m.get("content", "")) for m in system_messages)
+    conversation_chars = sum(_serialized_chars(m) for m in conversation_messages)
+    message_chars = sum(_serialized_chars(m) for m in messages)
+    tool_schema_chars = _serialized_chars(tool_defs) if tool_defs else 0
+
+    return {
+        "message_count": len(messages),
+        "tool_count": len(tool_defs),
+        "system_prompt_chars": system_prompt_chars,
+        "system_prompt_tokens": _rough_tokens_for_chars(system_prompt_chars),
+        "conversation_chars": conversation_chars,
+        "conversation_tokens": estimate_messages_tokens_rough(conversation_messages),
+        "message_chars": message_chars,
+        "message_tokens": estimate_messages_tokens_rough(messages),
+        "tool_schema_chars": tool_schema_chars,
+        "tool_schema_tokens": _rough_tokens_for_chars(tool_schema_chars),
+        "top_tool_schema_tokens": _tool_schema_contributors(tool_defs),
+        "total_rough_tokens": estimate_request_tokens_rough(
+            messages,
+            tools=tool_defs or None,
+        ),
+    }
+
+
+def _format_top_tool_schema_tokens(budget: Dict[str, Any], *, limit: int = 3) -> str:
+    contributors = budget.get("top_tool_schema_tokens")
+    if not isinstance(contributors, list):
+        return ""
+    parts: list[str] = []
+    for item in contributors[: max(0, int(limit))]:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "unknown")
+        tokens = item.get("schema_tokens", 0)
+        try:
+            token_count = int(tokens)
+        except (TypeError, ValueError):
+            token_count = 0
+        parts.append(f"{name}~{token_count}")
+    return ", ".join(parts)
+
+
+def _log_request_budget_telemetry(agent: Any, api_call_count: int, budget: Dict[str, Any]) -> None:
+    """Persist per-call request-size telemetry without changing user output."""
+    try:
+        setattr(agent, "session_last_request_budget", dict(budget))
+    except Exception:
+        pass
+    top_tools = _format_top_tool_schema_tokens(budget)
+    suffix = f" top_tools={top_tools}" if top_tools else ""
+    logger.info(
+        "Request budget #%d: total~%d tokens messages~%d system~%d tools~%d "
+        "(message_chars=%d system_chars=%d tool_schema_chars=%d tool_count=%d)%s",
+        api_call_count,
+        budget.get("total_rough_tokens", 0),
+        budget.get("message_tokens", 0),
+        budget.get("system_prompt_tokens", 0),
+        budget.get("tool_schema_tokens", 0),
+        budget.get("message_chars", 0),
+        budget.get("system_prompt_chars", 0),
+        budget.get("tool_schema_chars", 0),
+        budget.get("tool_count", 0),
+        suffix,
+    )
+
 # Stable prefix of the local interrupt status string emitted when a turn is
 # cancelled while waiting on the provider. Surfaces (ACP, TUI) match on this
 # to treat it as cancellation metadata rather than assistant prose.
@@ -924,12 +1043,12 @@ def run_conversation(
         # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
         _sanitize_messages_surrogates(api_messages)
 
-        # Calculate approximate request size for logging
-        total_chars = sum(len(str(msg)) for msg in api_messages)
-        approx_tokens = estimate_messages_tokens_rough(api_messages)
-        approx_request_tokens = estimate_request_tokens_rough(
-            api_messages, tools=agent.tools or None
-        )
+        # Calculate approximate request size for logging and telemetry.
+        _request_budget = _request_budget_snapshot(api_messages, agent.tools or None)
+        total_chars = _request_budget["message_chars"]
+        approx_tokens = _request_budget["message_tokens"]
+        approx_request_tokens = _request_budget["total_rough_tokens"]
+        _log_request_budget_telemetry(agent, api_call_count, _request_budget)
 
         _runtime_context_error = _ollama_context_limit_error(
             agent, approx_request_tokens
@@ -1125,7 +1244,12 @@ def run_conversation(
                             message_count=len(api_messages),
                             tool_count=len(agent.tools or []),
                             approx_input_tokens=approx_tokens,
+                            approx_request_tokens=approx_request_tokens,
+                            tool_schema_tokens=_request_budget.get("tool_schema_tokens", 0),
+                            system_prompt_tokens=_request_budget.get("system_prompt_tokens", 0),
+                            top_tool_schema_tokens=list(_request_budget.get("top_tool_schema_tokens", [])),
                             request_char_count=total_chars,
+                            request_budget=dict(_request_budget),
                             max_tokens=agent.max_tokens,
                             started_at=api_start_time,
                             middleware_trace=list(_llm_middleware_trace),

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -101,6 +101,7 @@ def _build_subprocess_env() -> dict[str, str]:
     env = hermes_subprocess_env(inherit_credentials=True)
     home = _resolve_home_dir()
     env["HOME"] = home
+    env["HERMES_REAL_HOME"] = home
     from hermes_constants import apply_subprocess_home_env
     apply_subprocess_home_env(env)
     return env

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -78,25 +78,124 @@ def _find_git_root(start: Path) -> Optional[Path]:
 _HERMES_MD_NAMES = (".hermes.md", "HERMES.md")
 
 
-def _find_hermes_md(cwd: Path) -> Optional[Path]:
-    """Discover the nearest ``.hermes.md`` or ``HERMES.md``.
-
-    Search order: *cwd* first, then each parent directory up to (and
-    including) the git repository root.  Returns the first match, or
-    ``None`` if nothing is found.
-    """
+def _context_search_dirs(cwd: Path) -> list[Path]:
+    """Return cwd→parent dirs up to the git root for project context search."""
     stop_at = _find_git_root(cwd)
     current = cwd.resolve()
-
+    dirs: list[Path] = []
     for directory in [current, *current.parents]:
-        for name in _HERMES_MD_NAMES:
+        dirs.append(directory)
+        if stop_at and directory == stop_at:
+            break
+    return dirs
+
+
+def _find_first_context_file(cwd: Path, names: tuple[str, ...]) -> Optional[Path]:
+    """Find the nearest matching context file from cwd up to git root."""
+    for directory in _context_search_dirs(cwd):
+        for name in names:
             candidate = directory / name
             if candidate.is_file():
                 return candidate
-        # Stop walking at the git root (or filesystem root).
-        if stop_at and directory == stop_at:
-            break
     return None
+
+
+def _find_hermes_md(cwd: Path) -> Optional[Path]:
+    """Discover the nearest ``.hermes.md`` or ``HERMES.md``."""
+    return _find_first_context_file(cwd, _HERMES_MD_NAMES)
+
+
+_AGENTS_MD_NAMES = ("AGENTS.md", "agents.md")
+_CLAUDE_MD_NAMES = ("CLAUDE.md", "claude.md")
+_CONTEXT_MANIFEST_MAX_FILES = 12
+
+
+def _find_agents_md(cwd: Path) -> Optional[Path]:
+    """Discover the nearest AGENTS.md / agents.md from cwd up to git root."""
+    return _find_first_context_file(cwd, _AGENTS_MD_NAMES)
+
+
+def _find_claude_md(cwd: Path) -> Optional[Path]:
+    """Discover the nearest CLAUDE.md / claude.md from cwd up to git root."""
+    return _find_first_context_file(cwd, _CLAUDE_MD_NAMES)
+
+
+def _find_cursorrules_paths(cwd: Path) -> list[Path]:
+    """Return cwd-local Cursor context files in deterministic order."""
+    paths: list[Path] = []
+    cursorrules_file = cwd / ".cursorrules"
+    if cursorrules_file.is_file():
+        paths.append(cursorrules_file)
+    cursor_rules_dir = cwd / ".cursor" / "rules"
+    if cursor_rules_dir.is_dir():
+        paths.extend(sorted(p for p in cursor_rules_dir.glob("*.mdc") if p.is_file()))
+    return paths
+
+
+def _discover_context_file_paths(cwd: Path) -> list[Path]:
+    """Discover project context files without reading their contents."""
+    found: list[Path] = []
+    for finder in (_find_hermes_md, _find_agents_md, _find_claude_md):
+        path = finder(cwd)
+        if path:
+            found.append(path)
+    found.extend(_find_cursorrules_paths(cwd.resolve()))
+
+    # Dedupe case-insensitively by resolved path while preserving priority order.
+    seen: set[str] = set()
+    result: list[Path] = []
+    for path in found:
+        try:
+            key = str(path.resolve()).lower()
+        except Exception:
+            key = str(path).lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(path)
+    return result
+
+
+def _context_path_label(path: Path, cwd: Path) -> str:
+    try:
+        return str(path.relative_to(cwd.resolve()))
+    except ValueError:
+        return str(path)
+
+
+def _format_skipped_context_manifest(cwd: Path, loaded_path: Optional[Path]) -> str:
+    """Return a small manifest of context files discovered but not injected."""
+    loaded_key = None
+    if loaded_path is not None:
+        try:
+            loaded_key = str(loaded_path.resolve()).lower()
+        except Exception:
+            loaded_key = str(loaded_path).lower()
+
+    skipped: list[Path] = []
+    for path in _discover_context_file_paths(cwd):
+        try:
+            key = str(path.resolve()).lower()
+        except Exception:
+            key = str(path).lower()
+        if loaded_key and key == loaded_key:
+            continue
+        skipped.append(path)
+
+    if not skipped:
+        return ""
+
+    shown = skipped[:_CONTEXT_MANIFEST_MAX_FILES]
+    lines = [
+        "## Additional context files discovered (not auto-loaded)",
+        "Hermes injects one project-context body per turn by priority. These files were found but not read; use read_file if they become relevant:",
+    ]
+    for path in shown:
+        lines.append(f"- {_context_path_label(path, cwd)}: {path}")
+    remaining = len(skipped) - len(shown)
+    if remaining > 0:
+        lines.append(f"- ... {remaining} more context file(s) omitted from this manifest")
+    return "\n".join(lines)
 
 
 def _strip_yaml_frontmatter(content: str) -> str:
@@ -1848,73 +1947,78 @@ def _load_hermes_md(cwd_path: Path, context_length: Optional[int] = None) -> str
 
 
 def _load_agents_md(cwd_path: Path, context_length: Optional[int] = None) -> str:
-    """AGENTS.md — top-level only (no recursive walk)."""
-    for name in ["AGENTS.md", "agents.md"]:
-        candidate = cwd_path / name
-        if candidate.exists():
-            try:
-                content = candidate.read_text(encoding="utf-8").strip()
-                if content:
-                    content = _scan_context_content(content, name)
-                    result = f"## {name}\n\n{content}"
-                    return _truncate_content(
-                        result, "AGENTS.md", context_length=context_length,
-                        read_path=str(candidate),
-                    )
-            except Exception as e:
-                logger.debug("Could not read %s: %s", candidate, e)
-    return ""
+    """AGENTS.md / agents.md — nearest file from cwd up to git root."""
+    candidate = _find_agents_md(cwd_path)
+    if not candidate:
+        return ""
+    try:
+        content = candidate.read_text(encoding="utf-8").strip()
+        if not content:
+            return ""
+        content = _scan_context_content(content, candidate.name)
+        rel = candidate.name
+        try:
+            rel = str(candidate.relative_to(cwd_path.resolve()))
+        except ValueError:
+            pass
+        result = f"## {rel}\n\n{content}"
+        return _truncate_content(
+            result, "AGENTS.md", context_length=context_length,
+            read_path=str(candidate),
+        )
+    except Exception as e:
+        logger.debug("Could not read %s: %s", candidate, e)
+        return ""
 
 
 def _load_claude_md(cwd_path: Path, context_length: Optional[int] = None) -> str:
-    """CLAUDE.md / claude.md — cwd only."""
-    for name in ["CLAUDE.md", "claude.md"]:
-        candidate = cwd_path / name
-        if candidate.exists():
-            try:
-                content = candidate.read_text(encoding="utf-8").strip()
-                if content:
-                    content = _scan_context_content(content, name)
-                    result = f"## {name}\n\n{content}"
-                    return _truncate_content(
-                        result, "CLAUDE.md", context_length=context_length,
-                        read_path=str(candidate),
-                    )
-            except Exception as e:
-                logger.debug("Could not read %s: %s", candidate, e)
-    return ""
+    """CLAUDE.md / claude.md — nearest file from cwd up to git root."""
+    candidate = _find_claude_md(cwd_path)
+    if not candidate:
+        return ""
+    try:
+        content = candidate.read_text(encoding="utf-8").strip()
+        if not content:
+            return ""
+        content = _scan_context_content(content, candidate.name)
+        rel = candidate.name
+        try:
+            rel = str(candidate.relative_to(cwd_path.resolve()))
+        except ValueError:
+            pass
+        result = f"## {rel}\n\n{content}"
+        return _truncate_content(
+            result, "CLAUDE.md", context_length=context_length,
+            read_path=str(candidate),
+        )
+    except Exception as e:
+        logger.debug("Could not read %s: %s", candidate, e)
+        return ""
 
 
 def _load_cursorrules(cwd_path: Path, context_length: Optional[int] = None) -> str:
     """.cursorrules + .cursor/rules/*.mdc — cwd only."""
     cursorrules_content = ""
-    cursorrules_file = cwd_path / ".cursorrules"
-    if cursorrules_file.exists():
+    for context_path in _find_cursorrules_paths(cwd_path):
         try:
-            content = cursorrules_file.read_text(encoding="utf-8").strip()
-            if content:
-                content = _scan_context_content(content, ".cursorrules")
-                cursorrules_content += f"## .cursorrules\n\n{content}\n\n"
-        except Exception as e:
-            logger.debug("Could not read .cursorrules: %s", e)
-
-    cursor_rules_dir = cwd_path / ".cursor" / "rules"
-    if cursor_rules_dir.exists() and cursor_rules_dir.is_dir():
-        mdc_files = sorted(cursor_rules_dir.glob("*.mdc"))
-        for mdc_file in mdc_files:
+            content = context_path.read_text(encoding="utf-8").strip()
+            if not content:
+                continue
             try:
-                content = mdc_file.read_text(encoding="utf-8").strip()
-                if content:
-                    content = _scan_context_content(content, f".cursor/rules/{mdc_file.name}")
-                    cursorrules_content += f"## .cursor/rules/{mdc_file.name}\n\n{content}\n\n"
-            except Exception as e:
-                logger.debug("Could not read %s: %s", mdc_file, e)
+                rel = str(context_path.relative_to(cwd_path))
+            except ValueError:
+                rel = context_path.name
+            content = _scan_context_content(content, rel)
+            cursorrules_content += f"## {rel}\n\n{content}\n\n"
+        except Exception as e:
+            logger.debug("Could not read %s: %s", context_path, e)
 
     if not cursorrules_content:
         return ""
+    read_path = str(_find_cursorrules_paths(cwd_path)[0])
     return _truncate_content(
         cursorrules_content, ".cursorrules", context_length=context_length,
-        read_path=str(cwd_path / ".cursorrules"),
+        read_path=read_path,
     )
 
 
@@ -1925,11 +2029,14 @@ def build_context_files_prompt(
 ) -> str:
     """Discover and load context files for the system prompt.
 
-    Priority (first found wins — only ONE project context type is loaded):
+    Priority (first found wins — only ONE project context body is loaded):
       1. .hermes.md / HERMES.md  (walk to git root)
-      2. AGENTS.md / agents.md   (cwd only)
-      3. CLAUDE.md / claude.md   (cwd only)
+      2. AGENTS.md / agents.md   (walk to git root)
+      3. CLAUDE.md / claude.md   (walk to git root)
       4. .cursorrules / .cursor/rules/*.mdc  (cwd only)
+
+    Files discovered but skipped because of this priority are listed as a small
+    manifest with read_file paths, not injected verbatim.
 
     SOUL.md from HERMES_HOME is independent and always included when present.
 
@@ -1947,15 +2054,32 @@ def build_context_files_prompt(
     cwd_path = Path(cwd).resolve()
     sections = []
 
-    # Priority-based project context: first match wins
-    project_context = (
-        _load_hermes_md(cwd_path, context_length)
-        or _load_agents_md(cwd_path, context_length)
-        or _load_claude_md(cwd_path, context_length)
-        or _load_cursorrules(cwd_path, context_length)
-    )
+    # Priority-based project context: first match wins. Track the path so we
+    # can list any skipped context files without injecting their contents.
+    loaded_context_path: Optional[Path] = None
+    project_context = ""
+    for finder, loader in (
+        (_find_hermes_md, _load_hermes_md),
+        (_find_agents_md, _load_agents_md),
+        (_find_claude_md, _load_claude_md),
+    ):
+        candidate = finder(cwd_path)
+        if not candidate:
+            continue
+        project_context = loader(cwd_path, context_length)
+        if project_context:
+            loaded_context_path = candidate
+            break
+    cursorrules_paths = _find_cursorrules_paths(cwd_path)
+    if not project_context and cursorrules_paths:
+        project_context = _load_cursorrules(cwd_path, context_length)
+        if project_context:
+            loaded_context_path = cursorrules_paths[0]
     if project_context:
         sections.append(project_context)
+        skipped_manifest = _format_skipped_context_manifest(cwd_path, loaded_context_path)
+        if skipped_manifest:
+            sections.append(skipped_manifest)
 
     # SOUL.md from HERMES_HOME only — skip when already loaded as identity
     if not skip_soul:

--- a/agent/verification_stop.py
+++ b/agent/verification_stop.py
@@ -117,9 +117,12 @@ def _session_is_messaging_surface() -> bool:
 
         platform = (
             os.getenv("HERMES_PLATFORM")
+            or os.getenv("HERMES_SESSION_PLATFORM")
             or get_session_env("HERMES_SESSION_PLATFORM", "")
         )
-        source = get_session_env("HERMES_SESSION_SOURCE", "")
+        source = os.getenv("HERMES_SESSION_SOURCE") or get_session_env(
+            "HERMES_SESSION_SOURCE", ""
+        )
     except Exception:
         platform = os.getenv("HERMES_PLATFORM", "") or os.environ.get(
             "HERMES_SESSION_PLATFORM", ""

--- a/cli.py
+++ b/cli.py
@@ -9311,7 +9311,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         if not view.logged_in:
             print()
-            _cprint(f"  💳 {_d('Not logged into Nous Portal.')}")
+            if getattr(self, "_app", None):
+                _cprint(f"  💳 {_d('Not logged into Nous Portal.')}")
+            else:
+                print("  💳 Not logged into Nous Portal.")
             print("  Run `hermes portal` to log in, then /credits.")
             return
 

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -495,6 +495,7 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         super().emit(record)
 
     def _open(self):
+        Path(self.baseFilename).parent.mkdir(parents=True, exist_ok=True)
         stream = super()._open()
         self._chmod_if_managed()
         return stream

--- a/model_tools.py
+++ b/model_tools.py
@@ -528,10 +528,11 @@ def _compute_tool_definitions(
         logger.warning("Schema sanitization skipped: %s", e)
 
     # ── Tool Search (progressive disclosure) ────────────────────────────
-    # Conditionally replace MCP + plugin (non-core) tools with three bridge
-    # tools (tool_search / tool_describe / tool_call) when the deferrable
-    # surface exceeds the configured threshold (default 10% of context
-    # window). Core Hermes tools (toolsets._HERMES_CORE_TOOLS) are NEVER
+    # Conditionally replace MCP/plugin/peripheral built-in tools with three
+    # bridge tools (tool_search / tool_describe / tool_call) when the
+    # deferrable surface exceeds the configured threshold (default:
+    # min(10% of context window, 10K schema tokens)). The narrow always-visible
+    # core (toolsets._HERMES_TOOL_SEARCH_ALWAYS_VISIBLE_TOOLS) is never
     # deferred. See tools/tool_search.py for full design notes.
     #
     # This is deliberately the last step before returning — sanitization
@@ -549,7 +550,7 @@ def _compute_tool_definitions(
             )
             if assembly.activated and not quiet_mode:
                 print(
-                    f"🔎 Tool Search: {assembly.deferred_count} MCP/plugin tools deferred "
+                    f"🔎 Tool Search: {assembly.deferred_count} tools deferred "
                     f"(~{assembly.deferred_tokens} tokens) behind tool_search/describe/call. "
                     f"Threshold ~{assembly.threshold_tokens} tokens."
                 )

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -148,6 +148,36 @@ def test_concurrent_compression_does_not_fork_session(tmp_path: Path) -> None:
     )
 
 
+def test_stale_parent_after_lock_release_does_not_fork_session(tmp_path: Path) -> None:
+    """A late stale compressor must skip after the winner already rotated.
+
+    The per-session lock prevents simultaneous rotation. It is not enough on
+    its own: a delayed path can acquire the lock after the winner releases it
+    while still holding the old parent session_id. In that case the parent has
+    already been compression-ended and has a continuation child, so the stale
+    path must no-op instead of creating a second child.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "STALE_PARENT_AFTER_RELEASE"
+    db.create_session(parent_sid, source="discord")
+
+    winner = _build_agent_with_db(db, parent_sid)
+    stale = _build_agent_with_db(db, parent_sid)
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+
+    winner._compress_context(messages, "sys", approx_tokens=120_000)
+    assert _count_children(db, parent_sid) == 1
+    assert winner.session_id != parent_sid
+    assert db.get_compression_lock_holder(parent_sid) is None
+
+    returned, _sp = stale._compress_context(messages, "sys", approx_tokens=120_000)
+
+    assert returned is messages or returned == messages
+    assert stale.session_id == parent_sid
+    assert _count_children(db, parent_sid) == 1
+    stale.context_compressor.compress.assert_not_called()
+
+
 def test_skipped_compression_returns_messages_unchanged(tmp_path: Path) -> None:
     """The loser of the lock race must return its input messages verbatim.
 

--- a/tests/agent/test_empty_tool_name_loop_dampening.py
+++ b/tests/agent/test_empty_tool_name_loop_dampening.py
@@ -115,14 +115,31 @@ def agent_env():
 
     test_home = tempfile.mkdtemp(prefix="hermes_e2e_47967_")
     os.makedirs(os.path.join(test_home, ".hermes"))
+    os.makedirs(os.path.join(test_home, ".hermes", "logs"), exist_ok=True)
     prev_home = os.environ.get("HERMES_HOME")
     os.environ["HERMES_HOME"] = os.path.join(test_home, ".hermes")
 
     # Import fresh so the patched conversation_loop is exercised even when the
-    # module was imported earlier in the same worker.
-    for mod in list(sys.modules):
-        if mod == "run_agent" or mod.startswith("agent.") or mod.startswith("tools.") or mod.startswith("hermes_"):
-            del sys.modules[mod]
+    # module was imported earlier in the same worker. Preserve and restore the
+    # original modules: pytest imports test modules during collection, so leaving
+    # fresh agent.* modules in sys.modules makes later string-target patches hit
+    # a different module object than already-imported symbols.
+    def _needs_fresh_import(mod: str) -> bool:
+        return (
+            mod in {"agent", "tools"}
+            or mod == "run_agent"
+            or mod.startswith("agent.")
+            or mod.startswith("tools.")
+            or mod.startswith("hermes_")
+        )
+
+    saved_modules = {
+        mod: sys.modules[mod]
+        for mod in list(sys.modules)
+        if _needs_fresh_import(mod)
+    }
+    for mod in saved_modules:
+        del sys.modules[mod]
     from run_agent import AIAgent
 
     agent = AIAgent(
@@ -139,6 +156,10 @@ def agent_env():
     finally:
         srv.shutdown()
         shutil.rmtree(test_home, ignore_errors=True)
+        for mod in list(sys.modules):
+            if _needs_fresh_import(mod):
+                del sys.modules[mod]
+        sys.modules.update(saved_modules)
         if prev_home is None:
             os.environ.pop("HERMES_HOME", None)
         else:

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -1,4 +1,5 @@
 """Tests for agent.models_dev — models.dev registry integration."""
+import pytest
 from unittest.mock import patch, MagicMock
 
 from agent.models_dev import (
@@ -8,6 +9,25 @@ from agent.models_dev import (
     get_model_capabilities,
     lookup_models_dev_context,
 )
+
+
+@pytest.fixture(autouse=True)
+def restore_models_dev_cache():
+    """Keep fake registry mutations local to each test.
+
+    These tests intentionally manipulate the in-memory models.dev cache. If a
+    sample registry leaks into later tests, capability lookups can turn known
+    text-only models into "unknown" and make vision routing permissive.
+    """
+    import agent.models_dev as md
+
+    old_cache = md._models_dev_cache
+    old_cache_time = md._models_dev_cache_time
+    try:
+        yield
+    finally:
+        md._models_dev_cache = old_cache
+        md._models_dev_cache_time = old_cache_time
 
 
 SAMPLE_REGISTRY = {

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -708,6 +708,15 @@ class TestBuildContextFilesPrompt:
         assert "Ruff for linting" in result
         assert "Project Context" in result
 
+    def test_agents_md_parent_dir_discovery(self, tmp_path):
+        """AGENTS.md is discovered from subdirectories up to the git root."""
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "AGENTS.md").write_text("Root agent instructions.")
+        sub = tmp_path / "src" / "pkg"
+        sub.mkdir(parents=True)
+        result = build_context_files_prompt(cwd=str(sub))
+        assert "Root agent instructions" in result
+
     def test_loads_cursorrules(self, tmp_path):
         (tmp_path / ".cursorrules").write_text("Always use type hints.")
         result = build_context_files_prompt(cwd=str(tmp_path))
@@ -819,12 +828,24 @@ class TestBuildContextFilesPrompt:
         assert "BLOCKED" in result
 
     def test_hermes_md_beats_agents_md(self, tmp_path):
-        """When both exist, .hermes.md wins and AGENTS.md is not loaded."""
+        """When both exist, .hermes.md wins and AGENTS.md content is not loaded."""
         (tmp_path / "AGENTS.md").write_text("Agent guidelines here.")
         (tmp_path / ".hermes.md").write_text("Hermes project rules.")
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "Hermes project rules" in result
         assert "Agent guidelines" not in result
+
+    def test_skipped_context_files_are_manifested_without_content(self, tmp_path):
+        (tmp_path / ".hermes.md").write_text("Primary project rules.")
+        (tmp_path / "AGENTS.md").write_text("Secondary secret should not load.")
+        (tmp_path / "CLAUDE.md").write_text("Tertiary secret should not load.")
+        result = build_context_files_prompt(cwd=str(tmp_path))
+        assert "Primary project rules" in result
+        assert "Additional context files discovered" in result
+        assert "AGENTS.md" in result
+        assert "CLAUDE.md" in result
+        assert "Secondary secret should not load" not in result
+        assert "Tertiary secret should not load" not in result
 
     def test_agents_md_beats_claude_md(self, tmp_path):
         (tmp_path / "AGENTS.md").write_text("Agent guidelines here.")

--- a/tests/agent/test_request_budget_telemetry.py
+++ b/tests/agent/test_request_budget_telemetry.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from agent.conversation_loop import (
+    _log_request_budget_telemetry,
+    _request_budget_snapshot,
+)
+
+
+def test_request_budget_snapshot_breaks_out_system_and_tool_schema():
+    messages = [
+        {"role": "system", "content": "system prompt" * 10},
+        {"role": "user", "content": "hello"},
+    ]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "mcp_big_tool",
+                "description": "x" * 400,
+                "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
+            },
+        }
+    ]
+
+    budget = _request_budget_snapshot(messages, tools)
+
+    assert budget["message_count"] == 2
+    assert budget["tool_count"] == 1
+    assert budget["system_prompt_chars"] >= len("system prompt")
+    assert budget["system_prompt_tokens"] > 0
+    assert budget["conversation_tokens"] > 0
+    assert budget["tool_schema_chars"] > 400
+    assert budget["tool_schema_tokens"] > 0
+    assert budget["total_rough_tokens"] >= budget["message_tokens"]
+
+
+def test_request_budget_snapshot_includes_top_tool_schema_contributors():
+    messages = [{"role": "user", "content": "hello"}]
+    tools = [
+        {"type": "function", "function": {"name": "tiny_tool", "description": "x", "parameters": {"type": "object", "properties": {}}}},
+        {"type": "function", "function": {"name": "huge_tool", "description": "y" * 800, "parameters": {"type": "object", "properties": {"q": {"type": "string", "description": "z" * 400}}}}},
+        {"type": "function", "function": {"name": "medium_tool", "description": "m" * 200, "parameters": {"type": "object", "properties": {}}}},
+    ]
+
+    budget = _request_budget_snapshot(messages, tools)
+
+    top = budget["top_tool_schema_tokens"]
+    assert [item["name"] for item in top[:3]] == ["huge_tool", "medium_tool", "tiny_tool"]
+    assert top[0]["schema_chars"] > top[1]["schema_chars"] > top[2]["schema_chars"]
+    assert top[0]["schema_tokens"] > 0
+
+
+def test_request_budget_telemetry_logs_and_stores_last_snapshot(caplog):
+    agent = SimpleNamespace()
+    budget = {
+        "total_rough_tokens": 123,
+        "message_tokens": 45,
+        "system_prompt_tokens": 20,
+        "tool_schema_tokens": 58,
+        "message_chars": 180,
+        "system_prompt_chars": 80,
+        "tool_schema_chars": 232,
+        "tool_count": 7,
+        "top_tool_schema_tokens": [
+            {"name": "huge_tool", "schema_chars": 160, "schema_tokens": 40},
+            {"name": "medium_tool", "schema_chars": 72, "schema_tokens": 18},
+        ],
+    }
+
+    with caplog.at_level(logging.INFO, logger="agent.conversation_loop"):
+        _log_request_budget_telemetry(agent, 3, budget)
+
+    assert agent.session_last_request_budget == budget
+    assert "Request budget #3: total~123 tokens" in caplog.text
+    assert "tools~58" in caplog.text
+    assert "tool_count=7" in caplog.text
+    assert "top_tools=huge_tool~40, medium_tool~18" in caplog.text

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -253,3 +253,18 @@ class TestDefaultPlatformWebSearchCoverage:
 
     def test_hermes_api_server_toolset_includes_web_search(self):
         assert "web_search" in resolve_toolset("hermes-api-server")
+
+def test_tool_search_always_visible_subset_of_core():
+    """Narrow-waist direct tools must remain available in every platform core."""
+    from toolsets import _HERMES_CORE_TOOLS, _HERMES_TOOL_SEARCH_ALWAYS_VISIBLE_TOOLS
+    missing = set(_HERMES_TOOL_SEARCH_ALWAYS_VISIBLE_TOOLS) - set(_HERMES_CORE_TOOLS)
+    assert not missing
+
+
+def test_tool_search_always_visible_excludes_peripheral_large_schemas():
+    """Browser/media/cron tools stay in platform core but can defer behind Tool Search."""
+    from toolsets import _HERMES_CORE_TOOLS, _HERMES_TOOL_SEARCH_ALWAYS_VISIBLE_TOOLS
+    assert "browser_navigate" in _HERMES_CORE_TOOLS
+    assert "browser_navigate" not in _HERMES_TOOL_SEARCH_ALWAYS_VISIBLE_TOOLS
+    assert "cronjob" in _HERMES_CORE_TOOLS
+    assert "cronjob" not in _HERMES_TOOL_SEARCH_ALWAYS_VISIBLE_TOOLS

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -114,34 +114,35 @@ class TestAtomicSnapshotWrite:
         assert f"export -p > {snap} " not in wrapped
         assert f"export -p > '{snap}'" not in wrapped
 
-    def test_temp_path_uses_bashpid_not_dollardollar(self):
-        """The temp name MUST use ``$BASHPID`` (the real subshell PID), not
-        ``$$``.  In ``&``-launched concurrent subshells ``$$`` stays the parent
-        shell's PID, so two writers would pick the same temp name, clobber each
-        other mid-write, and mv would publish a torn file — the corruption is
-        only narrowed, not closed.  This is the bug shared by every prior PR in
-        the #38249 cluster."""
+    def test_temp_path_uses_mktemp_not_shell_pid_vars(self):
+        """The temp name MUST be allocated by ``mktemp``, not shell PID vars.
+
+        ``$$`` is shared by ``&``-launched subshells, while macOS bash 3.2 has
+        an empty ``$BASHPID``.  Either PID-based spelling can make concurrent
+        writers share a temp path and publish a torn snapshot.
+        """
         env = _TestableEnv()
         env._snapshot_ready = True
         wrapped = env._wrap_command("echo hi", "/tmp")
-        assert "$BASHPID" in wrapped
-        # The bare $$ temp form must be gone.
+        assert "mktemp " in wrapped
+        assert ".tmp.XXXXXXXXXX" in wrapped
+        assert "$BASHPID" not in wrapped
         assert ".tmp.$$" not in wrapped
 
-    def test_temp_path_static_part_is_quoted_bashpid_outside(self):
+    def test_temp_path_template_static_part_is_quoted_for_mktemp(self):
         """The static path portion must be shlex-quoted (Windows/Git-Bash
-        ``C:/Users/...`` or spaces) while ``$BASHPID`` stays OUTSIDE the quotes
-        so it still expands."""
+        ``C:/Users/...`` or spaces) while the mktemp ``X`` suffix remains in the
+        same shell word."""
         env = _TestableEnv()
         env._snapshot_ready = True
         env._snapshot_path = "/tmp/has space/hermes-snap-x.sh"
         wrapped = env._wrap_command("echo hi", "/tmp")
-        # The static path (with its space) is shlex-quoted as a single word, with
-        # $BASHPID appended OUTSIDE the quotes so it still expands at runtime.
-        assert "'/tmp/has space/hermes-snap-x.sh.tmp.'$BASHPID" in wrapped
-        # The space must never appear bare/unquoted in the temp token (that would
-        # word-split into two args and break the redirect/mv).
-        assert " space/hermes-snap-x.sh.tmp.$BASHPID" not in wrapped
+        # The full mktemp template (including its X suffix) is shlex-quoted as a
+        # single word so spaces do not split the redirect/mv path.
+        assert "mktemp '/tmp/has space/hermes-snap-x.sh.tmp.XXXXXXXXXX'" in wrapped
+        # The mktemp template must not appear as an unquoted shell word (that
+        # would word-split at the space and break temp allocation).
+        assert "mktemp /tmp/has space/hermes-snap-x.sh.tmp.XXXXXXXXXX" not in wrapped
 
     def test_wrap_command_mv_chained_on_export_success(self):
         """A failed/partial ``export -p`` must NOT mv a torn temp over a good
@@ -153,10 +154,10 @@ class TestAtomicSnapshotWrite:
         assert "export -p > " in wrapped and "&& mv -f " in wrapped
         assert "rm -f " in wrapped  # temp cleanup on failure
 
-    def test_init_session_bootstrap_also_atomic_and_bashpid(self):
+    def test_init_session_bootstrap_also_atomic_and_mktemp(self):
         """The init_session bootstrap (first snapshot write) is the same shared
-        file a concurrent command could source — it must be atomic and use
-        ``$BASHPID`` too."""
+        file a concurrent command could source — it must be atomic and use a
+        uniquely allocated temp file too."""
         env = _TestableEnv()
         captured = {}
 
@@ -171,7 +172,9 @@ class TestAtomicSnapshotWrite:
             pass
         boot = captured.get("cmd", "")
         assert ".tmp." in boot and "mv -f " in boot, boot
-        assert "$BASHPID" in boot
+        assert "mktemp " in boot
+        assert ".tmp.XXXXXXXXXX" in boot
+        assert "$BASHPID" not in boot
         assert ".tmp.$$" not in boot
 
 
@@ -183,8 +186,9 @@ class TestAtomicSnapshotConcurrencyBehavioral:
     the emitted script's guarantee holds under real concurrency: N concurrent
     writers + readers, and the snapshot is ALWAYS a complete, parseable env
     dump — never truncated mid-line with a ``declare -x`` / ``export`` fragment
-    that would corrupt PATH.  Crucially it uses ``$BASHPID`` (per-subshell
-    unique), which is what closes the race; ``$$`` would still tear here.
+    that would corrupt PATH.  Crucially it allocates a fresh temp path with
+    ``mktemp`` for every writer; shell PID variables are not portable enough
+    for this on macOS bash 3.2.
     """
 
     def _run(self, script):
@@ -199,13 +203,14 @@ class TestAtomicSnapshotConcurrencyBehavioral:
         import shlex
         snap = str(tmp_path / "hermes-snap-x.sh")
         _q = shlex.quote
-        _snap_tmp = _q(snap + ".tmp.") + "$BASHPID"
+        _snap_tmp_template = _q(snap + ".tmp.XXXXXXXXXX")
         # One writer iteration = the exact atomic sequence _wrap_command emits.
         writer = (
             "for i in $(seq 1 80); do "
             "export BIG_$i=$(head -c 600 /dev/zero | tr '\\0' x); "
-            f"{{ export -p > {_snap_tmp} && mv -f {_snap_tmp} {_q(snap)}; }} "
-            f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true; "
+            f"__hermes_snap_tmp=$(mktemp {_snap_tmp_template}) && "
+            f"{{ export -p > \"$__hermes_snap_tmp\" && mv -f \"$__hermes_snap_tmp\" {_q(snap)}; }} "
+            f"2>/dev/null || rm -f \"$__hermes_snap_tmp\" 2>/dev/null || true; "
             "done"
         )
         # Reader: repeatedly source the snapshot and check PATH never absorbs
@@ -238,12 +243,13 @@ class TestAtomicSnapshotConcurrencyBehavioral:
         snap = str(tmp_path / "snap.sh")
         _q = shlex.quote
         self._run(f"echo 'export GOOD=1' > {_q(snap)}")  # seed good snapshot
-        # Redirect export into an unwritable dir so the export side fails; mv
-        # must then NOT run (&&) and not clobber snap.
-        bad_tmp = _q("/nonexistent-dir/snap.tmp.") + "$BASHPID"
+        # Simulate a failed snapshot assembly after mktemp succeeds; mv must
+        # then NOT run (&&) and must not clobber snap.
+        bad_tmp_template = _q(str(tmp_path / "snap.tmp.XXXXXXXXXX"))
         script = (
-            f"{{ export -p > {bad_tmp} && mv -f {bad_tmp} {_q(snap)}; }} "
-            f"2>/dev/null || rm -f {bad_tmp} 2>/dev/null || true"
+            f"__hermes_snap_tmp=$(mktemp {bad_tmp_template}) && "
+            f"{{ false > \"$__hermes_snap_tmp\" && mv -f \"$__hermes_snap_tmp\" {_q(snap)}; }} "
+            f"2>/dev/null || rm -f \"$__hermes_snap_tmp\" 2>/dev/null || true"
         )
         self._run(script)
         out = self._run(f"cat {_q(snap)}")

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -78,6 +78,21 @@ class TestSandboxRequirements(unittest.TestCase):
         self.assertIn("code", EXECUTE_CODE_SCHEMA["parameters"]["properties"])
         self.assertIn("code", EXECUTE_CODE_SCHEMA["parameters"]["required"])
 
+    def test_schema_stays_compact_but_preserves_usage_guidance(self):
+        schema = build_execute_code_schema()
+        schema_text = json.dumps(schema, ensure_ascii=False)
+        description = schema["description"]
+
+        self.assertLess(len(schema_text), 2_100)
+        self.assertIn("hermes_tools", description)
+        self.assertIn("3+ tool calls", description)
+        self.assertIn("50KB stdout", description)
+        self.assertIn("max 50 tool calls", description)
+        self.assertIn("json_parse", description)
+        self.assertIn("shell_quote", description)
+        self.assertIn("retry", description)
+        self.assertIn("Print final result", description)
+
 
 class TestHermesToolsGeneration(unittest.TestCase):
     def test_generates_all_allowed_tools(self):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -109,6 +109,24 @@ class TestDelegateRequirements(unittest.TestCase):
             self.assertNotIn("default 3", surface)
             self.assertNotIn("default 2", surface)
 
+
+    def test_schema_stays_compact_but_preserves_operational_guidance(self):
+        """delegate_task is always visible, so its schema must stay budget-conscious."""
+        import json
+        from tools.registry import registry
+        from agent.conversation_loop import _serialized_chars
+
+        defs = registry.get_definitions({"delegate_task"})
+        schema = defs[0]["function"]
+        schema_text = json.dumps(schema, ensure_ascii=False)
+
+        self.assertLess(_serialized_chars({"type": "function", "function": schema}), 5_000)
+        self.assertIn(f"up to {_get_max_concurrent_children()}", schema["description"])
+        self.assertIn(f"max_spawn_depth={MAX_DEPTH}", schema["description"])
+        self.assertIn("no parent history", schema_text.lower())
+        self.assertIn("verify", schema_text.lower())
+        self.assertIn("toolsets", schema["parameters"]["properties"])
+
     def test_schema_overrides_applied_via_get_definitions(self):
         """Registry.get_definitions() must apply dynamic_schema_overrides so
         the model API call sees current values, not the static import-time text.

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -63,6 +63,30 @@ def _make_safe_tempdir(prefix: str) -> str:
 # Device path blocking
 # ---------------------------------------------------------------------------
 
+class TestReadFileOutputBudget(unittest.TestCase):
+    @patch("tools.file_tools._get_file_ops")
+    def test_read_file_truncates_large_successful_reads_by_default_budget(self, mock_ops):
+        fake = _make_fake_ops(content="A" * 70_000, total_lines=1, file_size=70_000)
+        mock_ops.return_value = fake
+
+        result = json.loads(read_file_tool("budget.txt", task_id="budget-default"))
+
+        self.assertTrue(result.get("truncated_by_budget"))
+        self.assertEqual(result.get("budget_chars"), 60_000)
+        self.assertLessEqual(len(result.get("content", "")), 60_000)
+        self.assertIn("max_chars", result.get("hint", ""))
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_read_file_max_chars_override_allows_larger_payload(self, mock_ops):
+        fake = _make_fake_ops(content="B" * 70_000, total_lines=1, file_size=70_000)
+        mock_ops.return_value = fake
+
+        result = json.loads(read_file_tool("budget.txt", task_id="budget-override", max_chars=80_000))
+
+        self.assertFalse(result.get("truncated_by_budget", False))
+        self.assertEqual(len(result.get("content", "")), 70_000)
+
+
 class TestDevicePathBlocking(unittest.TestCase):
     """Paths like /dev/zero should be rejected before any I/O."""
 

--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -24,6 +24,15 @@ import tools.file_tools as ft
 import tools.terminal_tool as terminal_tool
 
 
+@pytest.fixture(autouse=True)
+def _isolate_last_known_cwd(monkeypatch):
+    """Keep cwd-resolution tests from leaking preserved cwd into later files."""
+    isolated = {}
+    monkeypatch.setattr(ft, "_last_known_cwd", isolated)
+    yield
+    isolated.clear()
+
+
 @pytest.fixture
 def _isolated_cwd(tmp_path, monkeypatch):
     """Two checkouts: workspace (intended) + decoy (process cwd)."""

--- a/tests/tools/test_memory_tool_schema.py
+++ b/tests/tools/test_memory_tool_schema.py
@@ -52,3 +52,15 @@ def test_memory_schema_is_well_formed():
 
 def test_memory_schema_is_json_serializable():
     json.dumps(MEMORY_SCHEMA)
+
+def test_memory_schema_stays_compact_but_preserves_curated_memory_guidance():
+    schema_text = json.dumps(MEMORY_SCHEMA, ensure_ascii=False)
+
+    assert len(schema_text) < 2_300
+    desc = MEMORY_SCHEMA["description"]
+    assert "operations" in desc
+    assert "atomically" in desc
+    assert "session_search" in desc
+    assert "task progress" in desc
+    assert "procedures belong in a skill" in desc
+    assert "declarative facts" in desc

--- a/tests/tools/test_resolve_path.py
+++ b/tests/tools/test_resolve_path.py
@@ -4,6 +4,18 @@ import os
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_file_tool_path_state(monkeypatch):
+    """Keep helper tests independent from preserved/live cwd process state."""
+    from tools import file_tools, terminal_tool
+
+    monkeypatch.setattr(file_tools, "_last_known_cwd", {})
+    monkeypatch.setattr(file_tools, "_file_ops_cache", {})
+    monkeypatch.setattr(terminal_tool, "_active_environments", {})
+
 
 
 class TestResolvePath:

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -62,6 +62,28 @@ def _seed_modpack_sessions(db):
 # Schema invariants
 # =========================================================================
 
+def _seed_long_session(db):
+    db.create_session("s_long", source="cli")
+    db._conn.execute("UPDATE sessions SET title = ? WHERE id = ?", ("Long Session", "s_long"))
+    db.append_message("s_long", role="user", content="U" * 20_000)
+    db.append_message("s_long", role="assistant", content="A" * 20_000)
+    db._conn.commit()
+
+
+class TestContentBudget:
+    def test_read_shape_truncates_large_message_content_by_default(self, db):
+        _seed_long_session(db)
+        result = json.loads(session_search(session_id="s_long", db=db))
+        assert result["success"] is True
+        assert any(m.get("content_truncated_by_budget") for m in result["messages"])
+
+    def test_read_shape_max_content_chars_override(self, db):
+        _seed_long_session(db)
+        result = json.loads(session_search(session_id="s_long", db=db, max_content_chars=30_000))
+        assert result["success"] is True
+        assert not any(m.get("content_truncated_by_budget") for m in result["messages"])
+
+
 class TestSchema:
     def test_schema_has_required_params(self):
         params = SESSION_SEARCH_SCHEMA["parameters"]["properties"]
@@ -571,7 +593,6 @@ class TestCrossProfileRead:
             assert result["mode"] == "read"
             assert result["session_id"] == "s_other"
 
-
 # =========================================================================
 # Cron demotion in discover ranking (#19434)
 # =========================================================================
@@ -638,3 +659,18 @@ class TestCronDemotion:
         # Interactive rows first, in original relative order; cron last, in
         # original relative order.
         assert [r["id"] for r in ordered] == [2, 4, 5, 1, 3]
+
+
+def test_session_search_schema_stays_compact_but_preserves_safety_guidance():
+    from tools.session_search_tool import SESSION_SEARCH_SCHEMA
+
+    schema_text = str(SESSION_SEARCH_SCHEMA)
+
+    assert len(schema_text) < 4_500
+    assert "SOURCE-FIRST" in SESSION_SEARCH_SCHEMA["description"]
+    assert "DISCOVERY" in SESSION_SEARCH_SCHEMA["description"]
+    assert "SCROLL" in SESSION_SEARCH_SCHEMA["description"]
+    assert "READ" in SESSION_SEARCH_SCHEMA["description"]
+    assert "BROWSE" in SESSION_SEARCH_SCHEMA["description"]
+    assert "@session:<profile>/<id>" in SESSION_SEARCH_SCHEMA["description"]
+    assert "max_content_chars" in SESSION_SEARCH_SCHEMA["parameters"]["properties"]

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1153,7 +1153,6 @@ class TestDeleteSkillRmtreeGuard:
         assert "skills root" in result["error"].lower()
         assert outside.exists()
 
-
 # ---------------------------------------------------------------------------
 # Curator consolidation-pass fail-closed delete guard (#29912)
 # ---------------------------------------------------------------------------
@@ -1281,3 +1280,18 @@ class TestCuratorConsolidationDeleteGuard:
             rec = skill_usage.get_record("narrow")
         # Record kept (not forgotten) and marked archived.
         assert rec.get("state") == skill_usage.STATE_ARCHIVED
+
+
+def test_skill_manage_schema_stays_compact_but_preserves_lifecycle_guidance():
+    import json
+    from tools.skill_manager_tool import SKILL_MANAGE_SCHEMA
+
+    schema_text = json.dumps(SKILL_MANAGE_SCHEMA, ensure_ascii=False)
+
+    assert len(schema_text) < 3_000
+    desc = SKILL_MANAGE_SCHEMA["description"]
+    assert "absorbed_into" in schema_text
+    assert "Create when" in desc
+    assert "Update when" in desc
+    assert "Pinned skills" in desc
+    assert "skill_view" in desc

--- a/tests/tools/test_skill_size_limits.py
+++ b/tests/tools/test_skill_size_limits.py
@@ -205,7 +205,11 @@ class TestHandPlacedSkillsNoLimit:
         huge = huge.replace("name: test-skill", "name: manual-giant")
         (skill_dir / "SKILL.md").write_text(huge, encoding="utf-8")
 
-        result = json.loads(skill_view("manual-giant"))
+        default_result = json.loads(skill_view("manual-giant"))
+        assert default_result.get("truncated_by_budget") is True
+
+        result = json.loads(skill_view("manual-giant", max_chars=0))
         assert "content" in result
-        # The full content is returned — no truncation at the storage layer
+        # Explicit max_chars=0 bypasses the soft response budget, proving the
+        # storage layer still accepts hand-placed oversized skills.
         assert len(result["content"]) > MAX_SKILL_CONTENT_CHARS

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -457,6 +457,25 @@ class TestSkillView:
         assert "Current date: !`printf SHOULD_NOT_RUN`" in result["content"]
         assert "Current date: SHOULD_NOT_RUN" not in result["content"]
 
+    def test_skill_view_truncates_large_skill_content_by_default_budget(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "large-skill", body="A" * 70_000)
+            raw = skill_view("large-skill")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["truncated_by_budget"] is True
+        assert result["budget_chars"] == 60_000
+        assert len(result["content"]) <= 60_000
+
+    def test_skill_view_max_chars_override_preserves_large_content(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "large-skill", body="B" * 70_000)
+            raw = skill_view("large-skill", max_chars=80_000)
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result.get("truncated_by_budget") is not True
+        assert len(result["content"]) > 69_000
+
     def test_view_nonexistent_skill(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(tmp_path, "other-skill")

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -196,6 +196,15 @@ def test_validate_workdir_allows_windows_unc_paths():
     assert terminal_tool._validate_workdir(r"\\server\share\project") is None
 
 
+def test_validate_workdir_allows_unicode_filesystem_paths():
+    assert terminal_tool._validate_workdir(
+        "/Users/alice/Documents/Obs_Hermes_Data/项目-projects/客户拜访"
+    ) is None
+    assert terminal_tool._validate_workdir(
+        "/Users/alice/Documents/附件-attachments/微信视频号下载"
+    ) is None
+
+
 def test_validate_workdir_blocks_shell_metacharacters_in_windows_paths():
     assert terminal_tool._validate_workdir(r"C:\Users\Alice\project; rm -rf /")
     assert terminal_tool._validate_workdir(r"C:\Users\Alice\project$(whoami)")
@@ -299,3 +308,16 @@ def test_transform_sudo_command_pipes_one_password_line_per_invocation(monkeypat
 def test_count_real_sudo_invocations_ignores_mentions(monkeypatch):
     assert terminal_tool._count_real_sudo_invocations("grep sudo README.md") == 0
     assert terminal_tool._count_real_sudo_invocations("sudo a; sudo b") == 2
+
+def test_terminal_schema_stays_compact_but_preserves_operational_guidance():
+    import json
+
+    schema_text = json.dumps(terminal_tool.TERMINAL_SCHEMA, ensure_ascii=False)
+
+    assert len(schema_text) < 3_600
+    desc = terminal_tool.TERMINAL_TOOL_DESCRIPTION
+    assert "exported environment variables persist between calls" in desc
+    assert "read_file" in desc
+    assert "search_files" in desc
+    assert "notify_on_complete=true" in schema_text
+    assert "watch_patterns" in terminal_tool.TERMINAL_SCHEMA["parameters"]["properties"]

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -45,6 +45,7 @@ class TestConfigParsing:
         cfg = ToolSearchConfig.from_raw(None)
         assert cfg.enabled == "auto"
         assert cfg.threshold_pct == 10.0
+        assert cfg.threshold_max_tokens == 10_000
 
     def test_bool_true_maps_to_auto(self):
         from tools.tool_search import ToolSearchConfig
@@ -73,6 +74,12 @@ class TestConfigParsing:
         cfg = ToolSearchConfig.from_raw({"threshold_pct": -5})
         assert cfg.threshold_pct == 0.0
 
+    def test_threshold_max_tokens_clamped_and_disable_cap(self):
+        from tools.tool_search import ToolSearchConfig
+        assert ToolSearchConfig.from_raw({"threshold_max_tokens": 5}).threshold_max_tokens == 1_000
+        assert ToolSearchConfig.from_raw({"threshold_max_tokens": 999_999}).threshold_max_tokens == 100_000
+        assert ToolSearchConfig.from_raw({"threshold_max_tokens": 0}).threshold_max_tokens == 0
+
     def test_search_limits_clamped(self):
         from tools.tool_search import ToolSearchConfig
         cfg = ToolSearchConfig.from_raw({
@@ -84,21 +91,32 @@ class TestConfigParsing:
 
 
 # ---------------------------------------------------------------------------
-# Classification — the hard invariant: core tools NEVER defer.
+# Classification — narrow always-visible core vs deferrable periphery.
 # ---------------------------------------------------------------------------
 
 
 class TestClassification:
-    def test_core_tools_never_defer(self):
-        """The critical invariant from the OpenClaw report."""
+    def test_always_visible_tools_never_defer(self):
+        """Runtime/discovery waist stays direct even when Tool Search activates."""
         from tools.tool_search import is_deferrable_tool_name
-        # Sample of core tools from _HERMES_CORE_TOOLS.
-        for core_name in ["terminal", "read_file", "write_file", "patch",
-                          "search_files", "todo", "memory", "browser_navigate",
-                          "web_search", "session_search", "clarify",
-                          "execute_code", "delegate_task", "send_message"]:
-            assert not is_deferrable_tool_name(core_name), (
-                f"Core tool '{core_name}' must NEVER be deferrable"
+        # Sample of _HERMES_TOOL_SEARCH_ALWAYS_VISIBLE_TOOLS plus one unknown
+        # historical name (unknowns must remain non-deferrable).
+        for visible_name in ["terminal", "read_file", "write_file", "patch",
+                             "search_files", "todo", "memory", "web_search",
+                             "session_search", "clarify", "execute_code",
+                             "delegate_task", "send_message"]:
+            assert not is_deferrable_tool_name(visible_name), (
+                f"Always-visible tool '{visible_name}' must not be deferrable"
+            )
+
+    def test_peripheral_builtin_tools_can_defer(self):
+        """Built-in browser/media/cron schemas are eligible for progressive disclosure."""
+        from tools.registry import discover_builtin_tools
+        from tools.tool_search import is_deferrable_tool_name
+        discover_builtin_tools()
+        for peripheral_name in ["browser_navigate", "vision_analyze", "image_generate", "text_to_speech", "cronjob"]:
+            assert is_deferrable_tool_name(peripheral_name), (
+                f"Peripheral built-in tool '{peripheral_name}' should be searchable/deferred"
             )
 
     def test_bridge_tools_never_defer(self):
@@ -152,21 +170,43 @@ class TestThresholdGate:
     def test_auto_below_threshold_does_not_activate(self):
         from tools.tool_search import ToolSearchConfig, should_activate
         cfg = ToolSearchConfig.from_raw({"enabled": "auto", "threshold_pct": 10})
-        # 5% of 200K = below 10% threshold
-        assert not should_activate(cfg, deferrable_tokens=10_000, context_length=200_000)
+        # Default fixed cap is 10K, so stay below that.
+        assert not should_activate(cfg, deferrable_tokens=9_999, context_length=200_000)
 
     def test_auto_at_or_above_threshold_activates(self):
         from tools.tool_search import ToolSearchConfig, should_activate
         cfg = ToolSearchConfig.from_raw({"enabled": "auto", "threshold_pct": 10})
-        assert should_activate(cfg, deferrable_tokens=20_000, context_length=200_000)
+        assert should_activate(cfg, deferrable_tokens=10_000, context_length=200_000)
         assert should_activate(cfg, deferrable_tokens=50_000, context_length=200_000)
 
+    def test_auto_caps_threshold_for_large_context_models(self):
+        """A 272K-context model must not carry ~16K schema tokens every turn.
+
+        The previous percentage-only gate set the threshold at ~27K here, so
+        MCP schemas around 15.9K stayed visible.  The default fixed cap flips
+        the decision at 10K instead.
+        """
+        from tools.tool_search import ToolSearchConfig, auto_threshold_tokens, should_activate
+        cfg = ToolSearchConfig.from_raw({"enabled": "auto", "threshold_pct": 10})
+        assert auto_threshold_tokens(cfg, context_length=272_000) == 10_000
+        assert should_activate(cfg, deferrable_tokens=15_900, context_length=272_000)
+
+    def test_auto_can_disable_fixed_cap_for_legacy_percentage_gate(self):
+        from tools.tool_search import ToolSearchConfig, auto_threshold_tokens, should_activate
+        cfg = ToolSearchConfig.from_raw({
+            "enabled": "auto",
+            "threshold_pct": 10,
+            "threshold_max_tokens": 0,
+        })
+        assert auto_threshold_tokens(cfg, context_length=200_000) == 20_000
+        assert not should_activate(cfg, deferrable_tokens=10_000, context_length=200_000)
+
     def test_auto_without_context_length_uses_20k_cutoff(self):
-        """Fallback cutoff used when the active model is unknown."""
+        """Fallback cutoff uses the fixed cap when the active model is unknown."""
         from tools.tool_search import ToolSearchConfig, should_activate
         cfg = ToolSearchConfig.from_raw({"enabled": "auto"})
-        assert not should_activate(cfg, deferrable_tokens=10_000, context_length=0)
-        assert should_activate(cfg, deferrable_tokens=25_000, context_length=0)
+        assert not should_activate(cfg, deferrable_tokens=9_999, context_length=0)
+        assert should_activate(cfg, deferrable_tokens=10_000, context_length=0)
 
     def test_token_estimate_proportional_to_schema_size(self):
         from tools.tool_search import estimate_tokens_from_schemas
@@ -278,6 +318,25 @@ class TestAssembly:
         # activation happened; here it didn't).
         assert "tool_search" not in names
 
+    def test_peripheral_builtin_deferred_but_core_visible(self):
+        from tools.registry import discover_builtin_tools
+        from tools.tool_search import assemble_tool_defs, ToolSearchConfig
+        discover_builtin_tools()
+        defs = [
+            _td("terminal", "Run shell"),
+            _td("browser_navigate", "Navigate browser", {"url": {"type": "string"}}),
+        ]
+        result = assemble_tool_defs(
+            defs,
+            context_length=200_000,
+            config=ToolSearchConfig.from_raw({"enabled": "on"}),
+        )
+        assert result.activated
+        names = {t["function"]["name"] for t in result.tool_defs}
+        assert "terminal" in names
+        assert "browser_navigate" not in names
+        assert {"tool_search", "tool_describe", "tool_call"}.issubset(names)
+
 
 # ---------------------------------------------------------------------------
 # Bridge dispatch
@@ -289,6 +348,18 @@ class TestBridgeDispatch:
         from tools.tool_search import dispatch_tool_search
         result = dispatch_tool_search({}, current_tool_defs=[])
         assert "error" in json.loads(result)
+
+    def test_tool_search_marks_builtin_source(self):
+        from tools.registry import discover_builtin_tools
+        from tools.tool_search import dispatch_tool_search
+        discover_builtin_tools()
+        result = dispatch_tool_search(
+            {"query": "browser navigate", "limit": 3},
+            current_tool_defs=[_td("browser_navigate", "Navigate browser")],
+        )
+        payload = json.loads(result)
+        assert payload["matches"]
+        assert payload["matches"][0]["source"] == "builtin"
 
     def test_tool_describe_requires_name(self):
         from tools.tool_search import dispatch_tool_describe

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -225,9 +225,9 @@ _TOOL_STUBS = {
     ),
     "read_file": (
         "read_file",
-        "path: str, offset: int = 1, limit: int = 500",
+        "path: str, offset: int = 1, limit: int = 500, max_chars: int = None",
         '"""Read a file (1-indexed lines). Returns dict with "content" and "total_lines"."""',
-        '{"path": path, "offset": offset, "limit": limit}',
+        '{"path": path, "offset": offset, "limit": limit, "max_chars": max_chars}',
     ),
     "write_file": (
         "write_file",
@@ -1717,27 +1717,13 @@ def _resolve_child_cwd(mode: str, staging_dir: str) -> str:
 # Per-tool documentation lines for the execute_code description.
 # Ordered to match the canonical display order.
 _TOOL_DOC_LINES = [
-    ("web_search",
-     "  web_search(query: str, limit: int = 5) -> dict\n"
-     "    Returns {\"data\": {\"web\": [{\"url\", \"title\", \"description\"}, ...]}}"),
-    ("web_extract",
-     "  web_extract(urls: list[str]) -> dict\n"
-     "    Returns {\"results\": [{\"url\", \"title\", \"content\", \"error\"}, ...]} where content is markdown"),
-    ("read_file",
-     "  read_file(path: str, offset: int = 1, limit: int = 500) -> dict\n"
-     "    Lines are 1-indexed. Returns {\"content\": \"...\", \"total_lines\": N}"),
-    ("write_file",
-     "  write_file(path: str, content: str) -> dict\n"
-     "    Always overwrites the entire file."),
-    ("search_files",
-     "  search_files(pattern: str, target=\"content\", path=\".\", file_glob=None, limit=50) -> dict\n"
-     "    target: \"content\" (search inside files) or \"files\" (find files by name). Returns {\"matches\": [...]}"),
-    ("patch",
-     "  patch(path: str, old_string: str, new_string: str, replace_all: bool = False) -> dict\n"
-     "    Replaces old_string with new_string in the file."),
-    ("terminal",
-     "  terminal(command: str, timeout=None, workdir=None) -> dict\n"
-     "    Foreground only (no background/pty). Returns {\"output\": \"...\", \"exit_code\": N}"),
+    ("web_search", "  web_search(query, limit=5) -> dict"),
+    ("web_extract", "  web_extract(urls) -> dict"),
+    ("read_file", "  read_file(path, offset=1, limit=500, max_chars=None) -> dict"),
+    ("write_file", "  write_file(path, content) -> dict"),
+    ("search_files", "  search_files(pattern, target='content', path='.', file_glob=None, limit=50) -> dict"),
+    ("patch", "  patch(path, old_string, new_string, replace_all=False) -> dict"),
+    ("terminal", "  terminal(command, timeout=None, workdir=None) -> dict"),
 ]
 
 
@@ -1789,25 +1775,14 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
         )
 
     description = (
-        "Run a Python script that can call Hermes tools programmatically. "
-        "Use this when you need 3+ tool calls with processing logic between them, "
-        "need to filter/reduce large tool outputs before they enter your context, "
-        "need conditional branching (if X then Y else Z), or need to loop "
-        "(fetch N pages, process N files, retry on failure).\n\n"
-        "Use normal tool calls instead when: single tool call with no processing, "
-        "you need to see the full result and apply complex reasoning, "
-        "or the task requires interactive user input.\n\n"
-        f"Available via `from hermes_tools import ...`:\n\n"
-        f"{tool_lines}\n\n"
-        "Limits: 5-minute timeout, 50KB stdout cap, max 50 tool calls per script. "
-        "terminal() is foreground-only (no background or pty).\n\n"
+        "Run Python that can call Hermes tools programmatically. Use for 3+ tool calls "
+        "with branching/loops or to filter large tool outputs before they enter context; "
+        "use normal tool calls for one call, full-output reasoning, or user interaction.\n\n"
+        f"Import enabled tools from `hermes_tools`:\n{tool_lines}\n\n"
+        "Limits: 5-minute timeout, 50KB stdout, max 50 tool calls; terminal() is foreground-only.\n\n"
         f"{cwd_note}\n\n"
-        "Print your final result to stdout. Use Python stdlib (json, re, math, csv, "
-        "datetime, collections, etc.) for processing between tool calls.\n\n"
-        "Also available (no import needed — built into hermes_tools):\n"
-        "  json_parse(text: str) — json.loads with strict=False; use for terminal() output with control chars\n"
-        "  shell_quote(s: str) — shlex.quote(); use when interpolating dynamic strings into shell commands\n"
-        "  retry(fn, max_attempts=3, delay=2) — retry with exponential backoff for transient failures"
+        "Print final result to stdout. Use stdlib for processing. Helpers: "
+        "json_parse(text), shell_quote(s), retry(fn, max_attempts=3, delay=2)."
     )
 
     return {
@@ -1819,9 +1794,8 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
                 "code": {
                     "type": "string",
                     "description": (
-                        "Python code to execute. Import tools with "
-                        f"`from hermes_tools import {import_str}` "
-                        "and print your final result to stdout."
+                        f"Python code. Import tools with `from hermes_tools import {import_str}`; "
+                        "print final result to stdout."
                     ),
                 },
             },

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2889,14 +2889,7 @@ def _load_config() -> dict:
 
 
 def _build_top_level_description() -> str:
-    """Compose the delegate_task tool description with current runtime limits.
-
-    The model needs to know its actual ceilings (not the framework defaults),
-    otherwise it self-caps at "default 3" / "default 2" even when the user has
-    raised delegation.max_concurrent_children / max_spawn_depth. Called both
-    at module import (to seed DELEGATE_TASK_SCHEMA) and on every
-    get_definitions() call via dynamic_schema_overrides.
-    """
+    """Compose the delegate_task tool description with current runtime limits."""
     try:
         max_children = _get_max_concurrent_children()
     except Exception:
@@ -2912,84 +2905,37 @@ def _build_top_level_description() -> str:
 
     if max_depth >= 2 and orchestrator_on:
         nesting_clause = (
-            f"Nested delegation IS enabled for this user "
-            f"(max_spawn_depth={max_depth}): pass role='orchestrator' on a "
-            f"child to let it spawn its own workers, up to {max_depth - 1} "
-            f"additional level(s) deep."
+            f"Nested delegation enabled (max_spawn_depth={max_depth}); "
+            "role='orchestrator' may spawn workers."
         )
     elif max_depth >= 2 and not orchestrator_on:
         nesting_clause = (
-            f"Nested delegation is DISABLED on this install "
-            f"(delegation.orchestrator_enabled=false), even though "
-            f"max_spawn_depth={max_depth}. role='orchestrator' is silently "
-            f"forced to 'leaf'."
+            f"Nested delegation disabled by delegation.orchestrator_enabled=false "
+            f"despite max_spawn_depth={max_depth}; orchestrator becomes leaf."
         )
     else:
         nesting_clause = (
-            f"Nested delegation is OFF for this user "
-            f"(max_spawn_depth={max_depth}): every child is a leaf and "
-            f"cannot delegate further. Raise delegation.max_spawn_depth in "
-            f"config.yaml to enable nesting."
+            f"Nested delegation OFF (max_spawn_depth={max_depth}); children are leaves."
         )
 
     return (
-        "Spawn one or more subagents to work on tasks in isolated contexts. "
-        "Each subagent gets its own conversation, terminal session, and toolset. "
-        "Only the final summary is returned -- intermediate tool results "
-        "never enter your context window.\n\n"
-        "TWO MODES (one of 'goal' or 'tasks' is required):\n"
-        "1. Single task: provide 'goal' (+ optional context, toolsets).\n"
-        f"2. Batch (parallel): provide 'tasks' array with up to {max_children} "
-        f"items concurrently for this user (configured via "
-        f"delegation.max_concurrent_children in config.yaml). {nesting_clause}\n\n"
-        "BOTH MODES RUN IN THE BACKGROUND. delegate_task returns immediately — "
-        "you and the user keep working, and each subagent's full result "
-        "re-enters the conversation as its own new message when it finishes. A "
-        "batch is just N independent background subagents (N handles, each "
-        "completes on its own). Do NOT wait or poll; just continue with other "
-        "work after dispatching.\n\n"
-        "WHEN TO USE delegate_task:\n"
-        "- Reasoning-heavy subtasks (debugging, code review, research synthesis)\n"
-        "- Tasks that would flood your context with intermediate data\n"
-        "- Parallel independent workstreams (research A and B simultaneously)\n\n"
-        "WHEN NOT TO USE (use these instead):\n"
-        "- Mechanical multi-step work with no reasoning needed -> use execute_code\n"
-        "- Single tool call -> just call the tool directly\n"
-        "- Tasks needing user interaction -> subagents cannot use clarify\n"
-        "- Durable long-running work that must outlive the current turn -> "
-        "use cronjob (action='create') or terminal(background=True, "
-        "notify_on_complete=True) instead. Background delegations are NOT "
-        "durable: if the parent session is closed (/new) or the process exits "
-        "before a subagent finishes, that subagent's work is discarded, and "
-        "/stop cancels every running background subagent.\n\n"
-        "IMPORTANT:\n"
-        "- Subagents have NO memory of your conversation. Pass all relevant "
-        "info (file paths, error messages, constraints) via the 'context' field.\n"
-        "- If the user is writing in a non-English language, or asked for "
-        "output in a specific language / tone / style, say so in 'context' "
-        "(e.g. \"respond in Chinese\", \"return output in Japanese\"). "
-        "Otherwise subagents default to English and their summaries will "
-        "contaminate your final reply with the wrong language.\n"
-        "- Subagent summaries are SELF-REPORTS, not verified facts. A subagent "
-        "that claims \"uploaded successfully\" or \"file written\" may be wrong. "
-        "For operations with external side-effects (HTTP POST/PUT, remote "
-        "writes, file creation at shared paths, publishing), require the "
-        "subagent to return a verifiable handle (URL, ID, absolute path, HTTP "
-        "status) and verify it yourself — fetch the URL, stat the file, read "
-        "back the content — before telling the user the operation succeeded.\n"
-        "- Leaf subagents (role='leaf', the default) CANNOT call: "
-        "delegate_task, clarify, memory, send_message, execute_code.\n"
-        "- Orchestrator subagents (role='orchestrator') retain "
-        "delegate_task so they can spawn their own workers, but still "
-        "cannot use clarify, memory, send_message, or execute_code. "
-        f"Orchestrators are bounded by max_spawn_depth={max_depth} for this "
-        f"user and can be disabled globally via "
-        "delegation.orchestrator_enabled=false.\n"
-        "- Subagent model is NOT selectable per call: children inherit the parent model (plus its fallback chain) unless you pin all subagents to a model via delegation.provider / delegation.model in config.yaml.\n"
-        "- Each subagent gets its own terminal session (separate working directory and state).\n"
-        "- Results are always returned as an array, one entry per task."
+        "Spawn background subagents in isolated contexts: no parent history, "
+        "own terminal session/toolsets, final summary only. Modes: single `goal`, "
+        f"or parallel `tasks` array with up to {max_children} children. "
+        f"{nesting_clause} Results re-enter this conversation asynchronously; "
+        "do not wait/poll. Not durable across /new, parent exit, or /stop.\n\n"
+        "Use for reasoning-heavy work, context-heavy debugging/review/research, or "
+        "parallel independent workstreams. Do not use for one tool call, simple "
+        "mechanical loops (use execute_code), user interaction (children cannot "
+        "clarify), or durable scheduled work (use cronjob/terminal background).\n\n"
+        "Pass all needed file paths/errors/constraints and requested language/tone "
+        "in context; subagents otherwise default to English. Treat summaries as "
+        "self-reports: for side effects require a handle (path/URL/id/status) and "
+        "verify it yourself before claiming success. Leaf children cannot call "
+        "delegate_task/clarify/memory/send_message/execute_code. Model is inherited "
+        "unless delegation.provider/model config pins all subagents. Returns an "
+        "array, one result per task."
     )
-
 
 def _build_tasks_param_description() -> str:
     """Compose the 'tasks' parameter description with current concurrency limit."""
@@ -2998,12 +2944,9 @@ def _build_tasks_param_description() -> str:
     except Exception:
         max_children = _DEFAULT_MAX_CONCURRENT_CHILDREN
     return (
-        f"Batch mode: tasks to run in parallel (up to {max_children} for this "
-        f"user, set via delegation.max_concurrent_children). Each gets "
-        "its own subagent with isolated context and terminal session. "
-        "When provided, top-level goal/context/toolsets are ignored."
+        f"Batch mode: up to {max_children} independent subagents in parallel. "
+        "Each item needs goal; top-level goal/context/toolsets are ignored."
     )
-
 
 def _build_role_param_description() -> str:
     """Compose the 'role' parameter description with current spawn-depth limit."""
@@ -3017,30 +2960,13 @@ def _build_role_param_description() -> str:
         orchestrator_on = True
 
     if max_depth >= 2 and orchestrator_on:
-        nesting_note = (
-            f"Nesting IS enabled for this user (max_spawn_depth={max_depth}): "
-            f"orchestrator children can themselves delegate up to {max_depth - 1} "
-            "more level(s) deep."
-        )
+        nesting_note = f"orchestrator can delegate further (max_spawn_depth={max_depth})."
     elif max_depth >= 2 and not orchestrator_on:
-        nesting_note = (
-            "Nesting is currently disabled "
-            "(delegation.orchestrator_enabled=false); 'orchestrator' is "
-            "silently forced to 'leaf'."
-        )
+        nesting_note = "orchestrator is forced to leaf by delegation.orchestrator_enabled=false."
     else:
-        nesting_note = (
-            f"Nesting is OFF for this user (max_spawn_depth={max_depth}); "
-            "'orchestrator' is silently forced to 'leaf'. Raise "
-            "delegation.max_spawn_depth in config.yaml to enable."
-        )
+        nesting_note = f"nesting off (max_spawn_depth={max_depth}); orchestrator is forced to leaf."
 
-    return (
-        "Role of the child agent. 'leaf' (default) = focused "
-        "worker, cannot delegate further. 'orchestrator' = can "
-        f"use delegate_task to spawn its own workers. {nesting_note}"
-    )
-
+    return f"Child role: leaf(default) or orchestrator; {nesting_note}"
 
 def _build_dynamic_schema_overrides() -> dict:
     """Return per-call schema overrides reflecting current config.
@@ -3085,29 +3011,20 @@ DELEGATE_TASK_SCHEMA = {
             "goal": {
                 "type": "string",
                 "description": (
-                    "What the subagent should accomplish. Be specific and "
-                    "self-contained -- the subagent knows nothing about your "
-                    "conversation history."
+                    "Task goal. Be specific/self-contained; child has no parent history."
                 ),
             },
             "context": {
                 "type": "string",
                 "description": (
-                    "Background information the subagent needs: file paths, "
-                    "error messages, project structure, constraints. The more "
-                    "specific you are, the better the subagent performs."
+                    "Needed context: paths, errors, constraints, language/tone, verification requirements."
                 ),
             },
             "toolsets": {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": (
-                    "Toolsets to enable for this subagent. "
-                    "Default: inherits your enabled toolsets. "
-                    f"Available toolsets: {_TOOLSET_LIST_STR}. "
-                    "Common patterns: ['terminal', 'file'] for code work, "
-                    "['web'] for research, ['browser'] for web interaction, "
-                    "['terminal', 'file', 'web'] for full-stack tasks."
+                    "Toolsets to enable. Default inherits parent. Common: ['terminal','file'] code, ['web'] research, ['browser'] interaction."
                 ),
             },
             "tasks": {
@@ -3123,14 +3040,12 @@ DELEGATE_TASK_SCHEMA = {
                         "toolsets": {
                             "type": "array",
                             "items": {"type": "string"},
-                            "description": f"Toolsets for this specific task. Available: {_TOOLSET_LIST_STR}. Use 'web' for network access, 'terminal' for shell, 'browser' for web interaction.",
+                            "description": "Toolsets for this task. Common: web, terminal, file, browser.",
                         },
                         "acp_command": {
                             "type": "string",
                             "description": (
-                                "Per-task ACP command override (e.g. 'copilot'). "
-                                "Overrides the top-level acp_command for this task only. "
-                                "Do NOT set unless the user explicitly told you an ACP CLI is installed."
+                                "Per-task ACP command override. Do NOT set unless user explicitly told you an ACP CLI is installed."
                             ),
                         },
                         "acp_args": {
@@ -3159,35 +3074,20 @@ DELEGATE_TASK_SCHEMA = {
             "background": {
                 "type": "boolean",
                 "description": (
-                    "DEPRECATED / IGNORED. Single-task delegations always run "
-                    "in the background automatically — you do not need to (and "
-                    "cannot) opt in or out. The result re-enters the "
-                    "conversation as a new message when the subagent finishes; "
-                    "just continue working in the meantime. Setting this has no "
-                    "effect; the parameter remains only for backward "
-                    "compatibility."
+                    "Deprecated/ignored; delegations already run asynchronously."
                 ),
             },
             "acp_command": {
                 "type": "string",
                 "description": (
-                    "Override ACP command for child agents (e.g. 'copilot'). "
-                    "When set, children use ACP subprocess transport instead of inheriting "
-                    "the parent's transport. Requires an ACP-compatible CLI "
-                    "(currently GitHub Copilot CLI via 'copilot --acp --stdio'). "
-                    "See agent/copilot_acp_client.py for the implementation. "
-                    "IMPORTANT: Do NOT set this unless the user has explicitly told you "
-                    "a specific ACP-compatible CLI is installed and configured. "
-                    "Leave empty to use the parent's default transport (Hermes subagents)."
+                    "ACP command override. Do NOT set unless user explicitly told you an ACP CLI is installed/configured."
                 ),
             },
             "acp_args": {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": (
-                    "Arguments for the ACP command (default: ['--acp', '--stdio']). "
-                    "Only used when acp_command is set. "
-                    "Leave empty unless acp_command is explicitly provided."
+                    "ACP args; only used with acp_command."
                 ),
             },
         },

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -371,34 +371,32 @@ class BaseEnvironment(ABC):
         # backends) into every terminal-tool response.
         _quoted_snap = shlex.quote(self._snapshot_path)
         _quoted_cwd_file = shlex.quote(self._cwd_file)
-        # Use atomic file replacement: assemble the snapshot in a temp file,
-        # then mv it over the final path.  This prevents concurrent source()
-        # calls from reading a half-written snapshot when another terminal
-        # command finishes and rewrites the env vars (issue #38249).  `mv` is
-        # atomic on POSIX when src and dest are on the same filesystem, so
-        # source() either sees the old complete snapshot or the new complete
-        # one — never a partial/truncated file.
+        # Use atomic file replacement: assemble the snapshot in a unique temp
+        # file, then mv it over the final path.  This prevents concurrent
+        # source() calls from reading a half-written snapshot when another
+        # terminal command finishes and rewrites the env vars (issue #38249).
+        # `mv` is atomic on POSIX when src and dest are on the same
+        # filesystem, so source() either sees the old complete snapshot or the
+        # new complete one — never a partial/truncated file.
         #
-        # The temp name MUST be unique per concurrent writer.  ``$$`` is the
-        # bash PID, but in ``&``-launched subshells (how concurrent terminal
-        # calls run) ``$$`` stays the *parent* shell's PID — so two concurrent
-        # writers would pick the SAME temp name, clobber each other's temp
-        # mid-write, and mv would then publish a torn file (the corruption is
-        # only narrowed, not closed).  ``$BASHPID`` is the actual subshell PID
-        # and is genuinely unique per writer, which closes the race.  The
-        # static path is shlex-quoted (Windows/Git-Bash drive letters, spaces)
-        # with ``$BASHPID`` left outside the quotes so it still expands.
-        _snap_tmp = shlex.quote(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # IMPORTANT: macOS ships bash 3.2, which does NOT provide $BASHPID.
+        # Using ``$$`` is also wrong here because in ``&``-launched subshells it
+        # stays the *parent* shell's PID, so concurrent writers would still
+        # share a temp name and clobber each other before mv.  Use ``mktemp``
+        # to allocate a per-writer unique path portably across bash versions.
+        _snap_tmp_template = shlex.quote(self._snapshot_path + ".tmp.XXXXXXXXXX")
         bootstrap = (
-            f"export -p > {_snap_tmp}\n"
-            f"declare -f | grep -vE '^_[^_]' >> {_snap_tmp}\n"
-            f"alias -p >> {_snap_tmp}\n"
-            f"echo 'shopt -s expand_aliases' >> {_snap_tmp}\n"
-            f"echo 'set +e' >> {_snap_tmp}\n"
-            f"echo 'set +u' >> {_snap_tmp}\n"
+            f"__hermes_snap_tmp=$(mktemp {_snap_tmp_template}) || exit 1\n"
             # Publish atomically only if assembly succeeded; otherwise drop the
             # partial temp rather than leave it to be sourced or orphaned.
-            f"mv -f {_snap_tmp} {_quoted_snap} || rm -f {_snap_tmp}\n"
+            f"{{ export -p > \"$__hermes_snap_tmp\" && "
+            f"{{ declare -f | grep -vE '^_[^_]' || true; }} >> \"$__hermes_snap_tmp\" && "
+            f"alias -p >> \"$__hermes_snap_tmp\" && "
+            f"echo 'shopt -s expand_aliases' >> \"$__hermes_snap_tmp\" && "
+            f"echo 'set +e' >> \"$__hermes_snap_tmp\" && "
+            f"echo 'set +u' >> \"$__hermes_snap_tmp\" && "
+            f"mv -f \"$__hermes_snap_tmp\" {_quoted_snap}; }} "
+            f"2>/dev/null || rm -f \"$__hermes_snap_tmp\" 2>/dev/null || true\n"
             f"builtin cd {_quoted_cwd} 2>/dev/null || true\n"
             f"pwd -P > {_quoted_cwd_file} 2>/dev/null || true\n"
             f"printf '\\n{self._cwd_marker}%s{self._cwd_marker}\\n' \"$(pwd -P)\"\n"
@@ -451,11 +449,10 @@ class BaseEnvironment(ABC):
         # Use atomic file replacement for env snapshot updates (issue #38249).
         # Assemble into a per-writer-unique temp file, then mv to atomically
         # replace the snapshot so concurrent source() calls never read a
-        # truncated/half-written file.  ``$BASHPID`` (not ``$$``) is the actual
-        # subshell PID — unique per concurrent ``&``-launched writer — so two
-        # writers never share a temp name and clobber each other before the mv.
-        # Static path shlex-quoted (Windows/spaces); ``$BASHPID`` left to expand.
-        _snap_tmp = shlex.quote(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # truncated/half-written file.  ``mktemp`` is used instead of
+        # ``$BASHPID``/``$$`` because macOS bash 3.2 lacks ``$BASHPID`` and
+        # ``$$`` is shared by ``&``-launched subshells.
+        _snap_tmp_template = shlex.quote(self._snapshot_path + ".tmp.XXXXXXXXXX")
 
         parts = []
 
@@ -486,8 +483,9 @@ class BaseEnvironment(ABC):
         # orphaned (cleaned up wholesale in LocalEnvironment.cleanup too).
         if self._snapshot_ready:
             parts.append(
-                f"{{ export -p > {_snap_tmp} && mv -f {_snap_tmp} {_quoted_snap}; }} "
-                f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true"
+                f"__hermes_snap_tmp=$(mktemp {_snap_tmp_template}) && "
+                f"{{ export -p > \"$__hermes_snap_tmp\" && mv -f \"$__hermes_snap_tmp\" {_quoted_snap}; }} "
+                f"2>/dev/null || rm -f \"$__hermes_snap_tmp\" 2>/dev/null || true"
             )
 
         # Write CWD to file (local reads this) and stdout marker (remote parses this)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -407,17 +407,20 @@ def _authoritative_workspace_root(task_id: str = "default") -> str | None:
     registered = _registered_task_cwd_override(task_id)
     if registered:
         return registered
+    configured = _configured_terminal_cwd()
+    if configured:
+        return configured
     # When the terminal env was cleaned up mid-conversation, the live cwd is
     # gone but the directory the agent navigated to is still recorded in the
-    # durable _last_known_cwd registry. Prefer it over the config/process
-    # fallback so a relative-path write resolved BEFORE the env is rebuilt
-    # still lands in the user's directory (root cause of #26211: write happens
-    # via _resolve_path_for_task -> here, which runs before _get_file_ops
-    # rebuilds the env). Keyed by the resolved container id, same as the save.
+    # durable _last_known_cwd registry. Use it only after explicit per-session
+    # and TERMINAL_CWD anchors: those describe the current request, while a
+    # preserved default anchor may be stale in long-lived test/process state.
+    # It still protects the #26211 path where no live/configured anchor exists
+    # and _resolve_path_for_task runs before _get_file_ops rebuilds the env.
     preserved = _last_known_cwd_for(task_id)
     if preserved:
         return preserved
-    return _configured_terminal_cwd()
+    return None
 
 
 def _resolve_base_dir(task_id: str = "default") -> Path:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -56,7 +56,9 @@ def _expand_tilde(path: str) -> str:
 # Configurable via config.yaml:  file_read_max_chars: 200000
 # ---------------------------------------------------------------------------
 _DEFAULT_MAX_READ_CHARS = 100_000
+_DEFAULT_READ_FILE_OUTPUT_BUDGET_CHARS = 60_000
 _max_read_chars_cached: int | None = None
+_read_file_output_budget_cached: int | None = None
 
 
 def _get_max_read_chars() -> int:
@@ -80,6 +82,91 @@ def _get_max_read_chars() -> int:
         pass
     _max_read_chars_cached = _DEFAULT_MAX_READ_CHARS
     return _max_read_chars_cached
+
+
+def _get_read_file_output_budget_chars(max_chars: int | None = None) -> int:
+    """Return the soft output budget for read_file content.
+
+    The hard ``file_read_max_chars`` guard still prevents pathological reads.
+    This softer budget keeps default successful reads from dumping large blobs
+    into context while giving callers an explicit ``max_chars`` override up to
+    the hard safety limit.
+    """
+    safety_limit = _get_max_read_chars()
+    if max_chars is not None:
+        try:
+            requested = int(max_chars)
+        except (TypeError, ValueError):
+            requested = _DEFAULT_READ_FILE_OUTPUT_BUDGET_CHARS
+        if requested <= 0:
+            requested = safety_limit
+        return max(1_000, min(requested, safety_limit))
+
+    global _read_file_output_budget_cached
+    if _read_file_output_budget_cached is not None:
+        return min(_read_file_output_budget_cached, safety_limit)
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        val = cfg.get("file_read_output_budget_chars")
+        if isinstance(val, (int, float)) and val > 0:
+            _read_file_output_budget_cached = max(1_000, min(int(val), safety_limit))
+            return _read_file_output_budget_cached
+    except Exception:
+        pass
+    _read_file_output_budget_cached = min(_DEFAULT_READ_FILE_OUTPUT_BUDGET_CHARS, safety_limit)
+    return _read_file_output_budget_cached
+
+
+def _truncate_content_with_budget(content: str, budget: int, label: str) -> str:
+    suffix = f"\n...[truncated by {label} output budget; use offset/limit or max_chars to retrieve more]"
+    if budget <= len(suffix):
+        return suffix[-budget:]
+    return content[: budget - len(suffix)] + suffix
+
+
+def _apply_read_file_output_budget(
+    result_dict: dict,
+    *,
+    offset: int,
+    limit: int,
+    max_chars: int | None,
+) -> None:
+    content = result_dict.get("content")
+    if not isinstance(content, str):
+        return
+    budget = _get_read_file_output_budget_chars(max_chars)
+    content_len = len(content)
+    if content_len <= budget:
+        return
+    result_dict["content"] = _truncate_content_with_budget(content, budget, "read_file")
+    result_dict["truncated_by_budget"] = True
+    result_dict["original_content_chars"] = content_len
+    result_dict["returned_content_chars"] = len(result_dict["content"])
+    result_dict["budget_chars"] = budget
+    result_dict["hint"] = (
+        f"read_file returned only the first {budget:,} chars from this page "
+        f"(offset={offset}, limit={limit}). Use a narrower offset/limit range, "
+        "or pass max_chars up to the hard safety limit when you truly need a "
+        "larger single response."
+    )
+
+
+def _operation_path_for_shell(original_path: str, resolved_path: str | None) -> str:
+    """Path to pass to the shell/file backend.
+
+    Relative paths must be passed as the tool-layer resolved absolute path so
+    the shell cwd cannot disagree with the guard/lock layer. Absolute paths are
+    already unambiguous; preserve the caller's spelling (notably /tmp on macOS,
+    where Path.resolve() becomes /private/tmp) for backwards compatibility with
+    existing handlers/tests.
+    """
+    try:
+        if Path(_expand_tilde(original_path)).is_absolute():
+            return original_path
+    except Exception:
+        pass
+    return resolved_path or original_path
 
 # If the total file size exceeds this AND the caller didn't specify a narrow
 # range (limit <= 200), we include a hint encouraging targeted reads.
@@ -156,6 +243,13 @@ def _registered_task_cwd_override(task_id: str = "default") -> str | None:
     value itself is still keyed by the raw session/task id, so file tools must
     read that raw override before falling back to the collapsed container key.
     """
+    # The shared/default container may carry the process/config cwd, but callers
+    # that explicitly set TERMINAL_CWD expect that env var to be the default
+    # anchor. Keep registered overrides for non-default raw task ids where the
+    # TUI/Desktop/ACP session has an explicit workspace.
+    if not task_id or task_id == "default":
+        return None
+
     try:
         from tools.terminal_tool import resolve_task_overrides
 
@@ -198,31 +292,91 @@ def _get_live_tracking_cwd(task_id: str = "default") -> str | None:
     except Exception:
         container_key = task_id
 
-    with _file_ops_lock:
-        cached = _file_ops_cache.get(container_key) or _file_ops_cache.get(task_id)
-    if cached is not None:
+    configured_cwd = _configured_terminal_cwd()
+
+    def _cwd_from_cached(cached, *, allow_unknown_owner: bool = True) -> str | None:
+        if cached is None:
+            return None
         env = getattr(cached, "env", None)
+        if (
+            not allow_unknown_owner
+            and env is not None
+            and not str(getattr(env, "cwd_owner", "") or "")
+        ):
+            return None
         live_cwd = _live_cwd_if_owned(env, task_id)
         if live_cwd:
             _remember_last_known_cwd(container_key, live_cwd)
             return live_cwd
         # Legacy: a cache entry carrying its own cwd with no env to own it.
-        if env is None and getattr(cached, "cwd", None):
+        if env is None and allow_unknown_owner and getattr(cached, "cwd", None):
             legacy_cwd = getattr(cached, "cwd", None)
             _remember_last_known_cwd(container_key, legacy_cwd)
             return legacy_cwd
+        return None
+
+    allow_unknown_owner = not configured_cwd
+
+    # Exact raw task entries are always authoritative for that task.
+    with _file_ops_lock:
+        raw_cached = _file_ops_cache.get(task_id)
+    raw_allow_unknown_owner = not (task_id == "default" and configured_cwd)
+    raw_cwd = _cwd_from_cached(
+        raw_cached, allow_unknown_owner=raw_allow_unknown_owner
+    )
+    if raw_cwd:
+        return raw_cwd
 
     try:
         from tools.terminal_tool import _active_environments, _env_lock
-
         with _env_lock:
-            env = _active_environments.get(container_key) or _active_environments.get(task_id)
-        live_cwd = _live_cwd_if_owned(env, task_id)
-        if live_cwd:
-            _remember_last_known_cwd(container_key, live_cwd)
-            return live_cwd
+            raw_env = _active_environments.get(task_id)
     except Exception:
-        pass
+        raw_env = None
+    if (
+        configured_cwd
+        and raw_env is not None
+        and not str(getattr(raw_env, "cwd_owner", "") or "")
+    ):
+        raw_env = None
+    raw_live = _live_cwd_if_owned(raw_env, task_id)
+    if raw_live:
+        _remember_last_known_cwd(container_key, raw_live)
+        return raw_live
+
+    # A non-default task with an explicit TERMINAL_CWD should not inherit a
+    # stale shared/default terminal cwd from another task. Returning None lets
+    # _authoritative_workspace_root fall through to that TERMINAL_CWD.
+    if task_id != "default" and configured_cwd:
+        return None
+
+    # Finally, allow collapsed/shared environment fallback for default sessions
+    # and for legacy sessions without an explicit TERMINAL_CWD.
+    if container_key != task_id:
+        with _file_ops_lock:
+            container_cached = _file_ops_cache.get(container_key)
+        container_cwd = _cwd_from_cached(
+            container_cached, allow_unknown_owner=allow_unknown_owner
+        )
+        if container_cwd:
+            return container_cwd
+
+        try:
+            from tools.terminal_tool import _active_environments, _env_lock
+            with _env_lock:
+                env = _active_environments.get(container_key)
+            if (
+                configured_cwd
+                and env is not None
+                and not str(getattr(env, "cwd_owner", "") or "")
+            ):
+                env = None
+            live_cwd = _live_cwd_if_owned(env, task_id)
+            if live_cwd:
+                _remember_last_known_cwd(container_key, live_cwd)
+                return live_cwd
+        except Exception:
+            pass
 
     return None
 
@@ -415,7 +569,8 @@ def _is_blocked_device(filepath: str, base_dir: str | Path | None = None) -> boo
 # terminal tool's approval system.  These match prefixes after os.path.realpath.
 _SENSITIVE_PATH_PREFIXES = (
     "/etc/", "/boot/", "/usr/lib/systemd/",
-    "/private/etc/", "/private/var/",
+    "/private/etc/", "/private/var/db/", "/private/var/root/",
+    "/private/var/run/",
 )
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
@@ -959,7 +1114,13 @@ def clear_file_ops_cache(task_id: str = None):
             _file_ops_cache.clear()
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = "default") -> str:
+def read_file_tool(
+    path: str,
+    offset: int = 1,
+    limit: int = 500,
+    task_id: str = "default",
+    max_chars: int | None = None,
+) -> str:
     """Read a file with pagination and line numbers."""
     try:
         offset, limit = normalize_read_pagination(offset, limit)
@@ -1007,12 +1168,12 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                         f"(showing {offset}-{min(end_line, total_lines)} of {total_lines} lines)"
                     )
                 content_len = len(result_dict["content"])
-                max_chars = _get_max_read_chars()
-                if content_len > max_chars:
+                hard_max_chars = _get_max_read_chars()
+                if content_len > hard_max_chars:
                     return json.dumps({
                         "error": (
                             f"Read produced {content_len:,} characters which exceeds "
-                            f"the safety limit ({max_chars:,} chars). "
+                            f"the safety limit ({hard_max_chars:,} chars). "
                             "Use offset and limit to read a smaller range. "
                             f"The document has {total_lines} lines of extracted text."
                         ),
@@ -1022,6 +1183,12 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                     }, ensure_ascii=False)
                 if result_dict["content"]:
                     result_dict["content"] = redact_sensitive_text(result_dict["content"], file_read=True)
+                _apply_read_file_output_budget(
+                    result_dict,
+                    offset=offset,
+                    limit=limit,
+                    max_chars=max_chars,
+                )
                 return json.dumps(result_dict, ensure_ascii=False)
 
         # ── Binary file guard ─────────────────────────────────────────
@@ -1120,13 +1287,13 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         # Check BEFORE redaction to avoid expensive regex on huge content.
         content_len = len(result.content or "")
         file_size = result_dict.get("file_size", 0)
-        max_chars = _get_max_read_chars()
-        if content_len > max_chars:
+        hard_max_chars = _get_max_read_chars()
+        if content_len > hard_max_chars:
             total_lines = result_dict.get("total_lines", "unknown")
             return json.dumps({
                 "error": (
                     f"Read produced {content_len:,} characters which exceeds "
-                    f"the safety limit ({max_chars:,} chars). "
+                    f"the safety limit ({hard_max_chars:,} chars). "
                     "Use offset and limit to read a smaller range. "
                     f"The file has {total_lines} lines total."
                 ),
@@ -1217,6 +1384,13 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 "The content has not changed since your last read. Use the information you already have. "
                 "If you are stuck in a loop, stop reading and proceed with writing or responding."
             )
+
+        _apply_read_file_output_budget(
+            result_dict,
+            offset=offset,
+            limit=limit,
+            max_chars=max_chars,
+        )
 
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
@@ -1448,7 +1622,9 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             # terminal's cwd (the worktree-cwd bug). Lowest priority of the three.
             cwd_warning = _path_resolution_warning(path, Path(_resolved), task_id)
             file_ops = _get_file_ops(task_id)
-            result = file_ops.write_file(_resolved, content)
+            result = file_ops.write_file(
+                _operation_path_for_shell(path, _resolved), content
+            )
             result_dict = result.to_dict()
             effective_warning = cross_warning or stale_warning or cwd_warning
             if effective_warning:
@@ -1571,7 +1747,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 # shell's own cwd may differ (worktree-cwd bug), and a relative
                 # path would let the two layers disagree about which file is
                 # being edited.
-                _replace_target = _path_to_resolved.get(path) or path
+                _replace_target = _operation_path_for_shell(
+                    path, _path_to_resolved.get(path)
+                )
                 result = file_ops.patch_replace(_replace_target, old_string, new_string, replace_all)
             elif mode == "patch":
                 if not patch:
@@ -1738,7 +1916,8 @@ READ_FILE_SCHEMA = {
         "properties": {
             "path": {"type": "string", "description": "Path to the file to read (absolute, relative, or ~/path)"},
             "offset": {"type": "integer", "description": "Line number to start reading from (1-indexed, default: 1)", "default": 1, "minimum": 1},
-            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 500, max: 2000)", "default": 500, "maximum": 2000}
+            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 500, max: 2000)", "default": 500, "maximum": 2000},
+            "max_chars": {"type": "integer", "description": "Soft output budget for returned content chars (default 60000, hard-capped by file_read_max_chars). Pass 0 to use the hard safety limit."}
         },
         "required": ["path"]
     }
@@ -1835,7 +2014,13 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    return read_file_tool(
+        path=args.get("path", ""),
+        offset=args.get("offset", 1),
+        limit=args.get("limit", 500),
+        task_id=tid,
+        max_chars=args.get("max_chars"),
+    )
 
 
 def _handle_write_file(args, **kw):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -921,8 +921,14 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
     chat_id = ""
     try:
         from gateway.session_context import get_session_env
-        platform = get_session_env("HERMES_SESSION_PLATFORM", "")
-        chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
+        platform = (
+            get_session_env("HERMES_SESSION_PLATFORM", "")
+            or os.environ.get("HERMES_SESSION_PLATFORM", "")
+        )
+        chat_id = (
+            get_session_env("HERMES_SESSION_CHAT_ID", "")
+            or os.environ.get("HERMES_SESSION_CHAT_ID", "")
+        )
         if not platform or not chat_id:
             # TUI / desktop fallback: platform/chat_id ContextVars are
             # cleared for TUI sessions, but the parent process exports
@@ -945,8 +951,16 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
                 return False  # CLI / cron / test — no persistent channel
             platform = "tui"
             chat_id = session_key
-        thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "") or None
-        user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
+        thread_id = (
+            get_session_env("HERMES_SESSION_THREAD_ID", "")
+            or os.environ.get("HERMES_SESSION_THREAD_ID", "")
+            or None
+        )
+        user_id = (
+            get_session_env("HERMES_SESSION_USER_ID", "")
+            or os.environ.get("HERMES_SESSION_USER_ID", "")
+            or None
+        )
         notifier_profile = os.environ.get("HERMES_PROFILE")
 
         # Lazy-import to keep the module-level dependency light

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1005,26 +1005,15 @@ def apply_memory_pending(payload: Dict[str, Any], store: "MemoryStore") -> Dict[
 MEMORY_SCHEMA = {
     "name": "memory",
     "description": (
-        "Save durable facts to persistent memory that survive across sessions. Memory is "
-        "injected into every future turn, so keep entries compact and high-signal.\n\n"
-        "HOW: make ALL your changes in ONE call via an 'operations' array (each item: "
-        "{action, content?, old_text?}). The batch applies atomically and the char limit is "
-        "checked only on the FINAL result — so a single call can remove/replace stale entries "
-        "to free room AND add new ones, even when an add alone would overflow. The response "
-        "reports current/limit chars and confirms completion; one batch call finishes the "
-        "update, so don't repeat it. Use the bare action/content/old_text fields only for a "
-        "single lone change.\n\n"
-        "WHEN: save proactively when the user states a preference, correction, or personal "
-        "detail, or you learn a stable fact about their environment, conventions, or workflow. "
-        "Priority: user preferences & corrections > environment facts > procedures. The best "
-        "memory stops the user repeating themselves.\n\n"
-        "IF FULL: an add is rejected with the current entries shown. Reissue as ONE batch that "
-        "removes or shortens enough stale entries and adds the new one together.\n\n"
-        "TARGETS: 'user' = who the user is (name, role, preferences, style). 'memory' = your "
-        "notes (environment, conventions, tool quirks, lessons).\n\n"
-        "SKIP: trivial/obvious info, easily re-discovered facts, raw data dumps, task progress, "
-        "completed-work logs, temporary TODO state (use session_search for those). Reusable "
-        "procedures belong in a skill, not memory."
+        "Save durable, compact, high-signal declarative facts injected into future sessions. "
+        "Prefer one operations batch: [{action, content?, old_text?}] applied atomically "
+        "against the final char budget, so you can remove/replace stale entries and add the new one in one call. "
+        "Use single action/content/old_text only for one lone change. "
+        "Save user preferences/corrections, personal details, stable environment facts, conventions, and tool quirks. "
+        "Targets: user = who the user is; memory = your environment/convention/tool notes. "
+        "If full, reissue ONE operations batch that frees space and adds the entry. "
+        "Skip trivial facts, raw dumps, task progress, completed-work logs, temporary TODO state, and volatile artifacts; use session_search for history. "
+        "Reusable procedures belong in a skill, not memory."
     ),
     "parameters": {
         "type": "object",
@@ -1032,34 +1021,30 @@ MEMORY_SCHEMA = {
             "action": {
                 "type": "string",
                 "enum": ["add", "replace", "remove"],
-                "description": "The action to perform (single-op shape). Omit when using 'operations'."
+                "description": "Single-op action; omit when using operations."
             },
             "target": {
                 "type": "string",
                 "enum": ["memory", "user"],
-                "description": "Which memory store: 'memory' for personal notes, 'user' for user profile."
+                "description": "Store: memory=agent notes, user=user profile."
             },
             "content": {
                 "type": "string",
-                "description": "The entry content. Required for 'add' and 'replace' (single-op shape)."
+                "description": "Entry content for add/replace."
             },
             "old_text": {
                 "type": "string",
-                "description": "REQUIRED for 'replace' and 'remove' (single-op shape): a short unique substring identifying the existing entry to modify. Omit only for 'add'."
+                "description": "Unique substring identifying entry for replace/remove."
             },
             "operations": {
                 "type": "array",
-                "description": (
-                    "Batch shape: a list of operations applied atomically in one call "
-                    "against the final char budget. Preferred when making multiple changes "
-                    "or consolidating to make room. Each item is {action, content?, old_text?}."
-                ),
+                "description": "Atomic batch applied in one call against final char budget; preferred for multiple changes or consolidation.",
                 "items": {
                     "type": "object",
                     "properties": {
                         "action": {"type": "string", "enum": ["add", "replace", "remove"]},
                         "content": {"type": "string", "description": "Entry content for add/replace."},
-                        "old_text": {"type": "string", "description": "Substring identifying the entry for replace/remove."},
+                        "old_text": {"type": "string", "description": "Substring identifying entry for replace/remove."},
                     },
                     "required": ["action"],
                 },
@@ -1068,7 +1053,6 @@ MEMORY_SCHEMA = {
         "required": ["target"],
     },
 }
-
 
 # --- Registry ---
 from tools.registry import registry, tool_error

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -38,6 +38,26 @@ from typing import Any, Dict, List, Optional, Union
 # delegate subagent runs are tagged "subagent" — neither belongs in the
 # user's session history.
 _HIDDEN_SESSION_SOURCES = ("subagent", "tool")
+_DEFAULT_SESSION_SEARCH_MESSAGE_CHARS = 12_000
+
+
+def _session_message_budget(max_content_chars: int | None = None) -> int:
+    if max_content_chars is None:
+        return _DEFAULT_SESSION_SEARCH_MESSAGE_CHARS
+    try:
+        requested = int(max_content_chars)
+    except (TypeError, ValueError):
+        return _DEFAULT_SESSION_SEARCH_MESSAGE_CHARS
+    if requested <= 0:
+        return 100_000
+    return max(1_000, min(requested, 100_000))
+
+
+def _truncate_session_content(content: str, budget: int) -> tuple[str, bool]:
+    if len(content) <= budget:
+        return content, False
+    suffix = "\n...[truncated by session_search message budget; use scroll/window or max_content_chars to retrieve more]"
+    return content[: max(0, budget - len(suffix))] + suffix, True
 
 # Automation sources that are kept searchable but DEMOTED below interactive
 # sessions in discover ranking. Cron jobs run on a schedule and accumulate
@@ -120,14 +140,31 @@ def _order_for_recall(raw_results: List[Dict[str, Any]]) -> List[Dict[str, Any]]
     )
 
 
-def _shape_message(m: Dict[str, Any], anchor_id: Optional[int] = None) -> Dict[str, Any]:
+def _shape_message(
+    m: Dict[str, Any],
+    anchor_id: Optional[int] = None,
+    max_content_chars: int | None = None,
+) -> Dict[str, Any]:
     """Slim a message row for the tool response. Keeps content even if empty."""
+    content = m.get("content")
+    content_truncated = False
+    original_content_chars = None
+    if isinstance(content, str):
+        original_content_chars = len(content)
+        content, content_truncated = _truncate_session_content(
+            content,
+            _session_message_budget(max_content_chars),
+        )
     entry = {
         "id": m.get("id"),
         "role": m.get("role"),
-        "content": m.get("content"),
+        "content": content,
         "timestamp": m.get("timestamp"),
     }
+    if content_truncated:
+        entry["content_truncated_by_budget"] = True
+        entry["original_content_chars"] = original_content_chars
+        entry["returned_content_chars"] = len(content)
     if m.get("tool_name"):
         entry["tool_name"] = m.get("tool_name")
     if m.get("tool_calls"):
@@ -208,7 +245,13 @@ def _locate_session_db(session_id: str):
     return None, None
 
 
-def _read_session(db, session_id: str, head: int = 20, tail: int = 10) -> str:
+def _read_session(
+    db,
+    session_id: str,
+    head: int = 20,
+    tail: int = 10,
+    max_content_chars: int | None = None,
+) -> str:
     """Read shape: dump a whole session by id (head + tail when large).
 
     Serves the linked-session case — the user dropped an @session reference and
@@ -230,7 +273,7 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10) -> str:
         logging.error("get_messages failed for %s: %s", session_id, e, exc_info=True)
         return tool_error(f"failed to load session: {e}", success=False)
 
-    shaped = [_shape_message(m) for m in rows]
+    shaped = [_shape_message(m, max_content_chars=max_content_chars) for m in rows]
     total = len(shaped)
     truncated = total > head + tail
     window = shaped[:head] + shaped[-tail:] if truncated else shaped
@@ -306,6 +349,7 @@ def _scroll(
     around_message_id: int,
     window: int = 5,
     current_session_id: str = None,
+    max_content_chars: int | None = None,
 ) -> str:
     """Scroll shape: return a window of messages centered on an anchor.
 
@@ -415,7 +459,10 @@ def _scroll(
             "title": session_meta.get("title"),
         },
         "window": window,
-        "messages": [_shape_message(m, anchor_id=around_message_id) for m in messages],
+        "messages": [
+            _shape_message(m, anchor_id=around_message_id, max_content_chars=max_content_chars)
+            for m in messages
+        ],
         "messages_before": view.get("messages_before", 0),
         "messages_after": view.get("messages_after", 0),
     }
@@ -433,6 +480,7 @@ def _title_match_result(
     db,
     query: str,
     current_lineage_root: Optional[str],
+    max_content_chars: int | None = None,
 ) -> Optional[Dict[str, Any]]:
     """Return a discovery-shaped result when the query matches a session title."""
     title_query = _normalize_title_query(query)
@@ -484,9 +532,18 @@ def _title_match_result(
         "matched_role": "session_title",
         "match_message_id": anchor_id,
         "snippet": f"Session title matched: {session_meta.get('title') or title_query}",
-        "bookend_start": [_shape_message(m) for m in (view.get("bookend_start") or messages[:3])],
-        "messages": [_shape_message(m, anchor_id=anchor_id) for m in (view.get("window") or messages[:5])],
-        "bookend_end": [_shape_message(m) for m in (view.get("bookend_end") or messages[-3:])],
+        "bookend_start": [
+            _shape_message(m, max_content_chars=max_content_chars)
+            for m in (view.get("bookend_start") or messages[:3])
+        ],
+        "messages": [
+            _shape_message(m, anchor_id=anchor_id, max_content_chars=max_content_chars)
+            for m in (view.get("window") or messages[:5])
+        ],
+        "bookend_end": [
+            _shape_message(m, max_content_chars=max_content_chars)
+            for m in (view.get("bookend_end") or messages[-3:])
+        ],
         "messages_before": view.get("messages_before", 0),
         "messages_after": view.get("messages_after", max(len(messages) - 5, 0)),
         "_lineage_root": lineage_root,
@@ -503,11 +560,14 @@ def _discover(
     limit: int,
     sort: Optional[str],
     current_session_id: str = None,
+    max_content_chars: int | None = None,
 ) -> str:
     """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
     role_list = role_filter if role_filter else ["user", "assistant"]
     current_lineage_root = _resolve_to_parent(db, current_session_id) if current_session_id else None
-    title_result = _title_match_result(db, query, current_lineage_root)
+    title_result = _title_match_result(
+        db, query, current_lineage_root, max_content_chars=max_content_chars
+    )
 
     try:
         raw_results = db.search_messages(
@@ -596,9 +656,18 @@ def _discover(
             "matched_role": match_info.get("role"),
             "match_message_id": msg_id,
             "snippet": match_info.get("snippet") or "",
-            "bookend_start": [_shape_message(m) for m in (view.get("bookend_start") or [])],
-            "messages": [_shape_message(m, anchor_id=msg_id) for m in (view.get("window") or [])],
-            "bookend_end": [_shape_message(m) for m in (view.get("bookend_end") or [])],
+            "bookend_start": [
+                _shape_message(m, max_content_chars=max_content_chars)
+                for m in (view.get("bookend_start") or [])
+            ],
+            "messages": [
+                _shape_message(m, anchor_id=msg_id, max_content_chars=max_content_chars)
+                for m in (view.get("window") or [])
+            ],
+            "bookend_end": [
+                _shape_message(m, max_content_chars=max_content_chars)
+                for m in (view.get("bookend_end") or [])
+            ],
             "messages_before": view.get("messages_before", 0),
             "messages_after": view.get("messages_after", 0),
         }
@@ -630,6 +699,7 @@ def session_search(
     sort: str = None,
     # Cross-profile (any shape)
     profile: str = None,
+    max_content_chars: int | None = None,
 ) -> str:
     """Single-shape tool. Mode inferred from which args are set.
 
@@ -683,12 +753,13 @@ def session_search(
             around_message_id=around_message_id,
             window=window,
             current_session_id=current_session_id,
+            max_content_chars=max_content_chars,
         )
 
     # Read shape: a session_id with no anchor → dump the whole session.
     if isinstance(session_id, str) and session_id.strip():
         sid = session_id.strip()
-        result = _read_session(db, sid)
+        result = _read_session(db, sid, max_content_chars=max_content_chars)
         if json.loads(result).get("success"):
             return result
 
@@ -698,7 +769,7 @@ def session_search(
         located, owner = _locate_session_db(sid)
         if located is not None:
             try:
-                found = json.loads(_read_session(located, sid))
+                found = json.loads(_read_session(located, sid, max_content_chars=max_content_chars))
             finally:
                 located.close()
             if found.get("success"):
@@ -737,6 +808,7 @@ def session_search(
         limit=limit,
         sort=sort_norm,
         current_session_id=current_session_id,
+        max_content_chars=max_content_chars,
     )
 
 
@@ -752,150 +824,71 @@ def check_session_search_requirements() -> bool:
 SESSION_SEARCH_SCHEMA = {
     "name": "session_search",
     "description": (
-        "Search past sessions stored in the local session DB, or scroll inside one. "
-        "FTS5-backed retrieval over the SQLite message store. No LLM calls — every "
-        "shape returns actual messages from the DB.\n\n"
-        "SOURCE-FIRST LIMIT\n\n"
-        "  This tool searches Hermes conversation history only. It is not evidence "
-        "about the current contents of external sources. If the user provided a "
-        "direct source such as a URL, phone number/contact, app/thread, file path, "
-        "account, website, or live system, inspect that original source before or "
-        "instead of session_search when accessible. Use session_search as secondary "
-        "context for what was previously said, not as primary proof of what the "
-        "source currently contains. If the original source is inaccessible, say so "
-        "and why before falling back to session history. Do not conclude 'not found' "
-        "or 'no prior correspondence' from session_search alone when a direct source "
-        "was provided.\n\n"
-        "FOUR CALLING SHAPES\n\n"
-        "  1) DISCOVERY — pass `query`:\n"
-        "     session_search(query=\"auth refactor\", limit=3)\n"
-        "     Runs FTS5, dedupes hits by session lineage, returns the top N sessions. "
-        "Each result carries:\n"
-        "       - session_id, title, when, source\n"
-        "       - snippet: FTS5-highlighted match excerpt\n"
-        "       - bookend_start: first 3 user+assistant messages of the session "
-        "(the goal / kickoff)\n"
-        "       - messages: ±5 messages around the FTS5 match, with the anchor message "
-        "flagged (the hit in context)\n"
-        "       - bookend_end: last 3 user+assistant messages of the session "
-        "(the resolution / decisions)\n"
-        "       - match_message_id, messages_before, messages_after\n"
-        "     Bookends + window together let you reconstruct goal → match → resolution "
-        "without paying for the whole transcript.\n\n"
-        "  2) SCROLL — pass `session_id` + `around_message_id`:\n"
-        "     session_search(session_id=\"...\", around_message_id=12345, window=10)\n"
-        "     Returns a window of ±`window` messages centered on the anchor. No FTS5, "
-        "no bookends — just the slice. Use after a discovery call when you need more "
-        "context than the ±5 default window.\n"
-        "       - To scroll FORWARD: pass messages[-1].id back as around_message_id.\n"
-        "       - To scroll BACKWARD: pass messages[0].id back as around_message_id.\n"
-        "       - The boundary message appears in both windows — orientation marker.\n"
-        "       - When messages_before or messages_after is < window, you're at the "
-        "start or end of the session.\n\n"
-        "  3) READ — pass `session_id` only (no around_message_id):\n"
-        "     session_search(session_id=\"...\", profile=\"work\")\n"
-        "     Dumps the whole session by id (first 20 + last 10 messages when "
-        "large). This is how you resolve an `@session:<profile>/<id>` link the "
-        "user dropped into the chat: split the value on `/` into profile + id "
-        "and call session_search(session_id=id, profile=profile).\n\n"
-        "  4) BROWSE — no args:\n"
-        "     session_search()\n"
-        "     Returns recent sessions chronologically: titles, previews, timestamps. "
-        "Use when the user asks \"what was I working on\" without naming a topic.\n\n"
-        "FTS5 SYNTAX\n\n"
-        "  AND is the default — multi-word queries require all terms. Use OR explicitly "
-        "for broader recall (`alpha OR beta OR gamma`), quoted phrases for exact match "
-        "(`\"docker networking\"`), boolean (`python NOT java`), or prefix wildcards "
-        "(`deploy*`).\n\n"
-        "WHEN TO USE\n\n"
-        "  Reach for this on questions about Hermes conversation history itself, such "
-        "as \"what did we do about X\", \"where did we leave Y\", or \"find the "
-        "session where Z\". If the user provided a direct source identifier, inspect "
-        "that source first when accessible; session_search can then supply historical "
-        "context. The session DB carries what was said when; external tools show "
-        "current source/world state."
+        "Search Hermes conversation history in the local SQLite/FTS5 session DB. "
+        "Returns actual stored messages; no LLM summarization. SOURCE-FIRST LIMIT: "
+        "conversation history only; use session_search as secondary memory, not proof "
+        "of current external state. If the user provides a direct source (URL, file "
+        "path, app/thread, contact, account, etc.), "
+        "inspect that source first when accessible; say why if it is inaccessible. "
+        "Do not conclude 'not found' from session history alone.\n\n"
+        "Calling shapes: DISCOVERY pass query (plus optional limit/sort/role_filter) "
+        "to get matching sessions with snippet, bookends, and a ±5 message window. "
+        "SCROLL pass session_id + around_message_id to page around an anchor; "
+        "scroll FORWARD with messages[-1].id and backward with messages[0].id. "
+        "READ pass session_id only "
+        "to dump first 20 + last 10 messages; for @session:<profile>/<id>, split the "
+        "profile into the profile arg and pass id as session_id. BROWSE pass no args "
+        "to list recent sessions.\n\n"
+        "FTS5 query notes: words are ANDed by default; use OR, quoted phrases, NOT, "
+        "or prefix wildcards like deploy*. Use this for cross-session recall such as "
+        "'what did we do about X' or 'where did we leave Y'."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "query": {
                 "type": "string",
-                "description": (
-                    "Search query (discovery shape). Keywords, phrases, or boolean "
-                    "expressions to find in past sessions. Omit to browse recent "
-                    "sessions. Ignored when session_id + around_message_id are set "
-                    "(scroll shape)."
-                ),
+                "description": "Discovery query. Omit to browse recent sessions; ignored for scroll/read shapes.",
             },
             "limit": {
                 "type": "integer",
-                "description": (
-                    "Discovery shape only. Max sessions to return (default 3, max 10). "
-                    "Bump to 5–10 when the topic likely spans several sessions and you "
-                    "want to pick the right one to scroll into."
-                ),
+                "description": "Discovery/browse max sessions (default 3, clamped 1-10).",
                 "default": 3,
             },
             "sort": {
                 "type": "string",
                 "enum": ["newest", "oldest"],
-                "description": (
-                    "Discovery shape only. Temporal bias on top of FTS5 ranking. Omit "
-                    "to keep relevance-only ordering (suitable for exploratory recall — "
-                    "\"what do we know about X\"). Set 'newest' for recency-shaped "
-                    "questions (\"where did we leave X\"). Set 'oldest' for "
-                    "origin-shaped questions (\"how did X start\"). Ignored in scroll "
-                    "and browse shapes."
-                ),
+                "description": "Discovery temporal bias. Omit for relevance; use newest/oldest for recency/origin questions.",
             },
             "session_id": {
                 "type": "string",
-                "description": (
-                    "Scroll shape. Session to read inside. Use the session_id returned "
-                    "from a prior discovery call. Must be paired with "
-                    "around_message_id."
-                ),
+                "description": "Session to read/scroll. Pair with around_message_id for scroll; alone means read.",
             },
             "around_message_id": {
                 "type": "integer",
-                "description": (
-                    "Scroll shape. Message id to center the window on. From a discovery "
-                    "result use match_message_id, or any id seen in a prior window. To "
-                    "scroll forward pass the last window message's id; to scroll "
-                    "backward pass the first."
-                ),
+                "description": "Scroll anchor message id. Reuse first/last returned id to page backward/forward.",
             },
             "window": {
                 "type": "integer",
-                "description": (
-                    "Scroll shape only. Messages to return on each side of the anchor "
-                    "(anchor itself always included). Clamped to [1, 20]. Default 5."
-                ),
+                "description": "Scroll messages on each side of anchor, clamped 1-20 (default 5).",
                 "default": 5,
             },
             "role_filter": {
                 "type": "string",
-                "description": (
-                    "Optional. Comma-separated roles to include. Discovery defaults to "
-                    "'user,assistant' (tool output is usually noise). Pass "
-                    "'user,assistant,tool' to include tool output (debugging tool "
-                    "behaviour) or 'tool' to search tool output only."
-                ),
+                "description": "Discovery roles CSV. Default user,assistant; include tool for debugging tool output.",
             },
             "profile": {
                 "type": "string",
-                "description": (
-                    "Optional. Read sessions from another Hermes profile's database "
-                    "(read-only). Use when resolving an `@session:<profile>/<id>` link: "
-                    "pass the profile segment here with session_id as the id segment. "
-                    "Omit to use the current profile."
-                ),
+                "description": "Read another profile DB read-only; for @session:<profile>/<id> pass the profile segment here.",
+            },
+            "max_content_chars": {
+                "type": "integer",
+                "description": "Soft per-message content budget (default 12000, max 100000; 0=max).",
             },
         },
         "required": [],
     },
 }
-
 
 # --- Registry ---
 from tools.registry import registry, tool_error
@@ -915,6 +908,7 @@ registry.register(
         profile=args.get("profile"),
         db=kw.get("db"),
         current_session_id=kw.get("current_session_id"),
+        max_content_chars=args.get("max_content_chars"),
     ),
     check_fn=check_session_search_requirements,
     emoji="🔍",

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1305,34 +1305,17 @@ def skill_manage(
 SKILL_MANAGE_SCHEMA = {
     "name": "skill_manage",
     "description": (
-        "Manage skills (create, update, delete). Skills are your procedural "
-        "memory — reusable approaches for recurring task types. "
-        f"New skills go to {display_hermes_home()}/skills/; existing skills can be modified wherever they live.\n\n"
-        "Actions: create (full SKILL.md + optional category), "
-        "patch (old_string/new_string — preferred for fixes), "
-        "edit (full SKILL.md rewrite — major overhauls only), "
-        "delete, write_file, remove_file.\n\n"
-        "On delete, pass `absorbed_into=<umbrella>` when you're merging this "
-        "skill's content into another one, or `absorbed_into=\"\"` when you're "
-        "pruning it with no forwarding target. This lets the curator tell "
-        "consolidation from pruning without guessing, so downstream consumers "
-        "(cron jobs that reference the old skill name, etc.) get updated "
-        "correctly. The target you name in `absorbed_into` must already "
-        "exist — create/patch the umbrella first, then delete.\n\n"
-        "Create when: complex task succeeded (5+ calls), errors overcome, "
-        "user-corrected approach worked, non-trivial workflow discovered, "
-        "or user asks you to remember a procedure.\n"
-        "Update when: instructions stale/wrong, OS-specific failures, "
-        "missing steps or pitfalls found during use. "
-        "If you used a skill and hit issues not covered by it, patch it immediately.\n\n"
-        "After difficult/iterative tasks, offer to save as a skill. "
-        "Skip for simple one-offs. Confirm with user before creating/deleting.\n\n"
-        "Good skills: trigger conditions, numbered steps with exact commands, "
-        "pitfalls section, verification steps. Use skill_view() to see format examples.\n\n"
-        "Pinned skills are protected from deletion only — skill_manage(action='delete') "
-        "will refuse with a message pointing the user to `hermes curator unpin <name>`. "
-        "Patches and edits go through on pinned skills so you can still improve them as "
-        "pitfalls come up; pin only guards against irrecoverable loss."
+        "Manage skills: procedural memory for reusable task workflows. "
+        f"New skills go to {display_hermes_home()}/skills/; existing skills can be modified in place. "
+        "Actions: create, patch (preferred targeted fix), edit (full SKILL.md rewrite), "
+        "delete, write_file, remove_file. "
+        "Create when: complex task succeeded, errors were overcome, a user-corrected "
+        "approach worked, non-trivial workflow was discovered, or the user asks to remember it. "
+        "Update when: loaded skill guidance is stale/wrong, OS-specific failures appear, "
+        "or missing pitfalls/steps are discovered. Use skill_view() before major edits and for examples. "
+        "On delete pass absorbed_into=<umbrella> when merged elsewhere, or absorbed_into=\"\" "
+        "when pruning with no forwarding target; name an existing umbrella before deleting. "
+        "Confirm with user before creating/deleting. Pinned skills cannot be deleted, but patch/edit is allowed."
     ),
     "parameters": {
         "type": "object",
@@ -1340,82 +1323,48 @@ SKILL_MANAGE_SCHEMA = {
             "action": {
                 "type": "string",
                 "enum": ["create", "patch", "edit", "delete", "write_file", "remove_file"],
-                "description": "The action to perform."
+                "description": "Operation to perform."
             },
             "name": {
                 "type": "string",
-                "description": (
-                    "Skill name (lowercase, hyphens/underscores, max 64 chars). "
-                    "Must match an existing skill for patch/edit/delete/write_file/remove_file."
-                )
+                "description": "Skill name: lowercase letters/numbers plus ._-; max 64 chars."
             },
             "content": {
                 "type": "string",
-                "description": (
-                    "Full SKILL.md content (YAML frontmatter + markdown body). "
-                    "Required for 'create' and 'edit'. For 'edit', read the skill "
-                    "first with skill_view() and provide the complete updated text."
-                )
+                "description": "Full SKILL.md with YAML frontmatter + body. Required for create/edit; read first with skill_view for edit."
             },
             "old_string": {
                 "type": "string",
-                "description": (
-                    "Text to find in the file (required for 'patch'). Must be unique "
-                    "unless replace_all=true. Include enough surrounding context to "
-                    "ensure uniqueness."
-                )
+                "description": "Patch find text. Must be unique unless replace_all=true; include enough context."
             },
             "new_string": {
                 "type": "string",
-                "description": (
-                    "Replacement text (required for 'patch'). Can be empty string "
-                    "to delete the matched text."
-                )
+                "description": "Patch replacement text; empty string deletes the match."
             },
             "replace_all": {
                 "type": "boolean",
-                "description": "For 'patch': replace all occurrences instead of requiring a unique match (default: false)."
+                "description": "For patch: replace all matches instead of requiring uniqueness."
             },
             "category": {
                 "type": "string",
-                "description": (
-                    "Optional category/domain for organizing the skill (e.g., 'devops', "
-                    "'data-science', 'mlops'). Creates a subdirectory grouping. "
-                    "Only used with 'create'."
-                )
+                "description": "Optional category subdir for create, e.g. devops or data-science."
             },
             "file_path": {
                 "type": "string",
-                "description": (
-                    "Path to a supporting file within the skill directory. "
-                    "For 'write_file'/'remove_file': required, must be under references/, "
-                    "templates/, scripts/, or assets/. "
-                    "For 'patch': optional, defaults to SKILL.md if omitted."
-                )
+                "description": "Supporting file path. write_file/remove_file require references/, templates/, scripts/, or assets/. patch defaults to SKILL.md."
             },
             "file_content": {
                 "type": "string",
-                "description": "Content for the file. Required for 'write_file'."
+                "description": "Supporting file content; required for write_file."
             },
             "absorbed_into": {
                 "type": "string",
-                "description": (
-                    "For 'delete' only — declares intent so the curator can "
-                    "tell consolidation from pruning without guessing. "
-                    "Pass the umbrella skill name when this skill's content "
-                    "was merged into another (the target must already exist). "
-                    "Pass an empty string when the skill is truly stale and "
-                    "being pruned with no forwarding target. Omitting the arg "
-                    "on delete is supported for backward compatibility but "
-                    "downstream tooling (e.g. cron-job skill reference "
-                    "rewriting) will have to guess at intent."
-                )
+                "description": "Delete intent: umbrella skill name if merged, or empty string for true prune/no forwarding target."
             },
         },
         "required": ["action", "name"],
     },
 }
-
 
 # --- Registry ---
 from tools.registry import registry, tool_error

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -87,6 +87,38 @@ from agent.skill_utils import (
 logger = logging.getLogger(__name__)
 
 
+_DEFAULT_SKILL_VIEW_OUTPUT_BUDGET_CHARS = 60_000
+
+
+def _skill_view_budget(max_chars: int | None = None) -> int:
+    if max_chars is None:
+        return _DEFAULT_SKILL_VIEW_OUTPUT_BUDGET_CHARS
+    try:
+        requested = int(max_chars)
+    except (TypeError, ValueError):
+        return _DEFAULT_SKILL_VIEW_OUTPUT_BUDGET_CHARS
+    if requested <= 0:
+        return 200_000
+    return max(1_000, min(requested, 200_000))
+
+
+def _apply_skill_view_budget(result: Dict[str, Any], max_chars: int | None = None) -> Dict[str, Any]:
+    content = result.get("content")
+    if not isinstance(content, str):
+        return result
+    budget = _skill_view_budget(max_chars)
+    if len(content) <= budget:
+        return result
+    suffix = "\n...[truncated by skill_view output budget; pass max_chars or load a linked file with file_path]"
+    result["content"] = content[: max(0, budget - len(suffix))] + suffix
+    result["truncated_by_budget"] = True
+    result["original_content_chars"] = len(content)
+    result["returned_content_chars"] = len(result["content"])
+    result["budget_chars"] = budget
+    result["hint"] = "skill_view content was budget-truncated. Pass max_chars for a larger response, or use file_path for targeted linked files."
+    return result
+
+
 # All skills live in ~/.hermes/skills/ (seeded from bundled skills/ on install).
 # This is the single source of truth -- agent edits, hub installs, and bundled
 # skills all coexist here without polluting the git repo.
@@ -762,6 +794,7 @@ def _serve_plugin_skill(
     *,
     preprocess: bool = True,
     session_id: str | None = None,
+    max_chars: int | None = None,
 ) -> str:
     """Read a plugin-provided skill, apply guards, return JSON."""
     from hermes_cli.plugins import _get_disabled_plugins, get_plugin_manager
@@ -846,17 +879,15 @@ def _serve_plugin_skill(
                 "Could not preprocess plugin skill %s:%s", namespace, bare, exc_info=True
             )
 
-    return json.dumps(
-        {
-            "success": True,
-            "name": f"{namespace}:{bare}",
-            "content": f"{banner}{rendered_content}" if banner else rendered_content,
-            "description": description,
-            "linked_files": None,
-            "readiness_status": SkillReadinessStatus.AVAILABLE.value,
-        },
-        ensure_ascii=False,
-    )
+    result = {
+        "success": True,
+        "name": f"{namespace}:{bare}",
+        "content": f"{banner}{rendered_content}" if banner else rendered_content,
+        "description": description,
+        "linked_files": None,
+        "readiness_status": SkillReadinessStatus.AVAILABLE.value,
+    }
+    return json.dumps(_apply_skill_view_budget(result, max_chars), ensure_ascii=False)
 
 
 def skill_view(
@@ -864,6 +895,7 @@ def skill_view(
     file_path: str = None,
     task_id: str = None,
     preprocess: bool = True,
+    max_chars: int | None = None,
 ) -> str:
     """
     View the content of a skill or a specific file within a skill directory.
@@ -876,6 +908,7 @@ def skill_view(
         preprocess: Apply configured SKILL.md template and inline shell rendering
             to main skill content. Internal slash/preload callers disable this
             because they render the skill message themselves.
+        max_chars: Optional soft output budget for content; defaults to 60K chars.
 
     Returns:
         JSON string with skill content or error message
@@ -943,6 +976,7 @@ def skill_view(
                     bare,
                     preprocess=preprocess,
                     session_id=task_id,
+                    max_chars=max_chars,
                 )
 
             # Plugin exists but this specific skill is missing?
@@ -1280,13 +1314,16 @@ def skill_view(
                 )
 
             return json.dumps(
-                {
-                    "success": True,
-                    "name": name,
-                    "file": file_path,
-                    "content": content,
-                    "file_type": target_file.suffix,
-                },
+                _apply_skill_view_budget(
+                    {
+                        "success": True,
+                        "name": name,
+                        "file": file_path,
+                        "content": content,
+                        "file_type": target_file.suffix,
+                    },
+                    max_chars,
+                ),
                 ensure_ascii=False,
             )
 
@@ -1504,7 +1541,7 @@ def skill_view(
         if isinstance(metadata, dict):
             result["metadata"] = metadata
 
-        return json.dumps(result, ensure_ascii=False)
+        return json.dumps(_apply_skill_view_budget(result, max_chars), ensure_ascii=False)
 
     except Exception as e:
         return tool_error(str(e), success=False)
@@ -1588,6 +1625,10 @@ SKILL_VIEW_SCHEMA = {
                 "type": "string",
                 "description": "OPTIONAL: Path to a linked file within the skill (e.g., 'references/api.md', 'templates/config.yaml', 'scripts/validate.py'). Omit to get the main SKILL.md content.",
             },
+            "max_chars": {
+                "type": "integer",
+                "description": "Soft output budget for returned content chars (default 60000). Pass 0 to allow up to 200000 chars for unusually large skills.",
+            },
         },
         "required": ["name"],
     },
@@ -1608,7 +1649,10 @@ def _skill_view_with_bump(args, **kw):
     telemetry failure never breaks the tool call."""
     name = args.get("name", "")
     result = skill_view(
-        name, file_path=args.get("file_path"), task_id=kw.get("task_id")
+        name,
+        file_path=args.get("file_path"),
+        task_id=kw.get("task_id"),
+        max_chars=args.get("max_chars"),
     )
     try:
         parsed = json.loads(result)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -202,14 +202,18 @@ def set_approval_callback(cb):
 
 def _get_sudo_password_cache_scope() -> str:
     """Return the cache scope for interactive sudo passwords."""
+    env_session_key = os.getenv("HERMES_SESSION_KEY", "")
     try:
         from gateway.session_context import get_session_env
 
-        session_key = get_session_env("HERMES_SESSION_KEY", "")
+        ctx_session_key = get_session_env("HERMES_SESSION_KEY", "")
     except Exception:
-        session_key = os.getenv("HERMES_SESSION_KEY", "")
-    if session_key:
-        return f"session:{session_key}"
+        ctx_session_key = ""
+    if env_session_key or ctx_session_key:
+        # Include both sources so a stale ContextVar cannot make a new
+        # HERMES_SESSION_KEY reuse another session's cached sudo password, and
+        # gateway ContextVars still scope sessions when no env key exists.
+        return f"session:{ctx_session_key or '-'}:{env_session_key or '-'}"
 
     callback = _get_sudo_password_callback()
     if callback is not None:
@@ -264,10 +268,22 @@ def _check_all_guards(command: str, env_type: str) -> dict:
 
 
 # Allowlist: characters that can legitimately appear in directory paths.
-# Covers alphanumeric, path separators, Windows drive/UNC separators, tilde,
-# dot, hyphen, underscore, space, plus, at, equals, and comma.  Everything
-# else is rejected.
-_WORKDIR_SAFE_RE = re.compile(r'^[A-Za-z0-9/\\:_\-.~ +@=,]+$')
+# Covers Unicode letters/digits, path separators, Windows drive/UNC separators,
+# tilde, dot, hyphen, underscore, space, plus, at, equals, and comma.  Shell
+# metacharacters remain rejected.  This intentionally fixes the old ASCII-only
+# guard that blocked perfectly normal workdirs such as Chinese Obsidian vault
+# paths while preserving the injection boundary around command execution.
+_WORKDIR_SAFE_ASCII_CHARS = frozenset('/\\:_-.~ +@=,')
+
+
+def _is_safe_workdir_char(ch: str) -> bool:
+    if not ch:
+        return False
+    # Reject control characters (including newlines/tabs) and NUL bytes before
+    # considering Unicode categories.
+    if ord(ch) < 32 or ord(ch) == 127:
+        return False
+    return ch.isalnum() or ch in _WORKDIR_SAFE_ASCII_CHARS
 
 
 def _validate_workdir(workdir: str) -> str | None:
@@ -280,15 +296,12 @@ def _validate_workdir(workdir: str) -> str | None:
     """
     if not workdir:
         return None
-    if not _WORKDIR_SAFE_RE.match(workdir):
-        # Find the first offending character for a helpful message.
-        for ch in workdir:
-            if not _WORKDIR_SAFE_RE.match(ch):
-                return (
-                    f"Blocked: workdir contains disallowed character {repr(ch)}. "
-                    "Use a simple filesystem path without shell metacharacters."
-                )
-        return "Blocked: workdir contains disallowed characters."
+    for ch in workdir:
+        if not _is_safe_workdir_char(ch):
+            return (
+                f"Blocked: workdir contains disallowed character {repr(ch)}. "
+                "Use a simple filesystem path without shell metacharacters."
+            )
     return None
 
 
@@ -932,27 +945,11 @@ import sys
 
 
 # Tool description for LLM
-TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on a Linux environment. Filesystem, current working directory, and exported environment variables persist between calls.
+TERMINAL_TOOL_DESCRIPTION = """Execute shell commands. Filesystem, current working directory, and exported environment variables persist between calls.
 
-Do NOT use cat/head/tail to read files — use read_file instead.
-Do NOT use grep/rg/find to search — use search_files instead.
-Do NOT use ls to list directories — use search_files(target='files') instead.
-Do NOT use sed/awk to edit files — use patch instead.
-Do NOT use echo/cat heredoc to create files — use write_file instead.
-Reserve terminal for: builds, installs, git, processes, scripts, network, package managers, and anything that needs a shell.
-Because exported environment state persists, activate a virtualenv or export setup variables once per session; do not re-source the same environment before every command unless a command proves the shell state was reset.
+Use specialized tools when possible: read_file not cat/head/tail; search_files not grep/rg/find/ls; patch not sed/awk; write_file not echo/heredoc. Reserve terminal for builds, installs, git, processes, scripts, network, package managers, servers, and shell-only tasks.
 
-Foreground (default): Commands return INSTANTLY when done, even if the timeout is high. Set timeout=300 for long builds/scripts — you'll still get the result in seconds if it's fast. Prefer foreground for short commands.
-Background: Set background=true to get a session_id. Almost always pair with notify_on_complete=true — bg without notify runs SILENTLY and you have no way to learn it finished short of calling process(action='poll') yourself. Two legitimate uses:
-  (1) Long-lived processes that never exit (servers, watchers, daemons) — silent is correct, there's no exit to notify on.
-  (2) Long-running bounded tasks (tests, builds, deploys, CI pollers, batch jobs) — MUST set notify_on_complete=true. Without it you'll either forget to poll or sit blocked waiting for the user to surface the result.
-For servers/watchers, do NOT use shell-level background wrappers (nohup/disown/setsid/trailing '&') in foreground mode. Use background=true so Hermes can track lifecycle and output.
-After starting a server, verify readiness with a health check or log signal, then run tests in a separate terminal() call. Avoid blind sleep loops.
-Use process(action="poll") for progress checks, process(action="wait") to block until done.
-Working directory: Use 'workdir' for per-command cwd.
-PTY mode: Set pty=true for interactive CLI tools (Codex, Claude Code, Python REPL).
-
-Do NOT use vim/nano/interactive tools without pty=true — they hang without a pseudo-terminal. Pipe git output to cat if it might page.
+Because state persists, activate a virtualenv or export setup variables once per session; do not re-source the same environment before every command unless the shell was reset. Foreground commands finish as soon as done; set generous timeout for long builds. For background bounded work, use background=true with notify_on_complete=true. For long-lived servers/watchers, use background=true (not nohup/disown/&), wait for a readiness signal, then test separately. Use process(action="poll"/"wait") for progress. Set workdir per command. Use pty=true for interactive CLIs/REPLs; do not run vim/nano without pty.
 """
 
 # Global state for environment lifecycle management
@@ -2894,12 +2891,12 @@ TERMINAL_SCHEMA = {
             },
             "background": {
                 "type": "boolean",
-                "description": "Run the command in the background. Almost always pair with notify_on_complete=true — without it, the process runs silently and you'll have no way to learn it finished short of calling process(action='poll') yourself (easy to forget, leading to silent blindness on long jobs). Two legitimate patterns: (1) Long-lived processes that never exit (servers, watchers, daemons) — these stay silent because there's no exit to notify on. (2) Long-running bounded tasks (tests, builds, deploys, CI pollers, batch jobs) — these MUST set notify_on_complete=true. For short commands, prefer foreground with a generous timeout instead.",
+                "description": "Run in background and return a session_id. For bounded jobs use notify_on_complete=true; for long-lived servers/watchers leave notify off and poll/read logs with process.",
                 "default": False
             },
             "timeout": {
                 "type": "integer",
-                "description": f"Max seconds to wait (default: 180, foreground max: {FOREGROUND_MAX_TIMEOUT}). Returns INSTANTLY when command finishes — set high for long tasks, you won't wait unnecessarily. Foreground timeout above {FOREGROUND_MAX_TIMEOUT}s is rejected; use background=true for longer commands.",
+                "description": f"Max seconds to wait (default 180, foreground max {FOREGROUND_MAX_TIMEOUT}). Finishes immediately when command exits; use background=true for longer jobs.",
                 "minimum": 1
             },
             "workdir": {
@@ -2908,18 +2905,18 @@ TERMINAL_SCHEMA = {
             },
             "pty": {
                 "type": "boolean",
-                "description": "Run in pseudo-terminal (PTY) mode for interactive CLI tools like Codex, Claude Code, or Python REPL. Only works with local and SSH backends. Default: false.",
+                "description": "Use a PTY for interactive CLIs/REPLs (Codex, Claude Code, Python). Local/SSH only.",
                 "default": False
             },
             "notify_on_complete": {
                 "type": "boolean",
-                "description": "When true (and background=true), you'll be automatically notified exactly once when the process finishes. **This is the right choice for almost every long-running task** — tests, builds, deployments, multi-item batch jobs, anything that takes over a minute and has a defined end. Use this and keep working on other things; the system notifies you on exit. MUTUALLY EXCLUSIVE with watch_patterns — when both are set, watch_patterns is dropped.",
+                "description": "With background=true, notify exactly once when the process exits. Best for tests/builds/deploys/batch jobs. Mutually exclusive with watch_patterns; notify_on_complete wins.",
                 "default": False
             },
             "watch_patterns": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Strings to watch for in background process output. HARD RATE LIMIT: at most 1 notification per 15 seconds per process — matches arriving inside the cooldown are dropped. After 3 consecutive 15-second windows with dropped matches, watch_patterns is automatically disabled for that process and promoted to notify_on_complete behavior (one notification on exit, no more mid-process spam). USE ONLY for truly rare, one-shot mid-process signals on LONG-LIVED processes that will never exit on their own — e.g. ['Application startup complete'] on a server so you know when to hit its endpoint, or ['migration done'] on a daemon. DO NOT use for: (1) end-of-run markers like 'DONE'/'PASS' — use notify_on_complete instead; (2) error patterns like 'ERROR'/'Traceback' in loops or multi-item batch jobs — they fire on every iteration and you'll hit the strike limit fast; (3) anything you'd ever combine with notify_on_complete. When in doubt, choose notify_on_complete. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both."
+                "description": "Rare one-shot output signals for long-lived background processes (e.g. server ready). Rate-limited; noisy matches are disabled. Do not use for PASS/DONE/errors or with notify_on_complete."
             }
         },
         "required": ["command"]

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -1,17 +1,24 @@
 """Progressive tool disclosure ("tool search") for Hermes Agent.
 
-When enabled, MCP and non-core plugin tools are replaced in the model-visible
-tools array by three bridge tools — ``tool_search``, ``tool_describe``,
-``tool_call`` — and surfaced on demand. Core Hermes tools never defer.
+When enabled, large non-essential tool surfaces are replaced in the
+model-visible tools array by three bridge tools — ``tool_search``,
+``tool_describe``, ``tool_call`` — and surfaced on demand. The default
+"narrow waist" keeps common exploration and agent-runtime tools directly
+visible, while MCP, plugin, and peripheral built-in platform tools may defer.
 
 Design constraints this module is built around (see ``openclaw-tool-search-report``
 for the full rationale):
 
-* Core tools defined in ``toolsets._HERMES_CORE_TOOLS`` are *never* deferred.
-  Always-load means always-load. No exceptions.
+* Tools defined in ``toolsets._HERMES_TOOL_SEARCH_ALWAYS_VISIBLE_TOOLS`` are
+  never deferred. This is intentionally narrower than platform composition's
+  ``_HERMES_CORE_TOOLS``: terminal/file/web/skills/runtime tools stay direct,
+  while browser/media/cron/smart-home/etc. schemas can move behind search.
 * The threshold gate runs every assembly: when deferrable tools would consume
-  less than ``threshold_pct`` of the model's context window (default 10%),
-  tool search is a no-op and the tools array passes through unchanged.
+  less than the smaller of ``threshold_pct`` of the model's context window and
+  ``threshold_max_tokens`` (default 10K), tool search is a no-op and the tools
+  array passes through unchanged.  The fixed cap prevents huge-context models
+  from carrying 15K+ tokens of MCP schema every turn just because 10% of their
+  context window is enormous.
 * The catalog is stateless across turns and tools-array assemblies. It is
   rebuilt from the current tool-defs list every time. This is the lesson
   from OpenClaw's cron regression (openclaw/openclaw#84141): a session-keyed
@@ -66,6 +73,7 @@ class ToolSearchConfig:
 
     enabled: str  # "auto" | "on" | "off"
     threshold_pct: float  # 0..100 — only used when enabled == "auto"
+    threshold_max_tokens: int  # fixed auto-mode cap; 0 disables the cap
     search_default_limit: int
     max_search_limit: int
 
@@ -81,12 +89,15 @@ class ToolSearchConfig:
         """
         if raw is True:
             return cls(enabled="auto", threshold_pct=10.0,
+                       threshold_max_tokens=10_000,
                        search_default_limit=5, max_search_limit=20)
         if raw is False:
             return cls(enabled="off", threshold_pct=10.0,
+                       threshold_max_tokens=10_000,
                        search_default_limit=5, max_search_limit=20)
         if not isinstance(raw, dict):
             return cls(enabled="auto", threshold_pct=10.0,
+                       threshold_max_tokens=10_000,
                        search_default_limit=5, max_search_limit=20)
 
         enabled_raw = str(raw.get("enabled", "auto")).strip().lower()
@@ -102,6 +113,15 @@ class ToolSearchConfig:
         threshold_pct = _safe_float(raw.get("threshold_pct"), 10.0)
         threshold_pct = max(0.0, min(100.0, threshold_pct))
 
+        threshold_max_tokens = _safe_int(raw.get("threshold_max_tokens"), 10_000)
+        # 0 is an explicit escape hatch for legacy percentage-only behavior.
+        # Positive values are clamped so typos do not accidentally activate on
+        # every tiny plugin schema or defer only at unusably high budgets.
+        if threshold_max_tokens < 0:
+            threshold_max_tokens = 10_000
+        elif threshold_max_tokens > 0:
+            threshold_max_tokens = max(1_000, min(100_000, threshold_max_tokens))
+
         max_search_limit = max(1, min(50, _safe_int(raw.get("max_search_limit"), 20)))
         search_default_limit = max(1, min(max_search_limit,
                                           _safe_int(raw.get("search_default_limit"), 5)))
@@ -109,6 +129,7 @@ class ToolSearchConfig:
         return cls(
             enabled=enabled,
             threshold_pct=threshold_pct,
+            threshold_max_tokens=threshold_max_tokens,
             search_default_limit=search_default_limit,
             max_search_limit=max_search_limit,
         )
@@ -147,40 +168,58 @@ def load_config() -> ToolSearchConfig:
 # ---------------------------------------------------------------------------
 
 
-def _core_tool_names() -> frozenset[str]:
-    """Return the set of tool names that must NEVER be deferred.
+def _always_visible_tool_names() -> frozenset[str]:
+    """Return tool names that must remain directly model-visible.
 
-    Imported lazily because ``toolsets`` imports from ``tools.registry``
-    and we don't want a hard cycle.
+    Imported lazily because ``toolsets`` imports from ``tools.registry`` and we
+    don't want a hard cycle. Falls back to the historical platform core if the
+    new narrow-waist constant is unavailable during upgrades/tests.
     """
     try:
-        from toolsets import _HERMES_CORE_TOOLS
-        return frozenset(_HERMES_CORE_TOOLS)
+        from toolsets import _HERMES_TOOL_SEARCH_ALWAYS_VISIBLE_TOOLS
+        return frozenset(_HERMES_TOOL_SEARCH_ALWAYS_VISIBLE_TOOLS)
     except Exception:
-        return frozenset()
+        try:
+            from toolsets import _HERMES_CORE_TOOLS
+            return frozenset(_HERMES_CORE_TOOLS)
+        except Exception:
+            return frozenset()
+
+
+def _always_visible_toolsets() -> frozenset[str]:
+    """Toolsets whose members need direct agent/runtime dispatch."""
+    return frozenset({
+        "todo",
+        "memory",
+        "session_search",
+        "clarify",
+        "delegation",
+        "context_engine",
+    })
 
 
 def is_deferrable_tool_name(name: str) -> bool:
     """Return True if a tool with this name is *eligible* for deferral.
 
-    A tool is deferrable iff it is registered with an MCP toolset prefix
-    OR it is not in ``_HERMES_CORE_TOOLS``. Core tools are never deferred
-    even when their toolset is technically plugin-provided (this protects
-    against accidental shadowing).
+    Tools in the narrow always-visible set stay direct. Everything else that
+    is registered and in-scope may be deferred: MCP servers, plugin tools, and
+    peripheral built-in platform tools such as browser automation, image/TTS,
+    cron, Home Assistant, computer-use, Discord, and similar large schemas.
+    Unknown names stay visible/unchanged so a catalog bug never silently drops
+    a tool.
     """
     if name in BRIDGE_TOOL_NAMES:
         return False
-    if name in _core_tool_names():
+    if name in _always_visible_tool_names():
         return False
-    # Check registry toolset for MCP prefix.
     try:
         from tools.registry import registry
         entry = registry.get_entry(name)
         if entry is None:
             return False
-        if entry.toolset.startswith("mcp-"):
-            return True
-        # Non-MCP, non-core → plugin tool, eligible.
+        toolset = str(getattr(entry, "toolset", "") or "")
+        if toolset in _always_visible_toolsets():
+            return False
         return True
     except Exception:
         return False
@@ -190,8 +229,8 @@ def classify_tools(tool_defs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]
     """Split a tool-defs list into (visible, deferrable).
 
     ``visible`` retains every tool that must stay in the model-facing array:
-    every core tool, plus any tool we can't classify. ``deferrable`` is the
-    candidate set for catalog entry.
+    every narrow-waist always-visible tool, plus any tool we can't classify.
+    ``deferrable`` is the candidate set for catalog entry.
     """
     visible: List[Dict[str, Any]] = []
     deferrable: List[Dict[str, Any]] = []
@@ -241,7 +280,10 @@ def should_activate(
     ``"off"`` skips unconditionally. ``"on"`` activates unconditionally
     (as long as there is at least one deferrable tool — there's no point
     swapping a no-op). ``"auto"`` activates when the deferrable schemas
-    would consume ``threshold_pct`` of context or more.
+    would consume the configured percentage threshold or the fixed cap,
+    whichever is lower.  The cap is load-bearing for large-context models:
+    a 272K-token model with a 10% threshold would otherwise carry ~27K
+    schema tokens before progressive disclosure activates.
     """
     if config.enabled == "off":
         return False
@@ -250,12 +292,24 @@ def should_activate(
     if config.enabled == "on":
         return True
     # auto
-    if not context_length or context_length <= 0:
-        # Without a known context size, fall back to a fixed 20K-token cutoff
-        # — the cliff above which Anthropic and OpenAI both saw quality drops.
-        return deferrable_tokens >= 20_000
-    threshold_tokens = int(context_length * (config.threshold_pct / 100.0))
+    threshold_tokens = auto_threshold_tokens(config, context_length)
     return deferrable_tokens >= threshold_tokens
+
+
+def auto_threshold_tokens(config: ToolSearchConfig, context_length: Optional[int]) -> int:
+    """Return the token threshold used by auto-mode activation.
+
+    Uses the smaller of the percentage threshold and ``threshold_max_tokens``.
+    When context length is unknown, the fixed cap becomes the threshold; if the
+    cap is disabled, fall back to the historical 20K-token cutoff.
+    """
+    fixed_cap = int(config.threshold_max_tokens or 0)
+    if not context_length or context_length <= 0:
+        return fixed_cap or 20_000
+    pct_threshold = int(context_length * (config.threshold_pct / 100.0))
+    if fixed_cap > 0:
+        return min(pct_threshold, fixed_cap)
+    return pct_threshold
 
 
 # ---------------------------------------------------------------------------
@@ -311,9 +365,16 @@ def _classify_source(name: str) -> Tuple[str, str]:
         entry = registry.get_entry(name)
         if entry is None:
             return ("other", "")
-        if entry.toolset.startswith("mcp-"):
-            return ("mcp", entry.toolset)
-        return ("plugin", entry.toolset)
+        toolset = str(entry.toolset or "")
+        if toolset.startswith("mcp-"):
+            return ("mcp", toolset)
+        try:
+            from toolsets import TOOLSETS
+            if toolset in TOOLSETS:
+                return ("builtin", toolset)
+        except Exception:
+            pass
+        return ("plugin", toolset)
     except Exception:
         return ("other", "")
 
@@ -535,9 +596,9 @@ def assemble_tool_defs(
     """Return the tool-defs list the model should actually see.
 
     When tool search is inactive (off, no deferrable tools, or below
-    threshold), this is a passthrough. When active, MCP and plugin tools
-    are stripped from the visible list and replaced with the three bridge
-    tools. Core tools are *never* deferred regardless of config.
+    threshold), this is a passthrough. When active, MCP/plugin/peripheral
+    built-in tools are stripped from the visible list and replaced with the
+    three bridge tools. Narrow-waist always-visible tools are never deferred.
 
     Idempotent: calling with bridge tools already in the input is a no-op
     (they classify as non-core/non-deferrable but their names are reserved,
@@ -562,15 +623,15 @@ def assemble_tool_defs(
             activated=False,
             deferred_count=len(deferrable),
             deferred_tokens=deferrable_tokens,
-            threshold_tokens=int((context_length or 0) * (config.threshold_pct / 100.0)),
+            threshold_tokens=auto_threshold_tokens(config, context_length),
         )
 
     bridge = bridge_tool_schemas(len(deferrable))
     result = visible + bridge
-    threshold_tokens = int((context_length or 0) * (config.threshold_pct / 100.0))
+    threshold_tokens = auto_threshold_tokens(config, context_length)
 
     logger.info(
-        "tool_search activated: %d core/visible tools kept, %d deferred (~%d tokens, threshold ~%d)",
+        "tool_search activated: %d visible tools kept, %d deferred (~%d tokens, threshold ~%d)",
         len(visible), len(deferrable), deferrable_tokens, threshold_tokens,
     )
 
@@ -723,6 +784,7 @@ __all__ = [
     "classify_tools",
     "estimate_tokens_from_schemas",
     "should_activate",
+    "auto_threshold_tokens",
     "build_catalog",
     "search_catalog",
     "bridge_tool_schemas",

--- a/toolsets.py
+++ b/toolsets.py
@@ -78,6 +78,27 @@ _HERMES_CORE_TOOLS = [
     "computer_use",
 ]
 
+
+# Tool Search's "narrow waist": these built-in tools stay model-visible even
+# when progressive disclosure activates. They cover common discovery/action
+# loops and every agent-runtime-owned tool whose execution needs live AIAgent
+# state. Other built-in platform tools remain part of _HERMES_CORE_TOOLS for
+# backward-compatible platform composition, but may be deferred behind
+# tool_search/tool_describe/tool_call when their schema budget is large.
+_HERMES_TOOL_SEARCH_ALWAYS_VISIBLE_TOOLS = [
+    # Web + terminal + file are the common exploratory loop.
+    "web_search", "web_extract",
+    "terminal", "process",
+    "read_terminal",
+    "read_file", "write_file", "patch", "search_files",
+    # Skills are mandatory procedural memory and must be directly reachable.
+    "skills_list", "skill_view", "skill_manage",
+    # Agent-runtime-owned tools need live AIAgent state/callbacks.
+    "todo", "memory", "session_search", "clarify", "delegate_task",
+    # execute_code is the compact escape hatch for multi-tool scripts.
+    "execute_code",
+]
+
 # Webhook events may originate from untrusted third-party content (for example,
 # public PR titles/comments). Keep the default webhook toolset intentionally
 # constrained to avoid local file/system execution by prompt injection.


### PR DESCRIPTION
## Summary

This PR reduces Hermes request/prompt overhead and hardens several runtime/tool edge cases while preserving existing behavior contracts.

- Add request budget telemetry and prompt context budgeting.
- Defer large tool surfaces behind scoped tool search.
- Add output budgets/progressive disclosure for large tool responses.
- Slim verbose tool schemas to reduce per-turn schema footprint.
- Harden session/runtime edge cases.
- Keep stale cwd fallback behind explicit cwd anchors after rebasing onto latest `origin/main`.
- Use `mktemp` for shell snapshot temp files so concurrent snapshot writes work on macOS bash 3.2 where `$BASHPID` is empty.

## Test plan

Local verification run from `/Users/f1aggo_macair/.hermes/hermes-agent`:

- `git diff --check`
- `python3 -m py_compile tests/tools/test_base_environment.py tools/environments/base.py`
- `TMPDIR=/tmp uv run --extra dev pytest tests/tools/test_base_environment.py -q`
  - `25 passed in 2.35s`
- `TMPDIR=/tmp uv run --extra dev pytest tests/tools tests/agent tests/test_toolsets.py -q`
  - `11738 passed, 103 skipped, 10 warnings in 579.10s (0:09:39)`

## Notes

The branch was rebuilt from latest `origin/main` instead of pushing the local diverged `main`, then cherry-picked into a clean PR branch and reverified.
