### PR TITLE
fix(desktop): default color mode to system

### DIFF
--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -46,7 +46,7 @@ const normalizeSkin = (name: string | null): string =>
   name && resolveTheme(name) && !RETIRED_SKINS.has(name) ? name : DEFAULT_SKIN_NAME
 
 const normalizeMode = (value: string | null): ThemeMode =>
-  value === 'light' || value === 'dark' || value === 'system' ? value : 'light'
+  value === 'light' || value === 'dark' || value === 'system' ? value : 'system'
 
 // ─── Per-profile appearance persistence ─────────────────────────────────────
 // Skin and mode are each stored per profile. "default" isn't a real profile —

--- a/apps/desktop/src/themes/profile-theme.test.ts
+++ b/apps/desktop/src/themes/profile-theme.test.ts
@@ -18,7 +18,7 @@ const cases = [
     b: 'midnight',
     junk: 'nope'
   },
-  { name: 'mode', pref: modePref as unknown as Pref, fallback: 'light', a: 'dark', b: 'system', junk: 'dusk' }
+  { name: 'mode', pref: modePref as unknown as Pref, fallback: 'system', a: 'dark', b: 'system', junk: 'dusk' }
 ]
 
 describe.each(cases)('per-profile $name', ({ pref, fallback, a, b, junk }) => {
@@ -44,5 +44,17 @@ describe.each(cases)('per-profile $name', ({ pref, fallback, a, b, junk }) => {
   it('normalizes an unknown stored value back to the default', () => {
     pref.assign('work', junk)
     expect(pref.resolve('work')).toBe(fallback)
+  })
+})
+
+describe('per-profile mode', () => {
+  beforeEach(() => window.localStorage.clear())
+
+  it('preserves an explicitly assigned light mode', () => {
+    modePref.assign('default', 'light')
+    modePref.assign('work', 'light')
+
+    expect(modePref.resolve('default')).toBe('light')
+    expect(modePref.resolve('work')).toBe('light')
   })
 })


### PR DESCRIPTION
## What does this PR do?

Defaults Hermes Desktop's Appearance color mode to `system` when no user preference has been stored yet. This makes fresh installs follow the OS light/dark preference on macOS, Windows, and Linux through the existing `system` mode path instead of forcing light mode on first launch.

This is a default correction for an already-supported mode, not a new theme surface. Existing explicit user choices are preserved: stored `light`, `dark`, and `system` values still resolve exactly as before.

## Related Issue

Fixes #54335

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/themes/context.tsx`
  - Changed the missing/invalid Desktop mode fallback from `light` to `system`.
- `apps/desktop/src/themes/profile-theme.test.ts`
  - Updated the per-profile mode fallback regression expectation.
  - Added coverage that explicitly stored `light` remains preserved for both default-profile and named-profile storage.

## How to Test

1. `cd apps/desktop && npm run test:ui -- src/themes/profile-theme.test.ts`
2. `cd apps/desktop && npm run typecheck`
3. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, Desktop TypeScript-only change; ran targeted Vitest and Desktop typecheck
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses existing Electron/native `system` theme path; no platform-specific branch needed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
$ npm run test:ui -- src/themes/profile-theme.test.ts
✓ src/themes/profile-theme.test.ts (9 tests) 3ms
Test Files  1 passed (1)
Tests       9 passed (9)

$ npm run typecheck
> tsc -p . --noEmit

$ git diff --check
# no output
```

