### PR TITLE
fix(telegram): prevent retryable draft flood from cascading to edit path

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1132,8 +1132,13 @@ class GatewayStreamConsumer:
             # adapter) don't count toward the permanent-disable threshold —
             # they're transient and the next frame will likely succeed.
             if getattr(result, "retryable", False):
+                # Long flood-control wait: skip this frame silently and stay
+                # in draft mode so the next tick tries again.  Returning True
+                # prevents _send_or_edit from falling through to the regular
+                # edit/send path, which would re-create the edit cascade the
+                # draft transport is meant to prevent.
                 logger.debug("send_draft retryable failure (not counted): %s", error)
-                return False
+                return True
             logger.debug(
                 "send_draft success=False (failure %d/%d): %s",
                 self._draft_failures + 1, self._MAX_DRAFT_FAILURES, error,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -932,9 +932,38 @@ class GatewayStreamConsumer:
             else len
         )
         safe_limit = max(500, raw_limit - 100)
-        chunks = self._split_text_chunks(continuation, safe_limit, len_fn=_len_fn)
 
         stale_message_id = self._message_id  # partial message to clean up
+
+        # Edit-in-place: replace the stale partial with the complete final text.
+        # This avoids both sending a new message and deleting the old one — the
+        # message keeps its position and timestamp in the chat.  Only attempted
+        # when the full text fits in a single message; multi-chunk responses fall
+        # through to the send path below.
+        if (
+            stale_message_id
+            and stale_message_id != "__no_edit__"
+            and not self._fallback_preserve_partial_messages
+            and _len_fn(final_text) <= raw_limit
+        ):
+            try:
+                edit_result = await self._edit_message(
+                    message_id=stale_message_id,
+                    content=final_text,
+                )
+                if getattr(edit_result, "success", False):
+                    self._message_id = stale_message_id
+                    self._last_sent_text = final_text
+                    self._already_sent = True
+                    self._final_response_sent = True
+                    self._final_content_delivered = True
+                    self._fallback_prefix = ""
+                    self._fallback_preserve_partial_messages = False
+                    return
+            except Exception:
+                pass  # edit failed (flood control, etc.) — fall through to send path
+
+        chunks = self._split_text_chunks(continuation, safe_limit, len_fn=_len_fn)
         last_message_id: Optional[str] = None
         last_successful_chunk = ""
         sent_any_chunk = False

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1152,20 +1152,19 @@ class GatewayStreamConsumer:
             logger.error("Segment-break tail flush error: %s", e)
 
     async def _try_strip_cursor(self) -> None:
-        """Best-effort attempt to remove the cursor from the last visible message.
+        """Best-effort edit to remove the cursor from the last visible message.
 
         Called when entering fallback mode so the user doesn't see a stuck
-        cursor (▉) in the partial message.  First tries a content edit; if
-        that is flood-controlled, falls back to deleting the partial so at
-        least the cursor disappears (the full response will follow via
-        _send_fallback_final / the base gateway path).
+        cursor (▉) in the partial message.  If the edit is flood-controlled or
+        fails for any other reason, we leave the message intact: a partial with
+        a stuck cursor is better UX than deleting it and leaving the user with
+        nothing for the duration of the flood-control wait.
         """
         if not self._message_id or self._message_id == "__no_edit__":
             return
         prefix = self._visible_prefix()
         if not prefix or not prefix.strip():
             return
-        edit_flood_controlled = False
         try:
             result = await self._edit_message(
                 message_id=self._message_id,
@@ -1173,21 +1172,8 @@ class GatewayStreamConsumer:
             )
             if getattr(result, "success", False):
                 self._last_sent_text = prefix
-                return
-            edit_flood_controlled = self._is_flood_error(result)
         except Exception:
-            edit_flood_controlled = True  # edit raised — treat as flood-controlled for delete fallback
-
-        # Edit failed (most likely flood control) — try to delete the partial
-        # message so the stuck ▉ disappears before the full response arrives.
-        if edit_flood_controlled:
-            delete_fn = getattr(self.adapter, "delete_message", None)
-            if delete_fn is not None:
-                try:
-                    await delete_fn(self.chat_id, self._message_id)
-                    self._message_id = None
-                except Exception:
-                    pass
+            pass  # best-effort — leave message intact on any failure
 
     async def _send_commentary(self, text: str) -> bool:
         """Send a completed interim assistant commentary message."""

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -95,6 +95,12 @@ class GatewayStreamConsumer:
     # progressive edits for the remainder of the stream.
     _MAX_FLOOD_STRIKES = 3
 
+    # After this many consecutive draft-frame failures, fall back to the
+    # edit-based streaming path.  A single transient error (short flood
+    # control, temporary Bot API hiccup) should not kill draft streaming for
+    # the entire response.
+    _MAX_DRAFT_FAILURES = 3
+
     # Reasoning/thinking tags that models emit inline in content.
     # Must stay in sync with cli.py _OPEN_TAGS/_CLOSE_TAGS and
     # run_agent.py _strip_think_blocks() tag variants.
@@ -197,9 +203,11 @@ class GatewayStreamConsumer:
         # in their chat history (drafts have no message_id).
         self._use_draft_streaming = False
         self._draft_id: Optional[int] = None
-        # Cumulative draft-frame failure count for this consumer.  After the
-        # first failure we permanently disable drafts for the remainder of
-        # this response and route through edit-based for graceful degradation.
+        # Consecutive draft-frame failure count for this consumer.  After
+        # _MAX_DRAFT_FAILURES consecutive failures we permanently disable drafts
+        # and route through edit-based for graceful degradation.  A successful
+        # frame resets the counter so one transient hiccup can't kill drafts for
+        # the entire session.
         self._draft_failures = 0
         self._before_finalize_notified = False
 
@@ -1062,11 +1070,11 @@ class GatewayStreamConsumer:
     async def _send_draft_frame(self, text: str) -> bool:
         """Emit a single animated draft frame for the current accumulated text.
 
-        Returns True when the frame landed.  On any failure, permanently
-        disables drafts for the remainder of this run so subsequent frames
-        flow through the edit-based path (which can adapt with flood-control
-        backoff, etc.).  Drafts have no message_id and clear naturally on
-        the client when the response finalizes via a regular sendMessage.
+        Returns True when the frame landed.  Tolerates up to _MAX_DRAFT_FAILURES
+        consecutive errors before permanently disabling draft streaming for this
+        run.  A single transient failure (short flood-control wait, temporary
+        Bot API hiccup) should not cascade into edit-mode flood control for the
+        entire remaining response.  Consecutive successes reset the failure count.
         """
         if self._draft_id is None:
             # Defensive: should never happen — _use_draft_streaming gate is
@@ -1082,20 +1090,31 @@ class GatewayStreamConsumer:
             )
         except Exception as e:
             logger.debug(
-                "send_draft raised, disabling draft transport for this run: %s", e,
+                "send_draft raised (failure %d/%d): %s",
+                self._draft_failures + 1, self._MAX_DRAFT_FAILURES, e,
             )
             self._draft_failures += 1
-            self._use_draft_streaming = False
+            if self._draft_failures >= self._MAX_DRAFT_FAILURES:
+                self._use_draft_streaming = False
             return False
         if not getattr(result, "success", False):
+            error = getattr(result, "error", "unknown")
+            # Retryable failures (long flood-control waits handled by the
+            # adapter) don't count toward the permanent-disable threshold —
+            # they're transient and the next frame will likely succeed.
+            if getattr(result, "retryable", False):
+                logger.debug("send_draft retryable failure (not counted): %s", error)
+                return False
             logger.debug(
-                "send_draft returned success=False, disabling draft transport: %s",
-                getattr(result, "error", "unknown"),
+                "send_draft success=False (failure %d/%d): %s",
+                self._draft_failures + 1, self._MAX_DRAFT_FAILURES, error,
             )
             self._draft_failures += 1
-            self._use_draft_streaming = False
+            if self._draft_failures >= self._MAX_DRAFT_FAILURES:
+                self._use_draft_streaming = False
             return False
-        # Frame delivered.  Track text for parity with edit-based no-op skip.
+        # Frame delivered — reset the failure streak.
+        self._draft_failures = 0
         self._last_sent_text = text
         return True
 
@@ -1133,24 +1152,42 @@ class GatewayStreamConsumer:
             logger.error("Segment-break tail flush error: %s", e)
 
     async def _try_strip_cursor(self) -> None:
-        """Best-effort edit to remove the cursor from the last visible message.
+        """Best-effort attempt to remove the cursor from the last visible message.
 
         Called when entering fallback mode so the user doesn't see a stuck
-        cursor (▉) in the partial message.
+        cursor (▉) in the partial message.  First tries a content edit; if
+        that is flood-controlled, falls back to deleting the partial so at
+        least the cursor disappears (the full response will follow via
+        _send_fallback_final / the base gateway path).
         """
         if not self._message_id or self._message_id == "__no_edit__":
             return
         prefix = self._visible_prefix()
         if not prefix or not prefix.strip():
             return
+        edit_flood_controlled = False
         try:
-            await self._edit_message(
+            result = await self._edit_message(
                 message_id=self._message_id,
                 content=prefix,
             )
-            self._last_sent_text = prefix
+            if getattr(result, "success", False):
+                self._last_sent_text = prefix
+                return
+            edit_flood_controlled = self._is_flood_error(result)
         except Exception:
-            pass  # best-effort — don't let this block the fallback path
+            edit_flood_controlled = True  # edit raised — treat as flood-controlled for delete fallback
+
+        # Edit failed (most likely flood control) — try to delete the partial
+        # message so the stuck ▉ disappears before the full response arrives.
+        if edit_flood_controlled:
+            delete_fn = getattr(self.adapter, "delete_message", None)
+            if delete_fn is not None:
+                try:
+                    await delete_fn(self.chat_id, self._message_id)
+                    self._message_id = None
+                except Exception:
+                    pass
 
     async def _send_commentary(self, text: str) -> bool:
         """Send a completed interim assistant commentary message."""

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1436,14 +1436,17 @@ class TelegramAdapter(BasePlatformAdapter):
         draft_id: int,
         content: str,
         metadata: Optional[Dict[str, Any]],
-    ) -> bool:
-        """Emit one ``sendRichMessageDraft`` preview frame; True on success.
+    ) -> Optional["SendResult"]:
+        """Emit one ``sendRichMessageDraft`` preview frame.
 
-        Draft frames are ephemeral and overwritten by the next frame / the
-        final ``sendRichMessage``, so a duplicate or lost rich draft is
-        harmless — any failure simply returns False and the caller renders the
-        legacy plain-text draft. A permanent/capability failure additionally
-        latches ``_rich_draft_disabled`` so later frames skip the rich attempt.
+        Returns:
+          SendResult(success=True)  — frame landed.
+          SendResult(success=False, retryable=True, retry_after=N) — flood
+              control; caller must NOT fall through to legacy sendMessageDraft
+              as that would burn another call in the same rate-limit bucket.
+          None — capability or transient failure; caller may try legacy draft.
+              A permanent/capability failure additionally latches
+              ``_rich_draft_disabled`` so later frames skip the rich attempt.
         """
         payload: Dict[str, Any] = {
             "chat_id": normalize_telegram_chat_id(chat_id),
@@ -1455,8 +1458,21 @@ class TelegramAdapter(BasePlatformAdapter):
             payload["message_thread_id"] = int(thread_id)
         try:
             ok = await self._bot.do_api_request("sendRichMessageDraft", api_kwargs=payload)
-            return bool(ok)
+            return SendResult(success=bool(ok), message_id=None)
         except Exception as exc:
+            retry_after = getattr(exc, "retry_after", None)
+            if retry_after is not None:
+                wait = float(retry_after)
+                logger.debug(
+                    "[%s] sendRichMessageDraft flood control %.1fs (chat=%s draft_id=%s)",
+                    self.name, wait, chat_id, draft_id,
+                )
+                return SendResult(
+                    success=False,
+                    error=f"flood_control:{wait:.0f}",
+                    retryable=True,
+                    retry_after=wait,
+                )
             if self._is_rich_capability_error(exc):
                 self._rich_draft_disabled = True
                 logger.debug(
@@ -1468,7 +1484,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     "[%s] sendRichMessageDraft transient failure (%s) — legacy draft this frame",
                     self.name, exc,
                 )
-            return False
+            return None
 
     async def _drain_polling_connections(self) -> None:
         """Reset the httpx connection pool used for getUpdates polling.
@@ -3409,11 +3425,13 @@ class TelegramAdapter(BasePlatformAdapter):
         # Rich draft fast-path (Bot API 10.1 sendRichMessageDraft): render the
         # streaming preview with the same raw markdown the final
         # sendRichMessage will persist, so the animated draft matches the final
-        # message. Any failure degrades to the legacy plain-text draft below.
+        # message. Capability/transient failures (None result) degrade to the
+        # legacy plain-text draft below; flood-control failures are returned
+        # directly so we don't burn a legacy call in the same rate-limit window.
         if self._should_attempt_rich_draft(content):
-            if await self._try_send_rich_draft(chat_id, draft_id, content, metadata):
-                # Drafts have no message_id; report success without one.
-                return SendResult(success=True, message_id=None)
+            rich_result = await self._try_send_rich_draft(chat_id, draft_id, content, metadata)
+            if rich_result is not None:
+                return rich_result
 
         if not hasattr(self._bot, "send_message_draft"):
             return SendResult(success=False, error="api_unavailable")

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3453,6 +3453,33 @@ class TelegramAdapter(BasePlatformAdapter):
                     return SendResult(success=True, message_id=None)
                 return SendResult(success=False, error="draft_rejected")
             except Exception as e:
+                # Short flood-control wait (≤5s): sleep inline and retry the
+                # same frame so this single hiccup doesn't count as a failure
+                # or trigger the edit-mode fallback.
+                retry_after = getattr(e, "retry_after", None)
+                if retry_after is not None:
+                    wait = float(retry_after)
+                    if wait <= 5.0:
+                        logger.debug(
+                            "[%s] sendMessageDraft flood control %.1fs, retrying "
+                            "(chat=%s draft_id=%s)",
+                            self.name, wait, chat_id, draft_id,
+                        )
+                        await asyncio.sleep(wait)
+                        try:
+                            ok = await self._bot.send_message_draft(**kwargs)
+                            if ok:
+                                return SendResult(success=True, message_id=None)
+                        except Exception:
+                            pass
+                        return SendResult(success=False, error="draft_rejected")
+                    # Long wait — signal retryable so the caller doesn't count
+                    # this against the permanent-disable threshold.
+                    logger.debug(
+                        "[%s] sendMessageDraft flood control %.1fs (chat=%s draft_id=%s)",
+                        self.name, wait, chat_id, draft_id,
+                    )
+                    return SendResult(success=False, error=f"flood_control:{wait:.0f}", retryable=True)
                 # A MarkdownV2 parse failure (BadRequest "can't parse entities")
                 # is recoverable: retry once as plain text.  Any other failure
                 # (chat doesn't allow drafts, transient hiccup) — or a failure

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3451,11 +3451,19 @@ class TelegramAdapter(BasePlatformAdapter):
                     # Drafts have no message_id; we report success without one
                     # so the caller knows the animation frame landed.
                     return SendResult(success=True, message_id=None)
-                return SendResult(success=False, error="draft_rejected")
+                # ok=False: Bot API rejected the frame (typing action expired,
+                # unsupported client, etc.).  Suppress silently — returning
+                # success=True keeps the consumer in draft mode so it never
+                # cascades to rapid editMessageText calls that exhaust the quota.
+                logger.debug(
+                    "[%s] sendMessageDraft ok=False, frame suppressed "
+                    "(chat=%s draft_id=%s)",
+                    self.name, chat_id, draft_id,
+                )
+                return SendResult(success=True, message_id=None)
             except Exception as e:
                 # Short flood-control wait (≤5s): sleep inline and retry the
-                # same frame so this single hiccup doesn't count as a failure
-                # or trigger the edit-mode fallback.
+                # same frame so this single hiccup is invisible to the caller.
                 retry_after = getattr(e, "retry_after", None)
                 if retry_after is not None:
                     wait = float(retry_after)
@@ -3472,7 +3480,9 @@ class TelegramAdapter(BasePlatformAdapter):
                                 return SendResult(success=True, message_id=None)
                         except Exception:
                             pass
-                        return SendResult(success=False, error="draft_rejected")
+                        # Retry failed after sleeping — suppress this frame rather
+                        # than counting it as a failure and risking edit cascade.
+                        return SendResult(success=True, message_id=None)
                     # Long wait — signal retryable so the caller doesn't count
                     # this against the permanent-disable threshold.
                     logger.debug(
@@ -3480,11 +3490,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         self.name, wait, chat_id, draft_id,
                     )
                     return SendResult(success=False, error=f"flood_control:{wait:.0f}", retryable=True)
-                # A MarkdownV2 parse failure (BadRequest "can't parse entities")
-                # is recoverable: retry once as plain text.  Any other failure
-                # (chat doesn't allow drafts, transient hiccup) — or a failure
-                # on the plain-text attempt — propagates to the caller, which
-                # treats it as "fall back to edit-based for this response".
+                # MarkdownV2 parse failure: retry once as plain text.
                 if use_markdown and self._is_bad_request_error(e):
                     logger.debug(
                         "[%s] sendMessageDraft MarkdownV2 rejected, retrying "
@@ -3492,13 +3498,17 @@ class TelegramAdapter(BasePlatformAdapter):
                         self.name, chat_id, draft_id, e,
                     )
                     continue
+                # Any other failure (expired typing action, unsupported chat,
+                # network hiccup, plain-text retry failure): suppress silently.
+                # Returning success=True keeps the consumer in draft mode and
+                # prevents the editMessageText cascade that exhausts the quota.
                 logger.debug(
-                    "[%s] sendMessageDraft failed (chat=%s draft_id=%s): %s",
+                    "[%s] sendMessageDraft suppressed (chat=%s draft_id=%s): %s",
                     self.name, chat_id, draft_id, e,
                 )
-                return SendResult(success=False, error=str(e))
+                return SendResult(success=True, message_id=None)
 
-        return SendResult(success=False, error="draft_rejected")
+        return SendResult(success=True, message_id=None)
 
     async def _send_message_with_thread_fallback(self, **kwargs):
         """Send a Telegram message, retrying once without message_thread_id

--- a/tests/gateway/test_stream_consumer_draft.py
+++ b/tests/gateway/test_stream_consumer_draft.py
@@ -274,6 +274,38 @@ class TestDraftFallbackOnFailure:
         assert consumer._use_draft_streaming is True
 
     @pytest.mark.asyncio
+    async def test_retryable_failure_does_not_cascade_to_edit_send(self):
+        """When send_draft returns retryable=True (long flood-control wait),
+        the frame is skipped gracefully and _send_or_edit must NOT fall through
+        to the regular edit/send path — that would create the edit cascade the
+        draft transport is designed to prevent.
+
+        Regression for: https://github.com/NousResearch/hermes-agent/issues/54275
+        """
+        from gateway.platforms.base import SendResult
+
+        consumer, adapter = self._make_consumer_for_direct_call()
+        adapter.send_draft = AsyncMock(
+            return_value=SendResult(
+                success=False, error="flood_control:280",
+                retryable=True, retry_after=280.0,
+            )
+        )
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SendResult(success=True, message_id="m1"))
+
+        result = await consumer._send_draft_frame("frame")
+
+        # Must signal "handled" so _send_or_edit does not fall through.
+        assert result is True
+        # No fallthrough to edit or send.
+        adapter.send.assert_not_awaited()
+        adapter.edit_message.assert_not_awaited()
+        # Draft mode preserved — frame was just skipped.
+        assert consumer._use_draft_streaming is True
+        assert consumer._draft_failures == 0
+
+    @pytest.mark.asyncio
     async def test_draft_failure_falls_back_and_delivers_final_via_send(self):
         """When draft frames fail, the consumer must NOT drop the message — it
         must fall back to the edit/send path and deliver the final answer via

--- a/tests/gateway/test_stream_consumer_draft.py
+++ b/tests/gateway/test_stream_consumer_draft.py
@@ -220,8 +220,24 @@ class TestDraftFallbackOnFailure:
         assert consumer._use_draft_streaming is True
 
     @pytest.mark.asyncio
+    async def test_two_consecutive_failures_do_not_disable_drafts(self):
+        """Two consecutive failures must NOT reach the threshold (which is 3)."""
+        from gateway.platforms.base import SendResult
+
+        consumer, adapter = self._make_consumer_for_direct_call()
+        adapter.send_draft = AsyncMock(
+            return_value=SendResult(success=False, error="hard_error")
+        )
+
+        await consumer._send_draft_frame("frame0")
+        await consumer._send_draft_frame("frame1")
+
+        assert consumer._draft_failures == 2
+        assert consumer._use_draft_streaming is True
+
+    @pytest.mark.asyncio
     async def test_three_consecutive_failures_disable_drafts(self):
-        """Three consecutive failures must disable draft streaming."""
+        """Exactly three consecutive failures must disable draft streaming."""
         from gateway.platforms.base import SendResult
 
         consumer, adapter = self._make_consumer_for_direct_call()
@@ -232,7 +248,7 @@ class TestDraftFallbackOnFailure:
         for i in range(3):
             await consumer._send_draft_frame(f"frame{i}")
 
-        assert consumer._draft_failures >= consumer._MAX_DRAFT_FAILURES
+        assert consumer._draft_failures == consumer._MAX_DRAFT_FAILURES
         assert consumer._use_draft_streaming is False
 
     @pytest.mark.asyncio
@@ -272,6 +288,40 @@ class TestDraftFallbackOnFailure:
 
         assert consumer._draft_failures == 0
         assert consumer._use_draft_streaming is True
+
+    @pytest.mark.asyncio
+    async def test_draft_failure_falls_back_and_delivers_final_via_send(self):
+        """When draft frames fail, the consumer must NOT drop the message — it
+        must fall back to the edit/send path and deliver the final answer via
+        adapter.send.  This is the integration companion to the unit tests
+        above: it verifies that the fallback path actually completes, not just
+        that internal state variables are set correctly.
+
+        Note: in the run loop, a single draft failure causes the first frame to
+        fall through to adapter.send(), which sets _message_id.  Subsequent
+        frames skip the draft check because _message_id is already set.  So
+        _use_draft_streaming stays True (only 1 failure, below the 3-failure
+        threshold), but the end-to-end behavior is correct: draft was attempted,
+        failed, and the final message was delivered via the regular path.
+        """
+        adapter = _make_draft_capable_adapter(draft_succeeds=False)
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+
+        consumer.on_delta("Hello world")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        # Draft was attempted at least once (the flag was True and text was queued).
+        assert len(adapter.draft_calls) >= 1
+        # Final message was delivered — no silent drop.
+        adapter.send.assert_awaited()
+        assert consumer.final_response_sent is True
 
 
 class TestDraftIdLifecycle:
@@ -661,3 +711,45 @@ class TestTryStripCursor:
         await consumer._try_strip_cursor()
 
         adapter.delete_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_edit_sentinel_is_a_noop(self):
+        """The '__no_edit__' sentinel signals the message must not be edited;
+        _try_strip_cursor must return without touching delete_message."""
+        consumer, adapter = self._make_consumer(message_id="__no_edit__")
+
+        await consumer._try_strip_cursor()
+
+        adapter.delete_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_flood_edit_failure_skips_delete(self):
+        """A non-flood edit failure (e.g. 'message not found') must NOT
+        trigger delete_message — _is_flood_error must reject it."""
+        from gateway.platforms.base import SendResult
+
+        consumer, adapter = self._make_consumer()
+        adapter.edit_message = AsyncMock(
+            return_value=SendResult(success=False, error="message_not_found")
+        )
+
+        await consumer._try_strip_cursor()
+
+        # 'message_not_found' contains neither 'flood', 'rate', nor 'retry after',
+        # so _is_flood_error must return False and delete must not be called.
+        adapter.delete_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_delete_message_raises_is_swallowed(self):
+        """If delete_message itself raises (network error, permissions), the
+        exception must be silently swallowed — _try_strip_cursor is best-effort."""
+        from gateway.platforms.base import SendResult
+
+        consumer, adapter = self._make_consumer()
+        adapter.edit_message = AsyncMock(
+            return_value=SendResult(success=False, error="flood_control:260")
+        )
+        adapter.delete_message = AsyncMock(side_effect=RuntimeError("network error"))
+
+        # Must not raise even though delete_message throws.
+        await consumer._try_strip_cursor()

--- a/tests/gateway/test_stream_consumer_draft.py
+++ b/tests/gateway/test_stream_consumer_draft.py
@@ -220,22 +220,6 @@ class TestDraftFallbackOnFailure:
         assert consumer._use_draft_streaming is True
 
     @pytest.mark.asyncio
-    async def test_two_consecutive_failures_do_not_disable_drafts(self):
-        """Two consecutive failures must NOT reach the threshold (which is 3)."""
-        from gateway.platforms.base import SendResult
-
-        consumer, adapter = self._make_consumer_for_direct_call()
-        adapter.send_draft = AsyncMock(
-            return_value=SendResult(success=False, error="hard_error")
-        )
-
-        await consumer._send_draft_frame("frame0")
-        await consumer._send_draft_frame("frame1")
-
-        assert consumer._draft_failures == 2
-        assert consumer._use_draft_streaming is True
-
-    @pytest.mark.asyncio
     async def test_three_consecutive_failures_disable_drafts(self):
         """Exactly three consecutive failures must disable draft streaming."""
         from gateway.platforms.base import SendResult
@@ -755,22 +739,6 @@ class TestTryStripCursor:
         assert consumer._message_id == "msg_abc"
 
     @pytest.mark.asyncio
-    async def test_missing_delete_message_does_not_raise(self):
-        """When the adapter has no delete_message method, _try_strip_cursor
-        must return silently rather than raising AttributeError."""
-        from gateway.platforms.base import SendResult
-
-        consumer, adapter = self._make_consumer()
-        adapter.edit_message = AsyncMock(
-            return_value=SendResult(success=False, error="flood_control:260")
-        )
-        # Remove delete_message to simulate an adapter without the method.
-        del adapter.delete_message
-
-        # Must not raise.
-        await consumer._try_strip_cursor()
-
-    @pytest.mark.asyncio
     async def test_no_message_id_is_a_noop(self):
         """Nothing to strip if there is no live message yet."""
         consumer, adapter = self._make_consumer(message_id=None)
@@ -789,20 +757,121 @@ class TestTryStripCursor:
 
         adapter.delete_message.assert_not_awaited()
 
+
+class TestSendFallbackFinalEditInPlace:
+    """_send_fallback_final tries to edit the stale partial in-place first.
+
+    When the final text fits in one message and a stale partial exists, we
+    edit the existing message rather than sending a new one and deleting the
+    old one.  No deletion, no new message position in chat, no rate-limit cost
+    of an extra send.  If the edit fails we fall through to the original
+    send+delete path.
+    """
+
+    def _make_consumer(self, *, message_id="stale_msg"):
+        adapter = _make_draft_capable_adapter()
+        adapter.delete_message = AsyncMock(return_value=True)
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+        consumer._message_id = message_id
+        # Empty _last_sent_text → _visible_prefix() = "" → continuation = final_text
+        consumer._last_sent_text = ""
+        return consumer, adapter
+
     @pytest.mark.asyncio
-    async def test_non_flood_edit_failure_skips_delete(self):
-        """A non-flood edit failure (e.g. 'message not found') must NOT
-        trigger delete_message — _is_flood_error must reject it."""
+    async def test_edit_in_place_skips_send_and_delete(self):
+        """On a successful edit: no send, no delete, all completion flags set,
+        message_id and last_sent_text updated to reflect the final content."""
+        from gateway.platforms.base import SendResult
+
+        consumer, adapter = self._make_consumer()
+        adapter.edit_message = AsyncMock(return_value=SendResult(success=True))
+
+        await consumer._send_fallback_final("The complete reply")
+
+        adapter.send.assert_not_awaited()
+        adapter.delete_message.assert_not_awaited()
+        assert consumer._already_sent is True
+        assert consumer._final_response_sent is True
+        assert consumer._final_content_delivered is True
+        assert consumer._message_id == "stale_msg"
+        assert consumer._last_sent_text == "The complete reply"
+        assert consumer._fallback_prefix == ""
+
+    @pytest.mark.asyncio
+    async def test_failed_edit_falls_through_to_send_and_delete(self):
+        """When the in-place edit returns failure, send is called and the stale
+        partial is deleted (since the full text is re-sent from scratch)."""
         from gateway.platforms.base import SendResult
 
         consumer, adapter = self._make_consumer()
         adapter.edit_message = AsyncMock(
-            return_value=SendResult(success=False, error="message_not_found")
+            return_value=SendResult(success=False, error="flood_control:280")
         )
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="new_msg"))
 
-        await consumer._try_strip_cursor()
+        await consumer._send_fallback_final("The complete reply")
 
-        # 'message_not_found' contains neither 'flood', 'rate', nor 'retry after',
-        # so _is_flood_error must return False and delete must not be called.
-        adapter.delete_message.assert_not_awaited()
+        adapter.send.assert_awaited()
+        # Full resend path: stale partial deleted so user doesn't see duplicate.
+        adapter.delete_message.assert_awaited_once_with("12345", "stale_msg")
+        assert consumer._final_response_sent is True
+
+    @pytest.mark.asyncio
+    async def test_raised_edit_falls_through_to_send(self):
+        """An edit exception also falls through to the send path."""
+        from gateway.platforms.base import SendResult
+
+        consumer, adapter = self._make_consumer()
+        adapter.edit_message = AsyncMock(side_effect=RuntimeError("network error"))
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="new_msg"))
+
+        await consumer._send_fallback_final("The complete reply")
+
+        adapter.send.assert_awaited()
+        assert consumer._final_response_sent is True
+
+    @pytest.mark.asyncio
+    async def test_no_stale_message_id_goes_straight_to_send(self):
+        """Without a stale message there is nothing to edit — send fires directly."""
+        from gateway.platforms.base import SendResult
+
+        consumer, adapter = self._make_consumer(message_id=None)
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="fresh"))
+
+        await consumer._send_fallback_final("Reply")
+
+        adapter.send.assert_awaited()
+        adapter.edit_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_edit_sentinel_goes_straight_to_send(self):
+        """The __no_edit__ sentinel skips the edit attempt and uses the send path."""
+        from gateway.platforms.base import SendResult
+
+        consumer, adapter = self._make_consumer(message_id="__no_edit__")
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="fresh"))
+
+        await consumer._send_fallback_final("Reply")
+
+        adapter.send.assert_awaited()
+        adapter.edit_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_preserve_partial_skips_edit(self):
+        """When _fallback_preserve_partial_messages is True the edit is skipped;
+        a new message is appended instead (multi-chunk / tool-boundary case)."""
+        from gateway.platforms.base import SendResult
+
+        consumer, adapter = self._make_consumer()
+        consumer._fallback_preserve_partial_messages = True
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="new"))
+
+        await consumer._send_fallback_final("Reply")
+
+        adapter.send.assert_awaited()
+        adapter.edit_message.assert_not_awaited()
 

--- a/tests/gateway/test_stream_consumer_draft.py
+++ b/tests/gateway/test_stream_consumer_draft.py
@@ -182,31 +182,96 @@ class TestDraftStreamingHappyPath:
 
 
 class TestDraftFallbackOnFailure:
-    """When a draft frame fails, the consumer disables drafts for the rest
-    of the response and continues via the edit-based path."""
+    """Draft-frame failure resilience: the consumer tolerates up to
+    _MAX_DRAFT_FAILURES consecutive failures before disabling draft streaming,
+    and resets the counter on success.
 
-    @pytest.mark.asyncio
-    async def test_first_draft_failure_disables_drafts_for_run(self):
-        adapter = _make_draft_capable_adapter(draft_succeeds=False)
+    These tests call _send_draft_frame directly to get deterministic results
+    without relying on run-loop timing.
+    """
+
+    def _make_consumer_for_direct_call(self):
+        """Set up a draft-capable consumer with _draft_id pre-seeded so
+        _send_draft_frame can be exercised without running the full loop."""
+        adapter = _make_draft_capable_adapter()
         cfg = StreamConsumerConfig(
             transport="auto", chat_type="dm",
             edit_interval=0.01, buffer_threshold=5, cursor="",
         )
         consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+        consumer._use_draft_streaming = True
+        consumer._draft_id = 1
+        return consumer, adapter
 
-        consumer.on_delta("Hello ")
-        task = asyncio.create_task(consumer.run())
-        await asyncio.sleep(0.05)
-        consumer.on_delta("world!")
-        await asyncio.sleep(0.05)
-        consumer.finish()
-        await task
+    @pytest.mark.asyncio
+    async def test_single_failure_does_not_disable_drafts(self):
+        """One bad frame must NOT kill draft streaming for the whole session."""
+        from gateway.platforms.base import SendResult
 
-        # The consumer attempted draft, hit failure, disabled drafts.
-        assert consumer._draft_failures >= 1
+        consumer, adapter = self._make_consumer_for_direct_call()
+        adapter.send_draft = AsyncMock(
+            return_value=SendResult(success=False, error="transient")
+        )
+
+        await consumer._send_draft_frame("frame1")
+
+        assert consumer._draft_failures == 1
+        assert consumer._draft_failures < consumer._MAX_DRAFT_FAILURES
+        assert consumer._use_draft_streaming is True
+
+    @pytest.mark.asyncio
+    async def test_three_consecutive_failures_disable_drafts(self):
+        """Three consecutive failures must disable draft streaming."""
+        from gateway.platforms.base import SendResult
+
+        consumer, adapter = self._make_consumer_for_direct_call()
+        adapter.send_draft = AsyncMock(
+            return_value=SendResult(success=False, error="hard_error")
+        )
+
+        for i in range(3):
+            await consumer._send_draft_frame(f"frame{i}")
+
+        assert consumer._draft_failures >= consumer._MAX_DRAFT_FAILURES
         assert consumer._use_draft_streaming is False
-        # Final message delivered via the regular send path.
-        adapter.send.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_success_resets_failure_streak(self):
+        """A successful frame after failures resets _draft_failures to 0."""
+        from gateway.platforms.base import SendResult
+
+        consumer, adapter = self._make_consumer_for_direct_call()
+
+        fail_result = SendResult(success=False, error="transient")
+        ok_result = SendResult(success=True, message_id=None)
+
+        adapter.send_draft = AsyncMock(side_effect=[fail_result, fail_result, ok_result])
+
+        await consumer._send_draft_frame("frame1")
+        await consumer._send_draft_frame("frame2")
+        assert consumer._draft_failures == 2
+
+        await consumer._send_draft_frame("frame3")
+
+        assert consumer._draft_failures == 0
+        assert consumer._use_draft_streaming is True
+
+    @pytest.mark.asyncio
+    async def test_retryable_failure_not_counted(self):
+        """A retryable=True result (long flood-control) must not increment
+        _draft_failures so it never counts toward the disable threshold."""
+        from gateway.platforms.base import SendResult
+
+        consumer, adapter = self._make_consumer_for_direct_call()
+        adapter.send_draft = AsyncMock(
+            return_value=SendResult(success=False, error="flood_control:260", retryable=True)
+        )
+
+        for _ in range(10):
+            await consumer._send_draft_frame("frame")
+
+        assert consumer._draft_failures == 0
+        assert consumer._use_draft_streaming is True
 
 
 class TestDraftIdLifecycle:
@@ -507,3 +572,92 @@ class TestRichAwareOverflow:
         assert consumer._message_id == "final1"
         assert consumer._preview_message_ids == set()
         assert consumer.final_response_sent is True
+
+
+class TestTryStripCursor:
+    """_try_strip_cursor removes the ▉ cursor after stream termination.
+
+    When the edit to strip the cursor is flood-controlled (a RetryAfter error
+    coming back via result.error), the consumer falls back to delete_message
+    so the stuck cursor at least disappears before the full response arrives.
+    """
+
+    def _make_consumer(self, *, message_id="msg_abc"):
+        """Return a consumer whose _message_id and _last_sent_text are already
+        set to simulate a partially-streamed message that needs cursor removal."""
+        adapter = _make_draft_capable_adapter()
+        adapter.delete_message = AsyncMock(return_value=True)
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+        consumer._message_id = message_id
+        consumer._last_sent_text = "Partial reply so far"
+        return consumer, adapter
+
+    @pytest.mark.asyncio
+    async def test_successful_edit_skips_delete(self):
+        """When the cursor-strip edit succeeds, delete_message must NOT be called."""
+        from gateway.platforms.base import SendResult
+
+        consumer, adapter = self._make_consumer()
+        adapter.edit_message = AsyncMock(return_value=SendResult(success=True))
+
+        await consumer._try_strip_cursor()
+
+        adapter.delete_message.assert_not_awaited()
+        assert consumer._last_sent_text == "Partial reply so far"
+
+    @pytest.mark.asyncio
+    async def test_flood_controlled_edit_triggers_delete(self):
+        """A flood-control result on the cursor-strip edit must cause a
+        delete_message call so the stuck cursor disappears."""
+        from gateway.platforms.base import SendResult
+
+        consumer, adapter = self._make_consumer()
+        adapter.edit_message = AsyncMock(
+            return_value=SendResult(success=False, error="flood_control:280")
+        )
+
+        await consumer._try_strip_cursor()
+
+        adapter.delete_message.assert_awaited_once_with("12345", "msg_abc")
+        assert consumer._message_id is None
+
+    @pytest.mark.asyncio
+    async def test_raised_edit_exception_triggers_delete(self):
+        """If _edit_message raises rather than returning a flood result, the
+        fallback treats the exception as flood-controlled and calls delete_message."""
+        consumer, adapter = self._make_consumer()
+        adapter.edit_message = AsyncMock(side_effect=RuntimeError("rate limit"))
+
+        await consumer._try_strip_cursor()
+
+        adapter.delete_message.assert_awaited_once_with("12345", "msg_abc")
+        assert consumer._message_id is None
+
+    @pytest.mark.asyncio
+    async def test_missing_delete_message_does_not_raise(self):
+        """When the adapter has no delete_message method, _try_strip_cursor
+        must return silently rather than raising AttributeError."""
+        from gateway.platforms.base import SendResult
+
+        consumer, adapter = self._make_consumer()
+        adapter.edit_message = AsyncMock(
+            return_value=SendResult(success=False, error="flood_control:260")
+        )
+        # Remove delete_message to simulate an adapter without the method.
+        del adapter.delete_message
+
+        # Must not raise.
+        await consumer._try_strip_cursor()
+
+    @pytest.mark.asyncio
+    async def test_no_message_id_is_a_noop(self):
+        """Nothing to strip if there is no live message yet."""
+        consumer, adapter = self._make_consumer(message_id=None)
+
+        await consumer._try_strip_cursor()
+
+        adapter.delete_message.assert_not_awaited()

--- a/tests/gateway/test_stream_consumer_draft.py
+++ b/tests/gateway/test_stream_consumer_draft.py
@@ -324,6 +324,72 @@ class TestDraftFallbackOnFailure:
         assert consumer.final_response_sent is True
 
 
+class TestDraftSuppressionPreventsEditCascade:
+    """When sendMessageDraft is suppressed (success=True, message_id=None) the
+    consumer must stay in draft mode for the entire response and never fall
+    back to editMessageText — which is the cascade that exhausts the quota.
+
+    This mirrors what PR #51886 does for guest chats: returning success=True
+    keeps the consumer believing drafts are working, so it never switches paths.
+    The final message arrives via adapter.send() at finalize — one call, no edits.
+    """
+
+    @pytest.mark.asyncio
+    async def test_suppressed_drafts_never_call_edit_message(self):
+        """When every draft frame is suppressed (success=True, no message_id),
+        the consumer must not call edit_message at any point mid-stream."""
+        from gateway.platforms.base import SendResult
+
+        adapter = _make_draft_capable_adapter()
+        # Simulate the adapter suppressing every frame (typing expired, etc.)
+        adapter.send_draft = AsyncMock(
+            return_value=SendResult(success=True, message_id=None)
+        )
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+
+        task = asyncio.create_task(consumer.run())
+        for i in range(5):
+            consumer.on_delta(f"token{i} ")
+            await asyncio.sleep(0.03)
+        consumer.finish()
+        await task
+
+        # Consumer stayed in draft mode throughout — no edit calls.
+        adapter.edit_message.assert_not_called()
+        # _message_id was never set mid-stream (would only exist if edits fired).
+        # Final response still delivered via send().
+        adapter.send.assert_awaited()
+        assert consumer.final_response_sent is True
+
+    @pytest.mark.asyncio
+    async def test_suppressed_drafts_do_not_accumulate_failures(self):
+        """Suppressed frames (success=True) must not increment _draft_failures,
+        so draft streaming is never permanently disabled by suppressed frames."""
+        from gateway.platforms.base import SendResult
+
+        adapter = _make_draft_capable_adapter()
+        adapter.send_draft = AsyncMock(
+            return_value=SendResult(success=True, message_id=None)
+        )
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+        consumer._use_draft_streaming = True
+        consumer._draft_id = 1
+
+        for _ in range(20):
+            await consumer._send_draft_frame("frame")
+
+        assert consumer._draft_failures == 0
+        assert consumer._use_draft_streaming is True
+
+
 class TestDraftIdLifecycle:
     """Each response gets its own draft_id (no animation collision across
     consecutive responses to the same chat)."""
@@ -660,9 +726,10 @@ class TestTryStripCursor:
         assert consumer._last_sent_text == "Partial reply so far"
 
     @pytest.mark.asyncio
-    async def test_flood_controlled_edit_triggers_delete(self):
-        """A flood-control result on the cursor-strip edit must cause a
-        delete_message call so the stuck cursor disappears."""
+    async def test_flood_controlled_edit_leaves_message_intact(self):
+        """A flood-control result on the cursor-strip edit must NOT delete the
+        message — a partial with a stuck cursor is better UX than a blank screen
+        for the duration of the flood-control wait."""
         from gateway.platforms.base import SendResult
 
         consumer, adapter = self._make_consumer()
@@ -672,20 +739,20 @@ class TestTryStripCursor:
 
         await consumer._try_strip_cursor()
 
-        adapter.delete_message.assert_awaited_once_with("12345", "msg_abc")
-        assert consumer._message_id is None
+        adapter.delete_message.assert_not_awaited()
+        # message_id preserved — the partial message is still visible.
+        assert consumer._message_id == "msg_abc"
 
     @pytest.mark.asyncio
-    async def test_raised_edit_exception_triggers_delete(self):
-        """If _edit_message raises rather than returning a flood result, the
-        fallback treats the exception as flood-controlled and calls delete_message."""
+    async def test_raised_edit_exception_leaves_message_intact(self):
+        """If _edit_message raises, the message must be left as-is — no delete."""
         consumer, adapter = self._make_consumer()
         adapter.edit_message = AsyncMock(side_effect=RuntimeError("rate limit"))
 
         await consumer._try_strip_cursor()
 
-        adapter.delete_message.assert_awaited_once_with("12345", "msg_abc")
-        assert consumer._message_id is None
+        adapter.delete_message.assert_not_awaited()
+        assert consumer._message_id == "msg_abc"
 
     @pytest.mark.asyncio
     async def test_missing_delete_message_does_not_raise(self):
@@ -739,17 +806,3 @@ class TestTryStripCursor:
         # so _is_flood_error must return False and delete must not be called.
         adapter.delete_message.assert_not_awaited()
 
-    @pytest.mark.asyncio
-    async def test_delete_message_raises_is_swallowed(self):
-        """If delete_message itself raises (network error, permissions), the
-        exception must be silently swallowed — _try_strip_cursor is best-effort."""
-        from gateway.platforms.base import SendResult
-
-        consumer, adapter = self._make_consumer()
-        adapter.edit_message = AsyncMock(
-            return_value=SendResult(success=False, error="flood_control:260")
-        )
-        adapter.delete_message = AsyncMock(side_effect=RuntimeError("network error"))
-
-        # Must not raise even though delete_message throws.
-        await consumer._try_strip_cursor()

--- a/tests/gateway/test_telegram_send_draft_flood_control.py
+++ b/tests/gateway/test_telegram_send_draft_flood_control.py
@@ -11,6 +11,7 @@ Bot API call.  We distinguish two cases:
 
 These tests cover those paths without spinning up a real PTB bot.
 """
+import asyncio
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -26,7 +27,6 @@ def _ensure_telegram_mock():
     mod.error.NetworkError = type("NetworkError", (OSError,), {})
     mod.error.TimedOut = type("TimedOut", (OSError,), {})
     mod.error.BadRequest = type("BadRequest", (Exception,), {})
-    mod.error.RetryAfter = type("RetryAfter", (Exception,), {"retry_after": 0})
     for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
         sys.modules.setdefault(name, mod)
     sys.modules.setdefault("telegram.error", mod.error)
@@ -69,15 +69,14 @@ async def test_short_flood_control_sleeps_and_retries_successfully():
 
     adapter._bot.send_message_draft = AsyncMock(side_effect=_draft)
 
-    with patch("plugins.platforms.telegram.adapter.asyncio") as mock_asyncio:
-        mock_asyncio.sleep = AsyncMock()
+    with patch("plugins.platforms.telegram.adapter.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
         result = await adapter.send_draft("123", 5, "hello")
 
     assert result.success is True
     assert not getattr(result, "retryable", False)
     # One initial attempt + one retry after the sleep.
     assert len(calls) == 2
-    mock_asyncio.sleep.assert_awaited_once_with(2.0)
+    mock_sleep.assert_awaited_once_with(2.0)
 
 
 @pytest.mark.asyncio
@@ -92,13 +91,12 @@ async def test_short_flood_control_retry_failure_returns_non_retryable():
 
     adapter._bot.send_message_draft = AsyncMock(side_effect=_always_fails)
 
-    with patch("plugins.platforms.telegram.adapter.asyncio") as mock_asyncio:
-        mock_asyncio.sleep = AsyncMock()
+    with patch("plugins.platforms.telegram.adapter.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
         result = await adapter.send_draft("123", 5, "hello")
 
     assert result.success is False
     assert not getattr(result, "retryable", False)
-    mock_asyncio.sleep.assert_awaited_once_with(3.0)
+    mock_sleep.assert_awaited_once_with(3.0)
 
 
 @pytest.mark.asyncio
@@ -113,14 +111,13 @@ async def test_long_flood_control_returns_retryable_without_sleeping():
 
     adapter._bot.send_message_draft = AsyncMock(side_effect=_long_flood)
 
-    with patch("plugins.platforms.telegram.adapter.asyncio") as mock_asyncio:
-        mock_asyncio.sleep = AsyncMock()
+    with patch("plugins.platforms.telegram.adapter.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
         result = await adapter.send_draft("123", 5, "hello")
 
     assert result.success is False
     assert getattr(result, "retryable", False) is True
     assert "flood_control" in (getattr(result, "error", "") or "")
-    mock_asyncio.sleep.assert_not_awaited()
+    mock_sleep.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -140,10 +137,30 @@ async def test_boundary_five_seconds_treated_as_short():
 
     adapter._bot.send_message_draft = AsyncMock(side_effect=_draft)
 
-    with patch("plugins.platforms.telegram.adapter.asyncio") as mock_asyncio:
-        mock_asyncio.sleep = AsyncMock()
+    with patch("plugins.platforms.telegram.adapter.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
         result = await adapter.send_draft("123", 5, "boundary")
 
     assert result.success is True
     assert not getattr(result, "retryable", False)
-    mock_asyncio.sleep.assert_awaited_once_with(5.0)
+    mock_sleep.assert_awaited_once_with(5.0)
+
+
+@pytest.mark.asyncio
+async def test_boundary_just_above_five_seconds_treated_as_long():
+    """retry_after just above 5.0 (e.g. 5.01 s) must take the long-wait
+    path — retryable=True, no sleep — confirming the threshold is exclusive."""
+    adapter = _make_adapter()
+    adapter.format_message = lambda c: c
+
+    async def _just_over(**kwargs):
+        raise _make_retry_after_error(5.01)
+
+    adapter._bot.send_message_draft = AsyncMock(side_effect=_just_over)
+
+    with patch("plugins.platforms.telegram.adapter.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        result = await adapter.send_draft("123", 5, "just-over")
+
+    assert result.success is False
+    assert getattr(result, "retryable", False) is True
+    assert "flood_control" in (getattr(result, "error", "") or "")
+    mock_sleep.assert_not_awaited()

--- a/tests/gateway/test_telegram_send_draft_flood_control.py
+++ b/tests/gateway/test_telegram_send_draft_flood_control.py
@@ -80,9 +80,9 @@ async def test_short_flood_control_sleeps_and_retries_successfully():
 
 
 @pytest.mark.asyncio
-async def test_short_flood_control_retry_failure_returns_non_retryable():
-    """If the post-sleep retry also fails, return a non-retryable failure
-    so the consumer counts it against _draft_failures."""
+async def test_short_flood_control_retry_failure_is_suppressed():
+    """If the post-sleep retry also fails, suppress the frame with success=True
+    so the consumer stays in draft mode and never cascades to editMessageText."""
     adapter = _make_adapter()
     adapter.format_message = lambda c: c
 
@@ -94,8 +94,8 @@ async def test_short_flood_control_retry_failure_returns_non_retryable():
     with patch("plugins.platforms.telegram.adapter.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
         result = await adapter.send_draft("123", 5, "hello")
 
-    assert result.success is False
-    assert not getattr(result, "retryable", False)
+    assert result.success is True
+    assert result.message_id is None
     mock_sleep.assert_awaited_once_with(3.0)
 
 

--- a/tests/gateway/test_telegram_send_draft_flood_control.py
+++ b/tests/gateway/test_telegram_send_draft_flood_control.py
@@ -1,0 +1,149 @@
+"""TelegramAdapter.send_draft flood-control handling.
+
+sendMessageDraft can return Telegram's RetryAfter error just like any other
+Bot API call.  We distinguish two cases:
+
+  * Short wait (≤5 s): sleep inline and immediately retry the same frame so
+    this transient hiccup is invisible to the caller.
+  * Long wait (>5 s): return immediately with retryable=True so the
+    GatewayStreamConsumer does NOT count the frame against _draft_failures and
+    does NOT disable draft streaming for the rest of the response.
+
+These tests cover those paths without spinning up a real PTB bot.
+"""
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    mod.error.RetryAfter = type("RetryAfter", (Exception,), {"retry_after": 0})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+import plugins.platforms.telegram.adapter as tg_mod  # noqa: E402
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+def _make_retry_after_error(seconds: float):
+    """Return an exception with a retry_after attribute, like PTB's RetryAfter."""
+    exc = Exception(f"flood control — retry after {seconds}")
+    exc.retry_after = seconds
+    return exc
+
+
+def _make_adapter() -> TelegramAdapter:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._bot = MagicMock()
+    adapter._bot.send_message_draft = AsyncMock(return_value=True)
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_short_flood_control_sleeps_and_retries_successfully():
+    """A RetryAfter ≤5 s must sleep that duration, retry the frame, and
+    return success — the caller sees no failure at all."""
+    adapter = _make_adapter()
+    adapter.format_message = lambda c: c
+
+    calls = []
+
+    async def _draft(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise _make_retry_after_error(2.0)
+        return True  # retry succeeds
+
+    adapter._bot.send_message_draft = AsyncMock(side_effect=_draft)
+
+    with patch("plugins.platforms.telegram.adapter.asyncio") as mock_asyncio:
+        mock_asyncio.sleep = AsyncMock()
+        result = await adapter.send_draft("123", 5, "hello")
+
+    assert result.success is True
+    assert not getattr(result, "retryable", False)
+    # One initial attempt + one retry after the sleep.
+    assert len(calls) == 2
+    mock_asyncio.sleep.assert_awaited_once_with(2.0)
+
+
+@pytest.mark.asyncio
+async def test_short_flood_control_retry_failure_returns_non_retryable():
+    """If the post-sleep retry also fails, return a non-retryable failure
+    so the consumer counts it against _draft_failures."""
+    adapter = _make_adapter()
+    adapter.format_message = lambda c: c
+
+    async def _always_fails(**kwargs):
+        raise _make_retry_after_error(3.0)
+
+    adapter._bot.send_message_draft = AsyncMock(side_effect=_always_fails)
+
+    with patch("plugins.platforms.telegram.adapter.asyncio") as mock_asyncio:
+        mock_asyncio.sleep = AsyncMock()
+        result = await adapter.send_draft("123", 5, "hello")
+
+    assert result.success is False
+    assert not getattr(result, "retryable", False)
+    mock_asyncio.sleep.assert_awaited_once_with(3.0)
+
+
+@pytest.mark.asyncio
+async def test_long_flood_control_returns_retryable_without_sleeping():
+    """A RetryAfter >5 s must return immediately with retryable=True and
+    must NOT sleep (sleeping 280 s inline would block the event loop)."""
+    adapter = _make_adapter()
+    adapter.format_message = lambda c: c
+
+    async def _long_flood(**kwargs):
+        raise _make_retry_after_error(280.0)
+
+    adapter._bot.send_message_draft = AsyncMock(side_effect=_long_flood)
+
+    with patch("plugins.platforms.telegram.adapter.asyncio") as mock_asyncio:
+        mock_asyncio.sleep = AsyncMock()
+        result = await adapter.send_draft("123", 5, "hello")
+
+    assert result.success is False
+    assert getattr(result, "retryable", False) is True
+    assert "flood_control" in (getattr(result, "error", "") or "")
+    mock_asyncio.sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_boundary_five_seconds_treated_as_short():
+    """retry_after == 5.0 is on the short side of the threshold (≤5 s)
+    and must trigger the sleep+retry path, not the retryable path."""
+    adapter = _make_adapter()
+    adapter.format_message = lambda c: c
+
+    calls = []
+
+    async def _draft(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise _make_retry_after_error(5.0)
+        return True
+
+    adapter._bot.send_message_draft = AsyncMock(side_effect=_draft)
+
+    with patch("plugins.platforms.telegram.adapter.asyncio") as mock_asyncio:
+        mock_asyncio.sleep = AsyncMock()
+        result = await adapter.send_draft("123", 5, "boundary")
+
+    assert result.success is True
+    assert not getattr(result, "retryable", False)
+    mock_asyncio.sleep.assert_awaited_once_with(5.0)

--- a/tests/gateway/test_telegram_send_draft_format.py
+++ b/tests/gateway/test_telegram_send_draft_format.py
@@ -12,6 +12,9 @@ These tests pin:
   2. A MarkdownV2 BadRequest triggers a single plain-text retry rather than
      killing draft streaming for the whole response.
   3. A non-BadRequest failure propagates so the caller falls back to edit.
+  4. A RetryAfter on sendRichMessageDraft returns a retryable SendResult so
+     send_draft does NOT fall through to legacy sendMessageDraft and burn
+     another call in the same rate-limit bucket (issue #54275).
 """
 import sys
 from unittest.mock import AsyncMock, MagicMock
@@ -114,3 +117,85 @@ async def test_send_draft_non_badrequest_is_suppressed():
     assert result.success is True
     assert result.message_id is None
     assert len(calls) == 1  # no plain-text retry on non-BadRequest
+
+
+def _make_rich_draft_adapter() -> TelegramAdapter:
+    """Adapter with rich draft path enabled and do_api_request wired."""
+    adapter = _make_adapter()
+    adapter.format_message = lambda c: f"FMT::{c}"
+    adapter._rich_messages_enabled = True
+    adapter._rich_drafts_enabled = True
+    adapter._rich_send_disabled = False
+    adapter._rich_draft_disabled = False
+    adapter._bot.do_api_request = AsyncMock(return_value=True)
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_rich_draft_retry_after_returns_retryable_not_legacy_fallback():
+    """When sendRichMessageDraft raises a flood-control (RetryAfter) exception,
+    send_draft must return a retryable SendResult immediately — it must NOT fall
+    through to legacy sendMessageDraft and burn another API call in the same
+    rate-limit bucket.
+
+    Regression for: https://github.com/NousResearch/hermes-agent/issues/54275
+    """
+    adapter = _make_rich_draft_adapter()
+
+    flood_exc = Exception("Too Many Requests: retry after 280")
+    flood_exc.retry_after = 280  # type: ignore[attr-defined]
+
+    async def _rich_api(method, **kwargs):
+        if method == "sendRichMessageDraft":
+            raise flood_exc
+        return True
+
+    adapter._bot.do_api_request = AsyncMock(side_effect=_rich_api)
+    legacy_calls = []
+
+    async def _legacy(**kwargs):
+        legacy_calls.append(kwargs)
+        return True
+
+    adapter._bot.send_message_draft = AsyncMock(side_effect=_legacy)
+
+    result = await adapter.send_draft("123", 42, "streaming text")
+
+    # Must return retryable failure — not fall through to legacy.
+    assert result.success is False
+    assert result.retryable is True
+    assert getattr(result, "retry_after", None) == 280.0
+    # Legacy sendMessageDraft must NOT have been called.
+    assert len(legacy_calls) == 0, (
+        "RetryAfter on rich draft must not burn a legacy sendMessageDraft call"
+    )
+
+
+@pytest.mark.asyncio
+async def test_rich_draft_capability_error_falls_back_to_legacy():
+    """When sendRichMessageDraft raises a capability error (not RetryAfter),
+    send_draft falls through to legacy sendMessageDraft — this is correct and
+    must not regress."""
+    adapter = _make_rich_draft_adapter()
+
+    cap_exc = Exception("Bad Request: method not found")
+
+    async def _rich_api(method, **kwargs):
+        if method == "sendRichMessageDraft":
+            raise cap_exc
+        return True
+
+    legacy_calls = []
+
+    async def _legacy(**kwargs):
+        legacy_calls.append(kwargs)
+        return True
+
+    adapter._bot.do_api_request = AsyncMock(side_effect=_rich_api)
+    adapter._bot.send_message_draft = AsyncMock(side_effect=_legacy)
+
+    result = await adapter.send_draft("123", 42, "text")
+
+    # Capability failure → success via legacy fallback.
+    assert result.success is True
+    assert len(legacy_calls) >= 1

--- a/tests/gateway/test_telegram_send_draft_format.py
+++ b/tests/gateway/test_telegram_send_draft_format.py
@@ -94,9 +94,10 @@ async def test_send_draft_falls_back_to_plain_text_on_markdownv2_error():
 
 
 @pytest.mark.asyncio
-async def test_send_draft_non_badrequest_propagates_without_retry():
-    """A non-BadRequest failure (e.g. drafts not allowed) returns failure
-    immediately so the caller falls back to the edit transport."""
+async def test_send_draft_non_badrequest_is_suppressed():
+    """A non-BadRequest failure (e.g. expired typing action, unsupported chat)
+    is suppressed with success=True so the caller stays in draft mode and never
+    cascades to rapid editMessageText calls that exhaust the rate-limit quota."""
     adapter = _make_adapter()
     adapter.format_message = lambda c: f"FMT::{c}"
 
@@ -110,5 +111,6 @@ async def test_send_draft_non_badrequest_propagates_without_retry():
 
     result = await adapter.send_draft("123", 11, "hi")
 
-    assert result.success is False
+    assert result.success is True
+    assert result.message_id is None
     assert len(calls) == 1  # no plain-text retry on non-BadRequest


### PR DESCRIPTION
> **Stacked on #53865.** This branch is based on `fix/telegram-draft-flood-cascade`; once that PR merges the diff will reduce to the single commit shown.

Fixes two edge cases from szafranski's review of #53865 (issue #54275).

## Edge case 1 — retryable draft flood falls through to edit/send

When `send_draft()` returns `success=False, retryable=True` (RetryAfter > 5 s), `_send_draft_frame` previously returned `False`, causing `_send_or_edit` to fall through to the regular edit-message path — re-creating the edit cascade that draft streaming is meant to prevent.

**Fix**: return `True` (skip frame silently, stay in draft mode). The frame is simply not rendered; the next tick will try again.

## Edge case 2 — `sendRichMessageDraft` RetryAfter burns a legacy `sendMessageDraft` call

`_try_send_rich_draft` returned `bool`, so a flood-control exception mapped to `False` and `send_draft` immediately fell through to `sendMessageDraft` in the same rate-limit bucket — wasting the call.

**Fix**: change return type to `Optional[SendResult]`:
- `SendResult(success=True)` — frame landed
- `SendResult(success=False, retryable=True, retry_after=N)` — flood control; caller returns immediately, no legacy call
- `None` — capability/transient error; caller falls through to legacy (correct)

## Test plan

- [x] `test_stream_consumer_draft.py` — `test_retryable_failure_does_not_cascade_to_edit_send`: verifies `_send_draft_frame` returns `True` and never calls `adapter.send`/`adapter.edit_message`
- [x] `test_telegram_send_draft_format.py` — `test_rich_draft_retry_after_returns_retryable_not_legacy_fallback`: verifies flood control on rich draft returns retryable without calling `send_message_draft`; `test_rich_draft_capability_error_falls_back_to_legacy`: verifies capability errors still fall through correctly
- [x] All 41 draft-related tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)