### PR TITLE
fix(dashboard): exclude compression children from session stats

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7911,9 +7911,9 @@ async def get_session_stats(profile: Optional[str] = None):
     """
     db = _open_session_db_for_profile(profile)
     try:
-        total = db.session_count(include_archived=True)
-        active_store = db.session_count(include_archived=False)
-        archived = db.session_count(archived_only=True)
+        total = db.session_count(include_archived=True, exclude_children=True)
+        active_store = db.session_count(include_archived=False, exclude_children=True)
+        archived = db.session_count(archived_only=True, exclude_children=True)
         messages = db.message_count()
         by_source: Dict[str, int] = {}
         try:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -782,6 +782,28 @@ class TestWebServerEndpoints:
         messages = self.client.get("/api/sessions/worker-only/messages?profile=worker").json()
         assert [m["content"] for m in messages["messages"]] == ["worker"]
 
+    def test_session_stats_excludes_compression_children(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="compressed-root", source="cli")
+            db.append_message(session_id="compressed-root", role="user", content="before")
+            db.end_session("compressed-root", "compression")
+            db.create_session(session_id="compressed-tip", source="cli", parent_session_id="compressed-root")
+            db.append_message(session_id="compressed-tip", role="user", content="after")
+            db.create_session(session_id="standalone", source="cli")
+            db.append_message(session_id="standalone", role="user", content="solo")
+        finally:
+            db.close()
+
+        listed = self.client.get("/api/sessions?limit=20&min_messages=0").json()
+        stats = self.client.get("/api/sessions/stats").json()
+
+        assert listed["total"] == 2
+        assert stats["total"] == listed["total"]
+        assert stats["active_store"] == listed["total"]
+
     def test_analytics_endpoints_read_requested_profile(self):
         from hermes_state import SessionDB
         from hermes_cli import profiles as profiles_mod


### PR DESCRIPTION
## Summary
- Count only listable sessions in `/api/sessions/stats` by passing `exclude_children=True` to the existing `SessionDB.session_count()` calls.
- Add a regression test for a compression root/tip chain so stats stay aligned with the Sessions list total.

## Root cause
`/api/sessions` already excludes compression-continuation children, but `/api/sessions/stats` used raw `session_count()` calls and counted those child rows.

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -q -k test_session_stats_excludes_compression_children`
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -q`

Fixes #54298