### PR TITLE
fix(desktop): handle custom-provider model switch confirmations

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -34,15 +34,17 @@ type Controls = ReturnType<typeof useModelControls>
 function Harness({
   activeSessionId,
   onReady,
+  queryClient,
   requestGateway
 }: {
   activeSessionId: string | null
   onReady: (controls: Controls) => void
+  queryClient?: QueryClient
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
 }) {
   const controls = useModelControls({
     activeSessionId,
-    queryClient: new QueryClient(),
+    queryClient: queryClient ?? new QueryClient(),
     requestGateway
   })
 
@@ -53,6 +55,7 @@ function Harness({
 
 describe('useModelControls', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     $activeSessionId.set(null)
     setCurrentModel('')
     setCurrentProvider('')
@@ -152,6 +155,56 @@ describe('useModelControls', () => {
       key: 'model',
       value: 'BeastMode --provider moa --session'
     })
+  })
+
+  it('rolls back active-session picker changes when config.set requires confirmation', async () => {
+    setCurrentModel('old/model')
+    setCurrentProvider('old-provider')
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(['model-options', 'session-1'], {
+      model: 'old/model',
+      provider: 'old-provider'
+    })
+    const requestGateway = vi.fn(
+      async () =>
+        ({
+          confirm_required: true,
+          confirm_message: 'EXPENSIVE MODEL WARNING'
+        }) as never
+    )
+    let controls!: Controls
+
+    render(
+      <Harness
+        activeSessionId="session-1"
+        onReady={value => (controls = value)}
+        queryClient={queryClient}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await expect(
+      controls.selectModel({
+        model: 'openai/gpt-5.5-pro',
+        provider: 'openrouter'
+      })
+    ).resolves.toBe(false)
+
+    expect($currentModel.get()).toBe('old/model')
+    expect($currentProvider.get()).toBe('old-provider')
+    expect(queryClient.getQueryData(['model-options', 'session-1'])).toMatchObject({
+      model: 'old/model',
+      provider: 'old-provider'
+    })
+    expect(requestGateway).toHaveBeenCalledWith('config.set', {
+      session_id: 'session-1',
+      key: 'model',
+      value: 'openai/gpt-5.5-pro --provider openrouter --session'
+    })
+    expect(notifyError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'EXPENSIVE MODEL WARNING' }),
+      'Model switch failed'
+    )
   })
 
   it('stores a no-session pick as UI state with no gateway or global write', async () => {

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -18,6 +18,33 @@ interface ModelControlsOptions {
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
 }
 
+interface ConfigSetModelResponse {
+  confirm_message?: unknown
+  confirm_required?: unknown
+  warning?: unknown
+}
+
+function confirmationMessage(result: unknown) {
+  if (!result || typeof result !== 'object') {
+    return null
+  }
+
+  const response = result as ConfigSetModelResponse
+  if (response.confirm_required !== true) {
+    return null
+  }
+
+  if (typeof response.confirm_message === 'string' && response.confirm_message.trim()) {
+    return response.confirm_message
+  }
+
+  if (typeof response.warning === 'string' && response.warning.trim()) {
+    return response.warning
+  }
+
+  return ''
+}
+
 export function useModelControls({ activeSessionId, queryClient, requestGateway }: ModelControlsOptions) {
   const { t } = useI18n()
   const copy = t.desktop
@@ -81,6 +108,11 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
       // rather than leave the UI showing a model the backend never selected.
       const prevModel = $currentModel.get()
       const prevProvider = $currentProvider.get()
+      const restorePreviousSelection = () => {
+        setCurrentModel(prevModel)
+        setCurrentProvider(prevProvider)
+        updateModelOptionsCache(prevProvider, prevModel, !activeSessionId)
+      }
 
       setCurrentModel(selection.model)
       setCurrentProvider(selection.provider)
@@ -93,19 +125,25 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
       }
 
       try {
-        await requestGateway('config.set', {
+        const result = await requestGateway<ConfigSetModelResponse>('config.set', {
           session_id: activeSessionId,
           key: 'model',
           value: `${selection.model} --provider ${selection.provider} --session`
         })
+        const confirmMessage = confirmationMessage(result)
+
+        if (confirmMessage !== null) {
+          restorePreviousSelection()
+          notifyError(new Error(confirmMessage || copy.modelSwitchFailed), copy.modelSwitchFailed)
+
+          return false
+        }
 
         void queryClient.invalidateQueries({ queryKey: ['model-options', activeSessionId] })
 
         return true
       } catch (err) {
-        setCurrentModel(prevModel)
-        setCurrentProvider(prevProvider)
-        updateModelOptionsCache(prevProvider, prevModel, !activeSessionId)
+        restorePreviousSelection()
         notifyError(err, copy.modelSwitchFailed)
 
         return false

--- a/hermes_cli/model_cost_guard.py
+++ b/hermes_cli/model_cost_guard.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from typing import Optional
 
-from agent.models_dev import ModelInfo
+from agent.models_dev import ModelInfo, PROVIDER_TO_MODELS_DEV
 
 
 INPUT_COST_WARNING_THRESHOLD = Decimal("20")
@@ -54,6 +54,40 @@ def _pricing_from_model_info(
     )
 
 
+def _known_models_dev_provider(provider: Optional[str]) -> Optional[str]:
+    normalized = (provider or "").strip().lower()
+    if not normalized:
+        return None
+    return PROVIDER_TO_MODELS_DEV.get(normalized)
+
+
+def _can_trust_model_info_pricing(
+    provider: Optional[str],
+    model_info: Optional[ModelInfo],
+) -> bool:
+    expected_provider = _known_models_dev_provider(provider)
+    if not expected_provider or model_info is None:
+        return False
+
+    actual_provider = str(getattr(model_info, "provider_id", "") or "").strip().lower()
+    return not actual_provider or actual_provider == expected_provider
+
+
+def _can_trust_pricing_lookup(
+    model_name: str,
+    *,
+    provider: Optional[str],
+    base_url: Optional[str],
+) -> bool:
+    try:
+        from agent.usage_pricing import resolve_billing_route
+
+        route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
+    except Exception:
+        return False
+    return route.billing_mode != "unknown"
+
+
 def expensive_model_warning(
     model_name: str,
     *,
@@ -71,8 +105,18 @@ def expensive_model_warning(
     if not model:
         return None
 
-    input_cost, output_cost, source = _pricing_from_model_info(model_info)
-    if input_cost is None and output_cost is None and provider:
+    input_cost: Optional[Decimal] = None
+    output_cost: Optional[Decimal] = None
+    source = ""
+
+    if _can_trust_model_info_pricing(provider, model_info):
+        input_cost, output_cost, source = _pricing_from_model_info(model_info)
+
+    if (
+        input_cost is None
+        and output_cost is None
+        and _known_models_dev_provider(provider)
+    ):
         try:
             from agent.models_dev import get_model_info
 
@@ -81,7 +125,12 @@ def expensive_model_warning(
             )
         except Exception:
             pass
-    if input_cost is None and output_cost is None:
+
+    if (
+        input_cost is None
+        and output_cost is None
+        and _can_trust_pricing_lookup(model, provider=provider, base_url=base_url)
+    ):
         try:
             from agent.usage_pricing import get_pricing_entry
 

--- a/tests/hermes_cli/test_model_cost_guard.py
+++ b/tests/hermes_cli/test_model_cost_guard.py
@@ -1,5 +1,7 @@
 from decimal import Decimal
 
+import pytest
+
 from agent.models_dev import ModelInfo
 from agent.usage_pricing import PricingEntry
 from hermes_cli.model_cost_guard import expensive_model_warning
@@ -10,12 +12,12 @@ def test_no_warning_when_known_prices_are_at_threshold():
         id="edge/model",
         name="edge/model",
         family="",
-        provider_id="test",
+        provider_id="anthropic",
         cost_input=20.0,
         cost_output=100.0,
     )
 
-    assert expensive_model_warning("edge/model", provider="test", model_info=info) is None
+    assert expensive_model_warning("edge/model", provider="anthropic", model_info=info) is None
 
 
 def test_warns_when_models_dev_input_price_exceeds_threshold():
@@ -23,14 +25,14 @@ def test_warns_when_models_dev_input_price_exceeds_threshold():
         id="expensive/input",
         name="expensive/input",
         family="",
-        provider_id="test",
+        provider_id="anthropic",
         cost_input=20.01,
         cost_output=1.0,
     )
 
     warning = expensive_model_warning(
         "expensive/input",
-        provider="test",
+        provider="anthropic",
         model_info=info,
     )
 
@@ -38,6 +40,51 @@ def test_warns_when_models_dev_input_price_exceeds_threshold():
     assert warning.input_cost_per_million == Decimal("20.01")
     assert "EXPENSIVE MODEL WARNING" in warning.message
     assert "$20/M input" in warning.message
+
+
+@pytest.mark.parametrize("provider", ["custom", "custom:routerai", "routerai"])
+def test_skips_foreign_models_dev_pricing_for_custom_or_unknown_providers(provider):
+    info = ModelInfo(
+        id="openai/gpt-5.5-pro",
+        name="openai/gpt-5.5-pro",
+        family="",
+        provider_id="openrouter",
+        cost_input=25.0,
+        cost_output=125.0,
+    )
+
+    assert (
+        expensive_model_warning(
+            "openai/gpt-5.5-pro",
+            provider=provider,
+            model_info=info,
+        )
+        is None
+    )
+
+
+def test_skips_untrusted_provider_pricing_lookup_for_custom_provider(monkeypatch):
+    monkeypatch.setattr("agent.models_dev.get_model_info", lambda *_args, **_kwargs: None)
+    pricing_calls = []
+
+    def fake_get_pricing_entry(*_args, **_kwargs):
+        pricing_calls.append(_args)
+        return PricingEntry(
+            input_cost_per_million=Decimal("25"),
+            output_cost_per_million=Decimal("125"),
+            source="provider_models_api",
+        )
+
+    monkeypatch.setattr("agent.usage_pricing.get_pricing_entry", fake_get_pricing_entry)
+
+    warning = expensive_model_warning(
+        "openai/gpt-5.5-pro",
+        provider="custom:routerai",
+        base_url="https://routerai.example/v1",
+    )
+
+    assert warning is None
+    assert pricing_calls == []
 
 
 def test_warns_when_pricing_entry_output_price_exceeds_threshold(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes a Desktop composer model-switch failure for user-defined custom providers. The cost guard now ignores pricing data when the selected provider is a custom or otherwise unknown route that Hermes cannot price reliably, while preserving expensive-model warnings for trusted/known pricing routes. Desktop also now treats a successful `config.set` response with `confirm_required: true` as a failed switch attempt: it restores the optimistic model/provider state and shows the backend warning instead of silently assuming success.

## Related Issue

Fixes #54348

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/model_cost_guard.py`: trust models.dev pricing only when it matches a known provider mapping, and skip generic pricing lookup for unknown/custom billing routes.
- `tests/hermes_cli/test_model_cost_guard.py`: add regression coverage for `custom`, `custom:<name>`, and unknown provider slugs while preserving known-provider warning behavior.
- `apps/desktop/src/app/session/hooks/use-model-controls.ts`: handle `confirm_required` responses from active-session `config.set` by rolling back the optimistic UI state and notifying the user.
- `apps/desktop/src/app/session/hooks/use-model-controls.test.tsx`: add coverage for rollback/notification when model switching requires confirmation.

## How to Test

1. Run the focused backend cost-guard tests.
2. Run the gateway expensive-model confirmation path test.
3. Run the Desktop hook test and Desktop typecheck.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_model_cost_guard.py -q` -> 9 passed
- `scripts/run_tests.sh tests/test_tui_gateway_server.py -q -k test_config_set_model_requires_confirmation_for_expensive_model` -> 1 passed
- `cd apps/desktop && npm run test:ui -- src/app/session/hooks/use-model-controls.test.tsx` -> 6 passed
- `cd apps/desktop && npm run typecheck` -> passed
- `git diff --check` -> clean

## Caveats

- Full repository test suite was not run; verification was focused on the backend guard, gateway confirmation path, Desktop hook behavior, and Desktop typecheck.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
