### PR TITLE
fix(state): repair trigram FTS constructor failures

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -16,6 +16,7 @@ Key design decisions:
 
 import json
 import logging
+import os
 import random
 import re
 import sqlite3
@@ -455,6 +456,14 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
         if problems:
             return "; ".join(problems[:3])
         conn.execute("SELECT COUNT(*) FROM sessions").fetchone()
+        for table_name in ("messages_fts", "messages_fts_trigram"):
+            try:
+                conn.execute(f"SELECT * FROM {table_name} LIMIT 0").fetchall()
+            except sqlite3.DatabaseError as exc:
+                msg = str(exc).lower()
+                if "no such table" in msg:
+                    continue
+                return str(exc)
 
         # FTS write probe: drive a row through the messages_fts* triggers in a
         # transaction that is always rolled back, so a corrupt FTS index that
@@ -492,6 +501,104 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
         conn.close()
 
 
+_CANONICAL_STATE_TABLES = (
+    "sessions",
+    "messages",
+    "state_meta",
+    "compression_locks",
+)
+
+
+def _copy_state_table_rows(
+    conn: sqlite3.Connection,
+    table_name: str,
+) -> int:
+    dest_cols = [
+        row[1] for row in conn.execute(f"PRAGMA main.table_info({table_name})")
+    ]
+    source_cols = [
+        row[1] for row in conn.execute(f"PRAGMA source.table_info({table_name})")
+    ]
+    shared_cols = [col for col in dest_cols if col in source_cols]
+    if not shared_cols:
+        return 0
+    quoted_cols = ", ".join(f'"{col.replace(chr(34), chr(34) * 2)}"' for col in shared_cols)
+    conn.execute(f"DELETE FROM main.{table_name}")
+    conn.execute(
+        f"INSERT INTO main.{table_name} ({quoted_cols}) "
+        f"SELECT {quoted_cols} FROM source.{table_name}"
+    )
+    row = conn.execute(f"SELECT COUNT(*) FROM main.{table_name}").fetchone()
+    return int(row[0] if row else 0)
+
+
+def _rebuild_state_db_from_canonical_tables(db_path: Path) -> Optional[str]:
+    temp_path = db_path.with_name(f"{db_path.name}.repair-{time.time_ns()}.tmp")
+    try:
+        fresh = SessionDB(db_path=temp_path)
+        fresh.close()
+
+        conn = sqlite3.connect(str(temp_path), isolation_level=None)
+        try:
+            conn.execute("PRAGMA journal_mode=DELETE")
+            conn.execute("PRAGMA foreign_keys=OFF")
+            conn.execute("ATTACH DATABASE ? AS source", (str(db_path),))
+            source_session_count = conn.execute(
+                "SELECT COUNT(*) FROM source.sessions"
+            ).fetchone()[0]
+            source_message_count = conn.execute(
+                "SELECT COUNT(*) FROM source.messages"
+            ).fetchone()[0]
+            copied_counts = {
+                table_name: _copy_state_table_rows(conn, table_name)
+                for table_name in _CANONICAL_STATE_TABLES
+            }
+            conn.execute("DETACH DATABASE source")
+            conn.execute("PRAGMA foreign_keys=ON")
+
+            if copied_counts["sessions"] != source_session_count:
+                return (
+                    "canonical rebuild copied "
+                    f"{copied_counts['sessions']} of {source_session_count} sessions"
+                )
+            if copied_counts["messages"] != source_message_count:
+                return (
+                    "canonical rebuild copied "
+                    f"{copied_counts['messages']} of {source_message_count} messages"
+                )
+
+            integrity = conn.execute("PRAGMA integrity_check").fetchone()
+            if not integrity or str(integrity[0]).lower() != "ok":
+                return f"rebuilt DB failed integrity_check: {integrity[0] if integrity else 'no result'}"
+            conn.execute("SELECT * FROM messages_fts LIMIT 0").fetchall()
+            conn.execute("SELECT * FROM messages_fts_trigram LIMIT 0").fetchall()
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        finally:
+            conn.close()
+
+        for suffix in ("-wal", "-shm"):
+            sidecar = db_path.with_name(db_path.name + suffix)
+            try:
+                sidecar.unlink()
+            except FileNotFoundError:
+                pass
+        os.replace(temp_path, db_path)
+        return None
+    except sqlite3.DatabaseError as exc:
+        return str(exc)
+    finally:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+        for suffix in ("-wal", "-shm"):
+            temp_sidecar = temp_path.with_name(temp_path.name + suffix)
+            try:
+                temp_sidecar.unlink()
+            except FileNotFoundError:
+                pass
+
+
 def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, Any]:
     """Repair a state.db whose ``sqlite_master`` schema is malformed or whose
     FTS indexes reject writes.
@@ -509,7 +616,10 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
       2. **De-duplicate** ``sqlite_master`` (keep the lowest rowid per
          ``type``/``name``). Fixes the canonical "table X already exists"
          case and PRESERVES the existing FTS index intact.
-      3. **Drop the FTS schema** (every ``messages_fts*`` object) + ``VACUUM``.
+      3. **Rebuild from canonical tables** into a fresh current-schema DB.
+         Fixes FTS virtual-table constructor failures where SQLite cannot even
+         drop the broken virtual table through ordinary DDL.
+      4. **Drop the FTS schema** (every ``messages_fts*`` object) + ``VACUUM``.
          The next ``SessionDB()`` open rebuilds the FTS indexes from the
          canonical ``messages`` table.
 
@@ -598,7 +708,21 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
     except sqlite3.DatabaseError as exc:
         logger.warning("state.db dedup repair pass failed: %s", exc)
 
-    # ── Strategy 2: drop all FTS schema, VACUUM, rebuild on next open ──
+    # ── Strategy 2: rebuild a fresh DB from canonical tables ─────────────
+    reason = _rebuild_state_db_from_canonical_tables(db_path)
+    if reason is None and _db_opens_cleanly(db_path) is None:
+        report["repaired"] = True
+        report["strategy"] = "rebuild_canonical_tables"
+        logger.warning(
+            "state.db repaired by rebuilding derived schema from canonical "
+            "tables: %s",
+            db_path,
+        )
+        return report
+    if reason is not None:
+        logger.warning("state.db canonical-table rebuild failed: %s", reason)
+
+    # ── Strategy 3: drop all FTS schema, VACUUM, rebuild on next open ──
     try:
         conn = sqlite3.connect(str(db_path), isolation_level=None)
         try:

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -333,6 +333,72 @@ def test_repair_noop_db_uses_already_healthy_shortcut(tmp_path):
     assert report["strategy"] == "already_healthy"
 
 
+def test_health_probe_detects_trigram_constructor_failure(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    real_connect = hermes_state.sqlite3.connect
+
+    class TrigramProbeFailureConnection:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def execute(self, sql, *args, **kwargs):
+            if str(sql).startswith("SELECT * FROM messages_fts_trigram LIMIT 0"):
+                raise sqlite3.DatabaseError(
+                    "vtable constructor failed: messages_fts_trigram"
+                )
+            return self._conn.execute(sql, *args, **kwargs)
+
+        def close(self):
+            self._conn.close()
+
+    def connect_with_broken_trigram(*args, **kwargs):
+        return TrigramProbeFailureConnection(real_connect(*args, **kwargs))
+
+    monkeypatch.setattr(hermes_state.sqlite3, "connect", connect_with_broken_trigram)
+
+    reason = hermes_state._db_opens_cleanly(db_path)
+
+    assert reason == "vtable constructor failed: messages_fts_trigram"
+
+
+def test_repair_rebuilds_canonical_tables_when_trigram_constructor_fails(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    real_check = hermes_state._db_opens_cleanly
+    checks = {"n": 0}
+
+    def check_reports_constructor_failure_then_real(path):
+        checks["n"] += 1
+        if checks["n"] <= 3:
+            return "vtable constructor failed: messages_fts_trigram"
+        return real_check(path)
+
+    monkeypatch.setattr(
+        hermes_state,
+        "_db_opens_cleanly",
+        check_reports_constructor_failure_then_real,
+    )
+
+    report = repair_state_db_schema(db_path, backup=False)
+
+    assert report["repaired"] is True
+    assert report["strategy"] == "rebuild_canonical_tables"
+    db = SessionDB(db_path=db_path)
+    try:
+        assert db._conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 1
+        assert db._conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 10
+        assert db._conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0] == 10
+        trigram_count = db._conn.execute(
+            "SELECT COUNT(*) FROM messages_fts_trigram"
+        ).fetchone()[0]
+        assert trigram_count == 10
+    finally:
+        db.close()
+
+
 def test_select_cached_agent_history_prefers_longer_live_transcript():
     """Gateway guard keeps the live transcript when persisted history lags."""
     from gateway.run import _select_cached_agent_history


### PR DESCRIPTION
## What does this PR do?

Fixes a `state.db` repair blind spot where a broken optional `messages_fts_trigram` virtual table can make `SessionDB` crash with:

```text
sqlite3.DatabaseError: vtable constructor failed: messages_fts_trigram
```

The canonical tables can still be intact, and current `origin/main` can report the DB as healthy because `_db_opens_cleanly()` only checks `integrity_check`, `sessions`, and a rolled-back write through triggers. In the observed DB, that health check returned healthy while dashboard endpoints that instantiate `SessionDB` still failed.

This follows up #52798 rather than duplicating it. #52798 fixed FTS write corruption that rejects message writes through triggers; this fixes the virtual-table constructor path where health/repair report `already_healthy` but `SessionDB` crashes before the dashboard can answer session endpoints. It supersedes stale draft #30082.

## Related Issue

Refs #52798
Refs #50504
Supersedes #30082

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding missing tests or correcting existing tests)
- [ ] ♻️ Refactor (no functional changes)
- [ ] 🎯 New skill / agent behavior

## Changes Made

- `hermes_state.py`
  - `_db_opens_cleanly()` now probes `messages_fts` and `messages_fts_trigram` constructors directly, while still allowing missing FTS tables.
  - Added a `rebuild_canonical_tables` repair tier that creates a fresh current-schema DB, copies canonical Hermes tables, verifies row counts/integrity/FTS probes, handles WAL/SHM sidecars, and atomically replaces the broken DB after the existing backup step.
- `tests/test_state_db_malformed_repair.py`
  - Added regression coverage for trigram constructor failures being reported by the health probe.
  - Added regression coverage for canonical-table rebuild preserving rows and rebuilding both FTS tables.

## How to Test

Reproduction against current `origin/main` using a broken `state.db` copy:

```text
origin_main_precheck None
origin_main_report {'repaired': True, 'strategy': 'already_healthy', ...}
sessiondb_opened False
DatabaseError vtable constructor failed: messages_fts_trigram
```

Validation on this branch:

```bash
python -m py_compile hermes_state.py tests/test_state_db_malformed_repair.py
python -m ruff check hermes_state.py tests/test_state_db_malformed_repair.py
python -m pytest tests/test_state_db_malformed_repair.py::test_health_probe_detects_trigram_constructor_failure tests/test_state_db_malformed_repair.py::test_repair_rebuilds_canonical_tables_when_trigram_constructor_fails -q
python -m pytest tests/test_hermes_state.py -k 'trigram or fts or search_messages' -q
```

Results:

- `py_compile` passed
- `ruff` passed
- new regression tests: 2 passed
- FTS/trigram state tests: 46 passed, 245 deselected

Local production-shaped validation:

- repaired a copy of an affected `state.db` with 446 sessions and 27,893 messages
- repaired the live local DB after taking a timestamped backup
- dashboard `/api/sessions/stats` returned 200 with 446 sessions / 27,893 messages
- dashboard `/api/sessions/empty/count` returned 200

Note: I did not run `pytest tests/ -q`. The full `tests/test_state_db_malformed_repair.py` file has existing local failures on this macOS/Python 3.11.9 SQLite build because older fixtures directly mutate `sqlite_master` / FTS shadow tables and SQLite defensive mode rejects those fixture writes before the tested repair code runs.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(state): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS, Python 3.11.9

### Documentation & Housekeeping

- [x] I've updated relevant documentation if needed — N/A
- [x] I've updated `cli-config.yaml.example` if needed — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if needed — N/A
- [x] I've considered cross-platform impact — SQLite-only repair path using stdlib `sqlite3`, `os.replace`, and sidecar cleanup
- [x] I've updated tool descriptions/schemas if needed — N/A

## Screenshots / Logs

```text
/api/sessions/stats -> 200
{"total":446,"active_store":446,"archived":0,"messages":27893,...}

/api/sessions/empty/count -> 200
{"count":11}
```