### PR TITLE
fix(tui): fall back to config terminal.backend when TERMINAL_ENV is unset in dashboard/TUI process

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1369,8 +1369,25 @@ def _terminal_task_cwd(session: dict | None) -> str:
     point at nonsense.  Non-local terminal backends are different: their cwd is
     inside the target environment, so an SSH path like /home/user/workspace may
     not exist on the local macOS host but is still the correct execution cwd.
+
+    When ``TERMINAL_ENV`` is unset (dashboard/TUI process) the config's
+    ``terminal.backend`` is consulted as a fallback so the non-local cwd
+    resolution path is taken even when the dashboard entrypoint did not call
+    ``apply_terminal_config_to_env`` on its own ``os.environ``.
     """
     backend = (os.environ.get("TERMINAL_ENV") or "").strip().lower()
+    if not backend or backend == "local":
+        # Fall back to config when TERMINAL_ENV is unset (dashboard/TUI process
+        # never calls apply_terminal_config_to_env on os.environ).
+        try:
+            terminal_cfg = _load_cfg().get("terminal", {})
+            if isinstance(terminal_cfg, dict):
+                cfg_backend = str(terminal_cfg.get("backend") or "").strip().lower()
+                if cfg_backend and cfg_backend != "local":
+                    backend = cfg_backend
+        except Exception:
+            pass
+
     if backend and backend != "local":
         raw = os.environ.get("TERMINAL_CWD", "").strip()
         if not raw:


### PR DESCRIPTION
Fixes #54449

## Description

`_terminal_task_cwd()` in `tui_gateway/server.py` reads `TERMINAL_ENV` from `os.environ` to determine whether the terminal backend is non-local (docker, ssh, etc.) and thus whether to use the configured container/remote cwd or fall back to the host session cwd.

The dashboard/TUI process never calls `apply_terminal_config_to_env()` on its own `os.environ` (that bridge only runs in the spawned agent env copy), so `TERMINAL_ENV` is unset and `_terminal_task_cwd` always assumes the `local` backend. The host cwd gets registered instead of `/workspace`, causing file tools to operate outside the container mount.

This fix adds a config fallback in `_terminal_task_cwd()`: when `TERMINAL_ENV` is unset or explicitly `local`, it reads `terminal.backend` from the config file — the same pattern already used for `TERMINAL_CWD `→ `terminal.cwd`. If the config says the backend is non-local, the non-local cwd resolution path is taken and returns the correct `/workspace` (or configured `terminal.cwd`).

## Verification

- All 4 existing `_terminal_task_cwd` tests pass unchanged (207/208 tests in `test_tui_gateway_server.py` pass; the 1 failure is a pre-existing issue about `_Agent.switch_model`)
- Python compilation check passes
- No secrets, no personal refs, only the fix file changed