### PR TITLE
fix(config): remove KEY=*** placeholders during .env sanitization

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6530,10 +6530,14 @@ def _sanitize_env_lines(lines: list) -> list:
     1. Concatenated KEY=VALUE pairs on a single line (missing newline between
        entries, e.g. ``ANTHROPIC_API_KEY=sk-...OPENAI_BASE_URL=https://...``).
     2. Stale ``KEY=***`` placeholder entries left by incomplete setup runs.
+       Any key set to exactly ``***`` (with or without surrounding quotes)
+       is discarded — ``***`` is never a valid credential value.
 
-    Uses a known-keys set (OPTIONAL_ENV_VARS + _EXTRA_ENV_KEYS) so we only
-    split on real Hermes env var names, avoiding false positives from values
-    that happen to contain uppercase text with ``=``.
+    The concatenation split uses a known-keys set (OPTIONAL_ENV_VARS +
+    _EXTRA_ENV_KEYS) so we only split on real Hermes env var names, avoiding
+    false positives from values that happen to contain uppercase text with
+    ``=``.  The placeholder removal is key-agnostic because ``***`` is
+    unambiguously a placeholder regardless of the key name.
     """
     # Build the known keys set lazily from OPTIONAL_ENV_VARS + extras.
     # Done inside the function so OPTIONAL_ENV_VARS is guaranteed to be defined.
@@ -6580,7 +6584,26 @@ def _sanitize_env_lines(lines: list) -> list:
         else:
             sanitized.append(stripped + "\n")
 
-    return sanitized
+    # Second pass: remove stale KEY=*** placeholder entries.
+    # ``***`` is never a valid credential value, so any key set to exactly
+    # ``***`` (with or without surrounding quotes) is a leftover from an
+    # incomplete setup run and should be discarded.
+    filtered: list[str] = []
+    for line in sanitized:
+        stripped = line.strip()
+        # Preserve comments — even if they contain a placeholder pattern,
+        # they are inert and should not be removed.
+        if stripped.startswith("#"):
+            filtered.append(line)
+            continue
+        if "=" in stripped:
+            key, _, value = stripped.partition("=")
+            normalised = value.strip().strip("\"'")
+            if normalised == "***":
+                continue
+        filtered.append(line)
+
+    return filtered
 
 
 def sanitize_env_file() -> int:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -655,6 +655,82 @@ class TestSanitizeEnvLines:
             fixes = sanitize_env_file()
             assert fixes == 0
 
+    def test_removes_stale_placeholder_known_key(self):
+        """A known key set to *** is removed."""
+        lines = [
+            "OPENAI_API_KEY=sk-xxx\n",
+            "ANTHROPIC_API_KEY=***\n",
+        ]
+        result = _sanitize_env_lines(lines)
+        assert result == ["OPENAI_API_KEY=sk-xxx\n"]
+
+    def test_removes_stale_placeholder_unknown_key(self):
+        """An unknown key set to *** is also removed — *** is never valid."""
+        lines = [
+            "OPENAI_API_KEY=sk-xxx\n",
+            "CUSTOM_SECRET=***\n",
+        ]
+        result = _sanitize_env_lines(lines)
+        assert result == ["OPENAI_API_KEY=sk-xxx\n"]
+
+    def test_removes_stale_placeholder_double_quoted(self):
+        """A placeholder wrapped in double quotes is removed."""
+        lines = ['OPENAI_API_KEY="***"\n']
+        result = _sanitize_env_lines(lines)
+        assert result == []
+
+    def test_removes_stale_placeholder_single_quoted(self):
+        """A placeholder wrapped in single quotes is removed."""
+        lines = ["OPENAI_API_KEY='***'\n"]
+        result = _sanitize_env_lines(lines)
+        assert result == []
+
+    def test_removes_stale_placeholder_with_whitespace(self):
+        """A placeholder with surrounding whitespace is removed."""
+        lines = ["OPENAI_API_KEY = *** \n"]
+        result = _sanitize_env_lines(lines)
+        assert result == []
+
+    def test_preserves_real_value_containing_stars(self):
+        """A real value that happens to contain *** is preserved."""
+        lines = ["MY_TOKEN=abc***def\n"]
+        result = _sanitize_env_lines(lines)
+        assert result == ["MY_TOKEN=abc***def\n"]
+
+    def test_preserves_value_with_multiple_equals(self):
+        """A value with = before *** is preserved (not a placeholder)."""
+        lines = ["MY_TOKEN=key=***\n"]
+        result = _sanitize_env_lines(lines)
+        assert result == ["MY_TOKEN=key=***\n"]
+
+    def test_preserves_commented_placeholder(self):
+        """A commented-out placeholder line is preserved (not removed)."""
+        lines = ["# ANTHROPIC_API_KEY=***\n"]
+        result = _sanitize_env_lines(lines)
+        assert result == ["# ANTHROPIC_API_KEY=***\n"]
+
+    def test_removes_placeholder_after_concatenation_split(self):
+        """A placeholder that appears after concatenation splitting is removed."""
+        lines = ["OPENAI_API_KEY=sk-xxxANTHROPIC_API_KEY=***\n"]
+        result = _sanitize_env_lines(lines)
+        assert result == ["OPENAI_API_KEY=sk-xxx\n"]
+
+    def test_placeholder_removal_count_in_sanitize_env_file(self, tmp_path):
+        """sanitize_env_file counts placeholder removals as fixes."""
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "OPENAI_API_KEY=sk-real\n"
+            "ANTHROPIC_API_KEY=***\n"
+            "TAVILY_API_KEY=***\n"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            fixes = sanitize_env_file()
+            assert fixes >= 2  # at least 2 placeholder removals
+            content = env_file.read_text()
+            assert "ANTHROPIC_API_KEY" not in content
+            assert "TAVILY_API_KEY" not in content
+            assert "OPENAI_API_KEY=sk-real" in content
+
 
 class TestOptionalEnvVarsRegistry:
     """Verify that key env vars are registered in OPTIONAL_ENV_VARS."""


### PR DESCRIPTION
## Summary

`_sanitize_env_lines()` in `hermes_cli/config.py` is documented to remove stale `KEY=***` placeholder entries, but the implementation never performed this removal. This PR adds a second pass that discards any line where the value is exactly `***` (with or without surrounding quotes).

Fixes #12651.

## What changed

**`hermes_cli/config.py`** — Added a post-processing pass to `_sanitize_env_lines()` after the existing concatenation-splitting logic. The pass uses `str.partition('=')` to safely split key from value, strips surrounding quotes and whitespace, and drops the line if the normalised value is exactly `***`.

**`tests/hermes_cli/test_config.py`** — 9 new test cases in `TestSanitizeEnvLines`:

| Test | What it covers |
|------|----------------|
| `test_removes_stale_placeholder_known_key` | Known key (`ANTHROPIC_API_KEY`) set to `***` is removed |
| `test_removes_stale_placeholder_unknown_key` | Unknown key (`CUSTOM_SECRET`) set to `***` is also removed — `***` is never valid |
| `test_removes_stale_placeholder_double_quoted` | `"***"` (double-quoted) is removed |
| `test_removes_stale_placeholder_single_quoted` | `'***'` (single-quoted) is removed |
| `test_removes_stale_placeholder_with_whitespace` | `= *** ` (whitespace around value) is removed |
| `test_preserves_real_value_containing_stars` | `abc***def` is preserved (not a placeholder) |
| `test_preserves_value_with_multiple_equals` | `key=***` is preserved (`***` is after a second `=`, not the whole value) |
| `test_removes_placeholder_after_concatenation_split` | Placeholder appearing after concatenation splitting is removed |
| `test_placeholder_removal_count_in_sanitize_env_file` | `sanitize_env_file()` counts placeholder removals as fixes |

## Design decisions

**Key-agnostic:** The placeholder check applies to all keys, not just those in `OPTIONAL_ENV_VARS` or a suffix list. `***` is unambiguously a placeholder regardless of the key name — no suffix matching needed.

**`partition("=")` not `split("=")[0]`:** Uses `str.partition('=')` to split key from value, which safely handles values containing `=` (e.g. `key=val=***` — the value is `val=***`, not a placeholder).

**Post-processing pass:** Runs after concatenation splitting so placeholders that were part of a jammed line are caught too.

## Supersedes

This PR addresses the same issue as two existing competing PRs:

- **#6183** (by Kolektori) — filed 2026-04-08, before the issue. Takes a broader approach: adds suffix-based placeholder detection (`_API_KEY`, `_TOKEN`, etc.) and duplicate-key deduplication. The suffix matching is unnecessarily restrictive (misses non-standard key names) and the deduplication is out of scope for this bug.
- **#12690** (by aniruddhaadak80) — filed 2026-04-19, same day as the issue. Takes a minimal approach but has bugs: `split('=')[0]` false-positives on values containing `=`, misses quoted/spaced placeholders, and the diff base is stale (line numbers off by ~1000).

Cross-vendor review (Gemini Flash + GPT-OSS) of both PRs confirmed: #12690 has BLOCKER-level false-positive risks; #6183 is over-scoped with suffix matching that can miss real placeholders. This PR takes the minimal approach (correct for the reported bug) with the robustness fixes both reviewers called for.

## Verification

All 130 tests in `tests/hermes_cli/test_config.py` pass, including the 9 new ones.
