### PR TITLE
fix(cli): detect basic plugin disabled when dashboard auth configured (#54489)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1122,6 +1122,27 @@ def run_doctor(args):
     except Exception:
         pass
 
+    # Check for dashboard auth misconfiguration: basic plugin disabled
+    # while dashboard.basic_auth is configured (#54489).
+    try:
+        from hermes_cli.config import load_config as _ldc
+        _dc = _ldc() or {}
+        _dp = _dc.get("plugins") or {}
+        _ddis = set(_dp.get("disabled") or [])
+        _dba = (_dc.get("dashboard") or {}).get("basic_auth") or {}
+        if "basic" in _ddis and _dba.get("username"):
+            check_warn(
+                "Dashboard basic auth",
+                "configured but 'basic' plugin is in plugins.disabled — "
+                "dashboard will refuse non-loopback binds",
+            )
+            check_info(
+                "Fix: remove 'basic' from plugins.disabled in config.yaml "
+                "(or: hermes plugins enable basic)"
+            )
+    except Exception:
+        pass
+
     _section("Directory Structure")
     hermes_home = HERMES_HOME
     if hermes_home.exists():

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13829,6 +13829,26 @@ def start_server(
             except Exception:
                 pass
 
+            # Detect when the basic (password) provider is explicitly
+            # disabled but dashboard.basic_auth is configured — a common
+            # misconfiguration after `hermes setup` blank-slate mode.
+            try:
+                from hermes_cli.config import load_config as _load_cfg
+                _cfg = _load_cfg() or {}
+                _disabled = set(
+                    (_cfg.get("plugins") or {}).get("disabled") or []
+                )
+                _basic_auth = (_cfg.get("dashboard") or {}).get("basic_auth") or {}
+                if "basic" in _disabled and _basic_auth.get("username"):
+                    skip_reasons.append(
+                        "  • basic: plugin is disabled in plugins.disabled "
+                        "but dashboard.basic_auth is configured.\n"
+                        "    Fix: remove 'basic' from plugins.disabled in "
+                        "config.yaml (or run: hermes plugins enable basic)"
+                    )
+            except Exception:
+                pass
+
             _fix_hint = (
                 "Configure an auth provider before exposing the dashboard:\n"
                 "  • Password: set dashboard.basic_auth.username + "


### PR DESCRIPTION
## Problem

When `basic` is in `plugins.disabled` but `dashboard.basic_auth` is configured, `hermes dashboard --host 0.0.0.0` fails with a generic "no auth providers registered" error. The root cause is that `hermes setup` (blank-slate mode) can add `basic` to `plugins.disabled`, silently breaking the password auth provider.

Users see:
```
Refusing to bind dashboard to 0.0.0.0 — the auth gate engages on non-loopback binds, but no auth providers are registered.
```

No hint that `plugins.disabled` is the cause.

## Fix

Two targeted changes in 2 files:

1. **`hermes_cli/web_server.py`**: When no auth providers are found on a non-loopback bind, check if `basic` is in `plugins.disabled` while `dashboard.basic_auth.username` is configured. If so, surface a specific diagnostic with actionable remediation:
   ```
   • basic: plugin is disabled in plugins.disabled but dashboard.basic_auth is configured.
     Fix: remove 'basic' from plugins.disabled in config.yaml (or run: hermes plugins enable basic)
   ```

2. **`hermes_cli/doctor.py`**: Add a check in the "Auth Providers" section that warns about this misconfiguration so users can detect it proactively via `hermes doctor`.

Fixes #54489