### PR TITLE
feat: port HQ desktop and clarify improvements

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1984,6 +1984,10 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     question=next_args.get("question", ""),
                     choices=next_args.get("choices"),
                     callback=agent.clarify_callback,
+                    multi_select=bool(next_args.get("multi_select", False)),
+                    min_selections=next_args.get("min_selections", 0),
+                    max_selections=next_args.get("max_selections"),
+                    allow_other=bool(next_args.get("allow_other", True)),
                 ),
                 next_args,
             )

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -363,6 +363,10 @@ const DESKTOP_WINDOW_STATE_PATH = path.join(app.getPath('userData'), 'window-sta
 // ~/.hermes/active_profile file. Unset (null) preserves the legacy behavior:
 // no --profile flag, so the backend honors active_profile / default.
 const DESKTOP_PROFILE_CONFIG_PATH = path.join(app.getPath('userData'), 'active-profile.json')
+// File-backed session pins bridge. The renderer still owns the visible sidebar
+// state/localStorage, but external automation can update this JSON file and the
+// running Desktop process will push the new ids into the renderer immediately.
+const DESKTOP_PINNED_SESSIONS_PATH = path.join(app.getPath('userData'), 'pinned-sessions.json')
 // Mirrors hermes_cli.profiles._PROFILE_ID_RE so we never hand the backend a
 // value its profile resolver would reject and exit on.
 const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
@@ -4712,6 +4716,76 @@ function writeActiveDesktopProfile(name) {
   return value || null
 }
 
+function sanitizePinnedSessionIds(value) {
+  const rawIds = Array.isArray(value)
+    ? value
+    : Array.isArray(value?.ids)
+      ? value.ids
+      : []
+  const seen = new Set()
+  const ids = []
+
+  for (const item of rawIds) {
+    const id = typeof item === 'string' ? item.trim() : ''
+
+    if (id && !seen.has(id)) {
+      seen.add(id)
+      ids.push(id)
+    }
+  }
+
+  return ids
+}
+
+function readDesktopPinnedSessions() {
+  try {
+    const raw = fs.readFileSync(DESKTOP_PINNED_SESSIONS_PATH, 'utf8')
+    return { exists: true, ids: sanitizePinnedSessionIds(JSON.parse(raw)), path: DESKTOP_PINNED_SESSIONS_PATH }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      rememberLog(`[pins] failed to read ${DESKTOP_PINNED_SESSIONS_PATH}: ${error?.message || error}`)
+    }
+
+    return { exists: false, ids: [], path: DESKTOP_PINNED_SESSIONS_PATH }
+  }
+}
+
+function writeDesktopPinnedSessions(ids) {
+  const nextIds = sanitizePinnedSessionIds(ids)
+
+  fs.mkdirSync(path.dirname(DESKTOP_PINNED_SESSIONS_PATH), { recursive: true })
+  writeFileAtomic(
+    DESKTOP_PINNED_SESSIONS_PATH,
+    JSON.stringify({ ids: nextIds, updated_at: new Date().toISOString(), source: 'desktop' }, null, 2)
+  )
+
+  return { exists: true, ids: nextIds, path: DESKTOP_PINNED_SESSIONS_PATH }
+}
+
+function broadcastPinnedSessionsChanged() {
+  const payload = readDesktopPinnedSessions()
+
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) {
+      window.webContents.send('hermes:pinnedSessions:changed', payload)
+    }
+  }
+}
+
+let pinnedSessionsWatcherStarted = false
+
+function ensurePinnedSessionsWatcher() {
+  if (pinnedSessionsWatcherStarted) return
+
+  pinnedSessionsWatcherStarted = true
+  fs.mkdirSync(path.dirname(DESKTOP_PINNED_SESSIONS_PATH), { recursive: true })
+  fs.watchFile(DESKTOP_PINNED_SESSIONS_PATH, { interval: 750 }, (curr, prev) => {
+    if (curr.mtimeMs !== prev.mtimeMs || curr.size !== prev.size) {
+      broadcastPinnedSessionsChanged()
+    }
+  })
+}
+
 // Sanitize a connection config into the renderer-facing shape. With no
 // `profile` this describes the global/default connection (the existing
 // behavior); with a `profile` it describes that profile's per-profile remote
@@ -6271,6 +6345,16 @@ ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
 })
 
 ipcMain.handle('hermes:profile:get', async () => ({ profile: readActiveDesktopProfile() }))
+ipcMain.handle('hermes:pinnedSessions:get', async () => {
+  ensurePinnedSessionsWatcher()
+  return readDesktopPinnedSessions()
+})
+ipcMain.handle('hermes:pinnedSessions:set', async (_event, ids) => {
+  ensurePinnedSessionsWatcher()
+  const result = writeDesktopPinnedSessions(ids)
+  broadcastPinnedSessionsChanged()
+  return result
+})
 ipcMain.handle('hermes:profile:set', async (_event, name) => {
   const next = writeActiveDesktopProfile(name)
 

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -45,6 +45,15 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     get: () => ipcRenderer.invoke('hermes:profile:get'),
     set: name => ipcRenderer.invoke('hermes:profile:set', name)
   },
+  pinnedSessions: {
+    get: () => ipcRenderer.invoke('hermes:pinnedSessions:get'),
+    set: ids => ipcRenderer.invoke('hermes:pinnedSessions:set', ids),
+    onChanged: callback => {
+      const listener = (_event, payload) => callback(payload)
+      ipcRenderer.on('hermes:pinnedSessions:changed', listener)
+      return () => ipcRenderer.removeListener('hermes:pinnedSessions:changed', listener)
+    }
+  },
   api: request => ipcRenderer.invoke('hermes:api', request),
   notify: payload => ipcRenderer.invoke('hermes:notify', payload),
   requestMicrophoneAccess: () => ipcRenderer.invoke('hermes:requestMicrophoneAccess'),

--- a/apps/desktop/electron/update-relaunch.cjs
+++ b/apps/desktop/electron/update-relaunch.cjs
@@ -46,6 +46,10 @@ function unpackedDirName(platform) {
   return 'linux-unpacked'
 }
 
+function pathForPlatform(platform) {
+  return platform === 'win32' ? path.win32 : path.posix
+}
+
 /**
  * If `execPath` lives under `<updateRoot>/apps/desktop/release/<plat>-unpacked`,
  * return that unpacked dir; otherwise null. A null result means the running
@@ -57,12 +61,16 @@ function unpackedDirName(platform) {
  */
 function resolveUnpackedRelease(execPath, updateRoot, platform) {
   if (!execPath || !updateRoot) return null
-  const releaseDir = path.join(updateRoot, 'apps', 'desktop', 'release')
-  const unpacked = path.join(releaseDir, unpackedDirName(platform))
-  const normalizedExec = path.resolve(String(execPath))
+  const pathMod = pathForPlatform(platform)
+  const releaseDir = pathMod.join(updateRoot, 'apps', 'desktop', 'release')
+  const unpacked = pathMod.resolve(pathMod.join(releaseDir, unpackedDirName(platform)))
+  const normalizedExec = pathMod.resolve(String(execPath))
   // execPath must be the unpacked dir itself or a descendant of it.
-  const withSep = unpacked.endsWith(path.sep) ? unpacked : unpacked + path.sep
-  if (normalizedExec === unpacked || normalizedExec.startsWith(withSep)) {
+  const withSep = unpacked.endsWith(pathMod.sep) ? unpacked : unpacked + pathMod.sep
+  const comparableExec = platform === 'win32' ? normalizedExec.toLowerCase() : normalizedExec
+  const comparableUnpacked = platform === 'win32' ? unpacked.toLowerCase() : unpacked
+  const comparableWithSep = platform === 'win32' ? withSep.toLowerCase() : withSep
+  if (comparableExec === comparableUnpacked || comparableExec.startsWith(comparableWithSep)) {
     return unpacked
   }
   return null

--- a/apps/desktop/electron/update-relaunch.test.cjs
+++ b/apps/desktop/electron/update-relaunch.test.cjs
@@ -37,7 +37,7 @@ const {
 } = require('./update-relaunch.cjs')
 
 const ROOT = '/home/u/.hermes/hermes-agent'
-const UNPACKED = path.join(ROOT, 'apps', 'desktop', 'release', 'linux-unpacked')
+const UNPACKED = path.posix.join(ROOT, 'apps', 'desktop', 'release', 'linux-unpacked')
 
 // ---------------------------------------------------------------------------
 // 1) The execPath split — the heart of the GUI/backend skew guard.
@@ -49,7 +49,7 @@ test('unpackedDirName maps platform to the electron-builder dir', () => {
 })
 
 test('resolveUnpackedRelease returns the dir for a binary UNDER release/<plat>-unpacked', () => {
-  const exec = path.join(UNPACKED, 'hermes')
+  const exec = path.posix.join(UNPACKED, 'hermes')
   assert.equal(resolveUnpackedRelease(exec, ROOT, 'linux'), UNPACKED)
   // The unpacked dir itself also counts.
   assert.equal(resolveUnpackedRelease(UNPACKED, ROOT, 'linux'), UNPACKED)
@@ -68,12 +68,12 @@ test('resolveUnpackedRelease is null for AppImage / .deb / .rpm / dev / unresolv
   )
   // empty / missing
   assert.equal(resolveUnpackedRelease('', ROOT, 'linux'), null)
-  assert.equal(resolveUnpackedRelease(path.join(UNPACKED, 'hermes'), '', 'linux'), null)
+  assert.equal(resolveUnpackedRelease(path.posix.join(UNPACKED, 'hermes'), '', 'linux'), null)
 })
 
 test('resolveUnpackedRelease is not fooled by a sibling prefix dir', () => {
   // `.../release/linux-unpacked-evil` must NOT match `.../release/linux-unpacked`.
-  const sneaky = path.join(ROOT, 'apps', 'desktop', 'release', 'linux-unpacked-evil', 'hermes')
+  const sneaky = path.posix.join(ROOT, 'apps', 'desktop', 'release', 'linux-unpacked-evil', 'hermes')
   assert.equal(resolveUnpackedRelease(sneaky, ROOT, 'linux'), null)
 })
 

--- a/apps/desktop/electron/windows-child-process.test.cjs
+++ b/apps/desktop/electron/windows-child-process.test.cjs
@@ -84,5 +84,5 @@ test('bootstrap PowerShell runner hides Windows console children', () => {
   const source = readElectronFile('bootstrap-runner.cjs')
 
   assert.match(source, /function hiddenWindowsChildOptions\(options = \{\}\)/)
-  requireHiddenChildOptions(source, 'spawn(ps, fullArgs')
+  requireHiddenChildOptions(source, /spawn\(\s*ps,\s*fullArgs/)
 })

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -110,7 +110,8 @@ import {
   $sessionsTotal,
   $workingSessionIds,
   sessionPinId,
-  setCurrentCwd
+  setCurrentCwd,
+  sortSessionsByNumber
 } from '@/store/session'
 
 import { type AppView, ARTIFACTS_ROUTE, MESSAGING_ROUTE, SKILLS_ROUTE } from '../../routes'
@@ -476,13 +477,9 @@ export function ChatSidebar({
     [sessions, showAllProfiles, profileScope]
   )
 
-  // Agent session order is pinned to creation time (started_at), NOT activity —
-  // a new message must never float a session to the top. Position only changes
-  // for a brand-new session or an explicit manual drag (agentOrderIds).
-  const sortedSessions = useMemo(
-    () => [...visibleSessions].sort((a, b) => (b.started_at || 0) - (a.started_at || 0)),
-    [visibleSessions]
-  )
+  // Keep #number-prefixed HQ sessions in stable numeric order. Unnumbered
+  // sessions retain the shared recency fallback used by other session pickers.
+  const sortedSessions = useMemo(() => sortSessionsByNumber(visibleSessions), [visibleSessions])
 
   const workingSessionIdSet = useMemo(() => new Set(workingSessionIds), [workingSessionIds])
 

--- a/apps/desktop/src/app/command-center/index.tsx
+++ b/apps/desktop/src/app/command-center/index.tsx
@@ -14,7 +14,7 @@ import { exportSession } from '@/lib/session-export'
 import { cn } from '@/lib/utils'
 import { upsertDesktopActionTask } from '@/store/activity'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
-import { $sessions, sessionPinId } from '@/store/session'
+import { $sessions, sessionPinId, sortSessionsByNumber } from '@/store/session'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { useRouteEnumParam } from '../hooks/use-route-enum-param'
@@ -128,12 +128,7 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
   const debouncedQuery = useDebouncedValue(query.trim(), 180)
 
   const filteredSessions = useMemo(() => {
-    const sorted = [...sessions].sort((a, b) => {
-      const left = a.last_active || a.started_at || 0
-      const right = b.last_active || b.started_at || 0
-
-      return right - left
-    })
+    const sorted = sortSessionsByNumber(sessions)
 
     const needle = debouncedQuery.toLowerCase()
 

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -53,6 +53,7 @@ import {
 import { $bindings } from '@/store/keybinds'
 import { openPetGenerate } from '@/store/pet-generate'
 import { requestStartWorkSession } from '@/store/projects'
+import { sortSessionsByNumber } from '@/store/session'
 import { runGatewayRestart } from '@/store/system-actions'
 import { luminance } from '@/themes/color'
 import { type ThemeMode, useTheme } from '@/themes/context'
@@ -256,8 +257,15 @@ export function CommandPalette() {
       : []
   }, [configQuery.data])
 
-  const sessions = useMemo(() => (sessionsQuery.data?.sessions ?? []).map(toSessionEntry), [sessionsQuery.data])
-  const archivedSessions = useMemo(() => (archivedQuery.data?.sessions ?? []).map(toSessionEntry), [archivedQuery.data])
+  const sessions = useMemo(
+    () => sortSessionsByNumber(sessionsQuery.data?.sessions ?? []).map(toSessionEntry),
+    [sessionsQuery.data]
+  )
+
+  const archivedSessions = useMemo(
+    () => sortSessionsByNumber(archivedQuery.data?.sessions ?? []).map(toSessionEntry),
+    [archivedQuery.data]
+  )
 
   // Reset the query/sub-page on close so it reopens clean.
   useEffect(() => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -1047,13 +1047,18 @@ export function useMessageStream({
         // over; the inline ClarifyTool reads the active session's entry.
         const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
         const question = typeof payload?.question === 'string' ? payload.question : ''
+        const clarifyPayload = payload as Record<string, unknown> | undefined
 
         if (requestId && question) {
           setClarifyRequest({
             requestId,
             question,
-            choices: Array.isArray(payload?.choices) ? payload!.choices!.filter(c => typeof c === 'string') : null,
-            sessionId: sessionId ?? null
+            choices: Array.isArray(payload?.choices) ? payload!.choices!.filter((c): c is string => typeof c === 'string') : null,
+            sessionId: sessionId ?? null,
+            multiSelect: clarifyPayload?.multi_select === true || clarifyPayload?.multiSelect === true,
+            minSelections: typeof clarifyPayload?.min_selections === 'number' ? clarifyPayload.min_selections : null,
+            maxSelections: typeof clarifyPayload?.max_selections === 'number' ? clarifyPayload.max_selections : null,
+            allowOther: clarifyPayload?.allow_other !== false
           })
 
           // The transcript only renders the active session, so a background

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { textPart } from '@/lib/chat-messages'
 import { $composerAttachments, type ComposerAttachment } from '@/store/composer'
+import { $notifications, clearNotifications } from '@/store/notifications'
 import { $busy, $connection, $messages, $sessions, setSessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
@@ -341,6 +342,7 @@ describe('usePromptActions desktop slash pickers', () => {
 describe('usePromptActions submit / queue drain semantics', () => {
   afterEach(() => {
     cleanup()
+    clearNotifications()
     vi.restoreAllMocks()
   })
 
@@ -471,6 +473,39 @@ describe('usePromptActions submit / queue drain semantics', () => {
     expect(seeds.some(s => Array.isArray(s.messages) && (s.messages as { error?: string }[]).some(m => m.error))).toBe(
       false
     )
+  })
+
+  it('explains prompt.submit ACK timeouts without encouraging duplicate retries', async () => {
+    const states: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        throw new Error('request timed out: prompt.submit')
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => states.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    expect(await handle!.submitText('will it send twice?')).toBe(false)
+
+    const lastState = states.at(-1) as { messages?: { error?: string }[] }
+    const assistantError = lastState.messages?.find(m => m.error)?.error ?? ''
+    const notification = $notifications.get()[0]
+
+    expect(assistantError).toContain('backend may still process it')
+    expect(assistantError).toContain('avoid sending it twice')
+    expect(notification?.message).toContain('backend may still process it')
+    expect(notification?.message).toContain('avoid sending it twice')
   })
 
   it('a normal (non-queue) submit still respects the busyRef guard', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -119,6 +119,20 @@ function inlineErrorMessage(error: unknown, fallback: string): string {
   return (raw.match(/Error invoking remote method '[^']+': Error: (.+)$/)?.[1] ?? raw).replace(/^Error:\s*/, '').trim()
 }
 
+function isPromptSubmitTimeoutError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return /request timed out:\s*prompt\.submit/i.test(message)
+}
+
+function submitErrorMessage(error: unknown, copy: Translations['desktop']): string {
+  if (isPromptSubmitTimeoutError(error)) {
+    return copy.promptSubmitTimedOut
+  }
+
+  return inlineErrorMessage(error, copy.promptFailed)
+}
+
 function isSessionNotFoundError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error)
 
@@ -818,7 +832,7 @@ export function usePromptActions({
           return false
         }
 
-        const message = inlineErrorMessage(err, copy.promptFailed)
+        const message = submitErrorMessage(err, copy)
 
         updateSessionState(sessionId, state => ({
           ...state,
@@ -840,6 +854,12 @@ export function usePromptActions({
 
         if (isProviderSetupError(err)) {
           requestDesktopOnboarding(copy.providerCredentialRequired)
+
+          return false
+        }
+
+        if (isPromptSubmitTimeoutError(err)) {
+          notify({ kind: 'error', title: copy.promptFailed, message })
 
           return false
         }

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -11,13 +11,28 @@ vi.mock('@/lib/haptics', () => ({
   triggerHaptic: vi.fn()
 }))
 
-function renderClarifyTool(requestMock = vi.fn().mockResolvedValue({ ok: true })) {
+type TestClarifyArgs = {
+  allowOther?: boolean
+  choices: string[]
+  maxSelections?: number | null
+  minSelections?: number | null
+  multiSelect?: boolean
+  question: string
+}
+
+function renderClarifyTool(requestMock = vi.fn().mockResolvedValue({ ok: true }), argsOverride: Partial<TestClarifyArgs> = {}) {
+  const args: TestClarifyArgs = {
+    question: 'Which context should Hermes use?',
+    choices: ['Past sessions', 'Local reports', 'Web sources'],
+    ...argsOverride
+  }
   $clarifyRequests.set({})
   $gateway.set({ request: requestMock } as never)
   setClarifyRequest({
     requestId: 'req-1',
     question: 'Which context should Hermes use?',
     choices: ['Past sessions', 'Local reports', 'Web sources'],
+    multiSelect: Boolean(args.multiSelect),
     sessionId: null
   })
 
@@ -25,10 +40,7 @@ function renderClarifyTool(requestMock = vi.fn().mockResolvedValue({ ok: true })
     type: 'tool-call',
     toolCallId: 'tool-1',
     toolName: 'clarify',
-    args: {
-      question: 'Which context should Hermes use?',
-      choices: ['Past sessions', 'Local reports', 'Web sources']
-    },
+    args,
     argsText: '',
     result: undefined,
     status: { type: 'running' },
@@ -85,8 +97,15 @@ describe('ClarifyTool selection status UX', () => {
     expect(status.textContent).toContain('Past sessions')
   })
 
-  it('uses the right-side circle to stage multiple choices without submitting until Send selected', async () => {
-    const request = renderClarifyTool()
+  it('does not expose staged multi-select controls for single-choice prompts', () => {
+    renderClarifyTool()
+
+    expect(screen.queryByRole('button', { name: 'Toggle Past sessions for multi-select' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Send selected' })).toBeNull()
+  })
+
+  it('uses multi-select rows to stage multiple choices without submitting until Send selected', async () => {
+    const request = renderClarifyTool(vi.fn().mockResolvedValue({ ok: true }), { multiSelect: true })
 
     fireEvent.click(screen.getByRole('button', { name: 'Toggle Past sessions for multi-select' }))
     fireEvent.click(screen.getByRole('button', { name: 'Toggle Web sources for multi-select' }))

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -1,0 +1,122 @@
+import { type ToolCallMessagePartProps } from '@assistant-ui/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ClarifyTool } from '@/components/assistant-ui/clarify-tool'
+import { I18nProvider } from '@/i18n'
+import { $clarifyRequests, setClarifyRequest } from '@/store/clarify'
+import { $gateway } from '@/store/gateway'
+
+vi.mock('@/lib/haptics', () => ({
+  triggerHaptic: vi.fn()
+}))
+
+function renderClarifyTool(requestMock = vi.fn().mockResolvedValue({ ok: true })) {
+  $clarifyRequests.set({})
+  $gateway.set({ request: requestMock } as never)
+  setClarifyRequest({
+    requestId: 'req-1',
+    question: 'Which context should Hermes use?',
+    choices: ['Past sessions', 'Local reports', 'Web sources'],
+    sessionId: null
+  })
+
+  const props: ToolCallMessagePartProps = {
+    type: 'tool-call',
+    toolCallId: 'tool-1',
+    toolName: 'clarify',
+    args: {
+      question: 'Which context should Hermes use?',
+      choices: ['Past sessions', 'Local reports', 'Web sources']
+    },
+    argsText: '',
+    result: undefined,
+    status: { type: 'running' },
+    addResult: vi.fn(),
+    resume: vi.fn()
+  }
+
+  render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <ClarifyTool {...props} />
+    </I18nProvider>
+  )
+
+  return requestMock
+}
+
+describe('ClarifyTool selection status UX', () => {
+  beforeEach(() => {
+    $clarifyRequests.set({})
+    $gateway.set(null)
+  })
+
+  afterEach(() => {
+    cleanup()
+    $clarifyRequests.set({})
+    $gateway.set(null)
+    vi.restoreAllMocks()
+  })
+
+  it('keeps regular choice clicks as immediate single-choice submit', async () => {
+    const request = renderClarifyTool()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Past sessions' }))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        request_id: 'req-1',
+        answer: 'Past sessions'
+      })
+    )
+  })
+
+  it('shows the selected single choice while the response is pending', () => {
+    const request = renderClarifyTool(vi.fn(() => new Promise(() => {})))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Past sessions' }))
+
+    expect(request).toHaveBeenCalledWith('clarify.respond', {
+      request_id: 'req-1',
+      answer: 'Past sessions'
+    })
+    const status = screen.getByRole('status')
+    expect(status.textContent).toContain('Selected')
+    expect(status.textContent).toContain('Past sessions')
+  })
+
+  it('uses the right-side circle to stage multiple choices without submitting until Send selected', async () => {
+    const request = renderClarifyTool()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle Past sessions for multi-select' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle Web sources for multi-select' }))
+
+    expect(request).not.toHaveBeenCalled()
+    expect(screen.getByText('2 selected')).toBeTruthy()
+    expect(screen.getByText('Selected')).toBeTruthy()
+    expect(screen.getByText('Past sessions, Web sources')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send selected' }))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        request_id: 'req-1',
+        answer: 'Past sessions, Web sources'
+      })
+    )
+  })
+
+  it('shows the current free-form draft as a custom selection', () => {
+    renderClarifyTool()
+
+    const other = screen.getByRole('textbox', { name: 'Other (type your answer)' })
+
+    fireEvent.focus(other)
+    fireEvent.change(other, {
+      target: { value: 'Use only local reports' }
+    })
+
+    expect(screen.getByText('Selected')).toBeTruthy()
+    expect(screen.getByText('Other (type your answer): Use only local reports')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -227,7 +227,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   const selectedSummary = selectedChoices.join(', ')
   const customSummary = trimmedDraft ? `${copy.other}: ${trimmedDraft}` : ''
   const selectionSummary = selectedSummary || selectedChoice || customSummary
-  const canSubmitSelected = selectedChoices.length > 0 && selectedChoices.length >= minSelections
+  const canSubmitSelected = multiSelect && selectedChoices.length > 0 && selectedChoices.length >= minSelections
 
   const selectChoice = useCallback(
     (choice: string) => {
@@ -241,11 +241,14 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
 
   const toggleMultiChoice = useCallback(
     (choice: string) => {
+      if (!multiSelect) {
+        return
+      }
       setDraft('')
       setSelectedChoice(null)
       setSelectedChoices(current => toggleChoice(current, choice, maxSelections))
     },
-    [maxSelections]
+    [maxSelections, multiSelect]
   )
 
   const submitSelected = useCallback(() => {
@@ -349,36 +352,22 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
             }
 
             return (
-              <div className="flex items-start gap-1" key={`${index}-${choice}`}>
-                <button
-                  aria-label={choice}
-                  className={cn(
-                    OPTION_ROW_CLASS,
-                    'flex-1 text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-(--ui-text-primary)',
-                    selectedChoice === choice && 'text-(--ui-text-primary)'
-                  )}
-                  data-choice
-                  disabled={submitting}
-                  onClick={() => selectChoice(choice)}
-                  type="button"
-                >
-                  <KeyBadge char={letterFor(index)} selected={selectedChoice === choice} />
-                  <span className="flex-1 wrap-anywhere">{choice}</span>
-                </button>
-                <button
-                  aria-label={`Toggle ${choice} for multi-select`}
-                  aria-pressed={staged}
-                  className={cn(
-                    'grid size-7 shrink-0 place-items-center rounded-[0.25rem] text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-(--ui-text-primary) disabled:cursor-not-allowed disabled:opacity-50',
-                    staged && 'text-primary'
-                  )}
-                  disabled={submitting}
-                  onClick={() => toggleMultiChoice(choice)}
-                  type="button"
-                >
-                  <SelectToggle selected={staged} />
-                </button>
-              </div>
+              <button
+                aria-label={choice}
+                className={cn(
+                  OPTION_ROW_CLASS,
+                  'text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-(--ui-text-primary)',
+                  selectedChoice === choice && 'text-(--ui-text-primary)'
+                )}
+                data-choice
+                disabled={submitting}
+                key={`${index}-${choice}`}
+                onClick={() => selectChoice(choice)}
+                type="button"
+              >
+                <KeyBadge char={letterFor(index)} selected={selectedChoice === choice} />
+                <span className="flex-1 wrap-anywhere">{choice}</span>
+              </button>
             )
           })}
           {allowOther && (
@@ -425,7 +414,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
         <Button disabled={submitting} onClick={() => void respond('')} size="xs" type="button" variant="text">
           {copy.skip}
         </Button>
-        {hasChoices && selectedChoices.length > 0 ? (
+        {multiSelect && selectedChoices.length > 0 ? (
           <Button disabled={submitting || !canSubmitSelected} onClick={submitSelected} size="xs" type="button">
             {submitting ? <Loader2 className="size-3" /> : 'Send selected'}
           </Button>

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -1,17 +1,8 @@
 'use client'
 
-import { type ToolCallMessagePartProps, useAuiState } from '@assistant-ui/react'
+import { type ToolCallMessagePartProps } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
-import {
-  type ComponentProps,
-  type FormEvent,
-  type KeyboardEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState
-} from 'react'
+import { type ComponentProps, type FormEvent, type KeyboardEvent, useCallback, useMemo, useRef, useState } from 'react'
 
 import { ToolFallback } from '@/components/assistant-ui/tool-fallback'
 import { Button } from '@/components/ui/button'
@@ -19,17 +10,31 @@ import { Kbd } from '@/components/ui/kbd'
 import { Textarea } from '@/components/ui/textarea'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
-import { Loader2, MessageQuestion } from '@/lib/icons'
+import { Check, Loader2, MessageQuestion } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { $clarifyRequest, clearClarifyRequest } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
 
-import { selectMessageRunning } from './tool-fallback-model'
-
 interface ClarifyArgs {
-  question?: string
+  allowOther?: boolean
   choices?: string[] | null
+  maxSelections?: number | null
+  minSelections?: number | null
+  multiSelect?: boolean
+  question?: string
+}
+
+function readNumber(row: Record<string, unknown>, camel: string, snake: string): number | null | undefined {
+  const value = row[camel] ?? row[snake]
+
+  return typeof value === 'number' ? value : value === null ? null : undefined
+}
+
+function readBoolean(row: Record<string, unknown>, camel: string, snake: string): boolean | undefined {
+  const value = row[camel] ?? row[snake]
+
+  return typeof value === 'boolean' ? value : undefined
 }
 
 function readClarifyArgs(args: unknown): ClarifyArgs {
@@ -41,8 +46,12 @@ function readClarifyArgs(args: unknown): ClarifyArgs {
   const choices = Array.isArray(row.choices) ? row.choices.filter((c): c is string => typeof c === 'string') : null
 
   return {
-    question: typeof row.question === 'string' ? row.question : undefined,
-    choices: choices && choices.length > 0 ? choices : null
+    allowOther: readBoolean(row, 'allowOther', 'allow_other'),
+    choices: choices && choices.length > 0 ? choices : null,
+    maxSelections: readNumber(row, 'maxSelections', 'max_selections'),
+    minSelections: readNumber(row, 'minSelections', 'min_selections'),
+    multiSelect: readBoolean(row, 'multiSelect', 'multi_select'),
+    question: typeof row.question === 'string' ? row.question : undefined
   }
 }
 
@@ -95,14 +104,38 @@ function KeyBadge({ char, preview, selected }: { char: string; preview?: boolean
   )
 }
 
-export const ClarifyTool = (props: ToolCallMessagePartProps) => {
-  const messageRunning = useAuiState(selectMessageRunning)
+function SelectToggle({ selected }: { selected: boolean }) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        'mt-px grid size-4 shrink-0 place-items-center rounded-full border transition-colors',
+        selected ? 'border-primary bg-primary text-white' : 'border-(--ui-stroke-secondary) text-transparent'
+      )}
+    >
+      {selected && <Check className="size-3" />}
+    </span>
+  )
+}
 
-  // Only the live, still-blocked turn shows the interactive panel. Once the
-  // message stops running — answered, the turn ended, or the user hit Stop —
-  // fall back to the standard tool block so the Q/A settles like every other
-  // row instead of stranding a dead prompt the gateway no longer waits on.
-  const isPending = messageRunning && props.result === undefined
+function toggleChoice(choices: string[], choice: string, maxSelections: number | null): string[] {
+  if (choices.includes(choice)) {
+    return choices.filter(item => item !== choice)
+  }
+
+  if (maxSelections !== null && choices.length >= maxSelections) {
+    return choices
+  }
+
+  return [...choices, choice]
+}
+
+export const ClarifyTool = (props: ToolCallMessagePartProps) => {
+  // The clarify request itself is the source of truth for interactivity. Using
+  // assistant-ui's messageRunning flag here can briefly flip false while the
+  // backend is still blocked on clarify.respond, which makes the selection block
+  // disappear even though the request is still live.
+  const isPending = props.result === undefined
 
   if (!isPending) {
     return <ToolFallback {...props} />
@@ -138,10 +171,15 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   )
 
   const hasChoices = choices.length > 0
+  const multiSelect = fromArgs.multiSelect ?? matchingRequest?.multiSelect ?? false
+  const allowOther = fromArgs.allowOther ?? matchingRequest?.allowOther ?? true
+  const minSelections = fromArgs.minSelections ?? matchingRequest?.minSelections ?? 0
+  const maxSelections = fromArgs.maxSelections ?? matchingRequest?.maxSelections ?? null
 
   const [draft, setDraft] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [selectedChoice, setSelectedChoice] = useState<string | null>(null)
+  const [selectedChoices, setSelectedChoices] = useState<string[]>([])
   const [otherFocused, setOtherFocused] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
 
@@ -186,28 +224,41 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   )
 
   const trimmedDraft = draft.trim()
-  // The answer is whichever input is active: a picked choice, or typed text.
-  // Picking a choice no longer fires immediately — it selects, then the user
-  // confirms with Continue (or Enter from the field).
-  const pendingAnswer = selectedChoice ?? (trimmedDraft || null)
+  const selectedSummary = selectedChoices.join(', ')
+  const customSummary = trimmedDraft ? `${copy.other}: ${trimmedDraft}` : ''
+  const selectionSummary = selectedSummary || selectedChoice || customSummary
+  const canSubmitSelected = selectedChoices.length > 0 && selectedChoices.length >= minSelections
 
-  const selectChoice = useCallback((choice: string) => {
-    // Picking a choice and typing are mutually exclusive answers.
-    setDraft('')
-    setSelectedChoice(choice)
-  }, [])
+  const selectChoice = useCallback(
+    (choice: string) => {
+      setDraft('')
+      setSelectedChoices([])
+      setSelectedChoice(choice)
+      void respond(choice)
+    },
+    [respond]
+  )
 
-  const submitAnswer = useCallback(() => {
-    if (selectedChoice !== null) {
-      void respond(selectedChoice)
+  const toggleMultiChoice = useCallback(
+    (choice: string) => {
+      setDraft('')
+      setSelectedChoice(null)
+      setSelectedChoices(current => toggleChoice(current, choice, maxSelections))
+    },
+    [maxSelections]
+  )
 
-      return
+  const submitSelected = useCallback(() => {
+    if (canSubmitSelected) {
+      void respond(selectedChoices.join(', '))
     }
+  }, [canSubmitSelected, respond, selectedChoices])
 
+  const submitDraft = useCallback(() => {
     if (trimmedDraft) {
       void respond(trimmedDraft)
     }
-  }, [respond, selectedChoice, trimmedDraft])
+  }, [respond, trimmedDraft])
 
   const handleTextareaKey = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -217,66 +268,19 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
 
       if (event.key === 'Enter' && !event.shiftKey) {
         event.preventDefault()
-        submitAnswer()
+        submitDraft()
       }
     },
-    [submitAnswer]
+    [submitDraft]
   )
 
-  const handleSubmit = useCallback(
+  const handleSubmitDraft = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault()
-      submitAnswer()
+      submitDraft()
     },
-    [submitAnswer]
+    [submitDraft]
   )
-
-  // Letter shortcuts: A/B/C… pick the matching option, the trailing letter jumps
-  // into "Other", and Enter confirms the current pick. Stands down whenever a
-  // field is focused (you're typing, not navigating) so it never eats keystrokes
-  // meant for the composer or the Other box.
-  useEffect(() => {
-    if (!ready || !hasChoices || submitting) {
-      return
-    }
-
-    const onKeyDown = (event: globalThis.KeyboardEvent) => {
-      if (event.metaKey || event.ctrlKey || event.altKey || event.defaultPrevented) {
-        return
-      }
-
-      const active = document.activeElement as HTMLElement | null
-
-      if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable)) {
-        return
-      }
-
-      const key = event.key.toLowerCase()
-
-      if (key.length === 1 && key >= 'a' && key <= 'z') {
-        const index = key.charCodeAt(0) - 97
-
-        if (index < choices.length) {
-          event.preventDefault()
-          selectChoice(choices[index])
-        } else if (index === choices.length) {
-          event.preventDefault()
-          textareaRef.current?.focus()
-        }
-
-        return
-      }
-
-      if (event.key === 'Enter' && pendingAnswer) {
-        event.preventDefault()
-        submitAnswer()
-      }
-    }
-
-    window.addEventListener('keydown', onKeyDown)
-
-    return () => window.removeEventListener('keydown', onKeyDown)
-  }, [choices, hasChoices, pendingAnswer, ready, selectChoice, submitAnswer, submitting])
 
   if (loading) {
     return (
@@ -289,10 +293,11 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   const onDraftChange = (value: string) => {
     setDraft(value)
 
-    // Typing is its own answer — drop any picked choice so the two inputs can't
-    // both look selected.
+    // Typing is its own answer — drop any picked/staged choice so the inputs
+    // can't both look selected.
     if (value.trim()) {
       setSelectedChoice(null)
+      setSelectedChoices([])
     }
   }
 
@@ -303,39 +308,91 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
         <MessageQuestion aria-hidden className="mt-px size-4 shrink-0 text-(--ui-text-tertiary)" />
       </div>
 
-      <form className="grid gap-2" onSubmit={handleSubmit}>
-        {hasChoices ? (
-          <div className="grid gap-px" role="group">
-            {choices.map((choice, index) => (
-              <button
-                className={cn(
-                  OPTION_ROW_CLASS,
-                  'text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-(--ui-text-primary)',
-                  selectedChoice === choice && 'text-(--ui-text-primary)'
-                )}
-                data-choice
-                disabled={submitting}
-                key={`${index}-${choice}`}
-                onClick={() => selectChoice(choice)}
-                type="button"
-              >
-                <KeyBadge char={letterFor(index)} selected={selectedChoice === choice} />
-                <span className="flex-1 wrap-anywhere">{choice}</span>
-              </button>
-            ))}
-            {/* "Other" is an inline content-sizing field, not a separate view. */}
+      {selectionSummary && (
+        <div className="rounded-[0.25rem] border border-primary/20 bg-primary/5 px-2 py-1 text-xs" role="status">
+          <div className="flex items-center justify-between gap-2">
+            <span className="font-medium text-primary">Selected</span>
+            {selectedChoices.length > 0 && (
+              <span className="text-(--ui-text-tertiary)">{selectedChoices.length} selected</span>
+            )}
+          </div>
+          <div className="mt-0.5 wrap-anywhere text-(--ui-text-secondary)">{selectionSummary}</div>
+        </div>
+      )}
+
+      {hasChoices && (
+        <div className="grid gap-px" role="group">
+          {choices.map((choice, index) => {
+            const staged = selectedChoices.includes(choice)
+
+            if (multiSelect) {
+              return (
+                <button
+                  aria-label={`Toggle ${choice} for multi-select`}
+                  aria-pressed={staged}
+                  className={cn(
+                    OPTION_ROW_CLASS,
+                    'text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-(--ui-text-primary)',
+                    staged && 'text-(--ui-text-primary)'
+                  )}
+                  data-choice
+                  disabled={submitting}
+                  key={`${index}-${choice}`}
+                  onClick={() => toggleMultiChoice(choice)}
+                  type="button"
+                >
+                  <KeyBadge char={letterFor(index)} selected={staged} />
+                  <span className="flex-1 wrap-anywhere">{choice}</span>
+                  <SelectToggle selected={staged} />
+                </button>
+              )
+            }
+
+            return (
+              <div className="flex items-start gap-1" key={`${index}-${choice}`}>
+                <button
+                  aria-label={choice}
+                  className={cn(
+                    OPTION_ROW_CLASS,
+                    'flex-1 text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-(--ui-text-primary)',
+                    selectedChoice === choice && 'text-(--ui-text-primary)'
+                  )}
+                  data-choice
+                  disabled={submitting}
+                  onClick={() => selectChoice(choice)}
+                  type="button"
+                >
+                  <KeyBadge char={letterFor(index)} selected={selectedChoice === choice} />
+                  <span className="flex-1 wrap-anywhere">{choice}</span>
+                </button>
+                <button
+                  aria-label={`Toggle ${choice} for multi-select`}
+                  aria-pressed={staged}
+                  className={cn(
+                    'grid size-7 shrink-0 place-items-center rounded-[0.25rem] text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-(--ui-text-primary) disabled:cursor-not-allowed disabled:opacity-50',
+                    staged && 'text-primary'
+                  )}
+                  disabled={submitting}
+                  onClick={() => toggleMultiChoice(choice)}
+                  type="button"
+                >
+                  <SelectToggle selected={staged} />
+                </button>
+              </div>
+            )
+          })}
+          {allowOther && (
             <label className={cn(OPTION_ROW_CLASS, 'focus-within:bg-(--chrome-action-hover)')}>
               <KeyBadge char={letterFor(choices.length)} preview={otherFocused} selected={Boolean(trimmedDraft)} />
               <textarea
+                aria-label={copy.other}
                 className={FREEFORM_INPUT_CLASS}
                 disabled={submitting}
                 onBlur={() => setOtherFocused(false)}
                 onChange={event => onDraftChange(event.target.value)}
-                // Focusing "Other" is a switch to typing your own answer, so it
-                // deselects any picked choice — a chosen option and an active
-                // Other field can never both look selected.
                 onFocus={() => {
                   setSelectedChoice(null)
+                  setSelectedChoices([])
                   setOtherFocused(true)
                 }}
                 onKeyDown={handleTextareaKey}
@@ -345,8 +402,12 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
                 value={draft}
               />
             </label>
-          </div>
-        ) : (
+          )}
+        </div>
+      )}
+
+      {!hasChoices && (
+        <form className="grid gap-2" onSubmit={handleSubmitDraft}>
           <Textarea
             className={FREEFORM_INPUT_CLASS}
             disabled={submitting}
@@ -357,13 +418,19 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
             rows={1}
             value={draft}
           />
-        )}
+        </form>
+      )}
 
-        <div className="flex items-center justify-end gap-1">
-          <Button disabled={submitting} onClick={() => void respond('')} size="xs" type="button" variant="text">
-            {copy.skip}
+      <div className="flex items-center justify-end gap-1">
+        <Button disabled={submitting} onClick={() => void respond('')} size="xs" type="button" variant="text">
+          {copy.skip}
+        </Button>
+        {hasChoices && selectedChoices.length > 0 ? (
+          <Button disabled={submitting || !canSubmitSelected} onClick={submitSelected} size="xs" type="button">
+            {submitting ? <Loader2 className="size-3" /> : 'Send selected'}
           </Button>
-          <Button disabled={submitting || !pendingAnswer} size="xs" type="submit">
+        ) : (
+          <Button disabled={submitting || !trimmedDraft} onClick={submitDraft} size="xs" type="button">
             {submitting ? (
               <Loader2 className="size-3 animate-spin" />
             ) : (
@@ -375,8 +442,8 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
               </>
             )}
           </Button>
-        </div>
-      </form>
+        )}
+      </div>
     </ClarifyShell>
   )
 }

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -62,6 +62,11 @@ declare global {
         // clear the preference.
         set: (name: string | null) => Promise<DesktopActiveProfile>
       }
+      pinnedSessions: {
+        get: () => Promise<DesktopPinnedSessions>
+        set: (ids: string[]) => Promise<DesktopPinnedSessions>
+        onChanged: (callback: (payload: DesktopPinnedSessions) => void) => () => void
+      }
       api: <T>(request: HermesApiRequest) => Promise<T>
       notify: (payload: HermesNotification) => Promise<boolean>
       requestMicrophoneAccess: () => Promise<boolean>
@@ -382,6 +387,12 @@ export interface DesktopActiveProfile {
   // The desktop's stored profile preference, or null when unset (legacy launch
   // that defers to the sticky active_profile / default).
   profile: string | null
+}
+
+export interface DesktopPinnedSessions {
+  exists: boolean
+  ids: string[]
+  path: string
 }
 
 export interface DesktopConnectionConfig {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2142,6 +2142,8 @@ export const en: Translations = {
     sessionUnavailable: 'Session unavailable',
     createSessionFailed: 'Could not create a new session',
     promptFailed: 'Prompt failed',
+    promptSubmitTimedOut:
+      'Hermes did not confirm this message in time. The backend may still process it, so wait a moment before retrying to avoid sending it twice.',
     providerCredentialRequired: 'Add a provider credential before sending your first message.',
     emptySlashCommand: 'empty slash command',
     desktopCommands: 'Desktop commands',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2282,6 +2282,8 @@ export const ja = defineLocale({
     sessionUnavailable: 'セッションが利用できません',
     createSessionFailed: '新しいセッションを作成できませんでした',
     promptFailed: 'プロンプトに失敗しました',
+    promptSubmitTimedOut:
+      'Hermes はこのメッセージを時間内に確認できませんでした。バックエンドでまだ処理される可能性があるため、二重送信を避けるため少し待ってから再試行してください。',
     providerCredentialRequired: '最初のメッセージを送信する前にプロバイダー認証情報を追加してください。',
     emptySlashCommand: '空のスラッシュコマンド',
     desktopCommands: 'デスクトップコマンド',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1756,6 +1756,7 @@ export interface Translations {
     sessionUnavailable: string
     createSessionFailed: string
     promptFailed: string
+    promptSubmitTimedOut: string
     providerCredentialRequired: string
     emptySlashCommand: string
     desktopCommands: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2190,6 +2190,7 @@ export const zhHant = defineLocale({
     sessionUnavailable: '工作階段不可用',
     createSessionFailed: '無法建立新工作階段',
     promptFailed: '提示詞傳送失敗',
+    promptSubmitTimedOut: 'Hermes 未能及時確認這則訊息。後端可能仍會處理它；請稍等再重試，以免重複傳送。',
     providerCredentialRequired: '傳送第一則訊息前請先新增提供方憑證。',
     emptySlashCommand: '空的斜線指令',
     desktopCommands: '桌面端指令',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2299,6 +2299,7 @@ export const zh: Translations = {
     sessionUnavailable: '会话不可用',
     createSessionFailed: '无法创建新会话',
     promptFailed: '提示词发送失败',
+    promptSubmitTimedOut: 'Hermes 未能及时确认这条消息。后端可能仍会处理它；请稍等再重试，以免重复发送。',
     providerCredentialRequired: '发送第一条消息前请先添加提供方凭据。',
     emptySlashCommand: '空 slash 命令',
     desktopCommands: '桌面端命令',

--- a/apps/desktop/src/store/clarify.ts
+++ b/apps/desktop/src/store/clarify.ts
@@ -7,6 +7,10 @@ export interface ClarifyRequest {
   question: string
   choices: string[] | null
   sessionId: string | null
+  multiSelect?: boolean
+  minSelections?: null | number
+  maxSelections?: null | number
+  allowOther?: boolean
 }
 
 // Pending clarify requests keyed by the runtime session id that raised them.

--- a/apps/desktop/src/store/layout.test.ts
+++ b/apps/desktop/src/store/layout.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const PIN_STORAGE_KEY = 'hermes.desktop.pinnedSessions'
+
+type PinnedPayload = { exists: boolean; ids: string[]; path: string }
+
+function flushMicrotasks() {
+  return new Promise(resolve => setTimeout(resolve, 0))
+}
+
+async function loadLayoutWithPinnedBridge(snapshot: PinnedPayload = { exists: false, ids: [], path: '/tmp/pins.json' }) {
+  vi.resetModules()
+  window.localStorage.clear()
+
+  let onChanged: ((payload: PinnedPayload) => void) | null = null
+
+  const bridge = {
+    get: vi.fn().mockResolvedValue(snapshot),
+    set: vi.fn().mockResolvedValue(snapshot),
+    onChanged: vi.fn((callback: (payload: PinnedPayload) => void) => {
+      onChanged = callback
+
+      return () => {
+        onChanged = null
+      }
+    })
+  }
+
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: { pinnedSessions: bridge }
+  })
+
+  const layout = await import('./layout')
+  await flushMicrotasks()
+
+  return {
+    bridge,
+    emitPinnedSessionsChanged: (payload: PinnedPayload) => onChanged?.(payload),
+    layout
+  }
+}
+
+afterEach(() => {
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: undefined
+  })
+  window.localStorage.clear()
+  vi.resetModules()
+})
+
+describe('external pinned sessions bridge', () => {
+  it('imports an existing external pin snapshot and sanitizes duplicate ids', async () => {
+    const { bridge, layout } = await loadLayoutWithPinnedBridge({
+      exists: true,
+      ids: ['alpha', 'beta', 'alpha', '', '  gamma  '],
+      path: '/tmp/pins.json'
+    })
+
+    expect(bridge.get).toHaveBeenCalledTimes(1)
+    expect(bridge.onChanged).toHaveBeenCalledTimes(1)
+    expect(layout.$pinnedSessionIds.get()).toEqual(['alpha', 'beta', 'gamma'])
+    expect(JSON.parse(window.localStorage.getItem(PIN_STORAGE_KEY) || '[]')).toEqual(['alpha', 'beta', 'gamma'])
+    expect(bridge.set).not.toHaveBeenCalled()
+  })
+
+  it('mirrors local pin changes back to the external bridge after initial sync', async () => {
+    const { bridge, layout } = await loadLayoutWithPinnedBridge({
+      exists: true,
+      ids: ['alpha'],
+      path: '/tmp/pins.json'
+    })
+
+    bridge.set.mockClear()
+    layout.pinSession('beta')
+
+    expect(layout.$pinnedSessionIds.get()).toEqual(['alpha', 'beta'])
+    expect(bridge.set).toHaveBeenCalledWith(['alpha', 'beta'])
+  })
+
+  it('applies external change events without writing them back in a loop', async () => {
+    const { bridge, emitPinnedSessionsChanged, layout } = await loadLayoutWithPinnedBridge({
+      exists: true,
+      ids: ['alpha'],
+      path: '/tmp/pins.json'
+    })
+
+    bridge.set.mockClear()
+    emitPinnedSessionsChanged({ exists: true, ids: ['delta', 'delta', 'epsilon'], path: '/tmp/pins.json' })
+
+    expect(layout.$pinnedSessionIds.get()).toEqual(['delta', 'epsilon'])
+    expect(bridge.set).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -178,6 +178,92 @@ export function restoreWorktree(id: string): void {
   }
 }
 
+let applyingExternalPinnedSessions = false
+let externalPinnedSessionsReady = false
+let externalPinnedSessionsUnsubscribe: (() => void) | null = null
+
+function externalPinnedSessionsBridge() {
+  if (typeof window === 'undefined') {
+    return undefined
+  }
+
+  return window.hermesDesktop?.pinnedSessions
+}
+
+function normalizePinnedSessionIds(ids: unknown): string[] {
+  if (!Array.isArray(ids)) {
+    return []
+  }
+
+  const seen = new Set<string>()
+  const out: string[] = []
+
+  for (const item of ids) {
+    const id = typeof item === 'string' ? item.trim() : ''
+
+    if (id && !seen.has(id)) {
+      seen.add(id)
+      out.push(id)
+    }
+  }
+
+  return out
+}
+
+function applyExternalPinnedSessions(ids: unknown) {
+  const next = normalizePinnedSessionIds(ids)
+
+  if (arraysEqual($pinnedSessionIds.get(), next)) {
+    return
+  }
+
+  applyingExternalPinnedSessions = true
+
+  try {
+    $pinnedSessionIds.set(next)
+  } finally {
+    applyingExternalPinnedSessions = false
+  }
+}
+
+export async function syncExternalPinnedSessions(): Promise<void> {
+  const bridge = externalPinnedSessionsBridge()
+
+  if (!bridge || externalPinnedSessionsUnsubscribe) {
+    return
+  }
+
+  try {
+    const snapshot = await bridge.get()
+    externalPinnedSessionsReady = true
+
+    if (snapshot?.exists) {
+      applyExternalPinnedSessions(snapshot.ids)
+    }
+
+    externalPinnedSessionsUnsubscribe = bridge.onChanged(payload => {
+      if (payload?.exists) {
+        applyExternalPinnedSessions(payload.ids)
+      }
+    })
+  } catch {
+    // External pin sync is optional. localStorage remains the fallback.
+  }
+}
+
+$pinnedSessionIds.subscribe(ids => {
+  if (applyingExternalPinnedSessions || !externalPinnedSessionsReady) {
+    return
+  }
+
+  const bridge = externalPinnedSessionsBridge()
+
+  if (bridge) {
+    void bridge.set([...ids]).catch(() => undefined)
+  }
+})
+void syncExternalPinnedSessions()
+
 export function setSidebarWidth(width: number) {
   const bounded = Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_DEFAULT_WIDTH, width))
   setPaneWidthOverride(CHAT_SIDEBAR_PANE_ID, bounded)

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -15,6 +15,7 @@ import {
   setCurrentCwd,
   setSessionAttention,
   setSessionWorking,
+  sortSessionsByNumber,
   workspaceCwdForNewSession
 } from './session'
 
@@ -74,6 +75,19 @@ describe('sessionPinId', () => {
     // After auto-compression the entry surfaces under a fresh tip id but keeps
     // the original root — pinning on the root keeps the pin stable.
     expect(sessionPinId(session({ id: 'tip', _lineage_root_id: 'root' }))).toBe('root')
+  })
+})
+
+describe('sortSessionsByNumber', () => {
+  it('sorts #number-prefixed sessions numerically before unnumbered recents', () => {
+    const rows = [
+      session({ id: 'recent', title: '최근', last_active: 30, started_at: 30 }),
+      session({ id: 'n10', title: '#0010 열번째', last_active: 10, started_at: 10 }),
+      session({ id: 'n2', title: '#0002 두번째', last_active: 20, started_at: 20 }),
+      session({ id: 'old', title: '오래됨', last_active: 1, started_at: 1 })
+    ]
+
+    expect(sortSessionsByNumber(rows).map(s => s.id)).toEqual(['n2', 'n10', 'recent', 'old'])
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -9,6 +9,46 @@ import type { SessionInfo, UsageStats } from '@/types/hermes'
 
 type Updater<T> = T | ((current: T) => T)
 
+const SESSION_NUMBER_RE = /^#(\d+)\b/
+
+function sessionSortActivity(session: SessionInfo): number {
+  return session.last_active || session.started_at || 0
+}
+
+export function sessionTitleNumber(session: SessionInfo): number | null {
+  const title = session.title?.trim() || ''
+  const match = SESSION_NUMBER_RE.exec(title)
+
+  if (!match) {
+    return null
+  }
+
+  const parsed = Number.parseInt(match[1], 10)
+
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+export function sortSessionsByNumber(sessions: SessionInfo[]): SessionInfo[] {
+  return [...sessions].sort((a, b) => {
+    const an = sessionTitleNumber(a)
+    const bn = sessionTitleNumber(b)
+
+    if (an !== null && bn !== null && an !== bn) {
+      return an - bn
+    }
+
+    if (an !== null && bn === null) {
+      return -1
+    }
+
+    if (an === null && bn !== null) {
+      return 1
+    }
+
+    return sessionSortActivity(b) - sessionSortActivity(a)
+  })
+}
+
 const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
 
 // The composer's model/effort/fast is sticky UI state, NOT the profile default

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2941,7 +2941,11 @@ class BasePlatformAdapter(ABC):
         if choices:
             lines = [f"❓ {question}", ""]
             if multi_select:
-                lines.append("Multiple selections allowed: reply with numbers/letters like `1,3` or `A+C`, option text, or your own answer.")
+                suffix = ", or your own answer" if allow_other else ""
+                lines.append(
+                    "Multiple selections allowed: reply with numbers/letters "
+                    f"like `1,3` or `A+C`, or option text{suffix}."
+                )
                 lines.append("")
             for i, choice in enumerate(choices, start=1):
                 prefix = f"{i}."
@@ -2951,9 +2955,12 @@ class BasePlatformAdapter(ABC):
                 lines.append(f"  {prefix} {choice}")
             lines.append("")
             if multi_select:
-                lines.append("Reply with one or more numbers/letters, option text, or your own answer.")
-            else:
+                suffix = ", option text, or your own answer" if allow_other else " or option text"
+                lines.append(f"Reply with one or more numbers/letters{suffix}.")
+            elif allow_other:
                 lines.append("Reply with the number, the option text, or your own answer.")
+            else:
+                lines.append("Reply with the number or the option text.")
             text = "\n".join(lines)
             # Text fallback: enable text-capture so the gateway intercept
             # picks up the user's typed reply (e.g. "2" or choice text).

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2904,6 +2904,10 @@ class BasePlatformAdapter(ABC):
         clarify_id: str,
         session_key: str,
         metadata: Optional[Dict[str, Any]] = None,
+        multi_select: bool = False,
+        min_selections: int = 0,
+        max_selections: Optional[int] = None,
+        allow_other: bool = True,
     ) -> SendResult:
         """Send a clarify prompt to the user.
 
@@ -2936,10 +2940,20 @@ class BasePlatformAdapter(ABC):
         """
         if choices:
             lines = [f"❓ {question}", ""]
+            if multi_select:
+                lines.append("Multiple selections allowed: reply with numbers/letters like `1,3` or `A+C`, option text, or your own answer.")
+                lines.append("")
             for i, choice in enumerate(choices, start=1):
-                lines.append(f"  {i}. {choice}")
+                prefix = f"{i}."
+                if multi_select:
+                    letter = chr(ord("A") + i - 1)
+                    prefix = f"{i}/{letter}."
+                lines.append(f"  {prefix} {choice}")
             lines.append("")
-            lines.append("Reply with the number, the option text, or your own answer.")
+            if multi_select:
+                lines.append("Reply with one or more numbers/letters, option text, or your own answer.")
+            else:
+                lines.append("Reply with the number, the option text, or your own answer.")
             text = "\n".join(lines)
             # Text fallback: enable text-capture so the gateway intercept
             # picks up the user's typed reply (e.g. "2" or choice text).

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -675,6 +675,10 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         clarify_id: str,
         session_key: str,
         metadata: Optional[Dict[str, Any]] = None,
+        multi_select: bool = False,
+        min_selections: int = 0,
+        max_selections: Optional[int] = None,
+        allow_other: bool = True,
     ) -> SendResult:
         """Render a clarify prompt as native WhatsApp interactive buttons.
 

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -682,10 +682,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     ) -> SendResult:
         """Render a clarify prompt as native WhatsApp interactive buttons.
 
-        - 1–3 choices → ``interactive.type=button`` (inline pill buttons).
-        - 4+ choices → ``interactive.type=list`` (tap-to-open sheet with
-          up to 10 rows). Telegram's "Other (type answer)" escape hatch
-          is appended as the final row, picking it flips the entry into
+        - Multi-select prompts fall back to the base numbered-text renderer
+          because WhatsApp Cloud interactive controls are single-select only.
+        - 1–3 single-select choices → ``interactive.type=button`` (inline pill buttons).
+        - 4+ single-select choices → ``interactive.type=list`` (tap-to-open sheet with
+          up to 10 rows). When ``allow_other`` is true, an "Other (type
+          answer)" row is appended; picking it flips the entry into
           text-capture mode handled by the gateway's text intercept.
         - 0 choices (open-ended) → plain text question; the next message
           in the session is captured by the gateway and resolves clarify.
@@ -702,6 +704,25 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # Open-ended → just send the question, gateway captures next msg.
         if not choices:
             return await self.send(chat_id, f"❓ {question}", reply_to=reply_to)
+
+        # WhatsApp Cloud interactive buttons/lists are single-select. Preserve
+        # multi-select semantics by deliberately degrading to BasePlatformAdapter's
+        # numbered text fallback, where the gateway parser accepts replies like
+        # "1,3" / "A+C" and enforces min/max/allow_other.
+        if multi_select:
+            return await BasePlatformAdapter.send_clarify(
+                self,
+                chat_id=chat_id,
+                question=question,
+                choices=choices,
+                clarify_id=clarify_id,
+                session_key=session_key,
+                metadata=metadata,
+                multi_select=multi_select,
+                min_selections=min_selections,
+                max_selections=max_selections,
+                allow_other=allow_other,
+            )
 
         # Mirror Telegram: render full choice text in body so long
         # options aren't truncated to the 20-char button label cap.
@@ -740,11 +761,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     "title": self._truncate_button_label(f"{idx + 1}", limit=24),
                     "description": self._truncate_button_label(choice_text, limit=72),
                 })
-            rows.append({
-                "id": f"cl:{clarify_id}:other",
-                "title": "✏️ Other",
-                "description": "Type your own answer",
-            })
+            if allow_other:
+                rows.append({
+                    "id": f"cl:{clarify_id}:other",
+                    "title": "✏️ Other",
+                    "description": "Type your own answer",
+                })
             interactive = {
                 "type": "list",
                 "body": {"text": body_text},

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8128,21 +8128,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # so the user can retry; if it times out, the agent unblocks
             # with an empty response.
             if _raw_clarify_reply and not _raw_clarify_reply.startswith("/"):
-                if getattr(_pending_clarify, "multi_select", False) and getattr(_pending_clarify, "choices", None):
-                    _resolved_reply = _raw_clarify_reply
-                    _parsed = _clarify_mod.parse_multi_select_response(
-                        _raw_clarify_reply,
-                        list(_pending_clarify.choices or []),
-                    )
-                    if _parsed:
-                        _resolved_reply = ", ".join(_parsed)
-                    _resolved = _clarify_mod.resolve_gateway_clarify(
-                        _pending_clarify.clarify_id, _resolved_reply,
-                    )
-                else:
-                    _resolved = _clarify_mod.resolve_text_response_for_session(
-                        _quick_key, _raw_clarify_reply,
-                    )
+                _resolved = _clarify_mod.resolve_text_response_for_session(
+                    _quick_key, _raw_clarify_reply,
+                )
                 if _resolved:
                     logger.info(
                         "Gateway intercepted clarify text response (session=%s, id=%s)",
@@ -8152,6 +8140,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # the agent's response don't double-post.  The agent
                     # itself will produce the next user-facing message.
                     return ""
+                logger.info(
+                    "Gateway rejected invalid clarify text response (session=%s, id=%s)",
+                    _quick_key, _pending_clarify.clarify_id,
+                )
+                return _clarify_mod.format_invalid_text_response_message(_pending_clarify)
 
         # Intercept messages that are responses to a pending /reload-mcp
         # (or future) slash-confirm prompt.  Recognized confirm replies are

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5439,21 +5439,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # On Windows there's no bash/setsid chain — spawn a tiny Python
         # watcher directly via sys.executable instead.  The watcher polls
-        # current_pid, waits for our exit, then runs `hermes gateway
-        # restart` with detach flags so the respawn survives the CLI
-        # that triggered the /restart command closing its console.
+        # current_pid, waits for our exit, then runs the HQ Admin Helper
+        # gateway_restart action when available.  That path cooperates with
+        # the durable Windows Scheduled Task owner and avoids the generic
+        # `hermes gateway restart` race.  Non-HQ installs fall back to the
+        # stock CLI restart command.
         if sys.platform == "win32":
             import textwrap
             from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
 
-            cmd_argv = [*hermes_cmd, "gateway", "restart"]
+            admin_invoker = _hermes_home / "scripts" / "invoke_hermes_admin_helper.ps1"
+            use_admin_helper = admin_invoker.exists()
+            if use_admin_helper:
+                cmd_argv = [
+                    "powershell.exe",
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                    str(admin_invoker),
+                    "-Action",
+                    "gateway_restart",
+                    "-TimeoutSeconds",
+                    "120",
+                ]
+            else:
+                cmd_argv = [*hermes_cmd, "gateway", "restart"]
+            fallback_argv = [*hermes_cmd, "gateway", "restart"]
             watcher = textwrap.dedent(
                 """
                 import os, subprocess, sys, time
                 from hermes_cli._subprocess_compat import windows_detach_flags_without_breakaway
                 pid = int(sys.argv[1])
                 restart_after_s = float(sys.argv[2])
-                cmd = sys.argv[3:]
+                use_admin_helper = sys.argv[3] == '1'
+                raw_args = sys.argv[4:]
+                try:
+                    split_at = raw_args.index('--fallback--')
+                    cmd = raw_args[:split_at]
+                    fallback_cmd = raw_args[split_at + 1:]
+                except ValueError:
+                    cmd = raw_args
+                    fallback_cmd = []
                 deadline = time.monotonic() + restart_after_s
 
                 def _alive(p):
@@ -5487,12 +5514,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if not _alive(pid):
                         break
                     time.sleep(0.2)
-                subprocess.Popen(
-                    cmd,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    creationflags=windows_detach_flags_without_breakaway(),
-                )
+                flags = windows_detach_flags_without_breakaway()
+
+                def _launch(command):
+                    subprocess.Popen(
+                        command,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        creationflags=flags,
+                    )
+
+                if use_admin_helper:
+                    try:
+                        completed = subprocess.run(
+                            cmd,
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL,
+                            creationflags=flags,
+                            timeout=150,
+                        )
+                        if completed.returncode == 0:
+                            sys.exit(0)
+                    except Exception:
+                        pass
+                    if fallback_cmd:
+                        _launch(fallback_cmd)
+                else:
+                    _launch(cmd)
                 """
             ).strip()
             watcher_env = os.environ.copy()
@@ -5523,7 +5571,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     pythonpath.append(watcher_env["PYTHONPATH"])
                 watcher_env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath))
             subprocess.Popen(
-                [watcher_python, "-c", watcher, str(current_pid), str(restart_after_s), *cmd_argv],
+                [
+                    watcher_python,
+                    "-c",
+                    watcher,
+                    str(current_pid),
+                    str(restart_after_s),
+                    "1" if use_admin_helper else "0",
+                    *cmd_argv,
+                    "--fallback--",
+                    *fallback_argv,
+                ],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 env=watcher_env,
@@ -5653,7 +5711,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     await self._launch_detached_restart_command()
                 except Exception as e:
                     logger.error("Failed to launch detached gateway restart helper: %s", e)
-            await asyncio.sleep(0.05)
+            await asyncio.sleep(1.5)
             await self.stop(restart=True, detached_restart=detached, service_restart=via_service)
 
         # _run_restart is a short-lived self-terminating task (calls stop()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8128,9 +8128,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # so the user can retry; if it times out, the agent unblocks
             # with an empty response.
             if _raw_clarify_reply and not _raw_clarify_reply.startswith("/"):
-                _resolved = _clarify_mod.resolve_text_response_for_session(
-                    _quick_key, _raw_clarify_reply,
-                )
+                if getattr(_pending_clarify, "multi_select", False) and getattr(_pending_clarify, "choices", None):
+                    _resolved_reply = _raw_clarify_reply
+                    _parsed = _clarify_mod.parse_multi_select_response(
+                        _raw_clarify_reply,
+                        list(_pending_clarify.choices or []),
+                    )
+                    if _parsed:
+                        _resolved_reply = ", ".join(_parsed)
+                    _resolved = _clarify_mod.resolve_gateway_clarify(
+                        _pending_clarify.clarify_id, _resolved_reply,
+                    )
+                else:
+                    _resolved = _clarify_mod.resolve_text_response_for_session(
+                        _quick_key, _raw_clarify_reply,
+                    )
                 if _resolved:
                     logger.info(
                         "Gateway intercepted clarify text response (session=%s, id=%s)",
@@ -16615,7 +16627,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # explaining that no response arrived (so the agent can adapt
             # rather than hang forever).
             # ------------------------------------------------------------------
-            def _clarify_callback_sync(question: str, choices) -> str:
+            def _clarify_callback_sync(
+                question: str,
+                choices,
+                *,
+                multi_select: bool = False,
+                min_selections: int = 0,
+                max_selections = None,
+                allow_other: bool = True,
+            ) -> str:
                 from tools import clarify_gateway as _clarify_mod
                 import uuid as _uuid
 
@@ -16628,6 +16648,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_key=session_key or "",
                     question=question,
                     choices=list(choices) if choices else None,
+                    multi_select=multi_select,
+                    min_selections=min_selections,
+                    max_selections=max_selections,
+                    allow_other=allow_other,
                 )
 
                 # Pause typing — like approval, we don't want a "thinking..."
@@ -16648,6 +16672,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         clarify_id=clarify_id,
                         session_key=session_key or "",
                         metadata=_status_thread_metadata,
+                        multi_select=multi_select,
+                        min_selections=min_selections,
+                        max_selections=max_selections,
+                        allow_other=allow_other,
                     ),
                     _loop_for_step,
                     logger=logger,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4999,9 +4999,13 @@ class DiscordAdapter(BasePlatformAdapter):
 
             if clean_choices:
                 if multi_select:
+                    help_text = "Pick one or more below, then submit selected"
+                    if allow_other:
+                        help_text += ", or click ✏️ Other to type a custom answer"
+                    help_text += "."
                     embed.add_field(
                         name="Choices",
-                        value="Pick one or more below, then submit selected, or click ✏️ Other to type a custom answer.",
+                        value=help_text,
                         inline=False,
                     )
                     view = ClarifyMultiSelectView(
@@ -5014,9 +5018,13 @@ class DiscordAdapter(BasePlatformAdapter):
                         allow_other=allow_other,
                     )
                 else:
+                    help_text = "Pick one below"
+                    if allow_other:
+                        help_text += ", or click ✏️ Other to type a custom answer"
+                    help_text += "."
                     embed.add_field(
                         name="Choices",
-                        value="Pick one below, or click ✏️ Other to type a custom answer.",
+                        value=help_text,
                         inline=False,
                     )
                     view = ClarifyChoiceView(
@@ -5024,6 +5032,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         clarify_id=clarify_id,
                         allowed_user_ids=self._allowed_user_ids,
                         allowed_role_ids=self._allowed_role_ids,
+                        allow_other=allow_other,
                     )
             else:
                 embed.add_field(
@@ -6798,12 +6807,14 @@ def _define_discord_view_classes() -> None:
             clarify_id: str,
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
+            allow_other: bool = True,
         ):
             super().__init__(timeout=300)  # 5-minute timeout
             self.choices = list(choices)[:24]
             self.clarify_id = clarify_id
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
+            self.allow_other = bool(allow_other)
             self.resolved = False
 
             for index, choice in enumerate(self.choices):
@@ -6854,13 +6865,14 @@ def _define_discord_view_classes() -> None:
                 button.callback = self._make_choice_callback(index, choice)
                 self.add_item(button)
 
-            other_btn = discord.ui.Button(
-                label="✏️ Other (type answer)",
-                style=discord.ButtonStyle.secondary,
-                custom_id=f"clarify:{clarify_id}:other",
-            )
-            other_btn.callback = self._on_other
-            self.add_item(other_btn)
+            if self.allow_other:
+                other_btn = discord.ui.Button(
+                    label="✏️ Other (type answer)",
+                    style=discord.ButtonStyle.secondary,
+                    custom_id=f"clarify:{clarify_id}:other",
+                )
+                other_btn.callback = self._on_other
+                self.add_item(other_btn)
 
         def _check_auth(self, interaction: "discord.Interaction") -> bool:
             return _component_check_auth(

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4913,6 +4913,10 @@ class DiscordAdapter(BasePlatformAdapter):
         clarify_id: str,
         session_key: str,
         metadata: Optional[Dict[str, Any]] = None,
+        multi_select: bool = False,
+        min_selections: int = 0,
+        max_selections: Optional[int] = None,
+        allow_other: bool = True,
     ) -> SendResult:
         """Render a clarify prompt with one Discord button per choice.
 
@@ -4994,17 +4998,33 @@ class DiscordAdapter(BasePlatformAdapter):
             clean_choices = clean_choices[:24]
 
             if clean_choices:
-                embed.add_field(
-                    name="Choices",
-                    value="Pick one below, or click ✏️ Other to type a custom answer.",
-                    inline=False,
-                )
-                view = ClarifyChoiceView(
-                    choices=clean_choices,
-                    clarify_id=clarify_id,
-                    allowed_user_ids=self._allowed_user_ids,
-                    allowed_role_ids=self._allowed_role_ids,
-                )
+                if multi_select:
+                    embed.add_field(
+                        name="Choices",
+                        value="Pick one or more below, then submit selected, or click ✏️ Other to type a custom answer.",
+                        inline=False,
+                    )
+                    view = ClarifyMultiSelectView(
+                        choices=clean_choices,
+                        clarify_id=clarify_id,
+                        allowed_user_ids=self._allowed_user_ids,
+                        allowed_role_ids=self._allowed_role_ids,
+                        min_selections=min_selections,
+                        max_selections=max_selections,
+                        allow_other=allow_other,
+                    )
+                else:
+                    embed.add_field(
+                        name="Choices",
+                        value="Pick one below, or click ✏️ Other to type a custom answer.",
+                        inline=False,
+                    )
+                    view = ClarifyChoiceView(
+                        choices=clean_choices,
+                        clarify_id=clarify_id,
+                        allowed_user_ids=self._allowed_user_ids,
+                        allowed_role_ids=self._allowed_role_ids,
+                    )
             else:
                 embed.add_field(
                     name="Reply",
@@ -5922,7 +5942,7 @@ def _define_discord_view_classes() -> None:
     lazy install sets DISCORD_AVAILABLE=True but leaves the classes
     undefined, causing NameError on the first button interaction.
     """
-    global ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView
+    global ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView, ClarifyMultiSelectView
 
     class ExecApprovalView(discord.ui.View):
         """
@@ -6562,6 +6582,196 @@ def _define_discord_view_classes() -> None:
                         description="⏱ Selection expired — no model change.",
                         color=discord.Color.greyple(),
                     )
+                    await msg.edit(embed=embed, view=self)
+                except Exception:
+                    pass
+
+
+    class ClarifyMultiSelectView(discord.ui.View):
+        """Native Discord multi-select clarify view.
+
+        Stages choices via a select menu and resolves only when the user taps
+        Submit. This preserves true multi-pick semantics instead of forcing a
+        single button click to end the clarify request.
+        """
+
+        def __init__(
+            self,
+            choices: List[str],
+            clarify_id: str,
+            allowed_user_ids: set,
+            allowed_role_ids: Optional[set] = None,
+            min_selections: int = 0,
+            max_selections: Optional[int] = None,
+            allow_other: bool = True,
+        ):
+            super().__init__(timeout=300)
+            self.choices = list(choices)[:24]
+            self.clarify_id = clarify_id
+            self.allowed_user_ids = allowed_user_ids
+            self.allowed_role_ids = allowed_role_ids or set()
+            self.min_selections = int(min_selections or 0)
+            self.max_selections = min(int(max_selections), len(self.choices)) if max_selections is not None else len(self.choices)
+            self.allow_other = bool(allow_other)
+            self.selected_indices: set[int] = set()
+            self.resolved = False
+
+            options = [
+                discord.SelectOption(label=str(choice)[:100], value=str(index))
+                for index, choice in enumerate(self.choices)
+            ]
+            select = discord.ui.Select(
+                placeholder="Select one or more choices…",
+                options=options,
+                custom_id=f"clarify:{clarify_id}:multi",
+                min_values=max(1, self.min_selections) if self.choices else 0,
+                max_values=max(1, self.max_selections) if self.choices else 1,
+            )
+            select.callback = self._on_select
+            self.add_item(select)
+
+            submit_btn = discord.ui.Button(
+                label="✅ Submit selected",
+                style=discord.ButtonStyle.success,
+                custom_id=f"clarify:{clarify_id}:multi_submit",
+            )
+            submit_btn.callback = self._on_submit
+            self.add_item(submit_btn)
+
+            if self.allow_other:
+                other_btn = discord.ui.Button(
+                    label="✏️ Other (type answer)",
+                    style=discord.ButtonStyle.secondary,
+                    custom_id=f"clarify:{clarify_id}:other",
+                )
+                other_btn.callback = self._on_other
+                self.add_item(other_btn)
+
+        def _check_auth(self, interaction: "discord.Interaction") -> bool:
+            return _component_check_auth(
+                interaction, self.allowed_user_ids, self.allowed_role_ids,
+            )
+
+        async def _on_select(self, interaction: "discord.Interaction") -> None:
+            if self.resolved:
+                await interaction.response.send_message(
+                    "This prompt has already been answered~", ephemeral=True,
+                )
+                return
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized to answer this prompt~", ephemeral=True,
+                )
+                return
+            values = getattr(interaction, "data", {}).get("values", [])
+            selected: set[int] = set()
+            for value in values:
+                try:
+                    idx = int(value)
+                except (TypeError, ValueError):
+                    continue
+                if 0 <= idx < len(self.choices):
+                    selected.add(idx)
+            self.selected_indices = selected
+
+            embed = interaction.message.embeds[0] if (
+                interaction.message and interaction.message.embeds
+            ) else None
+            if embed:
+                selected_text = ", ".join(self.choices[i] for i in sorted(selected)) or "none yet"
+                embed.set_footer(text=f"Selected: {selected_text}")
+            await interaction.response.edit_message(embed=embed, view=self)
+
+        async def _on_submit(self, interaction: "discord.Interaction") -> None:
+            if self.resolved:
+                await interaction.response.send_message(
+                    "This prompt has already been answered~", ephemeral=True,
+                )
+                return
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized to answer this prompt~", ephemeral=True,
+                )
+                return
+            if len(self.selected_indices) < self.min_selections:
+                await interaction.response.send_message(
+                    f"Select at least {self.min_selections} choices~", ephemeral=True,
+                )
+                return
+
+            resolved_text = ", ".join(
+                self.choices[i] for i in sorted(self.selected_indices) if 0 <= i < len(self.choices)
+            )
+            self.resolved = True
+            for child in self.children:
+                child.disabled = True
+
+            embed = interaction.message.embeds[0] if (
+                interaction.message and interaction.message.embeds
+            ) else None
+            if embed:
+                user = getattr(interaction, "user", None)
+                display_name = getattr(user, "display_name", "user")
+                embed.color = discord.Color.green()
+                embed.set_footer(text=f"Answered by {display_name}: {resolved_text}")
+
+            try:
+                from tools.clarify_gateway import resolve_gateway_clarify
+                resolved = resolve_gateway_clarify(self.clarify_id, resolved_text)
+                logger.info(
+                    "Discord clarify multi-select resolved (id=%s, choices=%r, ok=%s)",
+                    self.clarify_id, resolved_text, resolved,
+                )
+            except Exception as exc:
+                logger.error(
+                    "Discord clarify multi-select resolve failed (id=%s): %s",
+                    self.clarify_id, exc,
+                )
+            await interaction.response.edit_message(embed=embed, view=self)
+
+        async def _on_other(self, interaction: "discord.Interaction") -> None:
+            if self.resolved:
+                await interaction.response.send_message(
+                    "This prompt has already been answered~", ephemeral=True,
+                )
+                return
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized to answer this prompt~", ephemeral=True,
+                )
+                return
+            try:
+                from tools.clarify_gateway import mark_awaiting_text
+                mark_awaiting_text(self.clarify_id)
+            except Exception as exc:
+                logger.warning(
+                    "Discord clarify multi-select mark_awaiting_text failed (id=%s): %s",
+                    self.clarify_id, exc,
+                )
+            self.resolved = True
+            for child in self.children:
+                child.disabled = True
+            embed = interaction.message.embeds[0] if (
+                interaction.message and interaction.message.embeds
+            ) else None
+            if embed:
+                user = getattr(interaction, "user", None)
+                display_name = getattr(user, "display_name", "user")
+                embed.color = discord.Color.blue()
+                embed.set_footer(text=f"Awaiting typed response from {display_name}…")
+            await interaction.response.edit_message(embed=embed, view=self)
+
+        async def on_timeout(self):
+            self.resolved = True
+            for child in self.children:
+                child.disabled = True
+            msg = getattr(self, '_message', None)
+            if msg:
+                try:
+                    embed = msg.embeds[0] if msg.embeds else None
+                    if embed:
+                        embed.color = discord.Color.greyple()
+                        embed.set_footer(text="⏱ Prompt expired — no action taken")
                     await msg.edit(embed=embed, view=self)
                 except Exception:
                     pass

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -478,6 +478,8 @@ class TelegramAdapter(BasePlatformAdapter):
         # Clarify button state: clarify_id → session_key (for the clarify tool's
         # multiple-choice prompts; see GatewayRunner clarify_callback wiring).
         self._clarify_state: Dict[str, str] = {}
+        # Native multi-select clarify state: clarify_id → {choices, selected, ...}.
+        self._clarify_multi_state: Dict[str, dict] = {}
         # Notification mode for message sends.
         # "important" — only final responses, approvals, and slash confirmations
         #               trigger notifications; tool progress, streaming, status
@@ -3890,6 +3892,10 @@ class TelegramAdapter(BasePlatformAdapter):
         clarify_id: str,
         session_key: str,
         metadata: Optional[Dict[str, Any]] = None,
+        multi_select: bool = False,
+        min_selections: int = 0,
+        max_selections: Optional[int] = None,
+        allow_other: bool = True,
     ) -> SendResult:
         """Render a clarify prompt with one inline button per choice.
 
@@ -3918,7 +3924,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     f"{i + 1}. {_html.escape(str(c))}"
                     for i, c in enumerate(choices)
                 )
-                text += f"\n\n{option_lines}"
+                if multi_select:
+                    text += f"\n\nSelect one or more, then tap ✅ Done.\n\n{option_lines}"
+                else:
+                    text += f"\n\n{option_lines}"
 
             kwargs: Dict[str, Any] = {
                 "chat_id": normalize_telegram_chat_id(chat_id),
@@ -3928,22 +3937,49 @@ class TelegramAdapter(BasePlatformAdapter):
             }
 
             if choices:
-                # Telegram caps callback_data at 64 bytes; keep "cl:<id>:<idx>"
-                # short.
+                # Telegram caps callback_data at 64 bytes; keep callback ids short.
                 rows = []
-                for idx in range(len(choices)):
+                if multi_select:
+                    clean_choices = [str(c).strip() for c in choices if str(c).strip()]
+                    self._clarify_multi_state[clarify_id] = {
+                        "choices": clean_choices,
+                        "selected": set(),
+                        "min_selections": int(min_selections or 0),
+                        "max_selections": max_selections,
+                        "allow_other": bool(allow_other),
+                    }
+                    for idx in range(len(clean_choices)):
+                        rows.append([
+                            InlineKeyboardButton(
+                                f"☐ {idx + 1}",
+                                callback_data=f"clms:{clarify_id}:toggle:{idx}",
+                            )
+                        ])
                     rows.append([
-                        InlineKeyboardButton(
-                            str(idx + 1),
-                            callback_data=f"cl:{clarify_id}:{idx}",
-                        )
+                        InlineKeyboardButton("✅ Done", callback_data=f"clms:{clarify_id}:done")
                     ])
-                rows.append([
-                    InlineKeyboardButton(
-                        "✏️ Other (type answer)",
-                        callback_data=f"cl:{clarify_id}:other",
-                    )
-                ])
+                    if allow_other:
+                        rows.append([
+                            InlineKeyboardButton(
+                                "✏️ Other (type answer)",
+                                callback_data=f"clms:{clarify_id}:other",
+                            )
+                        ])
+                else:
+                    for idx in range(len(choices)):
+                        rows.append([
+                            InlineKeyboardButton(
+                                str(idx + 1),
+                                callback_data=f"cl:{clarify_id}:{idx}",
+                            )
+                        ])
+                    if allow_other:
+                        rows.append([
+                            InlineKeyboardButton(
+                                "✏️ Other (type answer)",
+                                callback_data=f"cl:{clarify_id}:other",
+                            )
+                        ])
                 kwargs["reply_markup"] = InlineKeyboardMarkup(rows)
 
             reply_to_id = self._reply_to_message_id_for_send(None, metadata)
@@ -4656,6 +4692,132 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._send_message_with_thread_fallback(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
+            return
+
+        # --- Clarify multi-select callbacks (clms:clarify_id:toggle:idx | done | other) ---
+        if data.startswith("clms:"):
+            parts = data.split(":")
+            if len(parts) >= 3:
+                clarify_id = parts[1]
+                action = parts[2]
+
+                caller_id = str(getattr(query.from_user, "id", ""))
+                if not self._is_callback_user_authorized(
+                    caller_id,
+                    chat_id=query_chat_id,
+                    chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                    thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                    user_name=query_user_name,
+                ):
+                    await query.answer(text="⛔ You are not authorized to answer this prompt.")
+                    return
+
+                session_key = self._clarify_state.get(clarify_id)
+                state = self._clarify_multi_state.get(clarify_id)
+                if not session_key or not state:
+                    await query.answer(text="This prompt has already been resolved.")
+                    return
+
+                user_display = getattr(query.from_user, "first_name", "User")
+                choices = list(state.get("choices") or [])
+                selected = state.setdefault("selected", set())
+
+                if action == "toggle" and len(parts) == 4:
+                    try:
+                        idx = int(parts[3])
+                    except (ValueError, TypeError):
+                        await query.answer(text="Invalid choice.")
+                        return
+                    if not 0 <= idx < len(choices):
+                        await query.answer(text="Invalid choice.")
+                        return
+                    if idx in selected:
+                        selected.remove(idx)
+                    else:
+                        max_sel = state.get("max_selections")
+                        if max_sel is not None and len(selected) >= int(max_sel):
+                            await query.answer(text=f"Select at most {max_sel}.")
+                            return
+                        selected.add(idx)
+                    await query.answer(text=f"{len(selected)} selected")
+                    try:
+                        rows = []
+                        for choice_idx in range(len(choices)):
+                            mark = "☑" if choice_idx in selected else "☐"
+                            rows.append([
+                                InlineKeyboardButton(
+                                    f"{mark} {choice_idx + 1}",
+                                    callback_data=f"clms:{clarify_id}:toggle:{choice_idx}",
+                                )
+                            ])
+                        rows.append([
+                            InlineKeyboardButton("✅ Done", callback_data=f"clms:{clarify_id}:done")
+                        ])
+                        if state.get("allow_other", True):
+                            rows.append([
+                                InlineKeyboardButton(
+                                    "✏️ Other (type answer)",
+                                    callback_data=f"clms:{clarify_id}:other",
+                                )
+                            ])
+                        await query.edit_message_text(
+                            text=query.message.text or "",
+                            parse_mode=ParseMode.HTML,
+                            reply_markup=InlineKeyboardMarkup(rows),
+                        )
+                    except Exception:
+                        pass
+                    return
+
+                if action == "other":
+                    try:
+                        from tools.clarify_gateway import mark_awaiting_text
+                        mark_awaiting_text(clarify_id)
+                    except Exception as exc:
+                        logger.warning("[%s] mark_awaiting_text failed: %s", self.name, exc)
+                    await query.answer(text="✏️ Type your answer in the chat.")
+                    try:
+                        await query.edit_message_text(
+                            text=f"❓ {query.message.text or ''}\n\n<i>Awaiting typed response from {_html.escape(user_display)}…</i>",
+                            parse_mode=ParseMode.HTML,
+                            reply_markup=None,
+                        )
+                    except Exception:
+                        pass
+                    return
+
+                if action == "done":
+                    min_sel = int(state.get("min_selections") or 0)
+                    if len(selected) < min_sel:
+                        await query.answer(text=f"Select at least {min_sel}.")
+                        return
+                    resolved_labels = [choices[i] for i in sorted(selected) if 0 <= i < len(choices)]
+                    resolved_text = ", ".join(resolved_labels)
+                    self._clarify_state.pop(clarify_id, None)
+                    self._clarify_multi_state.pop(clarify_id, None)
+                    try:
+                        from tools.clarify_gateway import resolve_gateway_clarify
+                        resolved = resolve_gateway_clarify(clarify_id, resolved_text)
+                    except Exception as exc:
+                        logger.error("[%s] resolve_gateway_clarify failed: %s", self.name, exc)
+                        resolved = False
+                    await query.answer(text=f"✓ {len(resolved_labels)} selected")
+                    try:
+                        await query.edit_message_text(
+                            text=f"❓ {_html.escape(query.message.text or '')}\n\n<b>{_html.escape(user_display)}:</b> {_html.escape(resolved_text)}",
+                            parse_mode=ParseMode.HTML,
+                            reply_markup=None,
+                        )
+                    except Exception:
+                        pass
+                    if resolved:
+                        logger.info(
+                            "Telegram clarify multi-select resolved (id=%s, choices=%r, user=%s)",
+                            clarify_id, resolved_text, user_display,
+                        )
+                    return
+
+                await query.answer(text="Invalid choice.")
             return
 
         # --- Clarify callbacks (cl:clarify_id:idx | cl:clarify_id:other) ---

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -29,6 +29,7 @@ from plugins.platforms.discord.adapter import (  # noqa: E402
     ClarifyChoiceView,
     DiscordAdapter,
 )
+import plugins.platforms.discord.adapter as discord_adapter  # noqa: E402
 from gateway.config import PlatformConfig  # noqa: E402
 
 
@@ -330,6 +331,50 @@ class TestClarifyOtherButton:
 
 
 # ===========================================================================
+# Multi-select view → stage then submit
+# ===========================================================================
+
+class TestClarifyMultiSelectView:
+    """Multi-select should not resolve until the user submits staged choices."""
+
+    def setup_method(self):
+        _clear_clarify_state()
+
+    @pytest.mark.asyncio
+    async def test_select_stages_then_submit_resolves_joined_choices(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("cidMS", "sk-MS", "Pick many", ["red", "green", "blue"], multi_select=True)
+        view = discord_adapter.ClarifyMultiSelectView(
+            choices=["red", "green", "blue"],
+            clarify_id="cidMS",
+            allowed_user_ids={"42"},
+        )
+
+        interaction = _make_interaction(user_id="42")
+        interaction.data = {"values": ["0", "2"]}
+        await view._on_select(interaction)
+
+        assert view.selected_indices == {0, 2}
+        with cm._lock:
+            entry = cm._entries.get("cidMS")
+        assert entry is not None
+        assert not entry.event.is_set()
+        interaction.response.edit_message.assert_called_once()
+
+        interaction2 = _make_interaction(user_id="42")
+        await view._on_submit(interaction2)
+
+        with cm._lock:
+            entry = cm._entries.get("cidMS")
+        assert entry is not None
+        assert entry.response == "red, blue"
+        assert entry.event.is_set()
+        assert all(child.disabled for child in view.children)
+        interaction2.response.edit_message.assert_called_once()
+
+
+# ===========================================================================
 # DiscordAdapter.send_clarify integration
 # ===========================================================================
 
@@ -366,6 +411,30 @@ class TestDiscordSendClarify:
         assert isinstance(kwargs["view"], ClarifyChoiceView)
         # 3 choice buttons + 1 Other
         assert len(kwargs["view"].children) == 4
+
+    @pytest.mark.asyncio
+    async def test_multi_select_attaches_native_multiselect_view(self):
+        adapter = _make_adapter(allowed_users={"42"})
+        channel = MagicMock()
+        sent_msg = MagicMock()
+        sent_msg.id = 123457
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+
+        result = await adapter.send_clarify(
+            chat_id="9001",
+            question="Pick colors",
+            choices=["red", "green", "blue"],
+            clarify_id="cidMS2",
+            session_key="sk-MS2",
+            multi_select=True,
+        )
+
+        assert result.success is True
+        kwargs = channel.send.call_args.kwargs
+        assert isinstance(kwargs["view"], discord_adapter.ClarifyMultiSelectView)
+        embed = kwargs["embed"]
+        assert any("one or more" in field["value"] for field in embed.fields)
 
     @pytest.mark.asyncio
     async def test_open_ended_omits_view(self):

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -173,6 +173,18 @@ class TestClarifyChoiceViewConstruction:
             f"Label cuts mid-word at {last_char!r}: {first_label!r}"
         )
 
+    def test_allow_other_false_omits_other_button(self):
+        view = ClarifyChoiceView(
+            choices=["apple", "banana"],
+            clarify_id="cidNoOther",
+            allowed_user_ids={"42"},
+            allow_other=False,
+        )
+
+        labels = [b.label for b in view.children]
+        assert len(labels) == 2
+        assert all("Other" not in label for label in labels)
+
 
 # ===========================================================================
 # Choice callback → resolve_gateway_clarify
@@ -411,6 +423,33 @@ class TestDiscordSendClarify:
         assert isinstance(kwargs["view"], ClarifyChoiceView)
         # 3 choice buttons + 1 Other
         assert len(kwargs["view"].children) == 4
+
+    @pytest.mark.asyncio
+    async def test_allow_other_false_omits_single_select_other_button(self):
+        adapter = _make_adapter(allowed_users={"42"})
+        channel = MagicMock()
+        sent_msg = MagicMock()
+        sent_msg.id = 123458
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+
+        result = await adapter.send_clarify(
+            chat_id="9001",
+            question="Pick a color",
+            choices=["red", "green"],
+            clarify_id="cidNoOtherSend",
+            session_key="sk-no-other-send",
+            allow_other=False,
+        )
+
+        assert result.success is True
+        kwargs = channel.send.call_args.kwargs
+        view = kwargs["view"]
+        assert isinstance(view, ClarifyChoiceView)
+        assert len(view.children) == 2
+        assert all("Other" not in child.label for child in view.children)
+        embed = kwargs["embed"]
+        assert all("Other" not in field["value"] for field in embed.fields)
 
     @pytest.mark.asyncio
     async def test_multi_select_attaches_native_multiselect_view(self):

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -177,10 +177,12 @@ def test_load_restart_drain_timeout_prefers_env_then_config_then_default(
 
 
 @pytest.mark.asyncio
-async def test_request_restart_is_idempotent():
+async def test_request_restart_is_idempotent(monkeypatch):
     runner, _adapter = make_restart_runner()
     runner.stop = AsyncMock()
     runner._launch_detached_restart_command = AsyncMock()
+    sleep = AsyncMock()
+    monkeypatch.setattr(gateway_run.asyncio, "sleep", sleep)
 
     # _run_restart is held on self._restart_task and is intentionally NOT in
     # _background_tasks, so _stop_impl's cancel loop can't abort it mid-await
@@ -193,6 +195,7 @@ async def test_request_restart_is_idempotent():
     await runner._restart_task
 
     runner._launch_detached_restart_command.assert_awaited_once_with()
+    sleep.assert_awaited_once_with(1.5)
     runner.stop.assert_awaited_once_with(
         restart=True, detached_restart=True, service_restart=False
     )
@@ -323,6 +326,7 @@ async def test_windows_detached_restart_scrubs_gateway_marker(monkeypatch, tmp_p
 
     monkeypatch.setattr(gateway_run.sys, "platform", "win32")
     monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["hermes"])
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
     monkeypatch.setenv("_HERMES_GATEWAY", "1")
     monkeypatch.setenv("VIRTUAL_ENV", str(venv_dir))
@@ -346,6 +350,7 @@ async def test_windows_detached_restart_scrubs_gateway_marker(monkeypatch, tmp_p
     assert len(popen_calls) == 1
     cmd, kwargs = popen_calls[0]
     assert cmd[-3:] == ["hermes", "gateway", "restart"]
+    assert "--fallback--" in cmd
     assert kwargs["env"].get("_HERMES_GATEWAY") is None
     assert kwargs["env"]["VIRTUAL_ENV"] == str(venv_dir)
     assert str(site_packages) in kwargs["env"]["PYTHONPATH"].split(gateway_run.os.pathsep)
@@ -364,6 +369,7 @@ async def test_windows_detached_restart_uses_pythonw_for_watcher(monkeypatch, tm
     monkeypatch.setattr(gateway_run.sys, "platform", "win32")
     monkeypatch.setattr(gateway_run.sys, "executable", r"C:\venv\Scripts\python.exe")
     monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["hermes"])
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
     monkeypatch.setenv("VIRTUAL_ENV", str(venv_dir))
 
@@ -392,8 +398,66 @@ async def test_windows_detached_restart_uses_pythonw_for_watcher(monkeypatch, tm
     assert len(popen_calls) == 1
     cmd, kwargs = popen_calls[0]
     assert cmd[0] == r"C:\Python311\pythonw.exe"
+    assert cmd[5] == "0"
     assert cmd[-3:] == ["hermes", "gateway", "restart"]
     assert kwargs["creationflags"] == 0x08000008
+
+
+@pytest.mark.asyncio
+async def test_windows_detached_restart_prefers_hq_admin_helper(monkeypatch, tmp_path):
+    runner, _adapter = make_restart_runner()
+    popen_calls = []
+    venv_dir = tmp_path / "venv"
+    site_packages = venv_dir / "Lib" / "site-packages"
+    site_packages.mkdir(parents=True)
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    admin_invoker = scripts_dir / "invoke_hermes_admin_helper.ps1"
+    admin_invoker.write_text("# test helper", encoding="utf-8")
+
+    monkeypatch.setattr(gateway_run.sys, "platform", "win32")
+    monkeypatch.setattr(gateway_run.sys, "executable", r"C:\venv\Scripts\python.exe")
+    monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["hermes"])
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
+    monkeypatch.setenv("_HERMES_GATEWAY", "1")
+    monkeypatch.setenv("VIRTUAL_ENV", str(venv_dir))
+
+    import hermes_cli._subprocess_compat as subprocess_compat
+    import hermes_cli.gateway_windows as gateway_windows
+
+    monkeypatch.setattr(
+        gateway_windows,
+        "_resolve_detached_python",
+        lambda _python: (r"C:\Python311\pythonw.exe", venv_dir, [str(site_packages)]),
+    )
+    monkeypatch.setattr(
+        subprocess_compat,
+        "windows_detach_popen_kwargs",
+        lambda: {},
+    )
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append((cmd, kwargs))
+        return MagicMock()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    await runner._launch_detached_restart_command()
+
+    assert len(popen_calls) == 1
+    cmd, kwargs = popen_calls[0]
+    assert cmd[0] == r"C:\Python311\pythonw.exe"
+    assert cmd[5] == "1"
+    assert "powershell.exe" in cmd
+    assert str(admin_invoker) in cmd
+    assert cmd[cmd.index("-Action") + 1] == "gateway_restart"
+    assert cmd[cmd.index("-TimeoutSeconds") + 1] == "120"
+    fallback_at = cmd.index("--fallback--")
+    assert cmd[fallback_at + 1 : fallback_at + 4] == ["hermes", "gateway", "restart"]
+    assert kwargs["env"].get("_HERMES_GATEWAY") is None
+    assert kwargs["stdout"] is subprocess.DEVNULL
+    assert kwargs["stderr"] is subprocess.DEVNULL
 
 
 # ── Shutdown notification tests ──────────────────────────────────────

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -565,6 +565,42 @@ class TestBaseAdapterClarifyFallback:
         assert "2." in text and "banana" in text
 
     @pytest.mark.asyncio
+    async def test_allow_other_false_text_fallback_does_not_invite_custom_answer(self):
+        from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+        class _Stub(BasePlatformAdapter):
+            name = "stub"
+
+            def __init__(self):
+                self.sent: list = []
+
+            async def connect(self, *, is_reconnect: bool = False): pass
+            async def disconnect(self): pass
+            async def send(self, chat_id, content, **kw):
+                self.sent.append({"chat_id": chat_id, "content": content})
+                return SendResult(success=True, message_id="1")
+            async def edit(self, *a, **k): return SendResult(success=False)
+            async def get_history(self, *a, **k): return []
+            async def get_chat_info(self, *a, **k): return {}
+
+        adapter = _Stub()
+
+        result = await adapter.send_clarify(
+            chat_id="c",
+            question="Pick fruits",
+            choices=["apple", "banana"],
+            clarify_id="x-no-other",
+            session_key="s-no-other",
+            multi_select=True,
+            allow_other=False,
+        )
+
+        assert result.success is True
+        text = adapter.sent[0]["content"]
+        assert "Reply with one or more numbers/letters or option text." in text
+        assert "own answer" not in text
+
+    @pytest.mark.asyncio
     async def test_open_ended_fallback_renders_question_only(self):
         from gateway.platforms.base import BasePlatformAdapter, SendResult
 

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -189,6 +189,29 @@ class TestTelegramSendClarify:
         assert "<script>" not in kwargs["text"]
         assert "&lt;script&gt;" in kwargs["text"]
 
+    @pytest.mark.asyncio
+    async def test_multi_select_renders_toggle_state_and_done_button(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 104
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        result = await adapter.send_clarify(
+            chat_id="12345",
+            question="Pick all that apply",
+            choices=["alpha", "beta", "gamma"],
+            clarify_id="cidMS",
+            session_key="sk-ms",
+            multi_select=True,
+        )
+
+        assert result.success is True
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert "Select one or more" in kwargs["text"]
+        assert "cidMS" in adapter._clarify_state
+        assert adapter._clarify_multi_state["cidMS"]["selected"] == set()
+        assert adapter._clarify_multi_state["cidMS"]["choices"] == ["alpha", "beta", "gamma"]
+
 
 # ===========================================================================
 # Callback dispatch — _handle_callback_query routing for cl:* prefixes
@@ -447,6 +470,54 @@ class TestTelegramClarifyCallback:
         assert not entry.event.is_set()
         query.answer.assert_called_once()
         assert "invalid" in query.answer.call_args[1]["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_multi_select_toggle_then_done_resolves_joined_choices(self):
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        cm.register("cidMS", "sk-ms", "Pick", ["red", "green", "blue"], multi_select=True)
+        adapter._clarify_state["cidMS"] = "sk-ms"
+        adapter._clarify_multi_state["cidMS"] = {
+            "choices": ["red", "green", "blue"],
+            "selected": set(),
+        }
+
+        async def click(data: str):
+            query = AsyncMock()
+            query.data = data
+            query.message = MagicMock()
+            query.message.chat_id = 12345
+            query.message.text = "Pick"
+            query.from_user = MagicMock()
+            query.from_user.id = "777"
+            query.from_user.first_name = "Tester"
+            query.answer = AsyncMock()
+            query.edit_message_text = AsyncMock()
+            update = MagicMock()
+            update.callback_query = query
+            context = MagicMock()
+            with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+                await adapter._handle_callback_query(update, context)
+            return query
+
+        first = await click("clms:cidMS:toggle:0")
+        assert adapter._clarify_multi_state["cidMS"]["selected"] == {0}
+        first.answer.assert_called_once()
+
+        second = await click("clms:cidMS:toggle:2")
+        assert adapter._clarify_multi_state["cidMS"]["selected"] == {0, 2}
+        second.answer.assert_called_once()
+
+        done = await click("clms:cidMS:done")
+        with cm._lock:
+            entry = cm._entries.get("cidMS")
+        assert entry is not None
+        assert entry.response == "red, blue"
+        assert entry.event.is_set()
+        assert "cidMS" not in adapter._clarify_state
+        assert "cidMS" not in adapter._clarify_multi_state
+        done.edit_message_text.assert_called_once()
 
 
 # ===========================================================================

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1629,6 +1629,78 @@ class TestSendClarifyButtons:
         assert "Other" in rows[4]["title"]
 
     @pytest.mark.asyncio
+    async def test_list_mode_honors_allow_other_false(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"messages": [{"id": "wamid.q2b"}]})
+        )
+
+        result = await adapter.send_clarify(
+            chat_id="15551234567",
+            question="Pick one",
+            choices=["A", "B", "C", "D"],
+            clarify_id="q2b",
+            session_key="sess-2b",
+            allow_other=False,
+        )
+
+        assert result.success
+        payload = adapter._http_client.post.call_args.kwargs["json"]
+        rows = payload["interactive"]["action"]["sections"][0]["rows"]
+        assert len(rows) == 4
+        assert all(row["id"] != "cl:q2b:other" for row in rows)
+        assert all("Other" not in row["title"] for row in rows)
+
+    @pytest.mark.asyncio
+    async def test_multi_select_uses_text_fallback_not_single_select_interactive(self):
+        from tools import clarify_gateway as cm
+
+        with cm._lock:
+            cm._entries.clear()
+            cm._session_index.clear()
+        cm.register(
+            "qms",
+            "sess-ms",
+            "Pick many",
+            ["Alpha", "Bravo", "Charlie"],
+            multi_select=True,
+            min_selections=1,
+            max_selections=2,
+            allow_other=False,
+        )
+
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"messages": [{"id": "wamid.qms"}]})
+        )
+
+        result = await adapter.send_clarify(
+            chat_id="15551234567",
+            question="Pick many",
+            choices=["Alpha", "Bravo", "Charlie"],
+            clarify_id="qms",
+            session_key="sess-ms",
+            multi_select=True,
+            min_selections=1,
+            max_selections=2,
+            allow_other=False,
+        )
+
+        assert result.success
+        payload = adapter._http_client.post.call_args.kwargs["json"]
+        assert payload["type"] == "text"
+        body = payload["text"]["body"]
+        assert "Multiple selections allowed" in body
+        assert "1/A. Alpha" in body
+        assert "own answer" not in body
+        with cm._lock:
+            entry = cm._entries.get("qms")
+        assert entry is not None
+        assert entry.awaiting_text is True
+
+    @pytest.mark.asyncio
     async def test_open_ended_falls_back_to_plain_text(self):
         """No choices → plain text send, no interactive payload."""
         adapter = _make_adapter()

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5088,6 +5088,106 @@ def test_respond_unpacks_sid_tuple_correctly():
         server._answers.pop("rid-x", None)
 
 
+def test_clarify_respond_rejects_custom_answer_when_other_disallowed():
+    ev = threading.Event()
+    server._pending["rid-no-other"] = ("sid_x", ev)
+    server._pending_prompt_payloads["rid-no-other"] = (
+        "clarify.request",
+        {
+            "question": "Pick one",
+            "choices": ["Alpha", "Beta"],
+            "multi_select": False,
+            "allow_other": False,
+        },
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "clarify.respond",
+                "params": {"request_id": "rid-no-other", "answer": "Alpha, Beta"},
+            }
+        )
+        assert resp.get("error")
+        assert resp["error"]["code"] == 4010
+        assert not ev.is_set()
+        assert "rid-no-other" not in server._answers
+    finally:
+        server._pending.pop("rid-no-other", None)
+        server._pending_prompt_payloads.pop("rid-no-other", None)
+        server._answers.pop("rid-no-other", None)
+
+
+def test_clarify_respond_normalizes_allowed_choice_text():
+    ev = threading.Event()
+    server._pending["rid-choice"] = ("sid_x", ev)
+    server._pending_prompt_payloads["rid-choice"] = (
+        "clarify.request",
+        {
+            "question": "Pick one",
+            "choices": ["Alpha", "Beta"],
+            "multi_select": False,
+            "allow_other": False,
+        },
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "clarify.respond",
+                "params": {"request_id": "rid-choice", "answer": "2"},
+            }
+        )
+        assert resp.get("result")
+        assert ev.is_set()
+        assert server._answers.get("rid-choice") == "Beta"
+    finally:
+        server._pending.pop("rid-choice", None)
+        server._pending_prompt_payloads.pop("rid-choice", None)
+        server._answers.pop("rid-choice", None)
+
+
+def test_clarify_respond_enforces_multi_select_bounds():
+    ev = threading.Event()
+    server._pending["rid-ms"] = ("sid_x", ev)
+    server._pending_prompt_payloads["rid-ms"] = (
+        "clarify.request",
+        {
+            "question": "Pick two",
+            "choices": ["Alpha", "Beta", "Gamma"],
+            "multi_select": True,
+            "min_selections": 2,
+            "max_selections": 2,
+            "allow_other": False,
+        },
+    )
+    try:
+        too_few = server.handle_request(
+            {
+                "id": "1",
+                "method": "clarify.respond",
+                "params": {"request_id": "rid-ms", "answer": "1"},
+            }
+        )
+        assert too_few.get("error")
+        assert not ev.is_set()
+
+        ok = server.handle_request(
+            {
+                "id": "2",
+                "method": "clarify.respond",
+                "params": {"request_id": "rid-ms", "answer": "1,3"},
+            }
+        )
+        assert ok.get("result")
+        assert ev.is_set()
+        assert server._answers.get("rid-ms") == "Alpha, Gamma"
+    finally:
+        server._pending.pop("rid-ms", None)
+        server._pending_prompt_payloads.pop("rid-ms", None)
+        server._answers.pop("rid-ms", None)
+
+
 # ---------------------------------------------------------------------------
 # /model switch and other agent-mutating commands must reject while the
 # session is running.  agent.switch_model() mutates self.model, self.provider,

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -90,6 +90,27 @@ class TestClarifyPrimitive:
         assert cm.resolve_text_response_for_session("sk3d", custom) is True
         assert cm.wait_for_response("id3d", timeout=0.1) == custom
 
+    def test_multi_select_metadata_is_stored_in_signature(self):
+        """Gateway entries carry multi-select metadata for adapters/Desktop."""
+        from tools import clarify_gateway as cm
+
+        entry = cm.register(
+            "id-ms",
+            "sk-ms",
+            "Pick several",
+            ["Alpha", "Beta", "Gamma"],
+            multi_select=True,
+            min_selections=1,
+            max_selections=2,
+            allow_other=False,
+        )
+
+        assert entry.multi_select is True
+        assert entry.min_selections == 1
+        assert entry.max_selections == 2
+        assert entry.allow_other is False
+        assert entry.signature()["multi_select"] is True
+
     def test_other_button_flips_to_text_mode(self):
         """mark_awaiting_text makes get_pending_for_session find the entry."""
         from tools import clarify_gateway as cm
@@ -250,3 +271,19 @@ class TestGatewayTextIntercept:
         
         # Clean up
         cm.clear_session("sk-tf")
+
+    def test_parse_multi_select_response_accepts_numbers_and_letters(self):
+        from tools import clarify_gateway as cm
+
+        choices = ["Alpha", "Beta", "Gamma", "Delta"]
+
+        assert cm.parse_multi_select_response("1,3", choices) == ["Alpha", "Gamma"]
+        assert cm.parse_multi_select_response("A+C", choices) == ["Alpha", "Gamma"]
+        assert cm.parse_multi_select_response("2 + 4", choices) == ["Beta", "Delta"]
+
+    def test_parse_multi_select_response_exact_labels_and_custom_text(self):
+        from tools import clarify_gateway as cm
+
+        choices = ["Alpha", "Beta", "Gamma"]
+        assert cm.parse_multi_select_response("Alpha, Gamma", choices) == ["Alpha", "Gamma"]
+        assert cm.parse_multi_select_response("Something else", choices) is None

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -90,6 +90,67 @@ class TestClarifyPrimitive:
         assert cm.resolve_text_response_for_session("sk3d", custom) is True
         assert cm.wait_for_response("id3d", timeout=0.1) == custom
 
+    def test_parse_multi_select_response_exact_label_beats_letter_shortcut(self):
+        from tools import clarify_gateway as cm
+
+        assert cm.parse_multi_select_response("A", ["Alpha", "A", "Gamma"]) == ["A"]
+
+    def test_resolve_text_response_rejects_custom_when_other_disallowed(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("id-no-other", "sk-no-other", "Pick", ["X", "Y"], allow_other=False)
+        assert cm.resolve_text_response_for_session("sk-no-other", "not offered") is False
+        with cm._lock:
+            entry = cm._entries.get("id-no-other")
+        assert entry is not None
+        assert entry.response is None
+        assert not entry.event.is_set()
+
+    def test_resolve_text_response_accepts_exact_choice_when_other_disallowed(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("id-exact", "sk-exact", "Pick", ["Alpha", "A"], allow_other=False)
+        assert cm.resolve_text_response_for_session("sk-exact", "A") is True
+        assert cm.wait_for_response("id-exact", timeout=0.1) == "A"
+
+    def test_multi_select_text_response_enforces_min_max_and_allow_other(self):
+        from tools import clarify_gateway as cm
+
+        cm.register(
+            "id-ms-bounds",
+            "sk-ms-bounds",
+            "Pick",
+            ["A", "B", "C"],
+            multi_select=True,
+            min_selections=2,
+            max_selections=2,
+            allow_other=False,
+        )
+        assert cm.resolve_text_response_for_session("sk-ms-bounds", "1") is False
+        assert cm.resolve_text_response_for_session("sk-ms-bounds", "1,2,3") is False
+        assert cm.resolve_text_response_for_session("sk-ms-bounds", "custom") is False
+        assert cm.resolve_text_response_for_session("sk-ms-bounds", "1,3") is True
+        assert cm.wait_for_response("id-ms-bounds", timeout=0.1) == "A, C"
+
+    def test_invalid_text_response_message_mentions_bounds(self):
+        from tools import clarify_gateway as cm
+
+        entry = cm.register(
+            "id-ms-message",
+            "sk-ms-message",
+            "Pick",
+            ["A", "B", "C"],
+            multi_select=True,
+            min_selections=2,
+            max_selections=2,
+            allow_other=False,
+        )
+
+        message = cm.format_invalid_text_response_message(entry)
+        assert "multi-select" in message
+        assert "at least 2" in message
+        assert "at most 2" in message
+
     def test_multi_select_metadata_is_stored_in_signature(self):
         """Gateway entries carry multi-select metadata for adapters/Desktop."""
         from tools import clarify_gateway as cm

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -229,6 +229,65 @@ class TestClarifyDictChoices:
         assert all("{" not in c for c in result["choices_offered"])
 
 
+class TestClarifyMultiSelect:
+    """Multi-select is an additive extension of clarify, not a new tool."""
+
+    def test_multi_select_metadata_reaches_callback_and_result(self):
+        seen = {}
+
+        def cb(question, choices, **kwargs):
+            seen["question"] = question
+            seen["choices"] = choices
+            seen.update(kwargs)
+            return "Alpha, Gamma"
+
+        result = json.loads(clarify_tool(
+            "Pick all that apply",
+            choices=["Alpha", "Beta", "Gamma"],
+            callback=cb,
+            multi_select=True,
+            min_selections=1,
+            max_selections=3,
+            allow_other=False,
+        ))
+
+        assert seen == {
+            "question": "Pick all that apply",
+            "choices": ["Alpha", "Beta", "Gamma"],
+            "multi_select": True,
+            "min_selections": 1,
+            "max_selections": 3,
+            "allow_other": False,
+        }
+        assert result["selection_mode"] == "multi"
+        assert result["user_response"] == "Alpha, Gamma"
+        assert result["selected_choices"] == ["Alpha", "Gamma"]
+
+    def test_single_select_result_keeps_backcompat_string(self):
+        result = json.loads(clarify_tool(
+            "Pick one",
+            choices=["Alpha", "Beta"],
+            callback=lambda q, c, **kw: "Beta",
+        ))
+
+        assert result["selection_mode"] == "single"
+        assert result["user_response"] == "Beta"
+        assert result["selected_choices"] == ["Beta"]
+
+    def test_invalid_multi_select_bounds_return_error(self):
+        result = json.loads(clarify_tool(
+            "Pick",
+            choices=["A"],
+            callback=lambda q, c, **kw: "A",
+            multi_select=True,
+            min_selections=2,
+            max_selections=1,
+        ))
+
+        assert "error" in result
+        assert "min_selections" in result["error"]
+
+
 class TestClarifySchema:
     """Tests for the OpenAI function-calling schema."""
 
@@ -253,6 +312,13 @@ class TestClarifySchema:
         """Schema should specify max items for choices."""
         choices_spec = CLARIFY_SCHEMA["parameters"]["properties"]["choices"]
         assert choices_spec.get("maxItems") == MAX_CHOICES
+
+    def test_schema_exposes_multi_select_fields(self):
+        properties = CLARIFY_SCHEMA["parameters"]["properties"]
+        assert properties["multi_select"]["type"] == "boolean"
+        assert properties["min_selections"]["type"] == "integer"
+        assert properties["max_selections"]["type"] == ["integer", "null"]
+        assert properties["allow_other"]["type"] == "boolean"
 
     def test_max_choices_is_four(self):
         """MAX_CHOICES constant should be 4."""

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -287,6 +287,40 @@ class TestClarifyMultiSelect:
         assert "error" in result
         assert "min_selections" in result["error"]
 
+    def test_multi_select_min_cannot_exceed_available_choices(self):
+        result = json.loads(clarify_tool(
+            "Pick",
+            choices=["A"],
+            callback=lambda q, c, **kw: "A",
+            multi_select=True,
+            min_selections=2,
+        ))
+
+        assert "error" in result
+        assert "available choices" in result["error"]
+
+    def test_multi_select_max_cannot_exceed_available_choices(self):
+        result = json.loads(clarify_tool(
+            "Pick",
+            choices=["A", "B"],
+            callback=lambda q, c, **kw: "A",
+            multi_select=True,
+            max_selections=3,
+        ))
+
+        assert "error" in result
+        assert "available choices" in result["error"]
+
+    def test_selected_choices_exact_label_beats_letter_shortcut(self):
+        result = json.loads(clarify_tool(
+            "Pick",
+            choices=["Alpha", "A", "Gamma"],
+            callback=lambda q, c, **kw: "A",
+            multi_select=True,
+        ))
+
+        assert result["selected_choices"] == ["A"]
+
 
 class TestClarifySchema:
     """Tests for the OpenAI function-calling schema."""

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -32,6 +32,7 @@ Two delivery paths from the adapter:
 from __future__ import annotations
 
 import logging
+import re
 import threading
 import time
 from dataclasses import dataclass, field
@@ -51,6 +52,10 @@ class _ClarifyEntry:
     session_key: str
     question: str
     choices: Optional[List[str]]
+    multi_select: bool = False
+    min_selections: int = 0
+    max_selections: Optional[int] = None
+    allow_other: bool = True
     event: threading.Event = field(default_factory=threading.Event)
     response: Optional[str] = None
     awaiting_text: bool = False  # set when user picked "Other" or clarify is open-ended
@@ -61,6 +66,10 @@ class _ClarifyEntry:
             "session_key": self.session_key,
             "question": self.question,
             "choices": list(self.choices) if self.choices else None,
+            "multi_select": self.multi_select,
+            "min_selections": self.min_selections,
+            "max_selections": self.max_selections,
+            "allow_other": self.allow_other,
         }
 
 
@@ -80,6 +89,10 @@ def register(
     session_key: str,
     question: str,
     choices: Optional[List[str]],
+    multi_select: bool = False,
+    min_selections: int = 0,
+    max_selections: Optional[int] = None,
+    allow_other: bool = True,
 ) -> _ClarifyEntry:
     """Register a pending clarify request and return the entry.
 
@@ -91,6 +104,10 @@ def register(
         session_key=session_key,
         question=question,
         choices=list(choices) if choices else None,
+        multi_select=bool(multi_select),
+        min_selections=int(min_selections or 0),
+        max_selections=max_selections,
+        allow_other=bool(allow_other),
         # Open-ended (no choices) → next message IS the response, no buttons needed.
         awaiting_text=not bool(choices),
     )
@@ -98,6 +115,45 @@ def register(
         _entries[clarify_id] = entry
         _session_index.setdefault(session_key, []).append(clarify_id)
     return entry
+
+
+def parse_multi_select_response(raw: str, choices: List[str]) -> Optional[List[str]]:
+    """Parse a text fallback multi-select response into offered choice labels.
+
+    Accepts compact forms like ``1,3``, ``A+C``, ``2 + 4``, and exact labels
+    like ``Alpha, Gamma``. Returns ``None`` when the response looks like a
+    custom free-form answer rather than a clean selection.
+    """
+    if not raw or not choices:
+        return None
+
+    tokens = [t.strip() for t in re.split(r"\s*(?:,|\+|;|\n)\s*", raw.strip()) if t.strip()]
+    if not tokens:
+        return None
+
+    labels = list(choices)
+    label_map = {label.lower(): label for label in labels}
+    selected: List[str] = []
+
+    for token in tokens:
+        label = None
+        if token.isdigit():
+            idx = int(token) - 1
+            if 0 <= idx < len(labels):
+                label = labels[idx]
+        elif len(token) == 1 and token.isalpha():
+            idx = ord(token.upper()) - ord("A")
+            if 0 <= idx < len(labels):
+                label = labels[idx]
+        else:
+            label = label_map.get(token.lower())
+
+        if label is None:
+            return None
+        if label not in selected:
+            selected.append(label)
+
+    return selected or None
 
 
 def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -136,17 +136,15 @@ def parse_multi_select_response(raw: str, choices: List[str]) -> Optional[List[s
     selected: List[str] = []
 
     for token in tokens:
-        label = None
-        if token.isdigit():
+        label = label_map.get(token.lower())
+        if label is None and token.isdigit():
             idx = int(token) - 1
             if 0 <= idx < len(labels):
                 label = labels[idx]
-        elif len(token) == 1 and token.isalpha():
+        elif label is None and len(token) == 1 and token.isalpha():
             idx = ord(token.upper()) - ord("A")
             if 0 <= idx < len(labels):
                 label = labels[idx]
-        else:
-            label = label_map.get(token.lower())
 
         if label is None:
             return None
@@ -243,20 +241,48 @@ def get_pending_for_session(
         return None
 
 
-def _coerce_text_response(entry: _ClarifyEntry, response: str) -> str:
-    """Map typed choice replies to canonical choice text, otherwise keep custom text."""
+def _coerce_text_response(entry: _ClarifyEntry, response: str) -> Optional[str]:
+    """Map typed replies to canonical choice text, or reject disallowed custom text."""
     text = str(response).strip()
     if entry.choices:
+        if entry.multi_select:
+            parsed = parse_multi_select_response(text, entry.choices)
+            if parsed:
+                if len(parsed) < int(entry.min_selections or 0):
+                    return None
+                if entry.max_selections is not None and len(parsed) > int(entry.max_selections):
+                    return None
+                return ", ".join(parsed)
+            return text if entry.allow_other else None
+
+        label_map = {str(choice).strip().casefold(): str(choice).strip() for choice in entry.choices}
+        exact = label_map.get(text.casefold())
+        if exact is not None:
+            return exact
         try:
             idx = int(text) - 1
         except ValueError:
             idx = -1
         if 0 <= idx < len(entry.choices):
             return entry.choices[idx]
-        for choice in entry.choices:
-            if text.casefold() == str(choice).strip().casefold():
-                return str(choice).strip()
+        return text if entry.allow_other else None
     return text
+
+
+def format_invalid_text_response_message(entry: _ClarifyEntry) -> str:
+    """Human retry hint for a typed reply that failed clarify coercion."""
+    if entry.multi_select:
+        bounds: List[str] = []
+        if entry.min_selections:
+            bounds.append(f"at least {entry.min_selections}")
+        if entry.max_selections is not None:
+            bounds.append(f"at most {entry.max_selections}")
+        bound_text = f" ({', '.join(bounds)})" if bounds else ""
+        return (
+            "That doesn't match this multi-select prompt. "
+            f"Reply with listed choices{bound_text}, for example `1,3` or `A+C`."
+        )
+    return "That doesn't match this prompt. Reply with one of the listed choices."
 
 
 def resolve_text_response_for_session(session_key: str, response: str) -> bool:
@@ -264,10 +290,10 @@ def resolve_text_response_for_session(session_key: str, response: str) -> bool:
     entry = get_pending_for_session(session_key, include_choice_prompts=True)
     if entry is None:
         return False
-    return resolve_gateway_clarify(
-        entry.clarify_id,
-        _coerce_text_response(entry, response),
-    )
+    coerced = _coerce_text_response(entry, response)
+    if coerced is None:
+        return False
+    return resolve_gateway_clarify(entry.clarify_id, coerced)
 
 
 def mark_awaiting_text(clarify_id: str) -> bool:

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -2,9 +2,10 @@
 """
 Clarify Tool Module - Interactive Clarifying Questions
 
-Allows the agent to present structured multiple-choice questions or open-ended
-prompts to the user. In CLI mode, choices are navigable with arrow keys. On
-messaging platforms, choices are rendered as a numbered list.
+Allows the agent to present structured multiple-choice questions, multi-select
+questions, or open-ended prompts to the user. In CLI mode, choices are
+navigable with arrow keys. On messaging platforms, choices are rendered as
+buttons or a numbered fallback list.
 
 The actual user-interaction logic lives in the platform layer (cli.py for CLI,
 gateway/run.py for messaging). This module defines the schema, validation, and
@@ -12,7 +13,8 @@ a thin dispatcher that delegates to a platform-provided callback.
 """
 
 import json
-from typing import List, Optional, Callable
+import re
+from typing import Callable, List, Optional
 
 
 # Maximum number of predefined choices the agent can offer.
@@ -53,21 +55,65 @@ def _flatten_choice(c) -> str:
     return str(c).strip()
 
 
+def _selected_choices_from_response(response: str, choices: Optional[List[str]]) -> List[str]:
+    """Best-effort parse of selected choice labels from a response string.
+
+    ``user_response`` remains the backcompat source of truth. This additive
+    structured field helps UI/test consumers understand which offered choices
+    were selected. Free-form custom text returns an empty list.
+    """
+    if not response or not choices:
+        return []
+
+    labels = list(choices)
+    label_map = {label.lower(): label for label in labels}
+    selected: List[str] = []
+    tokens = [t.strip() for t in re.split(r"\s*(?:,|\+|;|\n)\s*", response) if t.strip()]
+    if not tokens:
+        tokens = [response.strip()]
+
+    for token in tokens:
+        label = None
+        if token.isdigit():
+            idx = int(token) - 1
+            if 0 <= idx < len(labels):
+                label = labels[idx]
+        elif len(token) == 1 and token.isalpha():
+            idx = ord(token.upper()) - ord("A")
+            if 0 <= idx < len(labels):
+                label = labels[idx]
+        else:
+            label = label_map.get(token.lower())
+        if label and label not in selected:
+            selected.append(label)
+    return selected
+
+
 def clarify_tool(
     question: str,
     choices: Optional[List[str]] = None,
     callback: Optional[Callable] = None,
+    multi_select: bool = False,
+    min_selections: int = 0,
+    max_selections: Optional[int] = None,
+    allow_other: bool = True,
 ) -> str:
     """
-    Ask the user a question, optionally with multiple-choice options.
+    Ask the user a question, optionally with selectable options.
 
     Args:
         question: The question text to present.
         choices:  Up to 4 predefined answer choices. When omitted the
                   question is purely open-ended.
         callback: Platform-provided function that handles the actual UI
-                  interaction. Signature: callback(question, choices) -> str.
+                  interaction. Preferred signature:
+                  callback(question, choices, **metadata) -> str.
                   Injected by the agent runner (cli.py / gateway).
+        multi_select: Preserve multi-pick UX when several choices can be
+                      selected together.
+        min_selections: Minimum requested selections for multi-select prompts.
+        max_selections: Maximum requested selections for multi-select prompts.
+        allow_other: Whether the UI should allow free-form "Other" answers.
 
     Returns:
         JSON string with the user's response.
@@ -76,6 +122,22 @@ def clarify_tool(
         return tool_error("Question text is required.")
 
     question = question.strip()
+
+    try:
+        min_selections = int(min_selections or 0)
+    except (TypeError, ValueError):
+        return tool_error("min_selections must be an integer.")
+    if max_selections is not None:
+        try:
+            max_selections = int(max_selections)
+        except (TypeError, ValueError):
+            return tool_error("max_selections must be an integer or null.")
+    if min_selections < 0:
+        return tool_error("min_selections must be >= 0.")
+    if max_selections is not None and max_selections < 0:
+        return tool_error("max_selections must be >= 0 when provided.")
+    if max_selections is not None and min_selections > max_selections:
+        return tool_error("min_selections cannot be greater than max_selections.")
 
     # Validate and trim choices
     if choices is not None:
@@ -99,17 +161,33 @@ def clarify_tool(
         )
 
     try:
-        user_response = callback(question, choices)
+        try:
+            user_response = callback(
+                question,
+                choices,
+                multi_select=bool(multi_select),
+                min_selections=min_selections,
+                max_selections=max_selections,
+                allow_other=bool(allow_other),
+            )
+        except TypeError:
+            # Backcompat for platform callbacks/plugins that still implement
+            # callback(question, choices). Hermes-owned callbacks accept the
+            # metadata, but this avoids breaking older integrations.
+            user_response = callback(question, choices)
     except Exception as exc:
         return json.dumps(
             {"error": f"Failed to get user input: {exc}"},
             ensure_ascii=False,
         )
 
+    user_response_text = str(user_response).strip()
     return json.dumps({
         "question": question,
         "choices_offered": choices,
-        "user_response": str(user_response).strip(),
+        "selection_mode": "multi" if multi_select else "single",
+        "user_response": user_response_text,
+        "selected_choices": _selected_choices_from_response(user_response_text, choices),
     }, ensure_ascii=False)
 
 
@@ -126,10 +204,13 @@ CLARIFY_SCHEMA = {
     "name": "clarify",
     "description": (
         "Ask the user a question when you need clarification, feedback, or a "
-        "decision before proceeding. Supports two modes:\n\n"
-        "1. **Multiple choice** — provide up to 4 choices. The user picks one "
-        "or types their own answer via a 5th 'Other' option.\n"
-        "2. **Open-ended** — omit choices entirely. The user types a free-form "
+        "decision before proceeding. Supports three modes:\n\n"
+        "1. **Single-choice multiple choice** — provide up to 4 choices. The "
+        "user picks one or types their own answer via a 5th 'Other' option.\n"
+        "2. **Multi-select** — set `multi_select=true` when several choices "
+        "may be selected together; the UI should preserve checkbox/multi-pick "
+        "semantics where supported.\n"
+        "3. **Open-ended** — omit choices entirely. The user types a free-form "
         "response.\n\n"
         "CRITICAL: when you are offering options, put each option ONLY in the "
         "`choices` array — NEVER enumerate the options inside the `question` "
@@ -169,6 +250,27 @@ CLARIFY_SCHEMA = {
                     "entirely ONLY for a genuinely open-ended free-text question."
                 ),
             },
+            "multi_select": {
+                "type": "boolean",
+                "description": (
+                    "Set true only when the user may select multiple choices "
+                    "together. Leave false for exclusive single-choice decisions."
+                ),
+            },
+            "min_selections": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Minimum number of selections requested for multi-select prompts.",
+            },
+            "max_selections": {
+                "type": ["integer", "null"],
+                "minimum": 0,
+                "description": "Maximum number of selections requested for multi-select prompts, or null for no explicit cap.",
+            },
+            "allow_other": {
+                "type": "boolean",
+                "description": "Whether the UI should offer a free-form Other answer. Defaults to true.",
+            },
         },
         "required": ["question"],
     },
@@ -185,7 +287,12 @@ registry.register(
     handler=lambda args, **kw: clarify_tool(
         question=args.get("question", ""),
         choices=args.get("choices"),
-        callback=kw.get("callback")),
+        callback=kw.get("callback"),
+        multi_select=bool(args.get("multi_select", False)),
+        min_selections=args.get("min_selections", 0),
+        max_selections=args.get("max_selections"),
+        allow_other=bool(args.get("allow_other", True)),
+    ),
     check_fn=check_clarify_requirements,
     emoji="❓",
 )

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -73,17 +73,17 @@ def _selected_choices_from_response(response: str, choices: Optional[List[str]])
         tokens = [response.strip()]
 
     for token in tokens:
-        label = None
-        if token.isdigit():
+        # Exact labels win before numeric/letter shortcuts so a real choice
+        # named "A" is not misread as shortcut A -> first option.
+        label = label_map.get(token.lower())
+        if label is None and token.isdigit():
             idx = int(token) - 1
             if 0 <= idx < len(labels):
                 label = labels[idx]
-        elif len(token) == 1 and token.isalpha():
+        elif label is None and len(token) == 1 and token.isalpha():
             idx = ord(token.upper()) - ord("A")
             if 0 <= idx < len(labels):
                 label = labels[idx]
-        else:
-            label = label_map.get(token.lower())
         if label and label not in selected:
             selected.append(label)
     return selected
@@ -153,6 +153,11 @@ def clarify_tool(
             choices = choices[:MAX_CHOICES]
         if not choices:
             choices = None  # empty list → open-ended
+        elif multi_select:
+            if min_selections > len(choices):
+                return tool_error("min_selections cannot exceed the number of available choices.")
+            if max_selections is not None and max_selections > len(choices):
+                return tool_error("max_selections cannot exceed the number of available choices.")
 
     if callback is None:
         return json.dumps(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9587,6 +9587,69 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"task_id": task_id})
 
 
+def _coerce_clarify_response_from_payload(payload: dict, answer: str) -> tuple[bool, str, str]:
+    """Validate/normalize Desktop clarify replies before unblocking the agent.
+
+    The renderer is a convenience layer, not the trust boundary.  Keep the
+    server-side bridge aligned with ``tools.clarify_gateway`` so a stale or
+    buggy UI cannot turn a constrained single-select prompt into free-form or
+    multi-select input.
+    """
+    text = str(answer or "").strip()
+    if not text:
+        return True, "", ""
+
+    choices = payload.get("choices")
+    if not isinstance(choices, list):
+        choices = []
+    clean_choices = [str(choice).strip() for choice in choices if str(choice).strip()]
+    if not clean_choices:
+        return True, text, ""
+
+    multi_select = bool(payload.get("multi_select", False))
+    allow_other = bool(payload.get("allow_other", True))
+    try:
+        min_selections = int(payload.get("min_selections") or 0)
+    except (TypeError, ValueError):
+        min_selections = 0
+    max_raw = payload.get("max_selections")
+    try:
+        max_selections = int(max_raw) if max_raw is not None else None
+    except (TypeError, ValueError):
+        max_selections = None
+
+    if multi_select:
+        try:
+            from tools.clarify_gateway import parse_multi_select_response
+
+            parsed = parse_multi_select_response(text, clean_choices)
+        except Exception:
+            parsed = None
+        if parsed:
+            if len(parsed) < min_selections:
+                return False, "", f"Select at least {min_selections} choices."
+            if max_selections is not None and len(parsed) > max_selections:
+                return False, "", f"Select at most {max_selections} choices."
+            return True, ", ".join(parsed), ""
+        if allow_other:
+            return True, text, ""
+        return False, "", "Reply with one or more listed choices."
+
+    label_map = {choice.casefold(): choice for choice in clean_choices}
+    exact = label_map.get(text.casefold())
+    if exact is not None:
+        return True, exact, ""
+    try:
+        idx = int(text) - 1
+    except ValueError:
+        idx = -1
+    if 0 <= idx < len(clean_choices):
+        return True, clean_choices[idx], ""
+    if allow_other:
+        return True, text, ""
+    return False, "", "Reply with one of the listed choices."
+
+
 # ── Methods: respond ─────────────────────────────────────────────────
 
 
@@ -9604,6 +9667,18 @@ def _respond(rid, params, key):
 
 @method("clarify.respond")
 def _(rid, params: dict) -> dict:
+    request_id = params.get("request_id", "")
+    answer = params.get("answer", "")
+    with _prompt_lock:
+        prompt_payload = _pending_prompt_payloads.get(request_id)
+    if prompt_payload and prompt_payload[0] == "clarify.request":
+        ok, coerced, message = _coerce_clarify_response_from_payload(
+            prompt_payload[1], str(answer),
+        )
+        if not ok:
+            return _err(rid, 4010, message or "Invalid clarify response")
+        params = dict(params)
+        params["answer"] = coerced
     return _respond(rid, params, "answer")
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3606,8 +3606,17 @@ def _agent_cbs(sid: str) -> dict:
         "notice_clear_callback": lambda key: _emit(
             "notification.clear", sid, {"key": key}
         ),
-        "clarify_callback": lambda q, c: _block(
-            "clarify.request", sid, {"question": q, "choices": c}
+        "clarify_callback": lambda q, c, **kw: _block(
+            "clarify.request",
+            sid,
+            {
+                "question": q,
+                "choices": c,
+                "multi_select": bool(kw.get("multi_select", False)),
+                "min_selections": kw.get("min_selections", 0),
+                "max_selections": kw.get("max_selections"),
+                "allow_other": kw.get("allow_other", True),
+            },
         ),
         # read_terminal tool (desktop GUI): same blocking bridge as clarify — the
         # renderer answers terminal.read.respond with the serialized buffer.


### PR DESCRIPTION
## Summary

This draft PR ports the verified HQ local stack onto current `origin/main`.

- Add a file-backed Hermes Desktop pinned-session bridge so external automation can read/write pinned session IDs while the renderer stays in sync.
- Harden Windows gateway restart behavior by combining the current no-console `pythonw` watcher path with HQ Admin Helper restart fallback and a longer flush delay before shutdown.
- Sort numbered Desktop sessions consistently.
- Explain prompt submit timeouts in Desktop UX/i18n and test the timeout path.
- Restore native clarify multi-select metadata/UI across gateway adapters, Desktop renderer state, TUI gateway, and fallback typed responses.

## Porting notes

- Base: `NousResearch/hermes-agent@9a0010fd4` (`origin/main`).
- Head: `5e7db25acc18966e4411ff2b470a1cd066c62708`.
- `4626ceb74` was already present upstream after unshallow/fetch.
- `cfc161bca` became empty against current upstream; its only effective change was already represented after conflict resolution.
- Conflict resolutions preserved upstream behavior and HQ behavior:
  - `gateway/run.py` Windows restart keeps upstream `pythonw` no-console watcher and adds HQ Admin Helper + CLI fallback.
  - `gateway/run.py` clarify text interception keeps single-choice typed coercion and adds multi-select text parsing.

## Verification

Local verification on Windows / HQ clean worktree:

- `git diff --check origin/main...HEAD` — pass.
- `python -m py_compile` on changed Python files — pass.
- Focused pytest:
  - `tests/gateway/test_restart_drain.py`
  - `tests/tools/test_clarify_gateway.py`
  - `tests/tools/test_clarify_tool.py`
  - `tests/gateway/test_telegram_clarify_buttons.py`
  - `tests/gateway/test_discord_clarify_buttons.py`
  - Result: `114 passed, 2 warnings`.
- Desktop focused Vitest after `npm ci --prefer-offline --no-audit --no-fund`:
  - `src/components/assistant-ui/clarify-tool.test.tsx`
  - `src/store/layout.test.ts`
  - `src/store/session.test.ts`
  - `src/app/session/hooks/use-prompt-actions.test.tsx`
  - Result: `4 passed`, `62 tests passed`.
- Desktop typecheck: `npm -C apps/desktop run typecheck` — pass.
- Desktop platform tests: `npm -C apps/desktop run test:desktop:platforms` — `282 passed`, `2 failed`; the exact two failures were reproduced unchanged on `origin/main` baseline and are not introduced by this PR.
- Added-line security scan v2 — `0 findings`; one initial false positive was `SESSION_NUMBER_RE.exec(title)` regex method use.

## Known baseline failures reproduced on origin/main

The following Windows Node tests fail on both this branch and `origin/main@9a0010fd4`:

- `electron/update-relaunch.test.cjs`: `resolveUnpackedRelease returns the dir for a binary UNDER release/<plat>-unpacked`.
- `electron/windows-child-process.test.cjs`: `bootstrap PowerShell runner hides Windows console children`.

They are recorded here to avoid conflating existing upstream Windows baseline failures with this PR.
