### PR TITLE
fix(tests): use platform-safe timeout method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,12 +300,13 @@ markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
     "real_concurrent_gate: opt out of the autouse stub that disables _detect_concurrent_hermes_instances",
 ]
-# pytest-timeout: per-test 30s hard cap with signal method.
+# pytest-timeout: per-test 30s hard cap.
 # This is the fallback inside each per-file pytest subprocess (see
 # scripts/run_tests_parallel.py). Per-file isolation gives every test
 # file a fresh Python interpreter; pytest-timeout catches Python-level
-# hangs within a file.
-addopts = "-m 'not integration' --timeout=30 --timeout-method=signal"
+# hangs within a file. Leave the timeout method unset so pytest-timeout can
+# choose a platform-safe default (signal on POSIX, thread on Windows).
+addopts = "-m 'not integration' --timeout=30"
 
 [tool.ty.environment]
 python-version = "3.13"


### PR DESCRIPTION
## Problem

The pytest config forces `pytest-timeout` to use `--timeout-method=signal`. That method is POSIX-specific and is not available on Windows, so Windows contributors cannot run the test suite with the repository's default pytest config.

## Before / after

Before, running pytest on Windows with the configured timeout plugin failed because the `signal` timeout method is not supported.

After, the config keeps the same `--timeout=30` per-test cap but leaves the timeout method unset, allowing `pytest-timeout` to choose its platform-safe default (`signal` on POSIX, `thread` on Windows).

## Verification

Ran locally on Windows:

```bash
uv run --extra dev pytest tests\test_base_url_hostname.py -q
```

Result: `25 passed`.

Also ran:

```bash
git diff --check origin/main...HEAD
```