### PR TITLE
fix(discord): route attachments to thread when metadata has thread_id

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2057,8 +2057,12 @@ class DiscordAdapter(BasePlatformAdapter):
         file_path: str,
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a local file as a Discord attachment.
+
+        When metadata contains a thread_id, the file is sent to that
+        thread instead of the parent channel identified by chat_id.
 
         Forum channels (type 15) get a new thread whose starter message
         carries the file — they reject direct POST /messages.
@@ -2066,11 +2070,19 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
-        channel = self._client.get_channel(int(chat_id))
-        if not channel:
-            channel = await self._client.fetch_channel(int(chat_id))
-        if not channel:
-            return SendResult(success=False, error=f"Channel {chat_id} not found")
+        thread_id = metadata.get("thread_id") if metadata else None
+        if thread_id:
+            channel = self._client.get_channel(int(thread_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(thread_id))
+            if not channel:
+                return SendResult(success=False, error=f"Thread {thread_id} not found")
+        else:
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            if not channel:
+                return SendResult(success=False, error=f"Channel {chat_id} not found")
 
         filename = file_name or os.path.basename(file_path)
         with open(file_path, "rb") as fh:
@@ -2114,12 +2126,21 @@ class DiscordAdapter(BasePlatformAdapter):
             return
 
         try:
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                logger.warning("[%s] Channel %s not found for multi-image send", self.name, chat_id)
-                return
+            thread_id = metadata.get("thread_id") if metadata else None
+            if thread_id:
+                channel = self._client.get_channel(int(thread_id))
+                if not channel:
+                    channel = await self._client.fetch_channel(int(thread_id))
+                if not channel:
+                    logger.warning("[%s] Thread %s not found for multi-image send", self.name, thread_id)
+                    return
+            else:
+                channel = self._client.get_channel(int(chat_id))
+                if not channel:
+                    channel = await self._client.fetch_channel(int(chat_id))
+                if not channel:
+                    logger.warning("[%s] Channel %s not found for multi-image send", self.name, chat_id)
+                    return
         except Exception as e:
             logger.warning("[%s] Failed to resolve channel for multi-image send: %s", self.name, e)
             await super().send_multiple_images(chat_id, images, metadata, human_delay)
@@ -3170,7 +3191,7 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a local image file natively as a Discord file attachment."""
         try:
-            return await self._send_file_attachment(chat_id, image_path, caption)
+            return await self._send_file_attachment(chat_id, image_path, caption, metadata=metadata)
         except FileNotFoundError:
             return SendResult(success=False, error=f"Image file not found: {image_path}")
         except Exception as e:  # pragma: no cover - defensive logging
@@ -3196,11 +3217,19 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             import aiohttp
 
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
+            thread_id = metadata.get("thread_id") if metadata else None
+            if thread_id:
+                channel = self._client.get_channel(int(thread_id))
+                if not channel:
+                    channel = await self._client.fetch_channel(int(thread_id))
+                if not channel:
+                    return SendResult(success=False, error=f"Thread {thread_id} not found")
+            else:
+                channel = self._client.get_channel(int(chat_id))
+                if not channel:
+                    channel = await self._client.fetch_channel(int(chat_id))
+                if not channel:
+                    return SendResult(success=False, error=f"Channel {chat_id} not found")
 
             # Download the image and send as a Discord file attachment
             # (Discord renders attachments inline, unlike plain URLs)
@@ -3275,11 +3304,19 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             import aiohttp
 
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
+            thread_id = metadata.get("thread_id") if metadata else None
+            if thread_id:
+                channel = self._client.get_channel(int(thread_id))
+                if not channel:
+                    channel = await self._client.fetch_channel(int(thread_id))
+                if not channel:
+                    return SendResult(success=False, error=f"Thread {thread_id} not found")
+            else:
+                channel = self._client.get_channel(int(chat_id))
+                if not channel:
+                    channel = await self._client.fetch_channel(int(chat_id))
+                if not channel:
+                    return SendResult(success=False, error=f"Channel {chat_id} not found")
 
             # Download the GIF and send as a Discord file attachment
             # (Discord renders .gif attachments as auto-playing animations inline)
@@ -3335,7 +3372,7 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a local video file natively as a Discord attachment."""
         try:
-            return await self._send_file_attachment(chat_id, video_path, caption)
+            return await self._send_file_attachment(chat_id, video_path, caption, metadata=metadata)
         except FileNotFoundError:
             return SendResult(success=False, error=f"Video file not found: {video_path}")
         except Exception as e:  # pragma: no cover - defensive logging
@@ -3353,7 +3390,7 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an arbitrary file natively as a Discord attachment."""
         try:
-            return await self._send_file_attachment(chat_id, file_path, caption, file_name=file_name)
+            return await self._send_file_attachment(chat_id, file_path, caption, file_name=file_name, metadata=metadata)
         except FileNotFoundError:
             return SendResult(success=False, error=f"File not found: {file_path}")
         except Exception as e:  # pragma: no cover - defensive logging

--- a/tests/gateway/test_discord_attachment_thread_routing.py
+++ b/tests/gateway/test_discord_attachment_thread_routing.py
@@ -1,0 +1,140 @@
+"""Tests for Discord attachment thread_id routing.
+
+Regression coverage for #12174: file/image/video/document sends should
+honor metadata["thread_id"] the same way text send() does.
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# Discord mock setup
+# ---------------------------------------------------------------------------
+
+def _ensure_discord_mock():
+    """Install a mock discord module when discord.py isn't available."""
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def adapter():
+    """Create a DiscordAdapter with a mocked client."""
+    _ensure_discord_mock()
+    config = PlatformConfig(enabled=True, token="fake-token")
+    a = DiscordAdapter(config)
+    a._client = MagicMock()
+    a._client.user = SimpleNamespace(id=999)
+    return a
+
+
+# ---------------------------------------------------------------------------
+# send_image_file / send_video / send_document metadata forwarding
+# ---------------------------------------------------------------------------
+
+class TestMediaMethodsMetadataForwarding:
+    async def test_send_image_file_forwards_metadata(self, adapter):
+        """send_image_file should forward metadata to _send_file_attachment."""
+        adapter._send_file_attachment = AsyncMock()
+        adapter._send_file_attachment.return_value = SimpleNamespace(
+            success=True, message_id="123"
+        )
+
+        await adapter.send_image_file(
+            chat_id="100",
+            image_path="/tmp/img.png",
+            caption="look",
+            metadata={"thread_id": "200"},
+        )
+
+        adapter._send_file_attachment.assert_called_once_with(
+            "100", "/tmp/img.png", "look", metadata={"thread_id": "200"}
+        )
+
+    async def test_send_video_forwards_metadata(self, adapter):
+        """send_video should forward metadata to _send_file_attachment."""
+        adapter._send_file_attachment = AsyncMock()
+        adapter._send_file_attachment.return_value = SimpleNamespace(
+            success=True, message_id="123"
+        )
+
+        await adapter.send_video(
+            chat_id="100",
+            video_path="/tmp/vid.mp4",
+            caption="watch",
+            metadata={"thread_id": "200"},
+        )
+
+        adapter._send_file_attachment.assert_called_once_with(
+            "100", "/tmp/vid.mp4", "watch", metadata={"thread_id": "200"}
+        )
+
+    async def test_send_document_forwards_metadata(self, adapter):
+        """send_document should forward metadata to _send_file_attachment."""
+        adapter._send_file_attachment = AsyncMock()
+        adapter._send_file_attachment.return_value = SimpleNamespace(
+            success=True, message_id="123"
+        )
+
+        await adapter.send_document(
+            chat_id="100",
+            file_path="/tmp/doc.pdf",
+            caption="read this",
+            file_name="doc.pdf",
+            metadata={"thread_id": "200"},
+        )
+
+        adapter._send_file_attachment.assert_called_once_with(
+            "100", "/tmp/doc.pdf", "read this",
+            file_name="doc.pdf", metadata={"thread_id": "200"},
+        )
+
+    async def test_send_image_file_no_metadata(self, adapter):
+        """send_image_file without metadata should pass None."""
+        adapter._send_file_attachment = AsyncMock()
+        adapter._send_file_attachment.return_value = SimpleNamespace(
+            success=True, message_id="123"
+        )
+
+        await adapter.send_image_file(
+            chat_id="100",
+            image_path="/tmp/img.png",
+        )
+
+        adapter._send_file_attachment.assert_called_once_with(
+            "100", "/tmp/img.png", None, metadata=None
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes Discord attachment routing when `metadata["thread_id"]` is present. Currently, `send_image_file()`, `send_video()`, `send_document()`, `send_image()`, `send_animation()`, and `send_multiple_images()` all ignore the `thread_id` metadata field, causing file/image/video attachments to be posted to the parent channel instead of the thread where the conversation is happening.

The text `send()` method already handles `thread_id` correctly — this PR extends the same routing logic to all media-sending methods.

## Related Issue

Fixes #12174

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/discord/adapter.py`: Added `metadata` parameter to `_send_file_attachment()` with `thread_id` resolution (same pattern as `send()`). Updated `send_image_file()`, `send_video()`, `send_document()` to forward `metadata`. Added `thread_id` resolution to `send_image()`, `send_animation()`, `send_multiple_images()`.
- `tests/gateway/test_discord_attachment_thread_routing.py`: Added regression tests verifying metadata is forwarded from media methods to `_send_file_attachment()`.

## How to Test

1. Run `pytest tests/gateway/test_discord_attachment_thread_routing.py -q` — should pass 4 tests.
2. Run `pytest tests/e2e/test_discord_adapter.py tests/gateway/test_discord_document_handling.py -q` — existing tests should still pass.
3. In a Discord thread, trigger a file/document send — the attachment should appear in the thread, not the parent channel.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_discord_attachment_thread_routing.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact — N/A (Discord adapter, platform-independent)
- [x] I've updated tool descriptions/schemas — or N/A
