### PR TITLE
fix(vision): detect Ollama vision models via /api/show (#54511)

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -251,6 +251,78 @@ def _supports_vision_override(
     return None
 
 
+def _resolve_inference_base_url(
+    cfg: Optional[Dict[str, Any]],
+    provider: str,
+) -> str:
+    """Best-effort base URL for the active inference provider."""
+    try:
+        from agent.auxiliary_client import _RUNTIME_MAIN_BASE_URL
+
+        runtime = str(_RUNTIME_MAIN_BASE_URL or "").strip()
+        if runtime:
+            return runtime
+    except Exception:
+        pass
+
+    if not isinstance(cfg, dict):
+        return ""
+
+    model_cfg_raw = cfg.get("model")
+    model_cfg: Dict[str, Any] = model_cfg_raw if isinstance(model_cfg_raw, dict) else {}
+    base_url = str(model_cfg.get("base_url") or "").strip()
+    if base_url:
+        return base_url
+
+    config_provider = str(model_cfg.get("provider") or "").strip()
+    candidate_names: set[str] = set()
+    for p in filter(None, (provider, config_provider)):
+        candidate_names.add(p)
+        if p.lower().startswith("custom:"):
+            candidate_names.add(p.split(":", 1)[1])
+        else:
+            candidate_names.add(f"custom:{p}")
+
+    providers_cfg = cfg.get("providers")
+    if isinstance(providers_cfg, dict):
+        for name in candidate_names:
+            entry = providers_cfg.get(name)
+            if isinstance(entry, dict):
+                bu = str(entry.get("base_url") or "").strip()
+                if bu:
+                    return bu
+
+    custom_providers = cfg.get("custom_providers")
+    if isinstance(custom_providers, list):
+        lowered = {n.lower() for n in candidate_names}
+        for entry_raw in custom_providers:
+            if not isinstance(entry_raw, dict):
+                continue
+            entry_name = str(entry_raw.get("name") or "").strip()
+            if entry_name not in candidate_names and entry_name.lower() not in lowered:
+                continue
+            bu = str(entry_raw.get("base_url") or "").strip()
+            if bu:
+                return bu
+
+    return ""
+
+
+def _should_probe_ollama_vision(provider: str, base_url: str) -> bool:
+    """True when the active provider likely fronts a local Ollama server."""
+    p = (provider or "").strip().lower()
+    if p == "ollama":
+        return True
+    if not base_url:
+        return False
+    try:
+        from agent.model_metadata import detect_local_server_type
+
+        return detect_local_server_type(base_url) == "ollama"
+    except Exception:
+        return False
+
+
 def _coerce_mode(raw: Any) -> str:
     """Normalize a config value into one of the valid modes."""
     if not isinstance(raw, str):
@@ -302,15 +374,33 @@ def _lookup_supports_vision(
         return override
     if not provider or not model:
         return None
+    caps = None
     try:
         from agent.models_dev import get_model_capabilities
         caps = get_model_capabilities(provider, model)
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("image_routing: caps lookup failed for %s:%s — %s", provider, model, exc)
-        return None
-    if caps is None:
-        return None
-    return bool(caps.supports_vision)
+    if caps is not None:
+        return bool(caps.supports_vision)
+
+    base_url = _resolve_inference_base_url(cfg, provider)
+    if not base_url and (provider or "").strip().lower() == "ollama":
+        base_url = "http://localhost:11434/v1"
+    if _should_probe_ollama_vision(provider, base_url):
+        try:
+            from agent.model_metadata import query_ollama_supports_vision
+
+            ollama_vision = query_ollama_supports_vision(model, base_url)
+            if ollama_vision is not None:
+                return ollama_vision
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug(
+                "image_routing: ollama vision probe failed for %s:%s — %s",
+                provider,
+                model,
+                exc,
+            )
+    return None
 
 
 def decide_image_input_mode(

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1199,6 +1199,56 @@ def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Option
     return None
 
 
+def query_ollama_supports_vision(model: str, base_url: str, api_key: str = "") -> Optional[bool]:
+    """Return True/False when Ollama ``/api/show`` reports vision support.
+
+    Uses the ``capabilities`` field on Ollama 0.6.0+ and falls back to
+    ``model_info.*.vision.block_count`` on older servers. Returns None when
+    the server is unreachable, not Ollama, or the model is unknown.
+    """
+    import httpx
+
+    bare_model = _strip_provider_prefix(model)
+    if not bare_model or not base_url:
+        return None
+
+    try:
+        if detect_local_server_type(base_url, api_key=api_key) != "ollama":
+            return None
+    except Exception:
+        return None
+
+    server_url = base_url.rstrip("/")
+    if server_url.endswith("/v1"):
+        server_url = server_url[:-3]
+
+    headers = _auth_headers(api_key)
+
+    try:
+        with httpx.Client(timeout=3.0, headers=headers) as client:
+            resp = client.post(f"{server_url}/api/show", json={"name": bare_model})
+            if resp.status_code != 200:
+                return None
+            data = resp.json()
+    except Exception:
+        return None
+
+    caps = data.get("capabilities")
+    if isinstance(caps, list):
+        if any(str(cap).lower() == "vision" for cap in caps):
+            return True
+        if caps:
+            return False
+
+    model_info = data.get("model_info")
+    if isinstance(model_info, dict):
+        for key in model_info:
+            if "vision.block_count" in str(key).lower():
+                return True
+
+    return None
+
+
 def _query_ollama_api_show(model: str, base_url: str, api_key: str = "") -> Optional[int]:
     """Query an Ollama server's native ``/api/show`` for context length.
 

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -248,8 +248,23 @@ class TestLookupSupportsVisionOverride:
             assert _lookup_supports_vision("anthropic", "claude-sonnet-4", {}) is True
 
     def test_no_override_no_models_dev_entry_returns_none(self):
-        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("agent.image_routing._should_probe_ollama_vision", return_value=False):
             assert _lookup_supports_vision("custom", "my-llava", {}) is None
+
+    def test_ollama_probe_when_models_dev_missing(self):
+        cfg = {"model": {"base_url": "http://localhost:11434/v1"}}
+        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("agent.image_routing._should_probe_ollama_vision", return_value=True), \
+             patch("agent.model_metadata.query_ollama_supports_vision", return_value=True):
+            assert _lookup_supports_vision("ollama", "gemma4:e2b", cfg) is True
+
+    def test_ollama_probe_false_for_text_only_model(self):
+        cfg = {"model": {"base_url": "http://localhost:11434/v1"}}
+        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("agent.image_routing._should_probe_ollama_vision", return_value=True), \
+             patch("agent.model_metadata.query_ollama_supports_vision", return_value=False):
+            assert _lookup_supports_vision("custom", "gemma4:31b", cfg) is False
 
     def test_cfg_none_falls_back_to_models_dev(self):
         # Caller didn't pass cfg at all — old call sites must still work.

--- a/tests/test_ollama_num_ctx.py
+++ b/tests/test_ollama_num_ctx.py
@@ -8,7 +8,7 @@ Covers:
 from unittest.mock import patch, MagicMock
 
 
-from agent.model_metadata import query_ollama_num_ctx
+from agent.model_metadata import query_ollama_num_ctx, query_ollama_supports_vision
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -131,4 +131,46 @@ class TestQueryOllamaNumCtx:
             with patch.object(httpx, "Client", return_value=mock_ctx):
                 result = query_ollama_num_ctx("model", "http://localhost:11434")
 
+        assert result is None
+
+
+class TestQueryOllamaSupportsVision:
+    """Test Ollama /api/show vision capability detection."""
+
+    def test_returns_true_when_capabilities_include_vision(self):
+        show_data = {"capabilities": ["completion", "vision"]}
+        mock_ctx, _ = _mock_httpx_client(show_data)
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="ollama"):
+            import httpx
+            with patch.object(httpx, "Client", return_value=mock_ctx):
+                result = query_ollama_supports_vision("gemma4:e2b", "http://localhost:11434/v1")
+
+        assert result is True
+
+    def test_returns_false_when_capabilities_exclude_vision(self):
+        show_data = {"capabilities": ["completion", "tools"]}
+        mock_ctx, _ = _mock_httpx_client(show_data)
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="ollama"):
+            import httpx
+            with patch.object(httpx, "Client", return_value=mock_ctx):
+                result = query_ollama_supports_vision("gemma4:31b", "http://localhost:11434/v1")
+
+        assert result is False
+
+    def test_falls_back_to_model_info_vision_block_count(self):
+        show_data = {"model_info": {"gemma3.vision.block_count": 27}}
+        mock_ctx, _ = _mock_httpx_client(show_data)
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="ollama"):
+            import httpx
+            with patch.object(httpx, "Client", return_value=mock_ctx):
+                result = query_ollama_supports_vision("llava", "http://localhost:11434")
+
+        assert result is True
+
+    def test_returns_none_for_non_ollama_server(self):
+        with patch("agent.model_metadata.detect_local_server_type", return_value="vllm"):
+            result = query_ollama_supports_vision("llava", "http://localhost:8000/v1")
         assert result is None


### PR DESCRIPTION
## Summary
Local Ollama vision models (gemma3:e2b, llava, llama3.2-vision) now receive image attachments natively instead of having them silently stripped to `[image attached]` text.

Root cause: `_lookup_supports_vision()` only consults models.dev, which has no entry for locally-served models (provider `ollama` / `custom`). The lookup returned `None`, `decide_image_input_mode()` treated that as non-vision, and image content parts were replaced with text placeholders before the request reached Ollama.

## Changes
- `agent/model_metadata.py`: new `query_ollama_supports_vision()` — probes the local server's `/api/show` (mirrors the existing `query_ollama_num_ctx` pattern), reading `capabilities: [..., vision]` (Ollama 0.6+) with a `model_info.*.vision.block_count` fallback for older servers.
- `agent/image_routing.py`: when models.dev returns `None` AND the active provider fronts a local Ollama server, fall through to the probe. Gated by `_should_probe_ollama_vision()` and base-URL resolution; any failure returns `None` (graceful → text).
- Tests: `tests/test_ollama_num_ctx.py`, `tests/agent/test_image_routing.py`.

## Validation
| Scenario | Before | After |
|---|---|---|
| Ollama vision model (`capabilities` has vision) | text (image stripped) | **native** |
| Ollama text-only model | text | text |
| Legacy server (`vision.block_count`) | text (image stripped) | **native** |
| Ollama server unreachable | text | text (graceful) |
| Non-Ollama providers (anthropic/openrouter) | unchanged | unchanged |

116 targeted tests pass (`test_ollama_num_ctx`, `test_image_routing`, `test_vision_aware_preprocessing`). E2E-verified the full `decide_image_input_mode` chain with mocked `/api/show` responses — all five scenarios correct; non-Ollama providers never trigger the probe.

Salvage of #54520 (@HexLab98), cherry-picked onto current main with authorship preserved. Closes #54511.

## Infographic
![Ollama vision detection](https://v3b.fal.media/files/b/0aa033a6/0ukx3h0vBWV1qAUifaw-l_i7wp3F1U.png)
