### PR TITLE
fix(security): add SSRF guard to OpenAI image_gen _load_image_bytes

### DIFF
--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -132,6 +132,12 @@ def _load_image_bytes(ref: str) -> Tuple[bytes, str]:
     ref = ref.strip()
     lower = ref.lower()
     if lower.startswith(("http://", "https://")):
+        from tools.url_safety import is_safe_url
+
+        if not is_safe_url(ref):
+            raise ValueError(
+                f"Blocked unsafe URL (SSRF protection): {ref}"
+            )
         import requests
 
         resp = requests.get(ref, timeout=60)


### PR DESCRIPTION
## Summary

Adds `is_safe_url()` SSRF guard to `_load_image_bytes()` in `plugins/image_gen/openai/__init__.py`.

## Root Cause

`_load_image_bytes(ref)` fetches user-supplied image URLs (from the `sources` parameter of the `generate` method) server-side via `requests.get()` without any SSRF protection. A model-supplied `reference_url` pointing to `http://169.254.169.254/latest/meta-data/` would make the gateway fetch cloud metadata endpoints.

This is the same class of bug fixed in PR #54470 (yuanbao_media SSRF guard) — the OpenAI image_gen plugin was the remaining unguarded server-side URL fetch.

## Fix

Add `is_safe_url()` pre-flight check before `requests.get()`, matching the pattern in `gateway/platforms/yuanbao_media.py` and `gateway/platforms/base.py`.

## Changed files
- `plugins/image_gen/openai/__init__.py`: Added SSRF guard in `_load_image_bytes()` (6 lines)