### PR TITLE
fix(logging): suppress Windows lock timeout tracebacks

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -115,6 +115,26 @@ def _safe_stderr():  # type: ignore[return]
     # Best-effort: if wrapping fails, return the original stream.
     return stream
 
+
+_CONCURRENT_LOG_LOCK_TIMEOUT = "Cannot acquire lock after 20 attempts"
+
+
+def _is_windows_concurrent_log_lock_timeout(exc: BaseException | None) -> bool:
+    """Return True for concurrent-log-handler's Windows lock timeout.
+
+    On Windows Desktop, slash-command workers and the gateway can all write to
+    the same rotating log files. ``concurrent-log-handler`` serializes rollover
+    with a cross-process lock, but when another process holds that lock too
+    long it raises this RuntimeError. Logging failures should not escape into
+    Desktop chat output.
+    """
+    return (
+        sys.platform == "win32"
+        and isinstance(exc, RuntimeError)
+        and _CONCURRENT_LOG_LOCK_TIMEOUT in str(exc)
+    )
+
+
 # Third-party loggers that are noisy at DEBUG/INFO level.
 _NOISY_LOGGERS = (
     "openai",
@@ -492,7 +512,19 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         # so the syscall is sub-microsecond on a hot file.
         if self.stream is not None or os.path.exists(self.baseFilename):
             self._reopen_if_externally_rotated()
-        super().emit(record)
+        try:
+            super().emit(record)
+        except RuntimeError as exc:
+            if _is_windows_concurrent_log_lock_timeout(exc):
+                return
+            raise
+
+    def handleError(self, record: logging.LogRecord) -> None:
+        """Suppress known Windows CLH lock timeouts instead of printing tracebacks."""
+        exc = sys.exc_info()[1]
+        if _is_windows_concurrent_log_lock_timeout(exc):
+            return
+        super().handleError(record)
 
     def _open(self):
         stream = super()._open()
@@ -500,7 +532,13 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         return stream
 
     def doRollover(self):
-        super().doRollover()
+        try:
+            super().doRollover()
+        except RuntimeError as exc:
+            if _is_windows_concurrent_log_lock_timeout(exc):
+                self._record_stream_stat()
+                return
+            raise
         self._chmod_if_managed()
         # Our own rollover writes a new baseFilename; refresh the snapshot
         # so the next emit doesn't mistake it for external rotation.

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -818,6 +818,79 @@ class TestAddRotatingHandler:
                 h.close()
 
 
+class TestWindowsConcurrentLogLockTimeout:
+    """Windows concurrent-log-handler lock timeouts stay inside logging."""
+
+    def _make_logger_and_handler(self, log_path: Path):
+        logger = logging.getLogger(f"_test_concurrent_lock_timeout_{log_path.stem}")
+        logger.handlers.clear()
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+
+        handler = hermes_logging._ManagedRotatingFileHandler(
+            str(log_path), maxBytes=1, backupCount=1, encoding="utf-8",
+        )
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+        return logger, handler
+
+    def test_helper_only_matches_windows_concurrent_lock_timeout(self):
+        with patch.object(hermes_logging.sys, "platform", "win32"):
+            assert hermes_logging._is_windows_concurrent_log_lock_timeout(
+                RuntimeError("Cannot acquire lock after 20 attempts")
+            )
+            assert not hermes_logging._is_windows_concurrent_log_lock_timeout(
+                RuntimeError("some other logging failure")
+            )
+
+        with patch.object(hermes_logging.sys, "platform", "linux"):
+            assert not hermes_logging._is_windows_concurrent_log_lock_timeout(
+                RuntimeError("Cannot acquire lock after 20 attempts")
+            )
+
+    def test_lock_timeout_during_emit_is_suppressed(self, tmp_path, capsys):
+        logger, handler = self._make_logger_and_handler(tmp_path / "agent.log")
+        try:
+            with (
+                patch.object(hermes_logging.sys, "platform", "win32"),
+                patch.object(
+                    handler,
+                    "doRollover",
+                    side_effect=RuntimeError("Cannot acquire lock after 20 attempts"),
+                ),
+            ):
+                logger.info("force rollover")
+
+            captured = capsys.readouterr()
+            assert "Cannot acquire lock after 20 attempts" not in captured.err
+            assert "--- Logging error ---" not in captured.err
+        finally:
+            logger.removeHandler(handler)
+            handler.close()
+
+    def test_other_runtime_errors_during_emit_still_use_normal_logging_error(
+        self, tmp_path, capsys,
+    ):
+        logger, handler = self._make_logger_and_handler(tmp_path / "agent.log")
+        try:
+            with (
+                patch.object(hermes_logging.sys, "platform", "win32"),
+                patch.object(
+                    handler,
+                    "doRollover",
+                    side_effect=RuntimeError("unexpected rollover failure"),
+                ),
+            ):
+                logger.info("force rollover")
+
+            captured = capsys.readouterr()
+            assert "unexpected rollover failure" in captured.err
+            assert "--- Logging error ---" in captured.err
+        finally:
+            logger.removeHandler(handler)
+            handler.close()
+
+
 class TestReadLoggingConfig:
     """_read_logging_config() reads from config.yaml."""
 


### PR DESCRIPTION
## What does this PR do?

Suppresses the specific Windows `concurrent-log-handler` rollover failure that prints `RuntimeError: Cannot acquire lock after 20 attempts` into Desktop/slash-command output when another Hermes process holds the rotating log lock too long.

This keeps that known logging backend failure inside logging instead of surfacing a traceback to the user. Other logging failures still use the normal Python logging error path.

## Related Issue

Refs #27649

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added a narrow Windows-only detector for `concurrent-log-handler` lock-timeout RuntimeErrors.
- Suppressed that known timeout from `_ManagedRotatingFileHandler.emit()`, `handleError()`, and direct `doRollover()` paths.
- Added regression tests that pin the support symptom: the known timeout is silent, while unrelated rollover failures still produce normal logging error output.

## How to Test

1. `scripts/run_tests.sh -j 1 tests/test_hermes_logging.py -q --tb=short`

Result: `65 passed`.

Native Windows Desktop reproduction was not run in this WSL checkout.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / focused unit test only

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Support report symptom:

`RuntimeError: Cannot acquire lock after 20 attempts`

Local focused test:

`65 passed`