### PR TITLE
fix(cli): skip expensive model warning for custom providers (Fixes #54348)

### DIFF
--- a/hermes_cli/model_cost_guard.py
+++ b/hermes_cli/model_cost_guard.py
@@ -71,6 +71,14 @@ def expensive_model_warning(
     if not model:
         return None
 
+    # Custom providers (custom:xxx) use their own pricing that differs from
+    # the models.dev catalog (which stores OpenRouter prices).  Triggering
+    # the expensive-model warning on inaccurate catalog data blocks model
+    # switching silently — skip the check entirely for custom providers.
+    # See #54348.
+    if provider and provider.startswith("custom:"):
+        return None
+
     input_cost, output_cost, source = _pricing_from_model_info(model_info)
     if input_cost is None and output_cost is None and provider:
         try:


### PR DESCRIPTION
## Summary

Fixes #54348

Custom providers (e.g. `custom:routerai`) cannot switch models because the `expensive_model_warning` guard triggers on inaccurate pricing data from the models.dev catalog (which stores OpenRouter prices, not the custom provider's prices).

## Root Cause

`expensive_model_warning()` in `hermes_cli/model_cost_guard.py` looks up pricing from models.dev or usage_pricing. For custom providers, the models.dev prices are for OpenRouter — wildly different from the custom provider's actual pricing. For example, `deepseek-v4-pro` costs $0.66/M on `custom:routerai` but models.dev shows OpenRouter's $61/M, triggering the warning.

When the warning fires, `_apply_model_switch` returns `confirm_required: true`, causing the desktop frontend to silently roll back the model change.

## Fix

Skip the expensive model check entirely when `provider` starts with `custom:`. Custom providers have their own pricing that Hermes cannot know from external catalogs. Users who configure custom providers are already aware of their pricing.

## Changed files
- `hermes_cli/model_cost_guard.py`: Early return for custom providers (8 lines)