### PR TITLE
fix(agent): limit .hermes.md parent walk to git repos only (salvage #6662)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -88,12 +88,15 @@ def _find_hermes_md(cwd: Path) -> Optional[Path]:
     stop_at = _find_git_root(cwd)
     current = cwd.resolve()
 
-    for directory in [current, *current.parents]:
+    # When there is no git root, only check cwd itself – walking parents
+    # could pick up a .hermes.md planted in /tmp, /home, etc.
+    search_dirs = [current, *current.parents] if stop_at else [current]
+
+    for directory in search_dirs:
         for name in _HERMES_MD_NAMES:
             candidate = directory / name
             if candidate.is_file():
                 return candidate
-        # Stop walking at the git root (or filesystem root).
         if stop_at and directory == stop_at:
             break
     return None

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -928,6 +928,43 @@ class TestFindHermesMd:
         (repo / ".git").mkdir()
         assert _find_hermes_md(repo) is None
 
+    def test_no_git_root_checks_cwd_only(self, tmp_path):
+        """Outside a git repo, only cwd is checked — parents are NOT walked.
+
+        Walking parents with no git root to stop the loop would climb all
+        the way to / and pick up a .hermes.md planted in /tmp, /home, or /
+        on a shared system — a cross-user prompt-injection vector.
+        """
+        from unittest.mock import patch
+
+        parent = tmp_path / "parent"
+        parent.mkdir()
+        (parent / ".hermes.md").write_text("planted by another user")
+        cwd = parent / "work"
+        cwd.mkdir()
+        # No git root anywhere up the tree.
+        with patch("agent.prompt_builder._find_git_root", return_value=None):
+            assert _find_hermes_md(cwd) is None
+
+    def test_no_git_root_finds_in_cwd(self, tmp_path):
+        """Outside a git repo, a .hermes.md in cwd itself is still found."""
+        from unittest.mock import patch
+
+        (tmp_path / ".hermes.md").write_text("local rules")
+        with patch("agent.prompt_builder._find_git_root", return_value=None):
+            assert _find_hermes_md(tmp_path) == tmp_path / ".hermes.md"
+
+    def test_walks_parents_inside_git_repo(self, tmp_path):
+        """Inside a git repo, parent walk up to the git root still works."""
+        from unittest.mock import patch
+
+        (tmp_path / ".hermes.md").write_text("repo root rules")
+        sub = tmp_path / "a" / "b"
+        sub.mkdir(parents=True)
+        # Simulate cwd being inside a repo rooted at tmp_path.
+        with patch("agent.prompt_builder._find_git_root", return_value=tmp_path):
+            assert _find_hermes_md(sub) == tmp_path / ".hermes.md"
+
 
 class TestFindGitRoot:
     def test_finds_git_dir(self, tmp_path):


### PR DESCRIPTION
## Summary
Outside a git repo, `.hermes.md` discovery now only checks `cwd` instead of walking up to the filesystem root — closing a cross-user prompt-injection vector on shared systems.

Salvage of #6662 by @aaronlab. Only the security half (`prompt_builder`) is carried forward; the image-token-estimate half of the original PR is already implemented on current `main` (see note below).

## Root cause
`_find_hermes_md()` walks parent directories looking for `.hermes.md`/`HERMES.md`, stopping at the git root. When there is no git repo, `_find_git_root()` returns `None`, the `if stop_at and directory == stop_at: break` guard never fires, and the loop walks all the way to `/`. On shared systems (CI runners, multi-tenant servers), a `.hermes.md` planted at `/tmp`, `/home`, or `/` would be loaded into the system prompt of any agent session not inside a git repo.

## Changes
- `agent/prompt_builder.py`: when there is no git root, search only `cwd`; do not walk parents. (contributor commit, authorship preserved)
- `tests/agent/test_prompt_builder.py`: regression tests — no-git-root checks cwd only (planted ancestor ignored), cwd-local `.hermes.md` still found, in-repo parent walk unchanged.

## Why only half of #6662
The original PR also rewrote `estimate_messages_tokens_rough` to flat-estimate image tokens. Current `main` already does this — more completely — via `_count_image_tokens()` + `_estimate_message_chars()`, which strip base64 image data and count `image`/`image_url`/`input_image` blocks plus `_anthropic_content_blocks` and `_multimodal` tool results at a flat per-image cost. Carrying the PR's version forward would regress that. So only the still-unfixed `.hermes.md` half is salvaged.

## Validation
| | Before | After |
|---|---|---|
| No git root, `.hermes.md` planted in ancestor | loaded into prompt (injection) | ignored |
| No git root, `.hermes.md` in cwd | loaded | loaded |
| Inside git repo, `.hermes.md` at repo root | loaded | loaded |

E2E verified against the real `_find_hermes_md` (not mocks): injection BLOCKED, both legitimate paths still work. Targeted suite: 18/18 passing.

## Infographic

![hermes-md-git-root-walk](https://v3b.fal.media/files/b/0aa02ecc/aqa4KIhqGGdHYGxUsMH6a_qRW1d32S.png)
