### PR TITLE
feat(kanban): allow custom swarm stage skills

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -383,6 +383,23 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_swarm.add_argument("--verifier", required=True, help="Verifier profile")
     p_swarm.add_argument("--synthesizer", required=True, help="Synthesizer/writer profile")
+    p_swarm.add_argument(
+        "--verifier-skill",
+        action="append",
+        default=None,
+        help="Skill to preload on verifier card. Repeatable. Defaults to requesting-code-review unless --no-default-stage-skills is set.",
+    )
+    p_swarm.add_argument(
+        "--synthesizer-skill",
+        action="append",
+        default=None,
+        help="Skill to preload on synthesizer card. Repeatable. Defaults to humanizer unless --no-default-stage-skills is set.",
+    )
+    p_swarm.add_argument(
+        "--no-default-stage-skills",
+        action="store_true",
+        help="Do not attach the built-in verifier/synthesizer default skills. Use with explicit profile-local skills.",
+    )
     p_swarm.add_argument("--tenant", default=None, help="Tenant namespace")
     p_swarm.add_argument("--priority", type=int, default=0, help="Priority tiebreaker")
     p_swarm.add_argument("--created-by", default=None, help="Creator/anchor profile")
@@ -1377,6 +1394,11 @@ def _cmd_swarm(args: argparse.Namespace) -> int:
     if not workers:
         print("kanban swarm: at least one --worker is required", file=sys.stderr)
         return 2
+    verifier_skills = args.verifier_skill
+    synthesizer_skills = args.synthesizer_skill
+    if args.no_default_stage_skills:
+        verifier_skills = verifier_skills or []
+        synthesizer_skills = synthesizer_skills or []
     with kb.connect_closing() as conn:
         created = ks.create_swarm(
             conn,
@@ -1388,6 +1410,8 @@ def _cmd_swarm(args: argparse.Namespace) -> int:
             created_by=args.created_by or _profile_author(),
             priority=args.priority,
             idempotency_key=getattr(args, "idempotency_key", None),
+            verifier_skills=verifier_skills,
+            synthesizer_skills=synthesizer_skills,
         )
     if getattr(args, "json", False):
         print(json.dumps(created.as_dict(), indent=2, ensure_ascii=False))

--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -90,6 +90,8 @@ def create_swarm(
     workspace_path: Optional[str] = None,
     priority: int = 0,
     idempotency_key: Optional[str] = None,
+    verifier_skills: Optional[list[str]] = None,
+    synthesizer_skills: Optional[list[str]] = None,
 ) -> SwarmCreated:
     """Create a durable Kanban swarm graph.
 
@@ -189,7 +191,7 @@ def create_swarm(
         priority=priority,
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
-        skills=["requesting-code-review"],
+        skills=verifier_skills if verifier_skills is not None else ["requesting-code-review"],
     )
 
     synthesizer_body = (
@@ -208,7 +210,7 @@ def create_swarm(
         priority=priority,
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
-        skills=["humanizer"],
+        skills=synthesizer_skills if synthesizer_skills is not None else ["humanizer"],
     )
 
     created = SwarmCreated(root, worker_ids, verifier, synthesizer)

--- a/tests/hermes_cli/test_kanban_swarm.py
+++ b/tests/hermes_cli/test_kanban_swarm.py
@@ -115,3 +115,55 @@ def test_swarm_verifier_and_synthesis_are_dependency_gated(tmp_path):
         assert kb.get_task(conn, created.synthesizer_id).status == "ready"
     finally:
         conn.close()
+
+
+def test_create_swarm_honors_custom_and_disabled_stage_skills(tmp_path):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        default = create_swarm(
+            conn,
+            goal="Use default stage skills.",
+            workers=[SwarmWorkerSpec(profile="worker", title="Worker", body="Do work")],
+            verifier_assignee="reviewer",
+            synthesizer_assignee="writer",
+        )
+        custom = create_swarm(
+            conn,
+            goal="Use custom stage skills.",
+            workers=[SwarmWorkerSpec(profile="worker", title="Worker", body="Do work")],
+            verifier_assignee="reviewer",
+            synthesizer_assignee="writer",
+            verifier_skills=["qa-reviewer"],
+            synthesizer_skills=["writer"],
+        )
+        disabled = create_swarm(
+            conn,
+            goal="Disable default stage skills.",
+            workers=[SwarmWorkerSpec(profile="worker", title="Worker", body="Do work")],
+            verifier_assignee="reviewer",
+            synthesizer_assignee="writer",
+            verifier_skills=[],
+            synthesizer_skills=[],
+        )
+
+        default_verifier = kb.get_task(conn, default.verifier_id)
+        default_synthesizer = kb.get_task(conn, default.synthesizer_id)
+        custom_verifier = kb.get_task(conn, custom.verifier_id)
+        custom_synthesizer = kb.get_task(conn, custom.synthesizer_id)
+        disabled_verifier = kb.get_task(conn, disabled.verifier_id)
+        disabled_synthesizer = kb.get_task(conn, disabled.synthesizer_id)
+
+        assert default_verifier is not None
+        assert default_synthesizer is not None
+        assert custom_verifier is not None
+        assert custom_synthesizer is not None
+        assert disabled_verifier is not None
+        assert disabled_synthesizer is not None
+        assert default_verifier.skills == ["requesting-code-review"]
+        assert default_synthesizer.skills == ["humanizer"]
+        assert custom_verifier.skills == ["qa-reviewer"]
+        assert custom_synthesizer.skills == ["writer"]
+        assert disabled_verifier.skills == []
+        assert disabled_synthesizer.skills == []
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

- add per-swarm verifier/synthesizer stage skill controls to `hermes kanban swarm`
- preserve existing default stage skills when flags are omitted
- add regression coverage for default, custom, and disabled stage-skill behavior

## Why

Swarm workers already support skill selection per card via `PROFILE:TITLE[:SKILL,SKILL]`, but verifier and synthesizer stages were hard-coded to `requesting-code-review` and `humanizer`. This adds a small, opt-in CLI surface for per-swarm stage skill control without changing existing behavior.

## Test plan

```bash
pytest tests/hermes_cli/test_kanban_swarm.py -q
```

Result locally after rebasing on `origin/main`:

```text
4 passed in 0.90s
```
