### PR TITLE
feat(desktop): remote-only mode to block local workstation file access (#54363)

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -87,6 +87,27 @@ Installers are built and uploaded to GitHub Releases manually. macOS/Windows sig
 
 The packaged app ships the Electron shell and a native React chat surface. On first launch it can install the Hermes Agent runtime into `HERMES_HOME` (`~/.hermes`, or `%LOCALAPPDATA%\hermes` on Windows) — the **same layout a CLI install uses**, so the two are interchangeable. Backend resolution first honours `HERMES_DESKTOP_HERMES_ROOT`, then a completed managed install, then a probed `hermes` on `PATH` (unless `HERMES_DESKTOP_IGNORE_EXISTING=1` is set), and finally an explicit `HERMES_DESKTOP_HERMES` command override for packagers/troubleshooting. The renderer (React, in `src/`) talks to a `hermes dashboard` backend over the `tui_gateway`/dashboard APIs and reuses the agent runtime rather than embedding `hermes --tui`. The install, backend-resolution, and self-update logic all live in `electron/main.cjs`.
 
+### Remote-only mode
+
+When Desktop is pointed at a remote gateway, operators may want a hard guarantee
+that the local workstation filesystem is never browsed, previewed, or attached —
+Desktop is still a native app, so its IPC surface can otherwise reach local
+files. Launch with **remote-only mode** to block that entirely:
+
+```bash
+hermes desktop --remote-only
+# or, equivalently, set the environment variable before launch:
+HERMES_DESKTOP_DISABLE_LOCAL_FILES=1 hermes desktop
+```
+
+When enabled, every local-filesystem IPC path (directory listing, file/preview
+reads, git-root and worktree detection, the native file picker) is refused in
+`electron/main.cjs` via `electron/local-files-policy.cjs`, and the file browser
+shows a clear *Remote-only mode* state instead of the local tree. Browsing files
+exposed by the **remote backend** is unaffected — that traffic goes over the
+gateway API, not the local handlers. The boundary is enforced in the main
+process, so it holds regardless of what the renderer requests.
+
 ### Verification
 
 Run before opening a PR (lint may surface pre-existing warnings but must exit cleanly):

--- a/apps/desktop/electron/hardening.cjs
+++ b/apps/desktop/electron/hardening.cjs
@@ -2,6 +2,7 @@ const fs = require('node:fs')
 const os = require('node:os')
 const path = require('node:path')
 const { fileURLToPath } = require('node:url')
+const { assertLocalFilesAllowed } = require('./local-files-policy.cjs')
 
 const DEFAULT_FETCH_TIMEOUT_MS = 15_000
 const DATA_URL_READ_MAX_BYTES = 16 * 1024 * 1024
@@ -143,6 +144,13 @@ function rejectUnsafePathSyntax(filePath, purpose = 'File read') {
 
 function resolveRequestedPathForIpc(filePath, options = {}) {
   const purpose = String(options.purpose || 'File read')
+
+  // Remote-only mode: refuse every local-filesystem path before we touch the
+  // disk. resolveDirectoryForIpc/resolveReadableFileForIpc both flow through
+  // here, so this one guard covers directory listing, file/preview reads, git
+  // root detection, worktree lookup, and media streaming.
+  assertLocalFilesAllowed(purpose, { env: options.env })
+
   let raw = rejectUnsafePathSyntax(filePath, purpose)
 
   // Gateway-reported cwds (config `terminal.cwd`, remote sessions) routinely
@@ -215,7 +223,7 @@ function rejectSensitiveFilePath(filePath, purpose) {
 async function resolveDirectoryForIpc(dirPath, options = {}) {
   const purpose = String(options.purpose || 'Directory read')
   const fsImpl = options.fs || fs
-  const resolvedPath = resolveRequestedPathForIpc(dirPath, { baseDir: options.baseDir, purpose })
+  const resolvedPath = resolveRequestedPathForIpc(dirPath, { baseDir: options.baseDir, env: options.env, purpose })
   const stat = await statForIpc(fsImpl, resolvedPath, purpose, 'directory')
 
   if (!stat.isDirectory()) {
@@ -230,7 +238,7 @@ async function resolveDirectoryForIpc(dirPath, options = {}) {
 async function resolveReadableFileForIpc(filePath, options = {}) {
   const purpose = String(options.purpose || 'File read')
   const fsImpl = options.fs || fs
-  const resolvedPath = resolveRequestedPathForIpc(filePath, { baseDir: options.baseDir, purpose })
+  const resolvedPath = resolveRequestedPathForIpc(filePath, { baseDir: options.baseDir, env: options.env, purpose })
 
   if (options.blockSensitive !== false) {
     rejectSensitiveFilePath(resolvedPath, purpose)

--- a/apps/desktop/electron/hardening.test.cjs
+++ b/apps/desktop/electron/hardening.test.cjs
@@ -106,6 +106,24 @@ test('resolveRequestedPathForIpc resolves relative paths from the trimmed base d
   )
 })
 
+test('resolveRequestedPathForIpc refuses local paths in remote-only mode', () => {
+  const remoteOnlyEnv = { HERMES_DESKTOP_DISABLE_LOCAL_FILES: '1' }
+
+  assert.throws(
+    () => resolveRequestedPathForIpc('notes.txt', { baseDir: os.tmpdir(), env: remoteOnlyEnv, purpose: 'File preview' }),
+    error => {
+      assert.equal(error.code, 'local-files-disabled')
+      return true
+    }
+  )
+
+  // A non-remote-only env still resolves normally.
+  assert.equal(
+    resolveRequestedPathForIpc('notes.txt', { baseDir: os.tmpdir(), env: {}, purpose: 'File preview' }),
+    path.resolve(os.tmpdir(), 'notes.txt')
+  )
+})
+
 test('resolveRequestedPathForIpc expands ~ to the home directory', () => {
   assert.equal(resolveRequestedPathForIpc('~', { purpose: 'Directory read' }), path.resolve(os.homedir()))
   assert.equal(

--- a/apps/desktop/electron/local-files-policy.cjs
+++ b/apps/desktop/electron/local-files-policy.cjs
@@ -1,0 +1,67 @@
+'use strict'
+
+// Remote-Only Mode (issue #54363).
+//
+// Hermes Desktop is a native local application, so its IPC surface can read,
+// list, and preview files on the user's workstation even when the agent is
+// connected to a remote gateway. Operators who run Desktop purely as a remote
+// client want a hard guarantee that the local filesystem is never browsed,
+// indexed, previewed, or exposed.
+//
+// When HERMES_DESKTOP_DISABLE_LOCAL_FILES is enabled (set by `hermes desktop
+// --remote-only`, or directly in the environment) every local-filesystem IPC
+// path funnels through assertLocalFilesAllowed() and is refused. Remote-backend
+// browsing is unaffected because that traffic goes over the gateway API, not
+// the local fs handlers.
+
+const LOCAL_FILES_DISABLED_ENV = 'HERMES_DESKTOP_DISABLE_LOCAL_FILES'
+
+// Accept the usual truthy spellings so the flag behaves the same whether it is
+// exported by a shell, a launcher, or the CLI wrapper.
+const TRUTHY = new Set(['1', 'true', 'yes', 'on'])
+
+const LOCAL_FILES_DISABLED_CODE = 'local-files-disabled'
+const LOCAL_FILES_DISABLED_MESSAGE =
+  'Remote-only mode is enabled, so Hermes Desktop will not browse or open local workstation files. ' +
+  `Unset ${LOCAL_FILES_DISABLED_ENV} (or relaunch without --remote-only) to allow local file access.`
+
+function isLocalFilesDisabled(env = process.env) {
+  const raw = env && env[LOCAL_FILES_DISABLED_ENV]
+  if (raw === undefined || raw === null) {
+    return false
+  }
+  return TRUTHY.has(String(raw).trim().toLowerCase())
+}
+
+function localFilesPolicy(env = process.env) {
+  const disabled = isLocalFilesDisabled(env)
+  return {
+    disabled,
+    reason: disabled ? LOCAL_FILES_DISABLED_MESSAGE : null
+  }
+}
+
+function localFilesDisabledError(purpose = 'Local file access') {
+  const error = new Error(`${purpose} blocked: ${LOCAL_FILES_DISABLED_MESSAGE}`)
+  error.code = LOCAL_FILES_DISABLED_CODE
+  return error
+}
+
+// Throw when the local filesystem is off-limits. Callers that funnel through
+// hardening.cjs get this for free; native-dialog handlers call it directly.
+function assertLocalFilesAllowed(purpose = 'Local file access', options = {}) {
+  const env = options.env || process.env
+  if (isLocalFilesDisabled(env)) {
+    throw localFilesDisabledError(purpose)
+  }
+}
+
+module.exports = {
+  LOCAL_FILES_DISABLED_CODE,
+  LOCAL_FILES_DISABLED_ENV,
+  LOCAL_FILES_DISABLED_MESSAGE,
+  assertLocalFilesAllowed,
+  isLocalFilesDisabled,
+  localFilesDisabledError,
+  localFilesPolicy
+}

--- a/apps/desktop/electron/local-files-policy.test.cjs
+++ b/apps/desktop/electron/local-files-policy.test.cjs
@@ -1,0 +1,46 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+  LOCAL_FILES_DISABLED_CODE,
+  LOCAL_FILES_DISABLED_ENV,
+  assertLocalFilesAllowed,
+  isLocalFilesDisabled,
+  localFilesPolicy
+} = require('./local-files-policy.cjs')
+
+test('isLocalFilesDisabled is false when the env var is unset or empty', () => {
+  assert.equal(isLocalFilesDisabled({}), false)
+  assert.equal(isLocalFilesDisabled({ [LOCAL_FILES_DISABLED_ENV]: '' }), false)
+  assert.equal(isLocalFilesDisabled({ [LOCAL_FILES_DISABLED_ENV]: '0' }), false)
+  assert.equal(isLocalFilesDisabled({ [LOCAL_FILES_DISABLED_ENV]: 'false' }), false)
+})
+
+test('isLocalFilesDisabled accepts the common truthy spellings', () => {
+  for (const value of ['1', 'true', 'TRUE', 'yes', 'On', '  1  ']) {
+    assert.equal(isLocalFilesDisabled({ [LOCAL_FILES_DISABLED_ENV]: value }), true, value)
+  }
+})
+
+test('localFilesPolicy reports a reason only when disabled', () => {
+  assert.deepEqual(localFilesPolicy({}), { disabled: false, reason: null })
+
+  const blocked = localFilesPolicy({ [LOCAL_FILES_DISABLED_ENV]: '1' })
+  assert.equal(blocked.disabled, true)
+  assert.match(blocked.reason, /Remote-only mode/i)
+})
+
+test('assertLocalFilesAllowed throws a coded error when disabled', () => {
+  assert.doesNotThrow(() => assertLocalFilesAllowed('Directory read', { env: {} }))
+
+  assert.throws(
+    () => assertLocalFilesAllowed('Directory read', { env: { [LOCAL_FILES_DISABLED_ENV]: '1' } }),
+    error => {
+      assert.equal(error.code, LOCAL_FILES_DISABLED_CODE)
+      assert.match(error.message, /Directory read blocked/)
+      return true
+    }
+  )
+})

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -91,6 +91,7 @@ const {
   resolveRequestedPathForIpc,
   resolveTimeoutMs
 } = require('./hardening.cjs')
+const { isLocalFilesDisabled, localFilesPolicy } = require('./local-files-policy.cjs')
 
 let nodePty = null
 let nodePtyDir = null
@@ -6173,7 +6174,17 @@ ipcMain.handle('hermes:readFileText', async (_event, filePath) => {
   }
 })
 
+ipcMain.handle('hermes:localFiles:policy', () => localFilesPolicy())
+
 ipcMain.handle('hermes:selectPaths', async (_event, options = {}) => {
+  // Remote-only mode disables local file/folder attachment: never open the
+  // native picker, and return nothing (same shape as a cancelled dialog) so
+  // callers simply attach nothing. Any subsequent local read is hard-blocked by
+  // the hardening guard regardless.
+  if (isLocalFilesDisabled()) {
+    return []
+  }
+
   const properties = options?.directories ? ['openDirectory'] : ['openFile']
   if (options?.multiple !== false) properties.push('multiSelections')
 

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -80,6 +80,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   },
   revealLogs: () => ipcRenderer.invoke('hermes:logs:reveal'),
   getRecentLogs: () => ipcRenderer.invoke('hermes:logs:recent'),
+  localFilesPolicy: () => ipcRenderer.invoke('hermes:localFiles:policy'),
   readDir: dirPath => ipcRenderer.invoke('hermes:fs:readDir', dirPath),
   gitRoot: startPath => ipcRenderer.invoke('hermes:fs:gitRoot', startPath),
   worktrees: cwds => ipcRenderer.invoke('hermes:fs:worktrees', cwds),

--- a/apps/desktop/src/app/right-sidebar/files/use-local-files-policy.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-local-files-policy.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+
+import type { HermesLocalFilesPolicy } from '@/global'
+
+const LOCAL_FILES_ALLOWED: HermesLocalFilesPolicy = { disabled: false, reason: null }
+
+// Remote-only mode is fixed for the lifetime of the process (it comes from the
+// launch environment), so a single read on mount is enough. Older bridges that
+// predate the policy handler simply report "allowed".
+export function useLocalFilesPolicy(): HermesLocalFilesPolicy {
+  const [policy, setPolicy] = useState<HermesLocalFilesPolicy>(LOCAL_FILES_ALLOWED)
+
+  useEffect(() => {
+    let cancelled = false
+    const read = window.hermesDesktop?.localFilesPolicy
+
+    if (!read) {
+      return
+    }
+
+    read()
+      .then(next => {
+        if (!cancelled && next) {
+          setPolicy(next)
+        }
+      })
+      .catch(() => {
+        // Treat a failed probe as "allowed" — the main-process IPC guard is the
+        // real boundary, so a missing banner never weakens enforcement.
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return policy
+}

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
@@ -38,6 +38,17 @@ describe('useProjectTree', () => {
     expect(readDir).not.toHaveBeenCalled()
   })
 
+  it('never reads the local filesystem when disabled (remote-only mode)', async () => {
+    readDir.mockResolvedValue(ok([{ name: 'README.md', path: '/p/README.md', isDirectory: false }]))
+
+    const { result } = renderHook(() => useProjectTree('/p', { disabled: true }))
+
+    await waitFor(() => expect(result.current.rootLoading).toBe(false))
+
+    expect(readDir).not.toHaveBeenCalled()
+    expect(result.current.data).toEqual([])
+  })
+
   it('loads root entries on mount and sorts folders before files', async () => {
     readDir.mockResolvedValueOnce(
       ok([

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
@@ -226,7 +226,8 @@ export function resetProjectTreeState() {
  * disclosure caret shows for unloaded folders. `refreshRoot` invalidates the
  * whole tree (used after cwd change or manual refresh).
  */
-export function useProjectTree(cwd: string): UseProjectTreeResult {
+export function useProjectTree(cwd: string, options: { disabled?: boolean } = {}): UseProjectTreeResult {
+  const disabled = Boolean(options.disabled)
   const state = useStore($projectTree)
   const connection = useStore($connection)
   const connectionKey = `${connection?.mode || 'local'}:${connection?.profile || ''}:${connection?.baseUrl || ''}`
@@ -309,6 +310,15 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
   )
 
   useEffect(() => {
+    // Remote-only mode: never read the local filesystem. Drop any cached tree
+    // so a toggle into remote-only can't leave stale local entries on screen.
+    if (disabled) {
+      clearProjectTree()
+      clearProjectDirCache()
+
+      return
+    }
+
     const connectionChanged = lastConnectionKey !== '' && lastConnectionKey !== connectionKey
     lastConnectionKey = connectionKey
 
@@ -320,7 +330,7 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
     }
 
     void loadRoot(cwd)
-  }, [connectionKey, cwd])
+  }, [connectionKey, cwd, disabled])
 
   // Self-heal: an errored root re-probes every few seconds while the tree is
   // mounted. Each attempt bumps requestId, so a persistent error re-arms the
@@ -362,21 +372,41 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
   }, [cwd, usingFallback])
 
   return useMemo(
-    () => ({
-      collapseAll,
-      collapseNonce: state.cwd === cwd ? state.collapseNonce : 0,
-      data: state.cwd === cwd ? state.data : [],
-      effectiveCwd: state.cwd === cwd && state.resolvedCwd ? state.resolvedCwd : cwd,
-      loadChildren,
-      openState: state.cwd === cwd ? state.openState : {},
-      refreshRoot,
-      rootError: state.cwd === cwd ? state.rootError : null,
-      rootLoading: state.cwd === cwd ? state.rootLoading : Boolean(cwd),
-      setNodeOpen
-    }),
+    () => {
+      // Remote-only mode never loads a local tree, so report a settled, empty
+      // state rather than a perpetual "loading" against a cwd we won't read.
+      if (disabled) {
+        return {
+          collapseAll,
+          collapseNonce: 0,
+          data: [],
+          effectiveCwd: cwd,
+          loadChildren,
+          openState: {},
+          refreshRoot,
+          rootError: null,
+          rootLoading: false,
+          setNodeOpen
+        }
+      }
+
+      return {
+        collapseAll,
+        collapseNonce: state.cwd === cwd ? state.collapseNonce : 0,
+        data: state.cwd === cwd ? state.data : [],
+        effectiveCwd: state.cwd === cwd && state.resolvedCwd ? state.resolvedCwd : cwd,
+        loadChildren,
+        openState: state.cwd === cwd ? state.openState : {},
+        refreshRoot,
+        rootError: state.cwd === cwd ? state.rootError : null,
+        rootLoading: state.cwd === cwd ? state.rootLoading : Boolean(cwd),
+        setNodeOpen
+      }
+    },
     [
       collapseAll,
       cwd,
+      disabled,
       loadChildren,
       refreshRoot,
       setNodeOpen,

--- a/apps/desktop/src/app/right-sidebar/index.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.test.tsx
@@ -10,6 +10,7 @@ import { RightSidebarPane } from './index'
 
 const readDir = vi.fn<(path: string) => Promise<HermesReadDirResult>>()
 const selectPaths = vi.fn()
+const localFilesPolicy = vi.fn()
 
 function ok(entries: { name: string; path: string; isDirectory: boolean }[]): HermesReadDirResult {
   return { entries }
@@ -21,9 +22,10 @@ function installBridge() {
       hermesDesktop: {
         readDir: typeof readDir
         selectPaths: typeof selectPaths
+        localFilesPolicy: typeof localFilesPolicy
       }
     }
-  ).hermesDesktop = { readDir, selectPaths }
+  ).hermesDesktop = { readDir, selectPaths, localFilesPolicy }
 }
 
 describe('RightSidebarPane', () => {
@@ -33,8 +35,10 @@ describe('RightSidebarPane', () => {
     setCurrentCwd('/repo')
     readDir.mockReset()
     selectPaths.mockReset()
+    localFilesPolicy.mockReset()
     readDir.mockResolvedValue(ok([{ name: 'README.md', path: '/repo/README.md', isDirectory: false }]))
     selectPaths.mockResolvedValue(['/repo-next'])
+    localFilesPolicy.mockResolvedValue({ disabled: false, reason: null })
     installBridge()
   })
 
@@ -71,5 +75,22 @@ describe('RightSidebarPane', () => {
       })
     )
     await waitFor(() => expect(onChangeCwd).toHaveBeenCalledWith('/repo-next'))
+  })
+
+  it('blocks local file browsing in remote-only mode', async () => {
+    localFilesPolicy.mockResolvedValue({
+      disabled: true,
+      reason: 'Remote-only mode is enabled.'
+    })
+
+    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} onChangeCwd={vi.fn()} />)
+
+    // The disabled state replaces the local tree and locks the picker.
+    // getByText throws until the remote-only body renders, so waitFor settles on it.
+    await waitFor(() => screen.getByText(/Local file browsing is disabled/))
+    expect(screen.getByRole('button', { name: 'Open folder' }).hasAttribute('disabled')).toBe(true)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open folder' }))
+    expect(selectPaths).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -7,7 +7,7 @@ import { Codicon } from '@/components/ui/codicon'
 import { Loader } from '@/components/ui/loader'
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
-import { selectDesktopPaths } from '@/lib/desktop-fs'
+import { isDesktopFsRemoteMode, selectDesktopPaths } from '@/lib/desktop-fs'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { cn } from '@/lib/utils'
 import { $panesFlipped } from '@/store/layout'
@@ -19,6 +19,7 @@ import { SidebarPanelLabel } from '../shell/sidebar-label'
 
 import { RemoteFolderPicker } from './files/remote-picker'
 import { ProjectTree } from './files/tree'
+import { useLocalFilesPolicy } from './files/use-local-files-policy'
 import { useProjectTree } from './files/use-project-tree'
 
 interface RightSidebarPaneProps {
@@ -33,6 +34,11 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder, onChangeCwd
   const panesFlipped = useStore($panesFlipped)
   const currentCwd = useStore($currentCwd).trim()
   const hasCwd = currentCwd.length > 0
+  // Remote-only mode blocks the local filesystem outright. When the displayed
+  // tree would be local (i.e. not a remote backend), surface a clear disabled
+  // state instead of an empty/error tree and lock the folder pickers.
+  const localFiles = useLocalFilesPolicy()
+  const localBrowsingBlocked = localFiles.disabled && !isDesktopFsRemoteMode()
 
   const {
     collapseAll,
@@ -45,7 +51,7 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder, onChangeCwd
     rootError,
     rootLoading,
     setNodeOpen
-  } = useProjectTree(currentCwd)
+  } = useProjectTree(currentCwd, { disabled: localBrowsingBlocked })
 
   const cwdName = hasCwd
     ? (effectiveCwd
@@ -57,6 +63,10 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder, onChangeCwd
   const canCollapse = Object.values(openState).some(Boolean)
 
   const chooseFolder = async () => {
+    if (localBrowsingBlocked) {
+      return
+    }
+
     const selected = await selectDesktopPaths({
       defaultPath: hasCwd ? effectiveCwd : undefined,
       directories: true,
@@ -104,6 +114,7 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder, onChangeCwd
         error={rootError}
         hasCwd={hasCwd}
         loading={rootLoading}
+        localBrowsingBlocked={localBrowsingBlocked}
         onActivateFile={onActivateFile}
         onActivateFolder={onActivateFolder}
         onChangeFolder={chooseFolder}
@@ -122,6 +133,7 @@ interface FilesystemTabProps extends FileTreeBodyProps {
   canCollapse: boolean
   cwdName: string
   hasCwd: boolean
+  localBrowsingBlocked: boolean
   onChangeFolder: () => Promise<void> | void
   onCollapseAll: () => void
   onRefresh: () => void
@@ -142,6 +154,7 @@ function FilesystemTab({
   data,
   error,
   hasCwd,
+  localBrowsingBlocked,
   loading,
   onActivateFile,
   onActivateFolder,
@@ -161,18 +174,19 @@ function FilesystemTab({
       <RightSidebarSectionHeader>
         <div className="flex min-w-0 flex-1">
           <button
-            className="flex w-full min-w-0 items-center rounded-md text-left hover:text-(--ui-text-secondary)"
+            className="flex w-full min-w-0 items-center rounded-md text-left hover:text-(--ui-text-secondary) disabled:pointer-events-none"
+            disabled={localBrowsingBlocked}
             onClick={() => void onChangeFolder()}
             type="button"
           >
-            <SidebarPanelLabel>{cwdName}</SidebarPanelLabel>
+            <SidebarPanelLabel>{localBrowsingBlocked ? r.remoteOnlyTitle : cwdName}</SidebarPanelLabel>
           </button>
         </div>
         <Tip label={r.refreshTree} side="left">
           <Button
             aria-label={r.refreshTree}
             className={HEADER_ACTION_LABEL_REVEAL}
-            disabled={!hasCwd || loading}
+            disabled={!hasCwd || loading || localBrowsingBlocked}
             onClick={onRefresh}
             size="icon-xs"
             variant="ghost"
@@ -184,6 +198,7 @@ function FilesystemTab({
           <Button
             aria-label={r.openFolder}
             className={HEADER_ACTION_CLASS}
+            disabled={localBrowsingBlocked}
             onClick={() => void onChangeFolder()}
             size="icon-xs"
             variant="ghost"
@@ -194,8 +209,8 @@ function FilesystemTab({
         <Tip label={r.collapseAll} side="left">
           <Button
             aria-label={r.collapseAll}
-            className={cn(HEADER_ACTION_CLASS, !canCollapse && 'pointer-events-none opacity-0')}
-            disabled={!hasCwd || !canCollapse}
+            className={cn(HEADER_ACTION_CLASS, (!canCollapse || localBrowsingBlocked) && 'pointer-events-none opacity-0')}
+            disabled={!hasCwd || !canCollapse || localBrowsingBlocked}
             onClick={onCollapseAll}
             size="icon-xs"
             variant="ghost"
@@ -210,6 +225,7 @@ function FilesystemTab({
         data={data}
         error={error}
         loading={loading}
+        localBrowsingBlocked={localBrowsingBlocked}
         onActivateFile={onActivateFile}
         onActivateFolder={onActivateFolder}
         onLoadChildren={onLoadChildren}
@@ -231,6 +247,7 @@ interface FileTreeBodyProps {
   cwd: string
   data: ReturnType<typeof useProjectTree>['data']
   error: string | null
+  localBrowsingBlocked: boolean
   loading: boolean
   onActivateFile: (path: string) => void
   onActivateFolder: (path: string) => void
@@ -248,6 +265,7 @@ function FileTreeBody({
   cwd,
   data,
   error,
+  localBrowsingBlocked,
   loading,
   onActivateFile,
   onActivateFolder,
@@ -259,6 +277,12 @@ function FileTreeBody({
 }: FileTreeBodyProps) {
   const { t } = useI18n()
   const r = t.rightSidebar
+
+  // Highest priority: remote-only mode never reveals the local workspace, even
+  // when a cwd is set or an error is pending.
+  if (localBrowsingBlocked) {
+    return <EmptyState body={r.remoteOnlyBody} title={r.remoteOnlyTitle} />
+  }
 
   if (!cwd) {
     return <EmptyState body={r.noProjectBody} title={r.noProjectTitle} />

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -91,6 +91,10 @@ declare global {
       }
       revealLogs: () => Promise<{ ok: boolean; path: string; error?: string }>
       getRecentLogs: () => Promise<{ path: string; lines: string[] }>
+      // Remote-only mode (HERMES_DESKTOP_DISABLE_LOCAL_FILES / `--remote-only`).
+      // When `disabled` is true the local-filesystem IPC handlers refuse to
+      // browse, read, or open workstation files and the UI hides local sources.
+      localFilesPolicy?: () => Promise<HermesLocalFilesPolicy>
       readDir: (path: string) => Promise<HermesReadDirResult>
       gitRoot?: (path: string) => Promise<string | null>
       // Resolve git-worktree identity for a batch of session cwds, reading git's
@@ -532,6 +536,13 @@ export interface HermesReadDirEntry {
 export interface HermesReadDirResult {
   entries: HermesReadDirEntry[]
   error?: string
+}
+
+export interface HermesLocalFilesPolicy {
+  /** True when remote-only mode is on and local file access is blocked. */
+  disabled: boolean
+  /** Human-readable explanation shown in the UI, or null when local files are allowed. */
+  reason: string | null
 }
 
 export interface HermesPreviewFileChanged {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1688,6 +1688,8 @@ export const en: Translations = {
     couldNotPreview: path => `Could not preview ${path}`,
     noProjectTitle: 'No project',
     noProjectBody: 'Set a working directory from the status bar to browse files.',
+    remoteOnlyTitle: 'Remote-only mode',
+    remoteOnlyBody: 'Local file browsing is disabled. Only files exposed by the remote backend are shown.',
     unreadableTitle: 'Unreadable',
     unreadableBody: error => `Could not read this folder (${error}).`,
     emptyTitle: 'Empty',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1817,6 +1817,8 @@ export const ja = defineLocale({
     couldNotPreview: path => `${path} をプレビューできませんでした`,
     noProjectTitle: 'プロジェクトなし',
     noProjectBody: 'ステータスバーから作業ディレクトリを設定してファイルを閲覧してください。',
+    remoteOnlyTitle: 'リモート専用モード',
+    remoteOnlyBody: 'ローカルファイルの閲覧は無効です。リモートバックエンドが公開するファイルのみ表示されます。',
     unreadableTitle: '読み取り不可',
     unreadableBody: error => `このフォルダーを読み取れませんでした (${error})。`,
     emptyTitle: '空',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1323,6 +1323,8 @@ export interface Translations {
     couldNotPreview: (path: string) => string
     noProjectTitle: string
     noProjectBody: string
+    remoteOnlyTitle: string
+    remoteOnlyBody: string
     unreadableTitle: string
     unreadableBody: (error: string) => string
     emptyTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1758,6 +1758,8 @@ export const zhHant = defineLocale({
     couldNotPreview: path => `無法預覽 ${path}`,
     noProjectTitle: '沒有專案',
     noProjectBody: '從狀態列設定工作目錄後即可瀏覽檔案。',
+    remoteOnlyTitle: '僅遠端模式',
+    remoteOnlyBody: '本機檔案瀏覽已停用。僅顯示遠端後端公開的檔案。',
     unreadableTitle: '無法讀取',
     unreadableBody: error => `無法讀取此資料夾 (${error})。`,
     emptyTitle: '空資料夾',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1863,6 +1863,8 @@ export const zh: Translations = {
     couldNotPreview: path => `无法预览 ${path}`,
     noProjectTitle: '没有项目',
     noProjectBody: '从状态栏设置工作目录后即可浏览文件。',
+    remoteOnlyTitle: '仅远程模式',
+    remoteOnlyBody: '本地文件浏览已禁用。仅显示远程后端公开的文件。',
     unreadableTitle: '无法读取',
     unreadableBody: error => `无法读取此文件夹 (${error})。`,
     emptyTitle: '空文件夹',

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5467,6 +5467,11 @@ def cmd_gui(args: argparse.Namespace):
         env["HERMES_DESKTOP_HERMES_ROOT"] = str(Path(args.hermes_root).expanduser().resolve())
     if getattr(args, "cwd", None):
         env["HERMES_DESKTOP_CWD"] = str(Path(args.cwd).expanduser().resolve())
+    # Remote-only mode is a hard boundary: the Electron main process refuses every
+    # local-filesystem IPC when this is set, so Desktop behaves as a pure remote
+    # client. Honour a pre-set env var too so launchers can pin it without --remote-only.
+    if getattr(args, "remote_only", False):
+        env["HERMES_DESKTOP_DISABLE_LOCAL_FILES"] = "1"
 
     source_mode = getattr(args, "source", False)
     skip_build = getattr(args, "skip_build", False)

--- a/hermes_cli/subcommands/gui.py
+++ b/hermes_cli/subcommands/gui.py
@@ -51,6 +51,14 @@ def build_gui_parser(subparsers, *, cmd_gui: Callable) -> None:
         help="Initial project directory for Desktop chat sessions (sets HERMES_DESKTOP_CWD)",
     )
     gui_parser.add_argument(
+        "--remote-only",
+        action="store_true",
+        help=(
+            "Remote-only mode: block all local workstation file browsing, preview, and "
+            "attachment in Desktop (sets HERMES_DESKTOP_DISABLE_LOCAL_FILES=1)"
+        ),
+    )
+    gui_parser.add_argument(
         "--skip-build",
         action="store_true",
         help="Skip npm install/package and launch the existing unpacked app from apps/desktop/release",

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -23,6 +23,7 @@ def _ns(**kw):
         ignore_existing=False,
         hermes_root=None,
         cwd=None,
+        remote_only=False,
     )
     defaults.update(kw)
     return argparse.Namespace(**defaults)
@@ -107,6 +108,28 @@ def test_gui_forwards_desktop_environment_overrides(tmp_path, monkeypatch):
     assert launch_env["HERMES_DESKTOP_IGNORE_EXISTING"] == "1"
     assert launch_env["HERMES_DESKTOP_HERMES_ROOT"] == str(hermes_root)
     assert launch_env["HERMES_DESKTOP_CWD"] == str(cwd)
+    # --remote-only was not passed, so local files stay enabled.
+    assert "HERMES_DESKTOP_DISABLE_LOCAL_FILES" not in launch_env
+
+
+def test_gui_remote_only_disables_local_files(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch)
+
+    ok = subprocess.CompletedProcess([], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=ok), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main.subprocess.run", side_effect=[ok, ok]) as mock_run, \
+         pytest.raises(SystemExit):
+        cli_main.cmd_gui(_ns(remote_only=True))
+
+    launch_env = mock_run.call_args_list[1].kwargs["env"]
+    assert launch_env["HERMES_DESKTOP_DISABLE_LOCAL_FILES"] == "1"
 
 
 def test_gui_exits_when_npm_missing(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Summary

Closes #54363.

Adds a true **Remote-Only Mode** for Hermes Desktop. Because Desktop is a native app, its IPC surface can browse, preview, index, and attach local workstation files even when the agent is connected to a remote gateway. This change lets operators enforce that the local filesystem is never exposed.

Enable it with:

```bash
hermes desktop --remote-only
# or
HERMES_DESKTOP_DISABLE_LOCAL_FILES=1 hermes desktop
```

## How it works

The boundary is enforced in the **Electron main process**, so it holds regardless of what the renderer requests:

- **`electron/local-files-policy.cjs`** (new) reads `HERMES_DESKTOP_DISABLE_LOCAL_FILES` and centralizes the `disabled`/`reason` decision (accepts `1/true/yes/on`).
- A single guard at the **`hardening.cjs` chokepoint** (`resolveRequestedPathForIpc`) refuses every local path before touching disk. Because `resolveDirectoryForIpc` and `resolveReadableFileForIpc` both flow through it, this one guard covers directory listing, file/preview reads, git-root + worktree detection, and media streaming.
- The native **file picker** (`hermes:selectPaths`) becomes a no-op, so local file/folder attachment (and drag-drop reads) are disabled.
- The policy is exposed to the renderer (`hermes:localFiles:policy` + preload). The file browser shows a clear **Remote-only mode** state, locks the folder pickers, and never even issues a local `readDir`.

Browsing files exposed by the **remote backend** is unaffected — that traffic goes over the gateway API, not the local fs handlers.

## Mapping to the request

| Requested behavior | Status |
| --- | --- |
| Don't show local files in the right rail | ✅ disabled state replaces the local tree |
| Don't browse local paths (`C:\`, Documents, …) | ✅ hard-blocked at the IPC chokepoint |
| Disable drag-and-drop / local attachment | ✅ picker no-op + content reads blocked |
| File browser shows only remote-backend files | ✅ remote browsing routes over the gateway API |
| Clear label of source | ✅ right rail labels the "Remote-only mode" state |
| `HERMES_DESKTOP_DISABLE_LOCAL_FILES=1` | ✅ |
| `hermes desktop --remote-only` | ✅ |

## Tests

- `electron/local-files-policy.test.cjs` (new) — env parsing, policy shape, coded error.
- `electron/hardening.test.cjs` — chokepoint refuses local paths in remote-only mode.
- `files/use-project-tree.test.ts` — tree hook never reads the FS when disabled.
- `right-sidebar/index.test.tsx` — right rail shows the disabled state and locks the picker.
- `tests/hermes_cli/test_gui_command.py` — `--remote-only` sets the env var (and isn't set otherwise).

All new/changed unit tests pass; desktop `typecheck` is clean and lint is clean for the touched source files.
