### PR TITLE
[codex] Drop duplicate tool results during message repair

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -372,6 +372,9 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
          any preceding assistant tool_call — dropped.
       2. Consecutive ``user`` messages — merged with newline separator
          so no user input is lost.
+      3. Duplicate ``tool`` messages for the same live tool_call_id are
+         dropped; distinct consecutive tool results from parallel calls are
+         preserved.
 
     Deliberately does NOT rewind orphan ``assistant(tool_calls)+tool``
     pairs that precede a user message — that pattern IS valid when the
@@ -391,6 +394,7 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
     # assistant tool_call_id. Uses a rolling set of known ids refreshed
     # on each assistant message.
     known_tool_ids: set = set()
+    seen_tool_ids: set = set()
     filtered: List[Dict] = []
     for msg in messages:
         if not isinstance(msg, dict):
@@ -399,6 +403,7 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
         role = msg.get("role")
         if role == "assistant":
             known_tool_ids = set()
+            seen_tool_ids = set()
             for tc in (msg.get("tool_calls") or []):
                 tc_id = tc.get("id") if isinstance(tc, dict) else None
                 if tc_id:
@@ -406,8 +411,9 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
             filtered.append(msg)
         elif role == "tool":
             tc_id = msg.get("tool_call_id")
-            if tc_id and tc_id in known_tool_ids:
+            if tc_id and tc_id in known_tool_ids and tc_id not in seen_tool_ids:
                 filtered.append(msg)
+                seen_tool_ids.add(tc_id)
             else:
                 repairs += 1
         else:
@@ -416,6 +422,7 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                 # tool messages without a fresh assistant tool_call
                 # are orphans.
                 known_tool_ids = set()
+                seen_tool_ids = set()
             filtered.append(msg)
 
     # Pass 2: merge consecutive user messages. Preserves all user input

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -162,6 +162,55 @@ def test_repair_leaves_valid_conversation_unchanged():
     assert messages == original
 
 
+def test_repair_preserves_parallel_tool_results():
+    """One assistant turn may legitimately produce multiple consecutive tool results."""
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "inspect both"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [
+             {"id": "t1", "type": "function",
+              "function": {"name": "read_file", "arguments": '{"path":"a"}'}},
+             {"id": "t2", "type": "function",
+              "function": {"name": "read_file", "arguments": '{"path":"b"}'}},
+         ]},
+        {"role": "tool", "tool_call_id": "t1", "content": "A"},
+        {"role": "tool", "tool_call_id": "t2", "content": "B"},
+        {"role": "assistant", "content": "A and B"},
+    ]
+    original = [dict(m) for m in messages]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 0
+    assert messages == original
+
+
+def test_repair_drops_duplicate_tool_result_for_same_call_id():
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "inspect"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "t1", "type": "function",
+                         "function": {"name": "read_file", "arguments": '{"path":"a"}'}}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "A"},
+        {"role": "tool", "tool_call_id": "t1", "content": "A retry duplicate"},
+        {"role": "assistant", "content": "A"},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 1
+    assert messages == [
+        {"role": "user", "content": "inspect"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "t1", "type": "function",
+                         "function": {"name": "read_file", "arguments": '{"path":"a"}'}}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "A"},
+        {"role": "assistant", "content": "A"},
+    ]
+
+
 def test_repair_preserves_multimodal_user_content():
     """Multimodal (list) content must NOT be merged — risks mangling attachments."""
     agent = _bare_agent()


### PR DESCRIPTION
## Summary

- Track tool results already accepted for the current assistant tool-call group.
- Drop duplicate `tool` messages with the same live `tool_call_id`.
- Preserve distinct consecutive tool results from parallel tool calls.

## Why

`repair_message_sequence` already drops tool messages whose `tool_call_id` does not belong to the most recent assistant tool-call group. It did not distinguish a valid first result from a duplicated result for the same call id, so a retry/replay artifact could leave two tool outputs for one tool call in history. Providers expect at most one tool result per tool call id.

## Validation

- `uv run --extra dev pytest tests/run_agent/test_message_sequence_repair.py`
- `uv run --extra dev ruff check agent/agent_runtime_helpers.py tests/run_agent/test_message_sequence_repair.py`
- `git diff --check -- agent/agent_runtime_helpers.py tests/run_agent/test_message_sequence_repair.py`