### PR TITLE
feat(telegram): add TELEGRAM_ALLOW_BOTS support (none/mentions/all)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6200,6 +6200,32 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
         if chat_id_str in self._telegram_free_response_chats():
             return True
+        # ── TELEGRAM_ALLOW_BOTS ─────────────────────────────────────
+        # Filter bot-to-bot messages. Three modes (matching DISCORD_ALLOW_BOTS):
+        #   "none"     — ignore all other bot messages (default)
+        #   "mentions" — accept bot messages only when they @mention us
+        #   "all"      — accept all bot messages
+        # Configure via config.yaml: telegram.extra.telegram_allow_bots
+        # or env var TELEGRAM_ALLOW_BOTS.
+        # Must run BEFORE _is_reply_to_bot so reply-chains between bots
+        # don't accidentally bypass the gate.  (#54370)
+        sender = getattr(message, "from_user", None)
+        if sender and getattr(sender, "is_bot", False):
+            allow_bots = self.config.extra.get(
+                "telegram_allow_bots",
+                os.getenv("TELEGRAM_ALLOW_BOTS", "none"),
+            )
+            if isinstance(allow_bots, str):
+                allow_bots = allow_bots.strip().lower()
+            if allow_bots in ("none", "false", "0"):
+                return False
+            if allow_bots == "mentions":
+                # Accept if explicitly @-mentioned, or if replying to
+                # this bot's message (legitimate reply-chain interaction).
+                # Do NOT accept for mere quote-replies to other users.
+                if not (self._message_mentions_bot(message) or self._is_reply_to_bot(message)):
+                    return False
+        # ─────────────────────────────────────────────────────────────
         if not self._telegram_require_mention():
             return True
         if self._is_reply_to_bot(message):


### PR DESCRIPTION
## Summary

Adds `TELEGRAM_ALLOW_BOTS` gate to Telegram's `_should_process_message()`, matching the existing `DISCORD_ALLOW_BOTS` semantics. This gives users a clean way to control bot-to-bot interactions in Telegram group chats, preventing the infinite reply loops described in #13083.

## Changes

**`plugins/platforms/telegram/adapter.py`** (+26 lines)

A new bot-sender check inserted in `_should_process_message()` **before** `_is_reply_to_bot()`, so reply-chains between bots don't accidentally bypass the gate.

### Three modes

| Mode | Behavior |
|------|----------|
| `none` | Ignore all other bot messages (default) |
| `mentions` | Accept bot messages only when they @mention or reply to this bot |
| `all` | Accept all bot messages (fall through to normal `require_mention` checks) |

### `mentions` gate logic

```python
if not (self._message_mentions_bot(message) or self._is_reply_to_bot(message)):
    return False
```

This means:
- Bot @mentions this bot → pass (explicit address)
- Bot replies to this bot's message → pass (legitimate reply-chain)
- Bot sends standalone message or replies to human → blocked (prevents loops)

### Configuration

```yaml
telegram:
  extra:
    telegram_allow_bots: mentions    # none | mentions | all
```

Or via environment variable: `TELEGRAM_ALLOW_BOTS=mentions`

Human-sent messages are unaffected regardless of mode.

## Related Issues

- Closes #54370 (require_mention gate bypass during active session)
- Refs #13083 (original feature request for TELEGRAM_ALLOW_BOTS)
