### PR TITLE
fix(gateway): prefer systemd scope for timeout check

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -342,12 +342,14 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
 
     # Try to identify our unit name and ask systemctl for its config.
     unit_name: Optional[str] = None
+    cgroup_path: Optional[str] = None
     try:
         # /proc/self/cgroup gives us "0::/user.slice/.../hermes-gateway.service"
         with open("/proc/self/cgroup", encoding="utf-8") as fh:
             for line in fh:
                 # systemd cgroup line ends with the unit name
                 if ".service" in line:
+                    cgroup_path = line.strip().split(":", 2)[-1]
                     parts = line.strip().split("/")
                     for p in reversed(parts):
                         if p.endswith(".service"):
@@ -360,11 +362,20 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
     if not unit_name:
         return None
 
-    # Query systemctl for TimeoutStopUSec.  Use --user OR system depending
-    # on which manager actually owns the unit.  Try user first since
-    # that's the common case for hermes.
+    # Query systemctl for TimeoutStopUSec. Use --user OR system depending
+    # on which manager actually owns the unit.  The cgroup path tells us
+    # which manager launched this process; respecting it avoids false
+    # positives when an inactive user unit with the same name has a stale
+    # TimeoutStopSec but the running service is a system unit.
     timeout_us: Optional[int] = None
-    for flag in (["--user"], []):
+    if cgroup_path and "/system.slice/" in cgroup_path:
+        flag_order = ([], ["--user"])
+    elif cgroup_path and "/user.slice/" in cgroup_path:
+        flag_order = (["--user"], [])
+    else:
+        flag_order = (["--user"], [])
+
+    for flag in flag_order:
         try:
             result = subprocess.run(
                 ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -199,13 +199,15 @@ def check_systemd_timing_alignment(
         return None  # Not running under systemd (or at least not directly)
     # /proc/self/cgroup: "0::/user.slice/.../hermes-gateway.service"
     unit_name: Optional[str] = None
+    cgroup_path: Optional[str] = None
     with contextlib.suppress(OSError), open("/proc/self/cgroup", encoding="utf-8") as fh:
         for line in fh:
             parts = reversed(line.strip().split("/"))
             unit_name = next((p for p in parts if p.endswith(".service")), None)
             if unit_name:
+                cgroup_path = line.strip().split(":", 2)[-1]
                 break
-    if (timeout_us := _systemd_timeout_stop_us(unit_name) if unit_name else None) is None:
+    if (timeout_us := _systemd_timeout_stop_us(unit_name, cgroup_path) if unit_name else None) is None:
         return None
     timeout_stop_sec = timeout_us / 1_000_000.0
     expected = float(resolve_systemd_timeout_stop_sec(drain_timeout, cron_drain_timeout))
@@ -214,9 +216,14 @@ def check_systemd_timing_alignment(
             "mismatch": timeout_stop_sec < expected}
 
 
-def _systemd_timeout_stop_us(unit_name: str) -> Optional[int]:
-    """``TimeoutStopUSec`` of ``unit_name`` in microseconds; ``--user`` first (hermes' usual)."""
-    for flag in (["--user"], []):
+def _systemd_timeout_stop_us(unit_name: str, cgroup_path: Optional[str] = None) -> Optional[int]:
+    """``TimeoutStopUSec`` of ``unit_name`` in microseconds. The cgroup path says which manager
+    launched this process: under ``/system.slice/`` ask the system manager first, so an inactive
+    same-named user unit with a stale ``TimeoutStopSec`` cannot yield a false mismatch; otherwise
+    ``--user`` first (hermes' usual).
+    """
+    flag_order = ([], ["--user"]) if cgroup_path and "/system.slice/" in cgroup_path else (["--user"], [])
+    for flag in flag_order:
         try:
             result = subprocess.run(
                 ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import io
 import os
 import signal
 import sys
@@ -248,3 +249,48 @@ class TestCheckSystemdTimingAlignment:
         # for whatever unit pytest IS in.  Both are valid; we just ensure
         # the function doesn't raise.
         assert result is None or isinstance(result, dict)
+
+    def test_system_slice_prefers_system_manager_over_stale_user_unit(self, monkeypatch):
+        """A system service must not read a same-named stale user unit.
+
+        Root can have both a system gateway unit and an inactive user unit with
+        the same name. If the system unit has TimeoutStopSec=210 but the user
+        manager reports the default 90s, consulting --user first produces a
+        false "stale systemd unit" warning at gateway startup.
+        """
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+
+        def fake_open(path, *args, **kwargs):
+            assert path == "/proc/self/cgroup"
+            return io.StringIO(
+                "0::/system.slice/hermes-gateway-mes-kanban-orchestrator.service\n"
+            )
+
+        class Result:
+            returncode = 0
+
+            def __init__(self, stdout):
+                self.stdout = stdout
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if "--user" in cmd:
+                return Result("TimeoutStopUSec=1min 30s\n")
+            return Result("TimeoutStopUSec=3min 30s\n")
+
+        monkeypatch.setattr("builtins.open", fake_open)
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert calls
+        assert "--user" not in calls[0]
+        assert result == {
+            "unit": "hermes-gateway-mes-kanban-orchestrator.service",
+            "timeout_stop_sec": 210.0,
+            "drain_timeout": 180.0,
+            "expected_min": 210.0,
+            "mismatch": False,
+        }

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import io
 import os
 import signal
 import sys
@@ -142,3 +143,49 @@ class TestCheckSystemdTimingAlignment:
         # for whatever unit pytest IS in.  Both are valid; we just ensure
         # the function doesn't raise.
         assert result is None or isinstance(result, dict)
+
+    def test_system_slice_prefers_system_manager_over_stale_user_unit(self, monkeypatch):
+        """A system service must not read a same-named stale user unit.
+
+        Root can have both a system gateway unit and an inactive user unit with
+        the same name. If the system unit has TimeoutStopSec=210 but the user
+        manager reports the default 90s, consulting --user first produces a
+        false "stale systemd unit" warning at gateway startup.
+        """
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+
+        def fake_open(path, *args, **kwargs):
+            assert path == "/proc/self/cgroup"
+            return io.StringIO(
+                "0::/system.slice/hermes-gateway-mes-kanban-orchestrator.service\n"
+            )
+
+        class Result:
+            returncode = 0
+
+            def __init__(self, stdout):
+                self.stdout = stdout
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if "--user" in cmd:
+                return Result("TimeoutStopUSec=1min 30s\n")
+            return Result("TimeoutStopUSec=3min 30s\n")
+
+        monkeypatch.setattr("builtins.open", fake_open)
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert calls
+        assert "--user" not in calls[0]
+        assert result == {
+            "unit": "hermes-gateway-mes-kanban-orchestrator.service",
+            "timeout_stop_sec": 210.0,
+            "drain_timeout": 180.0,
+            "cron_drain_timeout": 30.0,
+            "expected_min": 210.0,
+            "mismatch": False,
+        }


### PR DESCRIPTION
## Summary
- Detect the running systemd manager from `/proc/self/cgroup` before checking `TimeoutStopUSec`.
- Prefer the system manager for services under `/system.slice` and the user manager for `/user.slice`.
- Add regression coverage for the false-positive case where a stale inactive user unit reports 90s while the active system unit is correctly configured at 210s.

## Why
Gateway startup could warn that a systemd unit was stale even when the running service was a system unit with a correct `TimeoutStopSec`. The check queried `systemctl --user` first, so a same-named inactive user unit could produce a false `TimeoutStopSec=90s` mismatch.

## Test plan
- `python -m py_compile gateway/shutdown_forensics.py tests/gateway/test_shutdown_forensics.py`
- `python -m pytest tests/gateway/test_shutdown_forensics.py -q -o 'addopts=' --tb=short`
