### PR TITLE
fix(managed-scope): strip export prefix when parsing managed .env

### DIFF
--- a/hermes_cli/managed_scope.py
+++ b/hermes_cli/managed_scope.py
@@ -183,6 +183,8 @@ def _parse_env(f) -> Dict[str, str]:
         line = line.strip()
         if not line or line.startswith("#") or "=" not in line:
             continue
+        if line.startswith("export ") or line.startswith("export\t"):
+            line = line[len("export"):].lstrip()
         key, _, value = line.partition("=")
         out[key.strip()] = value.strip().strip("\"'")
     return out

--- a/tests/hermes_cli/test_managed_scope.py
+++ b/tests/hermes_cli/test_managed_scope.py
@@ -47,6 +47,14 @@ def test_load_managed_env_and_is_env_managed(tmp_path, monkeypatch):
     assert managed_scope.is_env_managed("OTHER") is False
 
 
+def test_load_managed_env_strips_export_prefix(tmp_path, monkeypatch):
+    from hermes_cli import managed_scope
+
+    _write_managed(tmp_path, monkeypatch, env="export OPENAI_API_KEY=sk-pinned\n")
+    assert managed_scope.load_managed_env() == {"OPENAI_API_KEY": "sk-pinned"}
+    assert managed_scope.is_env_managed("OPENAI_API_KEY") is True
+
+
 
 
 def test_managed_dir_env_scrubbed_by_default():


### PR DESCRIPTION
## What does this PR do?

Fixes a parser disagreement in the managed-scope (`/etc/hermes`) `.env` layer that silently breaks the managed-env immutability guard.

A managed `.env` line using the shell `export VAR=...` form (a supported, documented input form — the `env_loader` docstring frames managed env in shell-`export` terms) was parsed by `managed_scope._parse_env` with the **literal key** `export VAR`. But at startup the same managed `.env` is actually applied by `env_loader._apply_managed_env()` via python-dotenv (`load_dotenv(..., override=True)`), which **strips** the `export ` prefix and pins `VAR` in `os.environ`.

Because the two parsers disagreed on the key name:

- `managed_scope.is_env_managed("VAR")` returned `False` (the dict key was `export VAR`).
- That inverts the immutability guard in `config.py` `save_env_value` and the unset path: a user's `hermes config set-env VAR ...` was **wrongly allowed** and reported success, writing the user `.env` — even though the managed value silently re-overrides it on the next startup (`override=True`). The intended invariant is "a managed env key can't be set by the user."
- `hermes doctor` and the "Managed env keys:" display surfaced the wrong key name `export VAR`.

This mirrors python-dotenv's own behavior so the guard/introspection parser agrees with the loader that actually applies the file.

## Related Issue

Code-originated install/config correctness fix; no existing issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/managed_scope.py` — in `_parse_env`, strip an optional leading `export ` (space or tab) before splitting on `=`, matching python-dotenv. Only the `export`-strip is added; value-quote handling is untouched.
- `tests/hermes_cli/test_managed_scope.py` — add `test_load_managed_env_strips_export_prefix` covering the `export VAR=...` form.

## How to Test

1. Create a managed `.env` containing `export OPENAI_API_KEY=sk-pinned` (point `HERMES_MANAGED_DIR` at its directory).
2. Before the fix: `managed_scope.load_managed_env()` yields `{"export OPENAI_API_KEY": "sk-pinned"}` and `is_env_managed("OPENAI_API_KEY")` is `False` (so `config set-env OPENAI_API_KEY ...` is wrongly allowed).
3. After the fix: `load_managed_env()` yields `{"OPENAI_API_KEY": "sk-pinned"}` and `is_env_managed("OPENAI_API_KEY")` is `True`.
4. Regression test proof:
   - With the production hunk reverted, `test_load_managed_env_strips_export_prefix` **fails** (key parsed as `export OPENAI_API_KEY`).
   - With the hunk applied, the full `tests/hermes_cli/test_managed_scope.py` passes (13 tests).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_managed_scope.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A (pure string parsing, platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A