### PR TITLE
fix: honor MCP connect timeout in CLI probes

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -262,6 +262,30 @@ def _probe_single_server(
     return tools_found
 
 
+def _connect_timeout_for(config: dict, default: float = 30) -> float:
+    """Return the per-server MCP probe timeout.
+
+    ``timeout`` is for individual tool calls after a server is connected;
+    discovery/auth probes use ``connect_timeout`` because slow remote servers
+    can legitimately need longer to initialize and list tools.
+    """
+    value = config.get("connect_timeout", default)
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError):
+        return default
+    return timeout if timeout > 0 else default
+
+
+def _probe_configured_server(name: str, config: dict) -> List[Tuple[str, str]]:
+    """Probe a configured server using its configured connect timeout."""
+    return _probe_single_server(
+        name,
+        config,
+        connect_timeout=_connect_timeout_for(config),
+    )
+
+
 def _oauth_tokens_present(name: str) -> bool:
     """Return True if an OAuth token file exists on disk for ``name``.
 
@@ -310,6 +334,7 @@ def cmd_mcp_add(args):
     auth_type = getattr(args, "auth", None)
     preset_name = getattr(args, "preset", None)
     raw_env = getattr(args, "env", None)
+    raw_connect_timeout = getattr(args, "connect_timeout", None)
 
     server_config: Dict[str, Any] = {}
     try:
@@ -355,6 +380,8 @@ def cmd_mcp_add(args):
             server_config["args"] = cmd_args
         if explicit_env:
             server_config["env"] = explicit_env
+    if raw_connect_timeout is not None:
+        server_config["connect_timeout"] = raw_connect_timeout
 
     issues = validate_mcp_server_entry(name, server_config)
     if issues:
@@ -421,7 +448,7 @@ def cmd_mcp_add(args):
     print(color(f"  Connecting to '{name}'...", Colors.CYAN))
 
     try:
-        tools = _probe_single_server(name, server_config)
+        tools = _probe_configured_server(name, server_config)
     except Exception as exc:
         _error(f"Failed to connect: {exc}")
         if _confirm("Save config anyway (you can test later)?", default=False):
@@ -645,7 +672,7 @@ def cmd_mcp_test(args):
     # Attempt connection
     start = time.monotonic()
     try:
-        tools = _probe_single_server(name, cfg)
+        tools = _probe_configured_server(name, cfg)
         elapsed_ms = (time.monotonic() - start) * 1000
     except Exception as exc:
         elapsed_ms = (time.monotonic() - start) * 1000
@@ -695,7 +722,7 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
 
     # Probe triggers the OAuth flow (browser redirect + callback capture).
     try:
-        tools = _probe_single_server(name, server_config)
+        tools = _probe_configured_server(name, server_config)
         # A clean probe is NOT proof of authentication. Some MCP servers
         # (notably Google's official Drive server) serve initialize +
         # tools/list WITHOUT auth, so the probe lists tools even when the
@@ -836,7 +863,7 @@ def cmd_mcp_configure(args):
     print(color(f"  Connecting to '{name}' to discover tools...", Colors.CYAN))
 
     try:
-        all_tools = _probe_single_server(name, cfg)
+        all_tools = _probe_configured_server(name, cfg)
     except Exception as exc:
         _error(f"Failed to connect: {exc}")
         return

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -61,6 +61,11 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
     mcp_add_p.add_argument("--auth", choices=["oauth", "header"], help="Auth method")
     mcp_add_p.add_argument("--preset", help="Known MCP preset name")
     mcp_add_p.add_argument(
+        "--connect-timeout",
+        type=float,
+        help="Timeout in seconds for initial connection and tool discovery",
+    )
+    mcp_add_p.add_argument(
         "--env",
         nargs="*",
         default=[],

--- a/tests/hermes_cli/test_mcp_add_command_dest.py
+++ b/tests/hermes_cli/test_mcp_add_command_dest.py
@@ -41,6 +41,7 @@ def _build_parser():
     mcp_add.add_argument("name")
     mcp_add.add_argument("--url")
     mcp_add.add_argument("--command", dest="mcp_command")
+    mcp_add.add_argument("--connect-timeout", type=float)
     mcp_add.add_argument("--args", nargs=argparse.REMAINDER, default=[])
 
     return parser
@@ -86,6 +87,25 @@ class TestMcpAddCommandDest:
         assert args.command == "mcp"
         assert args.mcp_command is None
         assert args.url is None
+
+    def test_connect_timeout_flag_sets_probe_timeout(self):
+        """`--connect-timeout` exposes the per-server discovery timeout."""
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "mcp",
+                "add",
+                "slow",
+                "--url",
+                "https://example.com/mcp",
+                "--connect-timeout",
+                "180",
+            ]
+        )
+
+        assert args.command == "mcp"
+        assert args.mcp_action == "add"
+        assert args.connect_timeout == 180
 
     def test_args_passthrough_keeps_nested_option_flags(self):
         """`--args` must keep command flags like Docker MCP's --profile."""

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -413,6 +413,30 @@ class TestMcpAdd:
         out = capsys.readouterr().out
         assert "Unknown MCP preset" in out
 
+    def test_add_uses_configured_connect_timeout(self, tmp_path, capsys, monkeypatch):
+        """Discovery for newly added servers honors connect_timeout."""
+        seen = {}
+
+        def mock_probe(name, config, connect_timeout=30):
+            seen["connect_timeout"] = connect_timeout
+            return [("search", "Search repos")]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        inputs = iter(["n", ""])  # no auth needed, enable all tools
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(
+            name="slow",
+            url="https://slow.example.com/mcp",
+            connect_timeout=180,
+        ))
+
+        assert seen["connect_timeout"] == 180
+
 
 # ---------------------------------------------------------------------------
 # Tests: cmd_mcp_test
@@ -444,6 +468,25 @@ class TestMcpTest:
         out = capsys.readouterr().out
         assert "Connected" in out
         assert "Tools discovered: 2" in out
+
+    def test_test_uses_configured_connect_timeout(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "slow": {"url": "https://slow.example.com/mcp", "connect_timeout": 180},
+        })
+        seen = {}
+
+        def mock_probe(name, config, connect_timeout=30):
+            seen["connect_timeout"] = connect_timeout
+            return [("list", "List")]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(_make_args(name="slow"))
+
+        assert seen["connect_timeout"] == 180
 
 
 # ---------------------------------------------------------------------------
@@ -716,7 +759,7 @@ class TestMcpLogin:
         # Probe returns tools even though auth never completed.
         monkeypatch.setattr(
             "hermes_cli.mcp_config._probe_single_server",
-            lambda name, cfg: [("search_files", "d"), ("read_file_content", "d")],
+            lambda name, cfg, **kw: [("search_files", "d"), ("read_file_content", "d")],
         )
         # No token file is created → _oauth_tokens_present() returns False.
         from hermes_cli.mcp_config import cmd_mcp_login
@@ -738,7 +781,7 @@ class TestMcpLogin:
         # cmd_mcp_login wipes tokens before probing, then the real OAuth flow
         # writes a fresh token during the probe. Simulate that: the mocked
         # probe drops a token file, mirroring a successful authorization.
-        def mock_probe(name, cfg):
+        def mock_probe(name, cfg, **kw):
             token_dir.mkdir(exist_ok=True)
             (token_dir / "realserver.json").write_text('{"access_token": "x"}')
             return [("a", "d"), ("b", "d"), ("c", "d")]
@@ -754,6 +797,34 @@ class TestMcpLogin:
 
         assert "Authenticated — 3 tool(s) available" in out
         assert "no OAuth token" not in out
+
+    def test_login_uses_configured_connect_timeout(self, tmp_path, capsys, monkeypatch):
+        """OAuth login can wait longer for large tool lists after auth."""
+        _seed_config(tmp_path, {
+            "slowoauth": {
+                "url": "https://slow.example.com/mcp",
+                "auth": "oauth",
+                "connect_timeout": 180,
+            },
+        })
+        token_dir = tmp_path / "mcp-tokens"
+        seen = {}
+
+        def mock_probe(name, cfg, connect_timeout=30):
+            seen["connect_timeout"] = connect_timeout
+            token_dir.mkdir(exist_ok=True)
+            (token_dir / "slowoauth.json").write_text('{"access_token": "x"}')
+            return [("a", "d")]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_login
+
+        cmd_mcp_login(_make_args(name="slowoauth"))
+
+        assert seen["connect_timeout"] == 180
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make MCP CLI add/test/login/configure probes honor per-server connect_timeout
- add --connect-timeout to hermes mcp add so slow servers can be configured from CLI
- add regression coverage for add/test/login timeout propagation and parser handling

## Verification
- RED: new timeout propagation tests initially failed with 30s default instead of configured 180s
- GREEN: pytest tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_add_command_dest.py -q -o addopts='' → 56 passed
- python3 -m compileall -q hermes_cli/mcp_config.py hermes_cli/subcommands/mcp.py