### PR TITLE
fix(codex): skip in-progress custom_tool_call items in Responses normalization

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -1247,6 +1247,8 @@ def _normalize_codex_response(
                 function=SimpleNamespace(name=fn_name, arguments=arguments),
             ))
         elif item_type == "custom_tool_call":
+            if item_status in {"queued", "in_progress", "incomplete"}:
+                continue
             fn_name = getattr(item, "name", "") or ""
             arguments = getattr(item, "input", "{}")
             if not isinstance(arguments, str):

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -139,6 +139,38 @@ def test_normalize_codex_response_in_progress_message_still_incomplete():
     assert finish_reason == "incomplete"
 
 
+def test_normalize_codex_response_skips_in_progress_custom_tool_call():
+    """An in_progress ``custom_tool_call`` (freeform/custom-grammar tool) is a
+    partial item with possibly truncated ``input``. It must NOT be appended to
+    ``tool_calls`` and dispatched as a completed ``finish_reason='tool_calls'``
+    turn — it must trigger the Codex incomplete-continuation path, exactly like
+    its ``function_call`` sibling does. Guards parity with the ``function_call``
+    branch, which already ``continue``s on queued/in_progress/incomplete."""
+    response = SimpleNamespace(
+        status="completed",
+        incomplete_details=None,
+        output=[
+            SimpleNamespace(
+                type="reasoning",
+                id="rs_1",
+                encrypted_content="opaque",
+                summary=[SimpleNamespace(text="drafting grammar")],
+            ),
+            SimpleNamespace(
+                type="custom_tool_call",
+                status="in_progress",
+                name="grammar_tool",
+                input='{"partial',
+            ),
+        ],
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "incomplete"
+    assert assistant_message.tool_calls == []
+
+
 # ---------------------------------------------------------------------------
 # _preflight_codex_api_kwargs — built-in (provider-executed) tools must pass
 # through validation.  Regression guard for the xAI native web_search


### PR DESCRIPTION
## What does this PR do?

In `_normalize_codex_response` (`agent/codex_responses_adapter.py`), the `function_call` branch guards partial items so a still-streaming tool call is not treated as a completed turn:

```python
elif item_type == "function_call":
    if item_status in {"queued", "in_progress", "incomplete"}:
        continue
    ...
```

The sibling `custom_tool_call` branch had **no** such guard — it unconditionally read `name`/`input` and appended the call to `tool_calls`:

```python
elif item_type == "custom_tool_call":
    fn_name = getattr(item, "name", "") or ""
    arguments = getattr(item, "input", "{}")
    ...  # appended regardless of item_status
```

`custom_tool_call` (freeform / custom-grammar tool calls) is not a server-side tool type, so an incomplete one correctly sets the incomplete flags (`has_incomplete_items` / `saw_streaming_or_item_incomplete`), which should yield `finish_reason="incomplete"`. But the finish-reason ladder checks `if tool_calls:` first:

```python
if tool_calls:
    finish_reason = "tool_calls"
elif ...
    finish_reason = "incomplete"
```

Because the partial call was already appended, the turn surfaces as a completed `finish_reason="tool_calls"` and the possibly-truncated `input` is dispatched — instead of triggering the Codex incomplete-continuation path. The `function_call` `continue` guard exists precisely to prevent this; `custom_tool_call` was missed.

The fix adds the identical guard at the top of the `custom_tool_call` branch.

## Related Issue

None — found while reading the Codex Responses adapter.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/codex_responses_adapter.py`: add the `if item_status in {"queued", "in_progress", "incomplete"}: continue` guard at the start of the `custom_tool_call` branch, mirroring the existing `function_call` guard.
- `tests/agent/test_codex_responses_adapter.py`: add `test_normalize_codex_response_skips_in_progress_custom_tool_call`, mirroring the in-progress server-side / message guard tests.

## How to Test

1. Construct a Responses output containing a completed reasoning item plus an `in_progress` `custom_tool_call` with a truncated `input` and no completed tool call.
2. Before the fix: the partial call is appended, so `finish_reason == "tool_calls"` and `assistant_message.tool_calls` has length 1 — the truncated freeform call is dispatched.
3. After the fix: `finish_reason == "incomplete"` and `assistant_message.tool_calls == []`, so the continuation path runs.

The new regression test fails before the production change (`'tool_calls' == 'incomplete'`) and passes after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_codex_responses_adapter.py -q` and all 17 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A