### PR TITLE
fix(gateway): keep code indentation when a long message is split

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6797,7 +6797,15 @@ class BasePlatformAdapter(ABC):
                         split_at = safe_split
 
             chunk_body = remaining[:split_at]
-            remaining = remaining[split_at:].lstrip()
+            # Advance past the separator we split on, but keep the next line's
+            # own leading indentation. A bare ``.lstrip()`` here strips the
+            # indentation off the first line of every continuation chunk, which
+            # silently de-indents code blocks that span more than one message.
+            # Drop a leading newline boundary (and any blank lines) when we
+            # split on a newline; drop the boundary space(s) when we split
+            # mid-line on a space; leave a hard mid-token cut untouched.
+            _next = remaining[split_at:]
+            remaining = _next.lstrip("\n") if _next[:1] == "\n" else _next.lstrip(" ")
 
             full_chunk = prefix + chunk_body
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -892,6 +892,26 @@ class TestTruncateMessage:
                 "No continuation chunk reopened with language tag"
             )
 
+    def test_indented_code_block_keeps_indentation_across_chunks(self):
+        """A code block split across chunks must keep each line's indentation.
+
+        The split point advances past the boundary newline, but it must not
+        also eat the next line's leading whitespace, or the first line of every
+        continuation chunk arrives de-indented and the code no longer runs.
+        """
+        adapter = self._adapter()
+        body = "\n".join(f"    value_{i} = compute(item_{i})" for i in range(60))
+        msg = "```python\n" + body + "\n```"
+        chunks = adapter.truncate_message(msg, max_length=400)
+        assert len(chunks) > 1, "message should have split into multiple chunks"
+        for i, chunk in enumerate(chunks):
+            for line in chunk.splitlines():
+                # Every real code line is indented; a de-indented one means the
+                # boundary strip removed its leading whitespace.
+                if line.startswith("value_"):
+                    raise AssertionError(
+                        f"chunk {i} has a de-indented code line: {line!r}"
+                    )
 
 # ---------------------------------------------------------------------------
 # _get_human_delay


### PR DESCRIPTION
Fixes #54579

### Problem

`BasePlatformAdapter.truncate_message` splits a long outbound reply into chunks and reopens code fences across the boundary. When it advances to the next chunk it runs `.lstrip()` on the remainder, which strips the boundary newline and the next line's leading indentation. The first code line of every continuation chunk arrives de-indented, so a code block that spans more than one message no longer matches its original indentation.

```python
body = "\n".join(f"    value_{i} = compute(item_{i})" for i in range(60))
chunks = BasePlatformAdapter.truncate_message("```python\n" + body + "\n```", 400)
# continuation chunks start with "value_12 = ..." instead of "    value_12 = ..."
```

This runs on every send path that chunks through `truncate_message` (the bundled Telegram, Discord, WhatsApp, Signal, BlueBubbles, WeChat, QQ and yuanbao adapters, and the streaming fallback).

### Fix

Replace the boundary `.lstrip()` with a separator-aware strip:

```python
_next = remaining[split_at:]
remaining = _next.lstrip("\n") if _next[:1] == "\n" else _next.lstrip(" ")
```

When the split landed on a newline, drop the leading newline(s) and any blank lines but keep the following indentation. When it landed mid-line on a space, drop the boundary space(s). A hard mid-token cut starts with a non-whitespace character and is left untouched. This brings the behavior in line with `_split_text_chunks` in `gateway/stream_consumer.py`, which already uses `.lstrip("\n")` at its boundary.

### Tests

Added a test that splits an indented Python block and asserts no continuation chunk contains a de-indented code line. The existing fence, whitespace and length tests are unchanged (their fixtures use unindented lines and prose, where the behavior is identical). `tests/gateway/test_platform_base.py` passes (163 passed, 2 skipped).
