### PR TITLE
fix(gateway): preserve sessions across restarts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5259,6 +5259,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if agent is None:
             return
+        if context.startswith("shutdown"):
+            try:
+                agent._end_session_on_close = False
+            except Exception:
+                pass
         try:
             await asyncio.wait_for(
                 self._run_in_executor_with_context(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -965,6 +965,93 @@ class SessionStore:
             thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
             profile=self._resolve_profile_for_key(source),
         )
+
+    def _create_entry_from_recovered_row(
+        self,
+        *,
+        row: Dict[str, Any],
+        session_key: str,
+        source: SessionSource,
+        now: datetime,
+    ) -> SessionEntry:
+        started_at = row.get("started_at")
+        try:
+            created_at = datetime.fromtimestamp(float(started_at)) if started_at else now
+        except (TypeError, ValueError, OSError):
+            created_at = now
+        return SessionEntry(
+            session_key=session_key,
+            session_id=str(row["id"]),
+            created_at=created_at,
+            updated_at=now,
+            origin=source,
+            display_name=source.chat_name,
+            platform=source.platform,
+            chat_type=source.chat_type,
+        )
+
+    def _recover_session_from_db(
+        self,
+        *,
+        session_key: str,
+        source: SessionSource,
+        now: datetime,
+    ) -> Optional[SessionEntry]:
+        """Rebuild a missing session-key mapping from durable state.db data."""
+        if not self._db:
+            return None
+        finder = getattr(self._db, "find_latest_gateway_session_for_peer", None)
+        if not callable(finder):
+            return None
+        try:
+            recovered = finder(
+                source=source.platform.value,
+                user_id=source.user_id,
+                session_key=session_key,
+                chat_id=source.chat_id,
+                chat_type=source.chat_type,
+                thread_id=source.thread_id,
+            )
+        except Exception as exc:
+            logger.debug("Gateway session DB recovery failed for %s: %s", session_key, exc)
+            return None
+        if not recovered:
+            return None
+        try:
+            self._db.reopen_session(str(recovered["id"]))
+        except Exception as exc:
+            logger.debug("Gateway session DB reopen failed for %s: %s", session_key, exc)
+        return self._create_entry_from_recovered_row(
+            row=recovered,
+            session_key=session_key,
+            source=source,
+            now=now,
+        )
+
+    def _record_gateway_session_peer(
+        self,
+        session_id: str,
+        session_key: str,
+        source: Optional[SessionSource],
+    ) -> None:
+        """Persist the routing peer for an existing gateway session row."""
+        if not self._db or not source:
+            return
+        recorder = getattr(self._db, "record_gateway_session_peer", None)
+        if not callable(recorder):
+            return
+        try:
+            recorder(
+                session_id,
+                source=source.platform.value,
+                user_id=source.user_id,
+                session_key=session_key,
+                chat_id=source.chat_id,
+                chat_type=source.chat_type,
+                thread_id=source.thread_id,
+            )
+        except Exception as exc:
+            logger.debug("Gateway session peer record failed for %s: %s", session_key, exc)
     
     def _is_session_expired(self, entry: SessionEntry) -> bool:
         """Check if a session has expired based on its reset policy.
@@ -1113,14 +1200,13 @@ class SessionStore:
                     reset_reason = "suspended"
                 elif entry.resume_pending:
                     # Restart-interrupted session: preserve the session_id
-                    # and return the existing entry so the transcript
-                    # reloads intact.  ``resume_pending`` is cleared after
-                    # the NEXT successful turn completes (not here), which
-                    # means a re-interrupted retry keeps trying — the
-                    # stuck-loop counter handles terminal escalation.
-                    entry.updated_at = now
-                    self._save()
-                    return entry
+                    # and return the existing entry so the transcript reloads
+                    # intact, but still honour normal daily/idle reset policy.
+                    reset_reason = self._should_reset(entry, source)
+                    if not reset_reason:
+                        entry.updated_at = now
+                        self._save()
+                        return entry
                 else:
                     reset_reason = self._should_reset(entry, source)
                 if not reset_reason:
@@ -1138,6 +1224,17 @@ class SessionStore:
                 was_auto_reset = False
                 auto_reset_reason = None
                 reset_had_activity = False
+
+            if not force_new and not db_end_session_id:
+                recovered_entry = self._recover_session_from_db(
+                    session_key=session_key,
+                    source=source,
+                    now=now,
+                )
+                if recovered_entry is not None:
+                    self._entries[session_key] = recovered_entry
+                    self._save()
+                    return recovered_entry
 
             # Create new session
             session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
@@ -1162,6 +1259,10 @@ class SessionStore:
                 "session_id": session_id,
                 "source": source.platform.value,
                 "user_id": source.user_id,
+                "session_key": session_key,
+                "chat_id": source.chat_id,
+                "chat_type": source.chat_type,
+                "thread_id": source.thread_id,
             }
 
         # SQLite operations outside the lock
@@ -1174,6 +1275,11 @@ class SessionStore:
         if self._db and db_create_kwargs:
             try:
                 self._db.create_session(**db_create_kwargs)
+                self._record_gateway_session_peer(
+                    session_id,
+                    session_key,
+                    source,
+                )
             except Exception as e:
                 print(f"[gateway] Warning: Failed to create SQLite session: {e}")
 
@@ -1194,6 +1300,11 @@ class SessionStore:
                 if last_prompt_tokens is not None:
                     entry.last_prompt_tokens = last_prompt_tokens
                 self._save()
+                self._record_gateway_session_peer(
+                    entry.session_id,
+                    session_key,
+                    entry.origin,
+                )
 
     def suspend_session(self, session_key: str) -> bool:
         """Mark a session as suspended so it auto-resets on next access.
@@ -1388,6 +1499,10 @@ class SessionStore:
                 "session_id": session_id,
                 "source": old_entry.platform.value if old_entry.platform else "unknown",
                 "user_id": old_entry.origin.user_id if old_entry.origin else None,
+                "session_key": session_key,
+                "chat_id": old_entry.origin.chat_id if old_entry.origin else None,
+                "chat_type": old_entry.origin.chat_type if old_entry.origin else None,
+                "thread_id": old_entry.origin.thread_id if old_entry.origin else None,
             }
 
         if self._db and db_end_session_id:
@@ -1399,6 +1514,11 @@ class SessionStore:
         if self._db and db_create_kwargs:
             try:
                 self._db.create_session(**db_create_kwargs)
+                self._record_gateway_session_peer(
+                    session_id,
+                    session_key,
+                    old_entry.origin,
+                )
             except Exception as e:
                 logger.debug("Session DB operation failed: %s", e)
 
@@ -1456,6 +1576,11 @@ class SessionStore:
                 self._db.reopen_session(target_session_id)
             except Exception as e:
                 logger.debug("Session DB reopen_session failed: %s", e)
+            self._record_gateway_session_peer(
+                target_session_id,
+                session_key,
+                new_entry.origin if new_entry else None,
+            )
 
         return new_entry
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -121,7 +121,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 16
+SCHEMA_VERSION = 17
 
 # ---------------------------------------------------------------------------
 # WAL-compatibility fallback
@@ -640,6 +640,10 @@ CREATE TABLE IF NOT EXISTS sessions (
     id TEXT PRIMARY KEY,
     source TEXT NOT NULL,
     user_id TEXT,
+    session_key TEXT,
+    chat_id TEXT,
+    chat_type TEXT,
+    thread_id TEXT,
     model TEXT,
     model_config TEXT,
     system_prompt TEXT,
@@ -724,6 +728,10 @@ CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(ex
 DEFERRED_INDEX_SQL = """
 CREATE INDEX IF NOT EXISTS idx_messages_session_active
     ON messages(session_id, active, timestamp);
+CREATE INDEX IF NOT EXISTS idx_sessions_session_key
+    ON sessions(session_key, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_sessions_gateway_peer
+    ON sessions(source, user_id, chat_id, chat_type, thread_id, started_at DESC);
 """
 
 FTS_SQL = """
@@ -1471,19 +1479,29 @@ class SessionDB:
         model_config: Dict[str, Any] = None,
         system_prompt: str = None,
         user_id: str = None,
+        session_key: str = None,
+        chat_id: str = None,
+        chat_type: str = None,
+        thread_id: str = None,
         parent_session_id: str = None,
         cwd: str = None,
     ) -> None:
         """Shared INSERT OR IGNORE for session rows."""
         def _do(conn):
             conn.execute(
-                """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, cwd, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                """INSERT OR IGNORE INTO sessions (
+                   id, source, user_id, session_key, chat_id, chat_type, thread_id,
+                   model, model_config, system_prompt, parent_session_id, cwd, started_at
+                )
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
                     user_id,
+                    session_key,
+                    chat_id,
+                    chat_type,
+                    thread_id,
                     model,
                     json.dumps(model_config) if model_config else None,
                     system_prompt,
@@ -1498,6 +1516,105 @@ class SessionDB:
         """Create a new session record. Returns the session_id."""
         self._insert_session_row(session_id, source, **kwargs)
         return session_id
+
+    def record_gateway_session_peer(
+        self,
+        session_id: str,
+        *,
+        source: str,
+        user_id: str = None,
+        session_key: str = None,
+        chat_id: str = None,
+        chat_type: str = None,
+        thread_id: str = None,
+    ) -> None:
+        """Persist the gateway routing peer for an existing session row."""
+        if not session_id or not session_key:
+            return
+
+        def _do(conn):
+            conn.execute(
+                """UPDATE sessions
+                   SET session_key = ?, source = ?, user_id = ?, chat_id = ?,
+                       chat_type = ?, thread_id = ?
+                   WHERE id = ?""",
+                (
+                    session_key,
+                    source,
+                    user_id,
+                    chat_id,
+                    chat_type,
+                    thread_id,
+                    session_id,
+                ),
+            )
+
+        self._execute_write(_do)
+
+    def find_latest_gateway_session_for_peer(
+        self,
+        *,
+        source: str,
+        user_id: Optional[str] = None,
+        session_key: Optional[str] = None,
+        chat_id: Optional[str] = None,
+        chat_type: Optional[str] = None,
+        thread_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Find the latest recoverable gateway session for a routing peer.
+
+        ``sessions.json`` is the fast routing index, but it can be missing or
+        pruned after process-level restart bugs.  New gateway sessions persist
+        the deterministic ``session_key`` on the durable session row so the
+        mapping can be rebuilt exactly.  Rows ended only by older gateway
+        cleanup's ``agent_close`` bug are treated as recoverable; explicit
+        conversation boundaries such as /new, /resume switches, and compression
+        splits are not.
+        """
+        if not session_key:
+            return None
+        with self._lock:
+            row = self._conn.execute(
+                """
+                SELECT * FROM sessions
+                WHERE session_key = ?
+                  AND source = ?
+                  AND (ended_at IS NULL OR end_reason = 'agent_close')
+                  AND (COALESCE(message_count, 0) > 0 OR EXISTS (
+                      SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1
+                  ))
+                ORDER BY started_at DESC
+                LIMIT 1
+                """,
+                (session_key, source),
+            ).fetchone()
+            if row is not None:
+                return dict(row)
+
+            # Conservative fallback for rows created by current code but with a
+            # temporarily-missing exact key: still require the complete peer
+            # tuple so we never cross chats/threads/users.
+            if chat_id is None or chat_type is None:
+                return None
+            row = self._conn.execute(
+                """
+                SELECT * FROM sessions
+                WHERE source = ?
+                  AND COALESCE(user_id, '') = COALESCE(?, '')
+                  AND COALESCE(chat_id, '') = COALESCE(?, '')
+                  AND COALESCE(chat_type, '') = COALESCE(?, '')
+                  AND COALESCE(thread_id, '') = COALESCE(?, '')
+                  AND (ended_at IS NULL OR end_reason = 'agent_close')
+                  AND (COALESCE(message_count, 0) > 0 OR EXISTS (
+                      SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1
+                  ))
+                ORDER BY started_at DESC
+                LIMIT 1
+                """,
+                (source, user_id, chat_id, chat_type, thread_id),
+            ).fetchone()
+        return dict(row) if row else None
+
     def end_session(self, session_id: str, end_reason: str) -> None:
         """Mark a session as ended.
 

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -223,3 +223,24 @@ class TestCleanShutdownMarker:
             asyncio.get_event_loop().run_until_complete(runner.stop(restart=True))
 
         assert marker.exists(), ".clean_shutdown marker should exist after restart-stop too"
+
+
+    def test_shutdown_cleanup_does_not_end_gateway_session_rows(self, tmp_path, monkeypatch):
+        """Gateway process restart/stop must not mark live chats ended in state.db."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        agent = MagicMock()
+        agent._end_session_on_close = True
+
+        async def _run():
+            await GatewayRunner._cleanup_agent_resources_off_loop(
+                runner, agent, context="shutdown idle-cache"
+            )
+
+        import asyncio
+        asyncio.get_event_loop().run_until_complete(_run())
+
+        assert agent._end_session_on_close is False
+        agent.close.assert_called_once()

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1400,3 +1400,93 @@ class TestRewriteTranscriptPreservesReasoning:
             "before user",
             "before assistant",
         ]
+
+
+class TestGatewaySessionDbRecovery:
+    def test_new_session_records_gateway_peer_fields(self, tmp_path):
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="chat-1",
+            chat_type="dm",
+            user_id="user-1",
+            thread_id="topic-1",
+        )
+
+        entry = store.get_or_create_session(source)
+        row = store._db.get_session(entry.session_id)
+
+        assert row["session_key"] == entry.session_key
+        assert row["chat_id"] == "chat-1"
+        assert row["chat_type"] == "dm"
+        assert row["thread_id"] == "topic-1"
+
+    def test_recovers_missing_sessions_json_mapping_from_state_db(self, tmp_path):
+        config = GatewayConfig()
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="chat-1",
+            chat_type="dm",
+            user_id="user-1",
+        )
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+        entry = store.get_or_create_session(source)
+        store.append_to_transcript(entry.session_id, {"role": "user", "content": "before restart"})
+
+        # Simulate the lightweight gateway routing index being lost while
+        # durable state.db still has the transcript and peer columns.
+        (tmp_path / "sessions.json").unlink()
+        recovered_store = SessionStore(sessions_dir=tmp_path, config=config)
+
+        recovered = recovered_store.get_or_create_session(source)
+
+        assert recovered.session_id == entry.session_id
+        assert recovered.session_key == entry.session_key
+        assert recovered_store.load_transcript(recovered.session_id)[0]["content"] == "before restart"
+
+    def test_agent_close_rows_are_recoverable_but_explicit_resets_are_not(self, tmp_path):
+        config = GatewayConfig()
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="chat-1",
+            chat_type="dm",
+            user_id="user-1",
+        )
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+        entry = store.get_or_create_session(source)
+        store.append_to_transcript(entry.session_id, {"role": "user", "content": "recover me"})
+        store._db.end_session(entry.session_id, "agent_close")
+        (tmp_path / "sessions.json").unlink()
+
+        recovered_store = SessionStore(sessions_dir=tmp_path, config=config)
+        recovered = recovered_store.get_or_create_session(source)
+        assert recovered.session_id == entry.session_id
+
+        recovered_store._db.end_session(recovered.session_id, "session_reset")
+        recovered_store._db._conn.execute(
+            "UPDATE sessions SET ended_at = ?, end_reason = ? WHERE id = ?",
+            (1.0, "session_reset", recovered.session_id),
+        )
+        recovered_store._db._conn.commit()
+        (tmp_path / "sessions.json").unlink()
+        reset_store = SessionStore(sessions_dir=tmp_path, config=config)
+        fresh = reset_store.get_or_create_session(source)
+        assert fresh.session_id != entry.session_id
+
+    def test_resume_pending_still_honors_idle_reset_policy(self, tmp_path):
+        from datetime import datetime, timedelta
+        from gateway.config import SessionResetPolicy
+
+        config = GatewayConfig(default_reset_policy=SessionResetPolicy(mode="idle", idle_minutes=1))
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="chat-1", user_id="user-1")
+        entry = store.get_or_create_session(source)
+        entry.resume_pending = True
+        entry.updated_at = datetime.now() - timedelta(minutes=5)
+        store._save()
+
+        reset = store.get_or_create_session(source)
+
+        assert reset.session_id != entry.session_id
+        assert reset.was_auto_reset is True
+        assert reset.auto_reset_reason == "idle"

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2445,7 +2445,7 @@ class TestSchemaInit:
         db = SessionDB(db_path=old_db)
         cursor = db._conn.execute("PRAGMA table_info(sessions)")
         columns = {row[1] for row in cursor.fetchall()}
-        assert {"chat_id", "chat_type", "thread_id", "session_key"}.isdisjoint(columns)
+        assert {"telegram_dm_topic_mode", "telegram_topic_thread_id"}.isdisjoint(columns)
         db.close()
 
     def test_apply_telegram_topic_migration_creates_topic_tables_explicitly(self, tmp_path):
@@ -4629,3 +4629,68 @@ class TestListCronJobRuns:
         detail = " ".join(row[-1] for row in plan)
         assert "USING INDEX" in detail or "USING COVERING INDEX" in detail, detail
         assert "idx_sessions_source" in detail, detail
+
+
+def test_gateway_session_peer_round_trip_and_recovery(db):
+    db.create_session(
+        "gw-session",
+        "telegram",
+        user_id="user-1",
+        session_key="agent:main:telegram:dm:chat-1",
+        chat_id="chat-1",
+        chat_type="dm",
+        thread_id=None,
+    )
+    db.append_message("gw-session", "user", "hello")
+
+    row = db.get_session("gw-session")
+    assert row["session_key"] == "agent:main:telegram:dm:chat-1"
+    assert row["chat_id"] == "chat-1"
+    assert row["chat_type"] == "dm"
+
+    recovered = db.find_latest_gateway_session_for_peer(
+        source="telegram",
+        user_id="user-1",
+        session_key="agent:main:telegram:dm:chat-1",
+        chat_id="chat-1",
+        chat_type="dm",
+    )
+    assert recovered["id"] == "gw-session"
+
+
+def test_gateway_session_recovery_reopens_legacy_agent_close_rows(db):
+    db.create_session(
+        "closed-gw-session",
+        "telegram",
+        user_id="user-1",
+        session_key="agent:main:telegram:dm:chat-1",
+        chat_id="chat-1",
+        chat_type="dm",
+    )
+    db.append_message("closed-gw-session", "user", "hello")
+    db.end_session("closed-gw-session", "agent_close")
+
+    recovered = db.find_latest_gateway_session_for_peer(
+        source="telegram",
+        user_id="user-1",
+        session_key="agent:main:telegram:dm:chat-1",
+        chat_id="chat-1",
+        chat_type="dm",
+    )
+    assert recovered["id"] == "closed-gw-session"
+
+    db.end_session("closed-gw-session", "session_reset")
+    # First end reason wins, so force explicit reset state for this branch.
+    db._conn.execute(
+        "UPDATE sessions SET ended_at = ?, end_reason = ? WHERE id = ?",
+        (time.time(), "session_reset", "closed-gw-session"),
+    )
+    db._conn.commit()
+
+    assert db.find_latest_gateway_session_for_peer(
+        source="telegram",
+        user_id="user-1",
+        session_key="agent:main:telegram:dm:chat-1",
+        chat_id="chat-1",
+        chat_type="dm",
+    ) is None


### PR DESCRIPTION
## Summary
Gateway restarts now preserve messaging session continuity instead of turning a lost routing index or legacy cleanup close into a fresh chat.

## Changes
- `hermes_state.py`: adds durable gateway peer fields (`session_key`, chat/thread metadata) to session rows and lookup helpers for exact peer recovery.
- `gateway/session.py`: records peer metadata on create/update/reset/resume, rebuilds missing `sessions.json` mappings from `state.db`, reopens rows only if they were ended by the old `agent_close` cleanup path, and preserves idle/daily reset policy for `resume_pending` sessions.
- `gateway/run.py`: prevents shutdown cleanup from marking live gateway chat sessions as ended.
- Tests cover lost `sessions.json` recovery, `agent_close` row recovery vs explicit reset boundaries, resume-pending reset policy, and shutdown cleanup behavior.

## Context
Informed by the restart/session recovery cluster: #44633, #43392, #47725, #46088, #41696, #38704. This keeps the fix narrow: durable routing recovery + live-row preservation, without adding a separate peer table or replay-loop reset policy.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/gateway/test_session.py tests/test_hermes_state.py tests/gateway/test_clean_shutdown_marker.py -q` | 393 passed |
| `scripts/run_tests.sh tests/gateway/test_restart_resume_pending.py tests/gateway/test_session_store_stale_prune.py tests/gateway/test_clean_shutdown_marker.py -q` | 94 passed |
| `python3 -m py_compile hermes_state.py gateway/session.py gateway/run.py tests/gateway/test_session.py tests/test_hermes_state.py tests/gateway/test_clean_shutdown_marker.py` | passed |
| Live E2E temp `HERMES_HOME` recovery harness | recovered Telegram session from `state.db` after deleted `sessions.json` + legacy `agent_close` row; shutdown cleanup disabled agent row finalization |

## Infographic

![gateway-sessions-survive-restarts](https://v3b.fal.media/files/b/0aa027f4/kB9oWJhaQtBEZLQZ4TzMc_HaDuAXKW.png)
