### PR TITLE
feat(cron): redirect stale-target deliveries to parent/home channel

### DIFF
--- a/cron/delivery_fallback.py
+++ b/cron/delivery_fallback.py
@@ -1,0 +1,179 @@
+"""Stale-target delivery fallback for cron jobs.
+
+A cron job created from a live conversation stores that conversation as its
+``origin`` and, by default, delivers its output back there. But the original
+thread/topic/channel can disappear between scheduling and firing — a Discord
+thread is deleted, a Telegram forum topic is closed, a Slack channel is
+archived, the bot is removed. When that happens the delivery fails and the
+notification is silently lost: the user simply never hears back from a reminder
+they explicitly asked for.
+
+This module decides, platform-neutrally, whether a delivery failure is
+*definitive* (the target genuinely cannot receive the message) and, if so,
+produces an ordered list of saner targets to retry instead:
+
+    original thread/topic  ->  parent channel  ->  home channel
+
+Crucially, only definitive failures are redirected. Uncertain failures —
+timeouts, rate limits, 5xx, anything unrecognized — are NOT, because the
+original send may already have landed and a redirect would deliver the message
+twice. Detection reuses the canonical
+:func:`gateway.platforms.base.classify_send_error`, so every platform whose
+adapter surfaces a recognizable reason is covered, and adding a new signature
+there benefits this fallback automatically.
+"""
+
+from typing import List, Optional
+
+from gateway.platforms.base import classify_send_error
+
+# ``classify_send_error`` kinds that mean the target definitely cannot receive
+# the message, so redirecting elsewhere is safe (it will not duplicate a send
+# that might otherwise have succeeded). Everything else — ``rate_limited``,
+# ``transient``, ``too_long``, ``bad_format``, ``unknown`` — is treated as
+# uncertain and left for the caller's normal error handling.
+_DEFINITIVE_ERROR_KINDS = frozenset({"not_found", "forbidden"})
+
+
+def is_definitive_delivery_failure(error: object) -> bool:
+    """Return True when *error* means the target cannot receive the message.
+
+    *error* may be an exception or any value carrying an error string (e.g. the
+    ``error`` field of a send result). It is classified via
+    :func:`gateway.platforms.base.classify_send_error`; only ``not_found`` and
+    ``forbidden`` are considered definitive. Transient/uncertain failures
+    (timeouts, rate limits, 5xx, unrecognized) return False so the caller does
+    not risk a duplicate delivery.
+    """
+    if error is None:
+        return False
+    if isinstance(error, BaseException):
+        kind = classify_send_error(error)
+    else:
+        text = str(error).strip()
+        if not text:
+            return False
+        kind = classify_send_error(None, error_text=text)
+    return kind in _DEFINITIVE_ERROR_KINDS
+
+
+def _parent_fallback_target(
+    platform: str, cur_chat: str, cur_thread: str, parent_chat_id: Optional[str]
+) -> Optional[dict]:
+    """Resolve the parent-channel retry target for a stale thread, if any.
+
+    Two thread models exist across platforms:
+
+    * **Separate parent id** (Discord, Matrix): the target ``chat_id`` *is* the
+      thread, and the parent channel is a distinct id carried in
+      ``parent_chat_id``. Redirect to that parent channel.
+    * **Thread inside a channel** (Telegram forum topics, Slack threads): the
+      target ``chat_id`` is already the parent channel and ``thread_id`` names
+      the topic/thread within it. Redirect to the channel by dropping the
+      thread id.
+
+    Returns ``None`` when neither applies (e.g. a flat DM, or the parent is the
+    same place that just failed).
+    """
+    if parent_chat_id and str(parent_chat_id) != cur_chat:
+        return {
+            "platform": platform,
+            "chat_id": str(parent_chat_id),
+            "thread_id": None,
+            "fallback_kind": "parent",
+        }
+    if cur_thread and cur_thread != cur_chat:
+        return {
+            "platform": platform,
+            "chat_id": cur_chat,
+            "thread_id": None,
+            "fallback_kind": "parent",
+        }
+    return None
+
+
+def build_fallback_targets(
+    target: dict,
+    *,
+    parent_chat_id: Optional[str] = None,
+    home_chat_id: str = "",
+    home_thread_id: Optional[str] = None,
+    is_direct_message: bool = False,
+) -> List[dict]:
+    """Ordered redirect targets for a definitively-undeliverable *target*.
+
+    Order is parent channel (when resolvable) then home channel. Each entry is
+    a delivery-target dict ``{platform, chat_id, thread_id, fallback_kind}``
+    where ``fallback_kind`` is ``"parent"`` or ``"home"``. Candidates equal to
+    the failed target, or to an earlier candidate, are skipped so a message is
+    never resent to the same place. Same platform throughout — a stale target is
+    retried on saner channels of the *same* platform, never cross-posted.
+
+    ``parent_chat_id`` should be supplied only when *target* is the job's own
+    origin thread (so the stored parent belongs to it); pass ``None`` for
+    fan-out/broadcast targets. ``home_chat_id`` / ``home_thread_id`` come from
+    the platform's configured cron home channel.
+
+    ``is_direct_message`` suppresses the *home-channel* fallback when the failed
+    target is a private 1:1 chat. A DM that becomes undeliverable (the user
+    blocked/deleted the bot) has no broader-but-still-private place to escalate
+    to: the configured home channel is typically a shared group, so redirecting
+    private DM content there would leak it. The parent fallback is unaffected —
+    dropping a deleted DM *topic* back to the DM root stays in the same private
+    conversation.
+    """
+    platform = str(target.get("platform", ""))
+    cur_chat = str(target.get("chat_id", ""))
+    cur_thread_raw = target.get("thread_id")
+    cur_thread = str(cur_thread_raw) if cur_thread_raw is not None else ""
+
+    def _key(t: dict) -> tuple:
+        tid = t.get("thread_id")
+        return (str(t.get("platform", "")).lower(), str(t.get("chat_id", "")),
+                str(tid) if tid is not None else "")
+
+    seen = {(platform.lower(), cur_chat, cur_thread)}
+    out: List[dict] = []
+
+    candidates = [_parent_fallback_target(platform, cur_chat, cur_thread, parent_chat_id)]
+    if home_chat_id and not is_direct_message:
+        candidates.append({
+            "platform": platform,
+            "chat_id": str(home_chat_id),
+            "thread_id": home_thread_id,
+            "fallback_kind": "home",
+        })
+
+    for cand in candidates:
+        if not cand:
+            continue
+        key = _key(cand)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(cand)
+    return out
+
+
+def format_fallback_notice(content: str, fallback_kind: Optional[str]) -> str:
+    """Prepend a plain-text notice explaining why delivery was redirected.
+
+    Plain English with a leading ``⚠️`` glyph and no markdown, matching the
+    cron/gateway notice convention so it renders uniformly across every
+    platform. Returns *content* unchanged for an unknown ``fallback_kind``.
+    """
+    if fallback_kind == "parent":
+        prefix = (
+            "⚠️ The original thread was no longer available, so this update was "
+            "delivered to the parent channel instead."
+        )
+    elif fallback_kind == "home":
+        prefix = (
+            "⚠️ The original conversation was no longer available, so this update "
+            "was delivered to the home channel instead."
+        )
+    else:
+        return content
+    if not content:
+        return prefix
+    return f"{prefix}\n\n{content}"

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1443,6 +1443,170 @@ def _is_channel_dm_topic(
     return is_channel
 
 
+def _run_send_blocking(make_coro):
+    """Run a ``_send_to_platform`` coroutine to completion from any thread.
+
+    Mirrors the standalone send path in :func:`_deliver_result`: ``asyncio.run``
+    in this thread, falling back to a worker thread when a loop is already
+    running here. ``make_coro`` is a zero-arg factory so a fresh coroutine can
+    be created for the retry (a coroutine cannot be awaited twice).
+    """
+    coro = make_coro()
+    try:
+        return asyncio.run(coro)
+    except RuntimeError:
+        # A loop is already running in this thread; the coro was never started.
+        # Close it to avoid a "coroutine was never awaited" warning, then run a
+        # fresh one in a worker thread that has no running loop.
+        coro.close()
+        # Explicit shutdown(wait=False) rather than a ``with`` block: matches the
+        # standalone-send threadpool pattern the #47163 loop-safety tests assert
+        # against, and drops the worker without blocking on the timed-out send.
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            return pool.submit(asyncio.run, make_coro()).result(timeout=30)
+        finally:
+            pool.shutdown(wait=False)
+
+
+def _attempt_delivery_fallback(
+    job: dict,
+    target: dict,
+    origin: dict,
+    platform,
+    pconfig,
+    content: str,
+    media_files,
+    error: object,
+    sent_keys: Optional[set] = None,
+) -> tuple:
+    """Redirect a definitively-undeliverable cron target to parent/home.
+
+    Returns ``(handled, error_message)``:
+
+    * ``(False, None)`` — no fallback applies: the failure was not definitive,
+      or no saner target exists. The caller should fall through to its normal
+      error handling.
+    * ``(True, None)`` — a fallback delivered the message. The caller should
+      treat the target as delivered (record no error).
+    * ``(True, <str>)`` — fallbacks were attempted but all failed. The caller
+      should record ``<str>`` and move on.
+
+    Only :func:`cron.delivery_fallback.is_definitive_delivery_failure` failures
+    are redirected, so an uncertain failure (timeout, rate limit, 5xx) is never
+    duplicated. A fallback that itself fails definitively advances to the next
+    fallback; a fallback that fails for an uncertain reason stops the chain so
+    that send is not retried elsewhere either.
+
+    ``sent_keys`` is a set, shared across all targets of one delivery run, of
+    ``(platform, chat_id, thread_id)`` tuples a fallback has already delivered
+    the (identical) job content to. It dedups across targets: when several
+    failing targets redirect to the same parent/home channel, the content is
+    sent there once, not once per failing target.
+    """
+    from cron.delivery_fallback import (
+        build_fallback_targets,
+        format_fallback_notice,
+        is_definitive_delivery_failure,
+    )
+
+    if not is_definitive_delivery_failure(error):
+        return (False, None)
+
+    platform_name = target["platform"]
+    chat_id = target["chat_id"]
+    thread_id = target.get("thread_id")
+
+    # The stored parent channel / chat_type belong to the origin conversation,
+    # so only trust them when this target IS the origin (not a fan-out target).
+    parent_chat_id = None
+    is_dm = False
+    if origin and _target_matches_origin(origin, platform_name, chat_id, thread_id):
+        parent_chat_id = origin.get("parent_chat_id")
+        # Suppress the home-channel fallback for a 1:1 DM: the home channel is
+        # typically a shared group, so escalating private DM content there would
+        # leak it. Only an explicit "dm" opts in (older jobs without chat_type
+        # keep prior behavior).
+        is_dm = str(origin.get("chat_type", "")).lower() in ("dm", "private")
+
+    fallback_targets = build_fallback_targets(
+        target,
+        parent_chat_id=parent_chat_id,
+        home_chat_id=_get_home_target_chat_id(platform_name),
+        home_thread_id=_get_home_target_thread_id(platform_name),
+        is_direct_message=is_dm,
+    )
+    if not fallback_targets:
+        return (False, None)
+
+    from tools.send_message_tool import _send_to_platform
+
+    if sent_keys is None:
+        sent_keys = set()
+
+    def _fb_key(t: dict) -> tuple:
+        tid = t.get("thread_id")
+        return (str(t.get("platform", "")).lower(), str(t.get("chat_id", "")),
+                str(tid) if tid is not None else "")
+
+    fail_prefix = f"delivery to {platform_name}:{chat_id} failed: {error}; "
+    last_error = error
+    for fb in fallback_targets:
+        kind = fb.get("fallback_kind", "fallback")
+        fb_key = _fb_key(fb)
+        if fb_key in sent_keys:
+            # An earlier target in this same run already delivered the identical
+            # content to this channel; re-sending would duplicate it. Treat as
+            # delivered and stop.
+            logger.info(
+                "Job '%s': %s fallback to %s skipped — content already delivered "
+                "there this run",
+                job["id"], kind, fb["chat_id"],
+            )
+            return (True, None)
+        logger.warning(
+            "Job '%s': %s target %s:%s is undeliverable (%s); "
+            "retrying %s channel %s",
+            job["id"], platform_name, chat_id, thread_id, last_error,
+            kind, fb["chat_id"],
+        )
+        notice = format_fallback_notice(content, fb.get("fallback_kind"))
+        try:
+            fb_result = _run_send_blocking(
+                lambda fb=fb, notice=notice: _send_to_platform(
+                    platform, pconfig, fb["chat_id"], notice,
+                    thread_id=fb.get("thread_id"), media_files=media_files,
+                )
+            )
+        except Exception as fb_exc:  # noqa: BLE001 - mirror standalone send handling
+            if is_definitive_delivery_failure(fb_exc):
+                last_error = fb_exc
+                continue
+            msg = f"{fail_prefix}{kind} fallback to {fb['chat_id']} failed: {fb_exc}"
+            logger.error("Job '%s': %s", job["id"], msg)
+            return (True, msg)
+
+        if fb_result and fb_result.get("error"):
+            fb_err = fb_result["error"]
+            if is_definitive_delivery_failure(fb_err):
+                last_error = fb_err
+                continue
+            msg = f"{fail_prefix}{kind} fallback error: {fb_err}"
+            logger.error("Job '%s': %s", job["id"], msg)
+            return (True, msg)
+
+        sent_keys.add(fb_key)
+        logger.info(
+            "Job '%s': delivered to %s:%s after %s fallback from %s:%s",
+            job["id"], fb["platform"], fb["chat_id"], kind, platform_name, chat_id,
+        )
+        return (True, None)
+
+    msg = f"{fail_prefix}all fallbacks failed; last error: {last_error}"
+    logger.error("Job '%s': %s", job["id"], msg)
+    return (True, msg)
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -1529,6 +1693,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         return msg
 
     delivery_errors = []
+    # Channels a stale-target fallback has already delivered this run's content
+    # to, shared across all targets so several failing targets that redirect to
+    # the same parent/home channel do not duplicate the message there.
+    fallback_sent_keys: set = set()
 
     for target in targets:
         platform_name = target["platform"]
@@ -2015,55 +2183,38 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 target_errors.append(msg)
                 delivery_errors.extend(target_errors)
                 continue
-            # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            # Standalone path: run the async send in a fresh event loop (safe
+            # from any thread). _run_send_blocking encapsulates the asyncio.run /
+            # worker-thread retry; a send error raised on EITHER path propagates
+            # to the except below (#47163 crash-safety), which downgrades a
+            # shutdown race to a warning and otherwise attempts the stale-target
+            # fallback.
             try:
-                result = asyncio.run(coro)
-            except RuntimeError as run_err:
-                # asyncio.run() checks for a running loop before awaiting the coroutine;
-                # when it raises, the original coro was never started — close it to
-                # prevent "coroutine was never awaited" RuntimeWarning, then retry in a
-                # fresh thread that has no running loop.
-                coro.close()
-                # If the RuntimeError is the interpreter-finalization signal,
-                # the fresh-thread fallback would fail identically — skip
-                # gracefully instead of logging a shutdown-race traceback.
-                if _interpreter_shutting_down(run_err):
+                result = _run_send_blocking(
+                    lambda: _send_to_platform(
+                        platform, pconfig, chat_id, cleaned_delivery_content,
+                        thread_id=thread_id, media_files=media_files,
+                    )
+                )
+            except Exception as e:
+                # A shutdown-race exception during teardown is expected — skip
+                # gracefully instead of treating it as a delivery failure or
+                # triggering a stale-target fallback (#58720, #55924).
+                if _interpreter_shutting_down(e):
                     msg = f"delivery to {platform_name}:{chat_id} skipped — interpreter is shutting down"
                     logger.warning("Job '%s': %s", job["id"], msg)
                     target_errors.append(msg)
                     delivery_errors.extend(target_errors)
                     continue
-                # The thread-pool fallback can itself raise (SMTP ConnectionError,
-                # future.result timeout, etc.). An exception raised inside this
-                # `except RuntimeError` block is NOT caught by the sibling
-                # `except Exception` below — it would escape _deliver_result()
-                # and crash the whole delivery loop, silently skipping every
-                # remaining target (#47163). Wrap the fallback in its own
-                # try/except so a per-target failure is logged and the loop
-                # continues to the next target.
-                try:
-                    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-                    try:
-                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
-                        result = future.result(timeout=30)
-                    finally:
-                        pool.shutdown(wait=False)
-                except Exception as e:
-                    # A shutdown-race here is expected during teardown; downgrade
-                    # to a warning so it doesn't read as a genuine failure.
-                    if _interpreter_shutting_down(e):
-                        msg = f"delivery to {platform_name}:{chat_id} skipped — interpreter is shutting down"
-                        logger.warning("Job '%s': %s", job["id"], msg)
-                        target_errors.append(msg)
+                handled, fb_msg = _attempt_delivery_fallback(
+                    job, target, origin, platform, pconfig,
+                    cleaned_delivery_content, media_files, e, fallback_sent_keys,
+                )
+                if handled:
+                    if fb_msg:
+                        target_errors.append(fb_msg)
                         delivery_errors.extend(target_errors)
-                        continue
-                    msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
-                    logger.error("Job '%s': %s", job["id"], msg, exc_info=True)
-                    target_errors.extend([msg])
-                    delivery_errors.extend(target_errors)
                     continue
-            except Exception as e:
                 msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
                 logger.error("Job '%s': %s", job["id"], msg, exc_info=True)
                 target_errors.extend([msg])
@@ -2071,7 +2222,17 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 continue
 
             if result and result.get("error"):
-                msg = f"delivery error: {result['error']}"
+                err = result["error"]
+                handled, fb_msg = _attempt_delivery_fallback(
+                    job, target, origin, platform, pconfig,
+                    cleaned_delivery_content, media_files, err, fallback_sent_keys,
+                )
+                if handled:
+                    if fb_msg:
+                        target_errors.append(fb_msg)
+                        delivery_errors.extend(target_errors)
+                    continue
+                msg = f"delivery error: {err}"
                 logger.error("Job '%s': %s", job["id"], msg)
                 target_errors.extend([msg])
                 delivery_errors.extend(target_errors)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1469,6 +1469,13 @@ def _run_send_blocking(make_coro):
             pool.shutdown(wait=False)
 
 
+# Platforms whose ``chat_type="thread"`` origin is ALWAYS a shared thread (never
+# a 1:1 DM), so a stale thread may escalate to the home channel without leaking
+# private content. Discord threads always live under a guild channel; Slack
+# threads can sit inside a DM, so Slack is deliberately excluded (fail closed).
+_THREAD_ALWAYS_SHARED_PLATFORMS = frozenset({"discord"})
+
+
 def _attempt_delivery_fallback(
     job: dict,
     target: dict,
@@ -1520,21 +1527,37 @@ def _attempt_delivery_fallback(
     # The stored parent channel / chat_type belong to the origin conversation,
     # so only trust them when this target IS the origin (not a fan-out target).
     parent_chat_id = None
-    is_dm = False
+    # Explicit fan-out targets (a user-typed ``deliver=platform:chan``) keep the
+    # home fallback: the user chose that destination, so a dead one redirecting
+    # to home is the intended behavior. The privacy guard applies only to the
+    # job's ORIGIN conversation, whose chat_type we captured.
+    suppress_home = False
     if origin and _target_matches_origin(origin, platform_name, chat_id, thread_id):
         parent_chat_id = origin.get("parent_chat_id")
-        # Suppress the home-channel fallback for a 1:1 DM: the home channel is
-        # typically a shared group, so escalating private DM content there would
-        # leak it. Only an explicit "dm" opts in (older jobs without chat_type
-        # keep prior behavior).
-        is_dm = str(origin.get("chat_type", "")).lower() in ("dm", "private")
+        # Fail closed: escalate origin content to the shared home channel only
+        # when the origin is POSITIVELY a shared chat. A missing/unknown
+        # chat_type — every job created before chat_type was captured — plus
+        # "webhook" and explicit DM kinds are treated as possibly-private and do
+        # NOT escalate. The parent fallback is unaffected: it stays inside the
+        # origin conversation and cannot leak.
+        #
+        # "thread" is platform-dependent: a Discord thread ALWAYS lives under a
+        # guild channel (never a DM), so it is shared and may escalate; on Slack
+        # a thread can sit inside a DM, so it stays fail-closed. (Matrix emits no
+        # "thread" origin; Telegram uses "forum".)
+        chat_type = str(origin.get("chat_type", "")).strip().lower()
+        shared = chat_type in ("group", "channel", "forum") or (
+            chat_type == "thread"
+            and platform_name.lower() in _THREAD_ALWAYS_SHARED_PLATFORMS
+        )
+        suppress_home = not shared
 
     fallback_targets = build_fallback_targets(
         target,
         parent_chat_id=parent_chat_id,
         home_chat_id=_get_home_target_chat_id(platform_name),
         home_thread_id=_get_home_target_thread_id(platform_name),
-        is_direct_message=is_dm,
+        is_direct_message=suppress_home,
     )
     if not fallback_targets:
         return (False, None)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2879,6 +2879,13 @@ def _run_send_blocking(make_coro):
             pool.shutdown(wait=False)
 
 
+# Platforms whose ``chat_type="thread"`` origin is ALWAYS a shared thread (never
+# a 1:1 DM), so a stale thread may escalate to the home channel without leaking
+# private content. Discord threads always live under a guild channel; Slack
+# threads can sit inside a DM, so Slack is deliberately excluded (fail closed).
+_THREAD_ALWAYS_SHARED_PLATFORMS = frozenset({"discord"})
+
+
 def _attempt_delivery_fallback(
     job: dict,
     target: dict,
@@ -2930,21 +2937,37 @@ def _attempt_delivery_fallback(
     # The stored parent channel / chat_type belong to the origin conversation,
     # so only trust them when this target IS the origin (not a fan-out target).
     parent_chat_id = None
-    is_dm = False
+    # Explicit fan-out targets (a user-typed ``deliver=platform:chan``) keep the
+    # home fallback: the user chose that destination, so a dead one redirecting
+    # to home is the intended behavior. The privacy guard applies only to the
+    # job's ORIGIN conversation, whose chat_type we captured.
+    suppress_home = False
     if origin and _target_matches_origin(origin, platform_name, chat_id, thread_id):
         parent_chat_id = origin.get("parent_chat_id")
-        # Suppress the home-channel fallback for a 1:1 DM: the home channel is
-        # typically a shared group, so escalating private DM content there would
-        # leak it. Only an explicit "dm" opts in (older jobs without chat_type
-        # keep prior behavior).
-        is_dm = str(origin.get("chat_type", "")).lower() in ("dm", "private")
+        # Fail closed: escalate origin content to the shared home channel only
+        # when the origin is POSITIVELY a shared chat. A missing/unknown
+        # chat_type — every job created before chat_type was captured — plus
+        # "webhook" and explicit DM kinds are treated as possibly-private and do
+        # NOT escalate. The parent fallback is unaffected: it stays inside the
+        # origin conversation and cannot leak.
+        #
+        # "thread" is platform-dependent: a Discord thread ALWAYS lives under a
+        # guild channel (never a DM), so it is shared and may escalate; on Slack
+        # a thread can sit inside a DM, so it stays fail-closed. (Matrix emits no
+        # "thread" origin; Telegram uses "forum".)
+        chat_type = str(origin.get("chat_type", "")).strip().lower()
+        shared = chat_type in ("group", "channel", "forum") or (
+            chat_type == "thread"
+            and platform_name.lower() in _THREAD_ALWAYS_SHARED_PLATFORMS
+        )
+        suppress_home = not shared
 
     fallback_targets = build_fallback_targets(
         target,
         parent_chat_id=parent_chat_id,
         home_chat_id=_get_home_target_chat_id(platform_name),
         home_thread_id=_get_home_target_thread_id(platform_name),
-        is_direct_message=is_dm,
+        is_direct_message=suppress_home,
     )
     if not fallback_targets:
         return (False, None)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2853,6 +2853,170 @@ def _is_channel_dm_topic(
     return is_channel
 
 
+def _run_send_blocking(make_coro):
+    """Run a ``_send_to_platform`` coroutine to completion from any thread.
+
+    Mirrors the standalone send path in :func:`_deliver_result`: ``asyncio.run``
+    in this thread, falling back to a worker thread when a loop is already
+    running here. ``make_coro`` is a zero-arg factory so a fresh coroutine can
+    be created for the retry (a coroutine cannot be awaited twice).
+    """
+    coro = make_coro()
+    try:
+        return asyncio.run(coro)
+    except RuntimeError:
+        # A loop is already running in this thread; the coro was never started.
+        # Close it to avoid a "coroutine was never awaited" warning, then run a
+        # fresh one in a worker thread that has no running loop.
+        coro.close()
+        # Explicit shutdown(wait=False) rather than a ``with`` block: matches the
+        # standalone-send threadpool pattern the #47163 loop-safety tests assert
+        # against, and drops the worker without blocking on the timed-out send.
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            return pool.submit(asyncio.run, make_coro()).result(timeout=30)
+        finally:
+            pool.shutdown(wait=False)
+
+
+def _attempt_delivery_fallback(
+    job: dict,
+    target: dict,
+    origin: dict,
+    platform,
+    pconfig,
+    content: str,
+    media_files,
+    error: object,
+    sent_keys: Optional[set] = None,
+) -> tuple:
+    """Redirect a definitively-undeliverable cron target to parent/home.
+
+    Returns ``(handled, error_message)``:
+
+    * ``(False, None)`` — no fallback applies: the failure was not definitive,
+      or no saner target exists. The caller should fall through to its normal
+      error handling.
+    * ``(True, None)`` — a fallback delivered the message. The caller should
+      treat the target as delivered (record no error).
+    * ``(True, <str>)`` — fallbacks were attempted but all failed. The caller
+      should record ``<str>`` and move on.
+
+    Only :func:`cron.delivery_fallback.is_definitive_delivery_failure` failures
+    are redirected, so an uncertain failure (timeout, rate limit, 5xx) is never
+    duplicated. A fallback that itself fails definitively advances to the next
+    fallback; a fallback that fails for an uncertain reason stops the chain so
+    that send is not retried elsewhere either.
+
+    ``sent_keys`` is a set, shared across all targets of one delivery run, of
+    ``(platform, chat_id, thread_id)`` tuples a fallback has already delivered
+    the (identical) job content to. It dedups across targets: when several
+    failing targets redirect to the same parent/home channel, the content is
+    sent there once, not once per failing target.
+    """
+    from cron.delivery_fallback import (
+        build_fallback_targets,
+        format_fallback_notice,
+        is_definitive_delivery_failure,
+    )
+
+    if not is_definitive_delivery_failure(error):
+        return (False, None)
+
+    platform_name = target["platform"]
+    chat_id = target["chat_id"]
+    thread_id = target.get("thread_id")
+
+    # The stored parent channel / chat_type belong to the origin conversation,
+    # so only trust them when this target IS the origin (not a fan-out target).
+    parent_chat_id = None
+    is_dm = False
+    if origin and _target_matches_origin(origin, platform_name, chat_id, thread_id):
+        parent_chat_id = origin.get("parent_chat_id")
+        # Suppress the home-channel fallback for a 1:1 DM: the home channel is
+        # typically a shared group, so escalating private DM content there would
+        # leak it. Only an explicit "dm" opts in (older jobs without chat_type
+        # keep prior behavior).
+        is_dm = str(origin.get("chat_type", "")).lower() in ("dm", "private")
+
+    fallback_targets = build_fallback_targets(
+        target,
+        parent_chat_id=parent_chat_id,
+        home_chat_id=_get_home_target_chat_id(platform_name),
+        home_thread_id=_get_home_target_thread_id(platform_name),
+        is_direct_message=is_dm,
+    )
+    if not fallback_targets:
+        return (False, None)
+
+    from tools.send_message_tool import _send_to_platform
+
+    if sent_keys is None:
+        sent_keys = set()
+
+    def _fb_key(t: dict) -> tuple:
+        tid = t.get("thread_id")
+        return (str(t.get("platform", "")).lower(), str(t.get("chat_id", "")),
+                str(tid) if tid is not None else "")
+
+    fail_prefix = f"delivery to {platform_name}:{chat_id} failed: {error}; "
+    last_error = error
+    for fb in fallback_targets:
+        kind = fb.get("fallback_kind", "fallback")
+        fb_key = _fb_key(fb)
+        if fb_key in sent_keys:
+            # An earlier target in this same run already delivered the identical
+            # content to this channel; re-sending would duplicate it. Treat as
+            # delivered and stop.
+            logger.info(
+                "Job '%s': %s fallback to %s skipped — content already delivered "
+                "there this run",
+                job["id"], kind, fb["chat_id"],
+            )
+            return (True, None)
+        logger.warning(
+            "Job '%s': %s target %s:%s is undeliverable (%s); "
+            "retrying %s channel %s",
+            job["id"], platform_name, chat_id, thread_id, last_error,
+            kind, fb["chat_id"],
+        )
+        notice = format_fallback_notice(content, fb.get("fallback_kind"))
+        try:
+            fb_result = _run_send_blocking(
+                lambda fb=fb, notice=notice: _send_to_platform(
+                    platform, pconfig, fb["chat_id"], notice,
+                    thread_id=fb.get("thread_id"), media_files=media_files,
+                )
+            )
+        except Exception as fb_exc:  # noqa: BLE001 - mirror standalone send handling
+            if is_definitive_delivery_failure(fb_exc):
+                last_error = fb_exc
+                continue
+            msg = f"{fail_prefix}{kind} fallback to {fb['chat_id']} failed: {fb_exc}"
+            logger.error("Job '%s': %s", job["id"], msg)
+            return (True, msg)
+
+        if fb_result and fb_result.get("error"):
+            fb_err = fb_result["error"]
+            if is_definitive_delivery_failure(fb_err):
+                last_error = fb_err
+                continue
+            msg = f"{fail_prefix}{kind} fallback error: {fb_err}"
+            logger.error("Job '%s': %s", job["id"], msg)
+            return (True, msg)
+
+        sent_keys.add(fb_key)
+        logger.info(
+            "Job '%s': delivered to %s:%s after %s fallback from %s:%s",
+            job["id"], fb["platform"], fb["chat_id"], kind, platform_name, chat_id,
+        )
+        return (True, None)
+
+    msg = f"{fail_prefix}all fallbacks failed; last error: {last_error}"
+    logger.error("Job '%s': %s", job["id"], msg)
+    return (True, msg)
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -2969,6 +3133,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         return msg
 
     delivery_errors = []
+    # Channels a stale-target fallback has already delivered this run's content
+    # to, shared across all targets so several failing targets that redirect to
+    # the same parent/home channel do not duplicate the message there.
+    fallback_sent_keys: set = set()
 
     for target in targets:
         platform_name = target["platform"]
@@ -3565,55 +3733,38 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 target_errors.append(msg)
                 delivery_errors.extend(target_errors)
                 continue
-            # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            # Standalone path: run the async send in a fresh event loop (safe
+            # from any thread). _run_send_blocking encapsulates the asyncio.run /
+            # worker-thread retry; a send error raised on EITHER path propagates
+            # to the except below (#47163 crash-safety), which downgrades a
+            # shutdown race to a warning and otherwise attempts the stale-target
+            # fallback.
             try:
-                result = asyncio.run(coro)
-            except RuntimeError as run_err:
-                # asyncio.run() checks for a running loop before awaiting the coroutine;
-                # when it raises, the original coro was never started — close it to
-                # prevent "coroutine was never awaited" RuntimeWarning, then retry in a
-                # fresh thread that has no running loop.
-                coro.close()
-                # If the RuntimeError is the interpreter-finalization signal,
-                # the fresh-thread fallback would fail identically — skip
-                # gracefully instead of logging a shutdown-race traceback.
-                if _interpreter_shutting_down(run_err):
+                result = _run_send_blocking(
+                    lambda: _send_to_platform(
+                        platform, pconfig, chat_id, cleaned_delivery_content,
+                        thread_id=thread_id, media_files=media_files,
+                    )
+                )
+            except Exception as e:
+                # A shutdown-race exception during teardown is expected — skip
+                # gracefully instead of treating it as a delivery failure or
+                # triggering a stale-target fallback (#58720, #55924).
+                if _interpreter_shutting_down(e):
                     msg = f"delivery to {platform_name}:{chat_id} skipped — interpreter is shutting down"
                     logger.warning("Job '%s': %s", job["id"], msg)
                     target_errors.append(msg)
                     delivery_errors.extend(target_errors)
                     continue
-                # The thread-pool fallback can itself raise (SMTP ConnectionError,
-                # future.result timeout, etc.). An exception raised inside this
-                # `except RuntimeError` block is NOT caught by the sibling
-                # `except Exception` below — it would escape _deliver_result()
-                # and crash the whole delivery loop, silently skipping every
-                # remaining target (#47163). Wrap the fallback in its own
-                # try/except so a per-target failure is logged and the loop
-                # continues to the next target.
-                try:
-                    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-                    try:
-                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
-                        result = future.result(timeout=30)
-                    finally:
-                        pool.shutdown(wait=False)
-                except Exception as e:
-                    # A shutdown-race here is expected during teardown; downgrade
-                    # to a warning so it doesn't read as a genuine failure.
-                    if _interpreter_shutting_down(e):
-                        msg = f"delivery to {platform_name}:{chat_id} skipped — interpreter is shutting down"
-                        logger.warning("Job '%s': %s", job["id"], msg)
-                        target_errors.append(msg)
+                handled, fb_msg = _attempt_delivery_fallback(
+                    job, target, origin, platform, pconfig,
+                    cleaned_delivery_content, media_files, e, fallback_sent_keys,
+                )
+                if handled:
+                    if fb_msg:
+                        target_errors.append(fb_msg)
                         delivery_errors.extend(target_errors)
-                        continue
-                    msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
-                    logger.error("Job '%s': %s", job["id"], msg, exc_info=True)
-                    target_errors.extend([msg])
-                    delivery_errors.extend(target_errors)
                     continue
-            except Exception as e:
                 msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
                 logger.error("Job '%s': %s", job["id"], msg, exc_info=True)
                 target_errors.extend([msg])
@@ -3621,11 +3772,21 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 continue
 
             if result and result.get("error"):
+                err = result["error"]
+                handled, fb_msg = _attempt_delivery_fallback(
+                    job, target, origin, platform, pconfig,
+                    cleaned_delivery_content, media_files, err, fallback_sent_keys,
+                )
+                if handled:
+                    if fb_msg:
+                        target_errors.append(fb_msg)
+                        delivery_errors.extend(target_errors)
+                    continue
                 # Include target context (platform/chat) so a bare error string
                 # like "Discord send failed: TimeoutError: " is attributable.
                 # Not inside an except block — the error comes from the send
                 # result dict, so there is no traceback to attach.
-                msg = f"delivery error: {result['error']} (target {platform_name}:{chat_id})"
+                msg = f"delivery error: {err} (target {platform_name}:{chat_id})"
                 logger.error("Job '%s': %s", job["id"], msg)
                 target_errors.extend([msg])
                 delivery_errors.extend(target_errors)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2124,7 +2124,16 @@ _SUBCHAT_NOT_FOUND_SUBSTRINGS = (
     "message to reply not found",
     "thread not found",
     "topic_deleted",
+    "topic_closed",
     "message_id_invalid",
+    # Discord: 10003 Unknown Channel (deleted/inaccessible channel|thread).
+    "unknown channel",
+    "error code: 10003",
+    # Slack: channel deleted or archived. A stale channel/thread is a
+    # sub-chat-level death (redirectable to parent/home), not a whole-chat
+    # death, so it must NOT mark the parent target dead.
+    "channel_not_found",
+    "is_archived",
 )
 
 
@@ -2178,10 +2187,37 @@ def classify_send_error(exc: Optional[BaseException], error_text: str = "") -> s
         or "not enough rights" in blob
         or "have no rights" in blob
         or "not a member" in blob
+        # Discord: 50001 Missing Access / 50013 Missing Permissions.
+        or "missing access" in blob
+        or "missing permissions" in blob
+        or "error code: 50001" in blob
+        or "error code: 50013" in blob
+        # Slack: bot removed from / never added to the channel, or its token
+        # lacks the scope to post there.
+        or "not_in_channel" in blob
+        or "missing_scope" in blob
+        or "restricted_action" in blob
     ):
         return "forbidden"
-    if any(s in blob for s in _CHAT_LEVEL_NOT_FOUND_SUBSTRINGS) or any(
-        s in blob for s in _SUBCHAT_NOT_FOUND_SUBSTRINGS
+    if (
+        any(s in blob for s in _CHAT_LEVEL_NOT_FOUND_SUBSTRINGS)
+        or any(s in blob for s in _SUBCHAT_NOT_FOUND_SUBSTRINGS)
+        # Generic deleted / archived / locked container, across platforms whose
+        # adapters surface a free-text reason (e.g. Discord "Thread X not
+        # found", a 404 naming a channel/conversation, an archived or locked
+        # thread). Scoped to container nouns so unrelated "not found" strings
+        # (a missing media file, an unknown user) are not misread as a stale
+        # target. These compound shapes stay inline (not simple substrings): a
+        # sub-chat-level death, so is_chat_level_not_found — which only consults
+        # the constant tuples — correctly leaves the parent target alive.
+        or ("not found" in blob and (
+            "channel" in blob
+            or "thread" in blob
+            or "conversation" in blob
+            or "room" in blob
+        ))
+        or ("archiv" in blob and ("thread" in blob or "channel" in blob))
+        or ("thread" in blob and "locked" in blob)
     ):
         return "not_found"
     if (

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2538,7 +2538,16 @@ _SUBCHAT_NOT_FOUND_SUBSTRINGS = (
     "message to reply not found",
     "thread not found",
     "topic_deleted",
+    "topic_closed",
     "message_id_invalid",
+    # Discord: 10003 Unknown Channel (deleted/inaccessible channel|thread).
+    "unknown channel",
+    "error code: 10003",
+    # Slack: channel deleted or archived. A stale channel/thread is a
+    # sub-chat-level death (redirectable to parent/home), not a whole-chat
+    # death, so it must NOT mark the parent target dead.
+    "channel_not_found",
+    "is_archived",
 )
 
 
@@ -2592,10 +2601,37 @@ def classify_send_error(exc: Optional[BaseException], error_text: str = "") -> s
         or "not enough rights" in blob
         or "have no rights" in blob
         or "not a member" in blob
+        # Discord: 50001 Missing Access / 50013 Missing Permissions.
+        or "missing access" in blob
+        or "missing permissions" in blob
+        or "error code: 50001" in blob
+        or "error code: 50013" in blob
+        # Slack: bot removed from / never added to the channel, or its token
+        # lacks the scope to post there.
+        or "not_in_channel" in blob
+        or "missing_scope" in blob
+        or "restricted_action" in blob
     ):
         return "forbidden"
-    if any(s in blob for s in _CHAT_LEVEL_NOT_FOUND_SUBSTRINGS) or any(
-        s in blob for s in _SUBCHAT_NOT_FOUND_SUBSTRINGS
+    if (
+        any(s in blob for s in _CHAT_LEVEL_NOT_FOUND_SUBSTRINGS)
+        or any(s in blob for s in _SUBCHAT_NOT_FOUND_SUBSTRINGS)
+        # Generic deleted / archived / locked container, across platforms whose
+        # adapters surface a free-text reason (e.g. Discord "Thread X not
+        # found", a 404 naming a channel/conversation, an archived or locked
+        # thread). Scoped to container nouns so unrelated "not found" strings
+        # (a missing media file, an unknown user) are not misread as a stale
+        # target. These compound shapes stay inline (not simple substrings): a
+        # sub-chat-level death, so is_chat_level_not_found — which only consults
+        # the constant tuples — correctly leaves the parent target alive.
+        or ("not found" in blob and (
+            "channel" in blob
+            or "thread" in blob
+            or "conversation" in blob
+            or "room" in blob
+        ))
+        or ("archiv" in blob and ("thread" in blob or "channel" in blob))
+        or ("thread" in blob and "locked" in blob)
     ):
         return "not_found"
     if (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17646,6 +17646,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ),
             chat_name=context.source.chat_name or "",
             thread_id=str(context.source.thread_id) if context.source.thread_id else "",
+            parent_chat_id=str(context.source.parent_chat_id) if context.source.parent_chat_id else "",
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24672,6 +24672,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ),
             chat_name=context.source.chat_name or "",
             thread_id=str(context.source.thread_id) if context.source.thread_id else "",
+            parent_chat_id=str(context.source.parent_chat_id) if context.source.parent_chat_id else "",
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_id_alt=str(context.source.user_id_alt) if context.source.user_id_alt else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -76,6 +76,10 @@ _SESSION_CHAT_ID: ContextVar = ContextVar("HERMES_SESSION_CHAT_ID", default=_UNS
 _SESSION_CHAT_TYPE: ContextVar = ContextVar("HERMES_SESSION_CHAT_TYPE", default=_UNSET)
 _SESSION_CHAT_NAME: ContextVar = ContextVar("HERMES_SESSION_CHAT_NAME", default=_UNSET)
 _SESSION_THREAD_ID: ContextVar = ContextVar("HERMES_SESSION_THREAD_ID", default=_UNSET)
+# Parent channel when chat_id refers to a thread (Discord/Matrix). Captured so a
+# cron job created inside a thread can retry its parent channel if the thread is
+# later deleted (see cron.delivery_fallback).
+_SESSION_PARENT_CHAT_ID: ContextVar = ContextVar("HERMES_SESSION_PARENT_CHAT_ID", default=_UNSET)
 _SESSION_USER_ID: ContextVar = ContextVar("HERMES_SESSION_USER_ID", default=_UNSET)
 _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
 _SESSION_KEY: ContextVar = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
@@ -127,6 +131,7 @@ _VAR_MAP = {
     "HERMES_SESSION_CHAT_TYPE": _SESSION_CHAT_TYPE,
     "HERMES_SESSION_CHAT_NAME": _SESSION_CHAT_NAME,
     "HERMES_SESSION_THREAD_ID": _SESSION_THREAD_ID,
+    "HERMES_SESSION_PARENT_CHAT_ID": _SESSION_PARENT_CHAT_ID,
     "HERMES_SESSION_USER_ID": _SESSION_USER_ID,
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
     "HERMES_SESSION_KEY": _SESSION_KEY,
@@ -162,6 +167,7 @@ def set_session_vars(
     chat_type: str = "",
     chat_name: str = "",
     thread_id: str = "",
+    parent_chat_id: str = "",
     user_id: str = "",
     user_name: str = "",
     session_key: str = "",
@@ -199,6 +205,7 @@ def set_session_vars(
         _SESSION_CHAT_TYPE.set(chat_type),
         _SESSION_CHAT_NAME.set(chat_name),
         _SESSION_THREAD_ID.set(thread_id),
+        _SESSION_PARENT_CHAT_ID.set(parent_chat_id),
         _SESSION_USER_ID.set(user_id),
         _SESSION_USER_NAME.set(user_name),
         _SESSION_KEY.set(session_key),
@@ -235,6 +242,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_CHAT_TYPE,
         _SESSION_CHAT_NAME,
         _SESSION_THREAD_ID,
+        _SESSION_PARENT_CHAT_ID,
         _SESSION_USER_ID,
         _SESSION_USER_NAME,
         _SESSION_KEY,

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -77,6 +77,10 @@ _SESSION_CHAT_ID: ContextVar = ContextVar("HERMES_SESSION_CHAT_ID", default=_UNS
 _SESSION_CHAT_TYPE: ContextVar = ContextVar("HERMES_SESSION_CHAT_TYPE", default=_UNSET)
 _SESSION_CHAT_NAME: ContextVar = ContextVar("HERMES_SESSION_CHAT_NAME", default=_UNSET)
 _SESSION_THREAD_ID: ContextVar = ContextVar("HERMES_SESSION_THREAD_ID", default=_UNSET)
+# Parent channel when chat_id refers to a thread (Discord/Matrix). Captured so a
+# cron job created inside a thread can retry its parent channel if the thread is
+# later deleted (see cron.delivery_fallback).
+_SESSION_PARENT_CHAT_ID: ContextVar = ContextVar("HERMES_SESSION_PARENT_CHAT_ID", default=_UNSET)
 _SESSION_USER_ID: ContextVar = ContextVar("HERMES_SESSION_USER_ID", default=_UNSET)
 _SESSION_USER_ID_ALT: ContextVar = ContextVar("HERMES_SESSION_USER_ID_ALT", default=_UNSET)
 _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
@@ -148,6 +152,7 @@ _VAR_MAP = {
     "HERMES_SESSION_CHAT_TYPE": _SESSION_CHAT_TYPE,
     "HERMES_SESSION_CHAT_NAME": _SESSION_CHAT_NAME,
     "HERMES_SESSION_THREAD_ID": _SESSION_THREAD_ID,
+    "HERMES_SESSION_PARENT_CHAT_ID": _SESSION_PARENT_CHAT_ID,
     "HERMES_SESSION_USER_ID": _SESSION_USER_ID,
     "HERMES_SESSION_USER_ID_ALT": _SESSION_USER_ID_ALT,
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
@@ -228,6 +233,7 @@ def set_session_vars(
     chat_type: str = "",
     chat_name: str = "",
     thread_id: str = "",
+    parent_chat_id: str = "",
     user_id: str = "",
     user_id_alt: str = "",
     user_name: str = "",
@@ -274,6 +280,7 @@ def set_session_vars(
         _SESSION_CHAT_TYPE.set(chat_type),
         _SESSION_CHAT_NAME.set(chat_name),
         _SESSION_THREAD_ID.set(thread_id),
+        _SESSION_PARENT_CHAT_ID.set(parent_chat_id),
         _SESSION_USER_ID.set(user_id),
         _SESSION_USER_ID_ALT.set(user_id_alt),
         _SESSION_USER_NAME.set(user_name),
@@ -315,6 +322,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_CHAT_TYPE,
         _SESSION_CHAT_NAME,
         _SESSION_THREAD_ID,
+        _SESSION_PARENT_CHAT_ID,
         _SESSION_USER_ID,
         _SESSION_USER_ID_ALT,
         _SESSION_USER_NAME,

--- a/tests/cron/test_delivery_fallback.py
+++ b/tests/cron/test_delivery_fallback.py
@@ -1,0 +1,155 @@
+"""Unit tests for cron.delivery_fallback (pure helpers).
+
+Covers the definitive-vs-uncertain failure decision, the parent/home fallback
+target resolution across both thread models, and the redirect notice text.
+"""
+
+import pytest
+
+from cron.delivery_fallback import (
+    build_fallback_targets,
+    format_fallback_notice,
+    is_definitive_delivery_failure,
+)
+
+
+class TestIsDefinitiveDeliveryFailure:
+    @pytest.mark.parametrize(
+        "error",
+        [
+            "404 Not Found (error code: 10003): Unknown Channel",  # Discord
+            "403 Forbidden (error code: 50001): Missing Access",   # Discord
+            "channel_not_found",                                    # Slack
+            "is_archived",                                          # Slack
+            "Bad Request: thread not found",                        # Telegram
+            "Bad Request: topic_closed",                            # Telegram
+            "This thread is locked",                                # generic
+        ],
+    )
+    def test_definitive_failures(self, error):
+        assert is_definitive_delivery_failure(error) is True
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            None,
+            "",
+            "Timeout sending message",
+            "503 Service Unavailable",
+            "Too Many Requests: retry after 30",
+            "some entirely novel provider message",
+            "media file not found on disk",
+        ],
+    )
+    def test_uncertain_failures_are_not_definitive(self, error):
+        assert is_definitive_delivery_failure(error) is False
+
+    def test_accepts_exception_objects(self):
+        assert is_definitive_delivery_failure(Exception("Unknown Channel")) is True
+        assert is_definitive_delivery_failure(TimeoutError("timed out")) is False
+
+
+class TestBuildFallbackTargets:
+    def test_discord_model_a_parent_then_home(self):
+        """Discord: chat_id IS the thread; redirect to the separate parent id, then home."""
+        target = {"platform": "discord", "chat_id": "thread-1", "thread_id": "thread-1"}
+        out = build_fallback_targets(
+            target,
+            parent_chat_id="parent-chan",
+            home_chat_id="home-chan",
+            home_thread_id=None,
+        )
+        assert out == [
+            {"platform": "discord", "chat_id": "parent-chan", "thread_id": None, "fallback_kind": "parent"},
+            {"platform": "discord", "chat_id": "home-chan", "thread_id": None, "fallback_kind": "home"},
+        ]
+
+    def test_telegram_model_b_drops_topic_to_channel(self):
+        """Telegram: chat_id is the channel, thread_id the topic; drop the topic."""
+        target = {"platform": "telegram", "chat_id": "-100chan", "thread_id": "topic-9"}
+        out = build_fallback_targets(target, home_chat_id="home-chan")
+        assert out[0] == {
+            "platform": "telegram",
+            "chat_id": "-100chan",
+            "thread_id": None,
+            "fallback_kind": "parent",
+        }
+        assert out[1]["fallback_kind"] == "home"
+        assert out[1]["chat_id"] == "home-chan"
+
+    def test_home_thread_id_is_preserved(self):
+        target = {"platform": "telegram", "chat_id": "c1", "thread_id": None}
+        out = build_fallback_targets(target, home_chat_id="home", home_thread_id="home-topic")
+        assert out == [
+            {"platform": "telegram", "chat_id": "home", "thread_id": "home-topic", "fallback_kind": "home"},
+        ]
+
+    def test_flat_dm_with_no_home_has_no_fallbacks(self):
+        target = {"platform": "sms", "chat_id": "+15550001111", "thread_id": None}
+        assert build_fallback_targets(target) == []
+
+    def test_parent_equal_to_failed_target_is_skipped(self):
+        target = {"platform": "discord", "chat_id": "same", "thread_id": "same"}
+        out = build_fallback_targets(target, parent_chat_id="same", home_chat_id="home")
+        # parent == current chat -> skipped; only home remains.
+        assert [t["fallback_kind"] for t in out] == ["home"]
+
+    def test_home_equal_to_failed_target_is_skipped(self):
+        target = {"platform": "telegram", "chat_id": "home", "thread_id": None}
+        out = build_fallback_targets(target, home_chat_id="home")
+        assert out == []
+
+    def test_home_deduped_against_parent(self):
+        """If the parent channel and home channel are the same place, list it once."""
+        target = {"platform": "discord", "chat_id": "thread-1", "thread_id": "thread-1"}
+        out = build_fallback_targets(target, parent_chat_id="shared", home_chat_id="shared")
+        assert [t["fallback_kind"] for t in out] == ["parent"]
+
+    def test_model_a_takes_precedence_over_model_b(self):
+        """An explicit parent id wins over dropping a differing thread id."""
+        target = {"platform": "matrix", "chat_id": "room-thread", "thread_id": "tid"}
+        out = build_fallback_targets(target, parent_chat_id="real-parent")
+        assert out == [
+            {"platform": "matrix", "chat_id": "real-parent", "thread_id": None, "fallback_kind": "parent"},
+        ]
+
+    def test_dm_suppresses_home_fallback(self):
+        """A 1:1 DM that fails must not escalate to a (shared) home channel."""
+        target = {"platform": "telegram", "chat_id": "user-123", "thread_id": None}
+        out = build_fallback_targets(target, home_chat_id="group-home", is_direct_message=True)
+        assert out == []  # no leak to the shared home channel
+
+    def test_dm_still_drops_topic_to_dm_root(self):
+        """A deleted DM *topic* still falls back to the DM root (stays private)."""
+        target = {"platform": "telegram", "chat_id": "user-123", "thread_id": "topic-5"}
+        out = build_fallback_targets(target, home_chat_id="group-home", is_direct_message=True)
+        assert out == [
+            {"platform": "telegram", "chat_id": "user-123", "thread_id": None, "fallback_kind": "parent"},
+        ]
+
+    def test_non_dm_still_uses_home(self):
+        target = {"platform": "slack", "chat_id": "C-archived", "thread_id": None}
+        out = build_fallback_targets(target, home_chat_id="slack-home", is_direct_message=False)
+        assert [t["fallback_kind"] for t in out] == ["home"]
+
+
+class TestFormatFallbackNotice:
+    def test_parent_notice_prepended(self):
+        out = format_fallback_notice("Daily report ready.", "parent")
+        assert out.startswith("⚠️")
+        assert "parent channel" in out
+        assert out.endswith("Daily report ready.")
+
+    def test_home_notice_prepended(self):
+        out = format_fallback_notice("Daily report ready.", "home")
+        assert out.startswith("⚠️")
+        assert "home channel" in out
+        assert "Daily report ready." in out
+
+    def test_unknown_kind_returns_content_unchanged(self):
+        assert format_fallback_notice("body", "mystery") == "body"
+
+    def test_empty_content_returns_bare_notice(self):
+        out = format_fallback_notice("", "parent")
+        assert out.startswith("⚠️")
+        assert "\n\n" not in out

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1228,7 +1228,8 @@ class TestDeliverResultStaleTargetFallback:
         job = {
             "id": "slack-stale",
             "deliver": "origin",
-            "origin": {"platform": "slack", "chat_id": "C-old"},
+            # Explicit shared chat_type: a channel origin DOES escalate to home.
+            "origin": {"platform": "slack", "chat_id": "C-old", "chat_type": "channel"},
         }
         with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.SLACK)), \
              patch("tools.send_message_tool._send_to_platform", new=send_mock), \
@@ -1279,6 +1280,9 @@ class TestDeliverResultStaleTargetFallback:
             "origin": {
                 "platform": "discord", "chat_id": "old-thread",
                 "thread_id": "old-thread", "parent_chat_id": "parent-chan",
+                # A Discord thread is always shared (under a guild channel), so
+                # the cascade may reach the home channel when the parent also dies.
+                "chat_type": "thread",
             },
         }
         with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.DISCORD)), \
@@ -1288,6 +1292,36 @@ class TestDeliverResultStaleTargetFallback:
 
         assert result is None
         assert [c.args[2] for c in send_mock.call_args_list] == ["old-thread", "parent-chan", "home-chan"]
+
+    def test_slack_thread_does_not_escalate_to_home(self, monkeypatch):
+        """A Slack thread can sit inside a DM, so its chat_type='thread' origin
+        must fail closed: parent (the channel) is tried, but home is NOT — unlike
+        a Discord thread, which is always shared. Locks the platform distinction
+        in _THREAD_ALWAYS_SHARED_PLATFORMS."""
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("SLACK_HOME_CHANNEL", "slack-home")
+        send_mock = AsyncMock(side_effect=[
+            {"error": "is_archived"},  # origin thread's channel gone
+            {"error": "is_archived"},  # parent (same channel, no thread) also gone
+        ])
+        job = {
+            "id": "slack-thread-priv",
+            "deliver": "origin",
+            "origin": {
+                "platform": "slack", "chat_id": "C-priv", "thread_id": "ts-1",
+                "chat_type": "thread",
+            },
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.SLACK)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "reminder")
+
+        assert result is not None  # dropped after parent, not escalated to home
+        # Only origin-thread and its parent channel tried; slack-home never used.
+        assert [c.args[2] for c in send_mock.call_args_list] == ["C-priv", "C-priv"]
 
     def test_uncertain_fallback_failure_stops_chain(self, monkeypatch):
         """If a fallback fails for an uncertain reason, stop (don't try home too)."""
@@ -1368,6 +1402,33 @@ class TestDeliverResultStaleTargetFallback:
         assert send_mock.call_count == 1  # no fallback send to the home group
         assert [c.args[2] for c in send_mock.call_args_list] == ["user-1"]
 
+    def test_legacy_origin_without_chat_type_does_not_leak_to_home(self, monkeypatch):
+        """Fail closed: a job created before chat_type was captured has no
+        chat_type in its origin. It may be a private DM, so a definitively
+        undeliverable send must NOT escalate to the shared home channel — the
+        old behavior (missing chat_type == non-DM) could leak private content."""
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-100groupHome")
+        send_mock = AsyncMock(side_effect=[
+            {"error": "Forbidden: bot was blocked by the user"},
+        ])
+        job = {
+            "id": "tg-legacy-origin",
+            "deliver": "origin",
+            # No chat_type — a legacy origin captured before chat_type existed.
+            "origin": {"platform": "telegram", "chat_id": "user-1"},
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.TELEGRAM)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "private reminder")
+
+        assert result is not None  # recorded as a delivery error, not redirected
+        assert send_mock.call_count == 1  # no fallback send to the home group
+        assert [c.args[2] for c in send_mock.call_args_list] == ["user-1"]
+
     def test_dm_deleted_topic_falls_back_to_dm_root_not_home(self, monkeypatch):
         """A deleted DM topic drops to the DM root (still private); home is not used."""
         from gateway.config import Platform
@@ -1395,6 +1456,65 @@ class TestDeliverResultStaleTargetFallback:
         # DM root retried (same chat, no topic); home group never used.
         assert [c.args[2] for c in send_mock.call_args_list] == ["user-1", "user-1"]
         assert send_mock.call_args_list[1].kwargs["thread_id"] is None
+
+    def test_matrix_stale_room_fallback_reuses_live_adapter(self, monkeypatch):
+        """A stale Matrix room must redirect through the live gateway adapter,
+        not a fresh/ephemeral send.
+
+        This proves ROUTING, not wire-level encryption: unlike the sibling tests
+        it does NOT mock ``_send_to_platform``; it drives the actual
+        ``_send_to_platform -> _send_matrix_via_adapter -> live adapter`` chain.
+        Both the failed origin send and the home redirect must land on the
+        persistent live adapter — the one holding the gateway's E2EE session
+        (#46310) — with no ephemeral connect/disconnect. That the adapter then
+        encrypts on the wire is the Matrix adapter's own contract, covered by its
+        adapter tests, not here. This closes the review concern that the redirect
+        bypasses ``DeliveryRouter._deliver_to_platform``: ``_send_to_platform`` is
+        itself adapter-aware for Matrix, so the redirect reuses the same session."""
+        import sys
+        from types import SimpleNamespace
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("MATRIX_HOME_ROOM", "!bot-room:example.org")
+
+        sends = []
+        connect_calls = []
+
+        class LiveMatrixAdapter:
+            async def connect(self, *a, **k):
+                connect_calls.append("connect")
+                return True
+
+            async def disconnect(self):
+                connect_calls.append("disconnect")
+
+            async def send(self, chat_id, message, metadata=None):
+                sends.append(chat_id)
+                if chat_id == "!old:example.org":
+                    return SimpleNamespace(success=False, error="M_FORBIDDEN: not in room", message_id=None)
+                return SimpleNamespace(success=True, error=None, message_id="$ok")
+
+        fake_runner = SimpleNamespace(adapters={Platform.MATRIX: LiveMatrixAdapter()})
+        job = {
+            "id": "matrix-stale",
+            "deliver": "origin",
+            # Explicit shared room: a channel origin may escalate to the home room.
+            "origin": {"platform": "matrix", "chat_id": "!old:example.org", "chat_type": "channel"},
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.MATRIX)), \
+             patch("gateway.run._gateway_runner_ref", return_value=fake_runner), \
+             patch.dict(sys.modules, {"plugins.platforms.matrix.adapter": SimpleNamespace()}), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "reminder")
+
+        assert result is None
+        # Origin room tried (fails M_FORBIDDEN), then redirected to the home room —
+        # BOTH through the live gateway adapter's persistent E2EE session.
+        assert sends == ["!old:example.org", "!bot-room:example.org"]
+        # No ephemeral connect/disconnect: the live E2EE session was reused (#46310),
+        # i.e. the redirect did not fall back to a cleartext/ephemeral send.
+        assert connect_calls == []
 
 
 class TestRunJobSessionPersistence:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1146,6 +1146,257 @@ class TestDeliverResultErrorReturns:
         assert "no delivery target" in result
 
 
+class TestDeliverResultStaleTargetFallback:
+    """Definitive delivery failures redirect to parent/home; uncertain ones don't."""
+
+    def _cfg(self, platform):
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {platform: pconfig}
+        return mock_cfg
+
+    def _clear_home_envs(self, monkeypatch):
+        for env in (
+            "DISCORD_HOME_CHANNEL", "DISCORD_HOME_CHANNEL_THREAD_ID",
+            "TELEGRAM_HOME_CHANNEL", "TELEGRAM_HOME_CHANNEL_THREAD_ID",
+            "TELEGRAM_CRON_THREAD_ID", "SLACK_HOME_CHANNEL",
+        ):
+            monkeypatch.delenv(env, raising=False)
+
+    def test_discord_unknown_channel_falls_back_parent_then_home(self, monkeypatch):
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("DISCORD_HOME_CHANNEL", "home-chan")
+
+        send_mock = AsyncMock(side_effect=[
+            {"error": "404 Not Found (error code: 10003): Unknown Channel"},
+            {"success": True},
+        ])
+        job = {
+            "id": "discord-stale",
+            "deliver": "origin",
+            "origin": {
+                "platform": "discord", "chat_id": "old-thread",
+                "thread_id": "old-thread", "parent_chat_id": "parent-chan",
+            },
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.DISCORD)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "reminder")
+
+        assert result is None
+        assert [c.args[2] for c in send_mock.call_args_list] == ["old-thread", "parent-chan"]
+        assert send_mock.call_args_list[1].kwargs["thread_id"] is None
+        assert "parent channel" in send_mock.call_args_list[1].args[3]
+
+    def test_telegram_topic_deleted_drops_to_channel(self, monkeypatch):
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        send_mock = AsyncMock(side_effect=[
+            {"error": "Bad Request: topic_deleted"},
+            {"success": True},
+        ])
+        job = {
+            "id": "tg-stale",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "-100chan", "thread_id": "topic-9"},
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.TELEGRAM)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "reminder")
+
+        assert result is None
+        # Model B: same channel, topic dropped.
+        assert [c.args[2] for c in send_mock.call_args_list] == ["-100chan", "-100chan"]
+        assert send_mock.call_args_list[1].kwargs["thread_id"] is None
+        assert "parent channel" in send_mock.call_args_list[1].args[3]
+
+    def test_slack_archived_channel_falls_back_to_home(self, monkeypatch):
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("SLACK_HOME_CHANNEL", "slack-home")
+        send_mock = AsyncMock(side_effect=[
+            {"error": "is_archived"},
+            {"success": True},
+        ])
+        job = {
+            "id": "slack-stale",
+            "deliver": "origin",
+            "origin": {"platform": "slack", "chat_id": "C-old"},
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.SLACK)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "reminder")
+
+        assert result is None
+        assert [c.args[2] for c in send_mock.call_args_list] == ["C-old", "slack-home"]
+        assert "home channel" in send_mock.call_args_list[1].args[3]
+
+    def test_timeout_does_not_redirect(self, monkeypatch):
+        """An uncertain failure (timeout) must not be duplicated to parent/home."""
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("DISCORD_HOME_CHANNEL", "home-chan")
+        send_mock = AsyncMock(side_effect=TimeoutError("timed out"))
+        job = {
+            "id": "discord-timeout",
+            "deliver": "origin",
+            "origin": {
+                "platform": "discord", "chat_id": "old-thread",
+                "thread_id": "old-thread", "parent_chat_id": "parent-chan",
+            },
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.DISCORD)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "reminder")
+
+        assert result is not None
+        assert "timed out" in result
+        assert send_mock.call_count == 1
+
+    def test_parent_definitive_failure_advances_to_home(self, monkeypatch):
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("DISCORD_HOME_CHANNEL", "home-chan")
+        send_mock = AsyncMock(side_effect=[
+            {"error": "404 Not Found (error code: 10003): Unknown Channel"},
+            {"error": "403 Forbidden (error code: 50001): Missing Access"},
+            {"success": True},
+        ])
+        job = {
+            "id": "discord-cascade",
+            "deliver": "origin",
+            "origin": {
+                "platform": "discord", "chat_id": "old-thread",
+                "thread_id": "old-thread", "parent_chat_id": "parent-chan",
+            },
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.DISCORD)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "reminder")
+
+        assert result is None
+        assert [c.args[2] for c in send_mock.call_args_list] == ["old-thread", "parent-chan", "home-chan"]
+
+    def test_uncertain_fallback_failure_stops_chain(self, monkeypatch):
+        """If a fallback fails for an uncertain reason, stop (don't try home too)."""
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("DISCORD_HOME_CHANNEL", "home-chan")
+        send_mock = AsyncMock(side_effect=[
+            {"error": "404 Not Found (error code: 10003): Unknown Channel"},
+            TimeoutError("timed out"),
+        ])
+        job = {
+            "id": "discord-stop",
+            "deliver": "origin",
+            "origin": {
+                "platform": "discord", "chat_id": "old-thread",
+                "thread_id": "old-thread", "parent_chat_id": "parent-chan",
+            },
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.DISCORD)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "reminder")
+
+        assert result is not None
+        assert "timed out" in result
+        assert send_mock.call_count == 2  # original + parent; home NOT attempted
+
+    def test_two_dead_targets_redirect_to_home_only_once(self, monkeypatch):
+        """Several failing targets redirecting to the same home channel must not
+        duplicate the message there (cross-target fallback dedup)."""
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("DISCORD_HOME_CHANNEL", "home-chan")
+        # chanA fails -> home (delivered); chanB fails -> home (skipped, dup).
+        send_mock = AsyncMock(side_effect=[
+            {"error": "404 Not Found (error code: 10003): Unknown Channel"},
+            {"success": True},
+            {"error": "404 Not Found (error code: 10003): Unknown Channel"},
+        ])
+        job = {
+            "id": "discord-dup",
+            "deliver": "discord:chanA,discord:chanB",
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.DISCORD)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "reminder")
+
+        assert result is None
+        sent_chat_ids = [c.args[2] for c in send_mock.call_args_list]
+        # chanA original, home fallback, chanB original; home NOT sent a 2nd time.
+        assert sent_chat_ids == ["chanA", "home-chan", "chanB"]
+        assert sent_chat_ids.count("home-chan") == 1
+
+    def test_dm_blocked_does_not_leak_to_home_channel(self, monkeypatch):
+        """A blocked 1:1 DM must NOT redirect private content to the shared home
+        channel — it has no broader-but-private target, so it fails quietly."""
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-100groupHome")
+        send_mock = AsyncMock(side_effect=[
+            {"error": "Forbidden: bot was blocked by the user"},
+        ])
+        job = {
+            "id": "tg-dm-blocked",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "user-1", "chat_type": "dm"},
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.TELEGRAM)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "private reminder")
+
+        assert result is not None  # recorded as a delivery error, not redirected
+        assert send_mock.call_count == 1  # no fallback send to the home group
+        assert [c.args[2] for c in send_mock.call_args_list] == ["user-1"]
+
+    def test_dm_deleted_topic_falls_back_to_dm_root_not_home(self, monkeypatch):
+        """A deleted DM topic drops to the DM root (still private); home is not used."""
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-100groupHome")
+        send_mock = AsyncMock(side_effect=[
+            {"error": "Bad Request: topic_deleted"},
+            {"success": True},
+        ])
+        job = {
+            "id": "tg-dm-topic",
+            "deliver": "origin",
+            "origin": {
+                "platform": "telegram", "chat_id": "user-1",
+                "thread_id": "topic-5", "chat_type": "dm",
+            },
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.TELEGRAM)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "private reminder")
+
+        assert result is None
+        # DM root retried (same chat, no topic); home group never used.
+        assert [c.args[2] for c in send_mock.call_args_list] == ["user-1", "user-1"]
+        assert send_mock.call_args_list[1].kwargs["thread_id"] is None
+
+
 class TestRunJobSessionPersistence:
     def test_run_job_passes_session_db_and_cron_platform(self, tmp_path):
         job = {

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -617,7 +617,8 @@ class TestDeliverResultStaleTargetFallback:
         job = {
             "id": "slack-stale",
             "deliver": "origin",
-            "origin": {"platform": "slack", "chat_id": "C-old"},
+            # Explicit shared chat_type: a channel origin DOES escalate to home.
+            "origin": {"platform": "slack", "chat_id": "C-old", "chat_type": "channel"},
         }
         with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.SLACK)), \
              patch("tools.send_message_tool._send_to_platform", new=send_mock), \
@@ -668,6 +669,9 @@ class TestDeliverResultStaleTargetFallback:
             "origin": {
                 "platform": "discord", "chat_id": "old-thread",
                 "thread_id": "old-thread", "parent_chat_id": "parent-chan",
+                # A Discord thread is always shared (under a guild channel), so
+                # the cascade may reach the home channel when the parent also dies.
+                "chat_type": "thread",
             },
         }
         with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.DISCORD)), \
@@ -677,6 +681,36 @@ class TestDeliverResultStaleTargetFallback:
 
         assert result is None
         assert [c.args[2] for c in send_mock.call_args_list] == ["old-thread", "parent-chan", "home-chan"]
+
+    def test_slack_thread_does_not_escalate_to_home(self, monkeypatch):
+        """A Slack thread can sit inside a DM, so its chat_type='thread' origin
+        must fail closed: parent (the channel) is tried, but home is NOT — unlike
+        a Discord thread, which is always shared. Locks the platform distinction
+        in _THREAD_ALWAYS_SHARED_PLATFORMS."""
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("SLACK_HOME_CHANNEL", "slack-home")
+        send_mock = AsyncMock(side_effect=[
+            {"error": "is_archived"},  # origin thread's channel gone
+            {"error": "is_archived"},  # parent (same channel, no thread) also gone
+        ])
+        job = {
+            "id": "slack-thread-priv",
+            "deliver": "origin",
+            "origin": {
+                "platform": "slack", "chat_id": "C-priv", "thread_id": "ts-1",
+                "chat_type": "thread",
+            },
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.SLACK)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "reminder")
+
+        assert result is not None  # dropped after parent, not escalated to home
+        # Only origin-thread and its parent channel tried; slack-home never used.
+        assert [c.args[2] for c in send_mock.call_args_list] == ["C-priv", "C-priv"]
 
     def test_uncertain_fallback_failure_stops_chain(self, monkeypatch):
         """If a fallback fails for an uncertain reason, stop (don't try home too)."""
@@ -757,6 +791,33 @@ class TestDeliverResultStaleTargetFallback:
         assert send_mock.call_count == 1  # no fallback send to the home group
         assert [c.args[2] for c in send_mock.call_args_list] == ["user-1"]
 
+    def test_legacy_origin_without_chat_type_does_not_leak_to_home(self, monkeypatch):
+        """Fail closed: a job created before chat_type was captured has no
+        chat_type in its origin. It may be a private DM, so a definitively
+        undeliverable send must NOT escalate to the shared home channel — the
+        old behavior (missing chat_type == non-DM) could leak private content."""
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-100groupHome")
+        send_mock = AsyncMock(side_effect=[
+            {"error": "Forbidden: bot was blocked by the user"},
+        ])
+        job = {
+            "id": "tg-legacy-origin",
+            "deliver": "origin",
+            # No chat_type — a legacy origin captured before chat_type existed.
+            "origin": {"platform": "telegram", "chat_id": "user-1"},
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.TELEGRAM)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "private reminder")
+
+        assert result is not None  # recorded as a delivery error, not redirected
+        assert send_mock.call_count == 1  # no fallback send to the home group
+        assert [c.args[2] for c in send_mock.call_args_list] == ["user-1"]
+
     def test_dm_deleted_topic_falls_back_to_dm_root_not_home(self, monkeypatch):
         """A deleted DM topic drops to the DM root (still private); home is not used."""
         from gateway.config import Platform
@@ -784,6 +845,65 @@ class TestDeliverResultStaleTargetFallback:
         # DM root retried (same chat, no topic); home group never used.
         assert [c.args[2] for c in send_mock.call_args_list] == ["user-1", "user-1"]
         assert send_mock.call_args_list[1].kwargs["thread_id"] is None
+
+    def test_matrix_stale_room_fallback_reuses_live_adapter(self, monkeypatch):
+        """A stale Matrix room must redirect through the live gateway adapter,
+        not a fresh/ephemeral send.
+
+        This proves ROUTING, not wire-level encryption: unlike the sibling tests
+        it does NOT mock ``_send_to_platform``; it drives the actual
+        ``_send_to_platform -> _send_matrix_via_adapter -> live adapter`` chain.
+        Both the failed origin send and the home redirect must land on the
+        persistent live adapter — the one holding the gateway's E2EE session
+        (#46310) — with no ephemeral connect/disconnect. That the adapter then
+        encrypts on the wire is the Matrix adapter's own contract, covered by its
+        adapter tests, not here. This closes the review concern that the redirect
+        bypasses ``DeliveryRouter._deliver_to_platform``: ``_send_to_platform`` is
+        itself adapter-aware for Matrix, so the redirect reuses the same session."""
+        import sys
+        from types import SimpleNamespace
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("MATRIX_HOME_ROOM", "!bot-room:example.org")
+
+        sends = []
+        connect_calls = []
+
+        class LiveMatrixAdapter:
+            async def connect(self, *a, **k):
+                connect_calls.append("connect")
+                return True
+
+            async def disconnect(self):
+                connect_calls.append("disconnect")
+
+            async def send(self, chat_id, message, metadata=None):
+                sends.append(chat_id)
+                if chat_id == "!old:example.org":
+                    return SimpleNamespace(success=False, error="M_FORBIDDEN: not in room", message_id=None)
+                return SimpleNamespace(success=True, error=None, message_id="$ok")
+
+        fake_runner = SimpleNamespace(adapters={Platform.MATRIX: LiveMatrixAdapter()})
+        job = {
+            "id": "matrix-stale",
+            "deliver": "origin",
+            # Explicit shared room: a channel origin may escalate to the home room.
+            "origin": {"platform": "matrix", "chat_id": "!old:example.org", "chat_type": "channel"},
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.MATRIX)), \
+             patch("gateway.run._gateway_runner_ref", return_value=fake_runner), \
+             patch.dict(sys.modules, {"plugins.platforms.matrix.adapter": SimpleNamespace()}), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "reminder")
+
+        assert result is None
+        # Origin room tried (fails M_FORBIDDEN), then redirected to the home room —
+        # BOTH through the live gateway adapter's persistent E2EE session.
+        assert sends == ["!old:example.org", "!bot-room:example.org"]
+        # No ephemeral connect/disconnect: the live E2EE session was reused (#46310),
+        # i.e. the redirect did not fall back to a cleartext/ephemeral send.
+        assert connect_calls == []
 
 
 class TestRunJobSessionPersistence:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -535,6 +535,257 @@ class TestDeliverResultErrorReturns:
         assert "not configured" in result
 
 
+class TestDeliverResultStaleTargetFallback:
+    """Definitive delivery failures redirect to parent/home; uncertain ones don't."""
+
+    def _cfg(self, platform):
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {platform: pconfig}
+        return mock_cfg
+
+    def _clear_home_envs(self, monkeypatch):
+        for env in (
+            "DISCORD_HOME_CHANNEL", "DISCORD_HOME_CHANNEL_THREAD_ID",
+            "TELEGRAM_HOME_CHANNEL", "TELEGRAM_HOME_CHANNEL_THREAD_ID",
+            "TELEGRAM_CRON_THREAD_ID", "SLACK_HOME_CHANNEL",
+        ):
+            monkeypatch.delenv(env, raising=False)
+
+    def test_discord_unknown_channel_falls_back_parent_then_home(self, monkeypatch):
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("DISCORD_HOME_CHANNEL", "home-chan")
+
+        send_mock = AsyncMock(side_effect=[
+            {"error": "404 Not Found (error code: 10003): Unknown Channel"},
+            {"success": True},
+        ])
+        job = {
+            "id": "discord-stale",
+            "deliver": "origin",
+            "origin": {
+                "platform": "discord", "chat_id": "old-thread",
+                "thread_id": "old-thread", "parent_chat_id": "parent-chan",
+            },
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.DISCORD)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "reminder")
+
+        assert result is None
+        assert [c.args[2] for c in send_mock.call_args_list] == ["old-thread", "parent-chan"]
+        assert send_mock.call_args_list[1].kwargs["thread_id"] is None
+        assert "parent channel" in send_mock.call_args_list[1].args[3]
+
+    def test_telegram_topic_deleted_drops_to_channel(self, monkeypatch):
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        send_mock = AsyncMock(side_effect=[
+            {"error": "Bad Request: topic_deleted"},
+            {"success": True},
+        ])
+        job = {
+            "id": "tg-stale",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "-100chan", "thread_id": "topic-9"},
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.TELEGRAM)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "reminder")
+
+        assert result is None
+        # Model B: same channel, topic dropped.
+        assert [c.args[2] for c in send_mock.call_args_list] == ["-100chan", "-100chan"]
+        assert send_mock.call_args_list[1].kwargs["thread_id"] is None
+        assert "parent channel" in send_mock.call_args_list[1].args[3]
+
+    def test_slack_archived_channel_falls_back_to_home(self, monkeypatch):
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("SLACK_HOME_CHANNEL", "slack-home")
+        send_mock = AsyncMock(side_effect=[
+            {"error": "is_archived"},
+            {"success": True},
+        ])
+        job = {
+            "id": "slack-stale",
+            "deliver": "origin",
+            "origin": {"platform": "slack", "chat_id": "C-old"},
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.SLACK)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "reminder")
+
+        assert result is None
+        assert [c.args[2] for c in send_mock.call_args_list] == ["C-old", "slack-home"]
+        assert "home channel" in send_mock.call_args_list[1].args[3]
+
+    def test_timeout_does_not_redirect(self, monkeypatch):
+        """An uncertain failure (timeout) must not be duplicated to parent/home."""
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("DISCORD_HOME_CHANNEL", "home-chan")
+        send_mock = AsyncMock(side_effect=TimeoutError("timed out"))
+        job = {
+            "id": "discord-timeout",
+            "deliver": "origin",
+            "origin": {
+                "platform": "discord", "chat_id": "old-thread",
+                "thread_id": "old-thread", "parent_chat_id": "parent-chan",
+            },
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.DISCORD)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "reminder")
+
+        assert result is not None
+        assert "timed out" in result
+        assert send_mock.call_count == 1
+
+    def test_parent_definitive_failure_advances_to_home(self, monkeypatch):
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("DISCORD_HOME_CHANNEL", "home-chan")
+        send_mock = AsyncMock(side_effect=[
+            {"error": "404 Not Found (error code: 10003): Unknown Channel"},
+            {"error": "403 Forbidden (error code: 50001): Missing Access"},
+            {"success": True},
+        ])
+        job = {
+            "id": "discord-cascade",
+            "deliver": "origin",
+            "origin": {
+                "platform": "discord", "chat_id": "old-thread",
+                "thread_id": "old-thread", "parent_chat_id": "parent-chan",
+            },
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.DISCORD)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "reminder")
+
+        assert result is None
+        assert [c.args[2] for c in send_mock.call_args_list] == ["old-thread", "parent-chan", "home-chan"]
+
+    def test_uncertain_fallback_failure_stops_chain(self, monkeypatch):
+        """If a fallback fails for an uncertain reason, stop (don't try home too)."""
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("DISCORD_HOME_CHANNEL", "home-chan")
+        send_mock = AsyncMock(side_effect=[
+            {"error": "404 Not Found (error code: 10003): Unknown Channel"},
+            TimeoutError("timed out"),
+        ])
+        job = {
+            "id": "discord-stop",
+            "deliver": "origin",
+            "origin": {
+                "platform": "discord", "chat_id": "old-thread",
+                "thread_id": "old-thread", "parent_chat_id": "parent-chan",
+            },
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.DISCORD)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "reminder")
+
+        assert result is not None
+        assert "timed out" in result
+        assert send_mock.call_count == 2  # original + parent; home NOT attempted
+
+    def test_two_dead_targets_redirect_to_home_only_once(self, monkeypatch):
+        """Several failing targets redirecting to the same home channel must not
+        duplicate the message there (cross-target fallback dedup)."""
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("DISCORD_HOME_CHANNEL", "home-chan")
+        # chanA fails -> home (delivered); chanB fails -> home (skipped, dup).
+        send_mock = AsyncMock(side_effect=[
+            {"error": "404 Not Found (error code: 10003): Unknown Channel"},
+            {"success": True},
+            {"error": "404 Not Found (error code: 10003): Unknown Channel"},
+        ])
+        job = {
+            "id": "discord-dup",
+            "deliver": "discord:chanA,discord:chanB",
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.DISCORD)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "reminder")
+
+        assert result is None
+        sent_chat_ids = [c.args[2] for c in send_mock.call_args_list]
+        # chanA original, home fallback, chanB original; home NOT sent a 2nd time.
+        assert sent_chat_ids == ["chanA", "home-chan", "chanB"]
+        assert sent_chat_ids.count("home-chan") == 1
+
+    def test_dm_blocked_does_not_leak_to_home_channel(self, monkeypatch):
+        """A blocked 1:1 DM must NOT redirect private content to the shared home
+        channel — it has no broader-but-private target, so it fails quietly."""
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-100groupHome")
+        send_mock = AsyncMock(side_effect=[
+            {"error": "Forbidden: bot was blocked by the user"},
+        ])
+        job = {
+            "id": "tg-dm-blocked",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "user-1", "chat_type": "dm"},
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.TELEGRAM)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "private reminder")
+
+        assert result is not None  # recorded as a delivery error, not redirected
+        assert send_mock.call_count == 1  # no fallback send to the home group
+        assert [c.args[2] for c in send_mock.call_args_list] == ["user-1"]
+
+    def test_dm_deleted_topic_falls_back_to_dm_root_not_home(self, monkeypatch):
+        """A deleted DM topic drops to the DM root (still private); home is not used."""
+        from gateway.config import Platform
+
+        self._clear_home_envs(monkeypatch)
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-100groupHome")
+        send_mock = AsyncMock(side_effect=[
+            {"error": "Bad Request: topic_deleted"},
+            {"success": True},
+        ])
+        job = {
+            "id": "tg-dm-topic",
+            "deliver": "origin",
+            "origin": {
+                "platform": "telegram", "chat_id": "user-1",
+                "thread_id": "topic-5", "chat_type": "dm",
+            },
+        }
+        with patch("gateway.config.load_gateway_config", return_value=self._cfg(Platform.TELEGRAM)), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "private reminder")
+
+        assert result is None
+        # DM root retried (same chat, no topic); home group never used.
+        assert [c.args[2] for c in send_mock.call_args_list] == ["user-1", "user-1"]
+        assert send_mock.call_args_list[1].kwargs["thread_id"] is None
+
+
 class TestRunJobSessionPersistence:
     def test_run_job_passes_session_db_and_cron_platform(self, tmp_path):
         job = {

--- a/tests/gateway/test_send_error_classification.py
+++ b/tests/gateway/test_send_error_classification.py
@@ -43,6 +43,53 @@ def test_classify_send_error_text(text, expected):
     assert classify_send_error(None, text) == expected
 
 
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        # Discord (discord.py stringifies HTTPException as "<status> ... (error
+        # code: <n>): <message>"). Unknown Channel = deleted/inaccessible target.
+        ("404 Not Found (error code: 10003): Unknown Channel", "not_found"),
+        ("Discord API error (404): {\"message\":\"Unknown Channel\",\"code\":10003}", "not_found"),
+        ("403 Forbidden (error code: 50001): Missing Access", "forbidden"),
+        ("403 Forbidden (error code: 50013): Missing Permissions", "forbidden"),
+        ("Thread 12345 not found", "not_found"),
+        ("Channel 67890 not found", "not_found"),
+        # Slack error codes (str(SlackApiError) carries the code).
+        ("channel_not_found", "not_found"),
+        ("is_archived", "not_found"),
+        ("not_in_channel", "forbidden"),
+        ("missing_scope (needed: chat:write)", "forbidden"),
+        # Telegram forum topic states beyond the pre-existing topic_deleted.
+        ("Bad Request: topic_closed", "not_found"),
+        # Generic deleted/archived/locked container phrasing.
+        ("The conversation was not found", "not_found"),
+        ("This thread is archived", "not_found"),
+        ("This thread is locked", "not_found"),
+        ("Matrix room not found", "not_found"),
+    ],
+)
+def test_classify_send_error_cross_platform_definitive(text, expected):
+    """Definitive (deleted/archived/no-access) targets classify across platforms."""
+    assert classify_send_error(None, text) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # Uncertain failures must NOT become definitive (would risk a redirect /
+        # duplicate delivery). They classify as a non-definitive kind.
+        "Timeout sending message",
+        "503 Service Unavailable",
+        "kaboom 500 internal",
+        "Too Many Requests: retry after 30",
+        # Container-less "not found" must not be misread as a stale target.
+        "media file not found on disk",
+    ],
+)
+def test_classify_uncertain_not_definitive(text):
+    assert classify_send_error(None, text) not in {"not_found", "forbidden"}
+
+
 def test_classify_uses_exception_class_name():
     # The class name participates in classification even when str(exc) is empty.
     exc = type("Forbidden", (Exception,), {})()

--- a/tests/gateway/test_send_error_classification.py
+++ b/tests/gateway/test_send_error_classification.py
@@ -43,6 +43,53 @@ def test_classify_send_error_text(text, expected):
     assert classify_send_error(None, text) == expected
 
 
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        # Discord (discord.py stringifies HTTPException as "<status> ... (error
+        # code: <n>): <message>"). Unknown Channel = deleted/inaccessible target.
+        ("404 Not Found (error code: 10003): Unknown Channel", "not_found"),
+        ("Discord API error (404): {\"message\":\"Unknown Channel\",\"code\":10003}", "not_found"),
+        ("403 Forbidden (error code: 50001): Missing Access", "forbidden"),
+        ("403 Forbidden (error code: 50013): Missing Permissions", "forbidden"),
+        ("Thread 12345 not found", "not_found"),
+        ("Channel 67890 not found", "not_found"),
+        # Slack error codes (str(SlackApiError) carries the code).
+        ("channel_not_found", "not_found"),
+        ("is_archived", "not_found"),
+        ("not_in_channel", "forbidden"),
+        ("missing_scope (needed: chat:write)", "forbidden"),
+        # Telegram forum topic states beyond the pre-existing topic_deleted.
+        ("Bad Request: topic_closed", "not_found"),
+        # Generic deleted/archived/locked container phrasing.
+        ("The conversation was not found", "not_found"),
+        ("This thread is archived", "not_found"),
+        ("This thread is locked", "not_found"),
+        ("Matrix room not found", "not_found"),
+    ],
+)
+def test_classify_send_error_cross_platform_definitive(text, expected):
+    """Definitive (deleted/archived/no-access) targets classify across platforms."""
+    assert classify_send_error(None, text) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # Uncertain failures must NOT become definitive (would risk a redirect /
+        # duplicate delivery). They classify as a non-definitive kind.
+        "Timeout sending message",
+        "503 Service Unavailable",
+        "kaboom 500 internal",
+        "Too Many Requests: retry after 30",
+        # Container-less "not found" must not be misread as a stale target.
+        "media file not found on disk",
+    ],
+)
+def test_classify_uncertain_not_definitive(text):
+    assert classify_send_error(None, text) not in {"not_found", "forbidden"}
+
+
 def test_every_classification_is_in_the_vocabulary():
     samples = [
         "message_too_long",

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -704,3 +704,64 @@ class TestValidateCronBaseUrl:
 
     def test_base_url_without_provider_rejected(self):
         assert self._v(None, "https://x.example/v1") is not None
+
+
+class TestOriginFromEnv:
+    """The cron origin must capture parent_chat_id for thread sessions so a
+    deleted thread can fall back to its parent channel at delivery time."""
+
+    def test_captures_parent_chat_id_for_thread_origin(self):
+        from tools.cronjob_tools import _origin_from_env
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        tokens = set_session_vars(
+            platform="discord",
+            chat_id="thread-456",
+            chat_name="#general / reminder thread",
+            thread_id="thread-456",
+            parent_chat_id="parent-channel-123",
+        )
+        try:
+            origin = _origin_from_env()
+        finally:
+            clear_session_vars(tokens)
+
+        assert origin["parent_chat_id"] == "parent-channel-123"
+        assert origin["platform"] == "discord"
+        assert origin["thread_id"] == "thread-456"
+
+    def test_parent_chat_id_omitted_when_absent(self):
+        from tools.cronjob_tools import _origin_from_env
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        tokens = set_session_vars(platform="telegram", chat_id="999")
+        try:
+            origin = _origin_from_env()
+        finally:
+            clear_session_vars(tokens)
+
+        assert "parent_chat_id" not in origin
+
+    def test_captures_chat_type_for_dm_origin(self):
+        from tools.cronjob_tools import _origin_from_env
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        tokens = set_session_vars(platform="telegram", chat_id="user-1", chat_type="dm")
+        try:
+            origin = _origin_from_env()
+        finally:
+            clear_session_vars(tokens)
+
+        assert origin["chat_type"] == "dm"
+
+    def test_chat_type_omitted_when_absent(self):
+        from tools.cronjob_tools import _origin_from_env
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        tokens = set_session_vars(platform="telegram", chat_id="999")
+        try:
+            origin = _origin_from_env()
+        finally:
+            clear_session_vars(tokens)
+
+        assert "chat_type" not in origin

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -615,3 +615,64 @@ class TestGithubExemptionAbuse:
         assert _scan_cron_prompt(
             "generate a keypair and explain id_rsa vs id_ed25519"
         ) == ""
+
+
+class TestOriginFromEnv:
+    """The cron origin must capture parent_chat_id for thread sessions so a
+    deleted thread can fall back to its parent channel at delivery time."""
+
+    def test_captures_parent_chat_id_for_thread_origin(self):
+        from tools.cronjob_tools import _origin_from_env
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        tokens = set_session_vars(
+            platform="discord",
+            chat_id="thread-456",
+            chat_name="#general / reminder thread",
+            thread_id="thread-456",
+            parent_chat_id="parent-channel-123",
+        )
+        try:
+            origin = _origin_from_env()
+        finally:
+            clear_session_vars(tokens)
+
+        assert origin["parent_chat_id"] == "parent-channel-123"
+        assert origin["platform"] == "discord"
+        assert origin["thread_id"] == "thread-456"
+
+    def test_parent_chat_id_omitted_when_absent(self):
+        from tools.cronjob_tools import _origin_from_env
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        tokens = set_session_vars(platform="telegram", chat_id="999")
+        try:
+            origin = _origin_from_env()
+        finally:
+            clear_session_vars(tokens)
+
+        assert "parent_chat_id" not in origin
+
+    def test_captures_chat_type_for_dm_origin(self):
+        from tools.cronjob_tools import _origin_from_env
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        tokens = set_session_vars(platform="telegram", chat_id="user-1", chat_type="dm")
+        try:
+            origin = _origin_from_env()
+        finally:
+            clear_session_vars(tokens)
+
+        assert origin["chat_type"] == "dm"
+
+    def test_chat_type_omitted_when_absent(self):
+        from tools.cronjob_tools import _origin_from_env
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        tokens = set_session_vars(platform="telegram", chat_id="999")
+        try:
+            origin = _origin_from_env()
+        finally:
+            clear_session_vars(tokens)
+
+        assert "chat_type" not in origin

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -293,7 +293,7 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
                 "Cron origin captured thread_id=%s for %s:%s",
                 thread_id, origin_platform, origin_chat_id,
             )
-        return {
+        origin = {
             "platform": origin_platform,
             "chat_id": origin_chat_id,
             "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME") or None,
@@ -305,6 +305,19 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
             # gateway.mirror.mirror_to_session. Harmless for DMs/shared sessions.
             "user_id": get_session_env("HERMES_SESSION_USER_ID") or None,
         }
+        # Parent channel of a thread origin (Discord/Matrix). Stored only when
+        # present so that if the origin thread is later deleted, delivery can
+        # fall back to the parent channel instead of being silently dropped
+        # (see cron.delivery_fallback). Omitted for non-threaded origins.
+        parent_chat_id = get_session_env("HERMES_SESSION_PARENT_CHAT_ID") or None
+        if parent_chat_id:
+            origin["parent_chat_id"] = parent_chat_id
+        # Chat kind, so stale-target fallback can avoid escalating a private 1:1
+        # DM to a shared home channel. Stored only when known.
+        chat_type = get_session_env("HERMES_SESSION_CHAT_TYPE") or None
+        if chat_type:
+            origin["chat_type"] = chat_type
+        return origin
     return None
 
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -341,7 +341,7 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
                 "Cron origin captured thread_id=%s for %s:%s",
                 thread_id, origin_platform, origin_chat_id,
             )
-        return {
+        origin = {
             "platform": origin_platform,
             "chat_id": origin_chat_id,
             "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME") or None,
@@ -363,6 +363,19 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
             # snapshots; None for platforms without scope.
             "scope_id": get_session_env("HERMES_SESSION_SCOPE_ID") or None,
         }
+        # Parent channel of a thread origin (Discord/Matrix). Stored only when
+        # present so that if the origin thread is later deleted, delivery can
+        # fall back to the parent channel instead of being silently dropped
+        # (see cron.delivery_fallback). Omitted for non-threaded origins.
+        parent_chat_id = get_session_env("HERMES_SESSION_PARENT_CHAT_ID") or None
+        if parent_chat_id:
+            origin["parent_chat_id"] = parent_chat_id
+        # Chat kind, so stale-target fallback can avoid escalating a private 1:1
+        # DM to a shared home channel. Stored only when known.
+        chat_type = get_session_env("HERMES_SESSION_CHAT_TYPE") or None
+        if chat_type:
+            origin["chat_type"] = chat_type
+        return origin
     return None
 
 

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -280,6 +280,20 @@ Semantics: `all` expands to every platform with a configured home channel. Zero 
 
 `all` composes with explicit targets. `origin,all` delivers to the origin chat *plus* every other connected home channel, de-duplicating by `(platform, chat_id, thread_id)`.
 
+### Stale-target fallback
+
+A `deliver="origin"` job sends its output back to the conversation it was created in. If that thread/channel is **deleted, archived, or otherwise inaccessible** by the time the job fires (e.g. a deleted Discord thread, a closed Telegram topic, an archived Slack channel, or the bot losing permission), Hermes does not drop the notification silently — it redirects, in order:
+
+> original thread/topic → parent channel → home channel
+
+The redirected message is prefixed with a short ⚠️ notice explaining that the original target was unavailable and where it went instead.
+
+Only **definitively** undeliverable failures redirect. **Uncertain** failures (timeouts, rate limits, 5xx) do not — the original send may already have landed, and a redirect would deliver the message twice.
+
+The mechanism is platform-neutral. Detection is most complete for Telegram, Discord, and Slack plus generic HTTP errors (including Matrix); platforms whose adapters return opaque error text are safely left alone (no redirect).
+
+**DM exception:** a 1:1 direct message that becomes undeliverable (e.g. the user blocked the bot) is **not** escalated to the home channel — that is typically a shared group and would leak private content. It only retries the DM's own root conversation.
+
 ### Telegram cron topic (`TELEGRAM_CRON_THREAD_ID`)
 
 When Telegram topic mode is enabled, the root DM is reserved as a system lobby — replies sent there are rebuffed with a lobby reminder and `reply_to_message_id` is dropped, so you cannot reply to a cron message that landed in the main chat.

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -401,6 +401,20 @@ Semantics: `all` expands to every platform with a configured home channel. Zero 
 
 `all` composes with explicit targets. `origin,all` delivers to the origin chat *plus* every other connected home channel, de-duplicating by `(platform, chat_id, thread_id)`.
 
+### Stale-target fallback
+
+A `deliver="origin"` job sends its output back to the conversation it was created in. If that thread/channel is **deleted, archived, or otherwise inaccessible** by the time the job fires (e.g. a deleted Discord thread, a closed Telegram topic, an archived Slack channel, or the bot losing permission), Hermes does not drop the notification silently — it redirects, in order:
+
+> original thread/topic → parent channel → home channel
+
+The redirected message is prefixed with a short ⚠️ notice explaining that the original target was unavailable and where it went instead.
+
+Only **definitively** undeliverable failures redirect. **Uncertain** failures (timeouts, rate limits, 5xx) do not — the original send may already have landed, and a redirect would deliver the message twice.
+
+The mechanism is platform-neutral. Detection is most complete for Telegram, Discord, and Slack plus generic HTTP errors (including Matrix); platforms whose adapters return opaque error text are safely left alone (no redirect).
+
+**DM exception:** a 1:1 direct message that becomes undeliverable (e.g. the user blocked the bot) is **not** escalated to the home channel — that is typically a shared group and would leak private content. It only retries the DM's own root conversation.
+
 ### Telegram cron topic (`TELEGRAM_CRON_THREAD_ID`)
 
 When Telegram topic mode is enabled, the root DM is reserved as a system lobby — replies sent there are rebuffed with a lobby reminder and `reply_to_message_id` is dropped, so you cannot reply to a cron message that landed in the main chat.


### PR DESCRIPTION
## Summary

A cron job created from a live conversation delivers its output back to that
conversation. When the target is definitively undeliverable by firing time — a
deleted Discord thread, a closed Telegram forum topic, an archived Slack
channel, or a lost permission — `cron/scheduler.py::_deliver_result` records a
delivery error and moves on. Nothing is delivered anywhere, so the user never
hears back from a reminder they scheduled (#54329).

This PR redirects such a delivery instead of dropping it, and leaves every
uncertain failure untouched.

Rebased onto `main` at `ec44116`.

## Related Issue

Fixes #54329

## Behavior

On a definitively undeliverable target, delivery retries in order:

```
original thread/topic  ->  parent channel  ->  home channel
```

The redirected message is prefixed with a one-line `⚠️` notice naming where it
went and why.

- **Definitive only.** "Definitive" means `classify_send_error` returns
  `not_found` or `forbidden`. Everything else — timeouts, rate limits, 5xx,
  unrecognized strings — is uncertain and is never redirected, because the
  original send may already have landed and a redirect would duplicate it.
- **Both thread models.** Discord and Matrix carry the thread as `chat_id` with
  a separate parent id, so the redirect targets that parent id. Telegram and
  Slack carry the parent as `chat_id` with the topic in `thread_id`, so the
  redirect drops the thread id.
- **DM content does not reach a shared home channel.** The home-channel step is
  taken only when the origin is positively a shared chat (`chat_type` in
  `group`/`channel`/`forum`, or `thread` on Discord, which always sits under a
  guild channel). A missing or unknown `chat_type` — every job created before
  this PR — plus `webhook` and explicit DM kinds fail closed. The parent step is
  never suppressed: it stays inside the origin conversation and cannot leak.
  Slack is excluded from the `thread` allowance because a Slack thread can sit
  inside a DM.
- **No duplicate on fan-out.** `deliver=all` with several dead targets that all
  redirect to the same home channel sends there once, not once per dead target.
- **Cascade rules.** A fallback that itself fails definitively advances to the
  next fallback. A fallback that fails for an uncertain reason stops the chain.

The hook sits on the standalone send path, which is where a live-adapter send
also lands after it fails. Relay-fronted targets are untouched: they already
fail closed before this point.

## Implementation

- `cron/delivery_fallback.py` *(new, 179 lines)* — pure helpers with no I/O:
  `is_definitive_delivery_failure`, `build_fallback_targets` (both thread
  models, DM home-suppression, dedup against the failed target and against
  earlier candidates), `format_fallback_notice`.
- `cron/scheduler.py` — `_run_send_blocking` extracts the existing
  `asyncio.run` / worker-thread send so the retry path is reusable, and a single
  `_attempt_delivery_fallback` is wired into both standalone send-failure sites
  in `_deliver_result` (the raised-exception site and the
  `result["error"]` site). A shutdown-race exception is still skipped with a
  warning before any fallback is considered.
- `gateway/platforms/base.py` — `classify_send_error` gains cross-platform
  definitive signatures: Discord `10003`/`50001`/`50013`, Slack
  `channel_not_found`/`is_archived`/`not_in_channel`/`missing_scope`/
  `restricted_action`, Telegram `topic_closed`, and generic
  archived/locked/"not found"-plus-container shapes. Before this, everything in
  that list except the Discord `50001`/`50013` codes — which already matched on
  the word "Forbidden" in the HTTP status line — classified as `unknown`.
  Detection lives here, not duplicated in the cron layer, so a new platform
  signature benefits both consumers.
- `gateway/session_context.py`, `gateway/run.py`, `tools/cronjob_tools.py` —
  propagate `parent_chat_id` and `chat_type` into the cron origin. Both are
  optional and written only when known, so existing jobs load unchanged and
  take the fail-closed path.
- `website/docs/user-guide/features/cron.md` — a "Stale-target fallback"
  section under Delivery options.

No new config keys and no new env vars; the redirect reuses the existing
`*_HOME_CHANNEL` targets.

## Tests

Added tests cover the new functions and the failure modes they gate, nothing
broader. All are mocked in-process tests: the platform send is stubbed, with
`_send_to_platform` patched in most and a fake live adapter substituted in the
Matrix case. No live Discord, Telegram, Slack, or Matrix run was performed, so
the error strings under test are the documented API shapes, not captured
traffic.

- `tests/cron/test_delivery_fallback.py` *(new)* — definitive vs. uncertain
  classification, both thread models, dedup, DM home-suppression, notice text.
- `tests/cron/test_scheduler.py` — `_deliver_result` integration: Discord
  parent→home cascade, Telegram topic→channel, Slack archived→home, timeout does
  not redirect, uncertain fallback failure stops the chain, cross-target dedup,
  DM does not leak to home, DM topic falls back to the DM root, legacy origin
  without `chat_type` does not leak, Slack `thread` fails closed while Discord
  `thread` escalates, and a Matrix redirect that drives the real
  `_send_to_platform → _send_matrix_via_adapter → live adapter` chain to show
  the redirect reuses the gateway's live adapter rather than an ephemeral send.
- `tests/gateway/test_send_error_classification.py` — the new cross-platform
  definitive signatures, plus uncertain strings that must stay non-definitive.
- `tests/tools/test_cronjob_tools.py` — origin capture of `parent_chat_id` and
  `chat_type`, and their omission when absent.

Commands run after the rebase, via the canonical runner:

```bash
scripts/run_tests.sh tests/cron/test_delivery_fallback.py
# 30 passed

scripts/run_tests.sh tests/cron/test_scheduler.py
# 115 passed

scripts/run_tests.sh tests/gateway/test_send_error_classification.py \
                     tests/tools/test_cronjob_tools.py
# 109 passed (37 + 72)

scripts/run_tests.sh tests/cron/ tests/gateway/test_dead_targets.py \
                     tests/gateway/test_session_env.py \
                     tests/gateway/test_session_hygiene.py \
                     tests/gateway/test_run_progress_topics.py \
                     tests/gateway/test_slack_block_kit_adapter.py
# 997 passed, 1 failed, 1 skipped
```

The single failure is
`tests/cron/test_script_claim_heartbeat.py::test_repeated_heartbeat_errors_cancel_after_bounded_grace`,
a wall-clock-sensitive fire-claim heartbeat test unrelated to delivery. It fails
identically on unmodified `main` at `ec44116` on the same machine, so it is
pre-existing and environmental, not a regression from this PR.

## Scope

In scope: the cron delivery path, the send-error classifier it reuses, and the
two origin fields the redirect needs.

Deliberately not included:

- No change to the relay path, which fails closed before the standalone send.
- No redirect for uncertain failures, and no retry/backoff mechanism.
- No per-platform error matching in the cron layer; new platform signatures go
  into `classify_send_error` and are picked up automatically.

One note for review: `classify_send_error` is shared with
`gateway.dead_targets` via `gateway/delivery.py::_classify_dead_from_error_text`,
so a wider `forbidden` vocabulary also widens what could be marked a dead
target. The new `not_found` signatures are unaffected — they are sub-chat-level
and `is_chat_level_not_found` already gates that path. The `forbidden` path has
no such gate, but its only consumer, `DeliveryRouter.deliver()`, has no
production call site on `main` today (only tests), so there is no live behavior
change. Flagging it rather than expanding this PR's scope to add a gate.
