### PR TITLE
nix: ship optional-skills/ and set HERMES_OPTIONAL_SKILLS

### DIFF
--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -140,6 +140,59 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
           echo "ok" > $out/result
         '';
 
+        # Verify official optional skills (optional-skills/) are shipped and
+        # resolvable. Regression for #54401 — the derivation never copied
+        # optional-skills/ nor set HERMES_OPTIONAL_SKILLS, so repair-official
+        # errored "No official optional skills directory found" and
+        # `hermes skills install official/...` had no local source.
+        bundled-optional-skills = pkgs.runCommand "hermes-bundled-optional-skills" { } ''
+          set -e
+          echo "=== Checking bundled optional skills ==="
+          test -d ${hermes-agent}/share/hermes-agent/optional-skills || \
+            (echo "FAIL: optional-skills directory missing"; exit 1)
+          echo "PASS: optional-skills directory exists"
+
+          SKILL_COUNT=$(find ${hermes-agent}/share/hermes-agent/optional-skills -name "SKILL.md" | wc -l)
+          test "$SKILL_COUNT" -gt 0 || (echo "FAIL: no SKILL.md files found in optional-skills directory"; exit 1)
+          echo "PASS: $SKILL_COUNT optional skills found"
+
+          grep -q "HERMES_OPTIONAL_SKILLS" ${hermes-agent}/bin/hermes || \
+            (echo "FAIL: HERMES_OPTIONAL_SKILLS not in wrapper"; exit 1)
+          echo "PASS: HERMES_OPTIONAL_SKILLS set in wrapper"
+
+          echo "=== Exercising OptionalSkillSource via the wrapper override ==="
+          export HOME=$(mktemp -d)
+          cd "$HOME"
+          HERMES_OPTIONAL_SKILLS=${hermes-agent}/share/hermes-agent/optional-skills \
+            ${hermesVenv}/bin/python3 -c '
+import sys
+from hermes_constants import get_optional_skills_dir
+from tools.skills_hub import OptionalSkillSource
+
+resolved = get_optional_skills_dir()
+expected = "${hermes-agent}/share/hermes-agent/optional-skills"
+if str(resolved) != expected:
+    sys.exit(f"FAIL: resolver returned {resolved}, expected {expected}")
+print(f"PASS: get_optional_skills_dir() -> {resolved}")
+
+src = OptionalSkillSource()
+metas = src.search("", limit=5)
+if not metas:
+    sys.exit("FAIL: OptionalSkillSource.search() found no skills in the store path")
+print(f"PASS: search() found {len(metas)} skills (e.g. {metas[0].identifier})")
+
+bundle = src.fetch(metas[0].identifier)
+if bundle is None or "SKILL.md" not in bundle.files:
+    sys.exit(f"FAIL: fetch({metas[0].identifier!r}) did not return a bundle with SKILL.md")
+print(f"PASS: fetch({metas[0].identifier!r}) returned {len(bundle.files)} files")
+'
+          echo "PASS: OptionalSkillSource resolves skills from the store path"
+
+          echo "=== All bundled optional skills checks passed ==="
+          mkdir -p $out
+          echo "ok" > $out/result
+        '';
+
         # Verify bundled plugins (platforms, memory, context_engine) are present
         bundled-plugins = pkgs.runCommand "hermes-bundled-plugins" { } ''
           set -e

--- a/nix/hermes-agent.nix
+++ b/nix/hermes-agent.nix
@@ -63,6 +63,17 @@ let
     filter = path: _type: !(lib.hasInfix "/index-cache/" path);
   };
 
+  # Official optional skills (optional-skills/). Shipped into the store and
+  # pointed at by HERMES_OPTIONAL_SKILLS so `hermes skills install official/...`
+  # and `hermes skills repair-official` resolve them locally. Without this the
+  # CLI falls back to <site-packages>/optional-skills (absent in the nix build),
+  # so repair-official errors "No official optional skills directory found" and
+  # install official/... has no local source to fall back on.
+  bundledOptionalSkills = lib.cleanSourceWith {
+    src = ../optional-skills;
+    filter = path: _type: !(lib.hasInfix "/index-cache/" path);
+  };
+
   # Import bundled plugins (memory, context_engine, platforms/*).  Keeping
   # them out of the Python site-packages keeps import semantics identical
   # to a dev checkout — the loader reads them from HERMES_BUNDLED_PLUGINS.
@@ -163,6 +174,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     mkdir -p $out/share/hermes-agent $out/bin
     cp -r ${bundledSkills} $out/share/hermes-agent/skills
+    cp -r ${bundledOptionalSkills} $out/share/hermes-agent/optional-skills
     cp -r ${bundledPlugins} $out/share/hermes-agent/plugins
     cp -r ${bundledLocales} $out/share/hermes-agent/locales
     cp -r ${hermesWeb} $out/share/hermes-agent/web_dist
@@ -175,6 +187,7 @@ stdenv.mkDerivation (finalAttrs: {
         makeWrapper ${hermesVenv}/bin/${name} $out/bin/${name} \
           --suffix PATH : "${runtimePath}" \
           --set HERMES_BUNDLED_SKILLS $out/share/hermes-agent/skills \
+          --set HERMES_OPTIONAL_SKILLS $out/share/hermes-agent/optional-skills \
           --set HERMES_BUNDLED_PLUGINS $out/share/hermes-agent/plugins \
           --set HERMES_BUNDLED_LOCALES $out/share/hermes-agent/locales \
           --set HERMES_WEB_DIST $out/share/hermes-agent/web_dist \


### PR DESCRIPTION
## Problem

The nix `installPhase` copies `skills/`, `plugins/`, `locales/` and `web_dist/` into the store and sets the matching `HERMES_BUNDLED_*` env vars — but **`optional-skills/` is never copied and `HERMES_OPTIONAL_SKILLS` is never set**.

`get_optional_skills_dir()` then falls back to `<site-packages>/optional-skills`, which does not exist in a nix build. Result on NixOS (and any nix install):

- `hermes skills repair-official all` → `Error: No official optional skills directory found.`
- `hermes skills install official/<cat>/<name>` → fetches remotely, and with no local `optional-skills/` to fall back on, fails with `Could not fetch '…' from any source.`

So none of the official optional skills (creative-ideation, audiocraft, vllm, segment-anything, …) are installable on a nix-packaged hermes, even though they live in this repo.

## Fix

Ship `optional-skills/` alongside the bundled skills (same `cleanSourceWith` shape) and point `HERMES_OPTIONAL_SKILLS` at it, mirroring `HERMES_BUNDLED_SKILLS`. Three small additions, all mirroring existing patterns.

## Verification

`nix-instantiate --parse` passes. Verified at runtime on a deployed nix install (hermes 0.17.0): with `HERMES_OPTIONAL_SKILLS` pointing at this repo's `optional-skills/`, both `repair-official all` and `install official/creative/creative-ideation` succeed (security scan SAFE, copied into the profile).

A parallel flake-check (like the bundled-locales one) could be added to guard against regressions; happy to follow up if wanted.