### PR TITLE
fix(tools): find explicit dotfile basenames in file search

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -3,6 +3,7 @@
 import os
 import re
 import pytest
+import shutil
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -700,6 +701,46 @@ class TestSearchFilesFallbackHiddenPaths:
 
         assert result.error is None
         assert set(result.files) == {str(visible_file), str(visible_nested_file)}
+
+
+    def test_normal_root_allows_explicit_dotfile_basename(self, tmp_path, monkeypatch):
+        """Fallback find should find root dotfiles when the basename is explicit."""
+        root = tmp_path / "repo"
+        root.mkdir()
+        dotfile = root / ".hermes_cross_tool_smoke.txt"
+        hidden_dir_file = root / ".hidden" / ".hermes_cross_tool_smoke.txt"
+
+        dotfile.write_text("x")
+        hidden_dir_file.parent.mkdir(parents=True)
+        hidden_dir_file.write_text("secret")
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+        result = ops._search_files(".hermes_cross_tool_smoke.txt", str(root), limit=50, offset=0)
+
+        assert result.error is None
+        assert result.files == [str(dotfile)]
+
+    def test_rg_search_allows_explicit_dotfile_basename(self, tmp_path, monkeypatch):
+        """rg --files path should add --hidden for explicit dotfile searches."""
+        if shutil.which("rg") is None:
+            pytest.skip("ripgrep not installed")
+
+        root = tmp_path / "repo"
+        root.mkdir()
+        dotfile = root / ".hermes_cross_tool_smoke.txt"
+        hidden_dir_file = root / ".hidden" / ".hermes_cross_tool_smoke.txt"
+
+        dotfile.write_text("x")
+        hidden_dir_file.parent.mkdir(parents=True)
+        hidden_dir_file.write_text("secret")
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "rg")
+        result = ops._search_files(".hermes_cross_tool_smoke.txt", str(root), limit=50, offset=0)
+
+        assert result.error is None
+        assert result.files == [str(dotfile)]
 
 
 class TestShellFileOpsWriteDenied:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2030,6 +2030,8 @@ class ShellFileOperations(FileOperations):
         else:
             search_pattern = pattern.split('/')[-1]
 
+        includes_hidden_basename = Path(search_pattern).name.startswith(".")
+
         search_root = Path(path)
         has_hidden_path_ancestor = any(
             part not in {".", ".."} and part.startswith(".")
@@ -2050,8 +2052,16 @@ class ShellFileOperations(FileOperations):
                       "https://github.com/BurntSushi/ripgrep#installation"
             )
 
-        # Exclude hidden directories (matching ripgrep's default behavior).
-        hidden_exclude = "-not -path '*/.*'" if not has_hidden_path_ancestor else ""
+        # Exclude hidden paths by default (matching ripgrep's default
+        # behavior). If the caller explicitly searches for a dotfile basename
+        # such as ".env" or ".hermes_smoke", allow hidden file basenames while
+        # still excluding descendants of hidden directories from normal roots.
+        if has_hidden_path_ancestor:
+            hidden_exclude = ""
+        elif includes_hidden_basename:
+            hidden_exclude = "-not -path '*/.*/*'"
+        else:
+            hidden_exclude = "-not -path '*/.*'"
         hidden_filter_expr = f" {hidden_exclude}" if hidden_exclude else ""
 
         # Use shell pagination for standard roots. For hidden roots, gather full
@@ -2118,15 +2128,20 @@ class ShellFileOperations(FileOperations):
         """
         # rg --files -g uses glob patterns; wrap bare names so they match
         # at any depth (equivalent to find -name).
-        if '/' not in pattern and not pattern.startswith('*'):
+        includes_hidden_basename = Path(pattern).name.startswith(".")
+        if includes_hidden_basename:
+            glob_pattern = pattern
+        elif '/' not in pattern and not pattern.startswith('*'):
             glob_pattern = f"*{pattern}"
         else:
             glob_pattern = pattern
 
+        hidden_arg = " --hidden" if includes_hidden_basename else ""
+
         fetch_limit = limit + offset
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
-            f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
+            f"rg --files{hidden_arg} --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
             f"{self._escape_shell_arg(path)} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
@@ -2137,13 +2152,27 @@ class ShellFileOperations(FileOperations):
         if not all_files and not limit_reason:
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
-                f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
+                f"rg --files{hidden_arg} -g {self._escape_shell_arg(glob_pattern)} "
                 f"{self._escape_shell_arg(path)} 2>/dev/null "
                 f"| head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
             all_files = [f for f in stdout.strip().split('\n') if f]
+
+        if includes_hidden_basename:
+            normalized_root = Path(path).resolve()
+            filtered_files = []
+            for file_path in all_files:
+                try:
+                    rel_parts = Path(file_path).resolve().relative_to(normalized_root).parts
+                except ValueError:
+                    rel_parts = Path(file_path).parts
+                parent_parts = rel_parts[:-1]
+                if any(part not in {".", ".."} and part.startswith(".") for part in parent_parts):
+                    continue
+                filtered_files.append(file_path)
+            all_files = filtered_files
 
         page = all_files[offset:offset + limit]
 


### PR DESCRIPTION
## Summary

- allow `search_files(target="files")` to honor explicit dotfile basename patterns such as `.env`, `.gitignore`, or `.hermes_smoke`
- keep hidden paths excluded for broad searches by default
- keep hidden descendant directories excluded when searching from a normal visible root

## Why

`search_files(target="files", path=<visible root>, pattern=".hidden_file")` currently returns zero results even when `<visible root>/.hidden_file` exists. Hidden paths should stay excluded for broad searches, but an explicit dotfile basename is a precise user request and should not silently return a false negative.

This follows the same intent as prior hidden-root handling: explicit hidden targets should work without enabling broad hidden traversal.

## Verification

- `python3 -m py_compile tools/file_operations.py tests/tools/test_file_operations.py`
- `git diff --check`
- ad-hoc fallback verification with a temporary visible root containing both:
  - `<root>/.hermes_cross_tool_smoke.txt`
  - `<root>/.hidden/.hermes_cross_tool_smoke.txt`

The fallback path returned only the root-level dotfile and excluded the hidden-directory descendant.
