### PR TITLE
Add controlled context rebuild before compression

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1425,6 +1425,15 @@ def init_agent(
     compression_in_place = is_truthy_value(
         _compression_cfg.get("in_place"), default=False
     )
+    compression_controlled_rebuild = is_truthy_value(
+        _compression_cfg.get("controlled_rebuild"), default=True
+    )
+    compression_controlled_rebuild_budget = int(
+        _compression_cfg.get("controlled_rebuild_budget", 12_000)
+    )
+    compression_controlled_rebuild_checkpoint_budget = int(
+        _compression_cfg.get("controlled_rebuild_checkpoint_budget", 16_000)
+    )
 
     # Read optional explicit context_length override for the auxiliary
     # compression model. Custom endpoints often cannot report this via
@@ -1667,6 +1676,9 @@ def init_agent(
         )
     agent.compression_enabled = compression_enabled
     agent.compression_in_place = compression_in_place
+    agent.controlled_context_rebuild_enabled = compression_controlled_rebuild
+    agent.controlled_context_rebuild_packet_budget = compression_controlled_rebuild_budget
+    agent.controlled_context_rebuild_checkpoint_budget = compression_controlled_rebuild_checkpoint_budget
 
     # Reject models whose context window is below the minimum required
     # for reliable tool-calling workflows (64K tokens).

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1428,12 +1428,31 @@ def init_agent(
     compression_controlled_rebuild = is_truthy_value(
         _compression_cfg.get("controlled_rebuild"), default=True
     )
-    compression_controlled_rebuild_budget = int(
-        _compression_cfg.get("controlled_rebuild_budget", 12_000)
-    )
-    compression_controlled_rebuild_checkpoint_budget = int(
-        _compression_cfg.get("controlled_rebuild_checkpoint_budget", 16_000)
-    )
+    try:
+        compression_controlled_rebuild_budget = int(
+            _compression_cfg.get("controlled_rebuild_budget", 12_000)
+        )
+    except (TypeError, ValueError):
+        if not quiet_mode:
+            print("⚠️ Invalid compression.controlled_rebuild_budget; using 12000")
+        compression_controlled_rebuild_budget = 12_000
+    if compression_controlled_rebuild_budget <= 0:
+        if not quiet_mode:
+            print("⚠️ Invalid compression.controlled_rebuild_budget; using 12000")
+        compression_controlled_rebuild_budget = 12_000
+
+    try:
+        compression_controlled_rebuild_checkpoint_budget = int(
+            _compression_cfg.get("controlled_rebuild_checkpoint_budget", 16_000)
+        )
+    except (TypeError, ValueError):
+        if not quiet_mode:
+            print("⚠️ Invalid compression.controlled_rebuild_checkpoint_budget; using 16000")
+        compression_controlled_rebuild_checkpoint_budget = 16_000
+    if compression_controlled_rebuild_checkpoint_budget <= 0:
+        if not quiet_mode:
+            print("⚠️ Invalid compression.controlled_rebuild_checkpoint_budget; using 16000")
+        compression_controlled_rebuild_checkpoint_budget = 16_000
 
     # Read optional explicit context_length override for the auxiliary
     # compression model. Custom endpoints often cannot report this via

--- a/agent/controlled_context_rebuild.py
+++ b/agent/controlled_context_rebuild.py
@@ -1,0 +1,309 @@
+"""Deterministic controlled context rebuild sidecar for compression.
+
+This module preserves exact operational anchors (paths, commands, errors, recent
+user intent) before lossy LLM summarization rewrites the active transcript.
+It deliberately stays pure/stdlib-ish so compression can call it best-effort
+without adding provider calls or tool dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from agent.redact import redact_sensitive_text
+from hermes_constants import get_hermes_home
+
+CONTROLLED_CONTEXT_REBUILD_HEADER = "[CONTROLLED CONTEXT REBUILD]"
+_PACKET_END_MARKER = (
+    "[END CONTROLLED CONTEXT REBUILD — continue from live messages below]"
+)
+_LLM_SUMMARY_HEADING = "## LLM Compaction Summary"
+
+_NOISE_MARKERS = (
+    "[CONTEXT COMPACTION",
+    "CONTEXT COMPACTION — REFERENCE ONLY",
+    "Historical Task Snapshot",
+    "Historical In-Progress State",
+    "Historical Pending User Asks",
+    "Historical Remaining Work",
+    "[Your active task list was preserved across context compression]",
+    CONTROLLED_CONTEXT_REBUILD_HEADER,
+)
+_PATH_RE = re.compile(
+    r"(?:(?:~|\$HOME|/)[\w.@%+=:,~/-]+|(?:[A-Za-z0-9_.-]+/){1,}[A-Za-z0-9_.-]+)"
+)
+_ERROR_RE = re.compile(
+    r"\b(?:error|failed|failure|exception|traceback|assertionerror|timeout|fatal|TS\d{3,5}|E\d{3,5})\b",
+    re.I,
+)
+_TOKENISH_RE = re.compile(
+    r"\b(?:gh[pousr]_[A-Za-z0-9_]{8,}|gh[pousr]_[A-Za-z0-9_]{2,}\.\.\.[A-Za-z0-9_]{2,}|sk-[A-Za-z0-9_-]{12,}|xox[baprs]-[A-Za-z0-9-]{10,}|[A-Za-z0-9_]{24,}\.[A-Za-z0-9_]{6,}\.[A-Za-z0-9_]{20,})\b"
+)
+
+
+def _message_dict(message: Any) -> dict[str, Any]:
+    if isinstance(message, dict):
+        return dict(message)
+    try:
+        return {key: message[key] for key in message.keys()}
+    except Exception:
+        return {
+            "role": getattr(message, "role", ""),
+            "content": getattr(message, "content", ""),
+        }
+
+
+def _content_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                if item.get("type") == "text":
+                    parts.append(str(item.get("text") or ""))
+                elif "text" in item:
+                    parts.append(str(item.get("text") or ""))
+            else:
+                parts.append(str(item))
+        return "\n".join(p for p in parts if p)
+    return str(content)
+
+
+def _redact(text: str) -> str:
+    text = redact_sensitive_text(str(text or ""), force=True)
+    # redact_sensitive_text intentionally targets full tokens. Catch shortened
+    # examples like ghp_ab...3456 that still should not fossilize into context.
+    return _TOKENISH_RE.sub("[REDACTED]", text)
+
+
+def _compact(text: Any, *, limit: int = 420) -> str:
+    value = _redact(_content_text(text))
+    value = re.sub(r"\s+", " ", value).strip()
+    if len(value) <= limit:
+        return value
+    return value[: max(0, limit - 18)].rstrip() + " ...[truncated]"
+
+
+def _is_noise(row: dict[str, Any]) -> bool:
+    text = _content_text(row.get("content"))
+    return any(marker in text for marker in _NOISE_MARKERS)
+
+
+def _clean_rows(messages: Iterable[Any]) -> list[dict[str, Any]]:
+    rows = [_message_dict(message) for message in messages]
+    return [
+        row
+        for row in rows
+        if (_content_text(row.get("content")) or row.get("tool_calls"))
+        and not _is_noise(row)
+    ]
+
+
+def _dedupe_append(items: list[str], value: str, *, limit: int = 20) -> None:
+    value = value.strip()
+    if not value or value in items:
+        return
+    items.append(value)
+    if len(items) > limit:
+        del items[0]
+
+
+def _extract_tool_calls(row: dict[str, Any]) -> list[tuple[str, str, str]]:
+    calls: list[tuple[str, str, str]] = []
+    for tc in row.get("tool_calls") or []:
+        if isinstance(tc, dict):
+            fn = tc.get("function") or {}
+            calls.append((
+                str(tc.get("id") or ""),
+                str(fn.get("name") or "unknown"),
+                str(fn.get("arguments") or ""),
+            ))
+            continue
+        fn = getattr(tc, "function", None)
+        calls.append((
+            str(getattr(tc, "id", "") or ""),
+            str(getattr(fn, "name", "unknown") if fn else "unknown"),
+            str(getattr(fn, "arguments", "") if fn else ""),
+        ))
+    return calls
+
+
+def _collect_paths(text: str, paths: list[str]) -> None:
+    for match in _PATH_RE.findall(text):
+        cleaned = match.rstrip(".,);]'\"")
+        if len(cleaned) >= 3:
+            _dedupe_append(paths, cleaned, limit=24)
+
+
+def _safe_session_id(session_id: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "_", session_id or "default").strip("._")
+    return cleaned or "default"
+
+
+def _trim_to_budget(text: str, budget: int) -> str:
+    if budget <= 0 or len(text) <= budget:
+        return text
+    marker = "\n...[controlled rebuild truncated]\n"
+    keep = max(0, budget - len(marker))
+    head = int(keep * 0.70)
+    tail = keep - head
+    return text[:head].rstrip() + marker + text[-tail:].lstrip()
+
+
+def build_controlled_rebuild_packet(
+    session_id: str,
+    messages: Iterable[Any],
+    *,
+    budget: int = 12_000,
+) -> str:
+    """Build a deterministic packet that survives lossy compression.
+
+    The packet is intentionally factual and bounded. It is not a replacement
+    for the LLM summary; it is a guardrail preserving exact literals.
+    """
+    rows = _clean_rows(messages)
+    users = [row for row in rows if row.get("role") == "user"]
+    assistants = [row for row in rows if row.get("role") == "assistant"]
+
+    paths: list[str] = []
+    commands: list[str] = []
+    errors: list[str] = []
+    tool_actions: list[str] = []
+    call_id_to_tool: dict[str, tuple[str, str]] = {}
+
+    for row in rows:
+        text = _compact(row.get("content"), limit=900)
+        _collect_paths(text, paths)
+        if _ERROR_RE.search(text):
+            _dedupe_append(errors, text, limit=10)
+        for call_id, name, raw_args in _extract_tool_calls(row):
+            args = _redact(raw_args)
+            call_id_to_tool[call_id] = (name, args)
+            _dedupe_append(
+                tool_actions, f"{name}: {_compact(args, limit=320)}", limit=18
+            )
+            _collect_paths(args, paths)
+            try:
+                parsed = json.loads(args)
+            except Exception:
+                parsed = None
+            if isinstance(parsed, dict):
+                cmd = parsed.get("command")
+                if isinstance(cmd, str):
+                    _dedupe_append(commands, _compact(cmd, limit=320), limit=18)
+                for key in ("path", "workdir", "file_path", "output_path"):
+                    val = parsed.get(key)
+                    if isinstance(val, str):
+                        _dedupe_append(paths, val, limit=24)
+
+    for row in rows:
+        if row.get("role") != "tool":
+            continue
+        text = _compact(row.get("content"), limit=600)
+        tool_name, tool_args = call_id_to_tool.get(
+            str(row.get("tool_call_id") or ""), ("unknown", "")
+        )
+        if text:
+            _dedupe_append(tool_actions, f"{tool_name} result: {text}", limit=18)
+            _collect_paths(text, paths)
+        if _ERROR_RE.search(text):
+            _dedupe_append(errors, text, limit=10)
+        _collect_paths(tool_args, paths)
+
+    recent_user = (
+        _compact(users[-1].get("content") if users else "", limit=650)
+        or "None detected."
+    )
+    recent_assistant = (
+        _compact(assistants[-1].get("content") if assistants else "", limit=650)
+        or "None detected."
+    )
+    tail = [
+        f"- {row.get('role', 'unknown')}: {_compact(row.get('content'), limit=260)}"
+        for row in rows[-8:]
+        if _compact(row.get("content"), limit=260)
+    ]
+
+    def bullets(items: list[str], *, empty: str = "None.", limit: int = 12) -> str:
+        return "\n".join(f"- {item}" for item in items[:limit]) if items else empty
+
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    packet = f"""{CONTROLLED_CONTEXT_REBUILD_HEADER}
+Generated: {generated}
+Session: {_safe_session_id(session_id)}
+
+## Purpose
+Deterministic rebuild packet produced before lossy compression. Treat it as exact-literal continuity: paths, commands, errors, current intent, and recent state. Do not treat historical/compression task-list noise as fresh user input.
+
+## Current User Intent
+{recent_user}
+
+## Latest Assistant State
+{recent_assistant}
+
+## Exact Paths / Files / URLs
+{bullets(paths, limit=18)}
+
+## Commands / Operations
+{bullets(commands, limit=12)}
+
+## Tool Evidence
+{bullets(tool_actions, limit=14)}
+
+## Errors / Blockers
+{bullets(errors, limit=8)}
+
+## Recent Live Tail
+{chr(10).join(tail) if tail else "None."}
+
+{_PACKET_END_MARKER}"""
+    return _trim_to_budget(_redact(packet), budget)
+
+
+def checkpoint_path_for_session(
+    session_id: str, *, hermes_home: str | Path | None = None
+) -> Path:
+    home = Path(hermes_home) if hermes_home is not None else get_hermes_home()
+    return (
+        home / "context" / "sessions" / _safe_session_id(session_id) / "checkpoint.md"
+    )
+
+
+def write_controlled_rebuild_checkpoint(
+    session_id: str,
+    messages: Iterable[Any],
+    *,
+    hermes_home: str | Path | None = None,
+    budget: int = 16_000,
+) -> Path:
+    path = checkpoint_path_for_session(session_id, hermes_home=hermes_home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = build_controlled_rebuild_packet(session_id, messages, budget=budget)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def append_controlled_rebuild_to_summary(
+    summary: str,
+    session_id: str,
+    messages: Iterable[Any],
+    *,
+    budget: int = 12_000,
+) -> str:
+    """Prefix an LLM compaction summary with the deterministic rebuild packet."""
+    summary = str(summary or "").strip()
+    if CONTROLLED_CONTEXT_REBUILD_HEADER in summary:
+        return summary
+    packet = build_controlled_rebuild_packet(
+        session_id, messages, budget=budget
+    ).strip()
+    if not summary:
+        return packet
+    return f"{packet}\n\n{_LLM_SUMMARY_HEADING}\n{summary}"

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -40,6 +40,8 @@ from agent.model_metadata import estimate_request_tokens_rough
 
 logger = logging.getLogger(__name__)
 
+_COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
+
 # Stable marker the gateway matches on to re-tag the auto-compaction lifecycle
 # status as ``kind="compacting"`` (tui_gateway/server.py::_status_update), so
 # drivers like the desktop app can show an explicit "Summarizing…" indicator
@@ -49,6 +51,58 @@ COMPACTION_STATUS_MARKER = "Compacting context"
 COMPACTION_STATUS = (
     f"🗜️ {COMPACTION_STATUS_MARKER} — summarizing earlier conversation so I can continue..."
 )
+
+
+def _controlled_rebuild_enabled(agent: Any) -> bool:
+    """Return whether deterministic rebuild packets should wrap compression."""
+    return bool(getattr(agent, "controlled_context_rebuild_enabled", False))
+
+
+def _write_controlled_rebuild_checkpoint(agent: Any, messages: list) -> None:
+    if not _controlled_rebuild_enabled(agent):
+        return
+    try:
+        from agent.controlled_context_rebuild import write_controlled_rebuild_checkpoint
+        write_controlled_rebuild_checkpoint(
+            agent.session_id or "default",
+            messages,
+            budget=int(getattr(agent, "controlled_context_rebuild_checkpoint_budget", 16_000)),
+        )
+    except Exception as exc:
+        logger.debug("controlled context rebuild checkpoint failed: %s", exc)
+
+
+def _inject_controlled_rebuild_packet(agent: Any, compressed: list, source_messages: list) -> list:
+    """Prefix the compaction summary with a deterministic rebuild packet.
+
+    Mutates only the already-created summary message. Roles, tool calls, tail
+    selection, and the prompt-cacheable system prompt stay as produced.
+    """
+    if not _controlled_rebuild_enabled(agent):
+        return compressed
+    try:
+        from agent.controlled_context_rebuild import append_controlled_rebuild_to_summary
+    except Exception as exc:
+        logger.debug("controlled context rebuild import failed: %s", exc)
+        return compressed
+
+    for msg in compressed:
+        if not isinstance(msg, dict) or not msg.get(_COMPRESSED_SUMMARY_METADATA_KEY):
+            continue
+        content = msg.get("content")
+        if not isinstance(content, str):
+            continue
+        try:
+            msg["content"] = append_controlled_rebuild_to_summary(
+                content,
+                agent.session_id or "default",
+                source_messages,
+                budget=int(getattr(agent, "controlled_context_rebuild_packet_budget", 12_000)),
+            )
+        except Exception as exc:
+            logger.debug("controlled context rebuild injection failed: %s", exc)
+        break
+    return compressed
 
 
 def _compression_lock_holder(agent: Any) -> str:
@@ -483,6 +537,10 @@ def compress_context(
         except Exception:
             pass
 
+    # Deterministic sidecar checkpoint: write exact anchors before the lossy
+    # LLM summarizer rewrites the transcript. Best-effort and profile-local.
+    _write_controlled_rebuild_checkpoint(agent, messages)
+
     try:
         compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic, force=force)
     except TypeError:
@@ -540,6 +598,8 @@ def compress_context(
                     f"({_aux_fail_err or 'unknown error'}). Recovered using main model — "
                     "check auxiliary.compression.model in config.yaml."
                 )
+
+    compressed = _inject_controlled_rebuild_packet(agent, compressed, messages)
 
     todo_snapshot = agent._todo_store.format_for_injection()
     if todo_snapshot:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1356,6 +1356,14 @@ DEFAULT_CONFIG = {
                                       # session_search and recoverable, not deleted.
                                       # Default False during rollout; will flip on
                                       # after live validation.
+        "controlled_rebuild": True,    # Before lossy compaction, write a deterministic
+                                      # checkpoint to ~/.hermes/context/sessions/<id>/
+                                      # checkpoint.md and prefix the compaction summary
+                                      # with exact literals (paths, commands, errors,
+                                      # current intent). Keeps prompt-cacheable system
+                                      # prompt and message roles unchanged.
+        "controlled_rebuild_budget": 12000,
+        "controlled_rebuild_checkpoint_budget": 16000,
     },
 
     # Kanban subsystem (orchestrator workers + dispatcher-driven child tasks).

--- a/tests/agent/test_controlled_context_rebuild.py
+++ b/tests/agent/test_controlled_context_rebuild.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+
+from agent.controlled_context_rebuild import (
+    CONTROLLED_CONTEXT_REBUILD_HEADER,
+    append_controlled_rebuild_to_summary,
+    build_controlled_rebuild_packet,
+    write_controlled_rebuild_checkpoint,
+)
+
+
+def test_packet_preserves_exact_literals_and_filters_compression_noise():
+    messages = [
+        {"role": "system", "content": "sys"},
+        {
+            "role": "user",
+            "content": "[Your active task list was preserved across context compression]\n- [>] stale old task",
+        },
+        {
+            "role": "user",
+            "content": "давай внедри MiMo rebuild в /home/niko/.hermes/hermes-agent",
+        },
+        {
+            "role": "assistant",
+            "content": "Буду править agent/conversation_compression.py",
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": '{"command":"pytest tests/agent/test_controlled_context_rebuild.py -q","workdir":"/home/niko/.hermes/hermes-agent"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "FAILED tests/test_x.py::test_y - AssertionError: TS2835 relative import",
+        },
+    ]
+
+    packet = build_controlled_rebuild_packet("session-1", messages, budget=6000)
+
+    assert packet.startswith(CONTROLLED_CONTEXT_REBUILD_HEADER)
+    assert "/home/niko/.hermes/hermes-agent" in packet
+    assert "agent/conversation_compression.py" in packet
+    assert "pytest tests/agent/test_controlled_context_rebuild.py -q" in packet
+    assert "TS2835 relative import" in packet
+    assert "stale old task" not in packet
+
+
+def test_checkpoint_write_is_profile_local_and_budgeted(tmp_path):
+    messages = [
+        {"role": "user", "content": "сохрани exact literal /tmp/example.py"},
+        {"role": "assistant", "content": "done"},
+    ]
+
+    path = write_controlled_rebuild_checkpoint(
+        "sid/with/slash", messages, hermes_home=tmp_path, budget=1200
+    )
+
+    assert (
+        path == tmp_path / "context" / "sessions" / "sid_with_slash" / "checkpoint.md"
+    )
+    content = path.read_text(encoding="utf-8")
+    assert CONTROLLED_CONTEXT_REBUILD_HEADER in content
+    assert "/tmp/example.py" in content
+    assert len(content) <= 1200
+
+
+def test_append_controlled_rebuild_to_summary_is_idempotent_and_secret_safe():
+    messages = [
+        {"role": "user", "content": "token ghp_abcdefghijklmnopqrstuvwxyz123456"},
+        {"role": "assistant", "content": "patched /repo/file.py"},
+    ]
+
+    summary = "## Goal\nShip it"
+    combined = append_controlled_rebuild_to_summary(
+        summary, "sid", messages, budget=4000
+    )
+    combined2 = append_controlled_rebuild_to_summary(
+        combined, "sid", messages, budget=4000
+    )
+
+    assert combined == combined2
+    assert combined.startswith(CONTROLLED_CONTEXT_REBUILD_HEADER)
+    assert "## LLM Compaction Summary" in combined
+    assert "ghp_abcdefghijklmnopqrstuvwxyz123456" not in combined
+    assert "[REDACTED]" in combined

--- a/tests/run_agent/test_controlled_rebuild_compression_hook.py
+++ b/tests/run_agent/test_controlled_rebuild_compression_hook.py
@@ -1,0 +1,119 @@
+from types import SimpleNamespace
+
+
+class _TodoStore:
+    def format_for_injection(self):
+        return ""
+
+
+class _FakeCompressor:
+    def __init__(self):
+        self._last_compress_aborted = False
+        self._last_summary_error = None
+        self._last_aux_model_failure_model = None
+        self._last_aux_model_failure_error = None
+        self.compression_count = 1
+        self.called_with = None
+
+    def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+        self.called_with = list(messages)
+        return [
+            {"role": "user", "content": "head"},
+            {
+                "role": "assistant",
+                "content": "[CONTEXT COMPACTION — REFERENCE ONLY] summary body",
+                "_compressed_summary": True,
+            },
+            {"role": "user", "content": "tail"},
+        ]
+
+    def on_session_start(self, *args, **kwargs):
+        pass
+
+
+def _agent(tmp_path, *, enabled=True):
+    compressor = _FakeCompressor()
+    return SimpleNamespace(
+        session_id="session/core",
+        model="test/model",
+        platform="cli",
+        compression_in_place=True,
+        compression_enabled=True,
+        controlled_context_rebuild_enabled=enabled,
+        controlled_context_rebuild_packet_budget=5000,
+        controlled_context_rebuild_checkpoint_budget=5000,
+        context_compressor=compressor,
+        _memory_manager=None,
+        _session_db=None,
+        _todo_store=_TodoStore(),
+        _last_compaction_in_place=False,
+        _cached_system_prompt=None,
+        _compression_warning=None,
+        _emit_status=lambda *a, **k: None,
+        _emit_warning=lambda *a, **k: None,
+        _invalidate_system_prompt=lambda: None,
+        _build_system_prompt=lambda system_message: f"SYSTEM:{system_message}",
+        _current_main_runtime=lambda: {},
+        _compression_feasibility_checked=True,
+        tools=[],
+        log_prefix="",
+    )
+
+
+def test_compress_context_prefixes_summary_and_writes_checkpoint(tmp_path, monkeypatch):
+    from agent.conversation_compression import compress_context
+    from agent.controlled_context_rebuild import CONTROLLED_CONTEXT_REBUILD_HEADER
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+
+    token = set_hermes_home_override(tmp_path)
+    try:
+        agent = _agent(tmp_path, enabled=True)
+        messages = [
+            {
+                "role": "user",
+                "content": "давай patch /home/niko/.hermes/hermes-agent/agent/conversation_compression.py",
+            },
+            {
+                "role": "assistant",
+                "content": "will run pytest tests/agent/test_controlled_context_rebuild.py -q",
+            },
+        ]
+
+        compressed, system_prompt = compress_context(
+            agent,
+            messages,
+            "sys",
+            approx_tokens=100_000,
+            task_id="t",
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+    summary = compressed[1]["content"]
+    assert summary.startswith(CONTROLLED_CONTEXT_REBUILD_HEADER)
+    assert "## LLM Compaction Summary" in summary
+    assert (
+        "/home/niko/.hermes/hermes-agent/agent/conversation_compression.py" in summary
+    )
+    assert "pytest tests/agent/test_controlled_context_rebuild.py -q" in summary
+    assert [m["role"] for m in compressed] == ["user", "assistant", "user"]
+    assert system_prompt == "SYSTEM:sys"
+    checkpoint = tmp_path / "context" / "sessions" / "session_core" / "checkpoint.md"
+    assert checkpoint.exists()
+    assert CONTROLLED_CONTEXT_REBUILD_HEADER in checkpoint.read_text(encoding="utf-8")
+
+
+def test_compress_context_can_disable_controlled_rebuild(tmp_path):
+    from agent.conversation_compression import compress_context
+    from agent.controlled_context_rebuild import CONTROLLED_CONTEXT_REBUILD_HEADER
+
+    agent = _agent(tmp_path, enabled=False)
+    compressed, _system_prompt = compress_context(
+        agent,
+        [{"role": "user", "content": "patch /x.py"}],
+        "sys",
+        approx_tokens=100_000,
+        task_id="t",
+    )
+
+    assert not compressed[1]["content"].startswith(CONTROLLED_CONTEXT_REBUILD_HEADER)

--- a/tests/run_agent/test_controlled_rebuild_config.py
+++ b/tests/run_agent/test_controlled_rebuild_config.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def test_invalid_controlled_rebuild_budgets_fall_back(capsys):
+    """Invalid compression controlled-rebuild budgets warn and use safe defaults."""
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "compression": {
+                    "controlled_rebuild_budget": "12K",
+                    "controlled_rebuild_checkpoint_budget": 0,
+                }
+            },
+        ),
+    ):
+        agent = AIAgent(
+            api_key="test-k...7890",
+            provider="custom",
+            model="claude-opus-4-6-thinking",
+            base_url="http://proxy.example/v1",
+            quiet_mode=False,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    out = capsys.readouterr().out
+    assert "Invalid compression.controlled_rebuild_budget" in out
+    assert "Invalid compression.controlled_rebuild_checkpoint_budget" in out
+    assert getattr(agent, "controlled_context_rebuild_packet_budget") == 12_000
+    assert getattr(agent, "controlled_context_rebuild_checkpoint_budget") == 16_000

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -84,6 +84,9 @@ compression:
   threshold: 0.50            # Fraction of context window (default: 0.50 = 50%)
   target_ratio: 0.20         # How much of threshold to keep as tail (default: 0.20)
   protect_last_n: 20         # Minimum protected tail messages (default: 20)
+  controlled_rebuild: true   # Deterministic exact-anchor packet before lossy summary
+  controlled_rebuild_budget: 12000
+  controlled_rebuild_checkpoint_budget: 16000
   codex_gpt55_autoraise: true  # gpt-5.5 on Codex OAuth: raise trigger to 85% (default: true)
 
 # Summarization model/provider configured under auxiliary:
@@ -102,7 +105,20 @@ auxiliary:
 | `target_ratio` | `0.20` | 0.10-0.80 | Controls tail protection token budget: `threshold_tokens × target_ratio` |
 | `protect_last_n` | `20` | ≥1 | Minimum number of recent messages always preserved |
 | `protect_first_n` | `3` | (hardcoded) | System prompt + first exchange always preserved |
+| `controlled_rebuild` | `true` | bool | Prefix the LLM summary with deterministic exact anchors and write a checkpoint before compression |
+| `controlled_rebuild_budget` | `12000` | positive int | Max chars for the packet injected into the compressed summary |
+| `controlled_rebuild_checkpoint_budget` | `16000` | positive int | Max chars written to `~/.hermes/context/sessions/<id>/checkpoint.md` |
 | `codex_gpt55_autoraise` | `true` | bool | Raise the trigger to 85% for gpt-5.5 on the ChatGPT Codex OAuth route (see below). Set `false` to keep the global `threshold` |
+
+### Controlled rebuild packet
+
+Before the lossy LLM summarizer runs, Hermes builds a deterministic packet with exact literals: current user intent, paths, commands, tool evidence, errors, and a short live tail. The packet is written to `~/.hermes/context/sessions/<session_id>/checkpoint.md` and prefixed to the compressed summary under `[CONTROLLED CONTEXT REBUILD]`.
+
+This is a safety net, not a second conversation engine. It does **not** change role alternation, tool-call adjacency, prompt caching, or which tail messages remain live. Disable it with:
+
+```bash
+hermes config set compression.controlled_rebuild false
+```
 
 ### Codex gpt-5.5 threshold autoraise
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -677,6 +677,7 @@ compression:
   threshold: 0.50
   target_ratio: 0.20         # fraction of threshold to preserve as recent tail
   protect_last_n: 20         # minimum recent messages to keep uncompressed
+  controlled_rebuild: true   # deterministic exact-anchor packet before lossy summary
 ```
 
 :::info Legacy migration

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -737,6 +737,9 @@ compression:
   target_ratio: 0.20                                # Fraction of threshold to preserve as recent tail
   protect_last_n: 20                                # Min recent messages to keep uncompressed
   protect_first_n: 3                                # Non-system head messages pinned across compactions (0 = pin nothing)
+  controlled_rebuild: true                          # Prefix summaries with deterministic anchors before lossy compaction
+  controlled_rebuild_budget: 12000                  # Max chars injected into the compressed summary
+  controlled_rebuild_checkpoint_budget: 16000       # Max chars written to ~/.hermes/context/sessions/<id>/checkpoint.md
   hygiene_hard_message_limit: 5000                  # Gateway safety valve — see below
 
 # The summarization model/provider is configured under auxiliary:
@@ -754,6 +757,8 @@ Older configs with `compression.summary_model`, `compression.summary_provider`, 
 `hygiene_hard_message_limit` is a gateway-only **pre-compression safety valve**. It exists to break a death spiral: when API calls keep disconnecting on an oversized session, the gateway never receives token-usage data, so the token-based threshold can't fire, so the transcript keeps growing and disconnects get worse. This count-based floor fires on message count alone (always known, regardless of API failures) to force compression and recover the session. Default `5000` — far above any normal session, including large-context (1M+) models doing thousands of short turns, which compress on the token threshold long before this. Raise it further for unusual platforms, lower it to force more aggressive compression. Editing this value on a running gateway takes effect on the next message (see below).
 
 `protect_first_n` controls how many **non-system** head messages are pinned across every compaction. Default `3` — the opening user/assistant exchange survives every summarizer pass so the original goal stays visible. On long-running rolling-compaction sessions where the opening turn is no longer relevant, set `protect_first_n: 0` to pin nothing but the system prompt + summary + tail. The system prompt itself is always preserved regardless of this setting.
+
+`controlled_rebuild` is a deterministic safety layer that runs before the lossy LLM summary. It writes a profile-local checkpoint to `~/.hermes/context/sessions/<session_id>/checkpoint.md` and prefixes the compressed summary with exact anchors: recent user intent, paths, commands, tool evidence, and errors. It does not change message roles, tool-call ordering, or the live tail; set `controlled_rebuild: false` to disable it.
 
 :::tip Gateway hot-reload of compression and context length
 As of recent releases, editing `model.context_length` or any `compression.*` key in `config.yaml` on a running gateway takes effect on the next message — no gateway restart, no `/reset`, no session rotation required. The cached-agent signature includes these keys, so the gateway transparently rebuilds the agent when it sees a change. API keys and tool/skill config still require the usual reload paths.


### PR DESCRIPTION
## Summary
- add deterministic controlled context rebuild packets before lossy context compression
- write profile-local checkpoints under ~/.hermes/context/sessions/<session>/checkpoint.md
- prefix the existing compaction summary without changing message roles, tool calls, tail selection, or system prompt caching
- add config knobs under compression.controlled_rebuild*

## Verification
- uv run pytest tests/agent/test_controlled_context_rebuild.py tests/run_agent/test_controlled_rebuild_compression_hook.py -q
- uv run pytest tests/agent/test_controlled_context_rebuild.py tests/run_agent/test_controlled_rebuild_compression_hook.py tests/run_agent/test_in_place_compaction.py tests/run_agent/test_compression_persistence.py tests/agent/test_compressed_summary_metadata.py -q
- uv run ruff check .
- uv run python -m compileall -q agent hermes_cli tests/agent tests/run_agent
- uv build
- uv run --with twine twine check --strict dist/hermes_agent-0.17.0-py3-none-any.whl dist/hermes_agent-0.17.0.tar.gz
- isolated wheel smoke import/build_controlled_rebuild_packet

Note: full `uv run pytest -q` was attempted but timed out at 600s with unrelated existing e2e/logging failures before completion; focused compression gates pass.