### PR TITLE
fix(agent): support vision for local providers not in models.dev (Fixes #54511)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4530,7 +4530,21 @@ class AIAgent:
             cfg = load_config()
             provider = (getattr(self, "provider", "") or "").strip()
             model = (getattr(self, "model", "") or "").strip()
-            return _lookup_supports_vision(provider, model, cfg) is True
+            result = _lookup_supports_vision(provider, model, cfg)
+            if result is not None:
+                return result
+            # Providers that serve local models via an OpenAI-compatible API
+            # and natively support image_url content parts.  When the model
+            # is absent from models.dev (common for locally-served models),
+            # assume vision support so images are not silently stripped.
+            # Users can still override via
+            #   providers.<provider>.models.<model>.supports_vision: false
+            # in config.yaml if needed.
+            _VISION_OPTIMISTIC_PROVIDERS = frozenset({
+                "ollama", "vllm", "lmstudio", "llamafile",
+                "text-generation-webui", "koboldcpp", "tabbyapi",
+            })
+            return provider in _VISION_OPTIMISTIC_PROVIDERS
         except Exception:
             return False
 


### PR DESCRIPTION
## Summary

Fixes #54511

When using local Ollama models (e.g. `ollama/gemma4:e2b`, `llama3.2-vision`, `llava`), image attachments are silently stripped from messages even though the model is vision-capable and Ollama supports native image input via its OpenAI-compatible API.

## Root Cause

`_model_supports_vision()` in `run_agent.py` calls `_lookup_supports_vision(provider, model, cfg) is True`. For local providers like `ollama` that are not in `PROVIDER_TO_MODELS_DEV`, the lookup returns `None`, and `None is True` evaluates to `False` — causing `_prepare_messages_for_non_vision_model` to strip all image content parts.

## Fix

When `_lookup_supports_vision` returns `None` (unknown capability), check if the provider is in a set of known local/self-hosted providers that serve models via OpenAI-compatible APIs with native image support (`ollama`, `vllm`, `lmstudio`, `llamafile`, `text-generation-webui`, `koboldcpp`, `tabbyapi`). For these providers, return `True` instead of `False`.

Users can still explicitly override via `providers.<provider>.models.<model>.supports_vision: false` in config.yaml if a specific model does not support vision.

## Changed files
- `run_agent.py`: Modified `_model_supports_vision()` method (~15 lines changed)