### PR TITLE
feat: add Honcho compartment routing

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1339,6 +1339,31 @@ class HonchoMemoryProvider(MemoryProvider):
             return []
         return list(ALL_TOOL_SCHEMAS)
 
+    def _compartment_access_error(
+        self,
+        tool_name: str,
+        args: dict,
+        compartment: str | None,
+    ) -> str | None:
+        """Return an access error when a named compartment disallows a tool."""
+        name = (compartment or "").strip()
+        if not name or not self._config:
+            return None
+        cfg = self._config.compartments.get(name)
+        if cfg is None:
+            return None
+
+        is_write = tool_name == "honcho_conclude" or (
+            tool_name == "honcho_profile" and bool(args.get("card"))
+        )
+        if is_write:
+            if not cfg.write:
+                return f"Honcho compartment '{name}' is not writable."
+            return None
+        if not cfg.read:
+            return f"Honcho compartment '{name}' is not readable."
+        return None
+
     def _tool_route(self, compartment: str | None) -> tuple[Any | None, str, str | None]:
         """Resolve a Honcho manager/session for an optional compartment.
 
@@ -1403,6 +1428,14 @@ class HonchoMemoryProvider(MemoryProvider):
 
         if not self._manager or not self._session_key:
             return tool_error("Honcho is not active for this session.")
+
+        access_error = self._compartment_access_error(
+            tool_name,
+            args,
+            args.get("compartment"),
+        )
+        if access_error:
+            return tool_error(access_error)
 
         manager, route_session_key, route_error = self._tool_route(args.get("compartment"))
         if route_error:

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -258,6 +258,11 @@ class HonchoMemoryProvider(MemoryProvider):
         self._session_initialized = False
         self._lazy_init_kwargs: Optional[dict] = None
         self._lazy_init_session_id: Optional[str] = None
+        # Preserve the logical session inputs after lazy initialization clears
+        # the network-init refs. Named compartments must route to the same
+        # session title/gateway key as the primary workspace.
+        self._session_init_kwargs: dict = {}
+        self._session_init_session_id: str = ""
         self._init_thread: Optional[threading.Thread] = None
         self._init_lock = threading.Lock()
         self._init_error = ""
@@ -363,6 +368,8 @@ class HonchoMemoryProvider(MemoryProvider):
 
             self._lazy_init_kwargs = dict(kwargs)
             self._lazy_init_session_id = session_id
+            self._session_init_kwargs = dict(kwargs)
+            self._session_init_session_id = session_id
             self._session_key = self._resolve_session_key(cfg, session_id, **kwargs)
 
             # Network-backed session creation can block on Honcho service or DB
@@ -548,10 +555,16 @@ class HonchoMemoryProvider(MemoryProvider):
             return False
 
         try:
+            init_session_id = self._lazy_init_session_id or "hermes-default"
+            init_kwargs = dict(self._lazy_init_kwargs)
+            if not self._session_init_session_id:
+                self._session_init_session_id = init_session_id
+            if not self._session_init_kwargs:
+                self._session_init_kwargs = dict(init_kwargs)
             self._do_session_init(
                 self._config,
-                self._lazy_init_session_id or "hermes-default",
-                **self._lazy_init_kwargs,
+                init_session_id,
+                **init_kwargs,
             )
             # Clear lazy refs
             self._lazy_init_kwargs = None
@@ -1352,8 +1365,13 @@ class HonchoMemoryProvider(MemoryProvider):
 
             cfg = self._config.for_compartment(name)
             client = get_honcho_client(cfg)
-            init_kwargs = dict(self._lazy_init_kwargs or {})
-            init_session_id = self._lazy_init_session_id or self._session_key or "hermes-default"
+            init_kwargs = dict(self._session_init_kwargs or self._lazy_init_kwargs or {})
+            init_session_id = (
+                self._session_init_session_id
+                or self._lazy_init_session_id
+                or self._session_key
+                or "hermes-default"
+            )
             session_key = self._resolve_session_key(cfg, init_session_id, **init_kwargs)
             manager = HonchoSessionManager(
                 honcho=client,

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -33,6 +33,16 @@ logger = logging.getLogger(__name__)
 # Tool schemas (moved from tools/honcho_tools.py)
 # ---------------------------------------------------------------------------
 
+COMPARTMENT_PROPERTY = {
+    "type": "string",
+    "description": (
+        "Optional named Honcho memory compartment to use, e.g. 'ops' or "
+        "'personal'. Compartments map to separate Honcho workspaces/keys, so "
+        "this is a hard routing boundary, not a tag. Omit for the default "
+        "workspace configured for this profile."
+    ),
+}
+
 PROFILE_SCHEMA = {
     "name": "honcho_profile",
     "description": (
@@ -50,6 +60,7 @@ PROFILE_SCHEMA = {
                 "type": "string",
                 "description": "Peer to query. Built-in aliases: 'user' (default), 'ai'. Or pass any peer ID from this workspace.",
             },
+            "compartment": COMPARTMENT_PROPERTY,
             "card": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -83,6 +94,7 @@ SEARCH_SCHEMA = {
                 "type": "string",
                 "description": "Peer to query. Built-in aliases: 'user' (default), 'ai'. Or pass any peer ID from this workspace.",
             },
+            "compartment": COMPARTMENT_PROPERTY,
         },
         "required": ["query"],
     },
@@ -122,6 +134,7 @@ REASONING_SCHEMA = {
                 "type": "string",
                 "description": "Peer to query. Built-in aliases: 'user' (default), 'ai'. Or pass any peer ID from this workspace.",
             },
+            "compartment": COMPARTMENT_PROPERTY,
         },
         "required": ["query"],
     },
@@ -146,6 +159,7 @@ CONTEXT_SCHEMA = {
                 "type": "string",
                 "description": "Peer to query. Built-in aliases: 'user' (default), 'ai'. Or pass any peer ID from this workspace.",
             },
+            "compartment": COMPARTMENT_PROPERTY,
         },
         "required": [],
     },
@@ -175,6 +189,7 @@ CONCLUDE_SCHEMA = {
                 "type": "string",
                 "description": "Peer to query. Built-in aliases: 'user' (default), 'ai'. Or pass any peer ID from this workspace.",
             },
+            "compartment": COMPARTMENT_PROPERTY,
         },
         "required": [],
     },
@@ -207,6 +222,8 @@ class HonchoMemoryProvider(MemoryProvider):
     def __init__(self):
         self._manager = None   # HonchoSessionManager
         self._config = None    # HonchoClientConfig
+        self._compartment_managers: dict[str, Any] = {}
+        self._compartment_session_keys: dict[str, str] = {}
         self._session_key = ""
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
@@ -281,7 +298,9 @@ class HonchoMemoryProvider(MemoryProvider):
     def get_config_schema(self):
         return [
             {"key": "api_key", "description": "Honcho API key", "secret": True, "env_var": "HONCHO_API_KEY", "url": "https://app.honcho.dev"},
+            {"key": "apiKeyFile", "description": "Path to a file containing a Honcho API key/JWT. Relative paths resolve next to honcho.json.", "secret": True},
             {"key": "baseUrl", "description": "Honcho base URL (for self-hosted)"},
+            {"key": "compartments", "description": "Optional named workspace/key compartments such as ops and personal. Each compartment may set workspace, apiKey, apiKeyFile, baseUrl, environment, and session settings."},
         ]
 
     def post_setup(self, hermes_home: str, config: dict) -> None:
@@ -1307,6 +1326,51 @@ class HonchoMemoryProvider(MemoryProvider):
             return []
         return list(ALL_TOOL_SCHEMAS)
 
+    def _tool_route(self, compartment: str | None) -> tuple[Any | None, str, str | None]:
+        """Resolve a Honcho manager/session for an optional compartment.
+
+        The default route uses the provider's primary workspace. A named
+        compartment builds or reuses a separate HonchoSessionManager configured
+        with that compartment's workspace/key. This keeps ops/personal routing
+        at the client boundary instead of relying on tags inside one workspace.
+        """
+        name = (compartment or "").strip()
+        if not name:
+            return self._manager, self._session_key, None
+
+        if not self._config or name not in getattr(self._config, "compartments", {}):
+            return None, "", f"Unknown Honcho compartment: {name}"
+
+        manager = self._compartment_managers.get(name)
+        session_key = self._compartment_session_keys.get(name)
+        if manager is not None and session_key:
+            return manager, session_key, None
+
+        try:
+            from plugins.memory.honcho.client import get_honcho_client
+            from plugins.memory.honcho.session import HonchoSessionManager
+
+            cfg = self._config.for_compartment(name)
+            client = get_honcho_client(cfg)
+            init_kwargs = dict(self._lazy_init_kwargs or {})
+            init_session_id = self._lazy_init_session_id or self._session_key or "hermes-default"
+            session_key = self._resolve_session_key(cfg, init_session_id, **init_kwargs)
+            manager = HonchoSessionManager(
+                honcho=client,
+                config=cfg,
+                context_tokens=cfg.context_tokens,
+                runtime_user_peer_name=init_kwargs.get("user_id") or None,
+                runtime_user_peer_name_alt=init_kwargs.get("user_id_alt") or None,
+            )
+            manager.get_or_create(session_key)
+        except Exception as exc:
+            logger.warning("Honcho compartment '%s' initialization failed: %s", name, exc)
+            return None, "", f"Honcho compartment '{name}' could not be initialized."
+
+        self._compartment_managers[name] = manager
+        self._compartment_session_keys[name] = session_key
+        return manager, session_key, None
+
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         """Handle a Honcho tool call, with lazy session init for tools-only mode."""
         if self._cron_skipped:
@@ -1322,16 +1386,22 @@ class HonchoMemoryProvider(MemoryProvider):
         if not self._manager or not self._session_key:
             return tool_error("Honcho is not active for this session.")
 
+        manager, route_session_key, route_error = self._tool_route(args.get("compartment"))
+        if route_error:
+            return tool_error(route_error)
+        if not manager or not route_session_key:
+            return tool_error("Honcho is not active for this session.")
+
         try:
             if tool_name == "honcho_profile":
                 peer = args.get("peer", "user")
                 card_update = args.get("card")
                 if card_update:
-                    result = self._manager.set_peer_card(self._session_key, card_update, peer=peer)
+                    result = manager.set_peer_card(route_session_key, card_update, peer=peer)
                     if result is None:
                         return tool_error("Failed to update peer card.")
                     return json.dumps({"result": f"Peer card updated ({len(result)} facts).", "card": result})
-                card = self._manager.get_peer_card(self._session_key, peer=peer)
+                card = manager.get_peer_card(route_session_key, peer=peer)
                 if not card:
                     return json.dumps(self._empty_profile_hint(peer))
                 return json.dumps({"result": card})
@@ -1342,8 +1412,8 @@ class HonchoMemoryProvider(MemoryProvider):
                     return tool_error("Missing required parameter: query")
                 max_tokens = min(int(args.get("max_tokens", 800)), 2000)
                 peer = args.get("peer", "user")
-                result = self._manager.search_context(
-                    self._session_key, query, max_tokens=max_tokens, peer=peer
+                result = manager.search_context(
+                    route_session_key, query, max_tokens=max_tokens, peer=peer
                 )
                 if not result:
                     return json.dumps({"result": "No relevant context found."})
@@ -1355,8 +1425,8 @@ class HonchoMemoryProvider(MemoryProvider):
                     return tool_error("Missing required parameter: query")
                 peer = args.get("peer", "user")
                 reasoning_level = args.get("reasoning_level")
-                result = self._manager.dialectic_query(
-                    self._session_key, query,
+                result = manager.dialectic_query(
+                    route_session_key, query,
                     reasoning_level=reasoning_level,
                     peer=peer,
                 )
@@ -1366,7 +1436,7 @@ class HonchoMemoryProvider(MemoryProvider):
 
             elif tool_name == "honcho_context":
                 peer = args.get("peer", "user")
-                ctx = self._manager.get_session_context(self._session_key, peer=peer)
+                ctx = manager.get_session_context(route_session_key, peer=peer)
                 if not ctx:
                     return json.dumps({"result": "No context available yet."})
                 parts = []
@@ -1396,11 +1466,11 @@ class HonchoMemoryProvider(MemoryProvider):
                     return tool_error("Exactly one of conclusion or delete_id must be provided.")
 
                 if has_delete_id:
-                    ok = self._manager.delete_conclusion(self._session_key, delete_id, peer=peer)
+                    ok = manager.delete_conclusion(route_session_key, delete_id, peer=peer)
                     if ok:
                         return json.dumps({"result": f"Conclusion {delete_id} deleted."})
                     return tool_error(f"Failed to delete conclusion {delete_id}.")
-                ok = self._manager.create_conclusion(self._session_key, conclusion, peer=peer)
+                ok = manager.create_conclusion(route_session_key, conclusion, peer=peer)
                 if ok:
                     return json.dumps({"result": f"Conclusion saved for {peer}: {conclusion}"})
                 return tool_error("Failed to save conclusion.")

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -269,6 +269,7 @@ class HonchoMemoryProvider(MemoryProvider):
 
         # Port #4053: cron guard — when True, plugin is fully inactive
         self._cron_skipped = False
+        self._agent_identity = ""
 
     @property
     def name(self) -> str:
@@ -340,6 +341,12 @@ class HonchoMemoryProvider(MemoryProvider):
                 return
 
             self._config = cfg
+            self._agent_identity = str(
+                kwargs.get("agent_identity")
+                or getattr(cfg, "ai_peer", None)
+                or getattr(cfg, "host", None)
+                or ""
+            ).strip()
 
             # ----- B1: recall_mode from config -----
             self._recall_mode = cfg.recall_mode  # "context", "tools", or "hybrid"
@@ -1352,6 +1359,14 @@ class HonchoMemoryProvider(MemoryProvider):
         cfg = self._config.compartments.get(name)
         if cfg is None:
             return None
+
+        allowlists = getattr(self._config, "agent_compartments", {}) or {}
+        if allowlists:
+            agent_id = (self._agent_identity or self._config.ai_peer or self._config.host or "").strip()
+            allowed = allowlists.get(agent_id)
+            if not agent_id or allowed is None or name not in allowed:
+                display_agent = agent_id or "unknown"
+                return f"Honcho compartment '{name}' is not allowed for agent '{display_agent}'."
 
         is_write = tool_name == "honcho_conclude" or (
             tool_name == "honcho_profile" and bool(args.get("card"))

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -1017,6 +1018,82 @@ def _all_profile_host_configs() -> list[tuple[str, str, dict]]:
     return results
 
 
+def _compartment_auth_label(block: dict) -> str:
+    """Return a display-safe auth label for a compartment block."""
+    if block.get("apiKeyFile"):
+        return f"apiKeyFile:{block['apiKeyFile']}"
+    if block.get("apiKey"):
+        return "apiKey:set"
+    return "inherited/default"
+
+
+def cmd_compartments(args) -> None:
+    """List or configure named Honcho workspace/key compartments."""
+    cfg = _read_config()
+    host = _host_key()
+    hosts = cfg.setdefault("hosts", {})
+    block = hosts.setdefault(host, {})
+    action = getattr(args, "compartment_action", None) or "list"
+
+    if action == "set":
+        name = (getattr(args, "name", "") or "").strip()
+        if not re.fullmatch(r"[A-Za-z0-9_-]+", name):
+            print("  Compartment name must contain only letters, numbers, '_' or '-'.")
+            return
+
+        workspace = (getattr(args, "workspace", "") or "").strip()
+        if not workspace:
+            print("  --workspace is required when setting a compartment.")
+            return
+
+        api_key = getattr(args, "api_key", None)
+        api_key_file = getattr(args, "api_key_file", None)
+        if api_key and api_key_file:
+            print("  Use only one of --api-key or --api-key-file.")
+            return
+
+        compartment = block.setdefault("compartments", {}).setdefault(name, {})
+        compartment["workspace"] = workspace
+        if api_key_file:
+            compartment["apiKeyFile"] = api_key_file
+            compartment.pop("apiKey", None)
+        elif api_key:
+            compartment["apiKey"] = api_key
+            compartment.pop("apiKeyFile", None)
+
+        for attr, key in (
+            ("base_url", "baseUrl"),
+            ("environment", "environment"),
+            ("session_strategy", "sessionStrategy"),
+            ("manual_session_name", "manualSessionName"),
+        ):
+            value = getattr(args, attr, None)
+            if value:
+                compartment[key] = value
+
+        _write_config(cfg)
+        print(f"  Compartment '{name}' configured for host '{host}'.")
+        print(f"  Workspace: {workspace}")
+        print(f"  Auth:      {_compartment_auth_label(compartment)}")
+        return
+
+    compartments = block.get("compartments") or {}
+    print(f"\nHoncho compartments [{host}]\n" + "─" * 55)
+    if not compartments:
+        print("  No named compartments configured.")
+        print("  Example:")
+        print("    hermes honcho compartments set ops --workspace james-ops-prod --api-key-file runtime-keys/james-ops-prod.jwt\n")
+        return
+
+    print(f"  {'Name':<16} {'Workspace':<28} Auth")
+    print(f"  {'─' * 16} {'─' * 28} {'─' * 18}")
+    for name in sorted(compartments):
+        item = compartments[name] if isinstance(compartments[name], dict) else {}
+        workspace = str(item.get("workspace") or "(default)")
+        print(f"  {name:<16} {workspace:<28} {_compartment_auth_label(item)}")
+    print()
+
+
 def cmd_status(args) -> None:
     """Show current Honcho config and connection status."""
     show_all = getattr(args, "all", False)
@@ -1739,6 +1816,8 @@ def honcho_command(args) -> None:
         cmd_status(args)
     elif sub == "status":
         cmd_status(args)
+    elif sub == "compartments":
+        cmd_compartments(args)
     elif sub == "peers":
         cmd_peers(args)
     elif sub == "sessions":
@@ -1765,7 +1844,7 @@ def honcho_command(args) -> None:
         cmd_sync(args)
     else:
         print(f"  Unknown honcho command: {sub}")
-        print("  Available: status, sessions, map, peer, mode, strategy, tokens, identity, migrate, enable, disable, sync\n")
+        print("  Available: status, compartments, sessions, map, peer, mode, strategy, tokens, identity, migrate, enable, disable, sync\n")
 
 
 def register_cli(subparser) -> None:
@@ -1792,6 +1871,30 @@ def register_cli(subparser) -> None:
     status_parser.add_argument(
         "--all", action="store_true", help="Show config overview across all profiles",
     )
+
+    compartments_parser = subs.add_parser(
+        "compartments", help="List or set named Honcho workspace/key compartments",
+    )
+    compartment_subs = compartments_parser.add_subparsers(
+        dest="compartment_action"
+    )
+    compartment_subs.add_parser("list", help="List configured compartments")
+    set_parser = compartment_subs.add_parser(
+        "set", help="Create or update a named compartment",
+    )
+    set_parser.add_argument("name", help="Compartment name, e.g. ops or personal")
+    set_parser.add_argument("--workspace", required=True, help="Honcho workspace ID")
+    auth_group = set_parser.add_mutually_exclusive_group()
+    auth_group.add_argument("--api-key-file", dest="api_key_file", help="Path to API/JWT key file; relative paths resolve next to honcho.json")
+    auth_group.add_argument("--api-key", dest="api_key", help="Inline API/JWT key (prefer --api-key-file for scoped runtime keys)")
+    set_parser.add_argument("--base-url", dest="base_url", help="Honcho base URL for this compartment")
+    set_parser.add_argument("--environment", help="Honcho SDK environment name")
+    set_parser.add_argument(
+        "--session-strategy",
+        choices=("per-session", "per-directory", "per-repo", "global", "manual"),
+        help="Override session strategy for this compartment",
+    )
+    set_parser.add_argument("--manual-session-name", help="Manual session name when using manual strategy")
 
     subs.add_parser("peers", help="Show peer identities across all profiles")
     subs.add_parser("sessions", help="List known Honcho session mappings")

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -1094,6 +1094,65 @@ def cmd_compartments(args) -> None:
     print()
 
 
+def _format_compartment_allowlist(names: list[str]) -> str:
+    return ", ".join(names) if names else "(none)"
+
+
+def cmd_agents(args) -> None:
+    """List or configure agent -> compartment allowlists."""
+    cfg = _read_config()
+    host = _host_key()
+    hosts = cfg.setdefault("hosts", {})
+    block = hosts.setdefault(host, {})
+    action = getattr(args, "agent_action", None) or "list"
+
+    if action == "set":
+        name = (getattr(args, "name", "") or "").strip()
+        if not re.fullmatch(r"[A-Za-z0-9_.-]+", name):
+            print("  Agent name must contain only letters, numbers, '.', '_' or '-'.")
+            return
+
+        compartments = [
+            str(item).strip()
+            for item in (getattr(args, "compartments", None) or [])
+            if str(item).strip()
+        ]
+        if not compartments:
+            print("  --compartments requires at least one compartment name.")
+            return
+        invalid = [item for item in compartments if not re.fullmatch(r"[A-Za-z0-9_-]+", item)]
+        if invalid:
+            print("  Compartment names must contain only letters, numbers, '_' or '-'.")
+            return
+
+        # Preserve first-seen order while removing duplicates.
+        unique_compartments = list(dict.fromkeys(compartments))
+        block.setdefault("agents", {})[name] = unique_compartments
+        _write_config(cfg)
+        print(f"  Agent '{name}' can access: {_format_compartment_allowlist(unique_compartments)}")
+        return
+
+    agents = block.get("agents") or {}
+    print(f"\nHoncho agent compartment access [{host}]\n" + "─" * 55)
+    if not agents:
+        print("  No agent allowlists configured.")
+        print("  Example:")
+        print("    hermes honcho agents set echo --compartments ops\n")
+        return
+
+    print(f"  {'Agent':<20} Compartments")
+    print(f"  {'─' * 20} {'─' * 28}")
+    for name in sorted(agents):
+        values = agents[name]
+        if isinstance(values, str):
+            values = [values]
+        if not isinstance(values, list):
+            values = []
+        compartments = [str(item) for item in values]
+        print(f"  {name:<20} {_format_compartment_allowlist(compartments)}")
+    print()
+
+
 def cmd_status(args) -> None:
     """Show current Honcho config and connection status."""
     show_all = getattr(args, "all", False)
@@ -1818,6 +1877,8 @@ def honcho_command(args) -> None:
         cmd_status(args)
     elif sub == "compartments":
         cmd_compartments(args)
+    elif sub == "agents":
+        cmd_agents(args)
     elif sub == "peers":
         cmd_peers(args)
     elif sub == "sessions":
@@ -1844,7 +1905,7 @@ def honcho_command(args) -> None:
         cmd_sync(args)
     else:
         print(f"  Unknown honcho command: {sub}")
-        print("  Available: status, compartments, sessions, map, peer, mode, strategy, tokens, identity, migrate, enable, disable, sync\n")
+        print("  Available: status, compartments, agents, sessions, map, peer, mode, strategy, tokens, identity, migrate, enable, disable, sync\n")
 
 
 def register_cli(subparser) -> None:
@@ -1895,6 +1956,22 @@ def register_cli(subparser) -> None:
         help="Override session strategy for this compartment",
     )
     set_parser.add_argument("--manual-session-name", help="Manual session name when using manual strategy")
+
+    agents_parser = subs.add_parser(
+        "agents", help="List or set agent compartment allowlists",
+    )
+    agent_subs = agents_parser.add_subparsers(dest="agent_action")
+    agent_subs.add_parser("list", help="List agent compartment allowlists")
+    agent_set_parser = agent_subs.add_parser(
+        "set", help="Create or update an agent compartment allowlist",
+    )
+    agent_set_parser.add_argument("name", help="Agent name, e.g. echo, bandit, miloh")
+    agent_set_parser.add_argument(
+        "--compartments",
+        nargs="+",
+        required=True,
+        help="Allowed compartment names for this agent, e.g. ops personal",
+    )
 
     subs.add_parser("peers", help="Show peer identities across all profiles")
     subs.add_parser("sessions", help="List known Honcho session mappings")

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -363,6 +363,8 @@ class HonchoCompartmentConfig:
     timeout: float | None = None
     read: bool = True
     write: bool = True
+    session_strategy: str | None = None
+    manual_session_name: str | None = None
     raw: dict[str, Any] = field(default_factory=dict)
     api_key_explicit: bool = False
 
@@ -449,6 +451,7 @@ class HonchoClientConfig:
     ai_observe_others: bool = True
     # Session resolution
     session_strategy: str = "per-directory"
+    manual_session_name: str | None = None
     session_peer_prefix: bool = False
     sessions: dict[str, str] = field(default_factory=dict)
     # Raw global config for anything else consumers need
@@ -575,6 +578,10 @@ class HonchoClientConfig:
             host_block.get("sessionStrategy")
             or raw.get("sessionStrategy", "per-directory")
         )
+        manual_session_name = (
+            host_block.get("manualSessionName")
+            or raw.get("manualSessionName")
+        )
         host_prefix = host_block.get("sessionPeerPrefix")
         session_peer_prefix = (
             host_prefix if host_prefix is not None
@@ -637,6 +644,8 @@ class HonchoClientConfig:
                     timeout=comp_timeout,
                     read=bool(raw_block.get("read", True)),
                     write=bool(raw_block.get("write", True)),
+                    session_strategy=raw_block.get("sessionStrategy"),
+                    manual_session_name=raw_block.get("manualSessionName"),
                     raw=raw_block,
                     api_key_explicit=comp_key_explicit,
                 )
@@ -757,6 +766,7 @@ class HonchoClientConfig:
                 host_block.get("observation") or raw.get("observation"),
             ),
             session_strategy=session_strategy,
+            manual_session_name=manual_session_name,
             session_peer_prefix=session_peer_prefix,
             sessions=raw.get("sessions", {}),
             raw=raw,
@@ -783,6 +793,8 @@ class HonchoClientConfig:
             base_url=compartment.base_url,
             timeout=compartment.timeout,
             enabled=bool(compartment.api_key or compartment.base_url),
+            session_strategy=compartment.session_strategy or self.session_strategy,
+            manual_session_name=compartment.manual_session_name or self.manual_session_name,
             compartments={},
             agent_compartments={},
             api_key_explicit=compartment.api_key_explicit,
@@ -850,13 +862,14 @@ class HonchoClientConfig:
 
         Resolution order:
           1. Gateway session key (stable per-chat identifier from gateway platforms)
-          2. per-session strategy — Hermes session_id ({timestamp}_{hex}); authoritative,
+          2. Manual strategy override
+          3. per-session strategy — Hermes session_id ({timestamp}_{hex}); authoritative,
              so a generated title never remaps a live conversation
-          3. Manual directory override from sessions map
-          4. Hermes session title (from /title command; non-per-session)
-          5. per-repo strategy — git repo root directory name
-          6. per-directory strategy — directory basename
-          7. global strategy — workspace name
+          4. Manual directory override from sessions map
+          5. Hermes session title (from /title command; non-per-session)
+          6. per-repo strategy — git repo root directory name
+          7. per-directory strategy — directory basename
+          8. global strategy — workspace name
         """
         import re
 
@@ -869,6 +882,11 @@ class HonchoClientConfig:
             sanitized = re.sub(r'[^a-zA-Z0-9_-]+', '-', gateway_session_key).strip('-')
             if sanitized:
                 return self._enforce_session_id_limit(sanitized, gateway_session_key)
+
+        # Manual compartment override: the CLI can pin a compartment to a
+        # specific Honcho session while the host keeps another strategy.
+        if self.session_strategy == "manual" and self.manual_session_name:
+            return self.manual_session_name
 
         # per-session: the run's session_id IS the identity — resolve before the
         # cwd map / title so an auto-generated title can't remap a live

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -17,7 +17,8 @@ import json
 import os
 import logging
 import hashlib
-from dataclasses import dataclass, field
+import threading
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
@@ -173,6 +174,68 @@ def _parse_optional_string(
     return str(value).strip()
 
 
+def _read_api_key_file(value: Any, *, config_path: Path) -> str | None:
+    """Read an API/JWT key from ``apiKeyFile`` without leaking it into config.
+
+    Relative paths are resolved next to the config file so a profile can carry
+    a self-contained ``honcho.json`` plus a sibling ``runtime-keys/`` directory.
+    Missing/unreadable files fail closed by returning ``None``; callers can
+    still enable loopback/no-auth configurations via ``baseUrl``.
+    """
+    if not value:
+        return None
+    try:
+        key_path = Path(str(value)).expanduser()
+        if not key_path.is_absolute():
+            key_path = config_path.parent / key_path
+        text = key_path.read_text(encoding="utf-8").strip()
+        return text or None
+    except OSError as exc:
+        logger.warning("Failed to read Honcho apiKeyFile %s: %s", value, exc)
+        return None
+
+
+def _resolve_api_key(block: dict, root: dict, *, config_path: Path) -> tuple[str | None, bool]:
+    """Resolve apiKey/apiKeyFile with host-block precedence.
+
+    Returns ``(api_key, host_explicit)`` where ``host_explicit`` is true only
+    when the active host/compartment block itself supplied key material.
+    """
+    if block.get("apiKey"):
+        return str(block.get("apiKey")), True
+    file_key = _read_api_key_file(block.get("apiKeyFile"), config_path=config_path)
+    if file_key:
+        return file_key, True
+    if root.get("apiKey"):
+        return str(root.get("apiKey")), False
+    file_key = _read_api_key_file(root.get("apiKeyFile"), config_path=config_path)
+    if file_key:
+        return file_key, False
+    env_key = os.environ.get("HONCHO_API_KEY")
+    return env_key, False
+
+
+def _parse_agent_compartments(source: Any) -> dict[str, list[str]]:
+    """Parse agent -> compartment allowlist mappings from honcho.json."""
+    if not isinstance(source, dict):
+        return {}
+    result: dict[str, list[str]] = {}
+    for raw_agent, raw_names in source.items():
+        agent = str(raw_agent).strip()
+        if not agent:
+            continue
+        if isinstance(raw_names, str):
+            names = [raw_names]
+        elif isinstance(raw_names, list):
+            names = raw_names
+        else:
+            continue
+        cleaned = [str(name).strip() for name in names if str(name).strip()]
+        if cleaned:
+            result[agent] = cleaned
+    return result
+
+
 def _parse_dialectic_depth(host_val, root_val) -> int:
     """Parse dialecticDepth: host wins, then root, then 1. Clamped to 1-3."""
     for val in (host_val, root_val):
@@ -289,6 +352,22 @@ def _resolve_observation(
 
 
 @dataclass
+class HonchoCompartmentConfig:
+    """Resolved Honcho compartment with its own workspace/key boundary."""
+
+    name: str
+    workspace_id: str
+    api_key: str | None = None
+    environment: str = "production"
+    base_url: str | None = None
+    timeout: float | None = None
+    read: bool = True
+    write: bool = True
+    raw: dict[str, Any] = field(default_factory=dict)
+    api_key_explicit: bool = False
+
+
+@dataclass
 class HonchoClientConfig:
     """Configuration for Honcho client, resolved for a specific host."""
 
@@ -374,6 +453,11 @@ class HonchoClientConfig:
     sessions: dict[str, str] = field(default_factory=dict)
     # Raw global config for anything else consumers need
     raw: dict[str, Any] = field(default_factory=dict)
+    # Named workspace/key compartments for hard memory boundaries (e.g. ops vs personal).
+    compartments: dict[str, HonchoCompartmentConfig] = field(default_factory=dict)
+    agent_compartments: dict[str, list[str]] = field(default_factory=dict)
+    # True when this config's api_key came from the active host/compartment block.
+    api_key_explicit: bool = False
     # True when Honcho was explicitly configured for this host (hosts.hermes
     # block exists or enabled was set explicitly), vs auto-enabled from a
     # stray HONCHO_API_KEY env var.
@@ -440,11 +524,7 @@ class HonchoClientConfig:
             or raw.get("aiPeer")
             or resolved_host
         )
-        api_key = (
-            host_block.get("apiKey")
-            or raw.get("apiKey")
-            or os.environ.get("HONCHO_API_KEY")
-        )
+        api_key, api_key_explicit = _resolve_api_key(host_block, raw, config_path=path)
 
         environment = (
             host_block.get("environment")
@@ -499,6 +579,46 @@ class HonchoClientConfig:
         session_peer_prefix = (
             host_prefix if host_prefix is not None
             else raw.get("sessionPeerPrefix", False)
+        )
+
+        compartment_source = host_block.get("compartments") or raw.get("compartments") or {}
+        compartments: dict[str, HonchoCompartmentConfig] = {}
+        if isinstance(compartment_source, dict):
+            for raw_name, raw_block in compartment_source.items():
+                name = str(raw_name).strip()
+                if not name or not isinstance(raw_block, dict):
+                    continue
+                comp_api_key, comp_key_explicit = _resolve_api_key(
+                    raw_block,
+                    raw,
+                    config_path=path,
+                )
+                comp_workspace = raw_block.get("workspace") or name
+                comp_base_url = (
+                    raw_block.get("baseUrl")
+                    or raw_block.get("base_url")
+                    or base_url
+                )
+                comp_timeout = _resolve_optional_float(
+                    raw_block.get("timeout"),
+                    raw_block.get("requestTimeout"),
+                    timeout,
+                )
+                compartments[name] = HonchoCompartmentConfig(
+                    name=name,
+                    workspace_id=str(comp_workspace),
+                    api_key=comp_api_key,
+                    environment=raw_block.get("environment") or environment,
+                    base_url=comp_base_url,
+                    timeout=comp_timeout,
+                    read=bool(raw_block.get("read", True)),
+                    write=bool(raw_block.get("write", True)),
+                    raw=raw_block,
+                    api_key_explicit=comp_key_explicit,
+                )
+
+        agent_compartments = _parse_agent_compartments(
+            host_block.get("agents") or raw.get("agents")
         )
 
         return cls(
@@ -616,7 +736,33 @@ class HonchoClientConfig:
             session_peer_prefix=session_peer_prefix,
             sessions=raw.get("sessions", {}),
             raw=raw,
+            compartments=compartments,
+            agent_compartments=agent_compartments,
+            api_key_explicit=api_key_explicit,
             explicitly_configured=_explicitly_configured,
+        )
+
+    def for_compartment(self, name: str) -> "HonchoClientConfig":
+        """Return a client config narrowed to a named Honcho compartment.
+
+        This is the adapter seam for dual-memory agents: each returned config
+        points at one workspace/key pair while preserving the host's peer,
+        recall, observation, and session settings.
+        """
+        compartment = self.compartments[name]
+        return replace(
+            self,
+            host=f"{self.host}:{name}",
+            workspace_id=compartment.workspace_id,
+            api_key=compartment.api_key,
+            environment=compartment.environment,
+            base_url=compartment.base_url,
+            timeout=compartment.timeout,
+            enabled=bool(compartment.api_key or compartment.base_url),
+            compartments={},
+            agent_compartments={},
+            api_key_explicit=compartment.api_key_explicit,
+            raw={**(self.raw or {}), "_compartment": name},
         )
 
     @staticmethod
@@ -739,7 +885,14 @@ class HonchoClientConfig:
         return self.workspace_id
 
 
-_honcho_client_slot: SingletonSlot = SingletonSlot()
+_honcho_client_slots: dict[tuple[str, str, str], SingletonSlot] = {}
+_honcho_client_slots_lock = threading.Lock()
+
+
+def _client_cache_key(config: HonchoClientConfig) -> tuple[str, str, str]:
+    """Return a non-secret cache key for a Honcho client connection."""
+    endpoint = (config.base_url or config.environment or "production").rstrip("/")
+    return (endpoint, config.workspace_id, config.host)
 
 
 def _apply_fresh_oauth_token(config: HonchoClientConfig) -> None:
@@ -770,7 +923,7 @@ def _refresh_cached_oauth(client: "Honcho", config: HonchoClientConfig | None) -
         host = config.host if config is not None else resolve_active_host()
         token, refreshed = oauth.ensure_fresh_token(resolve_config_path(), host)
         if refreshed and token and not oauth.apply_token_to_client(client, token):
-            _honcho_client_slot.reset()
+            reset_honcho_client()
     except Exception:
         logger.warning("Honcho OAuth cached refresh failed", exc_info=True)
 
@@ -785,13 +938,17 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
     first calls (double-checked locking via ``SingletonSlot``), so racing
     threads can't each construct a client and leak the loser's connection.
     """
-    cached = _honcho_client_slot.peek()
+    if config is None:
+        config = HonchoClientConfig.from_global_config()
+
+    cache_key = _client_cache_key(config)
+    with _honcho_client_slots_lock:
+        slot = _honcho_client_slots.setdefault(cache_key, SingletonSlot())
+
+    cached = slot.peek()
     if cached is not None:
         _refresh_cached_oauth(cached, config)
         return cached
-
-    if config is None:
-        config = HonchoClientConfig.from_global_config()
 
     # Refresh a near-expiry OAuth grant before the first build so the client
     # starts with a live access token rather than 401ing an hour in.
@@ -883,7 +1040,7 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
             # required-non-empty placeholder unless the host block opts in.
             _raw = config.raw or {}
             _host_block = (_raw.get("hosts") or {}).get(config.host, {})
-            _host_has_key = bool(_host_block.get("apiKey"))
+            _host_has_key = config.api_key_explicit or bool(_host_block.get("apiKey") or _host_block.get("apiKeyFile"))
             effective_api_key = config.api_key if _host_has_key else "local"
         else:
             effective_api_key = config.api_key
@@ -912,9 +1069,12 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
 
         return Honcho(**kwargs)
 
-    return _honcho_client_slot.get(_build)
+    return slot.get(_build)
 
 
 def reset_honcho_client() -> None:
-    """Reset the Honcho client singleton (useful for testing)."""
-    _honcho_client_slot.reset()
+    """Reset all cached Honcho clients (useful for testing)."""
+    with _honcho_client_slots_lock:
+        for slot in _honcho_client_slots.values():
+            slot.reset()
+        _honcho_client_slots.clear()

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -588,11 +588,35 @@ class HonchoClientConfig:
                 name = str(raw_name).strip()
                 if not name or not isinstance(raw_block, dict):
                     continue
-                comp_api_key, comp_key_explicit = _resolve_api_key(
-                    raw_block,
-                    raw,
-                    config_path=path,
-                )
+                if raw_block.get("apiKey"):
+                    comp_api_key = str(raw_block.get("apiKey"))
+                    comp_key_explicit = True
+                else:
+                    comp_api_key = _read_api_key_file(
+                        raw_block.get("apiKeyFile"),
+                        config_path=path,
+                    )
+                    comp_key_explicit = bool(comp_api_key)
+                if not comp_api_key:
+                    # Compartment-level auth inherits from the active host before
+                    # falling back to root/env. The CLI labels this state as
+                    # "inherited/default", so host-scoped JWTs must work when a
+                    # compartment only overrides its workspace.
+                    if host_block.get("apiKey"):
+                        comp_api_key = str(host_block.get("apiKey"))
+                    else:
+                        comp_api_key = _read_api_key_file(
+                            host_block.get("apiKeyFile"),
+                            config_path=path,
+                        )
+                    comp_key_explicit = False
+                if not comp_api_key:
+                    comp_api_key, _ = _resolve_api_key(
+                        {},
+                        raw,
+                        config_path=path,
+                    )
+                    comp_key_explicit = False
                 comp_workspace = raw_block.get("workspace") or name
                 comp_base_url = (
                     raw_block.get("baseUrl")

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -819,17 +819,28 @@ class TestResolveSessionNameLengthLimit:
 
 
 class TestResetHonchoClient:
-    def test_reset_clears_singleton(self):
+    def test_reset_clears_all_compartment_slots(self):
         import plugins.memory.honcho.client as mod
+        from plugins.plugin_utils import SingletonSlot
 
-        # Seed the cached client through the slot's public surface, then
-        # verify reset_honcho_client() clears it. (The client is cached in
-        # mod._honcho_client_slot, a thread-safe SingletonSlot, not a bare
-        # module global anymore — see #24759.)
-        mod._honcho_client_slot.get(lambda: MagicMock())
-        assert mod._honcho_client_slot.peek() is not None
+        # Seed multiple cached clients through the slot public surface, then
+        # verify reset_honcho_client() clears every slot. Compartment routing
+        # now caches one SingletonSlot per resolved workspace/key/session tuple
+        # rather than one process-wide _honcho_client_slot.
+        slot_a = SingletonSlot()
+        slot_b = SingletonSlot()
+        slot_a.get(lambda: MagicMock())
+        slot_b.get(lambda: MagicMock())
+        with mod._honcho_client_slots_lock:
+            mod._honcho_client_slots[("env", "workspace-a", "peer")] = slot_a
+            mod._honcho_client_slots[("env", "workspace-b", "peer")] = slot_b
+
+        assert slot_a.peek() is not None
+        assert slot_b.peek() is not None
         reset_honcho_client()
-        assert mod._honcho_client_slot.peek() is None
+        assert slot_a.peek() is None
+        assert slot_b.peek() is None
+        assert mod._honcho_client_slots == {}
 
 
 class TestDialecticDepthParsing:

--- a/tests/test_honcho_cli_compartments.py
+++ b/tests/test_honcho_cli_compartments.py
@@ -1,0 +1,84 @@
+import json
+from argparse import Namespace
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from plugins.memory.honcho import cli
+
+
+def _with_home(path):
+    token = set_hermes_home_override(path)
+    return token
+
+
+def test_cmd_compartments_set_writes_host_scoped_api_key_file(tmp_path, capsys):
+    token = _with_home(tmp_path)
+    old_profile = cli._profile_override
+    cli._profile_override = None
+    try:
+        (tmp_path / "honcho.json").write_text(
+            json.dumps({"baseUrl": "http://honcho.local", "hosts": {"hermes": {"workspace": "primary"}}}),
+            encoding="utf-8",
+        )
+
+        cli.cmd_compartments(
+            Namespace(
+                compartment_action="set",
+                name="ops",
+                workspace="james-ops-prod",
+                api_key_file="runtime-keys/james-ops-prod.jwt",
+                api_key=None,
+                base_url=None,
+                environment=None,
+                session_strategy=None,
+                manual_session_name=None,
+            )
+        )
+
+        cfg = json.loads((tmp_path / "honcho.json").read_text(encoding="utf-8"))
+        ops = cfg["hosts"]["hermes"]["compartments"]["ops"]
+        assert ops == {
+            "workspace": "james-ops-prod",
+            "apiKeyFile": "runtime-keys/james-ops-prod.jwt",
+        }
+        assert "apiKey" not in ops
+        assert "Compartment 'ops' configured" in capsys.readouterr().out
+    finally:
+        cli._profile_override = old_profile
+        reset_hermes_home_override(token)
+
+
+def test_cmd_compartments_list_shows_file_backed_compartment_without_secret(tmp_path, capsys):
+    token = _with_home(tmp_path)
+    old_profile = cli._profile_override
+    cli._profile_override = None
+    try:
+        (tmp_path / "honcho.json").write_text(
+            json.dumps(
+                {
+                    "hosts": {
+                        "hermes": {
+                            "workspace": "primary",
+                            "compartments": {
+                                "personal": {
+                                    "workspace": "james-personal-prod",
+                                    "apiKeyFile": "runtime-keys/james-personal-prod.jwt",
+                                }
+                            },
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        cli.cmd_compartments(Namespace(compartment_action="list"))
+
+        output = capsys.readouterr().out
+        assert "personal" in output
+        assert "james-personal-prod" in output
+        assert "apiKeyFile" in output
+        assert "runtime-keys/james-personal-prod.jwt" in output
+        assert "apiKey=" not in output
+    finally:
+        cli._profile_override = old_profile
+        reset_hermes_home_override(token)

--- a/tests/test_honcho_cli_compartments.py
+++ b/tests/test_honcho_cli_compartments.py
@@ -82,3 +82,63 @@ def test_cmd_compartments_list_shows_file_backed_compartment_without_secret(tmp_
     finally:
         cli._profile_override = old_profile
         reset_hermes_home_override(token)
+
+
+def test_cmd_agents_set_writes_host_scoped_compartment_allowlist(tmp_path, capsys):
+    token = _with_home(tmp_path)
+    old_profile = cli._profile_override
+    cli._profile_override = None
+    try:
+        (tmp_path / "honcho.json").write_text(
+            json.dumps({"hosts": {"hermes": {"workspace": "primary"}}}),
+            encoding="utf-8",
+        )
+
+        cli.cmd_agents(
+            Namespace(
+                agent_action="set",
+                name="echo",
+                compartments=["ops"],
+            )
+        )
+
+        cfg = json.loads((tmp_path / "honcho.json").read_text(encoding="utf-8"))
+        assert cfg["hosts"]["hermes"]["agents"] == {"echo": ["ops"]}
+        assert "Agent 'echo' can access: ops" in capsys.readouterr().out
+    finally:
+        cli._profile_override = old_profile
+        reset_hermes_home_override(token)
+
+
+def test_cmd_agents_list_shows_allowlists(tmp_path, capsys):
+    token = _with_home(tmp_path)
+    old_profile = cli._profile_override
+    cli._profile_override = None
+    try:
+        (tmp_path / "honcho.json").write_text(
+            json.dumps(
+                {
+                    "hosts": {
+                        "hermes": {
+                            "workspace": "primary",
+                            "agents": {
+                                "echo": ["ops"],
+                                "miloh": ["ops", "personal"],
+                            },
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        cli.cmd_agents(Namespace(agent_action="list"))
+
+        output = capsys.readouterr().out
+        assert "echo" in output
+        assert "ops" in output
+        assert "miloh" in output
+        assert "ops, personal" in output
+    finally:
+        cli._profile_override = old_profile
+        reset_hermes_home_override(token)

--- a/tests/test_honcho_client_concurrency.py
+++ b/tests/test_honcho_client_concurrency.py
@@ -98,6 +98,38 @@ def test_reset_allows_rebuild(monkeypatch):
     assert c2 is not c1
 
 
+def test_distinct_compartment_configs_get_distinct_cached_clients(monkeypatch):
+    """Ops and personal compartments must not share the first-built client."""
+    build_count = {"n": 0}
+    build_lock = threading.Lock()
+    _install_fake_honcho_sdk(monkeypatch, build_count, build_lock)
+
+    ops = HonchoClientConfig(
+        host="hermes:ops",
+        api_key="ops-key",
+        workspace_id="ops-prod",
+        base_url="https://honcho.example.test",
+        api_key_explicit=True,
+    )
+    personal = HonchoClientConfig(
+        host="hermes:personal",
+        api_key="personal-key",
+        workspace_id="personal-prod",
+        base_url="https://honcho.example.test",
+        api_key_explicit=True,
+    )
+
+    ops_client = get_honcho_client(ops)
+    personal_client = get_honcho_client(personal)
+
+    assert build_count["n"] == 2
+    assert personal_client is not ops_client
+    assert ops_client.kwargs["workspace_id"] == "ops-prod"
+    assert personal_client.kwargs["workspace_id"] == "personal-prod"
+    assert get_honcho_client(ops) is ops_client
+    assert get_honcho_client(personal) is personal_client
+
+
 def test_missing_credentials_still_raises_before_build(monkeypatch):
     build_count = {"n": 0}
     build_lock = threading.Lock()

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -179,6 +179,34 @@ class TestHonchoClientConfigAutoEnable:
         assert personal_cfg.api_key == "personal-key"
         assert personal_cfg.host == "hermes:personal"
 
+    def test_compartment_without_key_inherits_active_host_key(self, tmp_path, monkeypatch):
+        """CLI-listed inherited/default auth should inherit the active host key."""
+        host_key = tmp_path / "host.jwt"
+        host_key.write_text("host-key\n")
+        config_path = tmp_path / "honcho.json"
+        config_path.write_text(json.dumps({
+            "baseUrl": "https://honcho.example.test",
+            "apiKey": "root-key",
+            "hosts": {
+                "hermes": {
+                    "workspace": "personal-prod",
+                    "apiKeyFile": "host.jwt",
+                    "compartments": {
+                        "ops": {"workspace": "ops-prod"},
+                    },
+                }
+            },
+        }))
+        monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+        ops_cfg = cfg.for_compartment("ops")
+
+        assert cfg.api_key == "host-key"
+        assert ops_cfg.workspace_id == "ops-prod"
+        assert ops_cfg.api_key == "host-key"
+        assert ops_cfg.api_key_explicit is False
+
 
 def test_honcho_config_schema_documents_file_backed_compartments():
     provider = HonchoMemoryProvider()

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -105,6 +105,91 @@ class TestHonchoClientConfigAutoEnable:
         assert cfg.api_key == "fallback-key"
         assert cfg.enabled is True  # from_env() sets enabled=True
 
+    def test_api_key_file_resolves_relative_to_config_file(self, tmp_path, monkeypatch):
+        """apiKeyFile keeps scoped JWTs out of reviewable honcho.json."""
+        key_file = tmp_path / "secrets" / "ops.jwt"
+        key_file.parent.mkdir()
+        key_file.write_text(" file-backed-key \n")
+        config_path = tmp_path / "honcho.json"
+        config_path.write_text(json.dumps({
+            "baseUrl": "https://honcho.example.test",
+            "hosts": {
+                "hermes": {
+                    "workspace": "ops-prod",
+                    "apiKeyFile": "secrets/ops.jwt",
+                }
+            },
+        }))
+        monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert cfg.api_key == "file-backed-key"
+        assert cfg.workspace_id == "ops-prod"
+        assert cfg.enabled is True
+
+    def test_named_compartments_parse_to_separate_workspace_key_pairs(self, tmp_path, monkeypatch):
+        """Milo/Miloh need ops and personal compartments at key/workspace level."""
+        ops_key = tmp_path / "ops.jwt"
+        personal_key = tmp_path / "personal.jwt"
+        ops_key.write_text("ops-key\n")
+        personal_key.write_text("personal-key\n")
+        config_path = tmp_path / "honcho.json"
+        config_path.write_text(json.dumps({
+            "baseUrl": "https://honcho.example.test",
+            "hosts": {
+                "hermes": {
+                    "workspace": "personal-prod",
+                    "apiKeyFile": "personal.jwt",
+                    "compartments": {
+                        "ops": {
+                            "workspace": "ops-prod",
+                            "apiKeyFile": "ops.jwt",
+                            "write": True,
+                        },
+                        "personal": {
+                            "workspace": "personal-prod",
+                            "apiKeyFile": "personal.jwt",
+                            "write": True,
+                        },
+                    },
+                    "agents": {
+                        "miloh": ["ops", "personal"],
+                        "echo": ["ops"],
+                    },
+                }
+            },
+        }))
+        monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert sorted(cfg.compartments) == ["ops", "personal"]
+        assert cfg.agent_compartments == {"miloh": ["ops", "personal"], "echo": ["ops"]}
+
+        ops_cfg = cfg.for_compartment("ops")
+        personal_cfg = cfg.for_compartment("personal")
+
+        assert ops_cfg.workspace_id == "ops-prod"
+        assert ops_cfg.api_key == "ops-key"
+        assert ops_cfg.base_url == "https://honcho.example.test"
+        assert ops_cfg.host == "hermes:ops"
+
+        assert personal_cfg.workspace_id == "personal-prod"
+        assert personal_cfg.api_key == "personal-key"
+        assert personal_cfg.host == "hermes:personal"
+
+
+def test_honcho_config_schema_documents_file_backed_compartments():
+    provider = HonchoMemoryProvider()
+
+    keys = {item["key"] for item in provider.get_config_schema()}
+
+    assert "api_key" in keys
+    assert "apiKeyFile" in keys
+    assert "baseUrl" in keys
+    assert "compartments" in keys
+
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits not enforced on Windows")
 def test_save_config_sets_owner_only_permissions(tmp_path, monkeypatch):

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -207,6 +207,41 @@ class TestHonchoClientConfigAutoEnable:
         assert ops_cfg.api_key == "host-key"
         assert ops_cfg.api_key_explicit is False
 
+    def test_compartment_manual_session_strategy_overrides_host_strategy(self, tmp_path, monkeypatch):
+        """CLI-persisted compartment manual sessions must affect routing."""
+        key_file = tmp_path / "host.jwt"
+        key_file.write_text("host-key\n")
+        config_path = tmp_path / "honcho.json"
+        config_path.write_text(json.dumps({
+            "baseUrl": "https://honcho.example.test",
+            "hosts": {
+                "hermes": {
+                    "workspace": "personal-prod",
+                    "apiKeyFile": "host.jwt",
+                    "sessionStrategy": "per-directory",
+                    "compartments": {
+                        "ops": {
+                            "workspace": "ops-prod",
+                            "sessionStrategy": "manual",
+                            "manualSessionName": "ops-shared-session",
+                        },
+                    },
+                }
+            },
+        }))
+        monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+        ops_cfg = cfg.for_compartment("ops")
+
+        assert cfg.session_strategy == "per-directory"
+        assert ops_cfg.session_strategy == "manual"
+        assert ops_cfg.resolve_session_name(
+            cwd="/tmp/hermes-agent",
+            session_title="Compartment Test",
+            session_id="session-123",
+        ) == "ops-shared-session"
+
 
 def test_honcho_config_schema_documents_file_backed_compartments():
     provider = HonchoMemoryProvider()

--- a/tests/test_honcho_compartment_routing.py
+++ b/tests/test_honcho_compartment_routing.py
@@ -115,6 +115,38 @@ def test_unknown_honcho_compartment_returns_tool_error_without_primary_fallback(
     assert provider._compartment_managers["ops"].calls == []
 
 
+def test_read_disabled_compartment_rejects_read_tools_without_primary_fallback():
+    provider = _provider_with_ready_managers()
+    provider._config.compartments["ops"].read = False
+
+    result = json.loads(
+        provider.handle_tool_call(
+            "honcho_search",
+            {"query": "ports", "compartment": "ops"},
+        )
+    )
+
+    assert result["error"] == "Honcho compartment 'ops' is not readable."
+    assert provider._manager.calls == []
+    assert provider._compartment_managers["ops"].calls == []
+
+
+def test_write_disabled_compartment_rejects_conclude_without_primary_fallback():
+    provider = _provider_with_ready_managers()
+    provider._config.compartments["ops"].write = False
+
+    result = json.loads(
+        provider.handle_tool_call(
+            "honcho_conclude",
+            {"conclusion": "do not write", "compartment": "ops"},
+        )
+    )
+
+    assert result["error"] == "Honcho compartment 'ops' is not writable."
+    assert provider._manager.calls == []
+    assert provider._compartment_managers["ops"].calls == []
+
+
 def test_honcho_tool_lazily_initializes_configured_compartment_manager(monkeypatch):
     provider = HonchoMemoryProvider()
     provider._session_initialized = True

--- a/tests/test_honcho_compartment_routing.py
+++ b/tests/test_honcho_compartment_routing.py
@@ -1,0 +1,165 @@
+"""Honcho named-compartment routing tests.
+
+These tests keep ops/personal isolation at the provider boundary: selecting a
+compartment must choose a different manager/session, not just pass a tag to the
+same workspace.
+"""
+
+import json
+
+from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho.client import HonchoClientConfig, HonchoCompartmentConfig
+
+
+class _FakeManager:
+    def __init__(self, name: str):
+        self.name = name
+        self.calls = []
+
+    def get_or_create(self, session_key):
+        self.calls.append(("get_or_create", session_key))
+        return object()
+
+    def search_context(self, session_key, query, max_tokens=800, peer="user"):
+        self.calls.append(("search_context", session_key, query, max_tokens, peer))
+        return f"{self.name}:{session_key}:{query}:{peer}"
+
+    def create_conclusion(self, session_key, conclusion, peer="user"):
+        self.calls.append(("create_conclusion", session_key, conclusion, peer))
+        return True
+
+
+def _provider_with_ready_managers():
+    provider = HonchoMemoryProvider()
+    provider._session_initialized = True
+    provider._session_key = "primary-session"
+    provider._manager = _FakeManager("primary")
+    provider._compartment_session_keys = {"ops": "ops-session"}
+    provider._compartment_managers = {"ops": _FakeManager("ops")}
+    provider._config = HonchoClientConfig(
+        workspace_id="personal-prod",
+        api_key="personal-key",
+        base_url="https://honcho.example.test",
+        compartments={
+            "ops": HonchoCompartmentConfig(
+                name="ops",
+                workspace_id="ops-prod",
+                api_key="ops-key",
+                base_url="https://honcho.example.test",
+            )
+        },
+    )
+    return provider
+
+
+def test_honcho_tool_schema_exposes_compartment_selector():
+    provider = HonchoMemoryProvider()
+    schemas = {schema["name"]: schema for schema in provider.get_tool_schemas()}
+
+    for tool_name in [
+        "honcho_profile",
+        "honcho_search",
+        "honcho_reasoning",
+        "honcho_context",
+        "honcho_conclude",
+    ]:
+        assert "compartment" in schemas[tool_name]["parameters"]["properties"]
+
+
+def test_honcho_search_routes_to_requested_ready_compartment_manager():
+    provider = _provider_with_ready_managers()
+
+    result = json.loads(
+        provider.handle_tool_call(
+            "honcho_search",
+            {"query": "ports", "peer": "user", "compartment": "ops"},
+        )
+    )
+
+    assert result == {"result": "ops:ops-session:ports:user"}
+    assert provider._manager.calls == []
+    assert provider._compartment_managers["ops"].calls == [
+        ("search_context", "ops-session", "ports", 800, "user")
+    ]
+
+
+def test_honcho_conclude_routes_write_to_requested_ready_compartment_manager():
+    provider = _provider_with_ready_managers()
+
+    result = json.loads(
+        provider.handle_tool_call(
+            "honcho_conclude",
+            {"conclusion": "ops memory belongs in ops", "compartment": "ops"},
+        )
+    )
+
+    assert result == {"result": "Conclusion saved for user: ops memory belongs in ops"}
+    assert provider._manager.calls == []
+    assert provider._compartment_managers["ops"].calls == [
+        ("create_conclusion", "ops-session", "ops memory belongs in ops", "user")
+    ]
+
+
+def test_unknown_honcho_compartment_returns_tool_error_without_primary_fallback():
+    provider = _provider_with_ready_managers()
+
+    result = json.loads(
+        provider.handle_tool_call(
+            "honcho_search",
+            {"query": "family", "compartment": "personal-but-missing"},
+        )
+    )
+
+    assert result["error"] == "Unknown Honcho compartment: personal-but-missing"
+    assert provider._manager.calls == []
+    assert provider._compartment_managers["ops"].calls == []
+
+
+def test_honcho_tool_lazily_initializes_configured_compartment_manager(monkeypatch):
+    provider = HonchoMemoryProvider()
+    provider._session_initialized = True
+    provider._session_key = "primary-session"
+    provider._lazy_init_session_id = "session-123"
+    provider._lazy_init_kwargs = {"session_title": "Compartment Test"}
+    provider._manager = _FakeManager("primary")
+    provider._config = HonchoClientConfig(
+        workspace_id="personal-prod",
+        api_key="personal-key",
+        base_url="https://honcho.example.test",
+        compartments={
+            "ops": HonchoCompartmentConfig(
+                name="ops",
+                workspace_id="ops-prod",
+                api_key="ops-key",
+                base_url="https://honcho.example.test",
+            )
+        },
+    )
+
+    built = []
+
+    def fake_get_honcho_client(cfg):
+        built.append((cfg.host, cfg.workspace_id, cfg.api_key))
+        return object()
+
+    class FakeSessionManager(_FakeManager):
+        def __init__(self, **kwargs):
+            super().__init__(kwargs["config"].workspace_id)
+            self.kwargs = kwargs
+
+    monkeypatch.setattr("plugins.memory.honcho.client.get_honcho_client", fake_get_honcho_client)
+    monkeypatch.setattr("plugins.memory.honcho.session.HonchoSessionManager", FakeSessionManager)
+
+    result = json.loads(
+        provider.handle_tool_call(
+            "honcho_search",
+            {"query": "routing", "compartment": "ops"},
+        )
+    )
+
+    assert result == {"result": "ops-prod:Compartment-Test:routing:user"}
+    assert built == [("hermes:ops", "ops-prod", "ops-key")]
+    assert provider._compartment_managers["ops"].calls == [
+        ("get_or_create", "Compartment-Test"),
+        ("search_context", "Compartment-Test", "routing", 800, "user"),
+    ]

--- a/tests/test_honcho_compartment_routing.py
+++ b/tests/test_honcho_compartment_routing.py
@@ -163,3 +163,57 @@ def test_honcho_tool_lazily_initializes_configured_compartment_manager(monkeypat
         ("get_or_create", "Compartment-Test"),
         ("search_context", "Compartment-Test", "routing", 800, "user"),
     ]
+
+def test_honcho_compartment_route_preserves_session_context_after_primary_lazy_init(monkeypatch):
+    """Compartment route must use the same logical session after lazy refs clear."""
+    provider = HonchoMemoryProvider()
+    provider._session_initialized = False
+    provider._lazy_init_session_id = "session-123"
+    provider._lazy_init_kwargs = {"session_title": "Compartment Test"}
+    provider._config = HonchoClientConfig(
+        workspace_id="personal-prod",
+        api_key="personal-key",
+        base_url="https://honcho.example.test",
+        compartments={
+            "ops": HonchoCompartmentConfig(
+                name="ops",
+                workspace_id="ops-prod",
+                api_key="ops-key",
+                base_url="https://honcho.example.test",
+            )
+        },
+    )
+
+    built = []
+
+    def fake_get_honcho_client(cfg):
+        built.append((cfg.host, cfg.workspace_id, cfg.api_key))
+        return object()
+
+    class FakeSessionManager(_FakeManager):
+        def __init__(self, **kwargs):
+            super().__init__(kwargs["config"].workspace_id)
+            self.kwargs = kwargs
+
+    monkeypatch.setattr("plugins.memory.honcho.client.get_honcho_client", fake_get_honcho_client)
+    monkeypatch.setattr("plugins.memory.honcho.session.HonchoSessionManager", FakeSessionManager)
+
+    result = json.loads(
+        provider.handle_tool_call(
+            "honcho_search",
+            {"query": "routing", "compartment": "ops"},
+        )
+    )
+
+    assert result == {"result": "ops-prod:Compartment-Test:routing:user"}
+    assert built == [
+        ("hermes", "personal-prod", "personal-key"),
+        ("hermes:ops", "ops-prod", "ops-key"),
+    ]
+    assert provider._lazy_init_kwargs is None
+    assert provider._lazy_init_session_id is None
+    assert provider._session_key == "Compartment-Test"
+    assert provider._compartment_managers["ops"].calls == [
+        ("get_or_create", "Compartment-Test"),
+        ("search_context", "Compartment-Test", "routing", 800, "user"),
+    ]

--- a/tests/test_honcho_compartment_routing.py
+++ b/tests/test_honcho_compartment_routing.py
@@ -147,6 +147,23 @@ def test_write_disabled_compartment_rejects_conclude_without_primary_fallback():
     assert provider._compartment_managers["ops"].calls == []
 
 
+def test_agent_allowlist_rejects_disallowed_compartment_without_primary_fallback():
+    provider = _provider_with_ready_managers()
+    provider._agent_identity = "echo"
+    provider._config.agent_compartments = {"echo": ["personal"]}
+
+    result = json.loads(
+        provider.handle_tool_call(
+            "honcho_search",
+            {"query": "ports", "compartment": "ops"},
+        )
+    )
+
+    assert result["error"] == "Honcho compartment 'ops' is not allowed for agent 'echo'."
+    assert provider._manager.calls == []
+    assert provider._compartment_managers["ops"].calls == []
+
+
 def test_honcho_tool_lazily_initializes_configured_compartment_manager(monkeypatch):
     provider = HonchoMemoryProvider()
     provider._session_initialized = True


### PR DESCRIPTION
## Summary
- add file-backed `apiKeyFile` and named Honcho compartment config parsing
- route Honcho tools through explicit `compartment` selection with fail-closed validation and per-compartment client caching
- preserve the same logical Honcho session when a tool routes to a compartment after primary lazy init cleared network-init refs
- make keyless compartment blocks inherit auth from the active host before root/env defaults, matching the CLI's `inherited/default` label
- enforce compartment `read` / `write` flags at tool dispatch before falling back to the primary workspace
- honor compartment-level `sessionStrategy: manual` + `manualSessionName` overrides persisted by the CLI
- enforce host-scoped `agents` compartment allowlists at runtime using `agent_identity` / configured AI peer identity
- add `hermes honcho compartments list|set` for reviewable workspace/key-file config
- add `hermes honcho agents list|set` for reviewable agent compartment allowlists
- update legacy Honcho client reset test for the new per-compartment cache-slot map

## Test plan
- [x] RED repros added for compartment session-context preservation, host-key inheritance, read/write flag enforcement, manual session overrides, and agent allowlist enforcement; each failed before the fix and passes now
- [x] `uv run --extra dev python -m pytest tests/test_honcho_cli_compartments.py tests/test_honcho_compartment_routing.py tests/test_honcho_client_config.py tests/test_honcho_client_concurrency.py tests/test_honcho_session_context.py tests/test_honcho_startup_fail_open.py tests/honcho_plugin/test_client.py -q -o 'addopts='` → 139 passed
- [x] `uv run --extra dev python -m pytest tests/honcho_plugin/test_client.py -q -o 'addopts='` → 97 passed
- [x] `uv run --extra dev python -m ruff check plugins/memory/honcho/cli.py plugins/memory/honcho/__init__.py plugins/memory/honcho/client.py tests/test_honcho_cli_compartments.py tests/test_honcho_compartment_routing.py tests/test_honcho_client_config.py tests/test_honcho_client_concurrency.py tests/honcho_plugin/test_client.py` → passed
- [x] `python3 -m py_compile ... && git diff --check` → passed
- [x] temp `HERMES_HOME` CLI smoke for `hermes honcho compartments set/list`
- [x] temp `HERMES_HOME` CLI smoke for `hermes honcho agents set/list`
- [x] staging write/search/isolation smoke using inert sentinel markers in separate staging compartments

## Broad local verification note
- `scripts/run_tests.sh -j 8` was attempted because this PR has no GitHub checks; the full repo suite does **not** pass in this local macOS environment before/around this slice because unrelated suites require missing optional `acp`, Linux `systemctl`, and other environment-specific assumptions.
- One relevant Honcho legacy test (`tests/honcho_plugin/test_client.py::TestResetHonchoClient`) surfaced during that broader run; this PR now updates it to assert `reset_honcho_client()` clears the new per-compartment slot map, and the Honcho plugin/client suite passes.

## Security / privacy
- no production agent config changed
- no prod keys copied into the repo or PR
- `apiKeyFile` is supported so scoped JWTs can stay outside reviewable config
- unknown compartments, disallowed agent/compartment pairs, disabled read/write paths, and failed compartment init all fail closed instead of falling back to the primary workspace
