### PR TITLE
feat(cron): make tick interval configurable via config.yaml

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17139,11 +17139,16 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     
     # Start background cron ticker so scheduled jobs fire automatically.
     # Pass the event loop so cron delivery can use live adapters (E2EE support).
+    _cron_cfg = _load_gateway_config().get("cron", {}) or {}
+    try:
+        _tick_interval = max(5, int(_cron_cfg.get("tick_interval_seconds", 60)))
+    except (TypeError, ValueError):
+        _tick_interval = 60
     cron_stop = threading.Event()
     cron_thread = threading.Thread(
         target=_start_cron_ticker,
         args=(cron_stop,),
-        kwargs={"adapters": runner.adapters, "loop": asyncio.get_running_loop()},
+        kwargs={"adapters": runner.adapters, "loop": asyncio.get_running_loop(), "interval": _tick_interval},
         daemon=True,
         name="cron-ticker",
     )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1464,6 +1464,11 @@ DEFAULT_CONFIG = {
         # 1 = serial (pre-v0.9 behaviour).
         # Also overridable via HERMES_CRON_MAX_PARALLEL env var.
         "max_parallel_jobs": None,
+        # Seconds between cron scheduler ticks in the gateway process.
+        # Lower values reduce job pickup latency (e.g. 5s = jobs fire
+        # within 5s of their target window). Higher values reduce
+        # background CPU overhead. Default 60. Minimum 5.
+        "tick_interval_seconds": 60,
     },
 
     # Kanban multi-agent coordination — controls the dispatcher loop that


### PR DESCRIPTION
## Summary

Add `cron.tick_interval_seconds` config option (default 60, minimum 5) so users can reduce cron job pickup latency without editing source code.

## Problem

The cron ticker in `gateway/run.py` hardcodes a 60-second interval. For time-sensitive jobs (e.g. trading bots that need to act within 5-minute market windows), this means up to 60s of idle delay before a scheduled job fires — wasting ~20% of the window.

## Solution

- **`hermes_cli/config.py`**: Add `tick_interval_seconds: 60` to the cron config schema with documentation
- **`gateway/run.py`**: Read `cron.tick_interval_seconds` from config at gateway startup, clamp to minimum 5s, pass to `_start_cron_ticker()`

## Behavior

```yaml
cron:
  tick_interval_seconds: 10  # jobs fire within 10s of target time
```

Backward compatible — defaults to 60 if not configured.

## Testing

- Set `tick_interval_seconds: 10` in config.yaml
- Gateway log confirms: `Cron ticker started (interval=10s)`
- Cron jobs fire within 10s of their `*/5 * * * *` schedule instead of up to 60s

## Files Changed

- `gateway/run.py` — 7 lines (+6/-1)
- `hermes_cli/config.py` — 5 lines (+5/-0)