### PR TITLE
fix(anthropic): don't let the OS system proxy hijack Anthropic client requests

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -778,12 +778,24 @@ def build_anthropic_client(
     # trust_env and route only through hermes's own env-/NO_PROXY-aware
     # resolver. Explicit HTTP(S)_PROXY env still applies for users who need
     # egress, and NO_PROXY is honored for hosts that must bypass it.
+    #
+    # trust_env=False also stops httpx from reading SSL_CERT_FILE/SSL_CERT_DIR
+    # into its default SSL context, so resolve the verify context explicitly to
+    # preserve custom-CA behavior. This routes through hermes's shared resolver
+    # (agent/ssl_verify.py), which honors HERMES_CA_BUNDLE, SSL_CERT_FILE,
+    # REQUESTS_CA_BUNDLE, and CURL_CA_BUNDLE — the same env conventions the
+    # OpenAI-wire and auxiliary clients use — falling back to the certifi
+    # default. Without this, users behind a corporate MITM proxy with a custom
+    # root CA (a population that overlaps heavily with proxy users) would hit
+    # TLS verification failures on the Anthropic path.
     import httpx as _httpx
     from agent.process_bootstrap import _get_proxy_for_base_url
+    from agent.ssl_verify import resolve_httpx_verify
     kwargs["http_client"] = _httpx.Client(
         timeout=kwargs["timeout"],
         trust_env=False,
         proxy=_get_proxy_for_base_url(base_url),
+        verify=resolve_httpx_verify(base_url=base_url),
     )
 
     if normalized_base_url:

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -768,6 +768,24 @@ def build_anthropic_client(
         # refill for minutes. (#26293)
         "max_retries": 0,
     }
+
+    # Build the SDK's httpx client ourselves so the OS *system* proxy is never
+    # silently applied. The Anthropic SDK's default client uses trust_env=True,
+    # which on macOS/Windows reads the system proxy (via urllib.getproxies()).
+    # That hijacks requests to endpoints the proxy cannot reach (e.g. an
+    # intranet gateway) and surfaces as an opaque APIConnectionError. Mirror the
+    # OpenAI-wire path (_build_keepalive_http_client in run_agent.py): disable
+    # trust_env and route only through hermes's own env-/NO_PROXY-aware
+    # resolver. Explicit HTTP(S)_PROXY env still applies for users who need
+    # egress, and NO_PROXY is honored for hosts that must bypass it.
+    import httpx as _httpx
+    from agent.process_bootstrap import _get_proxy_for_base_url
+    kwargs["http_client"] = _httpx.Client(
+        timeout=kwargs["timeout"],
+        trust_env=False,
+        proxy=_get_proxy_for_base_url(base_url),
+    )
+
     if normalized_base_url:
         # Azure Anthropic endpoints require an ``api-version`` query parameter.
         # Pass it via default_query so the SDK appends it to every request URL

--- a/tests/agent/test_anthropic_client_proxy.py
+++ b/tests/agent/test_anthropic_client_proxy.py
@@ -1,0 +1,121 @@
+"""Regression guard: build_anthropic_client must not pick up the OS system proxy.
+
+The Anthropic SDK's default httpx client uses ``trust_env=True``. On macOS (and
+Windows) httpx then resolves proxies via ``urllib.request.getproxies()``, which
+includes the *system* proxy (``scutil --proxy`` on macOS) — not just the
+``*_PROXY`` env vars. When a system proxy is configured (e.g. Clash/mihomo at
+``127.0.0.1:7890``) but no proxy env var is set, requests to an endpoint the
+proxy cannot reach (e.g. an intranet Anthropic-compatible gateway) get tunneled
+through the proxy and fail with an opaque ``APIConnectionError`` /
+``ConnectError [SSL: UNEXPECTED_EOF_WHILE_READING]``.
+
+The OpenAI-wire path (``_build_keepalive_http_client`` in ``run_agent.py``) is
+already immune because it builds a custom ``httpx.Client`` (which disables
+httpx's ``trust_env`` proxy auto-detection) and routes only through hermes's
+own env-/NO_PROXY-aware resolver. ``build_anthropic_client`` now mirrors that:
+it injects an ``httpx.Client(trust_env=False, proxy=_get_proxy_for_base_url(...))``
+so the system proxy is never silently applied, while explicit HTTP(S)_PROXY env
+still works and NO_PROXY is honored.
+
+Tracked in NousResearch/hermes-agent#25319 (the httpx-path sibling of the
+already-fixed OpenAI/auxiliary cases #14451 / #25319 loopback fixes).
+"""
+import types
+
+import httpx
+
+import agent.anthropic_adapter as aa
+
+
+_PROXY_ENV_KEYS = (
+    "HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+    "https_proxy", "http_proxy", "all_proxy",
+    "NO_PROXY", "no_proxy",
+)
+
+
+def _clear_proxy_env(monkeypatch):
+    for key in _PROXY_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _capture_anthropic_kwargs(monkeypatch):
+    """Stub the lazily-imported anthropic SDK so no real client/network is needed."""
+    captured = {}
+
+    class _FakeAnthropic:
+        def __init__(self, **kwargs):
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(
+        aa, "_get_anthropic_sdk",
+        lambda: types.SimpleNamespace(Anthropic=_FakeAnthropic),
+    )
+    return captured
+
+
+def _proxy_pool_names(http_client):
+    return [
+        type(mount._pool).__name__
+        for mount in http_client._mounts.values()
+        if mount is not None and hasattr(mount, "_pool")
+    ]
+
+
+def test_anthropic_client_disables_trust_env(monkeypatch):
+    """With no proxy env vars, the injected client must have trust_env=False so
+    the OS system proxy (getproxies()) is never consulted, and no proxy pool is
+    mounted."""
+    _clear_proxy_env(monkeypatch)
+    captured = _capture_anthropic_kwargs(monkeypatch)
+
+    aa.build_anthropic_client(
+        "sk-test", base_url="https://gateway.internal.example.com/anthropic"
+    )
+
+    http_client = captured["kwargs"].get("http_client")
+    assert isinstance(http_client, httpx.Client), (
+        "build_anthropic_client must inject its own httpx.Client; got %r"
+        % (http_client,)
+    )
+    assert http_client._trust_env is False, (
+        "trust_env must be False so the SDK's httpx never reads the OS system "
+        "proxy via urllib.getproxies()"
+    )
+    assert "HTTPProxy" not in _proxy_pool_names(http_client)
+    http_client.close()
+
+
+def test_anthropic_client_honors_env_proxy(monkeypatch):
+    """An explicit HTTPS_PROXY env var must still route a remote endpoint through
+    the proxy (egress users are unaffected)."""
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+    captured = _capture_anthropic_kwargs(monkeypatch)
+
+    aa.build_anthropic_client("sk-test", base_url="https://api.anthropic.com")
+
+    http_client = captured["kwargs"]["http_client"]
+    assert "HTTPProxy" in _proxy_pool_names(http_client), (
+        "Explicit HTTPS_PROXY must still be honored for remote endpoints"
+    )
+    http_client.close()
+
+
+def test_anthropic_client_honors_no_proxy(monkeypatch):
+    """NO_PROXY must suppress the proxy for a matching host even when HTTPS_PROXY
+    is set."""
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+    monkeypatch.setenv("NO_PROXY", "internal.example.com")
+    captured = _capture_anthropic_kwargs(monkeypatch)
+
+    aa.build_anthropic_client(
+        "sk-test", base_url="https://gw.internal.example.com/anthropic"
+    )
+
+    http_client = captured["kwargs"]["http_client"]
+    assert "HTTPProxy" not in _proxy_pool_names(http_client), (
+        "NO_PROXY host must not route through HTTPProxy"
+    )
+    http_client.close()

--- a/tests/agent/test_anthropic_client_proxy.py
+++ b/tests/agent/test_anthropic_client_proxy.py
@@ -17,9 +17,17 @@ it injects an ``httpx.Client(trust_env=False, proxy=_get_proxy_for_base_url(...)
 so the system proxy is never silently applied, while explicit HTTP(S)_PROXY env
 still works and NO_PROXY is honored.
 
+``trust_env=False`` also stops httpx from loading ``SSL_CERT_FILE`` /
+``SSL_CERT_DIR`` into its default SSL context, so ``build_anthropic_client``
+forwards an explicit ``verify`` resolved via ``agent.ssl_verify`` (honoring
+``HERMES_CA_BUNDLE`` / ``SSL_CERT_FILE`` / ``REQUESTS_CA_BUNDLE`` /
+``CURL_CA_BUNDLE``) to preserve custom-root-CA behavior for corporate-MITM
+users — the last test below pins that contract.
+
 Tracked in NousResearch/hermes-agent#25319 (the httpx-path sibling of the
 already-fixed OpenAI/auxiliary cases #14451 / #25319 loopback fixes).
 """
+import ssl
 import types
 
 import httpx
@@ -117,5 +125,41 @@ def test_anthropic_client_honors_no_proxy(monkeypatch):
     http_client = captured["kwargs"]["http_client"]
     assert "HTTPProxy" not in _proxy_pool_names(http_client), (
         "NO_PROXY host must not route through HTTPProxy"
+    )
+    http_client.close()
+
+
+def test_anthropic_client_forwards_resolved_ca_verify(monkeypatch):
+    """trust_env=False stops httpx from reading SSL_CERT_FILE/SSL_CERT_DIR into
+    its SSL context, so build_anthropic_client must forward an explicit verify
+    context from hermes's shared CA resolver. This pins the wiring: the injected
+    client's SSL context is exactly what resolve_httpx_verify(base_url=...)
+    returned. Without it, users behind a corporate MITM proxy with a custom root
+    CA would hit TLS verification failures on the Anthropic path."""
+    _clear_proxy_env(monkeypatch)
+    captured = _capture_anthropic_kwargs(monkeypatch)
+
+    sentinel_ctx = ssl.create_default_context()
+    seen = {}
+
+    import agent.ssl_verify as ssl_verify_mod
+
+    def _fake_resolve(**kwargs):
+        seen.update(kwargs)
+        return sentinel_ctx
+
+    monkeypatch.setattr(ssl_verify_mod, "resolve_httpx_verify", _fake_resolve)
+
+    aa.build_anthropic_client(
+        "sk-test", base_url="https://gateway.internal.example.com/anthropic"
+    )
+
+    http_client = captured["kwargs"]["http_client"]
+    assert http_client._transport._pool._ssl_context is sentinel_ctx, (
+        "build_anthropic_client must forward resolve_httpx_verify() output as the "
+        "httpx client's verify context so custom-CA env vars survive trust_env=False"
+    )
+    assert seen.get("base_url") == "https://gateway.internal.example.com/anthropic", (
+        "the provider base_url must be threaded into resolve_httpx_verify"
     )
     http_client.close()


### PR DESCRIPTION
## What does this PR do?

On macOS/Windows, requests from the **Anthropic Messages** client can be silently hijacked by the **OS system proxy**, failing with an opaque `APIConnectionError` / `ConnectError [SSL: UNEXPECTED_EOF_WHILE_READING]`.

Root cause: `build_anthropic_client` (`agent/anthropic_adapter.py`) returns `Anthropic(**kwargs)` with no `http_client`. The Anthropic SDK's default client uses `trust_env=True`, and httpx then resolves proxies via `urllib.request.getproxies()`, which on macOS includes the **system proxy** (`scutil --proxy`, e.g. a local Clash/mihomo at `127.0.0.1:7890`) — not just `*_PROXY` env vars. So even with an empty proxy env, a request to an endpoint the proxy can't reach (e.g. an intranet Anthropic-compatible gateway) gets tunneled through the proxy and dies during the TLS handshake.

The **OpenAI-wire path is already immune**: `_build_keepalive_http_client` (`run_agent.py`) passes a custom `httpx.HTTPTransport`, which disables httpx's `trust_env` proxy auto-detection, and resolves the proxy via `_get_proxy_for_base_url` (env-/`NO_PROXY`-aware). The Anthropic path had no equivalent, so behavior was inconsistent between the two wire formats on the same machine/config.

This PR makes the Anthropic path mirror the OpenAI path: build the SDK's httpx client with `trust_env=False` and a proxy resolved by `_get_proxy_for_base_url(base_url)`.

**Behavior note for reviewers:** this stops the *system* proxy from being applied implicitly (matching the OpenAI path's long-standing behavior). Explicit `HTTP(S)_PROXY` / `ALL_PROXY` env vars still apply for egress users, and `NO_PROXY` is honored. Users who relied on the *system* proxy (no env var) to reach a remote Anthropic endpoint should set `HTTPS_PROXY` explicitly — same as they already must for OpenAI-wire providers.

## Related Issue

Refs #25319

Not a duplicate: #25319 and the related fixes (#14451, #31421) all target the **OpenAI / auxiliary / urllib** paths and/or **loopback (localhost)** endpoints (via `_is_loopback_url`). This is the **Anthropic Messages** path with a **remote, non-loopback** endpoint, which none of those cover. Context comment: https://github.com/NousResearch/hermes-agent/issues/25319#issuecomment-4828417646

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_adapter.py` — `build_anthropic_client` now injects `http_client=httpx.Client(timeout=..., trust_env=False, proxy=_get_proxy_for_base_url(base_url))` so the SDK's default `trust_env=True` client (which reads the OS system proxy) is no longer used. Applies to all static-key sub-branches (x-api-key, bearer/MiniMax, third-party, OAuth). The Entra/Azure callable path was already building its own `http_client` and is unchanged.
- `tests/agent/test_anthropic_client_proxy.py` — new regression tests: (1) `trust_env=False` and no proxy pool when no proxy env is set, (2) explicit `HTTPS_PROXY` still mounts an `HTTPProxy` pool, (3) `NO_PROXY` suppresses the proxy for a matching host.

## How to Test

Reproduction (macOS with a system proxy configured, **no** `*_PROXY` env vars), using an Anthropic-compatible endpoint the proxy can't reach:

```python
import urllib.request, httpx, os
print(urllib.request.getproxies())     # shows the system proxy
URL = os.environ["ENDPOINT"]           # an Anthropic /v1/messages endpoint
httpx.post(URL, ...)                   # ConnectError UNEXPECTED_EOF (routed via system proxy)
with httpx.Client(trust_env=False) as c:
    c.post(URL, ...)                   # 200 — direct
```

Automated:

```bash
pytest tests/agent/test_anthropic_client_proxy.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(anthropic): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (2 files)
- [x] I've run the new tests and the `build_anthropic_client` suite locally — `tests/agent/test_anthropic_client_proxy.py` passes (3/3); `tests/agent/test_anthropic_adapter.py` is 166 passed (3 unrelated `TestRunOauthSetupToken` failures reproduce identically on a clean checkout in my minimal env, i.e. not caused by this change). Full CI will validate.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.1 (arm64), httpx 0.28.1, httpcore 1.0.9, OpenSSL 3.5.6

### Documentation & Housekeeping

- [x] Docs — N/A
- [x] `cli-config.yaml.example` — N/A (no new config keys; `NO_PROXY`/`HTTP(S)_PROXY` are standard env vars)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — the fix helps macOS and Windows (system-proxy pickup); no Unix-only assumptions
- [x] Tool descriptions/schemas — N/A
