### PR TITLE
feat(cli): substring matching for slash-command completion

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1377,6 +1377,26 @@ class SlashCommandCompleter(Completer):
         return f"{cmd_name} "
 
     @staticmethod
+    def _name_match_rank(cmd_name: str, word: str) -> int | None:
+        """Rank a command name against the typed word for completion.
+
+        Returns 0 for a prefix match, 1 for a substring ("contains") match,
+        or None for no match. Case-insensitive. Substring matching lets users
+        recall a command by any word it contains (e.g. ``/mcp`` surfaces
+        ``/reload-mcp``); prefix matches still rank first so typing the start
+        of a command keeps it at the top.
+        """
+        if not word:
+            return 0
+        name_lower = cmd_name.lower()
+        word_lower = word.lower()
+        if name_lower.startswith(word_lower):
+            return 0
+        if word_lower in name_lower:
+            return 1
+        return None
+
+    @staticmethod
     def _extract_path_word(text: str) -> str | None:
         """Extract the current word if it looks like a file path.
 
@@ -1917,58 +1937,58 @@ class SlashCommandCompleter(Completer):
 
         word = text[1:]
 
+        # Collect candidates from every source, then yield ranked so prefix
+        # matches come before substring ("contains") matches while each source's
+        # original discovery order is preserved within a rank (stable sort). This
+        # matters because downstream consumers truncate the list (e.g. the gateway
+        # caps complete.slash at 30) — ranking first keeps prefix hits from being
+        # pushed off the end by substring hits.
+        ranked: list[tuple[int, int, Completion]] = []
+
+        def _add(cmd_name: str, completion_display: str, meta: str) -> None:
+            rank = self._name_match_rank(cmd_name, word)
+            if rank is None:
+                return
+            ranked.append((
+                rank,
+                len(ranked),
+                Completion(
+                    self._completion_text(cmd_name, word),
+                    start_position=-len(word),
+                    display=completion_display,
+                    display_meta=meta,
+                ),
+            ))
+
         for cmd, desc in COMMANDS.items():
             if not self._command_allowed(cmd):
                 continue
-            cmd_name = cmd[1:]
-            if cmd_name.startswith(word):
-                yield Completion(
-                    self._completion_text(cmd_name, word),
-                    start_position=-len(word),
-                    display=cmd,
-                    display_meta=desc,
-                )
+            _add(cmd[1:], cmd, desc)
 
         for cmd, info in self._iter_skill_bundles().items():
-            cmd_name = cmd[1:]
-            if cmd_name.startswith(word):
-                description = str(info.get("description", "Skill bundle"))
-                short_desc = description[:50] + ("..." if len(description) > 50 else "")
-                skill_count = len(info.get("skills", []))
-                yield Completion(
-                    self._completion_text(cmd_name, word),
-                    start_position=-len(word),
-                    display=cmd,
-                    display_meta=f"▣ {short_desc} ({skill_count} skills)",
-                )
+            description = str(info.get("description", "Skill bundle"))
+            short_desc = description[:50] + ("..." if len(description) > 50 else "")
+            skill_count = len(info.get("skills", []))
+            _add(cmd[1:], cmd, f"▣ {short_desc} ({skill_count} skills)")
 
         for cmd, info in self._iter_skill_commands().items():
-            cmd_name = cmd[1:]
-            if cmd_name.startswith(word):
-                description = str(info.get("description", "Skill command"))
-                short_desc = description[:50] + ("..." if len(description) > 50 else "")
-                yield Completion(
-                    self._completion_text(cmd_name, word),
-                    start_position=-len(word),
-                    display=cmd,
-                    display_meta=f"⚡ {short_desc}",
-                )
+            description = str(info.get("description", "Skill command"))
+            short_desc = description[:50] + ("..." if len(description) > 50 else "")
+            _add(cmd[1:], cmd, f"⚡ {short_desc}")
 
         # Plugin-registered slash commands
         try:
             from hermes_cli.plugins import get_plugin_commands
             for cmd_name, cmd_info in get_plugin_commands().items():
-                if cmd_name.startswith(word):
-                    desc = str(cmd_info.get("description", "Plugin command"))
-                    short_desc = desc[:50] + ("..." if len(desc) > 50 else "")
-                    yield Completion(
-                        self._completion_text(cmd_name, word),
-                        start_position=-len(word),
-                        display=f"/{cmd_name}",
-                        display_meta=f"🔌 {short_desc}",
-                    )
+                desc = str(cmd_info.get("description", "Plugin command"))
+                short_desc = desc[:50] + ("..." if len(desc) > 50 else "")
+                _add(cmd_name, f"/{cmd_name}", f"🔌 {short_desc}")
         except Exception:
             pass
+
+        ranked.sort(key=lambda item: (item[0], item[1]))
+        for _rank, _order, completion in ranked:
+            yield completion
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1356,6 +1356,11 @@ class SlashCommandCompleter(Completer):
     # - Adding space makes "/model" → "/model " which blocks picker execution
     _PICKER_COMMANDS = frozenset({"model", "skin", "personality"})
 
+    # Minimum query length before substring ("contains") matching is used.
+    # Below this, completion stays prefix-only so a very short query (e.g. "/s")
+    # doesn't surface every command containing that character.
+    _SUBSTRING_MIN_LEN = 2
+
     @staticmethod
     def _completion_text(cmd_name: str, word: str) -> str:
         """Return replacement text for a completion.
@@ -1385,6 +1390,11 @@ class SlashCommandCompleter(Completer):
         recall a command by any word it contains (e.g. ``/mcp`` surfaces
         ``/reload-mcp``); prefix matches still rank first so typing the start
         of a command keeps it at the top.
+
+        Substring matching only applies once the query is at least
+        ``_SUBSTRING_MIN_LEN`` characters; shorter queries stay prefix-only so
+        a single character (e.g. ``/s``) doesn't surface every command that
+        merely contains it. Prefix matching is unaffected at any length.
         """
         if not word:
             return 0
@@ -1392,7 +1402,7 @@ class SlashCommandCompleter(Completer):
         word_lower = word.lower()
         if name_lower.startswith(word_lower):
             return 0
-        if word_lower in name_lower:
+        if len(word_lower) >= SlashCommandCompleter._SUBSTRING_MIN_LEN and word_lower in name_lower:
             return 1
         return None
 

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -605,6 +605,42 @@ class TestSlashCommandCompleter:
         # "⚡ " prefix + 50 chars + "..."
         assert meta == f"⚡ {'A' * 50}..."
 
+    # -- substring ("contains") matching + ranking -----------------------
+
+    def test_substring_completion_matches_contained_word(self):
+        """A word contained mid-command (not a prefix) still completes."""
+        completions = _completions(SlashCommandCompleter(), "/mcp")
+        texts = {item.text for item in completions}
+        # "mcp" is not a prefix of "reload-mcp" but is contained in it.
+        assert "reload-mcp" in texts
+
+    def test_substring_completion_is_case_insensitive(self):
+        completions = _completions(SlashCommandCompleter(), "/MCP")
+        texts = {item.text for item in completions}
+        assert "reload-mcp" in texts
+
+    def test_prefix_matches_rank_before_substring_matches(self):
+        """Prefix hits must precede substring hits so truncation keeps them."""
+        texts = [item.text for item in _completions(SlashCommandCompleter(), "/re")]
+        # "reset" starts with "re"; "compress" only contains it.
+        assert "reset" in texts and "compress" in texts
+        assert texts.index("reset") < texts.index("compress")
+
+    def test_prefix_completion_still_works(self):
+        """The original prefix behavior is unchanged for prefix queries."""
+        texts = {item.text for item in _completions(SlashCommandCompleter(), "/hel")}
+        assert "help" in texts
+
+    def test_skill_substring_completion_from_provider(self):
+        """Skill commands also match on a contained word, not just prefix."""
+        completer = SlashCommandCompleter(
+            skill_commands_provider=lambda: {
+                "/gif-search": {"description": "Search for GIFs"},
+            }
+        )
+        texts = {item.text for item in _completions(completer, "/search")}
+        assert "gif-search" in texts
+
     def test_skill_missing_description_uses_fallback(self):
         completer = SlashCommandCompleter(
             skill_commands_provider=lambda: {

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -641,6 +641,28 @@ class TestSlashCommandCompleter:
         texts = {item.text for item in _completions(completer, "/search")}
         assert "gif-search" in texts
 
+    def test_single_char_query_is_prefix_only(self):
+        """A 1-char query must stay prefix-only (substring noise guard).
+
+        Every returned command must START with the typed character — none may
+        match only as a substring.
+        """
+        completions = _completions(SlashCommandCompleter(), "/r")
+        names = [item.display_text.lstrip("/") for item in completions]
+        assert names, "expected at least one /r* command"
+        assert all(name.lower().startswith("r") for name in names)
+
+    def test_two_char_query_enables_substring(self):
+        """At the >=2 char threshold, substring matching is active.
+
+        'mc' is contained in 'reload-mcp' without being a prefix.
+        """
+        names = {
+            item.display_text.lstrip("/")
+            for item in _completions(SlashCommandCompleter(), "/mc")
+        }
+        assert "reload-mcp" in names
+
     def test_skill_missing_description_uses_fallback(self):
         completer = SlashCommandCompleter(
             skill_commands_provider=lambda: {


### PR DESCRIPTION
## What does this PR do?

Slash-command completion matched command names by **prefix only** (`cmd_name.startswith(word)`), so users had to remember how a command *starts*. This makes completion match any **contained substring**, case-insensitively — e.g. typing `/mcp` now surfaces `/reload-mcp`.

Prefix matches still **rank first** (stable, ahead of substring matches), so typing the start of a command keeps it at the top — and so downstream truncation (the gateway caps `complete.slash` at 30 results) never drops a prefix hit behind newly-matching substring results.

The change lives in the shared `SlashCommandCompleter`, so it applies uniformly to built-in commands, skill bundles, skill commands, and plugin commands — and **both the desktop composer and the TUI** benefit (the desktop delegates to the gateway's `complete.slash`, which uses this completer). Inline ghost-text auto-suggest is intentionally left prefix-only, since it can only append to what you've typed.

## Related Issue

Fixes #54388

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/commands.py`:
  - Add `SlashCommandCompleter._name_match_rank(cmd_name, word)` → `0` (prefix), `1` (substring), or `None` (no match), case-insensitive.
  - Rework `get_completions` to collect candidates from all sources, then yield **ranked** (prefix before substring; stable within a rank) so truncation keeps the best hits.
- `tests/hermes_cli/test_commands.py`:
  - Add tests for substring matching, case-insensitivity, prefix-before-substring ranking, and skill substring completion.

## How to Test

1. In the desktop composer or TUI, type `/mcp` → `/reload-mcp` now appears (previously nothing).
2. Type `/re` → prefix hits (`/reset`, `/retry`, …) appear **before** substring hits (`/compress`, …).
3. `pytest tests/hermes_cli/test_commands.py -q` → all pass (161 existing + 5 new).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(cli): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the relevant suite (`pytest tests/hermes_cli/test_commands.py -q`) — all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 24.6)

### Documentation & Housekeeping

- [x] Documentation — N/A (behavioral UX change; no config/keys)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A (no architecture change)
- [x] Cross-platform impact — N/A (pure Python string matching)
- [x] Tool descriptions/schemas — N/A
