### PR TITLE
fix(ssh): constrain auth to configured identity

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -218,6 +218,7 @@ terminal:
 #   ssh_user: "myuser"
 #   ssh_port: 22
 #   ssh_key: "~/.ssh/id_rsa"  # Optional - uses ssh-agent if not specified
+#   ssh_identities_only: false  # Set true to pass -o IdentitiesOnly=yes
 
 # -----------------------------------------------------------------------------
 # OPTION 3: Docker container

--- a/cli.py
+++ b/cli.py
@@ -175,7 +175,7 @@ from hermes_cli.browser_connect import (
     try_launch_chrome_debug,
 )
 from hermes_cli.env_loader import load_hermes_dotenv
-from utils import base_url_host_matches
+from utils import base_url_host_matches, env_bool
 
 _hermes_home = get_hermes_home()
 _project_env = Path(__file__).parent / '.env'
@@ -614,6 +614,7 @@ def load_cli_config() -> Dict[str, Any]:
         "ssh_user": "TERMINAL_SSH_USER",
         "ssh_port": "TERMINAL_SSH_PORT",
         "ssh_key": "TERMINAL_SSH_KEY",
+        "ssh_identities_only": "TERMINAL_SSH_IDENTITIES_ONLY",
         # Container resource config (docker, singularity, modal, daytona -- ignored for local/ssh)
         "container_cpu": "TERMINAL_CONTAINER_CPU",
         "container_memory": "TERMINAL_CONTAINER_MEMORY",
@@ -6497,7 +6498,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             ssh_host = os.getenv("TERMINAL_SSH_HOST", "not set")
             ssh_user = os.getenv("TERMINAL_SSH_USER", "not set")
             ssh_port = os.getenv("TERMINAL_SSH_PORT", "22")
+            ssh_identities_only = env_bool("TERMINAL_SSH_IDENTITIES_ONLY")
             print(f"  SSH Target:   {ssh_user}@{ssh_host}:{ssh_port}")
+            identities_label = (
+                "configured only" if ssh_identities_only else "default SSH behavior"
+            )
+            print(f"  Identities:   {identities_label}")
         print(f"  Working Dir:  {terminal_cwd}")
         print(f"  Timeout:      {terminal_timeout}s")
         print()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1451,6 +1451,7 @@ if _config_path.exists():
                 "ssh_user": "TERMINAL_SSH_USER",
                 "ssh_port": "TERMINAL_SSH_PORT",
                 "ssh_key": "TERMINAL_SSH_KEY",
+                "ssh_identities_only": "TERMINAL_SSH_IDENTITIES_ONLY",
                 "container_cpu": "TERMINAL_CONTAINER_CPU",
                 "container_memory": "TERMINAL_CONTAINER_MEMORY",
                 "container_disk": "TERMINAL_CONTAINER_DISK",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1155,6 +1155,11 @@ DEFAULT_CONFIG = {
         # Enabled by default for non-local backends (SSH); local is always opt-in
         # via TERMINAL_LOCAL_PERSISTENT env var.
         "persistent_shell": True,
+        # When true, pass OpenSSH IdentitiesOnly=yes for SSH backends. This
+        # forces SSH/SCP to use only the configured identity file(s), avoiding
+        # accidental authentication as a different account when an agent has
+        # multiple keys loaded.
+        "ssh_identities_only": False,
     },
 
     "web": {
@@ -6078,6 +6083,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "ssh_user": "TERMINAL_SSH_USER",
     "ssh_port": "TERMINAL_SSH_PORT",
     "ssh_key": "TERMINAL_SSH_KEY",
+    "ssh_identities_only": "TERMINAL_SSH_IDENTITIES_ONLY",
     "container_cpu": "TERMINAL_CONTAINER_CPU",
     "container_memory": "TERMINAL_CONTAINER_MEMORY",
     "container_disk": "TERMINAL_CONTAINER_DISK",
@@ -7101,6 +7107,7 @@ def show_config():
         ssh_user = get_env_value('TERMINAL_SSH_USER')
         print(f"  SSH host:     {ssh_host or '(not set)'}")
         print(f"  SSH user:     {ssh_user or '(not set)'}")
+        print(f"  Identities:   {'configured only' if terminal.get('ssh_identities_only', False) else 'default SSH behavior'}")
     
     # Timezone
     print()

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -26,7 +26,7 @@ load_hermes_dotenv(hermes_home=_env_path.parent, project_env=PROJECT_ROOT / ".en
 from hermes_cli.colors import Colors, color
 from hermes_cli.models import _HERMES_USER_AGENT
 from hermes_constants import OPENROUTER_MODELS_URL
-from utils import base_url_host_matches
+from utils import base_url_host_matches, env_bool
 
 
 _PROVIDER_ENV_HINTS = (
@@ -1466,8 +1466,11 @@ def run_doctor(args):
             ssh_user = os.getenv("TERMINAL_SSH_USER")
             ssh_port = os.getenv("TERMINAL_SSH_PORT")
             ssh_key = os.getenv("TERMINAL_SSH_KEY")
+            ssh_identities_only = env_bool("TERMINAL_SSH_IDENTITIES_ONLY")
             target = f"{ssh_user}@{ssh_host}" if ssh_user else ssh_host
             cmd = ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes"]
+            if ssh_identities_only:
+                cmd += ["-o", "IdentitiesOnly=yes"]
             if ssh_port:
                 cmd += ["-p", ssh_port]
             if ssh_key:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1428,12 +1428,20 @@ def setup_terminal_backend(config: dict):
         if ssh_key:
             save_env_value("TERMINAL_SSH_KEY", ssh_key)
 
+        identities_only = prompt_yes_no(
+            "  Limit authentication to the configured SSH identity?",
+            bool(config["terminal"].get("ssh_identities_only", False)),
+        )
+        config["terminal"]["ssh_identities_only"] = identities_only
+
         # Test connection
         if host and prompt_yes_no("  Test SSH connection?", True):
             print_info("  Testing connection...")
             import subprocess
 
             ssh_cmd = ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=5"]
+            if identities_only:
+                ssh_cmd.extend(["-o", "IdentitiesOnly=yes"])
             if ssh_key:
                 ssh_cmd.extend(["-i", ssh_key])
             if port and port != "22":

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -554,6 +554,10 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Modal sandbox mode",
         "options": ["sandbox", "function"],
     },
+    "terminal.ssh_identities_only": {
+        "type": "boolean",
+        "description": "Pass OpenSSH IdentitiesOnly=yes for SSH terminal connections",
+    },
     "tts.provider": {
         "type": "select",
         "description": "Text-to-speech provider",

--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -62,6 +62,32 @@ class TestBuildSSHCommand:
         cmd = env._build_ssh_command()
         assert "-i" in cmd and "/k" in cmd
 
+    def test_identities_only(self):
+        env = SSHEnvironment(host="h", user="u", identities_only=True)
+        cmd = env._build_ssh_command()
+        assert "-o" in cmd
+        assert "IdentitiesOnly=yes" in cmd
+
+    def test_identities_only_default_off(self):
+        env = SSHEnvironment(host="h", user="u")
+        assert "IdentitiesOnly=yes" not in env._build_ssh_command()
+
+    def test_scp_upload_uses_identities_only(self, monkeypatch):
+        env = SSHEnvironment(host="h", user="u", identities_only=True)
+        calls = []
+
+        def _capture_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr("tools.environments.ssh.subprocess.run", _capture_run)
+
+        env._scp_upload("/local/file", "/remote/file")
+
+        scp_calls = [cmd for cmd in calls if cmd and cmd[0] == "scp"]
+        assert scp_calls
+        assert "IdentitiesOnly=yes" in scp_calls[0]
+
     def test_user_host_suffix(self):
         env = SSHEnvironment(host="h", user="u")
         assert env._build_ssh_command()[-1] == "u@h"
@@ -134,6 +160,16 @@ class TestControlSocketPath:
         assert SSHEnvironment(host="h", user="v", port=22).control_socket != base
         assert SSHEnvironment(host="g", user="u", port=22).control_socket != base
 
+    def test_path_differs_for_different_key_path(self):
+        """Different SSH identities must not reuse a stale ControlMaster socket."""
+        base = SSHEnvironment(host="h", user="u", key_path="/k1").control_socket
+        assert SSHEnvironment(host="h", user="u", key_path="/k2").control_socket != base
+
+    def test_path_differs_for_identities_only(self):
+        """IdentitiesOnly changes authentication semantics, so it changes socket identity."""
+        base = SSHEnvironment(host="h", user="u", identities_only=False).control_socket
+        assert SSHEnvironment(host="h", user="u", identities_only=True).control_socket != base
+
 
 class TestTerminalToolConfig:
     def test_ssh_persistent_default_true(self, monkeypatch):
@@ -160,6 +196,16 @@ class TestTerminalToolConfig:
         monkeypatch.setenv("TERMINAL_PERSISTENT_SHELL", "false")
         from tools.terminal_tool import _get_env_config
         assert _get_env_config()["ssh_persistent"] is False
+
+    def test_ssh_identities_only_default_false(self, monkeypatch):
+        monkeypatch.delenv("TERMINAL_SSH_IDENTITIES_ONLY", raising=False)
+        from tools.terminal_tool import _get_env_config
+        assert _get_env_config()["ssh_identities_only"] is False
+
+    def test_ssh_identities_only_explicit_true(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_SSH_IDENTITIES_ONLY", "true")
+        from tools.terminal_tool import _get_env_config
+        assert _get_env_config()["ssh_identities_only"] is True
 
 
 class TestSSHPreflight:

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -290,6 +290,20 @@ def test_docker_orphan_reaper_is_bridged_everywhere():
     assert "TERMINAL_DOCKER_ORPHAN_REAPER" in _terminal_tool_env_var_names()
 
 
+def test_ssh_identities_only_is_bridged_everywhere():
+    """Regression pin for SSH identity selection.
+
+    ``terminal.ssh_identities_only`` maps to OpenSSH ``IdentitiesOnly=yes``.
+    It must be bridged in every terminal entry point because an SSH backend can
+    initialize from CLI/TUI, gateway/desktop, or a one-shot ``hermes config
+    set`` update.
+    """
+    assert "ssh_identities_only" in _cli_env_map_keys()
+    assert "ssh_identities_only" in _gateway_env_map_keys()
+    assert "ssh_identities_only" in _save_config_env_sync_keys()
+    assert "TERMINAL_SSH_IDENTITIES_ONLY" in _terminal_tool_env_var_names()
+
+
 def test_docker_volumes_is_bridged_everywhere():
     """Regression pin for ``terminal.docker_volumes`` being silently dropped by
     ``hermes config set``.

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -666,6 +666,7 @@ def _get_or_create_env(task_id: str):
                 "user": config.get("ssh_user", ""),
                 "port": config.get("ssh_port", 22),
                 "key": config.get("ssh_key", ""),
+                "identities_only": config.get("ssh_identities_only", False),
                 "persistent": config.get("ssh_persistent", False),
             }
 

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -43,12 +43,14 @@ class SSHEnvironment(BaseEnvironment):
     """
 
     def __init__(self, host: str, user: str, cwd: str = "~",
-                 timeout: int = 60, port: int = 22, key_path: str = ""):
+                 timeout: int = 60, port: int = 22, key_path: str = "",
+                 identities_only: bool = False):
         super().__init__(cwd=cwd, timeout=timeout)
         self.host = host
         self.user = user
         self.port = port
         self.key_path = key_path
+        self.identities_only = identities_only
 
         self.control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
         self.control_dir.mkdir(parents=True, exist_ok=True)
@@ -58,10 +60,10 @@ class SSHEnvironment(BaseEnvironment):
         # IPv6 host — plus the 16-byte random suffix SSH appends in
         # ControlMaster mode easily exceeds the limit under macOS's
         # deeply-nested $TMPDIR (e.g. /var/folders/xx/yy/T/). Hashing the
-        # triple keeps the path stable across reconnects so ControlMaster
-        # reuse still works.
+        # target/auth tuple keeps the path stable across reconnects while
+        # preventing reuse of a master connection opened with a different key.
         _socket_id = hashlib.sha256(
-            f"{user}@{host}:{port}".encode()
+            f"{user}@{host}:{port}:{key_path}:{identities_only}".encode()
         ).hexdigest()[:16]
         self.control_socket = self.control_dir / f"{_socket_id}.sock"
         _ensure_ssh_available()
@@ -80,6 +82,14 @@ class SSHEnvironment(BaseEnvironment):
 
         self.init_session()
 
+    def _ssh_identity_args(self) -> list[str]:
+        args = []
+        if self.identities_only:
+            args.extend(["-o", "IdentitiesOnly=yes"])
+        if self.key_path:
+            args.extend(["-i", self.key_path])
+        return args
+
     def _build_ssh_command(self, extra_args: list | None = None) -> list:
         cmd = ["ssh"]
         cmd.extend(["-o", f"ControlPath={self.control_socket}"])
@@ -90,8 +100,7 @@ class SSHEnvironment(BaseEnvironment):
         cmd.extend(["-o", "ConnectTimeout=10"])
         if self.port != 22:
             cmd.extend(["-p", str(self.port)])
-        if self.key_path:
-            cmd.extend(["-i", self.key_path])
+        cmd.extend(self._ssh_identity_args())
         if extra_args:
             cmd.extend(extra_args)
         cmd.append(f"{self.user}@{self.host}")
@@ -172,8 +181,7 @@ class SSHEnvironment(BaseEnvironment):
         scp_cmd = ["scp", "-o", f"ControlPath={self.control_socket}"]
         if self.port != 22:
             scp_cmd.extend(["-P", str(self.port)])
-        if self.key_path:
-            scp_cmd.extend(["-i", self.key_path])
+        scp_cmd.extend(self._ssh_identity_args())
         scp_cmd.extend([host_path, f"{self.user}@{self.host}:{remote_path}"])
         result = subprocess.run(
             scp_cmd,
@@ -360,7 +368,11 @@ class SSHEnvironment(BaseEnvironment):
         if self.control_socket.exists():
             try:
                 cmd = ["ssh", "-o", f"ControlPath={self.control_socket}",
-                       "-O", "exit", f"{self.user}@{self.host}"]
+                       "-O", "exit"]
+                if self.port != 22:
+                    cmd.extend(["-p", str(self.port)])
+                cmd.extend(self._ssh_identity_args())
+                cmd.append(f"{self.user}@{self.host}")
                 subprocess.run(
                     cmd,
                     capture_output=True,

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -915,6 +915,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "user": config.get("ssh_user", ""),
                     "port": config.get("ssh_port", 22),
                     "key": config.get("ssh_key", ""),
+                    "identities_only": config.get("ssh_identities_only", False),
                     "persistent": config.get("ssh_persistent", False),
                 }
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -45,7 +45,7 @@ import subprocess
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
-from utils import env_var_enabled
+from utils import env_bool, env_var_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -1301,6 +1301,7 @@ def _get_env_config() -> Dict[str, Any]:
         "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
         "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
         "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
+        "ssh_identities_only": env_bool("TERMINAL_SSH_IDENTITIES_ONLY"),
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.
         # Per-backend env vars override if explicitly set.
@@ -1486,6 +1487,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             user=ssh_config["user"],
             port=ssh_config.get("port", 22),
             key_path=ssh_config.get("key", ""),
+            identities_only=ssh_config.get("identities_only", False),
             cwd=cwd,
             timeout=timeout,
         )
@@ -2152,6 +2154,7 @@ def terminal_tool(
                                 "user": config.get("ssh_user", ""),
                                 "port": config.get("ssh_port", 22),
                                 "key": config.get("ssh_key", ""),
+                                "identities_only": config.get("ssh_identities_only", False),
                                 "persistent": config.get("ssh_persistent", False),
                             }
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -214,6 +214,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `TERMINAL_SSH_USER` | SSH username |
 | `TERMINAL_SSH_PORT` | SSH port (default: 22) |
 | `TERMINAL_SSH_KEY` | Path to private key |
+| `TERMINAL_SSH_IDENTITIES_ONLY` | Override `terminal.ssh_identities_only`; when true, pass `-o IdentitiesOnly=yes` |
 | `TERMINAL_SSH_PERSISTENT` | Override persistent shell for SSH (default: follows `TERMINAL_PERSISTENT_SHELL`) |
 
 ## Container Resources (Docker, Singularity, Modal, Daytona)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -309,22 +309,23 @@ Runs commands on a remote server over SSH. Uses ControlMaster for connection reu
 terminal:
   backend: ssh
   persistent_shell: true           # Keep a long-lived bash session (default: true)
+  ssh_host: my-server.example.com
+  ssh_user: ubuntu
+  ssh_port: 22
+  ssh_key: ~/.ssh/id_rsa           # Optional; uses ssh-agent/system defaults if omitted
+  ssh_identities_only: false       # true => pass -o IdentitiesOnly=yes
 ```
 
-**Required environment variables:**
+**SSH options:**
 
-```bash
-TERMINAL_SSH_HOST=my-server.example.com
-TERMINAL_SSH_USER=ubuntu
-```
-
-**Optional:**
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `TERMINAL_SSH_PORT` | `22` | SSH port |
-| `TERMINAL_SSH_KEY` | (system default) | Path to SSH private key |
-| `TERMINAL_SSH_PERSISTENT` | `true` | Enable persistent shell |
+| Config key | Env override | Default | Description |
+|---|---|---|---|
+| `ssh_host` | `TERMINAL_SSH_HOST` | required | Remote server hostname |
+| `ssh_user` | `TERMINAL_SSH_USER` | required | SSH username |
+| `ssh_port` | `TERMINAL_SSH_PORT` | `22` | SSH port |
+| `ssh_key` | `TERMINAL_SSH_KEY` | (system default) | Path to SSH private key |
+| `ssh_identities_only` | `TERMINAL_SSH_IDENTITIES_ONLY` | `false` | Pass `-o IdentitiesOnly=yes` so SSH only offers the configured identity |
+| `persistent_shell` | `TERMINAL_SSH_PERSISTENT` | `true` | Enable persistent shell |
 
 **How it works:** Connects at init time with `BatchMode=yes` and `StrictHostKeyChecking=accept-new`. Persistent shell keeps a single `bash -l` process alive on the remote host, communicating via temporary files. Commands that need `stdin_data` or `sudo` automatically fall back to one-shot mode.
 
@@ -393,7 +394,7 @@ If terminal commands fail immediately or the terminal tool is reported as disabl
 
 - **Local** — No special requirements. The safest default when getting started.
 - **Docker** — Run `docker version` to verify Docker is working. If it fails, fix Docker or `hermes config set terminal.backend local`.
-- **SSH** — Both `TERMINAL_SSH_HOST` and `TERMINAL_SSH_USER` must be set. Hermes logs a clear error if either is missing.
+- **SSH** — Both `terminal.ssh_host` and `terminal.ssh_user` must be set (or their `TERMINAL_SSH_HOST` / `TERMINAL_SSH_USER` overrides). Hermes logs a clear error if either is missing.
 - **Modal** — Needs `MODAL_TOKEN_ID` env var or `~/.modal.toml`. Run `hermes doctor` to check.
 - **Daytona** — Needs `DAYTONA_API_KEY`. The Daytona SDK handles server URL configuration.
 - **Singularity** — Needs `apptainer` or `singularity` in `$PATH`. Common on HPC clusters.

--- a/website/docs/user-guide/features/tools.md
+++ b/website/docs/user-guide/features/tools.md
@@ -101,6 +101,7 @@ terminal:
 TERMINAL_SSH_HOST=my-server.example.com
 TERMINAL_SSH_USER=myuser
 TERMINAL_SSH_KEY=~/.ssh/id_rsa
+TERMINAL_SSH_IDENTITIES_ONLY=true  # Optional: pass -o IdentitiesOnly=yes
 ```
 
 ### Singularity/Apptainer

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -618,6 +618,7 @@ terminal:
 TERMINAL_SSH_HOST=agent-worker.local
 TERMINAL_SSH_USER=hermes
 TERMINAL_SSH_KEY=~/.ssh/hermes_agent_key
+TERMINAL_SSH_IDENTITIES_ONLY=true  # Optional: pass -o IdentitiesOnly=yes
 ```
 
 The SSH connection details live in `.env` (not `config.yaml`) so they aren't checked in or shared along with profile exports. This keeps the gateway's messaging connections separate from the agent's command execution.


### PR DESCRIPTION
## What does this PR do?

Adds `terminal.ssh_identities_only` for SSH terminal backends, mapping to OpenSSH `-o IdentitiesOnly=yes` for SSH command execution, SCP file sync, setup/doctor checks, and terminal entry points.

This fixes a real SSH backend blocker: when `ssh-agent` offers multiple identities, OpenSSH can authenticate with a different key than the configured `terminal.ssh_key`. Some SSH targets derive the remote backend identity from the key used, so using the wrong key can connect Hermes to the wrong environment or fail auth before the desired key is attempted.

This keeps the existing default OpenSSH behavior unless the user explicitly enables the config key.

## Related Issue

Fixes #51384

Supersedes #51145 with the same implementation rebased onto current upstream `main` as a clean single-commit branch.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/ssh.py`
  - Adds `identities_only` support and threads `IdentitiesOnly=yes` into SSH/SCP commands.
  - Includes `ssh_key` and `ssh_identities_only` in the ControlMaster socket identity so a master connection opened with one auth tuple is not reused for another.
  - Includes port and identity args in ControlMaster teardown.
- Terminal/config entry points
  - Bridges `terminal.ssh_identities_only` through CLI, gateway, desktop/dashboard config surfaces, terminal/file/code-exec tools, setup, and doctor.
- Tests
  - Adds SSH command/SCP/ControlMaster regression coverage.
  - Adds a config/env bridge regression pin.
- Docs/examples
  - Documents the config key and env override where SSH terminal configuration is described.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_ssh_environment.py tests/tools/test_terminal_config_env_sync.py`
2. `python -m compileall -q tools/environments/ssh.py tools/terminal_tool.py tools/file_tools.py tools/code_execution_tool.py hermes_cli/config.py hermes_cli/setup.py hermes_cli/doctor.py hermes_cli/web_server.py cli.py gateway/run.py`
3. `git diff --check upstream/main...HEAD`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A for targeted SSH backend fix; ran focused `scripts/run_tests.sh` coverage and compile checks
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — SSH terminal config docs updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — this uses OpenSSH's existing `IdentitiesOnly` option and preserves the default unless explicitly enabled
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
$ scripts/run_tests.sh tests/tools/test_ssh_environment.py tests/tools/test_terminal_config_env_sync.py
=== Summary: 2 files, 32 tests passed, 0 failed (100% complete) ===

$ python -m compileall -q tools/environments/ssh.py tools/terminal_tool.py tools/file_tools.py tools/code_execution_tool.py hermes_cli/config.py hermes_cli/setup.py hermes_cli/doctor.py hermes_cli/web_server.py cli.py gateway/run.py
# no output

$ git diff --check upstream/main...HEAD
# no output
```
