### PR TITLE
feat(themes): add Código Sin Siesta dashboard theme preset

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12693,6 +12693,7 @@ _BUILTIN_DASHBOARD_THEMES = [
     {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},
     {"name": "cyberpunk", "label": "Cyberpunk",      "description": "Neon green on black — matrix terminal"},
     {"name": "rose",      "label": "Rosé",           "description": "Soft pink and warm ivory — easy on the eyes"},
+    {"name": "codigo-sin-siesta", "label": "Código Sin Siesta", "description": "Dark blueprint — cobalto sobre slate-900 con tipografía Space Grotesk · Inter · JetBrains Mono"},
 ]
 
 

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -299,6 +299,71 @@ export const defaultLargeTheme: DashboardTheme = {
   },
 };
 
+/**
+ * Código Sin Siesta — port of the @codigosinsiesta/theme v0.7.0 "dark
+ * blueprint" tokens onto the dashboard palette triplet.
+ *
+ * Source of truth: https://github.com/CodigoSinSiesta/theme
+ *   --color-fondo    → background (slate-900 canvas)
+ *   --color-tinta    → midground (slate-100 primary text)
+ *   --color-cielo    → warm-glow tint (sky-400)
+ *   --font-display   → Space Grotesk (themed chrome)
+ *   --font-body      → Inter (body)
+ *   --font-mono      → JetBrains Mono (technical)
+ *   --radius-md      → 1rem corner radius
+ *
+ * We do NOT touch index.css or any component — this is a pure preset
+ * addition so users can pick the CSS look from the ThemeSwitcher. The
+ * existing shadcn-compat cascade in index.css already derives every
+ * card / muted / border token from background+midground via color-mix(),
+ * so injecting the CSS palette triplet propagates automatically.
+ */
+export const codigoSinSiestaTheme: DashboardTheme = {
+  name: "codigo-sin-siesta",
+  label: "Código Sin Siesta",
+  description:
+    "Dark blueprint — cobalto sobre slate-900 con tipografía Space Grotesk · Inter · JetBrains Mono",
+  palette: {
+    background: { hex: "#0f172a", alpha: 1 }, // --color-fondo (slate-900)
+    midground: { hex: "#f1f5f9", alpha: 1 }, // --color-tinta (slate-100)
+    foreground: { hex: "#ffffff", alpha: 0 },
+    warmGlow: "rgba(96, 165, 250, 0.28)", // --color-cielo (sky-400) @ 0.28
+    noiseOpacity: 0.85,
+  },
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: `"Inter", ${SYSTEM_SANS}`,
+    fontDisplay: `"Space Grotesk", "Inter", ${SYSTEM_SANS}`,
+    fontMono: `"JetBrains Mono", ${SYSTEM_MONO}`,
+    fontUrl:
+      "https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap",
+    baseSize: "15px",
+    lineHeight: "1.6",
+    letterSpacing: "0",
+  },
+  layout: {
+    radius: "1rem", // --radius-md
+    density: "comfortable",
+  },
+  // Pin a few semantic tokens to the CSS-theme equivalents so chart /
+  // badge / destructive reads match the deck palette instead of falling
+  // back to the LENS_0 defaults.
+  colorOverrides: {
+    success: "#34d399", // --color-ok (emerald-400)
+    warning: "#fbbf24", // --color-warn (amber-400)
+    destructive: "#f87171", // --color-err (red-400)
+  },
+  // Data-series accents for Analytics/Models — input reads as slate-300,
+  // output as electric-blue (sky-500 in the V4 palette, the most
+  // recognizable CSS-theme accent).
+  seriesColors: {
+    inputTokenAccent: "#cbd5e1", // --color-tinta2 (slate-300)
+    outputTokenAccent: "#3b82f6", // --color-electrico (blue-500)
+  },
+  swatchColors: ["#0f172a", "#3b82f6", "#60a5fa"], // bg / electric / sky
+  terminalBackground: "#0c1e4f", // --color-marino (navy canvas)
+};
+
 export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
   default: defaultTheme,
   "default-large": defaultLargeTheme,
@@ -308,4 +373,5 @@ export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
   mono: monoTheme,
   cyberpunk: cyberpunkTheme,
   rose: roseTheme,
+  "codigo-sin-siesta": codigoSinSiestaTheme,
 };


### PR DESCRIPTION
## Summary

Añade el theme **Código Sin Siesta** como preset built-in del dashboard, portando los tokens de `@codigosinsiesta/theme` v0.7.0 al triplete de paleta del dashboard (`background` / `midground` / `warm-glow`). Cero cambios en `index.css`, layout o componentes — solo añadir al catálogo `BUILTIN_THEMES` y registrarlo en el backend.

Aparece automáticamente en `ThemeSwitcher` para que cualquier usuario lo pueda seleccionar.

## Mapeo de tokens

| `@codigosinsiesta/theme` | Hex | Slot `DashboardTheme` |
|---|---|---|
| `--color-fondo` | `#0f172a` | `palette.background` (slate-900 canvas) |
| `--color-tinta` | `#f1f5f9` | `palette.midground` (slate-100 text) |
| `--color-cielo` | `#60a5fa` | `palette.warmGlow` @ 0.28 alpha |
| `--color-ok` | `#34d399` | `colorOverrides.success` |
| `--color-warn` | `#fbbf24` | `colorOverrides.warning` |
| `--color-err` | `#f87171` | `colorOverrides.destructive` |
| `--color-tinta2` | `#cbd5e1` | `seriesColors.inputTokenAccent` |
| `--color-electrico` | `#3b82f6` | `seriesColors.outputTokenAccent` |
| `--color-marino` | `#0c1e4f` | `terminalBackground` |
| `--font-display` | Space Grotesk | `typography.fontDisplay` |
| `--font-body` | Inter | `typography.fontSans` |
| `--font-mono` | JetBrains Mono | `typography.fontMono` |
| `--radius-md` | 1rem | `layout.radius` |

## Why a preset, not a full re-skin?

La cascada `shadcn-compat` en `web/src/index.css` ya deriva todos los tokens `bg-card` / `text-muted-foreground` / `border-border` etc. del triplete de paleta vía `color-mix()`. Inyectar la paleta CSS Theme al `ThemeProvider` propaga automáticamente a toda la UI sin tocar un solo componente.

## Files changed

- `web/src/themes/presets.ts` (+66 lines) — nuevo `codigoSinSiestaTheme` + entrada en `BUILTIN_THEMES`
- `hermes_cli/web_server.py` (+1 line) — entrada en `_BUILTIN_DASHBOARD_THEMES`

## Verification

- `npm run typecheck` ✓ (sin errores)
- `npm run build` ✓ (1.99s, 481 modules, sin warnings nuevos)
- 2 files changed, 67 insertions(+), 0 deletions(-)

## Trade-offs / futuras iteraciones

- El theme hereda las reglas de typography del README (`text-xs` floor, opacity ≥ 0.7, `text-display` para brand chrome) — no introducimos overrides que las rompan.
- Si quieres un look **más agresivo** (reemplazar chrome, AppShell, bento layout del CSS Theme) abriríamos un PR separado de tipo `style(web): redesign chrome` con migración pixel-perfect. Aquí hemos tomado el camino conservador: añadir, no romper.