### PR TITLE
fix(acp): size Markdown fence by longest backtick run, not between-backtick text

### DIFF
--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import uuid
 from typing import Any, Dict, List, Optional
 
@@ -248,7 +249,7 @@ def _truncate_text(text: str, limit: int = 5000) -> str:
 
 def _fenced_text(text: str, language: str = "") -> str:
     """Return a Markdown fence that cannot be broken by backticks in text."""
-    longest = max((len(run) for run in text.split("`")[1::2]), default=0)
+    longest = max((len(run) for run in re.findall(r"`+", text)), default=0)
     fence = "`" * max(3, longest + 1)
     return f"{fence}{language}\n{text}\n{fence}"
 

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -1,5 +1,7 @@
 """Tests for acp_adapter.tools — tool kind mapping and ACP content building."""
 
+import json
+import re
 
 from acp_adapter.edit_approval import EditProposal
 from acp_adapter.tools import (
@@ -427,6 +429,27 @@ class TestBuildToolComplete:
         assert "Read README.md" in text
         assert "```\n1|hello\n2|world\n```" in text
         assert result.raw_output is None
+
+    def test_read_file_fence_longer_than_internal_backtick_run(self):
+        # File content with a 4-backtick run: the outer Markdown fence must be
+        # strictly longer than the longest consecutive backtick run, else Zed/ACP
+        # closes the code block early and the rest renders as broken markdown.
+        content = "value = " + ("`" * 4)
+        result = build_tool_complete(
+            "tc-fence",
+            "read_file",
+            json.dumps({"content": content}),
+        )
+        text = result.content[0].content.text
+        # The fenced payload follows a "Read <path>" header; find the opening
+        # fence (first line that begins with a backtick run).
+        opening_fence = next(
+            line for line in text.splitlines() if line.startswith("`")
+        )
+        opening_fence_backticks = len(opening_fence) - len(opening_fence.lstrip("`"))
+        longest_run = max(len(m) for m in re.findall(r"`+", content))
+        assert longest_run == 4
+        assert opening_fence_backticks > longest_run
 
     def test_build_tool_complete_for_search_files_formats_matches(self):
         result = build_tool_complete(


### PR DESCRIPTION
## What does this PR do?

`_fenced_text` in `acp_adapter/tools.py` builds the Markdown fence that wraps tool-result payloads sent to ACP clients (Zed). Its docstring promises "a Markdown fence that cannot be broken by backticks in text" — meaning the outer fence must be strictly longer than the longest *consecutive backtick run* inside the content.

The implementation measured the wrong thing:

```python
longest = max((len(run) for run in text.split("`")[1::2]), default=0)
```

`text.split("`")[1::2]` yields the text *segments between* backticks, not backtick-run lengths. A maximal run of N backticks produces N-1 empty segments, so for content whose longest run is >= 4 and falls on even split boundaries, `[1::2]` returns empty strings → `longest = 0` → a 3-backtick outer fence that is **shorter than or equal to** the inner run. The fence then closes early and the rest of the file renders as broken Markdown.

This is reached from `_format_read_file_result` (`_fenced_text(content)`), so any file the agent reads over ACP whose content contains a 4+ backtick run renders corrupted in Zed.

The fix measures the actual longest backtick run:

```python
longest = max((len(run) for run in re.findall(r"`+", text)), default=0)
```

`fence = "`" * max(3, longest + 1)` is already correct and is left unchanged.

## Related Issue

None — found while reading the ACP adapter.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `acp_adapter/tools.py`: replace the between-backtick segment measure with a real backtick-run scan (`re.findall(r"`+", text)`); add `import re`.
- `tests/acp/test_tools.py`: add `test_read_file_fence_longer_than_internal_backtick_run` asserting the rendered opening fence is strictly longer than the longest backtick run in the file content.

## How to Test

1. Read a file over ACP whose content contains a run of 4 backticks (e.g. `value = \`\`\`\``).
2. Before the fix: the opening fence is 3 backticks (≤ the inner 4-run), so the block closes early and the payload renders broken.
3. After the fix: the opening fence is 5 backticks (> 4), so the block stays intact.

The new regression test fails before the production change (`assert 3 > 4`) and passes after (`5 > 4`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched-area tests (`tests/acp/`) and the new test passes; pre-existing `test_edit_approval.py` failures reproduce unchanged on clean `main`
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A