### PR TITLE
fix(zai): rewrite /api/anthropic to /api/coding/paas/v4, not /api/paas/v4

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1010,15 +1010,23 @@ def _to_openai_base_url(base_url: str) -> str:
     Some providers (MiniMax, MiniMax-CN) expose an ``/anthropic`` endpoint for
     the Anthropic Messages API and a separate ``/v1`` endpoint for OpenAI chat
     completions.  The auxiliary client uses the OpenAI SDK, so it must hit the
-    ``/v1`` surface.  Passing the raw ``inference_base_url`` causes requests to
-    land on ``/anthropic/chat/completions`` — a 404.
+    provider's OpenAI-compatible surface.  Passing the raw
+    ``inference_base_url`` causes requests to land on
+    ``/anthropic/chat/completions`` — a 404.
+
+    ZAI exposes its general API and Coding Plan on separate endpoints.  Its
+    Anthropic-compatible Coding Plan endpoint maps to ``/api/coding/paas/v4``
+    on the OpenAI wire, not the general ``/api/paas/v4`` endpoint.  Rewriting
+    to the general endpoint changes the billing pool and can return a false
+    insufficient-balance error for a valid Coding Plan key.
     """
     url = str(base_url or "").strip().rstrip("/")
     if url.endswith("/anthropic"):
-        # ZAI (open.bigmodel.cn) uses /api/anthropic for Anthropic wire
-        # but /api/paas/v4 for OpenAI wire — the generic /v1 rewrite is wrong.
-        if "open.bigmodel.cn" in url or "bigmodel" in url:
-            rewritten = url[: -len("/anthropic")] + "/paas/v4"
+        # ZAI uses /api/anthropic for the Coding Plan's Anthropic wire.  The
+        # matching OpenAI-wire endpoint is /api/coding/paas/v4; /api/paas/v4
+        # is the independently billed general API.
+        if "open.bigmodel.cn" in url or "bigmodel" in url or "api.z.ai" in url:
+            rewritten = url[: -len("/anthropic")] + "/coding/paas/v4"
             logger.debug("Auxiliary client: rewrote ZAI base URL %s → %s", url, rewritten)
             return rewritten
         rewritten = url[: -len("/anthropic")] + "/v1"

--- a/tests/agent/test_minimax_auxiliary_url.py
+++ b/tests/agent/test_minimax_auxiliary_url.py
@@ -1,7 +1,9 @@
-"""Tests for MiniMax auxiliary client URL normalization.
+"""Tests for Anthropic-to-OpenAI auxiliary URL normalization.
 
 MiniMax and MiniMax-CN set inference_base_url to the /anthropic path.
-The auxiliary client uses the OpenAI SDK, which needs /v1 instead.
+The auxiliary client uses the OpenAI SDK, which needs /v1 instead. ZAI's
+Anthropic endpoint belongs to Coding Plan, whose OpenAI-compatible peer is the
+separately billed /api/coding/paas/v4 endpoint.
 """
 
 import sys
@@ -16,12 +18,17 @@ class TestToOpenaiBaseUrl:
     def test_minimax_global_anthropic_suffix_replaced(self):
         assert _to_openai_base_url("https://api.minimax.io/anthropic") == "https://api.minimax.io/v1"
 
+    def test_zai_anthropic_routes_to_coding_plan_openai_endpoint(self):
+        assert (
+            _to_openai_base_url("https://api.z.ai/api/anthropic")
+            == "https://api.z.ai/api/coding/paas/v4"
+        )
 
-
-
-
-
-
+    def test_bigmodel_anthropic_routes_to_coding_plan_openai_endpoint(self):
+        assert (
+            _to_openai_base_url("https://open.bigmodel.cn/api/anthropic")
+            == "https://open.bigmodel.cn/api/coding/paas/v4"
+        )
 
     def test_none(self):
         assert _to_openai_base_url(None) == ""


### PR DESCRIPTION
## Problem

ZAI (open.bigmodel.cn / api.z.ai) MoA reference models and auxiliary tasks fail with HTTP 429 (`code 1113` — "余额不足或无可用资源包,请充值。") even when the **same key** works on the main session model.

Symptom observed in logs:

```
Auxiliary moa_reference: using custom (glm-5.2) at https://open.bigmodel.cn/api/paas/v4/
MoA reference model zai:glm-5.2 failed: Error code: 429 - {'code': '1113', 'message': '余额不足或无可用资源包,请充值。'}}
```

But the main agent session using the **same key** on `.../api/anthropic` succeeds. The same key also succeeds on `.../api/coding/paas/v4`.

## Root cause

ZAI has **two separate OpenAI-compatible endpoints with independent billing/credit pools**:

| Endpoint | Billing path |
|---|---|
| `/api/paas/v4` | Standard API (pay-as-you-go) |
| `/api/coding/paas/v4` | **Coding Plan** (separate subscription/credit) |

The `/api/anthropic` endpoint (Anthropic Messages wire) serves the **same Coding-Plan models** (glm-5.2, glm-5.1, glm-5v-turbo, glm-4.7) as `/api/coding/paas/v4` — same key, same billing path.

`_to_openai_base_url()` rewrites the `/anthropic` suffix to the OpenAI-compatible surface. But it chose `/api/paas/v4` (standard) instead of `/api/coding/paas/v4` (Coding Plan). This routes the request to a **different billing pool** than the one the user's key is actually provisioned on, so a Coding-Plan key with zero standard-pool balance gets 429 even though the key is valid and well-provisioned on the coding/anthropic endpoints.

This is the official endpoint list (`ZAI_ENDPOINTS` in `hermes_cli/auth.py`):

```python
("global",        "https://api.z.ai/api/paas/v4",        ["glm-5"]),
("cn",            "https://open.bigmodel.cn/api/paas/v4", ["glm-5"]),
("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"]),
("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"]),
```

## Why only auxiliary/MoA paths break

The **main agent session** uses `anthropic_messages` transport → talks directly to `/api/anthropic` → works.

But **MoA references, compression, vision, session_search** all go through the auxiliary client, which uses the **OpenAI SDK**. The OpenAI SDK needs the `/paas/v4` surface, so `_to_openai_base_url()` rewrites the URL — and the mistranslation sends these calls to the wrong billing pool.

## Fix

Rewrite `/api/anthropic` to `/api/coding/paas/v4` (the correct OpenAI-wire equivalent), and extend the host match to cover `api.z.ai` alongside `open.bigmodel.cn` / `bigmodel`.

```diff
-            rewritten = url[: -len("/anthropic")] + "/paas/v4"
+            rewritten = url[: -len("/anthropic")] + "/coding/paas/v4"
```

## Testing

**Unit** — `_to_openai_base_url()` input to output:

| Input | Before | After |
|---|---|---|
| `https://open.bigmodel.cn/api/anthropic` | `.../api/paas/v4` (wrong pool) | `.../api/coding/paas/v4` (correct) |
| `https://api.z.ai/api/anthropic` | no match | `.../api/coding/paas/v4` |
| `https://open.bigmodel.cn/api/paas/v4` | unchanged | unchanged |
| `https://open.bigmodel.cn/api/coding/paas/v4` | unchanged | unchanged |
| `https://api.minimaxi.chat/v1/anthropic` | `.../v1/v1` | `.../v1/v1` |
| `https://api.anthropic.com` | unchanged | unchanged |

**End-to-end** — MoA reference call to `zai:glm-5.2` (the exact path that failed):

```
label: zai:glm-5.2
text: OK
call succeeded — GLM via coding/paas/v4 endpoint
```

Before this fix, the same call returned `429 code 1113 (余额不足)`.

## Scope

1-line core change + docstring. Affects only the ZAI URL rewrite branch; all other providers (MiniMax, Kimi, Anthropic-direct) unchanged.

## Checklist

- [x] Reproduced the bug on current `main`
- [x] Fix targets the exact mistranslated endpoint
- [x] Unit-tested all rewrite branches (ZAI + MiniMax + passthrough)
- [x] End-to-end verified: MoA reference to zai:glm-5.2 now succeeds
- [x] No existing issue/PR found for this specific billing-pool mismatch (searched `coding/paas`, `_to_openai_base_url`, `余额不足`, `wrong billing`)
