### PR TITLE
fix(desktop): stabilize local macOS signing identity

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -257,12 +257,14 @@ if _try_termux_ultrafast_version():
 import argparse
 import hashlib
 import json
+import plistlib
 import shlex
 import shutil
 import stat
 import subprocess
 from pathlib import Path
 from typing import Optional
+
 
 
 from hermes_cli.subcommands._shared import add_accept_hooks_flag as _add_accept_hooks_flag
@@ -5382,21 +5384,104 @@ def _stop_desktop_processes_locking_build(desktop_dir: Path) -> list[int]:
     return stopped
 
 
+def _desktop_macos_bundle_id(bundle: Path) -> Optional[str]:
+    """Return a bundle/framework identifier for local macOS signing."""
+    info = bundle / "Contents" / "Info.plist"
+    if not info.exists() and bundle.suffix == ".framework":
+        candidates = list(bundle.glob("Versions/*/Resources/Info.plist")) + list(
+            bundle.glob("Resources/Info.plist")
+        )
+        if candidates:
+            info = candidates[0]
+    if not info.exists():
+        return None
+    try:
+        data = plistlib.loads(info.read_bytes())
+    except Exception:
+        return None
+    ident = data.get("CFBundleIdentifier")
+    return str(ident) if ident else None
+
+
+def _desktop_macos_local_codesign(app: Path, *, desktop_dir: Path) -> bool:
+    """Ad-hoc sign a local Desktop build with a stable designated requirement.
+
+    Plain ad-hoc signatures get a cdhash-only designated requirement. Every local
+    Desktop rebuild changes that cdhash, so macOS TCC/App Management treats the
+    rebuilt Hermes.app as different code and the user has to grant permission
+    again. Signing bundles with an explicit identifier-only designated
+    requirement keeps local rebuilds relaunchable *and* gives TCC a stable
+    requirement to persist against until a real Developer ID/notarized build is
+    available.
+    """
+    codesign = shutil.which("codesign")
+    if not codesign:
+        return False
+
+    ent_main = desktop_dir / "electron" / "entitlements.mac.plist"
+    ent_inherit = desktop_dir / "electron" / "entitlements.mac.inherit.plist"
+
+    def sign_path(
+        path: Path,
+        *,
+        entitlements: Optional[Path] = None,
+        identifier: Optional[str] = None,
+        runtime: bool = True,
+    ) -> None:
+        args = [codesign, "--force", "--sign", "-"]
+        if runtime:
+            args += ["--options", "runtime"]
+        if entitlements and entitlements.exists():
+            args += ["--entitlements", str(entitlements)]
+        if identifier:
+            args += ["--requirements", f'=designated => identifier "{identifier}"']
+        args.append(str(path))
+        subprocess.run(args, check=True)
+
+    standalone: list[Path] = []
+    for root, _dirs, files in os.walk(app / "Contents"):
+        root_path = Path(root)
+        if any(part.endswith(".app") for part in root_path.parts):
+            continue
+        for name in files:
+            fp = root_path / name
+            if name in {"chrome_crashpad_handler", "spawn-helper"} or fp.suffix in {
+                ".node",
+                ".dylib",
+            }:
+                standalone.append(fp)
+    for fp in sorted(standalone, key=lambda p: len(p.parts), reverse=True):
+        sign_path(fp, runtime=False)
+
+    bundles: list[Path] = []
+    frameworks_dir = app / "Contents" / "Frameworks"
+    if frameworks_dir.exists():
+        for root, _dirs, _files in os.walk(frameworks_dir):
+            p = Path(root)
+            if p.suffix in {".framework", ".app"}:
+                bundles.append(p)
+    for bundle in sorted(set(bundles), key=lambda p: len(p.parts), reverse=True):
+        ident = _desktop_macos_bundle_id(bundle)
+        ent = ent_inherit if bundle.suffix == ".app" and "Helper" in bundle.name else None
+        sign_path(bundle, entitlements=ent, identifier=ident)
+
+    sign_path(app, entitlements=ent_main, identifier=_desktop_macos_bundle_id(app))
+    subprocess.run(
+        [codesign, "--verify", "--deep", "--strict", "--verbose=2", str(app)],
+        check=True,
+    )
+    return True
+
+
 def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
-    """Make a locally-built (unsigned) macOS desktop app survive in-place self-update.
+    """Make a locally-built macOS desktop app survive in-place self-update.
 
-    An ad-hoc-signed .app has no stable Designated Requirement (no Team ID), so
-    when the self-updater rebuilds the bundle in place with a fresh build (a new,
-    different cdhash) Gatekeeper/LaunchServices treats the changed code as
-    tampering and macOS reports "Hermes is damaged and can't be opened." The
-    bundle also inherits the com.apple.quarantine flag from the downloaded
-    installer process chain. Both make the relaunch fail.
-
-    Clearing the quarantine xattrs and re-applying a clean deep ad-hoc signature
-    (omitting the hardened-runtime flag, which is meaningless without a real
-    Developer ID) lets the rebuilt app relaunch. No-op when a real signing
-    identity is configured (CSC_LINK / APPLE_SIGNING_IDENTITY) so a properly
-    signed/notarized build is never clobbered. Best-effort: never raises.
+    A default ad-hoc-signed .app has a cdhash-only Designated Requirement. When
+    Desktop rebuilds in place, the cdhash changes and macOS can treat the new
+    build as a different app for Gatekeeper/TCC/App Management, which makes Brian
+    re-enable permissions. Clear quarantine and re-sign the local bundle with a
+    stable identifier-only requirement while preserving Hermes' macOS
+    entitlements. No-op when a real signing identity is configured.
     """
     if sys.platform != "darwin":
         return
@@ -5409,12 +5494,12 @@ def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
     app = exe.parents[2]
     if not str(app).endswith(".app") or not app.is_dir():
         return
-    codesign = shutil.which("codesign")
-    if not codesign:
-        return
     try:
         subprocess.run(["xattr", "-cr", str(app)], check=False)
-        subprocess.run([codesign, "--force", "--deep", "--sign", "-", str(app)], check=False)
+        if _desktop_macos_local_codesign(app, desktop_dir=desktop_dir):
+            print(
+                "  → macOS local Desktop signing stabilized for TCC/App Management permissions"
+            )
     except Exception as exc:
         print(f"  (warning: macOS relaunch fixup skipped: {exc})")
 

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import plistlib
 import subprocess
 import sys
 from pathlib import Path
@@ -48,6 +49,104 @@ def _make_packaged_executable(root: Path, monkeypatch, platform: str = "darwin")
     exe.parent.mkdir(parents=True)
     exe.write_text("", encoding="utf-8")
     return exe
+
+
+def _write_info_plist(bundle: Path, identifier: str) -> None:
+    info = bundle / "Contents" / "Info.plist"
+    info.parent.mkdir(parents=True, exist_ok=True)
+    info.write_bytes(plistlib.dumps({"CFBundleIdentifier": identifier}))
+
+
+def test_desktop_macos_local_codesign_uses_stable_requirements_and_entitlements(tmp_path, monkeypatch):
+    """Local ad-hoc macOS fixup must not leave Desktop with cdhash-only identity.
+
+    TCC/App Management grants churn when the rebuilt ad-hoc app's designated
+    requirement is just a cdhash. The fixup signs each bundle with an explicit
+    identifier requirement and preserves main/helper entitlements.
+    """
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    ent_main = desktop_dir / "electron" / "entitlements.mac.plist"
+    ent_inherit = desktop_dir / "electron" / "entitlements.mac.inherit.plist"
+    ent_main.parent.mkdir(parents=True)
+    ent_main.write_text("<plist/>", encoding="utf-8")
+    ent_inherit.write_text("<plist/>", encoding="utf-8")
+
+    app = desktop_dir / "release" / "mac-arm64" / "Hermes.app"
+    _write_info_plist(app, "com.nousresearch.hermes")
+    helper = app / "Contents" / "Frameworks" / "Hermes Helper.app"
+    _write_info_plist(helper, "com.nousresearch.hermes.helper")
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(cli_main.shutil, "which", lambda name: "/usr/bin/codesign" if name == "codesign" else None)
+    monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+
+    assert cli_main._desktop_macos_local_codesign(app, desktop_dir=desktop_dir) is True
+
+    sign_calls = [call for call in calls if call[:3] == ["/usr/bin/codesign", "--force", "--sign"]]
+    assert any(
+        "=designated => identifier \"com.nousresearch.hermes\"" in call
+        and str(ent_main) in call
+        for call in sign_calls
+    )
+    assert any(
+        "=designated => identifier \"com.nousresearch.hermes.helper\"" in call
+        and str(ent_inherit) in call
+        for call in sign_calls
+    )
+    assert calls[-1][:4] == ["/usr/bin/codesign", "--verify", "--deep", "--strict"]
+
+
+def test_desktop_macos_local_codesign_reports_false_without_codesign(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    app = desktop_dir / "release" / "mac-arm64" / "Hermes.app"
+
+    monkeypatch.setattr(cli_main.shutil, "which", lambda name: None)
+
+    assert cli_main._desktop_macos_local_codesign(app, desktop_dir=desktop_dir) is False
+
+
+def test_desktop_macos_relaunchable_fixup_clears_quarantine_and_stable_signs(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    monkeypatch.delenv("CSC_LINK", raising=False)
+    monkeypatch.delenv("APPLE_SIGNING_IDENTITY", raising=False)
+
+    exe = _make_packaged_executable(root, monkeypatch, platform="darwin")
+    app = exe.parents[2]
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    signed = []
+
+    def fake_sign(target_app, *, desktop_dir):
+        signed.append((target_app, desktop_dir))
+        return True
+
+    monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(cli_main, "_desktop_macos_local_codesign", fake_sign)
+
+    cli_main._desktop_macos_relaunchable_fixup(desktop_dir)
+
+    assert ["xattr", "-cr", str(app)] in calls
+    assert signed == [(app, desktop_dir)]
+    assert "macOS local Desktop signing stabilized" in capsys.readouterr().out
 
 
 def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -111,6 +111,12 @@ The app checks for updates in the background and offers a one-click update when 
 
 The [manual update process](https://hermes-agent.nousresearch.com/docs/getting-started/updating) also works with the GUI.
 
+### macOS Privacy permissions after local Desktop rebuilds
+
+For locally-built macOS Desktop apps, Hermes re-signs the unpacked app with a stable local designated requirement after rebuilds. If macOS Privacy & Security permissions were granted before this fix, quit and reopen Hermes Desktop and grant the permission one more time so macOS records the stable requirement.
+
+This only applies to local/source builds launched with `hermes desktop`; a notarized release build uses its Developer ID signature instead.
+
 ## Uninstalling
 
 Open **Settings → About → Danger zone** and pick how much to remove:


### PR DESCRIPTION
## Summary
- Stabilize local macOS Desktop ad-hoc signing with identifier-based designated requirements instead of cdhash-only requirements
- Preserve main/helper macOS entitlements during the local relaunch fixup
- Add regression coverage for stable local signing, no-codesign skip behavior, and relaunch fixup xattr/signing flow
- Document the one-time macOS Privacy and Security re-enable step for local/source Desktop builds

## Why
Local `hermes desktop` rebuilds can produce an ad-hoc signed `Hermes.app` whose designated requirement is only its cdhash. Since the cdhash changes on each rebuild, macOS TCC/App Management can treat the rebuilt app as different code and drop privacy grants.

## Validation
- `uv run python -m pytest tests/hermes_cli/test_gui_command.py tests/test_desktop_mac_entitlements.py -q -o 'addopts='` -> 56 passed
- `uv run python -m pytest tests/hermes_cli/test_web_ui_build.py tests/test_desktop_electron_pin.py -q -o 'addopts='` -> 27 passed
- `uv run python -m pytest tests/hermes_cli/test_gui_command.py tests/test_desktop_mac_entitlements.py tests/hermes_cli/test_web_ui_build.py tests/test_desktop_electron_pin.py -q -o 'addopts='` -> 83 passed
- `uv run python -m hermes_cli.main desktop --build-only --force-build` -> build succeeded and printed local signing stabilization message
- `codesign --verify --deep --strict --verbose=2 apps/desktop/release/mac-arm64/Hermes.app` -> valid on disk / satisfies Designated Requirement
- `codesign -d -r- apps/desktop/release/mac-arm64/Hermes.app` -> `designated => identifier "com.nousresearch.hermes"`
- `xattr -p com.apple.quarantine ... || echo none` -> `none`

## Notes
Real Developer ID/CSC signing remains untouched. This only applies to local/source Desktop builds without a configured signing identity.
