### PR TITLE
fix(matrix,mattermost): invite auth check + API path traversal guard

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2892,6 +2892,25 @@ class MatrixAdapter(BasePlatformAdapter):
         is_direct = bool(getattr(content, "is_direct", False))
         inviter = str(getattr(event, "sender", ""))
 
+        # Only auto-join when the inviter is authorized. Without this, any
+        # federated Matrix user could invite the bot into arbitrary rooms,
+        # exposing its presence and metadata. Mirrors the allow-list gate
+        # used on the message/reaction paths.
+        allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {
+            "true",
+            "1",
+            "yes",
+        }
+        if not allow_all and not (
+            self._allowed_user_ids and inviter in self._allowed_user_ids
+        ):
+            logger.warning(
+                "Matrix: rejecting invite to %s from unauthorized user %s",
+                room_id,
+                inviter,
+            )
+            return
+
         logger.info(
             "Matrix: invited to %s — joining (is_direct=%s)",
             room_id,

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -117,6 +117,9 @@ class MattermostAdapter(BasePlatformAdapter):
     async def _api_get(self, path: str) -> Dict[str, Any]:
         """GET /api/v4/{path}."""
         import aiohttp
+        if ".." in path:
+            logger.error("MM API path traversal blocked: %s", path)
+            return {}
         url = f"{self._base_url}/api/v4/{path.lstrip('/')}"
         try:
             async with self._session.get(url, headers=self._headers(), timeout=aiohttp.ClientTimeout(total=30)) as resp:
@@ -134,6 +137,9 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> Dict[str, Any]:
         """POST /api/v4/{path} with JSON body."""
         import aiohttp
+        if ".." in path:
+            logger.error("MM API path traversal blocked: %s", path)
+            return {}
         url = f"{self._base_url}/api/v4/{path.lstrip('/')}"
         self._last_post_status = None
         self._last_post_error = ""
@@ -213,6 +219,9 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> Dict[str, Any]:
         """PUT /api/v4/{path} with JSON body."""
         import aiohttp
+        if ".." in path:
+            logger.error("MM API path traversal blocked: %s", path)
+            return {}
         url = f"{self._base_url}/api/v4/{path.lstrip('/')}"
         try:
             async with self._session.put(

--- a/tests/gateway/test_matrix_dm_invite_recording.py
+++ b/tests/gateway/test_matrix_dm_invite_recording.py
@@ -31,6 +31,10 @@ def _make_adapter(tmp_path=None):
     adapter._text_batch_delay_seconds = 0
     adapter.handle_message = AsyncMock()
     adapter._startup_ts = time.time() - 10
+    # Authorize the inviter used throughout this module so the invite-auth
+    # gate in _on_invite (rejects auto-joins from non-allow-listed users)
+    # lets the join through and the DM-recording side effects are exercised.
+    adapter._allowed_user_ids = {"@alice:example.org"}
     return adapter
 
 


### PR DESCRIPTION
## Summary

Closes two platform-level auth gaps: a Matrix bot will now only auto-join rooms when the inviter is on its allow-list, and the Mattermost adapter rejects any API path containing `..`.

Salvage of #6704 by @aaronlab onto current `main`. The adapters moved to `plugins/platforms/{matrix,mattermost}/adapter.py` since the PR was opened, so this re-applies the still-valid fixes against the relocated code.

## Changes

- `plugins/platforms/matrix/adapter.py`: `_on_invite` now gates on the inviter against the existing `_allowed_user_ids` / `GATEWAY_ALLOW_ALL_USERS` allow-list before scheduling an auto-join. The message and reaction paths already enforced this; the invite path bypassed it, so any federated Matrix user could invite the bot into arbitrary rooms.
- `plugins/platforms/mattermost/adapter.py`: `_api_get` / `_api_post` / `_api_put` reject any `path` containing `..` and return `{}`. WebSocket-event values (`channel_id`, `post_id`, `file_id`) are interpolated directly into API paths, so a malicious/compromised server could craft traversal payloads to make the bot hit arbitrary endpoints with its bearer token.

The configurable-E2EE-passphrase change from the original PR is **dropped**: the Matrix adapter was rewritten onto `mautrix`, and the passphrase-protected key-export file (`exported_keys.txt`) it targeted no longer exists.

Adapted from the original: the invite gate reuses the current `GATEWAY_ALLOW_ALL_USERS` + `_allowed_user_ids` pattern rather than introducing a parallel `MATRIX_ALLOW_ALL_USERS` env var.

## Validation

| | Before | After |
|---|---|---|
| Matrix invite from unauthorized user | auto-joins | rejected (logged) |
| Matrix invite from allow-listed user | auto-joins | auto-joins |
| `GATEWAY_ALLOW_ALL_USERS=true` | n/a | overrides allow-list (joins) |
| Empty allow-list, no allow_all | auto-joins | fail-closed (rejected) |
| Mattermost API path with `..` | request sent with bearer token | blocked, returns `{}` |
| Mattermost legit API path | sent | sent (unchanged) |

E2E: both guards exercised with real imports against the relocated adapters (4/4 invite cases, 3/3 traversal helpers + legit passthrough). `tests/gateway/test_mattermost.py`: 58/58 pass.

## Infographic

![Platform security hardening — PR #6704](https://v3b.fal.media/files/b/0aa02f0c/S_lJT_yZX7FJomYTtkeQj_mtzSqkFk.png)

---
Original PR: #6704 — credit to @aaronlab. Authorship preserved via the commit author on this branch.
