### PR TITLE
fix(delegate): subtract blocked tools from child agents

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1414,6 +1414,38 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             self.assertEqual(kwargs["base_url"], "http://localhost:11434/v1")
             self.assertEqual(kwargs["api_key"], "ollama")
 
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_build_child_agent_disables_delegate_blocked_tools(self, mock_cfg):
+        """Delegated children subtract blocked tools from mixed platform bundles.
+
+        Gateway platform bundles such as hermes-telegram contain both safe tools
+        and blocked child-only tools. The child keeps the bundle enabled but must
+        also pass a subtraction toolset so model_tools removes cronjob,
+        delegate_task, execute_code, memory, clarify, and send_message during
+        schema resolution.
+        """
+        parent = _make_mock_parent(depth=0)
+        parent.enabled_toolsets = ["hermes-telegram"]
+        parent.disabled_toolsets = ["browser"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="check delegated tool boundary",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["enabled_toolsets"], ["hermes-telegram"])
+        self.assertIn("browser", kwargs["disabled_toolsets"])
+        self.assertIn("delegate_blocked", kwargs["disabled_toolsets"])
+
     @patch("tools.delegate_tool._load_config")
     @patch("tools.delegate_tool._resolve_delegation_credentials")
     def test_credential_error_returns_json_error(self, mock_creds, mock_cfg):

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -63,3 +63,27 @@ class TestToolsetIntersection:
         scoped = [t for t in requested if t in parent_toolsets]
 
         assert scoped == []
+
+    def test_composite_platform_toolset_subtracts_delegate_blocked_tools(self):
+        """Mixed platform bundles keep safe tools but subtract blocked child tools.
+
+        A platform bundle such as ``hermes-telegram`` contains a mix of safe
+        tools and tools that delegated children must not receive.  Stripping
+        only whole toolset names is not enough because the bundle itself must
+        remain enabled for the safe tools.
+        """
+        from model_tools import get_tool_definitions
+
+        child_tools = get_tool_definitions(
+            enabled_toolsets=["hermes-telegram"],
+            disabled_toolsets=["delegate_blocked"],
+            quiet_mode=True,
+        )
+
+        child_tool_names = {t["function"]["name"] for t in child_tools}
+        assert "cronjob" not in child_tool_names
+        assert "delegate_task" not in child_tool_names
+        assert "execute_code" not in child_tool_names
+        assert "memory" not in child_tool_names
+        assert "clarify" not in child_tool_names
+        assert "read_file" in child_tool_names

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1266,6 +1266,10 @@ def _build_child_agent(
         # openrouter/pareto-code), so we keep it inherited even when the
         # provider is overridden — it's a no-op on any other model.
 
+    child_disabled_toolsets = list(getattr(parent_agent, "disabled_toolsets", None) or [])
+    if "delegate_blocked" not in child_disabled_toolsets:
+        child_disabled_toolsets.append("delegate_blocked")
+
     child = AIAgent(
         base_url=effective_base_url,
         api_key=effective_api_key,
@@ -1280,6 +1284,7 @@ def _build_child_agent(
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
         fallback_model=parent_fallback,
         enabled_toolsets=child_toolsets,
+        disabled_toolsets=child_disabled_toolsets,
         quiet_mode=True,
         ephemeral_system_prompt=child_prompt,
         log_prefix=f"[subagent-{task_index}]",

--- a/toolsets.py
+++ b/toolsets.py
@@ -246,6 +246,19 @@ TOOLSETS = {
         "includes": []
     },
 
+    "delegate_blocked": {
+        "description": "Tools that delegated child agents must never receive",
+        "tools": [
+            "delegate_task",
+            "clarify",
+            "memory",
+            "send_message",
+            "execute_code",
+            "cronjob",
+        ],
+        "includes": []
+    },
+
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
 


### PR DESCRIPTION
## Summary

This prevents delegated child agents from receiving blocked tools through mixed platform bundles such as `hermes-telegram`.

## Why

Delegated children must not receive tools listed in `DELEGATE_BLOCKED_TOOLS`, including `delegate_task`, `clarify`, `memory`, `send_message`, `execute_code`, and `cronjob`.

The direct `cronjob` toolset path was handled in #52121, but mixed platform bundles still expose a sibling gap. For example, `_strip_blocked_tools(["hermes-telegram"])` keeps `hermes-telegram` because the bundle contains safe tools as well as blocked tools. When that bundle is later resolved into individual tools, blocked tools such as `cronjob`, `delegate_task`, `execute_code`, `memory`, and `clarify` can still appear in the child schema.

The child should keep safe tools from the platform bundle, but blocked child tools must be subtracted after bundle resolution.

## Changes

- Add a virtual `delegate_blocked` toolset containing the tools delegated children must never receive.
- Preserve the parent agent's existing `disabled_toolsets`.
- Append `delegate_blocked` when constructing a child agent.
- Pass `disabled_toolsets` into the child `AIAgent`, so `model_tools.get_tool_definitions()` subtracts blocked tools even when they came from a mixed composite bundle.
- Add regression coverage for both:
  - schema-level subtraction from `hermes-telegram`
  - `_build_child_agent()` passing `delegate_blocked` into child construction

## Tests

```text
python -m pytest tests\tools\test_delegate_toolset_scope.py -q --timeout-method=thread
6 passed

python -m pytest tests\tools\test_delegate.py -k "build_child_agent_disables_delegate_blocked_tools or StripBlockedTools" -q --timeout-method=thread
6 passed, 139 deselected

python -m pytest tests\tools\test_delegate_composite_toolsets.py -q --timeout-method=thread
5 passed

git diff --check
clean