### PR TITLE
fix: cover empty dirs and local browser warnings

### DIFF
--- a/agent/browser_provider.py
+++ b/agent/browser_provider.py
@@ -26,6 +26,7 @@ Session metadata contract (preserved from the legacy ``CloudBrowserProvider``)::
         "session_name": str,        # unique name for agent-browser --session
         "bb_session_id": str,       # provider session ID (for close/cleanup)
         "cdp_url": str,             # CDP websocket URL
+        "backend": str,             # stable provider/backend identifier
         "features": dict,           # feature flags that were enabled
         "external_call_id": str,    # optional, managed-gateway billing key
     }
@@ -96,12 +97,16 @@ class BrowserProvider(abc.ABC):
                 "session_name": str,    # unique name for agent-browser --session
                 "bb_session_id": str,   # provider session ID (for close/cleanup)
                 "cdp_url": str,         # CDP websocket URL
+                "backend": str,         # stable provider/backend identifier
                 "features": dict,       # feature flags that were enabled
             }
 
         ``bb_session_id`` is a legacy key name kept for backward compat with
         the rest of :mod:`tools.browser_tool` — it holds the provider's
         session ID regardless of which provider is in use.
+
+        Providers may omit ``backend``; :mod:`tools.browser_tool` backfills it
+        from :attr:`name` for compatibility with older provider plugins.
 
         May raise ``ValueError`` (missing credentials) or ``RuntimeError``
         (network / API failure); the dispatcher surfaces these to the user.

--- a/tests/tools/test_browser_open_timeout.py
+++ b/tests/tools/test_browser_open_timeout.py
@@ -1,5 +1,6 @@
 """Tests for browser first-open timeout and timeout diagnostics."""
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -110,3 +111,55 @@ class TestBrowserNavigateOpenTimeout:
 
         bt.browser_navigate("https://example.com", task_id="task-1")
         assert captured["timeout"] == 120
+
+
+class TestBrowserNavigateWarnings:
+    def _patch_successful_navigation(self, monkeypatch, *, features, title="OK"):
+        def fake_run(task_id, command, args, timeout=None):
+            if command == "open":
+                return {"success": True, "data": {"title": title, "url": args[0]}}
+            if command == "snapshot":
+                return {"success": True, "data": {"snapshot": "", "refs": {}}}
+            return {"success": True, "data": {}}
+
+        monkeypatch.setattr(bt, "_get_open_command_timeout", lambda first_open=False: 60)
+        monkeypatch.setattr(bt, "_run_browser_command", fake_run)
+        monkeypatch.setattr(bt, "_get_session_info", lambda key: {"_first_nav": True, "features": features})
+        monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
+        monkeypatch.setattr(bt, "_is_local_backend", lambda: bool(features.get("local")))
+        monkeypatch.setattr(bt, "_is_local_sidecar_key", lambda key: False)
+        monkeypatch.setattr(bt, "_navigation_session_key", lambda task_id, url: task_id)
+        monkeypatch.setattr(bt, "_maybe_start_recording", lambda *a, **kw: None)
+        monkeypatch.setattr(bt, "check_website_access", lambda url: None)
+
+    def test_local_session_omits_browserbase_stealth_warning(self, monkeypatch):
+        self._patch_successful_navigation(monkeypatch, features={"local": True})
+
+        result = json.loads(bt.browser_navigate("https://example.com", task_id="task-1"))
+
+        assert result["success"] is True
+        assert result["stealth_features"] == ["local"]
+        assert "stealth_warning" not in result
+
+    def test_local_bot_detection_warning_omits_browserbase_advice(self, monkeypatch):
+        self._patch_successful_navigation(
+            monkeypatch,
+            features={"local": True},
+            title="Access Denied",
+        )
+
+        result = json.loads(bt.browser_navigate("https://example.com", task_id="task-1"))
+
+        assert "bot_detection_warning" in result
+        assert "BROWSERBASE_ADVANCED_STEALTH" not in result["bot_detection_warning"]
+
+    def test_browserbase_session_keeps_browserbase_stealth_warning(self, monkeypatch):
+        self._patch_successful_navigation(
+            monkeypatch,
+            features={"basic_stealth": True, "proxies": False},
+        )
+
+        result = json.loads(bt.browser_navigate("https://example.com", task_id="task-1"))
+
+        assert result["success"] is True
+        assert "Browserbase plan" in result["stealth_warning"]

--- a/tests/tools/test_browser_open_timeout.py
+++ b/tests/tools/test_browser_open_timeout.py
@@ -114,7 +114,7 @@ class TestBrowserNavigateOpenTimeout:
 
 
 class TestBrowserNavigateWarnings:
-    def _patch_successful_navigation(self, monkeypatch, *, features, title="OK"):
+    def _patch_successful_navigation(self, monkeypatch, *, features, backend=None, title="OK"):
         def fake_run(task_id, command, args, timeout=None):
             if command == "open":
                 return {"success": True, "data": {"title": title, "url": args[0]}}
@@ -124,16 +124,23 @@ class TestBrowserNavigateWarnings:
 
         monkeypatch.setattr(bt, "_get_open_command_timeout", lambda first_open=False: 60)
         monkeypatch.setattr(bt, "_run_browser_command", fake_run)
-        monkeypatch.setattr(bt, "_get_session_info", lambda key: {"_first_nav": True, "features": features})
+        session_info = {"_first_nav": True, "features": features}
+        if backend is not None:
+            session_info["backend"] = backend
+        monkeypatch.setattr(bt, "_get_session_info", lambda key: dict(session_info))
         monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
-        monkeypatch.setattr(bt, "_is_local_backend", lambda: bool(features.get("local")))
+        monkeypatch.setattr(
+            bt,
+            "_is_local_backend",
+            lambda: backend in {"local", "cdp"} or bool(features.get("local")),
+        )
         monkeypatch.setattr(bt, "_is_local_sidecar_key", lambda key: False)
         monkeypatch.setattr(bt, "_navigation_session_key", lambda task_id, url: task_id)
         monkeypatch.setattr(bt, "_maybe_start_recording", lambda *a, **kw: None)
         monkeypatch.setattr(bt, "check_website_access", lambda url: None)
 
     def test_local_session_omits_browserbase_stealth_warning(self, monkeypatch):
-        self._patch_successful_navigation(monkeypatch, features={"local": True})
+        self._patch_successful_navigation(monkeypatch, features={"local": True}, backend="local")
 
         result = json.loads(bt.browser_navigate("https://example.com", task_id="task-1"))
 
@@ -141,10 +148,46 @@ class TestBrowserNavigateWarnings:
         assert result["stealth_features"] == ["local"]
         assert "stealth_warning" not in result
 
+    def test_cdp_session_omits_browserbase_stealth_warning(self, monkeypatch):
+        self._patch_successful_navigation(
+            monkeypatch,
+            features={"cdp_override": True, "basic_stealth": True},
+            backend="cdp",
+        )
+
+        result = json.loads(bt.browser_navigate("https://example.com", task_id="task-1"))
+
+        assert result["success"] is True
+        assert "stealth_warning" not in result
+
+    def test_other_cloud_provider_omits_browserbase_stealth_warning(self, monkeypatch):
+        self._patch_successful_navigation(
+            monkeypatch,
+            features={"basic_stealth": True, "proxies": False},
+            backend="browser-use",
+        )
+
+        result = json.loads(bt.browser_navigate("https://example.com", task_id="task-1"))
+
+        assert result["success"] is True
+        assert "stealth_warning" not in result
+
+    def test_legacy_session_without_backend_omits_browserbase_stealth_warning(self, monkeypatch):
+        self._patch_successful_navigation(
+            monkeypatch,
+            features={"basic_stealth": True, "proxies": False},
+        )
+
+        result = json.loads(bt.browser_navigate("https://example.com", task_id="task-1"))
+
+        assert result["success"] is True
+        assert "stealth_warning" not in result
+
     def test_local_bot_detection_warning_omits_browserbase_advice(self, monkeypatch):
         self._patch_successful_navigation(
             monkeypatch,
             features={"local": True},
+            backend="local",
             title="Access Denied",
         )
 
@@ -157,9 +200,23 @@ class TestBrowserNavigateWarnings:
         self._patch_successful_navigation(
             monkeypatch,
             features={"basic_stealth": True, "proxies": False},
+            backend="browserbase",
         )
 
         result = json.loads(bt.browser_navigate("https://example.com", task_id="task-1"))
 
         assert result["success"] is True
         assert "Browserbase plan" in result["stealth_warning"]
+
+    def test_browserbase_bot_detection_warning_keeps_browserbase_advice(self, monkeypatch):
+        self._patch_successful_navigation(
+            monkeypatch,
+            features={"basic_stealth": True, "proxies": False},
+            backend="browserbase",
+            title="Access Denied",
+        )
+
+        result = json.loads(bt.browser_navigate("https://example.com", task_id="task-1"))
+
+        assert "bot_detection_warning" in result
+        assert "BROWSERBASE_ADVANCED_STEALTH" in result["bot_detection_warning"]

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -701,6 +701,40 @@ class TestSearchFilesFallbackHiddenPaths:
         assert result.error is None
         assert set(result.files) == {str(visible_file), str(visible_nested_file)}
 
+    def test_find_fallback_includes_empty_directories(self, tmp_path, monkeypatch):
+        """Fallback find should surface matching directories, including empty ones."""
+        root = tmp_path / "repo"
+        vault = root / "vault"
+        vault.mkdir(parents=True)
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+        result = ops._search_files("vault", str(root), limit=50, offset=0)
+
+        assert result.error is None
+        assert result.files == [str(vault)]
+
+    def test_rg_search_supplements_matching_directories(self, monkeypatch):
+        """The rg fast path should add directory hits that rg --files omits."""
+        env = MagicMock()
+        env.cwd = "/"
+        ops = ShellFileOperations(env)
+
+        def fake_exec(command, *args, **kwargs):
+            if command.startswith("rg --files"):
+                return MagicMock(exit_code=0, stdout="")
+            if command.startswith("find "):
+                return MagicMock(exit_code=0, stdout="123 /repo/vault\n")
+            return MagicMock(exit_code=0, stdout="")
+
+        monkeypatch.setattr(ops, "_has_command", lambda command: command in {"rg", "find"})
+        monkeypatch.setattr(ops, "_exec", fake_exec)
+
+        result = ops._search_files_rg("vault", "/repo", limit=50, offset=0)
+
+        assert result.error is None
+        assert result.files == ["/repo/vault"]
+
 
 class TestShellFileOpsWriteDenied:
     def test_write_file_denied_path(self, file_ops):

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -652,6 +652,7 @@ class TestSearchFilesFallbackHiddenPaths:
                 command,
                 shell=True,
                 text=True,
+                input=kwargs.get("stdin_data"),
                 capture_output=True,
             )
             return {
@@ -734,6 +735,80 @@ class TestSearchFilesFallbackHiddenPaths:
 
         assert result.error is None
         assert result.files == ["/repo/vault"]
+
+    def test_rg_search_orders_files_and_directories_before_pagination(self, tmp_path, monkeypatch):
+        """Directory hits should participate in the global page ordering."""
+        root = tmp_path / "repo"
+        root.mkdir()
+        older = root / "vault-old.txt"
+        newer = root / "vault-new.txt"
+        vault = root / "vault"
+        older.write_text("old", encoding="utf-8")
+        newer.write_text("new", encoding="utf-8")
+        vault.mkdir()
+        os.utime(older, (100, 100))
+        os.utime(newer, (200, 200))
+        os.utime(vault, (300, 300))
+
+        env = MagicMock()
+        env.cwd = "/"
+        ops = ShellFileOperations(env)
+
+        def fake_exec(command, *args, **kwargs):
+            if command.startswith("rg --files --sortr"):
+                return MagicMock(exit_code=0, stdout=f"{older}\n{newer}\n")
+            if command.startswith("find "):
+                return MagicMock(exit_code=0, stdout=f"300 {vault}\n")
+            if " -c " in command:
+                completed = subprocess.run(
+                    command,
+                    shell=True,
+                    text=True,
+                    input=kwargs.get("stdin_data"),
+                    capture_output=True,
+                )
+                return MagicMock(exit_code=completed.returncode, stdout=completed.stdout)
+            return MagicMock(exit_code=0, stdout="")
+
+        monkeypatch.setattr(ops, "_has_command", lambda command: command in {"rg", "find", "python3"})
+        monkeypatch.setattr(ops, "_exec", fake_exec)
+
+        result = ops._search_files_rg("vault", str(root), limit=2, offset=0)
+
+        assert result.error is None
+        assert result.files == [str(vault), str(newer)]
+
+    def test_rg_search_uses_python_directory_fallback_without_find(self, tmp_path, monkeypatch):
+        """The rg fast path should still find directories when find is absent."""
+        root = tmp_path / "repo"
+        vault = root / "vault"
+        vault.mkdir(parents=True)
+
+        env = MagicMock()
+        env.cwd = "/"
+        ops = ShellFileOperations(env)
+
+        def fake_exec(command, *args, **kwargs):
+            if command.startswith("rg --files"):
+                return MagicMock(exit_code=0, stdout="")
+            if " -c " in command:
+                completed = subprocess.run(
+                    command,
+                    shell=True,
+                    text=True,
+                    input=kwargs.get("stdin_data"),
+                    capture_output=True,
+                )
+                return MagicMock(exit_code=completed.returncode, stdout=completed.stdout)
+            return MagicMock(exit_code=0, stdout="")
+
+        monkeypatch.setattr(ops, "_has_command", lambda command: command in {"rg", "python3"})
+        monkeypatch.setattr(ops, "_exec", fake_exec)
+
+        result = ops._search_files_rg("vault", str(root), limit=50, offset=0)
+
+        assert result.error is None
+        assert result.files == [str(vault)]
 
 
 class TestShellFileOpsWriteDenied:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -768,6 +768,20 @@ def _is_local_backend() -> bool:
     return terminal_backend in ("local", "")
 
 
+_BROWSERBASE_FEATURE_KEYS = frozenset({
+    "basic_stealth",
+    "advanced_stealth",
+    "keep_alive",
+    "custom_timeout",
+})
+
+
+def _has_browserbase_feature_advice(features: Dict[str, object]) -> bool:
+    return bool(_BROWSERBASE_FEATURE_KEYS.intersection(features)) and not (
+        features.get("local") or features.get("cdp_override")
+    )
+
+
 _auto_local_for_private_urls_resolved = False
 _cached_auto_local_for_private_urls: bool = True
 
@@ -2731,6 +2745,11 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         }
         _copy_fallback_warning(response, result)
 
+        features = session_info.get("features", {})
+        if not isinstance(features, dict):
+            features = {}
+        show_browserbase_advice = _has_browserbase_feature_advice(features)
+
         # Detect common "blocked" page patterns from title/url
         blocked_patterns = [
             "access denied", "access to this page has been denied",
@@ -2742,18 +2761,23 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         title_lower = title.lower()
 
         if any(pattern in title_lower for pattern in blocked_patterns):
-            response["bot_detection_warning"] = (
+            warning = (
                 f"Page title '{title}' suggests bot detection. The site may have blocked this request. "
                 "Options: 1) Try adding delays between actions, 2) Access different pages first, "
-                "3) Enable advanced stealth (BROWSERBASE_ADVANCED_STEALTH=true, requires Scale plan), "
-                "4) Some sites have very aggressive bot detection that may be unavoidable."
             )
+            if show_browserbase_advice:
+                warning += (
+                    "3) Enable advanced stealth (BROWSERBASE_ADVANCED_STEALTH=true, requires Scale plan), "
+                    "4) Some sites have very aggressive bot detection that may be unavoidable."
+                )
+            else:
+                warning += "3) Some sites have very aggressive bot detection that may be unavoidable."
+            response["bot_detection_warning"] = warning
 
         # Include feature info on first navigation so model knows what's active
         if is_first_nav and "features" in session_info:
-            features = session_info["features"]
             active_features = [k for k, v in features.items() if v]
-            if not features.get("proxies"):
+            if show_browserbase_advice and not features.get("proxies"):
                 response["stealth_warning"] = (
                     "Running WITHOUT residential proxies. Bot detection may be more aggressive. "
                     "Consider upgrading Browserbase plan for proxy support."

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -776,9 +776,11 @@ _BROWSERBASE_FEATURE_KEYS = frozenset({
 })
 
 
-def _has_browserbase_feature_advice(features: Dict[str, object]) -> bool:
-    return bool(_BROWSERBASE_FEATURE_KEYS.intersection(features)) and not (
-        features.get("local") or features.get("cdp_override")
+def _has_browserbase_feature_advice(session_info: Dict[str, object],
+                                    features: Dict[str, object]) -> bool:
+    return (
+        session_info.get("backend") == "browserbase"
+        and bool(_BROWSERBASE_FEATURE_KEYS.intersection(features))
     )
 
 
@@ -1898,6 +1900,7 @@ def _create_local_session(task_id: str) -> Dict[str, str]:
         "session_name": session_name,
         "bb_session_id": None,
         "cdp_url": None,
+        "backend": "local",
         "features": {"local": True},
     }
 
@@ -1912,6 +1915,7 @@ def _create_cdp_session(task_id: str, cdp_url: str) -> Dict[str, str]:
         "session_name": session_name,
         "bb_session_id": None,
         "cdp_url": cdp_url,
+        "backend": "cdp",
         "features": {"cdp_override": True},
     }
 
@@ -1970,10 +1974,11 @@ def _get_session_info(task_id: Optional[str] = None) -> Dict[str, str]:
                 # Validate cloud provider returned a usable session
                 if not session_info or not isinstance(session_info, dict):
                     raise ValueError(f"Cloud provider returned invalid session: {session_info!r}")
+                session_info = dict(session_info)
+                session_info.setdefault("backend", provider.name)
                 if session_info.get("cdp_url"):
                     # Some cloud providers (including Browser-Use v3) return an HTTP
                     # CDP discovery URL instead of a raw websocket endpoint.
-                    session_info = dict(session_info)
                     session_info["cdp_url"] = _resolve_cdp_override(str(session_info["cdp_url"]))
             except Exception as e:
                 provider_name = type(provider).__name__
@@ -2748,7 +2753,7 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         features = session_info.get("features", {})
         if not isinstance(features, dict):
             features = {}
-        show_browserbase_advice = _has_browserbase_feature_advice(features)
+        show_browserbase_advice = _has_browserbase_feature_advice(session_info, features)
 
         # Detect common "blocked" page patterns from title/url
         blocked_patterns = [

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2061,7 +2061,8 @@ class ShellFileOperations(FileOperations):
         if not has_hidden_path_ancestor:
             pagination_expr = f" | tail -n +{offset + 1} | head -n {limit}"
 
-        cmd = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
+        cmd = f"find {self._escape_shell_arg(path)} -mindepth 1{hidden_filter_expr} " \
+              f"\\( -type f -o -type d \\) -name {self._escape_shell_arg(search_pattern)} " \
               f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn{pagination_expr}"
 
         result = self._exec(cmd, timeout=60)
@@ -2069,7 +2070,8 @@ class ShellFileOperations(FileOperations):
 
         if not stdout.strip() and not limit_reason:
             # Try without -printf (BSD find compatibility -- macOS)
-            cmd_simple = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
+            cmd_simple = f"find {self._escape_shell_arg(path)} -mindepth 1{hidden_filter_expr} " \
+                        f"\\( -type f -o -type d \\) -name {self._escape_shell_arg(search_pattern)} " \
                         f"2>/dev/null | sort -rn{pagination_expr}"
             result = self._exec(cmd_simple, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
@@ -2108,6 +2110,61 @@ class ShellFileOperations(FileOperations):
             limit_reason=limit_reason,
         )
 
+    def _search_dirs_find(self, pattern: str, path: str, limit: int) -> tuple[List[str], Optional[str]]:
+        """Supplement rg file results with matching directory paths."""
+        if not self._has_command('find'):
+            return [], None
+
+        search_root = Path(path)
+        has_hidden_path_ancestor = any(
+            part not in {".", ".."} and part.startswith(".")
+            for part in search_root.parts
+        )
+        hidden_exclude = "-not -path '*/.*'" if not has_hidden_path_ancestor else ""
+        hidden_filter_expr = f" {hidden_exclude}" if hidden_exclude else ""
+
+        cmd = (
+            f"find {self._escape_shell_arg(path)} -mindepth 1{hidden_filter_expr} "
+            f"-type d -name {self._escape_shell_arg(pattern)} "
+            f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn | head -n {limit}"
+        )
+        result = self._exec(cmd, timeout=60)
+        stdout, limit_reason = _search_stdout_and_limit(result)
+
+        if not stdout.strip() and not limit_reason:
+            cmd_simple = (
+                f"find {self._escape_shell_arg(path)} -mindepth 1{hidden_filter_expr} "
+                f"-type d -name {self._escape_shell_arg(pattern)} "
+                f"2>/dev/null | sort -rn | head -n {limit}"
+            )
+            result = self._exec(cmd_simple, timeout=60)
+            stdout, limit_reason = _search_stdout_and_limit(result)
+
+        dirs = []
+        for line in stdout.strip().split('\n'):
+            if not line:
+                continue
+            parts = line.split(' ', 1)
+            if len(parts) == 2 and parts[0].replace('.', '').isdigit():
+                dirs.append(parts[1])
+            else:
+                dirs.append(line)
+
+        if has_hidden_path_ancestor:
+            normalized_root = search_root.resolve()
+            filtered_dirs = []
+            for dir_path in dirs:
+                try:
+                    rel_parts = Path(dir_path).resolve().relative_to(normalized_root).parts
+                except ValueError:
+                    rel_parts = Path(dir_path).parts
+                if any(part not in {".", ".."} and part.startswith(".") for part in rel_parts):
+                    continue
+                filtered_dirs.append(dir_path)
+            dirs = filtered_dirs
+
+        return dirs, limit_reason
+
     def _search_files_rg(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
         """Search for files by name using ripgrep's --files mode.
 
@@ -2144,6 +2201,15 @@ class ShellFileOperations(FileOperations):
             result = self._exec(cmd_plain, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
             all_files = [f for f in stdout.strip().split('\n') if f]
+
+        dirs, dir_limit_reason = self._search_dirs_find(glob_pattern, path, fetch_limit)
+        if dirs:
+            seen = set()
+            all_files = [
+                item for item in [*all_files, *dirs]
+                if not (item in seen or seen.add(item))
+            ]
+        limit_reason = limit_reason or dir_limit_reason
 
         page = all_files[offset:offset + limit]
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -28,6 +28,7 @@ Usage:
 import os
 import re
 import difflib
+import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any, ClassVar
@@ -2113,7 +2114,7 @@ class ShellFileOperations(FileOperations):
     def _search_dirs_find(self, pattern: str, path: str, limit: int) -> tuple[List[str], Optional[str]]:
         """Supplement rg file results with matching directory paths."""
         if not self._has_command('find'):
-            return [], None
+            return self._search_dirs_python(pattern, path, limit)
 
         search_root = Path(path)
         has_hidden_path_ancestor = any(
@@ -2165,6 +2166,124 @@ class ShellFileOperations(FileOperations):
 
         return dirs, limit_reason
 
+    def _search_python_command(self) -> Optional[str]:
+        if self._has_command("python3"):
+            return "python3"
+        if self._has_command("python"):
+            return "python"
+        return None
+
+    def _search_dirs_python(self, pattern: str, path: str, limit: int) -> tuple[List[str], Optional[str]]:
+        """Enumerate matching directories in the terminal environment without find."""
+        python_cmd = self._search_python_command()
+        if python_cmd is None:
+            return [], None
+
+        search_root = Path(path)
+        include_hidden = any(
+            part not in {".", ".."} and part.startswith(".")
+            for part in search_root.parts
+        )
+        payload = json.dumps({
+            "root": path,
+            "pattern": pattern,
+            "include_hidden": include_hidden,
+            "limit": limit,
+        })
+        script = r"""
+import fnmatch
+import json
+import os
+import sys
+
+payload = json.load(sys.stdin)
+root = payload["root"]
+pattern = payload["pattern"]
+include_hidden = bool(payload["include_hidden"])
+limit = int(payload["limit"])
+
+matches = []
+for current, dirnames, _filenames in os.walk(root):
+    if not include_hidden:
+        dirnames[:] = [d for d in dirnames if not d.startswith(".")]
+    for dirname in dirnames:
+        full_path = os.path.join(current, dirname)
+        if fnmatch.fnmatch(dirname, pattern):
+            try:
+                mtime = os.path.getmtime(full_path)
+            except OSError:
+                mtime = 0.0
+            matches.append((mtime, full_path))
+
+matches.sort(key=lambda item: (-item[0], item[1]))
+json.dump({
+    "paths": [path for _mtime, path in matches[:limit]],
+    "truncated": len(matches) > limit,
+}, sys.stdout)
+"""
+        result = self._exec(
+            f"{python_cmd} -c {self._escape_shell_arg(script)}",
+            timeout=60,
+            stdin_data=payload,
+        )
+        if result.exit_code != 0 or not result.stdout.strip():
+            return [], None
+        try:
+            parsed = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return [], None
+        dirs = [path for path in parsed.get("paths", []) if isinstance(path, str)]
+        limit_reason = "directory_search_limit" if parsed.get("truncated") else None
+        return dirs, limit_reason
+
+    def _sort_search_candidates(self, paths: List[str]) -> List[str]:
+        seen = set()
+        unique_paths = []
+        for path in paths:
+            if path and path not in seen:
+                seen.add(path)
+                unique_paths.append(path)
+
+        if len(unique_paths) < 2:
+            return unique_paths
+
+        python_cmd = self._search_python_command()
+        if python_cmd is None:
+            return unique_paths
+
+        script = r"""
+import json
+import os
+import sys
+
+paths = json.load(sys.stdin)
+
+def sort_key(item):
+    index, path = item
+    try:
+        mtime = os.path.getmtime(path)
+    except OSError:
+        mtime = 0.0
+    return (-mtime, index, path)
+
+ordered = [path for _index, path in sorted(enumerate(paths), key=sort_key)]
+json.dump(ordered, sys.stdout)
+"""
+        result = self._exec(
+            f"{python_cmd} -c {self._escape_shell_arg(script)}",
+            timeout=60,
+            stdin_data=json.dumps(unique_paths),
+        )
+        if result.exit_code != 0 or not result.stdout.strip():
+            return unique_paths
+        try:
+            ordered = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return unique_paths
+        if not isinstance(ordered, list) or not all(isinstance(path, str) for path in ordered):
+            return unique_paths
+        return ordered
+
     def _search_files_rg(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
         """Search for files by name using ripgrep's --files mode.
 
@@ -2203,12 +2322,7 @@ class ShellFileOperations(FileOperations):
             all_files = [f for f in stdout.strip().split('\n') if f]
 
         dirs, dir_limit_reason = self._search_dirs_find(glob_pattern, path, fetch_limit)
-        if dirs:
-            seen = set()
-            all_files = [
-                item for item in [*all_files, *dirs]
-                if not (item in seen or seen.add(item))
-            ]
+        all_files = self._sort_search_candidates([*all_files, *dirs])
         limit_reason = limit_reason or dir_limit_reason
 
         page = all_files[offset:offset + limit]


### PR DESCRIPTION
## Summary
- include matching directories in search_files file searches so empty folders are discoverable
- keep Browserbase-specific warning text out of local/CDP browser sessions while preserving it for Browserbase sessions
- add regression tests for both tool edge cases

## Validation
- .venv/bin/python -m pytest tests/tools/test_file_operations.py::TestSearchFilesFallbackHiddenPaths tests/tools/test_browser_open_timeout.py::TestBrowserNavigateWarnings
- .venv/bin/python -m pytest tests/tools/test_file_operations.py tests/tools/test_file_operations_edge_cases.py tests/tools/test_search_hidden_dirs.py tests/tools/test_browser_open_timeout.py tests/tools/test_browser_ssrf_local.py
- git diff --check

Fixes #54347
Fixes #54197