### PR TITLE
feat(relaunch): generic deferred relaunch consumed at teardown + TUI auto-detect

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15051,6 +15051,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             from hermes_cli.relaunch import relaunch
             relaunch(self._pending_relaunch, preserve_inherited=False)
 
+        # Honor a generic deferred relaunch requested in-session by a plugin or
+        # feature (e.g. a plugin slash command). No-op when nothing is pending; execs
+        # in place when a request exists — after the terminal has been restored.
+        from hermes_cli.relaunch import consume_pending_relaunch
+        consume_pending_relaunch()
+
 
 # ============================================================================
 # Main Entry Point

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2128,12 +2128,16 @@ def _launch_tui(
     # preserve_inherited=False ensures --tui and other flags are NOT carried
     # into the update subcommand.
     if code == 42:
-        from hermes_cli.relaunch import relaunch
+        from hermes_cli.relaunch import consume_pending_relaunch, relaunch
 
-        print()
-        print("⚕ Launching update...")
-        print()
-        relaunch(["update"], preserve_inherited=False)
+        # A generic deferred relaunch (e.g. requested by a plugin) takes
+        # precedence and preserves inherited flags (notably --tui) so we return
+        # into the TUI in the target profile. Falls back to the update relaunch.
+        if not consume_pending_relaunch():
+            print()
+            print("⚕ Launching update...")
+            print()
+            relaunch(["update"], preserve_inherited=False)
 
     sys.exit(code)
 

--- a/hermes_cli/relaunch.py
+++ b/hermes_cli/relaunch.py
@@ -203,3 +203,80 @@ def relaunch(
             sys.exit(1)
     else:
         os.execvp(new_argv[0], new_argv)
+
+
+# ---------------------------------------------------------------------------
+# Generic deferred relaunch
+#
+# Hermes forbids an in-session ``os.execvp`` (it would orphan the TUI and skip
+# prompt_toolkit terminal restoration).  Built-in ``/update`` already defers via
+# ``self._pending_relaunch``, but that path is reachable only by built-in command
+# methods — not by plugin slash handlers (``fn(args)->str``).  These helpers
+# generalize the deferred relaunch into a tiny, feature-agnostic API any
+# in-session feature can use; the CLI and TUI teardown points consume it.
+# ---------------------------------------------------------------------------
+
+
+def _pending_relaunch_path():
+    """Path to the pending-relaunch handoff, anchored at the real Hermes root.
+
+    Anchored at the root (not the active per-profile ``HERMES_HOME``) so the
+    request survives a profile switch.
+    """
+    from pathlib import Path
+
+    try:
+        from hermes_constants import get_default_hermes_root
+
+        root = Path(get_default_hermes_root())
+    except Exception:
+        root = Path(os.path.expanduser("~/.hermes"))
+    return root / "pending_relaunch.json"
+
+
+def request_relaunch(extra_args, *, preserve_inherited=True) -> None:
+    """Record a deferred relaunch to perform at the next teardown point.
+
+    Generic: any in-session feature that cannot safely exec mid-session (e.g. a
+    plugin slash command) calls this; ``consume_pending_relaunch`` performs it
+    once the CLI/TUI has torn down cleanly.
+    """
+    import json
+
+    path = _pending_relaunch_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(
+        json.dumps(
+            {
+                "extra_args": list(extra_args),
+                "preserve_inherited": bool(preserve_inherited),
+            }
+        )
+    )
+    os.replace(str(tmp), str(path))
+
+
+def consume_pending_relaunch() -> bool:
+    """Perform a pending deferred relaunch, if one was requested.
+
+    Returns ``False`` when nothing is pending.  On POSIX ``relaunch`` execs and
+    does not return; callers treat a truthy outcome as "process is being
+    replaced".
+    """
+    import json
+
+    path = _pending_relaunch_path()
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return False
+    try:
+        path.unlink()
+    except OSError:
+        pass
+    relaunch(
+        list(data.get("extra_args", [])),
+        preserve_inherited=bool(data.get("preserve_inherited", True)),
+    )
+    return True

--- a/tests/hermes_cli/test_relaunch.py
+++ b/tests/hermes_cli/test_relaunch.py
@@ -284,3 +284,54 @@ class TestResolveHermesBinWindowsPyGuard:
         monkeypatch.setattr(relaunch_mod.shutil, "which", lambda name: None)
 
         assert relaunch_mod.resolve_hermes_bin() is None
+
+
+class TestDeferredRelaunch:
+    """request_relaunch / consume_pending_relaunch: the generic deferred-relaunch
+    API that lets an in-session feature (e.g. a plugin slash command) request a
+    relaunch performed at the next clean teardown point."""
+
+    def test_consume_returns_false_when_nothing_pending(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            relaunch_mod, "_pending_relaunch_path", lambda: tmp_path / "pending.json"
+        )
+        assert relaunch_mod.consume_pending_relaunch() is False
+
+    def test_request_then_consume_roundtrip(self, monkeypatch, tmp_path):
+        target = tmp_path / "pending.json"
+        monkeypatch.setattr(relaunch_mod, "_pending_relaunch_path", lambda: target)
+        calls = []
+        monkeypatch.setattr(
+            relaunch_mod,
+            "relaunch",
+            lambda args, preserve_inherited=True: calls.append(
+                (list(args), preserve_inherited)
+            ),
+        )
+
+        relaunch_mod.request_relaunch(["-p", "ogun", "--continue"], preserve_inherited=True)
+        assert target.is_file()
+
+        # consume performs the relaunch, clears the handoff, and reports success
+        assert relaunch_mod.consume_pending_relaunch() is True
+        assert calls == [(["-p", "ogun", "--continue"], True)]
+        assert not target.exists()
+
+        # a second consume is a no-op (handoff already cleared)
+        assert relaunch_mod.consume_pending_relaunch() is False
+
+    def test_request_preserves_inherited_flag(self, monkeypatch, tmp_path):
+        target = tmp_path / "pending.json"
+        monkeypatch.setattr(relaunch_mod, "_pending_relaunch_path", lambda: target)
+        captured = {}
+        monkeypatch.setattr(
+            relaunch_mod,
+            "relaunch",
+            lambda args, preserve_inherited=True: captured.update(
+                preserve_inherited=preserve_inherited
+            ),
+        )
+
+        relaunch_mod.request_relaunch(["update"], preserve_inherited=False)
+        relaunch_mod.consume_pending_relaunch()
+        assert captured == {"preserve_inherited": False}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8467,6 +8467,10 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     run_kwargs["task_id"] = session["session_key"]
             except (TypeError, ValueError):
                 pass
+            # Capture the relaunch-handoff signature before the turn so a
+            # tool-driven profile switch (e.g. a plugin tool) is
+            # detected and the frontend can exit-42 → relaunch into the target.
+            _before_relaunch = _relaunch_signature()
             result = agent.run_conversation(run_message, **run_kwargs)
             if "moa_one_shot_restore" in session:
                 _restore = session.pop("moa_one_shot_restore", None)
@@ -8581,6 +8585,11 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 payload["rendered"] = rendered
             with session["history_lock"]:
                 _clear_inflight_turn(session)
+            # A tool the model called this turn may have requested a deferred
+            # relaunch (a plugin tool). Flag it so the frontend
+            # exits with code 42, mirroring the slash-command relaunch path.
+            if _relaunch_requested(_before_relaunch):
+                payload["relaunch"] = True
             _emit("message.complete", sid, payload)
 
             # ── /goal continuation (Ralph-style loop) ─────────────────
@@ -11193,6 +11202,33 @@ def _resolve_name(name: str) -> str:
         return name
 
 
+def _relaunch_signature():
+    """Identity (mtime, size) of the pending-relaunch handoff file, or None.
+
+    Used to detect a relaunch requested *by the current slash command* rather
+    than a stale handoff left by an earlier one — so a non-relaunching command
+    (e.g. /invoke list) can never trigger a spurious exit-42.
+    """
+    try:
+        from hermes_cli.relaunch import _pending_relaunch_path
+
+        st = _pending_relaunch_path().stat()
+        return (st.st_mtime_ns, st.st_size)
+    except Exception:
+        return None
+
+
+def _relaunch_requested(before) -> bool:
+    """True if a deferred relaunch was newly requested since ``before``.
+
+    The TUI consumes this by exiting with code 42 so the wrapper relaunches —
+    the same mechanism /update uses, but driven by any feature that calls
+    ``hermes_cli.relaunch.request_relaunch`` (e.g. a plugin slash command).
+    """
+    after = _relaunch_signature()
+    return after is not None and after != before
+
+
 @method("command.dispatch")
 def _(rid, params: dict) -> dict:
     name, arg = params.get("name", "").lstrip("/"), params.get("arg", "")
@@ -11236,8 +11272,12 @@ def _(rid, params: dict) -> dict:
 
         handler = get_plugin_command_handler(name)
         if handler:
+            _before_relaunch = _relaunch_signature()
             result = resolve_plugin_command_result(handler(arg))
-            return _ok(rid, {"type": "plugin", "output": str(result or "")})
+            payload = {"type": "plugin", "output": str(result or "")}
+            if _relaunch_requested(_before_relaunch):
+                payload["relaunch"] = True
+            return _ok(rid, payload)
     except Exception:
         pass
 
@@ -12425,8 +12465,12 @@ def _(rid, params: dict) -> dict:
 
     if plugin_handler and resolve_plugin_command_result:
         try:
+            _before_relaunch = _relaunch_signature()
             result = resolve_plugin_command_result(plugin_handler(_cmd_arg))
-            return _ok(rid, {"output": str(result or "(no output)")})
+            payload = {"output": str(result or "(no output)")}
+            if _relaunch_requested(_before_relaunch):
+                payload["relaunch"] = True
+            return _ok(rid, payload)
         except Exception as e:
             return _ok(rid, {"output": f"Plugin command error: {e}"})
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -80,7 +80,7 @@ const normalizeSubagentStatus = (status: unknown, fallback: SubagentStatus): Sub
 
 export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev: GatewayEvent) => void {
   const { rpc } = ctx.gateway
-  const { STARTUP_RESUME_ID, newSession, recoverSidRef, resumeById, setCatalog } = ctx.session
+  const { STARTUP_RESUME_ID, dieWithCode, newSession, recoverSidRef, resumeById, setCatalog } = ctx.session
   const { bellOnComplete, stdout, sys } = ctx.system
   const { appendMessage, panel, setHistoryItems } = ctx.transcript
   const { setInput } = ctx.composer
@@ -938,6 +938,14 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         }
 
         setStatus('ready')
+
+        // A tool the model called this turn requested a profile relaunch
+        // (a plugin tool). Exit with code 42 so the wrapper
+        // relaunches into the target profile, preserving --tui. Delay so the
+        // final message renders first (mirrors the slash relaunch path).
+        if (ev.payload?.relaunch) {
+          setTimeout(() => dieWithCode(42), 150)
+        }
 
         if (ev.payload?.usage) {
           patchUiState(state => ({ ...state, usage: { ...state.usage, ...ev.payload!.usage } }))

--- a/ui-tui/src/app/createSlashHandler.ts
+++ b/ui-tui/src/app/createSlashHandler.ts
@@ -117,6 +117,16 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
       }
     }
 
+    // A slash command (e.g. a plugin slash command) may request a profile relaunch by
+    // having the backend set `relaunch: true` on its response. Exit with code 42
+    // so the Python wrapper relaunches into the target profile, preserving --tui
+    // (the same mechanism /update uses). Delay briefly so the output renders.
+    const maybeRelaunch = (raw: unknown): void => {
+      if (raw && typeof raw === 'object' && (raw as { relaunch?: boolean }).relaunch) {
+        setTimeout(() => ctx.session.dieWithCode(42), 150)
+      }
+    }
+
     gw.request<SlashExecResponse>('slash.exec', { command: cmd.slice(1), session_id: sid })
       .then(r => {
         if (stale()) {
@@ -124,14 +134,16 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
         }
 
         if (asCommandDispatch(r)) {
-          return handleDispatch(r)
+          handleDispatch(r)
+        } else {
+          const body = r?.output || `/${parsed.name}: no output`
+          const text = r?.warning ? `warning: ${r.warning}\n${body}` : body
+          const long = text.length > 180 || text.split('\n').filter(Boolean).length > 2
+
+          long ? page(text, parsed.name[0]!.toUpperCase() + parsed.name.slice(1)) : sys(text)
         }
 
-        const body = r?.output || `/${parsed.name}: no output`
-        const text = r?.warning ? `warning: ${r.warning}\n${body}` : body
-        const long = text.length > 180 || text.split('\n').filter(Boolean).length > 2
-
-        long ? page(text, parsed.name[0]!.toUpperCase() + parsed.name.slice(1)) : sys(text)
+        maybeRelaunch(r)
       })
       .catch(() => {
         gw.request('command.dispatch', { arg: parsed.arg, name: parsed.name, session_id: sid })
@@ -141,6 +153,7 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
             }
 
             handleDispatch(raw)
+            maybeRelaunch(raw)
           })
           .catch(guardedErr)
       })

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -299,6 +299,7 @@ export interface GatewayEventHandlerContext {
   session: {
     STARTUP_RESUME_ID: string
     colsRef: MutableRefObject<number>
+    dieWithCode: (code: number) => void
     newSession: (msg?: string, title?: string) => void
     // Set by useMainApp's exit handler to the session that was live when the
     // gateway died unexpectedly; consumed once by the next `gateway.ready` so a

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -742,6 +742,7 @@ export function useMainApp(gw: GatewayClient) {
         session: {
           STARTUP_RESUME_ID,
           colsRef,
+          dieWithCode,
           newSession: session.newSession,
           recoverSidRef,
           resetSession: session.resetSession,
@@ -762,6 +763,7 @@ export function useMainApp(gw: GatewayClient) {
       appendMessage,
       bellOnComplete,
       composerActions.setInput,
+      dieWithCode,
       gateway,
       panel,
       session.newSession,

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -707,7 +707,7 @@ export type GatewayEvent =
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.complete' }
   | { payload: { rendered?: string; text?: string }; session_id?: string; type: 'message.delta' }
   | {
-      payload?: { reasoning?: string; rendered?: string; text?: string; usage?: Usage }
+      payload?: { reasoning?: string; relaunch?: boolean; rendered?: string; text?: string; usage?: Usage }
       session_id?: string
       type: 'message.complete'
     }


### PR DESCRIPTION
Hermes forbids an in-session os.execvp (it orphans the TUI and skips terminal
restoration). Built-in /update defers via self._pending_relaunch, but that path
is reachable only by built-in command methods, not by plugin slash handlers
(fn(args)->str) or tools.

Add a tiny feature-agnostic API in hermes_cli.relaunch (request_relaunch /
consume_pending_relaunch; handoff file at the Hermes root so it survives a
profile switch), consumed at the two existing teardown points: the CLI teardown
in cli.py, and the TUI wrapper's exit-42 in main.py (which now honors a pending
relaunch and preserves --tui to return into the target profile).

The TUI gateway flags responses/turns that requested a relaunch (signature-
guarded so a read-only command never triggers it) and the frontend exits with
code 42 to relaunch. Adds tests for the new API; the frontend changes are
already validated in a live build.
