### PR TITLE
fix(cli): guard legacy hermes-agent entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -295,7 +295,7 @@ all = [
 
 [project.scripts]
 hermes = "hermes_cli.main:main"
-hermes-agent = "run_agent:main"
+hermes-agent = "run_agent:legacy_cli_main"
 hermes-acp = "acp_adapter.entry:main"
 
 [tool.setuptools]

--- a/run_agent.py
+++ b/run_agent.py
@@ -31,6 +31,7 @@ except ModuleNotFoundError:
     # means UTF-8 stdio setup is skipped on Windows; POSIX is unaffected.
     pass
 
+import argparse
 import asyncio
 import base64
 import copy
@@ -5431,6 +5432,96 @@ class AIAgent:
         from agent.codex_runtime import run_codex_app_server_turn
         return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
 
+
+def _build_legacy_cli_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="hermes-agent",
+        description=(
+            "Legacy Hermes Agent runner. For the primary CLI, use the "
+            "`hermes` command."
+        ),
+        add_help=False,
+    )
+    parser.add_argument(
+        "prompt",
+        nargs="*",
+        help="Natural language query to run. Prefer --query for scripted use.",
+    )
+    parser.add_argument("-h", "--help", action="store_true", dest="show_help")
+    parser.add_argument("--version", "-V", action="store_true")
+    parser.add_argument("--query", "-q")
+    parser.add_argument("--model", default="")
+    parser.add_argument("--api-key", "--api_key", dest="api_key")
+    parser.add_argument("--base-url", "--base_url", dest="base_url", default="")
+    parser.add_argument("--max-turns", "--max_turns", dest="max_turns", type=int, default=10)
+    parser.add_argument("--enabled-toolsets", "--enabled_toolsets", dest="enabled_toolsets")
+    parser.add_argument("--disabled-toolsets", "--disabled_toolsets", dest="disabled_toolsets")
+    parser.add_argument("--list-tools", "--list_tools", dest="list_tools", action="store_true")
+    parser.add_argument(
+        "--save-trajectories",
+        "--save_trajectories",
+        dest="save_trajectories",
+        action="store_true",
+    )
+    parser.add_argument("--save-sample", "--save_sample", dest="save_sample", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument(
+        "--log-prefix-chars",
+        "--log_prefix_chars",
+        dest="log_prefix_chars",
+        type=int,
+        default=20,
+    )
+    return parser
+
+
+def legacy_cli_main(argv: Optional[List[str]] = None) -> int:
+    """Console-script wrapper for the legacy ``hermes-agent`` entry point.
+
+    The packaged console script calls the target function with no arguments.
+    Pointing it at ``main`` therefore used to start a live model request before
+    flags like ``--version`` or ``--help`` could be parsed.
+    """
+    parser = _build_legacy_cli_parser()
+    args = parser.parse_args(argv)
+
+    if args.version:
+        from hermes_cli import __release_date__, __version__
+
+        print(f"Hermes Agent v{__version__} ({__release_date__})")
+        return 0
+
+    if args.show_help:
+        parser.print_help()
+        return 0
+
+    positional_query = " ".join(args.prompt).strip() if args.prompt else None
+    if args.query and positional_query:
+        parser.error("pass the query either positionally or via --query, not both")
+
+    query = args.query or positional_query
+    if not query and not args.list_tools:
+        parser.print_help()
+        print("\nNo query provided; pass --query to run the legacy agent entry point.")
+        return 0
+
+    main(
+        query=query,
+        model=args.model,
+        api_key=args.api_key,
+        base_url=args.base_url,
+        max_turns=args.max_turns,
+        enabled_toolsets=args.enabled_toolsets,
+        disabled_toolsets=args.disabled_toolsets,
+        list_tools=args.list_tools,
+        save_trajectories=args.save_trajectories,
+        save_sample=args.save_sample,
+        verbose=args.verbose,
+        log_prefix_chars=args.log_prefix_chars,
+    )
+    return 0
+
+
 def main(
     query: str = None,
     model: str = "",
@@ -5646,5 +5737,4 @@ def main(
 
 
 if __name__ == "__main__":
-    import fire
-    fire.Fire(main)
+    raise SystemExit(legacy_cli_main())

--- a/tests/hermes_cli/test_verify_console_scripts.py
+++ b/tests/hermes_cli/test_verify_console_scripts.py
@@ -21,7 +21,7 @@ def temp_pyproject(tmp_path, monkeypatch):
 
         [project.scripts]
         hermes = "hermes_cli.main:main"
-        hermes-agent = "run_agent:main"
+        hermes-agent = "run_agent:legacy_cli_main"
         hermes-acp = "acp_adapter.entry:main"
     """
         )

--- a/tests/run_agent/test_legacy_cli_entrypoint.py
+++ b/tests/run_agent/test_legacy_cli_entrypoint.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import run_agent
+
+
+def _raise_if_agent_starts(**_kwargs):
+    raise AssertionError("legacy metadata commands must not start the agent")
+
+
+def test_legacy_cli_version_does_not_start_agent(monkeypatch, capsys):
+    monkeypatch.setattr(run_agent, "main", _raise_if_agent_starts)
+
+    assert run_agent.legacy_cli_main(["--version"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Hermes Agent v" in output
+
+
+def test_legacy_cli_help_does_not_start_agent(monkeypatch, capsys):
+    monkeypatch.setattr(run_agent, "main", _raise_if_agent_starts)
+
+    assert run_agent.legacy_cli_main(["--help"]) == 0
+
+    output = capsys.readouterr().out
+    assert "usage: hermes-agent" in output
+
+
+def test_legacy_cli_no_args_is_side_effect_free(monkeypatch, capsys):
+    monkeypatch.setattr(run_agent, "main", _raise_if_agent_starts)
+
+    assert run_agent.legacy_cli_main([]) == 0
+
+    output = capsys.readouterr().out
+    assert "usage: hermes-agent" in output
+    assert "No query provided" in output
+
+
+def test_legacy_cli_query_dispatches_to_existing_runner(monkeypatch):
+    calls = {}
+
+    def fake_main(**kwargs):
+        calls.update(kwargs)
+
+    monkeypatch.setattr(run_agent, "main", fake_main)
+
+    assert run_agent.legacy_cli_main(
+        [
+            "--query",
+            "hello from the legacy entry point",
+            "--model",
+            "provider/model",
+            "--max-turns",
+            "3",
+            "--enabled-toolsets",
+            "web,terminal",
+            "--verbose",
+        ]
+    ) == 0
+
+    assert calls == {
+        "query": "hello from the legacy entry point",
+        "model": "provider/model",
+        "api_key": None,
+        "base_url": "",
+        "max_turns": 3,
+        "enabled_toolsets": "web,terminal",
+        "disabled_toolsets": None,
+        "list_tools": False,
+        "save_trajectories": False,
+        "save_sample": False,
+        "verbose": True,
+        "log_prefix_chars": 20,
+    }
+
+
+def test_packaged_hermes_agent_script_uses_safe_wrapper():
+    repo_root = Path(__file__).resolve().parents[2]
+    pyproject = tomllib.loads((repo_root / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert pyproject["project"]["scripts"]["hermes-agent"] == "run_agent:legacy_cli_main"


### PR DESCRIPTION
## What does this PR do?

Fixes the legacy `hermes-agent` console script so metadata/probe invocations are side-effect free.

Today `pyproject.toml` maps `hermes-agent` directly to `run_agent:main`. A generated console script calls that function with no parsed CLI args, so `hermes-agent --version`, `hermes-agent --help`, and even bare `hermes-agent` can fall into the default Python 3.13 demo prompt and start a live agent/provider request.

This PR adds a small argparse wrapper for the legacy entry point and points the packaged script at it. The wrapper handles `--version`, `--help`, and no-argument invocations without calling `main()`, while preserving explicit runs through `--query`, positional prompt text, and the existing model/toolset flags.

Related note: #13712 also touches adjacent legacy version handling, but it is a broad 5k+ line integration PR. This PR keeps the fix narrow and reviewable.

## Related Issue

Fixes #54648

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `run_agent.py`: add `legacy_cli_main()` and a legacy argparse parser for `hermes-agent`.
- `pyproject.toml`: point `hermes-agent` at `run_agent:legacy_cli_main`.
- `tests/run_agent/test_legacy_cli_entrypoint.py`: cover `--version`, `--help`, no args, explicit query dispatch, and packaged script target.
- `tests/hermes_cli/test_verify_console_scripts.py`: update the fake pyproject fixture to match the real script target.

## How to Test

Reproduced on Windows with the installed `hermes-agent.exe --version`, which started the default Python 3.13 demo agent path and attempted a provider request before failing.

Validated the fix with:

1. `uv run --extra dev python -m pytest tests\run_agent\test_legacy_cli_entrypoint.py -q`
   - `5 passed`
2. `uv run --extra dev python -m pytest tests\hermes_cli\test_verify_console_scripts.py -q`
   - `6 passed`
3. `uv run --extra dev python -m pytest tests\test_hermes_bootstrap.py::TestEntryPointsImportBootstrap::test_entry_point_imports_bootstrap -q`
   - `6 passed`
4. `uv run --extra dev python -m ruff check run_agent.py tests\run_agent\test_legacy_cli_entrypoint.py tests\hermes_cli\test_verify_console_scripts.py`
   - passed; ruff still reports an existing warning for an unrelated invalid `# noqa` directive in `run_agent.py`
5. `python -m py_compile run_agent.py`
6. Smoke-tested the generated worktree console script:
   - `.venv\Scripts\hermes-agent.exe --version`
   - `.venv\Scripts\hermes-agent.exe --help`
   - `.venv\Scripts\hermes-agent.exe`

I first tried the canonical `bash scripts/run_tests.sh tests/run_agent/test_legacy_cli_entrypoint.py -q`, but this Windows worktree had no `.venv`/`venv` and the script's POSIX `$HOME/.hermes/hermes-agent/venv` fallback did not match the local Windows install location.

## Checklist

### Code

- [x] I've read the Contributing Guide / repo guidance
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 Pro 10.0.22631, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) - console script behavior is platform-independent; reproduced on Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

No raw failing provider output is included because the failing path can print credential-bearing request metadata. The regression tests and console-script smoke cover the side-effect-free behavior directly.
