### PR TITLE
fix(tui): skip redundant TUI dep reinstall on every launch

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1438,6 +1438,22 @@ def _termux_workspace_install_context(
     return ws_root, tuple(workspace_args)
 
 
+def _tui_install_stamp(ws_root: Path) -> Path:
+    """Sentinel under the hoisted ``node_modules`` recording the
+    ``package-lock.json`` digest of the last successful TUI dependency install."""
+    return ws_root / "node_modules" / ".hermes-tui-install"
+
+
+def _lock_digest(lock: Path) -> Optional[str]:
+    """Hex SHA-256 of the lockfile bytes, or ``None`` if it cannot be read."""
+    import hashlib
+
+    try:
+        return hashlib.sha256(lock.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
 def _tui_need_npm_install(root: Path) -> bool:
     """True when @hermes/ink is missing or node_modules is behind package-lock.json.
 
@@ -1451,6 +1467,12 @@ def _tui_need_npm_install(root: Path) -> bool:
     ``ui-tui/`` directory).  The lockfile / ink / marker checks use that
     workspace root; only the prebuilt-bundle sentinel stays relative to
     *root* (``ui-tui/dist/entry.js``).
+
+    Fast path: a digest sentinel (``node_modules/.hermes-tui-install``) written
+    after a successful install records the lockfile content that was installed.
+    When it still matches, the comparison below is skipped — without it, a SCOPED
+    ``--workspace ui-tui`` install (whose hidden lock omits the other workspaces'
+    packages, e.g. apps/desktop and web) would reinstall on every launch.
 
     Compares ``package-lock.json`` against ``node_modules/.package-lock.json``
     (npm's hidden lockfile) by **content**, not mtime: git checkouts and npm
@@ -1483,6 +1505,22 @@ def _tui_need_npm_install(root: Path) -> bool:
         return True
     if not lock.is_file():
         return False
+
+    # Fast path: a successful install records the lockfile's digest (see
+    # _make_tui_argv). If it still matches, nothing to do. This short-circuits
+    # the hidden-lock package-set comparison below, which yields false positives
+    # for SCOPED installs (``npm install --workspace ui-tui``): the hidden lock
+    # then legitimately omits the other workspaces' packages (apps/desktop,
+    # web, …), so the comparison would otherwise reinstall on every launch.
+    digest = _lock_digest(lock)
+    stamp = _tui_install_stamp(ws_root)
+    if digest is not None and stamp.is_file():
+        try:
+            if stamp.read_text(encoding="utf-8").strip() == digest:
+                return False
+        except OSError:
+            pass
+
     marker = ws_root / "node_modules" / ".package-lock.json"
     if not marker.is_file():
         return True
@@ -1819,6 +1857,18 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
                 print(preview)
             sys.exit(1)
         did_install = True
+        # Record the lockfile digest so the next launch's _tui_need_npm_install
+        # fast-path can skip the hidden-lock comparison (which is unsafe for the
+        # scoped --workspace install above). Best-effort; never fatal.
+        _ws_root = _workspace_root(tui_dir)
+        _digest = _lock_digest(_ws_root / "package-lock.json")
+        if _digest is not None:
+            try:
+                _stamp = _tui_install_stamp(_ws_root)
+                _stamp.parent.mkdir(parents=True, exist_ok=True)
+                _stamp.write_text(_digest, encoding="utf-8")
+            except OSError:
+                pass
 
     if tui_dev:
         # Keep the local @hermes/ink package exports in sync with source.

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -570,3 +570,89 @@ def test_make_tui_argv_omits_workspace_when_tui_has_own_lockfile(
     assert install_cmd[:2] == ["/bin/npm", "install"]
     # cwd must be tui_dir (standalone), not parent
     assert calls[0][1]["cwd"] == str(tui_dir)
+
+
+# ── digest-stamp fast path (scoped --workspace install) ──────────────
+
+
+def _write_lock(root: Path, packages: dict) -> Path:
+    import json as _json
+
+    lock = root / "package-lock.json"
+    lock.write_text(_json.dumps({"packages": packages}))
+    return lock
+
+
+def test_no_reinstall_for_scoped_install_when_stamp_matches(
+    tmp_path: Path, main_mod
+) -> None:
+    """Regression: a scoped ``npm install --workspace ui-tui`` produces a hidden
+    lock that legitimately omits the other workspaces (apps/desktop, web), so the
+    full root lock lists packages absent from the hidden lock — which used to
+    force a reinstall on EVERY launch. A digest stamp from the last install must
+    short-circuit that."""
+    _touch_ink(tmp_path)
+    lock = _write_lock(
+        tmp_path,
+        {
+            "node_modules/foo": {"version": "1.0.0"},
+            "apps/desktop": {"version": "1.0.0"},
+            "apps/desktop/node_modules/electron": {"version": "30.0.0"},
+        },
+    )
+    # Hidden lock from the scoped install: only the ui-tui-relevant package.
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        '{"packages":{"node_modules/foo":{"version":"1.0.0"}}}'
+    )
+    # Without a stamp this is a guaranteed (false-positive) reinstall...
+    assert main_mod._tui_need_npm_install(tmp_path) is True
+    # ...but once the last install's digest is recorded, it's a no-op.
+    main_mod._tui_install_stamp(tmp_path).write_text(main_mod._lock_digest(lock))
+    assert main_mod._tui_need_npm_install(tmp_path) is False
+
+
+def test_stale_stamp_falls_through_to_comparison(tmp_path: Path, main_mod) -> None:
+    """A stamp that doesn't match the current lockfile must NOT mask a genuinely
+    needed reinstall — the check falls through to the hidden-lock comparison."""
+    _touch_ink(tmp_path)
+    _write_lock(
+        tmp_path,
+        {
+            "node_modules/foo": {"version": "1.0.0"},
+            "node_modules/bar": {"version": "1.0.0"},
+        },
+    )
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        '{"packages":{"node_modules/foo":{"version":"1.0.0"}}}'
+    )
+    main_mod._tui_install_stamp(tmp_path).write_text("stale-digest")
+    # bar is required but missing from the hidden lock → still reinstall.
+    assert main_mod._tui_need_npm_install(tmp_path) is True
+
+
+def test_install_writes_digest_stamp(tmp_path: Path, main_mod, monkeypatch) -> None:
+    """After a successful TUI install, _make_tui_argv records the lockfile digest
+    so the next launch's fast path can skip the comparison."""
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (tui_dir / "dist").mkdir()
+    (tui_dir / "dist" / "entry.js").write_text("console.log('tui')")
+    lock = _write_lock(tmp_path, {"node_modules/foo": {"version": "1.0.0"}})
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    monkeypatch.setattr(
+        main_mod.subprocess,
+        "run",
+        lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    stamp = main_mod._tui_install_stamp(tmp_path)
+    assert stamp.is_file()
+    assert stamp.read_text().strip() == main_mod._lock_digest(lock)


### PR DESCRIPTION
The TUI launch installs deps scoped to the ui-tui workspace (npm install --workspace ui-tui, #38772) to keep apps/desktop (Electron + node-pty) out of the hot path. But _tui_need_npm_install compares the full monorepo package-lock.json against npm's hidden lock from the scoped install; the hidden lock legitimately omits the other workspaces' packages, so the comparison always finds them 'missing' and reinstalls on every launch (and every /invoke relaunch).

Fix: record the lockfile's SHA-256 in node_modules/.hermes-tui-install after a successful install and short-circuit the comparison when it still matches. Self-healing, content-based, still reinstalls on real lockfile changes; the hidden-lock comparison remains the fallback. Adds regression tests.
