### PR TITLE
chore(gitignore): ignore private operator notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,7 @@ RELEASE_v*.md
 # Desktop demo-run scratch output (hermes writes demo/*.txt during recorded
 # walkthroughs). Throwaway artifacts, never part of the app.
 apps/desktop/demo/
+
+# Private operator notes stashed outside the repo.
+daily/
+projects/


### PR DESCRIPTION
Adds `daily/` and `projects/` to .gitignore so private operator notes stashed in those directories outside the repo aren't accidentally committed. Diff is .gitignore-only (4 lines added, no other files changed).