### PR TITLE
fix(agent): stream copilot ACP chat completions

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -21,6 +21,11 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+    Function,
+)
+
 from agent.file_safety import get_read_block_error, is_write_denied
 from agent.redact import redact_sensitive_text
 from tools.environments.local import hermes_subprocess_env
@@ -228,11 +233,27 @@ def _render_message_content(content: Any) -> str:
     return str(content).strip()
 
 
-def _extract_tool_calls_from_text(text: str) -> tuple[list[SimpleNamespace], str]:
+def _build_openai_tool_call(
+    *,
+    call_id: str,
+    name: str,
+    arguments: str,
+) -> ChatCompletionMessageToolCall:
+    """Build an OpenAI-compatible tool-call object for downstream handling."""
+    return ChatCompletionMessageToolCall(
+        id=call_id,
+        call_id=call_id,
+        response_item_id=None,
+        type="function",
+        function=Function(name=name, arguments=arguments),
+    )
+
+
+def _extract_tool_calls_from_text(text: str) -> tuple[list[ChatCompletionMessageToolCall], str]:
     if not isinstance(text, str) or not text.strip():
         return [], ""
 
-    extracted: list[SimpleNamespace] = []
+    extracted: list[ChatCompletionMessageToolCall] = []
     consumed_spans: list[tuple[int, int]] = []
 
     def _try_add_tool_call(raw_json: str) -> None:
@@ -256,12 +277,10 @@ def _extract_tool_calls_from_text(text: str) -> tuple[list[SimpleNamespace], str
             call_id = f"acp_call_{len(extracted)+1}"
 
         extracted.append(
-            SimpleNamespace(
-                id=call_id,
+            _build_openai_tool_call(
                 call_id=call_id,
-                response_item_id=None,
-                type="function",
-                function=SimpleNamespace(name=fn_name.strip(), arguments=fn_args),
+                name=fn_name.strip(),
+                arguments=fn_args,
             )
         )
 

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -249,6 +249,52 @@ def _build_openai_tool_call(
     )
 
 
+def _completion_to_stream_chunks(completion: SimpleNamespace) -> list[SimpleNamespace]:
+    """Convert a one-shot ACP response into OpenAI-style stream chunks."""
+    choice = completion.choices[0]
+    message = choice.message
+    tool_call_deltas = None
+    if message.tool_calls:
+        tool_call_deltas = []
+        for index, tool_call in enumerate(message.tool_calls):
+            tool_call_deltas.append(
+                SimpleNamespace(
+                    index=index,
+                    id=getattr(tool_call, "id", None),
+                    type=getattr(tool_call, "type", "function"),
+                    function=SimpleNamespace(
+                        name=getattr(tool_call.function, "name", None),
+                        arguments=getattr(tool_call.function, "arguments", None),
+                    ),
+                )
+            )
+
+    delta = SimpleNamespace(
+        role="assistant",
+        content=message.content or None,
+        tool_calls=tool_call_deltas,
+        reasoning_content=message.reasoning_content,
+        reasoning=message.reasoning,
+    )
+    data_chunk = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                index=0,
+                delta=delta,
+                finish_reason=choice.finish_reason,
+            )
+        ],
+        model=completion.model,
+        usage=None,
+    )
+    usage_chunk = SimpleNamespace(
+        choices=[],
+        model=completion.model,
+        usage=completion.usage,
+    )
+    return [data_chunk, usage_chunk]
+
+
 def _extract_tool_calls_from_text(text: str) -> tuple[list[ChatCompletionMessageToolCall], str]:
     if not isinstance(text, str) or not text.strip():
         return [], ""
@@ -399,6 +445,7 @@ class CopilotACPClient:
         timeout: float | None = None,
         tools: list[dict[str, Any]] | None = None,
         tool_choice: Any = None,
+        stream: bool = False,
         **_: Any,
     ) -> Any:
         prompt_text = _format_messages_as_prompt(
@@ -445,11 +492,14 @@ class CopilotACPClient:
         )
         finish_reason = "tool_calls" if tool_calls else "stop"
         choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
-        return SimpleNamespace(
+        completion = SimpleNamespace(
             choices=[choice],
             usage=usage,
             model=model or "copilot-acp",
         )
+        if stream:
+            return _completion_to_stream_chunks(completion)
+        return completion
 
     def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
         try:

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -22,6 +22,40 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
     def setUp(self) -> None:
         self.client = CopilotACPClient(acp_cwd="/tmp")
 
+    def test_extracted_tool_calls_match_openai_sdk_shape(self) -> None:
+        tool_response = (
+            "I'll inspect that.\n"
+            "<tool_call>"
+            '{"id":"call_read","type":"function",'
+            '"function":{"name":"read_file","arguments":"{\\"path\\":\\"README.md\\"}"}}'
+            "</tool_call>"
+        )
+
+        with patch.object(self.client, "_run_prompt", return_value=(tool_response, "")):
+            response = self.client._create_chat_completion(
+                model="copilot-acp",
+                messages=[{"role": "user", "content": "read README.md"}],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {"name": "read_file", "parameters": {}},
+                    }
+                ],
+            )
+
+        choice = response.choices[0]
+        self.assertEqual(choice.finish_reason, "tool_calls")
+        tool_call = choice.message.tool_calls[0]
+        self.assertEqual(tool_call.id, "call_read")
+        self.assertEqual(tool_call.function.name, "read_file")
+        self.assertEqual(
+            json.loads(tool_call.function.arguments),
+            {"path": "README.md"},
+        )
+        self.assertEqual(dict(tool_call)["id"], "call_read")
+        self.assertEqual(dict(tool_call.function)["name"], "read_file")
+        self.assertEqual(choice.message.content, "I'll inspect that.")
+
     def _dispatch(self, message: dict, *, cwd: str) -> dict:
         process = _FakeProcess()
         handled = self.client._handle_server_message(

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -56,6 +56,77 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.assertEqual(dict(tool_call.function)["name"], "read_file")
         self.assertEqual(choice.message.content, "I'll inspect that.")
 
+    def test_stream_true_returns_iterable_text_chunks(self) -> None:
+        with patch.object(self.client, "_run_prompt", return_value=("Hello from ACP", "")):
+            stream = self.client._create_chat_completion(
+                model="copilot-acp",
+                messages=[{"role": "user", "content": "hello"}],
+                stream=True,
+            )
+
+        chunks = list(stream)
+        self.assertEqual(len(chunks), 2)
+        self.assertEqual(chunks[0].choices[0].delta.content, "Hello from ACP")
+        self.assertIsNone(chunks[0].choices[0].delta.tool_calls)
+        self.assertEqual(chunks[0].choices[0].finish_reason, "stop")
+        self.assertEqual(chunks[1].choices, [])
+        self.assertEqual(chunks[1].usage.total_tokens, 0)
+
+    def test_stream_true_preserves_tool_call_deltas(self) -> None:
+        tool_response = (
+            "<tool_call>"
+            '{"id":"call_read","type":"function",'
+            '"function":{"name":"read_file","arguments":"{\\"path\\":\\"README.md\\"}"}}'
+            "</tool_call>"
+        )
+
+        with patch.object(self.client, "_run_prompt", return_value=(tool_response, "")):
+            stream = self.client._create_chat_completion(
+                model="copilot-acp",
+                messages=[{"role": "user", "content": "read README.md"}],
+                stream=True,
+            )
+
+        chunks = list(stream)
+        delta = chunks[0].choices[0].delta
+        self.assertIsNone(delta.content)
+        self.assertEqual(chunks[0].choices[0].finish_reason, "tool_calls")
+        self.assertEqual(len(delta.tool_calls), 1)
+        tool_delta = delta.tool_calls[0]
+        self.assertEqual(tool_delta.index, 0)
+        self.assertEqual(tool_delta.id, "call_read")
+        self.assertEqual(tool_delta.function.name, "read_file")
+        self.assertEqual(
+            json.loads(tool_delta.function.arguments),
+            {"path": "README.md"},
+        )
+        self.assertEqual(chunks[1].choices, [])
+
+    def test_timeout_object_is_coerced_for_streaming_requests(self) -> None:
+        captured: dict[str, float] = {}
+
+        def fake_run_prompt(prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+            captured["timeout"] = timeout_seconds
+            return "ok", ""
+
+        timeout = type(
+            "TimeoutLike",
+            (),
+            {"read": 12.0, "write": 5.0, "connect": 3.0, "pool": 1.0},
+        )()
+
+        with patch.object(self.client, "_run_prompt", side_effect=fake_run_prompt):
+            list(
+                self.client._create_chat_completion(
+                    model="copilot-acp",
+                    messages=[{"role": "user", "content": "hello"}],
+                    timeout=timeout,
+                    stream=True,
+                )
+            )
+
+        self.assertEqual(captured["timeout"], 12.0)
+
     def _dispatch(self, message: dict, *, cwd: str) -> dict:
         process = _FakeProcess()
         handled = self.client._handle_server_message(


### PR DESCRIPTION
## Summary
Copilot ACP now works on the streaming chat-completions path instead of crashing on the first chunk. The ACP shim returns OpenAI-style iterable stream chunks when `stream=true`, and parses tool calls into real `ChatCompletionMessageToolCall` SDK objects so downstream handling matches every other provider.

Root cause: `copilot-acp` resolves to `api_mode="chat_completions"`, the streaming path. `interruptible_streaming_api_call` does `for chunk in stream`, but the shim ignored `stream` and returned a one-shot `SimpleNamespace` → `TypeError: 'SimpleNamespace' object is not iterable`.

## Changes
- `agent/copilot_acp_client.py`: `_create_chat_completion` accepts `stream` and, when set, returns iterable chunks via `_completion_to_stream_chunks` — a **data chunk** (content + tool-call deltas with indices + `finish_reason`) followed by a separate **usage chunk** with empty `choices`. Parsed ACP tool calls are built as `ChatCompletionMessageToolCall(id, call_id, function=Function(...))`, preserving Hermes `call_id` metadata.
- `tests/agent/test_copilot_acp_client.py`: regression coverage for stream text chunks, stream tool-call deltas, OpenAI SDK tool-call shape, and timeout-object coercion on streaming requests.

The two-chunk split matters: the consumer reads `chunk.usage` **only** when `chunk.choices` is empty, so a single combined chunk would silently drop usage accounting.

## Validation
| Path | Result |
|---|---|
| `tests/agent/test_copilot_acp_client.py` | 11 passed |
| copilot-acp stays on chat_completions / uses ACP client | 2 passed |
| E2E vs real `interruptible_streaming_api_call` consumer loop | text + tool-call + usage capture verified |
| Non-stream path | unchanged (still returns one-shot completion) |

Salvage of @sgaofen's PR #14438, cherry-picked onto current `main` with authorship preserved. Supersedes duplicate PRs #12274 (@coendewit, earliest reporter of the same `stream=True` TypeError) and #9578 (@EralChen).

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa033ab/lP06fuozzdnMeSvOsdnAw_PkjDtOdd.png)
