### PR TITLE
fix: change DeepSeek default aux model from deepseek-chat to deepseek-v4-flash

### DIFF
--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -94,7 +94,7 @@ deepseek = DeepSeekProfile(
         "deepseek-reasoner",
     ),
     base_url="https://api.deepseek.com/v1",
-    default_aux_model="deepseek-chat",
+    default_aux_model="deepseek-v4-flash",
 )
 
 register_provider(deepseek)

--- a/tests/plugins/model_providers/test_deepseek_profile.py
+++ b/tests/plugins/model_providers/test_deepseek_profile.py
@@ -195,12 +195,12 @@ class TestDeepSeekAuxModel:
     system.
     """
 
-    def test_profile_advertises_deepseek_chat(self, deepseek_profile):
-        assert deepseek_profile.default_aux_model == "deepseek-chat"
+    def test_profile_advertises_deepseek_v4_flash(self, deepseek_profile):
+        assert deepseek_profile.default_aux_model == "deepseek-v4-flash"
 
-    def test_consumer_api_returns_deepseek_chat(self):
+    def test_consumer_api_returns_deepseek_v4_flash(self):
         from agent.auxiliary_client import _get_aux_model_for_provider
-        assert _get_aux_model_for_provider("deepseek") == "deepseek-chat"
+        assert _get_aux_model_for_provider("deepseek") == "deepseek-v4-flash"
 
     def test_consumer_api_returns_non_empty(self):
         from agent.auxiliary_client import _get_aux_model_for_provider


### PR DESCRIPTION
## Summary

Change the DeepSeek provider's `default_aux_model` from `deepseek-chat` (V3) to `deepseek-v4-flash` (V4).

## Motivation

`deepseek-v4-flash` is a modern V4-generation model that offers:
- Better capability than V3 (`deepseek-chat`)
- Faster and cheaper than V4 Pro
- Supports thinking mode natively

This makes it a better default for auxiliary tasks like context compression, vision fallback, and other side-jobs that use the provider's default model.

## Changes

- `plugins/model-providers/deepseek/__init__.py`: `default_aux_model` → `deepseek-v4-flash`
- `tests/plugins/model_providers/test_deepseek_profile.py`: update two test assertions to match

## Test Plan

```
scripts/run_tests.sh tests/plugins/model_providers/test_deepseek_profile.py -q
```

→ 29 tests passed, 0 failed