### PR TITLE
fix(desktop): show unprojected sessions in project grouping

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -707,7 +707,7 @@ export function ChatSidebar({
 
     const sorted = sortProjectsForOverview(
       projectTree
-        .filter(node => !(node.isAuto && dismissed.has(node.id)))
+        .filter(node => !(node.isAuto && !node.isNoProject && dismissed.has(node.id)))
         .map(project => ({ ...project, repos: orderRepos(project.repos) })),
       activeProjectId
     )
@@ -898,7 +898,13 @@ export function ChatSidebar({
   // "Sessions" when flat, "Projects" at the overview, and the project's name
   // once you've entered one.
   const sessionsLabel =
-    inProject && enteredProject ? enteredProject.label : worktreeGroupingActive ? s.projects.sectionLabel : s.sessions
+    inProject && enteredProject
+      ? enteredProject.isNoProject
+        ? s.noProject
+        : enteredProject.label
+      : worktreeGroupingActive
+        ? s.projects.sectionLabel
+        : s.sessions
 
   // Mirror the section's skeleton gate (projectsLoading + nothing to show yet):
   // while the skeleton is up there's no point also spinning the header count.
@@ -1855,7 +1861,11 @@ function SidebarSessionsSection({
         key={project.id}
         onEnter={onEnterProject}
         onNewSession={onNewSessionInWorkspace}
-        previewSessions={project.path ? projectOverviewPreviews?.[project.path] : undefined}
+        previewSessions={
+          projectOverviewPreviews?.[project.id] ??
+          (project.path ? projectOverviewPreviews?.[project.path] : undefined) ??
+          project.previewSessions
+        }
         project={project}
         renderRows={renderRows}
       />

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/lib/utils'
 
 import {
   SIDEBAR_LEAD_ICON_SIZE,
+  SidebarCount,
   SidebarRowBody,
   SidebarRowCluster,
   SidebarRowGrab,
@@ -91,16 +92,18 @@ export function ProjectOverviewRow({
   const { t } = useI18n()
   const s = t.sidebar
   const isActive = project.id === activeProjectId
+  const projectLabel = project.isNoProject ? s.noProject : project.label
   const [open, toggleOpen] = useWorkspaceNodeOpen(project.id)
   // The appearance popover anchors here (the full row) so it opens flush with
   // the sidebar's content edge regardless of which side the sidebar is on.
   const rowRef = useRef<HTMLDivElement>(null)
   const fetched = (previewSessions ?? []).slice(0, PROJECT_PREVIEW_COUNT)
   const preview = renderRows ? (fetched.length ? fetched : latestProjectSessions(project, PROJECT_PREVIEW_COUNT)) : []
+  const remainingCount = Math.max(0, project.sessionCount - preview.length)
 
   const lead = reorderable ? (
     <SidebarRowGrab
-      ariaLabel={s.projects.reorder(project.label)}
+      ariaLabel={s.projects.reorder(projectLabel)}
       dragging={dragging}
       dragHandleProps={dragHandleProps}
       leadClassName="overflow-visible"
@@ -117,7 +120,7 @@ export function ProjectOverviewRow({
         actions={
           <>
             {onNewSession && (
-              <WorkspaceAddButton label={s.newSessionIn(project.label)} onClick={() => onNewSession(project.path)} />
+              <WorkspaceAddButton label={s.newSessionIn(projectLabel)} onClick={() => onNewSession(project.path)} />
             )}
             <ProjectMenu anchorRef={rowRef} isActive={isActive} project={project} />
           </>
@@ -128,15 +131,16 @@ export function ProjectOverviewRow({
         <SidebarRowCluster className="min-w-0 flex-1">
           {lead}
           <SidebarRowLink
-            aria-label={s.projects.enter(project.label)}
+            aria-label={s.projects.enter(projectLabel)}
             labelClassName={cn('hover:text-foreground hover:underline', isActive && 'text-foreground')}
             onClick={() => onEnter?.(project.id)}
           >
-            {project.label}
+            {projectLabel}
           </SidebarRowLink>
+          {project.sessionCount > 0 && <SidebarCount>{project.sessionCount}</SidebarCount>}
           {preview.length > 0 ? (
             <button
-              aria-label={s.projects.toggle(project.label)}
+              aria-label={s.projects.toggle(projectLabel)}
               className="flex flex-1 items-center self-stretch bg-transparent p-0"
               onClick={toggleOpen}
               type="button"
@@ -151,7 +155,28 @@ export function ProjectOverviewRow({
           )}
         </SidebarRowCluster>
       </SidebarRowShell>
-      {open && preview.length > 0 && <SidebarRowNest>{renderRows?.(preview)}</SidebarRowNest>}
+      {open && preview.length > 0 && (
+        <SidebarRowNest>
+          {renderRows?.(preview)}
+          {remainingCount > 0 && onEnter && (
+            <SidebarRowShell>
+              <SidebarRowBody
+                className="group/show-more text-(--ui-text-tertiary) hover:text-foreground"
+                onClick={() => onEnter(project.id)}
+              >
+                <SidebarRowLead>
+                  <SidebarRowLeadGlyph>
+                    <Codicon name="ellipsis" size={SIDEBAR_LEAD_ICON_SIZE} />
+                  </SidebarRowLeadGlyph>
+                </SidebarRowLead>
+                <SidebarRowLabel className="text-xs underline-offset-4 group-hover/show-more:underline">
+                  {s.showMoreIn(remainingCount, projectLabel)}
+                </SidebarRowLabel>
+              </SidebarRowBody>
+            </SidebarRowShell>
+          )}
+        </SidebarRowNest>
+      )}
     </div>
   )
 }

--- a/apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx
@@ -94,6 +94,10 @@ export function ProjectMenu({
   // when the panes are flipped (sidebar on the right).
   const panesFlipped = useStore($panesFlipped)
 
+  if (project.isNoProject) {
+    return null
+  }
+
   const removeAuto = () => {
     dismissAutoProject(project.id)
 

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -698,6 +698,20 @@ describe('overlayLivePreviews', () => {
     const previews = overlayLivePreviews([project], live, [], 3)
 
     expect(previews['/www/app'].map(s => s.id)).toEqual(['fresh', 'old'])
+    expect(previews[project.id].map(s => s.id)).toEqual(['fresh', 'old'])
+  })
+
+  it('keeps backend previews reachable for a pathless No project bucket', () => {
+    const project = projectNode({
+      id: '__no_project__',
+      isNoProject: true,
+      path: null,
+      previewSessions: [makeSession(null, { id: 'rootless', started_at: 1, last_active: 1 })]
+    })
+
+    const previews = overlayLivePreviews([project], [], [], 3)
+
+    expect(previews.__no_project__.map(s => s.id)).toEqual(['rootless'])
   })
 
   it('evicts a deleted session from a project preview (snapshot + live)', () => {

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -532,7 +532,7 @@ export function overlayLiveLanes(
   return { ...project, repos, sessionCount: repos.reduce((n, repo) => n + repo.sessionCount, 0) }
 }
 
-/** Merge live sessions into per-project overview previews, keyed by project path. */
+/** Merge live sessions into per-project overview previews, keyed by project id (and legacy path when present). */
 export function overlayLivePreviews(
   projects: SidebarProjectTree[],
   live: SessionInfo[],
@@ -561,10 +561,6 @@ export function overlayLivePreviews(
   const out: Record<string, SessionInfo[]> = {}
 
   for (const node of projects) {
-    if (!node.path) {
-      continue
-    }
-
     const liveRows = byProject.get(node.id) ?? []
     const base = (node.previewSessions ?? []).filter(session => !removed.has(session.id))
 
@@ -581,7 +577,13 @@ export function overlayLivePreviews(
       }
     }
 
-    out[node.path] = [...map.values()].sort((a, b) => sessionRecency(b) - sessionRecency(a)).slice(0, limit)
+    out[node.id] = [...map.values()].sort((a, b) => sessionRecency(b) - sessionRecency(a)).slice(0, limit)
+
+    // Legacy callers keyed previews by project path; pathless projects (the
+    // synthetic "No project" bucket) need the stable id key, so publish both.
+    if (node.path) {
+      out[node.path] = out[node.id]
+    }
   }
 
   return out

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -216,8 +216,40 @@ def test_scoped_session_ids_is_union_of_placed_sessions():
 
     tree = pt.build_tree([project], [owned, auto, homeless], [], resolve, hydrate=True)
 
-    assert set(tree["scoped_session_ids"]) == {owned["id"], auto["id"]}
-    assert homeless["id"] not in tree["scoped_session_ids"]
+    assert set(tree["scoped_session_ids"]) == {owned["id"], auto["id"], homeless["id"]}
+    no_project = next(p for p in tree["projects"] if p.get("isNoProject"))
+    assert no_project["sessionCount"] == 1
+
+
+def test_no_project_bucket_keeps_unplaced_sessions_visible():
+    # Project grouping must not make non-repo / cwd-less conversations vanish.
+    # Older sessions may have no cwd at all, cwd='/' (the filesystem root), or a
+    # cwd inside a junk root that should not become an auto project. They still
+    # need a stable "No project" bucket in the grouped sidebar.
+    resolve = _resolver({"/home/me/.hermes": ("/home/me/.hermes", "/home/me/.hermes"), "/repo": ("/repo", "/repo")})
+    cwdless = _session(None)
+    fs_root = _session("/")
+    junk = _session("/home/me/.hermes", branch="main")
+    real = _session("/repo", branch="main")
+
+    tree = pt.build_tree(
+        [],
+        [cwdless, fs_root, junk, real],
+        [],
+        resolve,
+        hydrate=True,
+        is_junk_root=lambda root: root == "/home/me/.hermes",
+    )
+
+    no_project = next(p for p in tree["projects"] if p.get("isNoProject"))
+    assert no_project["id"] == pt.NO_PROJECT_ID
+    assert no_project["sessionCount"] == 3
+    assert [s["id"] for s in no_project["repos"][0]["groups"][0]["sessions"]] == [
+        cwdless["id"],
+        fs_root["id"],
+        junk["id"],
+    ]
+    assert set(tree["scoped_session_ids"]) == {cwdless["id"], fs_root["id"], junk["id"], real["id"]}
 
 
 def test_overview_drops_session_rows_but_keeps_counts_and_previews():
@@ -309,8 +341,8 @@ def test_nested_project_folders_pick_the_deepest_match():
 
 def test_junk_root_never_becomes_an_auto_project():
     # A session whose git root is HERMES_HOME (config/state) must not spawn a
-    # phantom project; it falls through to flat Recents (unscoped). A real repo
-    # alongside it still groups normally.
+    # phantom repo project; it lands in the synthetic No project bucket instead.
+    # A real repo alongside it still groups normally.
     resolve = _resolver(
         {
             "/home/me/.hermes": ("/home/me/.hermes", "/home/me/.hermes"),
@@ -324,8 +356,10 @@ def test_junk_root_never_becomes_an_auto_project():
     tree = pt.build_tree([], [junk, real], [], resolve, hydrate=True, is_junk_root=is_junk)
 
     ids = {p["id"] for p in tree["projects"]}
-    assert ids == {"/www/app"}
-    assert junk["id"] not in tree["scoped_session_ids"]
+    assert ids == {"/www/app", pt.NO_PROJECT_ID}
+    no_project = next(p for p in tree["projects"] if p.get("isNoProject"))
+    assert no_project["sessionCount"] == 1
+    assert junk["id"] in tree["scoped_session_ids"]
     assert real["id"] in tree["scoped_session_ids"]
 
 

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -40,6 +40,9 @@ Resolve = Callable[[str], Optional[dict]]
 _KANBAN_DIR_RE = re.compile(r"^(.*[/\\]\.worktrees)[/\\]t_[0-9a-f]+[/\\]?$")
 _TRUNK_BRANCHES = {"main", "master", "trunk", "develop"}
 DEFAULT_BRANCH_LABEL = "main"
+NO_PROJECT_ID = "__no_project__"
+NO_PROJECT_LABEL = "No project"
+_NO_PROJECT_LANE_ID = f"{NO_PROJECT_ID}::sessions"
 
 
 def _branch_lane_id(repo_root: str, branch: str = "") -> str:
@@ -406,8 +409,9 @@ def _project_node(
     color: Any = None,
     icon: Any = None,
     is_auto: bool = False,
+    is_no_project: bool = False,
 ) -> dict:
-    return {
+    node = {
         "id": pid,
         "label": label,
         "path": path,
@@ -419,6 +423,32 @@ def _project_node(
         "repos": repos,
         "previewSessions": preview_sessions,
     }
+    if is_no_project:
+        node["isNoProject"] = True
+    return node
+
+
+def _no_project_repos(project_sessions: list[dict], hydrate: bool) -> list[dict]:
+    ordered = sorted(project_sessions, key=_session_time, reverse=True)
+    lane_sessions = ordered if hydrate else []
+    return [
+        {
+            "id": NO_PROJECT_ID,
+            "label": NO_PROJECT_LABEL,
+            "path": None,
+            "groups": [
+                {
+                    "id": _NO_PROJECT_LANE_ID,
+                    "label": NO_PROJECT_LABEL,
+                    "path": None,
+                    "isMain": False,
+                    "isKanban": False,
+                    "sessions": lane_sessions,
+                }
+            ],
+            "sessionCount": len(project_sessions),
+        }
+    ]
 
 
 def build_tree(
@@ -438,8 +468,9 @@ def build_tree(
     ``git_branch``, ``git_repo_root``, ``started_at``, ``last_active``).
     ``discovered_repos`` are ``{"root", "label", "sessions", "last_active"}``.
     ``is_junk_root`` flags roots that must never become an AUTO project (the
-    bare home dir, the HERMES_HOME subtree) — their sessions fall through to the
-    flat Recents list. User-created projects are honored regardless.
+    bare home dir, the HERMES_HOME subtree) — their sessions go into the
+    synthetic "No project" bucket instead of a phantom repo. User-created
+    projects are honored regardless.
 
     Returns ``{"projects": [...], "scoped_session_ids": [...]}``. When
     ``hydrate`` is False (overview), lane ``sessions`` arrays are emptied but
@@ -460,6 +491,7 @@ def build_tree(
             unowned.append(session)
 
     scoped_ids: list[str] = []
+    placed_ids: set[str] = set()
 
     def _previews(project_sessions: list[dict]) -> list[dict]:
         if preview_limit <= 0:
@@ -476,6 +508,7 @@ def build_tree(
     for project in active_projects:
         psessions = by_project.get(project["id"], [])
         scoped_ids.extend(s["id"] for s in psessions if s.get("id"))
+        placed_ids.update(s["id"] for s in psessions if s.get("id"))
         repos = _seed_folder_repos(
             _build_repos(psessions, resolve, hydrate), project.get("folders") or [], resolve
         )
@@ -502,8 +535,10 @@ def build_tree(
 
     seen: set[str] = set()
     for repo_root, repo_sessions in by_repo.items():
-        # The home dir / HERMES_HOME subtree is config + state, never a project;
-        # its sessions stay loose in Recents (not scoped to a phantom project).
+        # The home dir / HERMES_HOME subtree is config + state, never a real
+        # auto project. Those rows remain unplaced here and are collected into
+        # the synthetic "No project" bucket below so grouped mode does not hide
+        # them.
         if _junk(repo_root):
             continue
         repos = _build_repos(repo_sessions, resolve, hydrate)
@@ -512,6 +547,7 @@ def build_tree(
             continue
         seen.add(repo_root)
         scoped_ids.extend(s["id"] for s in repo_sessions if s.get("id"))
+        placed_ids.update(s["id"] for s in repo_sessions if s.get("id"))
         result.append(
             _project_node(
                 pid=repo_root,
@@ -522,6 +558,23 @@ def build_tree(
                 last_active=_last_active(repo_sessions),
                 preview_sessions=_previews(repo_sessions),
                 is_auto=True,
+            )
+        )
+
+    no_project_sessions = [s for s in sessions if s.get("id") and s["id"] not in placed_ids]
+    if no_project_sessions:
+        scoped_ids.extend(s["id"] for s in no_project_sessions if s.get("id"))
+        result.append(
+            _project_node(
+                pid=NO_PROJECT_ID,
+                label=NO_PROJECT_LABEL,
+                path=None,
+                repos=_no_project_repos(no_project_sessions, hydrate),
+                session_count=len(no_project_sessions),
+                last_active=_last_active(no_project_sessions),
+                preview_sessions=_previews(no_project_sessions),
+                is_auto=True,
+                is_no_project=True,
             )
         )
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10590,8 +10590,9 @@ def _build_project_tree(
 def _(rid, params: dict) -> dict:
     """Authoritative project overview: project -> repo -> lane structure with
     counts + a few preview sessions per project, plus the flat set of session
-    ids claimed by any project (so the desktop excludes them from flat Recents).
-    Lanes carry no session rows here; drill-in uses ``projects.project_sessions``.
+    ids represented by the grouped view (for optimistic eviction/tombstone
+    reconciliation). Lanes carry no session rows here; drill-in uses
+    ``projects.project_sessions``.
     """
     try:
         db = _get_db()


### PR DESCRIPTION
## Summary

- Add a synthetic `No project` bucket to the Desktop project tree for sessions that cannot be assigned to an explicit project or git repo.
- Keep cwd-less/root/junk-root sessions visible in the Projects grouped sidebar instead of only showing real/auto repo projects.
- Teach the sidebar preview/rendering path to handle pathless project rows and prevent treating the synthetic bucket as a removable auto project.
- Show each project row's real session count and add a visible "show more in project" affordance when the overview only displays a preview.

## Why

After the Desktop project-grouped sidebar was introduced, historical sessions with `cwd` missing, `cwd='/'`, home/Hermes state paths, or other non-project locations could disappear from the grouped Projects view. The sessions still existed in the database and flat recents, but the Projects overview could appear to contain only one real project, which looks like sessions were lost after an upgrade.

Even after adding the synthetic bucket, the overview intentionally previews only a few rows per project. Without a count/"show more" affordance, a bucket with many sessions can still look like it only contains the preview rows.

## Tests

- `/Users/xiewenfen/.hermes/hermes-agent/venv/bin/python -m pytest tests/tui_gateway/test_project_tree.py tests/tui_gateway/test_projects_rpc.py -q` — 32 passed
- `npm run test:ui -- src/app/chat/sidebar/projects/workspace-groups.test.ts` — 37 passed
- `npm run typecheck`
- `npm run build`
