### PR TITLE
docs: fix small skill and cli references

### DIFF
--- a/optional-skills/productivity/here-now/SKILL.md
+++ b/optional-skills/productivity/here-now/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: here.now
+name: here-now
 description: Publish static sites to {slug}.here.now and store private files in cloud Drives for agent-to-agent handoff.
 version: 1.15.3
 author: here.now

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -312,7 +312,6 @@ The registry of record is `hermes_cli/commands.py` — every consumer
 /tools               Manage tools (CLI)
 /toolsets            List toolsets (CLI)
 /skills              Search/install skills (CLI)
-/skill <name>        Load a skill into session
 /reload-skills       Re-scan ~/.hermes/skills/ for added/removed skills
 /reload              Reload .env variables into the running session (CLI)
 /reload-mcp          Reload MCP servers
@@ -359,7 +358,7 @@ The registry of record is `hermes_cli/commands.py` — every consumer
 
 ### Exit
 ```
-/quit (/exit, /q)    Exit CLI
+/quit (/exit)        Exit CLI
 ```
 
 ---
@@ -917,7 +916,7 @@ and logs — avoids shell-escaping backslashes in bash.
 ### Skills not showing
 1. `hermes skills list` — verify installed
 2. `hermes skills config` — check platform enablement
-3. Load explicitly: `/skill name` or `hermes -s name`
+3. Load explicitly with the generated `/<skill-name>` slash command or `hermes -s name`
 
 ### Gateway issues
 Check logs first:

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -161,6 +161,11 @@ HERMES_INFERENCE_MODEL=anthropic/claude-sonnet-4.6 hermes -z "…"
 
 Same agent, same tools, same skills — just strips every interactive / cosmetic layer. If you need tool output in the transcript too, use `hermes chat -q` instead; `-z` is explicitly for "I only want the final answer".
 
+Compatibility notes:
+
+- `hermes -z` / `--oneshot` is available in Hermes v0.12.0 / v2026.4.30 and later. For scripts that must support older installs, prefer `hermes chat -q "..."`.
+- Top-level `hermes -z` and `hermes chat -q` do not currently accept a `--timeout` flag. Use your shell's timeout wrapper for a whole-process deadline, or tune provider/API timeouts through the existing configuration and environment options.
+
 ## `hermes model`
 
 Interactive provider + model selector. **This is the command for adding new providers, setting up API keys, and running OAuth flows.** Run it from your terminal — not from inside an active Hermes chat session.


### PR DESCRIPTION
## Summary
- remove stale hermes-agent skill references to the nonexistent /skill command and the /q quit alias
- rename the optional here.now skill frontmatter id to the valid here-now form
- document the hermes -z compatibility boundary and current lack of --timeout support for one-shot/chat invocations

## Validation
- git diff --check
- .venv/bin/python command-registry check for /skill, /skills, /queue, and /quit aliases
- .venv/bin/python frontmatter name validation for optional-skills/productivity/here-now/SKILL.md

Fixes #50605
Fixes #53382
Fixes #25121