### PR TITLE
fix(agent): reset api_mode to chat_completions when switching to MoA (#54259)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1621,6 +1621,20 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         if (new_provider or "").strip().lower() == "moa":
             from agent.moa_loop import MoAClient
 
+            # MoA is a virtual chat-completions facade: ``MoAClient`` exposes
+            # only ``chat.completions.create()`` and the runtime carries a
+            # non-HTTP ``base_url`` ("moa://local"). If the session was
+            # previously on a provider with a different ``api_mode`` (e.g.
+            # ``codex_responses`` from a codex slot) the conversation loop
+            # would route the primary call through ``client.responses.create``
+            # or an OpenAI SDK bound to the placeholder URL, returning 404 and
+            # falling back to a reference model. Force ``chat_completions`` so
+            # the existing ``elif agent.provider == "moa"`` branch in
+            # ``interruptible_api_call`` / ``interruptible_streaming_api_call``
+            # is the only one that can match. Mirrors the init-time force in
+            # ``agent_init.py`` (line 724).
+            agent.api_mode = "chat_completions"
+            api_mode = "chat_completions"
             agent.api_key = api_key or "moa-virtual-provider"
             agent.base_url = "moa://local"
             agent._client_kwargs = {}

--- a/tests/run_agent/test_switch_model_moa_api_mode.py
+++ b/tests/run_agent/test_switch_model_moa_api_mode.py
@@ -1,0 +1,133 @@
+"""Regression tests for #54259: switch_model() must reset api_mode to
+``chat_completions`` when switching to the MoA virtual provider.
+
+The MoA facade is exposed via ``MoAClient.chat.completions.create()`` and
+carries the non-HTTP ``base_url`` "moa://local". When a session was
+previously on a provider with a different ``api_mode`` (most commonly
+``codex_responses`` from a codex slot), ``switch_model`` left
+``agent.api_mode`` unchanged, and the conversation loop's primary call
+went through ``client.responses.create()`` (or the OpenAI SDK bound to
+``moa://local``) — returning 404 and triggering a fallback to a
+reference model. The init path in ``agent_init.py`` already forces
+``api_mode = "chat_completions"`` at line 724; this test pins the
+matching contract on the runtime switch path.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from agent.agent_runtime_helpers import switch_model
+
+
+def _make_agent(current_provider, current_model, current_api_mode):
+    """Bare agent object with the minimum attributes switch_model touches."""
+    agent = MagicMock(name=f"Agent[{current_provider}]")
+    agent.provider = current_provider
+    agent.model = current_model
+    agent.base_url = f"https://{current_provider}.example/v1"
+    agent.api_key = f"{current_provider}-key"
+    agent.api_mode = current_api_mode
+    agent.client = MagicMock(name="Client")
+    agent._client_kwargs = {
+        "api_key": "***",
+        "base_url": f"https://{current_provider}.example/v1",
+    }
+    agent._anthropic_client = None
+    agent._anthropic_api_key = ""
+    agent._anthropic_base_url = None
+    agent._is_anthropic_oauth = False
+    agent._config_context_length = None
+    agent._transport_cache = {}
+    agent._cached_system_prompt = "cached-system-prompt"
+    agent.context_compressor = None
+    agent._use_prompt_caching = False
+    agent._use_native_cache_layout = False
+    agent._primary_runtime = {}
+    agent._fallback_activated = False
+    agent._fallback_index = 0
+    agent._fallback_chain = []
+    agent._fallback_model = None
+    agent._credential_pool = None
+    agent._anthropic_prompt_cache_policy = MagicMock(return_value=(False, False))
+    agent._ensure_lmstudio_runtime_loaded = MagicMock()
+    return agent
+
+
+class TestSwitchModelMoAApiMode:
+    """Issue #54259: switching to MoA must reset api_mode to chat_completions."""
+
+    def test_switch_to_moa_from_codex_resets_api_mode(self):
+        """Session running on codex_responses → /moa must end in chat_completions.
+
+        The original bug: api_mode stayed ``codex_responses``, the primary
+        call was routed through ``client.responses.create()`` against
+        ``moa://local``, the SDK returned HTTP 404, and the conversation
+        loop fell back to a reference model. ``switch_model`` must
+        overwrite ``api_mode`` to ``chat_completions`` when the new
+        provider is MoA.
+        """
+        agent = _make_agent("openai-codex", "gpt-5.5", "codex_responses")
+
+        with patch("agent.moa_loop.MoAClient") as moa_client_cls:
+            switch_model(
+                agent,
+                new_model="frontier",
+                new_provider="moa",
+                api_key="",
+                base_url="",
+                api_mode="codex_responses",  # caller still thinks codex
+            )
+
+        assert agent.provider == "moa"
+        # The MoA virtual runtime, not the old codex base_url.
+        assert agent.base_url == "moa://local"
+        assert agent.api_key == "moa-virtual-provider"
+        # The fix: api_mode must be chat_completions so the conversation
+        # loop's ``elif agent.provider == "moa"`` branch matches.
+        assert agent.api_mode == "chat_completions", (
+            f"switch_model did not reset api_mode for moa (got "
+            f"{agent.api_mode!r}); primary call would route to "
+            f"client.responses.create() and 404 on moa://local"
+        )
+        moa_client_cls.assert_called_once_with("frontier")
+
+    def test_switch_to_moa_from_chat_completions_keeps_api_mode(self):
+        """Switching to MoA from a chat_completions session must not regress."""
+        agent = _make_agent("openrouter", "anthropic/claude-opus-4.6", "chat_completions")
+
+        with patch("agent.moa_loop.MoAClient") as moa_client_cls:
+            switch_model(
+                agent,
+                new_model="review",
+                new_provider="moa",
+                api_key="",
+                base_url="",
+                api_mode="chat_completions",
+            )
+
+        assert agent.provider == "moa"
+        assert agent.base_url == "moa://local"
+        assert agent.api_mode == "chat_completions"
+        moa_client_cls.assert_called_once_with("review")
+
+    def test_switch_to_moa_invalidates_transport_cache(self):
+        """The transport cache (keyed on api_mode) must be cleared on switch."""
+        agent = _make_agent("openai-codex", "gpt-5.5", "codex_responses")
+        agent._transport_cache = {"old-key": object()}
+
+        with patch("agent.moa_loop.MoAClient"):
+            switch_model(
+                agent,
+                new_model="frontier",
+                new_provider="moa",
+                api_key="",
+                base_url="",
+                api_mode="codex_responses",
+            )
+
+        assert agent.api_mode == "chat_completions"
+        # ``switch_model`` clears the transport cache when api_mode flips
+        # from chat_completions to codex_responses (see line 1594-1595).
+        # The MoA branch above does the flip in the other direction; the
+        # init path clears it directly. Either way the cache must NOT
+        # retain stale entries from the previous provider.
+        assert agent._transport_cache == {}


### PR DESCRIPTION
Fixes #54259

## Description

When a session is switched to a MoA preset (via `/moa` or a persisted MoA-model session), `switch_model()` left `agent.api_mode` unchanged from whatever the previous provider used. If the previous provider was a codex slot (`api_mode = "codex_responses"`), the conversation loop's primary/acting call was routed through `client.responses.create()` against the non-HTTP placeholder `base_url = "moa://local"`, returning HTTP 404 and falling back to a reference model — the final answer was never the aggregator's.

The init path in `agent_init.py:724` already forces `agent.api_mode = "chat_completions"` when the provider is MoA. This change applies the same force inside the runtime `switch_model()` path so a session that started on a codex slot and is then switched to a MoA preset reaches a consistent state.

## Verification

- **Targeted tests** — `pytest tests/run_agent/test_switch_model_moa_api_mode.py -v`: 3 passed
  - `test_switch_to_moa_from_codex_resets_api_mode` — repro: codex_responses → moa must end in `chat_completions`
  - `test_switch_to_moa_from_chat_completions_keeps_api_mode` — regression: chat_completions → moa stays `chat_completions`
  - `test_switch_to_moa_invalidates_transport_cache` — transport cache is cleared on the switch
- **S1 (Secrets)** — clean
- **S2 (Personal refs)** — clean
- **C1 (Conventional commit)** — `fix(agent): ...`
- **F1 (Focused)** — only `agent/agent_runtime_helpers.py` and a new test file
- **Compile check** — `ast.parse` passes for both files
