### PR TITLE
[codex] Preserve a user anchor in truncated API histories

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -884,6 +884,7 @@ def run_conversation(
             api_messages,
             drop_codex_reasoning_items=agent.api_mode != "codex_responses",
         )
+        agent._ensure_user_anchor(api_messages)
 
         # Normalize message whitespace and tool-call JSON for consistent
         # prefix matching.  Ensures bit-perfect prefixes across turns,

--- a/run_agent.py
+++ b/run_agent.py
@@ -4871,10 +4871,44 @@ class AIAgent:
         """Return True when the base URL targets Qwen Portal."""
         return base_url_host_matches(self._base_url_lower, "portal.qwen.ai")
 
+    @staticmethod
+    def _ensure_user_anchor(messages: list) -> None:
+        """Ensure API payloads still contain at least one user-role message.
+
+        Some chat-template backends reject a request with only system,
+        assistant, and tool messages because there is no user query left after
+        long-context truncation. Add a minimal user anchor to the API copy so
+        those already-truncated histories fail less catastrophically. This is a
+        no-op for normal histories that still contain any user message.
+        """
+        if not messages:
+            return
+        if any(isinstance(m, dict) and m.get("role") == "user" for m in messages):
+            return
+        anchor = {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        "(Earlier user message was truncated from long context. "
+                        "Continue the current task.)"
+                    ),
+                }
+            ],
+        }
+        insert_at = 0
+        for i, message in enumerate(messages):
+            if isinstance(message, dict) and message.get("role") == "system":
+                insert_at = i + 1
+                break
+        messages.insert(insert_at, anchor)
+
     def _qwen_prepare_chat_messages(self, api_messages: list) -> list:
         prepared = copy.deepcopy(api_messages)
         if not prepared:
             return prepared
+        self._ensure_user_anchor(prepared)
 
         for msg in prepared:
             if not isinstance(msg, dict):
@@ -4908,6 +4942,7 @@ class AIAgent:
         """In-place variant — mutates an already-copied message list."""
         if not messages:
             return
+        self._ensure_user_anchor(messages)
 
         for msg in messages:
             if not isinstance(msg, dict):

--- a/tests/agent/test_user_anchor_guard.py
+++ b/tests/agent/test_user_anchor_guard.py
@@ -1,0 +1,59 @@
+from run_agent import AIAgent
+
+
+def _roles(messages):
+    return [message["role"] for message in messages]
+
+
+def test_injects_user_after_system_when_absent():
+    messages = [
+        {"role": "system", "content": "S"},
+        {"role": "assistant", "content": "A"},
+        {"role": "tool", "content": "T"},
+    ]
+
+    AIAgent._ensure_user_anchor(messages)
+
+    assert _roles(messages)[:2] == ["system", "user"]
+
+
+def test_noop_when_user_already_present():
+    messages = [
+        {"role": "system", "content": "S"},
+        {"role": "user", "content": "U"},
+        {"role": "assistant", "content": "A"},
+    ]
+    before = [dict(message) for message in messages]
+
+    AIAgent._ensure_user_anchor(messages)
+
+    assert messages == before
+
+
+def test_injects_at_head_when_no_system():
+    messages = [
+        {"role": "assistant", "content": "A"},
+        {"role": "tool", "content": "T"},
+    ]
+
+    AIAgent._ensure_user_anchor(messages)
+
+    assert _roles(messages)[0] == "user"
+
+
+def test_empty_list_is_noop():
+    messages = []
+
+    AIAgent._ensure_user_anchor(messages)
+
+    assert messages == []
+
+
+def test_anchor_content_is_normalized_parts():
+    messages = [{"role": "tool", "content": "T"}]
+
+    AIAgent._ensure_user_anchor(messages)
+
+    user = next(message for message in messages if message["role"] == "user")
+    assert isinstance(user["content"], list)
+    assert user["content"][0]["type"] == "text"


### PR DESCRIPTION
## Summary

- Add `AIAgent._ensure_user_anchor()` as a defensive no-op for normal histories.
- Insert a minimal user-role anchor when an API payload has no remaining user message after long-context truncation.
- Call the guard from the Qwen message preparation path and the extracted conversation loop API-copy path.

## Why

Some chat-template backends reject requests that contain only system, assistant, and tool messages, because the user turn has been truncated out of long history. That turns an already-degraded context into a hard provider error. Keeping a tiny user anchor in the API copy preserves provider compatibility without mutating normal histories that still contain a user message.

## Validation

- `uv run --extra dev pytest tests/agent/test_user_anchor_guard.py tests/run_agent/test_message_sequence_repair.py`
- `uv run --extra dev ruff check run_agent.py agent/conversation_loop.py tests/agent/test_user_anchor_guard.py`
- `git diff --check -- run_agent.py agent/conversation_loop.py tests/agent/test_user_anchor_guard.py`

Note: ruff reports an existing warning about an unrelated `# noqa` directive in `run_agent.py`, but exits successfully.