### PR TITLE
test: make custom provider picker tests deterministic

### DIFF
--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -343,7 +343,12 @@ def test_list_dedupes_dict_model_matching_singular_default(monkeypatch):
 
 def test_list_authenticated_providers_groups_same_endpoint(monkeypatch):
     """Multiple custom_providers entries sharing a base_url+api_key must be
-    returned as a single picker row with all their models merged."""
+    returned as a single picker row with all their models merged.
+
+    These cases assert explicit config grouping, not live endpoint discovery;
+    opt out so a developer's local Ollama catalog cannot replace the fixture
+    models and make the test environment-dependent.
+    """
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
 
@@ -353,11 +358,11 @@ def test_list_authenticated_providers_groups_same_endpoint(monkeypatch):
         user_providers={},
         custom_providers=[
             {"name": "Ollama — MiniMax M2.7", "base_url": "http://localhost:11434/v1",
-             "api_key": "ollama", "model": "minimax-m2.7"},
+             "api_key": "ollama", "model": "minimax-m2.7", "discover_models": False},
             {"name": "Ollama — GLM 5.1",      "base_url": "http://localhost:11434/v1",
-             "api_key": "ollama", "model": "glm-5.1"},
+             "api_key": "ollama", "model": "glm-5.1", "discover_models": False},
             {"name": "Ollama — Qwen3-coder", "base_url": "http://localhost:11434/v1",
-             "api_key": "ollama", "model": "qwen3-coder"},
+             "api_key": "ollama", "model": "qwen3-coder", "discover_models": False},
         ],
         max_models=50,
     )
@@ -388,7 +393,7 @@ def test_list_authenticated_providers_current_endpoint_uses_current_slug(monkeyp
         user_providers={},
         custom_providers=[
             {"name": "Ollama — GLM 5.1", "base_url": "http://localhost:11434/v1",
-             "api_key": "ollama", "model": "glm-5.1"},
+             "api_key": "ollama", "model": "glm-5.1", "discover_models": False},
         ],
         max_models=50,
     )
@@ -414,7 +419,7 @@ def test_list_authenticated_providers_bare_custom_slug_recovers(monkeypatch):
         user_providers={},
         custom_providers=[
             {"name": "Ollama — GLM 5.1", "base_url": "http://localhost:11434/v1",
-             "api_key": "ollama", "model": "glm-5.1"},
+             "api_key": "ollama", "model": "glm-5.1", "discover_models": False},
         ],
         max_models=50,
     )
@@ -437,11 +442,11 @@ def test_list_authenticated_providers_distinct_endpoints_stay_separate(monkeypat
         user_providers={},
         custom_providers=[
             {"name": "Ollama — GLM 5.1", "base_url": "http://localhost:11434/v1",
-             "api_key": "ollama", "model": "glm-5.1"},
+             "api_key": "ollama", "model": "glm-5.1", "discover_models": False},
             {"name": "Moonshot", "base_url": "https://api.moonshot.cn/v1",
-             "api_key": "sk-m", "model": "moonshot-v1"},
+             "api_key": "sk-m", "model": "moonshot-v1", "discover_models": False},
             {"name": "Ollama — Qwen3-coder", "base_url": "http://localhost:11434/v1",
-             "api_key": "ollama", "model": "qwen3-coder"},
+             "api_key": "ollama", "model": "qwen3-coder", "discover_models": False},
         ],
         max_models=50,
     )
@@ -530,7 +535,7 @@ def test_list_authenticated_providers_total_models_reflects_grouped_count(monkey
 
     entries = [
         {"name": f"Ollama \u2014 Model {i}", "base_url": "http://localhost:11434/v1",
-         "api_key": "ollama", "model": f"model-{i}"}
+         "api_key": "ollama", "model": f"model-{i}", "discover_models": False}
         for i in range(6)
     ]
     providers = list_authenticated_providers(


### PR DESCRIPTION
## Summary
- make custom provider picker grouping tests opt out of live model discovery when they assert explicit fixture models
- document why the tests disable discovery: local Ollama/OpenAI-compatible endpoints can replace the fixture list and make results environment-dependent

## Tests
- `python -m pytest tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_models.py -q --tb=short -o 'addopts='`
- `python -m py_compile tests/hermes_cli/test_model_switch_custom_providers.py`
- `git diff --check`
