### PR TITLE
fix(checkpoint): share a logical workdir key across Docker bind-mount checkpoint create/rollback (#54356)

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -97,7 +97,7 @@ def _ensure_file_checkpoint(
     from tools.file_tools import _resolve_path_for_task
 
     resolved_path = _resolve_path_for_task(file_path, effective_task_id or "default")
-    work_dir = agent._checkpoint_mgr.get_working_dir_for_path(str(resolved_path))
+    work_dir = agent._checkpoint_mgr.checkpoint_dir_for_file(str(resolved_path))
     agent._checkpoint_mgr.ensure_checkpoint(work_dir, f"before {function_name}")
 
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -71,7 +71,7 @@ def _ensure_file_checkpoint(
     from tools.file_tools import _resolve_path_for_task
 
     resolved_path = _resolve_path_for_task(file_path, effective_task_id or "default")
-    work_dir = agent._checkpoint_mgr.get_working_dir_for_path(str(resolved_path))
+    work_dir = agent._checkpoint_mgr.checkpoint_dir_for_file(str(resolved_path))
     agent._checkpoint_mgr.ensure_checkpoint(work_dir, f"before {function_name}")
 
 

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -263,6 +263,7 @@ def test_relay_rewrite_precedes_sequential_policy_approval_checkpoint_and_dispat
     agent._checkpoint_mgr = SimpleNamespace(
         enabled=True,
         get_working_dir_for_path=lambda path: path,
+        checkpoint_dir_for_file=lambda path: path,
         ensure_checkpoint=lambda path, reason: observed["checkpoint"].append(
             (path, reason)
         ),

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -22,6 +22,9 @@ from tools.checkpoint_manager import (
     _ref_name,
     _project_meta_path,
     _touch_project,
+    _parse_volume_specs,
+    _map_logical_to_physical,
+    format_checkpoint_list,
     prune_checkpoints,
     maybe_auto_prune_checkpoints,
     store_status,
@@ -1312,3 +1315,221 @@ class TestSessionDiff:
         assert result["success"] is True
         assert "feature.py" in result["diff"]
         assert "+x = 1" in result["diff"]
+
+    def test_no_changes_since_baseline_reports_empty(self, mgr, work_dir):
+        """A checkpoint with no subsequent edits yields an empty diff."""
+        mgr.ensure_checkpoint(str(work_dir), "baseline")
+        result = mgr.session_diff(str(work_dir))
+        assert result["success"] is True
+        assert result.get("empty") is True
+        assert result["diff"] == ""
+# Docker bind-mount: logical key (container path) ↔ physical dir (host path)
+#
+# Regression coverage for the checkpoint/rollback workdir-key mismatch:
+# checkpoint creation snapshotted the host bind-mount path while /rollback
+# looked checkpoints up under the container runtime workdir (TERMINAL_CWD),
+# so rollback reported no checkpoints for the active workdir.
+# =========================================================================
+
+class TestVolumeSpecParsing:
+    def test_parses_host_container_pairs(self):
+        mounts = _parse_volume_specs([
+            "/Users/dev/hermes-work/repos:/workspace/repos",
+            "/etc/localtime:/etc/localtime:ro",
+        ])
+        assert ("/Users/dev/hermes-work/repos", "/workspace/repos") in mounts
+        # Options (``:ro``) are stripped; host/container still captured.
+        assert ("/etc/localtime", "/etc/localtime") in mounts
+
+    def test_accepts_json_string_from_env(self):
+        raw = '["/Users/dev/hermes-work/repos:/workspace/repos"]'
+        assert _parse_volume_specs(raw) == [
+            ("/Users/dev/hermes-work/repos", "/workspace/repos"),
+        ]
+
+    def test_ignores_malformed_entries(self):
+        assert _parse_volume_specs(["no-colon", 123, ""]) == []
+        assert _parse_volume_specs("not json") == []
+        assert _parse_volume_specs(None) == []
+
+
+class TestLogicalToPhysicalMapping:
+    def test_maps_subpath_under_mount(self):
+        mounts = [("/Users/dev/hermes-work/repos", "/workspace/repos")]
+        assert _map_logical_to_physical("/workspace/repos/myrepo", mounts) == (
+            "/Users/dev/hermes-work/repos/myrepo"
+        )
+
+    def test_maps_mount_root_exactly(self):
+        mounts = [("/Users/dev/hermes-work/repos", "/workspace/repos")]
+        assert _map_logical_to_physical("/workspace/repos", mounts) == (
+            "/Users/dev/hermes-work/repos"
+        )
+
+    def test_unmapped_path_returns_none(self):
+        mounts = [("/Users/dev/hermes-work/repos", "/workspace/repos")]
+        assert _map_logical_to_physical("/some/other/path", mounts) is None
+
+    def test_most_specific_mount_wins(self):
+        mounts = [
+            ("/host/all", "/workspace"),
+            ("/host/repos", "/workspace/repos"),
+        ]
+        assert _map_logical_to_physical("/workspace/repos/x", mounts) == (
+            "/host/repos/x"
+        )
+
+
+class TestDockerBindMountCheckpoints:
+    """End-to-end: container logical key, host physical git I/O."""
+
+    @pytest.fixture()
+    def docker_repo(self, tmp_path):
+        """A host bind-mount source standing in for ``docker_volumes``."""
+        host_repos = tmp_path / "hermes-work" / "repos"
+        repo = host_repos / "myrepo"
+        repo.mkdir(parents=True)
+        (repo / ".git").mkdir()  # repo marker
+        (repo / "README.md").write_text("# docs v1\n")
+        container_target = "/workspace/repos"
+        logical = "/workspace/repos/myrepo"
+        return host_repos, repo, container_target, logical
+
+    def _mgr(self, host_repos, container_target, checkpoint_base, monkeypatch):
+        monkeypatch.setattr(
+            "tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base,
+        )
+        return CheckpointManager(
+            enabled=True,
+            max_snapshots=50,
+            docker_volumes=[f"{host_repos}:{container_target}"],
+        )
+
+    def test_create_under_logical_key_lists_under_logical_key(
+        self, docker_repo, checkpoint_base, monkeypatch,
+    ):
+        host_repos, repo, container_target, logical = docker_repo
+        mgr = self._mgr(host_repos, container_target, checkpoint_base, monkeypatch)
+
+        # File-tool preflight checkpoints the *logical* container workdir.
+        assert mgr.ensure_checkpoint(logical, "before write_file") is True
+
+        # /rollback lists under the same logical key (TERMINAL_CWD) and finds it.
+        listed = mgr.list_checkpoints(logical)
+        assert len(listed) == 1
+        assert listed[0]["reason"] == "before write_file"
+
+    def test_metadata_records_existing_host_path_not_container_path(
+        self, docker_repo, checkpoint_base, monkeypatch,
+    ):
+        host_repos, repo, container_target, logical = docker_repo
+        mgr = self._mgr(host_repos, container_target, checkpoint_base, monkeypatch)
+        mgr.ensure_checkpoint(logical, "before write_file")
+
+        # Project metadata is keyed by the logical hash but stores the physical
+        # host path, so the orphan sweep (which checks workdir existence) does
+        # not flag the live checkpoint just because the container path is absent
+        # on the host.
+        store = _store_path(checkpoint_base)
+        meta_path = _project_meta_path(store, _project_hash(logical))
+        assert meta_path.exists()
+        recorded = json.loads(meta_path.read_text())["workdir"]
+        assert recorded == str(repo.resolve())
+        assert Path(recorded).exists()
+
+    def test_diff_and_restore_round_trip_via_logical_key(
+        self, docker_repo, checkpoint_base, monkeypatch,
+    ):
+        host_repos, repo, container_target, logical = docker_repo
+        mgr = self._mgr(host_repos, container_target, checkpoint_base, monkeypatch)
+
+        mgr.ensure_checkpoint(logical, "before write_file")
+        cps = mgr.list_checkpoints(logical)
+        first_hash = cps[0]["hash"]
+
+        # Edit the file on the host (as the in-container tool would, via mount).
+        mgr.new_turn()
+        (repo / "README.md").write_text("# docs v2 — edited\n")
+
+        # Diff against the checkpoint, looked up by the logical key.
+        diff = mgr.diff(logical, first_hash)
+        assert diff["success"] is True
+        assert "README.md" in diff["diff"]
+
+        # Restore by the logical key writes back to the physical host file.
+        result = mgr.restore(logical, first_hash)
+        assert result["success"] is True
+        assert result["directory"] == logical  # user-facing identity is logical
+        assert (repo / "README.md").read_text() == "# docs v1\n"
+
+    def test_relative_edit_keys_off_terminal_cwd(
+        self, docker_repo, checkpoint_base, monkeypatch,
+    ):
+        """A relative write_file in a Docker runtime keys off TERMINAL_CWD,
+        matching exactly what /rollback uses — the core issue scenario."""
+        host_repos, repo, container_target, logical = docker_repo
+        monkeypatch.setattr(
+            "tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base,
+        )
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CWD", logical)
+        monkeypatch.setenv(
+            "TERMINAL_DOCKER_VOLUMES",
+            json.dumps([f"{host_repos}:{container_target}"]),
+        )
+
+        # No constructor override — mounts come from the runtime env, exactly
+        # like the agent/gateway-constructed managers.
+        mgr = CheckpointManager(enabled=True, max_snapshots=50)
+
+        # Preflight resolves a relative file edit to the runtime cwd.
+        assert mgr.checkpoint_dir_for_file("README.md") == logical
+        mgr.ensure_checkpoint(
+            mgr.checkpoint_dir_for_file("README.md"), "before write_file",
+        )
+
+        # A second manager (e.g. the /rollback handler) reads the same env and
+        # finds the checkpoint under TERMINAL_CWD.
+        rollback_mgr = CheckpointManager(enabled=True, max_snapshots=50)
+        listed = rollback_mgr.list_checkpoints(os.environ["TERMINAL_CWD"])
+        assert len(listed) == 1
+        assert listed[0]["reason"] == "before write_file"
+
+    def test_rollback_resolves_via_metadata_when_mounts_absent(
+        self, docker_repo, checkpoint_base, monkeypatch,
+    ):
+        """A /rollback handler with no live docker_volumes still resolves the
+        host tree from project metadata recorded at creation time."""
+        host_repos, repo, container_target, logical = docker_repo
+        creator = self._mgr(host_repos, container_target, checkpoint_base, monkeypatch)
+        creator.ensure_checkpoint(logical, "before write_file")
+
+        # A second manager with NO mount override and no Docker env — it must
+        # still find and operate on the checkpoint via the recorded host path.
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.delenv("TERMINAL_DOCKER_VOLUMES", raising=False)
+        rollback_mgr = CheckpointManager(enabled=True, max_snapshots=50)
+
+        listed = rollback_mgr.list_checkpoints(logical)
+        assert len(listed) == 1
+
+        result = rollback_mgr.restore(logical, listed[0]["hash"])
+        assert result["success"] is True
+        assert (repo / "README.md").read_text() == "# docs v1\n"
+
+    def test_local_backend_relative_edit_walks_to_repo_root(
+        self, work_dir, checkpoint_base, monkeypatch,
+    ):
+        """Without Docker mounts, relative edits keep the local walk-up
+        behavior (no regression for the common case)."""
+        monkeypatch.setattr(
+            "tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base,
+        )
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.delenv("TERMINAL_DOCKER_VOLUMES", raising=False)
+        (work_dir / ".git").mkdir()
+        mgr = CheckpointManager(enabled=True, max_snapshots=50)
+        monkeypatch.chdir(work_dir)
+
+        # Falls through to get_working_dir_for_path → the repo root.
+        assert mgr.checkpoint_dir_for_file("main.py") == str(work_dir.resolve())

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -22,6 +22,9 @@ from tools.checkpoint_manager import (
     _ref_name,
     _project_meta_path,
     _touch_project,
+    _parse_volume_specs,
+    _map_logical_to_physical,
+    format_checkpoint_list,
     prune_checkpoints,
     maybe_auto_prune_checkpoints,
     store_status,
@@ -1044,3 +1047,221 @@ class TestSessionDiff:
         assert result["success"] is True
         assert "feature.py" in result["diff"]
         assert "+x = 1" in result["diff"]
+
+    def test_no_changes_since_baseline_reports_empty(self, mgr, work_dir):
+        """A checkpoint with no subsequent edits yields an empty diff."""
+        mgr.ensure_checkpoint(str(work_dir), "baseline")
+        result = mgr.session_diff(str(work_dir))
+        assert result["success"] is True
+        assert result.get("empty") is True
+        assert result["diff"] == ""
+# Docker bind-mount: logical key (container path) ↔ physical dir (host path)
+#
+# Regression coverage for the checkpoint/rollback workdir-key mismatch:
+# checkpoint creation snapshotted the host bind-mount path while /rollback
+# looked checkpoints up under the container runtime workdir (TERMINAL_CWD),
+# so rollback reported no checkpoints for the active workdir.
+# =========================================================================
+
+class TestVolumeSpecParsing:
+    def test_parses_host_container_pairs(self):
+        mounts = _parse_volume_specs([
+            "/Users/dev/hermes-work/repos:/workspace/repos",
+            "/etc/localtime:/etc/localtime:ro",
+        ])
+        assert ("/Users/dev/hermes-work/repos", "/workspace/repos") in mounts
+        # Options (``:ro``) are stripped; host/container still captured.
+        assert ("/etc/localtime", "/etc/localtime") in mounts
+
+    def test_accepts_json_string_from_env(self):
+        raw = '["/Users/dev/hermes-work/repos:/workspace/repos"]'
+        assert _parse_volume_specs(raw) == [
+            ("/Users/dev/hermes-work/repos", "/workspace/repos"),
+        ]
+
+    def test_ignores_malformed_entries(self):
+        assert _parse_volume_specs(["no-colon", 123, ""]) == []
+        assert _parse_volume_specs("not json") == []
+        assert _parse_volume_specs(None) == []
+
+
+class TestLogicalToPhysicalMapping:
+    def test_maps_subpath_under_mount(self):
+        mounts = [("/Users/dev/hermes-work/repos", "/workspace/repos")]
+        assert _map_logical_to_physical("/workspace/repos/myrepo", mounts) == (
+            "/Users/dev/hermes-work/repos/myrepo"
+        )
+
+    def test_maps_mount_root_exactly(self):
+        mounts = [("/Users/dev/hermes-work/repos", "/workspace/repos")]
+        assert _map_logical_to_physical("/workspace/repos", mounts) == (
+            "/Users/dev/hermes-work/repos"
+        )
+
+    def test_unmapped_path_returns_none(self):
+        mounts = [("/Users/dev/hermes-work/repos", "/workspace/repos")]
+        assert _map_logical_to_physical("/some/other/path", mounts) is None
+
+    def test_most_specific_mount_wins(self):
+        mounts = [
+            ("/host/all", "/workspace"),
+            ("/host/repos", "/workspace/repos"),
+        ]
+        assert _map_logical_to_physical("/workspace/repos/x", mounts) == (
+            "/host/repos/x"
+        )
+
+
+class TestDockerBindMountCheckpoints:
+    """End-to-end: container logical key, host physical git I/O."""
+
+    @pytest.fixture()
+    def docker_repo(self, tmp_path):
+        """A host bind-mount source standing in for ``docker_volumes``."""
+        host_repos = tmp_path / "hermes-work" / "repos"
+        repo = host_repos / "myrepo"
+        repo.mkdir(parents=True)
+        (repo / ".git").mkdir()  # repo marker
+        (repo / "README.md").write_text("# docs v1\n")
+        container_target = "/workspace/repos"
+        logical = "/workspace/repos/myrepo"
+        return host_repos, repo, container_target, logical
+
+    def _mgr(self, host_repos, container_target, checkpoint_base, monkeypatch):
+        monkeypatch.setattr(
+            "tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base,
+        )
+        return CheckpointManager(
+            enabled=True,
+            max_snapshots=50,
+            docker_volumes=[f"{host_repos}:{container_target}"],
+        )
+
+    def test_create_under_logical_key_lists_under_logical_key(
+        self, docker_repo, checkpoint_base, monkeypatch,
+    ):
+        host_repos, repo, container_target, logical = docker_repo
+        mgr = self._mgr(host_repos, container_target, checkpoint_base, monkeypatch)
+
+        # File-tool preflight checkpoints the *logical* container workdir.
+        assert mgr.ensure_checkpoint(logical, "before write_file") is True
+
+        # /rollback lists under the same logical key (TERMINAL_CWD) and finds it.
+        listed = mgr.list_checkpoints(logical)
+        assert len(listed) == 1
+        assert listed[0]["reason"] == "before write_file"
+
+    def test_metadata_records_existing_host_path_not_container_path(
+        self, docker_repo, checkpoint_base, monkeypatch,
+    ):
+        host_repos, repo, container_target, logical = docker_repo
+        mgr = self._mgr(host_repos, container_target, checkpoint_base, monkeypatch)
+        mgr.ensure_checkpoint(logical, "before write_file")
+
+        # Project metadata is keyed by the logical hash but stores the physical
+        # host path, so the orphan sweep (which checks workdir existence) does
+        # not flag the live checkpoint just because the container path is absent
+        # on the host.
+        store = _store_path(checkpoint_base)
+        meta_path = _project_meta_path(store, _project_hash(logical))
+        assert meta_path.exists()
+        recorded = json.loads(meta_path.read_text())["workdir"]
+        assert recorded == str(repo.resolve())
+        assert Path(recorded).exists()
+
+    def test_diff_and_restore_round_trip_via_logical_key(
+        self, docker_repo, checkpoint_base, monkeypatch,
+    ):
+        host_repos, repo, container_target, logical = docker_repo
+        mgr = self._mgr(host_repos, container_target, checkpoint_base, monkeypatch)
+
+        mgr.ensure_checkpoint(logical, "before write_file")
+        cps = mgr.list_checkpoints(logical)
+        first_hash = cps[0]["hash"]
+
+        # Edit the file on the host (as the in-container tool would, via mount).
+        mgr.new_turn()
+        (repo / "README.md").write_text("# docs v2 — edited\n")
+
+        # Diff against the checkpoint, looked up by the logical key.
+        diff = mgr.diff(logical, first_hash)
+        assert diff["success"] is True
+        assert "README.md" in diff["diff"]
+
+        # Restore by the logical key writes back to the physical host file.
+        result = mgr.restore(logical, first_hash)
+        assert result["success"] is True
+        assert result["directory"] == logical  # user-facing identity is logical
+        assert (repo / "README.md").read_text() == "# docs v1\n"
+
+    def test_relative_edit_keys_off_terminal_cwd(
+        self, docker_repo, checkpoint_base, monkeypatch,
+    ):
+        """A relative write_file in a Docker runtime keys off TERMINAL_CWD,
+        matching exactly what /rollback uses — the core issue scenario."""
+        host_repos, repo, container_target, logical = docker_repo
+        monkeypatch.setattr(
+            "tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base,
+        )
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CWD", logical)
+        monkeypatch.setenv(
+            "TERMINAL_DOCKER_VOLUMES",
+            json.dumps([f"{host_repos}:{container_target}"]),
+        )
+
+        # No constructor override — mounts come from the runtime env, exactly
+        # like the agent/gateway-constructed managers.
+        mgr = CheckpointManager(enabled=True, max_snapshots=50)
+
+        # Preflight resolves a relative file edit to the runtime cwd.
+        assert mgr.checkpoint_dir_for_file("README.md") == logical
+        mgr.ensure_checkpoint(
+            mgr.checkpoint_dir_for_file("README.md"), "before write_file",
+        )
+
+        # A second manager (e.g. the /rollback handler) reads the same env and
+        # finds the checkpoint under TERMINAL_CWD.
+        rollback_mgr = CheckpointManager(enabled=True, max_snapshots=50)
+        listed = rollback_mgr.list_checkpoints(os.environ["TERMINAL_CWD"])
+        assert len(listed) == 1
+        assert listed[0]["reason"] == "before write_file"
+
+    def test_rollback_resolves_via_metadata_when_mounts_absent(
+        self, docker_repo, checkpoint_base, monkeypatch,
+    ):
+        """A /rollback handler with no live docker_volumes still resolves the
+        host tree from project metadata recorded at creation time."""
+        host_repos, repo, container_target, logical = docker_repo
+        creator = self._mgr(host_repos, container_target, checkpoint_base, monkeypatch)
+        creator.ensure_checkpoint(logical, "before write_file")
+
+        # A second manager with NO mount override and no Docker env — it must
+        # still find and operate on the checkpoint via the recorded host path.
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.delenv("TERMINAL_DOCKER_VOLUMES", raising=False)
+        rollback_mgr = CheckpointManager(enabled=True, max_snapshots=50)
+
+        listed = rollback_mgr.list_checkpoints(logical)
+        assert len(listed) == 1
+
+        result = rollback_mgr.restore(logical, listed[0]["hash"])
+        assert result["success"] is True
+        assert (repo / "README.md").read_text() == "# docs v1\n"
+
+    def test_local_backend_relative_edit_walks_to_repo_root(
+        self, work_dir, checkpoint_base, monkeypatch,
+    ):
+        """Without Docker mounts, relative edits keep the local walk-up
+        behavior (no regression for the common case)."""
+        monkeypatch.setattr(
+            "tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base,
+        )
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.delenv("TERMINAL_DOCKER_VOLUMES", raising=False)
+        (work_dir / ".git").mkdir()
+        mgr = CheckpointManager(enabled=True, max_snapshots=50)
+        monkeypatch.chdir(work_dir)
+
+        # Falls through to get_working_dir_for_path → the repo root.
+        assert mgr.checkpoint_dir_for_file("main.py") == str(work_dir.resolve())

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -154,6 +154,13 @@ _MAX_FILES = 50_000
 # Valid git commit hash pattern: 4–40 hex chars (short or full SHA-1/SHA-256).
 _COMMIT_HASH_RE = re.compile(r'^[0-9a-fA-F]{4,64}$')
 
+# Docker bind-mount spec: ``host:container[:options]`` where the container path
+# is absolute.  Kept in sync with gateway/run.py's ``_DOCKER_VOLUME_SPEC_RE`` —
+# duplicated here so the checkpoint layer never imports the gateway package.
+_DOCKER_VOLUME_SPEC_RE = re.compile(
+    r"^(?P<host>.+):(?P<container>/[^:]+?)(?::(?P<options>[^:]+))?$"
+)
+
 
 # ---------------------------------------------------------------------------
 # Input validation helpers
@@ -206,6 +213,98 @@ def _project_hash(working_dir: str) -> str:
     """Deterministic per-project hash: sha256(abs_path)[:16]."""
     abs_path = str(_normalize_path(working_dir))
     return hashlib.sha256(abs_path.encode()).hexdigest()[:16]
+
+
+def _abspath_no_resolve(path_value: str) -> str:
+    """Absolute, normalised path *without* symlink resolution.
+
+    Used for matching a logical runtime (container) path against bind-mount
+    targets.  ``_normalize_path`` calls ``Path.resolve()`` which would chase
+    host symlinks — wrong for a container path like ``/workspace/repos/x`` that
+    has no meaning on the host filesystem.
+    """
+    return os.path.normpath(os.path.abspath(os.path.expanduser(path_value)))
+
+
+def _parse_volume_specs(raw) -> List[Tuple[str, str]]:
+    """Parse ``docker_volumes`` into ``[(host, container), ...]`` pairs.
+
+    Accepts either the already-decoded list (constructor/config path) or the
+    JSON string carried in ``TERMINAL_DOCKER_VOLUMES`` (runtime path).  Entries
+    that are not ``host:container[:options]`` specs are ignored.
+    """
+    if not raw:
+        return []
+    items = raw
+    if isinstance(raw, str):
+        try:
+            items = json.loads(raw)
+        except (ValueError, TypeError):
+            return []
+    if not isinstance(items, list):
+        return []
+    mounts: List[Tuple[str, str]] = []
+    for spec in items:
+        if not isinstance(spec, str):
+            continue
+        m = _DOCKER_VOLUME_SPEC_RE.match(spec.strip())
+        if not m:
+            continue
+        mounts.append((m.group("host"), m.group("container")))
+    return mounts
+
+
+def _physical_from_metadata(logical_key: str) -> Optional[str]:
+    """Recover the physical host path for ``logical_key`` from project metadata.
+
+    Project metadata records the on-disk ``workdir`` that git operated on when
+    the checkpoint was created.  This lets list/diff/restore still find the host
+    tree for a logical (container) key even when the live ``docker_volumes``
+    mounts are no longer present in the environment — a safety net for the
+    primary ``docker_volumes`` mapping in ``_resolve_dirs``.  Returns None when
+    no usable metadata exists.
+    """
+    store = _store_path(CHECKPOINT_BASE)
+    meta_path = _project_meta_path(store, _project_hash(logical_key))
+    if not meta_path.exists():
+        return None
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if isinstance(meta, dict):
+        workdir = meta.get("workdir")
+        if workdir and Path(workdir).exists():
+            return str(_normalize_path(workdir))
+    return None
+
+
+def _map_logical_to_physical(
+    logical_dir: str, mounts: List[Tuple[str, str]],
+) -> Optional[str]:
+    """Translate a logical (container) workdir to its host bind-mount path.
+
+    Returns the host path if ``logical_dir`` equals or sits under a mount's
+    container target, choosing the most specific (longest) target when several
+    match.  Returns None when no mount applies (caller keeps the logical path).
+    """
+    logical_norm = _abspath_no_resolve(logical_dir)
+    best_len = -1
+    best_path: Optional[str] = None
+    for host, container in mounts:
+        container_norm = os.path.normpath(container)
+        if logical_norm == container_norm:
+            rel = ""
+        elif logical_norm.startswith(container_norm.rstrip("/") + os.sep):
+            rel = os.path.relpath(logical_norm, container_norm)
+        else:
+            continue
+        host_norm = os.path.normpath(os.path.expanduser(host))
+        mapped = host_norm if rel in ("", ".") else os.path.join(host_norm, rel)
+        if len(container_norm) > best_len:
+            best_len = len(container_norm)
+            best_path = mapped
+    return best_path
 
 
 def _store_path(base: Optional[Path] = None) -> Path:
@@ -574,9 +673,18 @@ def _volume_evidence(workdir: Path) -> Dict:
         return {}
 
 
-def _register_project(store: Path, working_dir: str) -> None:
-    """Create or update ``projects/<hash>.json`` with workdir + timestamps."""
-    dir_hash = _project_hash(working_dir)
+def _register_project(
+    store: Path, working_dir: str, dir_hash: Optional[str] = None,
+) -> None:
+    """Create or update ``projects/<hash>.json`` with workdir + timestamps.
+
+    ``dir_hash`` lets callers key a project by its *logical* runtime path while
+    persisting the *physical* ``working_dir`` git operates on (Docker bind
+    mounts).  When omitted it is derived from ``working_dir`` (local backend,
+    where logical == physical).
+    """
+    if dir_hash is None:
+        dir_hash = _project_hash(working_dir)
     meta_path = _project_meta_path(store, dir_hash)
     now = time.time()
     meta: Dict = {"workdir": str(_normalize_path(working_dir)),
@@ -606,12 +714,19 @@ def _register_project(store: Path, working_dir: str) -> None:
         logger.debug("Could not write project metadata %s: %s", meta_path, exc)
 
 
-def _touch_project(store: Path, working_dir: str) -> None:
-    """Update last_touch for a project, preserving created_at."""
-    dir_hash = _project_hash(working_dir)
+def _touch_project(
+    store: Path, working_dir: str, dir_hash: Optional[str] = None,
+) -> None:
+    """Update last_touch for a project, preserving created_at.
+
+    ``dir_hash`` follows the same logical/physical split as
+    ``_register_project`` — supply it to key by the logical runtime path.
+    """
+    if dir_hash is None:
+        dir_hash = _project_hash(working_dir)
     meta_path = _project_meta_path(store, dir_hash)
     if not meta_path.exists():
-        _register_project(store, working_dir)
+        _register_project(store, working_dir, dir_hash)
         return
     try:
         meta = json.loads(meta_path.read_text(encoding="utf-8"))
@@ -780,6 +895,7 @@ class CheckpointManager:
         max_snapshots: int = 20,
         max_total_size_mb: int = 500,
         max_file_size_mb: int = 10,
+        docker_volumes: Optional[List[str]] = None,
     ):
         self.enabled = enabled
         self.max_snapshots = max(1, int(max_snapshots))
@@ -787,6 +903,10 @@ class CheckpointManager:
         self.max_file_size_mb = max(0, int(max_file_size_mb))
         self._checkpointed_dirs: Set[str] = set()
         self._git_available: Optional[bool] = None  # lazy probe
+        # Explicit bind-mount override (tests / direct config).  When None the
+        # mounts are read from the runtime env (TERMINAL_ENV / DOCKER_VOLUMES)
+        # at call time, mirroring how runtime_cwd reads TERMINAL_CWD.
+        self._docker_volumes_override = docker_volumes
 
     # ------------------------------------------------------------------
     # Turn lifecycle
@@ -795,6 +915,63 @@ class CheckpointManager:
     def new_turn(self) -> None:
         """Reset per-turn dedup.  Call at the start of each agent iteration."""
         self._checkpointed_dirs.clear()
+
+    # ------------------------------------------------------------------
+    # Logical (runtime) ↔ physical (host) workdir resolution
+    # ------------------------------------------------------------------
+
+    def _docker_mounts(self) -> List[Tuple[str, str]]:
+        """Return the active ``(host, container)`` bind mounts, or ``[]``.
+
+        An explicit constructor override wins (tests / direct config).
+        Otherwise mounts are read from the runtime env, and only when the
+        active terminal backend is Docker — a stale ``TERMINAL_DOCKER_VOLUMES``
+        left over from a previous backend must not remap local-backend paths.
+        """
+        if self._docker_volumes_override is not None:
+            return _parse_volume_specs(self._docker_volumes_override)
+        if (os.getenv("TERMINAL_ENV") or "local").strip().lower() != "docker":
+            return []
+        return _parse_volume_specs(os.getenv("TERMINAL_DOCKER_VOLUMES", ""))
+
+    def _resolve_dirs(self, working_dir: str) -> Tuple[str, str]:
+        """Split a workdir into ``(logical_key, physical_dir)``.
+
+        The *logical key* is the stable runtime path used to identify the
+        project (so checkpoint creation and ``/rollback`` agree on one key).
+        The *physical dir* is where git actually reads and writes — for a
+        Docker bind mount that's the host source path; otherwise it is the same
+        as the logical key (local backend, the common case).
+        """
+        logical_key = str(_normalize_path(working_dir))
+        mounts = self._docker_mounts()
+        if mounts:
+            mapped = _map_logical_to_physical(working_dir, mounts)
+            if mapped:
+                return logical_key, str(_normalize_path(mapped))
+        # No live mount mapped the key.  If the logical path doesn't exist on
+        # disk (e.g. a container path queried after the Docker env is gone),
+        # fall back to the physical host path recorded in project metadata.
+        if not Path(logical_key).exists():
+            recovered = _physical_from_metadata(logical_key)
+            if recovered:
+                return logical_key, recovered
+        return logical_key, logical_key
+
+    def checkpoint_dir_for_file(self, file_path: str) -> str:
+        """Return the logical workdir key to checkpoint for a file edit.
+
+        Inside a Docker bind-mount runtime a *relative* edit resolves against
+        the container runtime cwd (``TERMINAL_CWD``) so the recorded key matches
+        what ``/rollback`` looks up; ``_resolve_dirs`` later maps that key to the
+        host path for git I/O.  In every other case this falls back to walking
+        up from the file's location to the project root (local backend).
+        """
+        if not os.path.isabs(file_path):
+            runtime_cwd = os.getenv("TERMINAL_CWD", "").strip()
+            if runtime_cwd and self._docker_mounts():
+                return runtime_cwd
+        return self.get_working_dir_for_path(file_path)
 
     # ------------------------------------------------------------------
     # Public API
@@ -909,33 +1086,36 @@ class CheckpointManager:
         if not self._git_available:
             return False
 
-        abs_dir = str(_normalize_path(working_dir))
+        logical_key, physical_dir = self._resolve_dirs(working_dir)
 
-        # Skip root, home, and other overly broad directories
-        if abs_dir in {"/", str(Path.home())}:
-            logger.debug("Checkpoint skipped: directory too broad (%s)", abs_dir)
+        # Skip root, home, and other overly broad directories — check the
+        # physical dir git would actually snapshot.
+        if physical_dir in {"/", str(Path.home())}:
+            logger.debug("Checkpoint skipped: directory too broad (%s)", physical_dir)
             return False
 
-        if abs_dir in self._checkpointed_dirs:
+        # Dedup on the logical key so one project is snapshotted once per turn
+        # regardless of which host path it maps to.
+        if logical_key in self._checkpointed_dirs:
             return False
 
-        self._checkpointed_dirs.add(abs_dir)
+        self._checkpointed_dirs.add(logical_key)
 
         try:
-            return self._take(abs_dir, reason)
+            return self._take(logical_key, physical_dir, reason)
         except Exception as e:
             logger.debug("Checkpoint failed (non-fatal): %s", e)
             return False
 
     def list_checkpoints(self, working_dir: str) -> List[Dict]:
         """List available checkpoints for a directory (most recent first)."""
-        abs_dir = str(_normalize_path(working_dir))
+        logical_key, abs_dir = self._resolve_dirs(working_dir)
         store = _store_path(CHECKPOINT_BASE)
 
         if not (store / "HEAD").exists():
             return []
 
-        ref = _ref_name(_project_hash(abs_dir))
+        ref = _ref_name(_project_hash(logical_key))
         ok, stdout, _ = _run_git(
             ["log", ref, "--format=%H|%h|%aI|%s", "-n", str(self.max_snapshots)],
             store, abs_dir,
@@ -1010,7 +1190,7 @@ class CheckpointManager:
         if hash_err:
             return {"success": False, "error": hash_err}
 
-        abs_dir = str(_normalize_path(working_dir))
+        logical_key, abs_dir = self._resolve_dirs(working_dir)
         store = _store_path(CHECKPOINT_BASE)
 
         if not (store / "HEAD").exists():
@@ -1022,7 +1202,7 @@ class CheckpointManager:
         if not ok:
             return {"success": False, "error": f"Checkpoint '{commit_hash}' not found"}
 
-        dir_hash = _project_hash(abs_dir)
+        dir_hash = _project_hash(logical_key)
         index_file = _index_path(store, dir_hash)
 
         # Stage current state into the per-project index to compare.
@@ -1107,7 +1287,7 @@ class CheckpointManager:
         if hash_err:
             return {"success": False, "error": hash_err}
 
-        abs_dir = str(_normalize_path(working_dir))
+        logical_key, abs_dir = self._resolve_dirs(working_dir)
 
         if file_path:
             path_err = _validate_file_path(file_path, abs_dir)
@@ -1153,9 +1333,10 @@ class CheckpointManager:
                     }
 
         # Take a pre-rollback snapshot so you can undo the undo.
-        self._take(abs_dir, f"pre-rollback snapshot (restoring to {commit_hash[:8]})")
+        self._take(logical_key, abs_dir,
+                   f"pre-rollback snapshot (restoring to {commit_hash[:8]})")
 
-        dir_hash = _project_hash(abs_dir)
+        dir_hash = _project_hash(logical_key)
         index_file = _index_path(store, dir_hash)
 
         if restore_paths is not None:
@@ -1220,7 +1401,8 @@ class CheckpointManager:
             "success": True,
             "restored_to": commit_hash[:8],
             "reason": reason,
-            "directory": abs_dir,
+            # Report the logical key — the stable, user-facing project identity.
+            "directory": logical_key,
         }
         if file_path:
             result["file"] = file_path
@@ -1262,8 +1444,16 @@ class CheckpointManager:
     # Internal
     # ------------------------------------------------------------------
 
-    def _take(self, working_dir: str, reason: str) -> bool:
-        """Take a snapshot.  Returns True on success."""
+    def _take(self, logical_key: str, physical_dir: str, reason: str) -> bool:
+        """Take a snapshot.  Returns True on success.
+
+        ``logical_key`` identifies the project (ref / index / metadata key);
+        ``physical_dir`` is the on-disk tree git reads and writes.  They differ
+        only for Docker bind mounts — elsewhere the caller passes the same value
+        for both.
+        """
+        # The git-facing body below operates entirely on the physical tree.
+        working_dir = physical_dir
         store = _store_path(CHECKPOINT_BASE)
 
         err = _init_store(store, working_dir)
@@ -1271,14 +1461,14 @@ class CheckpointManager:
             logger.debug("Checkpoint store init failed: %s", err)
             return False
 
-        _touch_project(store, working_dir)
+        dir_hash = _project_hash(logical_key)
+        _touch_project(store, working_dir, dir_hash)
 
         # Quick size guard — don't try to snapshot enormous directories
         if _dir_file_count(working_dir) > _MAX_FILES:
             logger.debug("Checkpoint skipped: >%d files in %s", _MAX_FILES, working_dir)
             return False
 
-        dir_hash = _project_hash(working_dir)
         index_file = _index_path(store, dir_hash)
         ref = _ref_name(dir_hash)
 

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -150,6 +150,13 @@ _MAX_FILES = 50_000
 # Valid git commit hash pattern: 4–40 hex chars (short or full SHA-1/SHA-256).
 _COMMIT_HASH_RE = re.compile(r'^[0-9a-fA-F]{4,64}$')
 
+# Docker bind-mount spec: ``host:container[:options]`` where the container path
+# is absolute.  Kept in sync with gateway/run.py's ``_DOCKER_VOLUME_SPEC_RE`` —
+# duplicated here so the checkpoint layer never imports the gateway package.
+_DOCKER_VOLUME_SPEC_RE = re.compile(
+    r"^(?P<host>.+):(?P<container>/[^:]+?)(?::(?P<options>[^:]+))?$"
+)
+
 
 # ---------------------------------------------------------------------------
 # Input validation helpers
@@ -202,6 +209,98 @@ def _project_hash(working_dir: str) -> str:
     """Deterministic per-project hash: sha256(abs_path)[:16]."""
     abs_path = str(_normalize_path(working_dir))
     return hashlib.sha256(abs_path.encode()).hexdigest()[:16]
+
+
+def _abspath_no_resolve(path_value: str) -> str:
+    """Absolute, normalised path *without* symlink resolution.
+
+    Used for matching a logical runtime (container) path against bind-mount
+    targets.  ``_normalize_path`` calls ``Path.resolve()`` which would chase
+    host symlinks — wrong for a container path like ``/workspace/repos/x`` that
+    has no meaning on the host filesystem.
+    """
+    return os.path.normpath(os.path.abspath(os.path.expanduser(path_value)))
+
+
+def _parse_volume_specs(raw) -> List[Tuple[str, str]]:
+    """Parse ``docker_volumes`` into ``[(host, container), ...]`` pairs.
+
+    Accepts either the already-decoded list (constructor/config path) or the
+    JSON string carried in ``TERMINAL_DOCKER_VOLUMES`` (runtime path).  Entries
+    that are not ``host:container[:options]`` specs are ignored.
+    """
+    if not raw:
+        return []
+    items = raw
+    if isinstance(raw, str):
+        try:
+            items = json.loads(raw)
+        except (ValueError, TypeError):
+            return []
+    if not isinstance(items, list):
+        return []
+    mounts: List[Tuple[str, str]] = []
+    for spec in items:
+        if not isinstance(spec, str):
+            continue
+        m = _DOCKER_VOLUME_SPEC_RE.match(spec.strip())
+        if not m:
+            continue
+        mounts.append((m.group("host"), m.group("container")))
+    return mounts
+
+
+def _physical_from_metadata(logical_key: str) -> Optional[str]:
+    """Recover the physical host path for ``logical_key`` from project metadata.
+
+    Project metadata records the on-disk ``workdir`` that git operated on when
+    the checkpoint was created.  This lets list/diff/restore still find the host
+    tree for a logical (container) key even when the live ``docker_volumes``
+    mounts are no longer present in the environment — a safety net for the
+    primary ``docker_volumes`` mapping in ``_resolve_dirs``.  Returns None when
+    no usable metadata exists.
+    """
+    store = _store_path(CHECKPOINT_BASE)
+    meta_path = _project_meta_path(store, _project_hash(logical_key))
+    if not meta_path.exists():
+        return None
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if isinstance(meta, dict):
+        workdir = meta.get("workdir")
+        if workdir and Path(workdir).exists():
+            return str(_normalize_path(workdir))
+    return None
+
+
+def _map_logical_to_physical(
+    logical_dir: str, mounts: List[Tuple[str, str]],
+) -> Optional[str]:
+    """Translate a logical (container) workdir to its host bind-mount path.
+
+    Returns the host path if ``logical_dir`` equals or sits under a mount's
+    container target, choosing the most specific (longest) target when several
+    match.  Returns None when no mount applies (caller keeps the logical path).
+    """
+    logical_norm = _abspath_no_resolve(logical_dir)
+    best_len = -1
+    best_path: Optional[str] = None
+    for host, container in mounts:
+        container_norm = os.path.normpath(container)
+        if logical_norm == container_norm:
+            rel = ""
+        elif logical_norm.startswith(container_norm.rstrip("/") + os.sep):
+            rel = os.path.relpath(logical_norm, container_norm)
+        else:
+            continue
+        host_norm = os.path.normpath(os.path.expanduser(host))
+        mapped = host_norm if rel in ("", ".") else os.path.join(host_norm, rel)
+        if len(container_norm) > best_len:
+            best_len = len(container_norm)
+            best_path = mapped
+    return best_path
 
 
 def _store_path(base: Optional[Path] = None) -> Path:
@@ -520,9 +619,18 @@ def _volume_evidence(workdir: Path) -> Dict:
         return {}
 
 
-def _register_project(store: Path, working_dir: str) -> None:
-    """Create or update ``projects/<hash>.json`` with workdir + timestamps."""
-    dir_hash = _project_hash(working_dir)
+def _register_project(
+    store: Path, working_dir: str, dir_hash: Optional[str] = None,
+) -> None:
+    """Create or update ``projects/<hash>.json`` with workdir + timestamps.
+
+    ``dir_hash`` lets callers key a project by its *logical* runtime path while
+    persisting the *physical* ``working_dir`` git operates on (Docker bind
+    mounts).  When omitted it is derived from ``working_dir`` (local backend,
+    where logical == physical).
+    """
+    if dir_hash is None:
+        dir_hash = _project_hash(working_dir)
     meta_path = _project_meta_path(store, dir_hash)
     now = time.time()
     meta: Dict = {"workdir": str(_normalize_path(working_dir)),
@@ -552,12 +660,19 @@ def _register_project(store: Path, working_dir: str) -> None:
         logger.debug("Could not write project metadata %s: %s", meta_path, exc)
 
 
-def _touch_project(store: Path, working_dir: str) -> None:
-    """Update last_touch for a project, preserving created_at."""
-    dir_hash = _project_hash(working_dir)
+def _touch_project(
+    store: Path, working_dir: str, dir_hash: Optional[str] = None,
+) -> None:
+    """Update last_touch for a project, preserving created_at.
+
+    ``dir_hash`` follows the same logical/physical split as
+    ``_register_project`` — supply it to key by the logical runtime path.
+    """
+    if dir_hash is None:
+        dir_hash = _project_hash(working_dir)
     meta_path = _project_meta_path(store, dir_hash)
     if not meta_path.exists():
-        _register_project(store, working_dir)
+        _register_project(store, working_dir, dir_hash)
         return
     try:
         meta = json.loads(meta_path.read_text(encoding="utf-8"))
@@ -726,6 +841,7 @@ class CheckpointManager:
         max_snapshots: int = 20,
         max_total_size_mb: int = 500,
         max_file_size_mb: int = 10,
+        docker_volumes: Optional[List[str]] = None,
     ):
         self.enabled = enabled
         self.max_snapshots = max(1, int(max_snapshots))
@@ -733,6 +849,10 @@ class CheckpointManager:
         self.max_file_size_mb = max(0, int(max_file_size_mb))
         self._checkpointed_dirs: Set[str] = set()
         self._git_available: Optional[bool] = None  # lazy probe
+        # Explicit bind-mount override (tests / direct config).  When None the
+        # mounts are read from the runtime env (TERMINAL_ENV / DOCKER_VOLUMES)
+        # at call time, mirroring how runtime_cwd reads TERMINAL_CWD.
+        self._docker_volumes_override = docker_volumes
 
     # ------------------------------------------------------------------
     # Turn lifecycle
@@ -741,6 +861,63 @@ class CheckpointManager:
     def new_turn(self) -> None:
         """Reset per-turn dedup.  Call at the start of each agent iteration."""
         self._checkpointed_dirs.clear()
+
+    # ------------------------------------------------------------------
+    # Logical (runtime) ↔ physical (host) workdir resolution
+    # ------------------------------------------------------------------
+
+    def _docker_mounts(self) -> List[Tuple[str, str]]:
+        """Return the active ``(host, container)`` bind mounts, or ``[]``.
+
+        An explicit constructor override wins (tests / direct config).
+        Otherwise mounts are read from the runtime env, and only when the
+        active terminal backend is Docker — a stale ``TERMINAL_DOCKER_VOLUMES``
+        left over from a previous backend must not remap local-backend paths.
+        """
+        if self._docker_volumes_override is not None:
+            return _parse_volume_specs(self._docker_volumes_override)
+        if (os.getenv("TERMINAL_ENV") or "local").strip().lower() != "docker":
+            return []
+        return _parse_volume_specs(os.getenv("TERMINAL_DOCKER_VOLUMES", ""))
+
+    def _resolve_dirs(self, working_dir: str) -> Tuple[str, str]:
+        """Split a workdir into ``(logical_key, physical_dir)``.
+
+        The *logical key* is the stable runtime path used to identify the
+        project (so checkpoint creation and ``/rollback`` agree on one key).
+        The *physical dir* is where git actually reads and writes — for a
+        Docker bind mount that's the host source path; otherwise it is the same
+        as the logical key (local backend, the common case).
+        """
+        logical_key = str(_normalize_path(working_dir))
+        mounts = self._docker_mounts()
+        if mounts:
+            mapped = _map_logical_to_physical(working_dir, mounts)
+            if mapped:
+                return logical_key, str(_normalize_path(mapped))
+        # No live mount mapped the key.  If the logical path doesn't exist on
+        # disk (e.g. a container path queried after the Docker env is gone),
+        # fall back to the physical host path recorded in project metadata.
+        if not Path(logical_key).exists():
+            recovered = _physical_from_metadata(logical_key)
+            if recovered:
+                return logical_key, recovered
+        return logical_key, logical_key
+
+    def checkpoint_dir_for_file(self, file_path: str) -> str:
+        """Return the logical workdir key to checkpoint for a file edit.
+
+        Inside a Docker bind-mount runtime a *relative* edit resolves against
+        the container runtime cwd (``TERMINAL_CWD``) so the recorded key matches
+        what ``/rollback`` looks up; ``_resolve_dirs`` later maps that key to the
+        host path for git I/O.  In every other case this falls back to walking
+        up from the file's location to the project root (local backend).
+        """
+        if not os.path.isabs(file_path):
+            runtime_cwd = os.getenv("TERMINAL_CWD", "").strip()
+            if runtime_cwd and self._docker_mounts():
+                return runtime_cwd
+        return self.get_working_dir_for_path(file_path)
 
     # ------------------------------------------------------------------
     # Public API
@@ -762,33 +939,36 @@ class CheckpointManager:
         if not self._git_available:
             return False
 
-        abs_dir = str(_normalize_path(working_dir))
+        logical_key, physical_dir = self._resolve_dirs(working_dir)
 
-        # Skip root, home, and other overly broad directories
-        if abs_dir in {"/", str(Path.home())}:
-            logger.debug("Checkpoint skipped: directory too broad (%s)", abs_dir)
+        # Skip root, home, and other overly broad directories — check the
+        # physical dir git would actually snapshot.
+        if physical_dir in {"/", str(Path.home())}:
+            logger.debug("Checkpoint skipped: directory too broad (%s)", physical_dir)
             return False
 
-        if abs_dir in self._checkpointed_dirs:
+        # Dedup on the logical key so one project is snapshotted once per turn
+        # regardless of which host path it maps to.
+        if logical_key in self._checkpointed_dirs:
             return False
 
-        self._checkpointed_dirs.add(abs_dir)
+        self._checkpointed_dirs.add(logical_key)
 
         try:
-            return self._take(abs_dir, reason)
+            return self._take(logical_key, physical_dir, reason)
         except Exception as e:
             logger.debug("Checkpoint failed (non-fatal): %s", e)
             return False
 
     def list_checkpoints(self, working_dir: str) -> List[Dict]:
         """List available checkpoints for a directory (most recent first)."""
-        abs_dir = str(_normalize_path(working_dir))
+        logical_key, abs_dir = self._resolve_dirs(working_dir)
         store = _store_path(CHECKPOINT_BASE)
 
         if not (store / "HEAD").exists():
             return []
 
-        ref = _ref_name(_project_hash(abs_dir))
+        ref = _ref_name(_project_hash(logical_key))
         ok, stdout, _ = _run_git(
             ["log", ref, "--format=%H|%h|%aI|%s", "-n", str(self.max_snapshots)],
             store, abs_dir,
@@ -840,7 +1020,7 @@ class CheckpointManager:
         if hash_err:
             return {"success": False, "error": hash_err}
 
-        abs_dir = str(_normalize_path(working_dir))
+        logical_key, abs_dir = self._resolve_dirs(working_dir)
         store = _store_path(CHECKPOINT_BASE)
 
         if not (store / "HEAD").exists():
@@ -852,7 +1032,7 @@ class CheckpointManager:
         if not ok:
             return {"success": False, "error": f"Checkpoint '{commit_hash}' not found"}
 
-        dir_hash = _project_hash(abs_dir)
+        dir_hash = _project_hash(logical_key)
         index_file = _index_path(store, dir_hash)
 
         # Stage current state into the per-project index to compare.
@@ -922,7 +1102,7 @@ class CheckpointManager:
         if hash_err:
             return {"success": False, "error": hash_err}
 
-        abs_dir = str(_normalize_path(working_dir))
+        logical_key, abs_dir = self._resolve_dirs(working_dir)
 
         if file_path:
             path_err = _validate_file_path(file_path, abs_dir)
@@ -942,9 +1122,10 @@ class CheckpointManager:
                     "debug": err or None}
 
         # Take a pre-rollback snapshot so you can undo the undo.
-        self._take(abs_dir, f"pre-rollback snapshot (restoring to {commit_hash[:8]})")
+        self._take(logical_key, abs_dir,
+                   f"pre-rollback snapshot (restoring to {commit_hash[:8]})")
 
-        dir_hash = _project_hash(abs_dir)
+        dir_hash = _project_hash(logical_key)
         index_file = _index_path(store, dir_hash)
 
         restore_target = file_path if file_path else "."
@@ -967,7 +1148,8 @@ class CheckpointManager:
             "success": True,
             "restored_to": commit_hash[:8],
             "reason": reason,
-            "directory": abs_dir,
+            # Report the logical key — the stable, user-facing project identity.
+            "directory": logical_key,
         }
         if file_path:
             result["file"] = file_path
@@ -995,8 +1177,16 @@ class CheckpointManager:
     # Internal
     # ------------------------------------------------------------------
 
-    def _take(self, working_dir: str, reason: str) -> bool:
-        """Take a snapshot.  Returns True on success."""
+    def _take(self, logical_key: str, physical_dir: str, reason: str) -> bool:
+        """Take a snapshot.  Returns True on success.
+
+        ``logical_key`` identifies the project (ref / index / metadata key);
+        ``physical_dir`` is the on-disk tree git reads and writes.  They differ
+        only for Docker bind mounts — elsewhere the caller passes the same value
+        for both.
+        """
+        # The git-facing body below operates entirely on the physical tree.
+        working_dir = physical_dir
         store = _store_path(CHECKPOINT_BASE)
 
         err = _init_store(store, working_dir)
@@ -1004,14 +1194,14 @@ class CheckpointManager:
             logger.debug("Checkpoint store init failed: %s", err)
             return False
 
-        _touch_project(store, working_dir)
+        dir_hash = _project_hash(logical_key)
+        _touch_project(store, working_dir, dir_hash)
 
         # Quick size guard — don't try to snapshot enormous directories
         if _dir_file_count(working_dir) > _MAX_FILES:
             logger.debug("Checkpoint skipped: >%d files in %s", _MAX_FILES, working_dir)
             return False
 
-        dir_hash = _project_hash(working_dir)
         index_file = _index_path(store, dir_hash)
         ref = _ref_name(dir_hash)
 


### PR DESCRIPTION
## What does this PR do?

Fixes a Docker bind-mount checkpoint key mismatch (#54356).

With the Docker terminal backend and a host bind mount (e.g. `/Users/me/hermes-work/repos:/workspace/repos`), **checkpoint creation and `/rollback` keyed off different paths**:

- File-tool checkpoint preflight (`write_file`/`patch`) resolved a relative edit on the **host** and recorded the checkpoint under the host path's project hash (e.g. `/Users/me/hermes-work/repos/<repo>`).
- `/rollback` reads `TERMINAL_CWD` — the **container** runtime workdir (`/workspace/repos/<repo>`) — and looked checkpoints up under that hash.

Different paths produce different project hashes, so rollback reported *no checkpoints* for the active workdir even though one had just been created, and the checkpoint status view showed an `orphan` entry for the container path that doesn't exist on the host.

**Approach:** split the single `working_dir` into two concepts inside `CheckpointManager`:

| Concept | Value | Used for |
|---|---|---|
| **Logical key** | the stable runtime/container path (`TERMINAL_CWD`) | project identity — ref / index / metadata hash |
| **Physical dir** | the host bind-mount path | all git I/O (snapshot, list, diff, restore) |

The manager resolves `(logical_key, physical_dir)` by mapping the logical path through the configured `docker_volumes` mounts (read from the constructor, or at call time from the `TERMINAL_ENV` / `TERMINAL_DOCKER_VOLUMES` runtime env — mirroring how `runtime_cwd` reads `TERMINAL_CWD`, so the gateway/CLI/TUI `/rollback` handlers need no extra wiring). Creation and rollback now hash the **same** logical key, while git keeps operating on the real host tree. Because resolution lives at the manager boundary, every caller is covered — file-tool preflight, the destructive-terminal-command preflight, and `/rollback`. Project metadata stores the **physical** (existing) host path, so the orphan sweep no longer flags live checkpoints; when no live mount maps a key (e.g. the Docker env is gone at query time), resolution falls back to that recorded host path.

## Related Issue

Fixes #54356

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`tools/checkpoint_manager.py`**
  - `_parse_volume_specs()` / `_map_logical_to_physical()` — parse `host:container[:opts]` mounts and translate a logical container path (or sub-path) to its host path, preferring the most specific mount.
  - `_physical_from_metadata()` — recover the recorded host path for a logical key when no live mount applies.
  - `CheckpointManager.__init__` gains an optional `docker_volumes` arg; `_docker_mounts()` falls back to the runtime env and only applies when the Docker backend is active.
  - `_resolve_dirs()` returns `(logical_key, physical_dir)`; `ensure_checkpoint`, `_take`, `list_checkpoints`, `diff`, `restore` hash by the logical key and run git against the physical dir.
  - `checkpoint_dir_for_file()` keys relative file edits off `TERMINAL_CWD` under a Docker mount, preserving the local-backend project-root walk-up otherwise.
  - `_register_project` / `_touch_project` accept an explicit `dir_hash` (logical) while persisting the physical workdir — backward-compatible (derived when omitted).
- **`agent/tool_executor.py`** — both file-tool checkpoint preflight sites call `checkpoint_dir_for_file(...)` instead of `get_working_dir_for_path(...)`.
- **`tests/tools/test_checkpoint_manager.py`** — regression coverage (see below).

No new config keys (the `docker_volumes` setting already exists), no dependency changes.

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_checkpoint_manager.py -q   # 90 passed
```

New tests cover: volume-spec parsing, logical→physical mapping (incl. most-specific-mount and unmapped cases), the metadata fallback when mounts are absent, a full create → list → diff → restore round trip under a simulated bind mount, the relative-edit + `TERMINAL_CWD` path, and a local-backend no-regression check.

End-to-end on a Docker backend with bind mounts: make a relative `write_file`/`patch` edit, then run `/rollback` and `/rollback diff 1` — the checkpoint is found under the container workdir, and `/rollback 1` restores the host file.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (ran `scripts/run_tests.sh tests/tools/test_checkpoint_manager.py -q` — 90 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (internal fix; behavior matches existing docs)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `scripts/check-windows-footguns.py --diff upstream/main` reports no footguns
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (checkpoint manager is transparent infrastructure, not an LLM-facing tool)