### PR TITLE
feat(desktop): filter Artifacts pane to Hermes-generated items

### DIFF
--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -60,3 +60,180 @@ describe('collectArtifactsForSession', () => {
     })
   })
 })
+
+describe('collectArtifactsForSession origin tagging', () => {
+  it('marks write_file tool results as generated', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: JSON.stringify({ path: '/out/report.md' }),
+        name: 'write_file',
+        role: 'tool',
+        timestamp: 2000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({ kind: 'file', origin: 'generated', value: '/out/report.md' })
+  })
+
+  it('marks patch tool results as generated (resolved_path)', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: JSON.stringify({ resolved_path: '/src/app.ts' }),
+        name: 'patch',
+        role: 'tool',
+        timestamp: 2000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({ origin: 'generated', value: '/src/app.ts' })
+  })
+
+  it('marks every image_generate output (host/sandbox/visible) as generated', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: JSON.stringify({
+          agent_visible_image: 'https://cdn.example.com/y.png',
+          host_image: '/i/out.png',
+          image: '/sb/out.png'
+        }),
+        name: 'image_generate',
+        role: 'tool',
+        timestamp: 2000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(3)
+    expect(artifacts.every(artifact => artifact.origin === 'generated')).toBe(true)
+  })
+
+  it('marks text_to_speech tool results as generated', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: JSON.stringify({ file_path: '/audio/v.mp3' }),
+        name: 'text_to_speech',
+        role: 'tool',
+        timestamp: 2000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({ origin: 'generated', value: '/audio/v.mp3' })
+  })
+
+  it('resolves the producing tool from tool_name when name is absent', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: JSON.stringify({ path: '/out/x.txt' }),
+        role: 'tool',
+        timestamp: 2000,
+        tool_name: 'write_file'
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({ origin: 'generated', value: '/out/x.txt' })
+  })
+
+  it('marks read_file results and prose mentions as referenced', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: JSON.stringify({ content: 'hello', path: '/src/x.json' }),
+        name: 'read_file',
+        role: 'tool',
+        timestamp: 2000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({ origin: 'referenced', value: '/src/x.json' })
+  })
+
+  it('upgrades a prior referenced mention to generated when the tool later produces it', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      { content: 'Editing /out/report.md now', role: 'assistant', timestamp: 1000 },
+      {
+        content: JSON.stringify({ path: '/out/report.md' }),
+        name: 'write_file',
+        role: 'tool',
+        timestamp: 2000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({ origin: 'generated', value: '/out/report.md' })
+  })
+
+  it('never downgrades a generated artifact to referenced', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: JSON.stringify({ path: '/out/report.md' }),
+        name: 'write_file',
+        role: 'tool',
+        timestamp: 1000
+      },
+      { content: 'See /out/report.md', role: 'assistant', timestamp: 2000 }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({ origin: 'generated', value: '/out/report.md' })
+  })
+
+  it('does not mark a failed generation ({ success: false }) as generated', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: JSON.stringify({ image: '/i/fail.png', success: false }),
+        name: 'image_generate',
+        role: 'tool',
+        timestamp: 2000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({ origin: 'referenced', value: '/i/fail.png' })
+  })
+
+  it('marks edit_file tool results as generated', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: JSON.stringify({ resolved_path: '/src/edited.ts' }),
+        name: 'edit_file',
+        role: 'tool',
+        timestamp: 2000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({ origin: 'generated', value: '/src/edited.ts' })
+  })
+
+  it('does not mark a failed generation ({ error }) as generated', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: JSON.stringify({ error: 'permission denied: /out/blocked.md' }),
+        name: 'write_file',
+        role: 'tool',
+        timestamp: 2000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({ origin: 'referenced', value: '/out/blocked.md' })
+  })
+
+  it('adopts the producing tool-result timestamp when upgrading to generated', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      { content: 'Editing /out/report.md now', role: 'assistant', timestamp: 1000 },
+      {
+        content: JSON.stringify({ path: '/out/report.md' }),
+        name: 'write_file',
+        role: 'tool',
+        timestamp: 2000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({ origin: 'generated', timestamp: 2000, value: '/out/report.md' })
+  })
+})

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -16,6 +16,7 @@ import {
   PaginationNext,
   PaginationPrevious
 } from '@/components/ui/pagination'
+import { Switch } from '@/components/ui/switch'
 import { TextTab, TextTabMeta } from '@/components/ui/text-tab'
 import { Tip } from '@/components/ui/tooltip'
 import { getSessionMessages, listAllProfileSessions } from '@/hermes'
@@ -39,12 +40,24 @@ type ArtifactKind = 'image' | 'file' | 'link'
 type ArtifactFilter = 'all' | ArtifactKind
 const ARTIFACT_FILTERS: readonly ArtifactFilter[] = ['all', 'image', 'file', 'link']
 
+// 'generated' = produced by a Hermes mutating/generating tool (created or edited);
+// 'referenced' = merely read, searched, or mentioned in prose.
+type ArtifactOrigin = 'generated' | 'referenced'
+
+// Tools whose output counts as an artifact Hermes created or edited. A tool-result
+// message naming one of these (message.name / message.tool_name) marks the artifacts
+// it surfaces as 'generated'. The file-edit names mirror FILE_EDIT_TOOL_NAMES in
+// components/assistant-ui/tool-fallback-model.ts; image_generate / text_to_speech add
+// the media generators.
+const GENERATING_TOOLS = new Set(['edit_file', 'write_file', 'patch', 'image_generate', 'text_to_speech'])
+
 interface ArtifactRecord {
   id: string
   kind: ArtifactKind
   value: string
   href: string
   label: string
+  origin: ArtifactOrigin
   sessionId: string
   sessionTitle: string
   timestamp: number
@@ -267,6 +280,33 @@ function collectArtifactsFromMessage(message: SessionMessage, pushValue: (value:
   }
 }
 
+// Provenance is a per-message property: artifacts surfaced by a tool result whose tool is
+// one of GENERATING_TOOLS are 'generated', everything else is 'referenced'. A failed
+// generation is treated as 'referenced' so it is not surfaced as something Hermes actually
+// produced. The backend's tool_error helper returns { error: "..." } (sometimes also
+// { success: false }), so both an explicit success:false and a non-empty error string count
+// as failure. (This is a per-message heuristic: an incidental path/URL embedded elsewhere in
+// a generating tool's result body also inherits 'generated' — acceptable for a UI filter.)
+function resolveMessageOrigin(message: SessionMessage): ArtifactOrigin {
+  if (message.role !== 'tool') {
+    return 'referenced'
+  }
+
+  const toolName = message.name ?? message.tool_name
+
+  if (!toolName || !GENERATING_TOOLS.has(toolName)) {
+    return 'referenced'
+  }
+
+  const parsed = parseMaybeJson(messageText(message))
+  const result = parsed && typeof parsed === 'object' ? (parsed as { error?: unknown; success?: unknown }) : null
+
+  const failed =
+    !!result && (result.success === false || (typeof result.error === 'string' && result.error.trim() !== ''))
+
+  return failed ? 'referenced' : 'generated'
+}
+
 export function collectArtifactsForSession(session: SessionInfo, messages: SessionMessage[]): ArtifactRecord[] {
   const found = new Map<string, ArtifactRecord>()
   const title = sessionTitle(session)
@@ -276,6 +316,8 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
       continue
     }
 
+    const messageOrigin = resolveMessageOrigin(message)
+
     collectArtifactsFromMessage(message, candidate => {
       const value = normalizeValue(candidate)
 
@@ -284,8 +326,18 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
       }
 
       const key = `${session.id}:${value}`
+      const existing = found.get(key)
 
-      if (found.has(key)) {
+      if (existing) {
+        // The same value commonly appears first as a prose mention ('referenced') and
+        // later in the producing tool result ('generated'). Generated always wins; never
+        // downgrade a record that was already marked generated. On upgrade, adopt the
+        // producing message's timestamp so the artifact sorts/displays by generation time
+        // rather than the earlier mention.
+        if (messageOrigin === 'generated' && existing.origin === 'referenced') {
+          found.set(key, { ...existing, origin: 'generated', timestamp: message.timestamp || existing.timestamp })
+        }
+
         return
       }
 
@@ -295,6 +347,7 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
         value,
         href: artifactHref(value),
         label: artifactLabel(value),
+        origin: messageOrigin,
         sessionId: session.id,
         sessionTitle: title,
         timestamp: message.timestamp || session.last_active || session.started_at || Date.now()
@@ -376,6 +429,14 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
 
   const [kindFilter, setKindFilter] = useRouteEnumParam('tab', ARTIFACT_FILTERS, 'all')
 
+  const [generatedParam, setGeneratedParam] = useRouteEnumParam<'false' | 'true'>(
+    'generated',
+    ['true', 'false'],
+    'false'
+  )
+
+  const generatedOnly = generatedParam === 'true'
+
   const [failedImageIds, setFailedImageIds] = useState<Set<string>>(() => new Set())
   const [imagePage, setImagePage] = useState(1)
   const [filePage, setFilePage] = useState(1)
@@ -415,7 +476,7 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
   useEffect(() => {
     setImagePage(1)
     setFilePage(1)
-  }, [artifacts, kindFilter, query])
+  }, [artifacts, kindFilter, generatedOnly, query])
 
   const visibleArtifacts = useMemo(() => {
     if (!artifacts) {
@@ -425,6 +486,10 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
     const q = query.trim().toLowerCase()
 
     return artifacts.filter(artifact => {
+      if (generatedOnly && artifact.origin !== 'generated') {
+        return false
+      }
+
       if (kindFilter !== 'all' && artifact.kind !== kindFilter) {
         return false
       }
@@ -439,7 +504,7 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
         artifact.sessionTitle.toLowerCase().includes(q)
       )
     })
-  }, [artifacts, kindFilter, query])
+  }, [artifacts, kindFilter, generatedOnly, query])
 
   const visibleImageArtifacts = useMemo(
     () => visibleArtifacts.filter(artifact => artifact.kind === 'image'),
@@ -466,16 +531,20 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
     [currentFilePage, visibleFileArtifacts]
   )
 
+  // Unfiltered total — drives empty-state and toggle visibility so the toggle never hides
+  // itself (and trap the user) when 'generated only' is on but no generated artifacts exist.
+  const totalCount = artifacts?.length ?? 0
+
   const counts = useMemo(() => {
-    const all = artifacts || []
+    const base = (artifacts || []).filter(artifact => !generatedOnly || artifact.origin === 'generated')
 
     return {
-      all: all.length,
-      image: all.filter(artifact => artifact.kind === 'image').length,
-      file: all.filter(artifact => artifact.kind === 'file').length,
-      link: all.filter(artifact => artifact.kind === 'link').length
+      all: base.length,
+      image: base.filter(artifact => artifact.kind === 'image').length,
+      file: base.filter(artifact => artifact.kind === 'file').length,
+      link: base.filter(artifact => artifact.kind === 'link').length
     }
-  }, [artifacts])
+  }, [artifacts, generatedOnly])
 
   const openArtifact = useCallback(
     async (href: string) => {
@@ -510,8 +579,21 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
   return (
     <PageSearchShell
       {...props}
+      filters={
+        totalCount > 0 ? (
+          <label className="flex cursor-pointer items-center gap-2 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-secondary)">
+            <Switch
+              aria-label={a.filterGeneratedLabel}
+              checked={generatedOnly}
+              onCheckedChange={checked => setGeneratedParam(checked ? 'true' : 'false')}
+              size="xs"
+            />
+            {a.filterGeneratedLabel}
+          </label>
+        ) : undefined
+      }
       onSearchChange={setQuery}
-      searchHidden={counts.all === 0}
+      searchHidden={totalCount === 0}
       searchPlaceholder={a.search}
       searchTrailingAction={
         <Button
@@ -550,8 +632,12 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
       ) : visibleArtifacts.length === 0 ? (
         <div className="grid h-full place-items-center px-6 text-center">
           <div>
-            <div className="text-sm font-medium">{a.noArtifactsTitle}</div>
-            <div className="mt-1 text-xs text-muted-foreground">{a.noArtifactsDesc}</div>
+            <div className="text-sm font-medium">
+              {generatedOnly && totalCount > 0 && counts.all === 0 ? a.noGeneratedTitle : a.noArtifactsTitle}
+            </div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              {generatedOnly && totalCount > 0 && counts.all === 0 ? a.noGeneratedDesc : a.noArtifactsDesc}
+            </div>
           </div>
         </div>
       ) : (

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1261,7 +1261,10 @@ export const en: Translations = {
     kindLink: 'link',
     chat: 'Chat',
     copyUrl: 'Copy URL',
-    copyPath: 'Copy path'
+    copyPath: 'Copy path',
+    filterGeneratedLabel: 'Hermes-generated only',
+    noGeneratedTitle: 'No Hermes-generated artifacts',
+    noGeneratedDesc: 'Files and media Hermes creates or edits will appear here.'
   },
 
   sidebar: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1385,7 +1385,10 @@ export const ja = defineLocale({
     kindLink: 'リンク',
     chat: 'チャット',
     copyUrl: 'URL をコピー',
-    copyPath: 'パスをコピー'
+    copyPath: 'パスをコピー',
+    filterGeneratedLabel: 'Hermes が生成したもののみ',
+    noGeneratedTitle: 'Hermes が生成したアーティファクトはありません',
+    noGeneratedDesc: 'Hermes が作成または編集したファイルやメディアがここに表示されます。'
   },
 
   sidebar: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1017,6 +1017,9 @@ export interface Translations {
     chat: string
     copyUrl: string
     copyPath: string
+    filterGeneratedLabel: string
+    noGeneratedTitle: string
+    noGeneratedDesc: string
   }
 
   sidebar: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1337,7 +1337,10 @@ export const zhHant = defineLocale({
     kindLink: '連結',
     chat: '聊天',
     copyUrl: '複製 URL',
-    copyPath: '複製路徑'
+    copyPath: '複製路徑',
+    filterGeneratedLabel: '僅 Hermes 產生',
+    noGeneratedTitle: '沒有 Hermes 產生的成品',
+    noGeneratedDesc: 'Hermes 建立或編輯的檔案與媒體會顯示在這裡。'
   },
 
   sidebar: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1444,7 +1444,10 @@ export const zh: Translations = {
     kindLink: '链接',
     chat: '对话',
     copyUrl: '复制 URL',
-    copyPath: '复制路径'
+    copyPath: '复制路径',
+    filterGeneratedLabel: '仅 Hermes 生成',
+    noGeneratedTitle: '没有 Hermes 生成的产物',
+    noGeneratedDesc: 'Hermes 创建或编辑的文件和媒体将显示在此处。'
   },
 
   sidebar: {


### PR DESCRIPTION
## What does this PR do?

Adds a **"Hermes-generated only"** toggle to the desktop Artifacts pane. The pane currently lists every image, file, and link found across recent sessions — regardless of whether Hermes produced it or merely read, searched, or mentioned it. This toggle filters the list to artifacts Hermes actually **created or edited**.

An artifact is tagged `generated` when it is surfaced by a tool-result message whose tool is one of `edit_file`, `write_file`, `patch`, `image_generate`, or `text_to_speech` (unless the result reports a failure); everything else is `referenced`. Provenance is computed **per-message** inside the existing `collectArtifactsForSession` collector — the producing tool's identity was already present in the message data (`message.name` / `message.tool_name`) and simply wasn't being used. No backend/API/Python changes and no new dependencies (reuses the existing Radix `Switch` primitive and `useRouteEnumParam`).

The toggle:
- defaults **off** — today's "show everything" behavior is preserved; the filter is opt-in;
- persists in the route as `?generated=true`;
- lives in `PageSearchShell`'s existing `filters` slot (same pattern as the skills page);
- is gated on the **unfiltered** artifact total so it can never hide itself;
- updates the kind-tab counts and the empty state to match the active filter.

## Related Issue

No existing tracking issue — searched open + merged PRs and issues, none found. Happy to open one if preferred.

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/artifacts/index.tsx` — add an `origin: 'generated' | 'referenced'` field to `ArtifactRecord`; tag it per-message in `collectArtifactsForSession` (with a `referenced`→`generated` dedup upgrade that adopts the producing message's timestamp, and a failure guard for `success:false` / `{ error }` results); add the `Switch` toggle, generated-aware tab counts, and a tailored empty state. No helper signatures changed.
- `apps/desktop/src/app/artifacts/index.test.ts` — unit tests for origin tagging across all generating tools, the referenced cases, the upgrade / no-downgrade behavior, the `tool_name` fallback, and failed-result handling.
- `apps/desktop/src/i18n/{types,en,ja,zh,zh-hant}.ts` — three new `artifacts` strings, added to all four locales.

## How to Test

1. `cd apps/desktop && npm run dev`
2. Open the **Artifacts** pane. Once artifacts load, a "Hermes-generated only" switch appears in the filter row under the kind tabs.
3. Toggle **on** → the list narrows to files/media Hermes created or edited; the `All / Images / Files / Links` counts update to match; the URL gains `?generated=true` (survives refresh).
4. Toggle **off** → the full list returns.
5. On a profile with no generated artifacts, the switch still shows (no trap) and a tailored "No Hermes-generated artifacts" empty state renders.

Automated (from `apps/desktop/`): `npm run typecheck && npm run lint && npm run test:ui` — all green; the collector is a pure, unit-tested function.

## Known limitations (by design — per-message heuristic)

- Provenance is resolved per tool-result message, so an incidental path/URL embedded elsewhere in a generating tool's result body inherits `generated`. Acceptable for a UI filter; avoiding it would require a backend artifact manifest.
- A generated file whose path appears only in the (unparsed) tool-call arguments and is never echoed in the result can remain `referenced`. Pre-existing extraction behavior; the common success path echoes the path and is tagged correctly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(desktop): …`)
- [x] I searched for existing PRs (open + merged) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] Tests pass — desktop change, so ran `npm run typecheck && npm run lint && npm run test:ui` (Python suite unaffected); added cases all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26 (darwin), `npm run dev`

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing docs affected)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` if I changed architecture/workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure React/TS, no OS-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (toggle off — all artifacts) 
<img width="1651" height="1079" alt="Screenshot 2026-06-28 at 12 49 31 PM" src="https://github.com/user-attachments/assets/9b52b5ff-78ba-4abc-bb9e-163963d71822" />

vs after (toggle on — Hermes-generated only).
<img width="1651" height="1079" alt="Screenshot 2026-06-28 at 12 49 45 PM" src="https://github.com/user-attachments/assets/13e70bb9-f8b7-4ee7-bd65-3c0e88ef6676" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8y7DSPwxnptP8n86Zit8S
