### PR TITLE
fix(skills): strict path containment for official skill fetch

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1846,6 +1846,23 @@ class TestOptionalSkillSourceBinaryAssets:
         assert bundle.files["assets/neutts-cli/samples/jo.txt"] == b"hello\n"
         assert "assets/neutts-cli/src/neutts_cli/__pycache__/cli.cpython-312.pyc" not in bundle.files
 
+    def test_fetch_rejects_sibling_directory_traversal(self, tmp_path):
+        optional_root = tmp_path / "optional-skills"
+        sibling_skill_dir = tmp_path / "optional-skills-escape" / "pwned"
+        optional_root.mkdir()
+        sibling_skill_dir.mkdir(parents=True)
+        (sibling_skill_dir / "SKILL.md").write_text(
+            "---\nname: pwned\ndescription: traversal\n---\n\nBody\n",
+            encoding="utf-8",
+        )
+
+        src = OptionalSkillSource()
+        src._optional_dir = optional_root
+
+        bundle = src.fetch("official/../optional-skills-escape/pwned")
+
+        assert bundle is None
+
 
 class TestQuarantineBundleBinaryAssets:
     def test_quarantine_bundle_writes_binary_files(self, tmp_path):

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3028,7 +3028,8 @@ class OptionalSkillSource(SkillSource):
         # Guard against path traversal (e.g. "official/../../etc")
         try:
             resolved = skill_dir.resolve()
-            if not str(resolved).startswith(str(self._optional_dir.resolve())):
+            optional_root = self._optional_dir.resolve()
+            if not resolved.is_relative_to(optional_root):
                 return None
         except (OSError, ValueError):
             return None


### PR DESCRIPTION
## Summary
Skill fetches can no longer escape the `optional-skills/` directory via a sibling directory whose name shares the same string prefix.

Root cause: `OptionalSkillSource.fetch()` validated resolved paths with `str(resolved).startswith(str(optional_root))`. A sibling like `optional-skills-escape/` matches the `optional-skills` prefix, so an identifier such as `official/../optional-skills-escape/pwned` resolves outside the allowed root yet passes the guard.

## Changes
- `tools/skills_hub.py`: replace the string-prefix check with `Path.is_relative_to(optional_root)` — a real ancestor/containment test.
- `tests/tools/test_skills_hub.py`: regression test covering sibling-directory traversal.

## Validation
| Input | Before | After |
|---|---|---|
| `official/../optional-skills-escape/pwned` | resolves outside root, **passes** guard | **rejected** (`None`) |
| `official/creative/good-skill` (legit) | fetched | fetched |

- `scripts/run_tests.sh tests/tools/test_skills_hub.py` — 154 passed.
- E2E against current `main`: attack identifier returns `None`, a legitimate skill under `optional-skills/` still fetches.
- `is_relative_to` is available on the `requires-python = ">=3.11"` floor.

Cherry-picked from #7238 by @Ruzzgar onto current `main`; authorship preserved.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa03144/uRx2ZG7y4RbklezTWbXVO_uVkc5IZY.png)
