### PR TITLE
fix: ignore SIGPIPE to prevent gateway crash on broken TCP connections

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18542,6 +18542,21 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 logger.debug("spawn_async_diagnostic failed: %s", _e)
         asyncio.create_task(runner.stop())
 
+    # Ignore SIGPIPE so that broken TCP connections (e.g. when a local
+    # HTTP server the gateway is connected to is killed) do not crash
+    # the gateway process.  Python's default SIGPIPE handler terminates
+    # the process, which takes down the entire Telegram session.  By
+    # ignoring the signal, writes to closed sockets raise
+    # BrokenPipeError / ConnectionResetError instead, which the
+    # existing exception handlers can catch and recover from.
+    if hasattr(signal, "SIGPIPE"):
+        try:
+            signal.signal(signal.SIGPIPE, signal.SIG_IGN)  # windows-footgun: ok — guarded by hasattr above + try/except (OSError, ValueError)
+            logger.info("SIGPIPE handler set to SIG_IGN (broken-pipe protection)")
+        except (OSError, ValueError):
+            # Can fail if not in main thread or signal is blocked
+            pass
+
     def restart_signal_handler():
         runner.request_restart(detached=False, via_service=True)
     


### PR DESCRIPTION
## Summary
Killing a local HTTP server the gateway holds a TCP connection to no longer crashes the gateway. A write to the orphaned socket could deliver SIGPIPE; if the disposition was ever reset to `SIG_DFL`, Python terminated the process instantly — no exception, no reconnect, every attached session lost.

Salvage of #10367 by @lrawnsley onto current `main` (the original diff anchored at line ~9533; the signal-handler setup has since moved to ~18567). Commit authorship preserved.

## Changes
- `gateway/run.py`: at gateway startup, set `signal.SIGPIPE` to `SIG_IGN` so writes to closed sockets raise `BrokenPipeError` / `ConnectionResetError`, which the existing network-error handlers already route to reconnect / clean shutdown. Guarded by `hasattr(signal, "SIGPIPE")` (Windows) and `except (OSError, ValueError)` (not-in-main-thread). Mirrors the handler already in `tui_gateway/entry.py`.

## Validation
| SIGPIPE disposition | write to peer-closed socket |
|---|---|
| `SIG_DFL` (the danger) | process **killed by signal 13 (SIGPIPE)** |
| `SIG_IGN` (this PR) | raises `BrokenPipeError`, caught, process survives |

E2E reproduced both paths against a real TCP loopback socket (peer closed, repeated `os.write` on the raw fd). `tests/tools/test_windows_native_support.py` green (66 passed) — the footgun guard already asserts the `hasattr(signal, "SIGPIPE")`-gated pattern.

Note: CPython installs `SIG_IGN` for SIGPIPE at interpreter startup by default, so the bare gateway won't crash unless something resets it to `SIG_DFL` (embedded interpreters, inherited dispositions, native extensions in Telegram/httpx stacks). This is belt-and-suspenders restoration of the safe disposition at startup.

## Infographic

![sigpipe-gateway-crash](https://v3b.fal.media/files/b/0aa0312e/f_2L1UzJ1fO2mA5jkFGf9_TT29Mt1c.png)
