### PR TITLE
fix(api): honor request model provider overrides

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1078,6 +1078,8 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_start_callback=None,
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
+        model_override: Optional[str] = None,
+        provider_override: Optional[str] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -1107,6 +1109,30 @@ class APIServerAdapter(BasePlatformAdapter):
         runtime_kwargs = _resolve_runtime_agent_kwargs()
         reasoning_config = GatewayRunner._load_reasoning_config()
         model = _resolve_gateway_model()
+
+        clean_model_override = str(model_override or "").strip()
+        clean_provider_override = str(provider_override or "").strip()
+        if clean_model_override or clean_provider_override:
+            from hermes_cli.runtime_provider import format_runtime_provider_error, resolve_runtime_provider
+
+            try:
+                runtime = resolve_runtime_provider(
+                    requested=clean_provider_override or None,
+                    target_model=clean_model_override or None,
+                )
+            except Exception as exc:
+                raise RuntimeError(format_runtime_provider_error(exc)) from exc
+            runtime_kwargs.update({
+                "api_key": runtime.get("api_key"),
+                "base_url": runtime.get("base_url"),
+                "provider": runtime.get("provider"),
+                "api_mode": runtime.get("api_mode"),
+                "command": runtime.get("command"),
+                "args": list(runtime.get("args") or []),
+                "credential_pool": runtime.get("credential_pool"),
+            })
+            if clean_model_override:
+                model = clean_model_override
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
@@ -1934,6 +1960,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
         model_name = body.get("model", self._model_name)
+        model_override = str(model_name or "").strip() if "model" in body else ""
+        provider_override = str(body.get("provider") or body.get("model_provider") or "").strip()
+        if model_override in {"", "default", self._model_name}:
+            model_override = ""
         created = int(time.time())
 
         if stream:
@@ -2018,6 +2048,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                model_override=model_override or None,
+                provider_override=provider_override or None,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -2037,6 +2069,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                model_override=model_override or None,
+                provider_override=provider_override or None,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -3763,6 +3797,8 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
+        model_override: Optional[str] = None,
+        provider_override: Optional[str] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -3794,6 +3830,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     tool_start_callback=tool_start_callback,
                     tool_complete_callback=tool_complete_callback,
                     gateway_session_key=gateway_session_key,
+                    model_override=model_override,
+                    provider_override=provider_override,
                 )
                 if agent_ref is not None:
                     agent_ref[0] = agent
@@ -3971,6 +4009,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = body.get("session_id") or stored_session_id or run_id
+        model_override = str(body.get("model") or "").strip()
+        provider_override = str(body.get("provider") or body.get("model_provider") or "").strip()
+        if model_override in {"", "default", self._model_name}:
+            model_override = ""
         approval_session_key = gateway_session_key or session_id or run_id
         ephemeral_system_prompt = instructions
         loop = asyncio.get_running_loop()
@@ -4013,6 +4055,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     stream_delta_callback=_text_cb,
                     tool_progress_callback=event_cb,
                     gateway_session_key=gateway_session_key,
+                    model_override=model_override or None,
+                    provider_override=provider_override or None,
                 )
                 self._active_run_agents[run_id] = agent
 

--- a/tests/gateway/test_api_server_request_model_overrides.py
+++ b/tests/gateway/test_api_server_request_model_overrides.py
@@ -1,0 +1,91 @@
+"""Request-scoped model/provider overrides for API-server agent runs."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+def _make_adapter() -> APIServerAdapter:
+    return APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+
+
+def _chat_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+    return app
+
+
+def _runs_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
+    return app
+
+
+def test_chat_completions_passes_request_model_provider_to_agent(monkeypatch):
+    async def _case():
+        adapter = _make_adapter()
+        captured = {}
+
+        async def fake_run_agent(**kwargs):
+            captured.update(kwargs)
+            return {"final_response": "ok"}, {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+
+        monkeypatch.setattr(adapter, "_run_agent", fake_run_agent)
+
+        async with TestClient(TestServer(_chat_app(adapter))) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "pichot-moa-frontier",
+                    "provider": "moa",
+                    "messages": [{"role": "user", "content": "hello"}],
+                },
+            )
+            body = await resp.json()
+
+        assert resp.status == 200
+        assert body["choices"][0]["message"]["content"] == "ok"
+        assert captured["model_override"] == "pichot-moa-frontier"
+        assert captured["provider_override"] == "moa"
+
+    asyncio.run(_case())
+
+
+def test_runs_api_passes_request_model_provider_to_created_agent(monkeypatch):
+    async def _case():
+        adapter = _make_adapter()
+        captured = {}
+        agent_created = asyncio.Event()
+
+        def fake_create_agent(**kwargs):
+            captured.update(kwargs)
+            agent_created.set()
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent.session_prompt_tokens = 1
+            mock_agent.session_completion_tokens = 1
+            mock_agent.session_total_tokens = 2
+            return mock_agent
+
+        monkeypatch.setattr(adapter, "_create_agent", fake_create_agent)
+
+        async with TestClient(TestServer(_runs_app(adapter))) as cli:
+            resp = await cli.post(
+                "/v1/runs",
+                json={"model": "pichot-moa-frontier", "provider": "moa", "input": "hello"},
+            )
+            body = await resp.json()
+            await asyncio.wait_for(agent_created.wait(), timeout=2)
+
+        assert resp.status == 202
+        assert body["status"] == "started"
+        assert captured["model_override"] == "pichot-moa-frontier"
+        assert captured["provider_override"] == "moa"
+
+    asyncio.run(_case())


### PR DESCRIPTION
## Thinking Path

`/moa` in a gateway-backed WebUI session needs the gateway API server to honor a per-request model/provider override. The API server accepted OpenAI-compatible `model` fields but still created agents from the configured global gateway model, so WebUI could not route one turn through the virtual `moa` provider.

## What Changed

- Adds request-scoped `model_override` / `provider_override` plumbing for `/v1/chat/completions`.
- Adds the same override plumbing for `/v1/runs`, used by gateway-backed WebUI flows that rely on the Runs API.
- Resolves override credentials through `resolve_runtime_provider(...)`, so virtual providers like `moa` use the same runtime path as CLI model selection.
- Adds regression coverage for `provider=moa`, `model=pichot-moa-frontier` on both endpoints.

## Why It Matters

This unblocks WebUI `/moa` on gateway-backed sessions without mutating the gateway's global configured model. The override is per request/per run only.

## Verification

- `python -m pytest tests/gateway/test_api_server_request_model_overrides.py -q` → `2 passed`
- `uvx ruff@0.15.10 check gateway/platforms/api_server.py tests/gateway/test_api_server_request_model_overrides.py` → `All checks passed!`
- `python -m compileall -q gateway/platforms/api_server.py tests/gateway/test_api_server_request_model_overrides.py` → exit 0

Note: `python -m pytest tests/gateway/test_api_server_runs.py -q` could not be used in this local environment because `pytest-asyncio` is not installed there; the failure is `async def functions are not natively supported`, before product assertions run.

## Risks / Follow-ups

- This intentionally affects only `/v1/chat/completions` and `/v1/runs`; `/v1/responses` remains unchanged.
- If a caller sends `model=default`, the server treats it as no model override and only applies the explicit provider override, if any.

## Model Used

AI-assisted: Hermes Agent using OpenAI Codex `gpt-5.5`, with local file/search/test tools.
