### PR TITLE
ci: guard PRs against runtime path leaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,12 @@ jobs:
     if: needs.detect.outputs.event_name == 'pull_request'
     uses: ./.github/workflows/history-check.yml
 
+  runtime-leak-guard:
+    name: PR runtime leak guard
+    needs: detect
+    if: needs.detect.outputs.event_name == 'pull_request'
+    uses: ./.github/workflows/pr-runtime-leak-guard.yml
+
   contributor-check:
     name: Check contributors
     needs: detect
@@ -142,6 +148,7 @@ jobs:
       - typecheck
       - docs-site
       - history-check
+      - runtime-leak-guard
       - contributor-check
       - uv-lockfile
       - docker-lint

--- a/.github/workflows/pr-runtime-leak-guard.yml
+++ b/.github/workflows/pr-runtime-leak-guard.yml
@@ -1,0 +1,20 @@
+name: PR Runtime Leak Guard
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check-pr-runtime-leaks:
+    name: Check PR runtime leaks
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Check PR diff for local runtime paths
+        run: python scripts/check_pr_runtime_leaks.py --base-ref "origin/${{ github.base_ref }}" --head-ref HEAD

--- a/scripts/check_pr_runtime_leaks.py
+++ b/scripts/check_pr_runtime_leaks.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Fail CI if a PR includes local runtime/overlay paths.
+
+This guard prevents accidental leakage of developer-local runtime state into
+upstream pull requests. It checks only repo-relative path names from the PR diff;
+it does not depend on any machine-local absolute paths or private manifests.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+
+FORBIDDEN_PREFIXES: tuple[str, ...] = (
+    ".hermes/",
+    "hermes-local-overlay/",
+    "ops/plugins/config/",
+)
+
+FORBIDDEN_FILENAMES: frozenset[str] = frozenset(
+    {
+        "config-overlay.yaml",
+        "local-only-files.txt",
+    }
+)
+
+
+def normalize_repo_path(path: str) -> str:
+    """Normalize a git path to a safe repo-relative POSIX-ish form."""
+    normalized = path.replace("\\", "/").strip()
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    parts: list[str] = []
+    for part in normalized.split("/"):
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            # Diff paths should never traverse out of the repo. Keep this
+            # fail-closed by returning the original-ish path with .. intact so
+            # it is visible in the error output if it ever happens.
+            return normalized
+        parts.append(part)
+    return "/".join(parts)
+
+
+def is_forbidden_path(path: str) -> bool:
+    """Return True if a repo-relative path is forbidden in an upstream PR."""
+    normalized = normalize_repo_path(path)
+    if normalized in {".hermes", "hermes-local-overlay", "ops/plugins/config"}:
+        return True
+    if any(normalized.startswith(prefix) for prefix in FORBIDDEN_PREFIXES):
+        return True
+    name = normalized.rsplit("/", 1)[-1]
+    return name in FORBIDDEN_FILENAMES
+
+
+def find_forbidden_paths(paths: Iterable[str]) -> list[str]:
+    """Return normalized forbidden paths in deterministic order."""
+    forbidden = {normalize_repo_path(path) for path in paths if is_forbidden_path(path)}
+    return sorted(forbidden)
+
+
+def pr_diff_paths(base_ref: str, head_ref: str) -> list[str]:
+    """Read PR diff paths via git. Fail closed if diff calculation fails."""
+    cmd = [
+        "git",
+        "diff",
+        "--name-only",
+        "-z",
+        "--diff-filter=ACMRTUXB",
+        f"{base_ref}...{head_ref}",
+    ]
+    try:
+        proc = subprocess.run(cmd, check=True, capture_output=True)
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.decode("utf-8", errors="replace")
+        stdout = exc.stdout.decode("utf-8", errors="replace")
+        raise RuntimeError(
+            "failed to calculate PR diff paths with "
+            f"base={base_ref!r} head={head_ref!r}: {stderr or stdout or exc}"
+        ) from exc
+    raw = proc.stdout.decode("utf-8", errors="surrogateescape")
+    return [path for path in raw.split("\0") if path]
+
+
+def default_base_ref() -> str:
+    base_ref = os.environ.get("GITHUB_BASE_REF") or "main"
+    return f"origin/{base_ref}"
+
+
+def emit_forbidden(paths: Sequence[str]) -> None:
+    print("Forbidden local runtime/overlay paths found in this PR diff:", file=sys.stderr)
+    for path in paths:
+        print(f"::error file={path}::Forbidden local runtime/overlay path in PR diff", file=sys.stderr)
+        print(f"- {path}", file=sys.stderr)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-ref", default=default_base_ref(), help="Git base ref for PR diff (default: origin/$GITHUB_BASE_REF or origin/main)")
+    parser.add_argument("--head-ref", default="HEAD", help="Git head ref for PR diff (default: HEAD)")
+    parser.add_argument(
+        "--paths-from-stdin",
+        action="store_true",
+        help="Read newline-delimited paths from stdin instead of running git diff (used by tests).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.paths_from_stdin:
+        paths = [line.rstrip("\n") for line in sys.stdin if line.rstrip("\n")]
+    else:
+        try:
+            paths = pr_diff_paths(args.base_ref, args.head_ref)
+        except RuntimeError as exc:
+            print(f"::error::{exc}", file=sys.stderr)
+            return 2
+
+    forbidden = find_forbidden_paths(paths)
+    if forbidden:
+        emit_forbidden(forbidden)
+        return 1
+
+    print("No forbidden local runtime/overlay paths found in PR diff.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_check_pr_runtime_leaks.py
+++ b/tests/ci/test_check_pr_runtime_leaks.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_pr_runtime_leaks.py"
+spec = importlib.util.spec_from_file_location("check_pr_runtime_leaks", MODULE_PATH)
+assert spec is not None
+check_pr_runtime_leaks = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(check_pr_runtime_leaks)
+
+
+def test_forbidden_runtime_and_overlay_paths_are_detected():
+    paths = [
+        ".hermes/state.db",
+        "./.hermes/config.yaml",
+        "hermes-local-overlay/patches/local.diff",
+        "ops/plugins/config/private.yaml",
+        "config-overlay.yaml",
+        "nested/config-overlay.yaml",
+        "local-only-files.txt",
+        "ops/hermes-local-overlay/local-only-files.txt",
+    ]
+
+    assert check_pr_runtime_leaks.find_forbidden_paths(paths) == [
+        ".hermes/config.yaml",
+        ".hermes/state.db",
+        "config-overlay.yaml",
+        "hermes-local-overlay/patches/local.diff",
+        "local-only-files.txt",
+        "nested/config-overlay.yaml",
+        "ops/hermes-local-overlay/local-only-files.txt",
+        "ops/plugins/config/private.yaml",
+    ]
+
+
+def test_similar_non_runtime_paths_are_allowed():
+    paths = [
+        "docs/config-overlay.yaml.md",
+        "docs/local-only-files.txt.md",
+        "ops/plugins/configuration/README.md",
+        "src/hermes-local-overlay-helper.py",
+        "some/.hermes-notes.md",
+    ]
+
+    assert check_pr_runtime_leaks.find_forbidden_paths(paths) == []
+
+
+def test_windows_style_paths_are_normalized():
+    assert check_pr_runtime_leaks.find_forbidden_paths([r".hermes\\state.db"]) == [".hermes/state.db"]


### PR DESCRIPTION
## Summary

Adds a lightweight PR runtime leak guard so upstream CI fails if a pull request accidentally includes local runtime/overlay state paths.

Forbidden path classes:
- `.hermes/**`
- `hermes-local-overlay/**`
- `ops/plugins/config/**`
- `config-overlay.yaml`
- `local-only-files.txt`

The guard uses only repo-relative diff paths. It does not include absolute local paths or any private overlay manifest content.

## Implementation

- Adds `scripts/check_pr_runtime_leaks.py`.
- Adds `.github/workflows/pr-runtime-leak-guard.yml` as a `workflow_call` sub-workflow.
- Wires the guard into the existing CI orchestrator and `All required checks pass` aggregate job.
- Adds unit tests for forbidden paths, near-miss allowed paths, and Windows-style path normalization.

## Local verification

```text
python -m py_compile scripts/check_pr_runtime_leaks.py tests/ci/test_check_pr_runtime_leaks.py
pytest tests/ci/test_check_pr_runtime_leaks.py -q -o addopts=
# 3 passed

printf '.hermes/state.db\ndocs/ok.md\n' | python scripts/check_pr_runtime_leaks.py --paths-from-stdin
# exits 1 and reports .hermes/state.db

printf 'docs/config-overlay.yaml.md\nsrc/hermes-local-overlay-helper.py\n' | python scripts/check_pr_runtime_leaks.py --paths-from-stdin
# passes

python scripts/check_pr_runtime_leaks.py --base-ref origin/main --head-ref HEAD
# No forbidden local runtime/overlay paths found in PR diff.
```

## Notes

This is intentionally separate from the active bugfix PRs so feature fixes and repository safety policy can be reviewed independently.
