### PR TITLE
fix(resume): filter current session from /resume list (Fixes #54326)

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3135,10 +3135,14 @@ class GatewaySlashCommandsMixin:
         ):
             name = name[1:-1].strip()
 
+        current_entry = self.session_store.get_or_create_session(source)
+        current_session_id = str(current_entry.session_id)
+
         def _list_titled_sessions() -> list[dict]:
             user_source = source.platform.value if source.platform else None
-            sessions = self._session_db.list_sessions_rich(source=user_source, limit=10)
-            return [s for s in sessions if s.get("title")][:10]
+            sessions = self._session_db.list_sessions_rich(source=user_source, limit=11)
+            return [s for s in sessions
+                    if s.get("title") and str(s.get("id")) != current_session_id][:10]
 
         if not name:
             # List recent titled sessions for this user/platform


### PR DESCRIPTION
## Summary

Fixes #54326

`/resume <number>` resolves to the wrong session because the numbered list shown to the user includes the current session, but the user expects it to be excluded (matching `/sessions` behavior).

## Root Cause

`_list_titled_sessions()` in `gateway/slash_commands.py` does not filter out the current session. When the user runs `/resume 3`, the displayed list includes the current session, creating an off-by-one shift between the displayed number and the resolved session.

## Fix

1. Get the current session ID via `self.session_store.get_or_create_session(source).session_id`
2. Filter it out in `_list_titled_sessions()` by comparing `str(s.get("id"))` against `current_session_id`
3. Bump `limit=10` to `limit=11` to compensate for the filtered-out session

The display and numeric resolution now both use the same filtered list, eliminating the off-by-one.

## Changed files
- `gateway/slash_commands.py`: Filter current session in `_list_titled_sessions()` (6 lines changed)