### PR TITLE
fix(agent): support run_agent browser test flag

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5430,6 +5430,7 @@ def main(
     enabled_toolsets: str = None,
     disabled_toolsets: str = None,
     list_tools: bool = False,
+    browser_test: bool = False,
     save_trajectories: bool = False,
     save_sample: bool = False,
     verbose: bool = False,
@@ -5449,6 +5450,7 @@ def main(
                               Multiple toolsets can be combined: "web,vision"
         disabled_toolsets (str): Comma-separated list of toolsets to disable (e.g., "terminal")
         list_tools (bool): Just list available tools and exit
+        browser_test (bool): Run a small browser smoke-test prompt using the browser toolset.
         save_trajectories (bool): Save conversation trajectories to JSONL files (appends to trajectory_samples.jsonl). Defaults to False.
         save_sample (bool): Save a single trajectory sample to a UUID-named JSONL file for inspection. Defaults to False.
         verbose (bool): Enable verbose logging for debugging. Defaults to False.
@@ -5546,6 +5548,9 @@ def main(
     # Parse toolset selection arguments
     enabled_toolsets_list = None
     disabled_toolsets_list = None
+
+    if browser_test and not enabled_toolsets:
+        enabled_toolsets = "browser"
     
     if enabled_toolsets:
         enabled_toolsets_list = [t.strip() for t in enabled_toolsets.split(",")]
@@ -5579,10 +5584,16 @@ def main(
     
     # Use provided query or default to Python 3.13 example
     if query is None:
-        user_query = (
-            "Tell me about the latest developments in Python 3.13 and what new features "
-            "developers should know about. Please search for current information and try it out."
-        )
+        if browser_test:
+            user_query = (
+                "Use the browser tools to open https://example.com and report "
+                "the page title."
+            )
+        else:
+            user_query = (
+                "Tell me about the latest developments in Python 3.13 and what new features "
+                "developers should know about. Please search for current information and try it out."
+            )
     else:
         user_query = query
     

--- a/run_agent.py
+++ b/run_agent.py
@@ -5430,11 +5430,11 @@ def main(
     enabled_toolsets: str = None,
     disabled_toolsets: str = None,
     list_tools: bool = False,
-    browser_test: bool = False,
     save_trajectories: bool = False,
     save_sample: bool = False,
     verbose: bool = False,
-    log_prefix_chars: int = 20
+    log_prefix_chars: int = 20,
+    browser_test: bool = False,
 ):
     """
     Main function for running the agent directly.
@@ -5450,11 +5450,11 @@ def main(
                               Multiple toolsets can be combined: "web,vision"
         disabled_toolsets (str): Comma-separated list of toolsets to disable (e.g., "terminal")
         list_tools (bool): Just list available tools and exit
-        browser_test (bool): Run a small browser smoke-test prompt using the browser toolset.
         save_trajectories (bool): Save conversation trajectories to JSONL files (appends to trajectory_samples.jsonl). Defaults to False.
         save_sample (bool): Save a single trajectory sample to a UUID-named JSONL file for inspection. Defaults to False.
         verbose (bool): Enable verbose logging for debugging. Defaults to False.
         log_prefix_chars (int): Number of characters to show in log previews for tool calls/responses. Defaults to 20.
+        browser_test (bool): Run a small browser smoke-test prompt using the browser toolset.
 
     Toolset Examples:
         - "research": Web search, extract, crawl + vision tools

--- a/tests/run_agent/test_run_agent_main_cli.py
+++ b/tests/run_agent/test_run_agent_main_cli.py
@@ -1,0 +1,55 @@
+import inspect
+
+import run_agent
+
+
+class _RecordingAgent:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.prompts = []
+        self.__class__.instances.append(self)
+
+    def run_conversation(self, prompt):
+        self.prompts.append(prompt)
+        return {
+            "completed": True,
+            "api_calls": 0,
+            "messages": [],
+            "final_response": "ok",
+        }
+
+
+def _patch_agent(monkeypatch):
+    _RecordingAgent.instances = []
+    monkeypatch.setattr(run_agent, "AIAgent", _RecordingAgent)
+    return _RecordingAgent.instances
+
+
+def test_main_accepts_browser_test_flag():
+    assert "browser_test" in inspect.signature(run_agent.main).parameters
+
+
+def test_browser_test_defaults_to_browser_toolset_and_prompt(monkeypatch):
+    agents = _patch_agent(monkeypatch)
+
+    run_agent.main(browser_test=True)
+
+    agent = agents[0]
+    assert agent.kwargs["enabled_toolsets"] == ["browser"]
+    assert "https://example.com" in agent.prompts[0]
+
+
+def test_browser_test_respects_explicit_query_and_toolsets(monkeypatch):
+    agents = _patch_agent(monkeypatch)
+
+    run_agent.main(
+        browser_test=True,
+        query="open https://example.org",
+        enabled_toolsets="browser,web",
+    )
+
+    agent = agents[0]
+    assert agent.kwargs["enabled_toolsets"] == ["browser", "web"]
+    assert agent.prompts == ["open https://example.org"]

--- a/tests/run_agent/test_run_agent_main_cli.py
+++ b/tests/run_agent/test_run_agent_main_cli.py
@@ -63,3 +63,14 @@ def test_browser_test_respects_explicit_query_and_toolsets(monkeypatch):
     agent = agents[0]
     assert agent.kwargs["enabled_toolsets"] == ["browser", "web"]
     assert agent.prompts == ["open https://example.org"]
+
+
+def test_existing_positional_save_trajectories_argument_remains_compatible(monkeypatch):
+    agents = _patch_agent(monkeypatch)
+
+    run_agent.main(None, "", None, "", 10, None, None, False, True)
+
+    agent = agents[0]
+    assert agent.kwargs["save_trajectories"] is True
+    assert agent.kwargs["enabled_toolsets"] is None
+    assert "Python 3.13" in agent.prompts[0]

--- a/tests/run_agent/test_run_agent_main_cli.py
+++ b/tests/run_agent/test_run_agent_main_cli.py
@@ -1,5 +1,6 @@
-import inspect
+import sys
 
+import fire
 import run_agent
 
 
@@ -27,8 +28,17 @@ def _patch_agent(monkeypatch):
     return _RecordingAgent.instances
 
 
-def test_main_accepts_browser_test_flag():
-    assert "browser_test" in inspect.signature(run_agent.main).parameters
+def test_fire_accepts_dashed_browser_test_flag(monkeypatch):
+    agents = _patch_agent(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["run_agent.py", "--browser-test"])
+
+    fire.Fire(run_agent.main)
+
+    agent = agents[0]
+    assert agent.kwargs["enabled_toolsets"] == ["browser"]
+    assert agent.prompts == [
+        "Use the browser tools to open https://example.com and report the page title."
+    ]
 
 
 def test_browser_test_defaults_to_browser_toolset_and_prompt(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Adds `browser_test` to `run_agent.py`'s Fire entry point so `python run_agent.py --browser-test` is accepted instead of failing with `Could not consume arg`.

When the flag is used without a custom query or toolset, it runs a small browser smoke-test prompt with the existing `browser` toolset.

## Related Issue

Closes #54199

## Changes Made

- Added a `browser_test` flag to `run_agent.py::main()`.
- Defaulted `--browser-test` to the existing `browser` toolset when no toolset is passed.
- Added focused tests that stub `AIAgent`, so no browser or API call is started during test runs.

## Verification

- `/Users/blackishgreen03/workspace/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_run_agent_main_cli.py -q`
- `git diff --check`
- `/Users/blackishgreen03/workspace/hermes-agent/venv/bin/python run_agent.py --browser-test --list-tools`

## Checklist

- [x] Linked the source issue.
- [x] Added focused test coverage.
- [x] Kept the change limited to the direct CLI entry point.
