### PR TITLE
fix: allow triage kanban tasks without assignee

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -925,6 +925,26 @@ def test_create_rejects_no_assignee(worker_env):
     assert json.loads(kt._handle_create({"title": "t"})).get("error")
 
 
+def test_create_triage_allows_missing_assignee(worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    out = kt._handle_create({
+        "title": "needs routing",
+        "triage": True,
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, d["task_id"])
+        assert task is not None
+        assert task.status == "triage"
+        assert task.assignee is None
+    finally:
+        conn.close()
+
+
 def test_create_rejects_non_list_parents(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_create({"title": "t", "assignee": "a", "parents": 42})

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -761,7 +761,10 @@ def _handle_create(args: dict, **kw) -> str:
     if not title or not str(title).strip():
         return tool_error("title is required")
     assignee = args.get("assignee")
-    if not assignee:
+    triage, bool_error = _parse_bool_arg(args, "triage")
+    if bool_error:
+        return tool_error(bool_error)
+    if not assignee and not triage:
         return tool_error(
             "assignee is required — name the profile that should execute this "
             "task (the dispatcher will only spawn tasks with an assignee)"
@@ -787,9 +790,6 @@ def _handle_create(args: dict, **kw) -> str:
     _inherit_workspace = workspace_kind is None and workspace_path is None
     if workspace_kind is None:
         workspace_kind = "scratch"
-    triage, bool_error = _parse_bool_arg(args, "triage")
-    if bool_error:
-        return tool_error(bool_error)
     idempotency_key = args.get("idempotency_key")
     max_runtime_seconds = args.get("max_runtime_seconds")
     initial_status = args.get("initial_status") or "running"
@@ -832,7 +832,7 @@ def _handle_create(args: dict, **kw) -> str:
                 conn,
                 title=str(title).strip(),
                 body=body,
-                assignee=str(assignee),
+                assignee=str(assignee) if assignee else None,
                 parents=tuple(parents),
                 tenant=tenant,
                 priority=int(priority) if priority is not None else 0,


### PR DESCRIPTION
## What does this PR do?

Allows `kanban_create` tool calls with `triage=true` to omit `assignee`, matching the DB/CLI behavior where triage tasks can be created first and routed later by the decomposer.

The fix parses the `triage` flag before assignee validation, keeps `assignee` required for normal runnable tasks, and persists `NULL` instead of the string `"None"` when a triage task is intentionally unassigned.

## Related Issue

Fixes #54510

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/kanban_tools.py`
  - Parse `triage` before validating `assignee`.
  - Require `assignee` only when `triage` is false.
  - Pass `None` through to `kanban_db.create_task` for unassigned triage tasks.
- `tests/tools/test_kanban_tools.py`
  - Added regression coverage for `kanban_create(title=..., triage=True)` without an assignee.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_kanban_tools.py -q`
2. `uv run --python 3.11 --extra dev python /tmp/hermes-verify-kanban-create-prod-path.py`
3. `uv run --python 3.11 --extra dev python scripts/check-windows-footguns.py tests/tools/test_kanban_tools.py tools/kanban_tools.py`
4. `git diff --check origin/main...HEAD`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / Linux with Python 3.11 via uv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Full-suite note

I attempted the canonical full suite with:

```text
scripts/run_tests.sh -j 8 -q
```

The run did not complete cleanly in this local checkout because of unrelated pre-existing/local-environment failures, primarily `ModuleNotFoundError: No module named 'acp'` in ACP tests, plus unrelated failures in `tests/tools/test_execute_code_approval_cluster.py` and `tests/tools/test_voice_mode.py`. The affected kanban tool suite and a prod-path dispatch harness both pass.

## Screenshots / Logs

```text
scripts/run_tests.sh tests/tools/test_kanban_tools.py -q
=> 91 tests passed, 0 failed

uv run --python 3.11 --extra dev python /tmp/hermes-verify-kanban-create-prod-path.py
=> ok: true; kanban_create through model_tools.handle_function_call created a triage task with assignee null

uv run --python 3.11 --extra dev python scripts/check-windows-footguns.py tests/tools/test_kanban_tools.py tools/kanban_tools.py
=> No Windows footguns found (2 file(s) scanned)

git diff --check origin/main...HEAD
=> clean
```
