### PR TITLE
fix(cli): pass target_model to resolve_runtime_provider in _ensure_runtime_credentials (Fixes #54147)

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -42,6 +42,7 @@ class CLIAgentSetupMixin:
                 requested=self.requested_provider,
                 explicit_api_key=self._explicit_api_key,
                 explicit_base_url=self._explicit_base_url,
+                target_model=self.model,
             )
         except Exception as exc:
             _primary_exc = exc


### PR DESCRIPTION
## Summary

Fixes #54147

`hermes chat -m <model>` uses the `api_mode` and `base_url` derived from `model.default` in config, not the requested model. This causes HTTP 404 when the requested model needs a different API surface.

## Root Cause

`_ensure_runtime_credentials()` in `hermes_cli/cli_agent_setup_mixin.py` calls `resolve_runtime_provider()` without passing `target_model`. The resolver falls back to `model_cfg.get("default")` to derive `api_mode`, picking the wrong mode for any model that differs from the config default.

## Fix

Pass `target_model=self.model` to `resolve_runtime_provider()` so the resolver derives `api_mode` from the requested model, not the config default.

## Changed files
- `hermes_cli/cli_agent_setup_mixin.py`: Added `target_model=self.model` parameter (1 line)