### PR TITLE
fix(feishu): suppress runtime status messages

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -164,6 +164,29 @@ _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+_FEISHU_RUNTIME_NOISE_PREFIXES = (
+    "📦 Preflight compression:",
+    "🗜️ Compacting context",
+    "⚠ Compression summary failed:",
+    "⚠️ Compression summary failed:",
+)
+_FEISHU_RUNTIME_WORKING_RE = re.compile(r"^\s*⏳\s*Working\s+—\s+\d+\s+min\b")
+
+
+def _is_feishu_runtime_noise_message(content: str) -> bool:
+    """Return True for local Hermes runtime status bubbles.
+
+    These status updates are useful in local logs but are too noisy in Feishu
+    groups. The matcher stays deliberately narrow so normal business messages
+    that merely mention these phrases are still delivered.
+    """
+    text = str(content or "").strip()
+    if not text:
+        return False
+    first_line = text.splitlines()[0].strip()
+    if _FEISHU_RUNTIME_WORKING_RE.match(first_line):
+        return True
+    return first_line.startswith(_FEISHU_RUNTIME_NOISE_PREFIXES)
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -1842,6 +1865,12 @@ class FeishuAdapter(BasePlatformAdapter):
         """Send a Feishu message."""
         if not self._client:
             return SendResult(success=False, error="Not connected")
+        if _is_feishu_runtime_noise_message(content):
+            logger.info(
+                "[Feishu] Suppressed runtime status message: %.160s",
+                str(content).replace("\n", " "),
+            )
+            return SendResult(success=True)
 
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
@@ -1900,6 +1929,13 @@ class FeishuAdapter(BasePlatformAdapter):
         """Edit a previously sent Feishu text/post message."""
         if not self._client:
             return SendResult(success=False, error="Not connected")
+        if _is_feishu_runtime_noise_message(content):
+            logger.info(
+                "[Feishu] Suppressed runtime status edit for %s: %.160s",
+                message_id,
+                str(content).replace("\n", " "),
+            )
+            return SendResult(success=True, message_id=message_id)
 
         content = self.format_message(content)
         try:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -417,6 +417,76 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_suppresses_runtime_status_messages(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = object()
+
+        with patch.object(adapter, "_feishu_send_with_retry", new_callable=AsyncMock) as mock_send:
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="⏳ Working — 1 min elapsed\nStill processing...",
+                )
+            )
+
+        self.assertTrue(result.success)
+        mock_send.assert_not_called()
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_does_not_suppress_near_miss_working_message(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = object()
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="om_sent"),
+        )
+
+        with patch.object(
+            adapter,
+            "_feishu_send_with_retry",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="⏳ Working — not a runtime heartbeat, please send this",
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_sent")
+        mock_send.assert_called_once()
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_edit_message_suppresses_runtime_status_messages(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace(update=Mock())))
+        )
+
+        result = asyncio.run(
+            adapter.edit_message(
+                chat_id="oc_chat",
+                message_id="om_runtime_status",
+                content="📦 Preflight compression: preparing context",
+            )
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_runtime_status")
+        adapter._client.im.v1.message.update.assert_not_called()
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_get_chat_info_uses_real_feishu_chat_api(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter


### PR DESCRIPTION
## Summary
- Suppress local Hermes runtime/progress status bubbles from Feishu outbound sends and edits
- Keep the matcher narrow so near-miss user-facing messages are still delivered
- Add regression tests for suppressed send/edit messages and a near-miss message that must still send

## Test Plan
- `uv run pytest tests/gateway/test_feishu.py -k 'runtime_status or near_miss_working' -q`
- `uv run pytest tests/gateway/test_feishu.py -q`
- `git diff --check`

## Notes
- This PR does not modify `.github/workflows/*`, so GitHub `workflow` scope is not required for this branch/PR.
