### PR TITLE
feat: Add configurable attribution string for agent identity

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1307,6 +1307,11 @@ def init_agent(
         _agent_section = {}
     agent._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
 
+    # Attribution string for agent identity.  Controls the "created by X"
+    # attribution in the system prompt.  Default "Nous Research" preserves
+    # backward compatibility.  Set to "" (empty) to omit attribution entirely.
+    agent._attribution = _agent_section.get("attribution", "Nous Research")
+
     # Intent-ack continuation config: "auto" (default — codex_responses only,
     # the historical gate), true (all api_modes), false (never), or a list of
     # model-name substrings.  Resolved against the active api_mode/model in the

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -18,7 +18,7 @@ import uuid
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
-from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+from agent.prompt_builder import build_agent_identity, DEFAULT_ATTRIBUTION
 
 logger = logging.getLogger(__name__)
 
@@ -809,7 +809,7 @@ def _preflight_codex_api_kwargs(
         instructions = ""
     if not isinstance(instructions, str):
         instructions = str(instructions)
-    instructions = instructions.strip() or DEFAULT_AGENT_IDENTITY
+    instructions = instructions.strip() or build_agent_identity(DEFAULT_ATTRIBUTION)
 
     normalized_input = _preflight_codex_input_items(api_kwargs.get("input"))
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -120,26 +120,52 @@ def _strip_yaml_frontmatter(content: str) -> str:
 # Constants
 # =========================================================================
 
-DEFAULT_AGENT_IDENTITY = (
-    "You are Hermes Agent, an intelligent AI assistant created by Nous Research. "
-    "You are helpful, knowledgeable, and direct. You assist users with a wide "
-    "range of tasks including answering questions, writing and editing code, "
-    "analyzing information, creative work, and executing actions via your tools. "
-    "You communicate clearly, admit uncertainty when appropriate, and prioritize "
-    "being genuinely useful over being verbose unless otherwise directed below. "
-    "Be targeted and efficient in your exploration and investigations."
-)
+DEFAULT_ATTRIBUTION = "Nous Research"
 
-HERMES_AGENT_HELP_GUIDANCE = (
-    "You run on Hermes Agent (by Nous Research). When the user needs help with "
-    "Hermes itself — configuring, setting up, using, extending, or troubleshooting "
-    "it — or when you need to understand your own features, tools, or capabilities, "
-    "the documentation at https://hermes-agent.nousresearch.com/docs is your "
-    "authoritative reference and always holds the latest, most up-to-date "
-    "information. Load the `hermes-agent` skill with skill_view(name='hermes-agent') "
-    "for additional guidance and proven workflows, but treat the docs as the source "
-    "of truth when the two differ."
-)
+
+def build_agent_identity(attribution: str = DEFAULT_ATTRIBUTION) -> str:
+    """Build the agent identity string with configurable attribution."""
+    if attribution:
+        return (
+            f"You are Hermes Agent, an intelligent AI assistant created by {attribution}. "
+            "You are helpful, knowledgeable, and direct. You assist users with a wide "
+            "range of tasks including answering questions, writing and editing code, "
+            "analyzing information, creative work, and executing actions via your tools. "
+            "You communicate clearly, admit uncertainty when appropriate, and prioritize "
+            "being genuinely useful over being verbose unless otherwise directed below. "
+            "Be targeted and efficient in your exploration and investigations."
+        )
+    else:
+        return (
+            "You are Hermes Agent, an intelligent AI assistant. "
+            "You are helpful, knowledgeable, and direct. You assist users with a wide "
+            "range of tasks including answering questions, writing and editing code, "
+            "analyzing information, creative work, and executing actions via your tools. "
+            "You communicate clearly, admit uncertainty when appropriate, and prioritize "
+            "being genuinely useful over being verbose unless otherwise directed below. "
+            "Be targeted and efficient in your exploration and investigations."
+        )
+
+
+def build_help_guidance(attribution: str = DEFAULT_ATTRIBUTION) -> str:
+    """Build the help guidance string with configurable attribution."""
+    if not attribution:
+        return ""  # Omit attribution block entirely when empty
+    return (
+        f"You run on Hermes Agent (by {attribution}). When the user needs help with "
+        "Hermes itself — configuring, setting up, using, extending, or troubleshooting "
+        "it — or when you need to understand your own features, tools, or capabilities, "
+        "the documentation at https://hermes-agent.nousresearch.com/docs is your "
+        "authoritative reference and always holds the latest, most up-to-date "
+        "information. Load the `hermes-agent` skill with skill_view(name='hermes-agent') "
+        "for additional guidance and proven workflows, but treat the docs as the source "
+        "of truth when the two differ."
+    )
+
+
+# Legacy constants for backward compatibility
+DEFAULT_AGENT_IDENTITY = build_agent_identity(DEFAULT_ATTRIBUTION)
+HERMES_AGENT_HELP_GUIDANCE = build_help_guidance(DEFAULT_ATTRIBUTION)
 
 MEMORY_GUIDANCE = (
     "You have persistent memory across sessions. Save durable facts using the memory "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -158,11 +158,18 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             _soul_loaded = True
 
     if not _soul_loaded:
-        # Fallback to hardcoded identity
-        stable_parts.append(DEFAULT_AGENT_IDENTITY)
+        # Fallback to identity with configurable attribution
+        from agent.prompt_builder import build_agent_identity
+        attribution = getattr(agent, "_attribution", "Nous Research")
+        stable_parts.append(build_agent_identity(attribution))
 
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
-    stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
+    # Skip when attribution is empty (user wants clean identity without attribution).
+    from agent.prompt_builder import build_help_guidance
+    attribution = getattr(agent, "_attribution", "Nous Research")
+    help_guidance = build_help_guidance(attribution)
+    if help_guidance:
+        stable_parts.append(help_guidance)
 
     # Universal task-completion / no-fabrication guidance.  Applied to ALL
     # models regardless of tool_use_enforcement gating — the failure modes

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -154,6 +154,16 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if agent.load_soul_identity or not agent.skip_context_files:
         _soul_content = _r.load_soul_md(_ctx_len)
         if _soul_content:
+            # When SOUL.md matches the default template, apply the
+            # configurable attribution so ``agent.attribution`` controls
+            # the identity even in the normal (SOUL-loaded) path.
+            from hermes_cli.default_soul import DEFAULT_SOUL_MD
+            attribution = getattr(agent, "_attribution", "Nous Research")
+            if _soul_content.strip() == DEFAULT_SOUL_MD.strip() and attribution != "Nous Research":
+                _soul_content = _soul_content.replace(
+                    "created by Nous Research",
+                    f"created by {attribution}",
+                )
             stable_parts.append(_soul_content)
             _soul_loaded = True
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -126,7 +126,7 @@ class ResponsesApiTransport(ProviderTransport):
             _responses_tools,
         )
 
-        from run_agent import DEFAULT_AGENT_IDENTITY
+        from agent.prompt_builder import build_agent_identity, DEFAULT_ATTRIBUTION
 
         instructions = params.get("instructions", "")
         payload_messages = messages
@@ -135,7 +135,7 @@ class ResponsesApiTransport(ProviderTransport):
                 instructions = str(messages[0].get("content") or "").strip()
                 payload_messages = messages[1:]
         if not instructions:
-            instructions = DEFAULT_AGENT_IDENTITY
+            instructions = build_agent_identity(DEFAULT_ATTRIBUTION)
 
         is_github_responses = params.get("is_github_responses", False)
         is_codex_backend = params.get("is_codex_backend", False)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -615,6 +615,13 @@ agent:
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
   max_turns: 60
 
+  # Attribution label for the agent identity.
+  # Controls the "created by X" attribution in the system prompt.
+  # - "Nous Research" (default) → current behavior, backward compatible
+  # - "Acme Corp"              → "created by Acme Corp" / "(by Acme Corp)"
+  # - "" (empty)               → attribution block omitted entirely
+  # attribution: "Nous Research"
+
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving
   # API responses.  Only fires after the agent has been idle for this duration.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -907,6 +907,7 @@ DEFAULT_CONFIG = {
     # pressure. Reopening one re-resumes it from disk. 0/null disables.
     "max_live_sessions": 16,
     "agent": {
+        "attribution": "Nous Research",
         "max_turns": 90,
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1609,3 +1609,174 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 
 
+
+
+# =========================================================================
+# Configurable attribution (#54548 / #54588)
+# =========================================================================
+
+
+class TestConfigurableAttribution:
+    """Regression tests for agent.attribution config.
+
+    Covers the reviewer feedback on #54588:
+    - Default attribution preserves backward compat
+    - Custom attribution propagates to identity + help guidance
+    - Empty attribution omits attribution block
+    - SOUL.md with default content gets attribution replaced
+    - Customized SOUL.md is preserved as-is
+    """
+
+    def test_default_attribution_identity(self):
+        from agent.prompt_builder import build_agent_identity
+        result = build_agent_identity("Nous Research")
+        assert "created by Nous Research" in result
+        assert "Hermes Agent" in result
+
+    def test_custom_attribution_identity(self):
+        from agent.prompt_builder import build_agent_identity
+        result = build_agent_identity("Acme Corp")
+        assert "created by Acme Corp" in result
+        assert "Nous Research" not in result
+
+    def test_empty_attribution_identity(self):
+        from agent.prompt_builder import build_agent_identity
+        result = build_agent_identity("")
+        assert "created by" not in result
+        assert "Hermes Agent" in result
+
+    def test_default_attribution_help_guidance(self):
+        from agent.prompt_builder import build_help_guidance
+        result = build_help_guidance("Nous Research")
+        assert "by Nous Research" in result
+        assert "hermes-agent" in result
+
+    def test_custom_attribution_help_guidance(self):
+        from agent.prompt_builder import build_help_guidance
+        result = build_help_guidance("Acme Corp")
+        assert "by Acme Corp" in result
+        assert "Nous Research" not in result
+
+    def test_empty_attribution_help_guidance_omitted(self):
+        from agent.prompt_builder import build_help_guidance
+        result = build_help_guidance("")
+        assert result == ""
+
+    def test_default_agent_identity_matches_legacy(self):
+        """Legacy constant must still resolve to Nous Research."""
+        from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+        assert "created by Nous Research" in DEFAULT_AGENT_IDENTITY
+
+    def test_hermes_agent_help_guidance_matches_legacy(self):
+        from agent.prompt_builder import HERMES_AGENT_HELP_GUIDANCE
+        assert "by Nous Research" in HERMES_AGENT_HELP_GUIDANCE
+
+    def test_default_config_has_attribution(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+        assert "attribution" in DEFAULT_CONFIG.get("agent", {})
+        assert DEFAULT_CONFIG["agent"]["attribution"] == "Nous Research"
+
+    def test_soul_md_default_gets_replacement(self, monkeypatch):
+        """When SOUL.md matches the default template and attribution is
+        non-default, the identity string should be replaced."""
+        from hermes_cli.default_soul import DEFAULT_SOUL_MD
+
+        class FakeAgent:
+            load_soul_identity = True
+            skip_context_files = False
+            _attribution = "Acme Corp"
+            context_compressor = None
+            valid_tool_names = set()
+            _task_completion_guidance = False
+            _parallel_tool_call_guidance = False
+
+        # Mock load_soul_md to return default content
+        import agent.system_prompt as sp
+        monkeypatch.setattr(sp._r, "load_soul_md", lambda ctx: DEFAULT_SOUL_MD)
+
+        parts, _ = sp.build_system_prompt_parts(FakeAgent())
+        soul_part = parts[0]
+        assert "created by Acme Corp" in soul_part
+        assert "Nous Research" not in soul_part
+
+    def test_soul_md_customized_preserved(self, monkeypatch):
+        """When SOUL.md is user-customized (different from default), the
+        attribution setting must NOT override it."""
+        custom_soul = "You are a coding assistant for Acme Corp's internal use."
+
+        class FakeAgent:
+            load_soul_identity = True
+            skip_context_files = False
+            _attribution = "Evil Corp"
+            context_compressor = None
+            valid_tool_names = set()
+            _task_completion_guidance = False
+            _parallel_tool_call_guidance = False
+
+        import agent.system_prompt as sp
+        monkeypatch.setattr(sp._r, "load_soul_md", lambda ctx: custom_soul)
+
+        parts, _ = sp.build_system_prompt_parts(FakeAgent())
+        soul_part = parts[0]
+        # Custom SOUL.md must be preserved verbatim
+        assert soul_part == custom_soul
+        assert "Evil Corp" not in soul_part
+
+    def test_soul_md_default_no_replacement_when_same(self, monkeypatch):
+        """When attribution is the default 'Nous Research', no replacement
+        should happen (default SOUL.md already has it)."""
+        from hermes_cli.default_soul import DEFAULT_SOUL_MD
+
+        class FakeAgent:
+            load_soul_identity = True
+            skip_context_files = False
+            _attribution = "Nous Research"
+            context_compressor = None
+            valid_tool_names = set()
+            _task_completion_guidance = False
+            _parallel_tool_call_guidance = False
+
+        import agent.system_prompt as sp
+        monkeypatch.setattr(sp._r, "load_soul_md", lambda ctx: DEFAULT_SOUL_MD)
+
+        parts, _ = sp.build_system_prompt_parts(FakeAgent())
+        soul_part = parts[0]
+        assert soul_part.strip() == DEFAULT_SOUL_MD.strip()
+
+    def test_fallback_identity_uses_attribution(self, monkeypatch):
+        """When SOUL.md is not loaded, build_agent_identity should use
+        the configured attribution."""
+        class FakeAgent:
+            load_soul_identity = False
+            skip_context_files = True
+            _attribution = "CustomOrg"
+            context_compressor = None
+            valid_tool_names = set()
+            _task_completion_guidance = False
+            _parallel_tool_call_guidance = False
+
+        import agent.system_prompt as sp
+        monkeypatch.setattr(sp._r, "load_soul_md", lambda ctx: None)
+
+        parts, _ = sp.build_system_prompt_parts(FakeAgent())
+        identity_part = parts[0]
+        assert "created by CustomOrg" in identity_part
+
+    def test_help_guidance_skipped_when_empty_attribution(self, monkeypatch):
+        """When attribution is empty, help guidance block should be omitted."""
+        class FakeAgent:
+            load_soul_identity = False
+            skip_context_files = True
+            _attribution = ""
+            context_compressor = None
+            valid_tool_names = set()
+            _task_completion_guidance = False
+            _parallel_tool_call_guidance = False
+
+        import agent.system_prompt as sp
+        monkeypatch.setattr(sp._r, "load_soul_md", lambda ctx: None)
+
+        parts, _ = sp.build_system_prompt_parts(FakeAgent())
+        # Help guidance should not be present when attribution is empty
+        for part in parts:
+            assert "hermes-agent.nousresearch.com" not in part


### PR DESCRIPTION
## Summary

Adds a configurable `attribution` field in the agent config section to control the "created by X" attribution in the system prompt.

## Changes

- **agent/agent_init.py**: Add `_attribution` attribute to agent (default: "Nous Research")
- **agent/prompt_builder.py**: Add `build_agent_identity()` and `build_help_guidance()` functions
- **agent/system_prompt.py**: Use dynamic attribution based on agent._attribution
- **cli-config.yaml.example**: Document the new setting

## Configuration

```yaml
agent:
  attribution: "Nous Research"  # default - backward compatible
  # attribution: "Acme Corp"    # custom org name
  # attribution: ""              # omit attribution entirely
```

## Behavior

| Value | DEFAULT_AGENT_IDENTITY | HERMES_AGENT_HELP_GUIDANCE |
|-------|----------------------|--------------------------|
| `"Nous Research"` (default) | `"...created by Nous Research."` | `"(by Nous Research)."` |
| `"Acme Corp"` | `"...created by Acme Corp."` | `"(by Acme Corp)."` |
| `""` or not set | `"You are Hermes Agent..."` (no attribution) | Block omitted entirely |

## Motivation

- **Developer sovereignty**: Users who run Hermes for their own work get "Nous Research" injected into every system prompt. If they ask the agent to generate artifacts autonomously (code, docs, PRs), the model may reproduce this attribution, creating legal/branding issues.
- **Subscription billing false-positives**: This same string trips Anthropic's subscription billing classifier, causing overage charges (#53212).
- **Inconsistency**: SOUL.md overrides identity for the main conversation loop, but subagents with `skip_context_files=True` and gateway platforms like Feishu fall back to `DEFAULT_AGENT_IDENTITY` (#6731).

## Implementation

The change is small (< 30 lines across 3 files) and fully backward compatible. The default value preserves existing behavior. Empty string cleanly omits attribution.

Closes #54548