### PR TITLE
test: add sanitized high-token session regression

### DIFF
--- a/tests/fixtures/observability/high_token_sessions.json
+++ b/tests/fixtures/observability/high_token_sessions.json
@@ -1,0 +1,22 @@
+{
+  "sessions": [
+    {
+      "id": "synthetic-cache-friendly-long-work-session",
+      "source_session_id_redacted": "[REDACTED_SESSION_ID]",
+      "description": "Sanitized aggregate-only fixture modeled on a high-token phone/engineer session. No transcript, prompts, tool output, file paths, or user content are included.",
+      "profile": "engineer",
+      "agent_name": "phone",
+      "model": "gpt-5.5",
+      "api_calls": 320,
+      "agent_turns": 28,
+      "max_api_prompt_tokens": 233572,
+      "max_request_message_count": 579,
+      "api_input_tokens": 40300611,
+      "api_output_tokens": 29453,
+      "api_cache_read_tokens": 38537216,
+      "assumed_context_length_tokens": 512000,
+      "compression_threshold_ratio": 0.5,
+      "diagnosis": "Long legitimate work with repeated largely unchanged context. Provider prompt-cache reads covered most input tokens; the largest single request stayed below a 50% threshold of a 512K context window, so cumulative session tokens alone must not trigger compression."
+    }
+  ]
+}

--- a/tests/run_agent/test_high_token_session_regression.py
+++ b/tests/run_agent/test_high_token_session_regression.py
@@ -1,0 +1,115 @@
+"""Sanitized regressions for high-token, cache-friendly Hermes sessions.
+
+The fixture intentionally stores aggregate counts only. It models the expensive
+pattern from a production session without retaining transcript text, tool
+outputs, file paths, prompts, or private user data.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+from agent.context_compressor import ContextCompressor
+from agent.prompt_caching import apply_anthropic_cache_control
+
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "observability"
+    / "high_token_sessions.json"
+)
+
+
+def _fixture() -> dict:
+    data = json.loads(FIXTURE_PATH.read_text())
+    return data["sessions"][0]
+
+
+def _has_cache_marker(message: dict) -> bool:
+    if message.get("cache_control"):
+        return True
+    content = message.get("content")
+    if isinstance(content, list):
+        return any(
+            isinstance(part, dict) and bool(part.get("cache_control"))
+            for part in content
+        )
+    return False
+
+
+def _synthetic_long_messages(turns: int = 28) -> list[dict]:
+    """Build a transcript-shaped fixture with synthetic, non-private content."""
+    messages: list[dict] = [
+        {
+            "role": "system",
+            "content": "stable cached system/context prefix " * 512,
+        }
+    ]
+    for idx in range(turns):
+        messages.append({"role": "user", "content": f"synthetic request {idx}"})
+        messages.append(
+            {
+                "role": "assistant",
+                "content": "synthetic progress reply " + ("detail " * 64),
+            }
+        )
+    return messages
+
+
+class TestHighTokenSessionFixture:
+    def test_fixture_is_aggregate_only_and_cache_friendly(self):
+        session = _fixture()
+
+        assert "source_session_id_redacted" in session
+        assert "transcript" not in session
+        assert "messages" not in session
+        assert "tool_outputs" not in session
+
+        cache_read_ratio = session["api_cache_read_tokens"] / session["api_input_tokens"]
+        uncached_input_per_call = (
+            session["api_input_tokens"] - session["api_cache_read_tokens"]
+        ) / session["api_calls"]
+
+        assert cache_read_ratio > 0.95
+        assert uncached_input_per_call < 6_000
+
+    def test_cumulative_session_tokens_do_not_drive_compression_threshold(self):
+        session = _fixture()
+        compressor = ContextCompressor(
+            model=session["model"],
+            threshold_percent=session["compression_threshold_ratio"],
+            quiet_mode=True,
+            config_context_length=session["assumed_context_length_tokens"],
+        )
+
+        assert compressor.threshold_tokens == 256_000
+        assert session["max_api_prompt_tokens"] < compressor.threshold_tokens
+
+        # The production pattern was expensive because many requests reused a
+        # large mostly-cached prefix. Compression should key off the current
+        # request size, not the cumulative token sum for the whole session.
+        assert not compressor.should_compress(session["max_api_prompt_tokens"])
+        assert compressor.should_compress(session["api_input_tokens"])
+
+    def test_prompt_cache_markers_preserve_stable_prefix_on_long_history(self):
+        session = _fixture()
+        messages = _synthetic_long_messages(turns=session["agent_turns"])
+        original = copy.deepcopy(messages)
+
+        cached = apply_anthropic_cache_control(messages, cache_ttl="5m")
+
+        assert messages == original, "cache-control insertion must not mutate history"
+        assert _has_cache_marker(cached[0]), "stable system prefix must stay cacheable"
+
+        non_system_indexes = [
+            idx for idx, message in enumerate(cached) if message.get("role") != "system"
+        ]
+        marked_non_system = [
+            idx for idx in non_system_indexes if _has_cache_marker(cached[idx])
+        ]
+
+        assert marked_non_system == non_system_indexes[-3:]
+        assert sum(1 for message in cached if _has_cache_marker(message)) == 4


### PR DESCRIPTION
## Summary
- add an aggregate-only sanitized fixture for a high-token, cache-friendly Hermes session pattern
- add regression tests that verify the fixture contains no transcript/tool output, that high cumulative tokens do not drive compression when a single request is below threshold, and that prompt-cache markers still protect the stable prefix plus recent messages

## Evidence
- Honeycomb aggregate classification: expensive long session with >95% API input tokens served from prompt cache and max observed request below a 50% / 512K compression threshold; no raw transcript content or raw source session id copied into the fixture
- scripts/run_tests.sh tests/run_agent/test_high_token_session_regression.py tests/run_agent/test_infinite_compaction_loop.py tests/run_agent/test_compression_boundary.py
- git diff --check / staged diff checks
- py_compile for tests/run_agent/test_high_token_session_regression.py
- local privacy scan confirmed no source session id or common secret markers in the new fixture/test

## Review note
- autoreview attempted with Codex and Copilot, but both external reviewer auth paths failed locally (Codex refresh token expired/reused; Copilot unauthenticated). I performed a fallback manual diff/privacy review and kept the fixture aggregate-only.
