### PR TITLE
fix: prevent dashboard WebSocket crash on concurrent browser tabs

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12496,7 +12496,17 @@ async def gateway_ws(ws: WebSocket) -> None:
 
     from tui_gateway.ws import handle_ws
 
-    await handle_ws(ws)
+    try:
+        await handle_ws(ws)
+    except Exception:
+        import logging
+        logging.getLogger("hermes.dashboard.ws").exception(
+            "gateway_ws: handle_ws crashed"
+        )
+        try:
+            await ws.close()
+        except Exception:
+            pass
 
 
 # ---------------------------------------------------------------------------

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -181,7 +181,12 @@ async def handle_ws(ws: Any) -> None:
     disconnect_reason = "not_connected"
 
     try:
-        await ws.accept()
+        try:
+            await ws.accept()
+        except (RuntimeError, Exception) as exc:
+            _log.warning("ws accept failed peer=%s error=%s", peer, exc)
+            disconnect_reason = "accept_failed"
+            return
         disconnect_reason = "connected"
         # Push small streamed frames out immediately instead of letting Nagle
         # batch them — keeps the live token cadence intact for GUI clients.


### PR DESCRIPTION
## Summary

When two browser tabs connect to the dashboard simultaneously, a race condition in uvicorn's WebSocket state machine causes `ws.accept()` to throw:

```
RuntimeError: Expected ASGI message 'websocket.send' or 'websocket.close', but got 'websocket.accept'
```

This exception was **unhandled** — it propagated through `gateway_ws()` (no try/except) and crashed the **entire uvicorn server**, killing the dashboard for all clients (ERR_CONNECTION_REFUSED).

## Reproduction

1. Start the dashboard: `hermes dashboard`
2. Open `http://127.0.0.1:9119` in a browser tab
3. Open the same URL in a second tab at roughly the same time
4. **Before fix:** second tab gets ERR_CONNECTION_REFUSED; dashboard process is dead
5. **After fix:** both tabs connect normally; any WS state errors are logged and the connection is closed cleanly

## Fix (two layers)

**1. `tui_gateway/ws.py`** — wrap `ws.accept()` in try/except so a failed accept is logged and handled gracefully instead of crashing:
```python
try:
    await ws.accept()
except (RuntimeError, Exception) as exc:
    _log.warning("ws accept failed peer=%s error=%s", peer, exc)
    disconnect_reason = "accept_failed"
    return
```

**2. `hermes_cli/web_server.py`** — wrap `handle_ws()` call in `gateway_ws()` as defense-in-depth so any unhandled exception in the WS handler is caught and logged without killing the server:
```python
try:
    await handle_ws(ws)
except Exception:
    logging.getLogger("hermes.dashboard.ws").exception(
        "gateway_ws: handle_ws crashed"
    )
    try:
        await ws.close()
    except Exception:
        pass
```

## Test Plan

- [ ] Start dashboard, open two browser tabs simultaneously — both should connect
- [ ] Verify dashboard stays alive after any WS connection failure
- [ ] Verify normal single-tab dashboard chat still works
- [ ] Check logs for `"ws accept failed"` warning on failed connections