### PR TITLE
feat(skills): add parallel-extract research skill

### DIFF
--- a/skills/research/parallel-extract/SKILL.md
+++ b/skills/research/parallel-extract/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: parallel-extract
-description: "Bulk public URLs to markdown via Parallel Extract for RAG."
-version: 1.0.0
+description: "Use when bulk URL lists need Parallel Extract for RAG."
+version: 1.0.1
 author: Nietzsche-Ubermensch, Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]

--- a/skills/research/parallel-extract/SKILL.md
+++ b/skills/research/parallel-extract/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: parallel-extract
-description: "Use when bulk-fetching many public URLs into markdown for a RAG or agent KB via Parallel Extract API (JS pages, PDFs, >5 URLs, objective-focused excerpts or full_content)."
+description: "Bulk public URLs to markdown via Parallel Extract for RAG."
 version: 1.0.0
-author: Hermes Agent
+author: Nietzsche-Ubermensch, Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
@@ -35,7 +35,9 @@ Don't use for:
 ## Prerequisites
 
 ```bash
-pip install "parallel-web>=1.0.1"   # import: from parallel import Parallel
+# v1 Extract API needs parallel-web>=1.0.1 (install in a venv).
+# Hermes optional extra pins parallel-web==0.4.2 — upgrade only in that venv.
+pip install "parallel-web>=1.0.1"
 export PARALLEL_API_KEY="..."       # platform.parallel.ai — never commit keys
 ```
 

--- a/skills/research/parallel-extract/SKILL.md
+++ b/skills/research/parallel-extract/SKILL.md
@@ -107,9 +107,15 @@ Serialize JSON yourself; prefer `full_content` for embedding, `excerpts` for qui
 
 ## Hermes workflow
 
-1. Collect URL list from user or prior Search.
-2. Run `scripts/extract_docs.py` from this skill (`extract_urls(urls, out_path=...)`).
-3. Run: `PARALLEL_API_KEY=... python3 skills/research/parallel-extract/scripts/extract_docs.py` from repo root, or import `extract_urls` in a one-off script.
+1. Collect URL list from user or prior Search; save as `urls.txt` (one URL per line, `#` comments OK).
+2. From repo root or any cwd:
+
+```bash
+export PARALLEL_API_KEY="..."
+python3 skills/research/parallel-extract/scripts/extract_docs.py urls.txt -o extracted_docs.json
+```
+
+3. Or import `extract_urls(urls, out_path=...)` from that script in a one-off notebook/script.
 4. Verify: `len(results) + len(errors) == len(urls)`; spot-check largest `full_content` lengths.
 5. Optional: split each `full_content` to `docs/<slug>.md` for llm-wiki / vector store.
 
@@ -143,4 +149,8 @@ print(len(r.results), r.errors, r.usage)
 "
 ```
 
-**Full corpus:** Pass URL list into `extract_urls()` in `scripts/extract_docs.py`.
+**Full corpus:**
+
+```bash
+python3 skills/research/parallel-extract/scripts/extract_docs.py urls.txt -o extracted_docs.json
+```

--- a/skills/research/parallel-extract/SKILL.md
+++ b/skills/research/parallel-extract/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: parallel-extract
+description: "Use when bulk-fetching many public URLs into markdown for a RAG or agent KB via Parallel Extract API (JS pages, PDFs, >5 URLs, objective-focused excerpts or full_content)."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [parallel, extract, rag, web, documentation, research]
+    related_skills: [llm-wiki, arxiv]
+---
+
+# Parallel Extract API
+
+## Overview
+
+Parallel **Extract** (`POST /v1/extract`) turns public URLs into LLM-ready markdown (JavaScript sites and PDFs). Use it when you have a **known URL list** and need **dense excerpts** aligned to an objective, or **full page markdown** for ingestion. Pair with Parallel **Search** when you must discover URLs first.
+
+Hermes `web_extract` is fine for a handful of pages; Parallel Extract scales to **20 URLs per request**, shared `session_id` across batches, and fetch policies (freshness, timeout, cache).
+
+## When to Use
+
+- User provides 6+ documentation or GitHub README URLs for a knowledge base
+- User asks for Parallel `client.extract`, `PARALLEL_API_KEY`, or `parallel-web`
+- Need `full_content` markdown plus optional objective-driven `excerpts`
+- LangSmith / MCP wiring for Parallel Task (separate product — do not confuse with Extract)
+
+Don't use for:
+
+- Unknown URLs → Parallel Search or `web_search` first
+- Single page, no JS/PDF pain → Hermes `web_extract` (cheaper, already in-agent)
+- Pasting Python/`requests` code into the API `objective` field (invalid — see pitfalls)
+
+## Prerequisites
+
+```bash
+pip install "parallel-web>=1.0.1"   # import: from parallel import Parallel
+export PARALLEL_API_KEY="..."       # platform.parallel.ai — never commit keys
+```
+
+Docs index: https://docs.parallel.ai/llms.txt · Quickstart: https://docs.parallel.ai/extract/quickstart
+
+**Note:** Installed `hermes-agent` may pin `parallel-web<1`. For v1 Extract features, use a venv or accept a resolver warning when upgrading `parallel-web`.
+
+## Minimal call (SDK)
+
+```python
+from parallel import Parallel
+
+client = Parallel()  # PARALLEL_API_KEY from env
+extract = client.extract(
+    urls=["https://docs.parallel.ai/extract/quickstart"],
+    objective="Extract setup steps, response fields, and Python example.",
+    search_queries=["Extract API", "full_content", "excerpts"],
+)
+for r in extract.results:
+    print(r.title, r.url, len(r.full_content or ""), sum(len(e) for e in r.excerpts))
+for e in extract.errors:
+    print("FAIL", e.url, e.error_type)
+```
+
+## RAG-oriented settings
+
+| Goal | `advanced_settings` |
+|------|---------------------|
+| Full pages for chunking | `"full_content": True` |
+| Token-efficient snippets only | `"full_content": False` (default) |
+| Fresh docs | `fetch_policy.max_age_seconds` (e.g. 172800 = 48h), `disable_cache_fallback: True` |
+| Slow sites | `fetch_policy.timeout_seconds` up to 120 |
+
+`objective` = natural-language extraction goal (what to keep from each page).  
+`search_queries` = 2–5 keyword angles that match the corpus (not single generic words).
+
+Optional: `client_model="claude-opus-4-7"` for provider-side tuning.
+
+## Batching (>20 URLs)
+
+Hard limit: **20 URLs per request**. Chunk URLs; pass returned `session_id` into the next batch.
+
+```python
+def chunk(seq, n):
+    for i in range(0, len(seq), n):
+        yield seq[i : i + n]
+
+session_id = None
+for batch in chunk(urls, 20):
+    resp = client.extract(urls=batch, objective=obj, search_queries=queries, session_id=session_id, ...)
+    session_id = resp.session_id
+```
+
+**Done when:** every input URL appears in `results[].url` or `errors[].url` with no silent drops.
+
+## Response shape (persist for RAG)
+
+Per `results[]` item:
+
+| Field | Use |
+|-------|-----|
+| `url`, `title`, `publish_date` | Metadata |
+| `excerpts[]` | Objective-focused markdown chunks |
+| `full_content` | Full page markdown if enabled |
+
+Top-level: `extract_id`, `session_id`, `errors[]`, `usage[]` (e.g. `sku_extract_excerpts`).
+
+Serialize JSON yourself; prefer `full_content` for embedding, `excerpts` for quick lookup.
+
+## Hermes workflow
+
+1. Collect URL list from user or prior Search.
+2. Run `scripts/extract_docs.py` from this skill (`extract_urls(urls, out_path=...)`).
+3. Run: `PARALLEL_API_KEY=... python3 skills/research/parallel-extract/scripts/extract_docs.py` from repo root, or import `extract_urls` in a one-off script.
+4. Verify: `len(results) + len(errors) == len(urls)`; spot-check largest `full_content` lengths.
+5. Optional: split each `full_content` to `docs/<slug>.md` for llm-wiki / vector store.
+
+## Common Pitfalls
+
+1. **`objective` contains Python or JSON** — API expects prose goals only; embedded `requests.post` snippets break focus and may confuse the extractor.
+2. **>20 URLs in one call** — last URLs fail or are rejected; always batch.
+3. **`full_content: False` while user asked for complete docs** — enable `full_content: True` for RAG.
+4. **Hardcoding API keys in source** — use `PARALLEL_API_KEY`; rotate if leaked in chat.
+5. **Ignoring `errors[]`** — failed fetches are not in `results`; re-run failed URLs or lower freshness constraints.
+6. **OAuth LangSmith “parallel-task-mcp” screen** — that shares your key for **Task** MCP, not required for a one-off Extract script.
+
+## Verification Checklist
+
+- [ ] `parallel-web` import works (`python3 -c "from parallel import Parallel"`)
+- [ ] `objective` is plain-language, matches user's KB goals
+- [ ] URL count handled in batches of ≤20 with `session_id` threaded
+- [ ] Output JSON includes `publish_date`, `usage`, and all `errors`
+- [ ] User told output path (e.g. `extracted_docs.json`) and result/error counts
+
+## One-Shot Recipes
+
+**Smoke test (1 URL):**
+
+```bash
+PARALLEL_API_KEY="$PARALLEL_API_KEY" python3 -c "
+from parallel import Parallel
+r = Parallel().extract(urls=['https://modelcontextprotocol.io/docs/getting-started/intro'],
+  objective='MCP intro: transports, messages, capabilities.')
+print(len(r.results), r.errors, r.usage)
+"
+```
+
+**Full corpus:** Pass URL list into `extract_urls()` in `scripts/extract_docs.py`.

--- a/skills/research/parallel-extract/scripts/extract_docs.py
+++ b/skills/research/parallel-extract/scripts/extract_docs.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 """Parallel v1 Extract — batch URLs to extracted_docs.json. Requires PARALLEL_API_KEY."""
+import argparse
 import json
+import sys
+from pathlib import Path
+
 from parallel import Parallel
 
 EXTRACTION_OBJECTIVE = (
@@ -30,6 +34,7 @@ def extract_urls(urls, out_path="extracted_docs.json", full_content=True):
     all_results, all_errors, all_usage = [], [], []
 
     for batch_idx, batch in enumerate(chunk(urls, BATCH_SIZE)):
+        print(f"[batch {batch_idx}] extracting {len(batch)} URLs...", file=sys.stderr)
         resp = client.extract(
             urls=batch,
             objective=EXTRACTION_OBJECTIVE,
@@ -49,6 +54,10 @@ def extract_urls(urls, out_path="extracted_docs.json", full_content=True):
         all_results.extend(resp.results)
         all_errors.extend(resp.errors)
         all_usage.extend(getattr(resp, "usage", None) or [])
+        print(
+            f"  ok={len(resp.results)} err={len(resp.errors)}",
+            file=sys.stderr,
+        )
 
     out = {
         "session_id": session_id,
@@ -78,4 +87,45 @@ def extract_urls(urls, out_path="extracted_docs.json", full_content=True):
     }
     with open(out_path, "w") as f:
         json.dump(out, f, indent=2)
+    print(
+        f"Wrote {len(all_results)} results, {len(all_errors)} errors to {out_path}",
+        file=sys.stderr,
+    )
     return out
+
+
+def _load_urls(path: Path) -> list[str]:
+    lines = path.read_text().splitlines()
+    return [ln.strip() for ln in lines if ln.strip() and not ln.strip().startswith("#")]
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Batch Parallel Extract to JSON")
+    p.add_argument(
+        "urls_file",
+        nargs="?",
+        help="Text file with one URL per line (# comments allowed)",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        default="extracted_docs.json",
+        help="Output JSON path (default: extracted_docs.json)",
+    )
+    p.add_argument(
+        "--no-full-content",
+        action="store_true",
+        help="Omit full page markdown (excerpts only)",
+    )
+    args = p.parse_args(argv)
+    if not args.urls_file:
+        p.error("urls_file is required (one URL per line)")
+    urls = _load_urls(Path(args.urls_file))
+    if not urls:
+        p.error(f"No URLs in {args.urls_file}")
+    extract_urls(urls, out_path=args.output, full_content=not args.no_full_content)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/research/parallel-extract/scripts/extract_docs.py
+++ b/skills/research/parallel-extract/scripts/extract_docs.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Parallel v1 Extract — batch URLs to extracted_docs.json. Requires PARALLEL_API_KEY."""
+import json
+from parallel import Parallel
+
+EXTRACTION_OBJECTIVE = (
+    "Extract comprehensive technical documentation from each URL for an AI "
+    "software-engineering knowledge base. Preserve hierarchy, API references, "
+    "env vars, auth, code examples, CLI/Docker guidance, limitations, and "
+    "best practices. Prefer complete technical content over abbreviated excerpts."
+)
+
+SEARCH_QUERIES = [
+    "LangChain LangGraph LangSmith",
+    "Model Context Protocol MCP",
+    "OpenRouter LiteLLM configuration",
+]
+
+BATCH_SIZE = 20
+
+
+def chunk(seq, n):
+    for i in range(0, len(seq), n):
+        yield seq[i : i + n]
+
+
+def extract_urls(urls, out_path="extracted_docs.json", full_content=True):
+    client = Parallel()
+    session_id = None
+    all_results, all_errors, all_usage = [], [], []
+
+    for batch_idx, batch in enumerate(chunk(urls, BATCH_SIZE)):
+        resp = client.extract(
+            urls=batch,
+            objective=EXTRACTION_OBJECTIVE,
+            search_queries=SEARCH_QUERIES,
+            session_id=session_id,
+            advanced_settings={
+                "full_content": full_content,
+                "excerpt_settings": {"max_chars_per_result": 100000},
+                "fetch_policy": {
+                    "disable_cache_fallback": True,
+                    "max_age_seconds": 172800,
+                    "timeout_seconds": 120,
+                },
+            },
+        )
+        session_id = resp.session_id
+        all_results.extend(resp.results)
+        all_errors.extend(resp.errors)
+        all_usage.extend(getattr(resp, "usage", None) or [])
+
+    out = {
+        "session_id": session_id,
+        "results": [
+            {
+                "url": r.url,
+                "title": r.title,
+                "publish_date": getattr(r, "publish_date", None),
+                "excerpts": list(r.excerpts or []),
+                "full_content": r.full_content,
+            }
+            for r in all_results
+        ],
+        "errors": [
+            {
+                "url": e.url,
+                "error_type": e.error_type,
+                "http_status_code": getattr(e, "http_status_code", None),
+                "content": e.content,
+            }
+            for e in all_errors
+        ],
+        "usage": [
+            {"name": getattr(u, "name", None), "count": getattr(u, "count", None)}
+            for u in all_usage
+        ],
+    }
+    with open(out_path, "w") as f:
+        json.dump(out, f, indent=2)
+    return out

--- a/tests/skills/test_parallel_extract.py
+++ b/tests/skills/test_parallel_extract.py
@@ -28,6 +28,7 @@ def frontmatter() -> dict:
 def test_description_under_60_chars(frontmatter) -> None:
     desc = frontmatter["description"]
     assert len(desc) <= 60, f"description is {len(desc)} chars: {desc!r}"
+    assert desc.startswith("Use when "), desc
 
 
 def test_author_credits_contributor(frontmatter) -> None:

--- a/tests/skills/test_parallel_extract.py
+++ b/tests/skills/test_parallel_extract.py
@@ -1,0 +1,83 @@
+"""Tests for skills/research/parallel-extract."""
+from __future__ import annotations
+
+import json
+import re
+import runpy
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / "skills" / "research" / "parallel-extract"
+SCRIPT = SKILL_DIR / "scripts" / "extract_docs.py"
+
+
+@pytest.fixture(scope="module")
+def frontmatter() -> dict:
+    src = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    m = re.search(r"^---\n(.*?)\n---", src, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+def test_description_under_60_chars(frontmatter) -> None:
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars: {desc!r}"
+
+
+def test_author_credits_contributor(frontmatter) -> None:
+    assert "Nietzsche-Ubermensch" in frontmatter["author"]
+
+
+def test_extract_urls_batches_and_writes_json(tmp_path, monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    class FakeParallel:
+        def __init__(self):
+            self._n = 0
+
+        def extract(self, *, urls, session_id=None, **kwargs):
+            calls.append(list(urls))
+            self._n += 1
+            return SimpleNamespace(
+                session_id=f"sess-{self._n}",
+                results=[
+                    SimpleNamespace(
+                        url=u,
+                        title="t",
+                        publish_date=None,
+                        excerpts=["ex"],
+                        full_content="body",
+                    )
+                    for u in urls
+                ],
+                errors=[],
+                usage=[SimpleNamespace(name="sku_extract_excerpts", count=len(urls))],
+            )
+
+    fake_parallel = MagicMock()
+    fake_parallel.Parallel = FakeParallel
+    monkeypatch.setitem(sys.modules, "parallel", fake_parallel)
+
+    mod = runpy.run_path(str(SCRIPT), run_name="extract_docs_under_test")
+    urls = [f"https://example.com/{i}" for i in range(25)]
+    out = tmp_path / "out.json"
+    payload = mod["extract_urls"](urls, out_path=str(out), full_content=True)
+
+    assert len(calls) == 2
+    assert len(calls[0]) == 20
+    assert len(calls[1]) == 5
+    assert len(payload["results"]) == 25
+    data = json.loads(out.read_text())
+    assert len(data["results"]) == 25
+
+
+def test_script_main_entrypoint_exists() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert 'if __name__ == "__main__"' in text
+    assert "def main(" in text


### PR DESCRIPTION
Adds `skills/research/parallel-extract/` with SKILL.md and `scripts/extract_docs.py` for Parallel v1 Extract API (batched URLs, full_content, RAG-oriented workflow).

Pushed from worktree branch `feature/hermes-parallel-extract` on fork `Nietzsche-Ubermensch/hermes-agent-1`.