### PR TITLE
fix(gateway): align resume index with session list

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3580,9 +3580,17 @@ class GatewaySlashCommandsMixin:
             name = name[1:-1].strip()
 
         async def _list_titled_sessions() -> list[dict]:
+            from hermes_cli.session_listing import query_session_listing
+
             user_source = source.platform.value if source.platform else None
-            sessions = await self._session_db.list_sessions_rich(source=user_source, limit=10)
-            return [s for s in sessions if s.get("title")][:10]
+            current_entry = self.session_store.get_or_create_session(source)
+            return await asyncio.to_thread(
+                query_session_listing,
+                getattr(self._session_db, "_db", self._session_db),
+                source=user_source,
+                current_session_id=current_entry.session_id,
+                limit=10,
+            )
 
         if not name:
             # List recent titled sessions for this user/platform

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3583,12 +3583,8 @@ class GatewaySlashCommandsMixin:
             from hermes_cli.session_listing import query_session_listing
 
             user_source = source.platform.value if source.platform else None
-            current_entry = self.session_store.get_or_create_session(source)
-            # Matrix /resume lists the current room's named session; excluding
-            # the live session would make the room look empty.
-            current_session_id = (
-                None if source.platform == Platform.MATRIX else current_entry.session_id
-            )
+            current_entry = await self.async_session_store.get_or_create_session(source)
+            current_session_id = current_entry.session_id
             return await asyncio.to_thread(
                 query_session_listing,
                 getattr(self._session_db, "_db", self._session_db),

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3584,11 +3584,16 @@ class GatewaySlashCommandsMixin:
 
             user_source = source.platform.value if source.platform else None
             current_entry = self.session_store.get_or_create_session(source)
+            # Matrix /resume lists the current room's named session; excluding
+            # the live session would make the room look empty.
+            current_session_id = (
+                None if source.platform == Platform.MATRIX else current_entry.session_id
+            )
             return await asyncio.to_thread(
                 query_session_listing,
                 getattr(self._session_db, "_db", self._session_db),
                 source=user_source,
-                current_session_id=current_entry.session_id,
+                current_session_id=current_session_id,
                 limit=10,
             )
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4799,14 +4799,19 @@ class GatewaySlashCommandsMixin:
             name = name[1:-1].strip()
 
         async def _list_titled_sessions() -> list[dict]:
+            from hermes_cli.session_listing import query_session_listing
+
             user_source = source.platform.value if source.platform else None
             widen = allow_all and self._resume_caller_is_admin(source)
-            sessions = await self._session_db.list_sessions_rich(
+            current_entry = await self.async_session_store.get_or_create_session(source)
+            return await asyncio.to_thread(
+                query_session_listing,
+                getattr(self._session_db, "_db", self._session_db),
                 source=user_source,
                 session_key=None if widen else session_key,
+                current_session_id=current_entry.session_id,
                 limit=10,
             )
-            return [s for s in sessions if s.get("title")][:10]
 
         if not name:
             # List recent titled sessions for this user/platform

--- a/tests/gateway/test_matrix_project_context_isolation.py
+++ b/tests/gateway/test_matrix_project_context_isolation.py
@@ -487,14 +487,17 @@ async def test_matrix_resume_cross_room_requires_explicit_flag_and_warns():
 async def test_matrix_resume_lists_only_current_room_by_default():
     source_a = _make_matrix_source(PROJECT_A_ROOM_ID, PROJECT_A_NAME, PROJECT_A_TOPIC)
     source_b = _make_matrix_source(PROJECT_B_ROOM_ID, PROJECT_B_NAME, PROJECT_B_TOPIC)
+    current_b = _entry(source_b, "session-b-current", "Current Project B")
+    previous_b = _entry(source_b, "session-b-previous", "Project B Plan")
     runner = _make_runner(
         source_b,
-        [_entry(source_a, "session-a", "Project A Plan"), _entry(source_b, "session-b", "Project B Plan")],
+        [_entry(source_a, "session-a", "Project A Plan"), current_b, previous_b],
     )
 
     result = await runner._handle_resume_command(_event("/resume", source_b))
 
     assert "Project B Plan" in result
+    assert "Current Project B" not in result
     assert "Project A Plan" not in result
 
 
@@ -502,9 +505,11 @@ async def test_matrix_resume_lists_only_current_room_by_default():
 async def test_matrix_resume_all_lists_room_names():
     source_a = _make_matrix_source(PROJECT_A_ROOM_ID, PROJECT_A_NAME, PROJECT_A_TOPIC)
     source_b = _make_matrix_source(PROJECT_B_ROOM_ID, PROJECT_B_NAME, PROJECT_B_TOPIC)
+    current_b = _entry(source_b, "session-b-current", "Current Project B")
+    previous_b = _entry(source_b, "session-b-previous", "Project B Plan")
     runner = _make_runner(
         source_b,
-        [_entry(source_a, "session-a", "Project A Plan"), _entry(source_b, "session-b", "Project B Plan")],
+        [_entry(source_a, "session-a", "Project A Plan"), current_b, previous_b],
     )
     # Cross-room `/resume --all` listing is admin-gated (IDOR scoping), so this
     # cross-room listing test must run as a configured admin.
@@ -515,3 +520,4 @@ async def test_matrix_resume_all_lists_room_names():
     assert "Project A Plan" in result
     assert PROJECT_A_NAME in result
     assert "Project B Plan" in result
+    assert "Current Project B" not in result

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -137,6 +137,48 @@ class TestHandleResumeCommand:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_resume_index_excludes_current_session(self, tmp_path):
+        """Numeric /resume choices must match the list shown to users."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("sess_001", "telegram")
+        db.set_session_title("sess_001", "First")
+        db.create_session("sess_002", "telegram")
+        db.set_session_title("sess_002", "Second")
+        # Make the current session the newest titled row. If /resume's numeric
+        # resolver includes it, /resume 1 will resolve to the current session
+        # instead of the first visible non-current row.
+        db.create_session("current_session_001", "telegram")
+        db.set_session_title("current_session_001", "Current")
+
+        list_event = _make_event(text="/resume")
+        list_runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=list_event,
+        )
+        listing = await list_runner._handle_resume_command(list_event)
+
+        assert "Current" not in listing
+        assert "1." in listing
+        assert "Second" in listing
+
+        resume_event = _make_event(text="/resume 1")
+        resume_runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=resume_event,
+        )
+        result = await resume_runner._handle_resume_command(resume_event)
+
+        assert "Resumed" in result
+        resume_runner.session_store.switch_session.assert_called_once()
+        call_args = resume_runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "sess_002"
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_resume_index_out_of_range(self, tmp_path):
         """Out-of-range numeric arguments show a helpful error."""
         from hermes_state import SessionDB

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -142,14 +142,16 @@ class TestHandleResumeCommand:
         from hermes_state import SessionDB
 
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("sess_001", "telegram")
+        db.create_session("sess_001", "telegram", user_id="12345", chat_id="67890")
         db.set_session_title("sess_001", "First")
-        db.create_session("sess_002", "telegram")
+        db.create_session("sess_002", "telegram", user_id="12345", chat_id="67890")
         db.set_session_title("sess_002", "Second")
         # Make the current session the newest titled row. If /resume's numeric
         # resolver includes it, /resume 1 will resolve to the current session
         # instead of the first visible non-current row.
-        db.create_session("current_session_001", "telegram")
+        db.create_session(
+            "current_session_001", "telegram", user_id="12345", chat_id="67890"
+        )
         db.set_session_title("current_session_001", "Current")
 
         list_event = _make_event(text="/resume")
@@ -176,6 +178,41 @@ class TestHandleResumeCommand:
         resume_runner.session_store.switch_session.assert_called_once()
         call_args = resume_runner.session_store.switch_session.call_args
         assert call_args[0][1] == "sess_002"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_matrix_resume_index_excludes_current_session(self, tmp_path):
+        """Matrix numbering must use the same current-session filter."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("matrix_old", "matrix", user_id="@alice:hs", chat_id="!room:hs")
+        db.set_session_title("matrix_old", "Earlier")
+        db.create_session(
+            "matrix_current",
+            "matrix",
+            user_id="@alice:hs",
+            chat_id="!room:hs",
+        )
+        db.set_session_title("matrix_current", "Current")
+
+        event = _make_event(
+            text="/resume",
+            platform=Platform.MATRIX,
+            user_id="@alice:hs",
+            chat_id="!room:hs",
+        )
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="matrix_current",
+            event=event,
+        )
+        runner._gateway_session_origin_for_id = lambda _session_id: event.source
+
+        listing = await runner._handle_resume_command(event)
+
+        assert "Current" not in listing
+        assert "Earlier" in listing
         db.close()
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -107,6 +107,57 @@ class TestHandleResumeCommand:
         assert "/resume 1" in result
         db.close()
 
+    @pytest.mark.asyncio
+    async def test_resume_index_excludes_current_session(self, tmp_path):
+        """Numeric /resume choices must match the list shown to users."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        list_event = _make_event(text="/resume")
+        lane_key = _session_key_for_event(list_event)
+        db.create_session(
+            "sess_001", "telegram", session_key=lane_key,
+            user_id="12345", chat_id="67890",
+        )
+        db.set_session_title("sess_001", "First")
+        db.create_session(
+            "sess_002", "telegram", session_key=lane_key,
+            user_id="12345", chat_id="67890",
+        )
+        db.set_session_title("sess_002", "Second")
+        # Make the current session the newest titled row. If /resume's numeric
+        # resolver includes it, /resume 1 will resolve to the current session
+        # instead of the first visible non-current row.
+        db.create_session(
+            "current_session_001", "telegram", session_key=lane_key,
+            user_id="12345", chat_id="67890",
+        )
+        db.set_session_title("current_session_001", "Current")
+
+        list_runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=list_event,
+        )
+        listing = await list_runner._handle_resume_command(list_event)
+
+        assert "Current" not in listing
+        assert "1." in listing
+        assert "Second" in listing
+
+        resume_event = _make_event(text="/resume 1")
+        resume_runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=resume_event,
+        )
+        result = await resume_runner._handle_resume_command(resume_event)
+
+        assert "Resumed" in result
+        resume_runner.session_store.switch_session.assert_called_once()
+        call_args = resume_runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "sess_002"
+        db.close()
 
     @pytest.mark.asyncio
     async def test_resume_clears_session_model_overrides(self, tmp_path):

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -160,6 +160,46 @@ class TestHandleResumeCommand:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_matrix_resume_index_excludes_current_session(self, tmp_path):
+        """Matrix numbering must use the same current-session filter."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        event = _make_event(
+            text="/resume",
+            platform=Platform.MATRIX,
+            user_id="@alice:hs",
+            chat_id="!room:hs",
+        )
+        lane_key = _session_key_for_event(event)
+        db.create_session(
+            "matrix_old", "matrix", session_key=lane_key,
+            user_id="@alice:hs", chat_id="!room:hs",
+        )
+        db.set_session_title("matrix_old", "Earlier")
+        db.create_session(
+            "matrix_current",
+            "matrix",
+            session_key=lane_key,
+            user_id="@alice:hs",
+            chat_id="!room:hs",
+        )
+        db.set_session_title("matrix_current", "Current")
+
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="matrix_current",
+            event=event,
+        )
+        runner._gateway_session_origin_for_id = lambda _session_id: event.source
+
+        listing = await runner._handle_resume_command(event)
+
+        assert "Current" not in listing
+        assert "Earlier" in listing
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_resume_clears_session_model_overrides(self, tmp_path):
         """Resume must not carry a previous session's /model override into the
         restored conversation, while leaving other chats' overrides intact (#10702)."""


### PR DESCRIPTION
## Summary

`/resume` built its numbered list with a local helper that included the current session, while `/sessions` uses `query_session_listing()` and excludes it. When the current session is the newest titled row, `/sessions` can show one list but `/resume 1` resolves against a different one and can even resolve back to the current session.

This changes `/resume` to use the shared session listing policy:
- source-scoped titled sessions
- current session excluded
- enough rows fetched to still fill up to 10 visible choices after filtering

Fixes #54326.

## Testing

- `TMPDIR=/tmp HERMES_HOME=/tmp/hermes-agent-test-home python3 -m pytest tests/gateway/test_resume_command.py::TestHandleResumeCommand::test_resume_index_excludes_current_session -q`
- `TMPDIR=/tmp HERMES_HOME=/tmp/hermes-agent-test-home python3 -m pytest tests/gateway/test_resume_command.py -q`
- `TMPDIR=/tmp HERMES_HOME=/tmp/hermes-agent-test-home python3 -m pytest tests/gateway/test_resume_command.py tests/gateway/test_gateway_command_help.py -q`
