### PR TITLE
fix(desktop): stop clipping descenders in sidebar row labels (#54634)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/chrome.tsx
+++ b/apps/desktop/src/app/chat/sidebar/chrome.tsx
@@ -27,7 +27,11 @@ const rowPadX = 'pl-2 pr-1'
 const rowGap = 'gap-1.5'
 const rowLead = 'grid size-3.5 shrink-0 place-items-center'
 const rowInset = cn(rowPadX, rowGap, 'flex h-full min-w-0 items-center self-stretch py-0.5')
-const rowLabel = 'min-w-0 truncate text-[0.8125rem] leading-none text-(--ui-text-secondary)'
+// leading-normal, not leading-none: truncate's overflow:hidden clips the line
+// box, and at line-height 1 a descender (g/j/y) hangs below it and gets shaved
+// (#54634). The shell owns row height, so a taller label box just centers —
+// row layout is unchanged.
+const rowLabel = 'min-w-0 truncate text-[0.8125rem] leading-normal text-(--ui-text-secondary)'
 
 /** Codicon size in sidebar row leads — matches the file tree (`tree.tsx`). */
 export const SIDEBAR_LEAD_ICON_SIZE = '0.875rem' as const


### PR DESCRIPTION
## What does this PR do?

Sidebar row labels in Hermes Desktop clip the bottom of descenders (`g`, `j`, `y`, etc.), most visibly in the **Sessions** list on macOS.

Root cause: the shared label style in `apps/desktop/src/app/chat/sidebar/chrome.tsx` sets `leading-none` (line-height: 1) on the truncating span. `truncate` applies `overflow: hidden`, which clips the line box on the vertical axis too — and at line-height 1 the box is exactly the font size, so descenders hang below it and get shaved.

The row's height is owned by the shell (`rowMinH` on `SidebarRowShell`), not by the label, so the label's line-height only sizes its own clip box. Widening it from `leading-none` to `leading-normal` gives descenders room; the taller box simply centers within the unchanged row, so row layout and density are untouched. Fixing the shared `rowLabel` constant covers every sidebar row label (sessions, projects, links) in one place.

## Related Issue

Fixes #54634

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/chrome.tsx`: change the shared `rowLabel` style from `leading-none` to `leading-normal` so the `truncate` clip box no longer shears descenders. Added a comment explaining why.

## How to Test

1. Run Hermes Desktop on macOS.
2. Open the **Sessions** sidebar and view session titles containing descenders (e.g. a "Telegram …" session — the `g` in "Telegram", or `g`/`y` in any title).
3. Before: the bottoms of `g`/`j`/`y` are clipped. After: descenders render fully.

Verified locally on macOS:
- `npm run typecheck` (tsc) — passes
- `npx eslint` on the changed file — passes
- Rendered the exact `truncate` + `leading-none` vs `leading-normal` label in Electron (the app's own Chromium, retina scale, `-webkit-font-smoothing: antialiased`): descenders are clipped with `leading-none` and render fully with `leading-normal`.

CI also confirms **TypeScript / Build desktop app** and **Check TypeScript (apps/desktop)** pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **N/A**: renderer-only CSS change, no Python is touched (the desktop validation is TypeScript build/typecheck, which passes locally and in CI)
- [ ] I've added tests for my changes — **N/A**: this is a visual line-height/descender fix with no unit-testable surface; the repo has no rendering/snapshot harness for sidebar typography. Verified by a real Electron render instead (see How to Test)
- [x] I've tested on my platform: **macOS 15** — typecheck + eslint + Electron visual render of the fix

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the same shared label is used on all platforms; descenders were at risk everywhere and `leading-normal` is platform-agnostic.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
