### PR TITLE
feat: add terminal timeout telemetry attribution

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -27,6 +27,83 @@ import os
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 
 
+TELEMETRY_SCHEMA_VERSION = "hermes.observer.v1"
+
+
+def _string_attr(agent, name: str) -> str:
+    value = getattr(agent, name, "")
+    return value if isinstance(value, str) else ""
+
+
+def build_terminal_telemetry(
+    agent,
+    *,
+    completed: bool,
+    interrupted: bool,
+    failed: bool = False,
+    api_call_count: int | None = None,
+    turn_exit_reason: str = "",
+) -> dict[str, object]:
+    """Return normalized terminal-attribution fields for observer hooks."""
+
+    exit_reason = str(turn_exit_reason or "")
+    timeout_kind = _string_attr(agent, "_timeout_kind")
+    if not timeout_kind and (
+        exit_reason == "budget_exhausted"
+        or exit_reason.startswith("error_near_max_iterations")
+        or "max_iterations" in exit_reason
+    ):
+        timeout_kind = "max_turns"
+
+    terminal_status = _string_attr(agent, "_terminal_status")
+    if not terminal_status:
+        if timeout_kind:
+            terminal_status = "timeout"
+        elif interrupted:
+            terminal_status = "interrupted"
+        elif failed:
+            terminal_status = "error"
+        elif completed:
+            terminal_status = "completed"
+        else:
+            terminal_status = "incomplete"
+
+    interrupted_by = _string_attr(agent, "_interrupted_by")
+    if interrupted and not interrupted_by:
+        if timeout_kind.startswith("cron"):
+            interrupted_by = "cron_scheduler"
+        elif getattr(agent, "_interrupt_message", None):
+            interrupted_by = "user"
+        else:
+            interrupted_by = "unknown"
+
+    attrs: dict[str, object] = {
+        "telemetry_schema_version": TELEMETRY_SCHEMA_VERSION,
+        "terminal_status": terminal_status,
+        "turn_exit_reason": exit_reason,
+    }
+    if timeout_kind:
+        attrs["timeout_kind"] = timeout_kind
+    if interrupted_by:
+        attrs["interrupted_by"] = interrupted_by
+    if api_call_count is not None:
+        attrs["api_call_count"] = api_call_count
+
+    max_turns = getattr(agent, "max_iterations", None)
+    if max_turns is not None:
+        attrs["max_turns"] = max_turns
+
+    for attr_name, field_name in (
+        ("_cron_job_id", "cron_job_id"),
+        ("_cron_job_name", "cron_job_name"),
+    ):
+        value = _string_attr(agent, attr_name)
+        if value:
+            attrs[field_name] = value
+
+    return attrs
+
+
 def finalize_turn(
     agent,
     *,
@@ -409,6 +486,15 @@ def finalize_turn(
     }
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
+    _terminal_telemetry = build_terminal_telemetry(
+        agent,
+        completed=completed,
+        interrupted=interrupted,
+        failed=failed,
+        api_call_count=api_call_count,
+        turn_exit_reason=_turn_exit_reason,
+    )
+    result.update(_terminal_telemetry)
     # Surface any post-loop cleanup failures so the caller can distinguish a
     # clean turn from one whose trajectory/session/resource teardown raised
     # (the response is still returned either way — #8049).
@@ -481,6 +567,7 @@ def finalize_turn(
             interrupted=interrupted,
             model=agent.model,
             platform=getattr(agent, "platform", None) or "",
+            **_terminal_telemetry,
         )
     except Exception as exc:
         logger.warning("on_session_end hook failed: %s", exc)

--- a/cli.py
+++ b/cli.py
@@ -1095,6 +1095,15 @@ def _emit_interrupted_session_end(cli, *, reason: str = "keyboard_interrupt") ->
 
     try:
         from hermes_cli.plugins import invoke_hook as _invoke_hook
+        from agent.turn_finalizer import build_terminal_telemetry
+
+        _terminal_telemetry = build_terminal_telemetry(
+            agent,
+            completed=False,
+            interrupted=True,
+            failed=True,
+            turn_exit_reason=reason,
+        )
         _invoke_hook(
             "on_session_end",
             session_id=session_id,
@@ -1106,6 +1115,7 @@ def _emit_interrupted_session_end(cli, *, reason: str = "keyboard_interrupt") ->
             model=getattr(agent, "model", None),
             platform=getattr(agent, "platform", None) or "cli",
             reason=reason,
+            **_terminal_telemetry,
         )
     except Exception:
         pass

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2505,6 +2505,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             session_id=_cron_session_id,
             session_db=_session_db,
         )
+        setattr(agent, "_cron_job_id", job_id)
+        setattr(agent, "_cron_job_name", job_name)
         
         # Run the agent with an *inactivity*-based timeout: the job can run
         # for hours if it's actively calling tools / receiving stream tokens,
@@ -2587,6 +2589,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 _cur_tool or "none",
             )
             if hasattr(agent, "interrupt"):
+                setattr(agent, "_timeout_kind", "cron_inactivity")
+                setattr(agent, "_terminal_status", "timeout")
+                setattr(agent, "_interrupted_by", "cron_scheduler")
                 agent.interrupt("Cron job timed out (inactivity)")
             raise TimeoutError(
                 f"Cron job '{job_name}' idle for "

--- a/tests/agent/test_turn_finalizer_cleanup_guard.py
+++ b/tests/agent/test_turn_finalizer_cleanup_guard.py
@@ -106,6 +106,8 @@ def _run(
     final_response=None,
     api_call_count=3,
     turn_exit_reason="unknown",
+    interrupted=False,
+    failed=False,
 ):
     messages = [
         {"role": "user", "content": "do a thing"},
@@ -122,8 +124,8 @@ def _run(
         agent,
         final_response=final_response,
         api_call_count=api_call_count,
-        interrupted=False,
-        failed=False,
+        interrupted=interrupted,
+        failed=failed,
         messages=messages,
         conversation_history=None,
         effective_task_id="task-1",
@@ -182,3 +184,42 @@ def test_text_response_on_last_allowed_call_is_completed():
     )
     assert result["final_response"] == "final report"
     assert result["completed"] is True
+
+
+def test_max_iterations_emit_normalized_timeout_metadata(monkeypatch):
+    calls = []
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *a, **kw: calls.append((a, kw)))
+    agent = _StubAgent(raise_in=())
+
+    result = _run(agent, turn_exit_reason="budget_exhausted")
+
+    assert result["terminal_status"] == "timeout"
+    assert result["timeout_kind"] == "max_turns"
+    assert result["max_turns"] == 3
+    assert result["api_call_count"] == 3
+    assert result["telemetry_schema_version"] == "hermes.observer.v1"
+    session_end = next(call for call in calls if call[0] == ("on_session_end",))
+    assert session_end[1]["terminal_status"] == "timeout"
+    assert session_end[1]["timeout_kind"] == "max_turns"
+    assert session_end[1]["max_turns"] == 3
+
+
+def test_cron_inactivity_metadata_is_preserved(monkeypatch):
+    calls = []
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *a, **kw: calls.append((a, kw)))
+    agent = _StubAgent(raise_in=())
+    setattr(agent, "_timeout_kind", "cron_inactivity")
+    setattr(agent, "_terminal_status", "timeout")
+    setattr(agent, "_interrupted_by", "cron_scheduler")
+    setattr(agent, "_cron_job_id", "abc123")
+    setattr(agent, "_cron_job_name", "Nightly digest")
+
+    result = _run(agent, turn_exit_reason="interrupted_by_user", interrupted=True, failed=True)
+
+    assert result["terminal_status"] == "timeout"
+    assert result["timeout_kind"] == "cron_inactivity"
+    assert result["interrupted_by"] == "cron_scheduler"
+    assert result["cron_job_id"] == "abc123"
+    session_end = next(call for call in calls if call[0] == ("on_session_end",))
+    assert session_end[1]["cron_job_id"] == "abc123"
+    assert session_end[1]["cron_job_name"] == "Nightly digest"

--- a/tests/cli/test_session_boundary_hooks.py
+++ b/tests/cli/test_session_boundary_hooks.py
@@ -85,6 +85,10 @@ def test_interrupted_session_end_helper_emits_observer_shape(mock_invoke_hook):
     assert call.kwargs["completed"] is False
     assert call.kwargs["interrupted"] is True
     assert call.kwargs["reason"] == "keyboard_interrupt"
+    assert call.kwargs["terminal_status"] == "interrupted"
+    assert call.kwargs["interrupted_by"] == "user"
+    assert call.kwargs["turn_exit_reason"] == "keyboard_interrupt"
+    assert call.kwargs["telemetry_schema_version"] == "hermes.observer.v1"
 
 
 @patch("hermes_cli.plugins.invoke_hook")

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -993,6 +993,8 @@ class TestRunJobSessionPersistence:
         assert kwargs["session_db"] is fake_db
         assert kwargs["platform"] == "cron"
         assert kwargs["session_id"].startswith("cron_test-job_")
+        assert mock_agent._cron_job_id == "test-job"
+        assert mock_agent._cron_job_name == "test"
         fake_db.end_session.assert_called_once()
         call_args = fake_db.end_session.call_args
         assert call_args[0][0].startswith("cron_test-job_")

--- a/tests/tui_gateway/test_finalize_session_persist.py
+++ b/tests/tui_gateway/test_finalize_session_persist.py
@@ -199,14 +199,15 @@ class TestOnSessionEndHook:
 
         _finalize_session(session, end_reason="tui_close")
 
-        mock_invoke_hook.assert_any_call(
-            "on_session_end",
-            session_id="hook_test_001",
-            completed=False,
-            interrupted=True,
-            model="claude-sonnet-4",
-            platform="tui",
-        )
+        call = next(c for c in mock_invoke_hook.call_args_list if c.args == ("on_session_end",))
+        assert call.kwargs["session_id"] == "hook_test_001"
+        assert call.kwargs["completed"] is False
+        assert call.kwargs["interrupted"] is True
+        assert call.kwargs["model"] == "claude-sonnet-4"
+        assert call.kwargs["platform"] == "tui"
+        assert call.kwargs["terminal_status"] == "interrupted"
+        assert call.kwargs["turn_exit_reason"] == "tui_close"
+        assert call.kwargs["telemetry_schema_version"] == "hermes.observer.v1"
 
     @patch("hermes_cli.plugins.invoke_hook")
     def test_hook_exception_does_not_block(self, mock_invoke_hook):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -522,6 +522,15 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
     if agent is not None:
         try:
             from hermes_cli.plugins import invoke_hook
+            from agent.turn_finalizer import build_terminal_telemetry
+
+            _terminal_telemetry = build_terminal_telemetry(
+                agent,
+                completed=False,
+                interrupted=True,
+                failed=True,
+                turn_exit_reason=end_reason,
+            )
 
             invoke_hook(
                 "on_session_end",
@@ -531,6 +540,7 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
                 interrupted=True,
                 model=getattr(agent, "model", "unknown"),
                 platform=getattr(agent, "platform", None) or "tui",
+                **_terminal_telemetry,
             )
         except Exception:
             pass


### PR DESCRIPTION
## Summary
- add normalized terminal telemetry fields to session-end hooks and run_conversation results (`terminal_status`, `timeout_kind`, `interrupted_by`, `max_turns`, `api_call_count`, schema version)
- propagate cron job id/name onto cron agents and mark cron inactivity timeouts as scheduler-attributed timeouts
- extend CLI/TUI interrupted-session hook coverage and focused finalizer/cron tests

## Tests
- `scripts/run_tests.sh tests/agent/test_turn_finalizer_cleanup_guard.py tests/cli/test_session_boundary_hooks.py tests/tui_gateway/test_finalize_session_persist.py tests/cron/test_scheduler.py tests/plugins/test_nemo_relay_plugin.py` (215 passed)

## Review
- Autoreview attempted with Codex: blocked by expired/reused Codex refresh token (`token_expired` / `refresh_token_reused`).
- Autoreview fallback attempts: Claude unavailable (`executable not found: claude`); Copilot unauthenticated.
