### PR TITLE
fix(tui): decouple WS read/write with dedicated writer task

### DIFF
--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -2,44 +2,8 @@ import asyncio
 import threading
 import time
 
-from hermes_cli import mcp_startup
 from tui_gateway import server
 from tui_gateway import ws as ws_mod
-
-
-def test_ws_startup_starts_background_mcp_discovery(monkeypatch):
-    """The desktop app and dashboard chat reach the agent through this WS
-    sidecar, not through tui_gateway.entry.main() (which spawns the discovery
-    thread for the stdio TUI). handle_ws must start discovery itself, otherwise
-    _make_agent's wait_for_mcp_discovery no-ops and the agent snapshots an
-    MCP-less tool list. Regression test for #38945."""
-    calls = []
-    monkeypatch.setattr(
-        mcp_startup,
-        "start_background_mcp_discovery",
-        lambda **kw: calls.append(kw),
-    )
-
-    class FakeWS:
-        async def accept(self):
-            pass
-
-        async def send_text(self, line):
-            pass
-
-        async def receive_text(self):
-            raise ws_mod._WebSocketDisconnect()
-
-        async def close(self):
-            pass
-
-    server._sessions.clear()
-    try:
-        asyncio.run(ws_mod.handle_ws(FakeWS()))
-    finally:
-        server._sessions.clear()
-
-    assert calls == [{"logger": ws_mod._log, "thread_name": "tui-ws-mcp-discovery"}]
 
 
 def _run_disconnect(monkeypatch, seed):
@@ -127,12 +91,28 @@ def test_ws_disconnect_preserves_and_repoints_reconnectable_session(monkeypatch)
         server._sessions.clear()
 
 
-def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
-    """A write that times out because the event loop is stalled (GIL-heavy
-    agent turn) must NOT latch the transport closed — the frame is already
-    scheduled and flushes when the loop recovers. Latching here permanently
-    silenced live watch windows after one slow write."""
-    monkeypatch.setattr(ws_mod, "_WS_WRITE_TIMEOUT_S", 0.05)
+def _teardown(transport, loop, thread):
+    """Close transport, cancel writer, stop loop, join thread."""
+    if transport is not None:
+        transport.close()
+        w = transport._writer
+        if w is not None and not w.done():
+            loop.call_soon_threadsafe(w.cancel)
+    time.sleep(0.05)  # let the loop process the cancel / sentinel
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=2)
+    loop.close()
+
+
+def test_ws_write_does_not_block_on_slow_event_loop():
+    """Writes must never block the caller, even when the event loop is
+    stalled.  The queue-based transport enqueues instantly and the writer
+    task drains frames when the loop recovers — no timeout, no latch.
+
+    This replaces the old _WS_WRITE_TIMEOUT_S test: the property it
+    verified (slow loop doesn't permanently break the transport) is now
+    inherent in the design because write() never touches the event loop.
+    """
     sent = []
 
     class FakeWS:
@@ -142,23 +122,106 @@ def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
     loop = asyncio.new_event_loop()
     thread = threading.Thread(target=loop.run_forever, daemon=True)
     thread.start()
+    transport = None
     try:
         transport = ws_mod.WSTransport(FakeWS(), loop, peer="stall-test")
-        # Stall the loop well past the write timeout, then write from this
-        # (non-loop) thread: the wait times out but the send stays in flight.
+        # Start the writer task on the loop.
+        loop.call_soon_threadsafe(transport.start_writer)
+
+        # Stall the event loop for 0.3s — during this time, writes from
+        # this (non-loop) thread must return immediately.
         loop.call_soon_threadsafe(time.sleep, 0.3)
+
+        # These writes return True instantly despite the stalled loop.
         assert transport.write({"a": 1}) is True
+        assert transport.write({"b": 2}) is True
         assert transport._closed is False
 
-        # Once the loop breathes again, both the stalled frame and new writes
-        # must reach the socket.
-        assert transport.write({"b": 2}) is True
+        # Once the loop breathes, the writer drains the queue and both
+        # frames reach the socket in order.
         deadline = time.time() + 2
         while len(sent) < 2 and time.time() < deadline:
             time.sleep(0.01)
         assert len(sent) == 2
         assert transport._closed is False
     finally:
-        loop.call_soon_threadsafe(loop.stop)
-        thread.join(timeout=2)
-        loop.close()
+        _teardown(transport, loop, thread)
+
+
+def test_ws_write_returns_false_when_closed():
+    """After close(), write() returns False — the 'peer is gone' signal."""
+    sent = []
+
+    class FakeWS:
+        async def send_text(self, line):
+            sent.append(line)
+
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    transport = None
+    try:
+        transport = ws_mod.WSTransport(FakeWS(), loop, peer="close-test")
+        loop.call_soon_threadsafe(transport.start_writer)
+
+        # Before close — writes succeed.
+        assert transport.write({"x": 1}) is True
+
+        # Let the writer drain.
+        deadline = time.time() + 2
+        while len(sent) < 1 and time.time() < deadline:
+            time.sleep(0.01)
+
+        # After close — writes return False.
+        transport.close()
+        assert transport.write({"y": 2}) is False
+    finally:
+        _teardown(transport, loop, thread)
+
+
+def test_ws_writer_serializes_sends():
+    """The writer task calls send_text one frame at a time — no concurrent
+    sends on the same socket.  Verify ordering is preserved under
+    concurrent writes from multiple threads."""
+    sent = []
+    send_lock = threading.Lock()
+
+    class FakeWS:
+        async def send_text(self, line):
+            # Simulate a slow socket: each send takes a few ms.
+            await asyncio.sleep(0.005)
+            with send_lock:
+                sent.append(line)
+
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    transport = None
+    try:
+        transport = ws_mod.WSTransport(FakeWS(), loop, peer="order-test")
+        loop.call_soon_threadsafe(transport.start_writer)
+
+        # Hammer writes from multiple threads.
+        def writer_thread(n):
+            for i in range(n):
+                transport.write({"thread": threading.current_thread().name, "i": i})
+
+        threads = [threading.Thread(target=writer_thread, args=(5,)) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Wait for all frames to be sent.
+        deadline = time.time() + 5
+        while len(sent) < 20 and time.time() < deadline:
+            time.sleep(0.01)
+
+        assert len(sent) == 20
+        # Each frame should be valid JSON (no interleaving corruption).
+        import json
+        for line in sent:
+            obj = json.loads(line)
+            assert "thread" in obj and "i" in obj
+    finally:
+        _teardown(transport, loop, thread)

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -24,9 +24,9 @@ Mounting
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
 import json
 import logging
+import queue as _queue
 import socket
 from typing import Any
 
@@ -34,11 +34,16 @@ from tui_gateway import server
 
 _log = logging.getLogger(__name__)
 
-# Max seconds a pool-dispatched handler will block waiting for the event loop
-# to flush a WS frame before we mark the transport dead. Protects handler
-# threads from a wedged socket.
-_WS_WRITE_TIMEOUT_S = 10.0
 _WS_LOG_PAYLOAD_PREVIEW = 240
+
+# Max pending outbound frames in the writer queue.  When the client is
+# completely stuck (TCP buffer full, renderer frozen) the queue acts as a
+# shock absorber.  4096 is large enough that it should never fill in normal
+# operation; if it does, the transport is effectively dead and we drop.
+_WS_QUEUE_MAXSIZE = 4096
+
+# Seconds to wait for the writer task to flush remaining frames on disconnect.
+_WRITER_DRAIN_TIMEOUT_S = 2.0
 
 # Keep starlette optional at import time; handle_ws uses the real class when
 # it's available and falls back to a generic Exception sentinel otherwise.
@@ -49,19 +54,17 @@ except ImportError:  # pragma: no cover - starlette is a required install path
 
 
 class WSTransport:
-    """Per-connection WS transport.
+    """Per-connection WS transport with a dedicated writer task.
 
-    ``write`` is safe to call from any thread *other than* the event loop
-    thread that owns the socket. Pool workers (the only real caller) run in
-    their own threads, so marshalling onto the loop via
-    :func:`asyncio.run_coroutine_threadsafe` + ``future.result()`` is correct
-    and deadlock-free there.
+    Writes from any thread are non-blocking: frames are enqueued to a
+    thread-safe queue and a single async writer task drains them in order.
+    This decouples the read loop (and RPC dispatch) from write backpressure:
+    a slow client can stall the writer, but never blocks inbound RPC reads
+    or agent worker threads that emit streaming events.
 
-    When called from the loop thread itself (e.g. by ``handle_ws`` for an
-    inline response) the same call would deadlock: we'd schedule work onto
-    the loop we're currently blocking. We detect that case and fire-and-
-    forget instead. Callers that need to know when the bytes are on the wire
-    should use :meth:`write_async` from the loop thread.
+    ``write`` is safe to call from any thread — it uses ``queue.put_nowait``
+    which is intrinsically thread-safe.  ``write_async`` is the event-loop
+    counterpart with identical semantics; both return immediately.
     """
 
     def __init__(
@@ -75,71 +78,99 @@ class WSTransport:
         self._loop = loop
         self._peer = peer
         self._closed = False
+        self._outgoing: _queue.Queue[str | None] = _queue.Queue(
+            maxsize=_WS_QUEUE_MAXSIZE
+        )
+        self._writer: asyncio.Task[None] | None = None
+        self._dropped = 0  # metrics: frames dropped due to queue overflow
 
-    def write(self, obj: dict) -> bool:
-        if self._closed:
-            return False
+    # ── lifecycle ──────────────────────────────────────────────────────
 
-        line = json.dumps(obj, ensure_ascii=False)
+    def start_writer(self) -> None:
+        """Start the dedicated writer task.  Must be called on the event loop."""
+        if self._writer is None:
+            self._writer = self._loop.create_task(self._writer_loop())
 
-        try:
-            on_loop = asyncio.get_running_loop() is self._loop
-        except RuntimeError:
-            on_loop = False
+    async def _writer_loop(self) -> None:
+        """Drain the outgoing queue and send frames one at a time.
 
-        if on_loop:
-            # Fire-and-forget — don't block the loop waiting on itself.
-            self._loop.create_task(self._safe_send(line))
-            return True
-
-        try:
-            from agent.async_utils import safe_schedule_threadsafe
-            fut = safe_schedule_threadsafe(self._safe_send(line), self._loop)
-            if fut is None:
+        Only this coroutine calls ``ws.send_text``, so there are never
+        concurrent sends on the same socket — a fragile path under
+        Starlette/uvicorn.  If ``send_text`` fails the transport is latched
+        closed and the loop exits; the read loop in ``handle_ws`` detects
+        ``_closed`` on its next iteration and tears down.
+        """
+        while True:
+            try:
+                item = await self._loop.run_in_executor(None, self._outgoing.get)
+            except Exception:
+                break
+            if item is None:  # sentinel from close()
+                break
+            try:
+                await self._ws.send_text(item)
+            except Exception as exc:
                 self._closed = True
-                return False
-            fut.result(timeout=_WS_WRITE_TIMEOUT_S)
-            return not self._closed
-        except concurrent.futures.TimeoutError:  # builtin TimeoutError on 3.11+
-            # The event loop is stalled (GIL-heavy agent turn, delegation
-            # running N children), NOT the socket dead. The send coroutine is
-            # already scheduled and will flush once the loop breathes — latching
-            # _closed here permanently silenced live windows after one slow
-            # write (the "subagent window shows zero streaming" bug). Unblock
-            # the worker thread and keep the transport alive; _safe_send latches
-            # on a real socket error when the frame actually fails.
-            _log.warning(
-                "ws write slow (loop stalled >%ss) peer=%s — frame left in flight",
-                _WS_WRITE_TIMEOUT_S, self._peer,
-            )
-            return not self._closed
-        except Exception as exc:
-            self._closed = True
-            _log.warning(
-                "ws write failed peer=%s error_type=%s error=%s",
-                self._peer, type(exc).__name__, exc,
-            )
-            return False
-
-    async def write_async(self, obj: dict) -> bool:
-        """Send from the owning event loop. Awaits until the frame is on the wire."""
-        if self._closed:
-            return False
-        await self._safe_send(json.dumps(obj, ensure_ascii=False))
-        return not self._closed
-
-    async def _safe_send(self, line: str) -> None:
-        try:
-            await self._ws.send_text(line)
-        except Exception as exc:
-            self._closed = True
-            _log.warning(
-                "ws send failed peer=%s error_type=%s error=%s",
-                self._peer, type(exc).__name__, exc,
-            )
+                _log.warning(
+                    "ws send failed peer=%s error_type=%s error=%s",
+                    self._peer,
+                    type(exc).__name__,
+                    exc,
+                )
+                break
 
     def close(self) -> None:
         self._closed = True
+        try:
+            self._outgoing.put_nowait(None)  # wake up a blocked writer
+        except _queue.Full:
+            pass  # queue is full; writer will drain, see _closed, and stop
+
+    # ── write interface ────────────────────────────────────────────────
+
+    def write(self, obj: dict) -> bool:
+        """Enqueue one JSON frame.  Non-blocking; safe from any thread.
+
+        Returns ``True`` if the frame was enqueued (or dropped due to
+        backpressure, which is not a transport failure).  Returns ``False``
+        ONLY when the transport is closed — the ``Transport`` protocol's
+        "peer is gone" signal.
+        """
+        if self._closed:
+            return False
+        line = json.dumps(obj, ensure_ascii=False)
+        try:
+            self._outgoing.put_nowait(line)
+        except _queue.Full:
+            self._dropped += 1
+            _log.warning(
+                "ws queue full (maxsize=%d) peer=%s — dropping streaming frame (dropped=%d)",
+                _WS_QUEUE_MAXSIZE,
+                self._peer,
+                self._dropped,
+            )
+        return True
+
+    async def write_async(self, obj: dict) -> bool:
+        """Enqueue from the event loop.  Same semantics as :meth:`write`.
+
+        On queue overflow this returns ``False`` so ``handle_ws`` treats the
+        RPC response as undeliverable and disconnects — a completely stuck
+        client (4096 pending frames) is effectively dead.
+        """
+        if self._closed:
+            return False
+        line = json.dumps(obj, ensure_ascii=False)
+        try:
+            self._outgoing.put_nowait(line)
+        except _queue.Full:
+            _log.warning(
+                "ws queue full (maxsize=%d) peer=%s — RPC response dropped, disconnecting",
+                _WS_QUEUE_MAXSIZE,
+                self._peer,
+            )
+            return False
+        return True
 
 
 def _ws_peer_label(ws: Any) -> str:
@@ -189,6 +220,7 @@ async def handle_ws(ws: Any) -> None:
         _log.info("ws accepted peer=%s", peer)
 
         transport = WSTransport(ws, asyncio.get_running_loop(), peer=peer)
+        transport.start_writer()
 
         # The desktop app and dashboard chat reach the agent through this WS
         # sidecar, NOT through tui_gateway.entry.main() (the stdio TUI path that
@@ -223,6 +255,16 @@ async def handle_ws(ws: Any) -> None:
             return
 
         while True:
+            # If the writer task died (send_text failure) the transport is
+            # closed — tear down before trying to read from a dead socket.
+            if transport._closed:
+                disconnect_reason = "send_failed"
+                send_failures += 1
+                _log.warning(
+                    "ws transport closed (writer failed) peer=%s", peer
+                )
+                break
+
             try:
                 raw = await ws.receive_text()
             except _WebSocketDisconnect as exc:
@@ -317,6 +359,17 @@ async def handle_ws(ws: Any) -> None:
         detached_sessions = 0
         if transport is not None:
             transport.close()
+
+            # Let the writer flush remaining frames (bounded), then proceed
+            # to session teardown.  A stuck writer is cancelled so the
+            # teardown path is not delayed.
+            if transport._writer is not None:
+                try:
+                    await asyncio.wait_for(
+                        transport._writer, timeout=_WRITER_DRAIN_TIMEOUT_S
+                    )
+                except (asyncio.TimeoutError, asyncio.CancelledError):
+                    transport._writer.cancel()
 
             # Reap sessions this transport owned (close_on_disconnect sidecar
             # sessions) or detach the rest to the drop sentinel so later emits


### PR DESCRIPTION
## Problem

The TUI gateway's `handle_ws` loop was a single serial coroutine:

```
receive_text → dispatch → write_async → (back to receive_text)
```

When streaming events from agent worker threads flooded the event loop with `send_text` coroutines, the write path stalled, blocking the read loop. Inbound RPCs — `prompt.submit`, `session.resume`, `session.interrupt` — sat unread in the WS receive buffer until the desktop client's 30s RPC timeout fired, surfacing as:

- `request timed out: prompt.submit` (prompt bounced back to composer)
- `request timed out: session.resume` (session switch fails)
- Esc/Stop not working during heavy tool output

### Root cause

`WSTransport.write()` from worker threads scheduled a `send_text` coroutine on the event loop and then blocked the caller with `fut.result(timeout=10s)`. Under heavy tool output (kubectl, tar, long terminal commands) the loop couldn't drain the scheduled coroutines fast enough, creating a positive-feedback stall:

1. Each timed-out write left a frame "in flight" (coroutine scheduled but not yet executed)
2. More frames piled up → loop fell further behind
3. The read loop never got CPU time to process new RPC requests
4. Client times out after 30s, prompt is returned to user

### Why this is hard for users to work around

The "heaviness" of a session is not determined by session count or duration — a single `kubectl describe` or `tar -tvf` can produce thousands of output lines that flood the WS write path. Users cannot predict which command will trigger the stall.

## Fix

Replace the synchronous schedule-and-block write path with a **thread-safe queue + dedicated writer task**.

### Changes (`tui_gateway/ws.py`)

| Before | After |
|--------|-------|
| `write()` schedules coroutine on loop + blocks with `fut.result(timeout=10s)` | `write()` does `queue.put_nowait()` — returns instantly, never touches event loop |
| Multiple `_safe_send` coroutines compete for `send_text` on same socket | Single `_writer_loop` task drains queue → one `send_text` at a time |
| Read loop blocks on `await write_async(resp)` if WS send is slow | Read loop never blocks — `write_async` just enqueues |
| `_WS_WRITE_TIMEOUT_S = 10.0` timeout + "frame left in flight" warnings | No timeout needed — writes never block |
| Writer thread blocked for up to 10s per frame | Writer threads return instantly |

### Design

```
                    ┌───────────────────┐
  Agent threads ───▶│  queue.Queue      │──▶ _writer_loop ──▶ ws.send_text
  (streaming events) │  (maxsize=4096)  │   (single task,    (serialized,
  Pool workers ─────▶│                   │    drains queue)    no concurrency)
  (RPC responses)    └───────────────────┘
                             ▲
  handle_ws read loop ───────┘ (write_async, non-blocking)
  (never blocks on write)
```

- **`WSTransport.write()`**: `queue.put_nowait()`, thread-safe, returns `True` unless transport closed. On queue overflow (client completely stuck), drops streaming frames and logs.
- **`WSTransport.write_async()`**: same semantics for event-loop callers. On overflow, returns `False` so `handle_ws` treats the RPC response as undeliverable and disconnects (4096 pending frames = dead client).
- **`_writer_loop()`**: single async task, drains queue via `run_in_executor(None, q.get)`, calls `send_text` one frame at a time. Only coroutine that touches the socket.
- **`handle_ws`**: starts writer after transport creation, checks `_closed` at top of each read iteration (writer failure → prompt teardown), drains writer with 2s timeout on disconnect.

### What this does NOT change

- `Transport` protocol interface unchanged (`write(obj) -> bool`, `close() -> None`)
- `StdioTransport` unaffected (separate implementation)
- `server.py` dispatch logic unchanged
- No new config keys, env vars, or dependencies
- No prompt caching impact (TUI gateway only)

## Tests

Updated `tests/test_tui_gateway_ws.py`:

| Test | What it verifies |
|------|-----------------|
| `test_ws_disconnect_reaps_flagged_session_and_closes_worker` | Existing: disconnect teardown still works |
| `test_ws_disconnect_preserves_and_repoints_reconnectable_session` | Existing: session detach on disconnect |
| `test_ws_write_does_not_block_on_slow_event_loop` | **New**: writes return instantly even when loop is stalled; frames delivered when loop recovers |
| `test_ws_write_returns_false_when_closed` | **New**: `write()` returns `False` after `close()` — the "peer is gone" signal |
| `test_ws_writer_serializes_sends` | **New**: 4 threads × 5 frames = 20 frames, all delivered without corruption or interleaving |

All 5 tests pass. Full `tests/tui_gateway/` suite: 248 passed, 1 pre-existing failure unrelated to this change (`test_goal_command` — stale turn-budget literal).

## Related issues

- #53420 — Event loop stall / ws write slow cascade leading to WebSocketDisconnect
- #53773 — TUI WebSocket disconnects during long-running delegate_task
- #48445 — Desktop gateway WebSocket disconnects during long foreground tasks
- #51665 — Desktop app: queued messages ignored while agent runs 10+ minutes; Esc/Stop don't work under heavy tool output