### PR TITLE
fix: fall back to HERMES_HOME for remote file attachments

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3942,6 +3942,57 @@ def test_file_attach_uploads_remote_file_into_session_workspace(monkeypatch, tmp
         server._sessions.pop("sid", None)
 
 
+def test_file_attach_falls_back_to_hermes_home_when_workspace_is_read_only(
+    monkeypatch, tmp_path
+):
+    """Container case: /opt/hermes is read-only, so stage uploads in HERMES_HOME."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    token = set_hermes_home_override(home)
+    workspace_upload_dir = (workspace / ".hermes" / "desktop-attachments").resolve()
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: None
+
+    real_access = os.access
+
+    def fake_access(path, mode):
+        if Path(path).resolve() == workspace_upload_dir and mode == os.W_OK:
+            return False
+        return real_access(path, mode)
+
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+    monkeypatch.setattr(server.os, "access", fake_access)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "file.attach",
+                "params": {
+                    "session_id": "sid",
+                    "path": "/Users/alice/Downloads/report.txt",
+                    "name": "report.txt",
+                    "data_url": "data:text/plain;base64,aGVsbG8gd29ybGQ=",
+                },
+            }
+        )
+
+        stored = (home / "desktop-attachments" / "session-key" / "report.txt").resolve()
+        assert resp["result"]["attached"] is True
+        assert resp["result"]["uploaded"] is True
+        assert resp["result"]["path"] == str(stored)
+        assert resp["result"]["ref_text"] == f"@file:{stored}"
+        assert stored.read_text(encoding="utf-8") == "hello world"
+    finally:
+        server._sessions.pop("sid", None)
+        reset_hermes_home_override(token)
+
+
 def test_file_attach_copies_gateway_visible_file_outside_workspace(monkeypatch, tmp_path):
     """Local case: gateway can see the file but it's outside the workspace → copy in."""
     workspace = tmp_path / "workspace"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7396,9 +7396,22 @@ def _attachment_ref_path(session: dict, target: Path) -> str:
 
 
 def _desktop_attachment_dir(session: dict) -> Path:
-    root = Path(_session_cwd(session)).resolve() / ".hermes" / "desktop-attachments"
-    root.mkdir(parents=True, exist_ok=True)
-    return root
+    import errno as _errno
+
+    workspace_root = Path(_session_cwd(session)).resolve() / ".hermes" / "desktop-attachments"
+    try:
+        workspace_root.mkdir(parents=True, exist_ok=True)
+        if os.access(workspace_root, os.W_OK):
+            return workspace_root
+    except OSError as exc:
+        if exc.errno not in {_errno.EACCES, _errno.EPERM, _errno.EROFS}:
+            raise
+
+    session_slug = _sanitize_attachment_name(str(session.get("session_key") or "session"))
+    home = Path(str(session.get("profile_home") or get_hermes_home())).expanduser()
+    fallback_root = home / "desktop-attachments" / session_slug
+    fallback_root.mkdir(parents=True, exist_ok=True)
+    return fallback_root
 
 
 def _sanitize_attachment_name(name: str) -> str:


### PR DESCRIPTION
## Summary
Fix remote document attachment staging when the session workspace is read-only, such as the Dockerized WSC deployment where sessions can run with cwd `/opt/hermes`.

## Changes
- keep staging attachments in the session workspace when that directory is writable
- fall back to `$HERMES_HOME/desktop-attachments/<session-key>/` when the workspace staging directory is not writable
- add a regression test covering the read-only workspace container case

## Verification
- reproduced the failing `file.attach` path locally with a simulated read-only workspace and confirmed fallback staging works
- validated the running WSC containers after patching: a session with cwd `/opt/hermes` now stages into `/opt/data/desktop-attachments/...` instead of failing with `[Errno 13] Permission denied: '/opt/hermes/.hermes'`
- `pytest` was not runnable in this checkout because the Hermes venv does not currently have `pytest` installed
