### PR TITLE
fix(discord): allow category-scoped channel policies

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1148,18 +1148,18 @@ class DiscordAdapter(BasePlatformAdapter):
                     # _is_allowed_user docstring).
                     _msg_guild = getattr(message, "guild", None)
                     _is_dm = isinstance(message.channel, discord.DMChannel) or _msg_guild is None
-                    _msg_channel_ids = None
+                    _msg_channel_keys = None
                     if not _is_dm:
-                        _msg_channel_ids = {str(message.channel.id)}
-                        _parent_id = adapter_self._get_parent_channel_id(message.channel)
-                        if _parent_id:
-                            _msg_channel_ids.add(_parent_id)
+                        # Use the same resolver as _handle_message and slash
+                        # authorization so ID/name/#name/parent/category policy
+                        # forms all reach this earlier fail-closed admission gate.
+                        _msg_channel_keys = adapter_self._discord_channel_keys(message)
                     if not self._is_allowed_user(
                         str(message.author.id),
                         message.author,
                         guild=_msg_guild,
                         is_dm=_is_dm,
-                        channel_ids=_msg_channel_ids,
+                        channel_ids=_msg_channel_keys,
                     ):
                         self._warn_if_fail_closed_default()
                         return
@@ -1194,12 +1194,8 @@ class DiscordAdapter(BasePlatformAdapter):
                         "DISCORD_IGNORE_NO_MENTION", "true"
                     ).lower() in {"true", "1", "yes"}
                     if _ignore_no_mention and not _self_mentioned and not _other_bots_mentioned:
-                        _channel_id = str(message.channel.id)
-                        _parent_id = None
-                        if hasattr(message.channel, "parent_id") and message.channel.parent_id:
-                            _parent_id = str(message.channel.parent_id)
                         _free_channels = adapter_self._discord_free_response_channels()
-                        _channel_keys = adapter_self._discord_channel_keys(message, _parent_id)
+                        _channel_keys = adapter_self._discord_channel_keys(message)
                         if "*" not in _free_channels and not (_channel_keys & _free_channels):
                             return
 
@@ -4904,9 +4900,9 @@ class DiscordAdapter(BasePlatformAdapter):
         """Return channel identifiers accepted by Discord channel config gates.
 
         Users commonly configure channels by Discord snowflake ID, bare name, or
-        ``#name``. Include the current channel and, for threads, the parent
-        channel so free-response/no-thread/allow/ignore rules work with either
-        form.
+        ``#name``. Include the current channel, a thread's parent channel, and
+        the containing category ID so free-response/no-thread/allow/ignore rules
+        retain their existing forms while also supporting category scope.
         """
         channel = getattr(message, "channel", None)
         return self._discord_channel_keys_from_channel(channel, parent_channel_id)
@@ -4917,9 +4913,9 @@ class DiscordAdapter(BasePlatformAdapter):
         """Build channel-config gate keys directly from a channel object.
 
         Same key set as :meth:`_discord_channel_keys` (ID, bare name, ``#name``,
-        and the parent channel for threads) but takes the channel directly so
-        callers holding an ``interaction.channel`` (slash-command authorization)
-        get name-form matching too — not just the ``on_message`` path.
+        thread parent, and category ID) but takes the channel directly so callers
+        holding an ``interaction.channel`` (slash-command authorization) use the
+        exact same policy contract as normal messages.
         """
         keys: set[str] = set()
 
@@ -4941,6 +4937,22 @@ class DiscordAdapter(BasePlatformAdapter):
         if parent_name:
             keys.add(parent_name)
             keys.add(f"#{parent_name}")
+
+        # Text channels expose their category as ``category_id``. Threads expose
+        # their immediate parent channel instead, so resolve the category through
+        # that parent as well. Keep this in the shared key resolver so every
+        # message/slash/mention policy path gets identical category behavior.
+        # ``discord.Thread.category_id`` is a computed property and raises
+        # ``ClientException`` when its parent is absent from the guild cache.
+        # Policy resolution must retain the thread/parent keys rather than
+        # crashing the message or slash authorization path in that state.
+        for scope_channel in (channel, parent_channel):
+            try:
+                category_id = getattr(scope_channel, "category_id", None)
+            except discord.ClientException:
+                category_id = None
+            if category_id is not None:
+                keys.add(str(category_id))
 
         return keys
 
@@ -6170,9 +6182,6 @@ class DiscordAdapter(BasePlatformAdapter):
                 normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
             message.content = normalized_content
         if not isinstance(message.channel, discord.DMChannel):
-            channel_ids = {str(message.channel.id)}
-            if parent_channel_id:
-                channel_ids.add(parent_channel_id)
             channel_keys = self._discord_channel_keys(message, parent_channel_id)
 
             # Check allowed channels - if set, only respond in these channels

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -140,6 +140,120 @@ class SlowSyncBot(FakeBot):
         self.tree = SlowSyncTree()
 
 
+async def _connect_category_policy_adapter(monkeypatch):
+    """Connect through the real event registration path with a fake client."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._handle_message = AsyncMock()
+    adapter._is_pairing_approved_user = MagicMock(return_value=False)
+
+    for name in (
+        "DISCORD_ALLOWED_USERS",
+        "DISCORD_ALLOWED_ROLES",
+        "DISCORD_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "5555")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "5555")
+    monkeypatch.setenv("DISCORD_IGNORE_NO_MENTION", "true")
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock", lambda scope, identity: None,
+    )
+    intents = SimpleNamespace(
+        message_content=False,
+        dm_messages=False,
+        guild_messages=False,
+        members=False,
+        voice_states=False,
+    )
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+    monkeypatch.setattr(
+        discord_platform.commands,
+        "Bot",
+        lambda **kwargs: FakeBot(
+            intents=kwargs["intents"],
+            proxy=kwargs.get("proxy"),
+            allowed_mentions=kwargs.get("allowed_mentions"),
+        ),
+    )
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+
+    assert await adapter.connect() is True
+    return adapter
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("in_thread", [False, True], ids=["channel", "thread-under-category"])
+async def test_on_message_category_scope_passes_early_auth_and_no_mention_gate(
+    monkeypatch, in_thread,
+):
+    """Category policy must survive both admission gates before _handle_message."""
+    adapter = await _connect_category_policy_adapter(monkeypatch)
+    guild = SimpleNamespace(
+        id=42,
+        name="Hermes Server",
+        get_member=lambda _uid: None,
+    )
+    category = SimpleNamespace(id=5555, name="operations")
+    parent = SimpleNamespace(
+        id=7777,
+        name="general",
+        category_id=category.id,
+        parent=category,
+        guild=guild,
+    )
+
+    if in_thread:
+        class PolicyThread:
+            pass
+
+        monkeypatch.setattr(discord_platform.discord, "Thread", PolicyThread)
+        channel = PolicyThread()
+        channel.id = 9999
+        channel.name = "incident"
+        channel.parent_id = parent.id
+        channel.parent = parent
+        channel.guild = guild
+    else:
+        channel = SimpleNamespace(
+            id=8888,
+            name="alerts",
+            category_id=category.id,
+            parent=category,
+            guild=guild,
+        )
+
+    author = SimpleNamespace(
+        id=42,
+        name="Jezza",
+        display_name="Jezza",
+        bot=False,
+        guild=guild,
+    )
+    mentioned_human = SimpleNamespace(id=43, bot=False)
+    message = SimpleNamespace(
+        id=123 if not in_thread else 124,
+        author=author,
+        channel=channel,
+        guild=guild,
+        type=discord_platform.discord.MessageType.default,
+        mentions=[mentioned_human],
+        content="please review this",
+    )
+
+    await adapter._client._events["on_message"](message)
+
+    adapter._handle_message.assert_awaited_once_with(
+        message, role_authorized=False,
+    )
+    await adapter.disconnect()
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("allowed_users", "expected_members_intent"),

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -58,10 +58,17 @@ class FakeDMChannel:
 
 
 class FakeTextChannel:
-    def __init__(self, channel_id: int = 1, name: str = "general", guild_name: str = "Hermes Server"):
+    def __init__(
+        self,
+        channel_id: int = 1,
+        name: str = "general",
+        guild_name: str = "Hermes Server",
+        category_id: int | None = None,
+    ):
         self.id = channel_id
         self.name = name
         self.guild = SimpleNamespace(name=guild_name)
+        self.category_id = category_id
         self.topic = None
 
     def history(self, *, limit, before, after=None, oldest_first=None):
@@ -280,6 +287,90 @@ async def test_discord_free_response_channel_overrides_mention_requirement(adapt
     adapter.handle_message.assert_awaited_once()
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "allowed without mention"
+
+
+@pytest.mark.asyncio
+async def test_discord_free_response_category_allows_channel(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "555")
+
+    channel = FakeTextChannel(channel_id=789, category_id=555)
+    message = make_message(channel=channel, content="allowed from category")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "allowed from category"
+
+
+def test_discord_channel_keys_preserve_existing_forms_and_add_category_id(adapter):
+    channel = FakeTextChannel(channel_id=789, name="general", category_id=555)
+    message = make_message(channel=channel, content="policy keys")
+
+    assert adapter._discord_channel_keys(message) == {
+        "789",
+        "general",
+        "#general",
+        "555",
+    }
+
+
+def test_discord_thread_channel_keys_include_parent_forms_and_category_id(adapter):
+    parent = FakeTextChannel(channel_id=789, name="general", category_id=555)
+    thread = FakeThread(channel_id=321, name="topic", parent=parent)
+    message = make_message(channel=thread, content="thread policy keys")
+
+    assert adapter._discord_channel_keys(message) == {
+        "321",
+        "topic",
+        "#topic",
+        "789",
+        "general",
+        "#general",
+        "555",
+    }
+
+
+def test_discord_uncached_thread_category_property_does_not_break_policy_keys(
+    adapter, monkeypatch,
+):
+    class ClientException(Exception):
+        pass
+
+    monkeypatch.setattr(discord_platform.discord, "ClientException", ClientException)
+
+    class UncachedThread(FakeThread):
+        @property
+        def category_id(self):
+            raise ClientException("Parent channel not found")
+
+    thread = UncachedThread(channel_id=321, name="topic")
+    thread.parent_id = 789
+    message = make_message(channel=thread, content="uncached thread policy keys")
+
+    assert adapter._discord_channel_keys(message) == {
+        "321",
+        "topic",
+        "#topic",
+        "789",
+    }
+
+
+@pytest.mark.asyncio
+async def test_discord_thread_under_category_is_free_response(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "555")
+
+    parent = FakeTextChannel(channel_id=789, name="general", category_id=555)
+    thread = FakeThread(channel_id=321, name="topic", parent=parent)
+    message = make_message(channel=thread, content="allowed thread from category")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "allowed thread from category"
 
 
 @pytest.mark.asyncio
@@ -1485,4 +1576,3 @@ async def test_discord_non_reply_free_channel_skips_backfill(adapter, monkeypatc
     await adapter._handle_message(message)
 
     adapter._fetch_channel_context.assert_not_awaited()
-

--- a/tests/gateway/test_discord_slash_auth.py
+++ b/tests/gateway/test_discord_slash_auth.py
@@ -130,7 +130,7 @@ _SENTINEL = object()
 
 def _make_interaction(
     user_id, *, channel_id=12345, guild_id=42, in_dm=False, in_thread=False,
-    parent_channel_id=None, user=_SENTINEL, channel_name=None,
+    parent_channel_id=None, category_id=None, user=_SENTINEL, channel_name=None,
 ):
     """Build a mock Discord Interaction with a still-unresponded response.
 
@@ -150,12 +150,17 @@ def _make_interaction(
         channel = discord.Thread()
         channel.id = channel_id
         channel.parent_id = parent_channel_id
+        channel.parent = SimpleNamespace(
+            id=parent_channel_id,
+            name="parent",
+            category_id=category_id,
+        )
         if channel_name is not None:
             channel.name = channel_name
     elif channel_id is None:
         channel = None
     else:
-        channel = SimpleNamespace(id=channel_id)
+        channel = SimpleNamespace(id=channel_id, category_id=category_id)
         if channel_name is not None:
             channel.name = channel_name
 
@@ -344,6 +349,30 @@ async def test_channel_allowlist_matches_by_hash_name(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_channel_category_in_allowlist_passes(adapter, monkeypatch):
+    """Slash auth accepts a text channel whose category ID is allowed."""
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "5555")
+    interaction = _make_interaction(
+        "100200300", channel_id=9999, category_id=5555,
+    )
+    assert await adapter._check_slash_authorization(interaction, "/help") is True
+
+
+@pytest.mark.asyncio
+async def test_thread_category_in_allowlist_passes(adapter, monkeypatch):
+    """A thread inherits category scope through its parent text channel."""
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "5555")
+    interaction = _make_interaction(
+        "100200300",
+        channel_id=9999,
+        in_thread=True,
+        parent_channel_id=7777,
+        category_id=5555,
+    )
+    assert await adapter._check_slash_authorization(interaction, "/help") is True
+
+
+@pytest.mark.asyncio
 async def test_channel_allowlist_does_not_apply_to_dms(adapter, monkeypatch):
     """DMs ignore channel allowlists and still require user allowlist or opt-in."""
     monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "1111")
@@ -378,6 +407,19 @@ async def test_ignored_channel_matches_by_name(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_IGNORED_CHANNELS", "cypher")
     interaction = _make_interaction("100200300", channel_id=9999, channel_name="cypher")
     assert await adapter._check_slash_authorization(interaction, "/help") is False
+
+
+@pytest.mark.asyncio
+async def test_channel_category_in_ignorelist_rejects(adapter, monkeypatch, caplog):
+    """Slash auth rejects a channel whose category ID is ignored."""
+    monkeypatch.setenv("DISCORD_ALLOWED_USERS", "100200300")
+    monkeypatch.setenv("DISCORD_IGNORED_CHANNELS", "5555")
+    interaction = _make_interaction(
+        "100200300", channel_id=9999, category_id=5555,
+    )
+    with caplog.at_level(logging.WARNING):
+        assert await adapter._check_slash_authorization(interaction, "/help") is False
+    assert any("DISCORD_IGNORED_CHANNELS" in record.message for record in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -280,14 +280,14 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_COMMAND_SYNC_POLICY` | No | `"safe"` | Controls native slash-command startup sync. `"safe"` diffs existing global commands and only updates what changed, recreating commands when Discord metadata changes cannot be applied via patch. `"bulk"` preserves the old `tree.sync()` behavior. `"off"` skips startup sync entirely. |
 | `DISCORD_REQUIRE_MENTION` | No | `true` | When `true`, the bot only responds in server channels when `@mentioned`. Set to `false` to respond to all messages in every channel. |
 | `DISCORD_THREAD_REQUIRE_MENTION` | No | `false` | When `true`, the in-thread mention shortcut is disabled — threads are gated the same as channels, requiring `@mention` even after the bot has already participated. Use this when multiple bots share a thread and you want each to fire only on explicit `@mention`. |
-| `DISCORD_FREE_RESPONSE_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds without requiring an `@mention`, even when `DISCORD_REQUIRE_MENTION` is `true`. |
+| `DISCORD_FREE_RESPONSE_CHANNELS` | No | — | Comma-separated channel or thread-parent IDs/names (`name` or `#name`), plus category IDs, where the bot responds without requiring an `@mention`, even when `DISCORD_REQUIRE_MENTION` is `true`. A category ID applies to channels and threads nested beneath it. |
 | `DISCORD_IGNORE_NO_MENTION` | No | `true` | When `true`, the bot stays silent if a message `@mentions` other users but does **not** mention the bot. Prevents the bot from jumping into conversations directed at other people. Only applies in server channels, not DMs. |
 | `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
 | `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. |
 | `DISCORD_REACTIONS` | No | `true` | When `true`, the bot adds emoji reactions to messages during processing (👀 when starting, ✅ on success, ❌ on error). Set to `false` to disable reactions entirely. |
-| `DISCORD_IGNORED_CHANNELS` | No | — | Comma-separated channel IDs where the bot **never** responds, even when `@mentioned`. Takes priority over all other channel settings. |
-| `DISCORD_ALLOWED_CHANNELS` | No | — | Comma-separated channel IDs. When set, the bot **only** responds in these channels (plus DMs if allowed). Overrides `config.yaml` `discord.allowed_channels`. Combine with `DISCORD_IGNORED_CHANNELS` to express allow/deny rules. |
-| `DISCORD_NO_THREAD_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds directly in the channel instead of creating a thread. Only relevant when `DISCORD_AUTO_THREAD` is `true`. |
+| `DISCORD_IGNORED_CHANNELS` | No | — | Comma-separated channel or thread-parent IDs/names (`name` or `#name`), plus category IDs, where the bot **never** responds, even when `@mentioned`. A category ID applies to channels and threads nested beneath it. Takes priority over all other channel settings. |
+| `DISCORD_ALLOWED_CHANNELS` | No | — | Comma-separated channel or thread-parent IDs/names (`name` or `#name`), plus category IDs. When set, the bot **only** responds in these scopes (plus DMs if allowed). A category ID applies to channels and threads nested beneath it. Overrides `config.yaml` `discord.allowed_channels`. Combine with `DISCORD_IGNORED_CHANNELS` to express allow/deny rules. |
+| `DISCORD_NO_THREAD_CHANNELS` | No | — | Comma-separated channel or thread-parent IDs/names (`name` or `#name`), plus category IDs, where the bot responds directly in the channel instead of creating a thread. A category ID applies to channels nested beneath it. Only relevant when `DISCORD_AUTO_THREAD` is `true`. |
 | `DISCORD_HISTORY_BACKFILL` | No | `true` | When `true`, prepend recent channel scrollback (since the bot's last response) to the user message when the bot is mentioned. Recovers context the bot would otherwise miss with `require_mention`. Skipped in DMs and free-response channels. Set to `false` to disable. |
 | `DISCORD_HISTORY_BACKFILL_LIMIT` | No | `50` | Maximum number of messages to scan backwards when assembling the backfill block. In practice the scan usually stops earlier — at the bot's own last message in the channel. |
 | `DISCORD_REPLY_TO_MODE` | No | `"first"` | Controls reply-reference behavior: `"off"` — never reply to the original message, `"first"` — reply-reference on the first message chunk only (default), `"all"` — reply-reference on every chunk. |
@@ -316,11 +316,11 @@ The `discord` section in `~/.hermes/config.yaml` mirrors the env vars above. Con
 discord:
   require_mention: true           # Require @mention in server channels
   thread_require_mention: false   # If true, require @mention in threads too (multi-bot threads)
-  free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
+  free_response_channels: ""      # Channel/parent keys or category IDs (string or list)
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing
-  ignored_channels: []            # Channel IDs where bot never responds
-  no_thread_channels: []          # Channel IDs where bot responds without threading
+  ignored_channels: []            # Channel/parent keys or category IDs to ignore
+  no_thread_channels: []          # Channel/parent keys or category IDs for inline replies
   history_backfill: true          # Prepend recent channel scrollback on mention (default: true)
   history_backfill_limit: 50      # Max messages to scan backwards (default: 50)
   channel_prompts: {}             # Per-channel ephemeral system prompts
@@ -358,7 +358,7 @@ discord:
 
 **Type:** string or list — **Default:** `""`
 
-Channel IDs where the bot responds to all messages without needing an `@mention`. Accepts either a comma-separated string or a YAML list:
+Channel or thread-parent IDs/names (`name` or `#name`), plus category IDs, where the bot responds to all messages without needing an `@mention`. Accepts either a comma-separated string or a YAML list:
 
 ```yaml
 # String format
@@ -372,7 +372,7 @@ discord:
     - 9876543210
 ```
 
-If a thread's parent channel is in this list, the thread also becomes mention-free.
+If a thread's parent channel is in this list, the thread also becomes mention-free. If a category ID is in the list, every channel and thread nested beneath that category becomes mention-free.
 
 Free-response channels also **skip auto-threading** — the bot replies inline rather than spinning off a new thread per message. This keeps the channel usable as a lightweight chat surface. If you want threading behavior, don't list the channel as free-response (use normal `@mention` flow instead).
 
@@ -399,7 +399,7 @@ Disable this if you find the reactions distracting or if the bot's role doesn't 
 
 **Type:** string or list — **Default:** `[]`
 
-Channel IDs where the bot **never** responds, even when directly `@mentioned`. This takes the highest priority — if a channel is in this list, the bot silently ignores all messages there, regardless of `require_mention`, `free_response_channels`, or any other setting.
+Channel or thread-parent IDs/names (`name` or `#name`), plus category IDs, where the bot **never** responds, even when directly `@mentioned`. This takes the highest priority — if a matching scope is in this list, the bot silently ignores all messages there, regardless of `require_mention`, `free_response_channels`, or any other setting.
 
 ```yaml
 # String format
@@ -413,13 +413,13 @@ discord:
     - 9876543210
 ```
 
-If a thread's parent channel is in this list, messages in that thread are also ignored.
+If a thread's parent channel is in this list, messages in that thread are also ignored. If a category ID is in the list, every channel and thread nested beneath that category is ignored.
 
 #### `discord.no_thread_channels`
 
 **Type:** string or list — **Default:** `[]`
 
-Channel IDs where the bot responds directly in the channel instead of auto-creating a thread. This only has an effect when `auto_thread` is `true` (the default). In these channels, the bot responds inline like a normal message rather than spawning a new thread.
+Channel or thread-parent IDs/names (`name` or `#name`), plus category IDs, where the bot responds directly in the channel instead of auto-creating a thread. This only has an effect when `auto_thread` is `true` (the default). In these channels, the bot responds inline like a normal message rather than spawning a new thread. A category ID applies to every channel nested beneath it.
 
 ```yaml
 discord:


### PR DESCRIPTION
## Summary

- Include Discord category IDs in the channel policy scope used by allowed, ignored, and free-response channel checks.
- Reuse one helper across message handling, no-mention filtering, and slash-command authorization.
- Add regression coverage for category-based free responses and slash-command allow/ignore policy.

## Motivation

Discord text channels expose their containing category as `category_id`, while threads expose their parent channel through `parent` or `parent_id`. Existing channel policy checks only considered the concrete channel ID and, in some paths, a thread parent ID. That meant deployments could allow a thread parent or single channel, but could not reliably target a whole category with `DISCORD_ALLOWED_CHANNELS` or `DISCORD_FREE_RESPONSE_CHANNELS`.

## Tests

```bash
python -m pytest tests/gateway/test_discord_free_response.py tests/gateway/test_discord_slash_auth.py
```

Result: `78 passed`.
