### PR TITLE
fix(gemini): prevent collision on parallel streaming tool call keys

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -672,6 +672,7 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
                 {
                     "part_index": part_index,
                     "name": name,
+                    "args": args_str,
                     "thought_signature": thought_signature,
                 },
                 sort_keys=True,

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -408,3 +408,38 @@ def test_explicit_max_tokens_is_respected():
 
     req = build_gemini_request(messages=[{"role": "user", "content": "hi"}], max_tokens=4096)
     assert req["generationConfig"]["maxOutputTokens"] == 4096
+
+
+def test_stream_event_translation_keeps_different_calls_with_reset_part_index_distinct():
+    from agent.gemini_native_adapter import translate_stream_event
+
+    tool_call_indices = {}
+    event1 = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"functionCall": {"name": "gimy_set_list_state", "args": {"movieId": "111", "state": 1}}}
+                    ]
+                }
+            }
+        ]
+    }
+    event2 = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"functionCall": {"name": "gimy_set_list_state", "args": {"movieId": "222", "state": 1}}}
+                    ]
+                }
+            }
+        ]
+    }
+
+    chunks1 = translate_stream_event(event1, model="gemini-2.5-flash", tool_call_indices=tool_call_indices)
+    chunks2 = translate_stream_event(event2, model="gemini-2.5-flash", tool_call_indices=tool_call_indices)
+
+    assert chunks1[0].choices[0].delta.tool_calls[0].index == 0
+    assert chunks2[0].choices[0].delta.tool_calls[0].index == 1
+    assert chunks1[0].choices[0].delta.tool_calls[0].id != chunks2[0].choices[0].delta.tool_calls[0].id


### PR DESCRIPTION
### RCA (Root Cause Analysis)
When a parallel/batch tool calling flow is triggered under Gemini models (e.g. running multiple parallel calls of the same tool), the Gemini streaming API can split function calls into separate SSE chunks. In Delta transmission mode, the `part_index` of the first part inside each subsequent chunk is reset to `0`.

The original implementation of `translate_stream_event` in `agent/gemini_native_adapter.py` computed the `call_key` as:
```python
call_key = json.dumps({
    "part_index": part_index,
    "name": name,
    "thought_signature": thought_signature,
}, sort_keys=True)
```
Because both the `part_index` (always `0` when reset) and the `name` (same function name) match, multiple distinct parallel calls map to the exact same slot/index (e.g., `index = 0`).

This causes the arguments of subsequent calls to be appended or concatenated onto the first call's accumulated arguments string, producing invalid JSON (e.g. `{"movieId": "111", "state": 1}{"movieId": "222", "state": 1}`). The agent sanitization flags this invalid JSON as `Unrepairable` and defaults to `{}`, causing the execution to abort mid-stream and ultimately report a misleading `Response truncated due to output length limit` error to the user.

### Resolution
1. **Refactored `call_key` generation**: Included the sorted serialized arguments `args` (`args_str`) into the `call_key`. This guarantees that parallel calls with the same name but distinct arguments will be correctly mapped to separate, unique slots with their own `index` and `id`.
2. **Added automated regression test**: Covered this in `tests/agent/test_gemini_native_adapter.py` with `test_stream_event_translation_keeps_different_calls_with_reset_part_index_distinct` to ensure distinct parallel calls with identical function names are cleanly separated when `part_index` is `0`. All 21 tests pass 100%.