### PR TITLE
fix(webhook): support Exit1.dev X-Exit1-Signature header

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -878,6 +878,16 @@ class WebhookAdapter(BasePlatformAdapter):
             ).hexdigest()
             return hmac.compare_digest(gh_sig, expected)
 
+        # Exit1.dev: X-Exit1-Signature = sha256=<hex HMAC-SHA256>
+        exit1_sig = request.headers.get("X-Exit1-Signature", "")
+        if exit1_sig:
+            # Strip optional sha256= prefix (Exit1 sends this format)
+            raw_sig = exit1_sig.replace("sha256=", "", 1) if exit1_sig.startswith("sha256=") else exit1_sig
+            expected = hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return hmac.compare_digest(raw_sig, expected)
+
         # GitLab: X-Gitlab-Token = <plain secret>
         gl_token = request.headers.get("X-Gitlab-Token", "")
         if gl_token:

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -103,6 +103,13 @@ def _generic_signature(body: bytes, secret: str) -> str:
     return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
 
+def _exit1_signature(body: bytes, secret: str) -> str:
+    """Compute X-Exit1-Signature for *body* using *secret* (sha256= prefixed)."""
+    return "sha256=" + hmac.new(
+        secret.encode(), body, hashlib.sha256
+    ).hexdigest()
+
+
 def _generic_v2_signature(body: bytes, secret: str, timestamp: str) -> str:
     """Compute X-Webhook-Signature-V2 (HMAC-SHA256 of "<timestamp>.<body>")."""
     signed_content = timestamp.encode() + b"." + body
@@ -190,6 +197,23 @@ class TestValidateSignature:
         sig = _generic_signature(body, secret)
         req = _mock_request(headers={"X-Webhook-Signature": sig})
         assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_exit1_signature_valid(self):
+        """Valid X-Exit1-Signature (sha256= HMAC-SHA256 hex) is accepted."""
+        adapter = _make_adapter()
+        body = b'{"monitor": "down"}'
+        secret = "exit1-secret"
+        sig = _exit1_signature(body, secret)
+        req = _mock_request(headers={"X-Exit1-Signature": sig})
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_exit1_signature_invalid(self):
+        """A wrong X-Exit1-Signature is rejected (constant-time compare fails)."""
+        adapter = _make_adapter()
+        body = b'{"monitor": "down"}'
+        secret = "exit1-secret"
+        req = _mock_request(headers={"X-Exit1-Signature": "sha256=deadbeef"})
+        assert adapter._validate_signature(req, body, secret) is False
 
     def test_validate_generic_v2_signature_valid(self):
         """Valid X-Webhook-Signature-V2 (timestamp-bound) is accepted."""

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -389,6 +389,7 @@ The adapter validates incoming webhook signatures using the appropriate method f
 - **GitLab**: `X-Gitlab-Token` header — plain secret string match
 - **Generic (V2, recommended)**: `X-Webhook-Signature-V2` + `X-Webhook-Timestamp` headers — HMAC-SHA256 hex digest of `<timestamp>.<body>`. The timestamp (Unix seconds) must be within ±300 seconds of the server clock, which prevents captured requests from being replayed later.
 - **Generic (V1, legacy)**: `X-Webhook-Signature` header — raw HMAC-SHA256 hex digest of the body only. Still accepted for backward compatibility, but it has no replay protection (a captured request replays indefinitely); the gateway logs a deprecation warning once per route. Switch senders to V2.
+- **Exit1.dev**: `X-Exit1-Signature` header — `sha256=`-prefixed HMAC-SHA256 hex digest of the body. Used by Exit1.dev website monitoring webhooks; identical HMAC computation to GitHub but with a different header name.
 
 If a secret is configured but no recognized signature header is present, the request is rejected.
 


### PR DESCRIPTION
## What does this PR do?

Adds support for Exit1.dev webhook signature validation. Exit1 sends its HMAC-SHA256 signature in the `X-Exit1-Signature` header using the format `sha256=<hex>`. This is the same HMAC computation as GitHub's `X-Hub-Signature-256` (signs the raw request body) but with a different header name.

## Related Issue

No existing issue. Exit1.dev is a website monitoring service that uses `X-Exit1-Signature` for webhook authentication.

## Type of Change

- [x] Bug fix (non-breaking change which adds missing functionality)

## Changes Made

`gateway/platforms/webhook.py`

Added `X-Exit1-Signature` header recognition in `_validate_signature()`, placed after the generic `X-Webhook-Signature` check. The implementation:
- Reads the `X-Exit1-Signature` header
- Strips the optional `sha256=` prefix (Exit1 sends this format)
- Computes HMAC-SHA256 of the raw body using the route secret
- Compares using constant-time `hmac.compare_digest()`

## How to Test

1. Create a webhook route in `webhook_subscriptions.json` with a known secret
2. Send a test request with Exit1-style signature:

```bash
SECRET="your...t": true}'
SIG="sha256=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')"

curl -X POST http://localhost:8644/webhooks/<route> \
  -H "Content-Type: application/json" \
  -H "X-Exit1-Signature: $SIG" \
  -d "$BODY"
```

3. Verify HTTP 200 response

## Note on Future Improvements

This PR takes the minimal approach — hardcoding the `X-Exit1-Signature` header name, consistent with how GitHub, GitLab, Svix, and Fireflies headers are currently handled in `_validate_signature()`.

A more general solution would be to add a configurable `signature_header` field to the webhook route config, so users can support any HMAC-SHA256 service without code changes:

```json
{
  "monitor": {
    "secret": "***",
    "signature_header": "X-Exit1-Signature",
    "deliver": "feishu"
  }
}
```

This would require threading the header name through `_reload_dynamic_routes()` → `_handle_webhook()` → `_validate_signature()`, and would eliminate the need for future provider-specific hardcoding. A follow-up PR could address this.

## Checklist

### Code
- [x] `fix(scope):` commit message format
- [x] No new dependencies
- [x] Existing tests pass
