### PR TITLE
fix(file-tools): use container cwd during docker cold starts

### DIFF
--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -17,6 +17,7 @@ Core invariant these tests pin:
 
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -389,6 +390,23 @@ class _FakeOwnedEnv:
     def __init__(self, cwd: str, cwd_owner: str):
         self.cwd = cwd
         self.cwd_owner = cwd_owner
+
+
+def test_raw_cached_cwd_wins_over_shared_default_cache(tmp_path, monkeypatch):
+    """A raw cached cwd must not inherit another session's shared default cwd."""
+    default_cwd = tmp_path / "default-session"
+    raw_cwd = tmp_path / "raw-session"
+    default_cwd.mkdir()
+    raw_cwd.mkdir()
+    monkeypatch.setattr(ft, "_last_known_cwd", {})
+    monkeypatch.setattr(terminal_tool, "_active_environments", {})
+    monkeypatch.setattr(ft, "_file_ops_cache", {
+        "default": SimpleNamespace(env=_FakeOwnedEnv(str(default_cwd), ""), cwd=str(default_cwd)),
+        "live-task": SimpleNamespace(env=_FakeOwnedEnv(str(raw_cwd), ""), cwd=str(raw_cwd)),
+    })
+
+    assert terminal_tool._resolve_container_task_id("live-task") == "default"
+    assert ft._get_live_tracking_cwd("live-task") == str(raw_cwd)
 
 
 @pytest.fixture

--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -89,6 +89,66 @@ def test_absolute_terminal_cwd_used_verbatim(_isolated_cwd, monkeypatch):
     assert resolved == (workspace / "target.py")
 
 
+def _docker_config(cwd="/root"):
+    return {
+        "env_type": "docker",
+        "cwd": cwd,
+    }
+
+
+def test_docker_file_resolution_uses_sanitized_container_cwd(_isolated_cwd, monkeypatch):
+    """Before the Docker env exists, file tools must not anchor to host cwd."""
+    monkeypatch.setenv("TERMINAL_CWD", "/Users/someone/project")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _docker_config("/root"))
+    monkeypatch.setattr(ft, "_last_known_cwd", {})
+
+    resolved = ft._resolve_path_for_task("target.py", task_id="docker-session")
+
+    assert resolved == Path("/root/target.py").resolve()
+    assert not str(resolved).startswith("/Users/someone/project")
+
+
+def test_docker_file_resolution_honors_workspace_mount_cwd(_isolated_cwd, monkeypatch):
+    """When Docker cwd mounting is enabled, first file calls resolve in /workspace."""
+    monkeypatch.setenv("TERMINAL_CWD", "/Users/someone/project")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _docker_config("/workspace"))
+    monkeypatch.setattr(ft, "_last_known_cwd", {})
+
+    resolved = ft._resolve_path_for_task("target.py", task_id="docker-mounted")
+
+    assert resolved == Path("/workspace/target.py").resolve()
+
+
+def test_docker_file_resolution_ignores_host_task_cwd_override(_isolated_cwd, monkeypatch):
+    """CWD-only desktop overrides can carry host paths; file tools must sanitize them too."""
+    task_id = "desktop-docker-session"
+    monkeypatch.setenv("TERMINAL_CWD", "/Users/someone/project")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _docker_config("/root"))
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {
+        task_id: {"cwd": "/Users/someone/project"},
+    })
+    monkeypatch.setattr(ft, "_last_known_cwd", {})
+
+    resolved = ft._resolve_path_for_task("target.py", task_id=task_id)
+
+    assert resolved == Path("/root/target.py").resolve()
+
+
+def test_docker_file_resolution_keeps_container_task_cwd_override(_isolated_cwd, monkeypatch):
+    """In-container overrides from benchmark/RL tasks still win."""
+    task_id = "docker-task"
+    monkeypatch.setenv("TERMINAL_CWD", "/Users/someone/project")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _docker_config("/root"))
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {
+        task_id: {"cwd": "/workspace/task"},
+    })
+    monkeypatch.setattr(ft, "_last_known_cwd", {})
+
+    resolved = ft._resolve_path_for_task("target.py", task_id=task_id)
+
+    assert resolved == Path("/workspace/task/target.py").resolve()
+
+
 def test_absolute_input_path_ignores_base(_isolated_cwd, monkeypatch):
     """An absolute input path is never re-anchored."""
     workspace, decoy = _isolated_cwd

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -249,7 +249,7 @@ def _get_live_tracking_cwd(task_id: str = "default") -> str | None:
         container_key = task_id
 
     with _file_ops_lock:
-        cached = _file_ops_cache.get(container_key) or _file_ops_cache.get(task_id)
+        cached = _file_ops_cache.get(task_id) or _file_ops_cache.get(container_key)
     if cached is not None:
         env = getattr(cached, "env", None)
         live_cwd = _live_cwd_if_owned(env, task_id)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -137,14 +137,59 @@ def _sentinel_free_abs_cwd(raw: str | None) -> str | None:
 
 
 def _configured_terminal_cwd() -> str | None:
-    """Return ``$TERMINAL_CWD`` only when it names a real directory anchor.
+    """Return a configured cwd only when it names a real directory anchor.
 
-    Sentinel values (see ``_TERMINAL_CWD_SENTINELS``) and relative paths are
-    rejected — a relative anchor is meaningless without knowing which cwd it is
-    relative to, which is exactly the ambiguity that misroutes worktree edits.
-    Only an absolute, sentinel-free value is honored.
+    Container backends use the sanitized in-container cwd from
+    ``terminal_tool._get_env_config()``. Local/SSH-style backends fall back to
+    ``$TERMINAL_CWD`` when it is absolute and not a sentinel value (see
+    ``_TERMINAL_CWD_SENTINELS``). Relative anchors are rejected because they are
+    ambiguous and can misroute worktree edits.
     """
+    container_cwd = _configured_container_cwd()
+    if container_cwd:
+        return container_cwd
     return _sentinel_free_abs_cwd(os.environ.get("TERMINAL_CWD"))
+
+
+def _configured_container_cwd() -> str | None:
+    """Return the sanitized in-container cwd for container backends.
+
+    ``terminal_tool._get_env_config()`` already maps host cwd values like
+    ``/Users/me/project`` to an in-container cwd (``/root`` by default, or
+    ``/workspace`` when Docker cwd mounting is explicitly enabled). File tools
+    must use that sanitized cwd before the first terminal/file call creates the
+    container; otherwise relative reads/writes can be resolved against the host
+    workspace during a Docker cold start.
+    """
+    try:
+        from tools.terminal_tool import _CONTAINER_BACKENDS, _get_env_config
+
+        config = _get_env_config()
+        if config.get("env_type") not in _CONTAINER_BACKENDS:
+            return None
+        return _sentinel_free_abs_cwd(config.get("cwd"))
+    except Exception:
+        return None
+
+
+def _container_safe_abs_cwd(raw: str | None) -> str | None:
+    """Return *raw* only when it is a usable cwd for the active backend."""
+    try:
+        from tools.terminal_tool import (
+            _CONTAINER_BACKENDS,
+            _get_env_config,
+            _is_unusable_container_cwd,
+        )
+
+        config = _get_env_config()
+        if (
+            config.get("env_type") in _CONTAINER_BACKENDS
+            and _is_unusable_container_cwd(str(raw or ""))
+        ):
+            return None
+    except Exception:
+        pass
+    return _sentinel_free_abs_cwd(raw)
 
 
 def _registered_task_cwd_override(task_id: str = "default") -> str | None:
@@ -163,7 +208,12 @@ def _registered_task_cwd_override(task_id: str = "default") -> str | None:
     except Exception:
         return None
 
-    return _sentinel_free_abs_cwd(overrides.get("cwd"))
+    return _container_safe_abs_cwd(overrides.get("cwd"))
+
+
+def _last_known_cwd_for_backend(task_id: str = "default") -> str | None:
+    """Return the preserved cwd when it is valid for the active backend."""
+    return _container_safe_abs_cwd(_last_known_cwd_for(task_id))
 
 
 def _live_cwd_if_owned(env, task_id: str) -> str | None:
@@ -260,7 +310,7 @@ def _authoritative_workspace_root(task_id: str = "default") -> str | None:
     # still lands in the user's directory (root cause of #26211: write happens
     # via _resolve_path_for_task -> here, which runs before _get_file_ops
     # rebuilds the env). Keyed by the resolved container id, same as the save.
-    preserved = _last_known_cwd_for(task_id)
+    preserved = _last_known_cwd_for_backend(task_id)
     if preserved:
         return preserved
     return _configured_terminal_cwd()


### PR DESCRIPTION
## Summary

File tools were still allowed to use a raw host `TERMINAL_CWD` as their pre-environment resolution anchor, even when the active terminal backend was Docker. That created a cold-start mismatch: `terminal_tool._get_env_config()` had already sanitized the Docker cwd to an in-container path such as `/root` or `/workspace`, but `file_tools` could resolve relative paths against the host workspace before the Docker env/file ops object existed.

This change makes file-tool cwd resolution use the same sanitized container cwd that terminal creation uses for container backends.

Concretely:
- use the sanitized in-container cwd from `_get_env_config()` for Docker/container backends before the first env exists
- ignore raw host cwd task overrides when resolving file-tool paths for container backends
- keep valid in-container task cwd overrides working for benchmark/RL-style isolated tasks
- add regression coverage for default Docker cwd, mounted `/workspace`, host task overrides, and valid container overrides

Refs #54354.

## Testing

- `TMPDIR=/tmp HERMES_HOME=/tmp/hermes-agent-test-home python3 -m pytest tests/tools/test_file_tools_cwd_resolution.py tests/tools/test_container_cwd_sanitize.py tests/tools/test_file_tools_container_config.py -q`
- `TMPDIR=/tmp HERMES_HOME=/tmp/hermes-agent-test-home python3 -m pytest tests/tools/test_file_staleness.py tests/tools/test_read_loop_detection.py -q`
