### PR TITLE
fix(agent): add `from e` to raise in OpenAI client init (agent_init.py)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -999,7 +999,7 @@ def init_agent(
                 else:
                     print("⚠️  Warning: API key appears invalid or missing")
         except Exception as e:
-            raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
+            raise RuntimeError(f"Failed to initialize OpenAI client: {e}") from e
     
     # Provider fallback chain — ordered list of backup providers tried
     # when the primary is exhausted (rate-limit, overload, connection


### PR DESCRIPTION
## Summary

Add `from e` to `raise RuntimeError(...)` in `agent/agent_init.py:1002` to preserve the original exception traceback when re-raising during OpenAI client initialization.

Without `from e`, the original exception chain is lost, making it harder to diagnose initialization failures.

## Changed files
- `agent/agent_init.py`: Added `from e` to 1 raise statement