### PR TITLE
feat(moa): allow reference reasoning effort

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -138,6 +138,11 @@ def _run_reference(
     concurrency primitive, mirroring ``delegate_task``'s batch fan-out.
     """
     label = _slot_label(slot)
+    extra_body = {}
+    effort = slot.get("reasoning_effort")
+    if effort:
+        extra_body["reasoning"] = {"effort": effort}
+
     try:
         # Prepend the advisory-role system prompt so the reference understands
         # it is analyzing state for an aggregator, not acting on the task. The
@@ -149,6 +154,7 @@ def _run_reference(
             messages=messages,
             temperature=temperature,
             max_tokens=max_tokens,
+            extra_body=extra_body,
             **_slot_runtime(slot),
         )
         return label, _extract_text(response) or "(empty response)"

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -36,6 +36,14 @@ _MAX_REFERENCE_WORKERS = 8
 # untrimmed transcript; this budget only shapes the advisory copy.
 _REFERENCE_TOOL_RESULT_BUDGET = 4000
 
+# Per-reference effort is currently a Codex-specific override. Other Hermes
+# providers expose reasoning through provider-specific contracts (OpenRouter
+# model gates, Anthropic adaptive thinking, Gemini thinking_config,
+# DeepSeek/Kimi/Ollama top-level reasoning_effort, xAI allowlists, etc.). MoA
+# must not blindly send an OpenAI-shaped ``extra_body.reasoning`` to those
+# providers; they should keep their normal defaults or existing session config.
+_REFERENCE_REASONING_EXTRA_BODY_PROVIDERS = {"openai-codex"}
+
 # System prompt prepended to every reference-model call. References are
 # advisory — they do NOT act, call tools, or own the task. Without this
 # framing a reference receives the bare trimmed conversation and assumes it is
@@ -67,6 +75,17 @@ _REFERENCE_SYSTEM_PROMPT = (
 
 def _slot_label(slot: dict[str, str]) -> str:
     return f"{slot.get('provider', '').strip()}:{slot.get('model', '').strip()}"
+
+
+def _reference_extra_body(slot: dict[str, str]) -> dict[str, Any]:
+    """Return per-reference extra_body overrides for providers that support it."""
+    provider = str(slot.get("provider") or "").strip().lower()
+    effort = str(slot.get("reasoning_effort") or "").strip().lower()
+    if not effort or provider not in _REFERENCE_REASONING_EXTRA_BODY_PROVIDERS:
+        return {}
+    if effort == "none":
+        return {"reasoning": {"enabled": False}}
+    return {"reasoning": {"effort": effort}}
 
 
 def _slot_runtime(slot: dict[str, str]) -> dict[str, Any]:
@@ -138,10 +157,7 @@ def _run_reference(
     concurrency primitive, mirroring ``delegate_task``'s batch fan-out.
     """
     label = _slot_label(slot)
-    extra_body = {}
-    effort = slot.get("reasoning_effort")
-    if effort:
-        extra_body["reasoning"] = {"effort": effort}
+    extra_body = _reference_extra_body(slot)
 
     try:
         # Prepend the advisory-role system prompt so the reference understands

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -769,6 +769,7 @@ export interface AuxiliaryModelsResponse {
 export interface MoaModelSlot {
   provider: string
   model: string
+  reasoning_effort?: string
 }
 
 export interface MoaConfigResponse {

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -53,6 +53,15 @@ _VALID_MOA_REASONING_EFFORTS = {
     "xhigh",
 }
 
+# Keep the initial MoA per-reference effort override deliberately narrow. The
+# current runtime forwards this field through auxiliary ``call_llm`` as
+# ``extra_body.reasoning`` for the Codex Responses adapter. Other providers in
+# Hermes use different reasoning contracts (Anthropic adaptive thinking,
+# Gemini thinking_config, DeepSeek/Kimi top-level reasoning_effort + thinking,
+# xAI model allowlists, etc.), so preserving this field for arbitrary providers
+# would silently impose an OpenAI-shaped knob on non-OpenAI backends.
+_MOA_REASONING_EFFORT_PROVIDERS = {"openai-codex"}
+
 
 def _clean_slot(slot: Any) -> dict[str, str] | None:
     if not isinstance(slot, dict):
@@ -69,13 +78,16 @@ def _clean_slot(slot: Any) -> dict[str, str] | None:
     if provider.lower() == "moa":
         return None
     cleaned: dict[str, str] = {"provider": provider, "model": model}
-    # Optional per-slot reasoning effort. Only forwarded to models whose
-    # backends understand it (e.g. OpenAI Codex Responses API, OpenRouter
-    # reasoning models). An invalid effort string is dropped rather than
-    # rejecting the whole slot, mirroring the tolerance for other hand-edited
-    # fields.
+    # Optional per-slot reasoning effort. This is intentionally provider-gated:
+    # the field currently maps to the OpenAI Codex Responses reasoning shape.
+    # Non-Codex providers keep their existing defaults/configuration instead of
+    # receiving an OpenAI-shaped reasoning field they may reject or ignore.
     effort = str(slot.get("reasoning_effort") or "").strip().lower()
-    if effort and effort in _VALID_MOA_REASONING_EFFORTS:
+    if (
+        effort
+        and effort in _VALID_MOA_REASONING_EFFORTS
+        and provider.lower() in _MOA_REASONING_EFFORT_PROVIDERS
+    ):
         cleaned["reasoning_effort"] = effort
     return cleaned
 

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -42,6 +42,18 @@ def _coerce_int(value: Any, default: int) -> int:
             return default
 
 
+_VALID_MOA_REASONING_EFFORTS = {
+    # Mirrors hermes_constants.parse_reasoning_effort(): none disables
+    # reasoning, while the remaining values request an effort level.
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+}
+
+
 def _clean_slot(slot: Any) -> dict[str, str] | None:
     if not isinstance(slot, dict):
         return None
@@ -56,7 +68,16 @@ def _clean_slot(slot: Any) -> dict[str, str] | None:
     # an invalid slot is dropped, falling back to the preset's defaults.
     if provider.lower() == "moa":
         return None
-    return {"provider": provider, "model": model}
+    cleaned: dict[str, str] = {"provider": provider, "model": model}
+    # Optional per-slot reasoning effort. Only forwarded to models whose
+    # backends understand it (e.g. OpenAI Codex Responses API, OpenRouter
+    # reasoning models). An invalid effort string is dropped rather than
+    # rejecting the whole slot, mirroring the tolerance for other hand-edited
+    # fields.
+    effort = str(slot.get("reasoning_effort") or "").strip().lower()
+    if effort and effort in _VALID_MOA_REASONING_EFFORTS:
+        cleaned["reasoning_effort"] = effort
+    return cleaned
 
 
 def _default_preset() -> dict[str, Any]:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -867,6 +867,10 @@ class ModelAssignment(BaseModel):
 class MoaModelSlot(BaseModel):
     provider: str = ""
     model: str = ""
+    # Optional per-slot effort for reasoning-capable reference models. Empty
+    # values are ignored by normalize_moa_config so existing clients that only
+    # send provider/model keep the old shape on disk.
+    reasoning_effort: str = ""
 
 
 class MoaPresetPayload(BaseModel):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -867,9 +867,9 @@ class ModelAssignment(BaseModel):
 class MoaModelSlot(BaseModel):
     provider: str = ""
     model: str = ""
-    # Optional per-slot effort for reasoning-capable reference models. Empty
-    # values are ignored by normalize_moa_config so existing clients that only
-    # send provider/model keep the old shape on disk.
+    # Optional per-slot effort for Codex reference models. Empty or unsupported
+    # provider values are ignored by normalize_moa_config so existing clients
+    # that only send provider/model keep the old shape on disk.
     reasoning_effort: str = ""
 
 

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -95,7 +95,7 @@ def test_normalize_moa_config_wraps_bare_dict_reference_models():
 
 
 def test_normalize_moa_config_preserves_reference_reasoning_effort():
-    """Reference slots can opt into model-specific reasoning effort."""
+    """Codex reference slots can opt into model-specific reasoning effort."""
     cfg = normalize_moa_config(
         {
             "presets": {
@@ -114,6 +114,29 @@ def test_normalize_moa_config_preserves_reference_reasoning_effort():
 
     assert cfg["presets"]["p"]["reference_models"] == [
         {"provider": "openai-codex", "model": "gpt-5.5", "reasoning_effort": "xhigh"}
+    ]
+
+
+def test_normalize_moa_config_drops_non_codex_reference_reasoning_effort():
+    """Do not impose OpenAI/Codex reasoning knobs on other providers."""
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "p": {
+                    "reference_models": [
+                        {
+                            "provider": "openrouter",
+                            "model": "anthropic/claude-opus-4.8",
+                            "reasoning_effort": "xhigh",
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    assert cfg["presets"]["p"]["reference_models"] == [
+        {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"}
     ]
 
 

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -94,6 +94,52 @@ def test_normalize_moa_config_wraps_bare_dict_reference_models():
     assert cfg["presets"]["p"]["reference_models"] == [{"provider": "openai", "model": "gpt-4o"}]
 
 
+def test_normalize_moa_config_preserves_reference_reasoning_effort():
+    """Reference slots can opt into model-specific reasoning effort."""
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "p": {
+                    "reference_models": [
+                        {
+                            "provider": "openai-codex",
+                            "model": "gpt-5.5",
+                            "reasoning_effort": "xhigh",
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    assert cfg["presets"]["p"]["reference_models"] == [
+        {"provider": "openai-codex", "model": "gpt-5.5", "reasoning_effort": "xhigh"}
+    ]
+
+
+def test_normalize_moa_config_drops_invalid_reference_reasoning_effort():
+    """Bad effort strings are ignored without dropping the whole slot."""
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "p": {
+                    "reference_models": [
+                        {
+                            "provider": "openai-codex",
+                            "model": "gpt-5.5",
+                            "reasoning_effort": "maximum",
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    assert cfg["presets"]["p"]["reference_models"] == [
+        {"provider": "openai-codex", "model": "gpt-5.5"}
+    ]
+
+
 def test_normalize_moa_config_coerces_numeric_strings():
     """Valid numeric strings (e.g. from YAML round-trip) must coerce correctly."""
     cfg = normalize_moa_config({"max_tokens": "8192", "reference_temperature": "0.9"})

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -467,6 +467,36 @@ class TestWebServerEndpoints:
         assert cfg["moa"]["reference_models"] == payload["reference_models"]
         assert cfg["moa"]["aggregator"] == payload["aggregator"]
 
+    def test_put_moa_models_preserves_reference_reasoning_effort(self):
+        from hermes_cli.config import load_config
+
+        payload = {
+            "reference_models": [
+                {
+                    "provider": "openai-codex",
+                    "model": "gpt-5.5",
+                    "reasoning_effort": "xhigh",
+                },
+                {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"},
+            ],
+            "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+            "reference_temperature": 0.6,
+            "aggregator_temperature": 0.4,
+            "max_tokens": 4096,
+            "enabled": True,
+        }
+
+        resp = self.client.put("/api/model/moa", json=payload)
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        cfg = load_config()
+        assert cfg["moa"]["reference_models"][0] == {
+            "provider": "openai-codex",
+            "model": "gpt-5.5",
+            "reasoning_effort": "xhigh",
+        }
+
     # ── GET /api/media (remote image display) ───────────────────────────
 
     def test_get_media_serves_image_in_root(self):

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -248,6 +248,55 @@ def test_moa_reference_forwards_reasoning_effort(monkeypatch):
     assert calls[0]["extra_body"] == {"reasoning": {"effort": "xhigh"}}
 
 
+def test_moa_reference_reasoning_effort_none_disables_codex_reasoning(monkeypatch):
+    from agent import moa_loop
+
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _response("reference advice")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {"provider": slot["provider"], "model": slot["model"]},
+    )
+
+    moa_loop._run_reference(
+        {"provider": "openai-codex", "model": "gpt-5.5", "reasoning_effort": "none"},
+        [{"role": "user", "content": "review this"}],
+    )
+
+    assert calls[0]["extra_body"] == {"reasoning": {"enabled": False}}
+
+
+def test_moa_reference_reasoning_effort_is_codex_scoped(monkeypatch):
+    """Non-Codex references keep their provider defaults/configuration."""
+    from agent import moa_loop
+
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _response("reference advice")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {"provider": slot["provider"], "model": slot["model"]},
+    )
+
+    moa_loop._run_reference(
+        {"provider": "openrouter", "model": "anthropic/claude-opus-4.8", "reasoning_effort": "xhigh"},
+        [{"role": "user", "content": "review this"}],
+    )
+
+    assert calls[0]["extra_body"] == {}
+
+
 def test_reference_messages_drops_system_but_renders_tools_as_text():
     """System prompt is dropped, but tool calls + results are RENDERED as text.
 

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -216,6 +216,38 @@ def test_moa_slot_runtime_falls_back_on_resolution_error(monkeypatch):
     assert "api_key" not in rt
 
 
+def test_moa_reference_forwards_reasoning_effort(monkeypatch):
+    """Reference slots may request model-specific reasoning effort.
+
+    MoA forwards the slot's reasoning_effort via extra_body.reasoning so the
+    provider-specific call path can translate it to that backend's wire format
+    (for example Codex Responses API reasoning={effort: ...}).
+    """
+    from agent import moa_loop
+
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _response("reference advice")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {"provider": slot["provider"], "model": slot["model"]},
+    )
+
+    label, text = moa_loop._run_reference(
+        {"provider": "openai-codex", "model": "gpt-5.5", "reasoning_effort": "xhigh"},
+        [{"role": "user", "content": "review this"}],
+    )
+
+    assert label == "openai-codex:gpt-5.5"
+    assert text == "reference advice"
+    assert calls[0]["extra_body"] == {"reasoning": {"effort": "xhigh"}}
+
+
 def test_reference_messages_drops_system_but_renders_tools_as_text():
     """System prompt is dropped, but tool calls + results are RENDERED as text.
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2105,6 +2105,7 @@ export interface AuxiliaryModelsResponse {
 export interface MoaModelSlot {
   provider: string;
   model: string;
+  reasoning_effort?: string;
 }
 
 export interface MoaConfigResponse {

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -852,10 +852,10 @@ function MoaModelsModal({
             }
             setError(null);
             updateSelectedPreset((prev) => {
-              if (picker.kind === "aggregator") return { ...prev, aggregator: { provider, model } };
+              if (picker.kind === "aggregator") return { ...prev, aggregator: { ...prev.aggregator, provider, model } };
               return {
                 ...prev,
-                reference_models: prev.reference_models.map((slot, i) => i === picker.index ? { provider, model } : slot),
+                reference_models: prev.reference_models.map((slot, i) => i === picker.index ? { ...slot, provider, model } : slot),
               };
             });
           }}

--- a/website/docs/user-guide/features/mixture-of-agents.md
+++ b/website/docs/user-guide/features/mixture-of-agents.md
@@ -80,6 +80,7 @@ moa:
       reference_models:
         - provider: openai-codex
           model: gpt-5.5
+          reasoning_effort: xhigh  # optional per-reference override
         - provider: openrouter
           model: deepseek/deepseek-v4-pro
       aggregator:

--- a/website/docs/user-guide/features/mixture-of-agents.md
+++ b/website/docs/user-guide/features/mixture-of-agents.md
@@ -80,7 +80,7 @@ moa:
       reference_models:
         - provider: openai-codex
           model: gpt-5.5
-          reasoning_effort: xhigh  # optional per-reference override
+          reasoning_effort: xhigh  # optional Codex-only per-reference override
         - provider: openrouter
           model: deepseek/deepseek-v4-pro
       aggregator:
@@ -137,3 +137,4 @@ So MoA does not sacrifice prompt caching on either call type. Its only real cost
 - A preset's aggregator cannot be another MoA preset. Recursive MoA trees are intentionally blocked.
 - Credential failures on one reference model do not abort the turn. Hermes includes the failure in the reference context and continues with whatever models returned.
 - MoA increases model-call count. A single model iteration can involve multiple reference calls plus the aggregator call.
+- `reasoning_effort` is currently honored only on `openai-codex` reference slots. Other providers keep their own default/session reasoning behavior because reasoning controls are provider-specific.


### PR DESCRIPTION
## What does this PR do?

Adds optional per-reference `reasoning_effort` support for Mixture-of-Agents presets, scoped to `openai-codex` reference slots.

MoA reference models are invoked through a separate advisory path, so they do not inherit the session-level `/reasoning` setting. This lets a preset explicitly request a higher-effort Codex reference model, e.g. `openai-codex:gpt-5.5` with `reasoning_effort: xhigh`, while preserving the default behavior for other providers.

Reasoning controls are provider-specific. This PR intentionally does **not** send OpenAI/Codex-shaped `extra_body.reasoning` to non-Codex providers like Anthropic, OpenRouter, Gemini, DeepSeek/Kimi, xAI, or local endpoints. Unsupported provider slots drop the field during normalization and keep their existing defaults/session config.

## Validated e2e

I instrumented the Codex adapter locally and confirmed the actual Responses API request metadata:

```json
{
  "chat_model": "gpt-5.5",
  "chat_extra_body": {
    "reasoning": {
      "effort": "xhigh"
    }
  },
  "responses_calls": [
    {
      "model": "gpt-5.5",
      "reasoning": {
        "effort": "xhigh",
        "summary": "auto"
      },
      "include": ["reasoning.encrypted_content"],
      "has_tools": false,
      "store": false
    }
  ]
}
```

That verifies the full path:

config.yaml MoA slot → normalization preserves `reasoning_effort` for `openai-codex` → MoA reference runtime → `call_llm` → Codex auxiliary adapter → live Codex Responses request with `reasoning.effort = xhigh`.

## Related issue

Fixes #53932

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes made

- Preserve valid `reasoning_effort` values on MoA model slots only when `provider: openai-codex`.
- Drop `reasoning_effort` from non-Codex slots during normalization so they keep provider defaults/session reasoning behavior.
- Forward Codex reference slot effort through `extra_body.reasoning.effort` when calling reference models.
- Map `reasoning_effort: none` to `extra_body.reasoning.enabled = false` instead of sending `effort: none`.
- Preserve the field through the web/dashboard API and TypeScript schemas.
- Document the optional field as Codex-only in the MoA config example.
- Add unit coverage for normalization, runtime forwarding, non-Codex isolation, disable semantics, and API persistence.

## How to test

```bash
scripts/run_tests.sh tests/hermes_cli/test_moa_config.py tests/run_agent/test_moa_loop_mode.py tests/hermes_cli/test_web_server.py
```

Result locally: 370 passed, 0 failed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing issues/PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & housekeeping

- [x] I've updated relevant documentation
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, this is an optional field under existing MoA slots
- [x] I've considered cross-platform impact — config/runtime/schema-only change
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A
