### PR TITLE
fix(tools): transcode to OGG/Opus for OpenAI-compatible TTS backends without opus (#54589)

### DIFF
--- a/tests/tools/test_tts_openai_opus.py
+++ b/tests/tools/test_tts_openai_opus.py
@@ -1,0 +1,99 @@
+"""OpenAI TTS opus handling for Telegram voice bubbles.
+
+Real OpenAI encodes opus natively, but many OpenAI-*compatible* backends
+(e.g. a self-hosted Speaches/Kokoro endpoint) only support mp3/flac/wav/pcm
+and reject ``response_format="opus"``. ``_generate_openai_tts`` must try
+native opus first and fall back to mp3 + local ffmpeg transcode so those
+backends still deliver a playable OGG/Opus voice bubble.
+"""
+from unittest.mock import MagicMock, patch
+
+
+def _client():
+    mock_response = MagicMock()
+    mock_client = MagicMock()
+    mock_client.audio.speech.create.return_value = mock_response
+    return mock_client, MagicMock(return_value=mock_client)
+
+
+def _formats(create):
+    """response_format passed to each create() call, in order."""
+    return [c.kwargs["response_format"] for c in create.call_args_list]
+
+
+class TestOpenaiOpusFallback:
+    def test_native_opus_no_transcode(self, tmp_path, monkeypatch):
+        """An opus-capable backend gets a single opus request, no ffmpeg."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client, mock_cls = _client()
+        out = str(tmp_path / "out.ogg")
+
+        with patch("tools.tts_tool._import_openai_client", return_value=mock_cls), \
+             patch("tools.tts_tool._resolve_openai_audio_client_config",
+                   return_value=("test-key", None)), \
+             patch("tools.tts_tool._convert_to_opus") as convert:
+            from tools.tts_tool import _generate_openai_tts
+            result = _generate_openai_tts("Hello", out, {})
+
+        assert _formats(mock_client.audio.speech.create) == ["opus"]
+        convert.assert_not_called()
+        assert result == out
+
+    def test_falls_back_to_mp3_and_transcodes(self, tmp_path, monkeypatch):
+        """A backend that rejects opus is retried as mp3 then transcoded."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client, mock_cls = _client()
+        # First call (opus) fails; second call (mp3) succeeds.
+        mock_client.audio.speech.create.side_effect = [
+            Exception("Unsupported response_format 'opus'"),
+            MagicMock(),
+        ]
+        out = str(tmp_path / "out.ogg")
+        converted = str(tmp_path / "out.ogg")
+
+        with patch("tools.tts_tool._import_openai_client", return_value=mock_cls), \
+             patch("tools.tts_tool._resolve_openai_audio_client_config",
+                   return_value=("test-key", None)), \
+             patch("tools.tts_tool._convert_to_opus", return_value=converted) as convert:
+            from tools.tts_tool import _generate_openai_tts
+            result = _generate_openai_tts("Hello", out, {})
+
+        assert _formats(mock_client.audio.speech.create) == ["opus", "mp3"]
+        convert.assert_called_once_with(str(tmp_path / "out.mp3"))
+        assert result == converted
+
+    def test_fallback_without_ffmpeg_keeps_mp3(self, tmp_path, monkeypatch):
+        """No ffmpeg => return the mp3 so the caller still has audio."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client, mock_cls = _client()
+        mock_client.audio.speech.create.side_effect = [
+            Exception("Unsupported response_format 'opus'"),
+            MagicMock(),
+        ]
+        out = str(tmp_path / "out.ogg")
+
+        with patch("tools.tts_tool._import_openai_client", return_value=mock_cls), \
+             patch("tools.tts_tool._resolve_openai_audio_client_config",
+                   return_value=("test-key", None)), \
+             patch("tools.tts_tool._convert_to_opus", return_value=None):
+            from tools.tts_tool import _generate_openai_tts
+            result = _generate_openai_tts("Hello", out, {})
+
+        assert result == str(tmp_path / "out.mp3")
+
+    def test_non_ogg_target_uses_mp3_directly(self, tmp_path, monkeypatch):
+        """A plain .mp3 target never asks for opus."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client, mock_cls = _client()
+        out = str(tmp_path / "out.mp3")
+
+        with patch("tools.tts_tool._import_openai_client", return_value=mock_cls), \
+             patch("tools.tts_tool._resolve_openai_audio_client_config",
+                   return_value=("test-key", None)), \
+             patch("tools.tts_tool._convert_to_opus") as convert:
+            from tools.tts_tool import _generate_openai_tts
+            result = _generate_openai_tts("Hello", out, {})
+
+        assert _formats(mock_client.audio.speech.create) == ["mp3"]
+        convert.assert_not_called()
+        assert result == out

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1027,15 +1027,18 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     base_url = oai_config.get("base_url", base_url)
     speed = float(oai_config.get("speed", tts_config.get("speed", 1.0)))
 
-    # Determine response format from extension
-    if output_path.endswith(".ogg"):
-        response_format = "opus"
-    else:
-        response_format = "mp3"
+    # Telegram voice bubbles need OGG/Opus. Real OpenAI encodes opus natively
+    # (no ffmpeg needed), but many OpenAI-*compatible* backends (e.g. a
+    # self-hosted Speaches/Kokoro endpoint) only support mp3/flac/wav/pcm and
+    # reject ``response_format="opus"``. Try native opus first, then fall back
+    # to mp3 + local ffmpeg transcode -- mirroring the Edge provider path so a
+    # non-opus backend still delivers a playable voice bubble.
+    wants_opus = output_path.endswith(".ogg")
 
     OpenAIClient = _import_openai_client()
     client = OpenAIClient(api_key=api_key, base_url=base_url)
-    try:
+
+    def _synthesize(response_format: str, target_path: str) -> None:
         create_kwargs = {
             "model": model,
             "voice": voice,
@@ -1046,9 +1049,29 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         if speed != 1.0:
             create_kwargs["speed"] = max(0.25, min(4.0, speed))
         response = client.audio.speech.create(**create_kwargs)
+        response.stream_to_file(target_path)
 
-        response.stream_to_file(output_path)
-        return output_path
+    try:
+        if not wants_opus:
+            _synthesize("mp3", output_path)
+            return output_path
+
+        try:
+            _synthesize("opus", output_path)
+            return output_path
+        except Exception as e:
+            # Backend likely can't encode opus. Re-synthesize as mp3 and
+            # transcode to OGG/Opus locally.
+            logger.info(
+                "OpenAI TTS opus request failed (%s); retrying as mp3 + ffmpeg transcode",
+                e,
+            )
+            mp3_path = output_path[:-4] + ".mp3"
+            _synthesize("mp3", mp3_path)
+            converted = _convert_to_opus(mp3_path)
+            # If ffmpeg is unavailable, keep the mp3 so the caller still has
+            # playable audio (delivered as a document rather than a voice bubble).
+            return converted or mp3_path
     finally:
         close = getattr(client, "close", None)
         if callable(close):
@@ -2272,7 +2295,7 @@ def text_to_speech_tool(
                     "error": "OpenAI provider selected but 'openai' package not installed."
                 }, ensure_ascii=False)
             logger.info("Generating speech with OpenAI TTS...")
-            _generate_openai_tts(text, file_str, tts_config)
+            file_str = _generate_openai_tts(text, file_str, tts_config)
 
         elif provider == "minimax":
             logger.info("Generating speech with MiniMax TTS...")


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `_generate_openai_tts()` in `tools/tts_tool.py` hardcoded `response_format="opus"` for any `.ogg` target (Telegram voice bubbles). Real OpenAI encodes opus natively, but many OpenAI-**compatible** backends — e.g. a self-hosted Speaches/Kokoro endpoint — only support `mp3/flac/wav/pcm` and reject the opus request, so the `audio.speech.create()` call errors and **no voice bubble is delivered**.

The fix makes the OpenAI path **try native opus first**, then fall back to synthesizing `mp3` and transcoding to OGG/Opus locally via the existing `_convert_to_opus()` helper — mirroring how the Edge provider already handles this. I chose try-opus-first over an unconditional mp3+transcode specifically to avoid regressing real-OpenAI users, who would otherwise gain an ffmpeg dependency and a lossy mp3→opus re-encode on every voice reply. If ffmpeg is unavailable, the mp3 is kept so the caller still has playable audio (delivered as a document instead of a voice bubble) rather than failing with "no output".

This is the inverse of #14841 (which assumes an opus-capable backend); both share this function. It is complementary to and does not overlap #54488, which transcodes at the Matrix/gateway layer (`gateway/run.py`) rather than in the TTS synthesis tool.

## Related Issue

Fixes #54589

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/tts_tool.py` — `_generate_openai_tts()`: try `response_format="opus"` for `.ogg` targets, and on failure re-synthesize as `mp3` and transcode to OGG/Opus via `_convert_to_opus()`; fall back to the mp3 when ffmpeg is absent. Non-`.ogg` targets are unchanged (direct mp3).
- `tools/tts_tool.py` — `text_to_speech_tool()`: capture the path returned by `_generate_openai_tts()` (consistent with the command/plugin providers) so the fallback path is honored downstream.
- `tests/tools/test_tts_openai_opus.py` — new tests covering native opus (no transcode), opus-rejection → mp3+transcode, no-ffmpeg → keep mp3, and plain `.mp3` targets.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_tts_openai_opus.py tests/tools/test_tts_speed.py tests/tools/test_tts_max_text_length.py tests/tools/test_managed_media_gateways.py`
   → `Summary: 4 files, 62 tests passed, 0 failed`.
2. Manual repro: point `tts.openai.base_url` at a Speaches/Kokoro endpoint (no opus encoder) and trigger a Telegram voice reply. Before: backend rejects `opus` and no bubble is sent. After: Hermes synthesizes mp3 and transcodes to OGG/Opus locally, delivering a playable voice bubble.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Backend error before the fix:

> Unsupported response_format "opus". Supported formats: mp3, flac, wav, pcm.
