### PR TITLE
fix(gateway): stop phantom typing bubble after proactive deliveries

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -393,6 +393,15 @@ class DeliveryRouter:
             }
 
         send_metadata = dict(metadata or {})
+        # Proactive/job deliveries (cron jobs, kanban alerts, home-channel
+        # pushes) are standalone FINAL messages — never intermediate progress.
+        # Mark them notify-worthy so the Telegram adapter does NOT re-arm its
+        # ~5s typing indicator after the message lands: an unmarked send is
+        # treated as a progress message and keeps the "…typing" bubble alive,
+        # leaving a phantom bubble with nothing behind it (the interactive
+        # final-reply path sets the same marker via _mark_notify_metadata).
+        # setdefault preserves an explicit caller opt-out (notify=False).
+        send_metadata.setdefault("notify", True)
         is_named_telegram_private_topic = False
         named_telegram_private_topic_name: Optional[str] = None
         if target.thread_id:

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -377,6 +377,12 @@ class GatewayKanbanWatchersMixin:
                         else:
                             continue
                         metadata: dict[str, Any] = {}
+                        # Terminal-event alerts are standalone FINAL messages;
+                        # mark them notify-worthy so the Telegram adapter does
+                        # not re-arm its ~5s typing indicator after the alert
+                        # lands (an unmarked send is treated as intermediate
+                        # progress and leaves a phantom "…typing" bubble).
+                        metadata["notify"] = True
                         if sub.get("thread_id"):
                             metadata["thread_id"] = sub["thread_id"]
                         sub_key = (

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -189,6 +189,7 @@ async def test_named_telegram_private_topic_is_created_before_delivery(tmp_path,
             "chat_id": "722341991",
             "content": "hello",
             "metadata": {
+                "notify": True,
                 "thread_id": "38049",
                 "telegram_dm_topic_created_for_send": True,
             },
@@ -232,6 +233,7 @@ async def test_explicit_telegram_private_thread_uses_reply_fallback_with_anchor(
             "chat_id": "722341991",
             "content": "hello",
             "metadata": {
+                "notify": True,
                 "telegram_reply_to_message_id": "9001",
                 "thread_id": "32344",
                 "telegram_dm_topic_reply_fallback": True,
@@ -253,7 +255,10 @@ async def test_explicit_telegram_direct_messages_topic_metadata_is_respected(tmp
         metadata={"telegram_direct_messages_topic_id": "32344"},
     )
 
-    assert adapter.calls[0]["metadata"] == {"telegram_direct_messages_topic_id": "32344"}
+    assert adapter.calls[0]["metadata"] == {
+        "notify": True,
+        "telegram_direct_messages_topic_id": "32344",
+    }
 
 
 @pytest.mark.asyncio
@@ -265,7 +270,7 @@ async def test_explicit_telegram_group_thread_does_not_mark_dm_fallback(tmp_path
 
     await router._deliver_to_platform(target, "hello", metadata=None)
 
-    assert adapter.calls[0]["metadata"] == {"thread_id": "42"}
+    assert adapter.calls[0]["metadata"] == {"notify": True, "thread_id": "42"}
 
 
 class FailingAdapter:
@@ -419,5 +424,51 @@ async def test_save_failure_during_truncation_raises_for_non_chunking_adapter(tm
     # retry (footer needs the path) re-raises.
     with pytest.raises(OSError, match="No space left on device"):
         await router._deliver_to_platform(target, long_content, metadata={"job_id": "job7"})
+
+
+# ---------------------------------------------------------------------------
+# Proactive deliveries are FINAL messages → must suppress the typing re-arm
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_proactive_delivery_marks_notify_to_prevent_phantom_typing(tmp_path, monkeypatch):
+    """Router deliveries (cron jobs, proactive notices) are standalone FINAL
+    messages, so they must be marked ``notify=True``.
+
+    The Telegram adapter re-arms its ~5s typing indicator after any send that
+    is NOT marked ``notify`` (it assumes an unmarked send is an intermediate
+    progress message and keeps the "…typing" bubble alive). Proactive/cron
+    deliveries never go through the interactive gateway path that sets the
+    marker, so without this they leave a phantom "…typing" bubble with nothing
+    behind it. Mirror of the interactive-reply contract pinned by
+    tests/gateway/test_telegram_format.py::test_final_send_does_not_retrigger_typing.
+    """
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = RecordingAdapter()
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.TELEGRAM: adapter})
+    target = DeliveryTarget.parse("telegram:-100123:42")
+
+    await router._deliver_to_platform(
+        target, "Morning briefing ready.", metadata={"job_id": "brief1"}
+    )
+
+    assert adapter.calls[0]["metadata"].get("notify") is True
+
+
+@pytest.mark.asyncio
+async def test_proactive_delivery_respects_explicit_notify_opt_out(tmp_path, monkeypatch):
+    """A caller may explicitly send silently by passing ``notify=False``; the
+    router must not clobber that intent."""
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = RecordingAdapter()
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.TELEGRAM: adapter})
+    target = DeliveryTarget.parse("telegram:-100123:42")
+
+    await router._deliver_to_platform(
+        target, "quietly", metadata={"job_id": "brief2", "notify": False}
+    )
+
+    assert adapter.calls[0]["metadata"].get("notify") is False
 
 

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -233,3 +233,26 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         f"deliveries (texts: {[d['text'] for d in adapter.sent]})"
     )
     assert "crashed" in adapter.sent[1]["text"].lower()
+
+
+def test_kanban_notifier_marks_notify_to_prevent_phantom_typing(tmp_path, monkeypatch):
+    """Kanban terminal-event notifications are standalone FINAL alerts, so they
+    must be marked ``notify=True``.
+
+    Without the marker the Telegram adapter re-arms its ~5s typing indicator
+    after each completion/crash alert lands — treating the alert as an
+    intermediate progress message — and leaves a phantom "…typing" bubble with
+    nothing behind it. Same root cause as the cron-delivery path in
+    tests/gateway/test_delivery.py.
+    """
+    db_path = tmp_path / "notify-flag.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    _create_completed_subscription()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["metadata"].get("notify") is True


### PR DESCRIPTION
## What does this PR do?

Cron jobs and kanban terminal-event alerts deliver **standalone final messages** to Telegram, but neither path marked them notify-worthy. The Telegram adapter re-arms its ~5s typing indicator after any send that lacks `metadata["notify"]` — it treats an unmarked send as an *intermediate progress* message and keeps the "…typing" bubble alive. (Telegram exposes no stop-typing API, so the bubble just expires ~5s after the last `sendChatAction`.)

Result: every cron briefing and every kanban completion/crash alert leaves a **phantom "…typing" bubble** in the user's DM with nothing behind it — it looks like the assistant is about to send a follow-up that never comes.

The interactive final-reply path already suppresses this by setting the marker via `_mark_notify_metadata` — the `#3003` / `#48678` line of phantom-typing fixes. This PR extends the **same contract** to the two proactive/background delivery paths that were missed.

## Related Issue

Extends #3003 (`fix(discord): stop phantom typing indicator after agent turn completes`) and #48678 (`fix(telegram): stop typing indicator after response delivery`) to **background/proactive deliveries**. No existing issue tracks the cron/kanban variant.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`gateway/delivery.py`** — `DeliveryRouter._deliver_to_platform` now does `send_metadata.setdefault("notify", True)`. Covers all router deliveries (cron jobs, home-channel pushes). `setdefault` preserves an explicit `notify=False` opt-out.
- **`gateway/kanban_watchers.py`** — the terminal-event notifier marks its alert metadata `notify=True`.
- **`tests/gateway/test_delivery.py`** — adds `test_proactive_delivery_marks_notify_to_prevent_phantom_typing` and `test_proactive_delivery_respects_explicit_notify_opt_out`; updates 4 existing exact-metadata assertions to reflect the new `notify` key.
- **`tests/gateway/test_kanban_notifier.py`** — adds `test_kanban_notifier_marks_notify_to_prevent_phantom_typing`.

Both call sites are standalone final deliveries — progress streaming uses a separate path (`gateway/run.py`), so this does not suppress legitimate intermediate typing.

## How to Test

1. Targeted: `pytest tests/gateway/test_delivery.py tests/gateway/test_kanban_notifier.py tests/gateway/test_telegram_format.py -q` → **143 passed**.
2. Broad sweep: `pytest tests/gateway tests/cron -k "deliver or notify or typing or cron or kanban" -q` → **980 passed, 5 skipped**.
3. Manual repro: configure a cron job (or kanban notify sub) delivering to a Telegram DM. Before: the "…typing" bubble appears for ~5s after the message lands. After: it does not.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes (RED verified before GREEN)
- [x] I've tested on my platform: Ubuntu (Linux 6.8)

> Note: ran the targeted + broad suites above (980+ tests) rather than the entire `tests/` tree; happy to run anything else reviewers want.

### Documentation & Housekeeping

- [x] No new/changed config keys — N/A
- [x] No architecture/workflow change — N/A
- [x] Cross-platform: pure metadata change, platform-agnostic — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
