### PR TITLE
fix(#1036): add circular dependency validation to kanban_create()

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2568,6 +2568,17 @@ def create_task(
                     if missing:
                         raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
 
+                # Validate no circular dependencies (matching link_tasks guards).
+                for pid in parents:
+                    if pid == task_id:
+                        raise ValueError(
+                            f"task cannot depend on itself (parent {pid})"
+                        )
+                    if _would_cycle(conn, pid, task_id):
+                        raise ValueError(
+                            f"adding parent {pid} -> child {task_id} would create a cycle"
+                        )
+
                 # Project-linked worktree: a fresh worktree dir under the repo
                 # plus a deterministic branch (project slug + task id). Together
                 # these kill the random ``wt/<task-id>`` worker fallback and the

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -236,6 +236,52 @@ def test_create_task_unknown_parent_errors(kanban_home):
         kb.create_task(conn, title="orphan", parents=["t_ghost"])
 
 
+def test_create_task_rejects_self_parent(kanban_home):
+    """Creating a task with itself as parent raises ValueError."""
+    with kb.connect() as conn:
+        # Pre-create a real task "t_self" so the existence check passes.
+        # The cycle guard runs AFTER the existence check, so the parent
+        # must exist for the self-reference error to surface first.
+        import time
+
+        conn.execute(
+            "INSERT INTO tasks (id, title, status, created_at) VALUES (?, ?, ?, ?)",
+            ("t_self", "pre-existing", "done", int(time.time())),
+        )
+        conn.commit()
+        with unittest.mock.patch.object(kb, "_new_task_id", return_value="t_self"):
+            with pytest.raises(ValueError, match="itself"):
+                kb.create_task(conn, title="self-ref", parents=["t_self"])
+
+
+def test_create_task_rejects_parent_that_would_create_cycle(kanban_home):
+    """Creating a task where any parent is already a descendant of the
+    new task (via existing links) raises ValueError.  For a brand-new task
+    this can't normally happen, but we test _would_cycle directionality:
+    the guard passes (parent_id, child_id) in the same order as link_tasks."""
+    with kb.connect() as conn:
+        a = kb.create_task(conn, title="a")
+        b = kb.create_task(conn, title="b", parents=[a])
+        c = kb.create_task(conn, title="c", parents=[b])
+        # c is a descendant of a.  Adding a -> c would NOT cycle
+        # (a is an ancestor of c, not a descendant).
+        assert kb._would_cycle(conn, a, c) is False
+        # Adding c -> a WOULD cycle (c is already a descendant of a,
+        # so making c a parent of a closes the loop).
+        assert kb._would_cycle(conn, c, a) is True
+
+
+def test_create_task_valid_parent_chain_no_false_positive(kanban_home):
+    """Cycle guard must not reject normal parent chains."""
+    with kb.connect() as conn:
+        a = kb.create_task(conn, title="a")
+        b = kb.create_task(conn, title="b", parents=[a])
+        c = kb.create_task(conn, title="c", parents=[b])
+        assert kb.get_task(conn, c).status == "todo"
+        assert kb.parent_ids(conn, b) == [a]
+        assert kb.parent_ids(conn, c) == [b]
+
+
 def test_workspace_kind_validation(kanban_home):
     with kb.connect() as conn, pytest.raises(ValueError, match="workspace_kind"):
         kb.create_task(conn, title="bad ws", workspace_kind="cloud")


### PR DESCRIPTION
## Problem
`kanban_create()` in `hermes_cli/kanban_db.py` validates parents exist but does NOT check for circular dependencies. The `link_tasks()` function HAS these checks (self-reference at line 2772, cycle detection via `_would_cycle()` at line 2778), but `kanban_create()` with `parents=[...]` bypasses them entirely.

This allows creating a task with `parents=[self_kanban_id]`, creating an impossible cycle that causes worker deadlocks.

## Fix
Added cycle detection guard in `create_task()` (kanban_db.py, line ~2571-2580) after triage parent validation and before the task INSERT:

- Self-reference check: `pid == task_id` → raise ValueError
- Cycle check: `_would_cycle(conn, pid, task_id)` → raise ValueError

This mirrors the existing guard in `link_tasks()` (lines 2771-2781).

## Tests
Added 3 tests in `tests/hermes_cli/test_kanban_db.py`:
- `test_create_task_rejects_self_parent` — validates self-reference rejection
- `test_create_task_rejects_parent_that_would_create_cycle` — validates `_would_cycle` directionality
- `test_create_task_valid_parent_chain_no_false_positive` — confirms normal chains pass

All 28 related tests pass.

## Related
- Issue: https://github.com/mosaiq-systems/mosaiq-chat/issues/1036