### PR TITLE
fix(agent): respect model.context_length config override for minimum check (#8430)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1671,6 +1671,13 @@ def init_agent(
     # Reject models whose context window is below the minimum required
     # for reliable tool-calling workflows (64K tokens).
     _ctx = getattr(agent.context_compressor, "context_length", 0)
+    # Respect explicit model.context_length override from config.yaml.
+    # If the user set it, trust their value — they know their server's
+    # true capacity and the override exists precisely for servers that
+    # report a smaller window than the model actually supports.
+    _config_ctx = getattr(agent, "_config_context_length", None)
+    if _config_ctx is not None and _config_ctx > 0:
+        _ctx = _config_ctx
     if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH:
         raise ValueError(
             f"Model {agent.model} has a context window of {_ctx:,} tokens, "


### PR DESCRIPTION
## Problem

The error message for low-context models tells users to set `model.context_length` in config.yaml to override, but the minimum context length check in `_init_agent()` ignores this config value entirely.

When a user explicitly sets `model.context_length: 32768` for a custom provider (e.g. Qwen3-235B-A22B with 32K context), the check still uses the auto-detected value from the compressor and raises:

```
Model Qwen3-235B-A22B has a context window of 32,768 tokens, which is below the minimum 64,000 required by Hermes Agent. Choose a model with at least 64K context. If your server reports a window smaller than the model's true window, set model.context_length in config.yaml to the real value (this must be at least 64K).
```

The config override exists precisely for servers that report a smaller window than the model actually supports, but it's completely ignored at the validation gate.

## Fix

In `agent/agent_init.py` `_init_agent()`, before the minimum context check, read `agent._config_context_length` (already populated from `model.context_length` in config.yaml earlier in the same function). If the user explicitly set it, use that value for the check.

This is a 7-line change: 6 comment lines + 3 lines of logic.

Fixes #8430