### PR TITLE
fix(qqbot): add missing is_reconnect parameter to connect() method

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
## Problem

The base class `BasePlatformAdapter` defines `connect()` with the signature:
```python
async def connect(self, *, is_reconnect: bool = False) -> bool:
```

But the QQ adapter's `connect()` was missing the `is_reconnect` parameter:
```python
async def connect(self) -> bool:
```

This causes the gateway's reconnect watcher to fail when re-establishing the QQ connection after an outage, because it passes `is_reconnect=True` to all adapters.

## Fix

Added the missing `*, is_reconnect: bool = False` parameter to match the base class interface. The QQ adapter uses a WebSocket connection and has no server-side message queue to preserve, so the flag is accepted and ignored (per the base class docstring: "Adapters with no such queue may ignore the flag").

## Related

This was discovered when Hermes updated the gateway with reconnect logic but the QQ adapter hadn't been updated to match.