### PR TITLE
fix(photon): handle inbound richlinks and fall back on outbound enable_data_detection errors

### DIFF
--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -739,7 +739,26 @@ const server = http.createServer(async (req, res) => {
       // readable plain text on platforms that don't.
       const builder =
         format === "markdown" ? spectrumMarkdown(text) : spectrumText(text);
-      const result = await space.send(builder);
+      let result;
+      try {
+        result = await space.send(builder);
+      } catch (err) {
+        // If Apple's IMAgentKit rejects enable_data_detection (set by
+        // spectrum-ts when the text contains links), strip protocol
+        // prefixes and retry. Without "https://" the markdown link
+        // detector won't fire, so data detection stays off and the
+        // message delivers. iOS still renders domain-like text as
+        // a tappable link on the receiving end.
+        const msg = err && (err.message || String(err));
+        if (msg && msg.includes("enable_data_detection")) {
+          const stripped = text.replace(/https?:\/\//g, "");
+          const fallbackBuilder =
+            format === "markdown" ? spectrumMarkdown(stripped) : spectrumText(stripped);
+          result = await space.send(fallbackBuilder);
+        } else {
+          throw err;
+        }
+      }
       return ok(res, { messageId: result?.id || null });
     }
     if (req.url === "/send-attachment") {

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -469,6 +469,13 @@ async function normalizeContent(content) {
       targetText: reactionTargetText(target),
     };
   }
+  // spectrum-ts converts Apple's URL balloon to a richlink content object
+  // with the URL in content.url. Extract it as plain text so the Python
+  // adapter sees a text message containing the link, not an opaque
+  // "richlink" content type it can't handle.
+  if (content.type === "richlink") {
+    return { type: "text", text: content.url || "" };
+  }
   return { type: content.type || "unknown" };
 }
 

--- a/tests/plugins/platforms/photon/test_spectrum_patch.py
+++ b/tests/plugins/platforms/photon/test_spectrum_patch.py
@@ -52,6 +52,22 @@ def test_sidecar_labels_catchup_internal_errors_as_upstream_photon() -> None:
     assert "PHOTON_ALLOWED_USERS" in index
 
 
+def test_sidecar_send_falls_back_on_enable_data_detection_error() -> None:
+    """When Apple rejects enable_data_detection, the /send handler must
+    catch the error and retry with protocol prefixes stripped."""
+    index = Path("plugins/platforms/photon/sidecar/index.mjs").read_text(encoding="utf-8")
+    assert "enable_data_detection" in index
+    assert "https?:\\/\\/" in index
+    assert "throw err" in index  # non-data-detection errors re-thrown
+
+
+def test_sidecar_normalize_content_handles_richlink() -> None:
+    """Inbound richlink content must be normalized to text with the URL."""
+    index = Path("plugins/platforms/photon/sidecar/index.mjs").read_text(encoding="utf-8")
+    assert 'content.type === "richlink"' in index
+    assert "content.url" in index
+
+
 def _tabify(src: str) -> str:
     """Convert the fixture's two-space indentation to the tab indentation that
     spectrum-ts ships in `@spectrum-ts/imessage/dist`, so the patch anchors


### PR DESCRIPTION
## Summary

Fixes two separate bugs in the Photon sidecar related to iMessage rich links — one inbound, one outbound.

**Bug 1 (inbound):** When someone sends a link via iMessage, Apple renders it as a rich link balloon. spectrum-ts converts this to a `richlink` content object with the URL in `content.url`, but the sidecar's `normalizeContent()` didn't handle this type — it fell through to the generic fallback, dropping the URL. The Python adapter received an empty message.

**Fix:** Added a `richlink` case to `normalizeContent()` that extracts the URL as plain text.

**Bug 2 (outbound):** When Hermes sends a message containing a URL with a protocol prefix, spectrum-ts sets `enable_data_detection: true` on the gRPC payload. Apple's IMAgentKit rejects this field with a `ValidationError`, silently dropping the message with HTTP 500.

**Fix:** Wrapped `space.send()` in a try/catch in the `/send` handler. When the error message contains `enable_data_detection`, the text is retried with protocol prefixes stripped. Without a protocol prefix, spectrum-ts's link detector doesn't fire, data detection stays off, and the message delivers. iOS still renders domain-like text as a tappable link on the receiving end. Non-data-detection errors are re-thrown unchanged.

An alternative approach for Bug 2 would be patching spectrum-ts's `dataDetectionOption` function at postinstall time (via the existing `patch-spectrum-mixed-attachments.mjs` infrastructure) to always return `{}`. That would be more aggressive — it disables data detection for all messages, not just on failure. The fallback approach in this PR is less invasive: it preserves data detection when it works and only strips it when Apple rejects the message.

Closes #54402

## Test Plan

- [ ] Send a link (e.g. `https://example.com`) to Hermes via iMessage — inbound message should contain the URL as text
- [ ] Ask Hermes to send a link (e.g. `https://example.com`) via iMessage — message should deliver successfully
- [ ] Send/receive messages without links — should work unchanged
- [ ] Verify non-data-detection errors still propagate correctly
