### PR TITLE
fix(wecom): raise on silent ws close to prevent 100% CPU reconnect spin

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -373,6 +373,12 @@ class WeComAdapter(BasePlatformAdapter):
             elif msg.type in {aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSING}:
                 raise RuntimeError("WeCom websocket closed")
 
+        # Loop exited without a CLOSE-typed message (ws went None/closed
+        # between iterations). Must raise — otherwise _listen_loop treats
+        # this as success, resets backoff_idx, and spins at 100% CPU.
+        if self._running:
+            raise RuntimeError("WeCom websocket closed (no message)")
+
     async def _heartbeat_loop(self) -> None:
         """Send lightweight application-level pings."""
         try:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1726,6 +1726,7 @@ AUTHOR_MAP = {
     "steveonjava@gmail.com": "steveonjava",  # PR #29669 (redact secrets in kanban tool payloads)
     "afnlegion01@gmail.com": "Afnath-max",  # PR #49129 salvage (opencode-zen catalog refresh + uncapped/live-first picker)
     "sharma.priyanshu96@gmail.com": "ipriyaaanshu",  # PR #51488 salvage (clear stale base_url on gateway model switches; #25107)
+    "huachi1990@hotmail.com": "leonxia1010",
 }
 
 

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -953,3 +953,42 @@ class TestTextBatchFlushRace:
         assert adapter._pending_text_batches.get(key) is None, (
             "active task must pop the event after processing"
         )
+
+
+class TestReadEventsRaisesOnSilentClose:
+    """Regression: _read_events must raise when the websocket is closed
+    without a CLOSE-typed message. Otherwise _listen_loop's success path
+    resets backoff_idx and spins at 100% CPU instead of backing off."""
+
+    def _make_adapter(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        return WeComAdapter(
+            PlatformConfig(enabled=True, extra={"bot_id": "b", "secret": "s"})
+        )
+
+    @pytest.mark.asyncio
+    async def test_raises_when_ws_is_none(self):
+        adapter = self._make_adapter()
+        adapter._running = True
+        adapter._ws = None
+
+        with pytest.raises(RuntimeError, match="not connected"):
+            await adapter._read_events()
+
+    @pytest.mark.asyncio
+    async def test_raises_when_ws_closed_without_close_message(self):
+        adapter = self._make_adapter()
+        adapter._running = True
+        adapter._ws = MagicMock(closed=True)
+
+        with pytest.raises(RuntimeError, match="closed"):
+            await adapter._read_events()
+
+    @pytest.mark.asyncio
+    async def test_does_not_raise_when_not_running(self):
+        adapter = self._make_adapter()
+        adapter._running = False
+        adapter._ws = MagicMock(closed=True)
+
+        await adapter._read_events()


### PR DESCRIPTION
## What does this PR do?

`_read_events()` in the WeCom adapter exited cleanly when `self._ws` became
`None` or `closed` between iterations without any CLOSE-typed message arriving.
`_listen_loop` treated this as a successful read, reset `backoff_idx` to 0, and
immediately re-entered `_read_events` — which returned cleanly again.

Result: a tight loop that burned ~100% CPU indefinitely with no `asyncio.sleep`
ever firing.

Observed in production as a single profile accumulating **90+ CPU-hours over
11 days** while `gateway.log` went silent.

This complements #28311 (`fix(wecom): handle WSMsgType.CLOSING to prevent CPU
spin`), which covered graceful server-side shutdowns via a new terminal
message type. This PR covers the orthogonal case where the websocket
transitions to closed/None between iterations without emitting any terminal
message type at all.

## Related Issue

No prior issue — surfaced in a local production deployment after an extended
silent-close interval. Reproducer included in the new test class.

Fixes # _(none)_

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/wecom/adapter.py` — `_read_events()` now raises
  `RuntimeError("WeCom websocket closed (no message)")` when the loop exits
  while `self._running` is True. `_listen_loop` already catches this and
  applies the existing `[2, 5, 10, 30, 60]` `RECONNECT_BACKOFF`.
- `tests/gateway/test_wecom.py` — new regression class
  `TestReadEventsRaisesOnSilentClose` with three cases (ws=None, ws closed
  without close-typed message, clean shutdown when not running).
- `scripts/release.py` — add `huachi1990@hotmail.com` → `leonxia1010`
  mapping to `AUTHOR_MAP` so `contributor-check.yml` passes for this PR's
  fix commit.

## How to Test

1. `scripts/run_tests.sh` (or `venv/bin/python -m pytest tests/gateway/test_wecom.py -v`)
2. Specifically the new class:
   `pytest tests/gateway/test_wecom.py::TestReadEventsRaisesOnSilentClose -v`
   should report 3 passed.
3. Manual: run `hermes` connected to WeCom, force a silent ws close (e.g.
   break the tunnel without sending a CLOSE frame). With the fix, reconnect
   backoff kicks in (`[2,5,10,30,60]`s); without it, CPU pegs at 100% and
   `gateway.log` goes silent.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (PR #28311 handled a different terminal-message-type case, this is the no-message case)
- [x] My PR contains **only** changes related to this fix (the `scripts/release.py` AUTHOR_MAP entry is required by `.github/workflows/contributor-check.yml` to gate this PR's attribution)
- [x] I've run `scripts/run_tests.sh` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (pure asyncio control flow, no public API or doc surface)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — verified on macOS; pure asyncio + aiohttp behavior is identical across platforms
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
