### PR TITLE
docs(windows): clarify post-install shell reload step for native PowerShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,17 @@ If you already have Git installed, the installer detects it and uses that instea
 
 After installation:
 
+**Linux, macOS, WSL2, Termux:** reload your shell, then run hermes:
+
 ```bash
-source ~/.bashrc    # reload shell (or: source ~/.zshrc)
+source ~/.bashrc    # reload shell (or: source ~/.zshrc on zsh)
 hermes              # start chatting!
+```
+
+**Windows (native PowerShell):** open a new terminal window, then run:
+
+```powershell
+hermes
 ```
 
 ### Troubleshooting
@@ -257,3 +265,5 @@ scripts/run_tests.sh
 MIT — see [LICENSE](LICENSE).
 
 Built by [Nous Research](https://nousresearch.com).
+
+

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you already have Git installed, the installer detects it and uses that instea
 
 After installation:
 
-**Linux, macOS, WSL2, Termux:** reload your shell, then run hermes:
+**Linux, macOS, WSL2:** reload your shell, then run hermes:
 
 ```bash
 source ~/.bashrc    # reload shell (or: source ~/.zshrc on zsh)


### PR DESCRIPTION
## Summary

- The 'After installation' block after the Quick Install section showed only \source ~/.bashrc\, which is a bash command that does not apply to native Windows PowerShell users.
- Split the block into platform-specific instructions: bash reload for Linux/macOS/WSL2/Termux, and a note to open a new terminal window for Windows native PowerShell.

## Validation

Docs-only change — no runtime code modified.
Checked open PRs for duplicates; closest prior fix (PR #38637) addressed macOS/zsh preference and did not cover the Windows native case.