### PR TITLE
fix(bluebubbles): replace deprecated datetime.utcnow() with datetime.now(timezone.utc)

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -15,7 +15,7 @@ import os
 import re
 import uuid
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -476,7 +476,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         payload = {
             "addresses": [address],
             "message": message,
-            "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+            "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
         }
         try:
             res = await self._api_post("/api/v1/chat/new", payload)
@@ -532,7 +532,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 )
             payload: Dict[str, Any] = {
                 "chatGuid": guid,
-                "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+                "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
                 "message": chunk,
             }
             if reply_to and self._private_api_enabled and self._helper_connected:


### PR DESCRIPTION
## Summary

Replace deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)` in `gateway/platforms/bluebubbles.py`.

`datetime.utcnow()` is deprecated since Python 3.12 and returns a naive datetime object. `datetime.now(timezone.utc)` returns an aware datetime and is the recommended replacement.

## Changed files
- `gateway/platforms/bluebubbles.py`: 2 occurrences replaced, added `timezone` to import