### PR TITLE
feat(i18n): update-proof user locale overrides

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -12,6 +12,12 @@ catalog is a flat dict keyed by dotted paths (e.g. ``approval.choose`` or
 is missing too, the key path itself is returned so a broken catalog never
 crashes the agent.
 
+User overrides: a file at ``<hermes-home>/locale-overrides/<lang>.yaml`` (or
+wherever ``HERMES_LOCALE_OVERRIDES`` points) is deep-merged on top of the
+bundled catalog, key by key.  Because it lives outside the installed bundle,
+it is NOT overwritten when the app updates -- so it is the durable place to
+pin your own wording or carry translations that haven't landed upstream.
+
 Usage::
 
     from agent.i18n import t
@@ -162,36 +168,88 @@ def _normalize_lang(value: Any) -> str:
     return DEFAULT_LANGUAGE
 
 
-def _load_catalog(lang: str) -> dict[str, str]:
-    """Load and flatten one locale YAML file into a dotted-key dict.
+def _read_yaml_flat(path: Path) -> dict[str, str]:
+    """Load one locale YAML file and flatten it to a dotted-key dict.
 
-    YAML files can be nested for human readability; this produces the flat
-    key space :func:`t` expects.  Cached per-language for the process.
+    Returns an empty dict when the file is missing or unreadable -- a broken or
+    absent catalog must never crash callers; it just means more English
+    fallback.
     """
-    with _catalog_lock:
-        cached = _catalog_cache.get(lang)
-        if cached is not None:
-            return cached
-
-    path = _locales_dir() / f"{lang}.yaml"
     if not path.is_file():
-        logger.debug("i18n catalog missing for %s at %s", lang, path)
-        with _catalog_lock:
-            _catalog_cache[lang] = {}
+        logger.debug("i18n catalog not present at %s", path)
         return {}
-
     try:
         import yaml  # PyYAML is already a hermes dependency
         with path.open("r", encoding="utf-8") as f:
             raw = yaml.safe_load(f) or {}
     except Exception as exc:
         logger.warning("Failed to load i18n catalog %s: %s", path, exc)
-        with _catalog_lock:
-            _catalog_cache[lang] = {}
         return {}
-
     flat: dict[str, str] = {}
     _flatten_into(raw, "", flat)
+    return flat
+
+
+def _user_overrides_path(lang: str) -> Path | None:
+    """Return the path to the user's locale-override file for ``lang``.
+
+    Overrides live under ``<hermes-home>/locale-overrides/<lang>.{yaml,yml}``
+    (or wherever ``HERMES_LOCALE_OVERRIDES`` points).  This directory sits
+    OUTSIDE the installed/bundled tree, so it is untouched by app updates that
+    replace the shipped catalog -- making it the durable home for a user's own
+    wording and for translations that haven't landed upstream yet.
+
+    Returns the first existing candidate, or ``None`` when none exists or the
+    Hermes home cannot be resolved.
+    """
+    base_env = os.getenv("HERMES_LOCALE_OVERRIDES", "").strip()
+    if base_env:
+        base = Path(base_env)
+    else:
+        try:
+            from hermes_constants import get_hermes_home
+            base = get_hermes_home() / "locale-overrides"
+        except Exception as exc:  # hermes_constants unavailable in some contexts
+            logger.debug("i18n: cannot resolve hermes home for overrides: %s", exc)
+            return None
+    for ext in ("yaml", "yml"):
+        candidate = base / f"{lang}.{ext}"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _load_catalog(lang: str) -> dict[str, str]:
+    """Load the effective catalog for ``lang`` as a flat dotted-key dict.
+
+    Two layers, merged in order (later wins):
+
+    1. The **bundled** catalog shipped with the app (``locales/<lang>.yaml``).
+    2. **User overrides** under ``<hermes-home>/locale-overrides/<lang>.yaml``,
+       which live outside the bundle and therefore survive updates.  Any key
+       present here replaces the bundled value; absent keys keep the bundled
+       (or, ultimately, English-fallback) text.
+
+    Cached per-language for the process; call :func:`reset_language_cache` to
+    pick up edits without a restart.
+    """
+    with _catalog_lock:
+        cached = _catalog_cache.get(lang)
+        if cached is not None:
+            return cached
+
+    flat = _read_yaml_flat(_locales_dir() / f"{lang}.yaml")
+
+    override_path = _user_overrides_path(lang)
+    if override_path is not None:
+        override_flat = _read_yaml_flat(override_path)
+        if override_flat:
+            flat = {**flat, **override_flat}
+            logger.debug(
+                "i18n: applied %d user override(s) for %s from %s",
+                len(override_flat), lang, override_path,
+            )
+
     with _catalog_lock:
         _catalog_cache[lang] = flat
     return flat

--- a/docs/i18n-user-overrides.md
+++ b/docs/i18n-user-overrides.md
@@ -1,0 +1,86 @@
+# User locale overrides (update-proof translations)
+
+## Problem
+
+Every translation in Hermes is **baked into the bundle that ships**:
+
+- Desktop UI strings are compiled in (`apps/desktop/src/i18n/<lang>.ts`, imported
+  statically by `catalog.ts`).
+- The TUI renders hard-coded strings in `ui-tui`.
+- The Python agent/CLI strings live in `locales/<lang>.yaml` inside the install.
+
+An app update replaces that bundle wholesale, so any **local** edit to a shipped
+catalog is reverted on the next update. The only durable home for a translation
+is therefore *outside* the bundle — a user-writable directory updates don't
+touch.
+
+## The convention
+
+A per-language override file:
+
+```
+<hermes-home>/locale-overrides/<lang>.yaml
+```
+
+- `<hermes-home>` is the usual Hermes home (`~/.hermes`, or `%LOCALAPPDATA%\hermes`
+  on Windows; `HERMES_HOME` wins if set). Override the directory directly with
+  `HERMES_LOCALE_OVERRIDES`.
+- The file uses the **same nested key structure** as the bundled catalog. It is
+  **deep-merged on top** of the bundled catalog, key by key:
+  - a key present in the override **replaces** the bundled value;
+  - a key absent from the override keeps the bundled value (or, ultimately, the
+    English fallback).
+- Missing or malformed files are ignored (more English fallback, never a crash).
+
+Example — pin two strings without forking:
+
+```yaml
+# ~/.hermes/locale-overrides/ja.yaml
+approval:
+  denied: "却下しました"
+gateway:
+  goal_cleared: "✓ 目標をクリアしました。"
+```
+
+These survive every update because they live in your home directory, not in the
+app bundle.
+
+## Status
+
+| Surface | Layer | Override support |
+|---|---|---|
+| Python agent / CLI (`locales/*.yaml`) | `agent/i18n.py` | ✅ implemented (this change) |
+| Desktop (Electron, `src/i18n/*.ts`) | renderer `TRANSLATIONS` | 🔜 proposed (below) |
+| TUI (`ui-tui`, Ink) | n/a (no i18n layer yet) | 🔜 proposed (below) |
+
+### Python (implemented)
+
+`agent.i18n._load_catalog()` loads the bundled `locales/<lang>.yaml`, then merges
+`<hermes-home>/locale-overrides/<lang>.yaml` over it. Caches per process; call
+`reset_language_cache()` to pick up edits without a restart.
+
+### Desktop (proposed)
+
+`apps/desktop/src/i18n/define-locale.ts` already has the exact deep-merge needed
+(`mergeTranslations`). To make desktop overrides update-proof, at startup the
+Electron **main** process would read `<hermes-home>/locale-overrides/<lang>.json`
+and hand it to the renderer (config is already plumbed this way via
+`getHermesConfigRecord`). The `I18nProvider` then merges it onto
+`TRANSLATIONS[locale]` with the existing `mergeTranslations`, mirroring this
+file's semantics. JSON keeps it parseable in the renderer without a YAML dep.
+
+### TUI (proposed)
+
+`ui-tui` has no i18n layer today — strings are hard-coded. Adoption is a larger,
+separate effort: extract user-facing strings into an `en` base + a `t()` helper
+(mirroring the desktop pattern), then read the same
+`<hermes-home>/locale-overrides/<lang>.{yaml,json}` on top. Much of what the user
+already sees in the terminal (approval prompts, slash-command replies) is emitted
+by Python and is **already** localized + overridable via the layer above.
+
+## Relationship to upstreaming
+
+Overrides are the durable home for translations that haven't landed upstream yet,
+and for personal wording. Translations that *do* land upstream ship in the bundle
+and become the default for everyone — at which point the matching override keys
+are redundant and can be dropped.

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -227,3 +227,69 @@ def test_t_resolves_real_string_in_source_checkout():
     regressions independent of packaging."""
     assert i18n.t("gateway.reset.header_default", lang="en") != "gateway.reset.header_default"
     assert i18n.t("gateway.status.header", lang="en") != "gateway.status.header"
+
+
+# ---------------------------------------------------------------------------
+# User locale overrides -- the durable, update-proof translation layer.
+# A file under <hermes-home>/locale-overrides/<lang>.yaml (or wherever
+# HERMES_LOCALE_OVERRIDES points) is deep-merged ON TOP of the bundled catalog,
+# so user wording survives app updates that replace locales/*.yaml.
+# ---------------------------------------------------------------------------
+
+def _write_override(dir_path: Path, lang: str, mapping: dict) -> None:
+    dir_path.mkdir(parents=True, exist_ok=True)
+    with (dir_path / f"{lang}.yaml").open("w", encoding="utf-8") as f:
+        yaml.safe_dump(mapping, f, allow_unicode=True)
+
+
+def test_user_override_replaces_bundled_value(tmp_path, monkeypatch):
+    """A key present in the override file wins over the bundled catalog."""
+    ov = tmp_path / "locale-overrides"
+    _write_override(ov, "ja", {"approval": {"denied": "却下しました（カスタム）"}})
+    monkeypatch.setenv("HERMES_LOCALE_OVERRIDES", str(ov))
+    i18n.reset_language_cache()
+    try:
+        assert i18n.t("approval.denied", lang="ja") == "却下しました（カスタム）"
+    finally:
+        i18n.reset_language_cache()
+
+
+def test_user_override_only_touches_specified_keys(tmp_path, monkeypatch):
+    """Keys absent from the override keep their bundled translation."""
+    ov = tmp_path / "locale-overrides"
+    bundled_cancelled = i18n.t("approval.cancelled", lang="ja")
+    i18n.reset_language_cache()
+    _write_override(ov, "ja", {"approval": {"denied": "X"}})
+    monkeypatch.setenv("HERMES_LOCALE_OVERRIDES", str(ov))
+    i18n.reset_language_cache()
+    try:
+        assert i18n.t("approval.denied", lang="ja") == "X"
+        assert i18n.t("approval.cancelled", lang="ja") == bundled_cancelled
+    finally:
+        i18n.reset_language_cache()
+
+
+def test_user_override_absent_is_noop(tmp_path, monkeypatch):
+    """An override dir with no file for the language leaves bundled intact."""
+    empty = tmp_path / "locale-overrides"
+    empty.mkdir()
+    bundled = i18n.t("approval.denied", lang="ja")
+    monkeypatch.setenv("HERMES_LOCALE_OVERRIDES", str(empty))
+    i18n.reset_language_cache()
+    try:
+        assert i18n.t("approval.denied", lang="ja") == bundled
+    finally:
+        i18n.reset_language_cache()
+
+
+def test_user_override_resolves_under_hermes_home(tmp_path, monkeypatch):
+    """With no explicit HERMES_LOCALE_OVERRIDES, the override is read from
+    <hermes-home>/locale-overrides/<lang>.yaml -- the update-proof default."""
+    monkeypatch.delenv("HERMES_LOCALE_OVERRIDES", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_override(tmp_path / "locale-overrides", "ja", {"approval": {"denied": "ホーム由来"}})
+    i18n.reset_language_cache()
+    try:
+        assert i18n.t("approval.denied", lang="ja") == "ホーム由来"
+    finally:
+        i18n.reset_language_cache()


### PR DESCRIPTION
## Problem

Every translation in Hermes ships **baked into the bundle** — `locales/<lang>.yaml`
inside the install, the compiled desktop `src/i18n/<lang>.ts`, hard-coded TUI
strings. An app update replaces that bundle wholesale, so any **local** edit to a
shipped catalog is reverted on the next update. There is currently no
user-writable place to keep a translation that updates won't clobber.

## What this adds

A durable override layer for the Python agent/CLI catalog that lives **outside**
the bundle:

```
<hermes-home>/locale-overrides/<lang>.yaml      # ~/.hermes/... ; HERMES_HOME respected
```

`agent/i18n.py` deep-merges this file on top of the bundled `locales/<lang>.yaml`,
key by key:

- a key in the override **replaces** the bundled value;
- absent keys keep the bundled value (or the English fallback);
- missing/malformed files are ignored — never a crash, just more English.

The directory can be redirected with `HERMES_LOCALE_OVERRIDES`. Cached per process;
`reset_language_cache()` picks up edits without a restart.

```yaml
# ~/.hermes/locale-overrides/ja.yaml — survives every update
approval:
  denied: "却下しました"
```

This is the durable home for personal wording and for translations that haven't
landed upstream yet. Once a translation merges upstream it ships in the bundle and
the matching override key becomes redundant.

## Changes

- `agent/i18n.py`: `_load_catalog` now loads bundled then merges user overrides
  (shared YAML-flatten refactored into `_read_yaml_flat`; new `_user_overrides_path`).
  Module docstring updated with the resolution order.
- `tests/agent/test_i18n.py`: override replaces a key, leaves siblings intact,
  no-op when absent, and resolves under `<hermes-home>/locale-overrides` by default.
- `docs/i18n-user-overrides.md`: documents the convention and **proposes the same
  `<hermes-home>/locale-overrides` path for the desktop (Electron) and TUI layers**,
  so the override story is uniform across surfaces.

## Testing

`./scripts/run_tests.sh tests/agent/test_i18n.py` → **51 passed** (4 new).
Existing catalog-parity and placeholder tests unchanged (the bundled `locales/`
files are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
