### PR TITLE
feat(agent): configurable attribution string for agent identity (closes #54548)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1761,6 +1761,15 @@ def init_agent(
     # targets.
     agent._task_completion_guidance = bool(_agent_section.get("task_completion_guidance", True))
 
+    # Attribution label for the agent identity.  Default "Nous Research".  When
+    # set to a different org name it rebrands the "created by ..." / "(by ...)"
+    # clauses; an empty string omits attribution entirely.  Used by the system
+    # prompt builder for the default-identity fallback and the Hermes self-help
+    # guidance block.
+    from agent.prompt_builder import DEFAULT_ATTRIBUTION as _DEFAULT_ATTRIBUTION
+    _attr = _agent_section.get("attribution", _DEFAULT_ATTRIBUTION)
+    agent._attribution = _attr if isinstance(_attr, str) else _DEFAULT_ATTRIBUTION
+
     # Universal parallel-tool-call guidance toggle.  Default True.  Separate
     # flag from task_completion_guidance because a user may want one but not
     # the other.  Steers the model to batch independent tool calls into a

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -141,26 +141,68 @@ def _strip_yaml_frontmatter(content: str) -> str:
 # Constants
 # =========================================================================
 
-DEFAULT_AGENT_IDENTITY = (
-    "You are Hermes Agent, an intelligent AI assistant created by Nous Research. "
-    "You are helpful, knowledgeable, and direct. You assist users with a wide "
-    "range of tasks including answering questions, writing and editing code, "
-    "analyzing information, creative work, and executing actions via your tools. "
-    "You communicate clearly, admit uncertainty when appropriate, and prioritize "
-    "being genuinely useful over being verbose unless otherwise directed below. "
-    "Be targeted and efficient in your exploration and investigations."
-)
+# Default attribution organization.  Surfaced via ``agent.attribution`` in
+# config.yaml so downstream operators can rebrand the agent identity or drop
+# attribution entirely (see ``build_agent_identity`` / ``build_help_guidance``).
+DEFAULT_ATTRIBUTION = "Nous Research"
 
-HERMES_AGENT_HELP_GUIDANCE = (
-    "You run on Hermes Agent (by Nous Research). When the user needs help with "
-    "Hermes itself — configuring, setting up, using, extending, or troubleshooting "
-    "it — or when you need to understand your own features, tools, or capabilities, "
-    "the documentation at https://hermes-agent.nousresearch.com/docs is your "
-    "authoritative reference and always holds the latest, most up-to-date "
-    "information. Load the `hermes-agent` skill with skill_view(name='hermes-agent') "
-    "for additional guidance and proven workflows, but treat the docs as the source "
-    "of truth when the two differ."
-)
+
+def build_agent_identity(attribution: str = DEFAULT_ATTRIBUTION) -> str:
+    """Build the fallback agent identity string.
+
+    *attribution* names the creating organization.  When it is empty (or
+    falsy after stripping) the "created by ..." clause is omitted entirely so
+    the identity reads as a clean, unattributed description.
+    """
+    attribution = (attribution or "").strip()
+    if attribution:
+        opening = (
+            f"You are Hermes Agent, an intelligent AI assistant created by {attribution}. "
+        )
+    else:
+        opening = "You are Hermes Agent, an intelligent AI assistant. "
+    return (
+        opening
+        + "You are helpful, knowledgeable, and direct. You assist users with a wide "
+        "range of tasks including answering questions, writing and editing code, "
+        "analyzing information, creative work, and executing actions via your tools. "
+        "You communicate clearly, admit uncertainty when appropriate, and prioritize "
+        "being genuinely useful over being verbose unless otherwise directed below. "
+        "Be targeted and efficient in your exploration and investigations."
+    )
+
+
+def build_help_guidance(attribution: str = DEFAULT_ATTRIBUTION) -> str:
+    """Build the Hermes self-help guidance block.
+
+    When *attribution* is empty the leading "You run on Hermes Agent (by ...)"
+    sentence is dropped; the docs/skill pointer (the functional part of the
+    block) is preserved so users still get help-routing guidance.
+    """
+    attribution = (attribution or "").strip()
+    if attribution:
+        lead = f"You run on Hermes Agent (by {attribution}). When the user needs help with "
+    else:
+        lead = "You run on Hermes Agent. When the user needs help with "
+    return (
+        lead
+        + "Hermes itself — configuring, setting up, using, extending, or troubleshooting "
+        "it — or when you need to understand your own features, tools, or capabilities, "
+        "the documentation at https://hermes-agent.nousresearch.com/docs is your "
+        "authoritative reference and always holds the latest, most up-to-date "
+        "information. Load the `hermes-agent` skill with skill_view(name='hermes-agent') "
+        "for additional guidance and proven workflows, but treat the docs as the source "
+        "of truth when the two differ."
+    )
+
+
+# Backward-compatible module-level constants (default attribution).  Existing
+# importers (run_agent, codex transport, codex_responses_adapter) keep working
+# unchanged; the system prompt builder uses the factories above to honor the
+# configured attribution.
+DEFAULT_AGENT_IDENTITY = build_agent_identity()
+
+HERMES_AGENT_HELP_GUIDANCE = build_help_guidance()
 
 MEMORY_GUIDANCE = (
     "You have persistent memory across sessions. Save durable facts using the memory "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -32,8 +32,11 @@ from typing import Any, Dict, List, Optional
 
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY,
+    DEFAULT_ATTRIBUTION,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE,
+    build_agent_identity,
+    build_help_guidance,
     KANBAN_GUIDANCE,
     MEMORY_GUIDANCE,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
@@ -196,12 +199,24 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             stable_parts.append(_soul_content)
             _soul_loaded = True
 
-    if not _soul_loaded:
-        # Fallback to hardcoded identity
-        stable_parts.append(DEFAULT_AGENT_IDENTITY)
+    # Resolve the configured attribution once.  Default preserves historical
+    # behavior; empty string drops attribution from both blocks below.
+    _attribution = getattr(agent, "_attribution", DEFAULT_ATTRIBUTION)
 
-    # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
-    stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
+    if not _soul_loaded:
+        # Fallback to hardcoded identity (honoring configured attribution).
+        if _attribution == DEFAULT_ATTRIBUTION:
+            stable_parts.append(DEFAULT_AGENT_IDENTITY)
+        else:
+            stable_parts.append(build_agent_identity(_attribution))
+
+    # Pointer to the hermes-agent skill + docs for user questions about Hermes
+    # itself.  When attribution is empty the leading "by ..." sentence is
+    # dropped but the docs/skill pointer is preserved.
+    if _attribution == DEFAULT_ATTRIBUTION:
+        stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
+    else:
+        stable_parts.append(build_help_guidance(_attribution))
 
     # Universal task-completion / no-fabrication guidance.  Applied to ALL
     # models regardless of tool_use_enforcement gating — the failure modes

--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)

--- a/tests/agent/test_attribution.py
+++ b/tests/agent/test_attribution.py
@@ -1,0 +1,129 @@
+"""Tests for the configurable ``agent.attribution`` identity string.
+
+Covers the prompt_builder factories (build_agent_identity / build_help_guidance)
+and their wiring into the assembled system prompt via build_system_prompt_parts.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.prompt_builder import (
+    DEFAULT_AGENT_IDENTITY,
+    DEFAULT_ATTRIBUTION,
+    HERMES_AGENT_HELP_GUIDANCE,
+    build_agent_identity,
+    build_help_guidance,
+)
+from agent.system_prompt import build_system_prompt_parts
+
+
+# ---------------------------------------------------------------------------
+# Factory-level behavior
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAgentIdentity:
+    def test_default_matches_legacy_constant(self):
+        # Backward compatibility: default attribution reproduces the historical
+        # constant byte-for-byte.
+        assert build_agent_identity() == DEFAULT_AGENT_IDENTITY
+        assert "created by Nous Research" in DEFAULT_AGENT_IDENTITY
+
+    def test_custom_attribution_rebrands(self):
+        out = build_agent_identity("Acme Corp")
+        assert "created by Acme Corp." in out
+        assert "Nous Research" not in out
+
+    def test_empty_attribution_omits_clause(self):
+        out = build_agent_identity("")
+        assert "created by" not in out
+        # The rest of the identity is preserved.
+        assert "intelligent AI assistant." in out
+        assert "exploration and investigations." in out
+
+    def test_whitespace_only_treated_as_empty(self):
+        out = build_agent_identity("   ")
+        assert "created by" not in out
+
+    def test_none_treated_as_empty(self):
+        out = build_agent_identity(None)  # type: ignore[arg-type]
+        assert "created by" not in out
+
+
+class TestBuildHelpGuidance:
+    def test_default_matches_legacy_constant(self):
+        assert build_help_guidance() == HERMES_AGENT_HELP_GUIDANCE
+        assert "(by Nous Research)" in HERMES_AGENT_HELP_GUIDANCE
+
+    def test_custom_attribution_rebrands(self):
+        out = build_help_guidance("Acme Corp")
+        assert "(by Acme Corp)" in out
+        assert "Nous Research" not in out
+
+    def test_empty_attribution_drops_lead_but_keeps_pointer(self):
+        out = build_help_guidance("")
+        assert "(by" not in out
+        # Functional docs/skill pointer must survive so help routing still works.
+        assert "hermes-agent.nousresearch.com/docs" in out
+        assert "skill_view(name='hermes-agent')" in out
+
+
+# ---------------------------------------------------------------------------
+# Integration with the assembled system prompt
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(**overrides):
+    base = dict(
+        load_soul_identity=False,
+        skip_context_files=False,
+        valid_tool_names=[],
+        _task_completion_guidance=False,
+        _tool_use_enforcement=False,
+        _environment_probe=False,
+        _kanban_worker_guidance="",
+        _memory_store=None,
+        _memory_manager=None,
+        model="",
+        provider="",
+        platform="",
+        pass_session_id=False,
+        session_id="",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _stable_prompt(agent):
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_nous_subscription_prompt", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", return_value=""),
+    ):
+        return build_system_prompt_parts(agent)["stable"]
+
+
+class TestSystemPromptAttribution:
+    def test_default_when_attribute_absent(self):
+        # No _attribution attr at all -> getattr fallback to default.
+        stable = _stable_prompt(_make_agent())
+        assert "created by Nous Research" in stable
+        assert "(by Nous Research)" in stable
+
+    def test_explicit_default(self):
+        stable = _stable_prompt(_make_agent(_attribution=DEFAULT_ATTRIBUTION))
+        assert "created by Nous Research" in stable
+
+    def test_custom_org(self):
+        stable = _stable_prompt(_make_agent(_attribution="Acme Corp"))
+        assert "created by Acme Corp." in stable
+        assert "(by Acme Corp)" in stable
+        assert "Nous Research" not in stable
+
+    def test_empty_omits_attribution_keeps_help_pointer(self):
+        stable = _stable_prompt(_make_agent(_attribution=""))
+        assert "created by" not in stable
+        assert "(by" not in stable
+        # Docs pointer (functional payload) must still be present.
+        assert "hermes-agent.nousresearch.com/docs" in stable

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1187,6 +1187,75 @@ class TestEnvironmentProbeIntegration:
         assert "Python toolchain:" not in prompt
 
 
+class TestAttributionConfigIntegration:
+    """End-to-end coverage for ``agent.attribution``: config.yaml value ->
+    ``hermes_cli.config.load_config()`` -> ``init_agent`` -> ``AIAgent._attribution``
+    -> generated system prompt.
+
+    The factory/prompt-assembly units live in tests/agent/test_attribution.py;
+    those construct ``_attribution`` directly and therefore do NOT verify the
+    config-loading wiring.  This class patches ``load_config`` (the real path
+    ``init_agent`` reads) so a wrong key or dropped config value is caught.
+    """
+
+    def _make_agent(self, attribution=None):
+        agent_section = {}
+        if attribution is not None:
+            agent_section["attribution"] = attribution
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("terminal"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"agent": agent_section},
+            ),
+        ):
+            a = AIAgent(
+                model="anthropic/claude-opus-4.8",
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            a.client = MagicMock()
+            return a
+
+    def test_default_when_key_absent(self):
+        """No attribution key -> historical Nous Research identity."""
+        agent = self._make_agent(attribution=None)
+        prompt = agent._build_system_prompt()
+        assert "created by Nous Research" in prompt
+        assert "(by Nous Research)" in prompt
+
+    def test_custom_attribution_rebrands_prompt(self):
+        """Custom org from config actually reaches the generated prompt."""
+        agent = self._make_agent(attribution="Acme Corp")
+        prompt = agent._build_system_prompt()
+        assert "created by Acme Corp." in prompt
+        assert "(by Acme Corp)" in prompt
+        assert "Nous Research" not in prompt
+
+    def test_empty_attribution_drops_clause_keeps_help_pointer(self):
+        """Empty string omits attribution but preserves the docs/skill pointer."""
+        agent = self._make_agent(attribution="")
+        prompt = agent._build_system_prompt()
+        assert "created by" not in prompt
+        assert "(by" not in prompt
+        # Functional help-routing payload must survive an empty attribution.
+        assert "hermes-agent.nousresearch.com/docs" in prompt
+
+    def test_non_string_attribution_falls_back_to_default(self):
+        """A misconfigured non-string value must not crash or blank identity."""
+        agent = self._make_agent(attribution=123)
+        prompt = agent._build_system_prompt()
+        assert "created by Nous Research" in prompt
+
+
 class TestInvalidateSystemPrompt:
     def test_clears_cache(self, agent):
         agent._cached_system_prompt = "cached value"


### PR DESCRIPTION
## Summary

Adds a configurable `agent.attribution` string that controls the organization woven into Hermes's built-in agent identity. Closes #54548.

Today "Nous Research" is hardcoded in two always-relevant places in `agent/prompt_builder.py`:
- `DEFAULT_AGENT_IDENTITY` — the identity fallback used when SOUL.md is absent (subagents with `skip_context_files`, Feishu, etc.)
- `HERMES_AGENT_HELP_GUIDANCE` — **always injected** regardless of SOUL.md (`agent/system_prompt.py`)

There was no toggle to rebrand or remove it. This adds one, fully backward compatible.

## Behaviour

| `agent.attribution` | DEFAULT_AGENT_IDENTITY | HERMES_AGENT_HELP_GUIDANCE |
|---|---|---|
| `"Nous Research"` (default) | `...created by Nous Research.` | `...(by Nous Research).` |
| `"Acme Corp"` | `...created by Acme Corp.` | `...(by Acme Corp).` |
| `""` (empty) | attribution clause omitted | leading `(by ...)` sentence dropped; **docs/skill pointer preserved** |

Empty attribution intentionally keeps the functional part of the help block (the docs URL + `skill_view(name='hermes-agent')` pointer) so help-routing still works — only the branding sentence is dropped.

## Changes

- **`agent/prompt_builder.py`** — factor the two constants into `build_agent_identity(attribution)` / `build_help_guidance(attribution)`. Module-level `DEFAULT_AGENT_IDENTITY` / `HERMES_AGENT_HELP_GUIDANCE` are retained (default attribution) so existing importers (`run_agent`, codex transport, `codex_responses_adapter`) are unchanged.
- **`agent/agent_init.py`** — thread `agent._attribution` from the `agent:` config section (non-string values fall back to default).
- **`agent/system_prompt.py`** — use the factories for the identity fallback + help block. Fast-path the default to reuse the cached constants.
- **`hermes_cli/config.py`** — add `attribution: "Nous Research"` to agent defaults.
- **`cli-config.yaml.example`** — documented under `agent:`.

## Tests

`tests/agent/test_attribution.py` — 12 cases:
- Factory output for default (byte-for-byte equal to legacy constants), custom org, empty/whitespace/None.
- Assembled system prompt via `build_system_prompt_parts` for default / custom / empty attribution, including the empty-keeps-docs-pointer contract.

```
$ python3 -m pytest tests/agent/test_attribution.py -q
............                                                             [100%]
12 passed in 1.25s

$ python3 -m pytest tests/agent/test_system_prompt.py -q   # no regression
.....                                                                    [100%]
5 passed in 0.71s
```

## Notes
- Backward compatible: default value reproduces current strings exactly (asserted in tests).
- Scope is intentionally minimal: identity + help-guidance only. SOUL.md still overrides the main identity slot when present.
