### PR TITLE
fix(matrix): fail closed for E2EE standalone sends

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -4253,12 +4253,24 @@ async def _standalone_send(
     """Out-of-process Matrix delivery via the Client-Server API.
 
     Implements the standalone_sender_fn contract so deliver=matrix cron jobs
-    succeed when cron runs separately from the gateway. Converts markdown to
-    HTML for rich rendering, falling back to plain text when the markdown
-    library is absent. Replaces the legacy _send_matrix helper.
+    can succeed when cron runs separately from the gateway. Plaintext
+    ``m.room.message`` fallback is only allowed when Matrix E2EE is explicitly
+    disabled; encrypted configurations must use a live Matrix adapter with a
+    crypto store so E2EE rooms fail closed instead of leaking plaintext.
     """
     extra = getattr(pconfig, "extra", {}) or {}
     token = getattr(pconfig, "token", None)
+    e2ee_mode = _resolve_e2ee_mode(extra)
+    if e2ee_mode != "off":
+        return {
+            "error": (
+                "Matrix standalone delivery refused because E2EE is "
+                f"{e2ee_mode!r}. Out-of-process Matrix delivery would send "
+                "a plaintext m.room.message; run the gateway/live adapter "
+                "with E2EE enabled or set MATRIX_E2EE_MODE=off only for "
+                "non-encrypted rooms."
+            )
+        }
     try:
         import aiohttp
     except ImportError:

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -359,6 +359,106 @@ class TestMatrixConfigLoading:
         assert mc.extra.get("user_id") == "@hermes:example.org"
 
 
+def _install_fake_matrix_aiohttp(monkeypatch):
+    """Install a fake aiohttp module so the red path never touches the network."""
+    fake = types.ModuleType("aiohttp")
+
+    class _Response:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def json(self):
+            return {"event_id": "$plaintext"}
+
+        async def text(self):
+            return ""
+
+    class _Session:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def put(self, *args, **kwargs):
+            return _Response()
+
+    setattr(fake, "ClientSession", _Session)
+    setattr(fake, "ClientTimeout", lambda *args, **kwargs: object())
+    monkeypatch.setitem(sys.modules, "aiohttp", fake)
+
+
+class TestMatrixStandaloneSendE2EEGuard:
+    @pytest.mark.asyncio
+    async def test_required_e2ee_refuses_plaintext_standalone_send(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_E2EE_MODE", "required")
+        monkeypatch.setenv("MATRIX_HOMESERVER", "https://matrix.example.org")
+        monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_test")
+        _install_fake_matrix_aiohttp(monkeypatch)
+
+        from plugins.platforms.matrix.adapter import _standalone_send
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "!encrypted:example.org",
+            "hello",
+        )
+
+        assert result == {
+            "error": (
+                "Matrix standalone delivery refused because E2EE is 'required'. "
+                "Out-of-process Matrix delivery would send a plaintext m.room.message; "
+                "run the gateway/live adapter with E2EE enabled or set MATRIX_E2EE_MODE=off "
+                "only for non-encrypted rooms."
+            )
+        }
+
+    @pytest.mark.asyncio
+    async def test_legacy_encryption_true_refuses_plaintext_standalone_send(self, monkeypatch):
+        monkeypatch.delenv("MATRIX_E2EE_MODE", raising=False)
+        monkeypatch.setenv("MATRIX_ENCRYPTION", "true")
+        monkeypatch.setenv("MATRIX_HOMESERVER", "https://matrix.example.org")
+        monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_test")
+        _install_fake_matrix_aiohttp(monkeypatch)
+
+        from plugins.platforms.matrix.adapter import _standalone_send
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "!encrypted:example.org",
+            "hello",
+        )
+
+        assert "refused because E2EE is 'required'" in result.get("error", "")
+        assert "plaintext m.room.message" in result.get("error", "")
+
+    @pytest.mark.asyncio
+    async def test_optional_e2ee_refuses_plaintext_standalone_send(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_E2EE_MODE", "optional")
+        monkeypatch.setenv("MATRIX_HOMESERVER", "https://matrix.example.org")
+        monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_test")
+        _install_fake_matrix_aiohttp(monkeypatch)
+
+        from plugins.platforms.matrix.adapter import _standalone_send
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "!possibly-encrypted:example.org",
+            "hello",
+        )
+
+        assert "refused because E2EE is 'optional'" in result.get("error", "")
+        assert "plaintext m.room.message" in result.get("error", "")
+
+
 # ---------------------------------------------------------------------------
 # Adapter helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- refuse Matrix standalone/out-of-process delivery when E2EE is `required` or `optional`
- keep plaintext `m.room.message` standalone fallback available only when Matrix E2EE is explicitly off
- add regression coverage proving encrypted configurations fail closed instead of sending plaintext

## Why

The Matrix standalone sender posts directly to `/send/m.room.message/...`. In encrypted production rooms that can bypass the live gateway adapter's Megolm crypto store and leak plaintext events from out-of-process callers such as manual cron runs or `hermes send`.

This change preserves non-E2EE standalone delivery while making encrypted configs use the live adapter path only.

## Test plan

RED evidence:

```text
pytest tests/gateway/test_matrix.py -q -k 'StandaloneSendE2EEGuard' -o 'addopts='
# with production-code patch reversed: 3 failed
# old behavior returned {'success': True, 'message_id': '$plaintext'} via fake aiohttp
```

GREEN checks:

```text
python3 -m py_compile plugins/platforms/matrix/adapter.py tests/gateway/test_matrix.py
uv run --with pytest --with pytest-asyncio python -m pytest tests/gateway/test_matrix.py -q -k 'StandaloneSendE2EEGuard or matrix_e2ee_mode_optional_sets_config or matrix_encryption_flag' -o 'addopts='
# 5 passed, 231 deselected

env -u MATRIX_E2EE_MODE -u MATRIX_ENCRYPTION -u MATRIX_ALLOWED_ROOMS -u MATRIX_CANARY_ROOM -u MATRIX_HOME_ROOM -u MATRIX_REACTIONS -u MATRIX_RECOVERY_KEY_OUTPUT_FILE -u MATRIX_SESSION_SCOPE -u MATRIX_ORIGIN_HEALTH_URL \
  uv run --with pytest --with pytest-asyncio python -m pytest tests/gateway/test_matrix.py -q -o 'addopts='
# 236 passed

uv run --with ruff ruff check plugins/platforms/matrix/adapter.py tests/gateway/test_matrix.py
# All checks passed
```

## Boundaries

- No local production hotpatch or gateway restart in this PR.
- No secrets, tokens, room contents, or Matrix event bodies included.
- This intentionally fails closed for E2EE configs rather than implementing out-of-process Megolm encryption in the standalone sender.
