### PR TITLE
docs: FAQ typo fix + hermes-agent-internals onboarding skill

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent-internals/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent-internals/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: hermes-agent-internals
+description: "Use when onboarding or pairing on the agent heartbeat — explain one user message through run_conversation (prologue, finish_reason loop, epilogue) with line anchors in a local clone."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [hermes, run_agent, conversation_loop, architecture, onboarding]
+    related_skills: [hermes-agent, git-worktrees-hermes]
+---
+
+# Hermes agent core (internals tour)
+
+## Overview
+
+Hermes turns each user message into one **turn** inside `run_conversation()`. The implementation is large, but the product shape is three acts: **prologue once**, **main loop until the model stops calling tools**, **epilogue once**. This skill keeps explanations at that conceptual level and points to verified line anchors in `agent/conversation_loop.py` and related modules.
+
+## When to Use
+
+- User asks where the loop lives, what `finish_reason` does, or how tools relate to the reply on screen.
+- Pair-programming on `conversation_loop.py`, `turn_context.py`, or `turn_finalizer.py`.
+- Module-style exercises (e.g. "walk one turn like a product builder").
+
+**Don't use for:** CLI setup, config keys, or tool authoring — load `hermes-agent` instead.
+
+## Plumbing above the loop
+
+```
+hermes (CLI) → HermesCLI (cli.py) → AIAgent (run_agent.py)
+              → run_conversation() in agent/conversation_loop.py
+```
+
+`AIAgent.run_conversation` in `run_agent.py` forwards into `conversation_loop.run_conversation`; the heartbeat body lives there.
+
+## One turn = three acts
+
+| Act | Responsibility | Primary symbol |
+|-----|----------------|----------------|
+| Prologue | Sanitize user message, build/restore system prompt **once**, turn bookkeeping | `build_turn_context()` in `agent/turn_context.py` |
+| Main loop | `messages` → `api_messages`, model call, branch on `finish_reason`, append trajectory | `while` in `conversation_loop.py` |
+| Epilogue | Trajectory save, SQLite persist, cleanup, background memory/skill review | `finalize_turn()` in `agent/turn_finalizer.py` |
+
+**Done when:** you can name the three acts, the trajectory roles (`user` / `assistant`+`tool_calls` / `tool`), and which `finish_reason` path shows the user a final answer.
+
+## Trajectory vs API payload
+
+- **`messages`** — durable transcript the loop appends to each lap.
+- **`api_messages`** — per-lap provider view (system + copies; ephemeral injections on the current user turn only — not persisted).
+
+## finish_reason (cheat sheet)
+
+| Signal | User sees final reply now? | Loop |
+|--------|---------------------------|------|
+| `tool_calls` | No | `_execute_tool_calls` → append `role: tool` → `continue` |
+| `stop` (no `tool_calls`) | Yes | Final text → `break` |
+| `length` | Often no explicit "we compressed" | Compress/retry/continuation paths |
+
+Tools: `run_agent.py` `_execute_tool_calls` (~5258) → `agent/tool_executor.py` (sequential vs concurrent when safe).
+
+## Guided tour workflow
+
+1. Resolve clone path (typical: `~/.hermes/hermes-agent/`).
+2. Load `references/conversation-loop-one-turn.md` for line anchors.
+3. Re-verify anchors with `search_files` on `def run_conversation`, `build_turn_context`, `finalize_turn` — **line numbers drift** on `main`.
+4. Explain conceptually first; offer click-through ranges only if the user wants them.
+
+**Done when:** the user can answer: "Model returned `tool_calls` — do I see a reply?" (No — next lap after tools.)
+
+## Common Pitfalls
+
+1. **Citing stale line numbers** — grep symbols before docs/PRs.
+2. **Patching bundled `hermes-agent` SKILL.md** — extend this skill or `references/` instead (protected skill).
+3. **Assuming epilogue is inline** — post-loop logic is `turn_finalizer.py` (handoff from `conversation_loop.py` ~4877+).
+4. **Confusing `api_messages` with `messages`** — only `messages` is the trajectory SQLite replays.
+
+## Verification Checklist
+
+- [ ] Clone path confirmed; `agent/conversation_loop.py` exists
+- [ ] Prologue, loop branch, and epilogue each tied to a file/function
+- [ ] `tool_calls` vs `stop` behavior stated correctly for product builders
+- [ ] Line anchors re-grepped if the user will open the editor
+
+## Reference
+
+- Line map: `references/conversation-loop-one-turn.md`

--- a/skills/autonomous-ai-agents/hermes-agent-internals/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent-internals/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hermes-agent-internals
-description: "One Hermes turn: run_conversation prologue, tool loop, epilogue."
-version: 1.0.0
+description: "Use when onboarding on run_conversation's three-act turn."
+version: 1.0.1
 author: Nietzsche-Ubermensch, Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]

--- a/skills/autonomous-ai-agents/hermes-agent-internals/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent-internals/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: hermes-agent-internals
-description: "Use when onboarding or pairing on the agent heartbeat — explain one user message through run_conversation (prologue, finish_reason loop, epilogue) with line anchors in a local clone."
+description: "One Hermes turn: run_conversation prologue, tool loop, epilogue."
 version: 1.0.0
-author: Hermes Agent
+author: Nietzsche-Ubermensch, Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [hermes, run_agent, conversation_loop, architecture, onboarding]
-    related_skills: [hermes-agent, git-worktrees-hermes]
+    related_skills: [hermes-agent]
 ---
 
 # Hermes agent core (internals tour)
@@ -70,7 +70,7 @@ Tools: `run_agent.py` `_execute_tool_calls` (~5258) → `agent/tool_executor.py`
 
 ## Common Pitfalls
 
-1. **Citing stale line numbers** — grep symbols before docs/PRs.
+1. **Citing stale line numbers** — re-run `search_files` on symbols before docs/PRs.
 2. **Patching bundled `hermes-agent` SKILL.md** — extend this skill or `references/` instead (protected skill).
 3. **Assuming epilogue is inline** — post-loop logic is `turn_finalizer.py` (handoff from `conversation_loop.py` ~4877+).
 4. **Confusing `api_messages` with `messages`** — only `messages` is the trajectory SQLite replays.
@@ -80,7 +80,7 @@ Tools: `run_agent.py` `_execute_tool_calls` (~5258) → `agent/tool_executor.py`
 - [ ] Clone path confirmed; `agent/conversation_loop.py` exists
 - [ ] Prologue, loop branch, and epilogue each tied to a file/function
 - [ ] `tool_calls` vs `stop` behavior stated correctly for product builders
-- [ ] Line anchors re-grepped if the user will open the editor
+- [ ] Line anchors re-checked with `search_files` if the user will open the editor
 
 ## Reference
 

--- a/skills/autonomous-ai-agents/hermes-agent-internals/references/conversation-loop-one-turn.md
+++ b/skills/autonomous-ai-agents/hermes-agent-internals/references/conversation-loop-one-turn.md
@@ -1,0 +1,55 @@
+# conversation_loop.py — one turn line anchors
+
+Repo-relative paths. Re-verify with ripgrep after pulling `main`.
+
+## Entry
+
+| Symbol | File | Approx lines |
+|--------|------|--------------|
+| `run_conversation` | `agent/conversation_loop.py` | 497+ |
+
+## Prologue
+
+| What | Lines (approx) | Notes |
+|------|----------------|-------|
+| Comment block "Per-turn setup (the prologue)" | 542–549 | |
+| `build_turn_context(...)` | 550–566 | `agent/turn_context.py` |
+| Unpack `_ctx` (messages, `_should_review_memory`, etc.) | 567–577 | |
+| Codex app-server bypass (optional) | 603–610 | Skips normal loop |
+
+## Main loop
+
+| What | Lines (approx) | Notes |
+|------|----------------|-------|
+| `while` iteration guard | 612+ | `max_iterations`, `iteration_budget` |
+| Build `api_messages` from `messages` | 724–950+ | `api_messages` starts ~761 |
+| Model call + inner retries | 979–1465 | |
+| Normalize `finish_reason` | 1466–1501 | Per `api_mode` / transport |
+| `content_filter` refusal path | 1517–1603 | Early return |
+| `finish_reason == "length"` (output cap / truncation) | 1605–1700+ | Continuation / exhaust paths |
+| Context overflow → `_compress_context` | 2830–3316, 4412–4421 | Also `conversation_history_after_compression` |
+| `if assistant_message.tool_calls:` | 4064+ | Not user-visible final answer |
+| `_execute_tool_calls` | 4331 | → `run_agent.py` ~5258 → `tool_executor.py` |
+| `continue` after tools | 4427 | Next lap |
+| `else` — no tool calls (final response path) | 4429–4818 | `break` on success ~4813–4818 |
+
+## Epilogue
+
+| What | Lines (approx) | Notes |
+|------|----------------|-------|
+| Handoff to `finalize_turn` | 4877–4895 | `agent/turn_finalizer.py` |
+| `_persist_session` (SQLite `state.db`) | turn_finalizer ~163–188 | |
+| `_spawn_background_review` (memory/skills) | turn_finalizer ~435–461 | After answer; best-effort |
+
+## Related files
+
+- `agent/turn_context.py` — prologue implementation
+- `agent/turn_finalizer.py` — epilogue implementation
+- `agent/tool_executor.py` — `execute_tool_calls_sequential` / `concurrent`
+- `run_agent.py` — `AIAgent`, `_execute_tool_calls` dispatcher
+
+## Quick check (teaching)
+
+**Q:** Model returns `finish_reason: tool_calls`. Does Hermes show the user a final reply?
+
+**A:** No. Run tools, append tool messages, loop again. User gets text when the model stops with no pending tool_calls (`stop` path).

--- a/skills/autonomous-ai-agents/hermes-agent-internals/references/conversation-loop-one-turn.md
+++ b/skills/autonomous-ai-agents/hermes-agent-internals/references/conversation-loop-one-turn.md
@@ -1,6 +1,6 @@
 # conversation_loop.py — one turn line anchors
 
-Repo-relative paths. Re-verify with ripgrep after pulling `main`.
+Repo-relative paths. Re-verify with `search_files` after pulling `main`.
 
 ## Entry
 

--- a/tests/skills/test_hermes_agent_internals_skill.py
+++ b/tests/skills/test_hermes_agent_internals_skill.py
@@ -1,0 +1,52 @@
+"""Frontmatter checks for skills/autonomous-ai-agents/hermes-agent-internals."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+SKILL_MD = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "autonomous-ai-agents"
+    / "hermes-agent-internals"
+    / "SKILL.md"
+)
+
+
+def _frontmatter() -> dict:
+    content = SKILL_MD.read_text(encoding="utf-8")
+    assert content.startswith("---")
+    m = re.search(r"\n---\s*\n", content[3:])
+    assert m
+    return yaml.safe_load(content[3 : m.start() + 3])
+
+
+def test_skill_file_exists() -> None:
+    assert SKILL_MD.is_file()
+
+
+def test_frontmatter_peer_shape() -> None:
+    fm = _frontmatter()
+    assert fm["name"] == "hermes-agent-internals"
+    assert fm["license"] == "MIT"
+    assert "hermes" in fm["metadata"]
+    assert fm["metadata"]["hermes"]["related_skills"] == ["hermes-agent"]
+
+
+def test_description_use_when_under_60() -> None:
+    desc = _frontmatter()["description"]
+    assert desc.startswith("Use when ")
+    assert len(desc) <= 60
+
+
+def test_body_has_required_sections() -> None:
+    body = SKILL_MD.read_text(encoding="utf-8").split("---", 2)[2]
+    for heading in (
+        "## Overview",
+        "## When to Use",
+        "## Common Pitfalls",
+        "## Verification Checklist",
+    ):
+        assert heading in body

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -28,7 +28,7 @@ Hermes Agent works with any OpenAI-compatible API. Supported providers include:
 
 Set your provider with `hermes model` or by editing `~/.hermes/.env`. See the [Environment Variables](./environment-variables.md) reference for all provider keys.
 
-### Does it work on Windows/Android/Termux/my plataform??
+### Does it work on Windows, Android, Termux, or my platform?
 See **[Platform Support](../getting-started/platform-support.md)** for the full platform availability matrix.
 
 ### I run Hermes in WSL2. What's the best way to control my normal Windows Chrome?


### PR DESCRIPTION
## Summary
- Fix FAQ heading typo (plataform??) from dogfood QA
- Add hermes-agent-internals skill for run_conversation onboarding

## Testing
- Frontmatter validation for new skill
- Dogfood confirmed typo on live docs before fix

Pushed from fork Nietzsche-Ubermensch/hermes-agent-1 branch peter/docs-faq-internals-skill.