### PR TITLE
fix(gateway): preserve Signal group ids in delivery and session recovery

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -256,19 +256,37 @@ class DeliveryTarget:
         if target_lower == "local":
             return cls(platform=Platform.LOCAL)
         
-        # Check for platform:chat_id or platform:chat_id:thread_id format
-        # Use the original case for chat_id/thread_id to preserve case-sensitive IDs
+        # Check for platform:chat_id or platform:chat_id:thread_id format.
+        # Use the original case for chat_id/thread_id to preserve case-sensitive IDs.
         if ":" in target_stripped:
-            parts = target_stripped.split(":", 2)
-            platform_str = parts[0].lower()  # Platform names are case-insensitive
-            chat_id = parts[1] if len(parts) > 1 else None
-            thread_id = parts[2] if len(parts) > 2 else None
+            platform_part, remainder = target_stripped.split(":", 1)
+            platform_str = platform_part.lower()  # Platform names are case-insensitive
             try:
                 platform = Platform(platform_str)
-                return cls(platform=platform, chat_id=chat_id, thread_id=thread_id, is_explicit=True)
             except ValueError:
                 # Unknown platform, treat as local
                 return cls(platform=Platform.LOCAL)
+
+            # Signal group chat IDs are themselves prefixed with ``group:`` and the
+            # payload is standard base64, so the first colon AFTER that payload is an
+            # optional thread/topic delimiter rather than part of the chat id.
+            if platform == Platform.SIGNAL and remainder.startswith("group:"):
+                signal_group_payload = remainder[len("group:"):]
+                encoded_group_id, sep, thread_id = signal_group_payload.partition(":")
+                return cls(
+                    platform=platform,
+                    chat_id=f"group:{encoded_group_id}" if encoded_group_id else None,
+                    thread_id=thread_id or None,
+                    is_explicit=True,
+                )
+
+            chat_id, sep, thread_id = remainder.partition(":")
+            return cls(
+                platform=platform,
+                chat_id=chat_id or None,
+                thread_id=thread_id or None,
+                is_explicit=True,
+            )
         
         # Just a platform name (use home channel)
         try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3061,16 +3061,19 @@ def _parse_session_key(session_key: str) -> "dict | None":
     optionally ``thread_id`` keys, or None if the key doesn't match.
 
     The 6th element is only returned as ``thread_id`` for chat types where
-    it is unambiguous (``dm`` and ``thread``).  For group/channel sessions
+    it is unambiguous (``dm`` and ``thread``). For group/channel sessions
     the suffix may be a user_id (per-user isolation) rather than a
     thread_id, so we leave ``thread_id`` out to avoid mis-routing.
     """
     parts = session_key.split(":")
     if len(parts) >= 5 and parts[0] == "agent" and parts[1] == "main":
+        chat_id = parts[4]
+        if len(parts) > 5 and parts[2] == "signal" and parts[3] == "group" and parts[4] == "group":
+            chat_id = f"group:{parts[5]}"
         result = {
             "platform": parts[2],
             "chat_type": parts[3],
-            "chat_id": parts[4],
+            "chat_id": chat_id,
         }
         if len(parts) > 5 and parts[3] in {"dm", "thread"}:
             result["thread_id"] = parts[5]

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -18,6 +18,30 @@ class TestParseTargetPlatformChat:
         assert target.chat_id == "12345"
         assert target.is_explicit is True
 
+    def test_signal_group_chat_id_with_base64_slash_preserved(self):
+        target = DeliveryTarget.parse("signal:group:NVMOlw+k0ONcmektl8eNTUQ/2gYG84IW8qbVvY8086c=")
+        assert target.platform == Platform.SIGNAL
+        assert target.chat_id == "group:NVMOlw+k0ONcmektl8eNTUQ/2gYG84IW8qbVvY8086c="
+        assert target.thread_id is None
+        assert target.is_explicit is True
+
+    def test_signal_group_chat_id_with_thread_segment_preserved_separately(self):
+        target = DeliveryTarget.parse("signal:group:NVMOlw+k0ONcmektl8eNTUQ/2gYG84IW8qbVvY8086c=:thread-42")
+        assert target.platform == Platform.SIGNAL
+        assert target.chat_id == "group:NVMOlw+k0ONcmektl8eNTUQ/2gYG84IW8qbVvY8086c="
+        assert target.thread_id == "thread-42"
+        assert target.is_explicit is True
+
+    def test_platform_only_no_chat_id(self):
+        target = DeliveryTarget.parse("discord")
+        assert target.platform == Platform.DISCORD
+        assert target.chat_id is None
+        assert target.is_explicit is False
+
+    def test_local_target(self):
+        target = DeliveryTarget.parse("local")
+        assert target.platform == Platform.LOCAL
+        assert target.chat_id is None
 
     def test_origin_with_source(self):
         origin = SessionSource(platform=Platform.TELEGRAM, chat_id="789", thread_id="42")
@@ -33,6 +57,43 @@ class TestTargetToStringRoundtrip:
         origin = SessionSource(platform=Platform.TELEGRAM, chat_id="111", thread_id="42")
         target = DeliveryTarget.parse("origin", origin=origin)
         assert target.to_string() == "origin"
+
+    def test_local_roundtrip(self):
+        target = DeliveryTarget.parse("local")
+        assert target.to_string() == "local"
+
+    def test_platform_only_roundtrip(self):
+        target = DeliveryTarget.parse("discord")
+        assert target.to_string() == "discord"
+
+    def test_explicit_chat_roundtrip(self):
+        target = DeliveryTarget.parse("telegram:999")
+        s = target.to_string()
+        assert s == "telegram:999"
+
+        reparsed = DeliveryTarget.parse(s)
+        assert reparsed.platform == Platform.TELEGRAM
+        assert reparsed.chat_id == "999"
+
+    def test_signal_group_roundtrip_preserves_full_group_id(self):
+        original = "signal:group:NVMOlw+k0ONcmektl8eNTUQ/2gYG84IW8qbVvY8086c="
+        target = DeliveryTarget.parse(original)
+        assert target.to_string() == original
+
+        reparsed = DeliveryTarget.parse(target.to_string())
+        assert reparsed.platform == Platform.SIGNAL
+        assert reparsed.chat_id == "group:NVMOlw+k0ONcmektl8eNTUQ/2gYG84IW8qbVvY8086c="
+        assert reparsed.thread_id is None
+
+    def test_signal_group_roundtrip_preserves_thread_segment(self):
+        original = "signal:group:NVMOlw+k0ONcmektl8eNTUQ/2gYG84IW8qbVvY8086c=:thread-42"
+        target = DeliveryTarget.parse(original)
+        assert target.to_string() == original
+
+        reparsed = DeliveryTarget.parse(target.to_string())
+        assert reparsed.platform == Platform.SIGNAL
+        assert reparsed.chat_id == "group:NVMOlw+k0ONcmektl8eNTUQ/2gYG84IW8qbVvY8086c="
+        assert reparsed.thread_id == "thread-42"
 
 
 class TestCaseSensitiveChatIdParsing:

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -57,6 +57,71 @@ class TestSessionSourceRoundtrip:
         assert restored.chat_type == "dm"  # default value preserved
 
 
+class TestSessionEntryValidation:
+    def test_signal_group_session_key_allows_base64_slash(self):
+        entry = SessionEntry.from_dict({
+            "session_key": "agent:main:signal:group:group:NVMOlw+k0ONcmektl8eNTUQ/2gYG84IW8qbVvY8086c=",
+            "session_id": "sess_signal_group",
+            "created_at": "2026-01-01T00:00:00",
+            "updated_at": "2026-01-01T00:00:00",
+            "origin": {
+                "platform": "signal",
+                "chat_id": "group:NVMOlw+k0ONcmektl8eNTUQ/2gYG84IW8qbVvY8086c=",
+                "chat_type": "group",
+            },
+        })
+        assert entry.session_key == "agent:main:signal:group:group:NVMOlw+k0ONcmektl8eNTUQ/2gYG84IW8qbVvY8086c="
+
+    def test_signal_group_session_key_allows_trailing_thread_segment(self):
+        entry = SessionEntry.from_dict({
+            "session_key": "agent:main:signal:group:group:NVMOlw+k0ONcmektl8eNTUQ/2gYG84IW8qbVvY8086c=:thread-42",
+            "session_id": "sess_signal_group_thread",
+            "created_at": "2026-01-01T00:00:00",
+            "updated_at": "2026-01-01T00:00:00",
+            "origin": {
+                "platform": "signal",
+                "chat_id": "group:NVMOlw+k0ONcmektl8eNTUQ/2gYG84IW8qbVvY8086c=",
+                "thread_id": "thread-42",
+                "chat_type": "group",
+            },
+        })
+        assert entry.session_key == "agent:main:signal:group:group:NVMOlw+k0ONcmektl8eNTUQ/2gYG84IW8qbVvY8086c=:thread-42"
+
+class TestSessionStorePersistence:
+    def test_signal_group_session_key_roundtrips_through_sessions_json(self, tmp_path):
+        config = GatewayConfig()
+        store = SessionStore(tmp_path / "sessions", config)
+        session_key = "agent:main:signal:group:group:NVMOlw+k0ONcmektl8eNTUQ/2gYG84IW8qbVvY8086c="
+        session_id = "sess_signal_group"
+
+        entry = SessionEntry(
+            session_key=session_key,
+            session_id=session_id,
+            created_at=datetime(2026, 1, 1, 0, 0, 0),
+            updated_at=datetime(2026, 1, 1, 0, 0, 0),
+            origin=SessionSource(
+                platform=Platform.SIGNAL,
+                chat_id="group:NVMOlw+k0ONcmektl8eNTUQ/2gYG84IW8qbVvY8086c=",
+                chat_type="group",
+            ),
+            platform=Platform.SIGNAL,
+            chat_type="group",
+        )
+
+        store._entries[session_key] = entry
+        store._save()
+
+        reloaded = SessionStore(tmp_path / "sessions", config)
+        reloaded._ensure_loaded()
+
+        assert session_key in reloaded._entries
+        restored = reloaded._entries[session_key]
+        assert restored.session_key == session_key
+        assert restored.session_id == session_id
+        assert restored.origin is not None
+        assert restored.origin.chat_id == "group:NVMOlw+k0ONcmektl8eNTUQ/2gYG84IW8qbVvY8086c="
+
+
 class TestSessionSourceDescription:
     def test_local_cli(self):
         source = SessionSource(


### PR DESCRIPTION
## Summary
- preserve explicit `signal:group:<base64>` chat IDs in `gateway/delivery.py`, including an optional trailing `:thread` segment without folding it into the group id
- preserve `group:<base64>` when reparsing persisted Signal group session keys in `gateway/run.py`
- keep focused session-key regression coverage showing canonical Signal group keys still survive `SessionEntry.from_dict(...)` and persistence round-trips on current `main`

## Root cause
Signal group IDs are base64 and may contain `/`, `+`, and `=`.

Two gateway layers were mishandling that shape:
- `DeliveryTarget.parse()` split `signal:group:<base64>` too aggressively and could truncate the chat id to `group`
- `_parse_session_key()` could reconstruct persisted Signal group keys as just `group` instead of `group:<base64>`

That combination can break explicit Signal delivery targets and corrupt persisted routing identity after session reload/recovery.

Current `main` has also moved since this PR was first prepared: the logical `session_key` traversal guard is now relaxed separately from filename/path validation, so the earlier `gateway/session.py` carve-out is no longer needed for canonical Signal group keys. This refresh therefore keeps the delivery/recovery fix and the regression coverage, while dropping the now-redundant `gateway/session.py` source change.

## Scope and overlap
This partially overlaps with #44967, but targets a different layer.

- #44967 / related work addresses explicit Signal group target parsing in the `send_message` tool path
- this patch targets gateway delivery-target parsing and persisted session-key recovery for Signal base64 group IDs
- current `main` already covers the newer logical-session-key safety semantics, so this refresh keeps only the remaining bug-fix delta plus regression coverage

I did not find an open PR that covers this remaining bug class end-to-end.

## Verification
Ran locally:

```bash
uv run --extra dev pytest -q tests/gateway/test_session.py tests/gateway/test_delivery.py tests/gateway/test_background_process_notifications.py
```

Result:
- `187 passed`
