### PR TITLE
feat(desktop): show collapsed todo running indicator

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/collapsed-indicator.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/collapsed-indicator.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { $todosBySession } from '@/store/todos'
+
+import { ComposerStatusStack } from './index'
+
+describe('ComposerStatusStack collapsed todo indicator', () => {
+  beforeAll(() => {
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        disconnect() {}
+        observe() {}
+      }
+    )
+  })
+
+  afterEach(() => {
+    cleanup()
+    $todosBySession.set({})
+  })
+
+  it('shows a running indicator next to the collapsed todo label', () => {
+    $todosBySession.set({
+      'session-1': [{ content: 'Wire the status stack', id: '1', status: 'in_progress' }]
+    })
+
+    render(
+      <MemoryRouter>
+        <ComposerStatusStack queue={null} sessionId="session-1" />
+      </MemoryRouter>
+    )
+
+    const button = screen.getByRole('button', { name: /Tasks 0\/1/ })
+    fireEvent.click(button)
+
+    const label = screen.getByText('Tasks 0/1')
+    const indicator = screen.getByRole('status')
+
+    expect(screen.queryByText('Wire the status stack')).toBeNull()
+    expect(button.contains(indicator)).toBe(true)
+    expect(label.compareDocumentPosition(indicator) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('does not show a collapsed todo indicator when no todo is running', () => {
+    $todosBySession.set({
+      'session-1': [{ content: 'Wire the status stack', id: '1', status: 'completed' }]
+    })
+
+    render(
+      <MemoryRouter>
+        <ComposerStatusStack queue={null} sessionId="session-1" />
+      </MemoryRouter>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Tasks 1\/1/ }))
+
+    expect(screen.queryByText('Wire the status stack')).toBeNull()
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -8,6 +8,7 @@ import { composerDockCard } from '@/components/chat/composer-dock'
 import { StatusSection } from '@/components/chat/status-section'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
+import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { type Translations, useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
 import {
@@ -50,6 +51,9 @@ const groupLabel = (group: StatusGroup, s: Translations['statusStack']) => {
 
   return group.type === 'subagent' ? s.subagents(group.items.length) : s.background(group.items.length)
 }
+
+const hasRunningTodo = (group: StatusGroup) =>
+  group.type === 'todo' && group.items.some(item => item.todoStatus === 'in_progress' && item.state === 'running')
 
 interface ComposerStatusStackProps {
   /** The queue, built by the composer (it owns the queue's callbacks). Rendered
@@ -133,6 +137,15 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
             >
               {t.statusStack.agents}
             </Button>
+          ) : undefined
+        }
+        collapsedIndicator={
+          hasRunningTodo(group) ? (
+            <GlyphSpinner
+              ariaLabel={t.statusStack.running}
+              className="text-[0.8rem] leading-none text-muted-foreground/80"
+              spinner="braille"
+            />
           ) : undefined
         }
         defaultCollapsed={group.type !== 'todo'}

--- a/apps/desktop/src/components/chat/status-section.tsx
+++ b/apps/desktop/src/components/chat/status-section.tsx
@@ -7,6 +7,8 @@ interface StatusSectionProps {
    *  `Button` with `size="micro"` + `variant="text"` or `"link"`. */
   accessory?: ReactNode
   children: ReactNode
+  /** Optional inline status shown only while the group is collapsed. */
+  collapsedIndicator?: ReactNode
   defaultCollapsed?: boolean
   /** Optional glyph between the caret and the label (e.g. a `Codicon`). */
   icon?: ReactNode
@@ -19,7 +21,14 @@ interface StatusSectionProps {
  * (queue, subagents, background) reads as one piece. The stack supplies the
  * outer card and the dividers between groups; this owns only its own collapse.
  */
-export function StatusSection({ accessory, children, defaultCollapsed = true, icon, label }: StatusSectionProps) {
+export function StatusSection({
+  accessory,
+  children,
+  collapsedIndicator,
+  defaultCollapsed = true,
+  icon,
+  label
+}: StatusSectionProps) {
   const [collapsed, setCollapsed] = useState(defaultCollapsed)
 
   return (
@@ -32,7 +41,10 @@ export function StatusSection({ accessory, children, defaultCollapsed = true, ic
         >
           <DisclosureCaret className="shrink-0" open={!collapsed} size="1em" />
           {icon && <span className="flex shrink-0 items-center">{icon}</span>}
-          <span className="truncate">{label}</span>
+          <span className="min-w-0 truncate">{label}</span>
+          {collapsed && collapsedIndicator && (
+            <span className="flex shrink-0 items-center">{collapsedIndicator}</span>
+          )}
         </button>
         {accessory && <div className="flex shrink-0 items-center gap-1">{accessory}</div>}
       </div>


### PR DESCRIPTION
## What does this PR do?

Adds an inline running indicator to the collapsed Desktop todo status group.

When a todo group contains a running `in_progress` item and the group is collapsed, the header now keeps the running state visible by rendering the same glyph spinner immediately after the todo count label, e.g. `Tasks 1/5 · [spinner]`.

## Related Issue

N/A. I searched existing PRs/issues for `collapsed todo spinner running indicator status stack` before opening this PR.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/components/chat/status-section.tsx`
  - Adds an optional inline `collapsedIndicator` slot rendered after the section label while collapsed.
- `apps/desktop/src/app/chat/composer/status-stack/index.tsx`
  - Shows a braille running indicator next to the collapsed todo label when the group has a running in-progress todo.
- `apps/desktop/src/app/chat/composer/status-stack/collapsed-indicator.test.tsx`
  - Adds focused coverage for showing the collapsed running indicator and omitting it when no todo is running.

## How to Test

1. Run the focused Desktop UI test:

   ```sh
   npm --workspace apps/desktop run test:ui -- src/app/chat/composer/status-stack/collapsed-indicator.test.tsx
   ```

   Result: `1 passed`, `2 passed`.

2. Run Desktop typecheck:

   ```sh
   npm --workspace apps/desktop run typecheck
   ```

   Result: passed.

3. Check whitespace:

   ```sh
   git diff --check
   ```

   Result: passed.

4. Manual Desktop verification:
   - Verified in the source Desktop app that the collapsed todo group shows the running glyph next to the task count label while work is in progress.

## Screenshots / Logs

Collapsed todo group with the running indicator next to the task count label:

<img width="184" height="58" alt="Recording 2026-06-29 at 04-43-40" src="https://github.com/user-attachments/assets/a313dab5-196c-4982-b6a2-064f24918c75" />