### PR TITLE
fix(tools): include directories in search_files file results (#54347)

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import shutil
 import pytest
 import subprocess
 from pathlib import Path
@@ -700,6 +701,162 @@ class TestSearchFilesFallbackHiddenPaths:
 
         assert result.error is None
         assert set(result.files) == {str(visible_file), str(visible_nested_file)}
+
+
+class TestSearchFilesIncludesDirectories:
+    """search_files (target='files') is documented as an ls replacement and
+    must list directories, not just files.  Both rg --files and find -type f
+    enumerate files only, so empty directories are invisible.  See #54347."""
+
+    def _make_env(self):
+        env = MagicMock()
+        env.cwd = "/"
+
+        def execute(command, **kwargs):
+            completed = subprocess.run(
+                command, shell=True, text=True, capture_output=True,
+            )
+            return {
+                "output": completed.stdout,
+                "returncode": completed.returncode,
+            }
+
+        env.execute = execute
+        return env
+
+    def test_find_fallback_lists_empty_dir(self, tmp_path, monkeypatch):
+        """Find-fallback path must include empty directories in results."""
+        root = tmp_path / "repo"
+        root.mkdir()
+        empty_dir = root / "vault"       # the reported bug: empty dir
+        full_dir = root / "src"           # dir with a file inside
+        empty_dir.mkdir()
+        full_dir.mkdir()
+        (full_dir / "main.py").write_text("x")
+        (root / "config.py").write_text("x")
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda cmd: cmd == "find")
+        result = ops._search_files("*", str(root), limit=50, offset=0)
+
+        assert result.error is None
+        names = {f.rstrip("/") for f in result.files}
+        assert str(empty_dir) in names     # empty dir must be visible
+        assert str(full_dir) in names      # non-empty dir also listed as entry
+
+    def test_find_fallback_excludes_hidden_dirs(self, tmp_path, monkeypatch):
+        """Hidden directories must still be excluded when listing dirs."""
+        root = tmp_path / "repo"
+        root.mkdir()
+        (root / "vault").mkdir()
+        (root / ".secret").mkdir()
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda cmd: cmd == "find")
+        result = ops._search_files("*", str(root), limit=50, offset=0)
+
+        assert result.error is None
+        assert not any(".secret" in f for f in result.files)
+
+    def test_find_fallback_excludes_search_root(self, tmp_path, monkeypatch):
+        """The search root itself must not appear as a result."""
+        root = tmp_path / "repo"
+        root.mkdir()
+        (root / "vault").mkdir()
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda cmd: cmd == "find")
+        result = ops._search_files("*", str(root), limit=50, offset=0)
+
+        assert result.error is None
+        names = {f.rstrip("/") for f in result.files}
+        assert str(root) not in names
+
+    @pytest.mark.skipif(not shutil.which("rg"), reason="ripgrep not installed")
+    def test_rg_lists_empty_dir(self, tmp_path, monkeypatch):
+        """RG path must include empty directories in results."""
+        root = tmp_path / "repo"
+        root.mkdir()
+        empty_dir = root / "vault"
+        full_dir = root / "src"
+        empty_dir.mkdir()
+        full_dir.mkdir()
+        (full_dir / "main.py").write_text("x")
+        (root / "config.py").write_text("x")
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda cmd: cmd in ("rg", "find"))
+        result = ops._search_files("*", str(root), limit=50, offset=0)
+
+        assert result.error is None
+        names = {f.rstrip("/") for f in result.files}
+        assert str(empty_dir) in names
+
+    @pytest.mark.skipif(not shutil.which("rg"), reason="ripgrep not installed")
+    def test_rg_excludes_hidden_dirs(self, tmp_path, monkeypatch):
+        """Hidden directories must still be excluded in the RG path."""
+        root = tmp_path / "repo"
+        root.mkdir()
+        (root / "vault").mkdir()
+        (root / ".secret").mkdir()
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda cmd: cmd in ("rg", "find"))
+        result = ops._search_files("*", str(root), limit=50, offset=0)
+
+        assert result.error is None
+        assert not any(".secret" in f for f in result.files)
+
+    def test_find_fallback_dir_appears_once_across_pages(self, tmp_path, monkeypatch):
+        """A directory must appear on exactly ONE page, not on every page.
+
+        Regression for the find-fallback path where directories were appended
+        after pagination and so repeated on every page (#54347).
+        """
+        root = tmp_path / "repo"
+        root.mkdir()
+        (root / "vault").mkdir()
+        for i in range(12):
+            (root / f"f{i:02d}.txt").write_text("x")
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda cmd: cmd == "find")
+
+        limit = 5
+        seen_dirs = []
+        for page_offset in range(0, 40, limit):
+            page = ops._search_files("*", str(root), limit=limit, offset=page_offset)
+            for entry in page.files:
+                if entry.endswith("/"):
+                    seen_dirs.append(entry.rstrip("/"))
+
+        # the single 'vault' directory must be listed exactly once across pages
+        vault_hits = [d for d in seen_dirs if d.endswith("vault")]
+        assert len(vault_hits) == 1, (
+            f"directory repeated across pages: {vault_hits}"
+        )
+
+    def test_find_fallback_respects_limit_with_dirs(self, tmp_path, monkeypatch):
+        """The number of returned entries must respect limit even with dirs."""
+        root = tmp_path / "repo"
+        root.mkdir()
+        for i in range(6):
+            (root / f"f{i:02d}.txt").write_text("x")
+        for d in range(6):
+            (root / f"sub{d}").mkdir()
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda cmd: cmd == "find")
+        page = ops._search_files("*", str(root), limit=5, offset=0)
+
+        assert page.error is None
+        assert len(page.files) <= 5, (
+            f"limit violated: returned {len(page.files)} entries for limit=5"
+        )
+        # 12 total entries -> a second page must exist
+        assert page.total_count == 12, (
+            f"total_count={page.total_count}, expected 12"
+        )
 
 
 class TestShellFileOpsWriteDenied:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2054,15 +2054,12 @@ class ShellFileOperations(FileOperations):
         hidden_exclude = "-not -path '*/.*'" if not has_hidden_path_ancestor else ""
         hidden_filter_expr = f" {hidden_exclude}" if hidden_exclude else ""
 
-        # Use shell pagination for standard roots. For hidden roots, gather full
-        # output so we can re-apply hidden-descendant filtering while allowing
-        # explicit hidden-root searches.
-        pagination_expr = ""
-        if not has_hidden_path_ancestor:
-            pagination_expr = f" | tail -n +{offset + 1} | head -n {limit}"
-
+        # Gather the full file list (no shell pagination) so that directory
+        # entries can be merged in and the combined set paginated consistently.
+        # find on the fallback path is already bounded by a timeout, and rg
+        # remains the preferred fast path for large trees.
         cmd = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
-              f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn{pagination_expr}"
+              f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn"
 
         result = self._exec(cmd, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
@@ -2070,7 +2067,7 @@ class ShellFileOperations(FileOperations):
         if not stdout.strip() and not limit_reason:
             # Try without -printf (BSD find compatibility -- macOS)
             cmd_simple = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
-                        f"2>/dev/null | sort -rn{pagination_expr}"
+                        f"2>/dev/null | sort -rn"
             result = self._exec(cmd_simple, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
 
@@ -2098,15 +2095,88 @@ class ShellFileOperations(FileOperations):
                 if any(part not in {".", ".."} and part.startswith(".") for part in rel_parts):
                     continue
                 filtered_files.append(file_path)
-            files = filtered_files[offset:offset + limit]
-        # pagination for standard roots is already applied in shell
+            files = filtered_files
+
+        # find -type f lists files only; supplement with matching directories so
+        # the tool honours its documented ls-replacement contract (#54347). Merge
+        # before paginating so directories appear once and limit/offset hold.
+        # Skip the extra traversal when the file search already timed out: we
+        # have partial results and a second find could time out too.
+        if limit_reason == "search_timeout":
+            merged = files
+        else:
+            merged = files + self._collect_matching_dirs(path, search_pattern)
+        page = merged[offset:offset + limit]
 
         return SearchResult(
-            files=files,
-            total_count=len(files),
-            truncated=bool(limit_reason),
+            files=page,
+            total_count=len(merged),
+            truncated=len(merged) > offset + limit or bool(limit_reason),
             limit_reason=limit_reason,
         )
+
+    def _collect_matching_dirs(self, path: str, glob_pattern: str) -> list:
+        """Find directories matching *glob_pattern* to supplement file-only results.
+
+        ``rg --files`` and ``find -type f`` both enumerate files only, so
+        directories — especially empty ones — are invisible. This returns
+        matching directory paths (suffixed with ``/`` to match ``ls -F``
+        convention) so the tool honours its documented ls-replacement contract.
+        """
+        if not self._has_command('find'):
+            return []
+
+        search_root = Path(path)
+        has_hidden_path_ancestor = any(
+            part not in {".", ".."} and part.startswith(".")
+            for part in search_root.parts
+        )
+        hidden_exclude = "-not -path '*/.*'" if not has_hidden_path_ancestor else ""
+        hidden_filter_expr = f" {hidden_exclude}" if hidden_exclude else ""
+
+        # GNU find: -printf for mtime-sorted output; BSD fallback without it.
+        cmd = (
+            f"find {self._escape_shell_arg(path)}{hidden_filter_expr} "
+            f"-type d -name {self._escape_shell_arg(glob_pattern)} "
+            f"-not -path {self._escape_shell_arg(path)} "
+            f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn"
+        )
+        result = self._exec(cmd, timeout=30)
+        lines = [l for l in result.stdout.strip().split('\n') if l]
+
+        if not lines:
+            cmd = (
+                f"find {self._escape_shell_arg(path)}{hidden_filter_expr} "
+                f"-type d -name {self._escape_shell_arg(glob_pattern)} "
+                f"-not -path {self._escape_shell_arg(path)} "
+                f"2>/dev/null"
+            )
+            result = self._exec(cmd, timeout=30)
+            lines = [l for l in result.stdout.strip().split('\n') if l]
+
+        dirs = []
+        for line in lines:
+            parts = line.split(' ', 1)
+            if len(parts) == 2 and parts[0].replace('.', '').isdigit():
+                dirs.append(parts[1])
+            else:
+                dirs.append(line)
+
+        # For explicit hidden roots, apply the same descendant filtering as files.
+        if has_hidden_path_ancestor:
+            normalized_root = search_root.resolve()
+            filtered = []
+            for dir_path in dirs:
+                try:
+                    rel_parts = Path(dir_path).resolve().relative_to(normalized_root).parts
+                except ValueError:
+                    rel_parts = Path(dir_path).parts
+                if any(part not in {".", ".."} and part.startswith(".") for part in rel_parts):
+                    continue
+                filtered.append(dir_path)
+            dirs = filtered
+
+        return [d.rstrip('/') + '/' for d in dirs]
 
     def _search_files_rg(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
         """Search for files by name using ripgrep's --files mode.
@@ -2144,6 +2214,12 @@ class ShellFileOperations(FileOperations):
             result = self._exec(cmd_plain, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
             all_files = [f for f in stdout.strip().split('\n') if f]
+
+        # rg --files lists files only; supplement with matching directories
+        # so the tool behaves like ls (its documented contract). See #54347.
+        # Skip the extra traversal when rg already timed out (#54347).
+        if limit_reason != "search_timeout":
+            all_files = all_files + self._collect_matching_dirs(path, glob_pattern)
 
         page = all_files[offset:offset + limit]
 


### PR DESCRIPTION
## What

`search_files` (`target=\\'files\\'`) is documented as an ls replacement ("Also use this instead of ls — results sorted by modification time"), but both enumeration backends only ever list files:

- ripgrep path: `rg --files` → files only
- find fallback: `find -type f` → files only

So directories — **especially empty ones** — are completely invisible. A user with an empty `vault/` folder who asks "list folders" cannot see it, and cannot target it ("add this file to the vault folder" fails) because Hermes never discovers the directory.

## Fix

Add a shared `_collect_matching_dirs` helper that finds directories matching the glob via `find -type d` with the same hidden-exclusion / hidden-root-filtering logic as the file paths. Directory entries are suffixed with `/` (matching `ls -F`) and **merged into the result list before pagination** so they appear exactly once and `limit`/`offset`/`total_count` are honoured on both backends.

## Why merge before paginating

The directories are merged into the full list *before* the `[offset:offset+limit]` slice. An earlier draft appended them after pagination, which caused directories to repeat on every page and violated `limit`. Two regression tests guard against that regression.

## Verification

- **RED (bug confirmed on `upstream/main` `b699d27a4`):** the empty-dir tests fail without the fix.
- **Pagination regression RED:** against the buggy append-after-pagination code, the empty `vault` dir was returned **8 times across 8 pages** and `limit=5` returned **11 entries** — the new regression tests fail on that code.
- **GREEN (with fix):** all new tests pass.

```
tests/tools/test_file_operations.py .......... (97 passed)
tests/tools/test_file_tools_live.py + test_search_hidden_dirs.py (60 passed)
```

New tests cover: empty dir visible (find + rg paths), hidden dirs still excluded (find + rg), search root not in results, **dir appears exactly once across pages**, and **limit respected when directories are present**.

- One focused commit ahead of `upstream/main` (`0 1`).
- No new dependencies, no junk files, no AI attribution.

Auto-published by Moonsong via Path B automated pipeline.