### PR TITLE
fix(desktop): load project overview without gateway-ready deadlock

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -624,7 +624,6 @@ export function ChatSidebar({
   // authoritatively on the backend (projects.tree). Parents reorder via
   // workspaceParentOrderIds; worktrees within a parent via workspaceOrderIds.
   const worktreeGroupingActive = agentsGrouped && !showAllProfiles
-  const gatewayReady = gatewayState === 'open'
 
   // The backend project tree is a structural snapshot, NOT a per-message feed.
   // Refresh it on structural edges only — entering the grouped view, a profile
@@ -633,8 +632,17 @@ export function ChatSidebar({
   // (overlayLiveLanes / overlayLivePreviews) off `$sessions`, so a turn
   // completing does NOT re-run the heavy list_sessions_rich scan. Project
   // mutations refresh the tree from their own store actions.
+  //
+  // Do NOT pre-gate this on the renderer-side `gatewayReady` flag.
+  // `gatewayRequest()` already calls `ensureActiveGatewayOpen()`, so it opens the
+  // connection itself; the renderer's `$gatewayState` is driven by IPC events
+  // about the Electron main-process gateway and can lag behind a connection that
+  // is in fact usable. Pre-gating here stranded `$projectTree` empty — the
+  // overview never fetched, and the sidebar silently fell back to cwd grouping.
+  // `gatewayState` stays in the dep list as a RETRY edge: if the first fetch runs
+  // before the connection settles, a later state transition re-runs it.
   useEffect(() => {
-    if (worktreeGroupingActive && gatewayReady) {
+    if (worktreeGroupingActive) {
       void refreshProjects()
       // Paint the list from the fast tree fetch (explicit projects + repos from
       // existing sessions / the backend cache) FIRST, then kick off the heavy
@@ -642,7 +650,7 @@ export function ChatSidebar({
       // of the crawl blocking the first render.
       void refreshProjectTree().finally(() => void scanAndRecordRepos())
     }
-  }, [worktreeGroupingActive, profileScope, gatewayReady])
+  }, [worktreeGroupingActive, profileScope, gatewayState])
 
   // Out-of-band repo changes (a `git init` / `rm -rf` in another terminal) emit
   // no git events, so — like every git GUI — re-pull on window focus / tab
@@ -651,7 +659,7 @@ export function ChatSidebar({
   // session regrouping); the heavy disk crawl that surfaces brand-new repos is
   // throttled. Agent-driven changes already refresh via $workspaceChangeTick.
   useEffect(() => {
-    if (!worktreeGroupingActive || !gatewayReady) {
+    if (!worktreeGroupingActive) {
       return
     }
 
@@ -681,7 +689,7 @@ export function ChatSidebar({
       window.removeEventListener('focus', onActive)
       document.removeEventListener('visibilitychange', onActive)
     }
-  }, [worktreeGroupingActive, gatewayReady])
+  }, [worktreeGroupingActive])
 
   // Apply the persisted repo + worktree orders to a project's repo subtrees.
   const orderRepos = useCallback(
@@ -741,7 +749,7 @@ export function ChatSidebar({
   const [enteredProjectTree, setEnteredProjectTree] = useState<SidebarProjectTree | null>(null)
 
   useEffect(() => {
-    if (!enteredProjectId || !gatewayReady) {
+    if (!enteredProjectId) {
       setEnteredProjectTree(null)
 
       return
@@ -749,18 +757,28 @@ export function ChatSidebar({
 
     let cancelled = false
 
-    void fetchProjectSessions(enteredProjectId).then(project => {
-      if (!cancelled) {
-        setEnteredProjectTree(project)
-      }
-    })
+    void fetchProjectSessions(enteredProjectId)
+      .then(project => {
+        if (!cancelled) {
+          setEnteredProjectTree(project)
+        }
+      })
+      .catch((err: unknown) => {
+        console.warn('[hermes-projects] failed to hydrate project sessions', err)
+
+        if (!cancelled) {
+          setEnteredProjectTree(null)
+        }
+      })
 
     return () => {
       cancelled = true
     }
     // `projectTree` in deps: re-hydrate after a tree refresh so the entered view
-    // stays current with new/ended sessions.
-  }, [enteredProjectId, gatewayReady, projectTree])
+    // stays current with new/ended sessions. Like the overview fetch, do NOT
+    // pre-gate on `gatewayReady` — `fetchProjectSessions` opens the gateway
+    // itself; `gatewayState` is only a retry edge.
+  }, [enteredProjectId, gatewayState, projectTree])
 
   // Prefer the hydrated tree; fall back to the overview node (empty lanes) while
   // the drill-in fetch is in flight, so the header/structure render immediately.

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -214,8 +214,11 @@ function applyPayload(payload: ProjectsPayload): void {
 export async function refreshProjects(): Promise<void> {
   try {
     applyPayload(await gatewayRequest<ProjectsPayload>('projects.list'))
-  } catch {
-    // Backend may not be ready; keep the last known list.
+  } catch (err: unknown) {
+    // Backend may not be ready; keep the last known list. Log so a persistent
+    // failure (the bug that made the sidebar silently fall back to cwd grouping)
+    // is visible instead of swallowed.
+    console.warn('[hermes-projects] failed to refresh projects list', err)
   }
 }
 
@@ -252,8 +255,11 @@ export async function refreshProjectTree(): Promise<void> {
         $removedSessionIds.set(pending)
       }
     }
-  } catch {
-    // Backend may not be ready; keep the last known tree.
+  } catch (err: unknown) {
+    // Backend may not be ready; keep the last known tree. Log persistent
+    // failures so the project overview cannot silently fall back to cwd grouping
+    // (the regression this guards against).
+    console.warn('[hermes-projects] failed to refresh project tree', err)
   } finally {
     $projectTreeLoading.set(false)
   }


### PR DESCRIPTION
## Summary

The workspace-grouped desktop sidebar rendered cwd-derived buckets (`Telegram`, `<repo-name>`, `<user>`) instead of the backend-authoritative **Projects** overview — even though `projects.tree` returned every explicit project correctly. Toggling "Group sessions by workspace" flipped state but the header stayed **SESSIONS** and the named projects never appeared.

## Root cause

The project-tree fetch effects in `apps/desktop/src/app/chat/sidebar/index.tsx` were pre-gated on a renderer-side `gatewayReady` flag (`$gatewayState === 'open'`):

```ts
const gatewayReady = gatewayState === 'open'
useEffect(() => {
  if (worktreeGroupingActive && gatewayReady) {
    void refreshProjects()
    void refreshProjectTree().finally(() => void scanAndRecordRepos())
  }
}, [worktreeGroupingActive, profileScope, gatewayReady])
```

`$gatewayState` is driven by IPC events about the Electron **main-process** gateway connection and can lag behind — or fail to settle to `'open'` on — a connection that is in fact usable. When that happened, the gated effect never ran, `$projectTree` stayed empty, and the sidebar silently fell back to client-side cwd grouping.

The pre-gate was also redundant: `gatewayRequest()` (used by `refreshProjects` / `refreshProjectTree`) and `fetchProjectSessions()` already call `ensureActiveGatewayOpen()`, so they establish the connection themselves.

## Fix

- Remove the `gatewayReady` pre-gate from the three affected effects (overview refresh, focus/visibility refresh, entered-project hydration). The store helpers open the gateway on demand.
- Keep `gatewayState` in the fetch dep arrays as a **retry edge** — if the first fetch runs before the connection settles, a later state transition re-runs it. (The focus/visibility-listener effect, which no longer reads gateway state in its body, drops the dep entirely so listeners aren't needlessly re-registered.)
- De-silence the previously empty `catch {}` blocks in `refreshProjects`, `refreshProjectTree`, and the entered-project hydration with `console.warn`, so a persistent failure of this class can't hide silently again. (Matches the existing `console.warn('[tag] …', err)` convention used elsewhere in the sidebar, e.g. `session-actions-menu.tsx`.)

## Validation

- `npm run typecheck` — clean
- `npx eslint src/app/chat/sidebar/index.tsx src/store/projects.ts` — clean
- `npx vitest run --environment jsdom src/app/chat/sidebar/` — **44/44 passing**
- **Live CDP verification** (drove the renderer over the Chrome DevTools Protocol, set grouping on, read the rendered DOM):
  - local `dist` build → header becomes **PROJECTS**, all 14 named projects render
  - packaged `--build-only` artifact → same
  - installed `/Applications/Hermes.app` → confirmed by screenshot: **PROJECTS** header with all 14 projects (work · Vend/Genesis, vault · Master Vault, code · Atelier/Forge, archive · Dead repos, code · Finn/Hermes/Siftly, content · Creator, lane · AI Signal/Atelier notes/Dating/Health/Style/Wealth)

Before the fix, the identical setup showed only `Telegram` / `<repo>` / `<user>` buckets under a **SESSIONS** header.

## Notes for reviewers

- Removing the pre-gate means a project refresh can attempt the connection slightly earlier; this is intended, since the store helpers already ensure/open the gateway.
- The first effect still calls `scanAndRecordRepos()` after `refreshProjectTree().finally(...)`. That heavy home-dir crawl already self-throttles (the separate focus/visibility effect gates it behind a 30s `SCAN_THROTTLE_MS`); the overview effect runs on structural edges (grouping toggle, profile switch, gateway state transition), not per message, so churn is bounded. Happy to add an explicit throttle on the overview path too if reviewers prefer.
- No new automated regression test: the failure is a renderer/IPC connection-state timing condition that's awkward to reproduce in jsdom without heavily mocking the gateway lifecycle. It was instead verified end-to-end via CDP against the real packaged app (described above). Guidance welcome on the preferred test shape if upstream wants one.
