### PR TITLE
fix(memory): reject content containing ENTRY_DELIMITER before writing (#54403)

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -786,3 +786,64 @@ class TestLoadTimeSnapshotSanitization:
         # Block marker appears exactly once, not nested
         assert snapshot.count("[BLOCKED:") == 1
         assert "Clean fact" in snapshot
+
+
+# =========================================================================
+# Entry-delimiter validation — content containing ENTRY_DELIMITER ("\n§\n")
+# must be rejected on every write path to prevent silent data corruption.
+# See issue #54403.
+# =========================================================================
+
+
+class TestEntryDelimiterValidation:
+    """Regression tests for #54403: user content containing the literal
+    ENTRY_DELIMITER ("\\n§\\n") collides with the stored-entry boundary and is
+    silently split on read, corrupting stored memory. The shared
+    _scan_memory_content() chokepoint must reject it across add(), replace(),
+    and apply_batch().
+    """
+
+    def test_scan_rejects_entry_delimiter(self):
+        # The full "\n§\n" sequence collides with the stored-entry boundary.
+        assert _scan_memory_content("line one\n§\nline two") is not None
+
+    def test_scan_accepts_lone_section_sign(self):
+        # A lone "§" (not the full newline-delimited sequence) is valid
+        # content and must NOT be rejected — the read split is on "\n§\n",
+        # not the single "§" character.
+        assert _scan_memory_content("User prefers § for sections") is None
+
+    def test_add_rejects_content_with_entry_delimiter(self, store):
+        result = store.add("memory", "heading one\n§\nheading two")
+        assert result["success"] is False
+        assert "delimiter" in result["error"].lower()
+        # Nothing was stored.
+        assert store.memory_entries == []
+
+    def test_add_accepts_lone_section_sign(self, store):
+        result = store.add("memory", "uses § as a section mark")
+        assert result["success"] is True
+        assert "uses § as a section mark" in store.memory_entries
+
+    def test_add_delimiter_rejection_preserves_existing_data(self, store):
+        store.add("memory", "safe entry one")
+        result = store.add("memory", "poisoned\n§\ncontent")
+        assert result["success"] is False
+        # Prior entry untouched.
+        assert store.memory_entries == ["safe entry one"]
+
+    def test_replace_rejects_content_with_entry_delimiter(self, store):
+        store.add("memory", "original entry")
+        result = store.replace("memory", "original", "new\n§\ncontent")
+        assert result["success"] is False
+        # Original entry unchanged.
+        assert store.memory_entries == ["original entry"]
+
+    def test_apply_batch_rejects_content_with_entry_delimiter(self, store):
+        result = store.apply_batch("memory", [
+            {"action": "add", "content": "good entry"},
+            {"action": "add", "content": "bad\n§\nentry"},
+        ])
+        assert result["success"] is False
+        # All-or-nothing: nothing committed.
+        assert store.memory_entries == []

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -77,6 +77,13 @@ from tools.threat_patterns import first_threat_message as _first_threat_message
 
 def _scan_memory_content(content: str) -> Optional[str]:
     """Scan memory content for injection/exfil patterns. Returns error string if blocked."""
+    if ENTRY_DELIMITER in content:
+        return (
+            "Blocked: content contains the memory entry delimiter sequence (a "
+            "section sign § between line breaks), which would corrupt stored "
+            "memory when it is read back — the entry would be silently split "
+            "into fragments. Please rephrase to avoid that sequence, then retry."
+        )
     return _first_threat_message(content, scope="strict")
 
 


### PR DESCRIPTION
## What

Fixes #54403 — `MemoryStore` uses `ENTRY_DELIMITER = "\n§\n"` (tools/memory_tool.py) to separate entries in the memory file. User content containing that literal sequence was accepted and stored, then **silently split into fragments on the next read**, corrupting stored memory with no error to the user.

## Root cause

`_scan_memory_content()` validates for injection/exfiltration patterns but never checked whether the content collides with the stored-entry boundary. When `_entries_for()` splits the file by `ENTRY_DELIMITER`, any user content containing the delimiter is incorrectly treated as a boundary between entries.

## Fix

Single check added to the shared `_scan_memory_content()` chokepoint, so all three write paths are protected in one place:
- `add()` (line 314)
- `replace()` (line 369)
- `apply_batch()` (line 482)

Content containing the full `\n§\n` sequence is rejected with a clear, actionable error. A lone `§` (not the full delimited sequence) remains valid content — the read-side lone-`§` splitting bug was already fixed by merged PR #162, which changed `split("§")` → `split(ENTRY_DELIMITER)`.

## Why the chokepoint

The fix lives in the shared scan function rather than duplicated across three write methods, so future write paths inherit the protection automatically.

## How verified

Test-first RED→GREEN on `upstream/main` (b31b0b9d9):

- **RED (bug proven on main):** 5 of 7 new regression tests fail without the fix (the 2 acceptance tests correctly pass — lone `§` was already valid).
- **GREEN:** all 7 pass with the fix; full memory_tool suite **83 passed, 0 regressions**.

Tests cover every layer:
1. `_scan_memory_content()` rejects the delimiter, accepts a lone `§`
2. `add()` rejects delimiter content; accepts lone `§`
3. A rejected `add()` leaves prior entries untouched
4. `replace()` rejects delimiter content (original unchanged)
5. `apply_batch()` rejects the whole batch if any op contains the delimiter (all-or-nothing)

## Duplicate check

No open competing PR. PR #162 (merged) fixed a different root cause (read-side split by lone `§`).

---

Auto-published by Moonsong via Path B automated pipeline.
