### PR TITLE
Normalize interactive TERM for TUI and dashboard PTY

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6151,6 +6151,23 @@ def apply_terminal_config_to_env(
     return target
 
 
+def apply_interactive_terminal_color_env(
+    *,
+    env: Optional[Dict[str, str]] = None,
+) -> Dict[str, str]:
+    """Ensure embedded interactive terminals can render ANSI colors."""
+    target = os.environ if env is None else env
+    target.pop("NO_COLOR", None)
+    target.pop("NODE_DISABLE_COLORS", None)
+    if not target.get("TERM") or target.get("TERM") == "dumb":
+        target["TERM"] = "xterm-256color"
+    if not target.get("COLORTERM"):
+        target["COLORTERM"] = "truecolor"
+    if not target.get("CLICOLOR"):
+        target["CLICOLOR"] = "1"
+    return target
+
+
 def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
     with _CONFIG_LOCK:
         ensure_hermes_home()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6151,20 +6151,15 @@ def apply_terminal_config_to_env(
     return target
 
 
-def apply_interactive_terminal_color_env(
+def apply_interactive_terminal_env(
     *,
     env: Optional[Dict[str, str]] = None,
 ) -> Dict[str, str]:
-    """Ensure embedded interactive terminals can render ANSI colors."""
+    """Normalize TERM for interactive child terminals without forcing color."""
     target = os.environ if env is None else env
-    target.pop("NO_COLOR", None)
-    target.pop("NODE_DISABLE_COLORS", None)
-    if not target.get("TERM") or target.get("TERM") == "dumb":
+    term = (target.get("TERM") or "").strip()
+    if not term or term == "dumb":
         target["TERM"] = "xterm-256color"
-    if not target.get("COLORTERM"):
-        target["COLORTERM"] = "truecolor"
-    if not target.get("CLICOLOR"):
-        target["CLICOLOR"] = "1"
     return target
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2002,11 +2002,11 @@ def _launch_tui(
     env = os.environ.copy()
     try:
         from hermes_cli.config import (
-            apply_interactive_terminal_color_env,
+            apply_interactive_terminal_env,
             apply_terminal_config_to_env,
         )
         apply_terminal_config_to_env(env=env)
-        apply_interactive_terminal_color_env(env=env)
+        apply_interactive_terminal_env(env=env)
     except Exception:
         logger.debug("Failed to apply terminal config bridge for TUI launch", exc_info=True)
     active_session_fd, active_session_file = tempfile.mkstemp(
@@ -5821,14 +5821,6 @@ def _find_stale_dashboard_pids(
         "hermes_cli.main dashboard",
         "hermes_cli/main.py dashboard",
     ]
-
-    def _looks_like_dashboard_server(command: str) -> bool:
-        return (
-            any(p in command for p in patterns)
-            and " --status" not in command
-            and " --stop" not in command
-        )
-
     self_pid = os.getpid()
     dashboard_pids: list[int] = []
 
@@ -5865,7 +5857,7 @@ def _find_stale_dashboard_pids(
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
                     if (
-                        _looks_like_dashboard_server(current_cmd)
+                        any(p in current_cmd for p in patterns)
                         and int(pid_str) != self_pid
                     ):
                         try:
@@ -5898,7 +5890,7 @@ def _find_stale_dashboard_pids(
                     except ValueError:
                         continue
                     command = parts[1]
-                    if _looks_like_dashboard_server(command) and pid != self_pid:
+                    if any(p in command for p in patterns) and pid != self_pid:
                         dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2001,8 +2001,12 @@ def _launch_tui(
 
     env = os.environ.copy()
     try:
-        from hermes_cli.config import apply_terminal_config_to_env
+        from hermes_cli.config import (
+            apply_interactive_terminal_color_env,
+            apply_terminal_config_to_env,
+        )
         apply_terminal_config_to_env(env=env)
+        apply_interactive_terminal_color_env(env=env)
     except Exception:
         logger.debug("Failed to apply terminal config bridge for TUI launch", exc_info=True)
     active_session_fd, active_session_file = tempfile.mkstemp(
@@ -5817,6 +5821,14 @@ def _find_stale_dashboard_pids(
         "hermes_cli.main dashboard",
         "hermes_cli/main.py dashboard",
     ]
+
+    def _looks_like_dashboard_server(command: str) -> bool:
+        return (
+            any(p in command for p in patterns)
+            and " --status" not in command
+            and " --stop" not in command
+        )
+
     self_pid = os.getpid()
     dashboard_pids: list[int] = []
 
@@ -5853,7 +5865,7 @@ def _find_stale_dashboard_pids(
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
                     if (
-                        any(p in current_cmd for p in patterns)
+                        _looks_like_dashboard_server(current_cmd)
                         and int(pid_str) != self_pid
                     ):
                         try:
@@ -5886,7 +5898,7 @@ def _find_stale_dashboard_pids(
                     except ValueError:
                         continue
                     command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
+                    if _looks_like_dashboard_server(command) and pid != self_pid:
                         dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []

--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -142,9 +142,9 @@ class PtyBridge:
         # CI often runs without TERM in the parent process, which makes
         # simple terminal probes like `tput cols` fail before winsize reads.
         # Preserve explicit caller overrides, but backfill a sensible default
-        # when TERM is missing or blank.
+        # when TERM is missing, blank, or the non-interactive "dumb" fallback.
         spawn_env = (os.environ.copy() if env is None else env.copy())
-        if not spawn_env.get("TERM"):
+        if not spawn_env.get("TERM") or spawn_env.get("TERM") == "dumb":
             spawn_env["TERM"] = "xterm-256color"
         proc = ptyprocess.PtyProcess.spawn(  # type: ignore[union-attr]
             list(argv),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12075,11 +12075,11 @@ def _resolve_chat_argv(
     env = os.environ.copy()
     try:
         from hermes_cli.config import (
-            apply_interactive_terminal_color_env,
+            apply_interactive_terminal_env,
             apply_terminal_config_to_env,
         )
         apply_terminal_config_to_env(env=env)
-        apply_interactive_terminal_color_env(env=env)
+        apply_interactive_terminal_env(env=env)
     except Exception:
         _log.debug("Failed to apply terminal config bridge for dashboard chat", exc_info=True)
     env.setdefault("NODE_ENV", "production")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12074,8 +12074,12 @@ def _resolve_chat_argv(
     argv, cwd = _make_tui_argv(PROJECT_ROOT / "ui-tui", tui_dev=False)
     env = os.environ.copy()
     try:
-        from hermes_cli.config import apply_terminal_config_to_env
+        from hermes_cli.config import (
+            apply_interactive_terminal_color_env,
+            apply_terminal_config_to_env,
+        )
         apply_terminal_config_to_env(env=env)
+        apply_interactive_terminal_color_env(env=env)
     except Exception:
         _log.debug("Failed to apply terminal config bridge for dashboard chat", exc_info=True)
     env.setdefault("NODE_ENV", "production")

--- a/hermes_cli/win_pty_bridge.py
+++ b/hermes_cli/win_pty_bridge.py
@@ -89,7 +89,7 @@ class WinPtyBridge:
                 )
             raise PtyUnavailableError("ConPTY is unavailable on this platform.")
         spawn_env = (os.environ.copy() if env is None else dict(env))
-        if not spawn_env.get("TERM"):
+        if not spawn_env.get("TERM") or spawn_env.get("TERM") == "dumb":
             spawn_env["TERM"] = "xterm-256color"
         # pywinpty mirrors ptyprocess: dimensions=(rows, cols).
         # This call shape is the one already used in tools/process_registry.py.

--- a/tests/hermes_cli/test_pty_bridge.py
+++ b/tests/hermes_cli/test_pty_bridge.py
@@ -306,6 +306,17 @@ class TestPtyBridgeEnv:
         finally:
             bridge.close()
 
+    def test_dumb_term_gets_pty_default(self):
+        bridge = PtyBridge.spawn(
+            ["/bin/sh", "-c", "printf %s \"$TERM\""],
+            env={**os.environ, "TERM": "dumb"},
+        )
+        try:
+            output = _read_until(bridge, b"xterm-256color")
+            assert b"xterm-256color" in output
+        finally:
+            bridge.close()
+
 
 class TestPtyBridgeUnavailable:
     """Platform fallback semantics — PtyUnavailableError is importable and

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5644,6 +5644,31 @@ class TestPtyWebSocket:
         assert env["HERMES_TUI_INLINE"] == "1"
         assert env["HERMES_TUI_DISABLE_MOUSE"] == "1"
 
+    def test_resolve_chat_argv_normalizes_dumb_term_without_forcing_color(
+        self, monkeypatch
+    ):
+        """Dashboard chat fixes TERM while preserving explicit color policy."""
+        import hermes_cli.main as main_mod
+
+        monkeypatch.setenv("TERM", "dumb")
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.setenv("NODE_DISABLE_COLORS", "1")
+        monkeypatch.delenv("COLORTERM", raising=False)
+        monkeypatch.delenv("CLICOLOR", raising=False)
+        monkeypatch.setattr(
+            main_mod,
+            "_make_tui_argv",
+            lambda project_root, tui_dev=False: (["node", "dist/entry.js"], "/tmp/ui-tui"),
+        )
+
+        _argv, _cwd, env = self.ws_module._resolve_chat_argv()
+
+        assert env["TERM"] == "xterm-256color"
+        assert env["NO_COLOR"] == "1"
+        assert env["NODE_DISABLE_COLORS"] == "1"
+        assert "COLORTERM" not in env
+        assert "CLICOLOR" not in env
+
     def test_resolve_chat_argv_applies_terminal_backend_config(
         self, monkeypatch, _isolate_hermes_home
     ):


### PR DESCRIPTION
## Summary
- normalize interactive child `TERM` for `hermes --tui` and dashboard chat PTY launches
- treat missing, blank, or `dumb` `TERM` as `xterm-256color` for interactive terminal children
- apply the same fallback inside the POSIX and Windows PTY bridges
- preserve explicit color-policy environment variables such as `NO_COLOR`, `NODE_DISABLE_COLORS`, and `FORCE_COLOR`

## Root cause
The TUI launch paths inherit the parent process environment. In agent, CI, and other non-interactive shells, `TERM` can be unset or set to `dumb`. That makes the Node TUI detect no useful terminal color capability and emit plain text before the output reaches the native terminal or the dashboard xterm.js PTY. The dashboard renderer is downstream: once the child process emits ANSI, xterm.js can render it.

## Standards / compatibility
- `TERM` should describe the terminal presented to the child process, not the non-interactive parent that launched Hermes. For a PTY/xterm.js-backed child, `xterm-256color` is the existing project fallback and matches the rendered terminal capabilities.
- The patch does not remove or override explicit color opt-outs. If `NO_COLOR` or a similar policy variable is present, the TUI remains free to honor it.
- The patch avoids forcing truecolor via `COLORTERM` or `FORCE_COLOR`; it only prevents the non-interactive `dumb` terminal fallback from leaking into interactive child terminals.

## Validation
- `python -m py_compile hermes_cli/config.py hermes_cli/main.py hermes_cli/web_server.py hermes_cli/pty_bridge.py hermes_cli/win_pty_bridge.py`
- `./.venv/bin/python -m pytest tests/hermes_cli/test_web_server.py::TestPtyWebSocket tests/hermes_cli/test_pty_bridge.py::TestPtyBridgeEnv -q`
- `git diff --check`