### PR TITLE
fix(nous): require limit>0 in header-path exhausted-bucket check

### DIFF
--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -246,8 +246,8 @@ def is_genuine_nous_rate_limit(
 
 def _parse_buckets_from_headers(
     headers: Optional[Mapping[str, str]],
-) -> dict[str, tuple[Optional[int], Optional[float]]]:
-    """Extract (remaining, reset_seconds) per bucket from x-ratelimit-* headers.
+) -> dict[str, tuple[Optional[int], Optional[int], Optional[float]]]:
+    """Extract (limit, remaining, reset_seconds) per bucket from x-ratelimit-* headers.
 
     Returns empty dict when no rate-limit headers are present.
     """
@@ -274,20 +274,30 @@ def _parse_buckets_from_headers(
         except (TypeError, ValueError):
             return None
 
-    result: dict[str, tuple[Optional[int], Optional[float]]] = {}
+    result: dict[str, tuple[Optional[int], Optional[int], Optional[float]]] = {}
     for tag in ("requests", "requests-1h", "tokens", "tokens-1h"):
+        limit = _maybe_int(lowered.get(f"x-ratelimit-limit-{tag}"))
         remaining = _maybe_int(lowered.get(f"x-ratelimit-remaining-{tag}"))
         reset = _maybe_float(lowered.get(f"x-ratelimit-reset-{tag}"))
-        if remaining is not None or reset is not None:
-            result[tag] = (remaining, reset)
+        if limit is not None or remaining is not None or reset is not None:
+            result[tag] = (limit, remaining, reset)
     return result
 
 
 def _has_exhausted_bucket(
-    buckets: Mapping[str, tuple[Optional[int], Optional[float]]],
+    buckets: Mapping[str, tuple[Optional[int], Optional[int], Optional[float]]],
 ) -> bool:
-    """Return True when any bucket has remaining == 0 AND a meaningful reset window."""
-    for remaining, reset in buckets.values():
+    """Return True when any bucket has remaining == 0 AND a meaningful reset window.
+
+    A bucket with no enforced limit (``limit`` absent or <= 0) is skipped:
+    Nous emits the full x-ratelimit-* suite on every response, so a
+    non-enforced dimension can report ``remaining == 0`` of a ``0`` cap,
+    which is not a genuine quota exhaustion. Mirrors the ``limit <= 0``
+    guard in ``_has_exhausted_bucket_in_object``.
+    """
+    for limit, remaining, reset in buckets.values():
+        if limit is None or limit <= 0:
+            continue
         if remaining is None or remaining > 0:
             continue
         if reset is None:

--- a/tests/agent/test_nous_rate_guard.py
+++ b/tests/agent/test_nous_rate_guard.py
@@ -389,3 +389,35 @@ class TestIsGenuineNousRateLimit:
         assert is_genuine_nous_rate_limit(
             headers=None, last_known_state=None
         ) is False
+
+
+class TestIsGenuineHeaderLimitGuard:
+    """Header path must require an enforced limit before tripping the breaker,
+    mirroring the object-path ``limit > 0`` guard in
+    ``_has_exhausted_bucket_in_object``."""
+
+    def test_zero_remaining_without_limit_header_is_not_genuine(self):
+        from agent.nous_rate_guard import is_genuine_nous_rate_limit
+
+        # Exhausted bucket but NO enforced limit header: Nous emits the
+        # full x-ratelimit-* suite on every response, so a dimension that
+        # is not enforced for the current model can report remaining == 0
+        # of a 0/absent cap. That must NOT trip the cross-session breaker.
+        headers = {
+            "x-ratelimit-remaining-tokens-1h": "0",
+            "x-ratelimit-reset-tokens-1h": "1800",
+        }
+        assert is_genuine_nous_rate_limit(headers=headers) is False
+
+    def test_zero_remaining_with_enforced_limit_is_genuine(self):
+        from agent.nous_rate_guard import is_genuine_nous_rate_limit
+
+        # Same exhaustion WITH an enforced limit is a genuine (a)-class
+        # rate limit and SHOULD trip the breaker. Parity guard ensuring the
+        # added limit check does not over-suppress real exhaustion.
+        headers = {
+            "x-ratelimit-limit-tokens-1h": "1000000",
+            "x-ratelimit-remaining-tokens-1h": "0",
+            "x-ratelimit-reset-tokens-1h": "1800",
+        }
+        assert is_genuine_nous_rate_limit(headers=headers) is True


### PR DESCRIPTION
## What does this PR do?

`_has_exhausted_bucket` — the header path of `is_genuine_nous_rate_limit` in `agent/nous_rate_guard.py` — trips the cross-session Nous rate breaker on any bucket reporting `remaining == 0` with a `>= 60s` reset window, **without** checking whether that dimension has an enforced limit. The object-path twin (`_has_exhausted_bucket_in_object`) already guards with `if limit <= 0: continue`, so today the two signals can return opposite verdicts on the same logical rate-limit state.

Nous Portal emits the full `x-ratelimit-*` suite on every response (per the function's own docstring). A dimension that is **not enforced** for the current model reports `remaining: 0` of a `0`/absent cap. The header path reads that as genuine quota exhaustion and writes the cross-session breaker file, blocking **all** Nous models for minutes on a perfectly healthy account — the (b)-class upstream-capacity false-positive that the object path was hardened against but which stayed live on the header path.

This PR parses `x-ratelimit-limit-<tag>` in `_parse_buckets_from_headers` and skips buckets with no enforced limit in `_has_exhausted_bucket`, mirroring the object path's `limit > 0` guard so both signals agree.

## Related Issue

<!-- No filed issue — author-found regression in the Nous rate-guard breaker logic. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/nous_rate_guard.py`: `_parse_buckets_from_headers` now also reads `x-ratelimit-limit-<tag>` and emits a `(limit, remaining, reset)` 3-tuple per bucket; `_has_exhausted_bucket` skips any bucket with `limit` absent or `<= 0` before considering it exhausted. Both helpers have exactly one caller each, so the tuple-shape change is fully contained. The object path is unchanged (it was already correct).
- `tests/agent/test_nous_rate_guard.py`: added `TestIsGenuineHeaderLimitGuard` with a fail-before/pass-after regression test plus a parity test confirming genuine exhaustion still trips.

## How to Test

1. Run the full file: `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/agent/test_nous_rate_guard.py -v` — 34 passed.
2. Regression proof (before): on `origin/main`, `is_genuine_nous_rate_limit(headers={"x-ratelimit-remaining-tokens-1h": "0", "x-ratelimit-reset-tokens-1h": "1800"})` returns `True` (false breaker trip — `test_zero_remaining_without_limit_header_is_not_genuine` FAILS).
3. Regression proof (after): the same call returns `False`; `test_zero_remaining_with_enforced_limit_is_genuine` confirms a bucket carrying `x-ratelimit-limit-tokens-1h` still trips correctly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on both touched helpers updated; N/A for README/docs
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure header-parsing logic, platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A