### PR TITLE
fix: offload blocking profiles endpoints from asyncio event loop (#54523)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3429,7 +3429,7 @@ async def get_sessions(
 
 
 @app.get("/api/profiles/sessions")
-async def get_profiles_sessions(
+def get_profiles_sessions(
     limit: int = 20,
     offset: int = 0,
     min_messages: int = 0,
@@ -10565,7 +10565,9 @@ def _disable_unselected_skills(profile_dir: Path, keep: List[str]) -> int:
 async def list_profiles_endpoint():
     from hermes_cli import profiles as profiles_mod
     try:
-        return {"profiles": [_profile_to_dict(p) for p in profiles_mod.list_profiles()]}
+        loop = asyncio.get_running_loop()
+        profiles = await loop.run_in_executor(None, profiles_mod.list_profiles)
+        return {"profiles": [_profile_to_dict(p) for p in profiles]}
     except Exception:
         _log.exception("GET /api/profiles failed; falling back to profile directory scan")
         return {"profiles": _fallback_profile_dicts(profiles_mod)}


### PR DESCRIPTION
Fixes #54523

## Description

Two blocking endpoints were running synchronous I/O-heavy work directly on the asyncio event loop, starving the WebSocket handshake and keepalive:

1. **`GET /api/profiles`** (`list_profiles_endpoint`): calls `profiles_mod.list_profiles()` which walks every profile's filesystem (`_count_skills` → `SKILL.md` rglob + `realpath`), reads + YAML-parses profile configs, and resolves aliases. With many installed skills/profiles this blocks the loop for 10–25s (cold FS cache → longer).

2. **`GET /api/profiles/sessions`** (`get_profiles_sessions`): calls `list_profiles()` (same blocking work) then opens each profile's `state.db` — zero `await` calls in the entire function. With ~6,000 session files across profiles this takes ~25s.

### Fix

- **`list_profiles_endpoint`**: offloaded the blocking `list_profiles()` call via `await loop.run_in_executor(None, ...)` so the event loop stays free.
- **`get_profiles_sessions`**: changed from `async def` to `def` (sync). FastAPI/Starlette runs sync endpoints in a threadpool automatically, keeping the event loop clear.

### Verification

- Compile check: `py_compile.compile` passes on the modified file.
- `git diff --stat`: 1 file, 4 insertions, 2 deletions — strictly scoped.
- The fix matches the pattern used by the existing `get_model_options` (sync `def`) in the same codebase.
- Original reporter confirmed a local equivalent of this fix drops the endpoint latency from ~25s→~3s.