### PR TITLE
fix(config): use is_truthy_value() for config boolean parsing

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1126,7 +1126,7 @@ def init_agent(
     try:
         from hermes_cli.config import load_config as _load_sess_cfg
         _sess_cfg = (_load_sess_cfg().get("sessions") or {})
-        agent._session_json_enabled = bool(_sess_cfg.get("write_json_snapshots", False))
+        agent._session_json_enabled = is_truthy_value(_sess_cfg.get("write_json_snapshots", False))
     except Exception:
         pass
     # logs_dir is retained unconditionally for request_dump_*.json (debug
@@ -1322,19 +1322,19 @@ def init_agent(
     # as a separate flag from tool_use_enforcement because the guidance
     # applies to ALL models, not just the model families enforcement
     # targets.
-    agent._task_completion_guidance = bool(_agent_section.get("task_completion_guidance", True))
+    agent._task_completion_guidance = is_truthy_value(_agent_section.get("task_completion_guidance", True))
 
     # Universal parallel-tool-call guidance toggle.  Default True.  Separate
     # flag from task_completion_guidance because a user may want one but not
     # the other.  Steers the model to batch independent tool calls into a
     # single turn; the runtime already executes such batches concurrently.
-    agent._parallel_tool_call_guidance = bool(_agent_section.get("parallel_tool_call_guidance", True))
+    agent._parallel_tool_call_guidance = is_truthy_value(_agent_section.get("parallel_tool_call_guidance", True))
 
     # Local Python toolchain probe toggle.  Default True.  When False,
     # the probe is skipped entirely (no subprocess calls, no system-prompt
     # line).  Useful for users on exotic setups where the probe heuristics
     # are noisy.
-    agent._environment_probe = bool(_agent_section.get("environment_probe", True))
+    agent._environment_probe = is_truthy_value(_agent_section.get("environment_probe", True))
 
     # Per-platform prompt-hint overrides (config.yaml → platform_hints).
     # Lets an enterprise admin append to or replace Hermes' built-in

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -32,7 +32,7 @@ from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set
 
 from hermes_constants import get_hermes_home
 from tools import skill_usage
-from utils import atomic_json_write
+from utils import atomic_json_write, is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +114,7 @@ def set_paused(paused: bool) -> None:
 
 
 def is_paused() -> bool:
-    return bool(load_state().get("paused"))
+    return is_truthy_value(load_state().get("paused"))
 
 
 # ---------------------------------------------------------------------------
@@ -140,7 +140,7 @@ def _load_config() -> Dict[str, Any]:
 def is_enabled() -> bool:
     """Default ON when no config says otherwise."""
     cfg = _load_config()
-    return bool(cfg.get("enabled", True))
+    return is_truthy_value(cfg.get("enabled", True))
 
 
 def get_interval_hours() -> int:
@@ -184,7 +184,7 @@ def get_prune_builtins() -> bool:
     Hub-installed skills are never pruned regardless of this flag.
     """
     cfg = _load_config()
-    return bool(cfg.get("prune_builtins", True))
+    return is_truthy_value(cfg.get("prune_builtins", True))
 
 
 def get_consolidate() -> bool:
@@ -200,7 +200,7 @@ def get_consolidate() -> bool:
     a single invocation regardless of the config value.
     """
     cfg = _load_config()
-    return bool(cfg.get("consolidate", DEFAULT_CONSOLIDATE))
+    return is_truthy_value(cfg.get("consolidate", DEFAULT_CONSOLIDATE))
 
 
 # ---------------------------------------------------------------------------

--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -50,6 +50,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
 from agent.skill_utils import is_excluded_skill_path
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -158,7 +159,7 @@ def _load_config() -> Dict[str, Any]:
 
 def is_enabled() -> bool:
     """Default ON — the whole point of the backup is safety by default."""
-    return bool(_load_config().get("enabled", True))
+    return is_truthy_value(_load_config().get("enabled", True))
 
 
 def get_keep() -> int:

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -41,6 +41,7 @@ import threading
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from utils import is_truthy_value
 from agent.lsp import eventlog
 from agent.lsp.client import (
     DIAGNOSTICS_DOCUMENT_WAIT,
@@ -201,7 +202,7 @@ class LSPService:
         if not isinstance(lsp_cfg, dict):
             lsp_cfg = {}
 
-        enabled = bool(lsp_cfg.get("enabled", True))
+        enabled = is_truthy_value(lsp_cfg.get("enabled", True))
         wait_mode = lsp_cfg.get("wait_mode", "document")
         wait_timeout = float(lsp_cfg.get("wait_timeout", DIAGNOSTICS_DOCUMENT_WAIT))
         install_strategy = lsp_cfg.get("install_strategy", "auto")

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -28,6 +28,7 @@ from rich.markup import escape as _escape
 from rich.panel import Panel
 
 from hermes_constants import display_hermes_home, is_termux as _is_termux_environment
+from utils import is_truthy_value
 from hermes_cli.browser_connect import (
     DEFAULT_BROWSER_CDP_URL,
     is_browser_debug_ready,
@@ -2345,7 +2346,7 @@ class CLICommandsMixin:
 
         cfg = load_config() or {}
         footer_cfg = ((cfg.get("display") or {}).get("runtime_footer") or {})
-        current = bool(footer_cfg.get("enabled", False))
+        current = is_truthy_value(footer_cfg.get("enabled", False))
         fields = footer_cfg.get("fields") or ["model", "context_pct", "cwd"]
 
         if arg in {"status", "?"}:

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -45,6 +45,7 @@ from typing import Optional
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import profiles as profiles_mod
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -294,7 +295,7 @@ def decompose_task(
     orchestrator = _resolve_orchestrator_profile(cfg)
     default_assignee = _resolve_default_assignee(cfg)
     kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
-    auto_promote = bool(kanban_cfg.get("auto_promote_children", True))
+    auto_promote = is_truthy_value(kanban_cfg.get("auto_promote_children", True))
     roster, valid_names = _build_roster()
 
     try:

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Dict
 
 from hermes_constants import display_hermes_home
-from utils import atomic_replace
+from utils import atomic_replace, is_truthy_value
 from hermes_cli.config import cfg_get
 
 
@@ -91,7 +91,7 @@ def _get_webhook_config() -> dict:
 
 
 def _is_webhook_enabled() -> bool:
-    return bool(_get_webhook_config().get("enabled"))
+    return is_truthy_value(_get_webhook_config().get("enabled"))
 
 
 def _get_webhook_base_url() -> str:

--- a/tests/hermes_cli/test_config_truthy_parsing.py
+++ b/tests/hermes_cli/test_config_truthy_parsing.py
@@ -1,0 +1,70 @@
+"""Tests for is_truthy_value() config boolean parsing.
+
+Verifies that string "false", "0", "off", "" are treated as False
+when used in config paths, instead of bool() which treats any
+non-empty string as True.
+"""
+import pytest
+from utils import is_truthy_value
+
+
+class TestIsTruthyValue:
+    def test_boolean_true(self):
+        assert is_truthy_value(True) is True
+
+    def test_boolean_false(self):
+        assert is_truthy_value(False) is False
+
+    def test_string_true(self):
+        assert is_truthy_value("true") is True
+        assert is_truthy_value("True") is True
+        assert is_truthy_value("TRUE") is True
+
+    def test_string_false(self):
+        assert is_truthy_value("false") is False
+        assert is_truthy_value("False") is False
+        assert is_truthy_value("FALSE") is False
+
+    def test_string_zero(self):
+        assert is_truthy_value("0") is False
+
+    def test_string_one(self):
+        assert is_truthy_value("1") is True
+
+    def test_string_off(self):
+        assert is_truthy_value("off") is False
+        assert is_truthy_value("Off") is False
+
+    def test_string_on(self):
+        assert is_truthy_value("on") is True
+
+    def test_string_no(self):
+        assert is_truthy_value("no") is False
+
+    def test_string_yes(self):
+        assert is_truthy_value("yes") is True
+
+    def test_empty_string(self):
+        assert is_truthy_value("") is False
+
+    def test_none_with_default_false(self):
+        assert is_truthy_value(None, default=False) is False
+
+    def test_none_with_default_true(self):
+        assert is_truthy_value(None, default=True) is True
+
+    def test_int_zero(self):
+        assert is_truthy_value(0) is False
+
+    def test_int_one(self):
+        assert is_truthy_value(1) is True
+
+    def test_bool_vs_is_truthy_divergence(self):
+        """The core bug: bool('false') is True, but is_truthy_value('false') is False."""
+        assert bool("false") is True  # the bug
+        assert is_truthy_value("false") is False  # the fix
+
+    def test_bool_vs_is_truthy_zero_string(self):
+        """bool('0') is True, but is_truthy_value('0') is False."""
+        assert bool("0") is True  # the bug
+        assert is_truthy_value("0") is False  # the fix


### PR DESCRIPTION
## What does this PR do?

Closes #49883

Several config paths used `bool()` to parse YAML config values, which treats any non-empty string as `True` — including `"false"`, `"0"`, `"off"`, and `"no"`. Users setting these string values in `config.yaml` expected them to disable features, but `bool()` silently enabled them instead.

## Root Cause

`bool("false")` returns `True` because `"false"` is a non-empty string. The codebase already has `is_truthy_value()` in `utils.py` that correctly handles string-to-boolean conversion, but 9 config paths in 7 files were still using `bool()`.

## Files Changed

| File | Config Keys Fixed |
|------|-------------------|
| `agent/agent_init.py` | `write_json_snapshots`, `task_completion_guidance`, `parallel_tool_call_guidance`, `environment_probe` |
| `agent/curator.py` | `paused`, `enabled`, `prune_builtins`, `consolidate` |
| `agent/curator_backup.py` | `enabled` |
| `agent/lsp/manager.py` | `enabled` |
| `hermes_cli/webhook.py` | `enabled` |
| `hermes_cli/cli_commands_mixin.py` | `enabled` |
| `hermes_cli/kanban_decompose.py` | `auto_promote_children` |

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How to Test

1. `python -m pytest tests/hermes_cli/test_config_truthy_parsing.py -v` — 17/17 passed
2. Verified `is_truthy_value("false")` returns `False` (was `True` with `bool()`)

## Checklist

- [x] Read CONTRIBUTING.md
- [x] Conventional commit format (`fix(config): ...`)
- [x] No competing PRs (old PR #50127 closed)
- [x] Tests added and passing
- [x] Tested on Ubuntu 24.04, Python 3.11
