### PR TITLE
fix(browser): send Authorization header to Camoufox when CAMOFOX_API_KEY is set

### DIFF
--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -348,6 +348,7 @@ def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, A
             "sessionKey": session["session_key"],
             "url": url,
         },
+        headers=_auth_headers(),
         timeout=_DEFAULT_TIMEOUT,
     )
     resp.raise_for_status()
@@ -384,10 +385,18 @@ def camofox_soft_cleanup(task_id: Optional[str] = None) -> bool:
 # HTTP helpers
 # ---------------------------------------------------------------------------
 
+def _auth_headers() -> Dict[str, str]:
+    """Return Authorization header when CAMOFOX_API_KEY is set."""
+    api_key = os.getenv("CAMOFOX_API_KEY", "").strip()
+    if api_key:
+        return {"Authorization": f"Bearer {api_key}"}
+    return {}
+
+
 def _post(path: str, body: dict, timeout: int = _DEFAULT_TIMEOUT) -> dict:
     """POST JSON to camofox and return parsed response."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.post(url, json=body, timeout=timeout)
+    resp = requests.post(url, json=body, headers=_auth_headers(), timeout=timeout)
     resp.raise_for_status()
     return resp.json()
 
@@ -395,7 +404,7 @@ def _post(path: str, body: dict, timeout: int = _DEFAULT_TIMEOUT) -> dict:
 def _get(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> dict:
     """GET from camofox and return parsed response."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.get(url, params=params, timeout=timeout)
+    resp = requests.get(url, params=params, headers=_auth_headers(), timeout=timeout)
     resp.raise_for_status()
     return resp.json()
 
@@ -403,7 +412,7 @@ def _get(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> dic
 def _get_raw(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> requests.Response:
     """GET from camofox and return raw response (for binary data)."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.get(url, params=params, timeout=timeout)
+    resp = requests.get(url, params=params, headers=_auth_headers(), timeout=timeout)
     resp.raise_for_status()
     return resp
 
@@ -411,7 +420,7 @@ def _get_raw(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) ->
 def _delete(path: str, body: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> dict:
     """DELETE to camofox and return parsed response."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.delete(url, json=body, timeout=timeout)
+    resp = requests.delete(url, json=body, headers=_auth_headers(), timeout=timeout)
     resp.raise_for_status()
     return resp.json()
 


### PR DESCRIPTION
## Problem

When `CAMOFOX_AUTH_MODE=auto` and `CAMOFOX_API_KEY` is set on the Camoufox server, the Hermes browser tools (`browser_navigate`, `browser_click`, etc.) receive `403 Forbidden` because the HTTP helpers never send the `Authorization: Bearer <key>` header.

This affects any setup where Hermes and Camoufox run on different machines (e.g. Hermes on Windows PC, Camoufox in Docker on NAS) — the connection is non-loopback, so the server enforces Bearer auth.

## Root Cause

The four HTTP helper functions (`_post`, `_get`, `_get_raw`, `_delete`) and `_ensure_tab` all call `requests.post/get/delete` without any `Authorization` header. The `session_key` config field is only used as a JSON body parameter for session identification, never as an HTTP auth credential.

## Fix

Add `_auth_headers()` helper that reads `CAMOFOX_API_KEY` from environment and returns `{'Authorization': 'Bearer <key>'}`. Apply it to all 5 HTTP request call sites.

## Testing

- All existing `TestCamofoxMode` tests pass (5/5)
- Manual verification: confirmed `_auth_headers()` returns correct Bearer header when key is set, empty dict when unset
- Integration test: confirmed all 4 HTTP helpers pass headers to `requests.*` calls