### PR TITLE
fix(photon): ignore iMessage media placeholders

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -621,6 +621,19 @@ class PhotonAdapter(BasePlatformAdapter):
             )
 
         ctype = content.get("type")
+        if ctype == "text":
+            raw_text = content.get("text") or ""
+            # iMessage emits U+FFFC OBJECT REPLACEMENT CHARACTER as a transient
+            # placeholder for some media bubbles (notably voice notes). Photon
+            # can then deliver the real attachment/voice event immediately
+            # afterwards with a different message id. If we dispatch the
+            # placeholder as a standalone text turn, the subsequent media event
+            # arrives while that turn is active and the gateway sends a bogus
+            # "Interrupting current task" busy ack. Drop placeholder-only text
+            # at the platform boundary; the real media event carries the bytes.
+            if raw_text.strip() == "\ufffc":
+                logger.debug("[photon] ignoring iMessage object-placeholder text event")
+                return
         if ctype == "reaction":
             # Route only tapbacks on messages WE sent — those are implicitly
             # addressed to the bot (feishu precedent: synthetic text event).

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "kelsia014@gmail.com": "kelsia14",  # PR #54514 (Photon iMessage voice placeholder fix)
     "carlosmcejas@gmail.com": "cmcejas",  # PR #41188 salvage (early Telegram auth gate before event build/observe; #40863)
     "ha-agent@homelab.4410.us": "oreoluwa",  # PR #49845 salvage (skip preflight content-type probe for OAuth MCP servers so OAuth discovery runs; Akiflow/Hospitable)
     "prathamesh290504@gmail.com": "PRATHAMESH75",  # PR #37550 salvage (ExecStopPost cgroup-orphan reaper to unblock systemd restart; #37454)

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -67,6 +67,24 @@ async def test_dispatch_text_dm(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_dispatch_ignores_imessage_object_placeholder_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Voice notes may arrive as U+FFFC placeholder text followed by media.
+
+    Dispatching the placeholder starts a bogus text turn; the real voice event
+    then lands during that turn and triggers the gateway's busy interrupt ack.
+    Drop placeholder-only text so only the actual voice/attachment is processed.
+    """
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    await adapter._dispatch_inbound(_dm_event("\ufffc", msg_id="placeholder"))
+
+    assert captured == []
+
+
+@pytest.mark.asyncio
 async def test_dispatch_group_type(monkeypatch: pytest.MonkeyPatch) -> None:
     adapter = _make_adapter(monkeypatch)
     captured = _capture(adapter, monkeypatch)


### PR DESCRIPTION
## Summary

Fixes a Photon/iMessage voice-note race where iMessage first emits a standalone U+FFFC object placeholder text event and then immediately emits the actual voice/attachment event.

Before this patch, Hermes treated the placeholder as a real text turn. The actual voice event then arrived while that bogus turn was active, triggering the gateway busy handler and sending a misleading:

```text
⚡ Interrupting current task...
```

This drops placeholder-only Photon text events at the platform boundary so the real voice/attachment event is processed normally.

## Test plan

```bash
pytest tests/plugins/platforms/photon/ -q
```

Result:

```text
109 passed
```
