### PR TITLE
fix(gateway): sanitize agent error messages, validate webhook gh args

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -938,13 +938,34 @@ class WebhookAdapter(BasePlatformAdapter):
                 success=False, error="Missing repo or pr_number"
             )
 
+        # --- Input validation (prevent CLI argument injection) ---
+        # pr_number must be a positive integer.
+        try:
+            pr_int = int(pr_number)
+            if pr_int <= 0:
+                raise ValueError("non-positive")
+        except (ValueError, TypeError):
+            logger.error(
+                "[webhook] invalid pr_number: %r", pr_number
+            )
+            return SendResult(
+                success=False, error="Invalid pr_number"
+            )
+
+        # repo must match owner/name (alphanumeric, hyphens, underscores, dots).
+        if not re.fullmatch(r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+", repo):
+            logger.error("[webhook] invalid repo format: %r", repo)
+            return SendResult(
+                success=False, error="Invalid repo format"
+            )
+
         try:
             result = subprocess.run(
                 [
                     "gh",
                     "pr",
                     "comment",
-                    str(pr_number),
+                    str(pr_int),
                     "--repo",
                     repo,
                     "--body",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10910,8 +10910,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
             except Exception:
                 logger.debug("Failed to persist inbound user message after agent exception", exc_info=True)
-            error_type = type(e).__name__
-            error_detail = str(e)[:300] if str(e) else "no details available"
+            # Log full details server-side only; never expose raw exception
+            # types or messages to end users (info-leakage risk).
             status_hint = ""
             status_code = getattr(e, "status_code", None)
             _hist_len = len(history) if 'history' in locals() else 0
@@ -10955,9 +10955,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 elif status_code == 400:
                     status_hint = " The request was rejected by the API."
             return (
-                f"Sorry, I encountered an error ({error_type}).\n"
-                f"{error_detail}\n"
-                f"{status_hint}"
+                f"Sorry, I encountered an unexpected error.{status_hint}\n"
                 "Try again or use /reset to start a fresh session."
             )
         finally:


### PR DESCRIPTION
## Summary
Hardens two gateway surfaces: agent error replies no longer leak raw exception details to chat-platform users, and webhook GitHub-comment delivery validates `pr_number`/`repo` before shelling out to `gh`.

Salvages the two valid fixes from #6660 by @aaronlab. The third change in that PR (cli.py `reopen_session` API) is moot — the raw `_conn.execute` reopen block it targeted no longer exists on `main`, and `reopen_session()` is already used everywhere it should be (`hermes_cli/cli_commands_mixin.py`, `tui_gateway/server.py`).

## Changes
- **gateway/run.py** — drop `error_type = type(e).__name__` / `error_detail = str(e)[:300]` from the agent-exception handler. Those were sent straight to users over Telegram/Discord/Slack and can carry provider API URLs, file paths, and partial credentials. The user now gets a generic message plus the existing curated HTTP-status hints (401/402/429/529/400); full detail stays in `logger.exception`.
- **gateway/platforms/webhook.py** — validate `pr_number` (positive int) and `repo` (`owner/name` regex) in `_deliver_github_comment` before the `gh pr comment` subprocess. Payload-controlled values could otherwise inject `gh` flags (`--help`, an alternate `--repo`) or a path-traversal repo. List-form subprocess means this is arg injection, not shell injection, but the validation is still correct.

## Validation
| | Before | After |
|---|---|---|
| Gateway error reply | `Sorry, I encountered an error (AuthenticationError).\n<raw provider text incl. URLs/paths>` | `Sorry, I encountered an unexpected error.<status hint>` |
| webhook `pr_number="--help"` | passed to `gh` subprocess | rejected, `Invalid pr_number`, subprocess not reached |
| webhook `repo="../../evil"` / `"--repo=x"` | passed to `gh` subprocess | rejected, `Invalid repo format` |
| Curated 401/402/429/529/400 hints | present | unchanged |

E2E: real `_deliver_github_comment` exercised with malicious payloads — all rejected, `subprocess.run` never invoked on bad input; 11/11 validation cases pass. Both files `py_compile` clean.

## Infographic

![gateway-hardening](https://v3b.fal.media/files/b/0aa02995/0AuVXg80dG6WbsmQqLriw_LRSCqbKQ.png)
