### PR TITLE
fix(redact): include authorization and private_key in form-body redaction

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -34,26 +34,8 @@ _SENSITIVE_QUERY_PARAMS = frozenset({
     "code",           # OAuth authorization codes
     "signature",      # pre-signed URL signatures
     "x-amz-signature",
-})
-
-# Sensitive form-urlencoded / JSON body key names (case-insensitive exact match).
-# Exact match, NOT substring — "token_count" and "session_id" must NOT match.
-# Ported from nearai/ironclaw#2529.
-_SENSITIVE_BODY_KEYS = frozenset({
-    "access_token",
-    "refresh_token",
-    "id_token",
-    "token",
-    "api_key",
-    "apikey",
-    "client_secret",
-    "password",
-    "auth",
-    "jwt",
-    "secret",
-    "private_key",
-    "authorization",
-    "key",
+    "authorization",  # Bearer tokens in form bodies
+    "private_key",    # PEM private keys in form bodies
 })
 
 # Snapshot at import time so runtime env mutations (e.g. LLM-generated

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -595,6 +595,21 @@ class TestFormBodyRedaction:
         # Should pass through (still subject to other redactors)
         assert "first=1" in redact_sensitive_text(text)
 
+    def test_redact_form_body_authorization(self):
+        """authorization was in _SENSITIVE_BODY_KEYS (dead code) but not in
+        _SENSITIVE_QUERY_PARAMS — form-encoded Bearer tokens leaked in logs."""
+        text = "client_id=app&authorization=Bearer+sk-test-secret123&scope=read"
+        result = redact_sensitive_text(text)
+        assert "sk-test-secret123" not in result
+        assert "authorization" in result.lower()  # key preserved, value masked
+
+    def test_redact_form_body_private_key(self):
+        """private_key was in _SENSITIVE_BODY_KEYS (dead code) but not in
+        _SENSITIVE_QUERY_PARAMS — PEM keys in form bodies leaked in logs."""
+        text = "action=sign&private_key=-----BEGIN+RSA+PRIVATE+KEY-----&data=hello"
+        result = redact_sensitive_text(text)
+        assert "-----BEGIN+RSA+PRIVATE+KEY-----" not in result
+
 
 class TestLowercaseDottedConfigKeys:
     """Issue #16413 — config-file passwords in lowercase/dotted/colon keys


### PR DESCRIPTION
## What does this PR do?

`_SENSITIVE_BODY_KEYS` (defined in `agent/redact.py`) listed `authorization`
and `private_key` as form-body–specific sensitive keys, but the constant was
never referenced anywhere in the codebase. `_redact_form_body()` delegates
to `_redact_query_string()`, which uses `_SENSITIVE_QUERY_PARAMS` — a
separate set that did not include these two keys.

As a result, a form-urlencoded POST body containing
`authorization=Bearer sk-…` or `private_key=-----BEGIN RSA PRIVATE KEY-----`
passed through the redaction pipeline unchanged and could appear in plain
text in agent logs.

This PR merges the two missing keys into `_SENSITIVE_QUERY_PARAMS` and
removes the now-dead `_SENSITIVE_BODY_KEYS` constant.

## Related Issue

<!-- No existing issue — discovered during code review. -->

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `agent/redact.py`: add `"authorization"` and `"private_key"` to
  `_SENSITIVE_QUERY_PARAMS`; remove unreferenced `_SENSITIVE_BODY_KEYS`
  constant and its comment block
- `tests/agent/test_redact.py`: add `test_redact_form_body_authorization`
  and `test_redact_form_body_private_key` regression tests

## How to Test

1. Run the redact test suite:
   ```
   uv run --extra dev pytest tests/agent/test_redact.py -q
   ```
2. Confirm the two new tests pass and no existing tests regress.
3. Manual spot-check:
   ```python
   from agent.redact import redact_sensitive_text
   print(redact_sensitive_text("client_id=app&authorization=Bearer+sk-secret&scope=read"))
   # "authorization" key should be present; "sk-secret" must not appear
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/agent/test_redact.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux x86_64, Python 3.11

### Documentation & Housekeeping

- [x] No documentation changes needed — or N/A
- [x] No config key changes — or N/A