### PR TITLE
fix(memory): validate ENTRY_DELIMITER not in user content (Fixes #54403)

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -77,6 +77,12 @@ from tools.threat_patterns import first_threat_message as _first_threat_message
 
 def _scan_memory_content(content: str) -> Optional[str]:
     """Scan memory content for injection/exfil patterns. Returns error string if blocked."""
+    if ENTRY_DELIMITER in content:
+        return (
+            "Content contains the internal entry delimiter sequence and "
+            "would corrupt stored memory. Please rephrase without the "
+            "literal '\\n§\\n' sequence."
+        )
     return _first_threat_message(content, scope="strict")
 
 


### PR DESCRIPTION
## Summary

Fixes #54403

Content containing the internal entry delimiter sequence (`\n§\n`) causes silent data corruption — the entry is split into multiple pieces on the next read.

## Root Cause

`_scan_memory_content()` validates for injection/exfiltration patterns but does not check whether the content contains `ENTRY_DELIMITER`. When `_entries_for()` splits the file by `ENTRY_DELIMITER`, any user content containing the delimiter is incorrectly treated as a boundary.

## Fix

Added a check at the top of `_scan_memory_content()` that rejects content containing `ENTRY_DELIMITER` with a clear error message, before the existing threat scan.

## Changed files
- `tools/memory_tool.py`: Added delimiter validation in `_scan_memory_content()` (6 lines)