### PR TITLE
feat: add natural WhatsApp cascade delivery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -471,6 +471,10 @@ async def _send_or_update_status_coro(adapter, chat_id, status_key, content, met
     Telegram) edit the previous bubble for the same status_key instead of
     appending a new one. Adapters without the method fall back to plain send.
     """
+    metadata = dict(metadata or {})
+    # Status/thinking/progress bubbles are gateway chrome, not the final answer.
+    # Keep them single-unit on platforms with natural cascade support.
+    metadata.setdefault("delivery_style", "single")
     sender = getattr(adapter, "send_or_update_status", None)
     if callable(sender):
         return await sender(chat_id, status_key, content, metadata=metadata)
@@ -16262,7 +16266,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _status_adapter.send(
                         _status_chat_id,
                         text,
-                        metadata=_status_thread_metadata,
+                        metadata={
+                            **(_status_thread_metadata or {}),
+                            "delivery_style": "single",
+                        },
                     ),
                     _loop_for_step,
                     logger=logger,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -223,6 +223,13 @@ class GatewayStreamConsumer:
         meta = dict(self.metadata) if self.metadata else {}
         if expect_edits:
             meta["expect_edits"] = True
+        if not final:
+            # Stream previews, tool-boundary text, and interim commentary are
+            # status/progress UI, not the final assistant reply.  Messaging
+            # adapters that support natural multi-bubble delivery (WhatsApp)
+            # must keep these as one unit so scratch/status text never fans out
+            # into a cascade.
+            meta.setdefault("delivery_style", "single")
         if final:
             meta["notify"] = True
         return meta or None
@@ -1161,7 +1168,7 @@ class GatewayStreamConsumer:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
-                metadata=self.metadata,
+                metadata=self._metadata_for_send(final=False),
             )
             # Note: do NOT set _already_sent = True here.
             # Commentary messages are interim status updates (e.g. "Using browser

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -418,6 +418,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._human_cascade_max_total_chars = self._coerce_int_extra(
             "human_cascade_max_total_chars", 900, env_var="WHATSAPP_HUMAN_CASCADE_MAX_TOTAL_CHARS"
         )
+        self._human_cascade_min_total_chars = self._coerce_int_extra(
+            "human_cascade_min_total_chars", 420
+        )
+        self._human_cascade_min_lead_chars = self._coerce_int_extra(
+            "human_cascade_min_lead_chars", 40
+        )
         self._human_cascade_max_bubble_chars = self._coerce_int_extra(
             "human_cascade_max_bubble_chars", 320, env_var="WHATSAPP_HUMAN_CASCADE_MAX_BUBBLE_CHARS"
         )
@@ -511,6 +517,43 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 structured_lines += 1
         return structured_lines >= 3
 
+    @staticmethod
+    def _word_count(text: str) -> int:
+        return len(re.findall(r"\b[\w'’.-]+\b", text))
+
+    def _is_substantive_cascade_lead(self, paragraph: str) -> bool:
+        """Return True when a paragraph is worth its own WhatsApp bubble."""
+        stripped = paragraph.strip()
+        if self._looks_structured_outbound(stripped):
+            return False
+        if len(stripped) < self._human_cascade_min_lead_chars:
+            return False
+        return self._word_count(stripped) >= 6
+
+    def _should_human_cascade(self, text: str, paragraphs: list[str], *, force: bool) -> bool:
+        """Gate human cascade on reading value, not just blank-line presence."""
+        if force:
+            return True
+        min_total = self._human_cascade_min_total_chars
+        if min_total > 0 and len(text) < min_total:
+            return False
+        return self._is_substantive_cascade_lead(paragraphs[0])
+
+    def _merge_structured_tail(self, paragraphs: list[str], max_bubbles: int) -> list[str] | None:
+        """Return lead paragraphs + glued structured tail, or None if not worth cascading."""
+        lead_limit = max(1, max_bubbles - 1)
+        lead: list[str] = []
+        for paragraph in paragraphs:
+            if len(lead) >= lead_limit or self._looks_structured_outbound(paragraph):
+                break
+            lead.append(paragraph)
+        if not lead or len(lead) >= len(paragraphs):
+            return None
+        if not self._is_substantive_cascade_lead(lead[0]):
+            return None
+        tail = "\n\n".join(paragraphs[len(lead):]).strip()
+        return [*lead, tail]
+
     def _split_outgoing_text(
         self,
         formatted: str,
@@ -558,19 +601,15 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         max_bubbles = self._human_cascade_max_bubbles
         if max_bubbles <= 1:
             return self.truncate_message(formatted, limit), False
+        if not self._should_human_cascade(text, paragraphs, force=force_cascade):
+            return self.truncate_message(formatted, limit), False
 
         merged_tail = False
         if not force_cascade and self._looks_structured_outbound(text):
-            lead_limit = max(1, max_bubbles - 1)
-            lead: list[str] = []
-            for paragraph in paragraphs:
-                if len(lead) >= lead_limit or self._looks_structured_outbound(paragraph):
-                    break
-                lead.append(paragraph)
-            if not lead or len(lead) >= len(paragraphs):
+            merged = self._merge_structured_tail(paragraphs, max_bubbles)
+            if merged is None:
                 return self.truncate_message(formatted, limit), False
-            tail = "\n\n".join(paragraphs[len(lead):]).strip()
-            paragraphs = [*lead, tail]
+            paragraphs = merged
             merged_tail = True
 
         if len(paragraphs) > max_bubbles and not force_cascade:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -437,11 +437,6 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             0.25,
             env_var="WHATSAPP_HUMAN_CASCADE_DELAY_JITTER_SECONDS",
         )
-        self._human_cascade_typing_indicators = self._coerce_bool_extra(
-            "human_cascade_typing_indicators",
-            True,
-            env_var="WHATSAPP_HUMAN_CASCADE_TYPING_INDICATORS",
-        )
         self._human_cascade_groups = self._coerce_bool_extra(
             "human_cascade_groups", False, env_var="WHATSAPP_HUMAN_CASCADE_GROUPS"
         )
@@ -1091,23 +1086,6 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._close_bridge_log()
         print(f"[{self.name}] Disconnected")
     
-    async def _send_typing_indicator(self, chat_id: str) -> None:
-        """Best-effort WhatsApp typing indicator before the next cascade bubble."""
-        if not self._human_cascade_typing_indicators or not self._http_session:
-            return
-        try:
-            import aiohttp
-
-            async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/typing",
-                json={"chatId": chat_id},
-                timeout=aiohttp.ClientTimeout(total=5),
-            ):
-                return
-        except Exception:
-            # Typing presence is pure UX sugar; never fail message delivery.
-            return
-
     async def send(
         self,
         chat_id: str,
@@ -1178,12 +1156,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         return SendResult(success=False, error=error)
 
                 # Small delay between chunks to avoid rate limiting.  Human
-                # cascade gets a slightly longer delay plus a best-effort typing
-                # indicator before the next bubble, so the follow-up feels typed
-                # rather than machine-gun posted.
+                # cascade gets a slightly longer delay so the bubbles feel
+                # deliberate instead of a bursty auto-split.
                 if len(chunks) > 1 and idx < len(chunks) - 1:
-                    if human_cascade:
-                        await self._send_typing_indicator(chat_id)
                     await asyncio.sleep(
                         self._cascade_delay_seconds() if human_cascade else self._chunk_delay_seconds
                     )

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -500,19 +500,31 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return float(default)
         return parsed
 
-    @staticmethod
-    def _has_approval_gate(text: str) -> bool:
+    @classmethod
+    def _has_approval_gate(cls, text: str) -> bool:
         """Return True for explicit approval/control prompts that must stay intact."""
+        command = r"`?/(approve|deny|reject|confirm|cancel|stop|new|reset|always)\b"
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped or cls._looks_list_like_line(stripped):
+                continue
+            if re.search(rf"(^|\b(reply|respond|type|send)\s+){command}", stripped, re.IGNORECASE):
+                return True
+        return False
+
+    @staticmethod
+    def _looks_list_like_line(text: str) -> bool:
+        """Return True for markdown/WhatsApp-style list item lines."""
+        stripped = text.strip().lstrip("\u200b\u200c\u200d\u2060\ufeff")
         return bool(
-            re.search(
-                r"`?/(approve|deny|reject|confirm|cancel|stop|new|reset|always)\b",
-                text,
-                re.IGNORECASE,
+            re.match(
+                r"^(?:[-*+•‣◦]\s|[-*+•‣◦][\u200b\u200c\u200d\u2060\ufeff]+\s*|\d+[.)]\s+)",
+                stripped,
             )
         )
 
-    @staticmethod
-    def _looks_structured_outbound(text: str) -> bool:
+    @classmethod
+    def _looks_structured_outbound(cls, text: str) -> bool:
         """Return True for reports/artifacts that should not be split mid-body."""
         structured_lines = 0
         artifact_lines = 0
@@ -520,14 +532,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             stripped = line.strip()
             if not stripped:
                 continue
-            if re.match(r"^(#{1,6}\s+|[*_-]{3,}$|[-*+]\s+|\d+[.)]\s+|>\s+|\|.*\|$)", stripped):
+            if re.match(r"^(#{1,6}\s+|[*_-]{3,}$|>\s+|\|.*\|$)", stripped) or cls._looks_list_like_line(stripped):
                 structured_lines += 1
             if re.match(
-                r"^(\{\s*$|\}\s*,?$|\[\s*$|\]\s*,?$|[\"']?[A-Za-z0-9_.-]+[\"']?\s*[:=]\s*.+$|[-+]{3}\s|@@\s|[+!]\s|\$\s+|(?:sudo\s+)?(?:git|gh|npm|pnpm|yarn|python\d*|pip|uv|docker|kubectl|helm|curl|ssh|scp|rsync|systemctl|journalctl)\b|(?:TRACE|DEBUG|INFO|WARN|WARNING|ERROR|CRITICAL)\b|Traceback \(most recent call last\):|File \".+\", line \d+|[A-Za-z_][\w.]*Error:|[-*+]\s+\[[ xX]\]\s+)",
+                r"^(\{\s*$|\}\s*,?$|\[\s*$|\]\s*,?$|[\"']?[A-Za-z0-9_.-]+[\"']?\s*[:=]\s*.+$|[-+]{3}\s|@@\s|[+!]\s|\$\s+|(?:sudo\s+)?(?:git|gh|npm|pnpm|yarn|python\d*|pip|uv|docker|kubectl|helm|curl|ssh|scp|rsync|systemctl|journalctl)\b|(?:TRACE|DEBUG|INFO|WARN|WARNING|ERROR|CRITICAL)\b|Traceback \(most recent call last\):|File \".+\", line \d+|[A-Za-z_][\w.]*Error:|[-*+•‣◦]\s+\[[ xX]\]\s+)",
                 stripped,
             ):
                 artifact_lines += 1
-        if structured_lines >= 3:
+        if structured_lines >= 2:
             return True
         return artifact_lines >= 3
 
@@ -551,7 +563,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         stripped = paragraph.strip()
         if self._looks_structured_outbound(stripped):
             return False
-        if len(stripped) < self._human_cascade_min_lead_chars:
+        min_lead_chars = self._human_cascade_min_lead_chars
+        if min_lead_chars <= 0:
+            return bool(stripped)
+        if len(stripped) < min_lead_chars:
             return False
         return self._word_count(stripped) >= 6
 
@@ -562,6 +577,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         min_total = self._human_cascade_min_total_chars
         if min_total > 0 and len(text) < min_total:
             return False
+        if len(paragraphs) > 1 and any(self._looks_list_like_line(line) for line in paragraphs[0].splitlines()):
+            return True
         return self._is_substantive_cascade_lead(paragraphs[0])
 
     @staticmethod
@@ -573,37 +590,104 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     @staticmethod
     def _contains_active_prompt(text: str) -> bool:
-        """Return True for user-response prompts that should stay at the end."""
+        """Return True for direct user-response prompts that should stay atomic."""
         stripped = text.strip()
-        if "?" in stripped:
-            return True
         return bool(
             re.search(
-                r"\b(reply|respond|choose|pick|select|confirm|approve|deny|send me|tell me|want me to|should i)\b",
+                r"\b(reply|respond|choose|pick|select|confirm this|approve this|deny this|send me|tell me|want me to|should i|do you want me to)\b",
                 stripped,
                 re.IGNORECASE,
             )
         )
 
-    def _protect_high_stakes_tail(self, paragraphs: list[str]) -> list[str] | None:
-        """Keep questions/actions last and keep links with immediate context."""
+    @staticmethod
+    def _split_cascade_paragraphs(text: str) -> list[str]:
+        """Split on blank lines while preserving fenced code blocks."""
+        paragraphs: list[str] = []
+        current: list[str] = []
+        in_fence = False
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("```"):
+                current.append(line)
+                in_fence = not in_fence
+                continue
+            if not stripped and not in_fence:
+                if current:
+                    paragraphs.append("\n".join(current).strip())
+                    current = []
+                continue
+            current.append(line)
+        if current:
+            paragraphs.append("\n".join(current).strip())
+        return [paragraph for paragraph in paragraphs if paragraph]
+
+    def _is_action_context_paragraph(self, paragraph: str) -> bool:
+        """Return True when a paragraph should travel with an action prompt."""
+        stripped = paragraph.strip()
+        if not stripped:
+            return False
+        if "```" in stripped:
+            return True
+        if self._has_approval_gate(stripped) or self._contains_outbound_link(stripped):
+            return True
+        if re.match(r"^(risk|command|target|branch|commit|diff|verify|verified|tests?|scope)\s*:", stripped, re.IGNORECASE):
+            return True
+        return self._looks_structured_outbound(stripped)
+
+    def _protect_atomic_sections(self, paragraphs: list[str]) -> list[str]:
+        """Keep code/action/link/copy-sensitive sections atomic without disabling cascade globally."""
         if len(paragraphs) < 2:
             return paragraphs
 
-        for idx, paragraph in enumerate(paragraphs[:-1]):
-            if self._contains_active_prompt(paragraph):
-                return None
+        protected: list[str] = []
+        idx = 0
+        while idx < len(paragraphs):
+            paragraph = paragraphs[idx]
 
-        link_indices = [idx for idx, paragraph in enumerate(paragraphs) if self._contains_outbound_link(paragraph)]
-        if not link_indices:
-            return paragraphs
+            paragraph_has_own_context = "\n" in paragraph and not paragraph.lstrip().startswith("```")
+            if (
+                ("```" in paragraph or self._contains_outbound_link(paragraph))
+                and protected
+                and not paragraph_has_own_context
+            ):
+                protected[-1] = f"{protected[-1]}\n\n{paragraph}".strip()
+                idx += 1
+                continue
 
-        first_link = link_indices[0]
-        if first_link == 0:
-            return None
-        merge_start = max(0, first_link - 1)
-        protected_tail = "\n\n".join(paragraphs[merge_start:]).strip()
-        return [*paragraphs[:merge_start], protected_tail]
+            starts_action = (
+                self._has_approval_gate(paragraph)
+                or self._contains_active_prompt(paragraph)
+                or self._has_copy_sensitive_outbound(paragraph)
+            )
+            if starts_action:
+                block = [paragraph]
+                idx += 1
+                copy_sensitive = self._has_copy_sensitive_outbound(paragraph)
+                if copy_sensitive and idx < len(paragraphs):
+                    block.append(paragraphs[idx])
+                    idx += 1
+                while idx < len(paragraphs) and self._is_action_context_paragraph(paragraphs[idx]):
+                    block.append(paragraphs[idx])
+                    idx += 1
+                protected.append("\n\n".join(block).strip())
+                continue
+
+            protected.append(paragraph)
+            idx += 1
+        return protected
+
+    def _merge_list_paragraphs_with_context(self, paragraphs: list[str]) -> list[str]:
+        """Attach bare list paragraphs to their immediate lead-in without collapsing later prose."""
+        merged: list[str] = []
+        for paragraph in paragraphs:
+            lines = [line for line in paragraph.splitlines() if line.strip()]
+            starts_with_list = bool(lines and self._looks_list_like_line(lines[0]))
+            if starts_with_list and merged:
+                merged[-1] = f"{merged[-1]}\n{paragraph}".strip()
+            else:
+                merged.append(paragraph)
+        return merged
 
     def _merge_structured_tail(self, paragraphs: list[str], max_bubbles: int) -> list[str] | None:
         """Return lead paragraphs + glued structured tail, or None if not worth cascading."""
@@ -642,16 +726,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if style in {"single", "off", "none"}:
             return self.truncate_message(formatted, limit), False
         is_group = bool(chat_id and str(chat_id).lower().endswith("@g.us"))
-        if (
-            not self._human_cascade_messages
-            or "```" in formatted
-            or self._has_copy_sensitive_outbound(text)
-        ):
+        if not self._human_cascade_messages:
             return self.truncate_message(formatted, limit), False
 
         force_cascade = style in {"cascade", "human_cascade", "human-cascade"}
-        if self._has_approval_gate(text):
-            return self.truncate_message(formatted, limit), False
         if not force_cascade and is_group and not self._human_cascade_groups:
             return self.truncate_message(formatted, limit), False
 
@@ -663,22 +741,27 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if not force_cascade and max_total > 0 and len(text) > max_total:
             return self.truncate_message(formatted, limit), False
 
-        paragraphs = [p.strip() for p in re.split(r"\n\s*\n+", text) if p.strip()]
+        paragraphs = self._split_cascade_paragraphs(text)
         if len(paragraphs) < 2:
             return self.truncate_message(formatted, limit), False
-        if not force_cascade:
-            protected = self._protect_high_stakes_tail(paragraphs)
-            if protected is None or len(protected) < 2:
-                return self.truncate_message(formatted, limit), False
-            paragraphs = protected
 
-        max_bubbles = self._human_cascade_max_bubbles
+        paragraphs = self._merge_list_paragraphs_with_context(paragraphs)
+        paragraphs = self._protect_atomic_sections(paragraphs)
+        if len(paragraphs) < 2:
+            return self.truncate_message(paragraphs[0], limit), False
+
+        max_bubbles_config = self._human_cascade_max_bubbles
+        max_bubbles = len(paragraphs) if max_bubbles_config == 0 else max_bubbles_config
         if max_bubbles <= 1:
             return self.truncate_message(formatted, limit), False
         if not self._should_human_cascade(text, paragraphs, force=force_cascade):
             return self.truncate_message(formatted, limit), False
 
-        if not force_cascade and self._looks_structured_outbound(text):
+        has_list_paragraph = any(
+            any(self._looks_list_like_line(line) for line in paragraph.splitlines())
+            for paragraph in paragraphs
+        )
+        if not force_cascade and not has_list_paragraph and self._looks_structured_outbound(text):
             merged = self._merge_structured_tail(paragraphs, max_bubbles)
             if merged is None:
                 return self.truncate_message(formatted, limit), False

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -19,6 +19,7 @@ import asyncio
 import logging
 import os
 import platform
+import random
 import re
 import signal
 import subprocess
@@ -312,8 +313,7 @@ def check_whatsapp_requirements() -> bool:
 
 
 class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
-    """
-    WhatsApp adapter.
+    """WhatsApp adapter.
     
     This implementation uses a simple HTTP bridge pattern where:
     1. A Node.js process runs the WhatsApp Web client
@@ -338,6 +338,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     provided by ``WhatsAppBehaviorMixin`` so the Cloud API adapter can
     share it. Only transport-specific code lives here.
     """
+
+    # Baileys exposes message editing, but WhatsApp surfaces each edit/delete as
+    # protocol-message upserts. With gateway token streaming enabled this creates
+    # a spray of blank-looking bubbles / protocol events on some clients,
+    # especially with chatty streaming models. Treat WhatsApp as non-editable for
+    # Hermes streaming so gateway replies are delivered once, as final text.
+    SUPPORTS_MESSAGE_EDITING = False
 
     # Default bridge location resolved via shared helper
     _DEFAULT_BRIDGE_DIR = None  # resolved in __init__
@@ -395,8 +402,78 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        # Outbound "human cascade" mode: split normal assistant replies on
+        # blank-line paragraph boundaries so WhatsApp gets a few natural text
+        # bubbles instead of one big wall of text.  Long/code-heavy payloads
+        # still use truncate_message() only, preserving copy/paste blocks.
+        self._human_cascade_messages = self._coerce_bool_extra(
+            "human_cascade_messages", True, env_var="WHATSAPP_HUMAN_CASCADE_MESSAGES"
+        )
+        self._human_cascade_max_bubbles = self._coerce_int_extra(
+            "human_cascade_max_bubbles", 4, env_var="WHATSAPP_HUMAN_CASCADE_MAX_BUBBLES"
+        )
+        self._human_cascade_delay_seconds = self._coerce_float_extra(
+            "human_cascade_delay_seconds", 0.7, env_var="WHATSAPP_HUMAN_CASCADE_DELAY_SECONDS"
+        )
+        self._human_cascade_max_total_chars = self._coerce_int_extra(
+            "human_cascade_max_total_chars", 900, env_var="WHATSAPP_HUMAN_CASCADE_MAX_TOTAL_CHARS"
+        )
+        self._human_cascade_max_bubble_chars = self._coerce_int_extra(
+            "human_cascade_max_bubble_chars", 320, env_var="WHATSAPP_HUMAN_CASCADE_MAX_BUBBLE_CHARS"
+        )
+        self._human_cascade_max_merged_bubble_chars = self._coerce_int_extra(
+            "human_cascade_max_merged_bubble_chars",
+            640,
+            env_var="WHATSAPP_HUMAN_CASCADE_MAX_MERGED_BUBBLE_CHARS",
+        )
+        self._human_cascade_delay_jitter_seconds = self._coerce_float_extra(
+            "human_cascade_delay_jitter_seconds",
+            0.25,
+            env_var="WHATSAPP_HUMAN_CASCADE_DELAY_JITTER_SECONDS",
+        )
+        self._human_cascade_groups = self._coerce_bool_extra(
+            "human_cascade_groups", False, env_var="WHATSAPP_HUMAN_CASCADE_GROUPS"
+        )
+        self._chunk_delay_seconds = self._coerce_float_extra(
+            "chunk_delay_seconds", 0.3, env_var="WHATSAPP_CHUNK_DELAY_SECONDS"
+        )
 
-    def _coerce_float_extra(self, key: str, default: float) -> float:
+    def _coerce_bool_extra(self, key: str, default: bool, *, env_var: Optional[str] = None) -> bool:
+        """Read a boolean from platform extra/env, accepting common string forms."""
+        value = None
+        if getattr(self.config, "extra", None):
+            value = self.config.extra.get(key)
+        if value is None and env_var:
+            value = os.getenv(env_var)
+        if value is None:
+            return bool(default)
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return bool(value)
+        normalized = str(value).strip().lower()
+        if normalized in {"1", "true", "yes", "y", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "n", "off"}:
+            return False
+        return bool(default)
+
+    def _coerce_int_extra(self, key: str, default: int, *, env_var: Optional[str] = None) -> int:
+        """Read a non-negative integer from platform extra/env."""
+        value = None
+        if getattr(self.config, "extra", None):
+            value = self.config.extra.get(key)
+        if value is None and env_var:
+            value = os.getenv(env_var)
+        if value is None:
+            return int(default)
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return int(default)
+        return max(0, parsed)
+
+    def _coerce_float_extra(self, key: str, default: float, *, env_var: Optional[str] = None) -> float:
         """Read a float from ``config.extra``, guarding against bad/non-finite values.
 
         The result is fed directly to ``asyncio.sleep()``, so NaN/Inf and
@@ -405,6 +482,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         import math
 
         value = self.config.extra.get(key) if getattr(self.config, "extra", None) else None
+        if value is None and env_var:
+            value = os.getenv(env_var)
         if value is None:
             return float(default)
         try:
@@ -414,6 +493,106 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if not math.isfinite(parsed) or parsed < 0:
             return float(default)
         return parsed
+
+    @staticmethod
+    def _looks_structured_outbound(text: str) -> bool:
+        """Return True for approval gates / reports / artifacts we should not cascade."""
+        if re.search(r"`/(approve|deny|reject|confirm|cancel|stop|new|reset)\b", text, re.IGNORECASE):
+            return True
+        structured_lines = 0
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if re.match(r"^(#{1,6}\s+|[*_-]{3,}$|[-*+]\s+|\d+[.)]\s+|>\s+|\|.*\|$)", stripped):
+                structured_lines += 1
+        return structured_lines >= 3
+
+    def _split_outgoing_text(
+        self,
+        formatted: str,
+        *,
+        chat_id: Optional[str] = None,
+        delivery_style: str = "auto",
+    ) -> tuple[list[str], bool]:
+        """Return outbound WhatsApp bubbles plus whether the split is human-cascade.
+
+        Human cascade is intentionally conservative: only blank-line separated
+        prose gets split.  Code blocks and single-paragraph/copyable payloads
+        stay intact unless they exceed the message limit, in which case the
+        normal truncator handles safe chunking.
+        """
+        limit = self._outgoing_chunk_limit()
+        if not formatted:
+            return [], False
+        text = formatted.strip()
+        style = (delivery_style or "auto").strip().lower()
+        if style in {"single", "off", "none"}:
+            return self.truncate_message(formatted, limit), False
+        is_group = bool(chat_id and str(chat_id).lower().endswith("@g.us"))
+        if (
+            not self._human_cascade_messages
+            or "```" in formatted
+        ):
+            return self.truncate_message(formatted, limit), False
+
+        force_cascade = style in {"cascade", "human_cascade", "human-cascade"}
+        if not force_cascade and (
+            (is_group and not self._human_cascade_groups)
+            or self._looks_structured_outbound(text)
+        ):
+            return self.truncate_message(formatted, limit), False
+
+        max_total = self._human_cascade_max_total_chars
+        if not force_cascade and max_total > 0 and len(text) > max_total:
+            return self.truncate_message(formatted, limit), False
+
+        paragraphs = [p.strip() for p in re.split(r"\n\s*\n+", text) if p.strip()]
+        if len(paragraphs) < 2:
+            return self.truncate_message(formatted, limit), False
+
+        max_bubbles = self._human_cascade_max_bubbles
+        if max_bubbles <= 1:
+            return self.truncate_message(formatted, limit), False
+
+        merged_tail = False
+        if len(paragraphs) > max_bubbles and not force_cascade:
+            # Keep the human cadence without machine-gunning the chat: send the
+            # first few thoughts as separate bubbles, then fold the remainder
+            # into the final bubble.  This handles natural 5–6 paragraph chatty
+            # replies better than falling all the way back to one glued block.
+            head = paragraphs[: max_bubbles - 1]
+            tail = "\n\n".join(paragraphs[max_bubbles - 1:]).strip()
+            paragraphs = [*head, tail]
+            merged_tail = True
+
+        max_bubble = self._human_cascade_max_bubble_chars
+        if not force_cascade and max_bubble > 0:
+            normal_bubbles = paragraphs[:-1] if merged_tail else paragraphs
+            if any(len(paragraph) > max_bubble for paragraph in normal_bubbles):
+                return self.truncate_message(formatted, limit), False
+            if merged_tail:
+                merged_limit = self._human_cascade_max_merged_bubble_chars or (max_bubble * 2)
+                if merged_limit > 0 and len(paragraphs[-1]) > merged_limit:
+                    return self.truncate_message(formatted, limit), False
+
+        chunks: list[str] = []
+        for idx, paragraph in enumerate(paragraphs):
+            if len(chunks) >= max_bubbles - 1:
+                remainder = "\n\n".join(paragraphs[idx:])
+                chunks.extend(self.truncate_message(remainder, limit))
+                break
+            chunks.extend(self.truncate_message(paragraph, limit))
+
+        return chunks, len(chunks) > 1
+
+    def _cascade_delay_seconds(self) -> float:
+        """Return a slightly jittered delay for human-cascade bubbles."""
+        delay = self._human_cascade_delay_seconds
+        jitter = self._human_cascade_delay_jitter_seconds
+        if delay <= 0 or jitter <= 0:
+            return max(0.0, delay)
+        return random.uniform(max(0.0, delay - jitter), delay + jitter)
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """
@@ -810,12 +989,24 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         try:
             import aiohttp
 
-            # Format and chunk the message
+            # Format and split the message.  Short prose can become natural
+            # WhatsApp bubbles (human cascade); oversized/code payloads still
+            # use hard chunking that preserves code block boundaries.
             formatted = self.format_message(content)
-            chunks = self.truncate_message(formatted, self._outgoing_chunk_limit())
+            delivery_style = "auto"
+            if isinstance(metadata, dict):
+                raw_style = metadata.get("whatsapp_delivery_style") or metadata.get("delivery_style")
+                if raw_style is not None:
+                    delivery_style = str(raw_style)
+            chunks, human_cascade = self._split_outgoing_text(
+                formatted,
+                chat_id=chat_id,
+                delivery_style=delivery_style,
+            )
 
             last_message_id = None
-            for chunk in chunks:
+            sent_message_ids: list[str] = []
+            for idx, chunk in enumerate(chunks):
                 payload: Dict[str, Any] = {
                     "chatId": chat_id,
                     "message": chunk,
@@ -831,18 +1022,29 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 ) as resp:
                     if resp.status == 200:
                         data = await resp.json()
-                        last_message_id = data.get("messageId")
+                        ids = data.get("messageIds") or []
+                        if not ids and data.get("messageId"):
+                            ids = [data.get("messageId")]
+                        sent_message_ids.extend(str(mid) for mid in ids if mid)
+                        if sent_message_ids:
+                            last_message_id = sent_message_ids[-1]
                     else:
                         error = await resp.text()
                         return SendResult(success=False, error=error)
 
-                # Small delay between chunks to avoid rate limiting
-                if len(chunks) > 1:
-                    await asyncio.sleep(0.3)
+                # Small delay between chunks to avoid rate limiting.  Human
+                # cascade gets a slightly longer delay so the bubbles feel
+                # deliberate instead of a bursty auto-split.
+                if len(chunks) > 1 and idx < len(chunks) - 1:
+                    await asyncio.sleep(
+                        self._cascade_delay_seconds() if human_cascade else self._chunk_delay_seconds
+                    )
 
             return SendResult(
                 success=True,
                 message_id=last_message_id,
+                continuation_message_ids=tuple(sent_message_ids[:-1]),
+                raw_response={"messageIds": sent_message_ids, "human_cascade": human_cascade},
             )
         except Exception as e:
             return SendResult(success=False, error=str(e))

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -419,7 +419,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             "human_cascade_max_total_chars", 900, env_var="WHATSAPP_HUMAN_CASCADE_MAX_TOTAL_CHARS"
         )
         self._human_cascade_min_total_chars = self._coerce_int_extra(
-            "human_cascade_min_total_chars", 320
+            "human_cascade_min_total_chars", 300
         )
         self._human_cascade_min_lead_chars = self._coerce_int_extra(
             "human_cascade_min_lead_chars", 40
@@ -503,7 +503,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     @staticmethod
     def _has_approval_gate(text: str) -> bool:
         """Return True for explicit approval/control prompts that must stay intact."""
-        return bool(re.search(r"`/(approve|deny|reject|confirm|cancel|stop|new|reset)\b", text, re.IGNORECASE))
+        return bool(
+            re.search(
+                r"`?/(approve|deny|reject|confirm|cancel|stop|new|reset|always)\b",
+                text,
+                re.IGNORECASE,
+            )
+        )
 
     @staticmethod
     def _looks_structured_outbound(text: str) -> bool:
@@ -644,17 +650,19 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return self.truncate_message(formatted, limit), False
 
         force_cascade = style in {"cascade", "human_cascade", "human-cascade"}
-        if not force_cascade and (
-            (is_group and not self._human_cascade_groups)
-            or self._has_approval_gate(text)
-        ):
+        if self._has_approval_gate(text):
+            return self.truncate_message(formatted, limit), False
+        if not force_cascade and is_group and not self._human_cascade_groups:
             return self.truncate_message(formatted, limit), False
 
-        # Do not reject long prose up front.  If a reply starts as a natural
-        # multi-paragraph chat but grows into a longer answer, still send the
-        # first few clean paragraphs as human-paced bubbles and fold/chunk the
-        # rest later.  Code/approval payloads are guarded above; report/list
-        # tails are merged below so only the prose lead-in cascades.
+        # Keep cascade for moderate DM-shaped replies. Very long answers fall
+        # back to one normal WhatsApp payload so they do not turn into a noisy
+        # multi-notification burst. Code/approval payloads are guarded above;
+        # report/list tails are merged below so only the prose lead-in cascades.
+        max_total = self._human_cascade_max_total_chars
+        if not force_cascade and max_total > 0 and len(text) > max_total:
+            return self.truncate_message(formatted, limit), False
+
         paragraphs = [p.strip() for p in re.split(r"\n\s*\n+", text) if p.strip()]
         if len(paragraphs) < 2:
             return self.truncate_message(formatted, limit), False
@@ -670,13 +678,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if not self._should_human_cascade(text, paragraphs, force=force_cascade):
             return self.truncate_message(formatted, limit), False
 
-        merged_tail = False
         if not force_cascade and self._looks_structured_outbound(text):
             merged = self._merge_structured_tail(paragraphs, max_bubbles)
             if merged is None:
                 return self.truncate_message(formatted, limit), False
             paragraphs = merged
-            merged_tail = True
 
         if len(paragraphs) > max_bubbles and not force_cascade:
             # Keep the human cadence without machine-gunning the chat: send the
@@ -686,7 +692,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             head = paragraphs[: max_bubbles - 1]
             tail = "\n\n".join(paragraphs[max_bubbles - 1:]).strip()
             paragraphs = [*head, tail]
-            merged_tail = True
+
+        max_merged = self._human_cascade_max_merged_bubble_chars
+        if not force_cascade and max_merged > 0 and len(paragraphs[-1]) > max_merged:
+            return self.truncate_message(formatted, limit), False
 
         max_bubble = self._human_cascade_max_bubble_chars
         if not force_cascade and max_bubble > 0:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -437,6 +437,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             0.25,
             env_var="WHATSAPP_HUMAN_CASCADE_DELAY_JITTER_SECONDS",
         )
+        self._human_cascade_typing_indicators = self._coerce_bool_extra(
+            "human_cascade_typing_indicators",
+            True,
+            env_var="WHATSAPP_HUMAN_CASCADE_TYPING_INDICATORS",
+        )
         self._human_cascade_groups = self._coerce_bool_extra(
             "human_cascade_groups", False, env_var="WHATSAPP_HUMAN_CASCADE_GROUPS"
         )
@@ -1086,6 +1091,23 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._close_bridge_log()
         print(f"[{self.name}] Disconnected")
     
+    async def _send_typing_indicator(self, chat_id: str) -> None:
+        """Best-effort WhatsApp typing indicator before the next cascade bubble."""
+        if not self._human_cascade_typing_indicators or not self._http_session:
+            return
+        try:
+            import aiohttp
+
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/typing",
+                json={"chatId": chat_id},
+                timeout=aiohttp.ClientTimeout(total=5),
+            ):
+                return
+        except Exception:
+            # Typing presence is pure UX sugar; never fail message delivery.
+            return
+
     async def send(
         self,
         chat_id: str,
@@ -1156,9 +1178,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         return SendResult(success=False, error=error)
 
                 # Small delay between chunks to avoid rate limiting.  Human
-                # cascade gets a slightly longer delay so the bubbles feel
-                # deliberate instead of a bursty auto-split.
+                # cascade gets a slightly longer delay plus a best-effort typing
+                # indicator before the next bubble, so the follow-up feels typed
+                # rather than machine-gun posted.
                 if len(chunks) > 1 and idx < len(chunks) - 1:
+                    if human_cascade:
+                        await self._send_typing_indicator(chat_id)
                     await asyncio.sleep(
                         self._cascade_delay_seconds() if human_cascade else self._chunk_delay_seconds
                     )

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -495,10 +495,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         return parsed
 
     @staticmethod
+    def _has_approval_gate(text: str) -> bool:
+        """Return True for explicit approval/control prompts that must stay intact."""
+        return bool(re.search(r"`/(approve|deny|reject|confirm|cancel|stop|new|reset)\b", text, re.IGNORECASE))
+
+    @staticmethod
     def _looks_structured_outbound(text: str) -> bool:
-        """Return True for approval gates / reports / artifacts we should not cascade."""
-        if re.search(r"`/(approve|deny|reject|confirm|cancel|stop|new|reset)\b", text, re.IGNORECASE):
-            return True
+        """Return True for reports/artifacts that should not be split mid-body."""
         structured_lines = 0
         for line in text.splitlines():
             stripped = line.strip()
@@ -539,14 +542,15 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         force_cascade = style in {"cascade", "human_cascade", "human-cascade"}
         if not force_cascade and (
             (is_group and not self._human_cascade_groups)
-            or self._looks_structured_outbound(text)
+            or self._has_approval_gate(text)
         ):
             return self.truncate_message(formatted, limit), False
 
         # Do not reject long prose up front.  If a reply starts as a natural
         # multi-paragraph chat but grows into a longer answer, still send the
         # first few clean paragraphs as human-paced bubbles and fold/chunk the
-        # rest later.  Code/structured payloads are guarded above.
+        # rest later.  Code/approval payloads are guarded above; report/list
+        # tails are merged below so only the prose lead-in cascades.
         paragraphs = [p.strip() for p in re.split(r"\n\s*\n+", text) if p.strip()]
         if len(paragraphs) < 2:
             return self.truncate_message(formatted, limit), False
@@ -556,6 +560,19 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return self.truncate_message(formatted, limit), False
 
         merged_tail = False
+        if not force_cascade and self._looks_structured_outbound(text):
+            lead_limit = max(1, max_bubbles - 1)
+            lead: list[str] = []
+            for paragraph in paragraphs:
+                if len(lead) >= lead_limit or self._looks_structured_outbound(paragraph):
+                    break
+                lead.append(paragraph)
+            if not lead or len(lead) >= len(paragraphs):
+                return self.truncate_message(formatted, limit), False
+            tail = "\n\n".join(paragraphs[len(lead):]).strip()
+            paragraphs = [*lead, tail]
+            merged_tail = True
+
         if len(paragraphs) > max_bubbles and not force_cascade:
             # Keep the human cadence without machine-gunning the chat: send the
             # first few thoughts as separate bubbles, then fold the remainder

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -543,10 +543,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         ):
             return self.truncate_message(formatted, limit), False
 
-        max_total = self._human_cascade_max_total_chars
-        if not force_cascade and max_total > 0 and len(text) > max_total:
-            return self.truncate_message(formatted, limit), False
-
+        # Do not reject long prose up front.  If a reply starts as a natural
+        # multi-paragraph chat but grows into a longer answer, still send the
+        # first few clean paragraphs as human-paced bubbles and fold/chunk the
+        # rest later.  Code/structured payloads are guarded above.
         paragraphs = [p.strip() for p in re.split(r"\n\s*\n+", text) if p.strip()]
         if len(paragraphs) < 2:
             return self.truncate_message(formatted, limit), False
@@ -568,13 +568,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         max_bubble = self._human_cascade_max_bubble_chars
         if not force_cascade and max_bubble > 0:
-            normal_bubbles = paragraphs[:-1] if merged_tail else paragraphs
+            # Keep the lead-in bubbles compact; the final/tail bubble can be
+            # longer and will be chunked by WhatsApp's normal safety splitter.
+            normal_bubbles = paragraphs[:-1]
             if any(len(paragraph) > max_bubble for paragraph in normal_bubbles):
                 return self.truncate_message(formatted, limit), False
-            if merged_tail:
-                merged_limit = self._human_cascade_max_merged_bubble_chars or (max_bubble * 2)
-                if merged_limit > 0 and len(paragraphs[-1]) > merged_limit:
-                    return self.truncate_message(formatted, limit), False
+            # The merged tail may be long.  Keep the first bubbles human-sized
+            # and let the normal WhatsApp chunker handle the tail, instead of
+            # collapsing the whole answer into one wall of text.
 
         chunks: list[str] = []
         for idx, paragraph in enumerate(paragraphs):

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -410,16 +410,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             "human_cascade_messages", True, env_var="WHATSAPP_HUMAN_CASCADE_MESSAGES"
         )
         self._human_cascade_max_bubbles = self._coerce_int_extra(
-            "human_cascade_max_bubbles", 4, env_var="WHATSAPP_HUMAN_CASCADE_MAX_BUBBLES"
+            "human_cascade_max_bubbles", 3, env_var="WHATSAPP_HUMAN_CASCADE_MAX_BUBBLES"
         )
         self._human_cascade_delay_seconds = self._coerce_float_extra(
-            "human_cascade_delay_seconds", 0.7, env_var="WHATSAPP_HUMAN_CASCADE_DELAY_SECONDS"
+            "human_cascade_delay_seconds", 0.55, env_var="WHATSAPP_HUMAN_CASCADE_DELAY_SECONDS"
         )
         self._human_cascade_max_total_chars = self._coerce_int_extra(
             "human_cascade_max_total_chars", 900, env_var="WHATSAPP_HUMAN_CASCADE_MAX_TOTAL_CHARS"
         )
         self._human_cascade_min_total_chars = self._coerce_int_extra(
-            "human_cascade_min_total_chars", 420
+            "human_cascade_min_total_chars", 320
         )
         self._human_cascade_min_lead_chars = self._coerce_int_extra(
             "human_cascade_min_lead_chars", 40
@@ -509,13 +509,32 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     def _looks_structured_outbound(text: str) -> bool:
         """Return True for reports/artifacts that should not be split mid-body."""
         structured_lines = 0
+        artifact_lines = 0
         for line in text.splitlines():
             stripped = line.strip()
             if not stripped:
                 continue
             if re.match(r"^(#{1,6}\s+|[*_-]{3,}$|[-*+]\s+|\d+[.)]\s+|>\s+|\|.*\|$)", stripped):
                 structured_lines += 1
-        return structured_lines >= 3
+            if re.match(
+                r"^(\{\s*$|\}\s*,?$|\[\s*$|\]\s*,?$|[\"']?[A-Za-z0-9_.-]+[\"']?\s*[:=]\s*.+$|[-+]{3}\s|@@\s|[+!]\s|\$\s+|(?:sudo\s+)?(?:git|gh|npm|pnpm|yarn|python\d*|pip|uv|docker|kubectl|helm|curl|ssh|scp|rsync|systemctl|journalctl)\b|(?:TRACE|DEBUG|INFO|WARN|WARNING|ERROR|CRITICAL)\b|Traceback \(most recent call last\):|File \".+\", line \d+|[A-Za-z_][\w.]*Error:|[-*+]\s+\[[ xX]\]\s+)",
+                stripped,
+            ):
+                artifact_lines += 1
+        if structured_lines >= 3:
+            return True
+        return artifact_lines >= 3
+
+    @staticmethod
+    def _has_copy_sensitive_outbound(text: str) -> bool:
+        """Return True when content likely needs to be copied/read as one unit."""
+        return bool(
+            re.search(
+                r"\b(copy|paste|run|send|use)\s+(this|it|the following)\s+(exactly|as-is|as is)\b",
+                text,
+                re.IGNORECASE,
+            )
+        )
 
     @staticmethod
     def _word_count(text: str) -> int:
@@ -538,6 +557,47 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if min_total > 0 and len(text) < min_total:
             return False
         return self._is_substantive_cascade_lead(paragraphs[0])
+
+    @staticmethod
+    def _contains_outbound_link(text: str) -> bool:
+        """Return True when a bubble contains a URL/markdown link."""
+        return bool(
+            re.search(r"https?://|www\.|\[[^\]]+\]\([^\)]+\)", text, re.IGNORECASE)
+        )
+
+    @staticmethod
+    def _contains_active_prompt(text: str) -> bool:
+        """Return True for user-response prompts that should stay at the end."""
+        stripped = text.strip()
+        if "?" in stripped:
+            return True
+        return bool(
+            re.search(
+                r"\b(reply|respond|choose|pick|select|confirm|approve|deny|send me|tell me|want me to|should i)\b",
+                stripped,
+                re.IGNORECASE,
+            )
+        )
+
+    def _protect_high_stakes_tail(self, paragraphs: list[str]) -> list[str] | None:
+        """Keep questions/actions last and keep links with immediate context."""
+        if len(paragraphs) < 2:
+            return paragraphs
+
+        for idx, paragraph in enumerate(paragraphs[:-1]):
+            if self._contains_active_prompt(paragraph):
+                return None
+
+        link_indices = [idx for idx, paragraph in enumerate(paragraphs) if self._contains_outbound_link(paragraph)]
+        if not link_indices:
+            return paragraphs
+
+        first_link = link_indices[0]
+        if first_link == 0:
+            return None
+        merge_start = max(0, first_link - 1)
+        protected_tail = "\n\n".join(paragraphs[merge_start:]).strip()
+        return [*paragraphs[:merge_start], protected_tail]
 
     def _merge_structured_tail(self, paragraphs: list[str], max_bubbles: int) -> list[str] | None:
         """Return lead paragraphs + glued structured tail, or None if not worth cascading."""
@@ -579,6 +639,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if (
             not self._human_cascade_messages
             or "```" in formatted
+            or self._has_copy_sensitive_outbound(text)
         ):
             return self.truncate_message(formatted, limit), False
 
@@ -597,6 +658,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         paragraphs = [p.strip() for p in re.split(r"\n\s*\n+", text) if p.strip()]
         if len(paragraphs) < 2:
             return self.truncate_message(formatted, limit), False
+        if not force_cascade:
+            protected = self._protect_high_stakes_tail(paragraphs)
+            if protected is None or len(protected) < 2:
+                return self.truncate_message(formatted, limit), False
+            paragraphs = protected
 
         max_bubbles = self._human_cascade_max_bubbles
         if max_bubbles <= 1:

--- a/tests/gateway/test_gateway_status_delivery_style.py
+++ b/tests/gateway/test_gateway_status_delivery_style.py
@@ -1,0 +1,52 @@
+"""Gateway status/progress sends should not trigger WhatsApp human cascade."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.run import _send_or_update_status_coro
+
+
+class _SendOnlyAdapter:
+    def __init__(self):
+        self.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+
+class _StatusAdapter(_SendOnlyAdapter):
+    def __init__(self):
+        super().__init__()
+        self.send_or_update_status = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+
+@pytest.mark.asyncio
+async def test_status_fallback_send_forces_single_delivery_style():
+    adapter = _SendOnlyAdapter()
+
+    await _send_or_update_status_coro(
+        adapter,
+        "chat-1",
+        "thinking",
+        "thinking\n\nstill checking",
+        {"thread_id": "thread-1"},
+    )
+
+    metadata = adapter.send.call_args.kwargs["metadata"]
+    assert metadata["thread_id"] == "thread-1"
+    assert metadata["delivery_style"] == "single"
+
+
+@pytest.mark.asyncio
+async def test_status_update_adapter_forces_single_delivery_style():
+    adapter = _StatusAdapter()
+
+    await _send_or_update_status_coro(
+        adapter,
+        "chat-1",
+        "thinking",
+        "thinking\n\nstill checking",
+        None,
+    )
+
+    metadata = adapter.send_or_update_status.call_args.kwargs["metadata"]
+    assert metadata["delivery_style"] == "single"

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -85,6 +85,48 @@ class TestCleanForDisplay:
         assert result == text
 
 
+# ── Stream send metadata ──────────────────────────────────────────────────
+
+
+class TestStreamSendMetadata:
+    def test_non_final_stream_metadata_forces_single_delivery_style(self):
+        consumer = GatewayStreamConsumer(
+            MagicMock(),
+            "chat_1",
+            metadata={"thread_id": "thread-1"},
+        )
+
+        assert consumer._metadata_for_send(final=False) == {
+            "thread_id": "thread-1",
+            "delivery_style": "single",
+        }
+        assert consumer._metadata_for_send(final=False, expect_edits=True) == {
+            "thread_id": "thread-1",
+            "expect_edits": True,
+            "delivery_style": "single",
+        }
+        assert consumer._metadata_for_send(final=True) == {
+            "thread_id": "thread-1",
+            "notify": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_commentary_send_forces_single_delivery_style(self):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            metadata={"thread_id": "thread-1"},
+        )
+
+        assert await consumer._send_commentary("thinking\n\nstill checking") is True
+
+        metadata = adapter.send.call_args.kwargs["metadata"]
+        assert metadata["thread_id"] == "thread-1"
+        assert metadata["delivery_style"] == "single"
+
+
 # ── Integration: _send_or_edit strips MEDIA: ─────────────────────────────
 
 

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -320,7 +320,10 @@ class TestSendChunking:
             metadata={"delivery_style": "cascade"},
         )
 
-        assert adapter._http_session.post.call_count == 3
+        assert adapter._http_session.post.call_count == 2
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert payloads[0]["message"] == "done\n- one\n- two\n- three"
+        assert payloads[1]["message"] == "next"
 
     @pytest.mark.asyncio
     async def test_machine_artifacts_do_not_human_cascade(self):
@@ -384,18 +387,118 @@ class TestSendChunking:
         assert "Reply `/approve`" in payload["message"]
 
     @pytest.mark.asyncio
-    async def test_approval_gates_ignore_forced_cascade(self):
+    async def test_approval_gates_keep_action_block_atomic_when_forced_cascade(self):
         adapter = _make_adapter()
-        resp = MagicMock(status=200)
-        resp.json = AsyncMock(return_value={"messageId": "msg1"})
-        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+        responses = []
+        for msg_id in ("msg1", "msg2"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
 
         content = "I can restart the gateway.\n\nReply /always to keep approving restarts.\n\nRisk: brief downtime."
         await adapter.send("chat1", content, metadata={"delivery_style": "cascade"})
 
-        assert adapter._http_session.post.call_count == 1
-        payload = adapter._http_session.post.call_args.kwargs["json"]
-        assert payload["message"] == content
+        assert adapter._http_session.post.call_count == 2
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert payloads[0]["message"] == "I can restart the gateway."
+        assert payloads[1]["message"] == "Reply /always to keep approving restarts.\n\nRisk: brief downtime."
+
+    @pytest.mark.asyncio
+    async def test_question_mark_explainer_with_lists_still_cascades(self):
+        adapter = _make_adapter()
+        adapter._human_cascade_max_bubbles = 0
+        adapter._human_cascade_max_total_chars = 0
+        adapter._human_cascade_max_bubble_chars = 0
+        adapter._human_cascade_max_merged_bubble_chars = 0
+        adapter._human_cascade_min_total_chars = 0
+        adapter._human_cascade_min_lead_chars = 0
+        responses = []
+        for msg_id in ("msg1", "msg2", "msg3", "msg4", "msg5"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        bubble1 = "it decides “is this safe/natural to split into multiple WhatsApp bubbles, or should it stay one atomic message?”"
+        bubble2 = "roughly:\n•\u2060  WhatsApp DM, not group by default\n•\u2060  cascade is enabled"
+        bubble3 = "stays one bubble when:\n•\u2060  approval/control gate: /approve, /deny, /always, /stop, etc\n•\u2060  code block: triple backticks"
+        bubble4 = "then list handling sits in the middle:\n•\u2060  heading+list becomes one bubble\n•\u2060  multiple heading+list sections become separate bubbles"
+        bubble5 = "for your approval message, the action block stays atomic, but earlier prose can still bubble separately."
+        await adapter.send("chat1", "\n\n".join([bubble1, bubble2, bubble3, bubble4, bubble5]))
+
+        assert adapter._http_session.post.call_count == 5
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert [payload["message"] for payload in payloads] == [bubble1, bubble2, bubble3, bubble4, bubble5]
+
+    @pytest.mark.asyncio
+    async def test_code_block_keeps_only_its_section_atomic(self):
+        adapter = _make_adapter()
+        adapter._human_cascade_max_bubbles = 0
+        adapter._human_cascade_max_total_chars = 0
+        adapter._human_cascade_max_bubble_chars = 0
+        adapter._human_cascade_max_merged_bubble_chars = 0
+        adapter._human_cascade_min_total_chars = 0
+        adapter._human_cascade_min_lead_chars = 0
+        responses = []
+        for msg_id in ("msg1", "msg2", "msg3"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        intro = "plain intro can still be its own bubble"
+        code = "run this:\n\n```bash\necho hi\n\necho bye\n```"
+        tail = "plain tail can still be its own bubble"
+        await adapter.send("chat1", "\n\n".join([intro, code, tail]))
+
+        assert adapter._http_session.post.call_count == 3
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert payloads[0]["message"] == intro
+        assert payloads[1]["message"] == code
+        assert payloads[2]["message"] == tail
+
+    @pytest.mark.asyncio
+    async def test_link_command_with_own_heading_does_not_merge_with_previous_list(self):
+        adapter = _make_adapter()
+        adapter._human_cascade_max_bubbles = 0
+        adapter._human_cascade_max_total_chars = 0
+        adapter._human_cascade_max_bubble_chars = 0
+        adapter._human_cascade_max_merged_bubble_chars = 0
+        adapter._human_cascade_min_total_chars = 0
+        adapter._human_cascade_min_lead_chars = 0
+        responses = []
+        for msg_id in ("msg1", "msg2"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        state = "PR state:\n•\u2060  local PR worktree updated\n•\u2060  amended commit ready: 9c81f3971\n•\u2060  not pushed yet"
+        command = "push command waiting on you:\ngit push https://github.com/devatnull/hermes-agent.git HEAD:feat/whatsapp-cascade-delivery"
+        await adapter.send("chat1", "\n\n".join([state, command]))
+
+        assert adapter._http_session.post.call_count == 2
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert payloads[0]["message"] == state
+        assert payloads[1]["message"] == command
+
+    @pytest.mark.asyncio
+    async def test_group_chats_can_human_cascade_when_configured(self):
+        adapter = _make_adapter()
+        adapter._human_cascade_groups = True
+        adapter._human_cascade_min_total_chars = 0
+        adapter._human_cascade_min_lead_chars = 0
+        responses = []
+        for msg_id in ("msg1", "msg2"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        await adapter.send("120363001234567890@g.us", "first\n\nsecond")
+
+        assert adapter._http_session.post.call_count == 2
 
     @pytest.mark.asyncio
     async def test_oversized_merged_tail_stays_single(self):
@@ -417,14 +520,11 @@ class TestSendChunking:
         assert payload["message"] == content
 
     @pytest.mark.asyncio
-    async def test_substantive_structured_tail_cascades_plain_lead_in_only(self):
+    async def test_intro_before_structured_tail_stays_single(self):
         adapter = _make_adapter()
-        responses = []
-        for msg_id in ("msg1", "msg2"):
-            resp = MagicMock(status=200)
-            resp.json = AsyncMock(return_value={"messageId": msg_id})
-            responses.append(_AsyncCM(resp))
-        adapter._http_session.post = MagicMock(side_effect=responses)
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
 
         lead = "Here’s the useful summary before the list, with enough context to deserve its own bubble."
         tail = "\n".join([
@@ -433,12 +533,13 @@ class TestSendChunking:
             "- kept approval prompts, code blocks, and group chats conservative so safety/copyability still wins",
             "- ran the focused gateway suite after the heuristic change to catch regressions",
         ])
-        await adapter.send("chat1", lead + "\n\n" + tail)
+        content = lead + "\n\n" + tail
+        await adapter.send("chat1", content)
 
-        assert adapter._http_session.post.call_count == 2
-        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
-        assert payloads[0]["message"] == lead
-        assert payloads[1]["message"] == tail
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        expected = lead + "\n" + tail
+        assert payload["message"] == expected
 
     @pytest.mark.asyncio
     async def test_short_opener_before_structured_tail_stays_single(self):
@@ -453,6 +554,99 @@ class TestSendChunking:
         assert adapter._http_session.post.call_count == 1
         payload = adapter._http_session.post.call_args.kwargs["json"]
         assert payload["message"] == content
+
+    @pytest.mark.asyncio
+    async def test_whatsapp_bullet_tail_stays_single(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        content = "but we only know two things for sure right now:\n\n•\u2060  gateway restarted after the code/config changes\n•\u2060  live config + imported adapter code both show the new behavior"
+        expected = "but we only know two things for sure right now:\n•\u2060  gateway restarted after the code/config changes\n•\u2060  live config + imported adapter code both show the new behavior"
+        await adapter.send("chat1", content)
+
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["message"] == expected
+
+    @pytest.mark.asyncio
+    async def test_intro_list_then_later_prose_cascades_after_list_block(self):
+        adapter = _make_adapter()
+        adapter._human_cascade_max_bubbles = 0
+        adapter._human_cascade_max_total_chars = 0
+        adapter._human_cascade_max_bubble_chars = 0
+        adapter._human_cascade_max_merged_bubble_chars = 0
+        adapter._human_cascade_min_total_chars = 0
+        adapter._human_cascade_min_lead_chars = 0
+        responses = []
+        for msg_id in ("msg1", "msg2"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        first = "settings now are:\n•\u2060  split: prose blank lines cascade\n•\u2060  lists/code/logs/config/status stay together\n•\u2060  delay: ~170–310ms between bubbles"
+        second = "if it still feels weird after one real message, we tune by like 50ms, not keep throwing spaghetti at it"
+        await adapter.send("chat1", "settings now are:\n\n•\u2060  split: prose blank lines cascade\n•\u2060  lists/code/logs/config/status stay together\n•\u2060  delay: ~170–310ms between bubbles" + "\n\n" + second)
+
+        assert adapter._http_session.post.call_count == 2
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert payloads[0]["message"] == first
+        assert payloads[1]["message"] == second
+
+    @pytest.mark.asyncio
+    async def test_multiple_intro_list_sections_cascade_as_separate_blocks(self):
+        adapter = _make_adapter()
+        adapter._human_cascade_max_bubbles = 0
+        adapter._human_cascade_max_total_chars = 0
+        adapter._human_cascade_max_bubble_chars = 0
+        adapter._human_cascade_max_merged_bubble_chars = 0
+        adapter._human_cascade_min_total_chars = 0
+        adapter._human_cascade_min_lead_chars = 0
+        responses = []
+        for msg_id in ("msg1", "msg2", "msg3", "msg4"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        bubble1 = "yeah — after my “don’t split lists” fix, it was too blunt"
+        bubble2 = "previous behavior:\n•\u2060  if any later paragraph had bullet/list lines, it returned the whole message as one bubble\n•\u2060  so intro + bullets + final prose all stayed glued together\n•\u2060  that’s why your “settings now are…” message didn’t cascade"
+        bubble3 = "new behavior:\n•\u2060  intro + bullets stays glued together\n•\u2060  later normal prose after another blank line can split into the next bubble"
+        bubble4 = "so the list is protected, but it doesn’t nuke the whole cascade anymore"
+        await adapter.send("chat1", "\n\n".join([bubble1, bubble2, bubble3, bubble4]))
+
+        assert adapter._http_session.post.call_count == 4
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert [payload["message"] for payload in payloads] == [bubble1, bubble2, bubble3, bubble4]
+
+    @pytest.mark.asyncio
+    async def test_plain_paragraph_between_list_sections_stays_separate(self):
+        adapter = _make_adapter()
+        adapter._human_cascade_max_bubbles = 0
+        adapter._human_cascade_max_total_chars = 0
+        adapter._human_cascade_max_bubble_chars = 0
+        adapter._human_cascade_max_merged_bubble_chars = 0
+        adapter._human_cascade_min_total_chars = 0
+        adapter._human_cascade_min_lead_chars = 0
+        responses = []
+        for msg_id in ("msg1", "msg2", "msg3", "msg4", "msg5"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        bubble1 = "yep, working now — but slightly too greedy on list sections"
+        bubble2 = "what happened:\n•\u2060  first prose bubble split correctly\n•\u2060  all three list sections got merged into one big protected list bubble\n•\u2060  delay/prose split correctly after that\n•\u2060  final prose split correctly too"
+        bubble3 = "so the remaining bug is: consecutive heading+list sections are being treated as one list block instead of separate blocks"
+        bubble4 = "expected should be:\n•\u2060  prose bubble\n•\u2060  previous behavior + bullets\n•\u2060  new behavior + bullets\n•\u2060  delay prose\n•\u2060  final prose"
+        bubble5 = "I’ll adjust the merge so a new non-list heading after a list starts a new section, not part of the previous protected block."
+        await adapter.send("chat1", "\n\n".join([bubble1, bubble2, bubble3, bubble4, bubble5]))
+
+        assert adapter._http_session.post.call_count == 5
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert [payload["message"] for payload in payloads] == [bubble1, bubble2, bubble3, bubble4, bubble5]
 
     @pytest.mark.asyncio
     async def test_report_heading_before_structured_tail_stays_single(self):

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -327,18 +327,36 @@ class TestSendChunking:
         assert "Reply `/approve`" in payload["message"]
 
     @pytest.mark.asyncio
-    async def test_structured_reports_do_not_human_cascade(self):
+    async def test_structured_report_tail_cascades_plain_lead_in_only(self):
+        adapter = _make_adapter()
+        responses = []
+        for msg_id in ("msg1", "msg2"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        content = "done\n\n- changed adapter\n- added tests\n- ran suite\n\n44 passed"
+        await adapter.send("chat1", content)
+
+        assert adapter._http_session.post.call_count == 2
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert payloads[0]["message"] == "done"
+        assert payloads[1]["message"] == "- changed adapter\n- added tests\n- ran suite\n\n44 passed"
+
+    @pytest.mark.asyncio
+    async def test_structured_report_without_plain_lead_in_stays_single(self):
         adapter = _make_adapter()
         resp = MagicMock(status=200)
         resp.json = AsyncMock(return_value={"messageId": "msg1"})
         adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
 
-        content = "done\n\n- changed adapter\n- added tests\n- ran suite\n\n44 passed"
+        content = "- changed adapter\n- added tests\n- ran suite\n\n44 passed"
         await adapter.send("chat1", content)
 
         assert adapter._http_session.post.call_count == 1
         payload = adapter._http_session.post.call_args.kwargs["json"]
-        assert "- changed adapter" in payload["message"]
+        assert payload["message"].startswith("- changed adapter")
 
     @pytest.mark.asyncio
     async def test_long_briefs_cascade_lead_in_then_chunk_tail(self):

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -247,6 +247,8 @@ class TestSendChunking:
     @pytest.mark.asyncio
     async def test_extra_paragraphs_merge_into_final_cascade_bubble(self):
         adapter = _make_adapter()
+        adapter._human_cascade_max_total_chars = 2000
+        adapter._human_cascade_max_merged_bubble_chars = 1200
         responses = []
         for msg_id in ("msg1", "msg2", "msg3"):
             resp = MagicMock(status=200)
@@ -382,6 +384,39 @@ class TestSendChunking:
         assert "Reply `/approve`" in payload["message"]
 
     @pytest.mark.asyncio
+    async def test_approval_gates_ignore_forced_cascade(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        content = "I can restart the gateway.\n\nReply /always to keep approving restarts.\n\nRisk: brief downtime."
+        await adapter.send("chat1", content, metadata={"delivery_style": "cascade"})
+
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["message"] == content
+
+    @pytest.mark.asyncio
+    async def test_oversized_merged_tail_stays_single(self):
+        adapter = _make_adapter()
+        adapter._human_cascade_max_merged_bubble_chars = 80
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        content = (
+            "First paragraph is substantive enough to be worth a separate WhatsApp bubble."
+            "\n\n"
+            + ("The final merged tail is intentionally too long for the configured tail bubble. " * 3).strip()
+        )
+        await adapter.send("chat1", content)
+
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["message"] == content
+
+    @pytest.mark.asyncio
     async def test_substantive_structured_tail_cascades_plain_lead_in_only(self):
         adapter = _make_adapter()
         responses = []
@@ -448,25 +483,22 @@ class TestSendChunking:
         assert payload["message"].startswith("- changed adapter")
 
     @pytest.mark.asyncio
-    async def test_long_briefs_cascade_lead_in_then_chunk_tail(self):
+    async def test_over_max_total_stays_single(self):
         adapter = _make_adapter()
-        responses = []
-        for msg_id in ("msg1", "msg2"):
-            resp = MagicMock(status=200)
-            resp.json = AsyncMock(return_value={"messageId": msg_id})
-            responses.append(_AsyncCM(resp))
-        adapter._http_session.post = MagicMock(side_effect=responses)
+        adapter._human_cascade_max_total_chars = 120
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
 
         lead = "Here’s the daily brief with enough context to make the first bubble useful before the longer body lands."
-        content = lead + "\n\n" + ("Lots of info here. " * 80)
+        content = lead + "\n\n" + ("Lots of info here. " * 20)
         result = await adapter.send("chat1", content)
 
         assert result.success
-        assert adapter._http_session.post.call_count == 2
-        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
-        assert payloads[0]["message"] == lead
-        assert payloads[1]["message"].startswith("Lots of info here.")
-        assert result.raw_response["human_cascade"] is True
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["message"] == content
+        assert result.raw_response["human_cascade"] is False
 
     @pytest.mark.asyncio
     async def test_active_question_before_tail_stays_single(self):

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -51,11 +51,11 @@ def _make_adapter():
     adapter._group_policy = "open"
     adapter._group_allow_from = set()
     adapter._human_cascade_messages = True
-    adapter._human_cascade_max_bubbles = 4
+    adapter._human_cascade_max_bubbles = 3
     adapter._human_cascade_delay_seconds = 0
     adapter._human_cascade_delay_jitter_seconds = 0
     adapter._human_cascade_max_total_chars = 900
-    adapter._human_cascade_min_total_chars = 420
+    adapter._human_cascade_min_total_chars = 320
     adapter._human_cascade_min_lead_chars = 40
     adapter._human_cascade_max_bubble_chars = 320
     adapter._human_cascade_max_merged_bubble_chars = 640
@@ -248,7 +248,7 @@ class TestSendChunking:
     async def test_extra_paragraphs_merge_into_final_cascade_bubble(self):
         adapter = _make_adapter()
         responses = []
-        for msg_id in ("msg1", "msg2", "msg3", "msg4"):
+        for msg_id in ("msg1", "msg2", "msg3"):
             resp = MagicMock(status=200)
             resp.json = AsyncMock(return_value={"messageId": msg_id})
             responses.append(_AsyncCM(resp))
@@ -264,16 +264,15 @@ class TestSendChunking:
         result = await adapter.send("chat1", "\n\n".join(messages))
 
         assert result.success
-        assert adapter._http_session.post.call_count == 4
+        assert adapter._http_session.post.call_count == 3
         payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
         assert [payload["message"] for payload in payloads] == [
             messages[0],
             messages[1],
-            messages[2],
-            messages[3] + "\n\n" + messages[4],
+            messages[2] + "\n\n" + messages[3] + "\n\n" + messages[4],
         ]
-        assert result.message_id == "msg4"
-        assert result.continuation_message_ids == ("msg1", "msg2", "msg3")
+        assert result.message_id == "msg3"
+        assert result.continuation_message_ids == ("msg1", "msg2")
         assert result.raw_response["human_cascade"] is True
 
     @pytest.mark.asyncio
@@ -320,6 +319,39 @@ class TestSendChunking:
         )
 
         assert adapter._http_session.post.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_machine_artifacts_do_not_human_cascade(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        content = "Here is the config to verify as one unit.\n\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n\nCopy this exactly into the config file."
+        await adapter.send("chat1", content)
+
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["message"] == content
+
+    @pytest.mark.asyncio
+    async def test_mixed_prose_and_json_artifact_splits_only_before_artifact_tail(self):
+        adapter = _make_adapter()
+        responses = []
+        for msg_id in ("msg1", "msg2"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        lead = "This is the human-readable setup context, long enough to deserve its own bubble before the machine-readable payload arrives for verification, and it explains why the next blob is deliberately kept intact instead of chopped into mobile confetti that would be annoying to copy, audit, or compare against the file on disk."
+        artifact = '{\n  "service": "gateway",\n  "mode": "safe",\n  "retries": 3\n}'
+        await adapter.send("chat1", lead + "\n\n" + artifact)
+
+        assert adapter._http_session.post.call_count == 2
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert payloads[0]["message"] == lead
+        assert payloads[1]["message"] == artifact
 
     @pytest.mark.asyncio
     async def test_code_blocks_do_not_human_cascade(self):
@@ -435,6 +467,42 @@ class TestSendChunking:
         assert payloads[0]["message"] == lead
         assert payloads[1]["message"].startswith("Lots of info here.")
         assert result.raw_response["human_cascade"] is True
+
+    @pytest.mark.asyncio
+    async def test_active_question_before_tail_stays_single(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        content = "Do you want me to restart the gateway?\n\n" + (
+            "These extra diagnostic details would bury the active question if they landed in a later bubble. " * 5
+        ).strip()
+        await adapter.send("chat1", content)
+
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["message"] == content
+
+    @pytest.mark.asyncio
+    async def test_link_tail_stays_with_immediate_context(self):
+        adapter = _make_adapter()
+        responses = []
+        for msg_id in ("msg1", "msg2"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        intro = "I found the relevant preview and this opening bubble is useful context before the actual action link arrives, rather than dropping a naked URL into the chat like a suspicious little phishing pellet."
+        context = "This link is for the draft preview, so it needs to travel with the sentence explaining what it is and why the user would tap it."
+        link = "Preview: https://example.com/draft/abc123"
+        await adapter.send("chat1", "\n\n".join([intro, context, link]))
+
+        assert adapter._http_session.post.call_count == 2
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert payloads[0]["message"] == intro
+        assert payloads[1]["message"] == context + "\n\n" + link
 
     @pytest.mark.asyncio
     async def test_group_chats_do_not_human_cascade_by_default(self):

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -50,6 +50,15 @@ def _make_adapter():
     adapter._allow_from = set()
     adapter._group_policy = "open"
     adapter._group_allow_from = set()
+    adapter._human_cascade_messages = True
+    adapter._human_cascade_max_bubbles = 4
+    adapter._human_cascade_delay_seconds = 0
+    adapter._human_cascade_delay_jitter_seconds = 0
+    adapter._human_cascade_max_total_chars = 900
+    adapter._human_cascade_max_bubble_chars = 320
+    adapter._human_cascade_max_merged_bubble_chars = 640
+    adapter._human_cascade_groups = False
+    adapter._chunk_delay_seconds = 0
     return adapter
 
 
@@ -190,6 +199,173 @@ class TestSendChunking:
         assert result.success
         # Only one call to bridge /send
         assert adapter._http_session.post.call_count == 1
+        assert result.raw_response["human_cascade"] is False
+
+    @pytest.mark.asyncio
+    async def test_blank_line_paragraphs_send_as_human_cascade(self):
+        adapter = _make_adapter()
+        responses = []
+        for msg_id in ("msg1", "msg2", "msg3"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        result = await adapter.send("chat1", "first thought\n\nsecond thought\n\nthird thought")
+
+        assert result.success
+        assert adapter._http_session.post.call_count == 3
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert [payload["message"] for payload in payloads] == [
+            "first thought",
+            "second thought",
+            "third thought",
+        ]
+        assert result.message_id == "msg3"
+        assert result.continuation_message_ids == ("msg1", "msg2")
+        assert result.raw_response["human_cascade"] is True
+
+    @pytest.mark.asyncio
+    async def test_extra_paragraphs_merge_into_final_cascade_bubble(self):
+        adapter = _make_adapter()
+        responses = []
+        for msg_id in ("msg1", "msg2", "msg3", "msg4"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        result = await adapter.send(
+            "chat1",
+            "one\n\ntwo\n\nthree\n\n" + ("four " * 40).strip() + "\n\n" + ("five " * 40).strip(),
+        )
+
+        assert result.success
+        assert adapter._http_session.post.call_count == 4
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert [payload["message"] for payload in payloads] == [
+            "one",
+            "two",
+            "three",
+            ("four " * 40).strip() + "\n\n" + ("five " * 40).strip(),
+        ]
+        assert result.message_id == "msg4"
+        assert result.continuation_message_ids == ("msg1", "msg2", "msg3")
+        assert result.raw_response["human_cascade"] is True
+
+    @pytest.mark.asyncio
+    async def test_human_cascade_can_be_disabled(self):
+        adapter = _make_adapter()
+        adapter._human_cascade_messages = False
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        await adapter.send("chat1", "first\n\nsecond")
+
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["message"] == "first\n\nsecond"
+
+    @pytest.mark.asyncio
+    async def test_metadata_delivery_style_single_suppresses_human_cascade(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        await adapter.send("chat1", "thinking\n\nstill checking", metadata={"delivery_style": "single"})
+
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["message"] == "thinking\n\nstill checking"
+
+    @pytest.mark.asyncio
+    async def test_metadata_delivery_style_cascade_can_force_structured_message(self):
+        adapter = _make_adapter()
+        responses = []
+        for msg_id in ("msg1", "msg2", "msg3"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        await adapter.send(
+            "chat1",
+            "done\n\n- one\n- two\n- three\n\nnext",
+            metadata={"delivery_style": "cascade"},
+        )
+
+        assert adapter._http_session.post.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_code_blocks_do_not_human_cascade(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        content = "copy this\n\n```bash\necho hi\n```\n\nthen run it"
+        await adapter.send("chat1", content)
+
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert "```bash\necho hi\n```" in payload["message"]
+
+    @pytest.mark.asyncio
+    async def test_approval_gates_do_not_human_cascade(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        content = "I can restart the gateway.\n\nReply `/approve` to restart.\n\nRisk: brief downtime."
+        await adapter.send("chat1", content)
+
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert "Reply `/approve`" in payload["message"]
+
+    @pytest.mark.asyncio
+    async def test_structured_reports_do_not_human_cascade(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        content = "done\n\n- changed adapter\n- added tests\n- ran suite\n\n44 passed"
+        await adapter.send("chat1", content)
+
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert "- changed adapter" in payload["message"]
+
+    @pytest.mark.asyncio
+    async def test_long_briefs_do_not_human_cascade(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        content = "Daily brief\n\n" + ("Lots of info here. " * 80)
+        await adapter.send("chat1", content)
+
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["message"].startswith("Daily brief")
+
+    @pytest.mark.asyncio
+    async def test_group_chats_do_not_human_cascade_by_default(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        await adapter.send("120363001234567890@g.us", "first\n\nsecond")
+
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["message"] == "first\n\nsecond"
 
     @pytest.mark.asyncio
     async def test_long_message_chunked(self):

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -54,7 +54,6 @@ def _make_adapter():
     adapter._human_cascade_max_bubbles = 3
     adapter._human_cascade_delay_seconds = 0
     adapter._human_cascade_delay_jitter_seconds = 0
-    adapter._human_cascade_typing_indicators = False
     adapter._human_cascade_max_total_chars = 900
     adapter._human_cascade_min_total_chars = 320
     adapter._human_cascade_min_lead_chars = 40
@@ -274,29 +273,6 @@ class TestSendChunking:
         ]
         assert result.message_id == "msg3"
         assert result.continuation_message_ids == ("msg1", "msg2")
-        assert result.raw_response["human_cascade"] is True
-
-    @pytest.mark.asyncio
-    async def test_human_cascade_sends_typing_indicator_between_bubbles(self):
-        adapter = _make_adapter()
-        adapter._human_cascade_typing_indicators = True
-        responses = []
-        for msg_id in ("msg1", None, "msg2"):
-            resp = MagicMock(status=200)
-            resp.json = AsyncMock(return_value={"success": True} if msg_id is None else {"messageId": msg_id})
-            responses.append(_AsyncCM(resp))
-        adapter._http_session.post = MagicMock(side_effect=responses)
-
-        first = "First paragraph is substantial and useful enough to land immediately as a natural WhatsApp bubble, giving the reader a clean opening thought before the follow-up arrives."
-        second = "Second paragraph is also substantial enough to follow after a typing presence event, making the delivery feel typed instead of sprayed into the chat, and it pushes the combined text over the mobile split threshold."
-        result = await adapter.send("chat1", first + "\n\n" + second)
-
-        assert result.success
-        urls = [call.args[0] for call in adapter._http_session.post.call_args_list]
-        assert urls[0].endswith("/send")
-        assert urls[1].endswith("/typing")
-        assert urls[2].endswith("/send")
-        assert adapter._http_session.post.call_args_list[1].kwargs["json"] == {"chatId": "chat1"}
         assert result.raw_response["human_cascade"] is True
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -341,18 +341,24 @@ class TestSendChunking:
         assert "- changed adapter" in payload["message"]
 
     @pytest.mark.asyncio
-    async def test_long_briefs_do_not_human_cascade(self):
+    async def test_long_briefs_cascade_lead_in_then_chunk_tail(self):
         adapter = _make_adapter()
-        resp = MagicMock(status=200)
-        resp.json = AsyncMock(return_value={"messageId": "msg1"})
-        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+        responses = []
+        for msg_id in ("msg1", "msg2"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
 
         content = "Daily brief\n\n" + ("Lots of info here. " * 80)
-        await adapter.send("chat1", content)
+        result = await adapter.send("chat1", content)
 
-        assert adapter._http_session.post.call_count == 1
-        payload = adapter._http_session.post.call_args.kwargs["json"]
-        assert payload["message"].startswith("Daily brief")
+        assert result.success
+        assert adapter._http_session.post.call_count == 2
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert payloads[0]["message"] == "Daily brief"
+        assert payloads[1]["message"].startswith("Lots of info here.")
+        assert result.raw_response["human_cascade"] is True
 
     @pytest.mark.asyncio
     async def test_group_chats_do_not_human_cascade_by_default(self):

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -54,6 +54,7 @@ def _make_adapter():
     adapter._human_cascade_max_bubbles = 3
     adapter._human_cascade_delay_seconds = 0
     adapter._human_cascade_delay_jitter_seconds = 0
+    adapter._human_cascade_typing_indicators = False
     adapter._human_cascade_max_total_chars = 900
     adapter._human_cascade_min_total_chars = 320
     adapter._human_cascade_min_lead_chars = 40
@@ -273,6 +274,29 @@ class TestSendChunking:
         ]
         assert result.message_id == "msg3"
         assert result.continuation_message_ids == ("msg1", "msg2")
+        assert result.raw_response["human_cascade"] is True
+
+    @pytest.mark.asyncio
+    async def test_human_cascade_sends_typing_indicator_between_bubbles(self):
+        adapter = _make_adapter()
+        adapter._human_cascade_typing_indicators = True
+        responses = []
+        for msg_id in ("msg1", None, "msg2"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"success": True} if msg_id is None else {"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        first = "First paragraph is substantial and useful enough to land immediately as a natural WhatsApp bubble, giving the reader a clean opening thought before the follow-up arrives."
+        second = "Second paragraph is also substantial enough to follow after a typing presence event, making the delivery feel typed instead of sprayed into the chat, and it pushes the combined text over the mobile split threshold."
+        result = await adapter.send("chat1", first + "\n\n" + second)
+
+        assert result.success
+        urls = [call.args[0] for call in adapter._http_session.post.call_args_list]
+        assert urls[0].endswith("/send")
+        assert urls[1].endswith("/typing")
+        assert urls[2].endswith("/send")
+        assert adapter._http_session.post.call_args_list[1].kwargs["json"] == {"chatId": "chat1"}
         assert result.raw_response["human_cascade"] is True
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -55,6 +55,8 @@ def _make_adapter():
     adapter._human_cascade_delay_seconds = 0
     adapter._human_cascade_delay_jitter_seconds = 0
     adapter._human_cascade_max_total_chars = 900
+    adapter._human_cascade_min_total_chars = 420
+    adapter._human_cascade_min_lead_chars = 40
     adapter._human_cascade_max_bubble_chars = 320
     adapter._human_cascade_max_merged_bubble_chars = 640
     adapter._human_cascade_groups = False
@@ -202,7 +204,23 @@ class TestSendChunking:
         assert result.raw_response["human_cascade"] is False
 
     @pytest.mark.asyncio
-    async def test_blank_line_paragraphs_send_as_human_cascade(self):
+    async def test_short_blank_line_reply_stays_single(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        content = "lol yeah that queued notice is separate\n\nbut the actual reply cascaded correctly"
+        result = await adapter.send("chat1", content)
+
+        assert result.success
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["message"] == content
+        assert result.raw_response["human_cascade"] is False
+
+    @pytest.mark.asyncio
+    async def test_substantive_blank_line_paragraphs_send_as_human_cascade(self):
         adapter = _make_adapter()
         responses = []
         for msg_id in ("msg1", "msg2", "msg3"):
@@ -211,16 +229,17 @@ class TestSendChunking:
             responses.append(_AsyncCM(resp))
         adapter._http_session.post = MagicMock(side_effect=responses)
 
-        result = await adapter.send("chat1", "first thought\n\nsecond thought\n\nthird thought")
+        messages = [
+            "First thought has enough actual content to deserve its own bubble, because it frames the answer before the heavier detail arrives and gives the reader a clean starting point.",
+            "Second thought is also a real sentence with useful substance, so it reads like a natural follow-up instead of a random tiny ack split for no reason.",
+            "Third thought closes the answer with enough context for the reader, proving the cascade is being used for cadence rather than just reacting to blank lines.",
+        ]
+        result = await adapter.send("chat1", "\n\n".join(messages))
 
         assert result.success
         assert adapter._http_session.post.call_count == 3
         payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
-        assert [payload["message"] for payload in payloads] == [
-            "first thought",
-            "second thought",
-            "third thought",
-        ]
+        assert [payload["message"] for payload in payloads] == messages
         assert result.message_id == "msg3"
         assert result.continuation_message_ids == ("msg1", "msg2")
         assert result.raw_response["human_cascade"] is True
@@ -235,19 +254,23 @@ class TestSendChunking:
             responses.append(_AsyncCM(resp))
         adapter._http_session.post = MagicMock(side_effect=responses)
 
-        result = await adapter.send(
-            "chat1",
-            "one\n\ntwo\n\nthree\n\n" + ("four " * 40).strip() + "\n\n" + ("five " * 40).strip(),
-        )
+        messages = [
+            "First paragraph is substantive enough to be worth a separate WhatsApp bubble.",
+            "Second paragraph keeps the cadence readable before the merged tail arrives.",
+            "Third paragraph is still short enough to fit as a clean lead-in bubble.",
+            ("The fourth paragraph is deliberately longer and should be merged with the final paragraph instead of creating a fifth bubble. " * 3).strip(),
+            ("The fifth paragraph continues the tail so the adapter proves it caps cascade count without collapsing everything into one wall. " * 3).strip(),
+        ]
+        result = await adapter.send("chat1", "\n\n".join(messages))
 
         assert result.success
         assert adapter._http_session.post.call_count == 4
         payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
         assert [payload["message"] for payload in payloads] == [
-            "one",
-            "two",
-            "three",
-            ("four " * 40).strip() + "\n\n" + ("five " * 40).strip(),
+            messages[0],
+            messages[1],
+            messages[2],
+            messages[3] + "\n\n" + messages[4],
         ]
         assert result.message_id == "msg4"
         assert result.continuation_message_ids == ("msg1", "msg2", "msg3")
@@ -327,7 +350,7 @@ class TestSendChunking:
         assert "Reply `/approve`" in payload["message"]
 
     @pytest.mark.asyncio
-    async def test_structured_report_tail_cascades_plain_lead_in_only(self):
+    async def test_substantive_structured_tail_cascades_plain_lead_in_only(self):
         adapter = _make_adapter()
         responses = []
         for msg_id in ("msg1", "msg2"):
@@ -336,13 +359,47 @@ class TestSendChunking:
             responses.append(_AsyncCM(resp))
         adapter._http_session.post = MagicMock(side_effect=responses)
 
-        content = "done\n\n- changed adapter\n- added tests\n- ran suite\n\n44 passed"
-        await adapter.send("chat1", content)
+        lead = "Here’s the useful summary before the list, with enough context to deserve its own bubble."
+        tail = "\n".join([
+            "- changed adapter so short acknowledgements do not split into fake-human theatre bubbles",
+            "- added tests for short replies, structured reports, substantive lead-ins, and long prose tails",
+            "- kept approval prompts, code blocks, and group chats conservative so safety/copyability still wins",
+            "- ran the focused gateway suite after the heuristic change to catch regressions",
+        ])
+        await adapter.send("chat1", lead + "\n\n" + tail)
 
         assert adapter._http_session.post.call_count == 2
         payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
-        assert payloads[0]["message"] == "done"
-        assert payloads[1]["message"] == "- changed adapter\n- added tests\n- ran suite\n\n44 passed"
+        assert payloads[0]["message"] == lead
+        assert payloads[1]["message"] == tail
+
+    @pytest.mark.asyncio
+    async def test_short_opener_before_structured_tail_stays_single(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        content = "yep found it\n\n- changed adapter\n- added tests\n- ran suite\n\n139 passed"
+        await adapter.send("chat1", content)
+
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["message"] == content
+
+    @pytest.mark.asyncio
+    async def test_report_heading_before_structured_tail_stays_single(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        content = "Summary\n\n- changed adapter\n- added tests\n- ran suite\n\nRisk\n\n- gateway restart needed"
+        await adapter.send("chat1", content)
+
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["message"] == content
 
     @pytest.mark.asyncio
     async def test_structured_report_without_plain_lead_in_stays_single(self):
@@ -368,13 +425,14 @@ class TestSendChunking:
             responses.append(_AsyncCM(resp))
         adapter._http_session.post = MagicMock(side_effect=responses)
 
-        content = "Daily brief\n\n" + ("Lots of info here. " * 80)
+        lead = "Here’s the daily brief with enough context to make the first bubble useful before the longer body lands."
+        content = lead + "\n\n" + ("Lots of info here. " * 80)
         result = await adapter.send("chat1", content)
 
         assert result.success
         assert adapter._http_session.post.call_count == 2
         payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
-        assert payloads[0]["message"] == "Daily brief"
+        assert payloads[0]["message"] == lead
         assert payloads[1]["message"].startswith("Lots of info here.")
         assert result.raw_response["human_cascade"] is True
 


### PR DESCRIPTION
## Summary
- add metadata-controlled WhatsApp delivery style (`single`, `cascade`, `auto`) for gateway outputs
- add natural DM-style final-message composition for substantive long prose, with jittered 300–800ms-ish delays between follow-up bubbles and tail merging
- keep approvals, code blocks, groups by default, status chrome, short/config-ish replies, copy-sensitive text, and machine/artifact payloads as single messages
- cap natural cascade at 3 bubbles, lower the default split threshold, and keep structured/list/code/log/json/config/diff/command/checklist tails glued
- keep active questions/actions out of early bubbles and keep links with their immediate context
- add regression coverage for cascade thresholds, structured/artifact tails, active prompts, links, stream-consumer metadata, and status delivery style

## Test Plan
- `scripts/run_tests.sh tests/gateway/test_whatsapp_formatting.py tests/gateway/test_stream_consumer.py tests/gateway/test_gateway_status_delivery_style.py`
