### PR TITLE
[codex] Add vertical skill packs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 graft skills
 graft optional-skills
+graft skill-bundles
 graft optional-mcps
 graft locales
 # Bundled plugin manifests (plugin.yaml / plugin.yml). Without these the

--- a/agent/skill_bundles.py
+++ b/agent/skill_bundles.py
@@ -8,7 +8,9 @@ referenced skill's full content into a single user message, the same way
 Storage
 -------
 Bundles live in ``~/.hermes/skill-bundles/*.yaml`` (and the equivalent
-profile-aware directory under ``HERMES_HOME``). Each file looks like::
+profile-aware directory under ``HERMES_HOME``). Hermes can also ship bundled
+defaults from the repo's ``skill-bundles/`` directory; user bundles with the
+same slug win. Each file looks like::
 
     name: backend-dev
     description: Backend feature work — code review, testing, PR workflow.
@@ -50,7 +52,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_bundled_skill_bundles_dir, get_hermes_home
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +77,13 @@ def _bundles_dir() -> Path:
     return get_hermes_home() / "skill-bundles"
 
 
+def _bundled_bundles_dir() -> Path:
+    """Return the directory containing repo-shipped default bundles."""
+    return get_bundled_skill_bundles_dir(
+        Path(__file__).resolve().parent.parent / "skill-bundles"
+    )
+
+
 def _slugify(name: str) -> str:
     cmd = name.lower().replace(" ", "-").replace("_", "-")
     cmd = _BUNDLE_INVALID_CHARS.sub("", cmd)
@@ -82,8 +91,7 @@ def _slugify(name: str) -> str:
     return cmd
 
 
-def _iter_bundle_files() -> List[Path]:
-    base = _bundles_dir()
+def _iter_bundle_files_in(base: Path) -> List[Path]:
     if not base.exists():
         return []
     files: List[Path] = []
@@ -92,20 +100,46 @@ def _iter_bundle_files() -> List[Path]:
     return files
 
 
-def _max_mtime(files: List[Path]) -> float:
-    """Highest mtime across the bundle files plus the dir itself.
+def _bundle_sources() -> List[Tuple[str, Path]]:
+    """Return bundle source directories in precedence order.
+
+    The user directory comes first so custom bundles override shipped defaults
+    with the same slash-command slug.
+    """
+    user_dir = _bundles_dir()
+    bundled_dir = _bundled_bundles_dir()
+    sources: List[Tuple[str, Path]] = [("user", user_dir)]
+    try:
+        same_dir = user_dir.resolve() == bundled_dir.resolve()
+    except OSError:
+        same_dir = user_dir == bundled_dir
+    if not same_dir:
+        sources.append(("bundled", bundled_dir))
+    return sources
+
+
+def _iter_bundle_files() -> List[Tuple[str, Path]]:
+    files: List[Tuple[str, Path]] = []
+    for source, base in _bundle_sources():
+        files.extend((source, path) for path in _iter_bundle_files_in(base))
+    return files
+
+
+def _max_mtime(files: List[Tuple[str, Path]]) -> float:
+    """Highest mtime across the bundle files plus their dirs.
 
     Watching the directory mtime catches deletions; watching individual
     files catches edits. Together they're a cheap freshness check.
     """
-    base = _bundles_dir()
     mtimes = []
-    if base.exists():
+    for _source, base in _bundle_sources():
+        if not base.exists():
+            continue
         try:
             mtimes.append(base.stat().st_mtime)
         except OSError:
             pass
-    for f in files:
+    for _source, f in files:
         try:
             mtimes.append(f.stat().st_mtime)
         except OSError:
@@ -175,17 +209,24 @@ def scan_bundles() -> Dict[str, Dict[str, Any]]:
     global _bundles_cache, _bundles_cache_mtime
     files = _iter_bundle_files()
     out: Dict[str, Dict[str, Any]] = {}
-    for f in files:
+    for source, f in files:
         info = _load_bundle_file(f)
         if not info:
             continue
         key = f"/{info['slug']}"
         if key in out:
-            logger.warning(
-                "Duplicate bundle slug %s from %s; keeping %s",
-                key, f, out[key]["path"],
-            )
+            if source == "bundled" and out[key].get("source") == "user":
+                logger.debug(
+                    "User bundle %s overrides bundled default from %s",
+                    out[key]["path"], f,
+                )
+            else:
+                logger.warning(
+                    "Duplicate bundle slug %s from %s; keeping %s",
+                    key, f, out[key]["path"],
+                )
             continue
+        info["source"] = source
         out[key] = info
     _bundles_cache = out
     _bundles_cache_mtime = _max_mtime(files)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -223,6 +223,26 @@ def get_bundled_skills_dir(default: Path | None = None) -> Path:
     return get_hermes_home() / "skills"
 
 
+def get_bundled_skill_bundles_dir(default: Path | None = None) -> Path:
+    """Return the bundled skill-bundles directory for source and packaged installs.
+
+    Resolution order mirrors :func:`get_bundled_skills_dir`:
+        1. ``HERMES_BUNDLED_SKILL_BUNDLES`` env var
+        2. Wheel-installed ``<sysconfig data>/skill-bundles``
+        3. Caller-supplied ``default`` (typically the source-checkout path)
+        4. ``<HERMES_HOME>/skill-bundles`` last-resort
+    """
+    override = os.getenv("HERMES_BUNDLED_SKILL_BUNDLES", "").strip()
+    if override:
+        return Path(override)
+    packaged = _get_packaged_data_dir("skill-bundles")
+    if packaged is not None:
+        return packaged
+    if default is not None:
+        return default
+    return get_hermes_home() / "skill-bundles"
+
+
 def get_hermes_dir(new_subpath: str, old_name: str) -> Path:
     """Resolve a Hermes subdirectory with backward compatibility.
 

--- a/setup.py
+++ b/setup.py
@@ -83,5 +83,6 @@ setup(
     data_files=[
         *_data_file_tree("skills"),
         *_data_file_tree("optional-skills"),
+        *_data_file_tree("skill-bundles"),
     ]
 )

--- a/skill-bundles/analyst.yaml
+++ b/skill-bundles/analyst.yaml
@@ -1,0 +1,6 @@
+name: analyst
+description: Analyst vertical pack for metric definitions, analysis memos, experiment readouts, and decision recommendations.
+skills:
+  - analyst
+instruction: |
+  Activate the analyst vertical. Treat the user instruction as an evidence question, define the analysis contract before calculating, and use the bundled templates when an analysis memo, metric definition, or experiment readout is requested.

--- a/skill-bundles/product-manager.yaml
+++ b/skill-bundles/product-manager.yaml
@@ -1,0 +1,6 @@
+name: product-manager
+description: Product management vertical pack for PRDs, backlog slices, launch plans, and decision-ready tradeoffs.
+skills:
+  - product-manager
+instruction: |
+  Activate the product manager vertical. Treat the user instruction as a product task, pick the smallest useful PM artifact, and use the bundled templates when a PRD, backlog, or launch plan is requested.

--- a/skills/verticals/DESCRIPTION.md
+++ b/skills/verticals/DESCRIPTION.md
@@ -1,0 +1,10 @@
+# Verticals
+
+Role-oriented workflow packs for Hermes. These skills turn a broad request like
+"act as a product manager" or "do the analyst work" into an edge-loaded working
+mode with intake defaults, output templates, quality bars, and optional tool
+expectations.
+
+Verticals are intentionally implemented as skills and skill bundles, not core
+tools. They should compose existing connectors, memory, documents, and subagents
+without mutating the system prompt or expanding the always-on model tool schema.

--- a/skills/verticals/analyst/SKILL.md
+++ b/skills/verticals/analyst/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: analyst
+description: "Analyst vertical: structure ambiguous business, product, or data questions into metric definitions, reproducible analysis plans, insight memos, and decision recommendations."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Vertical, Analyst, Metrics, Data, Experiment, Insights]
+    related_skills: [jupyter-live-kernel, google-workspace]
+---
+
+# Analyst Vertical
+
+Use this skill when the user asks you to work as an analyst, data analyst,
+business analyst, product analyst, research analyst, or decision-support
+partner. This working mode turns a question into an evidence-backed answer with
+clear assumptions and reproducible steps.
+
+## Operating Model
+
+Act like a careful analyst:
+
+- Start by defining the decision the analysis should inform.
+- Name the population, time window, grain, filters, and exclusions.
+- Distinguish observed facts from interpretation.
+- Prefer reproducible analysis over one-off arithmetic.
+- Cite source tables, files, docs, dashboard links, queries, or assumptions.
+- Include confidence and caveats. Do not overstate weak evidence.
+
+If the data source is unavailable, create the analysis plan, required schema,
+queries/pseudocode, and decision framework instead of inventing results.
+
+## Intake Defaults
+
+Common presets:
+
+| Preset | Use when | Default output |
+| --- | --- | --- |
+| `analysis-memo` | broad product/business question | memo with answer, evidence, caveats |
+| `metric-definition` | ambiguous metric, KPI, or dashboard request | canonical metric spec |
+| `experiment-readout` | A/B test, launch, treatment/control | experiment readout with validity checks |
+| `dashboard-review` | dashboard quality, metric drift, stakeholder trust | findings and remediation plan |
+| `forecast` | planning question with uncertainty | assumptions, scenarios, sensitivity |
+
+If the user just says "be an analyst" or invokes `/analyst` with no task, ask
+which preset they want and what source data or artifact should be used.
+
+## Workflow
+
+1. Restate the decision question in one sentence.
+2. Define the analysis contract:
+   - Population:
+   - Time range:
+   - Unit of analysis:
+   - Success metric:
+   - Segments:
+   - Exclusions:
+   - Required data/source:
+3. Inspect available data or documents before calculating.
+4. Validate data quality: missingness, duplicates, joins, time zones, sampling,
+   cohort leakage, survivorship bias, and instrumentation changes.
+5. Produce the right artifact:
+   - Analysis memo: use `templates/analysis-memo.md`.
+   - Metric definition: use `templates/metric-definition.md`.
+   - Experiment readout: use `templates/experiment-readout.md`.
+6. End with a recommendation, confidence level, caveats, and the next analysis
+   that would change the recommendation.
+
+## Optional Tools And Connectors
+
+Use configured tools when they exist, but do not require them:
+
+- SQL warehouses, BI tools, notebooks, Python, CSV files, or spreadsheets for data.
+- Product docs, metric catalogs, Jira/Linear tickets, Slack, and launch notes for context.
+- Local files for reproducible notebooks or query drafts.
+- Google Sheets or Docs for stakeholder-facing summaries.
+
+For any write action, preview the target file, sheet, query, or doc update before
+writing unless the user explicitly asked you to create it.
+
+## Subagent Briefs
+
+When delegation is useful, split the work by validation concern:
+
+- `Data contract reviewer`: verify schemas, definitions, joins, and grain.
+- `Business context reviewer`: find launch notes, policy changes, and known incidents.
+- `Notebook builder`: create reproducible calculations and charts.
+- `Skeptic`: challenge causal claims, sample bias, metric drift, and confounders.
+
+Merge delegated work into one answer with contradictions called out.
+
+## Quality Bar
+
+A good analyst output has:
+
+- A precise question tied to a decision.
+- Defined metric(s), population, grain, and time window.
+- Clear source trail and reproducibility notes.
+- Sanity checks and data-quality caveats.
+- Segmented findings where segmentation changes the answer.
+- Confidence level and what would change the recommendation.
+
+Do not use exact-looking numbers without a source. Do not claim causality from
+correlation unless the design supports it.

--- a/skills/verticals/analyst/templates/analysis-memo.md
+++ b/skills/verticals/analyst/templates/analysis-memo.md
@@ -1,0 +1,54 @@
+# Analysis Memo Template
+
+## Question
+
+What decision should this analysis inform?
+
+## Answer
+
+- Recommendation:
+- Confidence:
+- Short rationale:
+
+## Scope
+
+- Population:
+- Time range:
+- Unit of analysis:
+- Segments:
+- Exclusions:
+
+## Sources
+
+- Data/source:
+- Query/file/notebook:
+- Related docs or tickets:
+
+## Findings
+
+1. Finding:
+   - Evidence:
+   - Caveat:
+2. Finding:
+   - Evidence:
+   - Caveat:
+
+## Data Quality Checks
+
+- Missingness:
+- Duplicates:
+- Join validity:
+- Time zone/calendar:
+- Instrumentation changes:
+
+## Interpretation
+
+- What this likely means:
+- Alternative explanations:
+- Risks of acting on this:
+
+## Next Step
+
+- Action:
+- Owner:
+- What would change the recommendation:

--- a/skills/verticals/analyst/templates/experiment-readout.md
+++ b/skills/verticals/analyst/templates/experiment-readout.md
@@ -1,0 +1,47 @@
+# Experiment Readout Template
+
+## Summary
+
+- Experiment:
+- Decision:
+- Recommendation:
+- Confidence:
+
+## Design
+
+- Hypothesis:
+- Population:
+- Treatment:
+- Control:
+- Primary metric:
+- Guardrails:
+- Start/end:
+
+## Validity Checks
+
+- Assignment/randomization:
+- Sample size:
+- Exposure:
+- SRM or allocation issues:
+- Instrumentation changes:
+- Novelty/seasonality:
+
+## Results
+
+| Metric | Control | Treatment | Delta | Notes |
+| --- | --- | --- | --- | --- |
+| Primary |  |  |  |  |
+| Guardrail |  |  |  |  |
+
+## Interpretation
+
+- What changed:
+- Who was affected:
+- Alternative explanations:
+- Risks:
+
+## Recommendation
+
+- Ship/hold/iterate:
+- Follow-up analysis:
+- Rollout caveats:

--- a/skills/verticals/analyst/templates/metric-definition.md
+++ b/skills/verticals/analyst/templates/metric-definition.md
@@ -1,0 +1,45 @@
+# Metric Definition Template
+
+## Metric
+
+- Name:
+- Owner:
+- Purpose:
+- Decision supported:
+
+## Definition
+
+- Numerator:
+- Denominator:
+- Grain:
+- Time window:
+- Inclusion criteria:
+- Exclusion criteria:
+
+## Calculation
+
+```sql
+-- Draft query or pseudocode
+```
+
+## Segments
+
+- Segment:
+- Segment:
+
+## Guardrails
+
+- Guardrail metric:
+- Expected range:
+- Alert threshold:
+
+## Source Of Truth
+
+- Table/file/dashboard:
+- Refresh cadence:
+- Known caveats:
+
+## Examples
+
+- Example included case:
+- Example excluded case:

--- a/skills/verticals/product-manager/SKILL.md
+++ b/skills/verticals/product-manager/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: product-manager
+description: "Product management vertical: turn ideas, customer pain, specs, and meetings into PRDs, backlog slices, launch plans, and decision-ready tradeoffs."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Vertical, Product, PM, PRD, Backlog, Planning]
+    related_skills: [notion, google-workspace, github-issues]
+---
+
+# Product Manager Vertical
+
+Use this skill when the user asks you to operate as a product manager, product
+strategist, roadmap owner, product analyst, or spec writer. This is not a tone
+preset. It is a working mode for turning fuzzy input into scoped product work.
+
+## Operating Model
+
+Act like a pragmatic product manager:
+
+- Start from the customer problem, not the proposed solution.
+- Separate facts, assumptions, decisions, and open questions.
+- Prefer small, shippable slices with explicit non-goals.
+- Tie recommendations to user value, business value, engineering cost, and risk.
+- Produce artifacts that an engineering, design, support, or GTM partner can use.
+- If a connector is unavailable, continue with a local artifact and mark the integration step as pending.
+
+Do not mutate the system prompt, ask to switch toolsets, or require a new core
+tool. Load this as an edge skill or as part of a bundle.
+
+## Intake Defaults
+
+When the user does not specify the context, infer the smallest useful path and
+state assumptions briefly. Ask at most three blocking questions; otherwise move
+forward with explicit assumptions.
+
+Common presets:
+
+| Preset | Use when | Default output |
+| --- | --- | --- |
+| `prd` | new feature, initiative, customer need | PRD with scope and acceptance criteria |
+| `backlog` | meeting notes, rough plan, issue breakdown | epic plus implementation tickets |
+| `spec-review` | user provides a PRD/spec/RFC | review notes, risks, missing requirements |
+| `launch` | release, rollout, migration | launch checklist and risk plan |
+| `decision` | tradeoff or roadmap question | decision memo with options and recommendation |
+
+If the user just says "be a PM" or invokes `/product-manager` with no task,
+offer these presets in one concise sentence and ask what they want to produce.
+
+## Workflow
+
+1. Identify the product surface, target user, job-to-be-done, and current pain.
+2. Gather or request evidence: customer quotes, tickets, metrics, docs, designs,
+   support threads, constraints, competitive context, or prior decisions.
+3. Convert evidence into a crisp problem statement and success metrics.
+4. Define scope with goals, non-goals, assumptions, dependencies, and risks.
+5. Pick the right artifact:
+   - PRD: use `templates/prd.md`.
+   - Backlog: use `templates/backlog.md`.
+   - Launch plan: use `templates/launch-plan.md`.
+6. Make the next action concrete: create tickets, draft a doc, request data,
+   identify owners, or list blocked decisions.
+
+## Optional Tools And Connectors
+
+Use configured tools when they exist, but do not require them:
+
+- Jira, Linear, or GitHub Issues for backlog creation.
+- Notion, Confluence, Google Docs, or local Markdown for PRDs and memos.
+- Slack, email, meeting notes, or support systems for customer/user evidence.
+- GitHub, repository search, or local code inspection for implementation constraints.
+- Figma, screenshots, or design docs for UX scope.
+
+When creating external work items, preview the exact title, body, labels, and
+links before writing unless the user has already asked you to create them.
+
+## Subagent Briefs
+
+When delegation is useful, split the work by perspective:
+
+- `Customer evidence scout`: find quotes, tickets, examples, and recurring pain.
+- `Technical feasibility reviewer`: inspect code/docs and identify constraints.
+- `Analyst`: validate metrics, funnels, cohorts, or experiment impact.
+- `Launch owner`: identify rollout, support, migration, comms, and fallback risks.
+
+Each subagent brief must include the product goal, evidence source, expected
+output, and what not to do. Merge their outputs into one PM recommendation.
+
+## Quality Bar
+
+A good PM output has:
+
+- A falsifiable problem statement.
+- Clear primary user and workflow.
+- Goals, non-goals, dependencies, risks, and open questions.
+- Success metrics and instrumentation gaps.
+- Explicit tradeoffs and recommendation.
+- Acceptance criteria that are testable.
+- A next action that can be assigned.
+
+Avoid vague roadmap language, generic persona theater, and unowned "follow ups".
+If evidence is missing, label it as missing instead of inventing certainty.

--- a/skills/verticals/product-manager/templates/backlog.md
+++ b/skills/verticals/product-manager/templates/backlog.md
@@ -1,0 +1,47 @@
+# Backlog Template
+
+## Epic
+
+**Title:**
+**Problem:**
+**Outcome:**
+**Non-goals:**
+
+## Tickets
+
+### Ticket 1
+
+**Title:**
+**Type:** Story
+**User value:**
+**Implementation notes:**
+**Acceptance criteria:**
+
+- Given, when, then.
+- Given, when, then.
+
+**Dependencies:**
+**Risks:**
+
+### Ticket 2
+
+**Title:**
+**Type:** Story
+**User value:**
+**Implementation notes:**
+**Acceptance criteria:**
+
+- Given, when, then.
+
+**Dependencies:**
+**Risks:**
+
+## Sequencing
+
+1. Foundation:
+2. User-visible slice:
+3. Follow-up hardening:
+
+## Out Of Scope
+
+-

--- a/skills/verticals/product-manager/templates/launch-plan.md
+++ b/skills/verticals/product-manager/templates/launch-plan.md
@@ -1,0 +1,48 @@
+# Launch Plan Template
+
+## Launch Summary
+
+- Product/change:
+- Audience:
+- Launch date or window:
+- Owner:
+
+## Readiness
+
+| Area | Owner | Status | Notes |
+| --- | --- | --- | --- |
+| Product |  |  |  |
+| Engineering |  |  |  |
+| Design |  |  |  |
+| Support |  |  |  |
+| GTM/comms |  |  |  |
+
+## Rollout
+
+1. Internal validation:
+2. Limited rollout:
+3. General availability:
+
+## Metrics
+
+- Activation:
+- Adoption:
+- Quality:
+- Guardrails:
+
+## Risks
+
+- Risk:
+- Detection:
+- Mitigation:
+- Rollback:
+
+## Communication
+
+- Internal announcement:
+- Customer-facing copy:
+- Support notes:
+
+## Open Questions
+
+- [ ]

--- a/skills/verticals/product-manager/templates/prd.md
+++ b/skills/verticals/product-manager/templates/prd.md
@@ -1,0 +1,66 @@
+# PRD Template
+
+## Summary
+
+- Problem:
+- Target users:
+- Proposed solution:
+- Recommendation:
+
+## Evidence
+
+- Customer/user signals:
+- Product/data signals:
+- Prior decisions/docs:
+- Constraints:
+
+## Goals
+
+- Goal 1:
+- Goal 2:
+- Goal 3:
+
+## Non-Goals
+
+- Non-goal 1:
+- Non-goal 2:
+
+## User Workflows
+
+1. As a `[user]`, I want to `[task]` so that `[outcome]`.
+2. As a `[user]`, I want to `[task]` so that `[outcome]`.
+
+## Requirements
+
+| ID | Requirement | Priority | Notes |
+| --- | --- | --- | --- |
+| R1 |  | Must |  |
+| R2 |  | Should |  |
+
+## Acceptance Criteria
+
+- Given `[state]`, when `[action]`, then `[observable result]`.
+- Given `[state]`, when `[action]`, then `[observable result]`.
+
+## Success Metrics
+
+- Primary metric:
+- Guardrail metric:
+- Instrumentation needed:
+
+## Risks And Tradeoffs
+
+- Risk:
+- Mitigation:
+- Tradeoff:
+
+## Rollout
+
+- Phase:
+- Owners:
+- Support/comms:
+- Rollback:
+
+## Open Questions
+
+- [ ] Question:

--- a/tests/agent/test_skill_bundles.py
+++ b/tests/agent/test_skill_bundles.py
@@ -56,9 +56,11 @@ def _make_skill(skills_dir: Path, name: str, body: str = "Do the thing.") -> Pat
 def bundles_env(tmp_path, monkeypatch):
     """Isolated bundles dir + skills dir."""
     bundles_dir = tmp_path / "skill-bundles"
+    bundled_bundles_dir = tmp_path / "bundled-skill-bundles"
     skills_dir = tmp_path / "skills"
     skills_dir.mkdir()
     monkeypatch.setenv("HERMES_BUNDLES_DIR", str(bundles_dir))
+    monkeypatch.setenv("HERMES_BUNDLED_SKILL_BUNDLES", str(bundled_bundles_dir))
     # Patch SKILLS_DIR so skill loading hits our temp tree.
     import tools.skills_tool as skills_tool_module
     monkeypatch.setattr(skills_tool_module, "SKILLS_DIR", skills_dir)
@@ -136,6 +138,39 @@ class TestScanBundles:
         result = scan_bundles()
         assert "/fallback" in result
         assert result["/fallback"]["name"] == "fallback"
+
+    def test_finds_bundled_bundle(self, bundles_env):
+        bundled_dir = Path(os.environ["HERMES_BUNDLED_SKILL_BUNDLES"])
+        _make_bundle_yaml(
+            bundled_dir,
+            "product-manager",
+            ["product-manager"],
+            description="Bundled PM pack",
+        )
+        result = scan_bundles()
+        assert "/product-manager" in result
+        assert result["/product-manager"]["source"] == "bundled"
+        assert result["/product-manager"]["description"] == "Bundled PM pack"
+
+    def test_user_bundle_overrides_bundled_default(self, bundles_env):
+        bundles_dir, _ = bundles_env
+        bundled_dir = Path(os.environ["HERMES_BUNDLED_SKILL_BUNDLES"])
+        _make_bundle_yaml(
+            bundled_dir,
+            "analyst",
+            ["bundled-analyst"],
+            description="Bundled default",
+        )
+        _make_bundle_yaml(
+            bundles_dir,
+            "analyst",
+            ["custom-analyst"],
+            description="User override",
+        )
+        result = scan_bundles()
+        assert result["/analyst"]["source"] == "user"
+        assert result["/analyst"]["skills"] == ["custom-analyst"]
+        assert result["/analyst"]["description"] == "User override"
 
 
 class TestGetSkillBundles:

--- a/tests/gateway/test_bundles_command.py
+++ b/tests/gateway/test_bundles_command.py
@@ -57,9 +57,11 @@ def _make_runner():
 @pytest.fixture
 def bundles_env(tmp_path, monkeypatch):
     bundles_dir = tmp_path / "skill-bundles"
+    bundled_bundles_dir = tmp_path / "bundled-skill-bundles"
     skills_dir = tmp_path / "skills"
     skills_dir.mkdir()
     monkeypatch.setenv("HERMES_BUNDLES_DIR", str(bundles_dir))
+    monkeypatch.setenv("HERMES_BUNDLED_SKILL_BUNDLES", str(bundled_bundles_dir))
     import tools.skills_tool as skills_tool_module
     monkeypatch.setattr(skills_tool_module, "SKILLS_DIR", skills_dir)
     import agent.skill_bundles as mod

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -114,6 +114,7 @@ def test_manifest_includes_bundled_skills():
 
     assert "graft skills" in manifest
     assert "graft optional-skills" in manifest
+    assert "graft skill-bundles" in manifest
 
 
 def test_bundled_plugin_manifests_ship_in_both_wheel_and_sdist():
@@ -264,4 +265,3 @@ def test_locale_catalogs_ship_in_both_wheel_and_sdist():
     # Every on-disk catalog has the .yaml extension the globs above match.
     on_disk = list((REPO_ROOT / "locales").glob("*.yaml"))
     assert on_disk, "expected locales/*.yaml catalogs on disk"
-

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -395,6 +395,31 @@ hermes bundles reload
 
 From inside a chat session, `/bundles` lists every installed bundle and its skills.
 
+### Bundled vertical packs
+
+Hermes also ships a small default bundle catalog for role-oriented verticals.
+These are ordinary skill bundles backed by ordinary bundled skills, so they work
+in every surface that already supports slash commands and they do not mutate the
+system prompt or add always-on model tools.
+
+```text
+/product-manager turn these meeting notes into a PRD
+/analyst define activation and check last week's launch impact
+```
+
+The first bundled verticals are:
+
+- `/product-manager` - loads the product management vertical for PRDs, backlog
+  slices, launch plans, spec reviews, and decision memos.
+- `/analyst` - loads the analyst vertical for metric definitions, analysis
+  memos, experiment readouts, dashboard reviews, and decision recommendations.
+
+Each vertical skill includes role guidance, workflow presets, optional connector
+expectations, subagent brief patterns, quality bars, and templates under the
+skill's `templates/` directory. Custom bundles in
+`~/.hermes/skill-bundles/` still win over bundled defaults with the same slug,
+so teams can replace `/analyst` or `/product-manager` with their own pack.
+
 ### Behavior
 
 - **Bundles take precedence over individual skills** when slugs collide. If you name a bundle `research` and you also have a skill called `research`, `/research` invokes the bundle. This is intentional — you opted into the bundle by naming it.


### PR DESCRIPTION
## Summary

Closes #54463.

This adds vertical packs as edge assets rather than core model-tool surface:

- ships default `/product-manager` and `/analyst` skill bundles
- adds bundled `product-manager` and `analyst` skills with workflow presets, optional connector expectations, subagent brief patterns, quality bars, and artifact templates
- extends bundle discovery so repo-shipped bundle YAMLs are available by default while user bundles in `~/.hermes/skill-bundles` still override shipped defaults
- packages `skill-bundles/` for wheel/sdist installs
- documents bundled vertical packs in the skills guide

## Validation

- `./.venv/bin/python -m pytest tests/agent/test_skill_bundles.py tests/gateway/test_bundles_command.py tests/cron/test_cron_prompt_injection_skill.py tests/openviking_plugin/test_openviking.py tests/test_packaging_metadata.py tests/tools/test_skills_tool.py tests/website/test_generate_skill_docs.py tests/website/test_extract_skills.py -q`
- temporary `HERMES_HOME` smoke test: sync bundled skills, discover `/analyst` and `/product-manager`, and build vertical bundle invocation payloads

## Notes

This intentionally does not add a new core tool, mutate the system prompt, or change the toolset mid-conversation. Vertical activation flows through the existing skill/bundle user-message path.