### PR TITLE
fix: block model switch when provider requires API key but none is resolved

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1218,6 +1218,35 @@ def switch_model(
     # --- Normalize model name for target provider ---
     new_model = normalize_model_for_provider(new_model, target_provider)
 
+    # --- Check: provider requires API key but none was resolved ---
+    # resolve_runtime_provider() returns api_key="" instead of raising when
+    # the env var is unset, so a missing-key provider slips through and
+    # bricks the session when the client build fails.  Catch it here so the
+    # user sees a clear message before any state mutation. (#50163)
+    if not api_key or not api_key.strip():
+        try:
+            from hermes_cli.auth import PROVIDER_REGISTRY as _PR
+            _pcfg = _PR.get(target_provider)
+        except Exception:
+            _pcfg = None
+        if (
+            _pcfg is not None
+            and getattr(_pcfg, "auth_type", "") == "api_key"
+            and getattr(_pcfg, "api_key_env_vars", ())
+        ):
+            _env_names = ", ".join(_pcfg.api_key_env_vars)
+            return ModelSwitchResult(
+                success=False,
+                new_model=new_model,
+                target_provider=target_provider,
+                provider_label=provider_label,
+                is_global=is_global,
+                error_message=(
+                    f"Provider '{provider_label}' requires an API key, "
+                    f"but none was found. Set one of: {_env_names}"
+                ),
+            )
+
     # --- Validate ---
     try:
         validation = validate_requested_model(


### PR DESCRIPTION
## Problem

When using `/model` to switch to a provider whose API key is not configured (e.g., `/model glm-5.2` with no `GLM_API_KEY` set), the session becomes permanently bricked:

1. `resolve_runtime_provider()` returns `api_key=` instead of raising when the env var is unset
2. `model_switch.switch_model()` returns `success=True` with empty API key
3. CLI handler sets `self.model`/`self.provider` to the new values
4. `agent.switch_model()` tries to build the client → fails because key is empty
5. Session DB is now stuck on the broken provider — resume always fails

Related: #50163

## Fix

Add an explicit API key check in `hermes_cli/model_switch.py` after credential resolution, before validation. If the provider's `PROVIDER_REGISTRY` entry has `auth_type == "api_key"` and `api_key_env_vars` are defined but no key was resolved, return `ModelSwitchResult(success=False)` with a clear error message.

## Verification

- `/model glm-5.2` without `GLM_API_KEY` → now returns: `Provider 'Z.AI' requires an API key, but none was found. Set one of: GLM_API_KEY, ZAI_API_KEY, Z_AI_API_KEY`
- `/model deepseek-v4-flash` with valid `DEEPSEEK_API_KEY` → still works normally