### PR TITLE
fix(wecom): use hmac.compare_digest for webhook signature check

### DIFF
--- a/plugins/platforms/wecom/wecom_crypto.py
+++ b/plugins/platforms/wecom/wecom_crypto.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import hmac
 import os
 import secrets
 import socket
@@ -87,7 +88,7 @@ class WXBizMsgCrypt:
 
     def decrypt(self, msg_signature: str, timestamp: str, nonce: str, encrypt: str) -> bytes:
         expected = _sha1_signature(self.token, timestamp, nonce, encrypt)
-        if expected != msg_signature:
+        if not hmac.compare_digest(expected, msg_signature):
             raise SignatureError("signature mismatch")
         try:
             cipher_text = base64.b64decode(encrypt)

--- a/tests/gateway/test_wecom_callback.py
+++ b/tests/gateway/test_wecom_callback.py
@@ -53,6 +53,36 @@ class TestWecomCrypto:
         with pytest.raises(SignatureError):
             crypt.decrypt("bad-sig", "1", "n", root.findtext("Encrypt", default=""))
 
+    def test_signature_mismatch_rejected(self):
+        """decrypt() rejects a well-formed but wrong 40-char hex signature."""
+        from plugins.platforms.wecom.wecom_crypto import SignatureError
+        app = _app()
+        crypt = WXBizMsgCrypt(app["token"], app["encoding_aes_key"], app["corp_id"])
+        encrypted_xml = crypt.encrypt("<xml/>", nonce="abc", timestamp="9999")
+        root = ET.fromstring(encrypted_xml)
+        with pytest.raises(SignatureError):
+            crypt.decrypt(
+                "0" * 40,  # correct length but wrong value
+                root.findtext("TimeStamp", default=""),
+                root.findtext("Nonce", default=""),
+                root.findtext("Encrypt", default=""),
+            )
+
+    def test_signature_match_accepted(self):
+        """decrypt() succeeds when the correct constant-time signature is supplied."""
+        app = _app()
+        crypt = WXBizMsgCrypt(app["token"], app["encoding_aes_key"], app["corp_id"])
+        plaintext = "<xml><Content>timing-safe</Content></xml>"
+        encrypted_xml = crypt.encrypt(plaintext, nonce="xyz", timestamp="1234")
+        root = ET.fromstring(encrypted_xml)
+        result = crypt.decrypt(
+            root.findtext("MsgSignature", default=""),
+            root.findtext("TimeStamp", default=""),
+            root.findtext("Nonce", default=""),
+            root.findtext("Encrypt", default=""),
+        )
+        assert b"timing-safe" in result
+
 
 class TestWecomCallbackEventConstruction:
     def test_build_event_extracts_text_message(self):


### PR DESCRIPTION
## What does this PR do?

`WXBizMsgCrypt.decrypt()` in `plugins/platforms/wecom/wecom_crypto.py` compared
the computed SHA-1 webhook signature against the incoming value using Python's
`!=` operator. Because Python string comparison short-circuits on the first
differing byte, this exposes a timing side-channel: an attacker can measure
response latency across many crafted requests to recover the correct signature
byte-by-byte, then forge a valid WeCom callback without knowing the token.

This PR replaces the comparison with `hmac.compare_digest()`, which always
runs in constant time. The Feishu platform adapter already uses this pattern
(`hmac.compare_digest` in `adapter.py`); this aligns WeCom with the same
standard.

## Related Issue

<!-- No existing issue — discovered during code review. -->

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `plugins/platforms/wecom/wecom_crypto.py`: add `import hmac`; replace
  `if expected != msg_signature:` with
  `if not hmac.compare_digest(expected, msg_signature):`
- `tests/gateway/test_wecom_callback.py`: add constant-time comparison
  regression tests

## How to Test

1. Run the WeCom callback tests (skip the three pre-existing XML failures):
   ```
   uv run --extra dev pytest tests/gateway/test_wecom_callback.py -q      -k "not test_build_event and not test_poll_loop"
   ```
2. Confirm the new signature tests pass and no previously-passing tests regress.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux x86_64, Python 3.11

### Documentation & Housekeeping

- [x] No documentation changes needed — or N/A