### PR TITLE
fix: include empty directories in file search

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import shutil
 import pytest
 import subprocess
 from pathlib import Path
@@ -446,6 +447,26 @@ def file_ops(mock_env):
     return ShellFileOperations(mock_env)
 
 
+def _make_subprocess_env(cwd="/"):
+    env = MagicMock()
+    env.cwd = cwd
+
+    def execute(command, **kwargs):
+        completed = subprocess.run(
+            command,
+            shell=True,
+            text=True,
+            capture_output=True,
+        )
+        return {
+            "output": completed.stdout,
+            "returncode": completed.returncode,
+        }
+
+    env.execute = execute
+    return env
+
+
 class TestShellFileOpsHelpers:
     def test_normalize_read_pagination_clamps_invalid_values(self):
         assert normalize_read_pagination(offset=0, limit=0) == (1, 1)
@@ -642,25 +663,160 @@ class TestSearchPathValidation:
         assert "search failed" in result.error.lower() or "Search error" in result.error
 
 
+class TestSearchFilesIncludesDirectories:
+    @pytest.mark.skipif(
+        shutil.which("rg") is None,
+        reason="ripgrep not installed",
+    )
+    def test_rg_target_files_includes_matching_empty_directory(self, tmp_path):
+        root = tmp_path / "repo"
+        empty_dir = root / "vault"
+        empty_dir.mkdir(parents=True)
+
+        ops = ShellFileOperations(_make_subprocess_env())
+        result = ops.search("vault", path=str(root), target="files")
+
+        assert result.error is None
+        assert str(empty_dir) in result.files
+
+    @pytest.mark.skipif(
+        shutil.which("rg") is None,
+        reason="ripgrep not installed",
+    )
+    def test_rg_hidden_root_still_excludes_hidden_descendants(self, tmp_path):
+        root = tmp_path / ".hermes" / "logs"
+        visible_file = root / "agent.log"
+        hidden_file = root / "nested" / ".secret.log"
+        visible_file.parent.mkdir(parents=True, exist_ok=True)
+        hidden_file.parent.mkdir(parents=True, exist_ok=True)
+        visible_file.write_text("x")
+        hidden_file.write_text("x")
+
+        ops = ShellFileOperations(_make_subprocess_env())
+        result = ops.search("*.log", path=str(root), target="files")
+
+        assert result.error is None
+        assert str(visible_file) in result.files
+        assert str(hidden_file) not in result.files
+
+    @pytest.mark.skipif(
+        shutil.which("rg") is None,
+        reason="ripgrep not installed",
+    )
+    def test_rg_hidden_root_filters_before_pagination(self, tmp_path):
+        root = tmp_path / ".hermes" / "logs"
+        visible_file = root / "agent.log"
+        hidden_file = root / "nested" / ".secret.log"
+        visible_file.parent.mkdir(parents=True, exist_ok=True)
+        hidden_file.parent.mkdir(parents=True, exist_ok=True)
+        visible_file.write_text("x")
+        hidden_file.write_text("x")
+        # Ensure the hidden descendant sorts ahead of the visible file by mtime.
+        hidden_file.touch()
+
+        ops = ShellFileOperations(_make_subprocess_env())
+        result = ops.search("*.log", path=str(root), target="files", limit=1)
+
+        assert result.error is None
+        assert result.files == [str(visible_file)]
+        assert result.truncated is False
+
+    @pytest.mark.skipif(
+        shutil.which("rg") is None,
+        reason="ripgrep not installed",
+    )
+    @pytest.mark.skipif(
+        shutil.which("git") is None,
+        reason="git not installed",
+    )
+    def test_rg_target_files_excludes_gitignored_empty_directory(self, tmp_path):
+        root = tmp_path / "repo"
+        ignored_dir = root / "ignored_dir"
+        visible_dir = root / "visible_dir"
+        ignored_dir.mkdir(parents=True)
+        visible_dir.mkdir()
+        (root / ".gitignore").write_text("ignored_dir/\n")
+        subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+
+        ops = ShellFileOperations(_make_subprocess_env())
+        result = ops.search("*dir", path=str(root), target="files")
+
+        assert result.error is None
+        assert str(visible_dir) in result.files
+        assert str(ignored_dir) not in result.files
+
+    @pytest.mark.skipif(
+        shutil.which("rg") is None,
+        reason="ripgrep not installed",
+    )
+    def test_rg_target_files_exact_page_is_not_truncated(self, tmp_path):
+        root = tmp_path / "repo"
+        one = root / "one.log"
+        two = root / "two.log"
+        root.mkdir()
+        one.write_text("x")
+        two.write_text("x")
+
+        ops = ShellFileOperations(_make_subprocess_env())
+        result = ops.search("*.log", path=str(root), target="files", limit=2)
+
+        assert result.error is None
+        assert set(result.files) == {str(one), str(two)}
+        assert result.truncated is False
+
+    def test_find_target_files_includes_matching_empty_directory(self, tmp_path, monkeypatch):
+        root = tmp_path / "repo"
+        empty_dir = root / "vault"
+        regular_file = root / "vault.txt"
+        empty_dir.mkdir(parents=True)
+        regular_file.write_text("x")
+
+        ops = ShellFileOperations(_make_subprocess_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+        result = ops.search("vault*", path=str(root), target="files")
+
+        assert result.error is None
+        assert {str(empty_dir), str(regular_file)}.issubset(set(result.files))
+
+    def test_target_files_still_excludes_hidden_matching_directories(self, tmp_path, monkeypatch):
+        root = tmp_path / "repo"
+        visible_dir = root / "visible" / "cache"
+        hidden_dir = root / ".hidden" / "cache"
+        visible_dir.mkdir(parents=True)
+        hidden_dir.mkdir(parents=True)
+
+        ops = ShellFileOperations(_make_subprocess_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+        result = ops.search("cache", path=str(root), target="files")
+
+        assert result.error is None
+        assert str(visible_dir) in result.files
+        assert str(hidden_dir) not in result.files
+
+    def test_target_files_paginates_combined_files_and_directories(self, tmp_path, monkeypatch):
+        root = tmp_path / "repo"
+        empty_dir = root / "alpha"
+        regular_file = root / "bravo"
+        empty_dir.mkdir(parents=True)
+        regular_file.write_text("x")
+
+        ops = ShellFileOperations(_make_subprocess_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+
+        first = ops.search("*", path=str(root), target="files", limit=1, offset=0)
+        second = ops.search("*", path=str(root), target="files", limit=1, offset=1)
+        combined = ops.search("*", path=str(root), target="files", limit=2, offset=0)
+
+        assert first.error is None
+        assert second.error is None
+        assert combined.error is None
+        assert first.files + second.files == combined.files
+        assert set(combined.files) == {str(empty_dir), str(regular_file)}
+
+
 class TestSearchFilesFallbackHiddenPaths:
     def _make_env(self):
-        env = MagicMock()
-        env.cwd = "/"
-
-        def execute(command, **kwargs):
-            completed = subprocess.run(
-                command,
-                shell=True,
-                text=True,
-                capture_output=True,
-            )
-            return {
-                "output": completed.stdout,
-                "returncode": completed.returncode,
-            }
-
-        env.execute = execute
-        return env
+        return _make_subprocess_env()
 
     def test_hidden_root_with_hidden_ancestor_includes_files(self, tmp_path, monkeypatch):
         """Fallback find should include visible files when path is inside hidden root."""

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -457,6 +457,7 @@ def _make_subprocess_env(cwd="/"):
             shell=True,
             text=True,
             capture_output=True,
+            input=kwargs.get("stdin_data"),
         )
         return {
             "output": completed.stdout,
@@ -664,6 +665,31 @@ class TestSearchPathValidation:
 
 
 class TestSearchFilesIncludesDirectories:
+    def test_rg_file_results_work_without_find(self, mock_env, monkeypatch):
+        executed_commands = []
+        availability_checks = []
+
+        def execute(command, **kwargs):
+            executed_commands.append(command)
+            if command.startswith("rg --files --sortr=modified"):
+                return {"output": "/repo/match.txt\n", "returncode": 0}
+            pytest.fail(f"Unexpected command: {command}")
+
+        def has_command(command):
+            availability_checks.append(command)
+            return command == "rg"
+
+        mock_env.execute.side_effect = execute
+        ops = ShellFileOperations(mock_env)
+        monkeypatch.setattr(ops, "_has_command", has_command)
+
+        result = ops._search_files("*.txt", "/repo", limit=50, offset=0)
+
+        assert result.error is None
+        assert result.files == ["/repo/match.txt"]
+        assert availability_checks == ["rg", "find"]
+        assert not any("find " in command for command in executed_commands)
+
     @pytest.mark.skipif(
         shutil.which("rg") is None,
         reason="ripgrep not installed",
@@ -763,6 +789,32 @@ class TestSearchFilesIncludesDirectories:
         assert result.error is None
         assert set(result.files) == {str(one), str(two)}
         assert result.truncated is False
+
+    @pytest.mark.skipif(
+        shutil.which("rg") is None,
+        reason="ripgrep not installed",
+    )
+    def test_rg_sorts_files_and_directories_before_pagination(self, tmp_path):
+        root = tmp_path / "repo"
+        older_file = root / "older.log"
+        newer_dir = root / "alpha-newer"
+        older_dirs = [root / "zulu-older", root / "yankee-older"]
+        root.mkdir()
+        older_file.write_text("x")
+        newer_dir.mkdir()
+        for older_dir in older_dirs:
+            older_dir.mkdir()
+        os.utime(older_file, (1_000, 1_000))
+        for older_dir in older_dirs:
+            os.utime(older_dir, (1_000, 1_000))
+        os.utime(newer_dir, (2_000, 2_000))
+
+        ops = ShellFileOperations(_make_subprocess_env())
+        result = ops.search("*", path=str(root), target="files", limit=1)
+
+        assert result.error is None
+        assert result.files == [str(newer_dir)]
+        assert result.truncated is True
 
     def test_find_target_files_includes_matching_empty_directory(self, tmp_path, monkeypatch):
         root = tmp_path / "repo"

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -317,7 +317,8 @@ class TestPaginationBounds:
         assert result.files == ["a.py"]
         rg_commands = [cmd for cmd in commands if cmd.startswith("rg --files")]
         assert rg_commands
-        assert "| head -n 1" in rg_commands[0]
+        # Fetch one sentinel beyond the clamped page so truncation is accurate.
+        assert "| head -n 2" in rg_commands[0]
 
 
 # =========================================================================

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2061,16 +2061,35 @@ class ShellFileOperations(FileOperations):
         if not has_hidden_path_ancestor:
             pagination_expr = f" | tail -n +{offset + 1} | head -n {limit}"
 
-        cmd = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
-              f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn{pagination_expr}"
+        escaped_path = self._escape_shell_arg(path)
+        escaped_pattern = self._escape_shell_arg(search_pattern)
+        file_or_descendant_dir_expr = r"\( -type f -o -type d \)"
+
+        cmd = (
+            f"if [ -d {escaped_path} ]; then "
+            f"find {escaped_path} -mindepth 1{hidden_filter_expr} "
+            f"{file_or_descendant_dir_expr} -name {escaped_pattern} "
+            f"-printf '%T@ %p\\n'; "
+            f"else "
+            f"find {escaped_path}{hidden_filter_expr} -type f "
+            f"-name {escaped_pattern} -printf '%T@ %p\\n'; "
+            f"fi 2>/dev/null | sort -rn{pagination_expr}"
+        )
 
         result = self._exec(cmd, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
 
         if not stdout.strip() and not limit_reason:
             # Try without -printf (BSD find compatibility -- macOS)
-            cmd_simple = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
-                        f"2>/dev/null | sort -rn{pagination_expr}"
+            cmd_simple = (
+                f"if [ -d {escaped_path} ]; then "
+                f"find {escaped_path} -mindepth 1{hidden_filter_expr} "
+                f"{file_or_descendant_dir_expr} -name {escaped_pattern}; "
+                f"else "
+                f"find {escaped_path}{hidden_filter_expr} -type f "
+                f"-name {escaped_pattern}; "
+                f"fi 2>/dev/null | sort -rn{pagination_expr}"
+            )
             result = self._exec(cmd_simple, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
 
@@ -2108,6 +2127,95 @@ class ShellFileOperations(FileOperations):
             limit_reason=limit_reason,
         )
 
+    def _filter_hidden_descendants(self, paths: List[str], root: Path) -> List[str]:
+        """Drop hidden descendants while allowing an explicit hidden search root."""
+        normalized_root = root.resolve()
+        filtered = []
+        for item_path in paths:
+            try:
+                rel_parts = Path(item_path).resolve().relative_to(normalized_root).parts
+            except ValueError:
+                rel_parts = Path(item_path).parts
+            if any(part not in {".", ".."} and part.startswith(".") for part in rel_parts):
+                continue
+            filtered.append(item_path)
+        return filtered
+
+    def _filter_gitignored_paths(self, paths: List[str], root: str) -> List[str]:
+        """Drop paths ignored by git when *root* is inside a git worktree."""
+        if not paths:
+            return paths
+
+        escaped_root = self._escape_shell_arg(root)
+        kept = []
+        for item_path in paths:
+            escaped_item = self._escape_shell_arg(item_path)
+            cmd = (
+                f"git -C {escaped_root} rev-parse --is-inside-work-tree >/dev/null 2>&1 "
+                f"&& git -C {escaped_root} check-ignore -q -- {escaped_item}"
+            )
+            result = self._exec(cmd, timeout=10)
+            # Outside a git worktree, rev-parse fails and the shell returns non-zero;
+            # inside one, check-ignore returns 0 only for ignored paths.
+            if result.exit_code == 0:
+                continue
+            kept.append(item_path)
+        return kept
+
+    def _search_directories_with_find(
+        self, pattern: str, path: str, fetch_limit: int
+    ) -> tuple[List[str], Optional[str]]:
+        """Return matching descendant directories using find, if available."""
+        if fetch_limit <= 0:
+            return [], None
+
+        search_root = Path(path)
+        has_hidden_path_ancestor = any(
+            part not in {".", ".."} and part.startswith(".")
+            for part in search_root.parts
+        )
+        hidden_exclude = "-not -path '*/.*'" if not has_hidden_path_ancestor else ""
+        hidden_filter_expr = f" {hidden_exclude}" if hidden_exclude else ""
+        pagination_expr = (
+            "" if has_hidden_path_ancestor else f" | head -n {fetch_limit}"
+        )
+
+        escaped_path = self._escape_shell_arg(path)
+        escaped_pattern = self._escape_shell_arg(pattern)
+        cmd = (
+            f"find {escaped_path} -mindepth 1{hidden_filter_expr} "
+            f"-type d -name {escaped_pattern} -printf '%T@ %p\\n' "
+            f"2>/dev/null | sort -rn{pagination_expr}"
+        )
+        result = self._exec(cmd, timeout=60)
+        stdout, limit_reason = _search_stdout_and_limit(result)
+
+        if not stdout.strip() and not limit_reason:
+            # Try without -printf (BSD find compatibility -- macOS)
+            cmd_simple = (
+                f"find {escaped_path} -mindepth 1{hidden_filter_expr} "
+                f"-type d -name {escaped_pattern} 2>/dev/null "
+                f"| sort -rn{pagination_expr}"
+            )
+            result = self._exec(cmd_simple, timeout=60)
+            stdout, limit_reason = _search_stdout_and_limit(result)
+
+        dirs = []
+        for line in stdout.strip().split('\n'):
+            if not line:
+                continue
+            parts = line.split(' ', 1)
+            if len(parts) == 2 and parts[0].replace('.', '').isdigit():
+                dirs.append(parts[1])
+            else:
+                dirs.append(line)
+
+        if has_hidden_path_ancestor:
+            dirs = self._filter_hidden_descendants(dirs, search_root)
+
+        dirs = self._filter_gitignored_paths(dirs, path)
+        return dirs[:fetch_limit], limit_reason
+
     def _search_files_rg(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
         """Search for files by name using ripgrep's --files mode.
 
@@ -2123,12 +2231,18 @@ class ShellFileOperations(FileOperations):
         else:
             glob_pattern = pattern
 
-        fetch_limit = limit + offset
+        search_root = Path(path)
+        has_hidden_path_ancestor = any(
+            part not in {".", ".."} and part.startswith(".")
+            for part in search_root.parts
+        )
+        fetch_limit = limit + offset + 1
+        head_expr = "" if has_hidden_path_ancestor else f" | head -n {fetch_limit}"
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
             f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
-            f"{self._escape_shell_arg(path)} 2>/dev/null "
-            f"| head -n {fetch_limit}"
+            f"{self._escape_shell_arg(path)} 2>/dev/null"
+            f"{head_expr}"
         )
         result = self._exec(cmd_sorted, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
@@ -2138,20 +2252,34 @@ class ShellFileOperations(FileOperations):
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
                 f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
-                f"{self._escape_shell_arg(path)} 2>/dev/null "
-                f"| head -n {fetch_limit}"
+                f"{self._escape_shell_arg(path)} 2>/dev/null"
+                f"{head_expr}"
             )
             result = self._exec(cmd_plain, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
             all_files = [f for f in stdout.strip().split('\n') if f]
 
-        page = all_files[offset:offset + limit]
+        if has_hidden_path_ancestor:
+            all_files = self._filter_hidden_descendants(all_files, search_root)
+
+        all_entries = all_files
+        directory_limit_reason = None
+        if not limit_reason:
+            dirs, directory_limit_reason = self._search_directories_with_find(
+                glob_pattern, path, fetch_limit
+            )
+            all_entries = all_files + dirs
+
+        page = all_entries[offset:offset + limit]
 
         return SearchResult(
             files=page,
-            total_count=len(all_files),
-            truncated=len(all_files) >= fetch_limit or bool(limit_reason),
-            limit_reason=limit_reason,
+            total_count=len(all_entries),
+            truncated=(
+                len(all_entries) > offset + limit
+                or bool(limit_reason or directory_limit_reason)
+            ),
+            limit_reason=limit_reason or directory_limit_reason,
         )
     
     def _search_content(self, pattern: str, path: str, file_glob: Optional[str],

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2147,26 +2147,56 @@ class ShellFileOperations(FileOperations):
             return paths
 
         escaped_root = self._escape_shell_arg(root)
-        kept = []
-        for item_path in paths:
-            escaped_item = self._escape_shell_arg(item_path)
-            cmd = (
-                f"git -C {escaped_root} rev-parse --is-inside-work-tree >/dev/null 2>&1 "
-                f"&& git -C {escaped_root} check-ignore -q -- {escaped_item}"
+        probe = self._exec(
+            f"git -C {escaped_root} rev-parse --is-inside-work-tree >/dev/null 2>&1",
+            timeout=10,
+        )
+        if probe.exit_code != 0:
+            return paths
+
+        result = self._exec(
+            f"git -C {escaped_root} check-ignore --stdin",
+            timeout=10,
+            stdin_data="\n".join(paths),
+        )
+        ignored = set(result.stdout.splitlines())
+        return [item_path for item_path in paths if item_path not in ignored]
+
+    def _sort_paths_by_mtime(self, paths: List[str]) -> List[str]:
+        """Sort paths newest-first using metadata from the active backend."""
+        if len(paths) < 2:
+            return paths
+
+        script = (
+            'while IFS= read -r item || [ -n "$item" ]; do '
+            'mtime="$(stat -c%Y "$item" 2>/dev/null '
+            '|| stat -f%m "$item" 2>/dev/null || true)"; '
+            'printf \'%s\\n\' "${mtime:-0}"; '
+            "done"
+        )
+        result = self._exec(script, timeout=60, stdin_data="\n".join(paths))
+
+        mtimes = []
+        for line in result.stdout.splitlines()[:len(paths)]:
+            try:
+                mtimes.append(float(line))
+            except ValueError:
+                mtimes.append(0.0)
+        # A path can disappear between traversal and stat. Keep such paths at
+        # the end, preserving their existing relative order as a stable fallback.
+        mtimes.extend([0.0] * (len(paths) - len(mtimes)))
+        return [
+            item
+            for _, item in sorted(
+                zip(mtimes, paths), key=lambda pair: pair[0], reverse=True
             )
-            result = self._exec(cmd, timeout=10)
-            # Outside a git worktree, rev-parse fails and the shell returns non-zero;
-            # inside one, check-ignore returns 0 only for ignored paths.
-            if result.exit_code == 0:
-                continue
-            kept.append(item_path)
-        return kept
+        ]
 
     def _search_directories_with_find(
         self, pattern: str, path: str, fetch_limit: int
     ) -> tuple[List[str], Optional[str]]:
         """Return matching descendant directories using find, if available."""
-        if fetch_limit <= 0:
+        if fetch_limit <= 0 or not self._has_command("find"):
             return [], None
 
         search_root = Path(path)
@@ -2176,16 +2206,12 @@ class ShellFileOperations(FileOperations):
         )
         hidden_exclude = "-not -path '*/.*'" if not has_hidden_path_ancestor else ""
         hidden_filter_expr = f" {hidden_exclude}" if hidden_exclude else ""
-        pagination_expr = (
-            "" if has_hidden_path_ancestor else f" | head -n {fetch_limit}"
-        )
-
         escaped_path = self._escape_shell_arg(path)
         escaped_pattern = self._escape_shell_arg(pattern)
         cmd = (
             f"find {escaped_path} -mindepth 1{hidden_filter_expr} "
             f"-type d -name {escaped_pattern} -printf '%T@ %p\\n' "
-            f"2>/dev/null | sort -rn{pagination_expr}"
+            f"2>/dev/null | sort -rn"
         )
         result = self._exec(cmd, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
@@ -2194,8 +2220,7 @@ class ShellFileOperations(FileOperations):
             # Try without -printf (BSD find compatibility -- macOS)
             cmd_simple = (
                 f"find {escaped_path} -mindepth 1{hidden_filter_expr} "
-                f"-type d -name {escaped_pattern} 2>/dev/null "
-                f"| sort -rn{pagination_expr}"
+                f"-type d -name {escaped_pattern} 2>/dev/null"
             )
             result = self._exec(cmd_simple, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
@@ -2214,7 +2239,7 @@ class ShellFileOperations(FileOperations):
             dirs = self._filter_hidden_descendants(dirs, search_root)
 
         dirs = self._filter_gitignored_paths(dirs, path)
-        return dirs[:fetch_limit], limit_reason
+        return self._sort_paths_by_mtime(dirs)[:fetch_limit], limit_reason
 
     def _search_files_rg(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
         """Search for files by name using ripgrep's --files mode.
@@ -2268,7 +2293,7 @@ class ShellFileOperations(FileOperations):
             dirs, directory_limit_reason = self._search_directories_with_find(
                 glob_pattern, path, fetch_limit
             )
-            all_entries = all_files + dirs
+            all_entries = self._sort_paths_by_mtime(all_files + dirs)
 
         page = all_entries[offset:offset + limit]
 


### PR DESCRIPTION
## Summary
- Include matching directories in `search_files(..., target="files")` results so empty directories are discoverable.
- Preserve existing hidden-directory, `.gitignore`, and pagination behavior while augmenting the `rg --files` path with directory matches.
- Add regression coverage for empty directories, hidden descendants, gitignored directories, and truncation/pagination edge cases.

Fixes #54347

## Verification
- `scripts/run_tests.sh tests/tools/test_file_operations.py -q` -> 98 tests passed, 0 failed
- `/opt/homebrew/bin/python3.12 -m py_compile tools/file_operations.py tests/tools/test_file_operations.py` -> passed
- `git diff --check` -> passed

## Caveats
- I ran the focused file-operation test suite rather than the full repository test suite.
