### PR TITLE
Add Sendblue messaging platform plugin

### DIFF
--- a/plugins/platforms/sendblue/README.md
+++ b/plugins/platforms/sendblue/README.md
@@ -1,0 +1,95 @@
+# Sendblue platform plugin
+
+Sendblue connects Hermes Agent to iMessage, SMS, and RCS through Sendblue's
+hosted REST API and receive webhooks.
+
+This is a bundled platform plugin, not a core gateway adapter. It follows the
+same Hermes platform-plugin surface as other bundled channels:
+
+- `plugin.yaml` declares `kind: platform` and the `SENDBLUE_*` environment
+  variables surfaced by `hermes config` / `hermes gateway setup`.
+- `adapter.py` defines `SendblueAdapter(BasePlatformAdapter)`.
+- `register(ctx)` calls `ctx.register_platform(name="sendblue", ...)`.
+- The registered platform opts into allowlists, pairing, cron delivery,
+  standalone `send_message` delivery, gateway status, and platform hints through
+  the plugin registry instead of editing Hermes core files.
+
+## Architecture
+
+```text
+User phone
+  <-> Sendblue iMessage/SMS/RCS line
+  <-> Sendblue receive webhook + REST API
+  <-> SendblueAdapter
+  <-> Hermes gateway runner
+```
+
+Inbound messages arrive as Sendblue receive webhooks. Hermes validates the
+configured webhook secret, deduplicates by `message_handle`, normalizes the
+payload into a `MessageEvent`, and calls `BasePlatformAdapter.handle_message`.
+
+Outbound replies use:
+
+- `/api/send-message` for direct messages
+- `/api/send-group-message` for `group:<id>` targets
+
+Sendblue requires a `from_number` on every send. If multiple Sendblue lines are
+configured, the adapter keeps a sticky recipient -> `from_number` map so each
+conversation continues from the same visible line.
+
+## Configuration
+
+Required:
+
+```bash
+SENDBLUE_API_KEY_ID=...
+SENDBLUE_API_SECRET_KEY=...
+SENDBLUE_FROM_NUMBER=+15551234567
+SENDBLUE_WEBHOOK_SECRET=...
+```
+
+Recommended:
+
+```bash
+SENDBLUE_ALLOWED_USERS=+15559876543
+SENDBLUE_HOME_CHANNEL=+15559876543
+```
+
+Optional:
+
+```bash
+SENDBLUE_FROM_NUMBERS=+15551234567,+15557654321
+SENDBLUE_WEBHOOK_HOST=127.0.0.1
+SENDBLUE_WEBHOOK_PORT=8650
+SENDBLUE_WEBHOOK_PATH=/sendblue/webhook
+SENDBLUE_STATUS_CALLBACK=https://example.com/sendblue/status
+SENDBLUE_SEAT_ID=...
+SENDBLUE_STICKY_STATE_PATH=~/.hermes/sendblue_sticky_senders.json
+```
+
+Use `SENDBLUE_INSECURE_NO_SIGNATURE=true` only for local development. Public
+gateways should always configure a receive webhook secret.
+
+## CLI
+
+The plugin registers a small management surface:
+
+```bash
+hermes sendblue status
+hermes sendblue setup
+```
+
+`status` reports whether credentials, line selection, webhook binding, access
+control, home channel, and sticky state are configured without printing secrets
+or full phone numbers.
+
+`setup` delegates to the same prompts used by `hermes gateway setup`.
+
+## Notes
+
+- Phone numbers are PII-sensitive; the platform registers `pii_safe=True` so
+  session descriptions are redacted before LLM-visible context.
+- Attachment-only inbound webhooks are accepted and dispatched with
+  `(attachment)` placeholder text plus `media_urls` metadata.
+- Local generated files from cron/send-message are not uploaded automatically.
+  Use Sendblue `media_url` metadata when sending outbound media.

--- a/plugins/platforms/sendblue/__init__.py
+++ b/plugins/platforms/sendblue/__init__.py
@@ -1,0 +1,1 @@
+"""Sendblue platform plugin."""

--- a/plugins/platforms/sendblue/adapter.py
+++ b/plugins/platforms/sendblue/adapter.py
@@ -58,7 +58,11 @@ DEDUP_MAX_SIZE = 2_000
 
 _SECRET_HEADER_CANDIDATES = (
     "sb-signing-secret",
+    "secret",
+    "webhook-secret",
+    "x-sendblue-secret",
     "x-sendblue-webhook-secret",
+    "sendblue-secret",
     "sendblue-webhook-secret",
     "x-webhook-secret",
 )

--- a/plugins/platforms/sendblue/adapter.py
+++ b/plugins/platforms/sendblue/adapter.py
@@ -1,0 +1,788 @@
+"""Sendblue iMessage platform adapter for Hermes Agent.
+
+This bundled platform plugin follows the Hermes platform-plugin path:
+it registers a ``BasePlatformAdapter`` subclass, runs a Sendblue receive
+webhook server for inbound messages, and sends replies through Sendblue's
+REST API without touching Hermes core files.
+
+Sendblue requirements reflected here:
+
+* ``from_number`` is required for every send.
+* Recipients should keep seeing the same Sendblue number, so the adapter
+  keeps a sticky recipient -> from_number map.
+* Inbound webhooks must be acknowledged quickly with a 2xx response.
+* 429 responses are rate limits and should be surfaced as retryable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+try:
+    import aiohttp
+    from aiohttp import web
+
+    AIOHTTP_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised by requirement tests
+    aiohttp = None  # type: ignore[assignment]
+    web = None  # type: ignore[assignment]
+    AIOHTTP_AVAILABLE = False
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+from gateway.platforms.helpers import redact_phone
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_API_BASE_URL = "https://api.sendblue.com"
+DEFAULT_WEBHOOK_HOST = "127.0.0.1"
+DEFAULT_WEBHOOK_PORT = 8650
+DEFAULT_WEBHOOK_PATH = "/sendblue/webhook"
+MAX_MESSAGE_LENGTH = 18_996
+WEBHOOK_BODY_MAX_BYTES = 1_048_576
+DEDUP_WINDOW_SECONDS = 300
+DEDUP_MAX_SIZE = 2_000
+
+_SECRET_HEADER_CANDIDATES = (
+    "sb-signing-secret",
+    "x-sendblue-webhook-secret",
+    "sendblue-webhook-secret",
+    "x-webhook-secret",
+)
+
+
+def _truthy(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _split_csv(value: str) -> List[str]:
+    return [
+        part.strip() for part in value.replace("\n", ",").split(",") if part.strip()
+    ]
+
+
+def _normalize_webhook_path(path: str) -> str:
+    path = (path or DEFAULT_WEBHOOK_PATH).strip()
+    if not path:
+        return DEFAULT_WEBHOOK_PATH
+    return path if path.startswith("/") else f"/{path}"
+
+
+def _default_sticky_state_path() -> Path:
+    home = os.getenv("HERMES_HOME", "").strip()
+    base = Path(home).expanduser() if home else Path("~/.hermes").expanduser()
+    return base / "sendblue_sticky_senders.json"
+
+
+def _redact_target(value: str) -> str:
+    if value.startswith("group:"):
+        return f"group:{value[6:12]}..."
+    return redact_phone(value)
+
+
+def _chat_id_for_payload(payload: Dict[str, Any]) -> str:
+    group_id = str(payload.get("group_id") or "").strip()
+    if group_id:
+        return f"group:{group_id}"
+    return str(
+        payload.get("from_number")
+        or payload.get("number")
+        or payload.get("to_number")
+        or ""
+    ).strip()
+
+
+def _sender_for_payload(payload: Dict[str, Any]) -> str:
+    return str(payload.get("from_number") or payload.get("number") or "").strip()
+
+
+def _sendblue_number_for_payload(payload: Dict[str, Any]) -> str:
+    return str(
+        payload.get("sendblue_number")
+        or payload.get("to_number")
+        or payload.get("from_number")
+        or ""
+    ).strip()
+
+
+def _response_message_id(data: Dict[str, Any]) -> Optional[str]:
+    value = data.get("message_handle") or data.get("id") or data.get("message_id")
+    return str(value) if value else None
+
+
+def _retry_after(headers: Any) -> Optional[float]:
+    raw = None
+    try:
+        raw = headers.get("Retry-After")
+    except Exception:
+        raw = None
+    if not raw:
+        return None
+    try:
+        delay = float(str(raw).strip())
+    except ValueError:
+        return None
+    return delay if delay >= 0 else None
+
+
+def _api_headers(api_key_id: str, api_secret_key: str) -> Dict[str, str]:
+    return {
+        "Content-Type": "application/json",
+        "sb-api-key-id": api_key_id,
+        "sb-api-secret-key": api_secret_key,
+    }
+
+
+async def _post_sendblue(
+    session: "aiohttp.ClientSession",
+    *,
+    api_base_url: str,
+    api_key_id: str,
+    api_secret_key: str,
+    endpoint: str,
+    payload: Dict[str, Any],
+) -> Tuple[int, Dict[str, str], Dict[str, Any] | str]:
+    url = f"{api_base_url.rstrip('/')}{endpoint}"
+    async with session.post(
+        url,
+        json=payload,
+        headers=_api_headers(api_key_id, api_secret_key),
+    ) as resp:
+        text = await resp.text()
+        try:
+            body: Dict[str, Any] | str = json.loads(text) if text else {}
+        except json.JSONDecodeError:
+            body = text
+        return resp.status, dict(resp.headers), body
+
+
+def _send_result_from_response(
+    status: int,
+    headers: Dict[str, str],
+    body: Dict[str, Any] | str,
+) -> SendResult:
+    if 200 <= status < 300:
+        data = body if isinstance(body, dict) else {}
+        return SendResult(
+            success=True, message_id=_response_message_id(data), raw_response=body
+        )
+
+    detail = body
+    if isinstance(body, dict):
+        detail = (
+            body.get("error_message")
+            or body.get("message")
+            or body.get("error")
+            or body
+        )
+    retry_after = _retry_after(headers)
+    return SendResult(
+        success=False,
+        error=f"Sendblue HTTP {status}: {str(detail)[:300]}",
+        raw_response=body,
+        retryable=status == 429 or 500 <= status < 600,
+        retry_after=retry_after,
+        error_kind="rate_limited" if status == 429 else None,
+    )
+
+
+def _standalone_dict(result: SendResult, chat_id: str) -> Dict[str, Any]:
+    if result.success:
+        return {
+            "success": True,
+            "platform": "sendblue",
+            "chat_id": chat_id,
+            "message_id": result.message_id,
+        }
+    out: Dict[str, Any] = {"error": result.error or "Sendblue send failed"}
+    if result.retry_after is not None:
+        out["retry_after"] = result.retry_after
+    if result.error_kind:
+        out["error_kind"] = result.error_kind
+    return out
+
+
+def check_requirements() -> bool:
+    return bool(
+        AIOHTTP_AVAILABLE
+        and os.getenv("SENDBLUE_API_KEY_ID")
+        and os.getenv("SENDBLUE_API_SECRET_KEY")
+        and (os.getenv("SENDBLUE_FROM_NUMBER") or os.getenv("SENDBLUE_FROM_NUMBERS"))
+    )
+
+
+def validate_config(config) -> bool:
+    extra = getattr(config, "extra", {}) or {}
+    return bool(
+        (extra.get("api_key_id") or os.getenv("SENDBLUE_API_KEY_ID"))
+        and (extra.get("api_secret_key") or os.getenv("SENDBLUE_API_SECRET_KEY"))
+        and (
+            extra.get("from_number")
+            or extra.get("from_numbers")
+            or os.getenv("SENDBLUE_FROM_NUMBER")
+            or os.getenv("SENDBLUE_FROM_NUMBERS")
+        )
+    )
+
+
+def is_connected(config) -> bool:
+    return validate_config(config)
+
+
+class SendblueAdapter(BasePlatformAdapter):
+    """Sendblue REST + receive-webhook adapter."""
+
+    MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config=config, platform=Platform("sendblue"))
+
+        extra = config.extra or {}
+        self._api_key_id = str(
+            extra.get("api_key_id") or os.getenv("SENDBLUE_API_KEY_ID", "")
+        ).strip()
+        self._api_secret_key = str(
+            extra.get("api_secret_key") or os.getenv("SENDBLUE_API_SECRET_KEY", "")
+        ).strip()
+        self._api_base_url = (
+            str(
+                extra.get("api_base_url")
+                or os.getenv("SENDBLUE_API_BASE_URL", DEFAULT_API_BASE_URL)
+            )
+            .strip()
+            .rstrip("/")
+        )
+        self._webhook_secret = str(
+            extra.get("webhook_secret") or os.getenv("SENDBLUE_WEBHOOK_SECRET", "")
+        ).strip()
+        self._webhook_host = str(
+            extra.get("webhook_host")
+            or os.getenv("SENDBLUE_WEBHOOK_HOST", DEFAULT_WEBHOOK_HOST)
+        ).strip()
+        self._webhook_port = int(
+            extra.get("webhook_port")
+            or os.getenv("SENDBLUE_WEBHOOK_PORT", str(DEFAULT_WEBHOOK_PORT))
+        )
+        self._webhook_path = _normalize_webhook_path(
+            str(
+                extra.get("webhook_path")
+                or os.getenv("SENDBLUE_WEBHOOK_PATH", DEFAULT_WEBHOOK_PATH)
+            )
+        )
+        self._status_callback = str(
+            extra.get("status_callback") or os.getenv("SENDBLUE_STATUS_CALLBACK", "")
+        ).strip()
+        self._seat_id = str(
+            extra.get("seat_id") or os.getenv("SENDBLUE_SEAT_ID", "")
+        ).strip()
+        from_number = str(
+            extra.get("from_number") or os.getenv("SENDBLUE_FROM_NUMBER", "")
+        ).strip()
+        from_numbers = extra.get("from_numbers")
+        if isinstance(from_numbers, str):
+            self._from_numbers = _split_csv(from_numbers)
+        elif isinstance(from_numbers, list):
+            self._from_numbers = [
+                str(v).strip() for v in from_numbers if str(v).strip()
+            ]
+        else:
+            self._from_numbers = _split_csv(os.getenv("SENDBLUE_FROM_NUMBERS", ""))
+        if from_number and from_number not in self._from_numbers:
+            self._from_numbers.insert(0, from_number)
+        self._default_from_number = from_number or (
+            self._from_numbers[0] if self._from_numbers else ""
+        )
+
+        self._state_path = (
+            Path(
+                str(
+                    extra.get("sticky_state_path")
+                    or os.getenv("SENDBLUE_STICKY_STATE_PATH", "")
+                )
+            ).expanduser()
+            if (
+                extra.get("sticky_state_path")
+                or os.getenv("SENDBLUE_STICKY_STATE_PATH")
+            )
+            else _default_sticky_state_path()
+        )
+        self._sticky_senders: Dict[str, str] = self._load_sticky_senders()
+        self._seen_messages: Dict[str, float] = {}
+        self._http_session: Optional["aiohttp.ClientSession"] = None
+        self._runner: Optional["web.AppRunner"] = None
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        if not AIOHTTP_AVAILABLE:
+            logger.warning("[sendblue] aiohttp not installed")
+            return False
+        if not self._api_key_id or not self._api_secret_key:
+            msg = "[sendblue] SENDBLUE_API_KEY_ID and SENDBLUE_API_SECRET_KEY are required"
+            logger.error(msg)
+            self._set_fatal_error("sendblue_missing_credentials", msg, retryable=False)
+            return False
+        if not self._from_numbers:
+            msg = "[sendblue] SENDBLUE_FROM_NUMBER or SENDBLUE_FROM_NUMBERS is required"
+            logger.error(msg)
+            self._set_fatal_error("sendblue_missing_from_number", msg, retryable=False)
+            return False
+
+        insecure = _truthy(os.getenv("SENDBLUE_INSECURE_NO_SIGNATURE", ""))
+        if not self._webhook_secret and not insecure:
+            msg = (
+                "[sendblue] Refusing to start without SENDBLUE_WEBHOOK_SECRET. "
+                "Configure a Sendblue receive webhook secret, or set "
+                "SENDBLUE_INSECURE_NO_SIGNATURE=true for local development only."
+            )
+            logger.error(msg)
+            self._set_fatal_error(
+                "sendblue_missing_webhook_secret", msg, retryable=False
+            )
+            return False
+        if insecure:
+            logger.warning("[sendblue] webhook secret validation is disabled")
+
+        app = web.Application(client_max_size=WEBHOOK_BODY_MAX_BYTES)
+        app.router.add_post(self._webhook_path, self._handle_webhook)
+        app.router.add_get("/health", lambda _: web.Response(text="ok"))
+
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self._webhook_host, self._webhook_port)
+        await site.start()
+        self._http_session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=30),
+            trust_env=True,
+        )
+        self._mark_connected()
+        logger.info(
+            "[sendblue] webhook listening on %s:%d%s, from=%s",
+            self._webhook_host,
+            self._webhook_port,
+            self._webhook_path,
+            ",".join(redact_phone(n) for n in self._from_numbers),
+        )
+        return True
+
+    async def disconnect(self) -> None:
+        if self._http_session:
+            await self._http_session.close()
+            self._http_session = None
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+        self._running = False
+        logger.info("[sendblue] disconnected")
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        metadata = metadata or {}
+        if not self._http_session:
+            return SendResult(success=False, error="Sendblue adapter not connected")
+
+        last_result = SendResult(success=True)
+        for chunk in self.truncate_message(content):
+            payload, endpoint = self._build_send_payload(
+                chat_id, chunk, metadata=metadata
+            )
+            if not payload.get("from_number"):
+                return SendResult(
+                    success=False, error="Sendblue from_number not configured"
+                )
+            if "number" not in payload and "group_id" not in payload:
+                return SendResult(success=False, error="Sendblue target missing")
+
+            status, headers, body = await _post_sendblue(
+                self._http_session,
+                api_base_url=self._api_base_url,
+                api_key_id=self._api_key_id,
+                api_secret_key=self._api_secret_key,
+                endpoint=endpoint,
+                payload=payload,
+            )
+            last_result = _send_result_from_response(status, headers, body)
+            if not last_result.success:
+                logger.warning(
+                    "[sendblue] send failed to %s: %s",
+                    _redact_target(chat_id),
+                    last_result.error,
+                )
+                return last_result
+            self._remember_sender(chat_id, str(payload["from_number"]))
+        return last_result
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        """Sendblue typing indicators are not required for gateway replies."""
+        return None
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {
+            "name": chat_id,
+            "type": "group" if chat_id.startswith("group:") else "dm",
+            "chat_id": chat_id,
+        }
+
+    def _build_send_payload(
+        self,
+        chat_id: str,
+        content: str,
+        *,
+        metadata: Dict[str, Any],
+    ) -> Tuple[Dict[str, Any], str]:
+        from_number = str(
+            metadata.get("from_number") or self._select_from_number(chat_id)
+        ).strip()
+        payload: Dict[str, Any] = {
+            "content": content,
+            "from_number": from_number,
+        }
+        if self._status_callback:
+            payload["status_callback"] = self._status_callback
+        if self._seat_id:
+            payload["seat_id"] = self._seat_id
+        if metadata.get("media_url"):
+            payload["media_url"] = metadata["media_url"]
+        if metadata.get("send_style"):
+            payload["send_style"] = metadata["send_style"]
+
+        if chat_id.startswith("group:"):
+            payload["group_id"] = chat_id.split(":", 1)[1]
+            return payload, "/api/send-group-message"
+
+        payload["number"] = chat_id
+        return payload, "/api/send-message"
+
+    def _select_from_number(self, chat_id: str) -> str:
+        sticky = self._sticky_senders.get(chat_id)
+        if sticky:
+            return sticky
+        if not self._from_numbers:
+            return ""
+        if len(self._from_numbers) == 1:
+            return self._from_numbers[0]
+        digest = hashlib.sha256(chat_id.encode("utf-8")).hexdigest()
+        return self._from_numbers[int(digest, 16) % len(self._from_numbers)]
+
+    def _remember_sender(self, chat_id: str, from_number: str) -> None:
+        if not chat_id or not from_number:
+            return
+        if self._sticky_senders.get(chat_id) == from_number:
+            return
+        self._sticky_senders[chat_id] = from_number
+        self._save_sticky_senders()
+
+    def _load_sticky_senders(self) -> Dict[str, str]:
+        try:
+            if not self._state_path.is_file():
+                return {}
+            data = json.loads(self._state_path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                return {}
+            return {
+                str(k): str(v)
+                for k, v in data.items()
+                if isinstance(k, str) and isinstance(v, str) and k and v
+            }
+        except Exception as exc:
+            logger.warning("[sendblue] failed to read sticky sender state: %s", exc)
+            return {}
+
+    def _save_sticky_senders(self) -> None:
+        try:
+            self._state_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._state_path.with_suffix(self._state_path.suffix + ".tmp")
+            tmp.write_text(
+                json.dumps(self._sticky_senders, sort_keys=True, indent=2),
+                encoding="utf-8",
+            )
+            tmp.replace(self._state_path)
+        except Exception as exc:
+            logger.warning("[sendblue] failed to write sticky sender state: %s", exc)
+
+    def _is_duplicate(self, message_handle: str) -> bool:
+        now = time.time()
+        if len(self._seen_messages) > DEDUP_MAX_SIZE:
+            cutoff = now - DEDUP_WINDOW_SECONDS
+            self._seen_messages = {
+                k: v for k, v in self._seen_messages.items() if v > cutoff
+            }
+        if message_handle in self._seen_messages:
+            return True
+        self._seen_messages[message_handle] = now
+        return False
+
+    def _validate_webhook_secret(self, headers: Any) -> bool:
+        if not self._webhook_secret:
+            return _truthy(os.getenv("SENDBLUE_INSECURE_NO_SIGNATURE", ""))
+        for header in _SECRET_HEADER_CANDIDATES:
+            value = headers.get(header)
+            if value and hmac.compare_digest(str(value), self._webhook_secret):
+                return True
+        auth = str(headers.get("authorization") or headers.get("Authorization") or "")
+        if auth.lower().startswith("bearer "):
+            return hmac.compare_digest(auth[7:].strip(), self._webhook_secret)
+        return False
+
+    async def _handle_webhook(self, request) -> "web.Response":
+        try:
+            raw = await request.read()
+            if len(raw) > WEBHOOK_BODY_MAX_BYTES:
+                return web.json_response({"error": "payload too large"}, status=413)
+            payload = json.loads(raw.decode("utf-8") or "{}")
+            if not isinstance(payload, dict):
+                return web.json_response({"error": "invalid payload"}, status=400)
+        except Exception as exc:
+            logger.warning("[sendblue] webhook parse error: %s", exc)
+            return web.json_response({"error": "invalid json"}, status=400)
+
+        if not self._validate_webhook_secret(request.headers):
+            logger.warning("[sendblue] rejected webhook: missing or invalid secret")
+            return web.json_response({"error": "forbidden"}, status=403)
+
+        if bool(payload.get("is_outbound")):
+            return web.json_response({"status": "ok"})
+        if str(payload.get("status") or "").upper() not in {"", "RECEIVED"}:
+            return web.json_response({"status": "ok"})
+
+        text = str(payload.get("content") or "").strip()
+        sender = _sender_for_payload(payload)
+        chat_id = _chat_id_for_payload(payload)
+        message_handle = str(payload.get("message_handle") or "").strip()
+        if not text or not sender or not chat_id:
+            return web.json_response({"error": "missing message fields"}, status=400)
+        if message_handle and self._is_duplicate(message_handle):
+            return web.json_response({"status": "duplicate"})
+
+        sendblue_number = _sendblue_number_for_payload(payload)
+        if sendblue_number:
+            self._remember_sender(chat_id, sendblue_number)
+
+        is_group = chat_id.startswith("group:")
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=str(payload.get("group_display_name") or chat_id),
+            chat_type="group" if is_group else "dm",
+            user_id=sender,
+            user_name=sender,
+            chat_id_alt=str(payload.get("sendblue_number") or ""),
+            message_id=message_handle or None,
+        )
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=payload,
+            message_id=message_handle or None,
+            media_urls=[str(payload["media_url"])] if payload.get("media_url") else [],
+            media_types=[str(payload.get("message_type") or "message")]
+            if payload.get("media_url")
+            else [],
+        )
+
+        logger.info(
+            "[sendblue] inbound from %s to %s via %s",
+            redact_phone(sender),
+            _redact_target(chat_id),
+            payload.get("service") or "unknown",
+        )
+        task = asyncio.create_task(self.handle_message(event))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return web.json_response({"status": "ok"})
+
+
+def _env_enablement() -> Dict[str, Any] | None:
+    api_key_id = os.getenv("SENDBLUE_API_KEY_ID", "").strip()
+    api_secret_key = os.getenv("SENDBLUE_API_SECRET_KEY", "").strip()
+    from_number = os.getenv("SENDBLUE_FROM_NUMBER", "").strip()
+    from_numbers = _split_csv(os.getenv("SENDBLUE_FROM_NUMBERS", ""))
+    if not (api_key_id and api_secret_key and (from_number or from_numbers)):
+        return None
+    seed: Dict[str, Any] = {
+        "api_key_id": api_key_id,
+        "api_secret_key": api_secret_key,
+        "api_base_url": os.getenv("SENDBLUE_API_BASE_URL", DEFAULT_API_BASE_URL).rstrip(
+            "/"
+        ),
+    }
+    if from_number:
+        seed["from_number"] = from_number
+    if from_numbers:
+        seed["from_numbers"] = from_numbers
+    for env_name, key in (
+        ("SENDBLUE_WEBHOOK_SECRET", "webhook_secret"),
+        ("SENDBLUE_STATUS_CALLBACK", "status_callback"),
+        ("SENDBLUE_SEAT_ID", "seat_id"),
+        ("SENDBLUE_STICKY_STATE_PATH", "sticky_state_path"),
+    ):
+        value = os.getenv(env_name, "").strip()
+        if value:
+            seed[key] = value
+    host = os.getenv("SENDBLUE_WEBHOOK_HOST", "").strip()
+    if host:
+        seed["webhook_host"] = host
+    port = os.getenv("SENDBLUE_WEBHOOK_PORT", "").strip()
+    if port:
+        seed["webhook_port"] = int(port)
+    path = os.getenv("SENDBLUE_WEBHOOK_PATH", "").strip()
+    if path:
+        seed["webhook_path"] = _normalize_webhook_path(path)
+    home = os.getenv("SENDBLUE_HOME_CHANNEL", "").strip()
+    if home:
+        seed["home_channel"] = {
+            "chat_id": home,
+            "name": os.getenv("SENDBLUE_HOME_CHANNEL_NAME", home),
+        }
+    return seed
+
+
+async def _standalone_send(
+    pconfig,
+    chat_id: str,
+    message: str,
+    *,
+    thread_id: Optional[str] = None,
+    media_files: Optional[List[str]] = None,
+    force_document: bool = False,
+) -> Dict[str, Any]:
+    if not AIOHTTP_AVAILABLE:
+        return {"error": "Sendblue standalone send: aiohttp not installed"}
+    extra = getattr(pconfig, "extra", {}) or {}
+    adapter = SendblueAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                **extra,
+                "sticky_state_path": extra.get("sticky_state_path")
+                or os.getenv(
+                    "SENDBLUE_STICKY_STATE_PATH", str(_default_sticky_state_path())
+                ),
+            },
+        )
+    )
+    if (
+        not adapter._api_key_id
+        or not adapter._api_secret_key
+        or not adapter._from_numbers
+    ):
+        return {
+            "error": (
+                "Sendblue not configured "
+                "(SENDBLUE_API_KEY_ID, SENDBLUE_API_SECRET_KEY, SENDBLUE_FROM_NUMBER required)"
+            )
+        }
+    if media_files:
+        message = f"{message}\n\n[{len(media_files)} attachment(s) generated; Sendblue requires public media_url delivery]"
+    chunks = adapter.truncate_message(message)
+    result = SendResult(success=True)
+    timeout = aiohttp.ClientTimeout(total=30)
+    async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
+        for chunk in chunks:
+            payload, endpoint = adapter._build_send_payload(chat_id, chunk, metadata={})
+            status, headers, body = await _post_sendblue(
+                session,
+                api_base_url=adapter._api_base_url,
+                api_key_id=adapter._api_key_id,
+                api_secret_key=adapter._api_secret_key,
+                endpoint=endpoint,
+                payload=payload,
+            )
+            result = _send_result_from_response(status, headers, body)
+            if not result.success:
+                return _standalone_dict(result, chat_id)
+            adapter._remember_sender(chat_id, str(payload["from_number"]))
+    return _standalone_dict(result, chat_id)
+
+
+def interactive_setup() -> None:
+    print()
+    print("Sendblue iMessage setup")
+    print("-----------------------")
+    print("Create API credentials and a receive webhook in the Sendblue dashboard.")
+    print("Set the receive webhook URL to your public tunnel plus /sendblue/webhook.")
+    print()
+    try:
+        from hermes_cli.config import get_env_var, set_env_var
+    except ImportError:
+        print(
+            "hermes_cli.config not available; set SENDBLUE_* vars manually in ~/.hermes/.env"
+        )
+        return
+
+    def _prompt(var: str, prompt: str, *, secret: bool = False) -> None:
+        existing = get_env_var(var) if callable(get_env_var) else None
+        suffix = " [keep current]" if existing else ""
+        try:
+            if secret:
+                from hermes_cli.secret_prompt import masked_secret_prompt
+
+                value = masked_secret_prompt(f"{prompt}{suffix}: ")
+            else:
+                value = input(f"{prompt}{suffix}: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if value:
+            set_env_var(var, value)
+
+    _prompt("SENDBLUE_API_KEY_ID", "API key id", secret=True)
+    _prompt("SENDBLUE_API_SECRET_KEY", "API secret key", secret=True)
+    _prompt("SENDBLUE_FROM_NUMBER", "Default from number")
+    _prompt("SENDBLUE_WEBHOOK_SECRET", "Webhook secret", secret=True)
+    _prompt(
+        "SENDBLUE_ALLOWED_USERS",
+        "Allowed E.164 numbers (comma-separated; blank=pairing)",
+    )
+    _prompt(
+        "SENDBLUE_HOME_CHANNEL", "Home channel E.164 number or group:<id> (optional)"
+    )
+    print("Done. Start the gateway, then send an iMessage to your Sendblue number.")
+
+
+def register(ctx) -> None:
+    ctx.register_platform(
+        name="sendblue",
+        label="Sendblue",
+        adapter_factory=lambda cfg: SendblueAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=[
+            "SENDBLUE_API_KEY_ID",
+            "SENDBLUE_API_SECRET_KEY",
+            "SENDBLUE_FROM_NUMBER",
+            "SENDBLUE_WEBHOOK_SECRET",
+        ],
+        install_hint="pip install aiohttp   # already included with Hermes messaging",
+        setup_fn=interactive_setup,
+        env_enablement_fn=_env_enablement,
+        cron_deliver_env_var="SENDBLUE_HOME_CHANNEL",
+        standalone_sender_fn=_standalone_send,
+        allowed_users_env="SENDBLUE_ALLOWED_USERS",
+        allow_all_env="SENDBLUE_ALLOW_ALL_USERS",
+        max_message_length=MAX_MESSAGE_LENGTH,
+        pii_safe=False,
+        allow_update_command=True,
+        platform_hint=(
+            "You are communicating over Sendblue iMessage/SMS/RCS. "
+            "Keep replies concise and natural for a phone messaging thread. "
+            "The transport may fall back from iMessage to SMS/RCS depending on the recipient."
+        ),
+    )

--- a/plugins/platforms/sendblue/adapter.py
+++ b/plugins/platforms/sendblue/adapter.py
@@ -118,6 +118,34 @@ def _sendblue_number_for_payload(payload: Dict[str, Any]) -> str:
     ).strip()
 
 
+def _media_url_for_payload(payload: Dict[str, Any]) -> str:
+    return str(payload.get("media_url") or "").strip()
+
+
+def _media_type_for_payload(payload: Dict[str, Any]) -> str:
+    return str(
+        payload.get("message_type")
+        or payload.get("media_type")
+        or payload.get("content_type")
+        or "attachment"
+    ).strip()
+
+
+def _message_type_for_payload(payload: Dict[str, Any]) -> MessageType:
+    media_type = _media_type_for_payload(payload).lower()
+    if not _media_url_for_payload(payload):
+        return MessageType.TEXT
+    if "image" in media_type or media_type in {"photo", "picture"}:
+        return MessageType.PHOTO
+    if "video" in media_type:
+        return MessageType.VIDEO
+    if "audio" in media_type:
+        return MessageType.AUDIO
+    if "voice" in media_type:
+        return MessageType.VOICE
+    return MessageType.DOCUMENT
+
+
 def _response_message_id(data: Dict[str, Any]) -> Optional[str]:
     value = data.get("message_handle") or data.get("id") or data.get("message_id")
     return str(value) if value else None
@@ -561,7 +589,11 @@ class SendblueAdapter(BasePlatformAdapter):
         if str(payload.get("status") or "").upper() not in {"", "RECEIVED"}:
             return web.json_response({"status": "ok"})
 
+        media_url = _media_url_for_payload(payload)
+        media_type = _media_type_for_payload(payload) if media_url else ""
         text = str(payload.get("content") or "").strip()
+        if not text and media_url:
+            text = "(attachment)"
         sender = _sender_for_payload(payload)
         chat_id = _chat_id_for_payload(payload)
         message_handle = str(payload.get("message_handle") or "").strip()
@@ -586,14 +618,12 @@ class SendblueAdapter(BasePlatformAdapter):
         )
         event = MessageEvent(
             text=text,
-            message_type=MessageType.TEXT,
+            message_type=_message_type_for_payload(payload),
             source=source,
             raw_message=payload,
             message_id=message_handle or None,
-            media_urls=[str(payload["media_url"])] if payload.get("media_url") else [],
-            media_types=[str(payload.get("message_type") or "message")]
-            if payload.get("media_url")
-            else [],
+            media_urls=[media_url] if media_url else [],
+            media_types=[media_type] if media_type else [],
         )
 
         logger.info(
@@ -757,6 +787,13 @@ def interactive_setup() -> None:
 
 
 def register(ctx) -> None:
+    try:
+        from . import cli as _cli
+    except ImportError:  # test loader imports adapter.py outside package context
+        import importlib
+
+        _cli = importlib.import_module("plugins.platforms.sendblue.cli")
+
     ctx.register_platform(
         name="sendblue",
         label="Sendblue",
@@ -778,11 +815,19 @@ def register(ctx) -> None:
         allowed_users_env="SENDBLUE_ALLOWED_USERS",
         allow_all_env="SENDBLUE_ALLOW_ALL_USERS",
         max_message_length=MAX_MESSAGE_LENGTH,
-        pii_safe=False,
+        pii_safe=True,
         allow_update_command=True,
         platform_hint=(
             "You are communicating over Sendblue iMessage/SMS/RCS. "
             "Keep replies concise and natural for a phone messaging thread. "
-            "The transport may fall back from iMessage to SMS/RCS depending on the recipient."
+            "The transport may fall back from iMessage to SMS/RCS depending on the recipient. "
+            "Recipient identifiers are E.164 phone numbers; never expose them in "
+            "responses unless the user asked."
         ),
+    )
+    ctx.register_cli_command(
+        name="sendblue",
+        help="Set up and inspect the Sendblue iMessage/SMS/RCS integration",
+        setup_fn=_cli.register_cli,
+        handler_fn=_cli.dispatch,
     )

--- a/plugins/platforms/sendblue/cli.py
+++ b/plugins/platforms/sendblue/cli.py
@@ -1,0 +1,113 @@
+"""``hermes sendblue ...`` CLI subcommands for the Sendblue platform plugin."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from .adapter import (
+    DEFAULT_API_BASE_URL,
+    DEFAULT_WEBHOOK_HOST,
+    DEFAULT_WEBHOOK_PATH,
+    DEFAULT_WEBHOOK_PORT,
+    _default_sticky_state_path,
+    _normalize_webhook_path,
+    _split_csv,
+    interactive_setup,
+)
+
+
+def register_cli(parser: argparse.ArgumentParser) -> None:
+    """Wire up ``hermes sendblue ...`` subcommands."""
+    subs = parser.add_subparsers(dest="sendblue_command", required=False)
+    subs.add_parser("status", help="Show Sendblue configuration state")
+    subs.add_parser("setup", help="Prompt for Sendblue environment variables")
+    parser.set_defaults(func=dispatch)
+
+
+def dispatch(args: argparse.Namespace) -> int:
+    sub = getattr(args, "sendblue_command", None)
+    if sub is None or sub == "status":
+        return _cmd_status()
+    if sub == "setup":
+        interactive_setup()
+        return 0
+    print(f"unknown subcommand: {sub}", file=sys.stderr)
+    return 2
+
+
+def _env(name: str, default: str = "") -> str:
+    value = os.getenv(name, "").strip()
+    if value:
+        return value
+    try:
+        from hermes_cli.config import get_env_var
+    except ImportError:
+        return default
+    try:
+        stored = get_env_var(name)
+    except Exception:
+        stored = None
+    return str(stored or default).strip()
+
+
+def _configured(name: str) -> str:
+    return "configured" if _env(name) else "missing"
+
+
+def _redact_phone(value: str) -> str:
+    value = value.strip()
+    if not value:
+        return ""
+    if value.startswith("group:"):
+        return f"group:{value[6:12]}..."
+    if len(value) <= 6:
+        return "***"
+    return f"{value[:3]}...{value[-4:]}"
+
+
+def _redact_list(values: list[str]) -> str:
+    return ", ".join(_redact_phone(v) for v in values) if values else "missing"
+
+
+def _cmd_status() -> int:
+    from_number = _env("SENDBLUE_FROM_NUMBER")
+    from_numbers = _split_csv(_env("SENDBLUE_FROM_NUMBERS"))
+    if from_number and from_number not in from_numbers:
+        from_numbers.insert(0, from_number)
+
+    webhook_host = _env("SENDBLUE_WEBHOOK_HOST", DEFAULT_WEBHOOK_HOST)
+    webhook_port = _env("SENDBLUE_WEBHOOK_PORT", str(DEFAULT_WEBHOOK_PORT))
+    webhook_path = _normalize_webhook_path(
+        _env("SENDBLUE_WEBHOOK_PATH", DEFAULT_WEBHOOK_PATH)
+    )
+    sticky_path = _env("SENDBLUE_STICKY_STATE_PATH", str(_default_sticky_state_path()))
+    allow_all = _env("SENDBLUE_ALLOW_ALL_USERS").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    allowed_users = _split_csv(_env("SENDBLUE_ALLOWED_USERS"))
+    access = (
+        "allow-all"
+        if allow_all
+        else f"allowlist ({len(allowed_users)})"
+        if allowed_users
+        else "pairing required"
+    )
+
+    print("Sendblue")
+    print(f"  API key id:      {_configured('SENDBLUE_API_KEY_ID')}")
+    print(f"  API secret key:  {_configured('SENDBLUE_API_SECRET_KEY')}")
+    print(f"  API base URL:    {_env('SENDBLUE_API_BASE_URL', DEFAULT_API_BASE_URL)}")
+    print(f"  From numbers:    {_redact_list(from_numbers)}")
+    print(f"  Webhook bind:    {webhook_host}:{webhook_port}{webhook_path}")
+    print(f"  Webhook secret:  {_configured('SENDBLUE_WEBHOOK_SECRET')}")
+    print(f"  Access:          {access}")
+    print(
+        f"  Home channel:    {_redact_phone(_env('SENDBLUE_HOME_CHANNEL')) or 'unset'}"
+    )
+    print(f"  Sticky state:    {sticky_path}")
+    return 0

--- a/plugins/platforms/sendblue/plugin.yaml
+++ b/plugins/platforms/sendblue/plugin.yaml
@@ -1,0 +1,79 @@
+name: sendblue-platform
+label: Sendblue
+kind: platform
+version: 1.0.0
+description: >
+  Sendblue iMessage/SMS/RCS gateway adapter for Hermes Agent. Runs an
+  aiohttp webhook listener for inbound Sendblue receive events and sends
+  replies through the Sendblue REST API.
+author: hermes-agent
+requires_env:
+  - name: SENDBLUE_API_KEY_ID
+    description: "Sendblue API key id"
+    prompt: "Sendblue API key id"
+    password: true
+  - name: SENDBLUE_API_SECRET_KEY
+    description: "Sendblue API secret key"
+    prompt: "Sendblue API secret key"
+    password: true
+  - name: SENDBLUE_FROM_NUMBER
+    description: "Default Sendblue line in E.164 format"
+    prompt: "Sendblue from number"
+    password: false
+  - name: SENDBLUE_WEBHOOK_SECRET
+    description: "Secret configured on the Sendblue receive webhook"
+    prompt: "Sendblue webhook secret"
+    password: true
+optional_env:
+  - name: SENDBLUE_FROM_NUMBERS
+    description: "Comma-separated Sendblue lines for sticky sender pooling"
+    prompt: "Sendblue from-number pool"
+    password: false
+  - name: SENDBLUE_API_BASE_URL
+    description: "Sendblue API base URL (default: https://api.sendblue.com)"
+    prompt: "Sendblue API base URL"
+    password: false
+  - name: SENDBLUE_WEBHOOK_HOST
+    description: "Webhook bind host (default: 127.0.0.1)"
+    prompt: "Sendblue webhook bind host"
+    password: false
+  - name: SENDBLUE_WEBHOOK_PORT
+    description: "Webhook bind port (default: 8650)"
+    prompt: "Sendblue webhook bind port"
+    password: false
+  - name: SENDBLUE_WEBHOOK_PATH
+    description: "Webhook path (default: /sendblue/webhook)"
+    prompt: "Sendblue webhook path"
+    password: false
+  - name: SENDBLUE_STATUS_CALLBACK
+    description: "Optional per-message status_callback URL"
+    prompt: "Sendblue status callback URL"
+    password: false
+  - name: SENDBLUE_SEAT_ID
+    description: "Optional Sendblue seat id for message attribution"
+    prompt: "Sendblue seat id"
+    password: false
+  - name: SENDBLUE_STICKY_STATE_PATH
+    description: "Optional JSON path for recipient->from_number stickiness"
+    prompt: "Sendblue sticky state path"
+    password: false
+  - name: SENDBLUE_ALLOWED_USERS
+    description: "Comma-separated E.164 phone numbers allowed to talk to the bot"
+    prompt: "Allowed phone numbers"
+    password: false
+  - name: SENDBLUE_ALLOW_ALL_USERS
+    description: "Allow any phone number to talk to the bot (dev only)"
+    prompt: "Allow all users? (true/false)"
+    password: false
+  - name: SENDBLUE_HOME_CHANNEL
+    description: "Default phone number or group:<id> for cron delivery"
+    prompt: "Home channel"
+    password: false
+  - name: SENDBLUE_HOME_CHANNEL_NAME
+    description: "Human label for the home channel"
+    prompt: "Home channel display name"
+    password: false
+  - name: SENDBLUE_INSECURE_NO_SIGNATURE
+    description: "Disable webhook secret validation for local development only"
+    prompt: "Disable webhook validation? (true/false)"
+    password: false

--- a/plugins/platforms/sendblue/plugin.yaml
+++ b/plugins/platforms/sendblue/plugin.yaml
@@ -3,10 +3,11 @@ label: Sendblue
 kind: platform
 version: 1.0.0
 description: >
-  Sendblue iMessage/SMS/RCS gateway adapter for Hermes Agent. Runs an
-  aiohttp webhook listener for inbound Sendblue receive events and sends
-  replies through the Sendblue REST API.
-author: hermes-agent
+  Bundled Sendblue iMessage/SMS/RCS platform plugin for Hermes Agent.
+  Runs an aiohttp webhook listener for inbound Sendblue receive events and
+  sends replies through the Sendblue REST API while staying on the standard
+  BasePlatformAdapter + ctx.register_platform plugin surface.
+author: NousResearch
 requires_env:
   - name: SENDBLUE_API_KEY_ID
     description: "Sendblue API key id"

--- a/tests/gateway/test_sendblue_plugin.py
+++ b/tests/gateway/test_sendblue_plugin.py
@@ -259,6 +259,32 @@ class TestWebhookHandling:
         assert event.source.chat_type == "group"
         assert event.source.user_id == "+15551112222"
 
+    def test_attachment_only_inbound_uses_placeholder_text(self, tmp_path):
+        adapter = SendblueAdapter(_config(tmp_path))
+        adapter.handle_message = AsyncMock()
+        payload = {
+            "content": "",
+            "is_outbound": False,
+            "status": "RECEIVED",
+            "message_handle": "mh-media",
+            "from_number": "+15551112222",
+            "to_number": "+15550000001",
+            "media_url": "https://cdn.example.test/photo.jpg",
+            "message_type": "image/jpeg",
+        }
+        response = _run(
+            adapter._handle_webhook(
+                _Request(payload, headers={"sb-signing-secret": "webhook-secret"})
+            )
+        )
+        _run(asyncio.sleep(0))
+        assert response.status == 200
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "(attachment)"
+        assert event.message_type == _sendblue.MessageType.PHOTO
+        assert event.media_urls == ["https://cdn.example.test/photo.jpg"]
+        assert event.media_types == ["image/jpeg"]
+
 
 class TestSendResults:
     def test_success_extracts_message_handle(self):
@@ -305,10 +331,16 @@ def test_register_calls_register_platform():
     ctx = MagicMock()
     register(ctx)
     ctx.register_platform.assert_called_once()
+    ctx.register_cli_command.assert_called_once()
     kwargs = ctx.register_platform.call_args.kwargs
     assert kwargs["name"] == "sendblue"
     assert kwargs["cron_deliver_env_var"] == "SENDBLUE_HOME_CHANNEL"
     assert kwargs["allowed_users_env"] == "SENDBLUE_ALLOWED_USERS"
     assert kwargs["allow_all_env"] == "SENDBLUE_ALLOW_ALL_USERS"
+    assert kwargs["pii_safe"] is True
     assert callable(kwargs["standalone_sender_fn"])
     assert callable(kwargs["env_enablement_fn"])
+    cli_kwargs = ctx.register_cli_command.call_args.kwargs
+    assert cli_kwargs["name"] == "sendblue"
+    assert callable(cli_kwargs["setup_fn"])
+    assert callable(cli_kwargs["handler_fn"])

--- a/tests/gateway/test_sendblue_plugin.py
+++ b/tests/gateway/test_sendblue_plugin.py
@@ -1,0 +1,314 @@
+"""Tests for the Sendblue platform-plugin adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+_sendblue = load_plugin_adapter("sendblue")
+
+SendblueAdapter = _sendblue.SendblueAdapter
+check_requirements = _sendblue.check_requirements
+validate_config = _sendblue.validate_config
+is_connected = _sendblue.is_connected
+register = _sendblue.register
+_env_enablement = _sendblue._env_enablement
+_send_result_from_response = _sendblue._send_result_from_response
+_standalone_send = _sendblue._standalone_send
+DEFAULT_API_BASE_URL = _sendblue.DEFAULT_API_BASE_URL
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _config(tmp_path: Path, **extra):
+    base = {
+        "api_key_id": "key-id",
+        "api_secret_key": "secret-key",
+        "from_number": "+15550000001",
+        "webhook_secret": "webhook-secret",
+        "sticky_state_path": str(tmp_path / "sticky.json"),
+    }
+    base.update(extra)
+    return PlatformConfig(enabled=True, extra=base)
+
+
+class _Headers(dict):
+    def get(self, key, default=None):  # noqa: D401 - dict compatibility helper
+        return super().get(key, super().get(str(key).lower(), default))
+
+
+class _Request:
+    def __init__(self, payload, headers=None):
+        self._raw = json.dumps(payload).encode("utf-8")
+        self.headers = _Headers(headers or {})
+
+    async def read(self):
+        return self._raw
+
+
+def test_platform_enum_resolves_via_plugin_scan():
+    from gateway.config import Platform
+
+    assert Platform("sendblue").value == "sendblue"
+
+
+class TestRequirements:
+    def test_check_requirements_needs_creds_and_from_number(self, monkeypatch):
+        monkeypatch.setattr(_sendblue, "AIOHTTP_AVAILABLE", True)
+        monkeypatch.delenv("SENDBLUE_API_KEY_ID", raising=False)
+        monkeypatch.delenv("SENDBLUE_API_SECRET_KEY", raising=False)
+        monkeypatch.delenv("SENDBLUE_FROM_NUMBER", raising=False)
+        assert check_requirements() is False
+
+        monkeypatch.setenv("SENDBLUE_API_KEY_ID", "key")
+        monkeypatch.setenv("SENDBLUE_API_SECRET_KEY", "secret")
+        monkeypatch.setenv("SENDBLUE_FROM_NUMBER", "+15550000001")
+        assert check_requirements() is True
+
+    def test_validate_config_accepts_extra(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SENDBLUE_API_KEY_ID", raising=False)
+        assert validate_config(PlatformConfig(enabled=True, extra={})) is False
+        assert validate_config(_config(tmp_path)) is True
+        assert is_connected(_config(tmp_path)) is True
+
+
+class TestAdapterInit:
+    def test_reads_from_number_pool_and_default(self, tmp_path):
+        adapter = SendblueAdapter(
+            _config(
+                tmp_path,
+                from_number="+15550000001",
+                from_numbers=["+15550000002", "+15550000003"],
+            )
+        )
+        assert adapter._from_numbers == [
+            "+15550000001",
+            "+15550000002",
+            "+15550000003",
+        ]
+        assert adapter._default_from_number == "+15550000001"
+
+    def test_sticky_state_loaded(self, tmp_path):
+        state = tmp_path / "sticky.json"
+        state.write_text('{" +15551112222 ": "+15550000002"}', encoding="utf-8")
+        adapter = SendblueAdapter(_config(tmp_path, sticky_state_path=str(state)))
+        assert adapter._sticky_senders[" +15551112222 "] == "+15550000002"
+
+    def test_env_enablement_seeds_config(self, monkeypatch):
+        monkeypatch.setenv("SENDBLUE_API_KEY_ID", "key")
+        monkeypatch.setenv("SENDBLUE_API_SECRET_KEY", "secret")
+        monkeypatch.setenv("SENDBLUE_FROM_NUMBER", "+15550000001")
+        monkeypatch.setenv("SENDBLUE_FROM_NUMBERS", "+15550000002,+15550000003")
+        monkeypatch.setenv("SENDBLUE_WEBHOOK_SECRET", "whsec")
+        monkeypatch.setenv("SENDBLUE_HOME_CHANNEL", "+15551112222")
+        seed = _env_enablement()
+        assert seed["api_base_url"] == DEFAULT_API_BASE_URL
+        assert seed["from_number"] == "+15550000001"
+        assert seed["from_numbers"] == ["+15550000002", "+15550000003"]
+        assert seed["webhook_secret"] == "whsec"
+        assert seed["home_channel"]["chat_id"] == "+15551112222"
+
+
+class TestPayloads:
+    def test_dm_payload_uses_send_message(self, tmp_path):
+        adapter = SendblueAdapter(_config(tmp_path))
+        payload, endpoint = adapter._build_send_payload(
+            "+15551112222", "hello", metadata={}
+        )
+        assert endpoint == "/api/send-message"
+        assert payload == {
+            "content": "hello",
+            "from_number": "+15550000001",
+            "number": "+15551112222",
+        }
+
+    def test_group_payload_uses_group_endpoint(self, tmp_path):
+        adapter = SendblueAdapter(
+            _config(tmp_path, status_callback="https://example.com/status")
+        )
+        payload, endpoint = adapter._build_send_payload(
+            "group:g123", "hello", metadata={}
+        )
+        assert endpoint == "/api/send-group-message"
+        assert payload["group_id"] == "g123"
+        assert payload["status_callback"] == "https://example.com/status"
+
+    def test_sticky_sender_persists(self, tmp_path):
+        adapter = SendblueAdapter(
+            _config(tmp_path, from_numbers=["+15550000001", "+15550000002"])
+        )
+        adapter._remember_sender("+15551112222", "+15550000002")
+        assert adapter._select_from_number("+15551112222") == "+15550000002"
+        data = json.loads((tmp_path / "sticky.json").read_text(encoding="utf-8"))
+        assert data["+15551112222"] == "+15550000002"
+
+
+class TestWebhookSecurity:
+    def test_accepts_configured_secret_header(self, tmp_path):
+        adapter = SendblueAdapter(_config(tmp_path))
+        assert (
+            adapter._validate_webhook_secret({"sb-signing-secret": "webhook-secret"})
+            is True
+        )
+        assert adapter._validate_webhook_secret({"sb-signing-secret": "wrong"}) is False
+
+    def test_accepts_bearer_secret(self, tmp_path):
+        adapter = SendblueAdapter(_config(tmp_path))
+        assert (
+            adapter._validate_webhook_secret({"authorization": "Bearer webhook-secret"})
+            is True
+        )
+
+
+class TestWebhookHandling:
+    def test_inbound_dispatches_message_and_records_sticky_sender(self, tmp_path):
+        adapter = SendblueAdapter(_config(tmp_path))
+        adapter.handle_message = AsyncMock()
+        payload = {
+            "content": "Hello",
+            "is_outbound": False,
+            "status": "RECEIVED",
+            "message_handle": "mh-1",
+            "from_number": "+15551112222",
+            "to_number": "+15550000001",
+            "sendblue_number": "+15550000001",
+            "service": "iMessage",
+        }
+        response = _run(
+            adapter._handle_webhook(
+                _Request(payload, headers={"sb-signing-secret": "webhook-secret"})
+            )
+        )
+        _run(asyncio.sleep(0))
+        assert response.status == 200
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "Hello"
+        assert event.source.chat_id == "+15551112222"
+        assert event.source.user_id == "+15551112222"
+        assert adapter._sticky_senders["+15551112222"] == "+15550000001"
+
+    def test_duplicate_message_handle_is_acked_without_dispatch(self, tmp_path):
+        adapter = SendblueAdapter(_config(tmp_path))
+        adapter.handle_message = AsyncMock()
+        payload = {
+            "content": "Hello",
+            "is_outbound": False,
+            "status": "RECEIVED",
+            "message_handle": "mh-1",
+            "from_number": "+15551112222",
+            "to_number": "+15550000001",
+        }
+        request = _Request(payload, headers={"sb-signing-secret": "webhook-secret"})
+        assert _run(adapter._handle_webhook(request)).status == 200
+        assert _run(adapter._handle_webhook(request)).status == 200
+        _run(asyncio.sleep(0))
+        adapter.handle_message.assert_awaited_once()
+
+    def test_outbound_status_callback_is_acked_without_dispatch(self, tmp_path):
+        adapter = SendblueAdapter(_config(tmp_path))
+        adapter.handle_message = AsyncMock()
+        payload = {
+            "content": "Hello",
+            "is_outbound": True,
+            "status": "SENT",
+            "message_handle": "mh-out",
+            "from_number": "+15550000001",
+            "to_number": "+15551112222",
+        }
+        response = _run(
+            adapter._handle_webhook(
+                _Request(payload, headers={"sb-signing-secret": "webhook-secret"})
+            )
+        )
+        assert response.status == 200
+        adapter.handle_message.assert_not_called()
+
+    def test_group_inbound_uses_group_chat_id(self, tmp_path):
+        adapter = SendblueAdapter(_config(tmp_path))
+        adapter.handle_message = AsyncMock()
+        payload = {
+            "content": "Group hello",
+            "is_outbound": False,
+            "status": "RECEIVED",
+            "message_handle": "mh-group",
+            "from_number": "+15551112222",
+            "to_number": "+15550000001",
+            "sendblue_number": "+15550000001",
+            "group_id": "group-123",
+            "group_display_name": "Friends",
+        }
+        response = _run(
+            adapter._handle_webhook(
+                _Request(payload, headers={"sb-signing-secret": "webhook-secret"})
+            )
+        )
+        _run(asyncio.sleep(0))
+        assert response.status == 200
+        event = adapter.handle_message.await_args.args[0]
+        assert event.source.chat_id == "group:group-123"
+        assert event.source.chat_type == "group"
+        assert event.source.user_id == "+15551112222"
+
+
+class TestSendResults:
+    def test_success_extracts_message_handle(self):
+        result = _send_result_from_response(
+            200,
+            {},
+            {"message_handle": "msg-123", "status": "QUEUED"},
+        )
+        assert result.success is True
+        assert result.message_id == "msg-123"
+
+    def test_429_is_retryable_rate_limit(self):
+        result = _send_result_from_response(
+            429,
+            {"Retry-After": "2.5"},
+            {"error_message": "Too many requests"},
+        )
+        assert result.success is False
+        assert result.retryable is True
+        assert result.retry_after == 2.5
+        assert result.error_kind == "rate_limited"
+
+
+class TestStandaloneSend:
+    def test_uses_standalone_sender_contract(self, tmp_path, monkeypatch):
+        async def fake_post(session, **kwargs):
+            assert kwargs["endpoint"] == "/api/send-message"
+            assert kwargs["payload"]["from_number"] == "+15550000001"
+            assert kwargs["payload"]["number"] == "+15551112222"
+            return 200, {}, {"message_handle": "msg-standalone"}
+
+        monkeypatch.setattr(_sendblue, "_post_sendblue", fake_post)
+        pconfig = _config(tmp_path)
+        result = _run(_standalone_send(pconfig, "+15551112222", "hello"))
+        assert result == {
+            "success": True,
+            "platform": "sendblue",
+            "chat_id": "+15551112222",
+            "message_id": "msg-standalone",
+        }
+
+
+def test_register_calls_register_platform():
+    ctx = MagicMock()
+    register(ctx)
+    ctx.register_platform.assert_called_once()
+    kwargs = ctx.register_platform.call_args.kwargs
+    assert kwargs["name"] == "sendblue"
+    assert kwargs["cron_deliver_env_var"] == "SENDBLUE_HOME_CHANNEL"
+    assert kwargs["allowed_users_env"] == "SENDBLUE_ALLOWED_USERS"
+    assert kwargs["allow_all_env"] == "SENDBLUE_ALLOW_ALL_USERS"
+    assert callable(kwargs["standalone_sender_fn"])
+    assert callable(kwargs["env_enablement_fn"])

--- a/tests/gateway/test_sendblue_plugin.py
+++ b/tests/gateway/test_sendblue_plugin.py
@@ -159,6 +159,11 @@ class TestWebhookSecurity:
             adapter._validate_webhook_secret({"sb-signing-secret": "webhook-secret"})
             is True
         )
+        assert adapter._validate_webhook_secret({"secret": "webhook-secret"}) is True
+        assert (
+            adapter._validate_webhook_secret({"x-sendblue-secret": "webhook-secret"})
+            is True
+        )
         assert adapter._validate_webhook_secret({"sb-signing-secret": "wrong"}) is False
 
     def test_accepts_bearer_secret(self, tmp_path):

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1442,6 +1442,11 @@ class TestParseTargetRefE164:
         assert chat_id == "+15551234567"
         assert is_explicit is True
 
+    def test_sendblue_e164_is_explicit(self):
+        chat_id, _, is_explicit = _parse_target_ref("sendblue", "+15551234567")
+        assert chat_id == "+15551234567"
+        assert is_explicit is True
+
     def test_signal_bare_digits_still_work(self):
         """Bare digit strings continue to match the generic numeric branch."""
         chat_id, _, is_explicit = _parse_target_ref("signal", "15551234567")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -38,7 +38,7 @@ _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # below and falls through to channel-name resolution, which has no way to
 # resolve a raw phone number. Keeping the '+' preserves the E.164 form that
 # downstream adapters (signal, etc.) expect.
-_PHONE_PLATFORMS = frozenset({"photon", "signal", "sms", "whatsapp"})
+_PHONE_PLATFORMS = frozenset({"photon", "sendblue", "signal", "sms", "whatsapp"})
 _E164_TARGET_RE = re.compile(r"^\s*\+(\d{7,15})\s*$")
 # WhatsApp JIDs: group chats (<digits>@g.us), individual users
 # (<phone>@s.whatsapp.net), linked identities (<id>@lid), and broadcast /

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -585,6 +585,31 @@ Used by the bundled LINE platform plugin (`plugins/platforms/line/`). See [Messa
 
 See [the ntfy messaging guide](/user-guide/messaging/ntfy) — particularly the **identity model** section — before deploying with untrusted topics.
 
+### Sendblue (iMessage/SMS/RCS)
+
+Connect Hermes to [Sendblue](https://www.sendblue.com/) as a managed
+iMessage/SMS/RCS channel. See [the Sendblue messaging guide](/user-guide/messaging/sendblue).
+
+| Variable | Description |
+|----------|-------------|
+| `SENDBLUE_API_KEY_ID` | Sendblue API key id. Required. |
+| `SENDBLUE_API_SECRET_KEY` | Sendblue API secret key. Required. |
+| `SENDBLUE_FROM_NUMBER` | Default Sendblue line in E.164 format. Required unless `SENDBLUE_FROM_NUMBERS` is set. |
+| `SENDBLUE_FROM_NUMBERS` | Comma-separated Sendblue line pool for sticky sender selection. |
+| `SENDBLUE_API_BASE_URL` | Sendblue API base URL (default: `https://api.sendblue.com`). |
+| `SENDBLUE_WEBHOOK_SECRET` | Secret configured on the Sendblue receive webhook. Required for inbound gateway mode. |
+| `SENDBLUE_WEBHOOK_HOST` | Webhook bind host (default: `127.0.0.1`). |
+| `SENDBLUE_WEBHOOK_PORT` | Webhook bind port (default: `8650`). |
+| `SENDBLUE_WEBHOOK_PATH` | Webhook path (default: `/sendblue/webhook`). |
+| `SENDBLUE_STATUS_CALLBACK` | Optional per-message status callback URL. |
+| `SENDBLUE_SEAT_ID` | Optional Sendblue seat id for message attribution. |
+| `SENDBLUE_STICKY_STATE_PATH` | JSON file for recipient -> `from_number` stickiness (default: `~/.hermes/sendblue_sticky_senders.json`). |
+| `SENDBLUE_ALLOWED_USERS` | Comma-separated E.164 phone numbers allowed to talk to the bot. |
+| `SENDBLUE_ALLOW_ALL_USERS` | Allow any sender to talk to the bot (dev only). |
+| `SENDBLUE_HOME_CHANNEL` | Default phone number or `group:<id>` for cron / notification delivery. |
+| `SENDBLUE_HOME_CHANNEL_NAME` | Human label for the home channel. |
+| `SENDBLUE_INSECURE_NO_SIGNATURE` | Disable webhook secret validation for local development only. |
+
 ### IRC
 
 Connect Hermes to an IRC server. No external dependencies. See [the IRC messaging guide](/user-guide/messaging/irc).

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
 title: "Messaging Gateway"
-description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Yuanbao, Microsoft Teams, LINE, Raft, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
+description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Sendblue, Email, Home Assistant, Mattermost, Matrix, DingTalk, Yuanbao, Microsoft Teams, LINE, Raft, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
 ---
 
 # Messaging Gateway
 
-Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, Microsoft Teams, LINE, ntfy, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
+Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Sendblue (iMessage/SMS/RCS), Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, Microsoft Teams, LINE, ntfy, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
 
 For the full voice feature set — including CLI microphone mode, spoken replies in messaging, and Discord voice-channel conversations — see [Voice Mode](/user-guide/features/voice-mode) and [Use Voice Mode with Hermes](/guides/use-voice-mode-with-hermes).
 
@@ -25,6 +25,7 @@ Bots need both a model provider and tool providers (TTS, web). A [Nous Portal](/
 | WhatsApp | — | ✅ | ✅ | — | — | ✅ | ✅ |
 | Signal | — | ✅ | ✅ | — | — | ✅ | ✅ |
 | SMS | — | — | — | — | — | — | — |
+| Sendblue | — | ✅ | — | ✅ | — | — | — |
 | Email | — | ✅ | ✅ | ✅ | — | — | — |
 | Home Assistant | — | — | — | — | — | — | — |
 | Mattermost | ✅ | ✅ | ✅ | ✅ | — | ✅ | ✅ |
@@ -58,6 +59,7 @@ flowchart TB
             gc[Google Chat]
             sig[Signal]
             sms[SMS]
+            sb[Sendblue]
             em[Email]
             ha[Home Assistant]
             mm[Mattermost]
@@ -87,6 +89,7 @@ flowchart TB
     gc --> store
     sig --> store
     sms --> store
+    sb --> store
     em --> store
     ha --> store
     mm --> store
@@ -229,6 +232,7 @@ TELEGRAM_ALLOWED_USERS=123456789,987654321
 DISCORD_ALLOWED_USERS=123456789012345678
 SIGNAL_ALLOWED_USERS=+155****4567,+155****6543
 SMS_ALLOWED_USERS=+155****4567,+155****6543
+SENDBLUE_ALLOWED_USERS=+155****4567,+155****6543
 EMAIL_ALLOWED_USERS=trusted@example.com,colleague@work.com
 MATTERMOST_ALLOWED_USERS=3uo8dkh1p7g1mfk49ear5fzs5c
 MATRIX_ALLOWED_USERS=@alice:matrix.org
@@ -511,6 +515,7 @@ Each platform has its own toolset:
 | Google Chat | `hermes-google_chat` | Full tools including terminal |
 | Signal | `hermes-signal` | Full tools including terminal |
 | SMS | `hermes-sms` | Full tools including terminal |
+| Sendblue | `hermes-sendblue` | Full tools including terminal |
 | Email | `hermes-email` | Full tools including terminal |
 | Home Assistant | `hermes-homeassistant` | Full tools + HA device control (ha_list_entities, ha_get_state, ha_call_service, ha_list_services) |
 | Mattermost | `hermes-mattermost` | Full tools including terminal |
@@ -640,6 +645,7 @@ Defaults to `false`. Only platforms whose adapter implements `delete_message` ho
 - [WhatsApp Business Cloud API Setup](whatsapp-cloud.md)
 - [Signal Setup](signal.md)
 - [SMS Setup (Twilio)](sms.md)
+- [Sendblue Setup (iMessage/SMS/RCS)](sendblue.md)
 - [Email Setup](email.md)
 - [Home Assistant Integration](homeassistant.md)
 - [Mattermost Setup](mattermost.md)

--- a/website/docs/user-guide/messaging/sendblue.md
+++ b/website/docs/user-guide/messaging/sendblue.md
@@ -1,0 +1,170 @@
+---
+sidebar_label: "Sendblue"
+title: "Sendblue"
+description: "Set up Hermes Agent as an iMessage/SMS/RCS chatbot via Sendblue"
+---
+
+# Sendblue Setup
+
+Hermes can connect to [Sendblue](https://www.sendblue.com/) as a bundled
+platform plugin. Users text your Sendblue line, Sendblue POSTs inbound receive
+webhooks to Hermes, and Hermes replies through Sendblue's REST API.
+
+This path is useful when you want a managed iMessage/SMS/RCS channel without
+running your own Mac relay.
+
+> Run `hermes gateway setup` and pick **Sendblue** for a guided walk-through.
+
+## Prerequisites
+
+- A Sendblue account with API credentials.
+- At least one Sendblue phone line in E.164 format.
+- A publicly reachable HTTPS URL for the receive webhook.
+- A receive webhook secret configured in Sendblue.
+
+The adapter uses `aiohttp`, which is included with the Hermes messaging extra.
+
+## Configure Hermes
+
+### Via setup wizard
+
+```bash
+hermes gateway setup
+```
+
+Select **Sendblue** and follow the prompts.
+
+### Via environment variables
+
+Add these to `~/.hermes/.env`:
+
+```bash
+SENDBLUE_API_KEY_ID=your_api_key_id
+SENDBLUE_API_SECRET_KEY=your_api_secret
+SENDBLUE_FROM_NUMBER=+15551234567
+SENDBLUE_WEBHOOK_SECRET=your_receive_webhook_secret
+SENDBLUE_ALLOWED_USERS=+15559876543
+SENDBLUE_HOME_CHANNEL=+15559876543
+```
+
+If you have multiple Sendblue lines, use a pool:
+
+```bash
+SENDBLUE_FROM_NUMBERS=+15551234567,+15557654321
+```
+
+Hermes keeps a sticky recipient -> `from_number` map so each contact continues
+to see the same Sendblue line after the first reply.
+
+## Configure Sendblue
+
+In the Sendblue dashboard or Webhooks API, create a **receive** webhook that
+points to:
+
+```text
+https://your-public-host/sendblue/webhook
+```
+
+Set the webhook secret to the same value as `SENDBLUE_WEBHOOK_SECRET`. Hermes
+rejects inbound webhooks that do not include the configured secret. For local
+development only, you can bypass this with:
+
+```bash
+SENDBLUE_INSECURE_NO_SIGNATURE=true
+```
+
+Do not use that bypass on a public server.
+
+## Start the gateway
+
+```bash
+hermes gateway start
+```
+
+Send an iMessage or SMS to your Sendblue number. Hermes will respond in the
+same thread.
+
+## Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `SENDBLUE_API_KEY_ID` | Yes | Sendblue API key id, sent as `sb-api-key-id`. |
+| `SENDBLUE_API_SECRET_KEY` | Yes | Sendblue API secret key, sent as `sb-api-secret-key`. |
+| `SENDBLUE_FROM_NUMBER` | Yes | Default Sendblue line in E.164 format. |
+| `SENDBLUE_FROM_NUMBERS` | Optional | Comma-separated line pool. Hermes chooses a stable line per recipient. |
+| `SENDBLUE_API_BASE_URL` | Optional | Sendblue API base URL. Default: `https://api.sendblue.com`. |
+| `SENDBLUE_WEBHOOK_SECRET` | Yes | Secret configured on the Sendblue receive webhook. |
+| `SENDBLUE_WEBHOOK_HOST` | Optional | Webhook bind host. Default: `127.0.0.1`. |
+| `SENDBLUE_WEBHOOK_PORT` | Optional | Webhook bind port. Default: `8650`. |
+| `SENDBLUE_WEBHOOK_PATH` | Optional | Webhook path. Default: `/sendblue/webhook`. |
+| `SENDBLUE_STATUS_CALLBACK` | Optional | Per-message Sendblue status callback URL for outbound delivery updates. |
+| `SENDBLUE_SEAT_ID` | Optional | Sendblue seat id for message attribution. |
+| `SENDBLUE_STICKY_STATE_PATH` | Optional | JSON file for recipient -> `from_number` stickiness. Default: `~/.hermes/sendblue_sticky_senders.json`. |
+| `SENDBLUE_ALLOWED_USERS` | Recommended | Comma-separated E.164 phone numbers allowed to talk to the bot. |
+| `SENDBLUE_ALLOW_ALL_USERS` | Dev only | Allow every sender. Not recommended for bots with terminal access. |
+| `SENDBLUE_HOME_CHANNEL` | Optional | Default phone number or `group:<id>` for cron / notification delivery. |
+| `SENDBLUE_HOME_CHANNEL_NAME` | Optional | Human label for the home channel. |
+| `SENDBLUE_INSECURE_NO_SIGNATURE` | Dev only | Set `true` to disable webhook secret validation locally. |
+
+## Cron delivery
+
+Once `SENDBLUE_HOME_CHANNEL` is set, cron jobs can deliver through Sendblue:
+
+```python
+cronjob(
+    action="create",
+    schedule="every 1h",
+    deliver="sendblue",
+    prompt="Send me a short status summary."
+)
+```
+
+Or target a recipient explicitly:
+
+```bash
+hermes send sendblue:+15559876543 "Done."
+```
+
+Group replies use `group:<id>` chat ids. The adapter uses Sendblue's
+`/api/send-group-message` endpoint for those targets.
+
+## Sendblue-specific behavior
+
+- **Inbound-first limits.** Sendblue's AI Agent plan is designed for contacts
+  who text you first. Replies within the 24-hour inbound window are unlimited;
+  follow-up messages after that window count against the plan's follow-up
+  contact limit.
+- **Sticky sender lines.** Sendblue requires `from_number` on every send and
+  recommends continuing to use the same line for a contact. Hermes persists
+  that mapping locally.
+- **Webhook ACKs.** Hermes returns 200-level responses immediately after
+  accepting inbound events so Sendblue does not retry the same webhook.
+- **Rate limits.** Sendblue returns HTTP 429 when a line is throttled. Hermes
+  marks those send failures as retryable and preserves `Retry-After` when
+  present.
+- **Attachments.** Outbound `media_url` is supported when provided as
+  metadata by a caller. Local `MEDIA:/...` attachments from cron are reported
+  as generated but are not uploaded automatically.
+
+## Troubleshooting
+
+**Gateway refuses to start without `SENDBLUE_WEBHOOK_SECRET`.** Configure a
+secret on the Sendblue receive webhook and set the same value in
+`~/.hermes/.env`.
+
+**Hermes receives no messages.** Confirm your public URL routes to
+`SENDBLUE_WEBHOOK_HOST:SENDBLUE_WEBHOOK_PORT` and the Sendblue webhook type is
+`receive`.
+
+**Outbound fails with HTTP 400.** Check that `SENDBLUE_FROM_NUMBER` is a line on
+your Sendblue account and the target is E.164 formatted.
+
+**Outbound fails with HTTP 429.** Slow down, wait for the Sendblue rate-limit
+window, or spread traffic across more lines with `SENDBLUE_FROM_NUMBERS`.
+
+## References
+
+- [Sendblue sending messages](https://docs.sendblue.com/getting-started/sending-messages/)
+- [Sendblue receiving messages](https://docs.sendblue.com/getting-started/receiving-messages/)
+- [Sendblue webhooks](https://docs.sendblue.com/getting-started/webhooks/)
+- [Sendblue limits](https://docs.sendblue.com/limits/)

--- a/website/docs/user-guide/messaging/sendblue.md
+++ b/website/docs/user-guide/messaging/sendblue.md
@@ -175,7 +175,7 @@ cronjob(
 Or target a recipient explicitly:
 
 ```bash
-hermes send sendblue:+15559876543 "Done."
+hermes send --to sendblue:+15559876543 "Done."
 ```
 
 Group replies use `group:<id>` chat ids. The adapter uses Sendblue's

--- a/website/docs/user-guide/messaging/sendblue.md
+++ b/website/docs/user-guide/messaging/sendblue.md
@@ -15,6 +15,27 @@ running your own Mac relay.
 
 > Run `hermes gateway setup` and pick **Sendblue** for a guided walk-through.
 
+## Architecture
+
+Sendblue is a **receive-webhook + REST-send** channel:
+
+```text
+User phone
+  <-> Sendblue iMessage/SMS/RCS line
+  <-> Sendblue receive webhook + REST API
+  <-> Hermes Sendblue platform plugin
+```
+
+The adapter lives under `plugins/platforms/sendblue/` and registers with
+Hermes through `ctx.register_platform(name="sendblue", ...)`. That means it uses
+the same plugin-platform path as other bundled channels: allowlists, pairing,
+gateway status, cron delivery, `send_message`, and platform hints are all wired
+through the plugin registry without editing gateway core files.
+
+Unlike persistent-stream channels such as Photon, Sendblue needs a public HTTPS
+URL for inbound receive webhooks and a shared secret so Hermes can reject
+forged requests.
+
 ## Prerequisites
 
 - A Sendblue account with API credentials.
@@ -33,6 +54,12 @@ hermes gateway setup
 ```
 
 Select **Sendblue** and follow the prompts.
+
+You can also inspect the plugin configuration without printing secrets:
+
+```bash
+hermes sendblue status
+```
 
 ### Via environment variables
 
@@ -74,6 +101,32 @@ SENDBLUE_INSECURE_NO_SIGNATURE=true
 ```
 
 Do not use that bypass on a public server.
+
+## Authorizing users
+
+Sendblue uses the standard Hermes platform authorization model.
+
+**DM pairing (default).** When an unknown number messages your Sendblue line,
+Hermes offers a pairing flow. Approve the code with:
+
+```bash
+hermes pairing approve sendblue <CODE>
+```
+
+**Pre-authorize specific numbers** in `~/.hermes/.env`:
+
+```bash
+SENDBLUE_ALLOWED_USERS=+15551234567,+15559876543
+```
+
+When `SENDBLUE_ALLOWED_USERS` is set, unknown senders are ignored instead of
+being offered a pairing code.
+
+**Open access** is for local development only:
+
+```bash
+SENDBLUE_ALLOW_ALL_USERS=true
+```
 
 ## Start the gateway
 
@@ -142,9 +195,14 @@ Group replies use `group:<id>` chat ids. The adapter uses Sendblue's
 - **Rate limits.** Sendblue returns HTTP 429 when a line is throttled. Hermes
   marks those send failures as retryable and preserves `Retry-After` when
   present.
-- **Attachments.** Outbound `media_url` is supported when provided as
-  metadata by a caller. Local `MEDIA:/...` attachments from cron are reported
-  as generated but are not uploaded automatically.
+- **PII redaction.** Sendblue identifiers are E.164 phone numbers, so the
+  plugin registers as PII-sensitive and Hermes redacts session descriptions
+  before exposing them to the model.
+- **Attachments.** Inbound attachment-only webhooks are accepted and delivered
+  with `(attachment)` placeholder text plus media metadata. Outbound `media_url`
+  is supported when provided as metadata by a caller. Local `MEDIA:/...`
+  attachments from cron are reported as generated but are not uploaded
+  automatically.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Add a bundled Sendblue platform plugin for iMessage/SMS/RCS via REST + receive webhooks
- Keep Sendblue on the same platform-plugin architecture as Photon: `plugins/platforms/sendblue/plugin.yaml`, `SendblueAdapter(BasePlatformAdapter)`, and `ctx.register_platform(name="sendblue", ...)`
- Support webhook secret validation, `message_handle` dedupe, sticky `from_number` selection, Sendblue group replies, cron/send_message standalone delivery, and 429 retry metadata
- Add `hermes sendblue status/setup`, PII-safe phone-number handling, attachment-only inbound webhook handling, explicit E.164 `sendblue:+...` send targets, and plugin README/user-guide docs

## Architecture note
- This PR intentionally avoids an in-tree `gateway/platforms/sendblue.py` adapter. The plugin registry wires allowlists, pairing, gateway status, cron delivery, standalone `send_message`, platform hints, and PII redaction without Hermes core edits.
- This matches the current bundled platform-plugin lane used by Photon and documented in the platform-adapter guide.

## Verification
- `uv run --extra dev --extra messaging python -m pytest tests/gateway/test_sendblue_plugin.py tests/gateway/test_plugin_platform_interface.py -q`
- `uv run --extra dev --extra messaging python -m pytest tests/tools/test_send_message_tool.py -k 'E164 or standalone_sender_fn' -q`
- `uv run --extra dev --extra messaging ruff check tools/send_message_tool.py tests/tools/test_send_message_tool.py website/docs/user-guide/messaging/sendblue.md`
- `uv run --extra dev --extra messaging ruff check plugins/platforms/sendblue/adapter.py plugins/platforms/sendblue/cli.py tests/gateway/test_sendblue_plugin.py`
- `uv run --extra dev --extra messaging ruff format --check plugins/platforms/sendblue/adapter.py plugins/platforms/sendblue/cli.py tests/gateway/test_sendblue_plugin.py`
- `uv run --extra dev --extra messaging python - <<'PY' ... cli.dispatch(Namespace(sendblue_command='status')) ... PY`
- `git diff --check`