### PR TITLE
fix(agent): guard Anthropic interrupt, cap vision data-URL size

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2319,7 +2319,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                                 _fire_first_delta()
                                 agent._fire_reasoning_delta(thinking_text)
 
-            # Return the native Anthropic Message for downstream processing
+            # Return the native Anthropic Message for downstream processing.
+            # If the stream was interrupted (the event loop broke out above on
+            # agent._interrupt_requested), do NOT call get_final_message() — on
+            # a partially-consumed stream the SDK may hang draining remaining
+            # events or return a Message with incomplete tool_use blocks (partial
+            # JSON in `input`). The outer poll loop raises InterruptedError, so
+            # this return value is discarded anyway.
+            if agent._interrupt_requested:
+                return None
             return stream.get_final_message()
 
     def _call():

--- a/run_agent.py
+++ b/run_agent.py
@@ -4429,9 +4429,19 @@ class AIAgent:
                 return True
         return False
 
+    # 20 MB base64 ≈ 15 MB decoded image — generous but prevents OOM from an
+    # oversized data: URL (a 100 MB+ payload creates ~275 MB of memory pressure,
+    # and gateway users sharing the same process can trivially OOM it).
+    _MAX_DATA_URL_BASE64_BYTES = 20 * 1024 * 1024
+
     @staticmethod
     def _materialize_data_url_for_vision(image_url: str) -> tuple[str, Optional[Path]]:
         header, _, data = str(image_url or "").partition(",")
+        if len(data) > AIAgent._MAX_DATA_URL_BASE64_BYTES:
+            logger.warning(
+                "data-URL payload too large (%d bytes), skipping", len(data)
+            )
+            return "", None
         mime = "image/jpeg"
         if header.startswith("data:"):
             mime_part = header[len("data:"):].split(";", 1)[0].strip()


### PR DESCRIPTION
## Summary
Two independent agent-loop hardening fixes: an interrupted Anthropic stream is no longer drained (no hang, no partial `tool_use`), and oversized vision data-URLs are rejected before decode so a shared gateway process can't be OOM'd.

## Changes
- `agent/chat_completion_helpers.py` — when the Anthropic streaming loop breaks on `agent._interrupt_requested`, `return None` instead of calling `stream.get_final_message()` on the partially-drained stream. The SDK can hang draining remaining events or return a `Message` with incomplete `tool_use` blocks (partial JSON in `input`). The outer poll loop raises `InterruptedError`, so the return value is discarded anyway.
- `run_agent.py` — add a 20 MB cap (`_MAX_DATA_URL_BASE64_BYTES`) on base64 data-URL payloads before `base64.b64decode()` in `_materialize_data_url_for_vision`. A 100 MB+ payload creates ~275 MB of memory pressure. Oversized payloads now return `("", None)`.

## Validation
| | Before | After |
|---|---|---|
| Interrupt mid Anthropic stream | calls `get_final_message()` on drained stream → hang / corrupt `tool_use` | returns `None`, no SDK re-entry |
| Oversized data-URL (>20 MB base64) | unbounded `b64decode` → OOM risk | returns `("", None)`, no decode |
| `tests/run_agent/test_streaming.py` + pool-cleanup | — | 40/40 pass |
| E2E (real imports, temp file I/O) | — | cap rejects oversized & materializes small; guard precedes `get_final_message` |

## Attribution
Salvaged from #6661 by @aaronlab onto current `main` with authorship preserved. The original PR's third change (streaming tool-name `+=` → assignment dedup) was dropped — it already landed independently on `main` (`agent/chat_completion_helpers.py` already uses assignment with the same rationale).

## Infographic

![agent-loop-hardening](https://v3b.fal.media/files/b/0aa0298d/KSTFcyTXba1diJ0-pdQCy_JbFbCsCB.png)
