### PR TITLE
fix(wecom): bound inbound callback body size to prevent OOM

### DIFF
--- a/plugins/platforms/wecom/callback_adapter.py
+++ b/plugins/platforms/wecom/callback_adapter.py
@@ -56,6 +56,7 @@ DEFAULT_PORT = 8645
 DEFAULT_PATH = "/wecom/callback"
 ACCESS_TOKEN_TTL_SECONDS = 7200
 MESSAGE_DEDUP_TTL_SECONDS = 300
+_WECOM_CALLBACK_MAX_BODY_BYTES = 1 * 1024 * 1024  # 1 MiB — mirrors feishu/line adapters
 
 
 def check_wecom_callback_requirements() -> bool:
@@ -273,7 +274,13 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         msg_signature = request.query.get("msg_signature", "")
         timestamp = request.query.get("timestamp", "")
         nonce = request.query.get("nonce", "")
-        body = await request.text()
+        content_length = request.content_length
+        if content_length is not None and content_length > _WECOM_CALLBACK_MAX_BODY_BYTES:
+            return web.Response(status=413, text="Request body too large")
+        raw = await request.read()
+        if len(raw) > _WECOM_CALLBACK_MAX_BODY_BYTES:
+            return web.Response(status=413, text="Request body too large")
+        body = raw.decode("utf-8", errors="replace")
 
         for app in self._apps:
             try:

--- a/tests/gateway/test_wecom_callback.py
+++ b/tests/gateway/test_wecom_callback.py
@@ -277,6 +277,65 @@ class TestWecomCallbackSendTokenRefresh:
         assert len(post_calls) == 2
 
 
+class TestWecomCallbackBodyLimit:
+    @pytest.mark.asyncio
+    async def test_callback_rejects_oversized_body_via_content_length(self):
+        """POST with Content-Length exceeding 1 MiB returns 413 without reading the body."""
+        from plugins.platforms.wecom.callback_adapter import _WECOM_CALLBACK_MAX_BODY_BYTES
+
+        adapter = WecomCallbackAdapter(_config())
+        read_called = []
+
+        class FakeRequest:
+            query = {"msg_signature": "", "timestamp": "", "nonce": ""}
+            content_length = _WECOM_CALLBACK_MAX_BODY_BYTES + 1
+
+            async def read(self):
+                read_called.append(True)
+                return b""
+
+        response = await adapter._handle_callback(FakeRequest())
+        assert response.status == 413
+        assert not read_called, "body should not be read when Content-Length already exceeds limit"
+
+    @pytest.mark.asyncio
+    async def test_callback_rejects_oversized_body_via_actual_read(self):
+        """POST where Content-Length is absent but actual body exceeds 1 MiB returns 413."""
+        from plugins.platforms.wecom.callback_adapter import _WECOM_CALLBACK_MAX_BODY_BYTES
+
+        adapter = WecomCallbackAdapter(_config())
+
+        class FakeRequest:
+            query = {"msg_signature": "", "timestamp": "", "nonce": ""}
+            content_length = None  # chunked / no Content-Length header
+
+            async def read(self):
+                return b"x" * (_WECOM_CALLBACK_MAX_BODY_BYTES + 1)
+
+        response = await adapter._handle_callback(FakeRequest())
+        assert response.status == 413
+
+    @pytest.mark.asyncio
+    async def test_callback_accepts_body_at_exactly_limit(self):
+        """POST body exactly at the 1 MiB limit is accepted (no 413)."""
+        from plugins.platforms.wecom.callback_adapter import _WECOM_CALLBACK_MAX_BODY_BYTES
+
+        adapter = WecomCallbackAdapter(_config())
+
+        class FakeRequest:
+            query = {"msg_signature": "", "timestamp": "", "nonce": ""}
+            content_length = _WECOM_CALLBACK_MAX_BODY_BYTES
+
+            async def read(self):
+                # Return valid-size but unparseable body — adapter should
+                # fall through to its normal 400 decryption error, not 413.
+                return b"x" * _WECOM_CALLBACK_MAX_BODY_BYTES
+
+        response = await adapter._handle_callback(FakeRequest())
+        # 413 must NOT be returned; exact-limit bodies must pass the size gate
+        assert response.status != 413
+
+
 class TestWecomCallbackPollLoop:
     @pytest.mark.asyncio
     async def test_poll_loop_dispatches_handle_message(self, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

`WeCom.callback_adapter._handle_callback()` called `request.text()` without
any body-size guard. An attacker can POST an unbounded payload to the WeCom
callback endpoint, consuming all available memory in the gateway process.

This PR adds `_WECOM_CALLBACK_MAX_BODY_BYTES = 1 MiB`, checks
`Content-Length` before reading, and also checks the actual bytes read after
`request.read()`. Requests that exceed the limit receive HTTP 413. This
mirrors the pattern already used by the Feishu adapter
(`_FEISHU_WEBHOOK_MAX_BODY_BYTES`) and the Line adapter.

## Related Issue

<!-- No existing issue — discovered during code review. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `plugins/platforms/wecom/callback_adapter.py`: add
  `_WECOM_CALLBACK_MAX_BODY_BYTES = 1 * 1024 * 1024`; replace
  `request.text()` with a guarded `request.read()` + decode; return 413
  when Content-Length or actual body exceeds the limit
- `tests/gateway/test_wecom_callback.py`: add
  `test_callback_rejects_oversized_body_via_content_length`,
  `test_callback_rejects_oversized_body_via_actual_read`, and
  `test_callback_accepts_body_at_exactly_limit` regression tests

## How to Test

1. Run the WeCom callback tests:
   ```
   uv run --extra dev --extra messaging --extra wecom pytest tests/gateway/test_wecom_callback.py -q
   ```
2. Confirm all 15 tests pass (3 new ones cover the body-limit path).
3. To verify manually: send a POST to the WeCom callback endpoint with
   `Content-Length: 2097152` (2 MiB) and confirm a `413` response is
   returned immediately without reading the body.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux x86_64, Python 3.11

### Documentation & Housekeeping

- [x] No documentation changes needed — or N/A