### PR TITLE
Expose configurable context window caps

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -209,6 +209,8 @@ def init_agent(
     notice_clear_callback: callable = None,
     event_callback: Optional[Callable[[str, dict], None]] = None,
     max_tokens: int = None,
+    config_context_length: int | None = None,
+    use_model_config_context_length: bool = True,
     reasoning_config: Dict[str, Any] = None,
     service_tier: str = None,
     request_overrides: Dict[str, Any] = None,
@@ -1472,28 +1474,42 @@ def init_agent(
                 )
     agent._session_init_model_config["max_tokens"] = agent.max_tokens
 
-    # Read explicit context_length override from model config
-    if isinstance(_model_cfg, dict):
-        _config_context_length = _model_cfg.get("context_length")
-    else:
-        _config_context_length = None
-    if _config_context_length is not None:
+    # Read explicit context-window override from model config.  The historical
+    # key is model.context_length; model.max_context_length is a clearer alias
+    # for capping a provider-advertised window (e.g. a 1M-token model) below its
+    # detected size.  context_length wins if both are present.
+    _context_length_key = None
+    _config_context_raw = None
+    _config_context_length = None
+    if config_context_length is not None:
         try:
-            _config_context_length = int(_config_context_length)
+            if isinstance(config_context_length, bool):
+                raise ValueError
+            _parsed_direct_ctx = int(config_context_length)
+            if _parsed_direct_ctx <= 0:
+                raise ValueError
+            _config_context_length = _parsed_direct_ctx
         except (TypeError, ValueError):
-            _ra().logger.warning(
-                "Invalid model.context_length in config.yaml: %r — "
-                "must be a plain integer (e.g. 256000, not '256K'). "
-                "Falling back to auto-detection.",
-                _config_context_length,
-            )
-            print(
-                f"\n⚠ Invalid model.context_length in config.yaml: {_config_context_length!r}\n"
-                f"  Must be a plain integer (e.g. 256000, not '256K').\n"
-                f"  Falling back to auto-detected context window.\n",
-                file=sys.stderr,
-            )
             _config_context_length = None
+    if _config_context_length is None and use_model_config_context_length:
+        try:
+            from hermes_cli.context_window import model_config_context_length
+            _config_context_length, _context_length_key, _config_context_raw = model_config_context_length(_model_cfg)
+        except Exception:
+            _config_context_length = None
+    if _context_length_key is not None and _config_context_length is None:
+        _ra().logger.warning(
+            "Invalid model.%s in config.yaml: %r — must be a plain positive integer "
+            "(e.g. 256000, not '256K'). Falling back to auto-detection.",
+            _context_length_key,
+            _config_context_raw,
+        )
+        print(
+            f"\n⚠ Invalid model.{_context_length_key} in config.yaml: {_config_context_raw!r}\n"
+            f"  Must be a plain positive integer (e.g. 256000, not '256K').\n"
+            f"  Falling back to auto-detected context window.\n",
+            file=sys.stderr,
+        )
 
     # Resolve custom_providers list once for reuse below (startup
     # context-length override and plugin context-engine init).

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1501,7 +1501,7 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     return client
 
 
-def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mode=''):
+def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mode='', config_context_length=None):
     """Switch the model/provider in-place for a live agent.
 
     Called by the /model command handlers (CLI and gateway) after
@@ -1574,10 +1574,11 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     _snapshot["_credential_pool"] = getattr(agent, "_credential_pool", _MISSING)
 
     try:
-        # Clear the per-config context_length override so the new model's
-        # actual context window is resolved via get_model_context_length()
-        # instead of inheriting the stale value from the previous model.
-        agent._config_context_length = None
+        # Use an explicit session cap when supplied by /model --max-context.
+        # Otherwise clear the per-config override so the new model's actual
+        # context window is resolved instead of inheriting a stale cap from the
+        # previous route.
+        agent._config_context_length = config_context_length
 
         # ── Swap core runtime fields ──
         agent.model = new_model

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1252,10 +1252,14 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
         old_model = agent.model
 
-        # Clear the per-config context_length override so the fallback
-        # model's actual context window is resolved instead of inheriting
-        # the stale value from the previous model.  See #22387.
-        agent._config_context_length = None
+        # Use a fallback-entry context cap when configured; otherwise clear the
+        # primary model's per-config override so the fallback resolves its own
+        # window instead of inheriting a stale value.
+        try:
+            from hermes_cli.context_window import entry_context_length
+            agent._config_context_length = entry_context_length(fb)
+        except Exception:
+            agent._config_context_length = None
         agent.model = fb_model
         agent.provider = fb_provider
         agent.base_url = fb_base_url

--- a/cli.py
+++ b/cli.py
@@ -7541,6 +7541,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    config_context_length=None,
                 )
             except Exception as exc:
                 # The agent rolled itself back to the old working model/client.
@@ -7706,12 +7707,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             is_global_flag,
             force_refresh,
             is_session,
+            max_context_arg,
         ) = parse_model_flags(raw_args)
         # Resolve the effective persistence once: --session overrides the
         # config-gated default, --global forces persist, otherwise defer to
         # model.persist_switch_by_default (defaults to True so /model survives
         # across sessions).
         persist_global = resolve_persist_behavior(is_global_flag, is_session)
+        from hermes_cli.context_window import parse_context_window_cap
+        max_context_cap = parse_context_window_cap(max_context_arg)
+        if max_context_arg is not None and max_context_cap is None and str(max_context_arg).strip().lower() != "auto":
+            _cprint(f"  ✗ Invalid --max-context value: {max_context_arg!r} (use an integer or auto)")
+            return
 
         # --refresh: wipe the on-disk picker cache before building the
         # provider list. Forces a live re-fetch of every authed provider's
@@ -7743,6 +7750,51 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # dicts; ConfigContext is the canonical source for both.
         user_provs = ctx.user_providers if ctx is not None else None
         custom_provs = ctx.custom_providers if ctx is not None else None
+
+        # A cap-only command updates this running session without switching.
+        if max_context_arg is not None and not model_input and not explicit_provider:
+            if persist_global:
+                if max_context_cap:
+                    save_config_value("model.max_context_length", max_context_cap)
+                    save_config_value("model.context_length", None)
+                else:
+                    save_config_value("model.max_context_length", None)
+                    save_config_value("model.context_length", None)
+            if self.agent is not None:
+                self.agent._config_context_length = max_context_cap
+                if getattr(self.agent, "context_compressor", None):
+                    from agent.model_metadata import get_model_context_length
+                    ctx_len = get_model_context_length(
+                        self.agent.model,
+                        base_url=getattr(self.agent, "base_url", "") or "",
+                        api_key=getattr(self.agent, "api_key", "") if isinstance(getattr(self.agent, "api_key", ""), str) else "",
+                        provider=getattr(self.agent, "provider", "") or "",
+                        config_context_length=max_context_cap,
+                        custom_providers=custom_provs,
+                    )
+                    self.agent.context_compressor.update_model(
+                        model=self.agent.model,
+                        context_length=ctx_len,
+                        base_url=getattr(self.agent, "base_url", "") or "",
+                        api_key=getattr(self.agent, "api_key", "") or "",
+                        provider=getattr(self.agent, "provider", "") or "",
+                        api_mode=getattr(self.agent, "api_mode", "") or "",
+                    )
+                ctx_len = getattr(getattr(self.agent, "context_compressor", None), "context_length", None) or max_context_cap
+            else:
+                ctx_len = max_context_cap
+            if max_context_cap:
+                _cprint(f"  ✓ Context cap set: {max_context_cap:,} tokens")
+            else:
+                _cprint("  ✓ Context cap cleared; using auto-detected context window")
+            if ctx_len:
+                _cprint(f"    Context: {int(ctx_len):,} tokens")
+                _cprint(f"    Compress around: {int(ctx_len * 0.5):,} tokens")
+            if persist_global:
+                _cprint("    Saved to config.yaml (--global)")
+            else:
+                _cprint("    (session only — add --global to persist)")
+            return
 
         # No args at all: open prompt_toolkit-native picker modal
         if not model_input and not explicit_provider:
@@ -7848,6 +7900,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    config_context_length=max_context_cap if max_context_arg is not None else None,
                 )
             except Exception as exc:
                 # Agent rolled itself back; roll the CLI back too and abort so a
@@ -7911,6 +7964,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             save_config_value("model.default", result.new_model)
             if result.provider_changed:
                 save_config_value("model.provider", result.target_provider)
+            if max_context_arg is not None:
+                if max_context_cap:
+                    save_config_value("model.max_context_length", max_context_cap)
+                    save_config_value("model.context_length", None)
+                else:
+                    save_config_value("model.max_context_length", None)
+                    save_config_value("model.context_length", None)
             _cprint("    Saved to config.yaml")
         else:
             _cprint("    (session only — add --global to persist)")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2214,6 +2214,17 @@ def _load_gateway_runtime_config() -> dict:
     return expanded if isinstance(expanded, dict) else {}
 
 
+def _override_context_length(override: dict | None) -> int | None:
+    """Return a session override context cap with legacy precedence."""
+    if not isinstance(override, dict):
+        return None
+    try:
+        from hermes_cli.context_window import entry_context_length
+        return entry_context_length(override)
+    except Exception:
+        return None
+
+
 def _resolve_gateway_model(config: dict | None = None) -> str:
     """Read model from config.yaml — single source of truth.
 
@@ -3495,6 +3506,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "base_url": override.get("base_url"),
                 "api_mode": override.get("api_mode"),
                 "max_tokens": override.get("max_tokens"),
+                "config_context_length": _override_context_length(override),
+                "use_model_config_context_length": False,
             }
             if override_runtime.get("api_key"):
                 logger.debug(
@@ -14398,6 +14411,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             val = override.get(key)
             if val is not None:
                 runtime_kwargs[key] = val
+        runtime_kwargs["config_context_length"] = _override_context_length(override)
+        runtime_kwargs["use_model_config_context_length"] = False
         return model, runtime_kwargs
 
     def _is_intentional_model_switch(self, session_key: str, agent_model: str) -> bool:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1133,8 +1133,13 @@ class GatewaySlashCommandsMixin:
             is_global_flag,
             force_refresh,
             is_session,
+            max_context_arg,
         ) = parse_model_flags(raw_args)
         persist_global = resolve_persist_behavior(is_global_flag, is_session)
+        from hermes_cli.context_window import parse_context_window_cap
+        max_context_cap = parse_context_window_cap(max_context_arg)
+        if max_context_arg is not None and max_context_cap is None and str(max_context_arg).strip().lower() != "auto":
+            return t("gateway.model.error_prefix", error=f"Invalid --max-context value: {max_context_arg!r} (use an integer or auto)")
 
         # --refresh: bust the disk cache so the picker shows live data.
         if force_refresh:
@@ -1183,6 +1188,71 @@ class GatewaySlashCommandsMixin:
             current_provider = override.get("provider", current_provider)
             current_base_url = override.get("base_url", current_base_url)
             current_api_key = override.get("api_key", current_api_key)
+
+        if max_context_arg is not None and not model_input and not explicit_provider:
+            cached_entry = None
+            _cache_lock = getattr(self, "_agent_cache_lock", None)
+            _cache = getattr(self, "_agent_cache", None)
+            if _cache_lock and _cache is not None:
+                with _cache_lock:
+                    cached_entry = _cache.get(session_key)
+            agent = cached_entry[0] if cached_entry and cached_entry[0] is not None else None
+            if agent is not None:
+                agent._config_context_length = max_context_cap
+                if getattr(agent, "context_compressor", None):
+                    from agent.model_metadata import get_model_context_length
+                    ctx_len = get_model_context_length(
+                        getattr(agent, "model", current_model),
+                        base_url=getattr(agent, "base_url", current_base_url) or "",
+                        api_key=getattr(agent, "api_key", "") if isinstance(getattr(agent, "api_key", ""), str) else "",
+                        provider=getattr(agent, "provider", current_provider) or "",
+                        config_context_length=max_context_cap,
+                        custom_providers=custom_provs,
+                    )
+                    agent.context_compressor.update_model(
+                        model=getattr(agent, "model", current_model),
+                        context_length=ctx_len,
+                        base_url=getattr(agent, "base_url", current_base_url) or "",
+                        api_key=getattr(agent, "api_key", "") or "",
+                        provider=getattr(agent, "provider", current_provider) or "",
+                        api_mode=getattr(agent, "api_mode", "") or "",
+                    )
+                ctx_len = getattr(getattr(agent, "context_compressor", None), "context_length", None) or max_context_cap
+            else:
+                ctx_len = max_context_cap
+            override_for_cap = self._session_model_overrides.get(session_key)
+            if not isinstance(override_for_cap, dict):
+                override_for_cap = {
+                    "model": getattr(agent, "model", current_model) if agent is not None else current_model,
+                    "provider": getattr(agent, "provider", current_provider) if agent is not None else current_provider,
+                    "api_key": getattr(agent, "api_key", current_api_key) if agent is not None else current_api_key,
+                    "base_url": getattr(agent, "base_url", current_base_url) if agent is not None else current_base_url,
+                    "api_mode": getattr(agent, "api_mode", "") if agent is not None else "",
+                }
+            if max_context_cap:
+                override_for_cap["max_context_length"] = max_context_cap
+                override_for_cap.pop("context_length", None)
+            else:
+                override_for_cap.pop("max_context_length", None)
+                override_for_cap.pop("context_length", None)
+            self._session_model_overrides[session_key] = override_for_cap
+            if persist_global:
+                try:
+                    from cli import save_config_value
+                    if max_context_cap:
+                        save_config_value("model.max_context_length", max_context_cap)
+                        save_config_value("model.context_length", None)
+                    else:
+                        save_config_value("model.max_context_length", None)
+                        save_config_value("model.context_length", None)
+                except Exception as exc:
+                    logger.warning("Failed to persist model context cap: %s", exc)
+            lines = ["Context cap set: {0:,} tokens".format(max_context_cap) if max_context_cap else "Context cap cleared; using auto-detected context window"]
+            if ctx_len:
+                lines.append(f"Context: {int(ctx_len):,} tokens")
+                lines.append(f"Compress around: {int(ctx_len * 0.5):,} tokens")
+            lines.append(t("gateway.model.saved_global") if persist_global else t("gateway.model.session_only_hint"))
+            return "\n".join(lines)
 
         # No args: show interactive picker (Telegram/Discord) or text list
         if not model_input and not explicit_provider:
@@ -1278,6 +1348,7 @@ class GatewaySlashCommandsMixin:
                                     api_key=result.api_key,
                                     base_url=result.base_url,
                                     api_mode=result.api_mode,
+                                    config_context_length=max_context_cap if max_context_arg is not None else None,
                                 )
                             except Exception as exc:
                                 # The in-place swap rolled the agent back to the
@@ -1360,6 +1431,13 @@ class GatewaySlashCommandsMixin:
                                 _persist_model_cfg["provider"] = result.target_provider
                                 if result.base_url:
                                     _persist_model_cfg["base_url"] = result.base_url
+                                if max_context_arg is not None:
+                                    if max_context_cap:
+                                        _persist_model_cfg["max_context_length"] = max_context_cap
+                                        _persist_model_cfg.pop("context_length", None)
+                                    else:
+                                        _persist_model_cfg.pop("max_context_length", None)
+                                        _persist_model_cfg.pop("context_length", None)
                                 if str(result.target_provider or "").strip().lower() != "custom":
                                     clear_model_endpoint_credentials(_persist_model_cfg, clear_base_url=True)
                                 from hermes_cli.config import save_config
@@ -1373,16 +1451,19 @@ class GatewaySlashCommandsMixin:
                         lines.append(t("gateway.model.provider_label", provider=plabel))
                         mi = result.model_info
                         from hermes_cli.model_switch import resolve_display_context_length
-                        _sw_config_ctx = None
-                        try:
-                            _sw_cfg = _load_gateway_config()
-                            _sw_model_cfg = _sw_cfg.get("model", {})
-                            if isinstance(_sw_model_cfg, dict):
-                                _sw_raw = _sw_model_cfg.get("context_length")
-                                if _sw_raw is not None:
-                                    _sw_config_ctx = int(_sw_raw)
-                        except Exception:
-                            pass
+                        _sw_config_ctx = max_context_cap if max_context_arg is not None else None
+                        if _sw_config_ctx is None:
+                            try:
+                                _sw_cfg = _load_gateway_config()
+                                from hermes_cli.context_window import scoped_model_config_context_length
+                                _sw_config_ctx = scoped_model_config_context_length(
+                                    _sw_cfg,
+                                    model=result.new_model,
+                                    provider=result.target_provider,
+                                    base_url=result.base_url or current_base_url or "",
+                                )
+                            except Exception:
+                                pass
                         ctx = resolve_display_context_length(
                             result.new_model,
                             result.target_provider,
@@ -1511,6 +1592,7 @@ class GatewaySlashCommandsMixin:
                         api_key=result.api_key,
                         base_url=result.base_url,
                         api_mode=result.api_mode,
+                        config_context_length=max_context_cap if max_context_arg is not None else None,
                     )
                 except Exception as exc:
                     # In-place swap rolled the agent back to the OLD working
@@ -1565,6 +1647,13 @@ class GatewaySlashCommandsMixin:
                 "base_url": result.base_url,
                 "api_mode": result.api_mode,
             }
+            if max_context_arg is not None:
+                if max_context_cap:
+                    self._session_model_overrides[session_key]["max_context_length"] = max_context_cap
+                    self._session_model_overrides[session_key].pop("context_length", None)
+                else:
+                    self._session_model_overrides[session_key].pop("max_context_length", None)
+                    self._session_model_overrides[session_key].pop("context_length", None)
 
             # Evict cached agent so the next turn creates a fresh agent from the
             # override rather than relying on cache signature mismatch detection.
@@ -1597,6 +1686,13 @@ class GatewaySlashCommandsMixin:
                     model_cfg["provider"] = result.target_provider
                     if result.base_url:
                         model_cfg["base_url"] = result.base_url
+                    if max_context_arg is not None:
+                        if max_context_cap:
+                            model_cfg["max_context_length"] = max_context_cap
+                            model_cfg.pop("context_length", None)
+                        else:
+                            model_cfg.pop("max_context_length", None)
+                            model_cfg.pop("context_length", None)
                     if str(result.target_provider or "").strip().lower() != "custom":
                         clear_model_endpoint_credentials(model_cfg, clear_base_url=True)
                     from hermes_cli.config import save_config
@@ -1613,16 +1709,19 @@ class GatewaySlashCommandsMixin:
             # Copilot, and Nous-enforced caps win over the raw models.dev entry.
             mi = result.model_info
             from hermes_cli.model_switch import resolve_display_context_length
-            _sw2_config_ctx = None
-            try:
-                _sw2_cfg = _load_gateway_config()
-                _sw2_model_cfg = _sw2_cfg.get("model", {})
-                if isinstance(_sw2_model_cfg, dict):
-                    _sw2_raw = _sw2_model_cfg.get("context_length")
-                    if _sw2_raw is not None:
-                        _sw2_config_ctx = int(_sw2_raw)
-            except Exception:
-                pass
+            _sw2_config_ctx = max_context_cap if max_context_arg is not None else None
+            if _sw2_config_ctx is None:
+                try:
+                    _sw2_cfg = _load_gateway_config()
+                    from hermes_cli.context_window import scoped_model_config_context_length
+                    _sw2_config_ctx = scoped_model_config_context_length(
+                        _sw2_cfg,
+                        model=result.new_model,
+                        provider=result.target_provider,
+                        base_url=result.base_url or current_base_url or "",
+                    )
+                except Exception:
+                    pass
             ctx = resolve_display_context_length(
                 result.new_model,
                 result.target_provider,

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -127,8 +127,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     # Configuration
     CommandDef("config", "Show current configuration", "Configuration",
                cli_only=True),
-    CommandDef("model", "Switch model (persists by default)", "Configuration",
-               args_hint="[model] [--provider name] [--global|--session] [--refresh]"),
+    CommandDef("model", "Switch model or set context cap (persists by default)", "Configuration",
+               args_hint="[model] [--provider name] [--max-context tokens|auto] [--global|--session] [--refresh]"),
     CommandDef("codex-runtime", "Toggle codex app-server runtime for OpenAI/Codex models",
                "Configuration", aliases=("codex_runtime",),
                args_hint="[auto|codex_app_server]"),

--- a/hermes_cli/context_switch_guard.py
+++ b/hermes_cli/context_switch_guard.py
@@ -144,9 +144,13 @@ def enrich_model_switch_warnings_for_gateway(
     if load_gateway_config is not None:
         try:
             cfg = load_gateway_config()
-            model_cfg = cfg.get("model", {}) if isinstance(cfg, dict) else {}
-            if isinstance(model_cfg, dict) and model_cfg.get("context_length") is not None:
-                cfg_ctx = int(model_cfg["context_length"])
+            from hermes_cli.context_window import scoped_model_config_context_length
+            cfg_ctx = scoped_model_config_context_length(
+                cfg,
+                model=result.new_model,
+                provider=result.target_provider,
+                base_url=result.base_url or getattr(agent, "base_url", "") or "",
+            )
         except Exception:
             pass
 

--- a/hermes_cli/context_window.py
+++ b/hermes_cli/context_window.py
@@ -1,0 +1,106 @@
+"""Helpers for user-configured context-window caps.
+
+``context_length`` is the historical config key. ``max_context_length`` is a
+clearer alias for the common case where a provider advertises a very large
+window and the user wants Hermes to behave as though the window were smaller.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+_CONTEXT_KEYS = ("context_length", "max_context_length")
+
+
+def parse_context_window_cap(value: Any) -> int | None:
+    """Parse a positive integer context-window cap.
+
+    ``None``, empty strings, and ``"auto"`` mean no explicit cap. Booleans are
+    rejected even though ``bool`` is an ``int`` subclass.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if not text or text == "auto":
+            return None
+        value = text.replace(",", "").replace("_", "")
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def model_config_context_length(model_cfg: Any) -> tuple[int | None, str | None, Any]:
+    """Return ``(cap, key, raw_value)`` from a model config dict.
+
+    ``context_length`` takes precedence for backward compatibility; only when it
+    is absent do we consult ``max_context_length``.
+    """
+    if not isinstance(model_cfg, dict):
+        return None, None, None
+    for key in _CONTEXT_KEYS:
+        if key in model_cfg and model_cfg.get(key) is not None:
+            raw = model_cfg.get(key)
+            cap = parse_context_window_cap(raw)
+            if cap is None and isinstance(raw, str) and raw.strip().lower() in {"", "auto"}:
+                return None, None, raw
+            return cap, key, raw
+    return None, None, None
+
+
+def route_matches_model_config(
+    model_cfg: Any,
+    *,
+    model: str,
+    provider: str = "",
+    base_url: str = "",
+) -> bool:
+    """Return whether a route is the primary route described by ``model_cfg``.
+
+    This keeps a flat ``model.max_context_length`` from leaking into unrelated
+    session-only /model switches. Provider and model must match when configured;
+    base_url is checked only when both sides have one.
+    """
+    if not isinstance(model_cfg, dict):
+        return False
+    cfg_model = str(model_cfg.get("default") or model_cfg.get("model") or "").strip().lower()
+    cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+    cfg_base = str(model_cfg.get("base_url") or "").strip().rstrip("/").lower()
+    route_model = str(model or "").strip().lower()
+    route_provider = str(provider or "").strip().lower()
+    route_base = str(base_url or "").strip().rstrip("/").lower()
+    if cfg_model and route_model and cfg_model != route_model:
+        return False
+    if cfg_provider and route_provider and cfg_provider != route_provider:
+        return False
+    if cfg_base and route_base and cfg_base != route_base:
+        return False
+    return bool(cfg_model or cfg_provider or cfg_base)
+
+
+def scoped_model_config_context_length(
+    config: dict[str, Any] | None,
+    *,
+    model: str,
+    provider: str = "",
+    base_url: str = "",
+) -> int | None:
+    """Return the flat model cap only when it belongs to this route."""
+    model_cfg = (config or {}).get("model") if isinstance(config, dict) else None
+    cap, _key, _raw = model_config_context_length(model_cfg)
+    if cap is None:
+        return None
+    if route_matches_model_config(model_cfg, model=model, provider=provider, base_url=base_url):
+        return cap
+    return None
+
+
+def entry_context_length(entry: Any) -> int | None:
+    """Return a cap from a fallback/custom-provider entry dict."""
+    cap, _key, _raw = model_config_context_length(entry)
+    return cap

--- a/hermes_cli/fallback_cmd.py
+++ b/hermes_cli/fallback_cmd.py
@@ -53,7 +53,13 @@ def _format_entry(entry: Dict[str, Any]) -> str:
     model = entry.get("model", "?")
     base = entry.get("base_url")
     suffix = f"  [{base}]" if base else ""
-    return f"{model}  (via {provider}){suffix}"
+    try:
+        from hermes_cli.context_window import entry_context_length
+        cap = entry_context_length(entry)
+    except Exception:
+        cap = None
+    cap_suffix = f"  (context cap {cap:,})" if cap else ""
+    return f"{model}  (via {provider}){suffix}{cap_suffix}"
 
 
 def _extract_fallback_from_model_cfg(model_cfg: Any) -> Optional[Dict[str, Any]]:
@@ -72,6 +78,13 @@ def _extract_fallback_from_model_cfg(model_cfg: Any) -> Optional[Dict[str, Any]]
     api_mode = (model_cfg.get("api_mode") or "").strip()
     if api_mode:
         entry["api_mode"] = api_mode
+    try:
+        from hermes_cli.context_window import entry_context_length
+        cap = entry_context_length(model_cfg)
+        if cap:
+            entry["max_context_length"] = cap
+    except Exception:
+        pass
     return entry
 
 
@@ -151,6 +164,16 @@ def cmd_fallback_add(args) -> None:
 
     _require_tty("fallback add")
 
+    from hermes_cli.context_window import parse_context_window_cap
+    cap_arg = getattr(args, "max_context", None)
+    if cap_arg is None:
+        cap_arg = getattr(args, "context_length", None)
+    cap_value = parse_context_window_cap(cap_arg)
+    if cap_arg is not None and cap_value is None and str(cap_arg).strip().lower() != "auto":
+        print()
+        print(f"  Invalid --max-context value: {cap_arg!r} (use an integer or auto).")
+        raise SystemExit(2)
+
     # Snapshot BEFORE the picker runs so we can distinguish "user actually
     # picked something" from "user cancelled" by comparing before/after.
     before_cfg = load_config()
@@ -182,6 +205,16 @@ def cmd_fallback_add(args) -> None:
         print()
         print("  No fallback added.")
         return
+
+    # Explicit CLI cap wins over any transient model config value written by
+    # the picker. ``auto`` means no entry-specific cap.
+    if cap_arg is not None:
+        new_entry.pop("context_length", None)
+        if cap_value:
+            new_entry["max_context_length"] = cap_value
+        else:
+            new_entry.pop("max_context_length", None)
+            new_entry.pop("context_length", None)
 
     # Picker picked the same thing that's already the primary → nothing changed,
     # and there's nothing useful to add as a fallback to itself.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12373,9 +12373,19 @@ def main():
         aliases=["ls"],
         help="Show the current fallback chain (default when no subcommand)",
     )
-    fallback_subparsers.add_parser(
+    fallback_add_parser = fallback_subparsers.add_parser(
         "add",
         help="Pick a provider + model (same picker as `hermes model`) and append to the chain",
+    )
+    fallback_add_parser.add_argument(
+        "--max-context",
+        dest="max_context",
+        help="Optional context cap for this fallback entry (integer tokens, or auto).",
+    )
+    fallback_add_parser.add_argument(
+        "--context-length",
+        dest="context_length",
+        help="Alias for --max-context for compatibility with model.context_length.",
     )
     fallback_subparsers.add_parser(
         "remove",

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -304,10 +304,10 @@ class ModelSwitchResult:
 # Flag parsing
 # ---------------------------------------------------------------------------
 
-def parse_model_flags(raw_args: str) -> tuple[str, str, bool, bool, bool]:
-    """Parse --provider, --global, --session, and --refresh flags from /model command args.
+def parse_model_flags(raw_args: str) -> tuple[str, str, bool, bool, bool, str | None]:
+    """Parse flags from /model command args.
 
-    Returns ``(model_input, explicit_provider, is_global, force_refresh, is_session)``.
+    Returns ``(model_input, explicit_provider, is_global, force_refresh, is_session, max_context)``.
 
     ``is_global`` and ``is_session`` are independent flag presences; the
     *effective* persistence decision is resolved by
@@ -328,11 +328,12 @@ def parse_model_flags(raw_args: str) -> tuple[str, str, bool, bool, bool]:
     explicit_provider = ""
     force_refresh = False
     is_session = False
+    max_context: str | None = None
 
     # Normalize Unicode dashes (Telegram/iOS auto-converts -- to em/en dash)
     # A single Unicode dash before a flag keyword becomes "--"
     import re as _re
-    raw_args = _re.sub(r'[\u2012\u2013\u2014\u2015](provider|global|session|refresh)', r'--\1', raw_args)
+    raw_args = _re.sub(r'[\u2012\u2013\u2014\u2015](provider|global|session|refresh|max-context|context-length)', r'--\1', raw_args)
 
     # Extract --global
     if "--global" in raw_args:
@@ -349,7 +350,8 @@ def parse_model_flags(raw_args: str) -> tuple[str, str, bool, bool, bool]:
         force_refresh = True
         raw_args = raw_args.replace("--refresh", "").strip()
 
-    # Extract --provider <name>
+    # Extract --provider <name>, --max-context <tokens|auto>, and
+    # --context-length <tokens|auto>.
     parts = raw_args.split()
     i = 0
     filtered: list[str] = []
@@ -357,12 +359,19 @@ def parse_model_flags(raw_args: str) -> tuple[str, str, bool, bool, bool]:
         if parts[i] == "--provider" and i + 1 < len(parts):
             explicit_provider = parts[i + 1]
             i += 2
+        elif parts[i] in {"--max-context", "--context-length"}:
+            if i + 1 < len(parts) and not parts[i + 1].startswith("--"):
+                max_context = parts[i + 1]
+                i += 2
+            else:
+                max_context = ""
+                i += 1
         else:
             filtered.append(parts[i])
             i += 1
 
     model_input = " ".join(filtered).strip()
-    return (model_input, explicit_provider, is_global, force_refresh, is_session)
+    return (model_input, explicit_provider, is_global, force_refresh, is_session, max_context)
 
 
 def resolve_persist_behavior(is_global: bool, is_session: bool) -> bool:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3522,10 +3522,11 @@ def _normalize_config_for_web(config: Dict[str, Any]) -> Dict[str, Any]:
     config = dict(config)  # shallow copy
     model_val = config.get("model")
     if isinstance(model_val, dict):
-        # Extract context_length before flattening the dict
-        ctx_len = model_val.get("context_length", 0)
+        # Extract the legacy context_length or the max_context_length alias before flattening.
+        from hermes_cli.context_window import model_config_context_length
+        ctx_len, _ctx_key, _raw_ctx = model_config_context_length(model_val)
         config["model"] = model_val.get("default", model_val.get("name", ""))
-        config["model_context_length"] = ctx_len if isinstance(ctx_len, int) else 0
+        config["model_context_length"] = ctx_len or 0
     else:
         config["model_context_length"] = 0
     return config
@@ -3731,7 +3732,8 @@ def get_model_info(profile: Optional[str] = None):
             model_name = model_cfg.get("default", model_cfg.get("name", ""))
             provider = model_cfg.get("provider", "")
             base_url = model_cfg.get("base_url", "")
-            config_ctx = model_cfg.get("context_length")
+            from hermes_cli.context_window import model_config_context_length
+            config_ctx, _ctx_key, _ctx_raw = model_config_context_length(model_cfg)
         else:
             model_name = str(model_cfg) if model_cfg else ""
             provider = ""
@@ -4379,18 +4381,22 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
                         model_val = norm_model
                 # Preserve all subkeys, update default with the new value
                 disk_model["default"] = model_val
-                # Write context_length into the model dict (0 = remove/auto)
+                # Write max_context_length into the model dict (0 = remove/auto).
+                # Keep context_length untouched unless it was the existing key;
+                # it remains the legacy spelling and has precedence at runtime.
+                target_key = "context_length" if "context_length" in disk_model else "max_context_length"
                 if ctx_override > 0:
-                    disk_model["context_length"] = ctx_override
+                    disk_model[target_key] = ctx_override
                 else:
+                    disk_model.pop("max_context_length", None)
                     disk_model.pop("context_length", None)
                 config["model"] = disk_model
             # Model was previously a bare string — upgrade to dict if
-            # user is setting a context_length override
+            # user is setting a context cap override
             elif ctx_override > 0:
                 config["model"] = {
                     "default": model_val,
-                    "context_length": ctx_override,
+                    "max_context_length": ctx_override,
                 }
         except Exception:
             pass  # can't read disk config — just use the string form

--- a/run_agent.py
+++ b/run_agent.py
@@ -400,6 +400,8 @@ class AIAgent:
         notice_clear_callback: callable = None,
         event_callback: Optional[Callable[[str, dict], None]] = None,
         max_tokens: int = None,
+        config_context_length: int | None = None,
+        use_model_config_context_length: bool = True,
         reasoning_config: Dict[str, Any] = None,
         service_tier: str = None,
         request_overrides: Dict[str, Any] = None,
@@ -475,6 +477,8 @@ class AIAgent:
             notice_clear_callback=notice_clear_callback,
             event_callback=event_callback,
             max_tokens=max_tokens,
+            config_context_length=config_context_length,
+            use_model_config_context_length=use_model_config_context_length,
             reasoning_config=reasoning_config,
             service_tier=service_tier,
             request_overrides=request_overrides,
@@ -700,10 +704,10 @@ class AIAgent:
         except Exception as err:
             logger.debug("LM Studio preload skipped: %s", err)
 
-    def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
+    def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode='', config_context_length=None):
         """Forwarder — see ``agent.agent_runtime_helpers.switch_model``."""
         from agent.agent_runtime_helpers import switch_model
-        return switch_model(self, new_model, new_provider, api_key, base_url, api_mode)
+        return switch_model(self, new_model, new_provider, api_key, base_url, api_mode, config_context_length)
 
     def _safe_print(self, *args, **kwargs):
         """Print that silently handles broken pipes / closed stdout.

--- a/tests/hermes_cli/test_context_window.py
+++ b/tests/hermes_cli/test_context_window.py
@@ -1,0 +1,32 @@
+from hermes_cli.context_window import (
+    entry_context_length,
+    model_config_context_length,
+    parse_context_window_cap,
+    scoped_model_config_context_length,
+)
+
+
+def test_max_context_length_alias_when_context_length_absent():
+    cap, key, raw = model_config_context_length({"max_context_length": "262144"})
+    assert cap == 262144
+    assert key == "max_context_length"
+    assert raw == "262144"
+
+
+def test_context_length_precedes_max_context_length():
+    cap, key, _raw = model_config_context_length(
+        {"context_length": 131072, "max_context_length": 262144}
+    )
+    assert cap == 131072
+    assert key == "context_length"
+
+
+def test_auto_clears_explicit_cap():
+    assert parse_context_window_cap("auto") is None
+    assert entry_context_length({"max_context_length": "auto"}) is None
+
+
+def test_scoped_model_config_does_not_leak_to_other_route():
+    cfg = {"model": {"default": "glm-5.2", "provider": "zai", "max_context_length": 262144}}
+    assert scoped_model_config_context_length(cfg, model="glm-5.2", provider="zai") == 262144
+    assert scoped_model_config_context_length(cfg, model="gpt-5.5", provider="openai-codex") is None

--- a/tests/hermes_cli/test_model_switch_persist_default.py
+++ b/tests/hermes_cli/test_model_switch_persist_default.py
@@ -20,10 +20,10 @@ from hermes_cli.model_switch import parse_model_flags, resolve_persist_behavior
 
 class TestParseModelFlagsSession:
     def test_no_flags(self):
-        assert parse_model_flags("sonnet") == ("sonnet", "", False, False, False)
+        assert parse_model_flags("sonnet") == ("sonnet", "", False, False, False, None)
 
     def test_global_flag(self):
-        assert parse_model_flags("sonnet --global") == ("sonnet", "", True, False, False)
+        assert parse_model_flags("sonnet --global") == ("sonnet", "", True, False, False, None)
 
     def test_session_flag(self):
         assert parse_model_flags("sonnet --session") == (
@@ -32,6 +32,7 @@ class TestParseModelFlagsSession:
             False,
             False,
             True,
+            None,
         )
 
     def test_session_with_provider(self):
@@ -41,10 +42,44 @@ class TestParseModelFlagsSession:
             False,
             False,
             True,
+            None,
         )
 
     def test_refresh_flag_still_parsed(self):
-        assert parse_model_flags("--refresh") == ("", "", False, True, False)
+        assert parse_model_flags("--refresh") == ("", "", False, True, False, None)
+
+    def test_max_context_flag(self):
+        assert parse_model_flags("glm-5.2 --provider zai --max-context 262144") == (
+            "glm-5.2",
+            "zai",
+            False,
+            False,
+            False,
+            "262144",
+        )
+
+    def test_context_length_alias_flag(self):
+        assert parse_model_flags("glm-5.2 --context-length auto --session") == (
+            "glm-5.2",
+            "",
+            False,
+            False,
+            True,
+            "auto",
+        )
+
+    def test_missing_max_context_value_marks_invalid_without_model_leak(self):
+        assert parse_model_flags("--max-context") == ("", "", False, False, False, "")
+
+    def test_missing_context_length_value_marks_invalid_without_model_leak(self):
+        assert parse_model_flags("glm-5.2 --context-length") == (
+            "glm-5.2",
+            "",
+            False,
+            False,
+            False,
+            "",
+        )
 
     def test_unicode_dash_session_normalized(self):
         # Telegram/iOS auto-converts -- to en/em dashes.
@@ -54,6 +89,7 @@ class TestParseModelFlagsSession:
             False,
             False,
             True,
+            None,
         )
 
 
@@ -74,7 +110,7 @@ class TestResolvePersistBehavior:
             assert resolve_persist_behavior(True, False) is True
 
     def test_default_persists_when_config_missing(self):
-        # No model section at all → built-in default (True).
+        # No model section at all → built-in default (True, None).
         with _config({}):
             assert resolve_persist_behavior(False, False) is True
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4013,6 +4013,35 @@ class TestModelContextLength:
         assert result["model"] == "anthropic/claude-opus-4.6"
         assert result["model_context_length"] == 200000
 
+    def test_normalize_extracts_max_context_length_alias_from_dict(self):
+        """normalize should surface max_context_length so saves preserve the alias cap."""
+        from hermes_cli.web_server import _normalize_config_for_web
+
+        cfg = {
+            "model": {
+                "default": "glm-5.2",
+                "provider": "zai",
+                "max_context_length": 262144,
+            }
+        }
+        result = _normalize_config_for_web(cfg)
+        assert result["model"] == "glm-5.2"
+        assert result["model_context_length"] == 262144
+
+    def test_normalize_context_length_precedes_max_context_length(self):
+        """normalize should preserve legacy context_length precedence when both are present."""
+        from hermes_cli.web_server import _normalize_config_for_web
+
+        cfg = {
+            "model": {
+                "default": "glm-5.2",
+                "context_length": 131072,
+                "max_context_length": 262144,
+            }
+        }
+        result = _normalize_config_for_web(cfg)
+        assert result["model_context_length"] == 131072
+
     def test_normalize_bare_string_model_yields_zero(self):
         """normalize should set model_context_length=0 for bare string model."""
         from hermes_cli.web_server import _normalize_config_for_web
@@ -4037,8 +4066,8 @@ class TestModelContextLength:
         result = _normalize_config_for_web(cfg)
         assert result["model_context_length"] == 0
 
-    def test_denormalize_writes_context_length_into_model_dict(self):
-        """denormalize should write model_context_length back into model dict."""
+    def test_denormalize_writes_max_context_length_into_model_dict(self):
+        """denormalize should write model_context_length back as max_context_length."""
         from hermes_cli.web_server import _denormalize_config_from_web
         from hermes_cli.config import save_config
 
@@ -4052,7 +4081,7 @@ class TestModelContextLength:
             "model_context_length": 100000,
         })
         assert isinstance(result["model"], dict)
-        assert result["model"]["context_length"] == 100000
+        assert result["model"]["max_context_length"] == 100000
         assert "model_context_length" not in result  # virtual field removed
 
     def test_denormalize_zero_removes_context_length(self):
@@ -4089,7 +4118,7 @@ class TestModelContextLength:
         })
         assert isinstance(result["model"], dict)
         assert result["model"]["default"] == "anthropic/claude-sonnet-4"
-        assert result["model"]["context_length"] == 65000
+        assert result["model"]["max_context_length"] == 65000
 
     def test_denormalize_bare_string_stays_string_when_zero(self):
         """denormalize should keep bare string model as string when context_length=0."""
@@ -4118,7 +4147,7 @@ class TestModelContextLength:
             "model_context_length": "32000",
         })
         assert isinstance(result["model"], dict)
-        assert result["model"]["context_length"] == 32000
+        assert result["model"]["max_context_length"] == 32000
 
 
 class TestDenormalizeProviderSwitch:
@@ -4214,7 +4243,7 @@ class TestDenormalizeProviderSwitch:
         })
         model = result["model"]
         assert model["provider"] == "openrouter"
-        assert model["context_length"] == 128000
+        assert model["max_context_length"] == 128000
 
 
 class TestModelContextLengthSchema:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2555,7 +2555,7 @@ def _restart_slash_worker(sid: str, session: dict):
     _attach_worker(sid, session, new_worker)
 
 
-def _persist_model_switch(result) -> None:
+def _persist_model_switch(result, *, max_context_cap=None, max_context_arg=None) -> None:
     # Use targeted, atomic key writes (comment/ordering-preserving) instead of
     # rewriting the whole `model:` block. A full-block rewrite via save_config()
     # destroys sibling keys the user set under `model:` — `model_slots`,
@@ -2573,6 +2573,13 @@ def _persist_model_switch(result) -> None:
         # removal without needing a key-delete. Leaving the old value would
         # route the new model at the previous custom host (#48305).
         save_config_value("model.base_url", None)
+    if max_context_arg is not None:
+        if max_context_cap:
+            save_config_value("model.max_context_length", max_context_cap)
+            save_config_value("model.context_length", None)
+        else:
+            save_config_value("model.max_context_length", None)
+            save_config_value("model.context_length", None)
 
 
 def _apply_model_switch(
@@ -2582,7 +2589,7 @@ def _apply_model_switch(
     *,
     confirm_expensive_model: bool = False,
     pin_session_override: bool = True,
-    parsed_flags: tuple[str, str, bool, bool, bool] | None = None,
+    parsed_flags: tuple[str, str, bool, bool, bool, str | None] | None = None,
 ) -> dict:
     from hermes_cli.model_switch import (
         parse_model_flags,
@@ -2599,8 +2606,62 @@ def _apply_model_switch(
         is_global_flag,
         _force_refresh,
         is_session,
+        max_context_arg,
     ) = parsed_flags
     persist_global = resolve_persist_behavior(is_global_flag, is_session)
+    from hermes_cli.context_window import parse_context_window_cap
+    max_context_cap = parse_context_window_cap(max_context_arg)
+    if max_context_arg is not None and max_context_cap is None and str(max_context_arg).strip().lower() != "auto":
+        raise ValueError(f"Invalid --max-context value: {max_context_arg!r} (use an integer or auto)")
+    if not model_input and max_context_arg is not None:
+        agent = session.get("agent")
+        if agent:
+            agent._config_context_length = max_context_cap
+            if getattr(agent, "context_compressor", None):
+                from agent.model_metadata import get_model_context_length
+                ctx_len = get_model_context_length(
+                    getattr(agent, "model", ""),
+                    base_url=getattr(agent, "base_url", "") or "",
+                    api_key=getattr(agent, "api_key", "") if isinstance(getattr(agent, "api_key", ""), str) else "",
+                    provider=getattr(agent, "provider", "") or "",
+                    config_context_length=max_context_cap,
+                    custom_providers=None,
+                )
+                agent.context_compressor.update_model(
+                    model=getattr(agent, "model", ""),
+                    context_length=ctx_len,
+                    base_url=getattr(agent, "base_url", "") or "",
+                    api_key=getattr(agent, "api_key", "") or "",
+                    provider=getattr(agent, "provider", "") or "",
+                    api_mode=getattr(agent, "api_mode", "") or "",
+                )
+            _emit("session.info", sid, _session_info(agent, session))
+        if isinstance(session, dict):
+            override = session.get("model_override")
+            if not isinstance(override, dict):
+                override = {
+                    "model": getattr(agent, "model", "") if agent else _resolve_model(),
+                    "provider": getattr(agent, "provider", "") if agent else None,
+                    "base_url": getattr(agent, "base_url", "") if agent else None,
+                    "api_key": getattr(agent, "api_key", "") if agent else None,
+                    "api_mode": getattr(agent, "api_mode", "") if agent else None,
+                }
+            if max_context_cap:
+                override["max_context_length"] = max_context_cap
+                override.pop("context_length", None)
+            else:
+                override.pop("max_context_length", None)
+                override.pop("context_length", None)
+            session["model_override"] = override
+        if persist_global:
+            from cli import save_config_value
+            if max_context_cap:
+                save_config_value("model.max_context_length", max_context_cap)
+                save_config_value("model.context_length", None)
+            else:
+                save_config_value("model.max_context_length", None)
+                save_config_value("model.context_length", None)
+        return {"value": getattr(agent, "model", ""), "warning": "", "confirm_required": False}
     if not model_input:
         raise ValueError("model value required")
 
@@ -2634,6 +2695,7 @@ def _apply_model_switch(
     # endpoints (e.g. "ollama-launch") and validate against saved model lists.
     user_provs = None
     custom_provs = None
+    cfg = {}
     try:
         from hermes_cli.config import get_compatible_custom_providers, load_config
 
@@ -2661,11 +2723,15 @@ def _apply_model_switch(
         try:
             from hermes_cli.context_switch_guard import merge_preflight_compression_warning
 
-            _cfg_ctx = None
-            if isinstance(cfg, dict):
-                _mc = cfg.get("model", {})
-                if isinstance(_mc, dict) and _mc.get("context_length") is not None:
-                    _cfg_ctx = int(_mc["context_length"])
+            _cfg_ctx = max_context_cap if max_context_arg is not None else None
+            if _cfg_ctx is None and isinstance(cfg, dict):
+                from hermes_cli.context_window import scoped_model_config_context_length
+                _cfg_ctx = scoped_model_config_context_length(
+                    cfg,
+                    model=result.new_model,
+                    provider=result.target_provider,
+                    base_url=result.base_url or current_base_url or "",
+                )
             merge_preflight_compression_warning(
                 result,
                 agent=agent,
@@ -2708,6 +2774,7 @@ def _apply_model_switch(
                 api_key=result.api_key,
                 base_url=result.base_url,
                 api_mode=result.api_mode,
+                config_context_length=max_context_cap if max_context_arg is not None else None,
             )
         except Exception as exc:
             # The in-place swap rolled the agent back to the old working
@@ -2751,8 +2818,15 @@ def _apply_model_switch(
             "api_key": result.api_key,
             "api_mode": result.api_mode,
         }
+        if max_context_arg is not None:
+            if max_context_cap:
+                session["model_override"]["max_context_length"] = max_context_cap
+                session["model_override"].pop("context_length", None)
+            else:
+                session["model_override"].pop("max_context_length", None)
+                session["model_override"].pop("context_length", None)
     if persist_global:
-        _persist_model_switch(result)
+        _persist_model_switch(result, max_context_cap=max_context_cap, max_context_arg=max_context_arg)
     return {
         "value": result.new_model,
         "warning": result.warning_message or "",
@@ -4200,6 +4274,15 @@ def _make_agent(
         pass
 
     cfg = _load_cfg()
+    config_context_length = None
+    use_model_config_context_length = True
+    if isinstance(model_override, dict):
+        use_model_config_context_length = False
+        try:
+            from hermes_cli.context_window import entry_context_length
+            config_context_length = entry_context_length(model_override)
+        except Exception:
+            config_context_length = None
     agent_cfg = cfg.get("agent") or {}
     system_prompt = _prompt_text(agent_cfg.get("system_prompt", ""))
     startup_skills = _parse_tui_skills_env()
@@ -4273,6 +4356,8 @@ def _make_agent(
     return AIAgent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 90),
+        config_context_length=config_context_length,
+        use_model_config_context_length=use_model_config_context_length,
         provider=runtime.get("provider"),
         base_url=runtime.get("base_url"),
         api_key=runtime.get("api_key"),
@@ -9663,7 +9748,7 @@ def _(rid, params: dict) -> dict:
                 from hermes_cli.model_switch import parse_model_flags
 
                 parsed_flags = parse_model_flags(value)
-                _model_input, explicit_provider, _persist_global, _force_refresh, _is_session = parsed_flags
+                _model_input, explicit_provider, _persist_global, _force_refresh, _is_session, _max_context = parsed_flags
                 if session.get("agent") is None and not explicit_provider.strip():
                     session_id = params.get("session_id", "")
                     _start_agent_build(session_id, session)

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1105,7 +1105,7 @@ Set `model.max_tokens` only when you need to limit how long individual responses
 
 Hermes uses a multi-source resolution chain to detect the correct context window for your model and provider:
 
-1. **Config override** — `model.context_length` in config.yaml (highest priority)
+1. **Config override** — `model.context_length`, or `model.max_context_length` as an alias when `context_length` is absent (highest priority)
 2. **Custom provider per-model** — `custom_providers[].models.<id>.context_length`
 3. **Persistent cache** — previously discovered values (survives restarts)
 4. **Endpoint `/models`** — queries your server's API (local/custom endpoints)
@@ -1117,13 +1117,29 @@ Hermes uses a multi-source resolution chain to detect the correct context window
 
 For most setups this works out of the box. The system is provider-aware — the same model can have different context limits depending on who serves it (e.g., `claude-opus-4.6` is 1M on Anthropic direct but 128K on GitHub Copilot).
 
-To set the context length explicitly, add `context_length` to your model config:
+To set the context length explicitly, add `context_length` to your model config. If you are intentionally capping a provider's advertised window, `max_context_length` is the clearer spelling; `context_length` remains supported and wins if both are present:
+
+```yaml
+model:
+  provider: "zai"
+  default: "glm-5.2"
+  max_context_length: 262144  # cap the detected 1M window to 256K tokens
+```
 
 ```yaml
 model:
   default: "qwen3.5:9b"
   base_url: "http://localhost:8080/v1"
-  context_length: 131072  # tokens
+  context_length: 131072  # legacy spelling, still supported
+```
+
+You can set the same cap for a running session with `/model --max-context 262144`, clear it with `/model --max-context auto`, and persist either change with `--global`. Fallback entries can also carry a per-entry cap:
+
+```yaml
+fallback_providers:
+  - provider: zai
+    model: glm-5.2
+    max_context_length: 262144
 ```
 
 For custom endpoints, you can also set context length per model:


### PR DESCRIPTION
## Summary
- add `model.max_context_length` as a clearer alias for capping provider-advertised context windows while preserving `model.context_length` precedence
- expose context caps through `/model --max-context`, fallback entries, gateway/TUI session rebuilds, and dashboard config roundtrips
- keep session model overrides scoped so a flat global cap does not leak into unrelated `/model` routes

## Testing
- `python3 -m py_compile hermes_cli/context_window.py agent/agent_init.py agent/chat_completion_helpers.py agent/agent_runtime_helpers.py run_agent.py cli.py gateway/slash_commands.py gateway/run.py hermes_cli/fallback_cmd.py hermes_cli/main.py hermes_cli/model_switch.py hermes_cli/context_switch_guard.py tui_gateway/server.py hermes_cli/web_server.py hermes_cli/commands.py tests/hermes_cli/test_context_window.py tests/hermes_cli/test_model_switch_persist_default.py tests/hermes_cli/test_web_server.py`
- `uvx --with pytest --with pyyaml --with requests --with fastapi --with 'uvicorn[standard]' --with python-multipart pytest tests/hermes_cli/test_context_window.py tests/hermes_cli/test_model_switch_persist_default.py tests/hermes_cli/test_web_server.py::TestModelContextLength tests/hermes_cli/test_web_server.py::TestDenormalizeProviderSwitch::test_context_length_override_survives_provider_switch -q -o 'addopts='`