### PR TITLE
Fix Windows bash cwd dialect handling

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1471,7 +1471,12 @@ class HermesACPAgent(acp.Agent):
                     clear_session_vars,
                     set_session_vars,
                 )
-                session_tokens = set_session_vars(session_key=session_id)
+                session_tokens = set_session_vars(
+                    platform="acp",
+                    session_key=session_id,
+                    session_id=session_id,
+                    cwd=getattr(state, "cwd", "") or "",
+                )
             except Exception:
                 session_tokens = None
                 clear_session_vars = None  # type: ignore[assignment]

--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -372,6 +372,41 @@ def _git_root(cwd: Path) -> Optional[Path]:
     return None
 
 
+def _git_dir_for_root(root: Path) -> Optional[Path]:
+    """Return the git metadata directory for a root without spawning git."""
+    dotgit = root / ".git"
+    try:
+        if dotgit.is_dir():
+            return dotgit
+        if dotgit.is_file():
+            text = dotgit.read_text(encoding="utf-8", errors="replace").strip()
+            prefix = "gitdir:"
+            if text.lower().startswith(prefix):
+                raw = text[len(prefix):].strip()
+                git_dir = Path(raw)
+                if not git_dir.is_absolute():
+                    git_dir = (root / git_dir).resolve()
+                return git_dir
+    except OSError:
+        return None
+    return None
+
+
+def _git_head_branch(root: Path) -> str:
+    """Read the current branch from .git/HEAD without invoking git."""
+    git_dir = _git_dir_for_root(root)
+    if git_dir is None:
+        return ""
+    try:
+        head = (git_dir / "HEAD").read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        return ""
+    prefix = "ref: refs/heads/"
+    if head.startswith(prefix):
+        return head[len(prefix):].strip()
+    return "(detached)" if head else ""
+
+
 def _home() -> Optional[Path]:
     try:
         return Path.home().resolve()
@@ -815,16 +850,13 @@ def build_coding_workspace_block(cwd: Optional[str | Path] = None) -> str:
     lines.append(f"- Root: {root}")
 
     if git_root is not None:
-        branch, counts = _parse_status(_git(root, "status", "--porcelain=2", "--branch"))
-        head = branch.get("head", "")
+        # Prompt construction is on the first-token path. Even short git
+        # subprocesses can stall on Windows/ACP workspaces under active file
+        # watchers, so this snapshot reads only .git/HEAD directly. The brief
+        # tells the model to run git when it needs live repo state.
+        head = _git_head_branch(root)
         if head and head != "(detached)":
-            line = f"- Branch: {head}"
-            if branch.get("upstream"):
-                line += f" \u2192 {branch['upstream']}"
-                ahead, behind = branch.get("ahead", "0"), branch.get("behind", "0")
-                if ahead != "0" or behind != "0":
-                    line += f" (ahead {ahead}, behind {behind})"
-            lines.append(line)
+            lines.append(f"- Branch: {head}")
         elif head == "(detached)":
             lines.append("- Branch: (detached HEAD)")
 
@@ -833,20 +865,10 @@ def build_coding_workspace_block(cwd: Optional[str | Path] = None) -> str:
         # are shared state) but deliberately do NOT expose the primary tree path —
         # giving the model a second absolute path causes it to sometimes run commands
         # in the wrong directory.
-        git_dir, common_dir = _git(root, "rev-parse", "--git-dir"), _git(root, "rev-parse", "--git-common-dir")
-        if git_dir and common_dir and Path(git_dir).resolve() != Path(common_dir).resolve():
+        if (root / ".git").is_file():
             lines.append("- Worktree: linked (git state shared with primary tree)")
 
-        dirty = [f"{n} {label}" for label, n in (
-            ("staged", counts["staged"]), ("modified", counts["modified"]),
-            ("untracked", counts["untracked"]), ("conflicts", counts["conflicts"]),
-        ) if n]
-        lines.append(f"- Status: {', '.join(dirty) if dirty else 'clean'}")
-
-        recent = _git(root, "log", "-3", "--pretty=%h %s")
-        if recent:
-            lines.append("- Recent commits:")
-            lines.extend(f"    {c}" for c in recent.splitlines())
+        lines.append("- Status: not checked in prompt snapshot; run `git status` before acting")
 
     lines.extend(_project_facts(root))
     return "\n".join(lines)

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1051,6 +1051,36 @@ class TestPrompt:
         assert state.agent.thinking_callback is None
 
     @pytest.mark.asyncio
+    async def test_prompt_binds_session_cwd_for_agent_context(self, agent, tmp_path):
+        """ACP turns should expose the session cwd to prompt/tool context code."""
+        new_resp = await agent.new_session(cwd=str(tmp_path))
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        def fake_run_conversation(**_kwargs):
+            from agent.runtime_cwd import resolve_context_cwd
+
+            assert resolve_context_cwd() == tmp_path
+            return {
+                "final_response": "ok",
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "ok"},
+                ],
+            }
+
+        state.agent.run_conversation = MagicMock(side_effect=fake_run_conversation)
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="hello")]
+        resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert resp.stop_reason == "end_turn"
+        state.agent.run_conversation.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_prompt_updates_history(self, agent):
         """After a prompt, session history should be updated."""
         new_resp = await agent.new_session(cwd=".")

--- a/tests/agent/test_coding_context.py
+++ b/tests/agent/test_coding_context.py
@@ -140,15 +140,26 @@ class TestWorkspaceBlock:
         assert "Workspace" in block
         assert f"Root: {tmp_path.resolve()}" in block or "Root:" in block
         assert "Branch: main" in block
-        assert "Status: clean" in block
-        assert "init commit" in block
+        assert "Status: not checked in prompt snapshot" in block
 
-    def test_reports_dirty_counts(self, tmp_path):
+    def test_does_not_scan_dirty_counts_on_prompt_path(self, tmp_path):
         _git_init(tmp_path)
-        (tmp_path / "untracked.txt").write_text("hi")
+        (tmp_path / "main.py").write_text("print('changed')\n")
         block = cc.build_coding_workspace_block(tmp_path)
-        assert "untracked" in block
-        assert "clean" not in block.split("Status:")[1].splitlines()[0]
+        status_line = block.split("Status:")[1].splitlines()[0]
+        assert "not checked" in status_line
+        assert "modified" not in status_line
+
+    def test_workspace_snapshot_does_not_spawn_git_for_prompt(self, tmp_path, monkeypatch):
+        _git_init(tmp_path)
+
+        def fail_git(*_args):
+            raise AssertionError("git subprocess not allowed during prompt snapshot")
+
+        monkeypatch.setattr(cc, "_git", fail_git)
+        block = cc.build_coding_workspace_block(tmp_path)
+        assert "Branch: main" in block
+        assert "Status: not checked in prompt snapshot" in block
 
 
 # ── project facts (verify-loop detection) ───────────────────────────────────

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -853,6 +853,87 @@ class TestLocalEnvironmentPathInjectionGated:
         assert _append_missing_sane_path_entries(path) == path
 
 
+class TestWindowsBashPathDialects:
+    """Windows-hosted terminal state must be normalized per bash dialect."""
+
+    def test_msys_and_wsl_mounts_roundtrip_to_native_windows(self, monkeypatch):
+        from tools.environments import local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert local_mod._msys_to_windows_path("/c/Users/NUC") == r"C:\Users\NUC"
+        assert local_mod._msys_to_windows_path("/mnt/c/Users/NUC") == r"C:\Users\NUC"
+        assert local_mod._msys_to_windows_path(r"C:\Users\NUC") == r"C:\Users\NUC"
+
+    def test_system32_bash_is_wsl_dialect(self, monkeypatch):
+        from tools.environments import local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setenv("SystemRoot", r"C:\Windows")
+        assert local_mod._windows_bash_path_style_for(
+            r"C:\Windows\System32\bash.exe"
+        ) == "wsl"
+        assert local_mod._windows_bash_path_style_for(
+            r"C:\Program Files\Git\bin\bash.exe"
+        ) == "msys"
+
+    def test_base_environment_cd_uses_selected_windows_bash_dialect(self, monkeypatch):
+        from tools.environments import base as base_mod
+        from tools.environments.base import BaseEnvironment
+
+        class DummyEnvironment(BaseEnvironment):
+            def _run_bash(self, *args, **kwargs):
+                raise AssertionError("not used")
+
+            def cleanup(self):
+                pass
+
+        monkeypatch.setattr(base_mod.os, "name", "nt")
+        env = DummyEnvironment(cwd=r"C:\Users\NUC", timeout=1)
+
+        env._bash_path_style = "msys"
+        assert env._quote_cwd_for_cd(r"C:\Users\NUC") == "/c/Users/NUC"
+        assert env._quote_cwd_for_cd("/mnt/c/Users/NUC") == "/c/Users/NUC"
+        assert "builtin cd -- /c/Users/NUC" in env._wrap_command(
+            "pwd", r"C:\Users\NUC"
+        )
+
+        env._bash_path_style = "wsl"
+        assert env._quote_cwd_for_cd(r"C:\Users\NUC") == "/mnt/c/Users/NUC"
+        assert env._quote_cwd_for_cd("/c/Users/NUC") == "/mnt/c/Users/NUC"
+        assert "builtin cd -- /mnt/c/Users/NUC" in env._wrap_command(
+            "pwd", r"C:\Users\NUC"
+        )
+
+    def test_file_operations_paths_follow_attached_bash_dialect(self, monkeypatch):
+        from tools import file_operations as fops_mod
+        from tools.file_operations import ShellFileOperations
+
+        monkeypatch.setattr(fops_mod.os, "name", "nt")
+
+        class DummyEnv:
+            cwd = r"C:\Users\NUC"
+            _bash_path_style = "msys"
+
+            def execute(self, command, cwd=None, **kwargs):
+                return {"output": "", "returncode": 0}
+
+        ops = ShellFileOperations(DummyEnv())
+        assert (
+            ops._expand_path(r"C:\Users\NUC\.hermes\skill.md")
+            == "/c/Users/NUC/.hermes/skill.md"
+        )
+
+        ops.env._bash_path_style = "wsl"
+        assert (
+            ops._expand_path(r"C:\Users\NUC\.hermes\skill.md")
+            == "/mnt/c/Users/NUC/.hermes/skill.md"
+        )
+        assert (
+            ops._expand_path("/c/Users/NUC/.hermes/skill.md")
+            == "/mnt/c/Users/NUC/.hermes/skill.md"
+        )
+
+
 # ---------------------------------------------------------------------------
 # cli.py git path normalization
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -896,12 +896,21 @@ class TestWindowsBashPathDialects:
         assert "builtin cd -- /c/Users/NUC" in env._wrap_command(
             "pwd", r"C:\Users\NUC"
         )
+        assert "eval 'cd /c/Users/NUC && pwd'" in env._wrap_command(
+            "cd /mnt/c/Users/NUC && pwd", r"C:\Users\NUC"
+        )
+        assert "/mnt/c/Users/NUC && pwd" not in env._wrap_command(
+            "cd /mnt/c/Users/NUC && pwd", r"C:\Users\NUC"
+        )
 
         env._bash_path_style = "wsl"
         assert env._quote_cwd_for_cd(r"C:\Users\NUC") == "/mnt/c/Users/NUC"
         assert env._quote_cwd_for_cd("/c/Users/NUC") == "/mnt/c/Users/NUC"
         assert "builtin cd -- /mnt/c/Users/NUC" in env._wrap_command(
             "pwd", r"C:\Users\NUC"
+        )
+        assert "eval 'cd /mnt/c/Users/NUC && pwd'" in env._wrap_command(
+            "cd /c/Users/NUC && pwd", r"C:\Users\NUC"
         )
 
     def test_file_operations_paths_follow_attached_bash_dialect(self, monkeypatch):

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -482,9 +482,37 @@ class BaseEnvironment(ABC):
         """Quote an internal shell path using the same path dialect as cwd."""
         return shlex.quote(self._normalize_cwd_for_bash_cd(path))
 
+    def _normalize_command_cd_paths_for_bash(self, command: str) -> str:
+        """Normalize simple shell ``cd`` targets to the selected bash dialect.
+
+        Hermes controls the wrapper cwd, but models often include an explicit
+        ``cd <path> && ...`` inside the command text. On Windows, WSL and Git
+        Bash use different drive mount dialects, so a copied ``/mnt/c/...`` path
+        fails under Git Bash even though the same filesystem exists. Normalize
+        only standalone ``cd`` command targets; leave arbitrary arguments and
+        string literals alone.
+        """
+        if os.name != "nt" or not command:
+            return command
+
+        drive_path = r"(?:/mnt/[A-Za-z](?:/[^\s;&|]*)?|/[A-Za-z](?:/[^\s;&|]*)?|[A-Za-z]:[\\/][^\s;&|]*)"
+        prefix = r"(?P<prefix>(?:^|(?<=[;\n])|&&\s*|\|\|\s*)\s*(?:builtin\s+)?cd(?:\s+--)?\s+)"
+
+        quoted = re.compile(prefix + r"(?P<quote>['\"])(?P<path>[^'\"]+)(?P=quote)")
+        unquoted = re.compile(prefix + rf"(?P<path>{drive_path})")
+
+        def replace(match: re.Match[str]) -> str:
+            path = match.group("path")
+            normalized = self._normalize_cwd_for_bash_cd(path)
+            return match.group("prefix") + shlex.quote(normalized)
+
+        command = quoted.sub(replace, command)
+        return unquoted.sub(replace, command)
+
     def _wrap_command(self, command: str, cwd: str) -> str:
         """Build the full bash script that sources snapshot, cd's, runs command,
         re-dumps env vars, and emits CWD markers."""
+        command = self._normalize_command_cd_paths_for_bash(command)
         escaped = command.replace("'", "'\\''")
 
         # Quote the snapshot / cwd-file paths so Git Bash on Windows handles

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -10,6 +10,7 @@ import codecs
 import json
 import logging
 import os
+import re
 import select
 import shlex
 import subprocess
@@ -361,7 +362,7 @@ class BaseEnvironment(ABC):
         # Restore configured cwd after login shell profile scripts, which may
         # change the working directory (e.g. bashrc `cd ~`).  Without this,
         # pwd -P captures the profile's directory, not terminal.cwd.
-        _quoted_cwd = shlex.quote(self.cwd)
+        _quoted_cwd = self._quote_cwd_for_cd(self.cwd)
         # Quote the snapshot / cwd-file paths so Git Bash on Windows handles
         # ``C:/Users/...``-shaped paths without glob-splitting the colon or
         # tripping on drive letters.  On POSIX this is a no-op (no colons /
@@ -369,8 +370,8 @@ class BaseEnvironment(ABC):
         # caused ``C:/Users/.../hermes-snap-*.sh: No such file or directory``
         # errors on Windows, leaking via stderr (merged into stdout on Linux
         # backends) into every terminal-tool response.
-        _quoted_snap = shlex.quote(self._snapshot_path)
-        _quoted_cwd_file = shlex.quote(self._cwd_file)
+        _quoted_snap = self._quote_shell_path(self._snapshot_path)
+        _quoted_cwd_file = self._quote_shell_path(self._cwd_file)
         # Use atomic file replacement: assemble the snapshot in a temp file,
         # then mv it over the final path.  This prevents concurrent source()
         # calls from reading a half-written snapshot when another terminal
@@ -388,7 +389,7 @@ class BaseEnvironment(ABC):
         # and is genuinely unique per writer, which closes the race.  The
         # static path is shlex-quoted (Windows/Git-Bash drive letters, spaces)
         # with ``$BASHPID`` left outside the quotes so it still expands.
-        _snap_tmp = shlex.quote(self._snapshot_path + ".tmp.") + "$BASHPID"
+        _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
         bootstrap = (
             f"export -p > {_snap_tmp}\n"
             f"declare -f | grep -vE '^_[^_]' >> {_snap_tmp}\n"
@@ -426,9 +427,49 @@ class BaseEnvironment(ABC):
     # Command wrapping
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _quote_cwd_for_cd(cwd: str) -> str:
+    def _windows_bash_path_style(self) -> str:
+        """Return the Windows bash path style for this backend."""
+        return getattr(self, "_bash_path_style", "msys")
+
+    def _normalize_cwd_for_bash_cd(self, cwd: str) -> str:
+        """Convert Windows drive paths to the path dialect used by this bash."""
+        if not cwd:
+            return cwd
+
+        value = str(cwd)
+        if os.name != "nt":
+            return value
+
+        value = value.replace("\\", "/")
+        style = self._windows_bash_path_style()
+
+        if len(value) >= 2 and value[1] == ":" and value[0].isalpha():
+            drive = value[0].lower()
+            rest = value[2:].lstrip("/")
+            prefix = f"/mnt/{drive}" if style == "wsl" else f"/{drive}"
+            return f"{prefix}/{rest}" if rest else prefix
+
+        m = re.match(r"^/mnt/([a-zA-Z])(?:/(.*))?$", value)
+        if m:
+            drive = m.group(1).lower()
+            rest = (m.group(2) or "").strip("/")
+            if style == "msys":
+                return f"/{drive}/{rest}" if rest else f"/{drive}"
+            return f"/mnt/{drive}/{rest}" if rest else f"/mnt/{drive}"
+
+        m = re.match(r"^/([a-zA-Z])(?:/(.*))?$", value)
+        if m:
+            drive = m.group(1).lower()
+            rest = (m.group(2) or "").strip("/")
+            if style == "wsl":
+                return f"/mnt/{drive}/{rest}" if rest else f"/mnt/{drive}"
+            return f"/{drive}/{rest}" if rest else f"/{drive}"
+
+        return value
+
+    def _quote_cwd_for_cd(self, cwd: str) -> str:
         """Quote a ``cd`` target while preserving ``~`` expansion."""
+        cwd = self._normalize_cwd_for_bash_cd(cwd)
         if cwd == "~":
             return cwd
         if cwd == "~/":
@@ -436,6 +477,10 @@ class BaseEnvironment(ABC):
         if cwd.startswith("~/"):
             return f"$HOME/{shlex.quote(cwd[2:])}"
         return shlex.quote(cwd)
+
+    def _quote_shell_path(self, path: str) -> str:
+        """Quote an internal shell path using the same path dialect as cwd."""
+        return shlex.quote(self._normalize_cwd_for_bash_cd(path))
 
     def _wrap_command(self, command: str, cwd: str) -> str:
         """Build the full bash script that sources snapshot, cd's, runs command,
@@ -446,8 +491,8 @@ class BaseEnvironment(ABC):
         # ``C:/Users/...``-shaped paths without glob-splitting the colon or
         # tripping on drive letters.  POSIX paths are unaffected.  See
         # :meth:`init_session` for the same fix on the bootstrap block.
-        _quoted_snap = shlex.quote(self._snapshot_path)
-        _quoted_cwd_file = shlex.quote(self._cwd_file)
+        _quoted_snap = self._quote_shell_path(self._snapshot_path)
+        _quoted_cwd_file = self._quote_shell_path(self._cwd_file)
         # Use atomic file replacement for env snapshot updates (issue #38249).
         # Assemble into a per-writer-unique temp file, then mv to atomically
         # replace the snapshot so concurrent source() calls never read a
@@ -455,7 +500,7 @@ class BaseEnvironment(ABC):
         # subshell PID — unique per concurrent ``&``-launched writer — so two
         # writers never share a temp name and clobber each other before the mv.
         # Static path shlex-quoted (Windows/spaces); ``$BASHPID`` left to expand.
-        _snap_tmp = shlex.quote(self._snapshot_path + ".tmp.") + "$BASHPID"
+        _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
 
         parts = []
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -31,13 +31,19 @@ def _msys_to_windows_path(cwd: str) -> str:
     """
     if not _IS_WINDOWS or not cwd:
         return cwd
+    # Match WSL's view of Windows drives: "/mnt/<letter>[/...]".
+    m = re.match(r'^/mnt/([a-zA-Z])(?:/(.*))?$', cwd)
+    if m:
+        drive = m.group(1).upper()
+        tail = (m.group(2) or "").replace('/', '\\')
+        return f"{drive}:{chr(92)}{tail}" if tail else f"{drive}:{chr(92)}"
     # Match leading "/<single letter>/" or exactly "/<letter>" (bare drive root).
-    m = re.match(r'^/([a-zA-Z])(/.*)?$', cwd)
+    m = re.match(r'^/([a-zA-Z])(?:/(.*))?$', cwd)
     if not m:
         return cwd
     drive = m.group(1).upper()
     tail = (m.group(2) or "").replace('/', '\\')
-    return f"{drive}:{tail or chr(92)}"  # chr(92) = backslash, avoid raw-string escape
+    return f"{drive}:{chr(92)}{tail}" if tail else f"{drive}:{chr(92)}"
 
 
 def _resolve_safe_cwd(cwd: str) -> str:
@@ -397,6 +403,18 @@ def _find_bash() -> str:
     )
 
 
+def _windows_bash_path_style_for(bash: str) -> str:
+    """Return the POSIX path dialect expected by the selected Windows bash."""
+    if not _IS_WINDOWS:
+        return "posix"
+
+    system_root = os.environ.get("SystemRoot", r"C:\Windows")
+    system_bash = os.path.join(system_root, "System32", "bash.exe")
+    if os.path.normcase(bash) == os.path.normcase(system_bash):
+        return "wsl"
+    return "msys"
+
+
 # POSIX-sh-family shells that understand the ``[shell, "-lic", "set +m; …"]``
 # invocation spawn_local uses. $SHELL values outside this set (fish, csh/tcsh,
 # nushell, elvish, xonsh, …) would error on that syntax, so _find_shell falls
@@ -738,6 +756,8 @@ class LocalEnvironment(BaseEnvironment):
         if cwd:
             cwd = os.path.expanduser(cwd)
         super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env)
+        self._bash_path = _find_bash()
+        self._bash_path_style = _windows_bash_path_style_for(self._bash_path)
         self.init_session()
 
     def get_temp_dir(self) -> str:
@@ -791,7 +811,7 @@ class LocalEnvironment(BaseEnvironment):
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
-        bash = _find_bash()
+        bash = getattr(self, "_bash_path", None) or _find_bash()
         # For login-shell invocations (used by init_session to build the
         # environment snapshot), prepend sources for the user's bashrc /
         # custom init files so tools registered outside bash_profile
@@ -802,7 +822,18 @@ class LocalEnvironment(BaseEnvironment):
             init_files = _resolve_shell_init_files()
             if init_files:
                 cmd_string = _prepend_shell_init(cmd_string, init_files)
-        args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
+        if _IS_WINDOWS and os.path.basename(bash).lower() == "bash.exe":
+            system_root = os.environ.get("SystemRoot", r"C:\Windows")
+            system_bash = os.path.join(system_root, "System32", "bash.exe")
+            wsl = os.path.join(system_root, "System32", "wsl.exe")
+            if os.path.isfile(wsl) and os.path.normcase(bash) == os.path.normcase(system_bash):
+                # Legacy bash.exe mangles shell variables in -c scripts. Use
+                # wsl.exe --exec so bash receives Hermes' wrapper unchanged.
+                args = [wsl, "--exec", "bash", "-lc" if login else "-c", cmd_string]
+            else:
+                args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
+        else:
+            args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
 
         # Recover when the cwd has been deleted out from under us — usually by

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -891,6 +891,42 @@ class ShellFileOperations(FileOperations):
                 line = line[:max_line_length] + "... [truncated]"
             numbered.append(f"{i}|{line}")
         return '\n'.join(numbered)
+
+    def _windows_bash_path_style(self) -> str:
+        """Return the Windows bash path style for the attached terminal backend."""
+        return getattr(self.env, "_bash_path_style", "msys")
+
+    def _normalize_windows_path_for_bash(self, path: str) -> str:
+        """Convert Windows drive paths to the path dialect used by bash."""
+        if not path or os.name != "nt":
+            return path
+
+        value = str(path).replace("\\", "/")
+        style = self._windows_bash_path_style()
+
+        if len(value) >= 2 and value[1] == ":" and value[0].isalpha():
+            drive = value[0].lower()
+            rest = value[2:].lstrip("/")
+            prefix = f"/mnt/{drive}" if style == "wsl" else f"/{drive}"
+            return f"{prefix}/{rest}" if rest else prefix
+
+        m = re.match(r"^/mnt/([a-zA-Z])(?:/(.*))?$", value)
+        if m:
+            drive = m.group(1).lower()
+            rest = (m.group(2) or "").strip("/")
+            if style == "msys":
+                return f"/{drive}/{rest}" if rest else f"/{drive}"
+            return f"/mnt/{drive}/{rest}" if rest else f"/mnt/{drive}"
+
+        m = re.match(r"^/([a-zA-Z])(?:/(.*))?$", value)
+        if m:
+            drive = m.group(1).lower()
+            rest = (m.group(2) or "").strip("/")
+            if style == "wsl":
+                return f"/mnt/{drive}/{rest}" if rest else f"/mnt/{drive}"
+            return f"/{drive}/{rest}" if rest else f"/{drive}"
+
+        return value
     
     def _expand_path(self, path: str) -> str:
         """
@@ -927,7 +963,7 @@ class ShellFileOperations(FileOperations):
                         suffix = path[1 + len(username):]  # e.g. "/rest/of/path"
                         return user_home + suffix
         
-        return path
+        return self._normalize_windows_path_for_bash(path)
     
     def _escape_shell_arg(self, arg: str) -> str:
         """Escape a string for safe use in shell commands."""


### PR DESCRIPTION
﻿## Summary

Fixes Windows-hosted local terminal sessions that can move between WSL-style and Git Bash/MSYS-style path dialects.

Hermes wraps each terminal command with a generated bash script that restores cwd before running the user command. On Windows, that cwd may be represented as a native path (`C:\Users\...`), a WSL path (`/mnt/c/Users/...`), or a Git Bash path (`/c/Users/...`). If the wrapper injects a cwd from the wrong dialect, the generated `cd` fails before the user command executes and later retries can keep reusing the bad cwd.

## Changes

- Detect whether the selected Windows bash expects WSL or MSYS path syntax.
- Normalize cwd targets before injecting `cd` into the terminal wrapper.
- Normalize internal snapshot/cwd-file shell paths with the same dialect rules.
- Convert both `/c/...` and `/mnt/c/...` back to native Windows paths for internal cwd tracking.
- Normalize file-operation paths before embedding Windows paths into shell commands.
- Add regression coverage for WSL/MSYS cwd dialect conversion.

## Validation

- `uv run --extra dev pytest tests/tools/test_windows_native_support.py::TestWindowsBashPathDialects -q`
- `uv run --extra dev ruff check tools/environments/base.py tools/environments/local.py tools/file_operations.py tests/tools/test_windows_native_support.py`
- `uv run --extra dev python -m py_compile tools/environments/base.py tools/environments/local.py tools/file_operations.py tests/tools/test_windows_native_support.py`
- Manual smoke tests on Windows with both WSL bash and Git Bash, including `cwd=/mnt/c/Users/NUC`, `echo OK`, shell variable expansion, and `pwd`.
