### PR TITLE
fix: salvage remaining P3 fixes onto current main

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1796,6 +1796,12 @@ def init_agent(
     # single turn; the runtime already executes such batches concurrently.
     agent._parallel_tool_call_guidance = bool(_agent_section.get("parallel_tool_call_guidance", True))
 
+    # Configurable attribution string for agent identity and help guidance.
+    # "Nous Research" (default) → current behavior, backward-compatible.
+    # "Acme Corp" → "created by Acme Corp" / "(by Acme Corp)".
+    # "" (empty) → attribution block omitted entirely.
+    agent._attribution = str(_agent_section.get("attribution", "Nous Research"))
+
     # Local Python toolchain probe toggle.  Default True.  When False,
     # the probe is skipped entirely (no subprocess calls, no system-prompt
     # line).  Useful for users on exotic setups where the probe heuristics

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2086,6 +2086,12 @@ def init_agent(
     # single turn; the runtime already executes such batches concurrently.
     agent._parallel_tool_call_guidance = bool(_agent_section.get("parallel_tool_call_guidance", True))
 
+    # Org attribution in the fallback identity / help-guidance blocks.
+    # "Nous Research" (default) keeps current wording. A custom string
+    # replaces the org name. Empty omits the "built by …" / "(by …)" clause.
+    _raw_attribution = _agent_section.get("attribution", "Nous Research")
+    agent._attribution = "" if _raw_attribution is None else str(_raw_attribution)
+
     # Local Python toolchain probe toggle.  Default True.  When False,
     # the probe is skipped entirely (no subprocess calls, no system-prompt
     # line).  Useful for users on exotic setups where the probe heuristics

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -141,26 +141,52 @@ def _strip_yaml_frontmatter(content: str) -> str:
 # Constants
 # =========================================================================
 
-DEFAULT_AGENT_IDENTITY = (
-    "You are Hermes Agent, an intelligent AI assistant created by Nous Research. "
-    "You are helpful, knowledgeable, and direct. You assist users with a wide "
-    "range of tasks including answering questions, writing and editing code, "
-    "analyzing information, creative work, and executing actions via your tools. "
-    "You communicate clearly, admit uncertainty when appropriate, and prioritize "
-    "being genuinely useful over being verbose unless otherwise directed below. "
-    "Be targeted and efficient in your exploration and investigations."
-)
+def _build_agent_identity(attribution: str = "Nous Research") -> str:
+    """Build the default agent identity string with configurable attribution."""
+    if attribution:
+        return (
+            f"You are Hermes Agent, an intelligent AI assistant created by "
+            f"{attribution}. You are helpful, knowledgeable, and direct. You "
+            "assist users with a wide range of tasks including answering "
+            "questions, writing and editing code, analyzing information, "
+            "creative work, and executing actions via your tools. You "
+            "communicate clearly, admit uncertainty when appropriate, and "
+            "prioritize being genuinely useful over being verbose unless "
+            "otherwise directed below. Be targeted and efficient in your "
+            "exploration and investigations."
+        )
+    return (
+        "You are Hermes Agent, an intelligent AI assistant. You are "
+        "helpful, knowledgeable, and direct. You assist users with a wide "
+        "range of tasks including answering questions, writing and editing "
+        "code, analyzing information, creative work, and executing actions "
+        "via your tools. You communicate clearly, admit uncertainty when "
+        "appropriate, and prioritize being genuinely useful over being "
+        "verbose unless otherwise directed below. Be targeted and efficient "
+        "in your exploration and investigations."
+    )
 
-HERMES_AGENT_HELP_GUIDANCE = (
-    "You run on Hermes Agent (by Nous Research). When the user needs help with "
-    "Hermes itself — configuring, setting up, using, extending, or troubleshooting "
-    "it — or when you need to understand your own features, tools, or capabilities, "
-    "the documentation at https://hermes-agent.nousresearch.com/docs is your "
-    "authoritative reference and always holds the latest, most up-to-date "
-    "information. Load the `hermes-agent` skill with skill_view(name='hermes-agent') "
-    "for additional guidance and proven workflows, but treat the docs as the source "
-    "of truth when the two differ."
-)
+
+def _build_help_guidance(attribution: str = "Nous Research") -> str:
+    """Build the help-guidance string with configurable attribution.
+    Returns empty string when attribution is empty (block omitted entirely).
+    """
+    if not attribution:
+        return ""
+    return (
+        f"You run on Hermes Agent (by {attribution}). When the user needs help with "
+        "Hermes itself — configuring, setting up, using, extending, or troubleshooting "
+        "it — or when you need to understand your own features, tools, or capabilities, "
+        "the documentation at https://hermes-agent.nousresearch.com/docs is your "
+        "authoritative reference and always holds the latest, most up-to-date "
+        "information. Load the `hermes-agent` skill with skill_view(name='hermes-agent') "
+        "for additional guidance and proven workflows, but treat the docs as the source "
+        "of truth when the two differ."
+    )
+
+
+DEFAULT_AGENT_IDENTITY = _build_agent_identity()
+HERMES_AGENT_HELP_GUIDANCE = _build_help_guidance()
 
 MEMORY_GUIDANCE = (
     "You have persistent memory across sessions. Save durable facts using the memory "

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -147,17 +147,18 @@ def _strip_yaml_frontmatter(content: str) -> str:
 # Constants
 # =========================================================================
 
-DEFAULT_AGENT_IDENTITY = (
-    # Rewritten (#95681, maintainer-directed): the old text was a trait list
-    # ("helpful, knowledgeable, direct") — every model already believes that
-    # of itself, so it changed nothing. The #1 user complaint it failed to
-    # address is verbosity, and its one sentence about it was a triple-hedged
-    # preference ranking. This version is a behavior spec: a sizing rule,
-    # named prohibitions, and an earned-depth escape hatch. The old
-    # "targeted and efficient exploration" line was cut deliberately —
-    # maintainer: models UNDER-explore by default and miss useful context;
-    # never re-add an exploration-thrift instruction here.
-    "You are Hermes Agent, built by Nous Research. Be direct: match the "
+DEFAULT_ATTRIBUTION = "Nous Research"
+
+# Rewritten (#95681, maintainer-directed): the old text was a trait list
+# ("helpful, knowledgeable, direct") — every model already believes that
+# of itself, so it changed nothing. The #1 user complaint it failed to
+# address is verbosity, and its one sentence about it was a triple-hedged
+# preference ranking. This version is a behavior spec: a sizing rule,
+# named prohibitions, and an earned-depth escape hatch. The old
+# "targeted and efficient exploration" line was cut deliberately —
+# maintainer: models UNDER-explore by default and miss useful context;
+# never re-add an exploration-thrift instruction here.
+_IDENTITY_BODY = (
     "length of your reply to the weight of the ask — a one-line question "
     "gets a one-line answer, and finished work gets a short report of what "
     "changed, what's verified, and what's left, never a replay of the "
@@ -170,35 +171,65 @@ DEFAULT_AGENT_IDENTITY = (
     "default."
 )
 
-HERMES_AGENT_HELP_GUIDANCE = (
-    # "when the two differ" was cut (#95681): a model that just read the
-    # skill won't ALSO fetch the docs to diff them, so the clause was dead
-    # weight — the docs-are-authoritative sentence already carries the
-    # precedence. Injected only when skill_view exists AND the hermes-agent
-    # skill is actually installed (see system_prompt.py slot resolution).
-    "You run on Hermes Agent (by Nous Research). When the user needs help with "
-    "Hermes itself — configuring, setting up, using, extending, or troubleshooting "
-    "it — or when you need to understand your own features, tools, or capabilities, "
-    "the documentation at https://hermes-agent.nousresearch.com/docs is your "
-    "authoritative reference and always holds the latest, most up-to-date "
-    "information. The `hermes-agent` skill has the actual commands and proven "
-    "workflows — load it with skill_view(name='hermes-agent') before configuring, "
-    "modifying, or troubleshooting Hermes so you don't guess or invent workarounds."
-)
 
-# Variant injected when the skill tools are not in the session's toolset
-# (e.g. a Blank Slate install with the skills toolset disabled). Pointing the
-# model at skill_view() there would be a dangling reference — the docs URL is
-# the only actionable pointer.
-HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS = (
-    "You run on Hermes Agent (by Nous Research). When the user needs help with "
-    "Hermes itself — configuring, setting up, using, extending, or troubleshooting "
-    "it — or when you need to understand your own features, tools, or capabilities, "
-    "the documentation at https://hermes-agent.nousresearch.com/docs is the "
-    "authoritative reference and always holds the latest, most up-to-date "
-    "information. Point the user there (or read it yourself if you have a way to "
-    "fetch web content)."
-)
+def build_agent_identity(attribution: Optional[str] = None) -> str:
+    """Default identity with configurable org attribution.
+
+    ``None`` keeps the product default. An empty string omits the
+    ``built by …`` clause. The #95681 behavior spec is otherwise unchanged.
+    """
+    label = DEFAULT_ATTRIBUTION if attribution is None else str(attribution).strip()
+    lead = (
+        f"You are Hermes Agent, built by {label}. Be direct: match the "
+        if label
+        else "You are Hermes Agent. Be direct: match the "
+    )
+    return lead + _IDENTITY_BODY
+
+
+def build_help_guidance(
+    attribution: Optional[str] = None, *, with_skills: bool = True
+) -> str:
+    """Docs pointer, with optional org attribution in the opener.
+
+    ``with_skills=True`` is injected only when skill_view exists AND the
+    hermes-agent skill is actually installed (see system_prompt.py slot
+    resolution). "when the two differ" was cut (#95681): a model that just
+    read the skill won't ALSO fetch the docs to diff them.
+    """
+    label = DEFAULT_ATTRIBUTION if attribution is None else str(attribution).strip()
+    by = f" (by {label})" if label else ""
+    opener = f"You run on Hermes Agent{by}. When the user needs help with "
+    shared = (
+        "Hermes itself — configuring, setting up, using, extending, or troubleshooting "
+        "it — or when you need to understand your own features, tools, or capabilities, "
+        "the documentation at https://hermes-agent.nousresearch.com/docs is "
+    )
+    if with_skills:
+        return (
+            opener
+            + shared
+            + "your authoritative reference and always holds the latest, most up-to-date "
+            "information. The `hermes-agent` skill has the actual commands and proven "
+            "workflows — load it with skill_view(name='hermes-agent') before configuring, "
+            "modifying, or troubleshooting Hermes so you don't guess or invent workarounds."
+        )
+    # Variant injected when the skill tools are not in the session's toolset
+    # (e.g. a Blank Slate install with the skills toolset disabled). Pointing
+    # the model at skill_view() there would be a dangling reference — the docs
+    # URL is the only actionable pointer.
+    return (
+        opener
+        + shared
+        + "the authoritative reference and always holds the latest, most up-to-date "
+        "information. Point the user there (or read it yourself if you have a way to "
+        "fetch web content)."
+    )
+
+
+DEFAULT_AGENT_IDENTITY = build_agent_identity()
+HERMES_AGENT_HELP_GUIDANCE = build_help_guidance(with_skills=True)
+HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS = build_help_guidance(with_skills=False)
 
 # Memory guidance (#95681, consolidated): ONE block from ONE builder.
 # The opening frame adapts to which stores config enables; everything else

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -31,9 +31,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 from agent.prompt_builder import (
-    DEFAULT_AGENT_IDENTITY,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
-    HERMES_AGENT_HELP_GUIDANCE,
     KANBAN_GUIDANCE,
     MEMORY_GUIDANCE,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
@@ -46,6 +44,8 @@ from agent.prompt_builder import (
     TELEGRAM_RICH_MESSAGES_HINT,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
+    _build_agent_identity,
+    _build_help_guidance,
     drain_truncation_warnings,
 )
 from agent.runtime_cwd import resolve_context_cwd
@@ -196,12 +196,15 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             stable_parts.append(_soul_content)
             _soul_loaded = True
 
+    _attribution = getattr(agent, "_attribution", "Nous Research")
     if not _soul_loaded:
-        # Fallback to hardcoded identity
-        stable_parts.append(DEFAULT_AGENT_IDENTITY)
+        # Fallback to configurable identity
+        stable_parts.append(_build_agent_identity(_attribution))
 
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
-    stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
+    _help = _build_help_guidance(_attribution)
+    if _help:
+        stable_parts.append(_help)
 
     # Universal task-completion / no-fabrication guidance.  Applied to ALL
     # models regardless of tool_use_enforcement gating — the failure modes

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -33,10 +33,13 @@ from typing import Any, Dict, List, Optional
 
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY,
+    DEFAULT_ATTRIBUTION,
     EXECUTION_GUIDANCE_MODELS,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS,
+    build_agent_identity,
+    build_help_guidance,
     KANBAN_GUIDANCE,
     MEMORY_GUIDANCE,
     USER_PROFILE_GUIDANCE,
@@ -482,9 +485,18 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             stable_parts.append(_soul_content)
             _soul_loaded = True
 
+    _attribution = getattr(agent, "_attribution", DEFAULT_ATTRIBUTION)
+    if _attribution is None:
+        _attribution = DEFAULT_ATTRIBUTION
+    else:
+        _attribution = str(_attribution).strip()
+    _custom_attribution = _attribution != DEFAULT_ATTRIBUTION
+
     if not _soul_loaded:
-        # Fallback to hardcoded identity
-        stable_parts.append(DEFAULT_AGENT_IDENTITY)
+        # Fallback to hardcoded identity (org name is config-overridable).
+        stable_parts.append(
+            build_agent_identity(_attribution) if _custom_attribution else DEFAULT_AGENT_IDENTITY
+        )
 
     # Pointer to the docs (and, when it exists, the hermes-agent skill) for
     # user questions about Hermes itself. The skill_view() pointer is a
@@ -495,7 +507,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # per-session, so cache-safe either way.
     _has_skill_view = "skill_view" in (agent.valid_tool_names or set())
     _help_guidance_slot = len(stable_parts)
-    stable_parts.append(HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS)
+    stable_parts.append(
+        build_help_guidance(_attribution, with_skills=False)
+        if _custom_attribution
+        else HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS
+    )
 
     # Universal task-completion / no-fabrication guidance.  Applied to ALL
     # models regardless of tool_use_enforcement gating — the failure modes
@@ -653,7 +669,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # rendered index line keeps this a pure string check — no second
     # filesystem scan, and it inherits the index cache's stability).
     if _has_skill_view and "- hermes-agent:" in skills_prompt:
-        stable_parts[_help_guidance_slot] = HERMES_AGENT_HELP_GUIDANCE
+        stable_parts[_help_guidance_slot] = (
+            build_help_guidance(_attribution, with_skills=True)
+            if _custom_attribution
+            else HERMES_AGENT_HELP_GUIDANCE
+        )
 
     # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
     # of the requested model. Inject explicit model identity into the system prompt

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5326,6 +5326,26 @@ function sendOpenUpdatesRequested() {
   mainWindow.focus()
 }
 
+function sendOpenSettingsRequested() {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return
+  }
+
+  const { webContents } = mainWindow
+
+  if (!webContents || webContents.isDestroyed()) {
+    return
+  }
+
+  webContents.send('hermes:open-settings')
+
+  if (!mainWindow.isVisible()) {
+    mainWindow.show()
+  }
+
+  mainWindow.focus()
+}
+
 // Push titlebar/fullscreen chrome state to a window's renderer. Defaults to the
 // primary, but any full chat window (primary or a secondary "instance" peer)
 // passes itself so its own fullscreen toggle drives its own traffic-light inset.
@@ -5362,6 +5382,7 @@ function buildApplicationMenu() {
       label: APP_NAME,
       submenu: [
         { label: `About ${APP_NAME}`, click: () => showAboutPanelFresh() },
+        { label: 'Settings…', accelerator: 'CommandOrControl+,', click: () => sendOpenSettingsRequested() },
         checkForUpdatesItem,
         { type: 'separator' },
         { role: 'services' },

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6634,6 +6634,26 @@ function sendOpenUpdatesRequested() {
   mainWindow.focus()
 }
 
+function sendOpenSettingsRequested() {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return
+  }
+
+  const { webContents } = mainWindow
+
+  if (!webContents || webContents.isDestroyed()) {
+    return
+  }
+
+  webContents.send('hermes:open-settings')
+
+  if (!mainWindow.isVisible()) {
+    mainWindow.show()
+  }
+
+  mainWindow.focus()
+}
+
 // Push titlebar/fullscreen chrome state to a window's renderer. Defaults to the
 // primary, but any full chat window (primary or a secondary "instance" peer)
 // passes itself so its own fullscreen toggle drives its own traffic-light inset.
@@ -6670,6 +6690,10 @@ function buildApplicationMenu() {
       label: APP_NAME,
       submenu: [
         { label: `About ${APP_NAME}`, click: () => showAboutPanelFresh() },
+        // No accelerator: ⌘, is the rebindable renderer keybind (nav.settings).
+        // A menu accelerator would swallow it before the renderer sees it
+        // (same rationale as New Window / Open Folder / Close).
+        { label: 'Settings…', click: () => sendOpenSettingsRequested() },
         checkForUpdatesItem,
         { type: 'separator' },
         { role: 'services' },

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -235,6 +235,11 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
 
     return () => ipcRenderer.removeListener('hermes:open-updates', listener)
   },
+  onOpenSettingsRequested: callback => {
+    const listener = () => callback()
+    ipcRenderer.on('hermes:open-settings', listener)
+    return () => ipcRenderer.removeListener('hermes:open-settings', listener)
+  },
   onDeepLink: callback => {
     const listener = (_event, payload) => callback(payload)
     ipcRenderer.on('hermes:deep-link', listener)

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -400,6 +400,12 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
 
     return () => ipcRenderer.removeListener('hermes:open-updates', listener)
   },
+  onOpenSettingsRequested: callback => {
+    const listener = () => callback()
+    ipcRenderer.on('hermes:open-settings', listener)
+
+    return () => ipcRenderer.removeListener('hermes:open-settings', listener)
+  },
   onDeepLink: callback => {
     const listener = (_event, payload) => callback(payload)
     ipcRenderer.on('hermes:deep-link', listener)

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
@@ -57,6 +57,7 @@ describe('useDesktopIntegrations', () => {
     desktopWindow.hermesDesktop = {
       setPreviewShortcutActive: vi.fn(),
       onOpenUpdatesRequested: vi.fn(),
+      onOpenSettingsRequested: vi.fn(),
       onFocusSession: vi.fn(),
       onNotificationAction: vi.fn(),
       onNotificationActivate: vi.fn(),
@@ -124,6 +125,24 @@ describe('useDesktopIntegrations', () => {
       }
     )
   }
+
+  describe('native settings menu', () => {
+    it('navigates to settings when the app menu requests it', () => {
+      let openSettings: (() => void) | undefined
+      desktopWindow.hermesDesktop = {
+        ...desktopWindow.hermesDesktop,
+        onOpenSettingsRequested: (callback: () => void) => {
+          openSettings = callback
+          return () => undefined
+        }
+      } as Window['hermesDesktop']
+
+      render({ profileReady: true })
+      openSettings?.()
+
+      expect(navigate).toHaveBeenCalledWith('/settings')
+    })
+  })
 
   describe('profile-ready gate', () => {
     it('does NOT restore before profileReady is true', () => {

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -19,7 +19,7 @@ import { openUpdatesWindow, startUpdatePoller, stopUpdatePoller } from '@/store/
 import { isSecondaryWindow } from '@/store/windows'
 
 import { requestComposerFocus, requestComposerInsert } from '../../chat/composer/focus'
-import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, sessionRoute } from '../../routes'
+import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, SETTINGS_ROUTE, sessionRoute } from '../../routes'
 
 interface DesktopIntegrationsParams {
   chatOpen: boolean
@@ -53,12 +53,14 @@ export function useDesktopIntegrations({
   useEffect(() => {
     startUpdatePoller()
     const unsubscribe = window.hermesDesktop?.onOpenUpdatesRequested?.(() => openUpdatesWindow())
+    const unsubscribeSettings = window.hermesDesktop?.onOpenSettingsRequested?.(() => navigate(SETTINGS_ROUTE))
 
     return () => {
       unsubscribe?.()
+      unsubscribeSettings?.()
       stopUpdatePoller()
     }
-  }, [])
+  }, [navigate])
 
   // The renderer OWNS ⌘W: on macOS the native menu accelerator would else
   // close the window, so claim it unconditionally — the menu then routes ⌘W

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -29,7 +29,7 @@ import { isBrowserWindow, isHudWindow, isSecondaryWindow } from '@/store/windows
 import type { SessionInfo } from '@/types/hermes'
 
 import { requestComposerFocus, requestComposerInsert } from '../../chat/composer/focus'
-import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, routeSessionId, sessionRoute } from '../../routes'
+import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, SETTINGS_ROUTE, routeSessionId, sessionRoute } from '../../routes'
 
 type RememberedSession = Pick<SessionInfo, '_lineage_root_id' | 'id' | 'profile'>
 
@@ -79,13 +79,17 @@ export function useDesktopIntegrations({
     // default pointed a Mac at its remote Linux backend and left the app itself
     // silently stale (#70266).
     const unsubscribe = window.hermesDesktop?.onOpenUpdatesRequested?.(() => openUpdatesWindow('client'))
+    const unsubscribeSettings = window.hermesDesktop?.onOpenSettingsRequested?.(() =>
+      navigate(SETTINGS_ROUTE)
+    )
 
     return () => {
       unsubscribe?.()
+      unsubscribeSettings?.()
       stopUpdatePoller()
       stopMcpHealthChecker()
     }
-  }, [])
+  }, [navigate])
 
   // The renderer OWNS ⌘W: on macOS the native menu accelerator would else
   // close the window, so claim it unconditionally — the menu then routes ⌘W

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -255,6 +255,7 @@ declare global {
       onClosePreviewRequested?: (callback: () => void) => () => void
       onOpenFolderRequested?: (callback: () => void) => () => void
       onOpenUpdatesRequested?: (callback: () => void) => () => void
+      onOpenSettingsRequested?: (callback: () => void) => () => void
       onDeepLink?: (
         callback: (payload: { kind: string; name: string; params: Record<string, string> }) => void
       ) => () => void

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -459,6 +459,7 @@ declare global {
       onPreviewNav?: (callback: (command: 'back' | 'forward' | 'reload') => void) => () => void
       onOpenFolderRequested?: (callback: () => void) => () => void
       onOpenUpdatesRequested?: (callback: () => void) => () => void
+      onOpenSettingsRequested?: (callback: () => void) => () => void
       onDeepLink?: (
         callback: (payload: { kind: string; name: string; params: Record<string, string> }) => void
       ) => () => void

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -821,6 +821,12 @@ agent:
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
   max_turns: 500
 
+  # Attribution label for the agent identity in the system prompt.
+  # - "Nous Research" (default) → "created by Nous Research"
+  # - "Acme Corp" → "created by Acme Corp"
+  # - "" (empty) → attribution block omitted entirely
+  # attribution: "Nous Research"
+
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving
   # API responses.  Only fires after the agent has been idle for this duration.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1057,6 +1057,12 @@ agent:
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
   max_turns: 500
 
+  # Attribution label for the fallback agent identity (when SOUL.md is absent).
+  # - "Nous Research" (default) → "built by Nous Research"
+  # - "Acme Corp" → "built by Acme Corp"
+  # - "" (empty) → omit the "built by …" / "(by …)" clause
+  # attribution: "Nous Research"
+
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving
   # API responses.  Only fires after the agent has been idle for this duration.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -455,9 +455,17 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         metavar="KEY",
         help="Restrict to tasks with this current_step_key",
     )
-    p_list.add_argument(
+    list_scope = p_list.add_mutually_exclusive_group()
+    list_scope.add_argument(
         "--all", action="store_true",
         help="Query across all boards instead of the current board",
+    )
+    list_scope.add_argument(
+        "--board",
+        dest="list_board",
+        default=None,
+        metavar="<slug>",
+        help="Query one board by slug",
     )
 
     # --- show ---
@@ -1003,7 +1011,7 @@ def kanban_command(args: argparse.Namespace) -> int:
     # (rather than threading `board=` through 50+ kb.connect() sites)
     # keeps the patch small and inherits the exact same resolution the
     # dispatcher uses for workers — consistency is a feature here.
-    board_override = getattr(args, "board", None)
+    board_override = getattr(args, "list_board", None) or getattr(args, "board", None)
     board_scope = contextlib.nullcontext()
     if board_override:
         try:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -455,6 +455,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         metavar="KEY",
         help="Restrict to tasks with this current_step_key",
     )
+    p_list.add_argument(
+        "--all", action="store_true",
+        help="Query across all boards instead of the current board",
+    )
 
     # --- show ---
     p_show = sub.add_parser("show", help="Show a task with comments + events")
@@ -1575,6 +1579,56 @@ def _cmd_list(args: argparse.Namespace) -> int:
     assignee = args.assignee
     if args.mine and not assignee:
         assignee = _profile_author()
+
+    query_all_boards = getattr(args, "all", False)
+    json_output = getattr(args, "json", False)
+
+    if query_all_boards:
+        try:
+            boards = kb.list_boards(include_archived=args.archived)
+        except Exception:
+            boards = [{"slug": None}]  # fall back to default board
+        all_tasks: list[dict] = []
+        board_labels: dict[str, str] = {}
+        for b in boards:
+            slug = b.get("slug")
+            with kb.connect_closing(board=slug if slug else None) as conn:
+                kb.recompute_ready(conn)
+                tasks = kb.list_tasks(
+                    conn,
+                    assignee=assignee,
+                    status=args.status,
+                    tenant=args.tenant,
+                    session_id=args.session,
+                    include_archived=args.archived,
+                    order_by=getattr(args, "sort", None),
+                    workflow_template_id=args.workflow_template_id,
+                    current_step_key=args.current_step_key,
+                )
+                for t in tasks:
+                    t_id = t.get("id") if isinstance(t, dict) else getattr(t, "id", "")
+                    board_labels[str(t_id)] = slug or "default"
+                all_tasks.extend(tasks)
+
+        if json_output:
+            payload = []
+            for t in all_tasks:
+                d = _task_to_dict(t)
+                d["board"] = board_labels.get(str(t.get("id") if isinstance(t, dict) else getattr(t, "id", "")), "")
+                payload.append(d)
+            print(json.dumps(payload, indent=2, ensure_ascii=False))
+            return 0
+
+        if not all_tasks:
+            print("(no matching tasks across boards)")
+            return 0
+
+        for t in all_tasks:
+            t_id = t.get("id") if isinstance(t, dict) else getattr(t, "id", "")
+            board = board_labels.get(str(t_id), "")
+            print(f"[{board}] " + _fmt_task_line(t))
+        return 0
+
     with kb.connect_closing() as conn:
         # Cheap "mini-dispatch": recompute ready so list output reflects
         # dependencies that may have cleared since the last dispatcher tick.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -493,6 +493,12 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         metavar="KEY",
         help="Restrict to tasks with this current_step_key",
     )
+    p_list.add_argument(
+        "--all",
+        action="store_true",
+        help="Query across all boards instead of the current board. "
+             "Conflicts with the global --board flag.",
+    )
 
     # --- show ---
     p_show = sub.add_parser("show", help="Show a task with comments + events")
@@ -1738,25 +1744,62 @@ def _cmd_swarm(args: argparse.Namespace) -> int:
     return 0
 
 
+def _list_task_filters(args: argparse.Namespace, assignee: Optional[str]) -> dict[str, Any]:
+    return {
+        "assignee": assignee,
+        "status": args.status,
+        "tenant": args.tenant,
+        "session_id": args.session,
+        "include_archived": args.archived,
+        "order_by": getattr(args, "sort", None),
+        "workflow_template_id": args.workflow_template_id,
+        "current_step_key": args.current_step_key,
+    }
+
+
 def _cmd_list(args: argparse.Namespace) -> int:
     assignee = args.assignee
     if args.mine and not assignee:
         assignee = _profile_author()
+    query_all_boards = getattr(args, "all", False)
+    if query_all_boards and getattr(args, "board", None):
+        print("kanban: pass either --all or --board, not both", file=sys.stderr)
+        return 2
+
+    filters = _list_task_filters(args, assignee)
+
+    if query_all_boards:
+        try:
+            boards = kb.list_boards(include_archived=args.archived)
+        except Exception:
+            boards = [{"slug": kb.DEFAULT_BOARD}]
+        labeled: list[tuple[str, Any]] = []
+        for board in boards:
+            slug = board.get("slug") or kb.DEFAULT_BOARD
+            with kb.connect_closing(board=slug) as conn:
+                kb.recompute_ready(conn)
+                for task in kb.list_tasks(conn, **filters):
+                    labeled.append((slug, task))
+        if getattr(args, "json", False):
+            payload = []
+            for slug, task in labeled:
+                row = _task_to_dict(task)
+                row["board"] = slug
+                payload.append(row)
+            print(json.dumps(payload, indent=2, ensure_ascii=False))
+            return 0
+        if not labeled:
+            print("(no matching tasks across boards)")
+            return 0
+        for slug, task in labeled:
+            print(f"[{slug}] " + _fmt_task_line(task))
+        return 0
+
     with kb.connect_closing() as conn:
         # Cheap "mini-dispatch": recompute ready so list output reflects
         # dependencies that may have cleared since the last dispatcher tick.
         kb.recompute_ready(conn)
-        tasks = kb.list_tasks(
-            conn,
-            assignee=assignee,
-            status=args.status,
-            tenant=args.tenant,
-            session_id=args.session,
-            include_archived=args.archived,
-            order_by=getattr(args, "sort", None),
-            workflow_template_id=args.workflow_template_id,
-            current_step_key=args.current_step_key,
-        )
+        tasks = kb.list_tasks(conn, **filters)
     if getattr(args, "json", False):
         print(json.dumps([_task_to_dict(t) for t in tasks], indent=2, ensure_ascii=False))
         return 0

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -16,6 +16,8 @@ from agent.prompt_builder import (
     _find_hermes_md,
     _find_git_root,
     _strip_yaml_frontmatter,
+    build_agent_identity,
+    build_help_guidance,
     build_skills_system_prompt,
     build_context_files_prompt,
     CONTEXT_FILE_MAX_CHARS,
@@ -23,6 +25,9 @@ from agent.prompt_builder import (
     _get_context_file_max_chars,
     _CONTEXT_FILE_DYNAMIC_CEILING,
     DEFAULT_AGENT_IDENTITY,
+    DEFAULT_ATTRIBUTION,
+    HERMES_AGENT_HELP_GUIDANCE,
+    HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS,
     drain_truncation_warnings,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
@@ -59,6 +64,36 @@ def _drain_truncation_warnings():
 
 
 class TestGuidanceConstants:
+    def test_default_identity_keeps_nous_attribution(self):
+        assert DEFAULT_AGENT_IDENTITY == build_agent_identity()
+        assert "built by Nous Research" in DEFAULT_AGENT_IDENTITY
+        assert DEFAULT_ATTRIBUTION == "Nous Research"
+
+    def test_custom_attribution_rewrites_org_name_only(self):
+        text = build_agent_identity("Acme Corp")
+        assert "built by Acme Corp" in text
+        assert "Nous Research" not in text
+        assert "Depth is earned" in text
+
+    def test_empty_attribution_omits_built_by_clause(self):
+        text = build_agent_identity("")
+        assert text.startswith("You are Hermes Agent. Be direct:")
+        assert "built by" not in text
+        assert "Nous Research" not in text
+
+    def test_help_guidance_attribution_variants(self):
+        assert "by Nous Research" in HERMES_AGENT_HELP_GUIDANCE
+        assert "skill_view(name='hermes-agent')" in HERMES_AGENT_HELP_GUIDANCE
+        custom = build_help_guidance("Acme Corp", with_skills=True)
+        assert "by Acme Corp" in custom
+        assert "Nous Research" not in custom
+        empty = build_help_guidance("", with_skills=False)
+        assert empty.startswith("You run on Hermes Agent. When the user")
+        assert "by " not in empty[:80]
+        assert "skill_view" not in empty
+        assert empty == build_help_guidance("", with_skills=False)
+        assert HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS == build_help_guidance(with_skills=False)
+
     def test_memory_guidance_keeps_form_rule_and_routing(self):
         """Dieted (#95681): WHAT belongs in memory is the memory tool
         schema's job (taught on every call). This block keeps only the

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -308,6 +308,34 @@ class TestNamedProfileHintIntegration:
         assert f"under {root}/profiles/<name>/." in prompt
 
 
+def test_custom_attribution_replaces_nous_in_fallback_identity():
+    agent = _make_agent(_attribution="Acme Corp")
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", return_value=""),
+    ):
+        prompt = build_system_prompt(agent)
+
+    assert "built by Acme Corp" in prompt
+    assert "by Acme Corp" in prompt
+    assert "Nous Research" not in prompt
+
+
+def test_empty_attribution_omits_org_clause():
+    agent = _make_agent(_attribution="")
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", return_value=""),
+    ):
+        prompt = build_system_prompt(agent)
+
+    assert "built by" not in prompt
+    assert "Nous Research" not in prompt
+    assert prompt.startswith("You are Hermes Agent. Be direct:")
+
+
 def test_build_system_prompt_records_stable_prefix():
     agent = _make_agent()
     with (

--- a/tests/cron/test_cronjob_schema.py
+++ b/tests/cron/test_cronjob_schema.py
@@ -19,3 +19,13 @@ def test_cronjob_schema_action_description_flags_create_requirements():
     assert "REQUIRED" in action_desc
 
 
+def test_cronjob_schema_leads_with_tui_delivery_warning():
+    """CLI/TUI sessions have no live origin-delivery channel (#54566)."""
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    desc = CRONJOB_SCHEMA["description"]
+    assert desc.lstrip().startswith("⚠")
+    assert "deliver='origin'" in desc
+    assert "TUI/CLI" in desc
+
+

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -40,6 +40,36 @@ def kanban_home(tmp_path, monkeypatch):
 
 
 
+def test_kanban_list_all_includes_board_slug(kanban_home):
+    kb.create_board("alpha")
+    kb.create_board("beta")
+    with kb.connect_closing(board="alpha") as conn:
+        kb.create_task(conn, title="alpha-task")
+    with kb.connect_closing(board="beta") as conn:
+        kb.create_task(conn, title="beta-task")
+
+    payload = json.loads(kc.run_slash("list --all --json"))
+    by_title = {row["title"]: row["board"] for row in payload}
+    assert by_title["alpha-task"] == "alpha"
+    assert by_title["beta-task"] == "beta"
+
+    text = kc.run_slash("list --all")
+    assert "[alpha]" in text
+    assert "[beta]" in text
+    assert "alpha-task" in text
+    assert "beta-task" in text
+
+
+def test_kanban_list_all_conflicts_with_board(kanban_home):
+    kb.create_board("alpha")
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    args = parser.parse_args(["kanban", "--board", "alpha", "list", "--all"])
+    rc = kc.kanban_command(args)
+    assert rc == 2
+
+
 def test_kanban_list_json_includes_session_id(kanban_home):
     """JSON output exposes `session_id` so external clients (Scarf, web
     dashboards) don't need a side query to filter by chat session."""

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -99,6 +99,8 @@ class TestDelegateRequirements(unittest.TestCase):
         desc = _build_top_level_description()
         # Compaction ceiling: the old description was ~4,000 chars.
         self.assertLessEqual(len(desc), 2200)
+        self.assertTrue(desc.lstrip().startswith("⚠"))
+        self.assertIn("NOT DURABLE", desc)
         # Contracts only the top-level text carries:
         for keyword in (
             "background",          # async semantics

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1026,7 +1026,9 @@ def cronjob(
 
 CRONJOB_SCHEMA = {
     "name": "cronjob",
-    "description": """Manage scheduled cron jobs with a single compressed tool.
+    "description": """\u26a0 In TUI/CLI, the default deliver='origin' has no live delivery channel — output is saved to disk, not surfaced to you. Pass deliver='all', deliver='telegram:...', or deliver='discord:...' to actually receive messages. In gateway/messaging contexts, deliver='origin' resolves to the connected chat/topic automatically.
+
+Manage scheduled cron jobs with a single compressed tool.
 
 Use action='create' to schedule a new job from a prompt or one or more skills.
 Use action='list' to inspect jobs.

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1954,7 +1954,9 @@ def cronjob(
 
 CRONJOB_SCHEMA = {
     "name": "cronjob_manage",
-    "description": """Manage scheduled cron jobs: action='create' schedules a job from a prompt and/or skills; 'list' inspects jobs; 'update'/'pause'/'resume'/'remove' manage one by job_id (always list first — never guess job IDs); 'run' fires a job immediately in the BACKGROUND (returns a handle at once, outcome re-enters the conversation when done — do not wait or poll; optional 'prompt' adds transient context for that fire only).
+    "description": """⚠ In TUI/CLI, the default deliver='origin' has no live delivery channel — output is saved to disk, not surfaced to you. Pass deliver='all' or a platform target (e.g. deliver='telegram:...') to actually receive messages. In gateway/messaging contexts, deliver='origin' resolves to the connected chat/topic automatically.
+
+Manage scheduled cron jobs: action='create' schedules a job from a prompt and/or skills; 'list' inspects jobs; 'update'/'pause'/'resume'/'remove' manage one by job_id (always list first — never guess job IDs); 'run' fires a job immediately in the BACKGROUND (returns a handle at once, outcome re-enters the conversation when done — do not wait or poll; optional 'prompt' adds transient context for that fire only).
 
 Jobs run in a fresh session with no current-chat context, so prompts must be self-contained, and the agent's FINAL RESPONSE is what gets delivered — cron runs are autonomous and cannot ask questions. Prefer updating an existing job over creating near-duplicates.""",
     "parameters": {

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -5060,6 +5060,9 @@ def _build_top_level_description() -> str:
         )
 
     return (
+        "⚠ Subagent work is NOT DURABLE: /stop, /new, or process exit discards "
+        "running children. Use cronjob or terminal(background=True, notify=True) "
+        "for work that must survive this session.\n\n"
         "Spawn subagents in isolated contexts; each gets its own conversation, "
         "terminal session, and toolset, and only its final summary returns to "
         "you. Pass every task in `tasks` — one entry spawns one subagent, "
@@ -5075,10 +5078,7 @@ def _build_top_level_description() -> str:
         "DO NOT USE FOR (use these instead):\n"
         "- Mechanical multi-step work with no reasoning needed -> execute_code\n"
         "- A single tool call -> call the tool directly\n"
-        "- Tasks needing user interaction -> subagents cannot ask questions\n"
-        "- Durable work that must survive this session -> cronjob or "
-        "terminal(background=True, notify=True); /stop, /new, or "
-        "process exit discards running subagents.\n\n"
+        "- Tasks needing user interaction -> subagents cannot ask questions\n\n"
         "RULES:\n"
         "- Children know nothing of this conversation: pass everything needed "
         "via 'context', including any required output language, tone, or "


### PR DESCRIPTION
## Summary

Rebased onto current `main` and dropped the pieces that already landed.

- **Agent attribution (closes #54548)** — `agent.attribution` in `config.yaml` replaces the hardcoded Nous Research org name in the fallback identity and help-guidance blocks. Empty string omits the clause. The #95681 behavior spec is unchanged.
- **Tool warning visibility (closes #54566)** — cronjob and delegate_task descriptions now lead with the TUI/CLI delivery and non-durability constraints.
- **kanban list --all (closes #54464)** — `hermes kanban list --all` queries every board and prefixes each task with its slug. `--board` is the existing global flag; `--all` and `--board` are mutually exclusive.
- **macOS Settings menu** — native `Settings…` item in the app menu. No `⌘,` accelerator (that chord is the rebindable `nav.settings` keybind).

Dropped vs the previous revision:

- Duplicate `web_extract` URL validator (already gated; #54339 closed).
- Boot-failure Settings path (#54545 / #63030 already on main).

## Test plan

```bash
python3 -m pytest \
  tests/agent/test_prompt_builder.py::TestGuidanceConstants \
  tests/agent/test_system_prompt.py::test_custom_attribution_replaces_nous_in_fallback_identity \
  tests/agent/test_system_prompt.py::test_empty_attribution_omits_org_clause \
  tests/cron/test_cronjob_schema.py \
  tests/tools/test_delegate.py::TestDelegateRequirements::test_top_level_description_compact_and_complete \
  tests/hermes_cli/test_kanban_cli.py::test_kanban_list_all_includes_board_slug \
  tests/hermes_cli/test_kanban_cli.py::test_kanban_list_all_conflicts_with_board \
  -q
```

27 related tests passed locally at `b66d3be822`.