### PR TITLE
fix(tui): paint the active skin on the first frame (no default-theme flash)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2102,6 +2102,35 @@ def _launch_tui(
     if resume_session_id:
         env["HERMES_TUI_RESUME"] = resume_session_id
 
+    # Hand the active profile's resolved skin to the TUI so it paints the
+    # correct skin on the FIRST frame instead of flashing the default theme
+    # until the async gateway.ready skin event arrives. HERMES_HOME is already
+    # set to the active profile here, so this resolves that profile's skin.
+    env.pop("HERMES_TUI_SKIN_JSON", None)
+    try:
+        import json as _json
+        from hermes_cli.config import load_config as _load_config
+        from hermes_cli.skin_engine import (
+            get_active_skin as _get_active_skin,
+            init_skin_from_config as _init_skin_from_config,
+        )
+
+        _init_skin_from_config(_load_config())
+        _sk = _get_active_skin()
+        env["HERMES_TUI_SKIN_JSON"] = _json.dumps(
+            {
+                "name": _sk.name,
+                "colors": _sk.colors,
+                "branding": _sk.branding,
+                "banner_logo": _sk.banner_logo,
+                "banner_hero": _sk.banner_hero,
+                "tool_prefix": _sk.tool_prefix,
+                "help_header": (_sk.branding or {}).get("help_header", ""),
+            }
+        )
+    except Exception:
+        pass
+
     argv, cwd = _make_tui_argv(tui_dir, tui_dev)
     code: Optional[int] = None
     try:

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -2,7 +2,7 @@ import { atom, computed } from 'nanostores'
 
 import { MOUSE_TRACKING } from '../config/env.js'
 import { ZERO } from '../domain/usage.js'
-import { DEFAULT_THEME } from '../theme.js'
+import { initialThemeFromEnv } from '../theme.js'
 
 import { DEFAULT_INDICATOR_STYLE, type UiState } from './interfaces.js'
 
@@ -28,7 +28,7 @@ const buildUiState = (): UiState => ({
   status: 'summoning hermes…',
   statusBar: 'top',
   streaming: true,
-  theme: DEFAULT_THEME,
+  theme: initialThemeFromEnv(),
   usage: ZERO
 })
 

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -508,6 +508,51 @@ export const DEFAULT_THEME: Theme = normalizeThemeForAnsiLightTerminal(
   DEFAULT_LIGHT_MODE
 )
 
+// Initial theme honoring a skin handed in at launch via HERMES_TUI_SKIN_JSON
+// (a first-party payload the Python wrapper writes from the active profile's
+// display.skin). This lets the TUI paint the active skin on the FIRST frame
+// rather than flashing the default theme until the async gateway.ready skin
+// event arrives. Hardened: size-capped, parsed with a reviver that drops
+// prototype-pollution keys, and only known string/object fields are read (no
+// spread of the parsed value). Falls back to DEFAULT_THEME on any problem.
+// (fromSkin is a hoisted function declaration, defined below.)
+export function initialThemeFromEnv(): Theme {
+  const raw = process.env.HERMES_TUI_SKIN_JSON
+  if (!raw || raw.length > 64_000) {
+    return DEFAULT_THEME
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw, (k, v) =>
+      k === '__proto__' || k === 'constructor' || k === 'prototype' ? undefined : v
+    )
+  } catch {
+    return DEFAULT_THEME
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    return DEFAULT_THEME
+  }
+
+  const src = parsed as Record<string, unknown>
+  const objField = (k: string): Record<string, string> => {
+    const v = src[k]
+
+    return v && typeof v === 'object' ? (v as Record<string, string>) : {}
+  }
+  const strField = (k: string): string => (typeof src[k] === 'string' ? (src[k] as string) : '')
+
+  return fromSkin(
+    objField('colors'),
+    objField('branding'),
+    strField('banner_logo'),
+    strField('banner_hero'),
+    strField('tool_prefix'),
+    strField('help_header')
+  )
+}
+
 // ── Skin → Theme ─────────────────────────────────────────────────────
 
 export function fromSkin(


### PR DESCRIPTION
The TUI starts with DEFAULT_THEME and only swaps to the active profile's skin
once the async gateway.ready skin event arrives, so a non-default skin visibly
flashes the default theme for the first frame(s).

Hand the resolved skin to the TUI at launch via HERMES_TUI_SKIN_JSON (written by
the Python wrapper from the active profile's display.skin); the TUI seeds its
initial theme from it. Hardened: size-capped, parsed with a prototype-pollution
reviver, only known string/object fields read. Falls back to DEFAULT_THEME on
any problem.
