### PR TITLE
feat(skill): add youtube-download — simple MP4 download via yt-dlp

### DIFF
--- a/skills/media/youtube-download/SKILL.md
+++ b/skills/media/youtube-download/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: youtube-download
+description: "Download YouTube videos as MP4 files using yt-dlp. Accepts any YouTube URL format (watch, youtu.be, shorts, embeds)."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [youtube, download, video, yt-dlp]
+    related_skills: [youtube-content]
+---
+
+# YouTube Download
+
+Download a single YouTube video as an MP4 file using `yt-dlp`.
+
+## When to Use
+
+Use when the user shares a YouTube URL and wants the video file downloaded.
+
+- User says "download this video", "save this video", "grab this video"
+- User wants to archive or clip a YouTube video locally
+
+**Don't use for:**
+- Summarizing or transcribing video content → use `youtube-content`
+- Downloading playlists or batch URLs (this skill is single-video only)
+
+## Prerequisites
+
+```bash
+# yt-dlp must be installed
+which yt-dlp || pip install yt-dlp
+
+# ffmpeg needed for MP4 muxing (video + audio merge)
+which ffmpeg || sudo apt install ffmpeg
+```
+
+## Download
+
+```bash
+# Default: best quality MP4, saved to ~/Downloads/
+yt-dlp -f "bv*+ba/b" --merge-output-format mp4 \
+  -o "~/Downloads/%(title)s.%(ext)s" \
+  "URL"
+```
+
+### Parameters
+
+| Part | What it does |
+|------|-------------|
+| `-f "bv*+ba/b"` | Best video stream + best audio stream, fallback to single best file |
+| `--merge-output-format mp4` | Force MP4 container (muxes with ffmpeg) |
+| `-o "~/Downloads/%(title)s.%(ext)s"` | Save as `<video title>.mp4` in ~/Downloads/ |
+
+### Custom output directory
+
+```bash
+yt-dlp -f "bv*+ba/b" --merge-output-format mp4 \
+  -o "<DIR>/%(title)s.%(ext)s" \
+  "URL"
+```
+
+## Workflow
+
+1. Parse the URL from the user's message. Accepts `youtube.com/watch?v=`, `youtu.be/`, `youtube.com/shorts/`, and `youtube.com/embed/` formats.
+2. Run the download command.
+3. Report the saved filename and file size to the user.
+
+## Common Pitfalls
+
+1. **Age-restricted or members-only videos**: needs `--cookies-from-browser` or a cookies file. Ask the user for credentials if needed:
+   ```bash
+   yt-dlp --cookies-from-browser chrome -f "bv*+ba/b" --merge-output-format mp4 "URL"
+   ```
+2. **HTTP 429 rate limiting**: yt-dlp auto-retries, but persistent throttling may require waiting. Updating yt-dlp often fixes extractor breakage:
+   ```bash
+   pip install -U yt-dlp
+   ```
+3. **No ffmpeg installed**: the merge step fails with "ffmpeg not found". Install it first.
+4. **Disk space on constrained devices**: check available space before downloading long videos — a 30-min 1080p video can be 500MB+.


### PR DESCRIPTION
## Summary

Adds a new skill `youtube-download` to the `media/` category for downloading single YouTube videos as MP4 files using `yt-dlp`.

## Motivation

The existing `youtube-content` skill handles transcript extraction and summarization but not file download. This skill fills that gap — a simple, single-video MP4 download using `yt-dlp` with best-quality format selection.

## What's included

- **`skills/media/youtube-download/SKILL.md`** — complete skill doc (2.5k chars)
- Accepts any YouTube URL format (watch, youtu.be, shorts, embeds)
- Format selection: `-f "bv*+ba/b"` for best video+audio, fallback to single best stream
- Force MP4 container via `--merge-output-format mp4`
- Prerequisites section (yt-dlp + ffmpeg)
- Common pitfalls (age-restricted videos, rate limiting, disk space on constrained devices)
- Cross-references `youtube-content` via `related_skills`

## Peer alignment

Surveyed `skills/media/youtube-content/` and `skills/media/gif-search/` for structure and tone. Matches the peer shape: frontmatter with `version`/`author`/`license`/`metadata.hermes.{tags, related_skills}`, `## When to Use`, actionable body with command examples and quick-reference table, and `## Common Pitfalls`.

## Test plan

- [x] Frontmatter validated (starts with `---`, closes with `\n---\n`, `name` + `description` present, description ≤ 1024 chars)
- [x] File size: 2,542 chars (well within 100k limit, peer range is 2.7k–8k)
- [x] Placed correctly at `skills/media/youtube-download/SKILL.md`
- [x] `yt-dlp` + `ffmpeg` prerequisites documented
- [x] No duplication with `youtube-content` (that skill is transcript/summary only)