### PR TITLE
fix(config): handle export-prefixed entries in save_env_value and remove_env_value

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6811,7 +6811,13 @@ def save_env_value(key: str, value: str):
     # Find and update or append
     found = False
     for i, line in enumerate(lines):
-        if line.strip().startswith(f"{key}="):
+        stripped = line.strip()
+        # load_env() already strips a leading ``export `` prefix (#6659); mirror
+        # that here so ``export KEY=old`` is correctly matched and updated rather
+        # than leaving the stale export line and appending a duplicate entry.
+        if stripped.startswith("export "):
+            stripped = stripped[len("export "):]
+        if stripped.startswith(f"{key}="):
             lines[i] = f"{key}={serialized_value}\n"
             found = True
             break
@@ -6890,7 +6896,16 @@ def remove_env_value(key: str) -> bool:
         lines = f.readlines()
     lines = _sanitize_env_lines(lines)
 
-    new_lines = [line for line in lines if not line.strip().startswith(f"{key}=")]
+    def _matches_key(line: str) -> bool:
+        stripped = line.strip()
+        # Mirror load_env()'s export-prefix handling (#6659): a line like
+        # ``export KEY=value`` should be treated the same as ``KEY=value``
+        # when deciding whether to remove it.
+        if stripped.startswith("export "):
+            stripped = stripped[len("export "):]
+        return stripped.startswith(f"{key}=")
+
+    new_lines = [line for line in lines if not _matches_key(line)]
     found = len(new_lines) < len(lines)
 
     if found:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -406,6 +406,24 @@ class TestSaveEnvValueSecure:
             assert parsed["ANTHROPIC_TOKEN"] == token
             assert load_env()["ANTHROPIC_TOKEN"] == token
 
+    def test_save_env_value_updates_export_prefixed_line(self, tmp_path):
+        """Regression: save_env_value must update lines written as
+        ``export KEY=value`` (bash-compatible syntax) rather than appending a
+        second plain ``KEY=value`` entry.  load_env() already strips the
+        ``export `` prefix (#6659); the write path must mirror that behaviour.
+        """
+        env_path = tmp_path / ".env"
+        env_path.write_text("export API_KEY=old_value\n")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            save_env_value("API_KEY", "new_value")
+            content = env_path.read_text(encoding="utf-8")
+
+        assert "new_value" in content
+        assert "old_value" not in content
+        # Must update in-place, not append a second line.
+        assert content.count("API_KEY=") == 1
+
 
 class TestRemoveEnvValue:
     def test_removes_key_from_env_file(self, tmp_path):
@@ -470,6 +488,27 @@ class TestRemoveEnvValue:
         assert "DROP" not in env_path.read_text()
         env_mode = env_path.stat().st_mode & 0o777
         assert env_mode == 0o640, f"expected 0o640, got {oct(env_mode)}"
+
+    def test_remove_env_value_removes_export_prefixed_line(self, tmp_path):
+        """Regression: remove_env_value must delete lines written as
+        ``export KEY=value`` rather than silently leaving them in place.
+        load_env() already strips the ``export `` prefix (#6659); the remove
+        path must mirror that behaviour.
+        """
+        env_path = tmp_path / ".env"
+        env_path.write_text("export STALE_KEY=stale_value\nOTHER=keep\n")
+
+        with patch.dict(
+            os.environ,
+            {"HERMES_HOME": str(tmp_path), "STALE_KEY": "stale_value"},
+            clear=False,
+        ):
+            result = remove_env_value("STALE_KEY")
+
+        assert result is True
+        content = env_path.read_text(encoding="utf-8")
+        assert "STALE_KEY" not in content
+        assert "OTHER=keep" in content
 
 
 class TestSaveConfigAtomicity:


### PR DESCRIPTION
## What does this PR do?

`load_env()` already strips the bash-style `export ` prefix from `.env`
lines (introduced in #6659): a line like `export API_KEY=secret` is
correctly read as key `API_KEY`. However, `save_env_value()` and
`remove_env_value()` match existing lines with:

```python
if line.strip().startswith(f"{key}="):
```

This never matches `export API_KEY=old` because the line starts with
`export `, not `API_KEY=`. The result:

- **`save_env_value("API_KEY", "new")`** appends a new `API_KEY=new` line
  while the old `export API_KEY=old` line stays, so the file contains two
  entries for the same key.
- **`remove_env_value("API_KEY")`** finds nothing and leaves the
  `export`-prefixed line in place.

This PR strips the `export ` prefix from the line before the comparison
in both functions, so they correctly locate and update or delete
export-prefixed entries.

## Related Issue

Follows the fix for `load_env()` in #6659.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: in `save_env_value()` and `remove_env_value()`,
  strip `export ` prefix from the line before comparing with `startswith(key + "=")`
- `tests/hermes_cli/test_config.py`: add
  `test_save_env_value_updates_export_prefixed_line` and
  `test_remove_env_value_removes_export_prefixed_line` regression tests

## How to Test

1. Run the config tests:
   ```
   uv run --extra dev pytest tests/hermes_cli/test_config.py -q
   ```
2. Confirm the two new export-prefix tests pass and no existing tests regress.
3. Manual test: write `export MY_VAR=old` to `~/.hermes/.env`, then run
   `hermes config set my_var=new` and confirm the file now contains
   `MY_VAR=new` (no duplicate line, no leftover `export MY_VAR=old`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/hermes_cli/test_config.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux x86_64, Python 3.11

### Documentation & Housekeeping

- [x] No documentation changes needed — or N/A