### PR TITLE
fix(sms): bound Twilio webhook body reads to prevent OOM

### DIFF
--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -42,6 +42,7 @@ TWILIO_API_BASE = "https://api.twilio.com/2010-04-01/Accounts"
 MAX_SMS_LENGTH = 1600  # ~10 SMS segments
 DEFAULT_WEBHOOK_PORT = 8080
 DEFAULT_WEBHOOK_HOST = "127.0.0.1"
+_TWILIO_WEBHOOK_MAX_BODY_BYTES = 65_536  # 64 KiB — Twilio payloads are small
 
 
 def check_sms_requirements() -> bool:
@@ -293,7 +294,20 @@ class SmsAdapter(BasePlatformAdapter):
         from aiohttp import web
 
         try:
+            content_length = request.content_length
+            if content_length is not None and content_length > _TWILIO_WEBHOOK_MAX_BODY_BYTES:
+                return web.Response(
+                    text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
+                    content_type="application/xml",
+                    status=413,
+                )
             raw = await request.read()
+            if len(raw) > _TWILIO_WEBHOOK_MAX_BODY_BYTES:
+                return web.Response(
+                    text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
+                    content_type="application/xml",
+                    status=413,
+                )
             # Twilio sends form-encoded data, not JSON
             form = urllib.parse.parse_qs(raw.decode("utf-8"), keep_blank_values=True)
         except Exception as e:

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -459,10 +459,11 @@ class TestWebhookSignatureEnforcement:
         adapter._message_handler = AsyncMock()
         return adapter
 
-    def _mock_request(self, body, headers=None):
+    def _mock_request(self, body, headers=None, content_length=None):
         request = MagicMock()
         request.read = AsyncMock(return_value=body)
         request.headers = headers or {}
+        request.content_length = content_length
         return request
 
     @pytest.mark.asyncio
@@ -536,3 +537,27 @@ class TestWebhookSignatureEnforcement:
         request = self._mock_request(body, headers={"X-Twilio-Signature": sig})
         resp = await adapter._handle_webhook(request)
         assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_webhook_rejects_oversized_body_via_content_length(self):
+        """POST with Content-Length exceeding 64 KiB returns 413 before reading."""
+        adapter = self._make_adapter(webhook_url="")
+        body = b"From=%2B15551234567&To=%2B15550001111&Body=hello&MessageSid=SM123"
+        request = self._mock_request(body, content_length=65_537)
+        resp = await adapter._handle_webhook(request)
+        assert resp.status == 413
+        # request.read must NOT have been called — we bailed on Content-Length
+        request.read.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_webhook_rejects_oversized_body_via_read_length(self):
+        """POST whose actual read size exceeds 64 KiB returns 413.
+
+        Covers the case where Content-Length is absent (chunked transfer) but
+        the body still exceeds the cap.
+        """
+        adapter = self._make_adapter(webhook_url="")
+        oversized = b"x" * 65_537
+        request = self._mock_request(oversized, content_length=None)
+        resp = await adapter._handle_webhook(request)
+        assert resp.status == 413


### PR DESCRIPTION
## What does this PR do?

The SMS/Twilio platform's `_handle_webhook()` called `request.read()` with
no size cap. Because the `/sms/webhook` endpoint is publicly reachable,
an attacker can POST an arbitrarily large body to exhaust gateway process
memory.

This PR adds `_TWILIO_WEBHOOK_MAX_BODY_BYTES = 64 KiB` (well above any
real Twilio payload size) and gates on both `Content-Length` and the
actual byte count after reading. Oversized requests get an HTTP 413 with
an empty TwiML `<Response>` body, consistent with how other error paths
in this adapter respond. Mirrors the guard already present in the Raft
adapter (`DEFAULT_MAX_BODY_BYTES`).

## Related Issue

<!-- No existing issue — discovered during code review. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `plugins/platforms/sms/adapter.py`: add `_TWILIO_WEBHOOK_MAX_BODY_BYTES
  = 65_536`; add Content-Length pre-check and post-read size check before
  parsing the form body; return HTTP 413 on oversized payloads
- `tests/gateway/test_sms.py`: add `test_webhook_rejects_oversized_body_via_content_length`
  and `test_webhook_rejects_oversized_body_via_read_length` regression tests

## How to Test

1. Run the SMS platform tests:
   ```
   uv run --extra sms --extra dev pytest tests/gateway/test_sms.py -q
   ```
2. Confirm the new oversized-body tests pass and no existing tests regress.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/gateway/test_sms.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux x86_64, Python 3.11

### Documentation & Housekeeping

- [x] No documentation changes needed — or N/A