### PR TITLE
fix(telegram): override stop_typing to clear stuck typing indicator (Fixes #28004)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5700,6 +5700,26 @@ class TelegramAdapter(BasePlatformAdapter):
                     exc_info=True,
                 )
 
+    async def stop_typing(self, chat_id: str) -> None:
+        """Replace the lingering typing indicator with a no-op action.
+
+        Telegram has no explicit 'stop typing' API — a ``sendChatAction("typing")``
+        persists for ~5 seconds.  Sending a different action (``find_location``)
+        immediately replaces the typing bubble with nothing visible, preventing
+        the indicator from lingering after the response is delivered.
+
+        Fixes #28004.
+        """
+        if self._bot:
+            try:
+                await self._bot.send_chat_action(
+                    chat_id=normalize_telegram_chat_id(chat_id),
+                    action="find_location",
+                )
+            except Exception:
+                # Non-fatal — the indicator will expire on its own in ~5s.
+                pass
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Get information about a Telegram chat."""
         if not self._bot:


### PR DESCRIPTION
## Summary

Fixes #28004

The Telegram typing indicator gets stuck indefinitely after the agent responds because `_keep_typing` cancellation races with a late `sendChatAction("typing")` call.

## Root Cause

Telegram has no explicit "stop typing" API. A `sendChatAction("typing")` persists for ~5 seconds. When `_stop_typing_task()` cancels the `_keep_typing` loop, a late `sendChatAction` may have already been dispatched, restarting the 5-second timer. Since the loop is dead, no further refresh fires, but the user sees "typing..." for the full duration.

## Fix

Override `stop_typing()` on `TelegramAdapter` to send `sendChatAction("find_location")` — a different action that immediately replaces the typing bubble with nothing visible.

## Changed files
- `plugins/platforms/telegram/adapter.py`: Added `stop_typing()` override (20 lines)