### PR TITLE
fix(windows): hide console flash on backend git/gh/pdftoppm spawns the sweep missed

### DIFF
--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -300,6 +300,44 @@ def test_local_stt_audio_prep_hides_ffmpeg_window(monkeypatch, tmp_path):
     assert captured[0][0][0] == "ffmpeg"
     assert captured[0][1]["creationflags"] == _CREATE_NO_WINDOW
 
+def test_checkpoint_manager_git_hides_windows(monkeypatch):
+    from tools import checkpoint_manager
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Completed(stdout="clean\n")
+
+    monkeypatch.setattr(checkpoint_manager, "IS_WINDOWS", True)
+    monkeypatch.setattr(checkpoint_manager, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
+    monkeypatch.setattr(checkpoint_manager.subprocess, "run", fake_run)
+
+    ok, _, _ = checkpoint_manager._run_git(["status", "--short"], Path("C:/store"), ".")
+    assert ok
+    assert captured[0][0][0] == "git"
+    assert captured[0][1]["creationflags"] == _CREATE_NO_WINDOW
+
+
+def test_skills_hub_gh_token_hides_windows(monkeypatch):
+    from tools import skills_hub
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Completed(stdout="gho_from_cli\n")
+
+    monkeypatch.setattr(skills_hub, "IS_WINDOWS", True)
+    monkeypatch.setattr(skills_hub, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
+    monkeypatch.setattr(skills_hub.subprocess, "run", fake_run)
+
+    auth = skills_hub.GitHubAuth.__new__(skills_hub.GitHubAuth)
+    assert auth._try_gh_cli() == "gho_from_cli"
+    assert captured[0][0] == ["gh", "auth", "token"]
+    assert captured[0][1]["creationflags"] == _CREATE_NO_WINDOW
+
+
 def test_tui_slash_worker_hides_python_window(monkeypatch):
     from tui_gateway import server
 

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -309,7 +309,6 @@ def test_checkpoint_manager_git_hides_windows(monkeypatch):
         captured.append((cmd, kwargs))
         return _Completed(stdout="clean\n")
 
-    monkeypatch.setattr(checkpoint_manager, "IS_WINDOWS", True)
     monkeypatch.setattr(checkpoint_manager, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
     monkeypatch.setattr(checkpoint_manager.subprocess, "run", fake_run)
 
@@ -328,7 +327,6 @@ def test_skills_hub_gh_token_hides_windows(monkeypatch):
         captured.append((cmd, kwargs))
         return _Completed(stdout="gho_from_cli\n")
 
-    monkeypatch.setattr(skills_hub, "IS_WINDOWS", True)
     monkeypatch.setattr(skills_hub, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
     monkeypatch.setattr(skills_hub.subprocess, "run", fake_run)
 

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -58,6 +58,7 @@ import subprocess
 import time
 from pathlib import Path
 from hermes_constants import get_hermes_home
+from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
 from typing import Dict, List, Optional, Set, Tuple
 
 from utils import env_int
@@ -321,6 +322,10 @@ def _run_git(
     env = _git_env(store, str(normalized_working_dir), index_file=index_file)
     cmd = ["git"] + list(args)
     allowed_returncodes = allowed_returncodes or set()
+    # Checkpoints run inside the console-less desktop/gateway backend; a bare
+    # git spawn there pops a fresh conhost window per call (status, add,
+    # commit, …) on Windows. No-op on POSIX.
+    _popen_kwargs = {"creationflags": windows_hide_flags()} if IS_WINDOWS else {}
     try:
         result = subprocess.run(
             cmd,
@@ -330,6 +335,7 @@ def _run_git(
             env=env,
             cwd=str(normalized_working_dir),
             stdin=subprocess.DEVNULL,
+            **_popen_kwargs,
         )
         ok = result.returncode == 0
         stdout = result.stdout.strip()
@@ -450,6 +456,7 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
             capture_output=True, text=True,
             env=init_env, timeout=_GIT_TIMEOUT,
             stdin=subprocess.DEVNULL,
+            **({"creationflags": windows_hide_flags()} if IS_WINDOWS else {}),
         )
         if result.returncode != 0:
             return f"Shadow store init failed: {result.stderr.strip()}"

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -58,7 +58,7 @@ import subprocess
 import time
 from pathlib import Path
 from hermes_constants import get_hermes_home
-from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
+from hermes_cli._subprocess_compat import windows_hide_flags
 from typing import Dict, List, Optional, Set, Tuple
 
 from utils import env_int
@@ -322,10 +322,7 @@ def _run_git(
     env = _git_env(store, str(normalized_working_dir), index_file=index_file)
     cmd = ["git"] + list(args)
     allowed_returncodes = allowed_returncodes or set()
-    # Checkpoints run inside the console-less desktop/gateway backend; a bare
-    # git spawn there pops a fresh conhost window per call (status, add,
-    # commit, …) on Windows. No-op on POSIX.
-    _popen_kwargs = {"creationflags": windows_hide_flags()} if IS_WINDOWS else {}
+
     try:
         result = subprocess.run(
             cmd,
@@ -335,7 +332,10 @@ def _run_git(
             env=env,
             cwd=str(normalized_working_dir),
             stdin=subprocess.DEVNULL,
-            **_popen_kwargs,
+            # Checkpoints fire several bare git calls per turn from the
+            # console-less desktop/gateway backend; suppress the per-call
+            # conhost flash on Windows (no-op on POSIX).
+            creationflags=windows_hide_flags(),
         )
         ok = result.returncode == 0
         stdout = result.stdout.strip()
@@ -456,7 +456,7 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
             capture_output=True, text=True,
             env=init_env, timeout=_GIT_TIMEOUT,
             stdin=subprocess.DEVNULL,
-            **({"creationflags": windows_hide_flags()} if IS_WINDOWS else {}),
+            creationflags=windows_hide_flags(),
         )
         if result.returncode != 0:
             return f"Shadow store init failed: {result.stderr.strip()}"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from hermes_constants import get_hermes_home
+from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
 from agent.skill_utils import is_excluded_skill_path
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urljoin, urlparse, urlunparse
@@ -302,6 +303,7 @@ class GitHubAuth:
                 ["gh", "auth", "token"],
                 capture_output=True, text=True, timeout=5,
                 stdin=subprocess.DEVNULL,
+                **({"creationflags": windows_hide_flags()} if IS_WINDOWS else {}),
             )
             if result.returncode == 0 and result.stdout.strip():
                 return result.stdout.strip()

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from hermes_constants import get_hermes_home
-from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
+from hermes_cli._subprocess_compat import windows_hide_flags
 from agent.skill_utils import is_excluded_skill_path
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urljoin, urlparse, urlunparse
@@ -303,7 +303,7 @@ class GitHubAuth:
                 ["gh", "auth", "token"],
                 capture_output=True, text=True, timeout=5,
                 stdin=subprocess.DEVNULL,
-                **({"creationflags": windows_hide_flags()} if IS_WINDOWS else {}),
+                creationflags=windows_hide_flags(),
             )
             if result.returncode == 0 and result.stdout.strip():
                 return result.stdout.strip()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9126,8 +9126,13 @@ def _(rid, params: dict) -> dict:
             "-f", str(first_page), "-l", str(last_page),
             str(pdf_path), str(out_prefix),
         ]
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
         try:
-            res = subprocess.run(argv, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL)
+            res = subprocess.run(
+                argv, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
+            )
         except subprocess.TimeoutExpired:
             return _err(rid, 5028, "pdftoppm timed out (>120s)")
         if res.returncode != 0:


### PR DESCRIPTION
## Summary

Three backend spawn legs that run inside the **console-less** desktop/gateway backend still flash a fresh console window on Windows. The recent backend sweep (#54236 "hide console-window flash on backend git/gh/wmic/bash subprocess spawns", #54417 "cover remaining console-flash spawn legs") routed `git_probe`, the repo-file picker, `coding_context`, `context_references`, `copilot_auth`, and the gateway process scans through `CREATE_NO_WINDOW` — but missed these sibling sites:

- **`tools/checkpoint_manager.py`** — `_run_git` (and the one-shot `git init --bare` in `_init_store`). When checkpoints are enabled, every file-mutating turn fires several bare `git` calls (status, add, write-tree/commit-tree, update-ref). The desktop spawns the backend with `windowsHide` (→ `CREATE_NO_WINDOW`), so the backend has no console, and each child `git.exe` allocates its own conhost → a flurry of terminal popups.
- **`tools/skills_hub.py`** — `GitHubAuth._try_gh_cli` (`gh auth token`). Same bug class as the already-fixed `copilot_auth` gh probe; this is the sibling call path.
- **`tui_gateway/server.py`** — the PDF-attach handler shells out to `pdftoppm`; one conhost flash per attach on Windows.

All route through `windows_hide_flags()` (no-op on POSIX), matching the established per-site form (`creationflags=windows_hide_flags()`, exactly how `server.py::_list_repo_files` already does it). This is the targeted-per-site approach the maintainers settled on after rolling back the global chokepoint in #53853 — not a resurrection of that approach.

## Why these were missed

They're not in the `tui_gateway`/`gateway`/`hermes_cli` cluster the sweep focused on — they live under `tools/` (and one `server.py` media handler) and only fire under specific feature flags (checkpoints on) or actions (installing a GitHub skill, attaching a PDF), so they didn't surface in the project-load reproduction.

## Commits

1. `fix(windows)` — checkpoint git + skills_hub gh probes (+ tests)
2. `fix(windows)` — pdftoppm console flash on PDF attach
3. `refactor(windows)` — unify all touched sites on `creationflags=windows_hide_flags()`; drop the `IS_WINDOWS` import + ternary/one-use-dict gating (no-op on POSIX anyway)

## Test plan

- [x] `scripts/run_tests.sh tests/test_windows_subprocess_no_window_flags.py -q` — 15 pass (2 new: checkpoint git, skills_hub gh)
- [x] `scripts/run_tests.sh tests/tools/test_checkpoint_manager.py -q` — 77 pass
- [x] import smoke + `ast.parse` on all edited files